### PR TITLE
Add compute items for GH constraints

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -166,6 +166,50 @@ struct EvolvedFieldsFromCharacteristicFields : db::SimpleTag {
     return "EvolvedFieldsFromCharacteristicFields";
   }
 };
+
+/*!
+ * \brief Tags corresponding to various constraints of the generalized
+ * harmonic system, and their diagnostically useful combinations.
+ * \details For details on how these are defined and computed, see
+ * `GaugeConstraintCompute`, `FConstraintCompute`, `TwoIndexConstraintCompute`,
+ * `ThreeIndexConstraintCompute`, `FourIndexConstraintCompute`, and
+ * `ConstraintEnergyCompute` respectively
+ */
+template <size_t SpatialDim, typename Frame>
+struct GaugeConstraint : db::SimpleTag {
+  using type = tnsr::a<DataVector, SpatialDim, Frame>;
+  static std::string name() noexcept { return "GaugeConstraint"; }
+};
+/// \copydoc GaugeConstraint
+template <size_t SpatialDim, typename Frame>
+struct FConstraint : db::SimpleTag {
+  using type = tnsr::a<DataVector, SpatialDim, Frame>;
+  static std::string name() noexcept { return "FConstraint"; }
+};
+/// \copydoc GaugeConstraint
+template <size_t SpatialDim, typename Frame>
+struct TwoIndexConstraint : db::SimpleTag {
+  using type = tnsr::ia<DataVector, SpatialDim, Frame>;
+  static std::string name() noexcept { return "TwoIndexConstraint"; }
+};
+/// \copydoc GaugeConstraint
+template <size_t SpatialDim, typename Frame>
+struct ThreeIndexConstraint : db::SimpleTag {
+  using type = tnsr::iaa<DataVector, SpatialDim, Frame>;
+  static std::string name() noexcept { return "ThreeIndexConstraint"; }
+};
+/// \copydoc GaugeConstraint
+template <size_t SpatialDim, typename Frame>
+struct FourIndexConstraint : db::SimpleTag {
+  using type = tnsr::iaa<DataVector, SpatialDim, Frame>;
+  static std::string name() noexcept { return "FourIndexConstraint"; }
+};
+/// \copydoc GaugeConstraint
+template <size_t SpatialDim, typename Frame>
+struct ConstraintEnergy : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "ConstraintEnergy"; }
+};
 }  // namespace Tags
 
 namespace OptionTags {

--- a/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
@@ -43,6 +43,19 @@ template <size_t Dim, typename Frame>
 struct CharacteristicFields;
 template <size_t Dim, typename Frame>
 struct EvolvedFieldsFromCharacteristicFields;
+
+template <size_t SpatialDim, typename Frame>
+struct GaugeConstraint;
+template <size_t SpatialDim, typename Frame>
+struct FConstraint;
+template <size_t SpatialDim, typename Frame>
+struct TwoIndexConstraint;
+template <size_t SpatialDim, typename Frame>
+struct ThreeIndexConstraint;
+template <size_t SpatialDim, typename Frame>
+struct FourIndexConstraint;
+template <size_t SpatialDim, typename Frame>
+struct ConstraintEnergy;
 }  // namespace Tags
 
 /// \brief Input option tags for the generalized harmonic evolution system

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -8,17 +8,20 @@
 #include <limits>
 #include <memory>
 #include <pup.h>
+#include <string>
 
