### PR TITLE
Swsh derivatives

### DIFF
--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
     Spectral.cpp
     SwshCoefficients.cpp
     SwshCollocation.cpp
+    SwshDerivatives.cpp
     SwshFiltering.cpp
     SwshTags.cpp
     SwshTransform.cpp

--- a/src/NumericalAlgorithms/Spectral/SwshCoefficients.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCoefficients.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/ComplexModalVector.hpp"
 #include "DataStructures/SpinWeighted.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshSettings.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
@@ -130,9 +131,6 @@ constexpr SPECTRE_ALWAYS_INLINE double sharp_swsh_sign(
 }
 
 namespace detail {
-
-constexpr size_t coefficients_maximum_l_max = collocation_maximum_l_max;
-
 struct DestroySharpAlm {
   void operator()(sharp_alm_info* to_delete) noexcept {
     sharp_destroy_alm_info(to_delete);

--- a/src/NumericalAlgorithms/Spectral/SwshCollocation.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCollocation.hpp
@@ -8,6 +8,7 @@
 #include <sharp_cxx.h>
 
 #include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
+#include "NumericalAlgorithms/Spectral/SwshSettings.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -49,12 +50,6 @@ number_of_swsh_phi_collocation_points(const size_t l_max) noexcept {
   return (2 * l_max + 1);
 }
 
-// In the static caching mechanism, we permit an l_max up to this macro
-// value. Higher l_max values may still be created manually using the
-// `CollocationMetadata` constructor. If l_max's are used several times at
-// higher value, consider increasing this value, but only after memory costs
-// have been evaluated.
-constexpr size_t collocation_maximum_l_max = 200;
 
 namespace detail {
 // Helping functor to appropriately delete a stored `sharp_geom_info**`

--- a/src/NumericalAlgorithms/Spectral/SwshDerivatives.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshDerivatives.cpp
@@ -1,0 +1,121 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
+
+#include "DataStructures/ComplexDataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/ComplexDiagonalModalOperator.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"  // IWYU pragma: keep
+#include "DataStructures/TempBuffer.hpp"
+#include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/StaticCache.hpp"
+
+// IWYU pragma: no_forward_declare SpinWeighted
+
+namespace Spectral {
+namespace Swsh {
+namespace detail {
+namespace {
+template <typename DerivativeKind, int Spin>
+ComplexDiagonalModalOperator derivative_factors(const size_t l_max) noexcept {
+  ComplexDiagonalModalOperator derivative_factors{
+      size_of_libsharp_coefficient_vector(l_max)};
+  for (const auto& mode : cached_coefficients_metadata(l_max)) {
+    // note that the libsharp transform data is stored as a pair of complex
+    // vectors: one for the transform of the real part and one for the transform
+    // of the imaginary part of the collocation data.
+    derivative_factors[mode.transform_of_real_part_offset] =
+        detail::derivative_factor<DerivativeKind>(mode.l, Spin);
+    derivative_factors[mode.transform_of_imag_part_offset] =
+        detail::derivative_factor<DerivativeKind>(mode.l, Spin);
+  }
+  // apply the sign change as appropriate due to the adjusted spin
+  // this loop is over the (complex) transform coefficients of first the real
+  // nodal data, followed by the imaginary nodal data. They receive the same
+  // derivative factors, but potentially different signs.
+  for (size_t i = 0; i < 2; i++) {
+    ComplexDiagonalModalOperator view_of_derivative_factor{
+        derivative_factors.data() +
+            i * size_of_libsharp_coefficient_vector(l_max) / 2,
+        size_of_libsharp_coefficient_vector(l_max) / 2};
+    view_of_derivative_factor *= sharp_swsh_sign_change(
+        Spin, Spin + Tags::derivative_spin_weight<DerivativeKind>, i == 0);
+  }
+  return derivative_factors;
+}
+
+template <typename DerivativeKind, int Spin>
+const ComplexDiagonalModalOperator& cached_derivative_factors(
+    const size_t l_max) noexcept {
+  const static auto lazy_derivative_operator_cache =
+      make_static_cache<CacheRange<0, swsh_derivative_maximum_l_max>>(
+          [](const size_t generator_l_max) noexcept {
+            return derivative_factors<DerivativeKind, Spin>(generator_l_max);
+          });
+  return lazy_derivative_operator_cache(l_max);
+}
+}  // namespace
+
+template <typename DerivativeKind, int Spin>
+void compute_coefficients_of_derivative(
+    const gsl::not_null<
+        SpinWeighted<ComplexModalVector,
+                     Spin + Tags::derivative_spin_weight<DerivativeKind>>*>
+        derivative_modes,
+    const gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*>
+        pre_derivative_modes,
+    const size_t l_max, const size_t number_of_radial_points) noexcept {
+  derivative_modes->data().destructive_resize(pre_derivative_modes->size());
+  const ComplexDiagonalModalOperator& modal_derivative_operator =
+      cached_derivative_factors<DerivativeKind, Spin>(l_max);
+  // multiply each radial chunk by the appropriate derivative factors.
+  for (size_t i = 0; i < number_of_radial_points; ++i) {
+    ComplexModalVector output_mode_view{
+        derivative_modes->data().data() +
+            i * size_of_libsharp_coefficient_vector(l_max),
+        size_of_libsharp_coefficient_vector(l_max)};
+    const ComplexModalVector input_mode_view{
+        pre_derivative_modes->data().data() +
+            i * size_of_libsharp_coefficient_vector(l_max),
+        size_of_libsharp_coefficient_vector(l_max)};
+    output_mode_view = modal_derivative_operator * input_mode_view;
+  }
+}
+}  // namespace detail
+
+#define GET_DERIVKIND(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define GET_SPIN(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define DERIVKIND_AND_SPIN_INSTANTIATION(r, data)                            \
+  namespace detail {                                                         \
+  template void                                                              \
+  compute_coefficients_of_derivative<GET_DERIVKIND(data), GET_SPIN(data)>(   \
+      const gsl::not_null<SpinWeighted<                                      \
+          ComplexModalVector, GET_SPIN(data) + Tags::derivative_spin_weight< \
+                                                   GET_DERIVKIND(data)>>*>   \
+          derivative_modes,                                                  \
+      const gsl::not_null<SpinWeighted<ComplexModalVector, GET_SPIN(data)>*> \
+          pre_derivative_modes,                                              \
+      const size_t l_max, const size_t number_of_radial_points) noexcept;    \
+  }
+
+GENERATE_INSTANTIATIONS(DERIVKIND_AND_SPIN_INSTANTIATION,
+                        (Tags::EthEthbar, Tags::EthbarEth), (-2, -1, 0, 1, 2))
+GENERATE_INSTANTIATIONS(DERIVKIND_AND_SPIN_INSTANTIATION, (Tags::Eth),
+                        (-2, -1, 0, 1))
+GENERATE_INSTANTIATIONS(DERIVKIND_AND_SPIN_INSTANTIATION, (Tags::EthEth),
+                        (-2, -1, 0))
+GENERATE_INSTANTIATIONS(DERIVKIND_AND_SPIN_INSTANTIATION, (Tags::Ethbar),
+                        (-1, 0, 1, 2))
+GENERATE_INSTANTIATIONS(DERIVKIND_AND_SPIN_INSTANTIATION, (Tags::EthbarEthbar),
+                        (0, 1, 2))
+
+#undef DERIVKIND_AND_SPIN_INSTANTIATION
+#undef GET_SPIN
+#undef GET_DERIVKIND
+}  // namespace Swsh
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SwshDerivatives.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshDerivatives.hpp
@@ -1,0 +1,325 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/ComplexDiagonalModalOperator.hpp"
+#include "DataStructures/ComplexModalVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/TempBuffer.hpp"  // IWYU pragma: keep
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshSettings.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_forward_declare ComplexDataVector
+// IWYU pragma: no_forward_declare SpinWeighted
+// IWYU pragma: no_forward_declare Variables
+
+namespace Spectral {
+namespace Swsh {
+namespace detail {
+
+// Factors that appear in the modal representation of spin-weighted angular
+// derivatives, needed for compute_coefficients_of_derivative
+template <typename DerivativeKind>
+SPECTRE_ALWAYS_INLINE std::complex<double> derivative_factor(int l,
+                                                             int s) noexcept;
+
+template <>
+SPECTRE_ALWAYS_INLINE std::complex<double> derivative_factor<Tags::Eth>(
+    const int l, const int s) noexcept {
+  return sqrt(static_cast<std::complex<double>>((l - s) * (l + s + 1)));
+}
+
+template <>
+SPECTRE_ALWAYS_INLINE std::complex<double> derivative_factor<Tags::Ethbar>(
+    const int l, const int s) noexcept {
+  return -sqrt(static_cast<std::complex<double>>((l + s) * (l - s + 1)));
+}
+
+template <>
+SPECTRE_ALWAYS_INLINE std::complex<double> derivative_factor<Tags::EthEth>(
+    const int l, const int s) noexcept {
+  return sqrt(static_cast<std::complex<double>>((l - s - 1) * (l + s + 2) *
+                                                (l - s) * (l + s + 1)));
+}
+
+template <>
+SPECTRE_ALWAYS_INLINE std::complex<double>
+derivative_factor<Tags::EthbarEthbar>(const int l, const int s) noexcept {
+  return sqrt(static_cast<std::complex<double>>((l + s - 1) * (l - s + 2) *
+                                                (l + s) * (l - s + 1)));
+}
+
+template <>
+SPECTRE_ALWAYS_INLINE std::complex<double> derivative_factor<Tags::EthbarEth>(
+    const int l, const int s) noexcept {
+  return static_cast<std::complex<double>>(-(l - s) * (l + s + 1));
+}
+
+template <>
+SPECTRE_ALWAYS_INLINE std::complex<double> derivative_factor<Tags::EthEthbar>(
+    const int l, const int s) noexcept {
+  return static_cast<std::complex<double>>(-(l + s) * (l - s + 1));
+}
+
+// For a particular derivative represented by `DerivativeKind` and input spin
+// `Spin`, multiplies the derivative spectral factors with
+// `pre_derivative_modes`, returning by pointer via parameter `derivative_modes`
+template <typename DerivativeKind, int Spin>
+void compute_coefficients_of_derivative(
+    gsl::not_null<
+        SpinWeighted<ComplexModalVector,
+                     Spin + Tags::derivative_spin_weight<DerivativeKind>>*>
+        derivative_modes,
+    gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*> pre_derivative_modes,
+    size_t l_max, size_t number_of_radial_points) noexcept;
+
+// Helper function for dealing with the parameter packs in the utilities which
+// evaluate several spin-weighted derivatives at once. The `apply` function of
+// this struct locates the appropriate mode buffer in the input tuple
+// `pre_derivative_mode_tuple`, and calls `compute_coefficients_of_derivative`,
+// deriving the coefficients for `DerivativeTag` and returning by pointer.
+template <typename DerivativeTag, typename PreDerivativeTagList>
+struct dispatch_to_compute_coefficients_of_derivative;
+
+template <typename DerivativeTag, typename... PreDerivativeTags>
+struct dispatch_to_compute_coefficients_of_derivative<
+    DerivativeTag, tmpl::list<PreDerivativeTags...>> {
+  template <int Spin, typename... ModalTypes>
+  static void apply(const gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*>
+                        derivative_modes,
+                    const std::tuple<ModalTypes...>& pre_derivative_mode_tuple,
+                    const size_t l_max,
+                    const size_t number_of_radial_points) noexcept {
+    compute_coefficients_of_derivative<typename DerivativeTag::derivative_kind>(
+        derivative_modes,
+        get<tmpl::position_of_first_v<tmpl::list<PreDerivativeTags...>,
+                                      typename DerivativeTag::derivative_of>>(
+            pre_derivative_mode_tuple),
+        l_max, number_of_radial_points);
+  }
+};
+
+// Helper function for dealing with the parameter packs in the utilities which
+// evaluate several spin-weighted derivatives at once. The `apply` function of
+// this struct locates the like-spin set of paired modes and nodes, and calls
+// the member function of `SwshTransform` or `InverseSwshTransform` to perform
+// the spin-weighted transform. This function is a friend of both
+// `SwshTransform` and `InverseSwshTransform` to gain access to the private
+// `apply_to_vectors`.
+// The calling code will pass as tuples a superset of the quantities to be
+// transformed, in the same order as the tags provided to `TagList`. The
+// `modal_tuple` must be the storage destinations of the transforms in the
+// same order as the `nodal_tuple`. The set of nodal tags to be transformed are
+// the `TransformTags...` determined by the `SwshTransform` or
+// `InverseSwshTransform`. The reason for using `tuple`s rather than
+// `TaggedTuple`s or similar is to pass around spin-weighted vectors directly,
+// rather than `Scalar`s, which allows for more condensed forwarding code.
+template <typename Transform, typename TagList>
+struct dispatch_to_transform;
+
+template <ComplexRepresentation Representation, typename... TransformTags,
+          typename... Tags>
+struct dispatch_to_transform<
+    SwshTransform<tmpl::list<TransformTags...>, Representation>,
+    tmpl::list<Tags...>> {
+  template <typename... ModalTypes, typename... NodalTypes>
+  static void apply(const gsl::not_null<std::tuple<ModalTypes...>*> modal_tuple,
+                    const std::tuple<NodalTypes...>& nodal_tuple,
+                    const size_t l_max,
+                    const size_t number_of_radial_points) noexcept {
+    SwshTransform<tmpl::list<TransformTags...>, Representation>::
+        apply_to_vectors(
+            get<tmpl::position_of_first_v<tmpl::list<Tags...>, TransformTags>>(
+                *modal_tuple)...,
+            get<tmpl::position_of_first_v<tmpl::list<Tags...>, TransformTags>>(
+                nodal_tuple)...,
+            l_max, number_of_radial_points);
+  }
+};
+
+template <ComplexRepresentation Representation, typename... TransformTags,
+          typename... Tags>
+struct dispatch_to_transform<
+    InverseSwshTransform<tmpl::list<TransformTags...>, Representation>,
+    tmpl::list<Tags...>> {
+  template <typename... NodalTypes, typename... ModalTypes>
+  static void apply(const gsl::not_null<std::tuple<NodalTypes...>*> nodal_tuple,
+                    const std::tuple<ModalTypes...>& modal_tuple,
+                    const size_t l_max,
+                    const size_t number_of_radial_points) noexcept {
+    InverseSwshTransform<tmpl::list<TransformTags...>, Representation>::
+        apply_to_vectors(
+            get<tmpl::position_of_first_v<tmpl::list<Tags...>, TransformTags>>(
+                *nodal_tuple)...,
+            *get<tmpl::position_of_first_v<tmpl::list<Tags...>, TransformTags>>(
+                modal_tuple)...,
+            l_max, number_of_radial_points);
+  }
+};
+
+// template 'implementation' for the DataBox mutate-compatible interface to
+// spin-weighted derivative evaluation. This impl version is needed to have easy
+// access to the `DeDuplicatedDifferentiatedFromTagList` as a parameter pack
+template <typename DerivativeTagList,
+          typename DeDuplicatedDifferentiatedFromTagList,
+          ComplexRepresentation Representation>
+struct AngularDerivativesImpl;
+
+template <typename... DerivativeTags,
+          typename... DeDuplicatedDifferentiatedFromTags,
+          ComplexRepresentation Representation>
+struct AngularDerivativesImpl<tmpl::list<DerivativeTags...>,
+                              tmpl::list<DeDuplicatedDifferentiatedFromTags...>,
+                              Representation> {
+  using return_tags =
+      tmpl::list<DerivativeTags..., Tags::SwshTransform<DerivativeTags>...,
+                 Tags::SwshTransform<DeDuplicatedDifferentiatedFromTags>...>;
+  using argument_tags = tmpl::list<DeDuplicatedDifferentiatedFromTags...,
+                                   Tags::LMax, Tags::NumberOfRadialPoints>;
+
+  static void apply(
+      const gsl::not_null<db::item_type<DerivativeTags>*>... derivative_scalars,
+      const gsl::not_null<db::item_type<Tags::SwshTransform<
+          DerivativeTags>>*>... transform_of_derivative_scalars,
+      const gsl::not_null<db::item_type<Tags::SwshTransform<
+          DeDuplicatedDifferentiatedFromTags>>*>... transform_of_input_scalars,
+      const db::item_type<DeDuplicatedDifferentiatedFromTags>&... input_scalars,
+      const size_t l_max, const size_t number_of_radial_points) noexcept {
+    apply_to_vectors(make_not_null(&get(*transform_of_derivative_scalars))...,
+                     make_not_null(&get(*transform_of_input_scalars))...,
+                     make_not_null(&get(*derivative_scalars))...,
+                     get(input_scalars)..., l_max, number_of_radial_points);
+  }
+
+  template <ComplexRepresentation FriendRepresentation,
+            typename... DerivativeKinds, typename... ArgumentTypes,
+            size_t... Is>
+  // NOLINTNEXTLINE(readability-redundant-declaratioon)
+  friend void angular_derivatives_impl(const std::tuple<ArgumentTypes...>&,
+                                       size_t, size_t,
+                                       std::index_sequence<Is...>,
+                                       tmpl::list<DerivativeKinds...>,
+                                       cpp17::bool_constant<true>) noexcept;
+
+ private:
+  // note inputs reordered to accommodate the alternative tag-free functions
+  // which call into this function.
+  static void apply_to_vectors(
+      const gsl::not_null<typename db::item_type<Tags::SwshTransform<
+          DerivativeTags>>::type*>... transform_of_derivatives,
+      const gsl::not_null<typename db::item_type<Tags::SwshTransform<
+          DeDuplicatedDifferentiatedFromTags>>::type*>... transform_of_inputs,
+      const gsl::not_null<
+          typename db::item_type<DerivativeTags>::type*>... derivatives,
+      const typename db::item_type<
+          DeDuplicatedDifferentiatedFromTags>::type&... inputs,
+      const size_t l_max, const size_t number_of_radial_points) noexcept {
+    // perform the forward transform on the minimal set of input nodal
+    // quantities to obtain all of the requested derivatives
+    using ForwardTransformList =
+        make_transform_list_from_derivative_tags<Representation,
+                                                 tmpl::list<DerivativeTags...>>;
+
+    tmpl::for_each<ForwardTransformList>([
+      &number_of_radial_points, &l_max, &inputs..., &transform_of_inputs...
+    ](auto transform_v) noexcept {
+      using transform = typename decltype(transform_v)::type;
+      auto input_transforms = std::make_tuple(transform_of_inputs...);
+      dispatch_to_transform<transform,
+                            tmpl::list<DeDuplicatedDifferentiatedFromTags...>>::
+          apply(make_not_null(&input_transforms),
+                std::forward_as_tuple(inputs...), l_max,
+                number_of_radial_points);
+    });
+
+    // apply the modal derivative factors and place the result in the
+    // `transform_of_derivatives`
+    EXPAND_PACK_LEFT_TO_RIGHT(
+        dispatch_to_compute_coefficients_of_derivative<
+            DerivativeTags, tmpl::list<DeDuplicatedDifferentiatedFromTags...>>::
+            apply(transform_of_derivatives,
+                  std::make_tuple(transform_of_inputs...), l_max,
+                  number_of_radial_points));
+
+    // perform the inverse transform on the derivative results, placing the
+    // result in the nodal `derivatives` passed by pointer.
+    using InverseTransformList =
+        make_inverse_transform_list<Representation,
+                                    tmpl::list<DerivativeTags...>>;
+
+    tmpl::for_each<InverseTransformList>([
+      &number_of_radial_points, &l_max, &derivatives...,
+      &transform_of_derivatives...
+    ](auto transform_v) noexcept {
+      using transform = typename decltype(transform_v)::type;
+      auto derivative_tuple = std::make_tuple(derivatives...);
+      dispatch_to_transform<transform, tmpl::list<DerivativeTags...>>::apply(
+          make_not_null(&derivative_tuple),
+          std::make_tuple(transform_of_derivatives...), l_max,
+          number_of_radial_points);
+    });
+  }
+};
+
+// metafunction for determining the tags needed to evaluate the derivative tags
+// in `DerivativeTagList`, removing all duplicate tags.
+template <typename DerivativeTagList>
+struct unique_derived_from_list;
+
+template <typename... DerivativeTags>
+struct unique_derived_from_list<tmpl::list<DerivativeTags...>> {
+  using type = tmpl::remove_duplicates<
+      tmpl::list<typename DerivativeTags::derivative_of...>>;
+};
+}  // namespace detail
+
+/*!
+ * \ingroup SpectralGroup
+ * \brief A \ref DataBoxGroup mutate-compatible computational struct for
+ * computing a set of spin-weighted spherical harmonic derivatives by
+ * grouping and batch-computing spin-weighted spherical harmonic transforms.
+ *
+ * \details A derivative is evaluated for each tag in `DerivativeTagList`. All
+ * entries in `DerivativeTagList` must be the tag
+ * `Spectral::Swsh::Tags::Derivative<Tag, DerivativeKind>` prefixing the `Tag`
+ * to be differentiated, and indicating the spin-weighted derivative
+ * `DerivativeKind` to be taken. A \ref DataBoxGroup on which this struct is
+ * invoked must contain:
+ * - each of the tags in `DerivativeTagList` (the results of the computation)
+ * - each of the tags `Tag` prefixed by `Spectral::Swsh::Tags::Derivative` in
+ * `DerivativeTagList` (the inputs of the computation).
+ * - each of the tags `Spectral::Swsh::Tags::SwshTransform<DerivativeTag>` for
+ *  `DerivativeTag`in `DerivativeTagList` (the buffers for the derivative
+ * applied to the modes)
+ * - each of the tags `Spectral::Swsh::Tags::SwshTransform<Tag>` for `Tag`
+ * prefixed by any `DerivativeTag` in `DerivativeTagList` (the buffers for the
+ * transforms of the input data).
+ *
+ * This function optimizes the derivative taking process by clustering like
+ * spins of tags, forward-transforming each spin cluster together, applying the
+ * factor for the derivative to each modal vector, re-clustering according to
+ * the new spin weights (the derivatives alter the spin weights), and finally
+ * inverse-transforming in clusters.
+ */
+template <typename DerivativeTagList, ComplexRepresentation Representation =
+                                          ComplexRepresentation::Interleaved>
+using AngularDerivatives = detail::AngularDerivativesImpl<
+    DerivativeTagList,
+    typename detail::unique_derived_from_list<DerivativeTagList>::type,
+    Representation>;
+}  // namespace Swsh
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SwshSettings.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshSettings.hpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace Spectral {
+namespace Swsh {
+
+// In the static caching mechanism, we permit an l_max up to this setting
+// value. `CollocationMetadata` can still be constructed manually above this
+// value.
+constexpr size_t collocation_maximum_l_max = 200;
+
+namespace detail {
+
+// currently, the operators for the swsh derivatives and for the coefficients
+// are cached to the same maximum l_max as the collocations, but it could
+// conceivably be useful to have distinct representation maximums for them, so
+// they have separate control parameters.
+constexpr size_t swsh_derivative_maximum_l_max = collocation_maximum_l_max;
+constexpr size_t coefficients_maximum_l_max = collocation_maximum_l_max;
+}  // namespace detail
+}  // namespace Swsh
+}  // namespace Spectral

--- a/src/Utilities/TMPL.hpp
+++ b/src/Utilities/TMPL.hpp
@@ -583,4 +583,19 @@ constexpr const bool list_contains_v = list_contains<Sequence, Item>::value;
 template <typename Sequence1, typename Sequence2>
 using list_difference =
     fold<Sequence2, Sequence1, lazy::remove<_state, _element>>;
+
+// @{
+/// The index in `Sequence` of the first item with type `Element`. If `Element`
+/// is not in `Sequence`, takes the value of the size of `Sequence`
+template <typename Sequence, typename Element>
+using position_of_first = tmpl::integral_constant<
+  std::size_t,
+  tmpl::size<Sequence>::value -
+  tmpl::size<
+    find<Sequence, std::is_same<_1, tmpl::pin<Element>>>>::value>;
+
+template <typename Sequence, typename Element>
+constexpr std::size_t position_of_first_v =
+    position_of_first<Sequence, Element>::value;
+// @}
 }  // namespace brigand

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
   Test_Spectral.cpp
   Test_SwshCoefficients.cpp
   Test_SwshCollocation.cpp
+  Test_SwshDerivatives.cpp
   Test_SwshFiltering.cpp
   Test_SwshTags.cpp
   Test_SwshTestHelpers.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.cpp
@@ -85,9 +85,9 @@ std::complex<double>
 derivative_of_spin_weighted_spherical_harmonic<Tags::EthbarEth>(
     const int s, const int l, const int m, const double theta,
     const double phi) noexcept {
-  return -sqrt(static_cast<std::complex<double>>((l + s) * (l - s + 1))) *
-         derivative_of_spin_weighted_spherical_harmonic<Tags::Eth>(s - 1, l, m,
-                                                                   theta, phi);
+  return sqrt(static_cast<std::complex<double>>((l - s) * (l + s + 1))) *
+         derivative_of_spin_weighted_spherical_harmonic<Tags::Ethbar>(
+             s + 1, l, m, theta, phi);
 }
 
 template <>
@@ -95,9 +95,9 @@ std::complex<double>
 derivative_of_spin_weighted_spherical_harmonic<Tags::EthEthbar>(
     const int s, const int l, const int m, const double theta,
     const double phi) noexcept {
-  return sqrt(static_cast<std::complex<double>>((l - s) * (l + s + 1))) *
-         derivative_of_spin_weighted_spherical_harmonic<Tags::Ethbar>(
-             s + 1, l, m, theta, phi);
+  return -sqrt(static_cast<std::complex<double>>((l + s) * (l - s + 1))) *
+         derivative_of_spin_weighted_spherical_harmonic<Tags::Eth>(s - 1, l, m,
+                                                                   theta, phi);
 }
 
 template <>

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshDerivatives.cpp
@@ -1,0 +1,342 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <random>
+#include <string>
+
+#include "DataStructures/ComplexDataVector.hpp"   // IWYU pragma: keep
+#include "DataStructures/ComplexModalVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+// IWYU pragma: no_forward_declare ComplexDataVector
+// IWYU pragma: no_forward_declare ComplexModalVector
+// IWYU pragma: no_forward_declare SpinWeighted
+
+namespace Spectral {
+namespace Swsh {
+namespace {
+
+template <size_t Index, int Spin>
+struct TestTag : db::SimpleTag {
+  static std::string name() noexcept { return "TestTag"; }
+  using type = Scalar<SpinWeighted<ComplexDataVector, Spin>>;
+};
+
+// This function verifies that the derivative coefficient routine works as
+// expected by comparing the result of transforming, multiplying by the
+// derivative operator in SWSH coefficients, then inverse transforming to an
+// analytical result for the derivative. This effectively tests a `detail`
+// feature, but the intermediate check has been important in catching subtle
+// bugs previously.
+template <typename DerivativeKind, ComplexRepresentation Representation,
+          int Spin>
+void test_derivative_via_transforms() noexcept {
+  // generate coefficients for the transformation
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> size_distribution{2, 7};
+  const size_t l_max = size_distribution(gen);
+  const size_t number_of_radial_points = 2;
+  UniformCustomDistribution<double> coefficient_distribution{-10.0, 10.0};
+
+  ComplexModalVector generated_modes{
+      size_of_libsharp_coefficient_vector(l_max) * number_of_radial_points};
+  TestHelpers::generate_swsh_modes<Spin>(
+      make_not_null(&generated_modes), make_not_null(&gen),
+      make_not_null(&coefficient_distribution), number_of_radial_points, l_max);
+
+  // fill the expected collocation point data by evaluating the analytic
+  // functions. This is very slow and imprecise (due to factorial division), but
+  // comparatively simple to formulate.
+  SpinWeighted<ComplexDataVector, Spin> computed_collocation{
+      number_of_swsh_collocation_points(l_max) * number_of_radial_points};
+  ComplexDataVector expected_derivative_collocation{
+      number_of_swsh_collocation_points(l_max) * number_of_radial_points};
+
+  // Fill the collocation values for the original function from the generated
+  // mode coefficients
+  TestHelpers::swsh_collocation_from_coefficients_and_basis_func<
+      Spin, Representation>(&computed_collocation.data(), generated_modes,
+                            l_max, number_of_radial_points,
+                            TestHelpers::spin_weighted_spherical_harmonic);
+
+  // Fill the collocation values for the derivative of the function using the
+  // analytical form of the derivatives of the spin-weighted harmonics.
+  TestHelpers::swsh_collocation_from_coefficients_and_basis_func<
+      Spin, Representation>(
+      &expected_derivative_collocation, generated_modes, l_max,
+      number_of_radial_points,
+      TestHelpers::derivative_of_spin_weighted_spherical_harmonic<
+          DerivativeKind>);
+
+  auto transform_modes = swsh_transform<Representation>(
+      l_max, number_of_radial_points, computed_collocation);
+
+  SpinWeighted<ComplexModalVector,
+               Spin + Tags::derivative_spin_weight<DerivativeKind>>
+      derivative_modes{size_of_libsharp_coefficient_vector(l_max) *
+                       number_of_radial_points};
+  // apply the derivative operator to the coefficients
+  detail::compute_coefficients_of_derivative<DerivativeKind, Spin>(
+      make_not_null(&derivative_modes), make_not_null(&transform_modes), l_max,
+      number_of_radial_points);
+  ComplexDataVector transform_derivative_collocation =
+      inverse_swsh_transform<Representation>(l_max, number_of_radial_points,
+                                             derivative_modes)
+          .data();
+
+  // approximation needs to be a little loose to consistently accommodate the
+  // ratios of factorials in the analytic form
+  Approx angular_derivative_approx =
+      Approx::custom()
+          .epsilon(std::numeric_limits<double>::epsilon() * 1.0e6)
+          .scale(1.0);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(transform_derivative_collocation,
+                               expected_derivative_collocation,
+                               angular_derivative_approx);
+}
+
+// This function verifies the operation of the compute_derivatives function for
+// processing collections of derivative operations which collect equal spin
+// objects during the forward and inverse transforms for transform
+// optimization. This calls the utility for two derivatives, `DerivativeKind0`
+// and `DerivativeKind1`, each applied to two scalars of spin-weight `Spin0` and
+// `Spin1`. The result is compared to analytical forms obtained by multiplying
+// the derivatives of the basis functions by the generated coefficients.
+template <ComplexRepresentation Representation, int Spin0, int Spin1,
+          typename DerivativeKind0, typename DerivativeKind1>
+void test_compute_angular_derivatives() noexcept {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> size_distribution{2, 7};
+  const size_t l_max = size_distribution(gen);
+  const size_t number_of_radial_points = 2;
+  UniformCustomDistribution<double> coefficient_distribution{-10.0, 10.0};
+
+  using input_tag_list = tmpl::list<TestTag<0, Spin0>, TestTag<1, Spin1>>;
+  using derivative_tag_list =
+      tmpl::list<Tags::Derivative<TestTag<0, Spin0>, DerivativeKind0>,
+                 Tags::Derivative<TestTag<1, Spin1>, DerivativeKind0>,
+                 Tags::Derivative<TestTag<0, Spin0>, DerivativeKind1>,
+                 Tags::Derivative<TestTag<1, Spin1>, DerivativeKind1>>;
+  using collocation_variables_tag =
+      ::Tags::Variables<tmpl::append<input_tag_list, derivative_tag_list>>;
+  using coefficients_variables_tag = ::Tags::Variables<db::wrap_tags_in<
+      Tags::SwshTransform, tmpl::append<input_tag_list, derivative_tag_list>>>;
+
+  auto box = db::create<
+      db::AddSimpleTags<collocation_variables_tag, coefficients_variables_tag,
+                        Tags::LMax, Tags::NumberOfRadialPoints>,
+      db::AddComputeTags<>>(
+      db::item_type<collocation_variables_tag>{
+          number_of_radial_points * number_of_swsh_collocation_points(l_max)},
+      db::item_type<coefficients_variables_tag>{
+          size_of_libsharp_coefficient_vector(l_max) * number_of_radial_points},
+      l_max, number_of_radial_points);
+
+  ComplexModalVector expected_modes_spin_0{
+      number_of_radial_points * size_of_libsharp_coefficient_vector(l_max)};
+  TestHelpers::generate_swsh_modes<Spin0>(
+      make_not_null(&expected_modes_spin_0), make_not_null(&gen),
+      make_not_null(&coefficient_distribution), number_of_radial_points, l_max);
+
+  ComplexModalVector expected_modes_spin_1{
+      number_of_radial_points * size_of_libsharp_coefficient_vector(l_max)};
+  TestHelpers::generate_swsh_modes<Spin1>(
+      make_not_null(&expected_modes_spin_1), make_not_null(&gen),
+      make_not_null(&coefficient_distribution), number_of_radial_points, l_max);
+
+  const auto coefficients_to_analytic_collocation = [&l_max](
+      const auto computed_collocation,
+      const ComplexModalVector& expected_modes) noexcept {
+    constexpr int lambda_spin =
+        std::decay_t<decltype(*computed_collocation)>::type::spin;
+    TestHelpers::swsh_collocation_from_coefficients_and_basis_func<
+        lambda_spin, Representation>(
+        make_not_null(&get(*computed_collocation).data()), expected_modes,
+        l_max, number_of_radial_points,
+        TestHelpers::spin_weighted_spherical_harmonic);
+  };
+  // Put the collocation information derived from the generated modes in the
+  // DataBox
+  db::mutate<TestTag<0, Spin0>>(make_not_null(&box),
+                                coefficients_to_analytic_collocation,
+                                expected_modes_spin_0);
+  db::mutate<TestTag<1, Spin1>>(make_not_null(&box),
+                                coefficients_to_analytic_collocation,
+                                expected_modes_spin_1);
+
+  // these could be packed into a variables, but the current test wouldn't be
+  // much shorter. If the test is expanded to verify more than four results at a
+  // time, using a `Variables` for the expected results is recommended for
+  // brevity.
+  ComplexDataVector expected_derivative_0_collocation_spin_0{
+      number_of_radial_points * number_of_swsh_collocation_points(l_max)};
+  ComplexDataVector expected_derivative_0_collocation_spin_1{
+      number_of_radial_points * number_of_swsh_collocation_points(l_max)};
+  ComplexDataVector expected_derivative_1_collocation_spin_0{
+      number_of_radial_points * number_of_swsh_collocation_points(l_max)};
+  ComplexDataVector expected_derivative_1_collocation_spin_1{
+      number_of_radial_points * number_of_swsh_collocation_points(l_max)};
+
+  TestHelpers::swsh_collocation_from_coefficients_and_basis_func<
+      Spin0, Representation>(
+      make_not_null(&expected_derivative_0_collocation_spin_0),
+      expected_modes_spin_0, l_max, number_of_radial_points,
+      TestHelpers::derivative_of_spin_weighted_spherical_harmonic<
+          DerivativeKind0>);
+
+  TestHelpers::swsh_collocation_from_coefficients_and_basis_func<
+      Spin1, Representation>(
+      make_not_null(&expected_derivative_0_collocation_spin_1),
+      expected_modes_spin_1, l_max, number_of_radial_points,
+      TestHelpers::derivative_of_spin_weighted_spherical_harmonic<
+          DerivativeKind0>);
+
+  TestHelpers::swsh_collocation_from_coefficients_and_basis_func<
+      Spin0, Representation>(
+      make_not_null(&expected_derivative_1_collocation_spin_0),
+      expected_modes_spin_0, l_max, number_of_radial_points,
+      TestHelpers::derivative_of_spin_weighted_spherical_harmonic<
+          DerivativeKind1>);
+
+  TestHelpers::swsh_collocation_from_coefficients_and_basis_func<
+      Spin1, Representation>(
+      make_not_null(&expected_derivative_1_collocation_spin_1),
+      expected_modes_spin_1, l_max, number_of_radial_points,
+      TestHelpers::derivative_of_spin_weighted_spherical_harmonic<
+          DerivativeKind1>);
+
+  // the actual derivative call
+  db::mutate_apply<AngularDerivatives<derivative_tag_list, Representation>>(
+      make_not_null(&box));
+
+  // large tolerance due to the necessity of factorial division in the analytic
+  // basis function being compared to.
+  Approx swsh_approx =
+      Approx::custom()
+          .epsilon(std::numeric_limits<double>::epsilon() * 1.0e6)
+          .scale(1.0);
+  {
+    INFO("Check the coefficient data intermediate step");
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        expected_modes_spin_0,
+        get(db::get<Tags::SwshTransform<TestTag<0, Spin0>>>(box)).data(),
+        swsh_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        expected_modes_spin_1,
+        get(db::get<Tags::SwshTransform<TestTag<1, Spin1>>>(box)).data(),
+        swsh_approx);
+  }
+  {
+    INFO("Check the collocation derivatives final result");
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        expected_derivative_0_collocation_spin_0,
+        get(db::get<Tags::Derivative<TestTag<0, Spin0>, DerivativeKind0>>(box))
+            .data(),
+        swsh_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        expected_derivative_0_collocation_spin_1,
+        get(db::get<Tags::Derivative<TestTag<1, Spin1>, DerivativeKind0>>(box))
+            .data(),
+        swsh_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        expected_derivative_1_collocation_spin_0,
+        get(db::get<Tags::Derivative<TestTag<0, Spin0>, DerivativeKind1>>(box))
+            .data(),
+        swsh_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        expected_derivative_1_collocation_spin_1,
+        get(db::get<Tags::Derivative<TestTag<1, Spin1>, DerivativeKind1>>(box))
+            .data(),
+        swsh_approx);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshDerivatives",
+                  "[Unit][NumericalAlgorithms]") {
+  // we do not test the full set of combinations of derivatives, spins, and
+  // slice kinds due to the slow execution time. We test a handful of each spin,
+  // each derivative, and of each slice type.
+  {
+    INFO("Test evaluation of Eth using generated values");
+    test_derivative_via_transforms<Tags::Eth,
+                                   ComplexRepresentation::Interleaved, -2>();
+    test_derivative_via_transforms<Tags::Eth,
+                                   ComplexRepresentation::RealsThenImags, 0>();
+  }
+  {
+    INFO("Test evaluation of Ethbar using generated values");
+    test_derivative_via_transforms<Tags::Ethbar,
+                                   ComplexRepresentation::RealsThenImags, -1>();
+    test_derivative_via_transforms<Tags::Ethbar,
+                                   ComplexRepresentation::Interleaved, 1>();
+  }
+  {
+    INFO("Test evaluation of EthEth using generated values");
+    test_derivative_via_transforms<Tags::EthEth,
+                                   ComplexRepresentation::Interleaved, -2>();
+    test_derivative_via_transforms<Tags::EthEth,
+                                   ComplexRepresentation::RealsThenImags, 0>();
+  }
+  {
+    INFO("Test evaluation of EthbarEthbar using generated values");
+    test_derivative_via_transforms<Tags::EthbarEthbar,
+                                   ComplexRepresentation::Interleaved, 0>();
+    test_derivative_via_transforms<Tags::EthbarEthbar,
+                                   ComplexRepresentation::RealsThenImags, 2>();
+  }
+  {
+    INFO("Test evaluation of EthEthbar using generated values");
+    test_derivative_via_transforms<Tags::EthEthbar,
+                                   ComplexRepresentation::Interleaved, -2>();
+    test_derivative_via_transforms<Tags::EthEthbar,
+                                   ComplexRepresentation::RealsThenImags, 0>();
+    test_derivative_via_transforms<Tags::EthEthbar,
+                                   ComplexRepresentation::Interleaved, 2>();
+  }
+  {
+    INFO("Test evaluation of EthbarEth using generated values");
+    test_derivative_via_transforms<Tags::EthbarEth,
+                                   ComplexRepresentation::RealsThenImags, -1>();
+    test_derivative_via_transforms<Tags::EthbarEth,
+                                   ComplexRepresentation::Interleaved, 0>();
+    test_derivative_via_transforms<Tags::EthbarEth,
+                                   ComplexRepresentation::RealsThenImags, 1>();
+  }
+  {
+    INFO("Test compute_swsh_derivatives utility");
+    test_compute_angular_derivatives<ComplexRepresentation::Interleaved, -1, 1,
+                                     Tags::Eth, Tags::Ethbar>();
+    test_compute_angular_derivatives<ComplexRepresentation::RealsThenImags, -1,
+                                     1, Tags::Eth, Tags::Ethbar>();
+    test_compute_angular_derivatives<ComplexRepresentation::Interleaved, -1, 1,
+                                     Tags::EthEthbar, Tags::EthbarEth>();
+    test_compute_angular_derivatives<ComplexRepresentation::RealsThenImags, -1,
+                                     1, Tags::EthEthbar, Tags::EthbarEth>();
+    test_compute_angular_derivatives<ComplexRepresentation::Interleaved, 0, 2,
+                                     Tags::Ethbar, Tags::EthbarEthbar>();
+    test_compute_angular_derivatives<ComplexRepresentation::RealsThenImags, -2,
+                                     0, Tags::Eth, Tags::EthEth>();
+  }
+}
+}  // namespace
+}  // namespace Swsh
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshDerivatives.cpp
@@ -268,9 +268,37 @@ void test_compute_angular_derivatives() noexcept {
             .data(),
         swsh_approx);
   }
+  {
+    INFO("Check the multiple argument function interface");
+    SpinWeighted<ComplexDataVector,
+                 Spin0 + Tags::derivative_spin_weight<DerivativeKind0>>
+        function_output_0{number_of_radial_points *
+                          number_of_swsh_collocation_points(l_max)};
+    SpinWeighted<ComplexDataVector,
+                 Spin1 + Tags::derivative_spin_weight<DerivativeKind1>>
+        function_output_1{number_of_radial_points *
+                          number_of_swsh_collocation_points(l_max)};
+    angular_derivatives<tmpl::list<DerivativeKind0, DerivativeKind1>,
+                        Representation>(
+        l_max, number_of_radial_points, make_not_null(&function_output_0),
+        make_not_null(&function_output_1), get(db::get<TestTag<0, Spin0>>(box)),
+        get(db::get<TestTag<1, Spin1>>(box)));
+    CHECK_ITERABLE_CUSTOM_APPROX(expected_derivative_0_collocation_spin_0,
+                                 function_output_0.data(), swsh_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(expected_derivative_1_collocation_spin_1,
+                                 function_output_1.data(), swsh_approx);
+  }
+  {
+    INFO("Check the single argument function interface");
+    auto function_return = angular_derivative<DerivativeKind0, Representation>(
+        l_max, number_of_radial_points, get(db::get<TestTag<0, Spin0>>(box)));
+    CHECK_ITERABLE_CUSTOM_APPROX(function_return.data(),
+                                 expected_derivative_0_collocation_spin_0,
+                                 swsh_approx);
+  }
 }
 
-SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshDerivatives",
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.AngularDerivatives",
                   "[Unit][NumericalAlgorithms]") {
   // we do not test the full set of combinations of derivatives, spins, and
   // slice kinds due to the slow execution time. We test a handful of each spin,
@@ -322,7 +350,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshDerivatives",
                                    ComplexRepresentation::RealsThenImags, 1>();
   }
   {
-    INFO("Test compute_swsh_derivatives utility");
+    INFO("Test angular_derivatives utility");
     test_compute_angular_derivatives<ComplexRepresentation::Interleaved, -1, 1,
                                      Tags::Eth, Tags::Ethbar>();
     test_compute_angular_derivatives<ComplexRepresentation::RealsThenImags, -1,

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTags.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTags.cpp
@@ -50,7 +50,7 @@ static_assert(Derivative<Spin2TestTag, Ethbar>::spin == 1,
               "failed testing DerivativeTag with DerivativeType Ethbar");
 
 static_assert(
-    cpp17::is_same_v<Derivative<SpinMinus1TestTag, Ethbar>::derived_from,
+    cpp17::is_same_v<Derivative<SpinMinus1TestTag, Ethbar>::derivative_of,
                      SpinMinus1TestTag>,
     "failed testing DerivativeTag with DerivativeType Ethbar");
 

--- a/tests/Unit/Utilities/Test_TMPL.cpp
+++ b/tests/Unit/Utilities/Test_TMPL.cpp
@@ -63,6 +63,18 @@ static_assert(cpp17::is_same_v<
                   tmpl::list<Templated<int>>>,
               "Failed testing list_difference");
 
+static_assert(tmpl::position_of_first_v<
+                  tmpl::list<char, int, double, char, float>, char> == 0,
+              "Failed testing `tmpl::position_of_first`");
+
+static_assert(tmpl::position_of_first_v<
+                  tmpl::list<char, int, double, char, float>, double> == 2,
+              "Failed testing `tmpl::position_of_first`");
+
+static_assert(tmpl::position_of_first_v<
+                  tmpl::list<char, int, double, char, float>, size_t> == 5,
+              "Failed testing `tmpl::position_of_first`");
+
 SPECTRE_TEST_CASE("Unit.Utilities.get_first_argument", "[Unit][Utilities]") {
   const long a0 = 5;
   const long a1 = 6;


### PR DESCRIPTION
## Proposed changes

Add utilities for taking the derivatives of spin-weighted spherical harmonic functions.

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies
- [x] #1522 
- [x] #1523
- [x] #1661