### PR TITLE
Split Minmod into limiter and troubled-cell indicator

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY SlopeLimiters)
 
 set(LIBRARY_SOURCES
   Minmod.cpp
+  MinmodType.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY SlopeLimiters)
 
 set(LIBRARY_SOURCES
   Minmod.cpp
+  MinmodTci.cpp
   MinmodType.cpp
   )
 

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <cmath>
 #include <iterator>
-#include <string>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
@@ -15,12 +14,9 @@
 #include "Domain/Mesh.hpp"  // IWYU pragma: keep
 #include "Domain/Side.hpp"
 #include "NumericalAlgorithms/LinearOperators/Linearize.hpp"
-#include "Options/ParseOptions.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeArray.hpp"
-
-// IWYU pragma: no_include <ostream>
 
 namespace Minmod_detail {
 
@@ -307,21 +303,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 #undef INSTANTIATE
 }  // namespace Minmod_detail
-
-template <>
-SlopeLimiters::MinmodType
-create_from_yaml<SlopeLimiters::MinmodType>::create<void>(
-    const Option& options) {
-  const std::string minmod_type_read = options.parse_as<std::string>();
-  if (minmod_type_read == "LambdaPi1") {
-    return SlopeLimiters::MinmodType::LambdaPi1;
-  } else if (minmod_type_read == "LambdaPiN") {
-    return SlopeLimiters::MinmodType::LambdaPiN;
-  } else if (minmod_type_read == "Muscl") {
-    return SlopeLimiters::MinmodType::Muscl;
-  }
-  PARSE_ERROR(options.context(), "Failed to convert \""
-                                     << minmod_type_read
-                                     << "\" to MinmodType. Expected one of: "
-                                        "{LambdaPi1, LambdaPiN, Muscl}.");
-}

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
@@ -3,8 +3,6 @@
 
 #include "Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp"
 
-#include <algorithm>
-#include <cmath>
 #include <iterator>
 
 #include "DataStructures/DataVector.hpp"
@@ -12,35 +10,11 @@
 #include "Domain/Direction.hpp"
 #include "Domain/DirectionMap.hpp"
 #include "Domain/Mesh.hpp"  // IWYU pragma: keep
