### PR TITLE
Store GH characteristic speeds in std::array

### DIFF
--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -109,17 +109,4 @@ struct Next : db::PrefixTag, db::SimpleTag {
   using tag = Tag;
   static std::string name() noexcept { return "Next(" + Tag::name() + ")"; }
 };
-
-/// \ingroup DataBoxTagsGroup
-/// \brief Prefix corresponding to the characteristic speed of the
-/// characteristic field given by `Tag`. Its `type` is always a
-/// `Scalar<DataVector>`.
-template<typename Tag>
-struct CharSpeed : db::PrefixTag, db::SimpleTag {
-  using type = Scalar<DataVector>;
-  using tag = Tag;
-  static std::string name() noexcept {
-    return "CharSpeed(" + Tag::name() + ")";
-  }
-};
 }  // namespace Tags

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
@@ -9,17 +9,13 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
-template <typename X, typename Symm, typename IndexList>
-class Tensor;
-/// \endcond
+// IWYU pragma: no_forward_declare Tensor
 
 namespace GeneralizedHarmonic {
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
@@ -8,14 +8,13 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
-
-// IWYU pragma: no_include "DataStructures/Tensor/Tensor.hpp"
 
 /// \cond
 template <typename X, typename Symm, typename IndexList>
@@ -173,13 +172,10 @@ EvolvedFieldsFromCharacteristicFieldsCompute<Dim, Frame>::function(
 
 template <size_t Dim, typename Frame>
 double ComputeLargestCharacteristicSpeed<Dim, Frame>::apply(
-    const Scalar<DataVector>& u_psi_speed,
-    const Scalar<DataVector>& u_zero_speed,
-    const Scalar<DataVector>& u_plus_speed,
-    const Scalar<DataVector>& u_minus_speed) noexcept {
+    const std::array<DataVector, 4>& char_speeds) noexcept {
   std::array<double, 4> max_speeds{
-      {max(abs(get(u_psi_speed))), max(abs(get(u_zero_speed))),
-       max(abs(get(u_plus_speed))), max(abs(get(u_minus_speed)))}};
+      {max(abs(char_speeds.at(0))), max(abs(char_speeds.at(1))),
+       max(abs(char_speeds.at(2))), max(abs(char_speeds.at(3)))}};
   return *std::max_element(max_speeds.begin(), max_speeds.end());
 }
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -60,7 +60,10 @@ namespace GeneralizedHarmonic {
  * surface.
  */
 template <size_t Dim, typename Frame>
-struct CharacteristicSpeedsCompute : db::ComputeTag {
+struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim, Frame>,
+                                     db::ComputeTag {
+  using base = Tags::CharacteristicSpeeds<Dim, Frame>;
+  using type = typename base::type;
   using argument_tags = tmpl::list<
       Tags::ConstraintGamma1, gr::Tags::Lapse<DataVector>,
       gr::Tags::Shift<Dim, Frame, DataVector>,
@@ -69,7 +72,7 @@ struct CharacteristicSpeedsCompute : db::ComputeTag {
   static typename Tags::CharacteristicSpeeds<Dim, Frame>::type function(
       const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, Dim, Frame>& shift,
-      const tnsr::i<DataVector, Dim, Frame>& normal) noexcept;
+      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
 };
 
 template <size_t Dim, typename Frame>
@@ -78,7 +81,7 @@ void compute_characteristic_speeds(
         char_speeds,
     const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim, Frame>& shift,
-    const tnsr::i<DataVector, Dim, Frame>& normal) noexcept;
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
 // @}
 
 // @{
@@ -129,20 +132,22 @@ void compute_characteristic_speeds(
  * \ref CharacteristicSpeedsCompute .
  */
 template <size_t Dim, typename Frame>
-struct CharacteristicFieldsCompute : db::ComputeTag {
+struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim, Frame>,
+                                     db::ComputeTag {
   using argument_tags = tmpl::list<
-      Tags::ConstraintGamma2, gr::Tags::SpacetimeMetric<Dim, Frame, DataVector>,
+      Tags::ConstraintGamma2,
       gr::Tags::InverseSpatialMetric<Dim, Frame, DataVector>,
-      Tags::Pi<Dim, Frame>, Tags::Phi<Dim, Frame>,
+      gr::Tags::SpacetimeMetric<Dim, Frame, DataVector>, Tags::Pi<Dim, Frame>,
+      Tags::Phi<Dim, Frame>,
       ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
 
   static typename Tags::CharacteristicFields<Dim, Frame>::type function(
       const Scalar<DataVector>& gamma_2,
+      const tnsr::II<DataVector, Dim, Frame>& inverse_spatial_metric,
       const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
       const tnsr::aa<DataVector, Dim, Frame>& pi,
       const tnsr::iaa<DataVector, Dim, Frame>& phi,
-      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
-      const tnsr::I<DataVector, Dim, Frame>& unit_normal_vector) noexcept;
+      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
 };
 
 template <size_t Dim, typename Frame>
@@ -150,11 +155,11 @@ void compute_characteristic_fields(
     gsl::not_null<typename Tags::CharacteristicFields<Dim, Frame>::type*>
         char_fields,
     const Scalar<DataVector>& gamma_2,
+    const tnsr::II<DataVector, Dim, Frame>& inverse_spatial_metric,
     const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
     const tnsr::aa<DataVector, Dim, Frame>& pi,
     const tnsr::iaa<DataVector, Dim, Frame>& phi,
-    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
-    const tnsr::I<DataVector, Dim, Frame>& unit_normal_vector) noexcept;
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
 // @}
 
 // @{
@@ -164,7 +169,9 @@ void compute_characteristic_fields(
  * characteristic ones, see \ref CharacteristicFieldsCompute.
  */
 template <size_t Dim, typename Frame>
-struct EvolvedFieldsFromCharacteristicFieldsCompute : db::ComputeTag {
+struct EvolvedFieldsFromCharacteristicFieldsCompute
+    : Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>,
+      db::ComputeTag {
   using argument_tags = tmpl::list<
       Tags::ConstraintGamma2, Tags::UPsi<Dim, Frame>, Tags::UZero<Dim, Frame>,
       Tags::UPlus<Dim, Frame>, Tags::UMinus<Dim, Frame>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -19,8 +20,6 @@ template <class T>
 class not_null;
 }  // namespace gsl
 namespace Tags {
-template <typename Tag>
-struct CharSpeed;
 template <typename Tag>
 struct Normalized;
 }  // namespace Tags
@@ -134,6 +133,8 @@ void compute_characteristic_speeds(
 template <size_t Dim, typename Frame>
 struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim, Frame>,
                                      db::ComputeTag {
+  using base = Tags::CharacteristicFields<Dim, Frame>;
+  using type = typename base::type;
   using argument_tags = tmpl::list<
       Tags::ConstraintGamma2,
       gr::Tags::InverseSpatialMetric<Dim, Frame, DataVector>,
@@ -172,6 +173,8 @@ template <size_t Dim, typename Frame>
 struct EvolvedFieldsFromCharacteristicFieldsCompute
     : Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>,
       db::ComputeTag {
+  using base = Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>;
+  using type = typename base::type;
   using argument_tags = tmpl::list<
       Tags::ConstraintGamma2, Tags::UPsi<Dim, Frame>, Tags::UZero<Dim, Frame>,
       Tags::UPlus<Dim, Frame>, Tags::UMinus<Dim, Frame>,
@@ -207,13 +210,7 @@ void compute_evolved_fields_from_characteristic_fields(
  */
 template <size_t Dim, typename Frame>
 struct ComputeLargestCharacteristicSpeed {
-  using argument_tags = tmpl::list<::Tags::CharSpeed<Tags::UPsi<Dim, Frame>>,
-                                   ::Tags::CharSpeed<Tags::UZero<Dim, Frame>>,
-                                   ::Tags::CharSpeed<Tags::UPlus<Dim, Frame>>,
-                                   ::Tags::CharSpeed<Tags::UMinus<Dim, Frame>>>;
-  static double apply(const Scalar<DataVector>& u_psi_speed,
-                      const Scalar<DataVector>& u_zero_speed,
-                      const Scalar<DataVector>& u_plus_speed,
-                      const Scalar<DataVector>& u_minus_speed) noexcept;
+  using argument_tags = tmpl::list<Tags::CharacteristicSpeeds<Dim, Frame>>;
+  static double apply(const std::array<DataVector, 4>& char_speeds) noexcept;
 };
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -95,9 +95,7 @@ struct UMinus : db::SimpleTag {
 
 template <size_t Dim, typename Frame>
 struct CharacteristicSpeeds : db::SimpleTag {
-  using type = Variables<db::wrap_tags_in<
-      ::Tags::CharSpeed, tmpl::list<UPsi<Dim, Frame>, UZero<Dim, Frame>,
-                                    UPlus<Dim, Frame>, UMinus<Dim, Frame>>>>;
+  using type = std::array<DataVector, 4>;
   static std::string name() noexcept { return "CharacteristicSpeeds"; }
 };
 

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
@@ -23,6 +23,5 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Prefixes",
   /// [next_name]
   CHECK(Tags::Next<Tag>::name() == "Next(" + Tag::name() + ")");
   /// [next_name]
-  CHECK(Tags::CharSpeed<Tag>::name() == "CharSpeed(Tag)");
   CHECK(Tags::dt<Tag>::name() == "dt(Tag)");
 }

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
@@ -228,26 +228,32 @@ def char_speed_uminus(gamma1, lapse, shift, unit_normal):
 
 
 # Test functions for characteristic fields
-def char_field_upsi(gamma2, spacetime_metric,
-                    pi, phi, normal_one_form, normal_vector):
+def char_field_upsi(gamma2, inverse_spatial_metric, spacetime_metric,
+                    pi, phi, normal_one_form):
     return spacetime_metric
 
 
-def char_field_uzero(gamma2, spacetime_metric,
-                     pi, phi, normal_one_form, normal_vector):
+def char_field_uzero(gamma2, inverse_spatial_metric, spacetime_metric,
+                     pi, phi, normal_one_form):
+    normal_vector =\
+        np.einsum('ij,j', inverse_spatial_metric, normal_one_form)
     projection_tensor = np.identity(len(normal_vector)) -\
         np.einsum('i,j', normal_one_form, normal_vector)
     return np.einsum('ij,jab->iab', projection_tensor, phi)
 
 
-def char_field_uplus(gamma2, spacetime_metric,
-                     pi, phi, normal_one_form, normal_vector):
+def char_field_uplus(gamma2, inverse_spatial_metric, spacetime_metric,
+                     pi, phi, normal_one_form):
+    normal_vector =\
+        np.einsum('ij,j', inverse_spatial_metric, normal_one_form)
     phi_dot_normal = np.einsum('i,iab->ab', normal_vector, phi)
     return pi + 1*phi_dot_normal - (gamma2 * spacetime_metric)
 
 
-def char_field_uminus(gamma2, spacetime_metric,
-                      pi, phi, normal_one_form, normal_vector):
+def char_field_uminus(gamma2, inverse_spatial_metric, spacetime_metric,
+                      pi, phi, normal_one_form):
+    normal_vector =\
+        np.einsum('ij,j', inverse_spatial_metric, normal_one_form)
     phi_dot_normal = np.einsum('i,iab->ab', normal_vector, phi)
     return pi - phi_dot_normal - (gamma2 * spacetime_metric)
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -40,7 +40,6 @@
 // IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UZero
 // IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UMinus
 // IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UPlus
-// IWYU pragma: no_forward_declare Tags::CharSpeed
 // IWYU pragma: no_forward_declare Tags::dt
 // IWYU pragma: no_forward_declare Tensor
 // IWYU pragma: no_forward_declare Variables
@@ -529,72 +528,74 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.Characteristics",
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.MaxCharSpeed",
                   "[Unit][Evolution]") {
-  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<1, Frame::Grid>::
-            apply(Scalar<DataVector>{{{{1., 4., 3., 2., 5.}}}},
-                  Scalar<DataVector>{{{{2., 8., 10., 6., 4.}}}},
-                  Scalar<DataVector>{{{{1., 7., 3., 2., 5.}}}},
-                  Scalar<DataVector>{{{{7., 3., 4., 2., 1.}}}}) == 10.);
-  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<1, Frame::Grid>::
-            apply(Scalar<DataVector>{{{{1., 4., 3., 2., 5.}}}},
-                  Scalar<DataVector>{{{{2., 8., 10., 6., 4.}}}},
-                  Scalar<DataVector>{{{{1., 7., 3., -11., 5.}}}},
-                  Scalar<DataVector>{{{{7., 3., 4., 2., 1.}}}}) == 11.);
-  CHECK(GeneralizedHarmonic::
-            ComputeLargestCharacteristicSpeed<1, Frame::Inertial>::apply(
-                Scalar<DataVector>{{{{1., 4., 3., 2., 5.}}}},
-                Scalar<DataVector>{{{{2., 8., 10., 6., 4.}}}},
-                Scalar<DataVector>{{{{1., 7., 3., 2., 5.}}}},
-                Scalar<DataVector>{{{{7., 3., 4., 2., 1.}}}}) == 10.);
-  CHECK(GeneralizedHarmonic::
-            ComputeLargestCharacteristicSpeed<1, Frame::Inertial>::apply(
-                Scalar<DataVector>{{{{1., 4., 3., 2., 5.}}}},
-                Scalar<DataVector>{{{{2., 8., 10., 6., 4.}}}},
-                Scalar<DataVector>{{{{1., 7., 3., -11., 5.}}}},
-                Scalar<DataVector>{{{{7., 3., 4., 2., 1.}}}}) == 11.);
+  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<
+            1, Frame::Grid>::apply({{DataVector{1., 4., 3., 2., 5.},
+                                     DataVector{2., 8., 10., 6., 4.},
+                                     DataVector{1., 7., 3., 2., 5.},
+                                     DataVector{7., 3., 4., 2., 1.}}}) == 10.);
+  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<
+            1, Frame::Grid>::apply({{DataVector{1., 4., 3., 2., 5.},
+                                     DataVector{2., 8., 10., 6., 4.},
+                                     DataVector{1., 7., 3., -11., 5.},
+                                     DataVector{7., 3., 4., 2., 1.}}}) == 11.);
+  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<
+            1, Frame::Inertial>::apply({{DataVector{1., 4., 3., 2., 5.},
+                                         DataVector{2., 8., 10., 6., 4.},
+                                         DataVector{1., 7., 3., 2., 5.},
+                                         DataVector{7., 3., 4., 2., 1.}}}) ==
+        10.);
+  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<
+            1, Frame::Inertial>::apply({{DataVector{1., 4., 3., 2., 5.},
+                                         DataVector{2., 8., 10., 6., 4.},
+                                         DataVector{1., 7., 3., -11., 5.},
+                                         DataVector{7., 3., 4., 2., 1.}}}) ==
+        11.);
 
-  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<2, Frame::Grid>::
-            apply(Scalar<DataVector>{{{{1., 4., 3., 2., 5.}}}},
-                  Scalar<DataVector>{{{{2., 8., 7., 6., 4.}}}},
-                  Scalar<DataVector>{{{{1., 10., 3., 2., 5.}}}},
-                  Scalar<DataVector>{{{{7., 3., 4., 2., 1.}}}}) == 10.);
-  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<2, Frame::Grid>::
-            apply(Scalar<DataVector>{{{{1., 4., 3., 2., 5.}}}},
-                  Scalar<DataVector>{{{{2., 8., 10., 6., 4.}}}},
-                  Scalar<DataVector>{{{{1., 7., 3., 1., 5.}}}},
-                  Scalar<DataVector>{{{{7., 3., 4., 2., -11.}}}}) == 11.);
-  CHECK(GeneralizedHarmonic::
-            ComputeLargestCharacteristicSpeed<2, Frame::Inertial>::apply(
-                Scalar<DataVector>{{{{1., 4., 3., 2., 5.}}}},
-                Scalar<DataVector>{{{{2., 8., 7., 6., 4.}}}},
-                Scalar<DataVector>{{{{1., 10., 3., 2., 5.}}}},
-                Scalar<DataVector>{{{{7., 3., 4., 2., 1.}}}}) == 10.);
-  CHECK(GeneralizedHarmonic::
-            ComputeLargestCharacteristicSpeed<2, Frame::Inertial>::apply(
-                Scalar<DataVector>{{{{1., 4., 3., 2., 5.}}}},
-                Scalar<DataVector>{{{{2., 8., 10., 6., 4.}}}},
-                Scalar<DataVector>{{{{1., 7., 3., 1., 5.}}}},
-                Scalar<DataVector>{{{{7., 3., 4., 2., -11.}}}}) == 11.);
+  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<
+            2, Frame::Grid>::apply({{DataVector{1., 4., 3., 2., 5.},
+                                     DataVector{2., 8., 7., 6., 4.},
+                                     DataVector{1., 10., 3., 2., 5.},
+                                     DataVector{7., 3., 4., 2., 1.}}}) == 10.);
+  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<
+            2, Frame::Grid>::apply({{DataVector{1., 4., 3., 2., 5.},
+                                     DataVector{2., 8., 10., 6., 4.},
+                                     DataVector{1., 7., 3., 1., 5.},
+                                     DataVector{7., 3., 4., 2., -11.}}}) ==
+        11.);
+  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<
+            2, Frame::Inertial>::apply({{DataVector{1., 4., 3., 2., 5.},
+                                         DataVector{2., 8., 7., 6., 4.},
+                                         DataVector{1., 10., 3., 2., 5.},
+                                         DataVector{7., 3., 4., 2., 1.}}}) ==
+        10.);
+  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<
+            2, Frame::Inertial>::apply({{DataVector{1., 4., 3., 2., 5.},
+                                         DataVector{2., 8., 10., 6., 4.},
+                                         DataVector{1., 7., 3., 1., 5.},
+                                         DataVector{7., 3., 4., 2., -11.}}}) ==
+        11.);
 
