### PR TITLE
Add volume_dim alias to KerrSchild class

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
@@ -208,6 +208,7 @@ namespace Solutions {
  */
 class KerrSchild {
  public:
+  static constexpr size_t volume_dim = 3;
   struct Mass {
     using type = double;
     static constexpr OptionString help = {"Mass of the black hole"};
@@ -215,13 +216,13 @@ class KerrSchild {
     static type lower_bound() noexcept { return 0.; }
   };
   struct Spin {
-    using type = std::array<double, 3>;
+    using type = std::array<double, volume_dim>;
     static constexpr OptionString help = {
         "The [x,y,z] dimensionless spin of the black hole"};
     static type default_value() noexcept { return {{0., 0., 0.}}; }
   };
   struct Center {
-    using type = std::array<double, 3>;
+    using type = std::array<double, volume_dim>;
     static constexpr OptionString help = {
         "The [x,y,z] center of the black hole"};
     static type default_value() noexcept { return {{0., 0., 0.}}; }
@@ -242,48 +243,51 @@ class KerrSchild {
   ~KerrSchild() = default;
 
   template <typename DataType>
-  using DerivLapse = ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<3>,
-                                   Frame::Inertial>;
+  using DerivLapse = ::Tags::deriv<gr::Tags::Lapse<DataType>,
+                                   tmpl::size_t<volume_dim>, Frame::Inertial>;
   template <typename DataType>
   using DerivShift =
-      ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataType>,
-                    tmpl::size_t<3>, Frame::Inertial>;
+      ::Tags::deriv<gr::Tags::Shift<volume_dim, Frame::Inertial, DataType>,
+                    tmpl::size_t<volume_dim>, Frame::Inertial>;
   template <typename DataType>
-  using DerivSpatialMetric =
-      ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
-                    tmpl::size_t<3>, Frame::Inertial>;
+  using DerivSpatialMetric = ::Tags::deriv<
+      gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataType>,
+      tmpl::size_t<volume_dim>, Frame::Inertial>;
   template <typename DataType>
   using tags = tmpl::list<
       gr::Tags::Lapse<DataType>, ::Tags::dt<gr::Tags::Lapse<DataType>>,
-      DerivLapse<DataType>, gr::Tags::Shift<3, Frame::Inertial, DataType>,
-      ::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataType>>,
+      DerivLapse<DataType>,
+      gr::Tags::Shift<volume_dim, Frame::Inertial, DataType>,
+      ::Tags::dt<gr::Tags::Shift<volume_dim, Frame::Inertial, DataType>>,
       DerivShift<DataType>,
-      gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
-      ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>,
+      gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataType>,
+      ::Tags::dt<
+          gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataType>>,
       DerivSpatialMetric<DataType>, gr::Tags::SqrtDetSpatialMetric<DataType>,
-      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType>,
-      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataType>>;
+      gr::Tags::ExtrinsicCurvature<volume_dim, Frame::Inertial, DataType>,
+      gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial, DataType>>;
 
   template <typename DataType>
   tuples::tagged_tuple_from_typelist<tags<DataType>> variables(
-      const tnsr::I<DataType, 3>& x, double t, tags<DataType> /*meta*/) const
-      noexcept;
+      const tnsr::I<DataType, volume_dim>& x, double t,
+      tags<DataType> /*meta*/) const noexcept;
 
   // clang-tidy: no runtime references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
   SPECTRE_ALWAYS_INLINE double mass() const noexcept { return mass_; }
-  SPECTRE_ALWAYS_INLINE const std::array<double, 3>& center() const noexcept {
+  SPECTRE_ALWAYS_INLINE const std::array<double, volume_dim>& center() const
+      noexcept {
     return center_;
   }
-  SPECTRE_ALWAYS_INLINE const std::array<double, 3>& dimensionless_spin() const
-      noexcept {
+  SPECTRE_ALWAYS_INLINE const std::array<double, volume_dim>&
+  dimensionless_spin() const noexcept {
     return dimensionless_spin_;
   }
 
  private:
   double mass_{1.0};
-  std::array<double, 3> dimensionless_spin_{{0.0, 0.0, 0.0}},
+  std::array<double, volume_dim> dimensionless_spin_{{0.0, 0.0, 0.0}},
       center_{{0.0, 0.0, 0.0}};
 };
 


### PR DESCRIPTION
## Proposed changes

Add an alias storing volume dimensionality in KerrSchild analytic solution class. This alias will be needed by a forthcoming wrapper class for analytic solutions, that will make them work nicely with the GeneralizedHarmonic evolution system. In itself, this is a fairly straightforward enhancement.


### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
