### PR TITLE
Add wrapper that applies minmod TCI to several tensors

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY SlopeLimiters)
 
 set(LIBRARY_SOURCES
+  MinmodHelpers.cpp
   MinmodTci.cpp
   MinmodType.cpp
   WenoGridHelpers.cpp

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.tpp
@@ -235,7 +235,7 @@ bool Minmod<VolumeDim, tmpl::list<Tags...>>::operator()(
   // Compute the slice indices once since this is (surprisingly) expensive
   const auto volume_and_slice_buffer_and_indices =
       volume_and_slice_indices(mesh.extents());
-  const auto volume_and_slice_indices =
+  const auto& volume_and_slice_indices =
       volume_and_slice_buffer_and_indices.second;
 
   bool limiter_activated = false;

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodHelpers.cpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodHelpers.hpp"
+
+#include <array>
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "Domain/Mesh.hpp"                // IWYU pragma: keep
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/Numeric.hpp"
+
+namespace SlopeLimiters {
+namespace Minmod_detail {
+
+template <size_t VolumeDim>
+void allocate_buffers(
+    const gsl::not_null<std::unique_ptr<double[], decltype(&free)>*>
+        contiguous_buffer,
+    const gsl::not_null<DataVector*> u_lin_buffer,
+    const gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
+    const Mesh<VolumeDim>& mesh) noexcept {
+  const size_t half_number_boundary_points = alg::accumulate(
+      alg::iota(std::array<size_t, VolumeDim>{{}}, 0_st),
+      0_st, [&mesh](const size_t state, const size_t d) noexcept {
+        return state + mesh.slice_away(d).number_of_grid_points();
+      });
+  contiguous_buffer->reset(static_cast<double*>(
+      malloc(sizeof(double) *
+             (mesh.number_of_grid_points() + half_number_boundary_points))));
+  size_t alloc_offset = 0;
+  u_lin_buffer->set_data_ref(contiguous_buffer->get() + alloc_offset,
+                             mesh.number_of_grid_points());
+  alloc_offset += mesh.number_of_grid_points();
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    const size_t num_points = mesh.slice_away(d).number_of_grid_points();
+    gsl::at(*boundary_buffer, d)
+        .set_data_ref(contiguous_buffer->get() + alloc_offset, num_points);
+    alloc_offset += num_points;
+  }
+}
+
+// Explicit instantiations
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                            \
+  template void allocate_buffers<DIM(data)>(                            \
+      const gsl::not_null<std::unique_ptr<double[], decltype(&free)>*>, \
+      const gsl::not_null<DataVector*>,                                 \
+      const gsl::not_null<std::array<DataVector, DIM(data)>*>,          \
+      const Mesh<DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+
+}  // namespace Minmod_detail
+}  // namespace SlopeLimiters

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodHelpers.hpp
@@ -1,0 +1,120 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstdlib>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/Tags.hpp"  // IWYU pragma: keep
+#include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+class DataVector;
+template <size_t VolumeDim>
+class Element;
+template <size_t VolumeDim>
+class ElementId;
+template <size_t VolumeDim>
+class Mesh;
+
+namespace boost {
+template <class T>
+struct hash;
+}  // namespace boost
+/// \endcond
+
+namespace SlopeLimiters {
+namespace Minmod_detail {
+
+// Allocate the buffers `u_lin_buffer` and `boundary_buffer` to the correct
+// sizes expected by `troubled_cell_indicator` for its arguments
+template <size_t VolumeDim>
+void allocate_buffers(
+    gsl::not_null<std::unique_ptr<double[], decltype(&free)>*>
+        contiguous_buffer,
+    gsl::not_null<DataVector*> u_lin_buffer,
+    gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
+    const Mesh<VolumeDim>& mesh) noexcept;
+
+// In each direction, average the size of all different neighbors in that
+// direction. Note that only the component of neighor_size that is normal
+// to the face is needed (and, therefore, computed).
+//
+// Expects type `PackagedData` to contain a variable `element_size` that is a
+// `std::array<double, VolumeDim>`.
+template <size_t VolumeDim, typename PackagedData>
+DirectionMap<VolumeDim, double> compute_effective_neighbor_sizes(
+    const Element<VolumeDim>& element,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_data) noexcept {
+  DirectionMap<VolumeDim, double> result;
+  for (const auto& dir : Direction<VolumeDim>::all_directions()) {
+    const auto& externals = element.external_boundaries();
+    const bool neighbors_in_this_dir = (externals.find(dir) == externals.end());
+    if (neighbors_in_this_dir) {
+      const double effective_neighbor_size =
+          [&dir, &element, &neighbor_data ]() noexcept {
+        const size_t dim = dir.dimension();
+        const auto& neighbor_ids = element.neighbors().at(dir).ids();
+        double size_accumulate = 0.;
+        for (const auto& id : neighbor_ids) {
+          size_accumulate += gsl::at(
+              neighbor_data.at(std::make_pair(dir, id)).element_size, dim);
+        }
+        return size_accumulate / neighbor_ids.size();
+      }
+      ();
+      result.insert(std::make_pair(dir, effective_neighbor_size));
+    }
+  }
+  return result;
+}
+
+// In each direction, average the mean of the specified tensor component over
+// all different neighbors that direction. This produces one effective neighbor
+// per direction.
+//
+// Expects type `PackagedData` to contain a variable `means` that is a
+// `TaggedTuple<Tags::Mean<Tags>...>`. Tags... must contain Tag, the tag
+// specifying the tensor to work with.
+template <typename Tag, size_t VolumeDim, typename PackagedData>
+DirectionMap<VolumeDim, double> compute_effective_neighbor_means(
+    const Element<VolumeDim>& element, const size_t tensor_storage_index,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_data) noexcept {
+  DirectionMap<VolumeDim, double> result;
+  for (const auto& dir : Direction<VolumeDim>::all_directions()) {
+    const auto& externals = element.external_boundaries();
+    const bool neighbors_in_this_dir = (externals.find(dir) == externals.end());
+    if (neighbors_in_this_dir) {
+      const double effective_neighbor_mean =
+          [&dir, &element, &neighbor_data, &tensor_storage_index ]() noexcept {
+        const auto& neighbor_ids = element.neighbors().at(dir).ids();
+        double mean_accumulate = 0.0;
+        for (const auto& id : neighbor_ids) {
+          mean_accumulate += tuples::get<::Tags::Mean<Tag>>(
+              neighbor_data.at(std::make_pair(dir, id))
+                  .means)[tensor_storage_index];
+        }
+        return mean_accumulate / neighbor_ids.size();
+      }
+      ();
+      result.insert(std::make_pair(dir, effective_neighbor_mean));
+    }
+  }
+  return result;
+}
+
+}  // namespace Minmod_detail
+}  // namespace SlopeLimiters

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodTci.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodTci.cpp
@@ -21,9 +21,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 
-namespace SlopeLimiters {
-namespace Minmod_detail {
-
+namespace {
 // Encodes the return status of the minmod_tvbm function.
 struct MinmodResult {
   const double value;
@@ -51,6 +49,10 @@ MinmodResult minmod_tvbm(const double a, const double b, const double c,
     return {0.0, true};
   }
 }
+}  // namespace
+
+namespace SlopeLimiters {
+namespace Minmod_detail {
 
 template <size_t VolumeDim>
 bool troubled_cell_indicator(

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodTci.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodTci.cpp
@@ -9,7 +9,6 @@
 #include <limits>
 #include <utility>
 
-#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "Domain/Direction.hpp"
 #include "Domain/Element.hpp"  // IWYU pragma: keep
 #include "Domain/Side.hpp"

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodTci.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodTci.cpp
@@ -12,7 +12,6 @@
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "Domain/Direction.hpp"
 #include "Domain/Element.hpp"  // IWYU pragma: keep
-#include "Domain/Mesh.hpp"     // IWYU pragma: keep
 #include "Domain/Side.hpp"
 #include "NumericalAlgorithms/LinearOperators/Linearize.hpp"
 #include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodTci.hpp
@@ -5,19 +5,33 @@
 
 #include <array>
 #include <cstdlib>
+#include <memory>
+#include <unordered_map>
 #include <utility>
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodHelpers.hpp"
 #include "Evolution/DiscontinuousGalerkin/SlopeLimiters/MinmodType.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+template <size_t VolumeDim>
+class Direction;
 template <size_t Dim, typename T>
 class DirectionMap;
 template <size_t VolumeDim>
 class Element;
 template <size_t VolumeDim>
+class ElementId;
+template <size_t VolumeDim>
 class Mesh;
+
+namespace boost {
+template <class T>
+struct hash;
+}  // namespace boost
 /// \endcond
 
 namespace SlopeLimiters {
@@ -45,6 +59,84 @@ bool troubled_cell_indicator(
     const std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,
                                gsl::span<std::pair<size_t, size_t>>>,
                      VolumeDim>& volume_and_slice_indices) noexcept;
+
+// Implements the minmod troubled-cell indicator on several tensors.
+//
+// Internally loops over all tensors and tensor components, calling the above
+// function for each case. Returns true if any of the components needs limiting.
+// Optimization: stops as soon as one component needs limiting, because no
+// intermediate results are passed "up" out of this function.
+//
+// Expects type `PackagedData` to contain, as in SlopeLimiters::Minmod:
+// - a variable `means` that is a `TaggedTuple<Tags::Mean<Tags>...>`
+// - a variable `element_size` that is a `std::array<double, VolumeDim>`
+template <size_t VolumeDim, typename PackagedData, typename... Tags>
+bool troubled_cell_indicator(
+    const db::item_type<Tags>&... tensors,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_data,
+    const SlopeLimiters::MinmodType& minmod_type, double tvbm_constant,
+    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
+    const std::array<double, VolumeDim>& element_size) noexcept {
+  // Optimization: allocate temporary buffer to be used in TCI
+  std::unique_ptr<double[], decltype(&free)> contiguous_buffer(nullptr, &free);
+  DataVector u_lin_buffer{};
+  std::array<DataVector, VolumeDim> boundary_buffer{};
+  Minmod_detail::allocate_buffers(make_not_null(&contiguous_buffer),
+                                  make_not_null(&u_lin_buffer),
+                                  make_not_null(&boundary_buffer), mesh);
+
+  // Optimization: precompute the slice indices since this is (surprisingly)
+  // expensive
+  const auto volume_and_slice_buffer_and_indices =
+      volume_and_slice_indices(mesh.extents());
+  const auto& volume_and_slice_indices =
+      volume_and_slice_buffer_and_indices.second;
+
+  const auto effective_neighbor_sizes =
+      compute_effective_neighbor_sizes(element, neighbor_data);
+
+  // Ideally, as soon as one component is found that needs limiting, then we
+  // would exit the TCI early with return value `true`. But there is no natural
+  // way to return early from the pack expansion. So we use this bool to keep
+  // track of whether a previous component needed limiting... and if so, then
+  // we simply skip any work.
+  bool some_component_needs_limiting = false;
+  const auto wrap_tci_one_tensor = [&](auto tag, const auto& tensor) noexcept {
+    if (some_component_needs_limiting) {
+      // Skip this tensor completely
+      return '0';
+    }
+
+    for (size_t tensor_storage_index = 0; tensor_storage_index < tensor.size();
+         ++tensor_storage_index) {
+      const auto effective_neighbor_means =
+          compute_effective_neighbor_means<decltype(tag)>(
+              element, tensor_storage_index, neighbor_data);
+
+      const DataVector& u = tensor[tensor_storage_index];
+      double u_mean;
+      std::array<double, VolumeDim> u_limited_slopes{};
+      const bool reduce_slope = troubled_cell_indicator(
+          make_not_null(&u_mean), make_not_null(&u_limited_slopes),
+          make_not_null(&u_lin_buffer), make_not_null(&boundary_buffer),
+          minmod_type, tvbm_constant, u, element, mesh, element_size,
+          effective_neighbor_means, effective_neighbor_sizes,
+          volume_and_slice_indices);
+
+      if (reduce_slope) {
+        some_component_needs_limiting = true;
+        // Skip remaining components of this tensor
+        return '0';
+      }
+    }
+    return '0';
+  };
+  expand_pack(wrap_tci_one_tensor(Tags{}, tensors)...);
+  return some_component_needs_limiting;
+}
 
 }  // namespace Minmod_detail
 }  // namespace SlopeLimiters


### PR DESCRIPTION
## Proposed changes

Adds a wrapper checks whether the minmod TCI triggers for any ~component of the Variables~ edit: of several input tensors, which can be used to trigger WENO or other more sophisticated limiters.

Depends on #1433  

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