-  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<3, Frame::Grid>::
-            apply(Scalar<DataVector>{{{{1., 4., 10., 2., 5.}}}},
-                  Scalar<DataVector>{{{{2., 8., 3., 6., 4.}}}},
-                  Scalar<DataVector>{{{{1., 7., 3., 2., 5.}}}},
-                  Scalar<DataVector>{{{{7., 3., 4., 2., 1.}}}}) == 10.);
-  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<3, Frame::Grid>::
-            apply(Scalar<DataVector>{{{{1., 4., 3., 2., 5.}}}},
-                  Scalar<DataVector>{{{{2., 8., 10., 6., 4.}}}},
-                  Scalar<DataVector>{{{{1., 7., 3., 2., 5.}}}},
-                  Scalar<DataVector>{{{{7., 3., 4., -11., 1.}}}}) == 11.);
-  CHECK(GeneralizedHarmonic::
-            ComputeLargestCharacteristicSpeed<3, Frame::Inertial>::apply(
-                Scalar<DataVector>{{{{1., 4., 10., 2., 5.}}}},
-                Scalar<DataVector>{{{{2., 8., 3., 6., 4.}}}},
-                Scalar<DataVector>{{{{1., 7., 3., 2., 5.}}}},
-                Scalar<DataVector>{{{{7., 3., 4., 2., 1.}}}}) == 10.);
-  CHECK(GeneralizedHarmonic::
-            ComputeLargestCharacteristicSpeed<3, Frame::Inertial>::apply(
-                Scalar<DataVector>{{{{1., 4., 3., 2., 5.}}}},
-                Scalar<DataVector>{{{{2., 8., 10., 6., 4.}}}},
-                Scalar<DataVector>{{{{1., 7., 3., 2., 5.}}}},
-                Scalar<DataVector>{{{{7., 3., 4., -11., 1.}}}}) == 11.);
+  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<
+            3, Frame::Grid>::apply({{DataVector{1., 4., 10., 2., 5.},
+                                     DataVector{2., 8., 3., 6., 4.},
+                                     DataVector{1., 7., 3., 2., 5.},
+                                     DataVector{7., 3., 4., 2., 1.}}}) == 10.);
+  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<
+            3, Frame::Grid>::apply({{DataVector{1., 4., 3., 2., 5.},
+                                     DataVector{2., 8., 10., 6., 4.},
+                                     DataVector{1., 7., 3., 2., 5.},
+                                     DataVector{7., 3., 4., -11., 1.}}}) ==
+        11.);
+  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<
+            3, Frame::Inertial>::apply({{DataVector{1., 4., 10., 2., 5.},
+                                         DataVector{2., 8., 3., 6., 4.},
+                                         DataVector{1., 7., 3., 2., 5.},
+                                         DataVector{7., 3., 4., 2., 1.}}}) ==
+        10.);
+  CHECK(GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<
+            3, Frame::Inertial>::apply({{DataVector{1., 4., 3., 2., 5.},
+                                         DataVector{2., 8., 10., 6., 4.},
+                                         DataVector{1., 7., 3., 2., 5.},
+                                         DataVector{7., 3., 4., -11., 1.}}}) ==
+        11.);
 }

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -46,39 +46,31 @@
 // IWYU pragma: no_forward_declare Variables
 
 namespace {
-template <typename Tag, size_t Dim, typename Frame>
-Scalar<DataVector> compute_speed_with_tag(
+template <size_t Index, size_t Dim, typename Frame>
+Scalar<DataVector> compute_speed_with_index(
     const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim, Frame>& shift,
     const tnsr::i<DataVector, Dim, Frame>& normal) {
-  return get<Tag>(
+  return Scalar<DataVector>{
       GeneralizedHarmonic::CharacteristicSpeedsCompute<Dim, Frame>::function(
-          gamma_1, lapse, shift, normal));
+          gamma_1, lapse, shift, normal)[Index]};
 }
 
 template <size_t Dim, typename Frame>
 void test_characteristic_speeds() noexcept {
   const DataVector used_for_size(5);
-  pypp::check_with_random_values<1>(
-      compute_speed_with_tag<
-          Tags::CharSpeed<GeneralizedHarmonic::Tags::UPsi<Dim, Frame>>, Dim,
-          Frame>,
-      "TestFunctions", "char_speed_upsi", {{{-10.0, 10.0}}}, used_for_size);
-  pypp::check_with_random_values<1>(
-      compute_speed_with_tag<
-          Tags::CharSpeed<GeneralizedHarmonic::Tags::UZero<Dim, Frame>>, Dim,
-          Frame>,
-      "TestFunctions", "char_speed_uzero", {{{-10.0, 10.0}}}, used_for_size);
-  pypp::check_with_random_values<1>(
-      compute_speed_with_tag<
-          Tags::CharSpeed<GeneralizedHarmonic::Tags::UMinus<Dim, Frame>>, Dim,
-          Frame>,
-      "TestFunctions", "char_speed_uminus", {{{-10.0, 10.0}}}, used_for_size);
-  pypp::check_with_random_values<1>(
-      compute_speed_with_tag<
-          Tags::CharSpeed<GeneralizedHarmonic::Tags::UPlus<Dim, Frame>>, Dim,
-          Frame>,
-      "TestFunctions", "char_speed_uplus", {{{-10.0, 10.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(compute_speed_with_index<0, Dim, Frame>,
+                                    "TestFunctions", "char_speed_upsi",
+                                    {{{-10.0, 10.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(compute_speed_with_index<1, Dim, Frame>,
+                                    "TestFunctions", "char_speed_uzero",
+                                    {{{-10.0, 10.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(compute_speed_with_index<3, Dim, Frame>,
+                                    "TestFunctions", "char_speed_uminus",
+                                    {{{-10.0, 10.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(compute_speed_with_index<2, Dim, Frame>,
+                                    "TestFunctions", "char_speed_uplus",
+                                    {{{-10.0, 10.0}}}, used_for_size);
 }
 
 // Test return-by-reference GH char speeds by comparing to Kerr-Schild
@@ -140,22 +132,10 @@ void test_characteristic_speeds_analytic(
       GeneralizedHarmonic::CharacteristicSpeedsCompute<
           spatial_dim, Frame::Inertial>::function(gamma_1, lapse, shift,
                                                   unit_normal_one_form);
-  const auto& upsi_speed_from_func =
-      get(get<Tags::CharSpeed<
-              GeneralizedHarmonic::Tags::UPsi<spatial_dim, Frame::Inertial>>>(
-          char_speeds_from_func));
-  const auto& uzero_speed_from_func =
-      get(get<Tags::CharSpeed<
-              GeneralizedHarmonic::Tags::UZero<spatial_dim, Frame::Inertial>>>(
-          char_speeds_from_func));
-  const auto& uplus_speed_from_func =
-      get(get<Tags::CharSpeed<
-              GeneralizedHarmonic::Tags::UPlus<spatial_dim, Frame::Inertial>>>(
-          char_speeds_from_func));
-  const auto& uminus_speed_from_func =
-      get(get<Tags::CharSpeed<
-              GeneralizedHarmonic::Tags::UMinus<spatial_dim, Frame::Inertial>>>(
-          char_speeds_from_func));
+  const auto& upsi_speed_from_func = char_speeds_from_func[0];
+  const auto& uzero_speed_from_func = char_speeds_from_func[1];
+  const auto& uplus_speed_from_func = char_speeds_from_func[2];
+  const auto& uminus_speed_from_func = char_speeds_from_func[3];
 
   CHECK_ITERABLE_APPROX(upsi_speed, upsi_speed_from_func);
   CHECK_ITERABLE_APPROX(uzero_speed, uzero_speed_from_func);
@@ -168,14 +148,15 @@ namespace {
 template <typename Tag, size_t Dim, typename Frame>
 typename Tag::type compute_field_with_tag(
     const Scalar<DataVector>& gamma_2,
+    const tnsr::II<DataVector, Dim, Frame>& inverse_spatial_metric,
     const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
     const tnsr::aa<DataVector, Dim, Frame>& pi,
     const tnsr::iaa<DataVector, Dim, Frame>& phi,
-    const tnsr::i<DataVector, Dim, Frame>& normal_one_form,
-    const tnsr::I<DataVector, Dim, Frame>& normal_vector) {
+    const tnsr::i<DataVector, Dim, Frame>& normal_one_form) {
   return get<Tag>(
       GeneralizedHarmonic::CharacteristicFieldsCompute<Dim, Frame>::function(
-          gamma_2, spacetime_metric, pi, phi, normal_one_form, normal_vector));
+          gamma_2, inverse_spatial_metric, spacetime_metric, pi, phi,
+          normal_one_form));
 }
 
 template <size_t Dim, typename Frame>
@@ -202,7 +183,8 @@ void test_characteristic_fields() noexcept {
   pypp::check_with_random_values<1>(
       compute_field_with_tag<GeneralizedHarmonic::Tags::UMinus<Dim, Frame>, Dim,
                              Frame>,
-      "TestFunctions", "char_field_uminus", {{{-100., 100.}}}, used_for_size);
+      "TestFunctions", "char_field_uminus", {{{-100., 100.}}}, used_for_size,
+      1.e-10);
 }
 
 // Test return-by-reference GH char fields by comparing to Kerr-Schild
@@ -315,9 +297,9 @@ void test_characteristic_fields_analytic(
 
   // Check that locally computed fields match returned ones
   const auto uvars = GeneralizedHarmonic::CharacteristicFieldsCompute<
-      spatial_dim, Frame::Inertial>::function(gamma_2, spacetime_metric, pi,
-                                              phi, unit_normal_one_form,
-                                              normal);
+      spatial_dim, Frame::Inertial>::function(gamma_2, inverse_spatial_metric,
+                                              spacetime_metric, pi, phi,
+                                              unit_normal_one_form);
 
   const auto& upsi_from_func =
       get<GeneralizedHarmonic::Tags::UPsi<spatial_dim, Frame::Inertial>>(uvars);


### PR DESCRIPTION
## Proposed changes

This PR changes the storage of characteristic fields for the GeneralizedHarmonic evolution system to `std::array` (from `Variables`). This is needed when imposing boundary conditions. This change also makes the GH system consistent with others, i.e. `GrMhd`, `NewtonianEuler` etc that already use `std::array`s.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
