### PR TITLE
Add linear elasticity executable

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/ImposeBoundaryConditions.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/ImposeBoundaryConditions.hpp
@@ -130,10 +130,11 @@ struct ImposeHomogeneousDirichletBoundaryConditions {
                   tmpl::type_from<decltype(dirichlet_tag_val)>;
               using dirichlet_operand_tag =
                   LinearSolver::Tags::Operand<dirichlet_tag>;
-              // Use mirror principle. This only works for scalars right now.
-              get(get<dirichlet_operand_tag>(exterior_vars)) =
-                  -1. *
-                  get<dirichlet_operand_tag>(interior_vars.at(direction)).get();
+              // Use mirror principle
+              const db::item_type<typename system::variables_tag>
+                  mirrored_interior_vars(-1. * interior_vars.at(direction));
+              get<dirichlet_operand_tag>(exterior_vars) =
+                  get<dirichlet_operand_tag>(mirrored_interior_vars);
             });
           }
         },
@@ -153,11 +154,11 @@ struct ImposeHomogeneousDirichletBoundaryConditions {
 
       auto interior_data = DgActions_detail::compute_local_mortar_data(
           box, direction, normal_dot_numerical_flux_computer,
-          Tags::BoundaryDirectionsInterior<volume_dim>{}, Metavariables{});
+          Tags::BoundaryDirectionsInterior<volume_dim>{}, cache);
 
       auto exterior_data = DgActions_detail::compute_packaged_data(
           box, direction, normal_dot_numerical_flux_computer,
-          Tags::BoundaryDirectionsExterior<volume_dim>{}, Metavariables{});
+          Tags::BoundaryDirectionsExterior<volume_dim>{}, cache);
 
       db::mutate<Tags::VariablesBoundaryData>(
           make_not_null(&box),

--- a/src/Elliptic/Executables/CMakeLists.txt
+++ b/src/Elliptic/Executables/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Elasticity)
 add_subdirectory(Poisson)

--- a/src/Elliptic/Executables/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Executables/Elasticity/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBS_TO_LINK
+  CoordinateMaps
+  ConstitutiveRelations
+  DiscontinuousGalerkin
+  DomainCreators
+  Elasticity
+  ElasticitySolutions
+  Informer
+  IO
+  LinearOperators
+  LinearSolver
+  MathFunctions
+  Utilities
+  ${SPECTRE_LIBRARIES}
+  )
+
+add_spectre_parallel_executable(
+  SolveElasticityProblem2D
+  SolveElasticityProblem
+  Elliptic/Executables/Elasticity
+  Metavariables<2>
+  "${LIBS_TO_LINK}"
+  )
+add_spectre_parallel_executable(
+  SolveElasticityProblem3D
+  SolveElasticityProblem
+  Elliptic/Executables/Elasticity
+  Metavariables<3>
+  "${LIBS_TO_LINK}"
+  )

--- a/src/Elliptic/Executables/Elasticity/SolveElasticityProblemFwd.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticityProblemFwd.hpp
@@ -1,0 +1,9 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+template <size_t Dim>
+struct Metavariables;

--- a/src/Elliptic/Initialization/BoundaryConditions.hpp
+++ b/src/Elliptic/Initialization/BoundaryConditions.hpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesHelpers.hpp"
+#include "Domain/Direction.hpp"
 #include "Domain/FaceNormal.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
@@ -66,106 +67,97 @@ namespace Initialization {
  */
 template <typename Metavariables>
 struct BoundaryConditions {
+ private:
   using system = typename Metavariables::system;
-
+  static constexpr const size_t volume_dim = system::volume_dim;
   using sources_tag =
       db::add_tag_prefix<Tags::Source, typename system::fields_tag>;
+  using numerical_flux_tag = typename Metavariables::normal_dot_numerical_flux;
+  using numerical_flux_type = typename numerical_flux_tag::type;
 
+ public:
   using simple_tags = db::AddSimpleTags<>;
   using compute_tags = db::AddComputeTags<>;
 
-  template <typename NormalDotNumericalFluxComputer,
-            typename... NumericalFluxTags, typename... BoundaryDataTags>
+  template <typename... NumericalFluxTags, typename... BoundaryDataTags,
+            typename DbTagList, typename... ArgumentTags, typename... CacheTags>
   static void compute_dirichlet_boundary_normal_dot_numerical_flux(
       const gsl::not_null<Variables<tmpl::list<NumericalFluxTags...>>*>
           numerical_fluxes,
-      const NormalDotNumericalFluxComputer& normal_dot_numerical_flux_computer,
+      const numerical_flux_type& normal_dot_numerical_flux_computer,
       const Variables<tmpl::list<BoundaryDataTags...>>& boundary_data,
-      const tnsr::i<DataVector, system::volume_dim, Frame::Inertial>&
-          normalized_face_normal) noexcept {
+      const db::DataBox<DbTagList>& box, const Direction<volume_dim>& direction,
+      tmpl::list<ArgumentTags...> /*meta*/,
+      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      tmpl::list<CacheTags...> /*meta*/) noexcept {
     normal_dot_numerical_flux_computer.compute_dirichlet_boundary(
         make_not_null(&get<NumericalFluxTags>(*numerical_fluxes))...,
-        get<BoundaryDataTags>(boundary_data)..., normalized_face_normal);
+        get<BoundaryDataTags>(boundary_data)...,
+        get<Tags::Interface<Tags::BoundaryDirectionsInterior<volume_dim>,
+                            ArgumentTags>>(box)
+            .at(direction)...,
+        get<CacheTags>(cache)...);
   }
 
   template <typename TagsList>
   static auto initialize(
       db::DataBox<TagsList>&& box,
       const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
-    static constexpr const size_t volume_dim = system::volume_dim;
-
     const auto& analytic_solution =
         Parallel::get<typename Metavariables::analytic_solution_tag>(cache);
     const auto& normal_dot_numerical_flux_computer =
-        Parallel::get<typename Metavariables::normal_dot_numerical_flux>(cache);
+        Parallel::get<numerical_flux_tag>(cache);
 
-    db::mutate<sources_tag>(
-        make_not_null(&box),
-        [
-          &analytic_solution, &normal_dot_numerical_flux_computer
-        ](const gsl::not_null<db::item_type<sources_tag>*> sources,
-          const Mesh<volume_dim>& mesh,
-          const db::item_type<Tags::BoundaryDirectionsInterior<volume_dim>>&
-              boundary_directions,
-          const db::item_type<
-              Tags::Interface<Tags::BoundaryDirectionsInterior<volume_dim>,
-                              Tags::Coordinates<volume_dim, Frame::Inertial>>>&
-              boundary_coordinates,
-          const db::item_type<Tags::Interface<
-              Tags::BoundaryDirectionsInterior<volume_dim>,
-              Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>>&
-              normalized_face_normals,
-          const db::item_type<Tags::Interface<
-              Tags::BoundaryDirectionsInterior<volume_dim>,
-              Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>>&
-              magnitude_of_face_normals) noexcept {
-          // Impose Dirichlet boundary conditions as contributions to the source
-          for (const auto& direction : boundary_directions) {
-            const size_t dimension = direction.dimension();
-            const auto mortar_mesh = mesh.slice_away(dimension);
-            // Compute Dirichlet data on mortar
-            Variables<typename system::impose_boundary_conditions_on_fields>
-                dirichlet_boundary_data{mortar_mesh.number_of_grid_points(),
-                                        0.};
-            dirichlet_boundary_data.assign_subset(analytic_solution.variables(
-                boundary_coordinates.at(direction),
-                typename system::impose_boundary_conditions_on_fields{}));
-            // Compute the numerical flux contribution from the Dirichlet data
-            db::item_type<
-                db::add_tag_prefix<Tags::NormalDotNumericalFlux, sources_tag>>
-                boundary_normal_dot_numerical_fluxes{
-                    mortar_mesh.number_of_grid_points(), 0.};
-            compute_dirichlet_boundary_normal_dot_numerical_flux(
-                make_not_null(&boundary_normal_dot_numerical_fluxes),
-                normal_dot_numerical_flux_computer,
-                std::move(dirichlet_boundary_data),
-                normalized_face_normals.at(direction));
-            // Flip sign of the boundary contributions, making them
-            // contributions to the source
-            db::item_type<sources_tag> lifted_boundary_data{
-                -1. *
-                dg::lift_flux(std::move(boundary_normal_dot_numerical_fluxes),
-                              mesh.extents(dimension),
-                              magnitude_of_face_normals.at(direction))};
-            add_slice_to_data(sources, std::move(lifted_boundary_data),
-                              mesh.extents(), dimension,
-                              index_to_slice_at(mesh.extents(), direction));
-          }
-        },
-        get<Tags::Mesh<volume_dim>>(box),
-        get<Tags::BoundaryDirectionsInterior<volume_dim>>(box),
+    const auto& mesh = get<Tags::Mesh<volume_dim>>(box);
+    const auto& boundary_directions =
+        get<Tags::BoundaryDirectionsInterior<volume_dim>>(box);
+    const auto& boundary_coordinates =
         get<Tags::Interface<Tags::BoundaryDirectionsInterior<volume_dim>,
                             Tags::Coordinates<volume_dim, Frame::Inertial>>>(
-            box),
-        get<Tags::Interface<
-            Tags::BoundaryDirectionsInterior<volume_dim>,
-            Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>>(box),
-        get<Tags::Interface<
-            Tags::BoundaryDirectionsInterior<volume_dim>,
-            Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>>(box));
+            box);
+    const auto& magnitude_of_face_normals = get<Tags::Interface<
+        Tags::BoundaryDirectionsInterior<volume_dim>,
+        Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>>(box);
+
+    // Impose Dirichlet boundary conditions as contributions to the source
+    for (const auto& direction : boundary_directions) {
+      const size_t dimension = direction.dimension();
+      const auto mortar_mesh = mesh.slice_away(dimension);
+      // Compute Dirichlet data on mortar
+      Variables<typename system::impose_boundary_conditions_on_fields>
+          dirichlet_boundary_data{mortar_mesh.number_of_grid_points(), 0.};
+      dirichlet_boundary_data.assign_subset(analytic_solution.variables(
+          boundary_coordinates.at(direction),
+          typename system::impose_boundary_conditions_on_fields{}));
+      // Compute the numerical flux contribution from the Dirichlet data
+      db::item_type<
+          db::add_tag_prefix<Tags::NormalDotNumericalFlux, sources_tag>>
+          boundary_normal_dot_numerical_fluxes{
+              mortar_mesh.number_of_grid_points(), 0.};
+      compute_dirichlet_boundary_normal_dot_numerical_flux(
+          make_not_null(&boundary_normal_dot_numerical_fluxes),
+          normal_dot_numerical_flux_computer,
+          std::move(dirichlet_boundary_data), box, direction,
+          typename numerical_flux_type::boundary_argument_tags{}, cache,
+          typename numerical_flux_type::const_global_cache_tags{});
+      // Flip sign of the boundary contributions, making them
+      // contributions to the source
+      db::item_type<sources_tag> lifted_boundary_data{
+          -1. * dg::lift_flux(std::move(boundary_normal_dot_numerical_fluxes),
+                              mesh.extents(dimension),
+                              magnitude_of_face_normals.at(direction))};
+      // Add contribution to source in the DataBox
+      db::mutate<sources_tag>(make_not_null(&box), [
+        &lifted_boundary_data, &mesh, &dimension, &direction
+      ](const gsl::not_null<db::item_type<sources_tag>*> sources) noexcept {
+        add_slice_to_data(sources, std::move(lifted_boundary_data),
+                          mesh.extents(), dimension,
+                          index_to_slice_at(mesh.extents(), direction));
+      });
+    }
 
     return std::move(box);
   }
