### PR TITLE
Add wrapper for IO/H5/Dat.hpp and IO/H5/File.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,6 @@ include(SetupCxxFlags)
 include(SetupSanitizers)
 include(SetupListTargets)
 include(AddSpectreExecutable)
-include(SpectreSetupPython)
-
 include(CheckBrokenArray0)
 
 # Need to load python libs before boost.python.
@@ -74,7 +72,7 @@ include(SetupLibsharp)
 include(SetupYamlCpp)
 
 include(SetupLIBCXXCharm)
-
+include(SpectreSetupPython)
 # The precompiled header must be setup after all libraries have been found
 include(SetupPch)
 

--- a/cmake/SpectreSetupPython.cmake
+++ b/cmake/SpectreSetupPython.cmake
@@ -10,6 +10,7 @@
 set(SPECTRE_LINK_PYBINDINGS
   -Wl,--whole-archive
   PUBLIC PyBindings
+  PUBLIC ${HDF5_LIBRARIES}
   -Wl,--no-whole-archive)
 
 set(SPECTRE_PYTHON_PREFIX "${CMAKE_BINARY_DIR}/bin/python/spectre/")

--- a/src/DataStructures/Python/ToNumpy.hpp
+++ b/src/DataStructures/Python/ToNumpy.hpp
@@ -4,12 +4,42 @@
 #pragma once
 
 #include <Python.h>
+#include <array>
+#include <cstdlib>
 
-/// \cond
-class Matrix;
-/// \endcond
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Python/Numpy.hpp"
+
+// IWYU pragma: no_include <numpy/ndarrayobject.h>
+// IWYU pragma: no_include <numpy/ndarraytypes.h>
 
 namespace py_bindings {
 /// Convert Matrix to a Numpy Array. Always creates a copy.
-PyObject* to_numpy(const Matrix& matrix);
+// We use `malloc` instead of `new` because we tell NumPy it needs to free the
+// memory and NumPy uses `free`, not `delete`.
+inline PyObject* to_numpy(const Matrix& matrix) {
+  auto* c_style_data = static_cast<double*>(
+      malloc(sizeof(double) * (matrix.rows()) * matrix.columns()));
+  for (size_t i = 0; i < matrix.rows(); ++i) {
+    for (size_t j = 0; j < matrix.columns(); ++j) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      c_style_data[j + i * matrix.columns()] = matrix(i, j);
+    }
+  }
+  std::array<long, 2> dims{
+      {static_cast<long>(matrix.rows()), static_cast<long>(matrix.columns())}};
+  // clang-tidy: C-style cast done implictly with Python
+  // NOLINTNEXTLINE
+  PyObject* npy_array = PyArray_SimpleNewFromData(2, dims.data(), NPY_DOUBLE,
+                                                  c_style_data);  // NOLINT
+
+  // The `reinterpret_cast` is intentional because we know the pointer actually
+  // points to an object of type `PyArrayObject` and we need to access it in
+  // that manner.
+
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  auto* npy_array_obj = reinterpret_cast<PyArrayObject*>(npy_array);
+  PyArray_ENABLEFLAGS(npy_array_obj, NPY_ARRAY_OWNDATA);
+  return npy_array;
+}
 }  // namespace py_bindings

--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -28,3 +28,5 @@ target_link_libraries(
   INTERFACE ErrorHandling
   INTERFACE Utilities
   )
+
+add_subdirectory(H5/Python)

