### PR TITLE
Adjust GhQuantities tests to fix #1392

### DIFF
--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -278,7 +278,7 @@ void test_shift_deriv_functions(const DataVector& used_for_size) noexcept {
                                                             DataType>),
       "GeneralRelativity.ComputeGhQuantities", "dt_lower_shift",
       {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size,
-      1.e-9);
+      5.e-9);
   // spacetime_deriv_of_norm_of_shift
   pypp::check_with_random_values<1>(
       static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
@@ -293,7 +293,7 @@ void test_shift_deriv_functions(const DataVector& used_for_size) noexcept {
               SpatialDim, Frame, DataType>),
       "GeneralRelativity.ComputeGhQuantities", "spacetime_deriv_norm_shift",
       {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size,
-      1.e-11);
+      1.e-10);
 }
 
 // Test computation of derivs of shift by comparing to Kerr-Schild


### PR DESCRIPTION
## Proposed changes

Reduce tolerance of tests to ensure that precision-related failure-rate of randomized tests is below 1 in 1000. This fixes #1392 .

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).