### PR TITLE
Add Support for Slicing Tags Containing Tensors

### DIFF
--- a/src/DataStructures/VariablesHelpers.hpp
+++ b/src/DataStructures/VariablesHelpers.hpp
@@ -15,6 +15,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/ModalVector.hpp"
 #include "DataStructures/SliceIterator.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -35,6 +36,55 @@ template <typename Tag, typename TagList>
 constexpr const typename Tag::type& get(  // NOLINT
     const Variables<TagList>& v) noexcept;
 /// \endcond
+
+// @{
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief Slices the data within `volume_tensor` to a codimension 1 slice. The
+ * slice has a constant logical coordinate in direction `sliced_dim`,
+ * slicing the volume at `fixed_index` in that dimension.  For
+ * example, to get the lower boundary of `sliced_dim`, pass `0` for
+ * `fixed_index`; to get the upper boundary, pass
+ * `extents[sliced_dim] - 1`.
+ *
+ * \see add_slice_to_data
+ *
+ * returns Tensor class sliced to a hypersurface.
+ */
+template <std::size_t VolumeDim, typename VectorType, typename... Structure>
+void data_on_slice(
+    const gsl::not_null<Tensor<VectorType, Structure...>*> interface_tensor,
+    const Tensor<VectorType, Structure...>& volume_tensor,
+    const Index<VolumeDim>& element_extents, const size_t sliced_dim,
+    const size_t fixed_index) noexcept {
+  const size_t interface_grid_points =
+      element_extents.slice_away(sliced_dim).product();
+  if (interface_tensor->begin()->size() != interface_grid_points) {
+    *interface_tensor = Tensor<VectorType, Structure...>(interface_grid_points);
+  }
+
+  for (SliceIterator si(element_extents, sliced_dim, fixed_index); si; ++si) {
+    for (decltype(auto) interface_and_volume_tensor_components :
+         boost::combine(*interface_tensor, volume_tensor)) {
+      boost::get<0>(interface_and_volume_tensor_components)[si.slice_offset()] =
+          boost::get<1>(
+              interface_and_volume_tensor_components)[si.volume_offset()];
+    }
+  }
+}
+
+template <std::size_t VolumeDim, typename VectorType, typename... Structure>
+Tensor<VectorType, Structure...> data_on_slice(
+    const Tensor<VectorType, Structure...>& volume_tensor,
+    const Index<VolumeDim>& element_extents, const size_t sliced_dim,
+    const size_t fixed_index) noexcept {
+  Tensor<VectorType, Structure...> interface_tensor(
+      element_extents.slice_away(sliced_dim).product());
+  data_on_slice(make_not_null(&interface_tensor), volume_tensor,
+                element_extents, sliced_dim, fixed_index);
+  return interface_tensor;
+}
+// @}
 
 // @{
 /*!

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -196,9 +196,9 @@ struct BoundaryDirectionsExterior : db::ComputeTag {
 /// If a SimpleTag is desired on the interface, then this tag can be added to
 /// the DataBox directly. If a ComputeTag which acts on Tags on the interface is
 /// desired, then the tag should be added using `InterfaceComputeItem`. If a
-/// ComputeTag which slices a VariablesTag in the volume to an Interface is
-/// desired, then it should be added using `Slice`. In all cases, the tag can
-/// then be retrieved using `Tags::Interface<DirectionsTag, Tag>`.
+/// ComputeTag which slices a TensorTag or a VariablesTag in the volume to an
+/// Interface is desired, then it should be added using `Slice`. In all cases,
+/// the tag can then be retrieved using `Tags::Interface<DirectionsTag, Tag>`.
 ///
 /// If using the base tag mechanism for an interface tag is desired,
 /// then `Tag` can have a `base` type alias pointing to its base
@@ -464,41 +464,41 @@ struct InterfaceComputeItem
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// \brief Derived tag for representing a compute item which slices a Tag
-/// containing a `Variables` from the volume to an interface. Retrievable from
-/// the DataBox using `Tags::Interface<DirectionsTag, VarsTag>`
+/// containing a `Tensor` or a `Variables` from the volume to an interface.
+/// Retrievable from the DataBox using `Tags::Interface<DirectionsTag, Tag>`
 ///
 /// The contained object will be a map from ::Direction to the item
 /// type of `Tag`, with the set of directions being those produced by
 /// `DirectionsTag`.
 ///
-/// \requires `Tag` correspond to a `Variables`
+/// \requires `Tag` correspond to a `Tensor` or a `Variables`
 ///
 /// \tparam DirectionsTag the item of Directions
-/// \tparam VarsTag the tag labeling the item
-template <typename DirectionsTag, typename VarsTag>
-struct Slice : Interface<DirectionsTag, VarsTag>, db::ComputeTag {
+/// \tparam Tag the tag labeling the item
+template <typename DirectionsTag, typename Tag>
+struct Slice : Interface<DirectionsTag, Tag>, db::ComputeTag {
   static constexpr size_t volume_dim =
       db::item_type<DirectionsTag>::value_type::volume_dim;
 
   using return_type =
-      std::unordered_map<::Direction<volume_dim>, db::item_type<VarsTag>>;
+      std::unordered_map<::Direction<volume_dim>, db::item_type<Tag>>;
 
   static constexpr void function(
       const gsl::not_null<
-          std::unordered_map<::Direction<volume_dim>, db::item_type<VarsTag>>*>
+          std::unordered_map<::Direction<volume_dim>, db::item_type<Tag>>*>
           sliced_vars,
       const ::Mesh<volume_dim>& mesh,
       const std::unordered_set<::Direction<volume_dim>>& directions,
-      const db::item_type<VarsTag>& variables) noexcept {
+      const db::item_type<Tag>& variables) noexcept {
     for (const auto& direction : directions) {
       data_on_slice(make_not_null(&((*sliced_vars)[direction])), variables,
                     mesh.extents(), direction.dimension(),
                     index_to_slice_at(mesh.extents(), direction));
     }
   }
-  static std::string name() { return "Interface<" + VarsTag::name() + ">"; };
-  using argument_tags = tmpl::list<Mesh<volume_dim>, DirectionsTag, VarsTag>;
-  using volume_tags = tmpl::list<Mesh<volume_dim>, VarsTag>;
+  static std::string name() { return "Interface<" + Tag::name() + ">"; };
+  using argument_tags = tmpl::list<Mesh<volume_dim>, DirectionsTag, Tag>;
+  using volume_tags = tmpl::list<Mesh<volume_dim>, Tag>;
 };
 
 /// \cond

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -270,7 +270,6 @@ void test_variables_move() noexcept {
                                                                          100.0};
   UniformCustomDistribution<size_t> sdist{5, 20};
 
-
   const size_t number_of_grid_points1 = sdist(gen);
   const size_t number_of_grid_points2 = sdist(gen);
   const std::array<value_type, 2> initial_fill_values =
@@ -329,8 +328,8 @@ void test_variables_math() noexcept {
   const auto value_in_variables = make_with_random_values<value_type>(
       make_not_null(&gen), make_not_null(&dist));
   const std::array<value_type, 3> rand_vals =
-      make_with_random_values<std::array<value_type,3>>(make_not_null(&gen),
-                                                        make_not_null(&dist));
+      make_with_random_values<std::array<value_type, 3>>(make_not_null(&gen),
+                                                         make_not_null(&dist));
 
   // Test math +, -, *, /
   const TestVariablesType vars{num_points, value_in_variables};
@@ -449,7 +448,7 @@ void test_variables_prefix_semantics() noexcept {
                                                       variables_vals[1]};
   VariablesType vars_to{prefix_vars_copy_construct_from};
   VariablesType move_constructed_vars{
-    std::move(prefix_vars_move_construct_from)};
+      std::move(prefix_vars_move_construct_from)};
 
   VariablesType expected{number_of_grid_points, variables_vals[0]};
   CHECK_VARIABLES_APPROX(vars_to, expected);
@@ -816,6 +815,20 @@ void test_variables_slice() noexcept {
       }
     }
   }
+
+  CHECK(data_on_slice(get<VariablesTestTags_detail::tensor<VectorType>>(vars),
+                      extents, 0, x_offset) ==
+        get<VariablesTestTags_detail::tensor<VectorType>>(
+            expected_vars_sliced_in_x));
+  CHECK(data_on_slice(get<VariablesTestTags_detail::tensor<VectorType>>(vars),
+                      extents, 1, y_offset) ==
+        get<VariablesTestTags_detail::tensor<VectorType>>(
+            expected_vars_sliced_in_y));
+  CHECK(data_on_slice(get<VariablesTestTags_detail::tensor<VectorType>>(vars),
+                      extents, 2, z_offset) ==
+        get<VariablesTestTags_detail::tensor<VectorType>>(
+            expected_vars_sliced_in_z));
+
   CHECK(data_on_slice(vars, extents, 0, x_offset) == expected_vars_sliced_in_x);
   CHECK(data_on_slice(vars, extents, 1, y_offset) == expected_vars_sliced_in_y);
   CHECK(data_on_slice(vars, extents, 2, z_offset) == expected_vars_sliced_in_z);
@@ -990,10 +1003,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
 #endif
 }
 
+    // clang-format off
 // [[OutputRegex, Must copy into same size]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.DataStructures.Variables.assign_to_default",
     "[DataStructures][Unit]") {
+  // clang-format on
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Variables<tmpl::list<VariablesTestTags_detail::scalar<DataVector>>> vars;
@@ -1019,11 +1034,13 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
 #endif
 }
 
+    // clang-format off
 // [[OutputRegex, vars_on_slice has wrong number of grid points.
 //  Expected 2, got 5]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.DataStructures.Variables.add_slice_to_data.BadSize.slice",
     "[DataStructures][Unit]") {
+  // clang-format on
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Variables<tmpl::list<VariablesTestTags_detail::tensor<DataVector>>> vars(8,


### PR DESCRIPTION
## Proposed changes

This PR adds support for slicing a Tag containing a `Tensor` from a volume to an interface (only slicing `Variables` is currently supported.) This offers an alternative for slicing tensors that have already been initialized on the volume, as opposed to (if I correctly understand) recomputing those tensors on the interface after adding the corresponding `InterfaceComputeItem` to the interface databox. 

Several of these changes proposed in this PR, as well as some functions already present in the files I'm modifying, should most likely be moved elsewhere, so I'm happy to discuss those changes after the new feature proposed here is approved.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
