### PR TITLE
Split volume and reduction observation events

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -121,7 +121,7 @@ EXCLUDE_SYMBOLS        = *brigand*                                    \
                          std*                                         \
                          YAML*
 
-EXAMPLE_PATH           = @PROJECT_SOURCE_DIR@/tests/Unit/ \
+EXAMPLE_PATH           = @PROJECT_SOURCE_DIR@/tests/ \
                          @PROJECT_SOURCE_DIR@/src/Executables/Examples/
 
 EXAMPLE_PATTERNS       =

--- a/docs/Tutorials/Visualization.md
+++ b/docs/Tutorials/Visualization.md
@@ -29,22 +29,17 @@ evolution, run the command:
 By default, the example input files do not produce any output. This can be
 changed by modifying the options passed to `EventsAndTriggers`:
 
-```
-EventsAndTriggers:
-  ? EveryNSlabs:
-      N: 3
-      Offset: 5
-  : - Observe:
-        VariablesToObserve: [MassDensity]
-```
+\snippet ObserveExample.yaml observe_event_trigger
 
-This will trigger an observation event for the Variable MassDensity every three
-slabs after the fifth one. A successful observation will result in the creation
-of H5 files whose names can be specified in the YAML file under the options
-`VolumeFileName` and `ReductionFileName`. One volume data file will be produced
-from each Charm++ node that is used to run the executable. Each volume data
-file will have its corresponding node number appended to its file name.
-Visualization of the volume data will be described in the next section.
+This will observe the norms of the errors in the system every three
+slabs starting with slab five and the volume data of Psi at the start
+of slabs 0 and 100.  A successful observation will result in the
+creation of H5 files whose names can be specified in the YAML file
+under the options `VolumeFileName` and `ReductionFileName`. One volume
+data file will be produced from each Charm++ node that is used to run
+the executable. Each volume data file will have its corresponding node
+number appended to its file name.  Visualization of the volume data
+will be described in the next section.
 
 ### 3D %Data Volume %Data In ParaView
 

