### PR TITLE
add check to not include lrtslock.h

### DIFF
--- a/docs/DevGuide/CodeReviewGuide.md
+++ b/docs/DevGuide/CodeReviewGuide.md
@@ -73,6 +73,7 @@ Code Quality Items:
   tests used to obtain said evidence.
 * Never include `<iostream>`, use `Parallel::printf` inside
   `Parallel/Printf.hpp` instead, which is safe to use in parallel.
+* When using charm++ nodelocks include `<converse.h>` instead of `<lrtslock.h>`.
 * Do not add anything to [the `std` namespace]
   (http://en.cppreference.com/w/cpp/language/extending_std).
 * Virtual functions are explicitly overridden using the `override` keyword.

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -220,6 +220,20 @@ long_lines_test() {
 }
 standard_checks+=(long_lines)
 
+# Check for lrtslock header
+lrtslock() {
+    is_c++ "$1" && grep -q '#include <lrtslock.h>' "$1"
+}
+lrtslock_report() {
+    echo "Found lrtslock header (include converse.h instead):"
+    pretty_grep '#include <lrtslock.h>' "$@"
+}
+lrtslock_test() {
+    test_check pass foo.cpp '#include <vector>'$'\n'
+    test_check fail foo.cpp '#include <lrtslock.h>'$'\n'
+}
+standard_checks+=(lrtslock)
+
 # Check for files containing tabs
 tabs() {
     whitelist "$1" '.h5' '.png' &&


### PR DESCRIPTION
## Proposed changes

Add a check in FileTestDefs.sh to prevent including lrtslock.h directly.

### Types of changes:

- [x] New feature

### Component:

- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).