### PR TITLE
Add mutate_apply overload that uses argument_tags and return_tags

### DIFF
--- a/docs/DevGuide/Databox.md
+++ b/docs/DevGuide/Databox.md
@@ -352,7 +352,7 @@ hard-coded type that we can factor out in favor of a template parameter:
 
 \snippet Test_DataBoxDocumentation.cpp my_first_action
 
-Note how the `mutate_tags` and `argument_tags` are used as metavariables and
+Note how the `return_tags` and `argument_tags` are used as metavariables and
 are resolved by the compiler. Our call to `db::mutate_apply` has been fully
 wrapped and now takes the form:
 

--- a/src/DataStructures/DataBox/Actions/MutateApply.hpp
+++ b/src/DataStructures/DataBox/Actions/MutateApply.hpp
@@ -1,0 +1,58 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace tuples {
+template <typename...>
+class TaggedTuple;
+}  // namespace tuples
+
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace db {
+namespace Actions {
+/*!
+ * \ingroup ActionsGroup
+ * \brief Apply the function `F::apply` to the DataBox
+ *
+ * The function `F::apply` is invoked with the `F::argument_tags`. The result
+ * of this computation is stored in the `F::return_tags`.
+ *
+ * Uses:
+ * - DataBox:
+ *   - All elements in `F::argument_tags`
+ *   - All elements in `F::return_tags`
+ *
+ * DataBox changes:
+ * - Modifies:
+ *   - All elements in `F::return_tags`
+ */
+template <typename F>
+struct MutateApply {
+  template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent,
+            Requires<tmpl::size<DbTagsList>::value != 0> = nullptr>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate_apply<F>(make_not_null(&box));
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions
+}  // namespace db

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -138,8 +138,8 @@ struct extract_expand_simple_subitems {
 // Given a typelist of items List, returns a new typelist containing
 // the items and all of their subitems.
 template <typename List>
-using expand_simple_subitems = tmpl::flatten<tmpl::transform<
-    List, extract_expand_simple_subitems<tmpl::_1>>>;
+using expand_simple_subitems = tmpl::flatten<
+    tmpl::transform<List, extract_expand_simple_subitems<tmpl::_1>>>;
 
 namespace detail {
 constexpr int select_expand_subitems_impl(const size_t pack_size) noexcept {
@@ -391,7 +391,7 @@ class DataBox<tmpl::list<Tags...>>
       "All structs used to Tag (compute) items in a DataBox must derive off of "
       "db::SimpleTag. Another static_assert will tell you which tag is the "
       "problematic one. Look for check_simple_or_compute_tag.");
-#endif // ifdef SPECTRE_DEBUG
+#endif  // ifdef SPECTRE_DEBUG
 
  public:
   /*!
@@ -516,7 +516,7 @@ class DataBox<tmpl::list<Tags...>>
   DataBox deep_copy() const noexcept;
 
   template <typename TagsList_>
-      // clang-tidy: redundant declaration
+  // clang-tidy: redundant declaration
   friend SPECTRE_ALWAYS_INLINE constexpr DataBox<TagsList_>  // NOLINT
   create_copy(                                               // NOLINT
       const DataBox<TagsList_>& box) noexcept;
@@ -987,7 +987,7 @@ template <typename... NonSubitemsTags, typename... ComputeTags>
 void DataBox<tmpl::list<Tags...>>::pup_impl(
     PUP::er& p, tmpl::list<NonSubitemsTags...> /*meta*/,
     tmpl::list<ComputeTags...> /*meta*/) noexcept {
-  const auto pup_simple_item = [&p, this](auto current_tag) noexcept {
+  const auto pup_simple_item = [&p, this ](auto current_tag) noexcept {
     (void)this;  // Compiler bug warning this capture is not used
     using tag = decltype(current_tag);
     if (p.isUnpacking()) {
@@ -1003,7 +1003,7 @@ void DataBox<tmpl::list<Tags...>>::pup_impl(
   (void)pup_simple_item;  // Silence GCC warning about unused variable
   EXPAND_PACK_LEFT_TO_RIGHT(pup_simple_item(NonSubitemsTags{}));
 
-  const auto pup_compute_item = [&p, this](auto current_tag) noexcept {
+  const auto pup_compute_item = [&p, this ](auto current_tag) noexcept {
     (void)this;  // Compiler bug warns this isn't used
     using tag = decltype(current_tag);
     if (p.isUnpacking()) {

--- a/src/Evolution/Actions/ComputeVolumeFluxes.hpp
+++ b/src/Evolution/Actions/ComputeVolumeFluxes.hpp
@@ -48,13 +48,8 @@ struct ComputeVolumeFluxes {
       const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
-    using system = typename Metavariables::system;
-    using variables_tag = typename system::variables_tag;
-    db::mutate_apply<db::split_tag<db::add_tag_prefix<
-                         Tags::Flux, variables_tag,
-                         tmpl::size_t<system::volume_dim>, Frame::Inertial>>,
-                     typename system::volume_fluxes::argument_tags>(
-        typename system::volume_fluxes{}, make_not_null(&box));
+    db::mutate_apply<typename Metavariables::system::volume_fluxes>(
+        make_not_null(&box));
     return std::forward_as_tuple(std::move(box));
   }
 };

--- a/src/Evolution/Actions/ComputeVolumeSources.hpp
+++ b/src/Evolution/Actions/ComputeVolumeSources.hpp
@@ -43,11 +43,8 @@ struct ComputeVolumeSources {
       const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
-    using system = typename Metavariables::system;
-    db::mutate_apply<
-        db::wrap_tags_in<Tags::Source, typename system::sourced_variables>,
-        typename system::volume_sources::argument_tags>(
-        typename system::volume_sources{}, make_not_null(&box));
+    db::mutate_apply<typename Metavariables::system::volume_sources>(
+        make_not_null(&box));
     return std::forward_as_tuple(std::move(box));
   }
 };

--- a/src/Evolution/Conservative/UpdateConservatives.hpp
+++ b/src/Evolution/Conservative/UpdateConservatives.hpp
@@ -41,11 +41,9 @@ struct UpdateConservatives {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using system = typename Metavariables::system;
     db::mutate_apply<
-        typename system::conservative_from_primitive::return_tags,
-        typename system::conservative_from_primitive::argument_tags>(
-        typename system::conservative_from_primitive{}, make_not_null(&box));
+        typename Metavariables::system::conservative_from_primitive>(
+        make_not_null(&box));
     return std::forward_as_tuple(std::move(box));
   }
 };

--- a/src/Evolution/Conservative/UpdatePrimitives.hpp
+++ b/src/Evolution/Conservative/UpdatePrimitives.hpp
@@ -47,9 +47,7 @@ struct UpdatePrimitives {
     using PrimFromCon =
         typename Metavariables::system::template primitive_from_conservative<
             typename Metavariables::ordered_list_of_primitive_recovery_schemes>;
-    db::mutate_apply<typename PrimFromCon::return_tags,
-                     typename PrimFromCon::argument_tags>(PrimFromCon{},
-                                                          make_not_null(&box));
+    db::mutate_apply<PrimFromCon>(make_not_null(&box));
     return std::forward_as_tuple(std::move(box));
   }
 };

--- a/src/Evolution/Initialization/ConservativeSystem.hpp
+++ b/src/Evolution/Initialization/ConservativeSystem.hpp
@@ -80,10 +80,8 @@ template <typename System>
 struct ConservativeVars {
   template <typename TagsList>
   static auto initialize(db::DataBox<TagsList>&& box) noexcept {
-    db::mutate_apply<
-        typename System::conservative_from_primitive::return_tags,
-        typename System::conservative_from_primitive::argument_tags>(
-        typename System::conservative_from_primitive{}, make_not_null(&box));
+    db::mutate_apply<typename System::conservative_from_primitive>(
+        make_not_null(&box));
     return std::move(box);
   }
 };

--- a/src/Evolution/Systems/Burgers/Fluxes.hpp
+++ b/src/Evolution/Systems/Burgers/Fluxes.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -24,6 +25,8 @@ namespace Burgers {
 /// The flux of \f$U\f$ is \f$\frac{1}{2} U^2\f$.
 struct Fluxes {
   using argument_tags = tmpl::list<Tags::U>;
+  using return_tags =
+      tmpl::list<::Tags::Flux<Tags::U, tmpl::size_t<1>, Frame::Inertial>>;
   static void apply(gsl::not_null<tnsr::I<DataVector, 1>*> flux,
                     const Scalar<DataVector>& u) noexcept;
 };

--- a/src/Evolution/VariableFixing/Actions.hpp
+++ b/src/Evolution/VariableFixing/Actions.hpp
@@ -56,9 +56,7 @@ struct FixVariables {
       const ParallelComponent* const /*meta*/) noexcept {
     const auto& variable_fixer =
         get<OptionTags::VariableFixerParams<VariableFixer>>(cache);
-    db::mutate_apply<typename VariableFixer::return_tags,
-                     typename VariableFixer::argument_tags>(
-        variable_fixer, make_not_null(&box));
+    db::mutate_apply(variable_fixer, make_not_null(&box));
     return std::forward_as_tuple(std::move(box));
   }
 };

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxDocumentation.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxDocumentation.cpp
@@ -394,7 +394,7 @@ struct IntendedMutation {
 
 /// [intended_mutation2]
 struct IntendedMutation2 {
-  using mutate_tags = tmpl::list<Time, FallingSpeed>;
+  using return_tags = tmpl::list<Time, FallingSpeed>;
   using argument_tags = tmpl::list<TimeStep, EarthGravity>;
 
   static void apply(const gsl::not_null<double*> time,
@@ -414,9 +414,7 @@ struct MyFirstAction{
   static void apply(
     const gsl::not_null<db::DataBox<DbTagsList>*> time_dependent_databox)
       noexcept {
-    db::mutate_apply<typename Mutator::mutate_tags,
-                     typename Mutator::argument_tags>(
-    Mutator{}, time_dependent_databox);
+    db::mutate_apply<Mutator>(time_dependent_databox);
   }
 };
 /// [my_first_action]
@@ -513,10 +511,7 @@ CHECK(-10.0 + 0.2 * -9.8 ==
   approx(db::get<FallingSpeed>(time_dependent_databox)));
 
 /// [time_dep_databox3]
-db::mutate_apply<
-  typename IntendedMutation2::mutate_tags,
-  typename IntendedMutation2::argument_tags>(
-    IntendedMutation2{}, make_not_null(&time_dependent_databox));
+db::mutate_apply<IntendedMutation2>(make_not_null(&time_dependent_databox));
 /// [time_dep_databox3]
 CHECK(0.0 + 0.3 == approx(db::get<Time>(time_dependent_databox)));
 CHECK(-10.0 + 0.3 * -9.8 ==

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
@@ -37,8 +37,11 @@ struct Var2 : db::SimpleTag {
   using type = tnsr::I<double, dim, Frame::Inertial>;
 };
 
+using flux_tag = Tags::Flux<Var1, tmpl::size_t<dim>, Frame::Inertial>;
+
 struct ComputeFluxes {
   using argument_tags = tmpl::list<Var2, Var1>;
+  using return_tags = tmpl::list<flux_tag>;
   static void apply(
       const gsl::not_null<tnsr::I<double, dim, Frame::Inertial>*> flux1,
       const tnsr::I<double, dim, Frame::Inertial>& var2,
@@ -47,8 +50,6 @@ struct ComputeFluxes {
     get<1>(*flux1) = get(var1) * (get<0>(var2) + get<1>(var2));
   }
 };
-
-using flux_tag = Tags::Flux<Var1, tmpl::size_t<dim>, Frame::Inertial>;
 
 struct System {
   static constexpr size_t volume_dim = dim;


### PR DESCRIPTION
## Proposed changes

This overload allows to call `mutate_apply<F>(box)` with a struct `F` that exposes `argument_tags` and `return_tags`, instead of having to specify those explicitly at the call site.
I also add an action that just calls `mutate_apply`, but I'm not sure if we actually need it, so would appreciate some feedback

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