-};
+};  // namespace Initialization
 }  // namespace Initialization
 }  // namespace Elliptic

--- a/src/Elliptic/Initialization/Interface.hpp
+++ b/src/Elliptic/Initialization/Interface.hpp
@@ -100,6 +100,9 @@ struct Interface {
               db::variables_tag_with_tags_list<typename System::variables_tag,
                                                typename System::gradient_tags>,
               tmpl::size_t<volume_dim>, Frame::Inertial>>,
+      Tags::InterfaceComputeItem<
+          Tags::BoundaryDirectionsExterior<volume_dim>,
+          Tags::BoundaryCoordinates<volume_dim, Frame::Inertial>>,
       Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<volume_dim>,
                                  Tags::UnnormalizedFaceNormal<volume_dim>>,
       Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<volume_dim>,

--- a/src/Elliptic/Systems/Elasticity/Actions/Actions.hpp
+++ b/src/Elliptic/Systems/Elasticity/Actions/Actions.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace Elasticity {
+/*!
+ * \brief Actions specific to the Elasticity system
+ */
+namespace Actions {}
+}  // namespace Elasticity

--- a/src/Elliptic/Systems/Elasticity/Actions/Observe.hpp
+++ b/src/Elliptic/Systems/Elasticity/Actions/Observe.hpp
@@ -1,0 +1,159 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "IO/Observer/Actions.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "IO/Observer/VolumeActions.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Reduction.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Elasticity {
+namespace Actions {
+
+/*!
+ * \brief Action to observe volume and reduction data for the Elasticity system
+ *
+ * This action observes the following:
+ * - Reduction data:
+ *   - `"Iteration"`: The linear solver iteration
+ *   - `"NumberOfPoints"`: The total number of grid points across all elements
+ *   - `"L2Error"`: The standard L2 vector norm of the pointwise difference
+ * between the numerical and analytic solution \f$\sqrt{\sum_i
+ * \frac{1}{D} \sum_j^\mathrm{D} \left( (u^j_\mathrm{numerical})_i -
+ * (u^j_\mathrm{analytic})_i \right)^2}\f$ over the grid points across all
+ * elements.
+ * - Volume data:
+ *   - `"Displacement": The numerical solution \f$u^i_\mathrm{numerical}\f$
+ *   - `"DisplacementAnalytic"`: The analytic solution
+ * \f$u^i_\mathrm{analytic}\f$
+ *   - `"DisplacementError"`: The pointwise error \f$u^i_\mathrm{numerical} -
+ * u^i_\mathrm{analytic}\f$
+ *   - `"InertialCoordinates"`
+ *
+ * Uses:
+ * - Metavariables:
+ *   - `analytic_solution_tag`
+ *   - Items required by `observers::Observer<Metavariables>`
+ * - DataBox:
+ *   - `LinearSolver::Tags::IterationId`
+ *   - `Tags::Mesh<Dim>`
+ *   - `Elasticity::Tags::Displacement`
+ *   - `Tags::Coordinates<Dim, Frame::Inertial>`
+ *
+ * \note This action can be adjusted before compiling an executable to observe
+ * only the desired quantities.
+ */
+struct Observe {
+ private:
+  using observed_reduction_data = Parallel::ReductionData<
+      Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<size_t, funcl::Plus<>>,
+      Parallel::ReductionDatum<double, funcl::Plus<>,
+                               funcl::Sqrt<funcl::Divides<>>,
+                               std::index_sequence<1>>>;
+  struct observation_type {};
+
+ public:
+  // Compile-time interface for observers
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<observed_reduction_data>>;
+
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ElementIndex<Dim>& array_index,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using field_tag = Elasticity::Tags::Displacement<Dim>;
+
+    const auto& iteration_id = get<LinearSolver::Tags::IterationId>(box);
+    const auto& mesh = get<::Tags::Mesh<Dim>>(box);
+    const std::string element_name = MakeString{} << ElementId<Dim>(array_index)
+                                                  << '/';
+
+    // Retrieve the current numeric solution
+    const auto& field = get<field_tag>(box);
+
+    // Compute the analytic solution
+    const auto& inertial_coordinates =
+        db::get<::Tags::Coordinates<Dim, Frame::Inertial>>(box);
+    const auto field_analytic = get<field_tag>(
+        Parallel::get<typename Metavariables::analytic_solution_tag>(cache)
+            .variables(inertial_coordinates, tmpl::list<field_tag>{}));
+
+    // Collect volume and reduction data
+    std::vector<TensorComponent> components;
+    components.reserve(4 * Dim);
+    auto field_error = make_with_value<db::item_type<field_tag>>(field, 0.);
+    double local_l2_error_square = 0;
+    for (size_t d = 0; d < Dim; d++) {
+      // Compute error between numeric and analytic solutions
+      field_error.get(d) = field.get(d) - field_analytic.get(d);
+      // Compute l2 error squared over local element
+      local_l2_error_square +=
+          alg::accumulate(field_error.get(d), 0.0,
+                          funcl::Plus<funcl::Identity, funcl::Square<>>{});
+      const std::string component_suffix = d == 0 ? "_x" : d == 1 ? "_y" : "_z";
+      components.emplace_back(
+          element_name + field_tag::name() + component_suffix, field.get(d));
+      components.emplace_back(
+          element_name + field_tag::name() + "Analytic" + component_suffix,
+          field_analytic.get(d));
+      components.emplace_back(
+          element_name + field_tag::name() + "Error" + component_suffix,
+          field_error.get(d));
+      components.emplace_back(
+          element_name + "InertialCoordinates" + component_suffix,
+          inertial_coordinates.get(d));
+    }
+    local_l2_error_square /= Dim;
+
+    // Send data to volume observer
+    auto& local_observer =
+        *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+             cache)
+             .ckLocalBranch();
+    Parallel::simple_action<observers::Actions::ContributeVolumeData>(
+        local_observer,
+        observers::ObservationId(iteration_id, observation_type{}),
+        std::string{"/element_data"},
+        observers::ArrayComponentId(
+            std::add_pointer_t<ParallelComponent>{nullptr},
+            Parallel::ArrayIndex<ElementIndex<Dim>>(array_index)),
+        std::move(components), mesh.extents());
+
+    // Send data to reduction observer
+    Parallel::simple_action<observers::Actions::ContributeReductionData>(
+        local_observer,
+        observers::ObservationId(iteration_id, observation_type{}),
+        std::string{"/element_data"},
+        std::vector<std::string>{"Iteration", "NumberOfPoints", "L2Error"},
+        observed_reduction_data{iteration_id.step_number,
+                                mesh.number_of_grid_points(),
+                                local_l2_error_square});
+
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions
+}  // namespace Elasticity

--- a/src/Elliptic/Systems/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Systems/Elasticity/CMakeLists.txt
@@ -2,3 +2,16 @@
 # See LICENSE.txt for details.
 
 set(LIBRARY Elasticity)
+
+set(LIBRARY_SOURCES
+  Equations.cpp
+  )
+
+add_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE ConstitutiveRelations
+  INTERFACE DataStructures
+  INTERFACE ErrorHandling
+  )

--- a/src/Elliptic/Systems/Elasticity/Equations.cpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.cpp
@@ -1,0 +1,239 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/Elasticity/Equations.hpp"
+
+#include <array>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"  // IWYU pragma: keep
+#include "Elliptic/Systems/Elasticity/FirstOrderSystem.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+// IWYU pragma: no_forward_declare Tags::deriv
+// IWYU pragma: no_forward_declare Tags::div
+// IWYU pragma: no_forward_declare Variables
+// IWYU pragma: no_forward_declare Tensor
+
+namespace Elasticity {
+
+template <size_t Dim>
+void ComputeFirstOrderOperatorAction<Dim>::apply(
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> operator_action,
+    const gsl::not_null<tnsr::II<DataVector, Dim>*> auxiliary_operator_action,
+    const tnsr::iJ<DataVector, Dim>& grad_displacement,
+    const tnsr::II<DataVector, Dim>& stress, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
+        inverse_jacobian,
+    const tnsr::I<DataVector, Dim>& inertial_coords,
+    const Elasticity::ConstitutiveRelations::ConstitutiveRelation<Dim>&
+        constitutive_relation) noexcept {
+  // Compute div(T)
+  auto div_vars =
+      make_with_value<Variables<tmpl::list<Tags::Stress<Dim>>>>(stress, 0.);
+  get<Tags::Stress<Dim>>(div_vars) = stress;
+  *operator_action = get<::Tags::div<Tags::Stress<Dim>>>(
+      divergence(div_vars, mesh, inverse_jacobian));
+  // Compute -\Y^{ijkl} S_{kl} - T^{ij}
+  const auto computed_stress =
+      constitutive_relation.stress(grad_displacement, inertial_coords);
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t j = 0; j < Dim; j++) {
+      auxiliary_operator_action->get(i, j) =
+          computed_stress.get(i, j) - stress.get(i, j);
+    }
+  }
+}
+
+template <size_t Dim>
+void ComputeFirstOrderNormalDotFluxes<Dim>::apply(
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> normal_dot_flux,
+    const gsl::not_null<tnsr::II<DataVector, Dim>*> auxiliary_normal_dot_flux,
+    const tnsr::I<DataVector, Dim>& displacement,
+    const tnsr::II<DataVector, Dim>& stress,
+    const tnsr::i<DataVector, Dim>& interface_unit_normal,
+    const tnsr::I<DataVector, Dim>& inertial_coords,
+    const Elasticity::ConstitutiveRelations::ConstitutiveRelation<Dim>&
+        constitutive_relation) noexcept {
+  for (size_t j = 0; j < Dim; j++) {
+    normal_dot_flux->get(j) = 0.;
+    for (size_t i = 0; i < Dim; i++) {
+      // The minus sign is to cancel the one in `lift_flux`
+      normal_dot_flux->get(j) -=
+          interface_unit_normal.get(i) * stress.get(i, j);
+    }
+  }
+
+  auto normal_times_displacement =
+      make_with_value<tnsr::iJ<DataVector, Dim>>(displacement, 0.);
+  // The minus sign is to cancel the one in `lift_flux`
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t j = 0; j < Dim; j++) {
+      normal_times_displacement.get(i, j) =
+          -1. * interface_unit_normal.get(i) * displacement.get(j);
+    }
+  }
+  *auxiliary_normal_dot_flux =
+      constitutive_relation.stress(normal_times_displacement, inertial_coords);
+}
+
+template <size_t Dim>
+void FirstOrderInternalPenaltyFlux<Dim>::package_data(
+    const gsl::not_null<Variables<package_tags>*> packaged_data,
+    const tnsr::I<DataVector, Dim>& displacement,
+    const tnsr::iJ<DataVector, Dim>& grad_displacement,
+    const tnsr::i<DataVector, Dim>& interface_unit_normal,
+    const tnsr::I<DataVector, Dim>& inertial_coords,
+    const Elasticity::ConstitutiveRelations::ConstitutiveRelation<Dim>&
+        constitutive_relation) const noexcept {
+  auto normal_times_displacement =
+      make_with_value<tnsr::iJ<DataVector, Dim>>(displacement, 0.);
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t j = 0; j < Dim; j++) {
+      normal_times_displacement.get(i, j) =
+          interface_unit_normal.get(i) * displacement.get(j);
+    }
+  }
+  get<AuxiliaryFlux>(*packaged_data) =
+      constitutive_relation.stress(normal_times_displacement, inertial_coords);
+
+  for (size_t j = 0; j < Dim; j++) {
+    get<NormalDotAuxiliaryFlux>(*packaged_data).get(j) =
+        get<0>(interface_unit_normal) *
+        get<AuxiliaryFlux>(*packaged_data).get(0, j);
+    for (size_t i = 1; i < Dim; i++) {
+      get<NormalDotAuxiliaryFlux>(*packaged_data).get(j) +=
+          interface_unit_normal.get(i) *
+          get<AuxiliaryFlux>(*packaged_data).get(i, j);
+    }
+  }
+
+  const auto computed_stress =
+      constitutive_relation.stress(grad_displacement, inertial_coords);
+  for (size_t j = 0; j < Dim; j++) {
+    get<NormalDotStress>(*packaged_data).get(j) =
+        get<0>(interface_unit_normal) * computed_stress.get(0, j);
+    for (size_t i = 1; i < Dim; i++) {
+      get<NormalDotStress>(*packaged_data).get(j) +=
+          interface_unit_normal.get(i) * computed_stress.get(i, j);
+    }
+  }
+}
+
+template <size_t Dim>
+void FirstOrderInternalPenaltyFlux<Dim>::operator()(
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> numerical_flux,
+    const gsl::not_null<tnsr::II<DataVector, Dim>*> auxiliary_numerical_flux,
+    const tnsr::II<DataVector, Dim>& auxiliary_flux_interior,
+    const tnsr::I<DataVector, Dim>& normal_dot_stress_interior,
+    const tnsr::I<DataVector, Dim>& normal_dot_auxiliary_flux_interior,
+    const tnsr::II<DataVector, Dim>& minus_auxiliary_flux_exterior,
+    const tnsr::I<DataVector, Dim>& minus_normal_dot_stress_exterior,
+    const tnsr::I<DataVector, Dim>& minus_normal_dot_auxiliary_flux_exterior)
+    const noexcept {
+  // Need polynomial degress and element size to compute this dynamically
+  const double penalty = penalty_parameter_;
+
+  // The outer minus sign is to cancel the one in `lift_flux`
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t j = 0; j < Dim; j++) {
+      auxiliary_numerical_flux->get(i, j) =
+          -0.5 * (auxiliary_flux_interior.get(i, j) -
+                  minus_auxiliary_flux_exterior.get(i, j));
+    }
+  }
+
+  // The outer minus sign is to cancel the one in `lift_flux`
+  for (size_t i = 0; i < Dim; i++) {
+    numerical_flux->get(i) =
+        -0.5 * (normal_dot_stress_interior.get(i) -
+                minus_normal_dot_stress_exterior.get(i)) +
+        penalty * (normal_dot_auxiliary_flux_interior.get(i) -
+                   minus_normal_dot_auxiliary_flux_exterior.get(i));
+  }
+}
+
+template <size_t Dim>
+void FirstOrderInternalPenaltyFlux<Dim>::compute_dirichlet_boundary(
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> numerical_flux,
+    const gsl::not_null<tnsr::II<DataVector, Dim>*> auxiliary_numerical_flux,
+    const tnsr::I<DataVector, Dim>& dirichlet_displacement,
+    const tnsr::i<DataVector, Dim>& interface_unit_normal,
+    const tnsr::I<DataVector, Dim>& inertial_coords,
+    const Elasticity::ConstitutiveRelations::ConstitutiveRelation<Dim>&
+        constitutive_relation) const noexcept {
+  // Need polynomial degress and element size to compute this dynamically
+  const double penalty = penalty_parameter_;
+
+  auto normal_times_displacement =
+      make_with_value<tnsr::iJ<DataVector, Dim>>(dirichlet_displacement, 0.);
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t j = 0; j < Dim; j++) {
+      normal_times_displacement.get(i, j) =
+          interface_unit_normal.get(i) * dirichlet_displacement.get(j);
+    }
+  }
+  const auto flux_for_stress =
+      constitutive_relation.stress(normal_times_displacement, inertial_coords);
+
+  // The minus sign is to cancel the one in `lift_flux`
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t j = 0; j < Dim; j++) {
+      auxiliary_numerical_flux->get(i, j) = -flux_for_stress.get(i, j);
+    }
+  }
+
+  // The minus sign is to cancel the one in `lift_flux`
+  for (size_t j = 0; j < Dim; j++) {
+    numerical_flux->get(j) = 0.;
+    for (size_t i = 0; i < Dim; i++) {
+      numerical_flux->get(j) -= 2. * penalty * interface_unit_normal.get(i) *
+                                flux_for_stress.get(i, j);
+    }
+  }
+}
+
+}  // namespace Elasticity
+
+// Instantiate needed gradient and divergence templates
+#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"  // IWYU pragma: keep
+
+template <size_t Dim>
+using variables_tags =
+    typename Elasticity::FirstOrderSystem<Dim>::variables_tag::type::tags_list;
+template <size_t Dim>
+using grad_tags = typename Elasticity::FirstOrderSystem<Dim>::gradient_tags;
+template <size_t Dim>
+using div_tags = typename Elasticity::FirstOrderSystem<Dim>::divergence_tags;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data)                                             \
+  template class Elasticity::ComputeFirstOrderOperatorAction<DIM(data)>;   \
+  template class Elasticity::ComputeFirstOrderNormalDotFluxes<DIM(data)>;  \
+  template class Elasticity::FirstOrderInternalPenaltyFlux<DIM(data)>;     \
+  template Variables<                                                      \
+      db::wrap_tags_in<Tags::deriv, grad_tags<DIM(data)>,                  \
+                       tmpl::size_t<DIM(data)>, Frame::Inertial>>          \
+  partial_derivatives<grad_tags<DIM(data)>, variables_tags<DIM(data)>,     \
+                      DIM(data), Frame::Inertial>(                         \
+      const Variables<variables_tags<DIM(data)>>&, const Mesh<DIM(data)>&, \
+      const InverseJacobian<DataVector, DIM(data), Frame::Logical,         \
+                            Frame::Inertial>&) noexcept;                   \
+  template Variables<db::wrap_tags_in<Tags::div, div_tags<DIM(data)>>>     \
+  divergence<div_tags<DIM(data)>, DIM(data), Frame::Inertial>(             \
+      const Variables<div_tags<DIM(data)>>&, const Mesh<DIM(data)>&,       \
+      const InverseJacobian<DataVector, DIM(data), Frame::Logical,         \
+                            Frame::Inertial>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (2, 3))
+
+#undef INSTANTIATION
+#undef DIM

