### PR TITLE
Add code to compute the HWENO modified neighbor solution

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -604,6 +604,19 @@
   url      = "http://cdsads.u-strasbg.fr/abs/1999JCoPh.150..199Y",
 }
 
+@article{Zhu2016,
+  author   = "Zhu, Jun and Zhong, Xinghui and Shu, Chi-Wang and Qiu, Jianxian",
+  title    = "{Runge-Kutta} Discontinuous {Galerkin} Method with a Simple and
+              Compact {Hermite} {WENO} Limiter",
+  journal  = "Communications in Computational Physics",
+  volume   = "19",
+  year     = "2016",
+  number   = "4",
+  pages    = "944–969",
+  doi      = "10.4208/cicp.070215.200715a",
+  url      = "https://doi.org/10.4208/cicp.070215.200715a",
+}
+
 
 # When editing this file, please follow the guidelines in
 # https://spectre-code.org/writing_good_dox.html#writing_dox_citations.

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY SlopeLimiters)
 
 set(LIBRARY_SOURCES
+  HwenoModifiedSolution.cpp
   MinmodHelpers.cpp
   MinmodTci.cpp
   MinmodType.cpp

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/HwenoModifiedSolution.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/HwenoModifiedSolution.cpp
@@ -1,0 +1,340 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/HwenoModifiedSolution.hpp"
+
+#include <array>
+#include <bitset>
+#include <cstddef>
+#include <ostream>
+#include <vector>
+
+#include "DataStructures/IndexIterator.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"  // IWYU pragma: keep
+#include "Domain/Mesh.hpp"     // IWYU pragma: keep
+#include "Domain/Side.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/WenoGridHelpers.hpp"
+#include "NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+
+// Compute the VolumeDim-dimensional quadrature weights, by taking the tensor
+// product of the 1D quadrature weights in each logical dimension of the Mesh.
+template <size_t VolumeDim>
+DataVector volume_quadrature_weights(const Mesh<VolumeDim>& mesh) noexcept {
+  std::array<DataVector, VolumeDim> quadrature_weights_1d{};
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    gsl::at(quadrature_weights_1d, d) =
+        Spectral::quadrature_weights(mesh.slice_through(d));
+  }
+
+  DataVector result{mesh.number_of_grid_points(), 1.};
+  for (IndexIterator<VolumeDim> s(mesh.extents()); s; ++s) {
+    result[s.collapsed_index()] = quadrature_weights_1d[0][s()[0]];
+    for (size_t d = 1; d < VolumeDim; ++d) {
+      result[s.collapsed_index()] *= gsl::at(quadrature_weights_1d, d)[s()[d]];
+    }
+  }
+  return result;
+}
+
+// Compute the matrix that interpolates data in VolumeDim dimensions from
+// source_mesh to the grid points of target_mesh, by taking the tensor product
+// of the 1D interpolation matrices in each logical dimension of the meshes.
+//
+// Note: typically it is more efficient to interpolate from source_mesh to
+// target_mesh in one logical direction at a time, and to avoid computing this
+// matrix. However, the HWENO algorithm requires constructing this matrix
+// explicitly.
+//
+// In particular, for this HWENO application:
+// - source_mesh is the mesh of local element.
+// - target_mesh is the mesh of the neighboring element in direction. Note that
+//   there can only be one neighbor in this direction, and this is checked in
+//   the call to `neighbor_grid_points_in_local_logical_coordinates`.
+// - rectilinear elements are assumed.
+template <size_t VolumeDim>
+Matrix volume_interpolation_matrix(
+    const Mesh<VolumeDim>& source_mesh, const Mesh<VolumeDim>& target_mesh,
+    const Element<VolumeDim>& element,
+    const Direction<VolumeDim>& direction) noexcept {
+  // The grid points of source_mesh and target_mesh must be in the same
+  // coordinates to construct the interpolation matrix. Here we get the points
+  // of target_mesh in the local logical coordinates.
+  const auto target_1d_coords =
+      SlopeLimiters::Weno_detail::neighbor_grid_points_in_local_logical_coords(
+          source_mesh, target_mesh, element, direction);
+
+  const auto interpolation_matrices_1d =
+      intrp::RegularGrid<VolumeDim>(source_mesh, target_mesh, target_1d_coords)
+          .interpolation_matrices();
+
+  // The 1D interpolation matrices will be empty if there is no need to
+  // interpolate in that particular direction (i.e., the interpolation in that
+  // direction is identity). This function undoes the optimization by returning
+  // elements of an identity matrix if an empty matrix is found.
+  const auto matrix_element = [&interpolation_matrices_1d](
+      const size_t dim, const size_t r, const size_t s) noexcept {
+    const auto& matrix = gsl::at(interpolation_matrices_1d, dim);
+    if (matrix.rows() * matrix.columns() == 0) {
+      return (r == s) ? 1. : 0.;
+    } else {
+      return matrix(r, s);
+    }
+  };
+
+  Matrix result(target_mesh.number_of_grid_points(),
+                source_mesh.number_of_grid_points(), 0.);
+  for (IndexIterator<VolumeDim> r(target_mesh.extents()); r; ++r) {
+    for (IndexIterator<VolumeDim> s(source_mesh.extents()); s; ++s) {
+      result(r.collapsed_index(), s.collapsed_index()) =
+          matrix_element(0, r()[0], s()[0]);
+      for (size_t d = 1; d < VolumeDim; ++d) {
+        result(r.collapsed_index(), s.collapsed_index()) *=
+            matrix_element(d, r()[d], s()[d]);
+      }
+    }
+  }
+  return result;
+}
+
+}  // namespace
+
+namespace SlopeLimiters {
+namespace Hweno_detail {
+
+template <size_t VolumeDim>
+Matrix inverse_a_matrix(
+    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
+    const DataVector& quadrature_weights,
+    const DirectionMap<VolumeDim, Matrix>& interpolation_matrices,
+    const DirectionMap<VolumeDim, DataVector>&
+        quadrature_weights_dot_interpolation_matrices,
+    const Direction<VolumeDim>& primary_direction,
+    const std::vector<Direction<VolumeDim>>& directions_to_exclude) noexcept {
+  const size_t number_of_grid_points = mesh.number_of_grid_points();
+  Matrix a(number_of_grid_points, number_of_grid_points, 0.);
+
+  // Loop only over directions where there is a neighbor
+  const std::vector<Direction<VolumeDim>>
+      directions_with_neighbors = [&element]() noexcept {
+    std::vector<Direction<VolumeDim>> result;
+    for (const auto& dir_and_neighbors : element.neighbors()) {
+      result.push_back(dir_and_neighbors.first);
+    }
+    return result;
+  }
+  ();
+
+  // Sanity check that directions_to_exclude is consistent with the element
+  ASSERT(
+      (not directions_to_exclude.empty()) or
+          directions_with_neighbors.size() == 1,
+      "directions_to_exclude can only be empty if there is a single neighbor");
+
+  for (const auto& dir : directions_with_neighbors) {
+    if (alg::found(directions_to_exclude, dir)) {
+      continue;
+    }
+
+    const auto& neighbor_mesh = mesh;
+    const auto& neighbor_quadrature_weights = quadrature_weights;
+    const auto& interpolation_matrix = interpolation_matrices.at(dir);
+    const auto& weights_dot_interpolation_matrix =
+        quadrature_weights_dot_interpolation_matrices.at(dir);
+
+    // Add terms from the primary neighbor
+    if (dir == primary_direction) {
+      for (size_t r = 0; r < neighbor_mesh.number_of_grid_points(); ++r) {
+        for (size_t s = 0; s < number_of_grid_points; ++s) {
+          for (size_t t = 0; t < number_of_grid_points; ++t) {
+            a(s, t) += neighbor_quadrature_weights[r] *
+                       interpolation_matrix(r, s) * interpolation_matrix(r, t);
+          }
+        }
+      }
+    }
+    // Add terms from the secondary neighbors
+    else {
+      for (size_t s = 0; s < number_of_grid_points; ++s) {
+        for (size_t t = 0; t < number_of_grid_points; ++t) {
+          a(s, t) += weights_dot_interpolation_matrix[s] *
+                     weights_dot_interpolation_matrix[t];
+        }
+      }
+    }
+  }
+
+  // Invert matrix in-place before returning
+  blaze::invert<blaze::asSymmetric>(a);
+  return a;
+}
+
+template <size_t VolumeDim>
+ConstrainedFitCache<VolumeDim>::ConstrainedFitCache(
+    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh) noexcept
+    : quadrature_weights(volume_quadrature_weights(mesh)) {
+  // Cache will only store quantities for directions that have neighbors.
+  const std::vector<Direction<VolumeDim>>
+      directions_with_neighbors = [&element]() noexcept {
+    std::vector<Direction<VolumeDim>> result;
+    for (const auto& dir_and_neighbors : element.neighbors()) {
+      result.push_back(dir_and_neighbors.first);
+    }
+    return result;
+  }
+  ();
+
+  for (const auto& dir : directions_with_neighbors) {
+    interpolation_matrices[dir] =
+        volume_interpolation_matrix(mesh, mesh, element, dir);
+    quadrature_weights_dot_interpolation_matrices[dir] = apply_matrices(
+        std::array<Matrix, 1>{{trans(interpolation_matrices.at(dir))}},
+        quadrature_weights, Index<1>(quadrature_weights.size()));
+  }
+
+  for (const auto& primary_dir : directions_with_neighbors) {
+    if (directions_with_neighbors.size() == 1) {
+      // With a single neighbor, there can be no neighbors to exclude.
+      std::vector<Direction<VolumeDim>> nothing_to_exclude{{}};
+      // To reuse the same data structure from the more common `else` branch,
+      // here we stick the data into the (normally nonsensical) slot where
+      // `dir_to_exclude == primary_dir`.
+      inverse_a_matrices[primary_dir][primary_dir] = inverse_a_matrix(
+          element, mesh, quadrature_weights, interpolation_matrices,
+          quadrature_weights_dot_interpolation_matrices, primary_dir,
+          nothing_to_exclude);
+    } else {
+      // Cache only handles the case of 1 neighbor to exclude.
+      for (const auto& dir_to_exclude : directions_with_neighbors) {
+        // Skip the nonsensical case where the primary and excluded neighbors
+        // are the same.
+        if (dir_to_exclude == primary_dir) {
+          continue;
+        }
+        inverse_a_matrices[primary_dir][dir_to_exclude] = inverse_a_matrix(
+            element, mesh, quadrature_weights, interpolation_matrices,
+            quadrature_weights_dot_interpolation_matrices, primary_dir,
+            {{dir_to_exclude}});
+      }
+    }
+  }
+}
+
+template <size_t VolumeDim>
+const Matrix& ConstrainedFitCache<VolumeDim>::retrieve_inverse_a_matrix(
+    const Direction<VolumeDim>& primary_direction,
+    const std::vector<Direction<VolumeDim>>& directions_to_exclude) const
+    noexcept {
+  if (LIKELY(directions_to_exclude.size() == 1)) {
+    return inverse_a_matrices.at(primary_direction)
+        .at(directions_to_exclude[0]);
+  } else if (directions_to_exclude.empty()) {
+    return inverse_a_matrices.at(primary_direction).at(primary_direction);
+  } else {
+    ERROR(
+        "Logic error: asked to retrieve a cached A^{-1} matrix for a\n"
+        "configuration where multiple neighboring elements are excluded from\n"
+        "the HWENO fit. Because this case is so rare, it is not handled by\n"
+        "the cache. The caller should check for multiple neighbors being\n"
+        "excluded, and, if this occurs, should bypass the cache and compute\n"
+        "A^{-1} directly.");
+  }
+}
+
+namespace {
+
+template <size_t VolumeDim, size_t DummyIndex>
+const ConstrainedFitCache<VolumeDim>& constrained_fit_cache_impl(
+    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh) noexcept {
+  // For the cache to be valid,
+  // - the mesh must always be the same, so we check it below
+  // - the element can be different, as long as it has the same configuration
+  //   of internal/external boundaries. this is handled in the calling code
+  //   because the boundary configuration sets the value of DummyIndex
+  static const Mesh<VolumeDim> mesh_for_cached_matrix = mesh;
+  ASSERT(mesh_for_cached_matrix == mesh,
+         "This call to constrained_fit_cache_impl received a different Mesh\n"
+         "than was previously cached, suggesting that multiple meshes are\n"
+         "used in the computational domain. This is not (yet) supported.\n"
+         "Cached mesh: "
+             << mesh_for_cached_matrix
+             << "\n"
+                "Argument mesh: "
+             << mesh);
+  static const ConstrainedFitCache<VolumeDim> result(element, mesh);
+  return result;
+}
+
+template <size_t VolumeDim, size_t... Is>
+const ConstrainedFitCache<VolumeDim>& constrained_fit_cache(
+    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
+    std::index_sequence<Is...> /*dummy_indices*/) noexcept {
+  static const std::array<
+      const ConstrainedFitCache<VolumeDim>& (*)(const Element<VolumeDim>&,
+                                                const Mesh<VolumeDim>&),
+      sizeof...(Is)>
+      cache{{&constrained_fit_cache_impl<VolumeDim, Is>...}};
+
+  // Use std::bitset to compute an integer based on the configuration of
+  // internal/external boundaries to the element. This is sort of like a hash
+  // for indexing into the std::array of ConstrainedFitCache's.
+  const size_t index_from_boundary_types = [&element]() noexcept {
+    std::bitset<2 * VolumeDim> bits;
+    for (size_t d = 0; d < VolumeDim; ++d) {
+      for (const Side& side : {Side::Lower, Side::Upper}) {
+        // Index into bitset
+        const size_t bit_index = 2 * d + (side == Side::Lower ? 0 : 1);
+        // Is there a neighbor in this direction?
+        const Direction<VolumeDim> dir(d, side);
+        const bool neighbor_exists =
+            (element.neighbors().find(dir) != element.neighbors().end());
+        bits[bit_index] = neighbor_exists;
+      }
+    }
+    return static_cast<size_t>(bits.to_ulong());
+  }
+  ();
+  ASSERT(index_from_boundary_types >= 0 and
+             index_from_boundary_types < sizeof...(Is),
+         "Got index_from_boundary_types = "
+             << index_from_boundary_types << ", but expect only "
+             << sizeof...(Is) << " configurations");
+  return gsl::at(cache, index_from_boundary_types)(element, mesh);
+}
+
+}  // namespace
+
+template <size_t VolumeDim>
+const ConstrainedFitCache<VolumeDim>& constrained_fit_cache(
+    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh) noexcept {
+  return constrained_fit_cache<VolumeDim>(
+      element, mesh, std::make_index_sequence<two_to_the(2 * VolumeDim)>{});
+}
+
+// Explicit instantiations
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template Matrix inverse_a_matrix<DIM(data)>(                                 \
+      const Element<DIM(data)>&, const Mesh<DIM(data)>&, const DataVector&,    \
+      const DirectionMap<DIM(data), Matrix>&,                                  \
+      const DirectionMap<DIM(data), DataVector>&, const Direction<DIM(data)>&, \
+      const std::vector<Direction<DIM(data)>>&) noexcept;                      \
+  template class ConstrainedFitCache<DIM(data)>;                               \
+  template const ConstrainedFitCache<DIM(data)>& constrained_fit_cache(        \
+      const Element<DIM(data)>&, const Mesh<DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+
+}  // namespace Hweno_detail
+}  // namespace SlopeLimiters

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/HwenoModifiedSolution.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/HwenoModifiedSolution.hpp
@@ -1,0 +1,547 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <boost/functional/hash.hpp>  // IWYU pragma: keep
+#include <cstddef>
+#include <functional>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tags.hpp"       // IWYU pragma: keep
+#include "DataStructures/Variables.hpp"  // IWYU pragma: keep
+#include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/WenoGridHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/ApplyMatrices.hpp"
+#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class Element;
+template <size_t VolumeDim>
+class ElementId;
+template <size_t>
+class Mesh;
+/// \endcond
+
+namespace SlopeLimiters {
+namespace Hweno_detail {
+
+// Caching class that holds various precomputed terms used in the constrained-
+// fit algebra on each element.
+//
+// The terms to precompute and cache depend on the configuration of neighbors to
+// the element (how many neighbors, in which directions, of what resolution).
+// Each instance of the caching class represents one particular neighbor
+// configuration, and typical simulations will create many instances of
+// the caching class: one instance for each neighbor-element configuration
+// present in the computational domain.
+//
+// Because the current implementation of the HWENO fitting makes the simplifying
+// restrictions of no h/p-refinement, the structure of the caching is also
+// simplified. In particular, with no h/p-refinement, the allowable neighbor
+// configurations satisfy,
+// 1. the element has at most one neighbor per dimension, AND
+// 2. the mesh on every neighbor is the same as on the element.
+// With these restrictions, the number of independent configurations to be
+// cached is greatly reduced. Because an element has 2*VolumeDim boundaries,
+// it has 2^(2*VolumeDim) possible configurations of internal/external
+// boundaries, and therefore there are 2^(2*VolumeDim) configurations to cache.
+// Different elements with the same configuration of internal/external
+// boundaries vs. direction can share the same caching-class instance.
+//
+// Each instance of the caching class holds several terms, some of which also
+// depend on the neighbor configuration. The restriction of no h/p-refinement
+// therefore simplifies each cache instance, as well as reducing the necessary
+// number of instances.
+//
+// The most complicated term to cache is the A^{-1} matrix. The complexity
+// arises because the matrix can take many values depending on (runtime) choices
+// made for each individual HWNEO fit: which element is the primary neighbor,
+// and which element(s) are the excluded neighbors.
+// Fits with one excluded neighbor are overwhelmingly the most likely, and the
+// cache is designed for this particular case. Fits with no excluded neighbors
+// can arise in elements with only one neighbor (always the primary neighbor);
+// these cases are also handled. However, the very rare case in which more than
+// one neighbor is excluded is not handled by the cache; the caller must compute
+// A^{-1} from scratch if this scenario arises.
+template <size_t VolumeDim>
+class ConstrainedFitCache {
+ public:
+  ConstrainedFitCache(const Element<VolumeDim>& element,
+                      const Mesh<VolumeDim>& mesh) noexcept;
+
+  // Valid calls must satisfy these constraints on directions_to_exclude:
+  // - the vector is empty, OR
+  // - the vector contains one element, and this element is a direction
+  //   different from the direction to the primary neighbor.
+  // The very rare case where more than one neighbor is excluded from the fit is
+  // not cached. In this case, A^{-1} must be computed from scratch.
+  const Matrix& retrieve_inverse_a_matrix(
+      const Direction<VolumeDim>& primary_direction,
+      const std::vector<Direction<VolumeDim>>& directions_to_exclude) const
+      noexcept;
+
+  DataVector quadrature_weights;
+  DirectionMap<VolumeDim, Matrix> interpolation_matrices;
+  DirectionMap<VolumeDim, DataVector>
+      quadrature_weights_dot_interpolation_matrices;
+  // The many possible values of A^{-1} are stored in a map of maps. The outer
+  // map indexes over the primary neighbor, and the inner map indexes over the
+  // excluded neighbor.
+  // This data structure is not perfect: configurations with only one neighbor
+  // (always the primary neighbor) lead to no excluded neighbors, and there is
+  // no natural place to hold A^{-1} in the maps. For this case, we simply store
+  // the data in the normally-nonsensical slot where
+  // excluded_neighbor == primary_neighbor.
+  DirectionMap<VolumeDim, DirectionMap<VolumeDim, Matrix>> inverse_a_matrices;
+};
+
+// Return the appropriate cache for the given element and mesh.
+template <size_t VolumeDim>
+const ConstrainedFitCache<VolumeDim>& constrained_fit_cache(
+    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh) noexcept;
+
+// Compute the inverse of the matrix A_st for the constrained fit.
+// See the documentation of `hweno_modified_neighbor_solution`.
+template <size_t VolumeDim>
+Matrix inverse_a_matrix(
+    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
+    const DataVector& quadrature_weights,
+    const DirectionMap<VolumeDim, Matrix>& interpolation_matrices,
+    const DirectionMap<VolumeDim, DataVector>&
+        quadrature_weights_dot_interpolation_matrices,
+    const Direction<VolumeDim>& primary_direction,
+    const std::vector<Direction<VolumeDim>>& directions_to_exclude) noexcept;
+
+// Not all secondary neighbors (i.e., neighbors that are not the primary) are
+// included in the HWENO constrained fit. In particular, for the tensor
+// component specified by `Tag` and `tensor_index`, the secondary neighbor whose
+// mean is most different from the troubled cell's mean is excluded.
+//
+// Zhu2016 indicate that when multiple secondary neighbors share the property of
+// being "most different" from the troubled cell, then all of these secondary
+// neighbors should be excluded from the minimization. The probability of this
+// occuring is exceedingly low, but we handle it anyway. We return the excluded
+// secondary neighbors in a vector.
+//
+// Note that if there is only one neighbor, it is the primary neighbor, and so
+// there are no secondary neighbors to exclude. We return an empty vector. This
+// scenario can arise in various test cases, but is unlikely to arise in science
+// cases.
+template <typename Tag, size_t VolumeDim, typename Package>
+std::vector<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>
+secondary_neighbors_to_exclude_from_fit(
+    const double local_mean, const size_t tensor_index,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, Package,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_data,
+    const std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>&
+        primary_neighbor) noexcept {
+  // Rare case: with only one neighbor, there is no secondary to exclude
+  if (UNLIKELY(neighbor_data.size() == 1)) {
+    return std::vector<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>{};
+  }
+
+  // Identify element with maximum mean difference
+  const auto mean_difference = [&tensor_index, &local_mean ](
+      const std::pair<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+                      Package>& neighbor_and_data) noexcept {
+    return fabs(
+        get<::Tags::Mean<Tag>>(neighbor_and_data.second.means)[tensor_index] -
+        local_mean);
+  };
+  const auto max_difference_neighbor_and_data = *alg::max_element(
+      neighbor_data,
+      [&mean_difference](
+          const std::pair<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+                          Package>& lhs,
+          const std::pair<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+                          Package>& rhs) noexcept {
+        return mean_difference(lhs) < mean_difference(rhs);
+      });
+
+  std::vector<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>
+      neighbors_to_exclude{{max_difference_neighbor_and_data.first}};
+
+  // See if other elements share this maximum mean difference. This loop should
+  // only rarely find other neighbors with the same maximal mean difference to
+  // add to the vector, so it will usually not change the vector.
+  const double max_difference =
+      mean_difference(max_difference_neighbor_and_data);
+  for (const auto& neighbor_and_data : neighbor_data) {
+    const auto& neighbor = neighbor_and_data.first;
+    if (neighbor == primary_neighbor or
+        neighbor == max_difference_neighbor_and_data.first) {
+      continue;
+    }
+    const double difference = mean_difference(neighbor_and_data);
+    if (UNLIKELY(equal_within_roundoff(difference, max_difference))) {
+      neighbors_to_exclude.push_back(neighbor);
+    }
+  }
+
+  return neighbors_to_exclude;
+}
+
+// Compute the vector b_s for the constrained fit. For details, see the
+// documentation of `hweno_modified_neighbor_solution` below.
+template <typename Tag, size_t VolumeDim, typename Package>
+DataVector b_vector(
+    const Mesh<VolumeDim>& mesh, const size_t tensor_index,
+    const DataVector& quadrature_weights,
+    const DirectionMap<VolumeDim, Matrix>& interpolation_matrices,
+    const DirectionMap<VolumeDim, DataVector>&
+        quadrature_weights_dot_interpolation_matrices,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, Package,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_data,
+    const std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>&
+        primary_neighbor,
+    const std::vector<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>&
+        neighbors_to_exclude) noexcept {
+  const size_t number_of_grid_points = mesh.number_of_grid_points();
+  DataVector b(number_of_grid_points, 0.);
+
+  for (const auto& neighbor_and_data : neighbor_data) {
+    // Generally, neighbors_to_exclude contains just one neighbor to exclude,
+    // and the loop over neighbor_data will hit this (in 3D) roughly 1/6 times.
+    // So the condition is somewhat, but not overwhelmingly, unlikely:
+    if (UNLIKELY(alg::found(neighbors_to_exclude, neighbor_and_data.first))) {
+      continue;
+    }
+
+    const auto& direction = neighbor_and_data.first.first;
+    ASSERT(interpolation_matrices.contains(direction),
+           "interpolation_matrices does not contain key: " << direction);
+    ASSERT(
+        quadrature_weights_dot_interpolation_matrices.contains(direction),
+        "quadrature_weights_dot_interpolation_matrices does not contain key: "
+            << direction);
+
+    const auto& neighbor_mesh = mesh;
+    const auto& neighbor_quadrature_weights = quadrature_weights;
+    const auto& interpolation_matrix = interpolation_matrices.at(direction);
+    const auto& quadrature_weights_dot_interpolation_matrix =
+        quadrature_weights_dot_interpolation_matrices.at(direction);
+
+    const auto& neighbor_tensor_component =
+        get<Tag>(neighbor_and_data.second.volume_data)[tensor_index];
+
+    // Add terms from the primary neighbor
+    if (neighbor_and_data.first == primary_neighbor) {
+      for (size_t r = 0; r < neighbor_mesh.number_of_grid_points(); ++r) {
+        for (size_t s = 0; s < number_of_grid_points; ++s) {
+          b[s] += neighbor_tensor_component[r] *
+                  neighbor_quadrature_weights[r] * interpolation_matrix(r, s);
+        }
+      }
+    }
+    // Add terms from the secondary neighbors
+    else {
+      const double quadrature_weights_dot_u = [&]() noexcept {
+        double result = 0.;
+        for (size_t r = 0; r < neighbor_mesh.number_of_grid_points(); ++r) {
+          result +=
+              neighbor_tensor_component[r] * neighbor_quadrature_weights[r];
+        }
+        return result;
+      }
+      ();
+      b += quadrature_weights_dot_u *
+           quadrature_weights_dot_interpolation_matrix;
+    }
+  }
+  return b;
+}
+
+// Solve the constrained fit problem that gives the HWENO modified solution,
+// for one particular tensor component. For details, see documentation of
+// `hweno_modified_neighbor_solution` below.
+template <typename Tag, size_t VolumeDim, typename Package>
+void solve_constrained_fit(
+    const gsl::not_null<DataVector*> constrained_fit_result,
+    const DataVector& u, const size_t tensor_index,
+    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, Package,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_data,
+    const std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>&
+        primary_neighbor,
+    const std::vector<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>&
+        neighbors_to_exclude) noexcept {
+  // Get the cache of linear algebra quantities for this element
+  const ConstrainedFitCache<VolumeDim>& cache =
+      constrained_fit_cache(element, mesh);
+
+  // Because we don't support h-refinement, the direction is the only piece
+  // of the neighbor information that we actually need.
+  const Direction<VolumeDim> primary_direction = primary_neighbor.first;
+  const std::vector<Direction<VolumeDim>>
+      directions_to_exclude = [&neighbors_to_exclude]() noexcept {
+    std::vector<Direction<VolumeDim>> result(neighbors_to_exclude.size());
+    for (size_t i = 0; i < result.size(); ++i) {
+      result[i] = neighbors_to_exclude[i].first;
+    }
+    return result;
+  }
+  ();
+
+  const DataVector& w = cache.quadrature_weights;
+  const DirectionMap<VolumeDim, Matrix>& interp_matrices =
+      cache.interpolation_matrices;
+  const DirectionMap<VolumeDim, DataVector>& w_dot_interp_matrices =
+      cache.quadrature_weights_dot_interpolation_matrices;
+
+  // Use cache if possible, or compute matrix if we are in edge case
+  const Matrix& inverse_a =
+      LIKELY(directions_to_exclude.size() < 2)
+          ? cache.retrieve_inverse_a_matrix(primary_direction,
+                                            directions_to_exclude)
+          : Hweno_detail::inverse_a_matrix(
+                element, mesh, w, interp_matrices, w_dot_interp_matrices,
+                primary_direction, directions_to_exclude);
+
+  const DataVector b = b_vector<Tag>(mesh, tensor_index, w, interp_matrices,
+                                     w_dot_interp_matrices, neighbor_data,
+                                     primary_neighbor, neighbors_to_exclude);
+
+  const size_t number_of_points = b.size();
+  const DataVector inverse_a_times_b = apply_matrices(
+      std::array<std::reference_wrapper<const Matrix>, 1>{{inverse_a}}, b,
+      Index<1>(number_of_points));
+  const DataVector inverse_a_times_w = apply_matrices(
+      std::array<std::reference_wrapper<const Matrix>, 1>{{inverse_a}}, w,
+      Index<1>(number_of_points));
+
+  // Compute Lagrange multiplier:
+  // Note: we take w as an argument (instead of as a lambda capture), because
+  //       some versions of Clang incorrectly warn about capturing w.
+  const double lagrange_multiplier =
+      [&number_of_points, &inverse_a_times_b, &inverse_a_times_w, &
+       u ](const DataVector& local_w) noexcept {
+    double numerator = 0.;
+    double denominator = 0.;
+    for (size_t s = 0; s < number_of_points; ++s) {
+      numerator += local_w[s] * (inverse_a_times_b[s] - u[s]);
+      denominator += local_w[s] * inverse_a_times_w[s];
+    }
+    return -numerator / denominator;
+  }
+  (w);
+
+  // Compute solution:
+  *constrained_fit_result =
+      inverse_a_times_b + lagrange_multiplier * inverse_a_times_w;
+}
+
+}  // namespace Hweno_detail
+
+template <size_t VolumeDim, typename Package>
+using LimiterNeighborData = std::unordered_map<
+    std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, Package,
+    boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>;
+
+/*!
+ * \ingroup SlopeLimitersGroup
+ * \brief Compute the HWENO modified solution for a particular tensor
+ * from a particular neighbor element
+ *
+ * The HWENO limiter reconstructs a new solution from the linear combination of
+ * the local DG solution and a "modified" solution from each neighbor element.
+ * This function computes the modified solution for a particular tensor and
+ * neighbor, following Section 3 of \cite Zhu2016.
+ *
+ * The modified solution associated with a particular neighbor (the "primary"
+ * neighbor) is obtained by solving a constrained fit over the local element,
+ * the primary neighbor, and the other ("secondary") neighbors of the local
+ * element. This fit seeks to minimize in a least-squared sense:
+ * 1. The distance between the modified solution and the original solution on
+ *    the primary neighbor.
+ * 2. The distance between the cell average of the modified solution and the
+ *    cell average of the original solution on each secondary neighbor. Note
+ *    however that one secondary neighbor (or, rarely, several) is excluded from
+ *    this minimization: the secondary neighbor(s) where the original solution
+ *    has the most different cell average from the local element. This helps to
+ *    prevent an outlier (e.g., near a shock) from biasing the fit.
+ *
+ * The constraint on the minimization is the following: the cell average of the
+ * modified solution on the local element must equal the cell average of the
+ * local element's original solution.
+ *
+ * Below we give the mathematical form of the constraints described above and
+ * show how these are translated into a numerical algorithm.
+ *
+ * Consider an element \f$I_0\f$ with neighbors \f$I_1, I_2, ...\f$. For a
+ * given tensor component \f$u\f$, the values on each of these elements are
+ * \f$u^{(0)}, u^{(1)}, u^{(2)}, ...\f$. Taking for the sake of example the
+ * primary neighbor to be \f$I_1\f$, the modified solution \f$\phi\f$ must
+ * minimize
+ *
+ * \f[
+ * \chi^2 = \int_{I_1} (\phi - u^{(1)})^2 dV
+ *          + \sum_{\ell \in L} \left(
+ *                              \int_{I_{\ell}} ( \phi - u^{(\ell)} ) dV
+ *                              \right)^2,
+ * \f]
+ *
+ * subject to the constaint
+ *
+ * \f[
+ * C = \int_{I_0} ( \phi - u^{(0)} ) dV = 0.
+ * \f]
+ *
+ * where \f$\ell\f$ ranges over a subset \f$L\f$ of the secondary neighbors.
+ * \f$L\f$ excludes the one (or more) secondary neighbor(s) where the mean of
+ * \f$u\f$ is the most different from the mean of \f$u^{(0)}\f$. Typically, only
+ * one secondary neighbor is excluded, so \f$L\f$ contains two fewer neighbors
+ * than the total number of neighbors to the element. Note that in 1D, this
+ * implies that \f$L\f$ is the empty set; for each modified solution, one
+ * neighbor is the primary neighbor and the other is the excluded neighbor.
+ *
+ * The integrals are evaluated by quadrature. We denote the quadrature weights
+ * by \f$w_s\f$ and the values of some data \f$X\f$ at the quadrature
+ * nodes by \f$X_s\f$. We use subscripts \f$r,s\f$ to denote quadrature nodes
+ * on the neighbor and local elements, respectively. The minimization becomes
+ *
+ * \f[
+ * \chi^2 = \sum_r w^{(1)}_r ( \phi_r - u^{(1)}_r )^2
+ *          + \sum_{\ell \in L} \left(
+ *                              \sum_r w^{(\ell)}_r ( \phi_r - u^{(\ell)}_r )
+ *                              \right)^2,
+ * \f]
+ *
+ * subject to the constraint
+ *
+ * \f[
+ * C = \sum_s w^{(0)}_s ( \phi_s - u^{(0)}_s ) = 0.
+ * \f]
+ *
+ * Note that \f$\phi\f$ is a function defined on the local element \f$I_0\f$,
+ * and so is fully represented by its values \f$\phi_s\f$ at the quadrature
+ * points on this element. When evaluating \f$\phi\f$ on element \f$I_{\ell}\f$,
+ * we obtain the function values \f$\phi_r\f$ by polynomial extrapolation,
+ * \f$\phi_r = \sum_s \mathcal{I}^{(\ell)}_{rs} \phi_s\f$, where
+ * \f$\mathcal{I}^{(\ell)}_{rs}\f$ is the interpolation/extrapolation matrix
+ * that interpolates data defined at grid points \f$x_s\f$ and evaluates it at
+ * grid points \f$x_r\f$ of \f$I_{\ell}\f$. Thus,
+ *
+ * \f[
+ * \chi^2 = \sum_r w^{(1)}_r
+ *                 \left(
+ *                 \sum_s \mathcal{I}^{(1)}_{rs} \phi_s - u^{(1)}_r
+ *                 \right)^2
+ *          + \sum_{\ell \in L} \left(
+ *                              \sum_r w^{(\ell)}_r
+ *                                     \left(
+ *                                     \sum_s \mathcal{I}^{(\ell)}_{rs} \phi_s
+ *                                             - u^{(\ell)}_r
+ *                                     \right)
+ *                      \right)^2.
+ * \f]
+ *
+ * The solution to this optimization problem is found in the standard way,
+ * using a Lagrange multiplier \f$\lambda\f$ to impose the constraint:
+ *
+ * \f[
+ * 0 = \frac{d}{d \phi_s} \left( \chi^2 + \lambda C \right).
+ * \f]
+ *
+ * Working out the differentiation with respect to \f$\phi_s\f$ leads to the
+ * linear problem that must be inverted to obtain the solution,
+ *
+ * \f[
+ * 0 = A_{st} \phi_t - b_s - \lambda w^{(0)}_s,
+ * \f]
+ *
+ * where
+ *
+ * \f{align*}{
+ * A_{st} &= \sum_r \left( w^{(1)}_r
+ *                  \mathcal{I}^{(1)}_{rs} \mathcal{I}^{(1)}_{rt}
+ *                  \right)
+ *          + \sum_{\ell \in L} \left(
+ *                              \sum_r \left(
+ *                                     w^{(\ell)}_r \mathcal{I}^{(\ell)}_{rt}
+ *                                     \right)
+ *                              \cdot
+ *                              \sum_r \left(
+ *                                     w^{(\ell)}_r \mathcal{I}^{(\ell)}_{rs}
+ *                                     \right)
+ *                              \right)
+ * \\
+ * b_s &= \sum_r \left( w^{(1)}_r u^{(1)}_r \mathcal{I}^{(1)}_{rs} \right)
+ *         + \sum_{\ell \in L} \left(
+ *                             \sum_r \left( w^{(\ell)}_r u^{(\ell)}_r \right)
+ *                             \cdot
+ *                             \sum_r \left(
+ *                                    w^{(\ell)}_r \mathcal{I}^{(\ell)}_{rs}
+ *                                    \right)
+ *                             \right).
+ * \f}
+ *
+ * Finally, the solution to the constrained fit is
+ *
+ * \f{align*}{
+ * \lambda &= - \frac{ \sum_s w^{(0)}_s
+ *                            \left( (A^{-1})_{st} b_t - u^{(0)}_s \right)
+ *              }{ \sum_s w^{(0)}_s (A^{-1})_{st} w^{(0)}_t }
+ * \\
+ * \phi_s &= (A^{-1})_{st} ( b_t + \lambda w^{(0)}_t ).
+ * \f}
+ *
+ * Note that the matrix \f$A\f$ does not depend on the values of the tensor
+ * \f$u\f$, so its inverse \f$A^{-1}\f$ can be precomputed and stored.
+ *
+ * \warning
+ * Note also that the implementation currently does not support h- or
+ * p-refinement; this is checked by some assertions. The implementation is
+ * untested for grids where elements are curved, and it should not be expected
+ * to work in these cases.
+ */
+template <typename Tag, size_t VolumeDim, typename Package>
+void hweno_modified_neighbor_solution(
+    const gsl::not_null<db::item_type<Tag>*> modified_tensor,
+    const db::item_type<Tag>& local_tensor, const Element<VolumeDim>& element,
+    const Mesh<VolumeDim>& mesh,
+    const LimiterNeighborData<VolumeDim, Package>& neighbor_data,
+    const std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>&
+        primary_neighbor) noexcept {
+  ASSERT(Weno_detail::check_element_has_one_similar_neighbor_in_direction(
+             element, primary_neighbor.first),
+         "Found some amount of h-refinement; this is not supported");
+  alg::for_each(neighbor_data, [&mesh](const auto& neighbor_and_data) noexcept {
+    ASSERT(neighbor_and_data.second.mesh == mesh,
+           "Found some amount of p-refinement; this is not supported");
+  });
+
+  for (size_t tensor_index = 0; tensor_index < local_tensor.size();
+       ++tensor_index) {
+    const auto& tensor_component = local_tensor[tensor_index];
+    const auto neighbors_to_exclude =
+        Hweno_detail::secondary_neighbors_to_exclude_from_fit<Tag>(
+            mean_value(tensor_component, mesh), tensor_index, neighbor_data,
+            primary_neighbor);
+    Hweno_detail::solve_constrained_fit<Tag>(
+        make_not_null(&(*modified_tensor)[tensor_index]),
+        local_tensor[tensor_index], tensor_index, element, mesh, neighbor_data,
+        primary_neighbor, neighbors_to_exclude);
+  }
+}
+
+}  // namespace SlopeLimiters

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/WenoGridHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/WenoGridHelpers.cpp
@@ -20,6 +20,9 @@ template <size_t VolumeDim>
 bool check_element_has_one_similar_neighbor_in_direction(
     const Element<VolumeDim>& element,
     const Direction<VolumeDim>& direction) noexcept {
+  ASSERT(element.neighbors().contains(direction),
+         "Inconsistent call: element "
+             << element << " has no neighbors in direction " << direction);
   const auto& neighbors = element.neighbors().at(direction);
   if (neighbors.size() > 1) {
     // More than one neighbor

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/WenoHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/WenoHelpers.hpp
@@ -64,12 +64,6 @@ double oscillation_indicator(const DataVector& data,
 //   A simple weighted essentially non-oscillatory limiter for Runge-Kutta
 //   discontinuous Galerkin methods
 //   https://doi.org/10.1016/j.jcp.2012.08.028
-//
-// Zhu20016
-//   Zhu, J and Zhong, X and Shu, C and Qiu, J
-//   Runge-Kutta Discontinuous Galerkin Method with a Simple and Compact Hermite
-//   WENO Limiter
-//   https://doi.org/10.4208/cicp.070215.200715a
 inline double unnormalized_nonlinear_weight(
     const double linear_weight, const double oscillation_indicator) noexcept {
   return linear_weight / square(1.e-6 + oscillation_indicator);

--- a/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.cpp
@@ -49,6 +49,12 @@ void RegularGrid<Dim>::pup(PUP::er& p) noexcept {
   p | interpolation_matrices_;
 }
 
+template <size_t Dim>
+const std::array<Matrix, Dim>& RegularGrid<Dim>::interpolation_matrices() const
+    noexcept {
+  return interpolation_matrices_;
+}
+
 template <size_t LocalDim>
 bool operator==(const RegularGrid<LocalDim>& lhs,
                 const RegularGrid<LocalDim>& rhs) noexcept {

--- a/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp
+++ b/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp
@@ -74,6 +74,14 @@ class RegularGrid {
       noexcept;
   //@}
 
+  /// \brief Return the internally-stored matrices that interpolate from the
+  /// source grid to the target grid.
+  ///
+  /// Each matrix interpolates in one logical direction, and can be empty if the
+  /// interpolation in that direction is the identity (i.e., if the source
+  /// and target grids have the same logical coordinates in this direction).
+  const std::array<Matrix, Dim>& interpolation_matrices() const noexcept;
+
  private:
   template <size_t LocalDim>
   // NOLINTNEXTLINE(readability-redundant-declaration)

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_SlopeLimiters")
 
 set(LIBRARY_SOURCES
+  Test_HwenoModifiedSolution.cpp
   Test_Krivodonova.cpp
   Test_LimiterActions.cpp
   Test_LimiterActionsWithMinmod.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_HwenoModifiedSolution.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_HwenoModifiedSolution.cpp
@@ -1,0 +1,1258 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Neighbors.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/HwenoModifiedSolution.hpp"
+#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+// IWYU pragma: no_forward_declare Variables
+
+namespace {
+
+struct ScalarTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "Scalar"; }
+};
+
+template <size_t VolumeDim>
+struct VectorTag : db::SimpleTag {
+  using type = tnsr::I<DataVector, VolumeDim>;
+  static std::string name() noexcept { return "Vector"; }
+};
+
+template <size_t VolumeDim>
+Neighbors<VolumeDim> make_neighbor_with_id(const size_t id) noexcept {
+  return {std::unordered_set<ElementId<VolumeDim>>{ElementId<VolumeDim>(id)},
+          OrientationMap<VolumeDim>{}};
+}
+
+// Construct an element with one neighbor in each direction.
+template <size_t VolumeDim>
+Element<VolumeDim> make_element() noexcept;
+
+template <>
+Element<1> make_element() noexcept {
+  return Element<1>{
+      ElementId<1>{0},
+      Element<1>::Neighbors_t{
+          {Direction<1>::lower_xi(), make_neighbor_with_id<1>(1)},
+          {Direction<1>::upper_xi(), make_neighbor_with_id<1>(2)}}};
+}
+
+template <>
+Element<2> make_element() noexcept {
+  return Element<2>{
+      ElementId<2>{0},
+      Element<2>::Neighbors_t{
+          {Direction<2>::lower_xi(), make_neighbor_with_id<2>(1)},
+          {Direction<2>::upper_xi(), make_neighbor_with_id<2>(2)},
+          {Direction<2>::lower_eta(), make_neighbor_with_id<2>(3)},
+          {Direction<2>::upper_eta(), make_neighbor_with_id<2>(4)}}};
+}
+
+template <>
+Element<3> make_element() noexcept {
+  return Element<3>{
+      ElementId<3>{0},
+      Element<3>::Neighbors_t{
+          {Direction<3>::lower_xi(), make_neighbor_with_id<3>(1)},
+          {Direction<3>::upper_xi(), make_neighbor_with_id<3>(2)},
+          {Direction<3>::lower_eta(), make_neighbor_with_id<3>(3)},
+          {Direction<3>::upper_eta(), make_neighbor_with_id<3>(4)},
+          {Direction<3>::lower_zeta(), make_neighbor_with_id<3>(5)},
+          {Direction<3>::upper_zeta(), make_neighbor_with_id<3>(6)}}};
+}
+
+void test_hweno_modified_solution_1d() {
+  INFO("Testing hweno_modified_neighbor_solution in 1D");
+  using TagsList = tmpl::list<ScalarTag>;
+  const auto element = make_element<1>();
+  const auto mesh = Mesh<1>{
+      {{3}}, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
+  const auto logical_coords = logical_coordinates(mesh);
+
+  const auto primary_neighbor =
+      std::make_pair(Direction<1>::lower_xi(), ElementId<1>{1});
+  const auto upper_xi_neighbor =
+      std::make_pair(Direction<1>::upper_xi(), ElementId<1>{2});
+
+  const auto local_tensor = [&logical_coords]() noexcept {
+    const auto& x = get<0>(logical_coords);
+    return Scalar<DataVector>{{{1. - 0.2 * x + 0.4 * square(x)}}};
+  }
+  ();
+
+  const auto primary_vars = [&mesh, &logical_coords ]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    const auto x = get<0>(logical_coords) - 2.;
+    get(get<ScalarTag>(result)) = 4. - 0.5 * x - 0.1 * square(x);
+    return result;
+  }
+  ();
+
+  const auto upper_xi_vars = [&mesh]() noexcept {
+    // Large values to make sure this neighbor is excluded
+    Variables<TagsList> result(mesh.number_of_grid_points(), 1.e3);
+    return result;
+  }
+  ();
+
+  const auto make_tuple_of_means = [&mesh](
+      const Variables<TagsList>& vars) noexcept {
+    return tuples::TaggedTuple<::Tags::Mean<ScalarTag>>(
+        mean_value(get(get<ScalarTag>(vars)), mesh));
+  };
+
+  struct PackagedData {
+    tuples::TaggedTuple<::Tags::Mean<ScalarTag>> means;
+    Variables<TagsList> volume_data;
+    Mesh<1> mesh;
+  };
+  std::unordered_map<std::pair<Direction<1>, ElementId<1>>, PackagedData,
+                     boost::hash<std::pair<Direction<1>, ElementId<1>>>>
+      neighbor_data{};
+  neighbor_data[primary_neighbor].means = make_tuple_of_means(primary_vars);
+  neighbor_data[primary_neighbor].volume_data = primary_vars;
+  neighbor_data[primary_neighbor].mesh = mesh;
+  neighbor_data[upper_xi_neighbor].means = make_tuple_of_means(upper_xi_vars);
+  neighbor_data[upper_xi_neighbor].volume_data = upper_xi_vars;
+  neighbor_data[upper_xi_neighbor].mesh = mesh;
+
+  Scalar<DataVector> modified_tensor;
+  SlopeLimiters::hweno_modified_neighbor_solution<ScalarTag>(
+      make_not_null(&modified_tensor), local_tensor, element, mesh,
+      neighbor_data, primary_neighbor);
+
+  // The expected coefficient values for the result of the constrained fit are
+  // found using Mathematica, using the following code (for Mathematica v10):
+  // qw3 = {1/3, 4/3, 1/3};
+  // qx3 = {-1, 0, 1};
+  // quad3[f_, dx_] := Sum[qw3[[qi]] f[qx3[[qi]] + dx], {qi, 1, 3}];
+  // trial[c0_, c1_, c2_][x_] := c0 + c1 x + c2 x^2;
+  // uLocal[x_] := 1 - 1/5 x + 2/5 x^2;
+  // uPrimary[x_] := 4 - 1/2 x - 1/10 x^2;
+  // primaryOptimizationTerm[c0_, c1_, c2_][x_] :=
+  //     (trial[c0, c1, c2][x] - uPrimary[x])^2;
+  // Minimize[
+  //     quad3[primaryOptimizationTerm[c0, c1, c2], -2],
+  //     quad3[trial[c0, c1, c2], 0] == quad3[uLocal, 0],
+  // {c0, c1, c2}
+  // ]
+  const auto expected = [&logical_coords]() noexcept {
+    const auto& x = get<0>(logical_coords);
+    constexpr std::array<double, 3> c{{41. / 30., -31. / 10., -7. / 10.}};
+    return Scalar<DataVector>{{{c[0] + c[1] * x + c[2] * square(x)}}};
+  }
+  ();
+
+  // Fit procedure has somewhat larger error scale than default
+  Approx local_approx = Approx::custom().epsilon(1e-11).scale(1.);
+  CHECK_ITERABLE_CUSTOM_APPROX(modified_tensor, expected, local_approx);
+  // Verify that the constraint is in fact satisfied
+  CHECK(mean_value(get(modified_tensor), mesh) ==
+        local_approx(mean_value(get(local_tensor), mesh)));
+}
+
+// Test in 2D using a vector tensor, to test multiple components. In particular,
+// check that different components will correctly exclude different neighbors if
+// needed.
+// Multiple components becomes very tedious in 3D, so 3D will test a scalar.
+void test_hweno_modified_solution_2d_vector() {
+  INFO("Testing hweno_modified_neighbor_solution in 2D");
+  using TagsList = tmpl::list<VectorTag<2>>;
+  const auto element = make_element<2>();
+  const auto mesh = Mesh<2>{
+      {{4, 3}}, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
+  const auto logical_coords = logical_coordinates(mesh);
+
+  const auto lower_xi_neighbor =
+      std::make_pair(Direction<2>::lower_xi(), ElementId<2>{1});
+  const auto upper_xi_neighbor =
+      std::make_pair(Direction<2>::upper_xi(), ElementId<2>{2});
+  const auto primary_neighbor =
+      std::make_pair(Direction<2>::lower_eta(), ElementId<2>{3});
+  const auto upper_eta_neighbor =
+      std::make_pair(Direction<2>::upper_eta(), ElementId<2>{4});
+
+  const auto local_tensor = [&logical_coords]() noexcept {
+    const auto& x = get<0>(logical_coords);
+    const auto& y = get<1>(logical_coords);
+    return VectorTag<2>::type{{{DataVector{1. + 0.1 * x + 0.2 * y +
+                                           0.1 * x * y + 0.1 * x * square(y)},
+                                DataVector(x.size(), 2.)}}};
+  }
+  ();
+
+  const auto lower_xi_vars = [&mesh]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    // The x component should exclude this neighbor
+    get<0>(get<VectorTag<2>>(result)) = 1.e3;
+    get<1>(get<VectorTag<2>>(result)) = 0.;
+    return result;
+  }
+  ();
+
+  const auto upper_xi_vars = [&mesh, &logical_coords ]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    const auto x = get<0>(logical_coords) + 2.;
+    const auto& y = get<1>(logical_coords);
+    get<0>(get<VectorTag<2>>(result)) =
+        1. + 1. / 3. * x + 0.25 * y - 0.05 * square(x);
+    get<1>(get<VectorTag<2>>(result)) = -0.5;
+    return result;
+  }
+  ();
+
+  const auto primary_vars = [&mesh, &logical_coords ]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    const auto& x = get<0>(logical_coords);
+    const auto y = get<1>(logical_coords) - 2.;
+    get<0>(get<VectorTag<2>>(result)) =
+        1. + 0.25 * x - 0.2 * square(y) + 0.1 * x * square(y);
+    get<1>(get<VectorTag<2>>(result)) =
+        1.2 + 0.5 * x - 0.1 * square(x) - 0.2 * y + 0.1 * square(x) * square(y);
+    return result;
+  }
+  ();
+
+  const auto upper_eta_vars = [&mesh, &logical_coords ]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    const auto& x = get<0>(logical_coords);
+    const auto y = get<1>(logical_coords) + 2.;
+    get<0>(get<VectorTag<2>>(result)) = 1. + 1. / 3. * x + 0.2 * y;
+    // The y component should exclude this neighbor
+    get<1>(get<VectorTag<2>>(result)) = 1.e3;
+    return result;
+  }
+  ();
+
+  const auto make_tuple_of_means = [&mesh](
+      const Variables<TagsList>& vars) noexcept {
+    return tuples::TaggedTuple<::Tags::Mean<VectorTag<2>>>(tnsr::I<double, 2>{
+        {{mean_value(get<0>(get<VectorTag<2>>(vars)), mesh),
+          mean_value(get<1>(get<VectorTag<2>>(vars)), mesh)}}});
+  };
+
+  struct PackagedData {
+    tuples::TaggedTuple<::Tags::Mean<VectorTag<2>>> means;
+    Variables<TagsList> volume_data;
+    Mesh<2> mesh;
+  };
+  std::unordered_map<std::pair<Direction<2>, ElementId<2>>, PackagedData,
+                     boost::hash<std::pair<Direction<2>, ElementId<2>>>>
+      neighbor_data{};
+  neighbor_data[lower_xi_neighbor].means = make_tuple_of_means(lower_xi_vars);
+  neighbor_data[lower_xi_neighbor].volume_data = lower_xi_vars;
+  neighbor_data[lower_xi_neighbor].mesh = mesh;
+  neighbor_data[upper_xi_neighbor].means = make_tuple_of_means(upper_xi_vars);
+  neighbor_data[upper_xi_neighbor].volume_data = upper_xi_vars;
+  neighbor_data[upper_xi_neighbor].mesh = mesh;
+  neighbor_data[primary_neighbor].means = make_tuple_of_means(primary_vars);
+  neighbor_data[primary_neighbor].volume_data = primary_vars;
+  neighbor_data[primary_neighbor].mesh = mesh;
+  neighbor_data[upper_eta_neighbor].means = make_tuple_of_means(upper_eta_vars);
+  neighbor_data[upper_eta_neighbor].volume_data = upper_eta_vars;
+  neighbor_data[upper_eta_neighbor].mesh = mesh;
+
+  VectorTag<2>::type modified_tensor;
+  SlopeLimiters::hweno_modified_neighbor_solution<VectorTag<2>>(
+      make_not_null(&modified_tensor), local_tensor, element, mesh,
+      neighbor_data, primary_neighbor);
+
+  // The expected coefficient values for the result of the constrained fit are
+  // found using Mathematica, using the following code (for Mathematica v10).
+  // This example computes the expected result for the vector x component; an
+  // analogous piece of code gives the expected result for the y component, but
+  // note that the neighbor to exclude changes in this case.
+  // qw3 = {1/3, 4/3, 1/3};
+  // qx3 = {-1, 0, 1};
+  // qw4 = {1/6, 5/6, 5/6, 1/6};
+  // qx4 = {-1, -1/Sqrt[5], 1/Sqrt[5], 1};
+  // quad43[f_, dx_, dy_] := Sum[
+  //     qw4[[qi]] qw3[[qj]] f[qx4[[qi]] + dx, qx3[[qj]] + dy],
+  //     {qi, 1, 4}, {qj, 1, 3}];
+  // trial[c0_, c1_, c2_, c3_, c4_, c5_, c6_, c7_, c8_, c9_, c10_, c11_][
+  //       x_, y_] :=
+  //     c0 + c1 x + c2 x^2 + c3 x^3 +
+  //     y (c4 + c5 x + c6 x^2 + c7 x^3) +
+  //     y^2 (c8 + c9 x + c10 x^2 + c11 x^3);
+  // uLocal[x_, y_] := 1 + 1/10 x + 1/5 y + 1/10 x y + 1/10 x y^2;
+  // uPrimary[x_, y_] := 1 + 1/4 x - 1/5 y^2 + 1/10 x y^2;
+  // uUpperXi[x_, y_] := 1 + 1/3 x + 1/4 y - 1/20 x^2;
+  // uUpperEta[x_, y_] := 1 + 1/3 x + 1/5 y;
+  // primaryOptimizationTerm[c0_, c1_, c2_, c3_, c4_, c5_, c6_, c7_, c8_,
+  //                         c9_, c10_, c11_][x_, y_] :=
+  //     (trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11][x, y]
+  //      - uPrimary[x, y])^2;
+  // Minimize[
+  //     quad43[primaryOptimizationTerm[c0, c1, c2, c3, c4, c5, c6, c7, c8,
+  //                                    c9, c10, c11],
+  //            0, -2]
+  //     + (quad43[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11],
+  //               2, 0] - quad43[uUpperXi, 2, 0])^2
+  //     + (quad43[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11],
+  //               0, 2] - quad43[uUpperEta, 0, 2])^2,
+  //     quad43[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11],
+  //            0, 0] == quad43[uLocal, 0, 0],
+  // {c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11}
+  // ]
+  const auto expected = [&logical_coords]() noexcept {
+    const auto& x = get<0>(logical_coords);
+    const auto& y = get<1>(logical_coords);
+    // x-component coefficients
+    constexpr std::array<double, 12> c{
+        {6049013. / 5913219., 92367. / 360620., -1659. / 558961.,
+         -6083. / 558961., 61831556. / 187251935., 42. / 6935., -126. / 42997.,
+         -462. / 42997., -2460491. / 37450387., 18283. / 180310.,
+         -378. / 558961., -1386. / 558961.}};
+    // y-component coefficients
+    constexpr std::array<double, 12> d{
+        {991516363. / 468183825., 1142461. / 1991042., -686461. / 1224010.,
+         -130350. / 995521., 110206607. / 156061275., 72540. / 995521.,
+         -55692. / 122401., -128700. / 995521., 10878374. / 52020425.,
+         16740. / 995521., -6119. / 1224010., -29700. / 995521.}};
+    return tnsr::I<DataVector, 2>{
+        {{DataVector{c[0] + c[1] * x + c[2] * square(x) + c[3] * cube(x) +
+                     y * (c[4] + c[5] * x + c[6] * square(x) + c[7] * cube(x)) +
+                     square(y) * (c[8] + c[9] * x + c[10] * square(x) +
+                                  c[11] * cube(x))},
+          DataVector{d[0] + d[1] * x + d[2] * square(x) + d[3] * cube(x) +
+                     y * (d[4] + d[5] * x + d[6] * square(x) + d[7] * cube(x)) +
+                     square(y) * (d[8] + d[9] * x + d[10] * square(x) +
+                                  d[11] * cube(x))}}}};
+  }
+  ();
+
+  // Fit procedure has somewhat larger error scale than default
+  Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.);
+  CHECK_ITERABLE_CUSTOM_APPROX(modified_tensor, expected, local_approx);
+  // Verify that the constraint is in fact satisfied
+  CHECK(mean_value(get<0>(modified_tensor), mesh) ==
+        local_approx(mean_value(get<0>(local_tensor), mesh)));
+  CHECK(mean_value(get<1>(modified_tensor), mesh) ==
+        local_approx(mean_value(get<1>(local_tensor), mesh)));
+}
+
+// Test in 2D (now using a scalar tensor) but with two of the neighbors being
+// excluded due to large means.
+void test_hweno_modified_solution_2d_exclude_two_neighbors() {
+  INFO("Testing hweno_modified_neighbor_solution in 2D");
+  using TagsList = tmpl::list<ScalarTag>;
+  const auto element = make_element<2>();
+  const auto mesh = Mesh<2>{
+      {{4, 3}}, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
+  const auto logical_coords = logical_coordinates(mesh);
+
+  const auto lower_xi_neighbor =
+      std::make_pair(Direction<2>::lower_xi(), ElementId<2>{1});
+  const auto upper_xi_neighbor =
+      std::make_pair(Direction<2>::upper_xi(), ElementId<2>{2});
+  const auto primary_neighbor =
+      std::make_pair(Direction<2>::lower_eta(), ElementId<2>{3});
+  const auto upper_eta_neighbor =
+      std::make_pair(Direction<2>::upper_eta(), ElementId<2>{4});
+
+  const auto local_tensor = [&logical_coords]() noexcept {
+    const auto& x = get<0>(logical_coords);
+    const auto& y = get<1>(logical_coords);
+    return ScalarTag::type{{{DataVector{1. + 0.1 * x + 0.2 * y + 0.1 * x * y +
+                                        0.1 * x * square(y)}}}};
+  }
+  ();
+
+  const auto lower_xi_vars = [&mesh]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    // Large values to make sure this neighbor is excluded
+    get(get<ScalarTag>(result)) = 1.e3;
+    return result;
+  }
+  ();
+
+  const auto upper_xi_vars = [&mesh, &logical_coords ]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    const auto x = get<0>(logical_coords) + 2.;
+    const auto& y = get<1>(logical_coords);
+    get(get<ScalarTag>(result)) =
+        1. + 1. / 3. * x + 0.25 * y - 0.05 * square(x);
+    return result;
+  }
+  ();
+
+  const auto primary_vars = [&mesh, &logical_coords ]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    const auto& x = get<0>(logical_coords);
+    const auto y = get<1>(logical_coords) - 2.;
+    get(get<ScalarTag>(result)) =
+        1. + 0.25 * x - 0.2 * square(y) + 0.1 * x * square(y);
+    return result;
+  }
+  ();
+
+  const auto upper_eta_vars = [&mesh]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    // Large values to make sure this neighbor is excluded
+    get(get<ScalarTag>(result)) = 1.e3;
+    return result;
+  }
+  ();
+
+  const auto make_tuple_of_means = [&mesh](
+      const Variables<TagsList>& vars) noexcept {
+    return tuples::TaggedTuple<::Tags::Mean<ScalarTag>>(
+        mean_value(get(get<ScalarTag>(vars)), mesh));
+  };
+
+  struct PackagedData {
+    tuples::TaggedTuple<::Tags::Mean<ScalarTag>> means;
+    Variables<TagsList> volume_data;
+    Mesh<2> mesh;
+  };
+  std::unordered_map<std::pair<Direction<2>, ElementId<2>>, PackagedData,
+                     boost::hash<std::pair<Direction<2>, ElementId<2>>>>
+      neighbor_data{};
+  neighbor_data[lower_xi_neighbor].means = make_tuple_of_means(lower_xi_vars);
+  neighbor_data[lower_xi_neighbor].volume_data = lower_xi_vars;
+  neighbor_data[lower_xi_neighbor].mesh = mesh;
+  neighbor_data[upper_xi_neighbor].means = make_tuple_of_means(upper_xi_vars);
+  neighbor_data[upper_xi_neighbor].volume_data = upper_xi_vars;
+  neighbor_data[upper_xi_neighbor].mesh = mesh;
+  neighbor_data[primary_neighbor].means = make_tuple_of_means(primary_vars);
+  neighbor_data[primary_neighbor].volume_data = primary_vars;
+  neighbor_data[primary_neighbor].mesh = mesh;
+  neighbor_data[upper_eta_neighbor].means = make_tuple_of_means(upper_eta_vars);
+  neighbor_data[upper_eta_neighbor].volume_data = upper_eta_vars;
+  neighbor_data[upper_eta_neighbor].mesh = mesh;
+
+  ScalarTag::type modified_tensor;
+  SlopeLimiters::hweno_modified_neighbor_solution<ScalarTag>(
+      make_not_null(&modified_tensor), local_tensor, element, mesh,
+      neighbor_data, primary_neighbor);
+
+  // The expected coefficient values for the result of the constrained fit are
+  // found using Mathematica, using the following code (for Mathematica v10).
+  // qw3 = {1/3, 4/3, 1/3};
+  // qx3 = {-1, 0, 1};
+  // qw4 = {1/6, 5/6, 5/6, 1/6};
+  // qx4 = {-1, -1/Sqrt[5], 1/Sqrt[5], 1};
+  // quad43[f_, dx_, dy_] := Sum[
+  //     qw4[[qi]] qw3[[qj]] f[qx4[[qi]] + dx, qx3[[qj]] + dy],
+  //     {qi, 1, 4}, {qj, 1, 3}];
+  // trial[c0_, c1_, c2_, c3_, c4_, c5_, c6_, c7_, c8_, c9_, c10_, c11_][
+  //       x_, y_] :=
+  //     c0 + c1 x + c2 x^2 + c3 x^3 +
+  //     y (c4 + c5 x + c6 x^2 + c7 x^3) +
+  //     y^2 (c8 + c9 x + c10 x^2 + c11 x^3);
+  // uLocal[x_, y_] := 1 + 1/10 x + 1/5 y + 1/10 x y + 1/10 x y^2;
+  // uPrimary[x_, y_] := 1 + 1/4 x - 1/5 y^2 + 1/10 x y^2;
+  // uUpperXi[x_, y_] := 1 + 1/3 x + 1/4 y - 1/20 x^2;
+  // primaryOptimizationTerm[c0_, c1_, c2_, c3_, c4_, c5_, c6_, c7_, c8_,
+  //                         c9_, c10_, c11_][x_, y_] :=
+  //     (trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11][x, y]
+  //      - uPrimary[x, y])^2;
+  // Minimize[
+  //     quad43[primaryOptimizationTerm[c0, c1, c2, c3, c4, c5, c6, c7, c8,
+  //                                    c9, c10, c11],
+  //            0, -2]
+  //     + (quad43[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11],
+  //               2, 0] - quad43[uUpperXi, 2, 0])^2,
+  //     quad43[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11],
+  //            0, 0] == quad43[uLocal, 0, 0],
+  // {c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11}
+  // ]
+  const auto expected = [&logical_coords]() noexcept {
+    const auto& x = get<0>(logical_coords);
+    const auto& y = get<1>(logical_coords);
+    constexpr std::array<double, 12> c{
+        {757538269. / 712675275., 92367. / 360620., -1659. / 558961.,
+         -6083. / 558961., 1135772. / 18273725., 42. / 6935., -126. / 42997.,
+         -462. / 42997., -44104369. / 237558425., 18283. / 180310.,
+         -378. / 558961., -1386. / 558961.}};
+    return Scalar<DataVector>{{{DataVector{
+        c[0] + c[1] * x + c[2] * square(x) + c[3] * cube(x) +
+        y * (c[4] + c[5] * x + c[6] * square(x) + c[7] * cube(x)) +
+        square(y) * (c[8] + c[9] * x + c[10] * square(x) + c[11] * cube(x))}}}};
+  }
+  ();
+
+  // Fit procedure has somewhat larger error scale than default
+  Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.);
+  CHECK_ITERABLE_CUSTOM_APPROX(modified_tensor, expected, local_approx);
+  // Verify that the constraint is in fact satisfied
+  CHECK(mean_value(get(modified_tensor), mesh) ==
+        local_approx(mean_value(get(local_tensor), mesh)));
+}
+
+void test_hweno_modified_solution_3d() {
+  INFO("Testing hweno_modified_neighbor_solution in 3D");
+  using TagsList = tmpl::list<ScalarTag>;
+  struct PackagedData {
+    tuples::TaggedTuple<::Tags::Mean<ScalarTag>> means;
+    Variables<TagsList> volume_data;
+    Mesh<3> mesh;
+  };
+
+  const auto lower_xi_neighbor =
+      std::make_pair(Direction<3>::lower_xi(), ElementId<3>{1});
+  const auto upper_xi_neighbor =
+      std::make_pair(Direction<3>::upper_xi(), ElementId<3>{2});
+  const auto lower_eta_neighbor =
+      std::make_pair(Direction<3>::lower_eta(), ElementId<3>{3});
+  const auto upper_eta_neighbor =
+      std::make_pair(Direction<3>::upper_eta(), ElementId<3>{4});
+  const auto lower_zeta_neighbor =
+      std::make_pair(Direction<3>::lower_zeta(), ElementId<3>{5});
+  const auto primary_neighbor =
+      std::make_pair(Direction<3>::upper_zeta(), ElementId<3>{6});
+
+  const auto element = make_element<3>();
+  const auto mesh = Mesh<3>{{{3, 3, 4}},
+                            Spectral::Basis::Legendre,
+                            Spectral::Quadrature::GaussLobatto};
+  const auto logical_coords = logical_coordinates(mesh);
+
+  const auto local_tensor = [&logical_coords]() noexcept {
+    const auto& x = get<0>(logical_coords);
+    const auto& y = get<1>(logical_coords);
+    const auto& z = get<2>(logical_coords);
+    return Scalar<DataVector>{{{0.5 + 0.2 * x + 0.1 * square(y) * z}}};
+  }
+  ();
+
+  const auto lower_xi_vars = [&mesh]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    get(get<ScalarTag>(result)) = 1.2;
+    return result;
+  }
+  ();
+
+  const auto upper_xi_vars = [&mesh]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    get(get<ScalarTag>(result)) = 4.;
+    return result;
+  }
+  ();
+
+  const auto lower_eta_vars = [&mesh]() noexcept {
+    // Large values to make sure this neighbor is excluded
+    Variables<TagsList> result(mesh.number_of_grid_points(), 1.e3);
+    return result;
+  }
+  ();
+
+  const auto upper_eta_vars = [&mesh]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    get(get<ScalarTag>(result)) = 2.5;
+    return result;
+  }
+  ();
+
+  const auto lower_zeta_vars = [&mesh]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    get(get<ScalarTag>(result)) = 2.;
+    return result;
+  }
+  ();
+
+  const auto primary_vars = [&mesh, &logical_coords ]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    const auto& x = get<0>(logical_coords);
+    const auto& y = get<1>(logical_coords);
+    const auto z = get<2>(logical_coords) + 2.;
+    get(get<ScalarTag>(result)) =
+        1. + 0.25 * x + 0.1 * y * z + 0.5 * x * square(y) * z + 0.1 * cube(z);
+    return result;
+  }
+  ();
+
+  const auto make_tuple_of_means = [&mesh](
+      const Variables<TagsList>& vars) noexcept {
+    return tuples::TaggedTuple<::Tags::Mean<ScalarTag>>(
+        mean_value(get(get<ScalarTag>(vars)), mesh));
+  };
+
+  std::unordered_map<std::pair<Direction<3>, ElementId<3>>, PackagedData,
+                     boost::hash<std::pair<Direction<3>, ElementId<3>>>>
+      neighbor_data{};
+  neighbor_data[lower_xi_neighbor].means = make_tuple_of_means(lower_xi_vars);
+  neighbor_data[lower_xi_neighbor].volume_data = lower_xi_vars;
+  neighbor_data[lower_xi_neighbor].mesh = mesh;
+  neighbor_data[upper_xi_neighbor].means = make_tuple_of_means(upper_xi_vars);
+  neighbor_data[upper_xi_neighbor].volume_data = upper_xi_vars;
+  neighbor_data[upper_xi_neighbor].mesh = mesh;
+  neighbor_data[lower_eta_neighbor].means = make_tuple_of_means(lower_eta_vars);
+  neighbor_data[lower_eta_neighbor].volume_data = lower_eta_vars;
+  neighbor_data[lower_eta_neighbor].mesh = mesh;
+  neighbor_data[upper_eta_neighbor].means = make_tuple_of_means(upper_eta_vars);
+  neighbor_data[upper_eta_neighbor].volume_data = upper_eta_vars;
+  neighbor_data[upper_eta_neighbor].mesh = mesh;
+  neighbor_data[lower_zeta_neighbor].means =
+      make_tuple_of_means(lower_zeta_vars);
+  neighbor_data[lower_zeta_neighbor].volume_data = lower_zeta_vars;
+  neighbor_data[lower_zeta_neighbor].mesh = mesh;
+  neighbor_data[primary_neighbor].means = make_tuple_of_means(primary_vars);
+  neighbor_data[primary_neighbor].volume_data = primary_vars;
+  neighbor_data[primary_neighbor].mesh = mesh;
+
+  Scalar<DataVector> modified_tensor;
+  SlopeLimiters::hweno_modified_neighbor_solution<ScalarTag>(
+      make_not_null(&modified_tensor), local_tensor, element, mesh,
+      neighbor_data, primary_neighbor);
+
+  // The expected coefficient values for the result of the constrained fit are
+  // found using Mathematica, using the following code (for Mathematica v10).
+  // qw3 = {1/3, 4/3, 1/3};
+  // qx3 = {-1, 0, 1};
+  // qw4 = {1/6, 5/6, 5/6, 1/6};
+  // qx4 = {-1, -1/Sqrt[5], 1/Sqrt[5], 1};
+  // quad334[f_, dx_, dy_, dz_] := Sum[
+  //     qw3[[qi]] qw3[[qj]] qw4[[qk]]
+  //     f[qx3[[qi]] + dx, qx3[[qj]] + dy, qx4[[qk]] + dz],
+  //     {qi, 1, 3}, {qj, 1, 3}, {qk, 1, 4}];
+  // trial[c0_, c1_, c2_, c3_, c4_, c5_, c6_, c7_, c8_, c9_, c10_, c11_,
+  //       c12_, c13_, c14_, c15_, c16_, c17_, c18_, c19_, c20_, c21_, c22_,
+  //       c23_, c24_, c25_, c26_, c27_, c28_, c29_, c30_, c31_, c32_, c33_,
+  //       c34_, c35_][x_, y_, z_] :=
+  //     c0 + c1 x + c2 x^2 + y (c3 + c4 x + c5 x^2) +
+  //                          y^2 (c6 + c7 x + c8 x^2) +
+  //     z (c9 + c10 x + c11 x^2 + y (c12 + c13 x + c14 x^2) +
+  //                               y^2 (c15 + c16 x + c17 x^2)) +
+  //     z^2 (c18 + c19 x + c20 x^2 + y (c21 + c22 x + c23 x^2) +
+  //                                  y^2 (c24 + c25 x + c26 x^2)) +
+  //     z^3 (c27 + c28 x + c29 x^2 + y (c30 + c31 x + c32 x^2) +
+  //                                  y^2 (c33 + c34 x + c35 x^2));
+  // uLocal[x_, y_, z_] := 1/2 + 1/5 x + 1/10 y^2 z;
+  // uPrimary[x_, y_, z_] := 1 + 1/4 x + 1/10 y z + 1/2 x y^2 z + 1/10 z^3;
+  // uLowerXi[x_, y_, z_] := 6/5;
+  // uUpperXi[x_, y_, z_] := 4;
+  // uUpperEta[x_, y_, z_] := 5/2;
+  // uLowerZeta[x_, y_, z_] := 2;
+  // primaryOptimizationTerm[c0_, c1_, c2_, c3_, c4_, c5_, c6_, c7_, c8_,
+  //                         c9_, c10_, c11_, c12_, c13_, c14_, c15_, c16_,
+  //                         c17_, c18_, c19_, c20_, c21_, c22_, c23_, c24_,
+  //                         c25_, c26_, c27_, c28_, c29_, c30_, c31_, c32_,
+  //                         c33_, c34_, c35_][x_, y_, z_] :=
+  //     (trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11,
+  //            c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23,
+  //            c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35][x,
+  //            y, z] - uPrimary[x, y, z])^2;
+  // Minimize[
+  //     quad334[primaryOptimizationTerm[c0, c1, c2, c3, c4, c5, c6, c7, c8,
+  //                                     c9, c10, c11, c12, c13, c14, c15, c16,
+  //                                     c17, c18, c19, c20, c21, c22, c23, c24,
+  //                                     c25, c26, c27, c28, c29, c30, c31, c32,
+  //                                     c33, c34, c35], 0, 0, 2]
+  //     + (quad334[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+  //                      c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23,
+  //                      c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34,
+  //                      c35], -2, 0, 0] - quad334[uLowerXi, -2, 0, 0])^2
+  //     + (quad334[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+  //                      c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23,
+  //                      c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34,
+  //                      c35], 2, 0, 0] - quad334[uUpperXi, 2, 0, 0])^2
+  //     + (quad334[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+  //                      c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23,
+  //                      c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34,
+  //                      c35], 0, 2, 0] - quad334[uUpperEta, 0, 2, 0])^2
+  //     + (quad334[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+  //                      c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23,
+  //                      c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34,
+  //                      c35], 0, 0, -2] - quad334[uLowerZeta, 0, 0, -2])^2,
+  //     quad334[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+  //                   c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23,
+  //                   c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34,
+  //                   c35], 0, 0, 0] == quad334[uLocal, 0, 0, 0],
+  // {c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14,
+  //  c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27,
+  //  c28, c29, c30, c31, c32, c33, c34, c35}
+  // ]
+  const auto expected = [&logical_coords]() noexcept {
+    const auto& x = get<0>(logical_coords);
+    const auto& y = get<1>(logical_coords);
+    const auto& z = get<2>(logical_coords);
+    constexpr std::array<double, 36> c{
+        {7734190419582420551. / 62148673763526035437.,
+         765121. / 1263364.,
+         786240. / 1895041.,
+         124800. / 1105441.,
+         0.,
+         0.,
+         374400. / 1105441.,
+         0.,
+         0.,
+         308447321809657439079. / 621486737635260354370.,
+         -892944. / 1579205.,
+         -6250608. / 9475205.,
+         -878879. / 11054410.,
+         0.,
+         0.,
+         -595296. / 1105441.,
+         1. / 2.,
+         0.,
+         21514562148445593021. / 124297347527052070874.,
+         89424. / 315841.,
+         625968. / 1895041.,
+         99360. / 1105441.,
+         0.,
+         0.,
+         298080. / 1105441.,
+         0.,
+         0.,
+         3655223967127444271. / 310743368817630177185.,
+         -14256. / 315841.,
+         -99792. / 1895041.,
+         -15840. / 1105441.,
+         0.,
+         0.,
+         -47520. / 1105441.,
+         0.,
+         0.}};
+    const DataVector term_z0 = c[0] + c[1] * x + c[2] * square(x) +
+                               y * (c[3] + c[4] * x + c[5] * square(x)) +
+                               square(y) * (c[6] + c[7] * x + c[8] * square(x));
+    const DataVector term_z1 =
+        c[9] + c[10] * x + c[11] * square(x) +
+        y * (c[12] + c[13] * x + c[14] * square(x)) +
+        square(y) * (c[15] + c[16] * x + c[17] * square(x));
+    const DataVector term_z2 =
+        c[18] + c[19] * x + c[20] * square(x) +
+        y * (c[21] + c[22] * x + c[23] * square(x)) +
+        square(y) * (c[24] + c[25] * x + c[26] * square(x));
+    const DataVector term_z3 =
+        c[27] + c[28] * x + c[29] * square(x) +
+        y * (c[30] + c[31] * x + c[32] * square(x)) +
+        square(y) * (c[33] + c[34] * x + c[35] * square(x));
+    return Scalar<DataVector>{
+        {{term_z0 + term_z1 * z + term_z2 * square(z) + term_z3 * cube(z)}}};
+  }
+  ();
+
+  // Fit procedure has somewhat larger error scale than default
+  Approx local_approx = Approx::custom().epsilon(1e-8).scale(1.);
+  CHECK_ITERABLE_CUSTOM_APPROX(modified_tensor, expected, local_approx);
+  // Verify that the constraint is in fact satisfied
+  CHECK(mean_value(get(modified_tensor), mesh) ==
+        local_approx(mean_value(get(local_tensor), mesh)));
+}
+
+void test_hweno_modified_solution_2d_boundary() {
+  INFO("Testing hweno_modified_neighbor_solution in 2D at boundary");
+  using TagsList = tmpl::list<ScalarTag>;
+  const Element<2> element{
+      ElementId<2>{0},
+      Element<2>::Neighbors_t{
+          {Direction<2>::lower_xi(), make_neighbor_with_id<2>(1)},
+          // upper_xi is external boundary
+          {Direction<2>::lower_eta(), make_neighbor_with_id<2>(3)},
+          {Direction<2>::upper_eta(), make_neighbor_with_id<2>(4)}}};
+  const auto mesh = Mesh<2>{
+      {{4, 3}}, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
+  const auto logical_coords = logical_coordinates(mesh);
+
+  const auto lower_xi_neighbor =
+      std::make_pair(Direction<2>::lower_xi(), ElementId<2>{1});
+  const auto primary_neighbor =
+      std::make_pair(Direction<2>::lower_eta(), ElementId<2>{3});
+  const auto upper_eta_neighbor =
+      std::make_pair(Direction<2>::upper_eta(), ElementId<2>{4});
+
+  const auto local_tensor = [&logical_coords]() noexcept {
+    const auto& x = get<0>(logical_coords);
+    const auto& y = get<1>(logical_coords);
+    return Scalar<DataVector>{
+        {{1. + 0.1 * x + 0.2 * y + 0.1 * x * y + 0.1 * x * square(y)}}};
+  }
+  ();
+
+  const auto lower_xi_vars = [&mesh]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    // Large values to make sure this neighbor is excluded
+    get(get<ScalarTag>(result)) = 1.e3;
+    return result;
+  }
+  ();
+
+  const auto primary_vars = [&mesh, &logical_coords ]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    const auto& x = get<0>(logical_coords);
+    const auto y = get<1>(logical_coords) - 2.;
+    get(get<ScalarTag>(result)) =
+        1. + 0.25 * x - 0.2 * square(y) + 0.1 * x * square(y);
+    return result;
+  }
+  ();
+
+  const auto upper_eta_vars = [&mesh, &logical_coords ]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    const auto& x = get<0>(logical_coords);
+    const auto y = get<1>(logical_coords) + 2.;
+    get(get<ScalarTag>(result)) = 1. + 1. / 3. * x + 0.2 * y;
+    return result;
+  }
+  ();
+
+  const auto make_tuple_of_means = [&mesh](
+      const Variables<TagsList>& vars) noexcept {
+    return tuples::TaggedTuple<::Tags::Mean<ScalarTag>>(
+        mean_value(get(get<ScalarTag>(vars)), mesh));
+  };
+
+  struct PackagedData {
+    tuples::TaggedTuple<::Tags::Mean<ScalarTag>> means;
+    Variables<TagsList> volume_data;
+    Mesh<2> mesh;
+  };
+  std::unordered_map<std::pair<Direction<2>, ElementId<2>>, PackagedData,
+                     boost::hash<std::pair<Direction<2>, ElementId<2>>>>
+      neighbor_data{};
+  neighbor_data[lower_xi_neighbor].means = make_tuple_of_means(lower_xi_vars);
+  neighbor_data[lower_xi_neighbor].volume_data = lower_xi_vars;
+  neighbor_data[lower_xi_neighbor].mesh = mesh;
+  neighbor_data[primary_neighbor].means = make_tuple_of_means(primary_vars);
+  neighbor_data[primary_neighbor].volume_data = primary_vars;
+  neighbor_data[primary_neighbor].mesh = mesh;
+  neighbor_data[upper_eta_neighbor].means = make_tuple_of_means(upper_eta_vars);
+  neighbor_data[upper_eta_neighbor].volume_data = upper_eta_vars;
+  neighbor_data[upper_eta_neighbor].mesh = mesh;
+
+  Scalar<DataVector> modified_tensor;
+  SlopeLimiters::hweno_modified_neighbor_solution<ScalarTag>(
+      make_not_null(&modified_tensor), local_tensor, element, mesh,
+      neighbor_data, primary_neighbor);
+
+  // The expected coefficient values for the result of the constrained fit are
+  // found using Mathematica, using the following code (for Mathematica v10).
+  // qw3 = {1/3, 4/3, 1/3};
+  // qx3 = {-1, 0, 1};
+  // qw4 = {1/6, 5/6, 5/6, 1/6};
+  // qx4 = {-1, -1/Sqrt[5], 1/Sqrt[5], 1};
+  // quad43[f_, dx_, dy_] := Sum[
+  //     qw4[[qi]] qw3[[qj]] f[qx4[[qi]] + dx, qx3[[qj]] + dy],
+  //     {qi, 1, 4}, {qj, 1, 3}];
+  // trial[c0_, c1_, c2_, c3_, c4_, c5_, c6_, c7_, c8_, c9_, c10_, c11_][
+  //       x_, y_] :=
+  //     c0 + c1 x + c2 x^2 + c3 x^3 +
+  //     y (c4 + c5 x + c6 x^2 + c7 x^3) +
+  //     y^2 (c8 + c9 x + c10 x^2 + c11 x^3);
+  // uLocal[x_, y_] := 1 + 1/10 x + 1/5 y + 1/10 x y + 1/10 x y^2;
+  // uPrimary[x_, y_] := 1 + 1/4 x - 1/5 y^2 + 1/10 x y^2;
+  // uUpperEta[x_, y_] := 1 + 1/3 x + 1/5 y;
+  // primaryOptimizationTerm[c0_, c1_, c2_, c3_, c4_, c5_, c6_, c7_, c8_,
+  //                         c9_, c10_, c11_][x_, y_] :=
+  //     (trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11][x, y]
+  //      - uPrimary[x, y])^2;
+  // Minimize[
+  //     quad43[primaryOptimizationTerm[c0, c1, c2, c3, c4, c5, c6, c7, c8,
+  //                                    c9, c10, c11],
+  //            0, -2]
+  //     + (quad43[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11],
+  //               0, 2] - quad43[uUpperEta, 0, 2])^2,
+  //     quad43[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11],
+  //            0, 0] == quad43[uLocal, 0, 0],
+  // {c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11}
+  // ]
+  const auto expected = [&logical_coords]() noexcept {
+    const auto& x = get<0>(logical_coords);
+    const auto& y = get<1>(logical_coords);
+    constexpr std::array<double, 12> c{{50738. / 49647., 1. / 4., 0., 0.,
+                                        27242. / 82745., 0., 0., 0.,
+                                        -1091. / 16549., 1. / 10., 0., 0.}};
+    return Scalar<DataVector>{
+        {{c[0] + c[1] * x + c[2] * square(x) + c[3] * cube(x) +
+          y * (c[4] + c[5] * x + c[6] * square(x) + c[7] * cube(x)) +
+          square(y) *
+              (c[8] + c[9] * x + c[10] * square(x) + c[11] * cube(x))}}};
+  }
+  ();
+
+  // Fit procedure has somewhat larger error scale than default
+  Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.);
+  CHECK_ITERABLE_CUSTOM_APPROX(modified_tensor, expected, local_approx);
+  // Verify that the constraint is in fact satisfied
+  CHECK(mean_value(get(modified_tensor), mesh) ==
+        local_approx(mean_value(get(local_tensor), mesh)));
+}
+
+void test_hweno_modified_solution_2d_boundary_single_neighbor() {
+  INFO("Testing hweno_modified_neighbor_solution in 2D at boundary");
+  using TagsList = tmpl::list<ScalarTag>;
+  const Element<2> element{
+      ElementId<2>{0}, Element<2>::Neighbors_t{{Direction<2>::lower_eta(),
+                                                make_neighbor_with_id<2>(3)}}};
+  const auto mesh = Mesh<2>{
+      {{4, 3}}, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
+  const auto logical_coords = logical_coordinates(mesh);
+
+  const auto primary_neighbor =
+      std::make_pair(Direction<2>::lower_eta(), ElementId<2>{3});
+
+  const auto local_tensor = [&logical_coords]() noexcept {
+    const auto& x = get<0>(logical_coords);
+    const auto& y = get<1>(logical_coords);
+    return Scalar<DataVector>{
+        {{1. + 0.1 * x + 0.2 * y + 0.1 * x * y + 0.1 * x * square(y)}}};
+  }
+  ();
+
+  const auto primary_vars = [&mesh, &logical_coords ]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    const auto& x = get<0>(logical_coords);
+    const auto y = get<1>(logical_coords) - 2.;
+    get(get<ScalarTag>(result)) =
+        1. + 0.25 * x - 0.2 * square(y) + 0.1 * x * square(y);
+    return result;
+  }
+  ();
+
+  const auto make_tuple_of_means = [&mesh](
+      const Variables<TagsList>& vars) noexcept {
+    return tuples::TaggedTuple<::Tags::Mean<ScalarTag>>(
+        mean_value(get(get<ScalarTag>(vars)), mesh));
+  };
+
+  struct PackagedData {
+    tuples::TaggedTuple<::Tags::Mean<ScalarTag>> means;
+    Variables<TagsList> volume_data;
+    Mesh<2> mesh;
+  };
+  std::unordered_map<std::pair<Direction<2>, ElementId<2>>, PackagedData,
+                     boost::hash<std::pair<Direction<2>, ElementId<2>>>>
+      neighbor_data{};
+  neighbor_data[primary_neighbor].means = make_tuple_of_means(primary_vars);
+  neighbor_data[primary_neighbor].volume_data = primary_vars;
+  neighbor_data[primary_neighbor].mesh = mesh;
+
+  Scalar<DataVector> modified_tensor;
+  SlopeLimiters::hweno_modified_neighbor_solution<ScalarTag>(
+      make_not_null(&modified_tensor), local_tensor, element, mesh,
+      neighbor_data, primary_neighbor);
+
+  // The expected coefficient values for the result of the constrained fit are
+  // found using Mathematica, using the following code (for Mathematica v10).
+  // qw3 = {1/3, 4/3, 1/3};
+  // qx3 = {-1, 0, 1};
+  // qw4 = {1/6, 5/6, 5/6, 1/6};
+  // qx4 = {-1, -1/Sqrt[5], 1/Sqrt[5], 1};
+  // quad43[f_, dx_, dy_] := Sum[
+  //     qw4[[qi]] qw3[[qj]] f[qx4[[qi]] + dx, qx3[[qj]] + dy],
+  //     {qi, 1, 4}, {qj, 1, 3}];
+  // trial[c0_, c1_, c2_, c3_, c4_, c5_, c6_, c7_, c8_, c9_, c10_, c11_][
+  //       x_, y_] :=
+  //     c0 + c1 x + c2 x^2 + c3 x^3 +
+  //     y (c4 + c5 x + c6 x^2 + c7 x^3) +
+  //     y^2 (c8 + c9 x + c10 x^2 + c11 x^3);
+  // uLocal[x_, y_] := 1 + 1/10 x + 1/5 y + 1/10 x y + 1/10 x y^2;
+  // uPrimary[x_, y_] := 1 + 1/4 x - 1/5 y^2 + 1/10 x y^2;
+  // primaryOptimizationTerm[c0_, c1_, c2_, c3_, c4_, c5_, c6_, c7_, c8_,
+  //                         c9_, c10_, c11_][x_, y_] :=
+  //     (trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11][x, y]
+  //      - uPrimary[x, y])^2;
+  // Minimize[
+  //     quad43[primaryOptimizationTerm[c0, c1, c2, c3, c4, c5, c6, c7, c8,
+  //                                    c9, c10, c11],
+  //            0, -2],
+  //     quad43[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11],
+  //            0, 0] == quad43[uLocal, 0, 0],
+  // {c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11}
+  // ]
+  const auto expected = [&logical_coords]() noexcept {
+    const auto& x = get<0>(logical_coords);
+    const auto& y = get<1>(logical_coords);
+    constexpr std::array<double, 12> c{{1354. / 1275., 1. / 4., 0., 0.,
+                                        26. / 425., 0., 0., 0., -79. / 425.,
+                                        1. / 10., 0., 0.}};
+    return Scalar<DataVector>{
+        {{c[0] + c[1] * x + c[2] * square(x) + c[3] * cube(x) +
+          y * (c[4] + c[5] * x + c[6] * square(x) + c[7] * cube(x)) +
+          square(y) *
+              (c[8] + c[9] * x + c[10] * square(x) + c[11] * cube(x))}}};
+  }
+  ();
+
+  // Fit procedure has somewhat larger error scale than default
+  Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.);
+  CHECK_ITERABLE_CUSTOM_APPROX(modified_tensor, expected, local_approx);
+  // Verify that the constraint is in fact satisfied
+  CHECK(mean_value(get(modified_tensor), mesh) ==
+        local_approx(mean_value(get(local_tensor), mesh)));
+}
+
+void test_hweno_modified_solution_3d_boundary() {
+  INFO("Testing hweno_modified_neighbor_solution in 3D at boundary");
+  using TagsList = tmpl::list<ScalarTag>;
+  struct PackagedData {
+    tuples::TaggedTuple<::Tags::Mean<ScalarTag>> means;
+    Variables<TagsList> volume_data;
+    Mesh<3> mesh;
+  };
+
+  const auto lower_xi_neighbor =
+      std::make_pair(Direction<3>::lower_xi(), ElementId<3>{1});
+  const auto upper_xi_neighbor =
+      std::make_pair(Direction<3>::upper_xi(), ElementId<3>{2});
+  const auto lower_eta_neighbor =
+      std::make_pair(Direction<3>::lower_eta(), ElementId<3>{3});
+  const auto upper_eta_neighbor =
+      std::make_pair(Direction<3>::upper_eta(), ElementId<3>{4});
+  const auto primary_neighbor =
+      std::make_pair(Direction<3>::upper_zeta(), ElementId<3>{6});
+
+  const Element<3> element{
+      ElementId<3>{0},
+      Element<3>::Neighbors_t{
+          {Direction<3>::lower_xi(), make_neighbor_with_id<3>(1)},
+          {Direction<3>::upper_xi(), make_neighbor_with_id<3>(2)},
+          {Direction<3>::lower_eta(), make_neighbor_with_id<3>(3)},
+          {Direction<3>::upper_eta(), make_neighbor_with_id<3>(4)},
+          // lower_zeta is external boundary
+          {Direction<3>::upper_zeta(), make_neighbor_with_id<3>(6)}}};
+  const auto mesh = Mesh<3>{{{3, 3, 4}},
+                            Spectral::Basis::Legendre,
+                            Spectral::Quadrature::GaussLobatto};
+  const auto logical_coords = logical_coordinates(mesh);
+
+  const auto local_tensor = [&logical_coords]() noexcept {
+    const auto& x = get<0>(logical_coords);
+    const auto& y = get<1>(logical_coords);
+    const auto& z = get<2>(logical_coords);
+    return Scalar<DataVector>{{{0.5 + 0.2 * x + 0.1 * square(y) * z}}};
+  }
+  ();
+
+  const auto lower_xi_vars = [&mesh]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    get(get<ScalarTag>(result)) = 1.2;
+    return result;
+  }
+  ();
+
+  const auto upper_xi_vars = [&mesh]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    get(get<ScalarTag>(result)) = 4.;
+    return result;
+  }
+  ();
+
+  const auto lower_eta_vars = [&mesh]() noexcept {
+    // Large values to make sure this neighbor is excluded
+    Variables<TagsList> result(mesh.number_of_grid_points(), 1.e3);
+    return result;
+  }
+  ();
+
+  const auto upper_eta_vars = [&mesh]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    get(get<ScalarTag>(result)) = 2.5;
+    return result;
+  }
+  ();
+
+  const auto primary_vars = [&mesh, &logical_coords ]() noexcept {
+    Variables<TagsList> result(mesh.number_of_grid_points());
+    const auto& x = get<0>(logical_coords);
+    const auto& y = get<1>(logical_coords);
+    const auto z = get<2>(logical_coords) + 2.;
+    get(get<ScalarTag>(result)) =
+        1. + 0.25 * x + 0.1 * y * z + 0.5 * x * square(y) * z + 0.1 * cube(z);
+    return result;
+  }
+  ();
+
+  const auto make_tuple_of_means = [&mesh](
+      const Variables<TagsList>& vars) noexcept {
+    return tuples::TaggedTuple<::Tags::Mean<ScalarTag>>(
+        mean_value(get(get<ScalarTag>(vars)), mesh));
+  };
+
+  std::unordered_map<std::pair<Direction<3>, ElementId<3>>, PackagedData,
+                     boost::hash<std::pair<Direction<3>, ElementId<3>>>>
+      neighbor_data{};
+  neighbor_data[lower_xi_neighbor].means = make_tuple_of_means(lower_xi_vars);
+  neighbor_data[lower_xi_neighbor].volume_data = lower_xi_vars;
+  neighbor_data[lower_xi_neighbor].mesh = mesh;
+  neighbor_data[upper_xi_neighbor].means = make_tuple_of_means(upper_xi_vars);
+  neighbor_data[upper_xi_neighbor].volume_data = upper_xi_vars;
+  neighbor_data[upper_xi_neighbor].mesh = mesh;
+  neighbor_data[lower_eta_neighbor].means = make_tuple_of_means(lower_eta_vars);
+  neighbor_data[lower_eta_neighbor].volume_data = lower_eta_vars;
+  neighbor_data[lower_eta_neighbor].mesh = mesh;
+  neighbor_data[upper_eta_neighbor].means = make_tuple_of_means(upper_eta_vars);
+  neighbor_data[upper_eta_neighbor].volume_data = upper_eta_vars;
+  neighbor_data[upper_eta_neighbor].mesh = mesh;
+  neighbor_data[primary_neighbor].means = make_tuple_of_means(primary_vars);
+  neighbor_data[primary_neighbor].volume_data = primary_vars;
+  neighbor_data[primary_neighbor].mesh = mesh;
+
+  Scalar<DataVector> modified_tensor;
+  SlopeLimiters::hweno_modified_neighbor_solution<ScalarTag>(
+      make_not_null(&modified_tensor), local_tensor, element, mesh,
+      neighbor_data, primary_neighbor);
+
+  // The expected coefficient values for the result of the constrained fit are
+  // found using Mathematica, using the following code (for Mathematica v10).
+  // qw3 = {1/3, 4/3, 1/3};
+  // qx3 = {-1, 0, 1};
+  // qw4 = {1/6, 5/6, 5/6, 1/6};
+  // qx4 = {-1, -1/Sqrt[5], 1/Sqrt[5], 1};
+  // quad334[f_, dx_, dy_, dz_] := Sum[
+  //     qw3[[qi]] qw3[[qj]] qw4[[qk]]
+  //     f[qx3[[qi]] + dx, qx3[[qj]] + dy, qx4[[qk]] + dz],
+  //     {qi, 1, 3}, {qj, 1, 3}, {qk, 1, 4}];
+  // trial[c0_, c1_, c2_, c3_, c4_, c5_, c6_, c7_, c8_, c9_, c10_, c11_,
+  //       c12_, c13_, c14_, c15_, c16_, c17_, c18_, c19_, c20_, c21_, c22_,
+  //       c23_, c24_, c25_, c26_, c27_, c28_, c29_, c30_, c31_, c32_, c33_,
+  //       c34_, c35_][x_, y_, z_] :=
+  //     c0 + c1 x + c2 x^2 + y (c3 + c4 x + c5 x^2) +
+  //                          y^2 (c6 + c7 x + c8 x^2) +
+  //     z (c9 + c10 x + c11 x^2 + y (c12 + c13 x + c14 x^2) +
+  //                               y^2 (c15 + c16 x + c17 x^2)) +
+  //     z^2 (c18 + c19 x + c20 x^2 + y (c21 + c22 x + c23 x^2) +
+  //                                  y^2 (c24 + c25 x + c26 x^2)) +
+  //     z^3 (c27 + c28 x + c29 x^2 + y (c30 + c31 x + c32 x^2) +
+  //                                  y^2 (c33 + c34 x + c35 x^2));
+  // uLocal[x_, y_, z_] := 1/2 + 1/5 x + 1/10 y^2 z;
+  // uPrimary[x_, y_, z_] := 1 + 1/4 x + 1/10 y z + 1/2 x y^2 z + 1/10 z^3;
+  // uLowerXi[x_, y_, z_] := 6/5;
+  // uUpperXi[x_, y_, z_] := 4;
+  // uUpperEta[x_, y_, z_] := 5/2;
+  // primaryOptimizationTerm[c0_, c1_, c2_, c3_, c4_, c5_, c6_, c7_, c8_,
+  //                         c9_, c10_, c11_, c12_, c13_, c14_, c15_, c16_,
+  //                         c17_, c18_, c19_, c20_, c21_, c22_, c23_, c24_,
+  //                         c25_, c26_, c27_, c28_, c29_, c30_, c31_, c32_,
+  //                         c33_, c34_, c35_][x_, y_, z_] :=
+  //     (trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11,
+  //            c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23,
+  //            c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35][x,
+  //            y, z] - uPrimary[x, y, z])^2;
+  // Minimize[
+  //     quad334[primaryOptimizationTerm[c0, c1, c2, c3, c4, c5, c6, c7, c8,
+  //                                     c9, c10, c11, c12, c13, c14, c15, c16,
+  //                                     c17, c18, c19, c20, c21, c22, c23, c24,
+  //                                     c25, c26, c27, c28, c29, c30, c31, c32,
+  //                                     c33, c34, c35], 0, 0, 2]
+  //     + (quad334[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+  //                      c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23,
+  //                      c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34,
+  //                      c35], -2, 0, 0] - quad334[uLowerXi, -2, 0, 0])^2
+  //     + (quad334[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+  //                      c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23,
+  //                      c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34,
+  //                      c35], 2, 0, 0] - quad334[uUpperXi, 2, 0, 0])^2
+  //     + (quad334[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+  //                      c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23,
+  //                      c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34,
+  //                      c35], 0, 2, 0] - quad334[uUpperEta, 0, 2, 0])^2
+  //     quad334[trial[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+  //                   c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23,
+  //                   c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34,
+  //                   c35], 0, 0, 0] == quad334[uLocal, 0, 0, 0],
+  // {c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14,
+  //  c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27,
+  //  c28, c29, c30, c31, c32, c33, c34, c35}
+  // ]
+  const auto expected = [&logical_coords]() noexcept {
+    const auto& x = get<0>(logical_coords);
+    const auto& y = get<1>(logical_coords);
+    const auto& z = get<2>(logical_coords);
+    constexpr std::array<double, 36> c{{243751581645799. / 689207629948649.,
+                                        765121. / 1263364.,
+                                        786240. / 1895041.,
+                                        124800. / 1105441.,
+                                        0.,
+                                        0.,
+                                        374400. / 1105441.,
+                                        0.,
+                                        0.,
+                                        1416550233603063. / 1378415259897298.,
+                                        -892944. / 1579205.,
+                                        -6250608. / 9475205.,
+                                        -878879. / 11054410.,
+                                        0.,
+                                        0.,
+                                        -595296. / 1105441.,
+                                        1. / 2.,
+                                        0.,
+                                        -709303092297615. / 1378415259897298.,
+                                        89424. / 315841.,
+                                        625968. / 1895041.,
+                                        99360. / 1105441.,
+                                        0.,
+                                        0.,
+                                        298080. / 1105441.,
+                                        0.,
+                                        0.,
+                                        627297076397287. / 3446038149743245.,
+                                        -14256. / 315841.,
+                                        -99792. / 1895041.,
+                                        -15840. / 1105441.,
+                                        0.,
+                                        0.,
+                                        -47520. / 1105441.,
+                                        0.,
+                                        0.}};
+    const DataVector term_z0 = c[0] + c[1] * x + c[2] * square(x) +
+                               y * (c[3] + c[4] * x + c[5] * square(x)) +
+                               square(y) * (c[6] + c[7] * x + c[8] * square(x));
+    const DataVector term_z1 =
+        c[9] + c[10] * x + c[11] * square(x) +
+        y * (c[12] + c[13] * x + c[14] * square(x)) +
+        square(y) * (c[15] + c[16] * x + c[17] * square(x));
+    const DataVector term_z2 =
+        c[18] + c[19] * x + c[20] * square(x) +
+        y * (c[21] + c[22] * x + c[23] * square(x)) +
+        square(y) * (c[24] + c[25] * x + c[26] * square(x));
+    const DataVector term_z3 =
+        c[27] + c[28] * x + c[29] * square(x) +
+        y * (c[30] + c[31] * x + c[32] * square(x)) +
+        square(y) * (c[33] + c[34] * x + c[35] * square(x));
+    return Scalar<DataVector>{
+        {{term_z0 + term_z1 * z + term_z2 * square(z) + term_z3 * cube(z)}}};
+  }
+  ();
+
+  // Fit procedure has somewhat larger error scale than default
+  Approx local_approx = Approx::custom().epsilon(1e-8).scale(1.);
+  CHECK_ITERABLE_CUSTOM_APPROX(modified_tensor, expected, local_approx);
+  // Verify that the constraint is in fact satisfied
+  CHECK(mean_value(get(modified_tensor), mesh) ==
+        local_approx(mean_value(get(local_tensor), mesh)));
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.HwenoModifiedSolution",
+                  "[SlopeLimiters][Unit]") {
+  test_hweno_modified_solution_1d();
+  test_hweno_modified_solution_2d_vector();
+  test_hweno_modified_solution_2d_exclude_two_neighbors();
+  test_hweno_modified_solution_3d();
+
+  test_hweno_modified_solution_2d_boundary();
+  test_hweno_modified_solution_2d_boundary_single_neighbor();
+  test_hweno_modified_solution_3d_boundary();
+}


### PR DESCRIPTION
## Proposed changes

For each neighbor, for each tensor component, HWENO requires the solution of a constrained optimization problem to obtain the modified neighbor solution from that neighbor for that tensor component. This commit adds the linear algebra that solves this constrained optimization problem.

This function will be called by the HWENO limiter, coming in a future PR.

Depends on
- [x] #1427 
- [x] #1431 

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