-#include "Domain/Side.hpp"
-#include "NumericalAlgorithms/LinearOperators/Linearize.hpp"
-#include "Utilities/ConstantExpressions.hpp"
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodTci.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
-#include "Utilities/MakeArray.hpp"
 
 namespace SlopeLimiters {
 namespace Minmod_detail {
-
-MinmodResult minmod_tvbm(const double a, const double b, const double c,
-                         const double tvbm_scale) noexcept {
-  if (fabs(a) <= tvbm_scale) {
-    return {a, false};
-  }
-  if ((std::signbit(a) == std::signbit(b)) and
-      (std::signbit(a) == std::signbit(c))) {
-    // The if/else group below could be more simply written as
-    //   std::copysign(std::min({fabs(a), fabs(b), fabs(c)}), a);
-    // however, by separating different cases, we gain the ability to
-    // distinguish whether or not the limiter activated.
-    if (fabs(a) <= fabs(b) and fabs(a) <= fabs(c)) {
-      return {a, false};
-    } else {
-      return {std::copysign(std::min(fabs(b), fabs(c)), a), true};
-    }
-  } else {
-    return {0.0, true};
-  }
-}
 
 // Implements the minmod limiter for one Tensor<DataVector> at a time.
 template <size_t VolumeDim>
@@ -74,19 +48,6 @@ bool limit_one_tensor(
       (minmod_type != SlopeLimiters::MinmodType::LambdaPiN);
   const bool using_linear_limiter_on_non_linear_mesh =
       minmod_type_is_linear and not mesh_is_linear;
-
-  const double tvbm_scale = [&tvbm_constant, &element_size ]() noexcept {
-    const double max_h =
-        *std::max_element(element_size.begin(), element_size.end());
-    return tvbm_constant * square(max_h);
-  }
-  ();
-
-  // Results from SpECTRE paper (https://arxiv.org/abs/1609.00098) used a
-  // max_slope_factor a factor of 2.0 too small, so that LambdaPi1 behaved
-  // like MUSCL, and MUSCL was even more dissipative.
-  const double max_slope_factor =
-      (minmod_type == SlopeLimiters::MinmodType::Muscl) ? 1.0 : 2.0;
 
   // In each direction, average the size of all different neighbors in that
   // direction. Note that only the component of neighor_size that is normal
@@ -123,10 +84,8 @@ bool limit_one_tensor(
 
   bool some_component_was_limited = false;
   for (auto iter = tensor_begin.get(); iter != tensor_end.get(); ++iter) {
-    DataVector& u = *iter;
-    const double u_mean = mean_value(u, mesh);
-
     const auto iter_offset = std::distance(tensor_begin.get(), iter);
+
     // In each direction, average the mean of the `iter` tensor component over
     // all different neighbors in that direction. This produces one effective
     // neighbor per direction.
@@ -159,105 +118,14 @@ bool limit_one_tensor(
     }
     ();
 
-    const auto difference_to_neighbor = [
-      &u_mean, &element, &element_size, &effective_neighbor_means, &
-      effective_neighbor_sizes
-    ](const size_t dim, const Side& side) noexcept {
-      const auto& externals = element.external_boundaries();
-      const auto dir = Direction<VolumeDim>(dim, side);
-      const bool has_neighbors = (externals.find(dir) == externals.end());
-      if (has_neighbors) {
-        const double neighbor_size = effective_neighbor_sizes.at(dir);
-        const double neighbor_mean = effective_neighbor_means.at(dir);
-
-        // Compute an effective element-center-to-neighbor-center distance
-        // that accounts for the possibility of different refinement levels
-        // or discontinuous maps (e.g., at Block boundaries). Treated naively,
-        // these domain features can make a smooth solution appear to be
-        // non-smooth in the logical coordinates, which could potentially lead
-        // to the limiter triggering erroneously. This effective distance is
-        // used to scale the difference in the means, so that a linear function
-        // at a refinement or Block boundary will still appear smooth to the
-        // limiter. The factor is normalized to be 1.0 on a uniform grid.
-        // Note that this is not "by the book" Minmod, but an attempt to
-        // generalize Minmod to work on non-uniform grids.
-        const double distance_factor =
-            0.5 * (1.0 + neighbor_size / gsl::at(element_size, dim));
-        return (side == Side::Lower ? -1.0 : 1.0) * (neighbor_mean - u_mean) /
-               distance_factor;
-      } else {
-        return 0.0;
-      }
-    };
-
-    // The LambdaPiN limiter allows high-order solutions to escape limiting if
-    // the boundary values are not too different from the mean value:
-    if (minmod_type == SlopeLimiters::MinmodType::LambdaPiN) {
-      bool u_needs_limiting = false;
-      for (size_t d = 0; d < VolumeDim; ++d) {
-        const double u_lower =
-            mean_value_on_boundary(&(gsl::at(*boundary_buffer, d)),
-                                   gsl::at(volume_and_slice_indices, d).first,
-                                   u, mesh, d, Side::Lower);
-        const double u_upper =
-            mean_value_on_boundary(&(gsl::at(*boundary_buffer, d)),
-                                   gsl::at(volume_and_slice_indices, d).second,
-                                   u, mesh, d, Side::Upper);
-        const double diff_lower = difference_to_neighbor(d, Side::Lower);
-        const double diff_upper = difference_to_neighbor(d, Side::Upper);
-
-        // Results from SpECTRE paper (https://arxiv.org/abs/1609.00098) used
-        // minmod_tvbm(..., 0.0), rather than minmod_tvbm(..., tvbm_scale)
-        const double v_lower =
-            u_mean -
-            minmod_tvbm(u_mean - u_lower, diff_lower, diff_upper, tvbm_scale)
-                .value;
-        const double v_upper =
-            u_mean +
-            minmod_tvbm(u_upper - u_mean, diff_lower, diff_upper, tvbm_scale)
-                .value;
-        // Value of epsilon from Hesthaven & Warburton, Chapter 5, in the
-        // SlopeLimitN.m code sample.
-        const double eps = 1.e-8;
-        if (fabs(v_lower - u_lower) > eps or fabs(v_upper - u_upper) > eps) {
-          u_needs_limiting = true;
-          break;
-        }
-      }
-
-      if (not u_needs_limiting) {
-        // Skip the limiting step for this tensor component
-        continue;
-      }
-    }
-
-    linearize(u_lin_buffer, u, mesh);
-    bool reduce_slope = false;
-    auto u_limited_slopes = make_array<VolumeDim>(0.0);
-
-    for (size_t d = 0; d < VolumeDim; ++d) {
-      const double u_lower =
-          mean_value_on_boundary(&(gsl::at(*boundary_buffer, d)),
-                                 gsl::at(volume_and_slice_indices, d).first,
-                                 *u_lin_buffer, mesh, d, Side::Lower);
-      const double u_upper =
-          mean_value_on_boundary(&(gsl::at(*boundary_buffer, d)),
-                                 gsl::at(volume_and_slice_indices, d).second,
-                                 *u_lin_buffer, mesh, d, Side::Upper);
-
-      // Divide by element's width (2.0 in logical coordinates) to get a slope
-      const double local_slope = 0.5 * (u_upper - u_lower);
-      const double upper_slope = 0.5 * difference_to_neighbor(d, Side::Upper);
-      const double lower_slope = 0.5 * difference_to_neighbor(d, Side::Lower);
-
-      const MinmodResult& result =
-          minmod_tvbm(local_slope, max_slope_factor * upper_slope,
-                      max_slope_factor * lower_slope, tvbm_scale);
-      gsl::at(u_limited_slopes, d) = result.value;
-      if (result.activated) {
-        reduce_slope = true;
-      }
-    }
+    DataVector& u = *iter;
+    double u_mean;
+    std::array<double, VolumeDim> u_limited_slopes{};
+    const bool reduce_slope = troubled_cell_indicator(
+        make_not_null(&u_mean), make_not_null(&u_limited_slopes), u_lin_buffer,
+        boundary_buffer, minmod_type, tvbm_constant, u, element, mesh,
+        element_size, effective_neighbor_means, effective_neighbor_sizes,
+        volume_and_slice_indices);
 
     if (reduce_slope or using_linear_limiter_on_non_linear_mesh) {
       u = u_mean;
@@ -266,7 +134,7 @@ bool limit_one_tensor(
       }
       some_component_was_limited = true;
     }
-  }
+  }  // end for loop over tensor components
 
   return some_component_was_limited;
 }

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
@@ -18,6 +18,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeArray.hpp"
 
+namespace SlopeLimiters {
 namespace Minmod_detail {
 
 MinmodResult minmod_tvbm(const double a, const double b, const double c,
@@ -303,3 +304,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 #undef INSTANTIATE
 }  // namespace Minmod_detail
+}  // namespace SlopeLimiters

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -21,6 +21,7 @@
 #include "Domain/Element.hpp"  // IWYU pragma: keep
 #include "Domain/MaxNumberOfNeighbors.hpp"
 #include "ErrorHandling/Assert.hpp"
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.hpp"
 #include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/Gsl.hpp"
@@ -60,14 +61,6 @@ template <size_t VolumeDim>
 struct SizeOfElement;
 }  // namespace Tags
 /// \endcond
-
-namespace SlopeLimiters {
-/// \ingroup SlopeLimitersGroup
-/// \brief Possible types of the minmod slope limiter.
-///
-/// \see SlopeLimiters::Minmod
-enum class MinmodType { LambdaPi1, LambdaPiN, Muscl };
-}  // namespace SlopeLimiters
 
 namespace Minmod_detail {
 // Encodes the return status of the minmod_tvbm function.
@@ -472,15 +465,3 @@ bool operator!=(const Minmod<VolumeDim, TagList>& lhs,
 }
 
 }  // namespace SlopeLimiters
-
-template <>
-struct create_from_yaml<SlopeLimiters::MinmodType> {
-  template <typename Metavariables>
-  static SlopeLimiters::MinmodType create(const Option& options) {
-    return create<void>(options);
-  }
-};
-template <>
-SlopeLimiters::MinmodType
-create_from_yaml<SlopeLimiters::MinmodType>::create<void>(
-    const Option& options);

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -62,6 +62,8 @@ struct SizeOfElement;
 }  // namespace Tags
 /// \endcond
 
+namespace SlopeLimiters {
+
 namespace Minmod_detail {
 // Encodes the return status of the minmod_tvbm function.
 struct MinmodResult {
@@ -110,7 +112,6 @@ bool limit_one_tensor(
                      VolumeDim>& volume_and_slice_indices) noexcept;
 }  // namespace Minmod_detail
 
-namespace SlopeLimiters {
 /// \ingroup SlopeLimitersGroup
 /// \brief A general minmod slope limiter
 ///

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -65,16 +65,6 @@ struct SizeOfElement;
 namespace SlopeLimiters {
 
 namespace Minmod_detail {
-// Encodes the return status of the minmod_tvbm function.
-struct MinmodResult {
-  const double value;
-  const bool activated;
-};
-
-// The TVBM-corrected minmod function, see e.g. Cockburn reference Eq. 2.26.
-MinmodResult minmod_tvbm(double a, double b, double c,
-                         double tvbm_scale) noexcept;
-
 // Implements the minmod limiter for one Tensor<DataVector>.
 //
 // The interface is designed to erase the tensor structure information, because

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodTci.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodTci.cpp
@@ -1,0 +1,215 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodTci.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"  // IWYU pragma: keep
+#include "Domain/Mesh.hpp"     // IWYU pragma: keep
+#include "Domain/Side.hpp"
+#include "NumericalAlgorithms/LinearOperators/Linearize.hpp"
+#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace SlopeLimiters {
+namespace Minmod_detail {
+
+// Encodes the return status of the minmod_tvbm function.
+struct MinmodResult {
+  const double value;
+  const bool activated;
+};
+
+// The TVBM-corrected minmod function, see e.g. Cockburn reference Eq. 2.26.
+MinmodResult minmod_tvbm(const double a, const double b, const double c,
+                         const double tvbm_scale) noexcept {
+  if (fabs(a) <= tvbm_scale) {
+    return {a, false};
+  }
+  if ((std::signbit(a) == std::signbit(b)) and
+      (std::signbit(a) == std::signbit(c))) {
+    // The if/else group below could be more simply written as
+    //   std::copysign(std::min({fabs(a), fabs(b), fabs(c)}), a);
+    // however, by separating different cases, we gain the ability to
+    // distinguish whether or not the limiter activated.
+    if (fabs(a) <= fabs(b) and fabs(a) <= fabs(c)) {
+      return {a, false};
+    } else {
+      return {std::copysign(std::min(fabs(b), fabs(c)), a), true};
+    }
+  } else {
+    return {0.0, true};
+  }
+}
+
+template <size_t VolumeDim>
+bool troubled_cell_indicator(
+    const gsl::not_null<double*> u_mean,
+    const gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
+    const gsl::not_null<DataVector*> u_lin_buffer,
+    const gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
+    const SlopeLimiters::MinmodType& minmod_type, const double tvbm_constant,
+    const DataVector& u, const Element<VolumeDim>& element,
+    const Mesh<VolumeDim>& mesh,
+    const std::array<double, VolumeDim>& element_size,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_means,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
+    const std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,
+                               gsl::span<std::pair<size_t, size_t>>>,
+                     VolumeDim>& volume_and_slice_indices) noexcept {
+  const double tvbm_scale = [&tvbm_constant, &element_size ]() noexcept {
+    const double max_h =
+        *std::max_element(element_size.begin(), element_size.end());
+    return tvbm_constant * square(max_h);
+  }
+  ();
+
+  // Results from SpECTRE paper (https://arxiv.org/abs/1609.00098) used a
+  // max_slope_factor a factor of 2.0 too small, so that LambdaPi1 behaved
+  // like MUSCL, and MUSCL was even more dissipative.
+  const double max_slope_factor =
+      (minmod_type == SlopeLimiters::MinmodType::Muscl) ? 1.0 : 2.0;
+
+  *u_mean = mean_value(u, mesh);
+
+  const auto difference_to_neighbor = [
+    &u_mean, &element, &element_size, &effective_neighbor_means, &
+    effective_neighbor_sizes
+  ](const size_t dim, const Side& side) noexcept {
+    const auto& externals = element.external_boundaries();
+    const auto dir = Direction<VolumeDim>(dim, side);
+    const bool has_neighbors = (externals.find(dir) == externals.end());
+    if (has_neighbors) {
+      const double neighbor_mean = effective_neighbor_means.at(dir);
+      const double neighbor_size = effective_neighbor_sizes.at(dir);
+
+      // Compute an effective element-center-to-neighbor-center distance
+      // that accounts for the possibility of different refinement levels
+      // or discontinuous maps (e.g., at Block boundaries). Treated naively,
+      // these domain features can make a smooth solution appear to be
+      // non-smooth in the logical coordinates, which could potentially lead
+      // to the limiter triggering erroneously. This effective distance is
+      // used to scale the difference in the means, so that a linear function
+      // at a refinement or Block boundary will still appear smooth to the
+      // limiter. The factor is normalized to be 1.0 on a uniform grid.
+      // Note that this is not "by the book" Minmod, but an attempt to
+      // generalize Minmod to work on non-uniform grids.
+      const double distance_factor =
+          0.5 * (1.0 + neighbor_size / gsl::at(element_size, dim));
+      return (side == Side::Lower ? -1.0 : 1.0) * (neighbor_mean - *u_mean) /
+             distance_factor;
+    } else {
+      return 0.0;
+    }
+  };
+
+  // The LambdaPiN limiter allows high-order solutions to escape limiting if
+  // the boundary values are not too different from the mean value:
+  if (minmod_type == SlopeLimiters::MinmodType::LambdaPiN) {
+    bool u_needs_limiting = false;
+    for (size_t d = 0; d < VolumeDim; ++d) {
+      const double u_lower = mean_value_on_boundary(
+          &(gsl::at(*boundary_buffer, d)),
+          gsl::at(volume_and_slice_indices, d).first, u, mesh, d, Side::Lower);
+      const double u_upper = mean_value_on_boundary(
+          &(gsl::at(*boundary_buffer, d)),
+          gsl::at(volume_and_slice_indices, d).second, u, mesh, d, Side::Upper);
+      const double diff_lower = difference_to_neighbor(d, Side::Lower);
+      const double diff_upper = difference_to_neighbor(d, Side::Upper);
+
+      // Results from SpECTRE paper (https://arxiv.org/abs/1609.00098) used
+      // minmod_tvbm(..., 0.0), rather than minmod_tvbm(..., tvbm_scale)
+      const double v_lower =
+          *u_mean -
+          minmod_tvbm(*u_mean - u_lower, diff_lower, diff_upper, tvbm_scale)
+              .value;
+      const double v_upper =
+          *u_mean +
+          minmod_tvbm(u_upper - *u_mean, diff_lower, diff_upper, tvbm_scale)
+              .value;
+      // Value of epsilon from Hesthaven & Warburton, Chapter 5, in the
+      // SlopeLimitN.m code sample.
+      const double eps = 1.e-8;
+      if (fabs(v_lower - u_lower) > eps or fabs(v_upper - u_upper) > eps) {
+        u_needs_limiting = true;
+        break;
+      }
+    }
+
+    if (not u_needs_limiting) {
+      // Skip the limiting step for this tensor component
+      return false;
+    }
+  }  // end if LambdaPiN
+
+  // If the LambdaPiN check did not skip the limiting, then proceed as normal
+  // to determine whether the slopes need to be reduced.
+  //
+  // Note that we expect the Muscl and LambdaPi1 limiters to linearize the
+  // solution whether or not the slope needed reduction. To permit this
+  // linearization, we always return (by reference) the slopes when these
+  // limiters are in use. In contrast, for LambdaPiN, we only return the slopes
+  // when they do in fact need to be reduced.
+  bool slopes_need_reducing = false;
+
+  linearize(u_lin_buffer, u, mesh);
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    const double u_lower =
+        mean_value_on_boundary(&(gsl::at(*boundary_buffer, d)),
+                               gsl::at(volume_and_slice_indices, d).first,
+                               *u_lin_buffer, mesh, d, Side::Lower);
+    const double u_upper =
+        mean_value_on_boundary(&(gsl::at(*boundary_buffer, d)),
+                               gsl::at(volume_and_slice_indices, d).second,
+                               *u_lin_buffer, mesh, d, Side::Upper);
+
+    // Divide by element's width (2.0 in logical coordinates) to get a slope
+    const double local_slope = 0.5 * (u_upper - u_lower);
+    const double upper_slope = 0.5 * difference_to_neighbor(d, Side::Upper);
+    const double lower_slope = 0.5 * difference_to_neighbor(d, Side::Lower);
+
+    const MinmodResult& result =
+        minmod_tvbm(local_slope, max_slope_factor * upper_slope,
+                    max_slope_factor * lower_slope, tvbm_scale);
+    gsl::at(*u_limited_slopes, d) = result.value;
+    if (result.activated) {
+      slopes_need_reducing = true;
+    }
+  }
+
+  return slopes_need_reducing;
+}
+
+// Explicit instantiations
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                             \
+  template bool troubled_cell_indicator<DIM(data)>(                      \
+      const gsl::not_null<double*>,                                      \
+      const gsl::not_null<std::array<double, DIM(data)>*>,               \
+      const gsl::not_null<DataVector*>,                                  \
+      const gsl::not_null<std::array<DataVector, DIM(data)>*>,           \
+      const SlopeLimiters::MinmodType&, const double, const DataVector&, \
+      const Element<DIM(data)>&, const Mesh<DIM(data)>&,                 \
+      const std::array<double, DIM(data)>&,                              \
+      const DirectionMap<DIM(data), double>&,                            \
+      const DirectionMap<DIM(data), double>&,                            \
+      const std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,   \
+                                 gsl::span<std::pair<size_t, size_t>>>,  \
+                       DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+
+}  // namespace Minmod_detail
+}  // namespace SlopeLimiters

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodTci.hpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstdlib>
+#include <utility>
+
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim, typename T>
+class DirectionMap;
+template <size_t VolumeDim>
+class Element;
+template <size_t VolumeDim>
+class Mesh;
+/// \endcond
+
+namespace SlopeLimiters {
+namespace Minmod_detail {
+
+// Implements the troubled-cell indicator corresponding to the Minmod limiter.
+//
+// The troubled-cell indicator (TCI) determines whether or not limiting is
+// needed. See SlopeLimiters::Minmod for a full description of the Minmod
+// limiter. Note that as an optimization, this TCI returns (by reference) some
+// additional data that are used by the Minmod limiter in the case where the
+// TCI returns true (i.e., the case where limiting is needed).
+template <size_t VolumeDim>
+bool troubled_cell_indicator(
+    gsl::not_null<double*> u_mean,
+    gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
+    gsl::not_null<DataVector*> u_lin_buffer,
+    gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
+    const SlopeLimiters::MinmodType& minmod_type, double tvbm_constant,
+    const DataVector& u, const Element<VolumeDim>& element,
+    const Mesh<VolumeDim>& mesh,
+    const std::array<double, VolumeDim>& element_size,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_means,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
+    const std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,
+                               gsl::span<std::pair<size_t, size_t>>>,
+                     VolumeDim>& volume_and_slice_indices) noexcept;
+
+}  // namespace Minmod_detail
+}  // namespace SlopeLimiters

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.cpp
@@ -6,8 +6,25 @@
 #include <ostream>
 #include <string>
 
+#include "ErrorHandling/Error.hpp"
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
+
+std::ostream& SlopeLimiters::operator<<(
+    std::ostream& os, const SlopeLimiters::MinmodType& minmod_type) {
+  switch (minmod_type) {
+    case SlopeLimiters::MinmodType::LambdaPi1:
+      return os << "LambdaPi1";
+    case SlopeLimiters::MinmodType::LambdaPiN:
+      return os << "LambdaPiN";
+    case SlopeLimiters::MinmodType::Muscl:
+      return os << "Muscl";
+    default:  // LCOV_EXCL_LINE
+      // LCOV_EXCL_START
+      ERROR("Missing a case for operator<<(MinmodType)");
+      // LCOV_EXCL_STOP
+  }
+}
 
 template <>
 SlopeLimiters::MinmodType

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.cpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.hpp"
+
+#include <ostream>
+#include <string>
+
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+
+template <>
+SlopeLimiters::MinmodType
+create_from_yaml<SlopeLimiters::MinmodType>::create<void>(
+    const Option& options) {
+  const std::string minmod_type_read = options.parse_as<std::string>();
+  if (minmod_type_read == "LambdaPi1") {
+    return SlopeLimiters::MinmodType::LambdaPi1;
+  } else if (minmod_type_read == "LambdaPiN") {
+    return SlopeLimiters::MinmodType::LambdaPiN;
+  } else if (minmod_type_read == "Muscl") {
+    return SlopeLimiters::MinmodType::Muscl;
+  }
+  PARSE_ERROR(options.context(), "Failed to convert \""
+                                     << minmod_type_read
+                                     << "\" to MinmodType. Expected one of: "
+                                        "{LambdaPi1, LambdaPiN, Muscl}.");
+}

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <ostream>
+
 class Option;
 template <typename T>
 struct create_from_yaml;
@@ -14,6 +16,9 @@ namespace SlopeLimiters {
 ///
 /// \see SlopeLimiters::Minmod for a description and reference.
 enum class MinmodType { LambdaPi1, LambdaPiN, Muscl };
+
+std::ostream& operator<<(std::ostream& os,
+                         const SlopeLimiters::MinmodType& minmod_type);
 }  // namespace SlopeLimiters
 
 template <>

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.hpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+class Option;
+template <typename T>
+struct create_from_yaml;
+
+namespace SlopeLimiters {
+/// \ingroup SlopeLimitersGroup
+/// \brief Possible types of the minmod slope limiter and/or troubled-cell
+/// indicator.
+///
+/// \see SlopeLimiters::Minmod for a description and reference.
+enum class MinmodType { LambdaPi1, LambdaPiN, Muscl };
+}  // namespace SlopeLimiters
+
+template <>
+struct create_from_yaml<SlopeLimiters::MinmodType> {
+  template <typename Metavariables>
+  static SlopeLimiters::MinmodType create(const Option& options) {
+    return create<void>(options);
+  }
+};
+template <>
+SlopeLimiters::MinmodType
+create_from_yaml<SlopeLimiters::MinmodType>::create<void>(
+    const Option& options);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_LimiterActions.cpp
   Test_LimiterActionsWithMinmod.cpp
   Test_Minmod.cpp
+  Test_MinmodType.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_LimiterActionsWithMinmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_LimiterActionsWithMinmod.cpp
@@ -28,6 +28,7 @@
 #include "Domain/Tags.hpp"
 #include "Evolution/DiscontinuousGalerkin/SlopeLimiters/LimiterActions.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp"
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
@@ -25,6 +25,7 @@
 #include "Domain/Neighbors.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp"
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.hpp"
 #include "NumericalAlgorithms/LinearOperators/Linearize.hpp"
 #include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -82,14 +83,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.Minmod.Options",
 
   test_creation<SlopeLimiters::Minmod<3, tmpl::list<ScalarTag>>>(
       "  Type: LambdaPiN\n  DisableForDebugging: True");
-}
-
-// [[OutputRegex, Failed to convert "BadType" to MinmodType]]
-SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.Minmod.OptionParseError",
-                  "[SlopeLimiters][Unit]") {
-  ERROR_TEST();
-  test_creation<SlopeLimiters::Minmod<1, tmpl::list<ScalarTag>>>(
-      "  Type: BadType");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.Minmod.Serialization",

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_MinmodType.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_MinmodType.cpp
@@ -8,6 +8,7 @@
 #include "Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.hpp"
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
@@ -25,11 +26,15 @@ void check_minmod_type_parse(
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.MinmodType.OptionParse",
+SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.MinmodType",
                   "[SlopeLimiters][Unit]") {
   check_minmod_type_parse("LambdaPi1", SlopeLimiters::MinmodType::LambdaPi1);
   check_minmod_type_parse("LambdaPiN", SlopeLimiters::MinmodType::LambdaPiN);
   check_minmod_type_parse("Muscl", SlopeLimiters::MinmodType::Muscl);
+
+  CHECK(get_output(SlopeLimiters::MinmodType::LambdaPi1) == "LambdaPi1");
+  CHECK(get_output(SlopeLimiters::MinmodType::LambdaPiN) == "LambdaPiN");
+  CHECK(get_output(SlopeLimiters::MinmodType::Muscl) == "Muscl");
 }
 
 // [[OutputRegex, Failed to convert "BadType" to MinmodType]]

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_MinmodType.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_MinmodType.cpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.hpp"
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct ExampleLimiterType {
+  using type = SlopeLimiters::MinmodType;
+  static constexpr OptionString help = {"Example help text"};
+};
+
+void check_minmod_type_parse(
+    const std::string& input,
+    const SlopeLimiters::MinmodType& expected_minmod_type) {
+  Options<tmpl::list<ExampleLimiterType>> opts("");
+  opts.parse("ExampleLimiterType: " + input);
+  CHECK(opts.get<ExampleLimiterType>() == expected_minmod_type);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.MinmodType.OptionParse",
+                  "[SlopeLimiters][Unit]") {
+  check_minmod_type_parse("LambdaPi1", SlopeLimiters::MinmodType::LambdaPi1);
+  check_minmod_type_parse("LambdaPiN", SlopeLimiters::MinmodType::LambdaPiN);
+  check_minmod_type_parse("Muscl", SlopeLimiters::MinmodType::Muscl);
+}
+
+// [[OutputRegex, Failed to convert "BadType" to MinmodType]]
+SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.MinmodType.OptionParseError",
+                  "[SlopeLimiters][Unit]") {
+  ERROR_TEST();
+  Options<tmpl::list<ExampleLimiterType>> opts("");
+  opts.parse("ExampleLimiterType: BadType");
+  opts.get<ExampleLimiterType>();
+}


### PR DESCRIPTION
## Proposed changes

The Minmod limiter (more precisely, whether the Minmod limiter triggers) is sometimes used to trigger other, more sophisticated, limiters. This PR splits Minmod into two parts: the troubled-cell indicator ("is limiting needed?"), and the the limiter ("yes, so let us limit").

The TCI is tested fairly thoroughly through its use in the Minmod limiter. A future PR will refactor the Minmod tests, by separating them into TCI tests and limiter tests.

Depends on #1406.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