--- a/src/Elliptic/Systems/Elasticity/Equations.hpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.hpp
@@ -1,0 +1,224 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"  // IWYU pragma: keep
+#include "DataStructures/VariablesHelpers.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"  // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_forward_declare Tags::deriv
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare Variables
+
+/// \cond
+class DataVector;
+template <size_t>
+class Mesh;
+namespace Tags {
+template <typename>
+struct Normalized;
+}  // namespace Tags
+namespace LinearSolver {
+namespace Tags {
+template <typename>
+struct Operand;
+}  // namespace Tags
+}  // namespace LinearSolver
+namespace Elasticity {
+namespace Tags {
+template <size_t Dim>
+struct Displacement;
+template <size_t Dim>
+struct Stress;
+}  // namespace Tags
+}  // namespace Elasticity
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Elasticity {
+
+/*!
+ * \brief The bulk contribution to the linear operator action for the
+ * first-order formulation of the Elasticity equations.
+ *
+ * \details The bulk contribution for the equation sourced by
+ * \f$f_\mathrm{ext}^j\f$ is \f$\nabla_i T^{ij}\f$ and the one for the auxiliary
+ * equation isn \f$-Y^{ijkl}\nabla_{(k}u_{l)} - T^{ij}\f$ (see
+ * `Elasticity::FirstOrderSystem`)
+ */
+template <size_t Dim>
+struct ComputeFirstOrderOperatorAction {
+  using argument_tags = tmpl::list<
+      ::Tags::deriv<LinearSolver::Tags::Operand<Tags::Displacement<Dim>>,
+                    tmpl::size_t<Dim>, Frame::Inertial>,
+      LinearSolver::Tags::Operand<Tags::Stress<Dim>>, ::Tags::Mesh<Dim>,
+      ::Tags::InverseJacobian<::Tags::ElementMap<Dim>,
+                              ::Tags::Coordinates<Dim, Frame::Logical>>,
+      ::Tags::Coordinates<Dim, Frame::Inertial>>;
+  using const_global_cache_tags =
+      tmpl::list<Elasticity::Tags::ConstitutiveRelationBase>;
+  static void apply(
+      gsl::not_null<tnsr::I<DataVector, Dim>*> operator_action,
+      gsl::not_null<tnsr::II<DataVector, Dim>*> auxiliary_operator_action,
+      const tnsr::iJ<DataVector, Dim>& grad_displacement,
+      const tnsr::II<DataVector, Dim>& stress, const Mesh<Dim>& mesh,
+      const InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
+          inverse_jacobian,
+      const tnsr::I<DataVector, Dim>& inertial_coords,
+      const Elasticity::ConstitutiveRelations::ConstitutiveRelation<Dim>&
+          constitutive_relation) noexcept;
+};
+
+/*
+ * \brief The interface normal dotted into the fluxes for the first order
+ * formulation of the Elasticity equations.
+ *
+ * \details For the sourced equation this is \f$n_i T^{ij}\f$ and for the
+ * auxiliary equation it is \f$-Y^{ijkl}\n_{(k}u_{l)}\f$ (see
+ * `Elsaticity::FirstOrderSystem` and `dg::lift_flux`).
+ */
+template <size_t Dim>
+struct ComputeFirstOrderNormalDotFluxes {
+  using argument_tags =
+      tmpl::list<LinearSolver::Tags::Operand<Tags::Displacement<Dim>>,
+                 LinearSolver::Tags::Operand<Tags::Stress<Dim>>,
+                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>,
+                 ::Tags::Coordinates<Dim, Frame::Inertial>>;
+  using const_global_cache_tags =
+      tmpl::list<Elasticity::Tags::ConstitutiveRelationBase>;
+  static void apply(
+      gsl::not_null<tnsr::I<DataVector, Dim>*> normal_dot_flux,
+      gsl::not_null<tnsr::II<DataVector, Dim>*> auxiliary_normal_dot_flux,
+      const tnsr::I<DataVector, Dim>& displacement,
+      const tnsr::II<DataVector, Dim>& stress,
+      const tnsr::i<DataVector, Dim>& interface_unit_normal,
+      const tnsr::I<DataVector, Dim>& inertial_coords,
+      const Elasticity::ConstitutiveRelations::ConstitutiveRelation<Dim>&
+          constitutive_relation) noexcept;
+};
+
+/*!
+ * \brief The internal penalty flux for the first oder formulation of the
+ * Elasticity equations.
+ *
+ * \details For the sourced equation this is
+ * \f[
+ * {T^*}^{ij}=\frac{1}{2}\left( -Y^{ijkl}\nabla_{(k} u_{l)}^\mathrm{int} -
+ * Y^{ijkl}\nabla_{(k)}u_{l)}^\mathrm{ext} \right) +
+ * \sigma \left(-Y^{ijkl}n_{(k}u_{l)}^\mathrm{int} +
+ * Y^{ijkl}n_{(k}u_{l)}^\mathrm{ext}\right)
+ * \f]
+ * and for the auxiliary equation it is
+ * \f[
+ * {u^*}_i=\frac{ u_i^\mathrm{int} + u_i^\mathrm{ext}}{2} \text{.}
+ * \f]
+ * The penalty factor \f$\sigma\f$ is responsible for removing zero eigenmodes
+ * and impacts the conditioning of the linear operator to be solved. It can be
+ * chosen as \f$\sigma=C\frac{N_\mathrm{points}^2}{h}\f$ where
+ * \f$N_\mathrm{points}\f$ is the number of collocation points (i.e. the
+ * polynomial degree plus 1), \f$h\f$ is a measure of the element size in
+ * inertial coordinates and \f$C\geq 1\f$ is a free parameter (see e.g.
+ * \cite HesthavenWarburton, section 7.2).
+ */
+template <size_t Dim>
+struct FirstOrderInternalPenaltyFlux {
+ public:
+  struct PenaltyParameter {
+    using type = double;
+    static constexpr OptionString help = {
+        "The prefactor to the penalty term of the flux."};
+  };
+  using options = tmpl::list<PenaltyParameter>;
+  static constexpr OptionString help = {
+      "Computes the internal penalty flux for an elasticity system."};
+
+  FirstOrderInternalPenaltyFlux() = default;
+  explicit FirstOrderInternalPenaltyFlux(double penalty_parameter)
+      : penalty_parameter_(penalty_parameter) {}
+
+  // clang-tidy: non-const reference
+  void pup(PUP::er& p) noexcept { p | penalty_parameter_; }  // NOLINT
+
+  // -Y^{ijkl} n_{(k} {u^*}^{l)}
+  struct AuxiliaryFlux : db::SimpleTag {
+    using type = tnsr::II<DataVector, Dim>;
+    static std::string name() noexcept { return "AuxiliaryFlux"; }
+  };
+
+  // -n_i Y^{ijkl} n_{(k} {u^*}^{l)}
+  struct NormalDotAuxiliaryFlux : db::SimpleTag {
+    using type = tnsr::I<DataVector, Dim>;
+    static std::string name() noexcept { return "NormalDotAuxiliaryFlux"; }
+  };
+
+  // -n_i Y^{ijkl} \nabla_{(k} u_{l)}
+  struct NormalDotStress : db::SimpleTag {
+    using type = tnsr::I<DataVector, Dim>;
+    static std::string name() noexcept { return "NormalDotStress"; }
+  };
+
+  using argument_tags = tmpl::list<
+      LinearSolver::Tags::Operand<Tags::Displacement<Dim>>,
+      ::Tags::deriv<LinearSolver::Tags::Operand<Tags::Displacement<Dim>>,
+                    tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>,
+      ::Tags::Coordinates<Dim, Frame::Inertial>>;
+  using const_global_cache_tags =
+      tmpl::list<Elasticity::Tags::ConstitutiveRelationBase>;
+
+  using package_tags =
+      tmpl::list<AuxiliaryFlux, NormalDotStress, NormalDotAuxiliaryFlux>;
+
+  void package_data(
+      gsl::not_null<Variables<package_tags>*> packaged_data,
+      const tnsr::I<DataVector, Dim>& displacement,
+      const tnsr::iJ<DataVector, Dim>& grad_displacement,
+      const tnsr::i<DataVector, Dim>& interface_unit_normal,
+      const tnsr::I<DataVector, Dim>& inertial_coords,
+      const Elasticity::ConstitutiveRelations::ConstitutiveRelation<Dim>&
+          constitutive_relation) const noexcept;
+
+  void operator()(
+      gsl::not_null<tnsr::I<DataVector, Dim>*> numerical_flux,
+      gsl::not_null<tnsr::II<DataVector, Dim>*> auxiliary_numerical_flux,
+      const tnsr::II<DataVector, Dim>& auxiliary_flux_interior,
+      const tnsr::I<DataVector, Dim>& normal_dot_stress_interior,
+      const tnsr::I<DataVector, Dim>& normal_dot_auxiliary_flux_interior,
+      const tnsr::II<DataVector, Dim>& minus_auxiliary_flux_exterior,
+      const tnsr::I<DataVector, Dim>& minus_normal_dot_stress_exterior,
+      const tnsr::I<DataVector, Dim>& minus_normal_dot_auxiliary_flux_exterior)
+      const noexcept;
+
+  using boundary_argument_tags =
+      tmpl::list<::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>,
+                 ::Tags::Coordinates<Dim, Frame::Inertial>>;
+
+  void compute_dirichlet_boundary(
+      gsl::not_null<tnsr::I<DataVector, Dim>*> numerical_flux,
+      gsl::not_null<tnsr::II<DataVector, Dim>*> auxiliary_numerical_flux,
+      const tnsr::I<DataVector, Dim>& dirichlet_displacement,
+      const tnsr::i<DataVector, Dim>& interface_unit_normal,
+      const tnsr::I<DataVector, Dim>& inertial_coords,
+      const Elasticity::ConstitutiveRelations::ConstitutiveRelation<Dim>&
+          constitutive_relation) const noexcept;
+
+ private:
+  double penalty_parameter_{};
+};
+
+}  // namespace Elasticity