--- a/src/IO/H5/Header.cpp
+++ b/src/IO/H5/Header.cpp
@@ -22,15 +22,25 @@ Header::Header(const bool exists, detail::OpenGroup&& group,
   if (exists) {
     header_info_ =
         h5::read_rank1_attribute<std::string>(location, name + extension())[0];
-    const auto printenv_location =
-        header_info_.find(printenv_delimiter_) + printenv_delimiter_.size();
-    const auto library_versions_location =
-        header_info_.find(library_versions_delimiter_);
-    environment_variables_ = header_info_.substr(
-        printenv_location, library_versions_location - printenv_location);
-    library_versions_ = header_info_.substr(library_versions_location +
-                                            library_versions_delimiter_.size());
-    header_info_.erase(printenv_location - printenv_delimiter_.size());
+    if (header_info_.find(printenv_delimiter_) != std::string::npos) {
+      const auto printenv_location =
+          header_info_.find(printenv_delimiter_) + printenv_delimiter_.size();
+      const auto library_versions_location =
+          header_info_.find(library_versions_delimiter_);
+      environment_variables_ = header_info_.substr(
+          printenv_location, library_versions_location - printenv_location);
+      library_versions_ = header_info_.substr(
+          library_versions_location + library_versions_delimiter_.size());
+      header_info_.erase(printenv_location - printenv_delimiter_.size());
+    }
+
+    else {
+      //If we cannot find the Formaline delimiter in the file then the file
+      //was written without Formaline support and so we fill in fake info.
+      environment_variables_ =
+          "Formaline was not supported when file was written";
+      library_versions_ = "Formaline was not supported when file was written";
+    }
   } else {
     auto build_info = info_from_build();
     environment_variables_ = formaline::get_environment_variables();

--- a/src/IO/H5/Python/Bindings.cpp
+++ b/src/IO/H5/Python/Bindings.cpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <boost/python.hpp>
+
+// These macros are required so that the NumPy API will work when used in
+// multiple cpp files.  See
+// https://docs.scipy.org/doc/numpy/reference/c-api.array.html#importing-the-api
+#define PY_ARRAY_UNIQUE_SYMBOL SPECTRE_IO_H5_PYTHON_BINDINGS
+// Code is clean against Numpy 1.7, see
+// https://docs.scipy.org/doc/numpy-1.15.1/reference/c-api.deprecations.html
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+
+// We do not use the antipattern:
+// #define NO_IMPORT_ARRAY
+// #include "DataStructures/Python/Numpy.hpp"
+// because
+// 1. This means we are controlling code in the header file with a
+//    local macro, which can be very confusing and should generally be avoided.
+// 2. When C++ modules land this type of pattern will no longer really be
+//    possible since it goes against exactly what modules is trying to do: make
+//    things modular.
+
+namespace py_bindings {
+void bind_h5file();
+void bind_h5dat();
+}  // namespace py_bindings
+
+BOOST_PYTHON_MODULE(_H5) {
+  Py_Initialize();
+  import_array();
+  py_bindings::bind_h5file();
+  py_bindings::bind_h5dat();
+}

--- a/src/IO/H5/Python/CMakeLists.txt
+++ b/src/IO/H5/Python/CMakeLists.txt
@@ -1,18 +1,25 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY "PyDataStructures")
+set(LIBRARY "PyH5")
 
 spectre_python_add_module(
-  DataStructures
+  H5
   SOURCES
   Bindings.cpp
-  DataVector.cpp
-  Matrix.cpp
+  Dat.cpp
+  File.cpp
+  MODULE_PATH "IO/"
   )
 
 target_link_libraries(
   ${LIBRARY}
+  PUBLIC IO
   PUBLIC DataStructures
   ${SPECTRE_LINK_PYBINDINGS}
+  )
+
+add_dependencies(
+  ${LIBRARY}
+  PyDataStructures
   )

--- a/src/IO/H5/Python/Dat.cpp
+++ b/src/IO/H5/Python/Dat.cpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <Python.h>
+#include <boost/python.hpp>
+#include <boost/python/stl_iterator.hpp>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include <hdf5.h>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/Matrix.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/Header.hpp"
+#include "IO/H5/OpenGroup.hpp"
+#include "IO/H5/Python/Numpy.hpp"
+#include "IO/H5/Python/ToNumpy.hpp"
+#include "IO/H5/Version.hpp"
+#include "PythonBindings/VectorPyList.hpp"
+
+namespace bp = boost::python;
+
+namespace py_bindings {
+void bind_h5dat() {
+  // Wrapper for basic H5Dat operations
+  bp::class_<h5::Dat, boost::noncopyable>("H5Dat", bp::no_init)
+      .def("append",
+           +[](h5::Dat& D, const bp::list& data) {
+             D.append(py_list_to_std_vector<double>(data));
+           }, "Requires a list as input")
+      .def("get_legend",
+           +[](h5::Dat& D) -> bp::list {
+             return std_vector_to_py_list<std::string>(D.get_legend());
+           })
+      .def("get_data",
+           +[](h5::Dat& D) -> PyObject* { return to_numpy(D.get_data()); })
+      .def("get_data_subset",
+           +[](h5::Dat& D, bp::list& columns, const size_t first_row = 0,
+               const size_t num_rows = 1) -> PyObject* {
+             return to_numpy(D.get_data_subset(
+                 py_list_to_std_vector<size_t>(columns), first_row, num_rows));
+           })
+      .def("get_dimensions",
+           +[](h5::Dat& D) -> bp::list {
+             std::array<hsize_t, 2> dimension = D.get_dimensions();
+             bp::list dim;
+             dim.append(dimension[0]);
+             dim.append(dimension[1]);
+             return dim;
+           })
+      .def("get_header", +[](h5::Dat& D) { return D.get_header(); })
+      .def("get_version", +[](h5::Dat& D) { return D.get_version(); });
+}
+}  // namespace py_bindings

--- a/src/IO/H5/Python/File.cpp
+++ b/src/IO/H5/Python/File.cpp
@@ -1,0 +1,51 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <boost/python.hpp>
+#include <boost/python/reference_existing_object.hpp>
+#include <boost/python/return_value_policy.hpp>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include <hdf5.h>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/Header.hpp"
+#include "IO/H5/OpenGroup.hpp"
+#include "IO/H5/Type.hpp"
+#include "IO/H5/Version.hpp"
+#include "PythonBindings/VectorPyList.hpp"
+
+namespace bp = boost::python;
+
+namespace py_bindings {
+void bind_h5file() {
+  // Wrapper for basic H5File operations
+  bp::class_<h5::H5File<h5::AccessType::ReadWrite>, boost::noncopyable>(
+      "H5File", bp::init<std::string, bool>())
+      .def("name",
+           +[](const h5::H5File<h5::AccessType::ReadWrite>& f) {
+             return f.name();
+           })
+      .def("get_dat",
+           +[](const h5::H5File<h5::AccessType::ReadWrite>& f,
+               const bp::str& path) -> const h5::Dat& {
+             const auto& dat_file =
+                 f.get<h5::Dat>(bp::extract<std::string>(path));
+             return dat_file;
+           },
+           bp::return_value_policy<bp::reference_existing_object>())
+      .def("insert_dat",
+           +[](h5::H5File<h5::AccessType::ReadWrite>& f, const bp::str& path,
+               const bp::list& legend, uint32_t version) {
+             f.insert<h5::Dat>(bp::extract<std::string>(path),
+                               py_list_to_std_vector<std::string>(legend),
+                               version);
+           })
+      .def("close", +[](const h5::H5File<h5::AccessType::ReadWrite>& f) {
+        f.close_current_object();
+      });
+}
+}  // namespace py_bindings

--- a/src/IO/H5/Python/Numpy.hpp
+++ b/src/IO/H5/Python/Numpy.hpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+// These macros are required so that the NumPy API will work when used in
+// multiple cpp files.  See
+// https://docs.scipy.org/doc/numpy/reference/c-api.array.html#importing-the-api
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL SPECTRE_IO_H5_PYTHON_BINDINGS
+// Code is clean against Numpy 1.7.  See
+// https://docs.scipy.org/doc/numpy-1.15.1/reference/c-api.deprecations.html
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>

--- a/src/IO/H5/Python/ToNumpy.hpp
+++ b/src/IO/H5/Python/ToNumpy.hpp
@@ -1,21 +1,21 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "DataStructures/Python/ToNumpy.hpp"
+#pragma once
 
+#include <Python.h>
 #include <array>
 #include <cstdlib>
+
+#include "DataStructures/Matrix.hpp"
 // IWYU pragma: no_include <numpy/ndarrayobject.h>
 // IWYU pragma: no_include <numpy/ndarraytypes.h>
 
-#include "DataStructures/Matrix.hpp"
-#include "DataStructures/Python/Numpy.hpp"  // IWYU pragma: keep
-
 namespace py_bindings {
-
+/// Convert Matrix to a Numpy Array. Always creates a copy.
 // We use `malloc` instead of `new` because we tell NumPy it needs to free the
 // memory and NumPy uses `free`, not `delete`.
-PyObject* to_numpy(const Matrix& matrix) {
+inline PyObject* to_numpy(const Matrix& matrix) {
   auto* c_style_data = static_cast<double*>(
       malloc(sizeof(double) * (matrix.rows()) * matrix.columns()));
   for (size_t i = 0; i < matrix.rows(); ++i) {

--- a/src/PythonBindings/CharmCompatibility.cpp
+++ b/src/PythonBindings/CharmCompatibility.cpp
@@ -4,6 +4,8 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <string>
+#include <vector>
 
 // In order to not get runtime errors that CmiPrintf, etc. are not defined we
 // provide resonable replacements for them. Getting the correct Charm++ library
@@ -39,7 +41,8 @@ void CmiError(const char* fmt, ...) {
 }
 
 int CmiMyPe() { return 0; }
-
+int _Cmi_mynode = 0;
+std::string info_from_build() { return "build_info"; }
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-noreturn"
 void CmiAbort(const char* msg) {
@@ -48,3 +51,18 @@ void CmiAbort(const char* msg) {
   fprintf(stderr, "%s", msg);
   abort();
 }
+namespace formaline {
+std::vector<char> get_archive() noexcept {
+  return {'N', 'o', 't', ' ', 's', 'u', 'p', 'p', 'o', 'r', 't', 'e', 'd'};
+}
+
+std::string get_environment_variables() noexcept {
+  return "Not supported on macOS";
+}
+
+std::string get_library_versions() noexcept {
+  return "Not supported in python";
+}
+
+std::string get_paths() noexcept { return "Not supported in python."; }
+}  // namespace formaline

--- a/src/PythonBindings/VectorPyList.hpp
+++ b/src/PythonBindings/VectorPyList.hpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <vector>
+
+#include <boost/python.hpp>
+#include <boost/python/stl_iterator.hpp>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+
+namespace bp = boost::python;
+
+namespace py_bindings {
+template <typename T>
+std::vector<T> py_list_to_std_vector(const bp::object& iterable) {
+  return std::vector<T>(bp::stl_input_iterator<T>(iterable),
+                        bp::stl_input_iterator<T>());
+}
+
+template <class T>
+bp::list std_vector_to_py_list(const std::vector<T>& vector) {
+  bp::list list;
+  for (auto iter = vector.begin(); iter != vector.end(); ++iter) {
+    list.append(*iter);
+  }
+  return list;
+}
+
+}  // namespace py_bindings

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -23,3 +23,8 @@ add_test_library(
   "${LIBRARY_SOURCES}"
   "IO"
   )
+
+spectre_add_python_test(
+  "Unit.IO.H5.Python"
+  "Test_H5.py"
+  "unit;IO;H5;python")

--- a/tests/Unit/IO/Test_H5.py
+++ b/tests/Unit/IO/Test_H5.py
@@ -1,0 +1,83 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre import DataStructures
+import  spectre.IO.H5 as spectre_h5
+import unittest
+import numpy as np
+import os
+import numpy.testing as npt
+
+class TestIOH5File(unittest.TestCase):
+    # Test Fixtures
+    def setUp(self):
+        self.file_name = "pythontest.h5"
+        self.data_1 = [1.0, 3.5]
+        self.data_1_array = np.array(self.data_1)
+        self.data_2 = [3.0, 10.3]
+        self.data_2_array = np.array(self.data_2)
+        if os.path.isfile(self.file_name):
+            os.remove(self.file_name)
+
+
+    def tearDown(self):
+        if os.path.isfile(self.file_name):
+            os.remove(self.file_name)
+
+
+    # Test whether an H5 file is created correctly,
+    def test_name(self):
+        file_spec = spectre_h5.H5File(self.file_name, 1)
+        self.assertEqual(self.file_name, file_spec.name())
+        file_spec.close()
+
+    # Test whether a dat file can be added correctly
+    def test_insert_dat(self):
+        file_spec = spectre_h5.H5File(self.file_name, 1)
+        file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
+        datfile = file_spec.get_dat("/element_data")
+        self.assertEqual(datfile.get_version(), 0)
+        file_spec.close()
+
+    # Test whether data can be added to the dat file correctly
+    def test_append(self):
+        file_spec = spectre_h5.H5File(self.file_name, 1)
+        file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
+        datfile = file_spec.get_dat("/element_data")
+        datfile.append(self.data_1)
+        outdata_array = datfile.get_data()
+        npt.assert_array_equal(outdata_array[0], self.data_1_array)
+        file_spec.close()
+
+    # More complicated test case for getting data subsets and dimensions
+    def test_get_data_subset(self):
+        file_spec = spectre_h5.H5File(self.file_name, 1)
+        file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
+        datfile = file_spec.get_dat("/element_data")
+        datfile.append(self.data_1)
+        datfile.append(self.data_2)
+        outdata_array = datfile.get_data_subset([1], 0, 2)
+        npt.assert_array_equal(outdata_array,  np.array(
+            [self.data_1[1:2], self.data_2[1:2]]))
+        self.assertEqual(datfile.get_dimensions()[0], 2)
+        file_spec.close()
+
+    # Getting Attributes
+    def test_get_legend(self):
+        file_spec = spectre_h5.H5File(self.file_name, 1)
+        file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
+        datfile = file_spec.get_dat("/element_data")
+        self.assertEqual(datfile.get_legend(), ["Time", "Value"])
+        self.assertEqual(datfile.get_version(), 0)
+        file_spec.close()
+
+    # The header is not universal, just checking the part that is predictable
+    def test_get_header(self):
+        file_spec = spectre_h5.H5File(self.file_name, 1)
+        file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
+        datfile = file_spec.get_dat("/element_data")
+        self.assertEqual(datfile.get_header()[0:16], "#\n# File created")
+        file_spec.close()
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes


This pull request creates wrapper classes for the H5 Input/Output classes so that h5 files, and in particular the dat file structure, can be used easily in python.  This will allow fo relatively easy access and visualization of data in a way which won't require additional effort if the H5 Input/Output functions are changed in the future to alter the dat file structure, etc.   


### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--

-->