-#include "DataStructures/DataBox/Prefixes.hpp" // IWYU pragma: keep
-#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"        // IWYU pragma: keep
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
-#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"  // IWYU pragma: keep
@@ -660,16 +663,288 @@ void test_constraint_energy_analytic(const Solution& solution,
 
   auto constraint_energy = make_with_value<Scalar<DataVector>>(
       x, std::numeric_limits<double>::signaling_NaN());
-  GeneralizedHarmonic::constraint_energy(make_not_null(&constraint_energy),
-      gauge_constraint, f_constraint, two_index_constraint,
-      three_index_constraint, four_index_constraint, inverse_spatial_metric,
-      determinant_spatial_metric, 2.0, -3.0, 4.0, -5.0);
+  GeneralizedHarmonic::constraint_energy(
+      make_not_null(&constraint_energy), gauge_constraint, f_constraint,
+      two_index_constraint, three_index_constraint, four_index_constraint,
+      inverse_spatial_metric, determinant_spatial_metric, 2.0, -3.0, 4.0, -5.0);
 
   Approx numerical_approx =
       Approx::custom().epsilon(error_tolerance).scale(1.0);
   CHECK_ITERABLE_CUSTOM_APPROX(
       constraint_energy, make_with_value<decltype(constraint_energy)>(x, 0.0),
       numerical_approx);
+}
+
+// Test compute items for various constraints via insertion and retrieval
+// in a databox
+template <typename Solution>
+void test_constraint_compute_items(
+    const Solution& solution, const size_t grid_size,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Check that compute items are named correctly
+  CHECK(GeneralizedHarmonic::Tags::ConstraintGamma0Compute<
+            3, Frame::Inertial>::name() == "ConstraintGamma0");
+  CHECK(GeneralizedHarmonic::Tags::ConstraintGamma1Compute<
+            3, Frame::Inertial>::name() == "ConstraintGamma1");
+  CHECK(GeneralizedHarmonic::Tags::ConstraintGamma2Compute<
+            3, Frame::Inertial>::name() == "ConstraintGamma2");
+  CHECK(GeneralizedHarmonic::Tags::GaugeHImplicitFrom3p1QuantitiesCompute<
+            3, Frame::Inertial>::name() == "GaugeH");
+  CHECK(GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<
+            3, Frame::Inertial>::name() == "SpacetimeDerivGaugeH");
+  CHECK(GeneralizedHarmonic::Tags::GaugeConstraintCompute<
+            3, Frame::Inertial>::name() == "GaugeConstraint");
+  CHECK(GeneralizedHarmonic::Tags::FConstraintCompute<
+            3, Frame::Inertial>::name() == "FConstraint");
+  CHECK(GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<
+            3, Frame::Inertial>::name() == "TwoIndexConstraint");
+  CHECK(GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<
+            3, Frame::Inertial>::name() == "ThreeIndexConstraint");
+  CHECK(GeneralizedHarmonic::Tags::FourIndexConstraintCompute<
+            3, Frame::Inertial>::name() == "FourIndexConstraint");
+  CHECK(GeneralizedHarmonic::Tags::ConstraintEnergyCompute<
+            3, Frame::Inertial>::name() == "ConstraintEnergy");
+
+  // Check vs. time-independent analytic solution
+  // Set up grid
+  const size_t data_size = pow<3>(grid_size);
+  Mesh<3> mesh{grid_size, Spectral::Basis::Legendre,
+               Spectral::Quadrature::GaussLobatto};
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          Affine3D{Affine{-1.0, 1.0, lower_bound[0], upper_bound[0]},
+                   Affine{-1.0, 1.0, lower_bound[1], upper_bound[1]},
+                   Affine{-1.0, 1.0, lower_bound[2], upper_bound[2]}});
+
+  // Set up coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = std::numeric_limits<double>::signaling_NaN();
+
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse = get<gr::Tags::Lapse<>>(vars);
+  const auto& time_deriv_lapse = get<Tags::dt<gr::Tags::Lapse<>>>(vars);
+  const auto& deriv_lapse =
+      get<typename Solution::template DerivLapse<DataVector>>(vars);
+  const auto& shift = get<gr::Tags::Shift<3>>(vars);
+  const auto& deriv_shift =
+      get<typename Solution::template DerivShift<DataVector>>(vars);
+  const auto& time_deriv_shift = get<Tags::dt<gr::Tags::Shift<3>>>(vars);
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<3>>(vars);
+  const auto& time_deriv_spatial_metric =
+      get<Tags::dt<gr::Tags::SpatialMetric<3>>>(vars);
+  const auto& deriv_spatial_metric =
+      get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
+
+  // Compute quantities from variables for the two-index constraint
+  const auto spacetime_normal_vector =
+      gr::spacetime_normal_vector(lapse, shift);
+  const auto spacetime_normal_one_form =
+      gr::spacetime_normal_one_form<3, Frame::Inertial, DataVector>(lapse);
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto det_spatial_metric = determinant_and_inverse(spatial_metric).first;
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+
+  const auto christoffel_first_kind =
+      gr::christoffel_first_kind(deriv_spatial_metric);
+  const auto trace_christoffel_first_kind =
+      trace_last_indices(christoffel_first_kind, inverse_spatial_metric);
+
+  // Compute derivatives d_phi, d_pi, and d_gauge_function numerically
+  // First, prepare
+  using VariablesTags =
+      tmpl::list<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>>;
+
+  Variables<VariablesTags> gh_vars(data_size);
+  auto& pi = get<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>>(gh_vars);
+  auto& phi = get<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>(gh_vars);
+  auto& gauge_source =
+      get<GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>>(gh_vars);
+  phi = GeneralizedHarmonic::phi(lapse, deriv_lapse, shift, deriv_shift,
+                                 spatial_metric, deriv_spatial_metric);
+  pi = GeneralizedHarmonic::pi(lapse, time_deriv_lapse, shift, time_deriv_shift,
+                               spatial_metric, time_deriv_spatial_metric, phi);
+  const auto extrinsic_curvature = GeneralizedHarmonic::extrinsic_curvature(
+      spacetime_normal_vector, pi, phi);
+  const auto trace_extrinsic_curvature =
+      trace(extrinsic_curvature, inverse_spatial_metric);
+  gauge_source = GeneralizedHarmonic::gauge_source(
+      lapse, time_deriv_lapse, deriv_lapse, shift, time_deriv_shift,
+      deriv_shift, spatial_metric, trace_extrinsic_curvature,
+      trace_christoffel_first_kind);
+  // Second, compute derivatives
+  const auto gh_derivs =
+      partial_derivatives<VariablesTags, VariablesTags, 3, Frame::Inertial>(
+          gh_vars, mesh, coord_map.inv_jacobian(x_logical));
+  const auto& deriv_pi =
+      get<Tags::deriv<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                      tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
+  const auto& deriv_phi =
+      get<Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                      tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
+  const auto& deriv_gauge_source =
+      get<Tags::deriv<GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>,
+                      tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
+
+  // Compute other derivatives
+  const auto derivatives_of_spacetime_metric =
+      gr::derivatives_of_spacetime_metric(
+          lapse, time_deriv_lapse, deriv_lapse, shift, time_deriv_shift,
+          deriv_shift, spatial_metric, time_deriv_spatial_metric,
+          deriv_spatial_metric);
+  const auto deriv_spacetime_metric =
+      gr::Tags::DerivSpacetimeMetricCompute<3, Frame::Inertial>::function(
+          derivatives_of_spacetime_metric);
+
+  auto time_deriv_gauge_source =
+      make_with_value<tnsr::a<DataVector, 3, Frame::Inertial>>(x, 0.);
+  get<0>(time_deriv_gauge_source) = 0.05;
+  get<1>(time_deriv_gauge_source) = 0.06;
+  get<2>(time_deriv_gauge_source) = 0.07;
+  get<3>(time_deriv_gauge_source) = -0.05;
+
+  const auto derivatives_of_gauge_source =
+      GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<
+          3, Frame::Inertial>::function(time_deriv_gauge_source,
+                                        deriv_gauge_source);
+
+  // Insert into databox
+  const auto box = db::create<
+      db::AddSimpleTags<
+          ::Tags::Coordinates<3, Frame::Inertial>,
+          gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+          gr::Tags::Lapse<DataVector>,
+          gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+          ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                        Frame::Inertial>,
+          ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>,
+          ::Tags::dt<gr::Tags::Lapse<DataVector>>,
+          ::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>,
+          ::Tags::deriv<GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::dt<GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>>,
+          ::Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::deriv<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                        tmpl::size_t<3>, Frame::Inertial>>,
+      db::AddComputeTags<
+          GeneralizedHarmonic::Tags::ConstraintGamma0Compute<3,
+                                                             Frame::Inertial>,
+          GeneralizedHarmonic::Tags::ConstraintGamma1Compute<3,
+                                                             Frame::Inertial>,
+          GeneralizedHarmonic::Tags::ConstraintGamma2Compute<3,
+                                                             Frame::Inertial>,
+          gr::Tags::SpacetimeNormalOneFormCompute<3, Frame::Inertial,
+                                                  DataVector>,
+          gr::Tags::SpacetimeNormalVectorCompute<3,
+                                                 Frame::Inertial, DataVector>,
+          gr::Tags::DetAndInverseSpatialMetricCompute<3, Frame::Inertial,
+                                                      DataVector>,
+          gr::Tags::InverseSpacetimeMetricCompute<3, Frame::Inertial,
+                                                  DataVector>,
+          gr::Tags::SpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                       DataVector>,
+          gr::Tags::TraceSpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                            DataVector>,
+          GeneralizedHarmonic::Tags::PhiCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::PiCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<3,
+                                                               Frame::Inertial>,
+          GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::GaugeHImplicitFrom3p1QuantitiesCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<
+              3, Frame::Inertial>,
+          gr::Tags::DerivativesOfSpacetimeMetricCompute<3, Frame::Inertial>,
+          gr::Tags::DerivSpacetimeMetricCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::FourIndexConstraintCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<3,
+                                                               Frame::Inertial>,
+          GeneralizedHarmonic::Tags::GaugeConstraintCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::FConstraintCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::ConstraintEnergyCompute<3,
+                                                             Frame::Inertial>>>(
+      x, spatial_metric, lapse, shift, deriv_spatial_metric, deriv_lapse,
+      deriv_shift, time_deriv_spatial_metric, time_deriv_lapse,
+      time_deriv_shift, deriv_gauge_source, time_deriv_gauge_source, deriv_phi,
+      deriv_pi);
+
+  // Compute tested quantities locally
+  const auto gamma0 = GeneralizedHarmonic::Tags::ConstraintGamma0Compute<
+      3, Frame::Inertial>::function(x);
+  const auto gamma1 = GeneralizedHarmonic::Tags::ConstraintGamma1Compute<
+      3, Frame::Inertial>::function(x);
+  const auto gamma2 = GeneralizedHarmonic::Tags::ConstraintGamma2Compute<
+      3, Frame::Inertial>::function(x);
+
+  const auto four_index_constraint =
+      GeneralizedHarmonic::four_index_constraint(deriv_phi);
+  const auto three_index_constraint =
+      GeneralizedHarmonic::three_index_constraint(deriv_spacetime_metric, phi);
+  const auto two_index_constraint = GeneralizedHarmonic::two_index_constraint(
+      deriv_gauge_source, spacetime_normal_one_form, spacetime_normal_vector,
+      inverse_spatial_metric, inverse_spacetime_metric, pi, phi, deriv_pi,
+      deriv_phi, gamma2, three_index_constraint);
+  const auto gauge_constraint = GeneralizedHarmonic::gauge_constraint(
+      gauge_source, spacetime_normal_one_form, spacetime_normal_vector,
+      inverse_spatial_metric, inverse_spacetime_metric, pi, phi);
+  const auto f_constraint = GeneralizedHarmonic::f_constraint(
+      gauge_source, deriv_gauge_source, spacetime_normal_one_form,
+      spacetime_normal_vector, inverse_spatial_metric, inverse_spacetime_metric,
+      pi, phi, deriv_pi, deriv_phi, gamma2, three_index_constraint);
+  const auto constraint_energy = GeneralizedHarmonic::constraint_energy(
+      gauge_constraint, f_constraint, two_index_constraint,
+      three_index_constraint, four_index_constraint, inverse_spatial_metric,
+      det_spatial_metric);
+
+  // Check that their compute items in databox furnish identical values
+  CHECK(db::get<GeneralizedHarmonic::Tags::ConstraintGamma0>(box) == gamma0);
+  CHECK(db::get<GeneralizedHarmonic::Tags::ConstraintGamma1>(box) == gamma1);
+  CHECK(db::get<GeneralizedHarmonic::Tags::ConstraintGamma2>(box) == gamma2);
+  CHECK(db::get<GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>>(box) ==
+        gauge_source);
+  CHECK(
+      db::get<
+          GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<3, Frame::Inertial>>(
+          box) == derivatives_of_gauge_source);
+  CHECK(db::get<
+            GeneralizedHarmonic::Tags::FourIndexConstraint<3, Frame::Inertial>>(
+            box) == four_index_constraint);
+  CHECK(
+      db::get<
+          GeneralizedHarmonic::Tags::ThreeIndexConstraint<3, Frame::Inertial>>(
+          box) == three_index_constraint);
+  CHECK(db::get<
+            GeneralizedHarmonic::Tags::TwoIndexConstraint<3, Frame::Inertial>>(
+            box) == two_index_constraint);
+  CHECK(db::get<GeneralizedHarmonic::Tags::GaugeConstraint<3, Frame::Inertial>>(
+            box) == gauge_constraint);
+  CHECK(db::get<GeneralizedHarmonic::Tags::FConstraint<3, Frame::Inertial>>(
+            box) == f_constraint);
+  CHECK(
+      db::get<GeneralizedHarmonic::Tags::ConstraintEnergy<3, Frame::Inertial>>(
+          box) == constraint_energy);
 }
 }  // namespace
 
