### PR TITLE
Add WENO grid-related helper functions

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY SlopeLimiters)
 set(LIBRARY_SOURCES
   MinmodTci.cpp
   MinmodType.cpp
+  WenoGridHelpers.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/WenoGridHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/WenoGridHelpers.cpp
@@ -1,0 +1,120 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/WenoGridHelpers.hpp"
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Direction.hpp"  // IWYU pragma: keep
+#include "Domain/Element.hpp"    // IWYU pragma: keep
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"  // IWYU pragma: keep
+#include "Domain/Side.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace SlopeLimiters {
+namespace Weno_detail {
+
+template <size_t VolumeDim>
+bool check_element_has_one_similar_neighbor_in_direction(
+    const Element<VolumeDim>& element,
+    const Direction<VolumeDim>& direction) noexcept {
+  const auto& neighbors = element.neighbors().at(direction);
+  if (neighbors.size() > 1) {
+    // More than one neighbor
+    return false;
+  } else {
+    const auto& orientation_map = neighbors.orientation();
+    const auto& neighbor_segment_ids = neighbors.ids().cbegin()->segment_ids();
+    const auto reoriented_neighbor_segment_ids =
+        orientation_map.inverse_map()(neighbor_segment_ids);
+    for (size_t d = 0; d < VolumeDim; ++d) {
+      if (gsl::at(reoriented_neighbor_segment_ids, d).refinement_level() !=
+          gsl::at(element.id().segment_ids(), d).refinement_level()) {
+        // One neighbor, but of a different refinement level
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+template <size_t VolumeDim>
+std::array<DataVector, VolumeDim> neighbor_grid_points_in_local_logical_coords(
+    const Mesh<VolumeDim>& local_mesh, const Mesh<VolumeDim>& neighbor_mesh,
+    const Element<VolumeDim>& element,
+    const Direction<VolumeDim>& direction_to_neighbor) noexcept {
+  ASSERT(check_element_has_one_similar_neighbor_in_direction(
+             element, direction_to_neighbor),
+         "Found some amount of h-refinement; this is not supported");
+
+  constexpr double logical_element_width = 2.0;
+  std::array<DataVector, VolumeDim> result{{{}}};
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    const auto neighbor_mesh_1d = neighbor_mesh.slice_through(d);
+    if (d == direction_to_neighbor.dimension()) {
+      // Coordinates normal to the interface cannot line up, so we must provide
+      // the coordinates to interpolate to
+      gsl::at(result, d) =
+          get<0>(logical_coordinates(neighbor_mesh_1d)) +
+          (direction_to_neighbor.side() == Side::Upper ? 1.0 : -1.0) *
+              logical_element_width;
+    } else if (neighbor_mesh_1d != local_mesh.slice_through(d)) {
+      // Coordinates parallel to the interface may or may not line up
+      gsl::at(result, d) = get<0>(logical_coordinates(neighbor_mesh_1d));
+    }
+  }
+  return result;
+}
+
+template <size_t VolumeDim>
+std::array<DataVector, VolumeDim> local_grid_points_in_neighbor_logical_coords(
+    const Mesh<VolumeDim>& local_mesh, const Mesh<VolumeDim>& neighbor_mesh,
+    const Element<VolumeDim>& element,
+    const Direction<VolumeDim>& direction_to_neighbor) noexcept {
+  ASSERT(check_element_has_one_similar_neighbor_in_direction(
+             element, direction_to_neighbor),
+         "Found some amount of h-refinement; this is not supported");
+
+  constexpr double logical_element_width = 2.0;
+  std::array<DataVector, VolumeDim> result{{{}}};
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    const auto local_mesh_1d = local_mesh.slice_through(d);
+    if (d == direction_to_neighbor.dimension()) {
+      // Coordinates normal to the interface cannot line up, so we must provide
+      // the coordinates to interpolate to
+      gsl::at(result, d) =
+          get<0>(logical_coordinates(local_mesh_1d)) +
+          (direction_to_neighbor.side() == Side::Upper ? -1.0 : 1.0) *
+              logical_element_width;
+    } else if (local_mesh_1d != neighbor_mesh.slice_through(d)) {
+      // Coordinates parallel to the interface may or may not line up
+      gsl::at(result, d) = get<0>(logical_coordinates(local_mesh_1d));
+    }
+  }
+  return result;
+}
+
+// Explicit instantiations
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                            \
+  template bool check_element_has_one_similar_neighbor_in_direction(    \
+      const Element<DIM(data)>&, const Direction<DIM(data)>&) noexcept; \
+  template std::array<DataVector, DIM(data)>                            \
+  neighbor_grid_points_in_local_logical_coords(                         \
+      const Mesh<DIM(data)>&, const Mesh<DIM(data)>&,                   \
+      const Element<DIM(data)>&, const Direction<DIM(data)>&) noexcept; \
+  template std::array<DataVector, DIM(data)>                            \
+  local_grid_points_in_neighbor_logical_coords(                         \
+      const Mesh<DIM(data)>&, const Mesh<DIM(data)>&,                   \
+      const Element<DIM(data)>&, const Direction<DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+
+}  // namespace Weno_detail
+}  // namespace SlopeLimiters

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/WenoGridHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/WenoGridHelpers.hpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+/// \cond
+class DataVector;
+template <size_t>
+class Direction;
+template <size_t>
+class Element;
+template <size_t>
+class Mesh;
+/// \endcond
+
+namespace SlopeLimiters {
+namespace Weno_detail {
+
+// Check that an element has just one neighbor in a particular direction, and
+// that this neighbor has the same refinement level as the element.
+template <size_t VolumeDim>
+bool check_element_has_one_similar_neighbor_in_direction(
+    const Element<VolumeDim>& element,
+    const Direction<VolumeDim>& direction) noexcept;
+
+// Compute the coordinate positions of a neighbor element's grid points in the
+// logical coordinates of the local element.
+//
+// However, the results are organized to match the expected input of a
+// RegularGridInterpolator constructor:
+// - The coordinates are given as an array of 1D coordinate values.
+// - For any dimension where the local and neighbor meshes share the same 1D
+//   submesh, the array is empty. (This tells the RegularGridInterpolator that
+//   no interpolation needs to be done in this dimension.)
+//
+// Limitations:
+// - No support for h-refinement. It is ASSERT'ed that the element has only one
+//   neighbor in the specified direction, and that this neighbor is of the same
+//   refinement level as the local element.
+// - Assumes a uniform rectilinear grid. No support for elements of different
+//   sizes (as could occur if all elements have the same refinement level but
+//   different blocks have different physical size), or curvilinear elements.
+//   This is not checked.
+template <size_t VolumeDim>
+std::array<DataVector, VolumeDim> neighbor_grid_points_in_local_logical_coords(
+    const Mesh<VolumeDim>& local_mesh, const Mesh<VolumeDim>& neighbor_mesh,
+    const Element<VolumeDim>& element,
+    const Direction<VolumeDim>& direction_to_neighbor) noexcept;
+
+// Compute the coordinate positions of the local element's grid points in the
+// logical coordinates of the a neighbor element.
+//
+// See documentation of `neighbor_grid_points_in_local_logical_coords` for
+// further details and limitations.
+template <size_t VolumeDim>
+std::array<DataVector, VolumeDim> local_grid_points_in_neighbor_logical_coords(
+    const Mesh<VolumeDim>& local_mesh, const Mesh<VolumeDim>& neighbor_mesh,
+    const Element<VolumeDim>& element,
+    const Direction<VolumeDim>& direction_to_neighbor) noexcept;
+
+}  // namespace Weno_detail
+}  // namespace SlopeLimiters

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_LimiterActionsWithMinmod.cpp
   Test_Minmod.cpp
   Test_MinmodType.cpp
+  Test_WenoGridHelpers.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_WenoGridHelpers.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_WenoGridHelpers.cpp
@@ -1,0 +1,213 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <unordered_set>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Neighbors.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "Domain/Side.hpp"
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/WenoGridHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+
+void test_check_element_no_href() {
+  // Make a 2D element with neighbors:
+  // - lower_xi: 1 neighbor, same refinement level => true
+  // - upper_xi: 1 neighbor, same refinement level, with orientation => true
+  // - lower_eta: 2 neighbors => false
+  // - lower_eta: 1 neighbor, different refinement level => false
+  const ElementId<2> self_id(0, {{{3, 7}, {4, 2}}});
+  const ElementId<2> lower_xi_id(1, {{{3, 5}, {4, 11}}});
+  const ElementId<2> upper_xi_id(2, {{{4, 7}, {3, 0}}});
+  const ElementId<2> lower_eta_id_1(3, {{{3, 7}, {4, 2}}});
+  const ElementId<2> lower_eta_id_2(4, {{{3, 7}, {4, 2}}});
+  const ElementId<2> upper_eta_id(5, {{{3, 7}, {3, 2}}});
+
+  const Neighbors<2> lower_xi_neighbors({lower_xi_id}, OrientationMap<2>{});
+  const Neighbors<2> upper_xi_neighbors(
+      {upper_xi_id},
+      OrientationMap<2>(std::array<Direction<2>, 2>{
+          {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}));
+  const Neighbors<2> lower_eta_neighbors({lower_eta_id_1, lower_eta_id_2},
+                                         OrientationMap<2>{});
+  const Neighbors<2> upper_eta_neighbors({upper_eta_id}, OrientationMap<2>{});
+
+  const Element<2> element(
+      self_id, Element<2>::Neighbors_t{
+                   {Direction<2>::lower_xi(), lower_xi_neighbors},
+                   {Direction<2>::upper_xi(), upper_xi_neighbors},
+                   {Direction<2>::lower_eta(), lower_eta_neighbors},
+                   {Direction<2>::upper_eta(), upper_eta_neighbors}});
+
+  CHECK(SlopeLimiters::Weno_detail::
+            check_element_has_one_similar_neighbor_in_direction(
+                element, Direction<2>::lower_xi()));
+  CHECK(SlopeLimiters::Weno_detail::
+            check_element_has_one_similar_neighbor_in_direction(
+                element, Direction<2>::upper_xi()));
+  CHECK_FALSE(SlopeLimiters::Weno_detail::
+                  check_element_has_one_similar_neighbor_in_direction(
+                      element, Direction<2>::lower_eta()));
+  CHECK_FALSE(SlopeLimiters::Weno_detail::
+                  check_element_has_one_similar_neighbor_in_direction(
+                      element, Direction<2>::upper_eta()));
+}
+
+template <size_t VolumeDim>
+Neighbors<VolumeDim> make_neighbor_with_id(const size_t id) noexcept {
+  return {std::unordered_set<ElementId<VolumeDim>>{ElementId<VolumeDim>(id)},
+          OrientationMap<VolumeDim>{}};
+}
+
+// Construct an element with one neighbor in each direction.
+template <size_t VolumeDim>
+Element<VolumeDim> make_element() noexcept;
+
+template <>
+Element<1> make_element() noexcept {
+  return Element<1>{
+      ElementId<1>{0},
+      Element<1>::Neighbors_t{
+          {Direction<1>::lower_xi(), make_neighbor_with_id<1>(1)},
+          {Direction<1>::upper_xi(), make_neighbor_with_id<1>(2)}}};
+}
+
+template <>
+Element<2> make_element() noexcept {
+  return Element<2>{
+      ElementId<2>{0},
+      Element<2>::Neighbors_t{
+          {Direction<2>::lower_xi(), make_neighbor_with_id<2>(1)},
+          {Direction<2>::upper_xi(), make_neighbor_with_id<2>(2)},
+          {Direction<2>::lower_eta(), make_neighbor_with_id<2>(3)},
+          {Direction<2>::upper_eta(), make_neighbor_with_id<2>(4)}}};
+}
+
+template <>
+Element<3> make_element() noexcept {
+  return Element<3>{
+      ElementId<3>{0},
+      Element<3>::Neighbors_t{
+          {Direction<3>::lower_xi(), make_neighbor_with_id<3>(1)},
+          {Direction<3>::upper_xi(), make_neighbor_with_id<3>(2)},
+          {Direction<3>::lower_eta(), make_neighbor_with_id<3>(3)},
+          {Direction<3>::upper_eta(), make_neighbor_with_id<3>(4)},
+          {Direction<3>::lower_zeta(), make_neighbor_with_id<3>(5)},
+          {Direction<3>::upper_zeta(), make_neighbor_with_id<3>(6)}}};
+}
+
+template <size_t VolumeDim>
+void check_grid_point_transform_no_href(
+    const Mesh<VolumeDim>& local_mesh, const Mesh<VolumeDim>& neighbor_mesh,
+    const Element<VolumeDim>& element) noexcept {
+  const auto check = [&local_mesh, &neighbor_mesh ](
+      const std::array<DataVector, VolumeDim>& transformed_coords,
+      const bool local_mesh_provides_grid_points, const size_t dim,
+      const double offset) noexcept {
+    const Mesh<VolumeDim>& source_mesh =
+        (local_mesh_provides_grid_points ? local_mesh : neighbor_mesh);
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      const DataVector source_coords =
+          get<0>(logical_coordinates(source_mesh.slice_through(i)));
+      if (i == dim) {
+        // Coordinates normal to the interface
+        const DataVector expected_coords = source_coords + offset;
+        CHECK(gsl::at(transformed_coords, i) == expected_coords);
+      } else {
+        // Coordinates parallel to the interface
+        if (neighbor_mesh.slice_through(i) == local_mesh.slice_through(i)) {
+          CHECK(gsl::at(transformed_coords, i).size() == 0);
+        } else {
+          const DataVector& expected_coords = source_coords;
+          CHECK(gsl::at(transformed_coords, i) == expected_coords);
+        }
+      }
+    }
+  };
+
+  for (size_t dim = 0; dim < VolumeDim; ++dim) {
+    const auto from_lower = SlopeLimiters::Weno_detail::
+        neighbor_grid_points_in_local_logical_coords(
+            local_mesh, neighbor_mesh, element,
+            Direction<VolumeDim>(dim, Side::Lower));
+    check(from_lower, false, dim, -2.);
+
+    const auto from_upper = SlopeLimiters::Weno_detail::
+        neighbor_grid_points_in_local_logical_coords(
+            local_mesh, neighbor_mesh, element,
+            Direction<VolumeDim>(dim, Side::Upper));
+    check(from_upper, false, dim, 2.);
+
+    const auto to_lower = SlopeLimiters::Weno_detail::
+        local_grid_points_in_neighbor_logical_coords(
+            local_mesh, neighbor_mesh, element,
+            Direction<VolumeDim>(dim, Side::Lower));
+    check(to_lower, true, dim, 2.);
+
+    const auto to_upper = SlopeLimiters::Weno_detail::
+        local_grid_points_in_neighbor_logical_coords(
+            local_mesh, neighbor_mesh, element,
+            Direction<VolumeDim>(dim, Side::Upper));
+    check(to_upper, true, dim, -2.);
+  }
+}
+
+void test_grid_helpers_1d() {
+  INFO("Testing WENO grid helpers in 1D");
+  const auto element = make_element<1>();
+  const Mesh<1> mesh({{6}}, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  check_grid_point_transform_no_href(mesh, mesh, element);
+
+  const Mesh<1> other_mesh({{6}}, Spectral::Basis::Legendre,
+                           Spectral::Quadrature::Gauss);
+  check_grid_point_transform_no_href(mesh, other_mesh, element);
+}
+
+void test_grid_helpers_2d() {
+  INFO("Testing WENO grid helpers in 2D");
+  const auto element = make_element<2>();
+  const Mesh<2> mesh({{5, 6}}, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  check_grid_point_transform_no_href(mesh, mesh, element);
+
+  const Mesh<2> other_mesh({{4, 6}}, Spectral::Basis::Legendre,
+                           Spectral::Quadrature::GaussLobatto);
+  check_grid_point_transform_no_href(mesh, other_mesh, element);
+}
+
+void test_grid_helpers_3d() {
+  INFO("Testing WENO grid helpers in 3D");
+  const auto element = make_element<3>();
+  const Mesh<3> mesh({{4, 5, 6}}, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  check_grid_point_transform_no_href(mesh, mesh, element);
+
+  const Mesh<3> other_mesh({{4, 5, 3}}, Spectral::Basis::Legendre,
+                           Spectral::Quadrature::GaussLobatto);
+  check_grid_point_transform_no_href(mesh, other_mesh, element);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.WenoGridHelpers",
+                  "[SlopeLimiters][Unit]") {
+  test_check_element_no_href();
+  test_grid_helpers_1d();
+  test_grid_helpers_2d();
+  test_grid_helpers_3d();
+}


### PR DESCRIPTION
## Proposed changes

The WENO limiters will need to extrapolate / extend data from one element onto neighboring elements. To perform this extrapolation, the location of the "destination" element's grid points must be known in the "source" element's logical coordinates.

This PR adds helper functions that compute the coordinate transformation. Since for now we only guarantee the limiter works on undeformed grids with no h- or p-refinement, the transformation is a simple translation.

Note: this code is really computing logical-frame transformations between elements, and is not particularly tied to WENO. But since the code may not be useful anywhere else, I opted to organize it as a WENO helper rather than a general Domain function. This can be easily changed if desired.

In the future, with more complex grids, the transformation will have to become aware of more grid information to produce the correct scaling/translation. For curved domains, whether or not this approach is still used will likely depend on how the limiter itself is generalized...

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
