### PR TITLE
Add ability to do flat-space integrals over a Strahlkorper.

### DIFF
--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -150,13 +150,45 @@ Scalar<DataVector> ricci_scalar(
  * these input arguments depend only on the Strahlkorper, not on the
  * metric, and can be computed from a Strahlkorper using ComputeItems
  * in `StrahlkorperTags`. Note that this does not include the factor
- * of \f$\sin\theta\f$, i.e., this returns \f$r^2\f$ for flat space.
+ * of \f$\sin\theta\f$, i.e., this returns \f$r^2\f$ for a spherical
+ * `Strahlkorper` in flat space.
  * This choice makes the area element returned here compatible with
  * `definite_integral` defined in `YlmSpherePack.hpp`.
  */
 template <typename Frame>
 Scalar<DataVector> area_element(
     const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const StrahlkorperTags::aliases::Jacobian<Frame>& jacobian,
+    const tnsr::i<DataVector, 3, Frame>& normal_one_form,
+    const DataVector& radius,
+    const tnsr::i<DataVector, 3, Frame>& r_hat) noexcept;
+
+/*!
+ * \ingroup SurfacesGroup
+ * \brief Euclidean area element of a 2D `Strahlkorper`.
+ *
+ * This is useful for computing a flat-space integral over an
+ * arbitrarily-shaped `Strahlkorper`.
+ *
+ * \details Implements Eq. (D.13), using Eqs. (D.4) and (D.5),
+ * of \cite Baumgarte1996hh. Specifically, computes
+ * \f$\sqrt{(\Theta^i\Theta_i)(\Phi^j\Phi_j)-(\Theta^i\Phi_i)^2}\f$,
+ * \f$\Theta^i=\left(n^i(n_j-s_j) r J^j_\theta + r J^i_\theta\right)\f$,
+ * \f$\Phi^i=\left(n^i(n_j-s_j)r J^j_\phi + r J^i_\phi\right)\f$,
+ * and \f$\Theta^i\f$ and \f$\Phi^i\f$ are lowered by the
+ * Euclidean spatial metric. Here \f$J^i_\alpha\f$, \f$s_j\f$,
+ * \f$r\f$, and \f$n^i=n_i\f$ correspond to the input arguments
+ * `jacobian`, `normal_one_form`, `radius`, and `r_hat`, respectively;
+ * these input arguments depend only on the Strahlkorper, not on the
+ * metric, and can be computed from a Strahlkorper using ComputeItems
+ * in `StrahlkorperTags`. Note that this does not include the factor
+ * of \f$\sin\theta\f$, i.e., this returns \f$r^2\f$ for a spherical
+ * `Strahlkorper`.
+ * This choice makes the area element returned here compatible with
+ * `definite_integral` defined in `YlmSpherePack.hpp`.
+ */
+template <typename Frame>
+Scalar<DataVector> euclidean_area_element(
     const StrahlkorperTags::aliases::Jacobian<Frame>& jacobian,
     const tnsr::i<DataVector, 3, Frame>& normal_one_form,
     const DataVector& radius,

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -7,11 +7,11 @@
 
 #include "ApparentHorizons/Strahlkorper.hpp"
 #include "ApparentHorizons/StrahlkorperGr.hpp"
-#include "ApparentHorizons/TagsDeclarations.hpp" // IWYU pragma: keep
+#include "ApparentHorizons/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "ApparentHorizons/TagsTypeAliases.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
-#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp" // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -215,6 +215,30 @@ struct Tangents : db::ComputeTag {
                                    Rhat<Frame>, Jacobian<Frame>>;
 };
 
+/// Computes the Euclidean area element on a Strahlkorper.
+/// Useful for flat space integrals.
+template <typename Frame>
+struct EuclideanAreaElement : db::ComputeTag {
+  static std::string name() noexcept { return "EuclideanAreaElement"; }
+  static constexpr auto function =
+      ::StrahlkorperGr::euclidean_area_element<Frame>;
+  using argument_tags = tmpl::list<
+      StrahlkorperTags::Jacobian<Frame>, StrahlkorperTags::NormalOneForm<Frame>,
+      StrahlkorperTags::Radius<Frame>, StrahlkorperTags::Rhat<Frame>>;
+};
+
+/// Computes the flat-space integral of a scalar over a Strahlkorper.
+template <typename IntegrandTag, typename Frame>
+struct EuclideanSurfaceIntegral : db::ComputeTag {
+  static std::string name() noexcept {
+    return "EuclideanSurfaceIntegral" + IntegrandTag::name();
+  }
+  static constexpr auto function =
+      ::StrahlkorperGr::surface_integral_of_scalar<Frame>;
+  using argument_tags = tmpl::list<EuclideanAreaElement<Frame>, IntegrandTag,
+                                   StrahlkorperTags::Strahlkorper<Frame>>;
+};
+
 template <typename Frame>
 using items_tags = tmpl::list<Strahlkorper<Frame>>;
 
@@ -254,5 +278,6 @@ struct SurfaceIntegral : db::ComputeTag {
   using argument_tags = tmpl::list<AreaElement<Frame>, IntegrandTag,
                                    StrahlkorperTags::Strahlkorper<Frame>>;
 };
+
 }  // namespace Tags
 }  // namespace StrahlkorperGr

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -31,6 +31,10 @@ template <typename Frame>
 struct NormalOneForm;
 template <typename Frame>
 struct Tangents;
+template <typename Frame>
+struct EuclideanAreaElement;
+template <typename IntegrandTag, typename Frame>
+struct EuclideanSurfaceIntegral;
 }  // namespace StrahlkorperTags
 
 namespace StrahlkorperGr {


### PR DESCRIPTION
## Proposed changes

Adds `euclidean_area_element` function, and `EuclideanAreaElement` and `EuclideanSurfaceIntegral`
compute items for Strahlkorpers.

This is needed for various integrals we need to do where the appropriate metric factors are included in the integrand and the integral is over flat space.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
