### PR TITLE
Fix order of arguments in LimitLorentzFactor

### DIFF
--- a/src/Evolution/VariableFixing/LimitLorentzFactor.cpp
+++ b/src/Evolution/VariableFixing/LimitLorentzFactor.cpp
@@ -26,9 +26,9 @@ void LimitLorentzFactor::pup(PUP::er& p) noexcept {
 }
 
 void LimitLorentzFactor::operator()(
+    const gsl::not_null<Scalar<DataVector>*> lorentz_factor,
     const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
         spatial_velocity,
-    const gsl::not_null<Scalar<DataVector>*> lorentz_factor,
     const Scalar<DataVector>& rest_mass_density) const noexcept {
   constexpr size_t dim = 3;
   const size_t number_of_grid_points = get(rest_mass_density).size();

--- a/src/Evolution/VariableFixing/LimitLorentzFactor.hpp
+++ b/src/Evolution/VariableFixing/LimitLorentzFactor.hpp
@@ -79,8 +79,8 @@ class LimitLorentzFactor {
   using argument_tags = tmpl::list<hydro::Tags::RestMassDensity<DataVector>>;
 
   void operator()(
-      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> spatial_velocity,
       gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> spatial_velocity,
       const Scalar<DataVector>& rest_mass_density) const noexcept;
 
  private:

--- a/tests/Unit/Evolution/VariableFixing/Test_LimitLorentzFactor.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_LimitLorentzFactor.cpp
@@ -50,8 +50,8 @@ void test_variable_fixer(const LimitLorentzFactor& variable_fixer) {
         DataVector{1.3567, 1.3566, 1.3567 * rescale_velocity_factor, 1.3566},
         DataVector{-0.200, -0.200, -0.200 * rescale_velocity_factor, -0.200}}}};
 
-  variable_fixer(make_not_null(&spatial_velocity),
-                 make_not_null(&lorentz_factor), density);
+  variable_fixer(make_not_null(&lorentz_factor),
+                 make_not_null(&spatial_velocity), density);
 
   CHECK(lorentz_factor == expected_lorentz_factor);
   CHECK(spatial_velocity == expected_spatial_velocity);


### PR DESCRIPTION
## Proposed changes

Make the ordering of the return arguments match the order of the `return_tags`.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