--- a/src/Elliptic/Systems/Elasticity/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Elasticity/FirstOrderSystem.hpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "Elliptic/Systems/Elasticity/Equations.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Tags {
+template <typename>
+class Variables;
+}  // namespace Tags
+
+namespace LinearSolver {
+namespace Tags {
+template <typename>
+struct Operand;
+}  // namespace Tags
+}  // namespace LinearSolver
+/// \endcond
+
+namespace Elasticity {
+
+/*!
+ * \brief The linear elasticity equations formulated as a set of coupled
+ * first-order PDEs.
+ *
+ * This system formulates the linear elasticity problem
+ * \f$-\nabla_i Y^{ijkl}\nabla_{(k}u_{l)}=f_\mathrm{ext}^j\f$ (see `Elasticity`)
+ * as the set of coupled first-order PDEs
+ * \f[
+ * \nabla_i T^{ij} = f_\mathrm{ext}^j \\
+ * -Y^{ijkl}\nabla_{(k}u_{l)} - T^{ij} = 0
+ * \f]
+ * by choosing the stress \f$T^{ij}=-Y^{ijkl}\nabla_{(k}u_{l)}\f$ as an
+ * auxiliary variable. See the `Poisson::FirstOrderSystem` for a discussion of
+ * alternatives to the first-order formulation.
+ */
+template <size_t Dim>
+struct FirstOrderSystem {
+  static constexpr size_t volume_dim = Dim;
+
+  // The physical fields to solve for
+  using fields_tag =
+      ::Tags::Variables<tmpl::list<Tags::Displacement<Dim>, Tags::Stress<Dim>>>;
+  using impose_boundary_conditions_on_fields =
+      tmpl::list<Tags::Displacement<Dim>>;
+
+  // The variables to compute bulk contributions and fluxes for.
+  using variables_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
+
+  // The bulk contribution to the linear operator action
+  using compute_operator_action = ComputeFirstOrderOperatorAction<Dim>;
+
+  // The interface normal dotted into the fluxes that is required by the strong
+  // flux lifting operation
+  using normal_dot_fluxes = ComputeFirstOrderNormalDotFluxes<Dim>;
+
+  // The tag of the operator to compute magnitudes on the manifold, e.g. to
+  // normalize vectors on the faces of an element
+  template <typename Tag>
+  using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;
+
+  // The tags to instantiate derivative functions for
+  using gradient_tags =
+      tmpl::list<LinearSolver::Tags::Operand<Tags::Displacement<Dim>>>;
+  using divergence_tags = tmpl::list<Tags::Stress<Dim>>;
+};
+
+}  // namespace Elasticity

