### PR TITLE
fill in name of wrapped tag in prefix dt's name

### DIFF
--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -26,7 +26,7 @@ namespace Tags {
 /// \brief Prefix indicating a time derivative
 template <typename Tag>
 struct dt : db::PrefixTag, db::SimpleTag {
-  static std::string name() noexcept { return "dt"; }
+  static std::string name() noexcept { return "dt(" + Tag::name() + ")"; }
   using type = db::item_type<Tag>;
   using tag = Tag;
 };

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
@@ -24,4 +24,5 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Prefixes",
   CHECK(Tags::Next<Tag>::name() == "Next(" + Tag::name() + ")");
   /// [next_name]
   CHECK(Tags::CharSpeed<Tag>::name() == "CharSpeed(Tag)");
+  CHECK(Tags::dt<Tag>::name() == "dt(Tag)");
 }


### PR DESCRIPTION
## Proposed changes

Change output of member function `name` for the prefix tag `dt`, to include the name of the tag that `dt` wraps.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