--- a/src/Evolution/DiscontinuousGalerkin/ObserveErrorNorms.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/ObserveErrorNorms.hpp
@@ -1,0 +1,177 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/EventsAndTriggers/Event.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
+#include "IO/Observer/ReductionActions.hpp"  // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Reduction.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+namespace Tags {
+struct Time;
+}  // namespace Tags
+/// \endcond
+
+namespace dg {
+namespace Events {
+template <size_t VolumeDim, typename Tensors, typename EventRegistrars>
+class ObserveErrorNorms;
+
+namespace Registrars {
+template <size_t VolumeDim, typename Tensors>
+struct ObserveErrorNorms {
+  template <typename RegistrarList>
+  using f = Events::ObserveErrorNorms<VolumeDim, Tensors, RegistrarList>;
+};
+}  // namespace Registrars
+
+template <size_t VolumeDim, typename Tensors,
+          typename EventRegistrars =
+              tmpl::list<Registrars::ObserveErrorNorms<VolumeDim, Tensors>>>
+class ObserveErrorNorms;  // IWYU pragma: keep
+
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief %Observe the RMS errors in the tensors compared to their
+ * analytic solution.
+ *
+ * Writes reduction quantities:
+ * - `Time`
+ * - `NumberOfPoints` = total number of points in the domain
+ * - `Error(*)` = RMS errors in `Tensors` =
+ *   \f$\operatorname{RMS}\left(\sqrt{\sum_{\text{independent components}}\left[
+ *   \text{value} - \text{analytic solution}\right]^2}\right)\f$
+ *   over all points
+ *
+ * \warning Currently, only one reduction observation event can be
+ * triggered at a given time.  Causing multiple events to run at once
+ * will produce unpredictable results.
+ */
+template <size_t VolumeDim, typename... Tensors, typename EventRegistrars>
+class ObserveErrorNorms<VolumeDim, tmpl::list<Tensors...>, EventRegistrars>
+    : public Event<EventRegistrars> {
+ private:
+  using coordinates_tag = ::Tags::Coordinates<VolumeDim, Frame::Inertial>;
+
+  template <typename Tag>
+  struct LocalSquareError {
+    using type = double;
+  };
+
+  using L2ErrorDatum = Parallel::ReductionDatum<double, funcl::Plus<>,
+                                                funcl::Sqrt<funcl::Divides<>>,
+                                                std::index_sequence<1>>;
+  using ReductionData = tmpl::wrap<
+      tmpl::append<
+          tmpl::list<Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+                     Parallel::ReductionDatum<size_t, funcl::Plus<>>>,
+          tmpl::filled_list<L2ErrorDatum, sizeof...(Tensors)>>,
+      Parallel::ReductionData>;
+
+ public:
+  /// \cond
+  explicit ObserveErrorNorms(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ObserveErrorNorms);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::list<>;
+  static constexpr OptionString help =
+      "Observe the RMS errors in the tensors compared to their analytic\n"
+      "solution.\n"
+      "\n"
+      "Writes reduction quantities:\n"
+      " * Time\n"
+      " * NumberOfPoints = total number of points in the domain\n"
+      " * Error(*) = RMS errors in Tensors (see online help details)\n"
+      "\n"
+      "Warning: Currently, only one reduction observation event can be\n"
+      "triggered at a given time.  Causing multiple events to run at once\n"
+      "will produce unpredictable results.";
+
+  ObserveErrorNorms() = default;
+
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
+
+  using argument_tags = tmpl::list<::Tags::Time, coordinates_tag, Tensors...>;
+
+  template <typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
+  void operator()(const Time& time,
+                  const db::item_type<coordinates_tag>& inertial_coordinates,
+                  const db::item_type<Tensors>&... tensors,
+                  Parallel::ConstGlobalCache<Metavariables>& cache,
+                  const ArrayIndex& /*array_index*/,
+                  const ParallelComponent* const /*meta*/) const noexcept {
+    const auto analytic_solution =
+        Parallel::get<OptionTags::AnalyticSolutionBase>(cache).variables(
+            inertial_coordinates, time.value(), tmpl::list<Tensors...>{});
+
+    tuples::TaggedTuple<LocalSquareError<Tensors>...> local_square_errors;
+    const auto record_errors = [&analytic_solution, &local_square_errors](
+        const auto tensor_tag_v, const auto& tensor) noexcept {
+      using tensor_tag = tmpl::type_from<decltype(tensor_tag_v)>;
+      double local_square_error = 0.0;
+      for (size_t i = 0; i < tensor.size(); ++i) {
+        const auto error = tensor[i] - get<tensor_tag>(analytic_solution)[i];
+        local_square_error += alg::accumulate(square(error), 0.0);
+      }
+      get<LocalSquareError<tensor_tag>>(local_square_errors) =
+          local_square_error;
+      return 0;
+    };
+    expand_pack(record_errors(tmpl::type_<Tensors>{}, tensors)...);
+    const size_t num_points = get_first_argument(tensors...).begin()->size();
+
+    // Send data to reduction observer
+    auto& local_observer =
+        *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+             cache)
+             .ckLocalBranch();
+    Parallel::simple_action<observers::Actions::ContributeReductionData>(
+        local_observer,
+        observers::ObservationId(
+            time.value(), typename Metavariables::element_observation_type{}),
+        std::string{"/element_data"},
+        std::vector<std::string>{"Time", "NumberOfPoints",
+                                 ("Error(" + Tensors::name() + ")")...},
+        ReductionData{
+            time.value(), num_points,
+            std::move(get<LocalSquareError<Tensors>>(local_square_errors))...});
+  }
+};
+
+/// \cond
+template <size_t VolumeDim, typename... Tensors, typename EventRegistrars>
+PUP::able::PUP_ID ObserveErrorNorms<VolumeDim, tmpl::list<Tensors...>,
+                                    EventRegistrars>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace Events
+}  // namespace dg

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -12,7 +12,8 @@
 #include "Evolution/Actions/ComputeVolumeFluxes.hpp"    // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/InitializeElement.hpp"
-#include "Evolution/DiscontinuousGalerkin/Observe.hpp"
+#include "Evolution/DiscontinuousGalerkin/ObserveErrorNorms.hpp"
+#include "Evolution/DiscontinuousGalerkin/ObserveFields.hpp"
 #include "Evolution/DiscontinuousGalerkin/SlopeLimiters/LimiterActions.hpp"
 #include "Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp"
 #include "Evolution/DiscontinuousGalerkin/SlopeLimiters/Tags.hpp"
