### PR TITLE
Add compute items for foliation related GR quantities

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.cpp
@@ -19,6 +19,43 @@
 
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
+void phi(const gsl::not_null<tnsr::iaa<DataType, SpatialDim, Frame>*> phi,
+         const Scalar<DataType>& lapse,
+         const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+         const tnsr::I<DataType, SpatialDim, Frame>& shift,
+         const tnsr::iJ<DataType, SpatialDim, Frame>& deriv_shift,
+         const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+         const tnsr::ijj<DataType, SpatialDim, Frame>&
+             deriv_spatial_metric) noexcept {
+  if (UNLIKELY(get_size(get<0, 0, 0>(*phi)) != get_size(get(lapse)))) {
+    *phi = tnsr::iaa<DataType, SpatialDim, Frame>(get_size(get(lapse)));
+  }
+  for (size_t k = 0; k < SpatialDim; ++k) {
+    phi->get(k, 0, 0) = -2. * get(lapse) * deriv_lapse.get(k);
+    for (size_t m = 0; m < SpatialDim; ++m) {
+      for (size_t n = 0; n < SpatialDim; ++n) {
+        phi->get(k, 0, 0) +=
+            deriv_spatial_metric.get(k, m, n) * shift.get(m) * shift.get(n) +
+            2. * spatial_metric.get(m, n) * shift.get(m) *
+                deriv_shift.get(k, n);
+      }
+    }
+
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      phi->get(k, 0, i + 1) = 0.;
+      for (size_t m = 0; m < SpatialDim; ++m) {
+        phi->get(k, 0, i + 1) +=
+            deriv_spatial_metric.get(k, m, i) * shift.get(m) +
+            spatial_metric.get(m, i) * deriv_shift.get(k, m);
+      }
+      for (size_t j = i; j < SpatialDim; ++j) {
+        phi->get(k, i + 1, j + 1) = deriv_spatial_metric.get(k, i, j);
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::iaa<DataType, SpatialDim, Frame> phi(
     const Scalar<DataType>& lapse,
     const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
@@ -27,31 +64,53 @@ tnsr::iaa<DataType, SpatialDim, Frame> phi(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ijj<DataType, SpatialDim, Frame>&
         deriv_spatial_metric) noexcept {
-  tnsr::iaa<DataType, SpatialDim, Frame> phi(
-      make_with_value<DataType>(deriv_lapse, 0.));
-  for (size_t k = 0; k < SpatialDim; ++k) {
-    phi.get(k, 0, 0) = -2.0 * get(lapse) * deriv_lapse.get(k);
-    for (size_t m = 0; m < SpatialDim; ++m) {
-      for (size_t n = 0; n < SpatialDim; ++n) {
-        phi.get(k, 0, 0) +=
-            deriv_spatial_metric.get(k, m, n) * shift.get(m) * shift.get(n) +
-            2. * spatial_metric.get(m, n) * shift.get(m) *
-                deriv_shift.get(k, n);
-      }
-    }
+  tnsr::iaa<DataType, SpatialDim, Frame> var_phi{};
+  GeneralizedHarmonic::phi<SpatialDim, Frame, DataType>(
+      make_not_null(&var_phi), lapse, deriv_lapse, shift, deriv_shift,
+      spatial_metric, deriv_spatial_metric);
+  return var_phi;
+}
 
-    for (size_t i = 0; i < SpatialDim; ++i) {
-      for (size_t m = 0; m < SpatialDim; ++m) {
-        phi.get(k, 0, i + 1) +=
-            deriv_spatial_metric.get(k, m, i) * shift.get(m) +
-            spatial_metric.get(m, i) * deriv_shift.get(k, m);
-      }
-      for (size_t j = i; j < SpatialDim; ++j) {
-        phi.get(k, i + 1, j + 1) = deriv_spatial_metric.get(k, i, j);
-      }
+template <size_t SpatialDim, typename Frame, typename DataType>
+void pi(const gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame>*> pi,
+        const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
+        const tnsr::I<DataType, SpatialDim, Frame>& shift,
+        const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
+        const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+        const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+        const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
+  if (UNLIKELY(get_size(get<0, 0>(*pi)) != get_size(get(lapse)))) {
+    *pi = tnsr::aa<DataType, SpatialDim, Frame>(get_size(get(lapse)));
+  }
+
+  get<0, 0>(*pi) = -2. * get(lapse) * get(dt_lapse);
+
+  for (size_t m = 0; m < SpatialDim; ++m) {
+    for (size_t n = 0; n < SpatialDim; ++n) {
+      get<0, 0>(*pi) +=
+          dt_spatial_metric.get(m, n) * shift.get(m) * shift.get(n) +
+          2. * spatial_metric.get(m, n) * shift.get(m) * dt_shift.get(n);
     }
   }
-  return phi;
+
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    pi->get(0, i + 1) = 0.;
+    for (size_t m = 0; m < SpatialDim; ++m) {
+      pi->get(0, i + 1) += dt_spatial_metric.get(m, i) * shift.get(m) +
+                           spatial_metric.get(m, i) * dt_shift.get(m);
+    }
+    for (size_t j = i; j < SpatialDim; ++j) {
+      pi->get(i + 1, j + 1) = dt_spatial_metric.get(i, j);
+    }
+  }
+  for (size_t mu = 0; mu < SpatialDim + 1; ++mu) {
+    for (size_t nu = mu; nu < SpatialDim + 1; ++nu) {
+      for (size_t i = 0; i < SpatialDim; ++i) {
+        pi->get(mu, nu) -= shift.get(i) * phi.get(i, mu, nu);
+      }
+      pi->get(mu, nu) /= -get(lapse);
+    }
+  }
 }
 
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -62,36 +121,10 @@ tnsr::aa<DataType, SpatialDim, Frame> pi(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
-  tnsr::aa<DataType, SpatialDim, Frame> pi{
-      make_with_value<DataType>(lapse, 0.)};
-
-  get<0, 0>(pi) = -2. * get(lapse) * get(dt_lapse);
-
-  for (size_t m = 0; m < SpatialDim; ++m) {
-    for (size_t n = 0; n < SpatialDim; ++n) {
-      get<0, 0>(pi) +=
-          dt_spatial_metric.get(m, n) * shift.get(m) * shift.get(n) +
-          2. * spatial_metric.get(m, n) * shift.get(m) * dt_shift.get(n);
-    }
-  }
-
-  for (size_t i = 0; i < SpatialDim; ++i) {
-    for (size_t m = 0; m < SpatialDim; ++m) {
-      pi.get(0, i + 1) += dt_spatial_metric.get(m, i) * shift.get(m) +
-                          spatial_metric.get(m, i) * dt_shift.get(m);
-    }
-    for (size_t j = i; j < SpatialDim; ++j) {
-      pi.get(i + 1, j + 1) = dt_spatial_metric.get(i, j);
-    }
-  }
-  for (size_t mu = 0; mu < SpatialDim + 1; ++mu) {
-    for (size_t nu = mu; nu < SpatialDim + 1; ++nu) {
-      for (size_t i = 0; i < SpatialDim; ++i) {
-        pi.get(mu, nu) -= shift.get(i) * phi.get(i, mu, nu);
-      }
-      pi.get(mu, nu) /= -get(lapse);
-    }
-  }
+  tnsr::aa<DataType, SpatialDim, Frame> pi{};
+  GeneralizedHarmonic::pi<SpatialDim, Frame, DataType>(
+      make_not_null(&pi), lapse, dt_lapse, shift, dt_shift, spatial_metric,
+      dt_spatial_metric, phi);
   return pi;
 }
 
@@ -696,6 +729,16 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_norm_of_shift(
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
 #define INSTANTIATE(_, data)                                                  \
+  template void GeneralizedHarmonic::phi(                                     \
+      const gsl::not_null<tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>*>    \
+          var_phi,                                                            \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& deriv_lapse,        \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>& deriv_shift,       \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,    \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          deriv_spatial_metric) noexcept;                                     \
   template tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>                     \
   GeneralizedHarmonic::phi(                                                   \
       const Scalar<DTYPE(data)>& lapse,                                       \
@@ -705,6 +748,15 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_norm_of_shift(
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,    \
       const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>&                   \
           deriv_spatial_metric) noexcept;                                     \
+  template void GeneralizedHarmonic::pi(                                      \
+      const gsl::not_null<tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>*>     \
+          var_pi,                                                             \
+      const Scalar<DTYPE(data)>& lapse, const Scalar<DTYPE(data)>& dt_lapse,  \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& dt_shift,           \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,    \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
   template tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>                      \
   GeneralizedHarmonic::pi(                                                    \
       const Scalar<DTYPE(data)>& lapse, const Scalar<DTYPE(data)>& dt_lapse,  \

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -18,6 +18,7 @@ class not_null;
 /// \endcond
 
 namespace GeneralizedHarmonic {
+// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the auxiliary variable \f$\Phi_{iab}\f$ used by the
@@ -36,6 +37,16 @@ namespace GeneralizedHarmonic {
  * \f}
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
+void phi(gsl::not_null<tnsr::iaa<DataType, SpatialDim, Frame>*> phi,
+         const Scalar<DataType>& lapse,
+         const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+         const tnsr::I<DataType, SpatialDim, Frame>& shift,
+         const tnsr::iJ<DataType, SpatialDim, Frame>& deriv_shift,
+         const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+         const tnsr::ijj<DataType, SpatialDim, Frame>&
+             deriv_spatial_metric) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::iaa<DataType, SpatialDim, Frame> phi(
     const Scalar<DataType>& lapse,
     const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
@@ -44,7 +55,9 @@ tnsr::iaa<DataType, SpatialDim, Frame> phi(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ijj<DataType, SpatialDim, Frame>&
         deriv_spatial_metric) noexcept;
+// @}
 
+// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the conjugate momentum \f$\Pi_{ab}\f$ of the spacetime metric
@@ -66,6 +79,15 @@ tnsr::iaa<DataType, SpatialDim, Frame> phi(
  * \f}
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
+void pi(gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame>*> pi,
+        const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
+        const tnsr::I<DataType, SpatialDim, Frame>& shift,
+        const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
+        const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+        const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+        const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::aa<DataType, SpatialDim, Frame> pi(
     const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
@@ -73,6 +95,7 @@ tnsr::aa<DataType, SpatialDim, Frame> pi(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+// @}
 
 /*!
  * \ingroup GeneralRelativityGroup

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
@@ -3,39 +3,58 @@
 
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
 
-#include <cmath>
+#include <cmath>  // IWYU pragma: keep
 
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+
+// IWYU pragma: no_include <complex>
 
 namespace gr {
 template <size_t Dim, typename Frame, typename DataType>
-tnsr::aa<DataType, Dim, Frame> spacetime_metric(
+void spacetime_metric(
+    const gsl::not_null<tnsr::aa<DataType, Dim, Frame>*> spacetime_metric,
     const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Frame>& shift,
     const tnsr::ii<DataType, Dim, Frame>& spatial_metric) noexcept {
-  auto spacetime_metric =
-      make_with_value<tnsr::aa<DataType, Dim, Frame>>(lapse, 0.);
+  if (UNLIKELY(get_size(get<0, 0>(*spacetime_metric)) !=
+               get_size(get(lapse)))) {
+    *spacetime_metric = tnsr::aa<DataType, Dim, Frame>(get_size(get(lapse)));
+  }
 
-  get<0, 0>(spacetime_metric) = -get(lapse) * get(lapse);
+  get<0, 0>(*spacetime_metric) = -square(get(lapse));
 
   for (size_t m = 0; m < Dim; ++m) {
-    get<0, 0>(spacetime_metric) +=
-        spatial_metric.get(m, m) * shift.get(m) * shift.get(m);
+    get<0, 0>(*spacetime_metric) +=
+        spatial_metric.get(m, m) * square(shift.get(m));
     for (size_t n = 0; n < m; ++n) {
-      get<0, 0>(spacetime_metric) +=
-          2 * spatial_metric.get(m, n) * shift.get(m) * shift.get(n);
+      get<0, 0>(*spacetime_metric) +=
+          2. * spatial_metric.get(m, n) * shift.get(m) * shift.get(n);
     }
   }
 
   for (size_t i = 0; i < Dim; ++i) {
+    spacetime_metric->get(0, i + 1) = 0.;
     for (size_t m = 0; m < Dim; ++m) {
-      spacetime_metric.get(0, i + 1) += spatial_metric.get(m, i) * shift.get(m);
+      spacetime_metric->get(0, i + 1) +=
+          spatial_metric.get(m, i) * shift.get(m);
     }
     for (size_t j = i; j < Dim; ++j) {
-      spacetime_metric.get(i + 1, j + 1) = spatial_metric.get(i, j);
+      spacetime_metric->get(i + 1, j + 1) = spatial_metric.get(i, j);
     }
   }
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::aa<DataType, Dim, Frame> spacetime_metric(
+    const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Frame>& shift,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_metric) noexcept {
+  tnsr::aa<DataType, Dim, Frame> spacetime_metric{};
+  gr::spacetime_metric<Dim, Frame, DataType>(make_not_null(&spacetime_metric),
+                                             lapse, shift, spatial_metric);
   return spacetime_metric;
 }
 
@@ -231,6 +250,13 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
 #define INSTANTIATE(_, data)                                                   \
+  template void gr::spacetime_metric(                                          \
+      const gsl::not_null<tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>*>      \
+          spacetime_metric,                                                    \
+      const Scalar<DTYPE(data)>& lapse,                                        \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,               \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spatial_metric) noexcept;                                            \
   template tnsr::aa<DTYPE(data), DIM(data), FRAME(data)> gr::spacetime_metric( \
       const Scalar<DTYPE(data)>& lapse,                                        \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,               \

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -6,9 +6,16 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstddef>
+#include <cstdint>
+#include <utility>
 
-#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
 namespace gsl {
@@ -190,4 +197,219 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
     const tnsr::ijj<DataType, SpatialDim, Frame>&
         deriv_spatial_metric) noexcept;
 
+namespace Tags {
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for spacetime metric \f$\psi_{ab}\f$ from the
+ * lapse \f$N\f$, shift \f$N^i\f$, and spatial metric \f$g_{ij}\f$..
+ *
+ * \details Can be retrieved using `gr::Tags::SpacetimeMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpacetimeMetricCompute : SpacetimeMetric<SpatialDim, Frame, DataType>,
+                                db::ComputeTag {
+  using argument_tags =
+      tmpl::list<Lapse<DataType>, Shift<SpatialDim, Frame, DataType>,
+                 SpatialMetric<SpatialDim, Frame, DataType>>;
+  using base = SpacetimeMetric<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+  static constexpr tnsr::aa<DataType, SpatialDim, Frame> (*function)(
+      const Scalar<DataType>&, const tnsr::I<DataType, SpatialDim, Frame>&,
+      const tnsr::ii<DataType, SpatialDim, Frame>&) =
+      &spacetime_metric<SpatialDim, Frame, DataType>;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for inverse spacetime metric \f$\psi^{ab}\f$
+ * in terms of the lapse \f$N\f$, shift \f$N^i\f$, and inverse
+ * spatial metric \f$g^{ij}\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::InverseSpacetimeMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct InverseSpacetimeMetricCompute
+    : InverseSpacetimeMetric<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<Lapse<DataType>, Shift<SpatialDim, Frame, DataType>,
+                 InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static constexpr auto function =
+      &inverse_spacetime_metric<SpatialDim, Frame, DataType>;
+  using base = InverseSpacetimeMetric<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for spatial metric \f$g_{ij}\f$ from the
+ * spacetime metric \f$\psi_{ab}\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::SpatialMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpatialMetricCompute : SpatialMetric<SpatialDim, Frame, DataType>,
+                              db::ComputeTag {
+  using argument_tags =
+      tmpl::list<SpacetimeMetric<SpatialDim, Frame, DataType>>;
+  static constexpr auto function = &spatial_metric<SpatialDim, Frame, DataType>;
+  using base = SpatialMetric<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for spatial metric determinant \f$\g\f$
+ * and inversre \f$g^{ij}\f$in terms of the spatial metric \f$g_{ij}\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::DetAndInverseSpatialMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct DetAndInverseSpatialMetricCompute
+    : DetAndInverseSpatialMetric<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<SpatialMetric<SpatialDim, Frame, DataType>>;
+  using base = DetAndInverseSpatialMetric<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+  static constexpr auto function =
+      &determinant_and_inverse<DataType,
+                               tmpl::integral_list<std::int32_t, 1, 1>,
+                               SpatialIndex<SpatialDim, UpLo::Lo, Frame>,
+                               SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item to get the square root of the determinant of the spatial
+ * metric \f$\sqrt{g}\f$ via `gr::Tags::DetAndInverseSpatialMetric`.
+ *
+ * \details Can be retrieved using `gr::Tags::DetSpatialMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct DetSpatialMetricCompute : DetSpatialMetric<DataType>, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<DetAndInverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static auto& function(
+      const std::pair<Scalar<DataType>, tnsr::II<DataType, SpatialDim, Frame>>&
+          det_and_inverse_spatial_metric) {
+    return det_and_inverse_spatial_metric.first;
+  }
+  using base = DetSpatialMetric<DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item to get the square root of the determinant of the spatial
+ * metric \f$\sqrt{g}\f$ via `gr::Tags::DetAndInverseSpatialMetric`.
+ *
+ * \details Can be retrieved using `gr::Tags::SqrtDetSpatialMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SqrtDetSpatialMetricCompute : SqrtDetSpatialMetric<DataType>,
+                                     db::ComputeTag {
+  using argument_tags =
+      tmpl::list<DetAndInverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static Scalar<DataType> function(
+      const std::pair<Scalar<DataType>, tnsr::II<DataType, SpatialDim, Frame>>&
+          det_and_inverse_spatial_metric) {
+    return Scalar<DataType>{sqrt(get(det_and_inverse_spatial_metric.first))};
+  }
+  using base = SqrtDetSpatialMetric<DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for inverse spatial metric \f$\g^{ij}\f$
+ * via `gr::Tags::DetAndInverseSpatialMetric`.
+ *
+ * \details Can be retrieved using `gr::Tags::InverseSpatialMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct InverseSpatialMetricCompute
+    : InverseSpatialMetric<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<DetAndInverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static const auto& function(
+      const std::pair<Scalar<DataType>, tnsr::II<DataType, SpatialDim, Frame>>&
+          det_and_inverse_spatial_metric) {
+    return det_and_inverse_spatial_metric.second;
+  }
+  using base = InverseSpatialMetric<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for shift \f$N^i\f$ from the spacetime metric
+ * \f$\psi_{ab}\f$ and the inverse spatial metric \f$g^{ij}\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::Shift`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct ShiftCompute : Shift<SpatialDim, Frame, DataType>, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<SpacetimeMetric<SpatialDim, Frame, DataType>,
+                 InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static constexpr auto function = &shift<SpatialDim, Frame, DataType>;
+  using base = Shift<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for lapse \f$N\f$ from the spacetime metric
+ * \f$\psi_{ab}\f$ and the shift \f$N^i\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::Lapse`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct LapseCompute : Lapse<DataType>, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<Shift<SpatialDim, Frame, DataType>,
+                 SpacetimeMetric<SpatialDim, Frame, DataType>>;
+  static constexpr auto function = &lapse<SpatialDim, Frame, DataType>;
+  using base = Lapse<DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for spacetime normal oneform \f$n_a\f$ from
+ * the lapse \f$N\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::SpacetimeNormalOneForm`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpacetimeNormalOneFormCompute
+    : SpacetimeNormalOneForm<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<Lapse<DataType>>;
+  static constexpr auto function =
+      &spacetime_normal_one_form<SpatialDim, Frame, DataType>;
+  using base = SpacetimeNormalOneForm<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for spacetime normal vector \f$n^a\f$ from
+ * the lapse \f$N\f$ and the shift \f$N^i\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::SpacetimeNormalVector`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpacetimeNormalVectorCompute
+    : SpacetimeNormalVector<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<Lapse<DataType>, Shift<SpatialDim, Frame, DataType>>;
+  static constexpr auto function =
+      &spacetime_normal_vector<SpatialDim, Frame, DataType>;
+  using base = SpacetimeNormalVector<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+};
+}  // namespace Tags
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -10,10 +10,17 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
+/// \cond
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
 /// \ingroup GeneralRelativityGroup
 /// Holds functions related to general relativity.
 namespace gr {
-
+// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the spacetime metric from the spatial metric, lapse, and
@@ -27,11 +34,18 @@ namespace gr {
  * where \f$ N, N^i\f$ and \f$ g_{ij}\f$ are the lapse, shift and spatial metric
  * respectively
  */
+template <size_t Dim, typename Frame, typename DataType>
+void spacetime_metric(
+    gsl::not_null<tnsr::aa<DataType, Dim, Frame>*> spacetime_metric,
+    const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Frame>& shift,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_metric) noexcept;
+
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::aa<DataType, SpatialDim, Frame> spacetime_metric(
     const Scalar<DataType>& lapse,
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric) noexcept;
+// @}
 
 /*!
  * \ingroup GeneralRelativityGroup

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -28,9 +28,19 @@ struct SpatialMetric : db::SimpleTag {
   static std::string name() noexcept { return "SpatialMetric"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
+struct DetAndInverseSpatialMetric : db::SimpleTag {
+  using type = std::pair<Scalar<DataType>, tnsr::II<DataType, Dim, Frame>>;
+  static std::string name() noexcept { return "DetAndInverseSpatialMetric"; }
+};
+template <size_t Dim, typename Frame, typename DataType>
 struct InverseSpatialMetric : db::SimpleTag {
   using type = tnsr::II<DataType, Dim, Frame>;
   static std::string name() noexcept { return "InverseSpatialMetric"; }
+};
+template <typename DataType>
+struct DetSpatialMetric : db::SimpleTag {
+  using type = Scalar<DataType>;
+  static std::string name() noexcept { return "DetSpatialMetric"; }
 };
 template <typename DataType>
 struct SqrtDetSpatialMetric : db::SimpleTag {
@@ -47,7 +57,11 @@ struct Lapse : db::SimpleTag {
   using type = Scalar<DataType>;
   static std::string name() noexcept { return "Lapse"; }
 };
-
+template <size_t Dim, typename Frame, typename DataType>
+struct DerivativesOfSpacetimeMetric : db::SimpleTag {
+  using type = tnsr::abb<DataType, Dim, Frame>;
+  static std::string name() noexcept { return "DerivativesOfSpacetimeMetric"; }
+};
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::abb<DataType, Dim, Frame>;
@@ -83,6 +97,13 @@ struct TraceSpacetimeChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::a<DataType, Dim, Frame>;
   static std::string name() noexcept {
     return "TraceSpacetimeChristoffelFirstKind";
+  }
+};
+template <size_t Dim, typename Frame, typename DataType>
+struct TraceSpatialChristoffelFirstKind : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+  static std::string name() noexcept {
+    return "TraceSpatialChristoffelFirstKind";
   }
 };
 template <size_t Dim, typename Frame, typename DataType>

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
@@ -3,13 +3,39 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <array>
 #include <cstddef>
+#include <utility>
 
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+/// \cond
+namespace GeneralizedHarmonic {
+namespace Tags {
+template <size_t SpatialDim, typename Frame>
+struct DerivativesOfSpacetimeMetricCompute;
+}  // namespace Tags
+}  // namespace GeneralizedHarmonic
+namespace Tags {
+template <typename Tag, typename Dim, typename Frame, typename>
+struct deriv;
+}  // namespace Tags
+template <typename X, typename Symm, typename IndexList>
+class Tensor;
+/// \endcond
 
 namespace {
 template <size_t Dim, IndexType Index, typename DataType>
@@ -18,7 +44,7 @@ void test_christoffel(const DataType& used_for_size) {
       const tnsr::abb<DataType, Dim, Frame::Inertial, Index>&) =
       &gr::christoffel_first_kind<Dim, Frame::Inertial, Index, DataType>;
   pypp::check_with_random_values<1>(f, "Christoffel", "christoffel_first_kind",
-                                    {{{-10.0, 10.0}}}, used_for_size);
+                                    {{{-10., 10.}}}, used_for_size);
 }
 }  // namespace
 
@@ -39,4 +65,165 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Christoffel.",
   test_christoffel<1, IndexType::Spacetime>(0.);
   test_christoffel<2, IndexType::Spacetime>(0.);
   test_christoffel<3, IndexType::Spacetime>(0.);
+
+  // Check that the compute items return correct values
+  const DataVector test_vector{5., 4.};
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, 3, Frame::Inertial>>(test_vector,
+                                                                0.);
+  get<0, 0>(spatial_metric) = 1.5;
+  get<0, 1>(spatial_metric) = 0.1;
+  get<0, 2>(spatial_metric) = 0.2;
+  get<1, 1>(spatial_metric) = 1.4;
+  get<1, 2>(spatial_metric) = 0.2;
+  get<2, 2>(spatial_metric) = 1.3;
+
+  auto lapse = make_with_value<Scalar<DataVector>>(test_vector, 0.94);
+
+  auto shift =
+      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(test_vector, 0.);
+  get<0>(shift) = 0.5;
+  get<1>(shift) = 0.6;
+  get<2>(shift) = 0.7;
+
+  auto dt_spatial_metric =
+      make_with_value<tnsr::ii<DataVector, 3, Frame::Inertial>>(test_vector,
+                                                                0.);
+  get<0, 0>(dt_spatial_metric) = 0.05;
+  get<0, 1>(dt_spatial_metric) = 0.01;
+  get<0, 2>(dt_spatial_metric) = 0.02;
+  get<1, 1>(dt_spatial_metric) = 0.04;
+  get<1, 2>(dt_spatial_metric) = 0.02;
+  get<2, 2>(dt_spatial_metric) = 0.03;
+
+  auto dt_lapse = make_with_value<Scalar<DataVector>>(test_vector, 0.);
+  get(dt_lapse) = 0.04;
+
+  auto dt_shift =
+      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(test_vector, 0.);
+  get<0>(dt_shift) = 0.05;
+  get<1>(dt_shift) = 0.06;
+  get<2>(dt_shift) = 0.07;
+
+  auto deriv_spatial_metric =
+      make_with_value<tnsr::ijj<DataVector, 3, Frame::Inertial>>(test_vector,
+                                                                 0.);
+  get<0, 0, 0>(deriv_spatial_metric) = 0.1;
+  get<0, 0, 1>(deriv_spatial_metric) = 0.2;
+  get<0, 0, 2>(deriv_spatial_metric) = 0.3;
+  get<0, 1, 1>(deriv_spatial_metric) = 0.2;
+  get<0, 1, 2>(deriv_spatial_metric) = 0.1;
+  get<0, 2, 2>(deriv_spatial_metric) = 0.2;
+  get<1, 0, 0>(deriv_spatial_metric) = 0.3;
+  get<1, 0, 1>(deriv_spatial_metric) = 0.2;
+  get<1, 0, 2>(deriv_spatial_metric) = 0.1;
+  get<1, 1, 1>(deriv_spatial_metric) = 0.2;
+  get<1, 1, 2>(deriv_spatial_metric) = 0.3;
+  get<1, 2, 2>(deriv_spatial_metric) = 0.2;
+  get<2, 0, 0>(deriv_spatial_metric) = -0.1;
+  get<2, 0, 1>(deriv_spatial_metric) = -0.2;
+  get<2, 0, 2>(deriv_spatial_metric) = -0.3;
+  get<2, 1, 1>(deriv_spatial_metric) = -0.2;
+  get<2, 1, 2>(deriv_spatial_metric) = -0.1;
+  get<2, 2, 2>(deriv_spatial_metric) = -0.2;
+
+  auto deriv_lapse =
+      make_with_value<tnsr::i<DataVector, 3, Frame::Inertial>>(test_vector, 0.);
+  get<0>(deriv_lapse) = -0.1;
+  get<1>(deriv_lapse) = -0.2;
+  get<2>(deriv_lapse) = -0.3;
+
+  auto deriv_shift = make_with_value<tnsr::iJ<DataVector, 3, Frame::Inertial>>(
+      test_vector, 0.);
+  get<0, 0>(deriv_shift) = -0.05;
+  get<0, 1>(deriv_shift) = 0.06;
+  get<0, 2>(deriv_shift) = 0.07;
+  get<1, 0>(deriv_shift) = -0.03;
+  get<1, 1>(deriv_shift) = 0.04;
+  get<1, 2>(deriv_shift) = 0.03;
+  get<2, 0>(deriv_shift) = 0.01;
+  get<2, 1>(deriv_shift) = 0.02;
+  get<2, 2>(deriv_shift) = -0.01;
+
+  const auto& derivatives_of_spacetime_metric =
+      gr::derivatives_of_spacetime_metric(
+          lapse, dt_lapse, deriv_lapse, shift, dt_shift, deriv_shift,
+          spatial_metric, dt_spatial_metric, deriv_spatial_metric);
+
+  const auto& inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto& inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
+
+  const auto& spacetime_christoffel_first_kind =
+      gr::christoffel_first_kind(derivatives_of_spacetime_metric);
+  const auto& trace_spacetime_christoffel_first_kind = trace_last_indices(
+      spacetime_christoffel_first_kind, inverse_spacetime_metric);
+  const auto& spatial_christoffel_first_kind =
+      gr::christoffel_first_kind(deriv_spatial_metric);
+  const auto& trace_spatial_christoffel_first_kind = trace_last_indices(
+      spatial_christoffel_first_kind, inverse_spatial_metric);
+  const auto& spacetime_christoffel_second_kind = raise_or_lower_first_index(
+      spacetime_christoffel_first_kind, inverse_spacetime_metric);
+  const auto& spatial_christoffel_second_kind = raise_or_lower_first_index(
+      spatial_christoffel_first_kind, inverse_spatial_metric);
+
+  const auto box = db::create<
+      db::AddSimpleTags<
+          gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+          gr::Tags::Lapse<DataVector>,
+          gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+          ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                        Frame::Inertial>,
+          ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>,
+          ::Tags::dt<gr::Tags::Lapse<DataVector>>,
+          ::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>>,
+      db::AddComputeTags<
+          gr::Tags::SpacetimeMetricCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::DetAndInverseSpatialMetricCompute<3, Frame::Inertial,
+                                                      DataVector>,
+          gr::Tags::SqrtDetSpatialMetricCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::InverseSpatialMetricCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::InverseSpacetimeMetricCompute<3, Frame::Inertial,
+                                                  DataVector>,
+          GeneralizedHarmonic::Tags::DerivativesOfSpacetimeMetricCompute<
+              3, Frame::Inertial>,
+          gr::Tags::SpacetimeChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                         DataVector>,
+          gr::Tags::TraceSpacetimeChristoffelFirstKindCompute<
+              3, Frame::Inertial, DataVector>,
+          gr::Tags::SpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                       DataVector>,
+          gr::Tags::TraceSpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                            DataVector>,
+          gr::Tags::SpacetimeChristoffelSecondKindCompute<3, Frame::Inertial,
+                                                          DataVector>,
+          gr::Tags::SpatialChristoffelSecondKindCompute<3, Frame::Inertial,
+                                                        DataVector>  //,
+
+          >>(spatial_metric, lapse, shift, deriv_spatial_metric, deriv_lapse,
+             deriv_shift, dt_spatial_metric, dt_lapse, dt_shift);
+
+  CHECK(db::get<gr::Tags::SpacetimeChristoffelFirstKind<3, Frame::Inertial,
+                                                        DataVector>>(box) ==
+        spacetime_christoffel_first_kind);
+  CHECK(db::get<gr::Tags::TraceSpacetimeChristoffelFirstKind<3, Frame::Inertial,
+                                                             DataVector>>(
+            box) == trace_spacetime_christoffel_first_kind);
+  CHECK(db::get<gr::Tags::SpatialChristoffelFirstKind<3, Frame::Inertial,
+                                                      DataVector>>(box) ==
+        spatial_christoffel_first_kind);
+  CHECK(db::get<gr::Tags::TraceSpatialChristoffelFirstKind<3, Frame::Inertial,
+                                                           DataVector>>(box) ==
+        trace_spatial_christoffel_first_kind);
+  CHECK(db::get<gr::Tags::SpacetimeChristoffelSecondKind<3, Frame::Inertial,
+                                                         DataVector>>(box) ==
+        spacetime_christoffel_second_kind);
+  CHECK(db::get<gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial,
+                                                       DataVector>>(box) ==
+        spatial_christoffel_second_kind);
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -44,14 +44,28 @@ using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 template <size_t Dim, typename DataType>
 void test_compute_phi(const DataType& used_for_size) {
   pypp::check_with_random_values<1>(
-      &GeneralizedHarmonic::phi<Dim, Frame::Inertial, DataType>,
+      static_cast<tnsr::iaa<DataType, Dim, Frame::Inertial> (*)(
+          const Scalar<DataType>&,
+          const tnsr::i<DataType, Dim, Frame::Inertial>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&,
+          const tnsr::iJ<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ijj<DataType, Dim, Frame::Inertial>&)>(
+          &::GeneralizedHarmonic::phi<Dim, Frame::Inertial, DataType>),
       "GeneralRelativity.ComputeGhQuantities", "phi", {{{-10., 10.}}},
       used_for_size);
 }
 template <size_t Dim, typename DataType>
 void test_compute_pi(const DataType& used_for_size) {
   pypp::check_with_random_values<1>(
-      &GeneralizedHarmonic::pi<Dim, Frame::Inertial, DataType>,
+      static_cast<tnsr::aa<DataType, Dim, Frame::Inertial> (*)(
+          const Scalar<DataType>&, const Scalar<DataType>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const tnsr::iaa<DataType, Dim, Frame::Inertial>&)>(
+          &::GeneralizedHarmonic::pi<Dim, Frame::Inertial, DataType>),
       "GeneralRelativity.ComputeGhQuantities", "pi", {{{-10., 10.}}},
       used_for_size);
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -9,7 +9,10 @@
 #include <memory>
 #include <pup.h>
 #include <random>
+#include <string>
+#include <utility>
 
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
@@ -19,6 +22,8 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
@@ -28,6 +33,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
@@ -35,6 +41,13 @@
 #include "tests/Utilities/MakeWithRandomValues.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
+
+/// \cond
+namespace Tags {
+template <typename Tag, typename Dim, typename Frame, typename>
+struct deriv;
+}  // namespace Tags
+/// \endcond
 
 namespace {
 using Affine = domain::CoordinateMaps::Affine;
@@ -98,7 +111,7 @@ void test_compute_extrinsic_curvature_and_deriv_metric(const T& used_for_size) {
     // Make sure spatial_metric isn't singular by adding
     // large enough positive diagonal values.
     for (size_t i = 0; i < Dim; ++i) {
-      spatial_metric_l.get(i, i) += 4.0;
+      spatial_metric_l.get(i, i) += 4.;
     }
     return spatial_metric_l;
   }();
@@ -176,7 +189,7 @@ void test_gij_deriv_functions(const DataVector& used_for_size) noexcept {
           &::GeneralizedHarmonic::time_deriv_of_spatial_metric<
               SpatialDim, Frame, DataType>),
       "GeneralRelativity.ComputeGhQuantities", "dt_spatial_metric",
-      {{{std::numeric_limits<double>::denorm_min(), 10.0}}}, used_for_size);
+      {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size);
   // spacetime_deriv_of_det_spatial_metric
   pypp::check_with_random_values<1>(
       static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
@@ -186,7 +199,7 @@ void test_gij_deriv_functions(const DataVector& used_for_size) noexcept {
           &::GeneralizedHarmonic::spacetime_deriv_of_det_spatial_metric<
               SpatialDim, Frame, DataType>),
       "GeneralRelativity.ComputeGhQuantities", "spacetime_deriv_detg",
-      {{{std::numeric_limits<double>::denorm_min(), 10.0}}}, used_for_size);
+      {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size);
 }
 
 // Test computation of derivs of lapse by comparing to Kerr-Schild
@@ -574,4 +587,244 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
                                     upper_bound);
   test_shift_deriv_functions_analytic(solution, grid_size, lower_bound,
                                       upper_bound);
+
+  // Check that compute items work correctly in the DataBox
+  // First, check that the names are correct
+  CHECK(GeneralizedHarmonic::Tags::PhiCompute<3, Frame::Inertial>::name() ==
+        "Phi");
+  CHECK(GeneralizedHarmonic::Tags::PiCompute<3, Frame::Inertial>::name() ==
+        "Pi");
+  CHECK(GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
+            3, Frame::Inertial>::name() == "TraceExtrinsicCurvature");
+  CHECK(GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<
+            3, Frame::Inertial>::name() == "ExtrinsicCurvature");
+  CHECK(GeneralizedHarmonic::Tags::DerivSpatialMetricCompute<
+            3, Frame::Inertial>::name() == "deriv(SpatialMetric)");
+  CHECK(GeneralizedHarmonic::Tags::DerivLapseCompute<3,
+                                                     Frame::Inertial>::name() ==
+        "deriv(Lapse)");
+  CHECK(GeneralizedHarmonic::Tags::DerivShiftCompute<3,
+                                                     Frame::Inertial>::name() ==
+        "deriv(Shift)");
+  CHECK(GeneralizedHarmonic::Tags::TimeDerivSpatialMetricCompute<
+            3, Frame::Inertial>::name() +
+            GeneralizedHarmonic::Tags::TimeDerivSpatialMetricCompute<
+                3, Frame::Inertial>::tag::name() ==
+        "dtSpatialMetric");
+  CHECK(GeneralizedHarmonic::Tags::TimeDerivLapseCompute<
+            3, Frame::Inertial>::name() +
+            GeneralizedHarmonic::Tags::TimeDerivLapseCompute<
+                3, Frame::Inertial>::tag::name() ==
+        "dtLapse");
+  CHECK(GeneralizedHarmonic::Tags::TimeDerivShiftCompute<
+            3, Frame::Inertial>::name() +
+            GeneralizedHarmonic::Tags::TimeDerivShiftCompute<
+                3, Frame::Inertial>::tag::name() ==
+        "dtShift");
+  CHECK(GeneralizedHarmonic::Tags::DerivativesOfSpacetimeMetricCompute<
+            3, Frame::Inertial>::name() == "DerivativesOfSpacetimeMetric");
+  CHECK(GeneralizedHarmonic::Tags::DerivSpacetimeMetricCompute<
+            3, Frame::Inertial>::name() == "deriv(SpacetimeMetric)");
+
+  // Check that the compute items return the correct values
+  const DataVector test_vector{5., 4.};
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, 3, Frame::Inertial>>(test_vector,
+                                                                0.);
+  get<0, 0>(spatial_metric) = 1.5;
+  get<0, 1>(spatial_metric) = 0.1;
+  get<0, 2>(spatial_metric) = 0.2;
+  get<1, 1>(spatial_metric) = 1.4;
+  get<1, 2>(spatial_metric) = 0.2;
+  get<2, 2>(spatial_metric) = 1.3;
+
+  auto lapse = make_with_value<Scalar<DataVector>>(test_vector, 0.94);
+
+  auto shift =
+      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(test_vector, 0.);
+  get<0>(shift) = 0.5;
+  get<1>(shift) = 0.6;
+  get<2>(shift) = 0.7;
+
+  auto dt_spatial_metric =
+      make_with_value<tnsr::ii<DataVector, 3, Frame::Inertial>>(test_vector,
+                                                                0.);
+  get<0, 0>(dt_spatial_metric) = 0.05;
+  get<0, 1>(dt_spatial_metric) = 0.01;
+  get<0, 2>(dt_spatial_metric) = 0.02;
+  get<1, 1>(dt_spatial_metric) = 0.04;
+  get<1, 2>(dt_spatial_metric) = 0.02;
+  get<2, 2>(dt_spatial_metric) = 0.03;
+
+  auto dt_lapse = make_with_value<Scalar<DataVector>>(test_vector, 0.);
+  get(dt_lapse) = 0.04;
+
+  auto dt_shift =
+      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(test_vector, 0.);
+  get<0>(dt_shift) = 0.05;
+  get<1>(dt_shift) = 0.06;
+  get<2>(dt_shift) = 0.07;
+
+  auto deriv_spatial_metric =
+      make_with_value<tnsr::ijj<DataVector, 3, Frame::Inertial>>(test_vector,
+                                                                 0.);
+  get<0, 0, 0>(deriv_spatial_metric) = 0.1;
+  get<0, 0, 1>(deriv_spatial_metric) = 0.2;
+  get<0, 0, 2>(deriv_spatial_metric) = 0.3;
+  get<0, 1, 1>(deriv_spatial_metric) = 0.2;
+  get<0, 1, 2>(deriv_spatial_metric) = 0.1;
+  get<0, 2, 2>(deriv_spatial_metric) = 0.2;
+  get<1, 0, 0>(deriv_spatial_metric) = 0.3;
+  get<1, 0, 1>(deriv_spatial_metric) = 0.2;
+  get<1, 0, 2>(deriv_spatial_metric) = 0.1;
+  get<1, 1, 1>(deriv_spatial_metric) = 0.2;
+  get<1, 1, 2>(deriv_spatial_metric) = 0.3;
+  get<1, 2, 2>(deriv_spatial_metric) = 0.2;
+  get<2, 0, 0>(deriv_spatial_metric) = -0.1;
+  get<2, 0, 1>(deriv_spatial_metric) = -0.2;
+  get<2, 0, 2>(deriv_spatial_metric) = -0.3;
+  get<2, 1, 1>(deriv_spatial_metric) = -0.2;
+  get<2, 1, 2>(deriv_spatial_metric) = -0.1;
+  get<2, 2, 2>(deriv_spatial_metric) = -0.2;
+
+  auto deriv_lapse =
+      make_with_value<tnsr::i<DataVector, 3, Frame::Inertial>>(test_vector, 0.);
+  get<0>(deriv_lapse) = -0.1;
+  get<1>(deriv_lapse) = -0.2;
+  get<2>(deriv_lapse) = -0.3;
+
+  auto deriv_shift = make_with_value<tnsr::iJ<DataVector, 3, Frame::Inertial>>(
+      test_vector, 0.);
+  get<0, 0>(deriv_shift) = -0.05;
+  get<0, 1>(deriv_shift) = 0.06;
+  get<0, 2>(deriv_shift) = 0.07;
+  get<1, 0>(deriv_shift) = -0.03;
+  get<1, 1>(deriv_shift) = 0.04;
+  get<1, 2>(deriv_shift) = 0.03;
+  get<2, 0>(deriv_shift) = 0.01;
+  get<2, 1>(deriv_shift) = 0.02;
+  get<2, 2>(deriv_shift) = -0.01;
+
+  const auto& derivatives_of_spacetime_metric =
+      gr::derivatives_of_spacetime_metric(
+          lapse, dt_lapse, deriv_lapse, shift, dt_shift, deriv_shift,
+          spatial_metric, dt_spatial_metric, deriv_spatial_metric);
+  const auto& deriv_spacetime_metric =
+      GeneralizedHarmonic::Tags::DerivSpacetimeMetricCompute<
+          3, Frame::Inertial>::function(derivatives_of_spacetime_metric);
+
+  const auto& spacetime_normal_vector =
+      gr::spacetime_normal_vector(lapse, shift);
+  const auto& inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto& inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
+
+  const auto& phi =
+      GeneralizedHarmonic::phi(lapse, deriv_lapse, shift, deriv_shift,
+                               spatial_metric, deriv_spatial_metric);
+  const auto& pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+
+  const auto& extrinsic_curvature = GeneralizedHarmonic::extrinsic_curvature(
+      spacetime_normal_vector, pi, phi);
+  const auto& trace_extrinsic_curvature =
+      trace(extrinsic_curvature, inverse_spatial_metric);
+
+  const auto& christoffel_first_kind =
+      gr::christoffel_first_kind(deriv_spatial_metric);
+  const auto& trace_christoffel_first_kind =
+      trace_last_indices(christoffel_first_kind, inverse_spatial_metric);
+
+  const auto box = db::create<
+      db::AddSimpleTags<
+          gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+          gr::Tags::Lapse<DataVector>,
+          gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+          ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                        Frame::Inertial>,
+          ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>,
+          ::Tags::dt<gr::Tags::Lapse<DataVector>>,
+          ::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>>,
+      db::AddComputeTags<
+          gr::Tags::SpacetimeNormalVectorCompute<3,
+                                                 Frame::Inertial, DataVector>,
+          gr::Tags::DetAndInverseSpatialMetricCompute<3, Frame::Inertial,
+                                                      DataVector>,
+          gr::Tags::InverseSpatialMetricCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::SpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                       DataVector>,
+          gr::Tags::TraceSpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                            DataVector>,
+          GeneralizedHarmonic::Tags::PhiCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::PiCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<3,
+                                                               Frame::Inertial>,
+          GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::DerivativesOfSpacetimeMetricCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::DerivSpacetimeMetricCompute<
+              3, Frame::Inertial>  //,
+
+          >>(spatial_metric, lapse, shift, deriv_spatial_metric, deriv_lapse,
+             deriv_shift, dt_spatial_metric, dt_lapse, dt_shift);
+
+  CHECK(db::get<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>(box) ==
+        phi);
+  CHECK(db::get<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>>(box) == pi);
+  CHECK(db::get<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>(
+            box) == extrinsic_curvature);
+  CHECK(db::get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(box) ==
+        trace_extrinsic_curvature);
+  CHECK(db::get<gr::Tags::DerivativesOfSpacetimeMetric<3, Frame::Inertial,
+                                                       DataVector>>(box) ==
+        derivatives_of_spacetime_metric);
+  CHECK(db::get<::Tags::deriv<
+            gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>,
+            tmpl::size_t<3>, Frame::Inertial>>(box) == deriv_spacetime_metric);
+
+  const auto other_box = db::create<
+      db::AddSimpleTags<
+          gr::Tags::Lapse<DataVector>,
+          gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+          gr::Tags::SpacetimeNormalVector<3, Frame::Inertial, DataVector>,
+          gr::Tags::InverseSpacetimeMetric<3, Frame::Inertial, DataVector>,
+          gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+          GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>>,
+      db::AddComputeTags<
+          GeneralizedHarmonic::Tags::DerivSpatialMetricCompute<3,
+                                                               Frame::Inertial>,
+          GeneralizedHarmonic::Tags::DerivLapseCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::DerivShiftCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::TimeDerivSpatialMetricCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::TimeDerivLapseCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::TimeDerivShiftCompute<3,
+                                                           Frame::Inertial>>>(
+      lapse, shift, spacetime_normal_vector, inverse_spacetime_metric,
+      inverse_spatial_metric, phi, pi);
+  CHECK(
+      db::get<
+          ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>>(other_box) ==
+      deriv_spatial_metric);
+  CHECK(db::get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                              Frame::Inertial>>(other_box) == deriv_lapse);
+  CHECK(db::get<::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                              tmpl::size_t<3>, Frame::Inertial>>(other_box) ==
+        deriv_shift);
+  CHECK(
+      db::get<
+          ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>(
+          other_box) == dt_spatial_metric);
+  CHECK(db::get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(other_box) ==
+        dt_lapse);
+  CHECK(db::get<::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>>(
+            other_box) == dt_shift);
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -21,7 +21,11 @@ namespace {
 template <size_t Dim, typename DataType>
 void test_compute_spacetime_metric(const DataType& used_for_size) {
   pypp::check_with_random_values<1>(
-      &gr::spacetime_metric<Dim, Frame::Inertial, DataType>,
+      static_cast<tnsr::aa<DataType, Dim, Frame::Inertial> (*)(
+          const Scalar<DataType>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&)>(
+          &gr::spacetime_metric<Dim, Frame::Inertial, DataType>),
       "ComputeSpacetimeQuantities", "spacetime_metric", {{{-10., 10.}}},
       used_for_size);
 }


### PR DESCRIPTION
## Proposed changes

This PR adds compute tags for foliation related quantities and their tests. These compute tags will be needed when evolving the `GeneralizedHarmonic` system.

**Note:** This has been split into #1468 , #1469 , #1470 , #1471 , #1473 , #1474 , #1475 , #1476 , #1477 , #1478 .

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