--- a/src/Elliptic/Systems/Poisson/Equations.hpp
+++ b/src/Elliptic/Systems/Poisson/Equations.hpp
@@ -102,16 +102,24 @@ struct ComputeFirstOrderNormalDotFluxes {
  * \brief The internal penalty flux for the first oder formulation of the
  * Poisson equation.
  *
- * \details For the sourced equation this is \f$-\frac{\nabla u_\mathrm{int} +
- * \nabla u_\mathrm{ext}}{2} + \sigma \left(u_\mathrm{int} -
- * u_\mathrm{ext}\right)\f$ and for the auxiliary equation it is \f$\frac{
- * u_\mathrm{int} + u_\mathrm{ext}}{2}\f$. The penalty factor \f$\sigma\f$ is
- * responsible for removing zero eigenmodes and impacts the conditioning of the
- * linear operator to be solved. It can be chosen as
- * \f$\sigma=C\frac{N_\mathrm{points}^2}{h}\f$ where \f$N_\mathrm{points}\f$ is
- * the number of collocation points (i.e. the polynomial degree plus 1),
- * \f$h\f$ is a measure of the element size in inertial coordinates and \f$C\leq
- * 1\f$ is a free parameter (see e.g. \cite HesthavenWarburton, section 7.2).
+ * \details For the sourced equation this is
+ * \f[
+ * \boldsymbol{v}^* = -\frac{\nabla u^\mathrm{int} +
+ * \nabla u^\mathrm{ext}}{2} + \sigma \left(
+ * \boldsymbol{n}^\mathrm{int} u^\mathrm{int} - \boldsymbol{n}^\mathrm{ext}
+ * u^\mathrm{ext} \right)
+ * \f]
+ * and for the auxiliary equation it is
+ * \f[
+ * u^* = \frac{u^\mathrm{int} + u^\mathrm{ext}}{2} \text{.}
+ * \f]
+ * The penalty factor \f$\sigma\f$ is responsible for removing zero eigenmodes
+ * and impacts the conditioning of the linear operator to be solved. It can be
+ * chosen as \f$\sigma=C\frac{N_\mathrm{points}^2}{h}\f$ where
+ * \f$N_\mathrm{points}\f$ is the number of collocation points (i.e. the
+ * polynomial degree plus 1), \f$h\f$ is a measure of the element size in
+ * inertial coordinates and \f$C\geq 1\f$ is a free parameter (see e.g.
+ * \cite HesthavenWarburton, section 7.2).
  */
 template <size_t Dim>
 struct FirstOrderInternalPenaltyFlux {

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
@@ -249,7 +249,7 @@ struct SendDataForFluxes {
 
       const auto packaged_data = DgActions_detail::compute_packaged_data(
           box, direction, normal_dot_numerical_flux_computer,
-          Tags::InternalDirections<volume_dim>{}, Metavariables{});
+          Tags::InternalDirections<volume_dim>{}, cache);
 
       const auto direction_from_neighbor = orientation(direction.opposite());
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
@@ -133,11 +133,11 @@ struct ImposeDirichletBoundaryConditions {
 
       auto interior_data = DgActions_detail::compute_local_mortar_data(
           *box, direction, normal_dot_numerical_flux_computer,
-          Tags::BoundaryDirectionsInterior<volume_dim>{}, Metavariables{});
+          Tags::BoundaryDirectionsInterior<volume_dim>{}, cache);
 
       auto exterior_data = DgActions_detail::compute_packaged_data(
           *box, direction, normal_dot_numerical_flux_computer,
-          Tags::BoundaryDirectionsExterior<volume_dim>{}, Metavariables{});
+          Tags::BoundaryDirectionsExterior<volume_dim>{}, cache);
 
       db::mutate<Tags::VariablesBoundaryData>(
           box, [&mortar_id, &temporal_id, &interior_data, &exterior_data ](

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/InterfaceActionHelpers.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/InterfaceActionHelpers.hpp
@@ -15,35 +15,52 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
 
 namespace DgActions_detail {
+
+template <typename NumericalFlux, typename Metavariables, typename... CacheTags,
+          typename... Args>
+void compute_packaged_data_with_cache_tags(
+    const gsl::not_null<Variables<typename NumericalFlux::package_tags>*>
+        packaged_data,
+    const NumericalFlux& normal_dot_numerical_flux_computer,
+    const Parallel::ConstGlobalCache<Metavariables>& cache,
+    tmpl::list<CacheTags...> /*meta*/, const Args&... args) {
+  normal_dot_numerical_flux_computer.package_data(packaged_data, args...,
+                                                  get<CacheTags>(cache)...);
+}
+
 template <typename Metavariables, typename DataBoxType, typename DirectionsTag,
           typename NumericalFlux>
 auto compute_packaged_data(
     const DataBoxType& box,
     const Direction<Metavariables::system::volume_dim>& direction,
     const NumericalFlux& normal_dot_numerical_flux_computer,
-    const DirectionsTag /*meta*/, const Metavariables /*meta*/) noexcept ->
+    const DirectionsTag /*meta*/,
+    const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept ->
     typename dg::FluxCommunicationTypes<Metavariables>::PackagedData {
   constexpr size_t volume_dim = Metavariables::system::volume_dim;
 
   using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
 
   using package_arguments =
-  typename Metavariables::normal_dot_numerical_flux::type::argument_tags;
+      typename Metavariables::normal_dot_numerical_flux::type::argument_tags;
 
-  const auto &face_mesh =
+  const auto& face_mesh =
       db::get<Tags::Interface<DirectionsTag, Tags::Mesh<volume_dim - 1>>>(box)
           .at(direction);
 
   return db::apply<tmpl::transform<
       package_arguments, tmpl::bind<Tags::Interface, DirectionsTag, tmpl::_1>>>(
-      [&face_mesh, &direction,
-       &normal_dot_numerical_flux_computer ](const auto&... args) noexcept {
+      [&face_mesh, &direction, &normal_dot_numerical_flux_computer,
+       &cache ](const auto&... args) noexcept {
         typename flux_comm_types::PackagedData ret(
             face_mesh.number_of_grid_points(), 0.0);
-        normal_dot_numerical_flux_computer.package_data(make_not_null(&ret),
-                                                        args.at(direction)...);
+        compute_packaged_data_with_cache_tags(
+            make_not_null(&ret), normal_dot_numerical_flux_computer, cache,
+            typename NumericalFlux::const_global_cache_tags{},
+            args.at(direction)...);
         return ret;
       },
       box);
@@ -55,30 +72,31 @@ auto compute_local_mortar_data(
     const DataBoxType& box,
     const Direction<Metavariables::system::volume_dim>& direction,
     const NumericalFlux& normal_dot_numerical_flux_computer,
-    const DirectionsTag /*meta*/, const Metavariables /*meta*/) noexcept ->
+    const DirectionsTag /*meta*/,
+    const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept ->
     typename dg::FluxCommunicationTypes<Metavariables>::LocalData {
   constexpr size_t volume_dim = Metavariables::system::volume_dim;
 
   using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
 
   using normal_dot_fluxes_tag =
-  Tags::Interface<DirectionsTag,
-                  typename flux_comm_types::normal_dot_fluxes_tag>;
+      Tags::Interface<DirectionsTag,
+                      typename flux_comm_types::normal_dot_fluxes_tag>;
 
-  const auto &face_mesh =
+  const auto& face_mesh =
       db::get<Tags::Interface<Tags::BoundaryDirectionsInterior<volume_dim>,
                               Tags::Mesh<volume_dim - 1>>>(box)
           .at(direction);
 
   const auto packaged_data =
       compute_packaged_data(box, direction, normal_dot_numerical_flux_computer,
-                            DirectionsTag{}, Metavariables{});
+                            DirectionsTag{}, cache);
 
   typename flux_comm_types::LocalData interface_data{};
   interface_data.magnitude_of_face_normal = db::get<Tags::Interface<
       DirectionsTag,
       Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>>(box)
-      .at(direction);
+                                                .at(direction);
 
   interface_data.mortar_data.initialize(face_mesh.number_of_grid_points());
   interface_data.mortar_data.assign_subset(packaged_data);
@@ -88,7 +106,7 @@ auto compute_local_mortar_data(
     // The local fluxes were not (all) included in the packaged
     // data, so we need to add them to the mortar data
     // explicitly.
-    const auto &normal_dot_fluxes =
+    const auto& normal_dot_fluxes =
         db::get<normal_dot_fluxes_tag>(box).at(direction);
     interface_data.mortar_data.assign_subset(normal_dot_fluxes);
   }

--- a/src/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Burgers)
+add_subdirectory(Elasticity)
 add_subdirectory(GeneralRelativity)
 add_subdirectory(GrMhd)
 add_subdirectory(NewtonianEuler)

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
@@ -1,0 +1,79 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp"
+
+#include <cmath>
+#include <pup.h>  // IWYU pragma: keep
+
+#include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+// IWYU pragma: no_forward_declare Tensor
+
+namespace Elasticity {
+namespace Solutions {
+
+BentBeam::BentBeam(double length, double height, double bending_moment,
+                   constitutive_relation_type constitutive_relation) noexcept
+    : length_(length),
+      height_(height),
+      bending_moment_(bending_moment),
+      constitutive_relation_(std::move(constitutive_relation)) {}
+
+tuples::TaggedTuple<Tags::Displacement<2>> BentBeam::variables(
+    const tnsr::I<DataVector, 2>& x,
+    tmpl::list<Tags::Displacement<2>> /*meta*/) const noexcept {
+  const double youngs_modulus = constitutive_relation_.youngs_modulus();
+  const double poisson_ratio = constitutive_relation_.poisson_ratio();
+  const double prefactor =
+      3. * bending_moment_ / (2. * youngs_modulus * pow<3>(height_));
+  return {tnsr::I<DataVector, 2>{
+      {{-prefactor * get<0>(x) * get<1>(x),
+        prefactor / 2. *
+            (pow<2>(get<0>(x)) + poisson_ratio * pow<2>(get<1>(x)) -
+             pow<2>(length_))}}}};
+}
+
+tuples::TaggedTuple<Tags::Stress<2>> BentBeam::variables(
+    const tnsr::I<DataVector, 2>& x, tmpl::list<Tags::Stress<2>> /*meta*/) const
+    noexcept {
+  auto result = make_with_value<tnsr::II<DataVector, 2>>(x, 0.);
+  get<0, 0>(result) = 3. * bending_moment_ / (2. * pow<3>(height_)) * get<1>(x);
+  return {std::move(result)};
+}
+
+tuples::TaggedTuple<::Tags::Source<Tags::Displacement<2>>> BentBeam::variables(
+    const tnsr::I<DataVector, 2>& x,
+    tmpl::list<::Tags::Source<Tags::Displacement<2>>> /*meta*/) const noexcept {
+  return {make_with_value<tnsr::I<DataVector, 2>>(x, 0.)};
+}
+
+tuples::TaggedTuple<::Tags::Source<Tags::Stress<2>>> BentBeam::variables(
+    const tnsr::I<DataVector, 2>& x,
+    tmpl::list<::Tags::Source<Tags::Stress<2>>> /*meta*/) const noexcept {
+  return {make_with_value<tnsr::II<DataVector, 2>>(x, 0.)};
+}
+
+void BentBeam::pup(PUP::er& p) noexcept {
+  p | length_;
+  p | height_;
+  p | bending_moment_;
+  p | constitutive_relation_;
+}
+
+bool operator==(const BentBeam& lhs, const BentBeam& rhs) noexcept {
+  return lhs.length() == rhs.length() and lhs.height() == rhs.height() and
+         lhs.bending_moment() == rhs.bending_moment() and
+         lhs.constitutive_relation() == rhs.constitutive_relation();
+}
+
+bool operator!=(const BentBeam& lhs, const BentBeam& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace Solutions
+}  // namespace Elasticity

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
@@ -1,0 +1,144 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"   // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"      // IWYU pragma: keep
+#include "Elliptic/Systems/Elasticity/Tags.hpp"  // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Elasticity {
+namespace Solutions {
+/*!
+ * \brief A state of pure bending of an elastic beam in 2D
+ *
+ * \details This solution describes a 2D slice through an elastic beam of length
+ * \f$L\f$ and height \f$H\f$ that is subject to a bending moment \f$M\f$. The
+ * beam material is characterized by an isotropic and homogeneous constitutive
+ * relation \f$Y^{ijkl}\f$ in the plane-stress approximation (see
+ * `Elasticity::ConstitutiveRelations::IsotropicHomogeneous`). In this scenario,
+ * no body-forces \f$f_\mathrm{ext}^j\f$ act on the material, so the
+ * \ref Elasticity equations reduce to \f$\nabla_i T^{ij}=0\f$, but the bending
+ * moment \f$M\f$ generates the stress \f[
+ * T^{xx} = \frac{3M}{2h^3} y \\
+ * T^{xy} = 0 = T^{yy} \text{.}
+ * \f]
+ * By fixing the rigid-body motions to
+ * \f[
+ * u^x(0,y)=0 \quad \text{and} \quad u^y(\pm L,0)=0
+ * \f]
+ * we find that this stress is produced by the displacement field
+ * \f{align}
+ * u^x&=-\frac{3M}{2Eh^3}xy
+ * u^y&=\frac{3M}{4Eh^3}(x^2+\nu y^2-L^2)
+ * \f}
+ * in terms of the Young's modulus \f$E\f$ and the Poisson ration \f$\nu\f$ of
+ * the material.
+ */
+class BentBeam {
+ public:
+  using constitutive_relation_type =
+      Elasticity::ConstitutiveRelations::IsotropicHomogeneous<2>;
+
+  struct Length {
+    using type = double;
+    static constexpr OptionString help{"The beam length"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct Height {
+    using type = double;
+    static constexpr OptionString help{"The beam height"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct BendingMoment {
+    using type = double;
+    static constexpr OptionString help{
+        "The bending moment applied to the beam"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  using options = tmpl::list<
+      Length, Height, BendingMoment,
+      Elasticity::Tags::ConstitutiveRelation<constitutive_relation_type>>;
+  static constexpr OptionString help{
+      "An elastic beam subject to a bending moment in 2D"};
+
+  BentBeam() = default;
+  BentBeam(const BentBeam&) noexcept = delete;
+  BentBeam& operator=(const BentBeam&) noexcept = delete;
+  BentBeam(BentBeam&&) noexcept = default;
+  BentBeam& operator=(BentBeam&&) noexcept = default;
+  ~BentBeam() noexcept = default;
+
+  explicit BentBeam(double length, double height, double bending_moment,
+                    constitutive_relation_type constitutive_relation) noexcept;
+
+  double length() const noexcept { return length_; }
+  double height() const noexcept { return height_; }
+  double bending_moment() const noexcept { return bending_moment_; }
+  const constitutive_relation_type& constitutive_relation() const noexcept {
+    return constitutive_relation_;
+  }
+
+  // @{
+  /// Retrieve variable at coordinates `x`
+  auto variables(const tnsr::I<DataVector, 2>& x,
+                 tmpl::list<Tags::Displacement<2>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<Tags::Displacement<2>>;
+
+  auto variables(const tnsr::I<DataVector, 2>& x,
+                 tmpl::list<Tags::Stress<2>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<Tags::Stress<2>>;
+
+  auto variables(
+      const tnsr::I<DataVector, 2>& x,
+      tmpl::list<::Tags::Source<Tags::Displacement<2>>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<::Tags::Source<Tags::Displacement<2>>>;
+
+  auto variables(const tnsr::I<DataVector, 2>& x,
+                 tmpl::list<::Tags::Source<Tags::Stress<2>>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<::Tags::Source<Tags::Stress<2>>>;
+  // @}
+
+  /// Retrieve a collection of variables at coordinates `x`
+  template <typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataVector, 2>& x,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
+    static_assert(sizeof...(Tags) > 1,
+                  "The generic template will recurse infinitely if only one "
+                  "tag is being retrieved.");
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  // clang-tidy: no pass by reference
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  double length_{std::numeric_limits<double>::signaling_NaN()};
+  double height_{std::numeric_limits<double>::signaling_NaN()};
+  double bending_moment_{std::numeric_limits<double>::signaling_NaN()};
+  constitutive_relation_type constitutive_relation_{};
+};
+
+bool operator==(const BentBeam& lhs, const BentBeam& rhs) noexcept;
+bool operator!=(const BentBeam& lhs, const BentBeam& rhs) noexcept;
+
+}  // namespace Solutions
+}  // namespace Elasticity

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY ElasticitySolutions)
+
+set(LIBRARY_SOURCES
+  BentBeam.cpp
+  )
+
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE DataStructures
+  INTERFACE ErrorHandling
+  INTERFACE Utilities
+  INTERFACE ConstitutiveRelations
+  )

--- a/tests/InputFiles/Elasticity/BentBeam2D.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam2D.yaml
@@ -1,0 +1,41 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: SolveElasticityProblem2D
+# Check: execute
+# ExpectedOutput:
+#   BentBeam2DReductions.h5
+#   BentBeam2DVolume0.h5
+
+AnalyticSolution:
+  Length: 5.
+  Height: 1.
+  BendingMoment: 1.
+  Material:
+    BulkModulus: 1.
+    ShearModulus: 1.
+
+Material:
+  BulkModulus: 1.
+  ShearModulus: 1.
+
+DomainCreator:
+  Rectangle:
+    LowerBound: [-5., -1.]
+    UpperBound: [5., 1.]
+    IsPeriodicIn: [false, false]
+    InitialRefinement: [1, 1]
+    InitialGridPoints: [3, 3]
+
+NumericalFluxParams:
+  PenaltyParameter: 9. # p^2 / h
+
+Verbosity: Verbose
+
+ConvergenceCriteria:
+  MaxIterations: 100
+  AbsoluteResidual: 0
+  RelativeResidual: 1e-15
+
+VolumeFileName: "./BentBeam2DVolume"
+ReductionFileName: "./BentBeam2DReductions"

--- a/tests/Unit/Elliptic/Systems/Elasticity/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Elasticity/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Elasticity")
 
 set(LIBRARY_SOURCES
+  Test_Equations.cpp
   Test_Tags.cpp
   )
 
@@ -11,5 +12,5 @@ add_test_library(
   ${LIBRARY}
   "Elliptic/Systems/Elasticity/"
   "${LIBRARY_SOURCES}"
-  ""
+  "Elasticity"
   )

--- a/tests/Unit/Elliptic/Systems/Elasticity/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/Test_Equations.cpp
@@ -1,0 +1,165 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/LogicalCoordinates.hpp"  // IWYU pragma: keep
+#include "Domain/Mesh.hpp"
+#include "Domain/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Systems/Elasticity/Equations.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+// IWYU pragma: no_include <pup.h>
+// IWYU pragma: no_forward_declare db::DataBox
+// IWYU pragma: no_forward_declare Tags::deriv
+// IWYU pragma: no_forward_declare Tags::div
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare Variables
+
+namespace {
+
+template <size_t Dim, typename DbTagsList, typename Solution>
+void test_first_order_operator(db::DataBox<DbTagsList>&& domain_box,
+                               const Solution& solution) {
+  using solution_vars_tag =
+      Tags::Variables<tmpl::list<Elasticity::Tags::Displacement<Dim>,
+                                 Elasticity::Tags::Stress<Dim>>>;
+  using operand_vars_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Operand, solution_vars_tag>;
+  using operator_vars_tag =
+      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
+                         operand_vars_tag>;
+  using source_vars_tag = db::add_tag_prefix<Tags::Source, solution_vars_tag>;
+  using inverse_jacobian_tag =
+      Tags::InverseJacobian<Tags::ElementMap<Dim>,
+                            Tags::Coordinates<Dim, Frame::Logical>>;
+  using deriv_compute_tag =
+      Tags::DerivCompute<operand_vars_tag, inverse_jacobian_tag,
+                         tmpl::list<LinearSolver::Tags::Operand<
+                             Elasticity::Tags::Displacement<Dim>>>>;
+
+  // Retrieve data from the analytic solution
+  const auto& inertial_coords =
+      get<Tags::Coordinates<Dim, Frame::Inertial>>(domain_box);
+  db::item_type<solution_vars_tag> solution_vars{
+      get<Tags::Mesh<Dim>>(domain_box).number_of_grid_points()};
+  solution_vars.assign_subset(solution.variables(
+      inertial_coords, typename solution_vars_tag::tags_list{}));
+  db::item_type<operand_vars_tag> operand_vars(solution_vars);
+  auto operator_vars = make_with_value<db::item_type<operator_vars_tag>>(
+      inertial_coords, std::numeric_limits<double>::signaling_NaN());
+  auto source_vars =
+      make_with_value<db::item_type<source_vars_tag>>(inertial_coords, 0.);
+  source_vars.assign_subset(solution.variables(
+      inertial_coords,
+      tmpl::list<Tags::Source<Elasticity::Tags::Displacement<Dim>>>{}));
+
+  // Apply operator to the analytic data
+  auto argument_box =
+      db::create_from<db::RemoveTags<>,
+                      db::AddSimpleTags<operand_vars_tag, operator_vars_tag>,
+                      db::AddComputeTags<deriv_compute_tag>>(
+          std::move(domain_box), std::move(operand_vars),
+          std::move(operator_vars));
+  db::mutate_apply<
+      tmpl::list<
+          LinearSolver::Tags::OperatorAppliedTo<
+              LinearSolver::Tags::Operand<Elasticity::Tags::Displacement<Dim>>>,
+          LinearSolver::Tags::OperatorAppliedTo<
+              LinearSolver::Tags::Operand<Elasticity::Tags::Stress<Dim>>>>,
+      typename Elasticity::ComputeFirstOrderOperatorAction<Dim>::argument_tags>(
+      Elasticity::ComputeFirstOrderOperatorAction<Dim>{},
+      make_not_null(&argument_box), solution.constitutive_relation());
+
+  // Test against the source supplied by the analytic solution. These should
+  // match on a sufficiently fine mesh, with the difference being the
+  // discretization error.
+  CHECK_ITERABLE_APPROX(
+      get<LinearSolver::Tags::OperatorAppliedTo<
+          LinearSolver::Tags::Operand<Elasticity::Tags::Displacement<Dim>>>>(
+          argument_box),
+      get<Tags::Source<Elasticity::Tags::Displacement<Dim>>>(source_vars));
+  CHECK_ITERABLE_APPROX(
+      get<LinearSolver::Tags::OperatorAppliedTo<
+          LinearSolver::Tags::Operand<Elasticity::Tags::Stress<Dim>>>>(
+          argument_box),
+      get<Tags::Source<Elasticity::Tags::Stress<Dim>>>(source_vars));
+}
+
+template <size_t Dim>
+using domain_simple_tags =
+    db::AddSimpleTags<Tags::Mesh<Dim>, Tags::ElementMap<Dim>>;
+
+template <size_t Dim>
+using domain_compute_tags = db::AddComputeTags<
+    Tags::LogicalCoordinates<Dim>,
+    Tags::MappedCoordinates<Tags::ElementMap<Dim>,
+                            Tags::Coordinates<Dim, Frame::Logical>>,
+    Tags::InverseJacobian<Tags::ElementMap<Dim>,
+                          Tags::Coordinates<Dim, Frame::Logical>>>;
+
+// Specialize this function for every analytic solution type to set up a
+// suitable solution and domain
+template <typename SolutionType>
+void test_operator_with_analytic_solution();
+
+template <>
+void test_operator_with_analytic_solution<Elasticity::Solutions::BentBeam>() {
+  const Elasticity::Solutions::BentBeam solution{
+      5., 1., 1.,
+      // Iron: E=100, nu=0.29
+      Elasticity::ConstitutiveRelations::IsotropicHomogeneous<2>{79.3651,
+                                                                 38.7597}};
+  // 3 grid points should be enough to represent this solution exactly, since it
+  // is a quadratic polynomial
+  Mesh<2> mesh_2d{3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto};
+  ElementMap<2, Frame::Inertial> element_map_2d{
+      ElementId<2>{0, make_array<2>(SegmentId{0, 0})},
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                         CoordinateMaps::Affine>(
+              CoordinateMaps::Affine{-1., 1., -solution.length(),
+                                     solution.length()},
+              CoordinateMaps::Affine{-1., 1., -solution.height(),
+                                     solution.height()}))};
+  auto domain_box_2d =
+      db::create<domain_simple_tags<2>, domain_compute_tags<2>>(
+          std::move(mesh_2d), std::move(element_map_2d));
+
+  test_first_order_operator<2>(std::move(domain_box_2d), solution);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Elasticity.FirstOrder",
+                  "[Unit][Elliptic]") {
+  test_operator_with_analytic_solution<Elasticity::Solutions::BentBeam>();
+}

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -71,6 +71,7 @@ struct System {
     using argument_tags =
         tmpl::list<Var, OtherArg, Var2,
                    Tags::Normalized<Tags::UnnormalizedFaceNormal<2>>>;
+    using const_global_cache_tags = tmpl::list<>;
     static void apply(
         const gsl::not_null<Scalar<DataVector>*> var_normal_dot_flux,
         const gsl::not_null<tnsr::ii<DataVector, 2>*> var2_normal_dot_flux,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -87,6 +87,7 @@ class NumericalFlux {
   };
 
   using package_tags = tmpl::list<ExtraData, Var>;
+  using const_global_cache_tags = tmpl::list<>;
   // This is a silly set of things to request, but it tests not
   // requesting the evolved variables and requesting multiple other
   // things.

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -79,6 +79,7 @@ class NumericalFlux {
   };
 
   using package_tags = tmpl::list<ExtraData, Var>;
+  using const_global_cache_tags = tmpl::list<>;
   // This is a silly set of things to request, but it tests not
   // requesting the evolved variables and requesting multiple other
   // things.

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -86,6 +86,7 @@ class NumericalFlux {
   };
 
   using package_tags = tmpl::list<ExtraData, Var>;
+  using const_global_cache_tags = tmpl::list<>;
 
   using argument_tags =
       tmpl::list<Tags::NormalDotFlux<Var>, OtherData,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Burgers)
+add_subdirectory(Elasticity)
 add_subdirectory(GeneralRelativity)
 add_subdirectory(GrMhd)
 add_subdirectory(NewtonianEuler)

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.py
@@ -1,0 +1,25 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def displacement(
+        x, length, height, bending_moment, bulk_modulus, shear_modulus):
+    youngs_modulus = 9 * bulk_modulus * shear_modulus / \
+        (3 * bulk_modulus + shear_modulus)
+    poisson_ratio = (3 * bulk_modulus - 2 * shear_modulus) / \
+        (6 * bulk_modulus + 2 * shear_modulus)
+    prefactor = 3 * bending_moment / (2 * youngs_modulus * height**3)
+    return np.array([
+        -prefactor * x[0] * x[1],
+        prefactor / 2 * (x[0]**2 + poisson_ratio * x[1]**2 - length**2)
+    ])
+
+
+def stress(x, length, height, bending_moment, bulk_modulus, shear_modulus):
+    return np.array([[3 * bending_moment / (2 * height**3) * x[1], 0], [0, 0]])
+
+
+def source(x):
+    return np.zeros(x.shape)

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_ElasticitySolutions")
+
+set(LIBRARY_SOURCES
+  Test_BentBeam.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "PointwiseFunctions/AnalyticSolutions/Elasticity/"
+  "${LIBRARY_SOURCES}"
+  "ElasticitySolutions;Utilities"
+  )

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
@@ -1,0 +1,79 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <tuple>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+
+struct BentBeamProxy : Elasticity::Solutions::BentBeam {
+  using Elasticity::Solutions::BentBeam::BentBeam;
+
+  using field_tags = tmpl::list<Elasticity::Tags::Displacement<2>,
+                                Elasticity::Tags::Stress<2>>;
+  using source_tags =
+      tmpl::list<Tags::Source<Elasticity::Tags::Displacement<2>>>;
+
+  tuples::tagged_tuple_from_typelist<field_tags> field_variables(
+      const tnsr::I<DataVector, 2>& x) const noexcept {
+    return Elasticity::Solutions::BentBeam::variables(x, field_tags{});
+  }
+
+  tuples::tagged_tuple_from_typelist<source_tags> source_variables(
+      const tnsr::I<DataVector, 2>& x) const noexcept {
+    return Elasticity::Solutions::BentBeam::variables(x, source_tags{});
+  }
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.Elasticity.BentBeam",
+    "[PointwiseFunctions][Unit][Elasticity]") {
+  const Elasticity::Solutions::BentBeam check_solution{
+      5., 1., 0.5,
+      // Iron: E=100, nu=0.29
+      Elasticity::ConstitutiveRelations::IsotropicHomogeneous<2>{79.3651,
+                                                                 38.7597}};
+  const Elasticity::Solutions::BentBeam created_solution =
+      test_creation<Elasticity::Solutions::BentBeam>(
+          "  Length: 5.\n"
+          "  Height: 1.\n"
+          "  BendingMoment: 0.5\n"
+          "  Material:\n"
+          "    BulkModulus: 79.3651\n"
+          "    ShearModulus: 38.7597\n");
+  CHECK(created_solution == check_solution);
+  test_serialization(check_solution);
+
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/Elasticity"};
+  const BentBeamProxy solution{
+      5., 1., 0.5,
+      Elasticity::ConstitutiveRelations::IsotropicHomogeneous<2>{79.3651,
+                                                                 38.7597}};
+  pypp::check_with_random_values<1,
+                                 tmpl::list<Elasticity::Tags::Displacement<2>,
+                                            Elasticity::Tags::Stress<2>>>(
+      &BentBeamProxy::field_variables, solution, "BentBeam",
+      {"displacement", "stress"}, {{{-5., 5.}}},
+      std::make_tuple(5., 1., 0.5, 79.3651, 38.7597), DataVector(5));
+  pypp::check_with_random_values<
+      1, tmpl::list<Tags::Source<Elasticity::Tags::Displacement<2>>>>(
+      &BentBeamProxy::source_variables, solution, "BentBeam", {"source"},
+      {{{-5., 5.}}}, std::make_tuple(), DataVector(5));
+}


### PR DESCRIPTION
## Proposed changes

This PR adds the elliptic system and executable for linear elasticity problems.

Depends on:
- [x] #1298 
- [x] #1374 
- [x] #1373, i.e. the system operators need items from the global cache. The plan is to retrieve them through the DataBox, which in turn depends on phase-dependent action lists (in progress by @nilsdeppe). Then I'll update this PR by renaming the `const_global_cache_tags` aliases to `volume_tags`, so that those are not sliced to the interface but taken from the DataBox directly.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
