### PR TITLE
Fixes in frustum_coordinate_maps in DomainHelpers

### DIFF
--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -590,6 +590,17 @@ frustum_coordinate_maps(const double length_inner_cube,
                         const double length_outer_cube,
                         const bool use_equiangular_map,
                         const std::array<double, 3>& origin_preimage) noexcept {
+  ASSERT(length_inner_cube < 0.5 * length_outer_cube,
+         "The outer cube is too small! The inner cubes will pierce the surface "
+         "of the outer cube.");
+  ASSERT(
+      abs(origin_preimage[0]) + length_inner_cube < 0.5 * length_outer_cube and
+          abs(origin_preimage[1]) + length_inner_cube <
+              0.5 * length_outer_cube and
+          abs(origin_preimage[2]) + 0.5 * length_inner_cube <
+              0.5 * length_outer_cube,
+      "The current choice for `origin_preimage` results in the inner cubes "
+      "piercing the surface of the outer cube.");
   const auto frustum_orientations = orientations_for_wrappings();
   const double lower = 0.5 * length_inner_cube;
   const double top = 0.5 * length_outer_cube;
@@ -600,53 +611,53 @@ frustum_coordinate_maps(const double length_inner_cube,
   std::vector<FrustumMap> frustums{};
   for (size_t i = 0; i < 4; i++) {
     // frustums on the left
-    std::array<double, 3> displacement_from_origin =
-        discrete_rotation(gsl::at(frustum_orientations, i), origin_preimage);
+    std::array<double, 3> displacement_from_origin = discrete_rotation(
+        gsl::at(frustum_orientations, i).inverse_map(), origin_preimage);
     frustums.push_back(FrustumMap{
-        {{{{-2.0 * lower + displacement_from_origin[0],
-            -lower + displacement_from_origin[1]}},
-          {{displacement_from_origin[0], lower + displacement_from_origin[1]}},
+        {{{{-2.0 * lower - displacement_from_origin[0],
+            -lower - displacement_from_origin[1]}},
+          {{-displacement_from_origin[0], lower - displacement_from_origin[1]}},
           {{-top, -top}},
           {{0.0, top}}}},
-        lower + displacement_from_origin[2],
+        lower - displacement_from_origin[2],
         top,
         gsl::at(frustum_orientations, i),
         use_equiangular_map});
     // frustums on the right
-    frustums.push_back(FrustumMap{
-        {{{{displacement_from_origin[0], -lower + displacement_from_origin[1]}},
-          {{2.0 * lower + displacement_from_origin[0],
-            lower + displacement_from_origin[1]}},
-          {{0.0, -top}},
-          {{top, top}}}},
-        lower + displacement_from_origin[2],
-        top,
-        gsl::at(frustum_orientations, i),
-        use_equiangular_map});
+    frustums.push_back(FrustumMap{{{{{-displacement_from_origin[0],
+                                      -lower - displacement_from_origin[1]}},
+                                    {{2.0 * lower - displacement_from_origin[0],
+                                      lower - displacement_from_origin[1]}},
+                                    {{0.0, -top}},
+                                    {{top, top}}}},
+                                  lower - displacement_from_origin[2],
+                                  top,
+                                  gsl::at(frustum_orientations, i),
+                                  use_equiangular_map});
   }
   // end cap frustum on the right
   std::array<double, 3> displacement_from_origin =
-      discrete_rotation(frustum_orientations[4], origin_preimage);
-  frustums.push_back(FrustumMap{{{{{-lower + displacement_from_origin[0],
-                                    -lower + displacement_from_origin[1]}},
-                                  {{lower + displacement_from_origin[0],
-                                    lower + displacement_from_origin[1]}},
+      discrete_rotation(frustum_orientations[4].inverse_map(), origin_preimage);
+  frustums.push_back(FrustumMap{{{{{-lower - displacement_from_origin[0],
+                                    -lower - displacement_from_origin[1]}},
+                                  {{lower - displacement_from_origin[0],
+                                    lower - displacement_from_origin[1]}},
                                   {{-top, -top}},
                                   {{top, top}}}},
-                                2.0 * lower + displacement_from_origin[2],
+                                2.0 * lower - displacement_from_origin[2],
                                 top,
                                 frustum_orientations[4],
                                 use_equiangular_map});
   // end cap frustum on the left
   displacement_from_origin =
-      discrete_rotation(frustum_orientations[5], origin_preimage);
-  frustums.push_back(FrustumMap{{{{{-lower + displacement_from_origin[0],
-                                    -lower + displacement_from_origin[1]}},
-                                  {{lower + displacement_from_origin[0],
-                                    lower + displacement_from_origin[1]}},
+      discrete_rotation(frustum_orientations[5].inverse_map(), origin_preimage);
+  frustums.push_back(FrustumMap{{{{{-lower - displacement_from_origin[0],
+                                    -lower - displacement_from_origin[1]}},
+                                  {{lower - displacement_from_origin[0],
+                                    lower - displacement_from_origin[1]}},
                                   {{-top, -top}},
                                   {{top, top}}}},
-                                2.0 * lower + displacement_from_origin[2],
+                                2.0 * lower - displacement_from_origin[2],
                                 top,
                                 frustum_orientations[5],
                                 use_equiangular_map});

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -498,134 +498,150 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.AllFrustumDirections",
   const double top = 5.2;
   const std::array<double, 3> origin_preimage{{0.2, 0.3, -0.1}};
   const auto displacement1 =
-      discrete_rotation(OrientationMap<3>{}, origin_preimage);
+      discrete_rotation(OrientationMap<3>{}.inverse_map(), origin_preimage);
   const auto displacement2 =
-      discrete_rotation(OrientationMap<3>{}, origin_preimage);
+      discrete_rotation(OrientationMap<3>{}.inverse_map(), origin_preimage);
   const auto displacement3 = discrete_rotation(
-      OrientationMap<3>{std::array<Direction<3>, 3>{
-          {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-           Direction<3>::lower_zeta()}}},
+      OrientationMap<3>{
+          std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                       Direction<3>::lower_eta(),
+                                       Direction<3>::lower_zeta()}}}
+          .inverse_map(),
       origin_preimage);
   const auto displacement4 = discrete_rotation(
-      OrientationMap<3>{std::array<Direction<3>, 3>{
-          {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-           Direction<3>::lower_zeta()}}},
+      OrientationMap<3>{
+          std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                       Direction<3>::lower_eta(),
+                                       Direction<3>::lower_zeta()}}}
+          .inverse_map(),
       origin_preimage);
   const auto displacement5 = discrete_rotation(
-      OrientationMap<3>{std::array<Direction<3>, 3>{
-          {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
-           Direction<3>::lower_eta()}}},
+      OrientationMap<3>{
+          std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                       Direction<3>::upper_zeta(),
+                                       Direction<3>::lower_eta()}}}
+          .inverse_map(),
       origin_preimage);
   const auto displacement6 = discrete_rotation(
-      OrientationMap<3>{std::array<Direction<3>, 3>{
-          {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
-           Direction<3>::lower_eta()}}},
+      OrientationMap<3>{
+          std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                       Direction<3>::upper_zeta(),
+                                       Direction<3>::lower_eta()}}}
+          .inverse_map(),
       origin_preimage);
   const auto displacement7 = discrete_rotation(
-      OrientationMap<3>{std::array<Direction<3>, 3>{
-          {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
-           Direction<3>::upper_eta()}}},
+      OrientationMap<3>{
+          std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                       Direction<3>::lower_zeta(),
+                                       Direction<3>::upper_eta()}}}
+          .inverse_map(),
       origin_preimage);
   const auto displacement8 = discrete_rotation(
-      OrientationMap<3>{std::array<Direction<3>, 3>{
-          {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
-           Direction<3>::upper_eta()}}},
+      OrientationMap<3>{
+          std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                       Direction<3>::lower_zeta(),
+                                       Direction<3>::upper_eta()}}}
+          .inverse_map(),
       origin_preimage);
   const auto displacement9 = discrete_rotation(
-      OrientationMap<3>{std::array<Direction<3>, 3>{
-          {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
-           Direction<3>::upper_eta()}}},
+      OrientationMap<3>{
+          std::array<Direction<3>, 3>{{Direction<3>::upper_zeta(),
+                                       Direction<3>::upper_xi(),
+                                       Direction<3>::upper_eta()}}}
+          .inverse_map(),
       origin_preimage);
   const auto displacement10 = discrete_rotation(
-      OrientationMap<3>{std::array<Direction<3>, 3>{
-          {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
-           Direction<3>::upper_eta()}}},
+      OrientationMap<3>{
+          std::array<Direction<3>, 3>{{Direction<3>::lower_zeta(),
+                                       Direction<3>::lower_xi(),
+                                       Direction<3>::upper_eta()}}}
+          .inverse_map(),
       origin_preimage);
 
   for (const bool use_equiangular_map : {true, false}) {
     const auto expected_coord_maps =
         make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-            FrustumMap{{{{{-2.0 * lower + displacement1[0],
-                           -lower + displacement1[1]}},
-                         {{displacement1[0], lower + displacement1[1]}},
+            FrustumMap{{{{{-2.0 * lower - displacement1[0],
+                           -lower - displacement1[1]}},
+                         {{-displacement1[0], lower - displacement1[1]}},
                          {{-top, -top}},
                          {{0.0, top}}}},
-                       lower + displacement1[2],
+                       lower - displacement1[2],
                        top,
                        OrientationMap<3>{},
                        use_equiangular_map},
             FrustumMap{
-                {{{{displacement2[0], -lower + displacement2[1]}},
-                  {{2.0 * lower + displacement2[0], lower + displacement2[1]}},
+                {{{{-displacement2[0], -lower - displacement2[1]}},
+                  {{2.0 * lower - displacement2[0], lower - displacement2[1]}},
                   {{0.0, -top}},
                   {{top, top}}}},
-                lower + displacement2[2],
+                lower - displacement2[2],
                 top,
                 OrientationMap<3>{},
                 use_equiangular_map},
-            FrustumMap{{{{{-2.0 * lower + displacement3[0],
-                           -lower + displacement3[1]}},
-                         {{displacement3[0], lower + displacement3[1]}},
+            FrustumMap{{{{{-2.0 * lower - displacement3[0],
+                           -lower - displacement3[1]}},
+                         {{-displacement3[0], lower - displacement3[1]}},
                          {{-top, -top}},
                          {{0.0, top}}}},
-                       lower + displacement3[2],
+                       lower - displacement3[2],
                        top,
                        OrientationMap<3>{std::array<Direction<3>, 3>{
                            {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                             Direction<3>::lower_zeta()}}},
                        use_equiangular_map},
             FrustumMap{
-                {{{{displacement4[0], -lower + displacement4[1]}},
-                  {{2.0 * lower + displacement4[0], lower + displacement4[1]}},
+                {{{{-displacement4[0], -lower - displacement4[1]}},
+                  {{2.0 * lower - displacement4[0], lower - displacement4[1]}},
                   {{0.0, -top}},
                   {{top, top}}}},
-                lower + displacement4[2],
+                lower - displacement4[2],
                 top,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                      Direction<3>::lower_zeta()}}},
                 use_equiangular_map},
             FrustumMap{
-                {{{{-2.0 * lower + displacement5[0],
-                    -lower + displacement5[1]}},
-                  {{displacement5[0], lower + displacement5[1]}},
+                {{{{-2.0 * lower - displacement5[0],
+                    -lower - displacement5[1]}},
+                  {{-displacement5[0], lower - displacement5[1]}},
                   {{-top, -top}},
                   {{0.0, top}}}},
-                lower + displacement5[2],
+                lower - displacement5[2],
                 top,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                      Direction<3>::lower_eta()}}},
                 use_equiangular_map},
             FrustumMap{
-                {{{{displacement6[0], -lower + displacement6[1]}},
-                  {{2.0 * lower + displacement6[0], lower + displacement6[1]}},
+                {{{{-displacement6[0], -lower - displacement6[1]}},
+                  {{2.0 * lower - displacement6[0], lower - displacement6[1]}},
                   {{0.0, -top}},
                   {{top, top}}}},
-                lower + displacement6[2],
+                lower - displacement6[2],
                 top,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                      Direction<3>::lower_eta()}}},
                 use_equiangular_map},
             FrustumMap{
-                {{{{-2.0 * lower + displacement7[0],
-                    -lower + displacement7[1]}},
-                  {{displacement7[0], lower + displacement7[1]}},
+                {{{{-2.0 * lower - displacement7[0],
+                    -lower - displacement7[1]}},
+                  {{-displacement7[0], lower - displacement7[1]}},
                   {{-top, -top}},
                   {{0.0, top}}}},
-                lower + displacement7[2],
+                lower - displacement7[2],
                 top,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
                      Direction<3>::upper_eta()}}},
                 use_equiangular_map},
             FrustumMap{
-                {{{{displacement8[0], -lower + displacement8[1]}},
-                  {{2.0 * lower + displacement8[0], lower + displacement8[1]}},
+                {{{{-displacement8[0], -lower - displacement8[1]}},
+                  {{2.0 * lower - displacement8[0], lower - displacement8[1]}},
                   {{0.0, -top}},
                   {{top, top}}}},
-                lower + displacement8[2],
+                lower - displacement8[2],
                 top,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
@@ -633,11 +649,11 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.AllFrustumDirections",
                 use_equiangular_map},
             // Frustum on right half in the +x direction
             FrustumMap{
-                {{{{-lower + displacement9[0], -lower + displacement9[1]}},
-                  {{lower + displacement9[0], lower + displacement9[1]}},
+                {{{{-lower - displacement9[0], -lower - displacement9[1]}},
+                  {{lower - displacement9[0], lower - displacement9[1]}},
                   {{-top, -top}},
                   {{top, top}}}},
-                2.0 * lower + displacement9[2],
+                2.0 * lower - displacement9[2],
                 top,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
@@ -645,11 +661,11 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.AllFrustumDirections",
                 use_equiangular_map},
             // Frustum on left half in the -x direction
             FrustumMap{
-                {{{{-lower + displacement10[0], -lower + displacement10[1]}},
-                  {{lower + displacement10[0], lower + displacement10[1]}},
+                {{{{-lower - displacement10[0], -lower - displacement10[1]}},
+                  {{lower - displacement10[0], lower - displacement10[1]}},
                   {{-top, -top}},
                   {{top, top}}}},
-                2.0 * lower + displacement10[2],
+                2.0 * lower - displacement10[2],
                 top,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
@@ -663,6 +679,42 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.AllFrustumDirections",
       CHECK(*expected_coord_maps[i] == *maps[i]);
     }
   }
+}
+
+// [[OutputRegex, The outer cube is too small! The inner cubes will pierce the
+// surface of the outer cube.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.FrustumCoordinateMaps.Assert1",
+    "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const double length_inner_cube = 0.9;
+  const double length_outer_cube = 1.5;
+  const bool use_equiangular_map = true;
+  const std::array<double, 3> origin_preimage = {{0.0, 0.0, 0.0}};
+  static_cast<void>(frustum_coordinate_maps<Frame::Inertial>(
+      length_inner_cube, length_outer_cube, use_equiangular_map,
+      origin_preimage));
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The current choice for `origin_preimage` results in the inner
+// cubes piercing the surface of the outer cube.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.FrustumCoordinateMaps.Assert2",
+    "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const double length_inner_cube = 1;
+  const double length_outer_cube = 3;
+  const bool use_equiangular_map = true;
+  const std::array<double, 3> origin_preimage = {{0.6, 0.0, 0.0}};
+  static_cast<void>(frustum_coordinate_maps<Frame::Inertial>(
+      length_inner_cube, length_outer_cube, use_equiangular_map,
+      origin_preimage));
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.ShellGraph", "[Domain][Unit]") {


### PR DESCRIPTION
## Proposed changes

I was able to test out frustum_coordinate_maps using the new FrustalCloak DomainCreator
in #1357 but I realized that origin_preimage is handled incorrectly, sending the frustums to the wrong
locations. This fixes that, but a proper test for this won't be in until the FrustalCloak is merged, as the domain/connectivity tests properly catch this bug. I've also added additional useful ASSERTs.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
