### PR TITLE
Structure for M1 flux

### DIFF
--- a/src/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY M1Grey)
 
 set(LIBRARY_SOURCES
+  Fluxes.cpp
   M1Closure.cpp
   Sources.cpp
   )

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Fluxes.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Fluxes.cpp
@@ -1,0 +1,51 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/RadiationTransport/M1Grey/Fluxes.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"  // IWYU pragma: keep
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace RadiationTransport {
+namespace M1Grey {
+
+namespace detail {
+void compute_fluxes_impl(
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_e_flux,
+    const gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> tilde_s_flux,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_s_M,
+    const Scalar<DataVector>& tilde_e,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& tilde_p,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>&
+        inv_spatial_metric) noexcept {
+  constexpr size_t spatial_dim = 3;
+
+  raise_or_lower_index(tilde_s_M, tilde_s, inv_spatial_metric);
+
+  for (size_t i = 0; i < spatial_dim; ++i) {
+    tilde_e_flux->get(i) =
+        get(lapse) * tilde_s_M->get(i) - shift.get(i) * get(tilde_e);
+    for (size_t j = 0; j < spatial_dim; ++j) {
+      tilde_s_flux->get(i, j) = -shift.get(i) * tilde_s.get(j);
+      for (size_t k = 0; k < spatial_dim; ++k) {
+        tilde_s_flux->get(i, j) +=
+            get(lapse) * tilde_p.get(i, k) * spatial_metric.get(j, k);
+      }
+    }
+  }
+}
+
+}  // namespace detail
+}  // namespace M1Grey
+}  // namespace RadiationTransport

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Fluxes.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Fluxes.hpp
@@ -1,0 +1,101 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"  // for item_type
+#include "DataStructures/DataBox/Prefixes.hpp"    // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "Utilities/Gsl.hpp"   // for not_null
+#include "Utilities/TMPL.hpp"  // for EXPAND_PACK_LEFT_TO...
+
+// IWYU pragma: no_include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+
+// IWYU pragma: no_forward_declare Tags::Flux
+// IWYU pragma: no_forward_declare Tensor
+
+namespace RadiationTransport {
+namespace M1Grey {
+
+// Implementation of the M1 fluxes for individual neutrino species
+namespace detail {
+void compute_fluxes_impl(
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_e_flux,
+    gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> tilde_s_flux,
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_s_M,
+    const Scalar<DataVector>& tilde_e,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& tilde_p,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>&
+        inv_spatial_metric) noexcept;
+}  // namespace detail
+
+/*!
+ * \brief The fluxes of the conservative variables in the M1 scheme
+ *
+ * \f{align*}
+ * F^i({\tilde E}) = &~ \alpha \gamma^{ij} {\tilde S}_j - \beta^j {\tilde E} \\
+ * F^i({\tilde S}_j) = &~ \alpha {\tilde P}^{ik} \gamma_{kj} - \beta^i {\tilde
+ * S}_j \f}
+ *
+ * where the conserved variables \f${\tilde E}\f$, \f${\tilde S}_i\f$,
+ * are a generalized mass-energy density and momentum density.
+ * Furthermore, \f${\tilde P^{ij}}\f$ is the pressure tensor density of the
+ * radiation field, \f$\alpha\f$ is the lapse, \f$\beta^i\f$ is the shift,
+ * \f$\gamma_{ij}\f$ the 3-metric, and \f$\gamma^{ij}\f$ its inverse.
+ *
+ * In the main function, we loop over all neutrino species, and then call
+ * the actual implementation of the fluxes.
+ */
+template <typename... NeutrinoSpecies>
+struct ComputeFluxes {
+  using return_tags =
+      tmpl::list<::Tags::Flux<Tags::TildeE<Frame::Inertial, NeutrinoSpecies>,
+                              tmpl::size_t<3>, Frame::Inertial>...,
+                 ::Tags::Flux<Tags::TildeS<Frame::Inertial, NeutrinoSpecies>,
+                              tmpl::size_t<3>, Frame::Inertial>...>;
+
+  using argument_tags =
+      tmpl::list<Tags::TildeE<Frame::Inertial, NeutrinoSpecies>...,
+                 Tags::TildeS<Frame::Inertial, NeutrinoSpecies>...,
+                 Tags::TildeP<Frame::Inertial, NeutrinoSpecies>...,
+                 gr::Tags::Lapse<>, gr::Tags::Shift<3>,
+                 gr::Tags::SpatialMetric<3>, gr::Tags::InverseSpatialMetric<3>>;
+
+  static void apply(
+      const gsl::not_null<db::item_type<
+          ::Tags::Flux<Tags::TildeE<Frame::Inertial, NeutrinoSpecies>,
+                       tmpl::size_t<3>, Frame::Inertial>>*>... tilde_e_flux,
+      const gsl::not_null<db::item_type<
+          ::Tags::Flux<Tags::TildeS<Frame::Inertial, NeutrinoSpecies>,
+                       tmpl::size_t<3>, Frame::Inertial>>*>... tilde_s_flux,
+      const db::item_type<
+          Tags::TildeE<Frame::Inertial, NeutrinoSpecies>>&... tilde_e,
+      const db::item_type<
+          Tags::TildeS<Frame::Inertial, NeutrinoSpecies>>&... tilde_s,
+      const db::item_type<
+          Tags::TildeP<Frame::Inertial, NeutrinoSpecies>>&... tilde_p,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+      const tnsr::II<DataVector, 3, Frame::Inertial>&
+          inv_spatial_metric) noexcept {
+    // Allocate memory for tildeS^i
+    tnsr::I<DataVector, 3, Frame::Inertial> tilde_s_M(get(lapse).size());
+    EXPAND_PACK_LEFT_TO_RIGHT(detail::compute_fluxes_impl(
+        tilde_e_flux, tilde_s_flux, &tilde_s_M, tilde_e, tilde_s, tilde_p,
+        lapse, shift, spatial_metric, inv_spatial_metric));
+  }
+};
+}  // namespace M1Grey
+}  // namespace RadiationTransport

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_M1Grey")
 
 set(LIBRARY_SOURCES
+  Test_Fluxes.cpp
   Test_M1Closure.cpp
   Test_Sources.cpp
   Test_Tags.cpp

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Fluxes.py
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Fluxes.py
@@ -1,0 +1,23 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+# Functions for testing Fluxes.cpp
+def tilde_e_flux(tilde_e, tilde_s, tilde_p, lapse,
+                   shift, spatial_metric, inv_spatial_metric):
+    result = (lapse * (np.einsum("a, ia", tilde_s, inv_spatial_metric)) -
+              shift * tilde_e)
+    return result
+
+
+def tilde_s_flux(tilde_e, tilde_s, tilde_p, lapse,
+                 shift, spatial_metric, inv_spatial_metric):
+    result = (lapse * (np.einsum("ia, aj", tilde_p, spatial_metric))-
+              np.outer(shift, tilde_s))
+    return result
+
+
+# End of functions for testing Fluxes.cpp
+

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Fluxes.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Fluxes.cpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/Fluxes.hpp"
+#include "Evolution/Systems/RadiationTransport/Tags.hpp"  // IWYU pragma: keep
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+SPECTRE_TEST_CASE("Unit.RadiationTransport.M1Grey.Fluxes", "[Unit][M1Grey]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/RadiationTransport/M1Grey"};
+
+  pypp::check_with_random_values<1>(&RadiationTransport::M1Grey::ComputeFluxes<
+                                        neutrinos::ElectronNeutrinos<0>>::apply,
+                                    "Fluxes", {"tilde_e_flux", "tilde_s_flux"},
+                                    {{{0.0, 1.0}}}, DataVector{5});
+}


### PR DESCRIPTION
## Proposed changes

Implement fluxes for the conservative formulation of M1 radiation transport

### Types of changes:

- [ ] Bugfix
- [ x] New feature

### Component:

- [x ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