@@ -76,9 +77,12 @@ struct EvolutionMetavars {
       SlopeLimiters::Minmod<1, system::variables_tag::tags_list>>;
 
   // public for use by the Charm++ registration code
-  using events = tmpl::list<dg::Events::Registrars::Observe<
-      1, db::get_variables_tags_list<system::variables_tag>,
-      db::get_variables_tags_list<system::variables_tag>>>;
+  using events =
+      tmpl::list<dg::Events::Registrars::ObserveFields<
+                     1, db::get_variables_tags_list<system::variables_tag>,
+                     db::get_variables_tags_list<system::variables_tag>>,
+                 dg::Events::Registrars::ObserveErrorNorms<
+                     1, db::get_variables_tags_list<system::variables_tag>>>;
   using triggers = Triggers::time_triggers;
 
   using const_global_cache_tag_list =

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -14,7 +14,8 @@
 #include "Evolution/Conservative/UpdateConservatives.hpp"
 #include "Evolution/Conservative/UpdatePrimitives.hpp"
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
-#include "Evolution/DiscontinuousGalerkin/Observe.hpp"  // IWYU pragma: keep
+#include "Evolution/DiscontinuousGalerkin/ObserveErrorNorms.hpp"
+#include "Evolution/DiscontinuousGalerkin/ObserveFields.hpp"
 #include "Evolution/DiscontinuousGalerkin/SlopeLimiters/LimiterActions.hpp"
 #include "Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp"
 #include "Evolution/DiscontinuousGalerkin/SlopeLimiters/Tags.hpp"
@@ -102,12 +103,14 @@ struct EvolutionMetavars {
                     grmhd::ValenciaDivClean::Tags::TildeB<Frame::Inertial>>>>;
 
   // public for use by the Charm++ registration code
-  using events = tmpl::list<dg::Events::Registrars::Observe<
-      3,
-      tmpl::append<
-          db::get_variables_tags_list<system::variables_tag>,
-          db::get_variables_tags_list<system::primitive_variables_tag>>,
-      analytic_variables_tags>>;
+  using events = tmpl::list<
+      dg::Events::Registrars::ObserveErrorNorms<3, analytic_variables_tags>,
+      dg::Events::Registrars::ObserveFields<
+          3,
+          tmpl::append<
+              db::get_variables_tags_list<system::variables_tag>,
+              db::get_variables_tags_list<system::primitive_variables_tag>>,
+          analytic_variables_tags>>;
   using triggers = Triggers::time_triggers;
 
   using step_choosers =

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -13,7 +13,8 @@
 #include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/InitializeElement.hpp"  // IWYU pragma: keep
-#include "Evolution/DiscontinuousGalerkin/Observe.hpp"  // IWYU pragma: keep
+#include "Evolution/DiscontinuousGalerkin/ObserveErrorNorms.hpp"  // IWYU pragma: keep
+#include "Evolution/DiscontinuousGalerkin/ObserveFields.hpp"  // IWYU pragma: keep
 #include "Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"  // IWYU pragma: keep
 #include "Evolution/EventsAndTriggers/Event.hpp"
 #include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"  // IWYU pragma: keep
@@ -77,9 +78,12 @@ struct EvolutionMetavars {
       OptionTags::NumericalFluxParams<ScalarWave::UpwindFlux<Dim>>;
 
   // public for use by the Charm++ registration code
-  using events = tmpl::list<dg::Events::Registrars::Observe<
-      Dim, db::get_variables_tags_list<typename system::variables_tag>,
-      db::get_variables_tags_list<typename system::variables_tag>>>;
+  using events = tmpl::list<
+      dg::Events::Registrars::ObserveFields<
+          Dim, db::get_variables_tags_list<typename system::variables_tag>,
+          db::get_variables_tags_list<typename system::variables_tag>>,
+      dg::Events::Registrars::ObserveErrorNorms<
+          Dim, db::get_variables_tags_list<typename system::variables_tag>>>;
   using triggers = Triggers::time_triggers;
 
   // A tmpl::list of tags to be added to the ConstGlobalCache by the

--- a/tests/InputFiles/ScalarWave/ObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/ObserveExample.yaml
@@ -1,0 +1,56 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveScalarWave1D
+
+AnalyticSolution:
+  WaveVector: [1.0]
+  Center: [0.0]
+  Profile:
+    Sinusoid:
+      Amplitude: 1.0
+      Wavenumber: 1.0
+      Phase: 0.0
+
+InitialTime: 0.0
+FinalTime: 0.1
+InitialTimeStep: 0.001
+InitialSlabSize: 0.01
+
+DomainCreator:
+  Interval:
+    LowerBound: [0.0]
+    UpperBound: [6.283185307179586]
+    IsPeriodicIn: [true]
+    InitialRefinement: [2]
+    InitialGridPoints: [7]
+
+TimeStepper:
+  AdamsBashforthN:
+    Order: 3
+
+StepController: BinaryFraction
+
+StepChoosers:
+  - Constant: 0.05
+  - Increase:
+      Factor: 2
+  - Cfl:
+      SafetyFactor: 0.2
+
+NumericalFluxParams:
+
+# [observe_event_trigger]
+EventsAndTriggers:
+  ? EveryNSlabs:
+      N: 3
+      Offset: 5
+  : - ObserveErrorNorms
+  ? SpecifiedSlabs:
+      Slabs: [0, 100]
+  : - ObserveFields:
+        VariablesToObserve: ["Psi"]
+# [observe_event_trigger]
+
+VolumeFileName: "./ScalarWave1DPeriodicVolume"
+ReductionFileName: "./ScalarWave1DPeriodicReductions"

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -5,7 +5,8 @@ set(LIBRARY "Test_EvolutionDiscontinuousGalerkin")
 
 set(LIBRARY_SOURCES
   Test_InitializeElement.cpp
-  Test_Observe.cpp
+  Test_ObserveErrorNorms.cpp
+  Test_ObserveFields.cpp
   )
 
 add_subdirectory(SlopeLimiters)

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ObserveErrorNorms.cpp
@@ -1,0 +1,337 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DiscontinuousGalerkin/ObserveErrorNorms.hpp"  // IWYU pragma: keep
+#include "Evolution/EventsAndTriggers/Event.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"  // IWYU pragma: keep
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"  // IWYU pragma: keep
+#include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+// IWYU pragma: no_include "DataStructures/DataBox/Prefixes.hpp"  // for Variables
+
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare dg::Events::ObserveErrorNorms
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+// IWYU pragma: no_forward_declare db::DataBox
+namespace observers {
+namespace Actions {
+struct ContributeReductionData;
+}  // namespace Actions
+}  // namespace observers
+
+namespace {
+
+struct MockContributeReductionData {
+  struct Results {
+    observers::ObservationId observation_id;
+    std::string subfile_name;
+    std::vector<std::string> reduction_names;
+    double time;
+    size_t number_of_grid_points;
+    std::vector<double> errors;
+  };
+  static Results results;
+
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent, typename... Ts>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const observers::ObservationId& observation_id,
+                    const std::string& subfile_name,
+                    const std::vector<std::string>& reduction_names,
+                    Parallel::ReductionData<Ts...>&& reduction_data) noexcept {
+    results.observation_id = observation_id;
+    results.subfile_name = subfile_name;
+    results.reduction_names = reduction_names;
+    results.time = std::get<0>(reduction_data.data());
+    results.number_of_grid_points = std::get<1>(reduction_data.data());
+    results.errors.clear();
+    tmpl::for_each<tmpl::range<size_t, 2, sizeof...(Ts)>>([&reduction_data](
+        const auto index_v) noexcept {
+      constexpr size_t index = tmpl::type_from<decltype(index_v)>::value;
+      results.errors.push_back(std::get<index>(reduction_data.data()));
+    });
+  }
+};
+
+MockContributeReductionData::Results MockContributeReductionData::results{};
+
+template <typename System>
+struct Metavariables;
+
+template <typename System>
+struct ElementComponent {
+  using component_being_mocked = void;
+
+  using metavariables = Metavariables<System>;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<db::AddSimpleTags<>>;
+  using action_list = tmpl::list<>;
+};
+
+template <typename System>
+struct MockObserverComponent {
+  using component_being_mocked = observers::Observer<Metavariables<System>>;
+  using replace_these_simple_actions =
+      tmpl::list<observers::Actions::ContributeReductionData>;
+  using with_these_simple_actions = tmpl::list<MockContributeReductionData>;
+
+  using metavariables = Metavariables<System>;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<db::AddSimpleTags<>>;
+  using action_list = tmpl::list<>;
+};
+
+template <typename System>
+struct Metavariables {
+  using system = System;
+  using component_list =
+      tmpl::list<ElementComponent<System>, MockObserverComponent<System>>;
+  using const_global_cache_tag_list = tmpl::list<
+      OptionTags::AnalyticSolution<typename System::solution_for_test>>;
+
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+};
+
+// Test systems
+
+struct ScalarSystem {
+  struct ScalarVar : db::SimpleTag {
+    static std::string name() noexcept { return "Scalar"; }
+    using type = Scalar<DataVector>;
+  };
+
+  static constexpr size_t volume_dim = 1;
+  using vars_for_test = tmpl::list<ScalarVar>;
+  struct solution_for_test {
+    template <typename CheckTensor>
+    static void check_data(const CheckTensor& check_tensor) noexcept {
+      check_tensor("Error(Scalar)", ScalarVar{});
+    }
+
+    tuples::tagged_tuple_from_typelist<vars_for_test> variables(
+        const tnsr::I<DataVector, 1>& x, const double t,
+        const vars_for_test /*meta*/) const noexcept {
+      return {Scalar<DataVector>{1.0 - t * get<0>(x)}};
+    }
+
+    void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+  };
+};
+
+struct ComplicatedSystem {
+  struct ScalarVar : db::SimpleTag {
+    static std::string name() noexcept { return "Scalar"; }
+    using type = Scalar<DataVector>;
+  };
+
+  struct VectorVar : db::SimpleTag {
+    static std::string name() noexcept { return "Vector"; }
+    using type = tnsr::I<DataVector, 2>;
+  };
+
+  struct TensorVar : db::SimpleTag {
+    static std::string name() noexcept { return "Tensor"; }
+    using type = tnsr::ii<DataVector, 2>;
+  };
+
+  struct TensorVar2 : db::SimpleTag {
+    static std::string name() noexcept { return "Tensor2"; }
+    using type = tnsr::ii<DataVector, 2>;
+  };
+
+  static constexpr size_t volume_dim = 2;
+  using vars_for_test = tmpl::list<VectorVar, TensorVar2>;
+  struct solution_for_test {
+    template <typename CheckTensor>
+    static void check_data(const CheckTensor& check_tensor) noexcept {
+      check_tensor("Error(Vector)", VectorVar{});
+      check_tensor("Error(Tensor2)", TensorVar2{});
+    }
+
+    tuples::tagged_tuple_from_typelist<vars_for_test> variables(
+        const tnsr::I<DataVector, 2>& x, const double t,
+        const vars_for_test /*meta*/) const noexcept {
+      auto vector = make_with_value<tnsr::I<DataVector, 2>>(x, 0.0);
+      auto tensor = make_with_value<tnsr::ii<DataVector, 2>>(x, 0.0);
+      // Arbitrary functions
+      get<0>(vector) = 1.0 - t * get<0>(x);
+      get<1>(vector) = 1.0 - t * get<1>(x);
+      get<0, 0>(tensor) = get<0>(x) + get<1>(x);
+      get<0, 1>(tensor) = get<0>(x) - get<1>(x);
+      get<1, 1>(tensor) = get<0>(x) * get<1>(x);
+      return {std::move(vector), std::move(tensor)};
+    }
+
+    void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+  };
+};
+
+template <typename System, typename ObserveEvent>
+void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
+  constexpr size_t volume_dim = System::volume_dim;
+  using element_component = ElementComponent<System>;
+  using observer_component = MockObserverComponent<System>;
+  using coordinates_tag = Tags::Coordinates<volume_dim, Frame::Inertial>;
+
+  const typename element_component::array_index array_index(0);
+  const size_t num_points = 5;
+  const double observation_time = 2.0;
+  Variables<tmpl::push_back<typename System::vars_for_test, coordinates_tag>>
+      vars(num_points);
+  // Fill the variables with some data.  It doesn't matter much what,
+  // but integers are nice in that we don't have to worry about
+  // roundoff error.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+  std::iota(vars.data(), vars.data() + vars.size(), 1.0);
+
+  const typename System::solution_for_test analytic_solution{};
+  using solution_variables = typename System::vars_for_test;
+  const Variables<solution_variables> errors =
+      vars.template extract_subset<solution_variables>() -
+      variables_from_tagged_tuple(analytic_solution.variables(
+          get<coordinates_tag>(vars), observation_time, solution_variables{}));
+
+  using MockRuntimeSystem =
+      ActionTesting::MockRuntimeSystem<Metavariables<System>>;
+
+  typename MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<typename MockRuntimeSystem::template MockDistributedObjectsTag<
+      element_component>>(dist_objects)
+      .emplace(array_index,
+               ActionTesting::MockDistributedObject<element_component>{});
+  tuples::get<typename MockRuntimeSystem::template MockDistributedObjectsTag<
+      observer_component>>(dist_objects)
+      .emplace(0, ActionTesting::MockDistributedObject<observer_component>{});
+  MockRuntimeSystem runner({std::move(analytic_solution)},
+                           std::move(dist_objects));
+
+  const auto box = db::create<
+      db::AddSimpleTags<Tags::TimeId,
+                        Tags::Variables<typename decltype(vars)::tags_list>>,
+      db::AddComputeTags<Tags::Time>>(
+      TimeId(true, 0, Slab(0., observation_time).end()), vars);
+
+  observe->run(box, runner.cache(), array_index,
+               std::add_pointer_t<element_component>{});
+
+  // Process the data
+  runner.template invoke_queued_simple_action<observer_component>(0);
+  CHECK(runner.template is_simple_action_queue_empty<observer_component>(0));
+
+  const auto& results = MockContributeReductionData::results;
+  CHECK(results.observation_id.value() == observation_time);
+  CHECK(results.subfile_name == "/element_data");
+  CHECK(results.reduction_names[0] == "Time");
+  CHECK(results.time == observation_time);
+  CHECK(results.reduction_names[1] == "NumberOfPoints");
+  CHECK(results.number_of_grid_points == num_points);
+  CHECK(results.reduction_names.size() == results.errors.size() + 2);
+
+  size_t num_tensors_observed = 0;
+  // Clang 6 believes the capture of results to be
+  // incorrect, presumably because it is checking the storage duration
+  // of the object referenced by reduction_results, rather than
+  // reduction_results itself.  gcc (correctly, I believe) requires
+  // the capture.
+#if defined(__clang__) && __clang_major__ > 4
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-lambda-capture"
+#endif  // __clang__
+  System::solution_for_test::check_data([
+    &errors, &num_tensors_observed, &results
+  ](const std::string& name, auto tag) noexcept {
+#if defined(__clang__) && __clang_major__ > 4
+#pragma GCC diagnostic pop
+#endif  // __clang__
+    double expected = 0.0;
+    for (const auto& component : get<decltype(tag)>(errors)) {
+      // The rest of the RMS calculation is done later by the writer.
+      expected += alg::accumulate(square(component), 0.0);
+    }
+
+    CAPTURE(results.reduction_names);
+    CAPTURE(name);
+    const auto it = alg::find(results.reduction_names, name);
+    CHECK(it != results.reduction_names.end());
+    if (it != results.reduction_names.end()) {
+      CHECK(results.errors[static_cast<size_t>(
+                               it - results.reduction_names.begin()) -
+                           2] == expected);
+    }
+    ++num_tensors_observed;
+  });
+  CHECK(results.errors.size() == num_tensors_observed);
+}
+
+template <typename System>
+void test_system() noexcept {
+  INFO(pretty_type::get_name<System>());
+  test_observe<System>(
+      std::make_unique<dg::Events::ObserveErrorNorms<
+          System::volume_dim, typename System::vars_for_test>>());
+
+  INFO("create/serialize");
+  using EventType = Event<tmpl::list<dg::Events::Registrars::ObserveErrorNorms<
+      System::volume_dim, typename System::vars_for_test>>>;
+  Parallel::register_derived_classes_with_charm<EventType>();
+  const auto factory_event =
+      test_factory_creation<EventType>("  ObserveErrorNorms");
+  auto serialized_event = serialize_and_deserialize(factory_event);
+  test_observe<System>(std::move(serialized_event));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveErrorNorms", "[Unit][Evolution]") {
+  test_system<ScalarSystem>();
+  test_system<ComplicatedSystem>();
+}


### PR DESCRIPTION
This first commit is a fixup on the second that only does file moves and copies.  This makes the changes on the second commit easier to review.

This PR conflicts with #1441 even though the diffs do not overlap.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