@@ -930,4 +1205,23 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.ConstraintEnergy",
       std::numeric_limits<double>::signaling_NaN());
   test_constraint_energy_random<3, Frame::Inertial, double>(
       std::numeric_limits<double>::signaling_NaN());
+}
+
+// [[TimeOut, 9]]
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.ConstraintComputeTags",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GeneralizedHarmonic/"};
+  // Test the F constraint against Kerr Schild
+  const double mass = 1.4;
+  const std::array<double, 3> dimensionless_spin{{0.4, 0.3, 0.2}};
+  const std::array<double, 3> center{{0.2, 0.3, 0.4}};
+  const gr::Solutions::KerrSchild solution(mass, dimensionless_spin, center);
+
+  const size_t grid_size = 8;
+  const std::array<double, 3> upper_bound{{0.82, 1.24, 1.32}};
+  const std::array<double, 3> lower_bound{{0.8, 1.22, 1.30}};
+
+  test_constraint_compute_items(solution, grid_size, lower_bound, upper_bound);
 }


### PR DESCRIPTION
## Proposed changes

This PR adds compute tags for GH constraints, and their tests. As constraints depend on the gauge source function H and its space/time deriviatives, we also add two compute items to assemble those from 3+1 variables and their derivatives. (These compute tags will be needed when evolving / observing from the GeneralizedHarmonic system.)

Note: This depends on #1468 , #1469 , #1470 , #1471 , #1473 , #1474 , #1475 , #1476 , #1477 , and #1478  , and changes from them have been patched here as the first commit. Please review the most recent commit only.

**Edit:** All dependencies have been merged into develop, and this PR rebased onto them.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
