### PR TITLE
Document the Vector to Python List and Python List to Vector Functions

### DIFF
--- a/src/PythonBindings/VectorPyList.hpp
+++ b/src/PythonBindings/VectorPyList.hpp
@@ -11,13 +11,28 @@
 
 namespace bp = boost::python;
 
+/*!
+ * \ingroup PythonBindingsGroup
+ * \brief A namespace containing functions for binding Python wrappers
+ * to their respective c++ classes and functions, as well as helper functions
+ * for these wrappers.
+ */
 namespace py_bindings {
+
+/*!
+ * \ingroup PythonBindingsGroup
+ * \brief Convert a bp::list of bp::object& to a std::vector
+ */
 template <typename T>
 std::vector<T> py_list_to_std_vector(const bp::object& iterable) {
   return std::vector<T>(bp::stl_input_iterator<T>(iterable),
                         bp::stl_input_iterator<T>());
 }
 
+/*!
+ * \ingroup PythonBindingsGroup
+ * \brief Convert a std::vector into a bp::list of bp::objects
+ */
 template <class T>
 bp::list std_vector_to_py_list(const std::vector<T>& vector) {
   bp::list list;


### PR DESCRIPTION
## Proposed changes

This pull request adds functions which allow the conversion between `std::vector` and `bp::list`.
Vector input
### Types of changes:

- [ ] Bugfix
- [ x] New feature

### Component:

- [x ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
