### PR TITLE
Add EvolveNewtonianEuler Executable

### DIFF
--- a/cmake/SpectreParseTests.py
+++ b/cmake/SpectreParseTests.py
@@ -35,6 +35,7 @@ allowed_tags = [
                 "Observers",
                 "Options",
                 "Parallel",
+                "ParallelAlgorithms",
                 "PointwiseFunctions",
                 "Pypp",
                 "RelativisticEuler",

--- a/src/Evolution/Executables/CMakeLists.txt
+++ b/src/Evolution/Executables/CMakeLists.txt
@@ -3,4 +3,5 @@
 
 add_subdirectory(Burgers)
 add_subdirectory(GrMhd)
+add_subdirectory(NewtonianEuler)
 add_subdirectory(ScalarWave)

--- a/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBS_TO_LINK
+  CoordinateMaps
+  DiscontinuousGalerkin
+  DomainCreators
+  Hydro
+  IO
+  Informer
+  Limiters
+  LinearOperators
+  MathFunctions
+  NewtonianEuler
+  NewtonianEulerSolutions
+  Time
+  Utilities
+  )
+
+add_spectre_parallel_executable(
+  EvolveNewtonianEuler2D
+  EvolveNewtonianEuler
+  Evolution/Executables/NewtonianEuler
+  EvolutionMetavars<2>
+  "${LIBS_TO_LINK}"
+  )
+
+add_spectre_parallel_executable(
+  EvolveNewtonianEuler3D
+  EvolveNewtonianEuler
+  Evolution/Executables/NewtonianEuler
+  EvolutionMetavars<3>
+  "${LIBS_TO_LINK}"
+  )

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -1,0 +1,262 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "Evolution/Actions/ComputeTimeDerivative.hpp"
+#include "Evolution/Actions/ComputeVolumeFluxes.hpp"
+#include "Evolution/Actions/ComputeVolumeSources.hpp"
+#include "Evolution/Conservative/UpdateConservatives.hpp"
+#include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp"
+#include "Evolution/DiscontinuousGalerkin/ObserveErrorNorms.hpp"
+#include "Evolution/DiscontinuousGalerkin/ObserveFields.hpp"
+#include "Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
+#include "Evolution/EventsAndTriggers/Event.hpp"
+#include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"
+#include "Evolution/EventsAndTriggers/Tags.hpp"
+#include "Evolution/Initialization/ConservativeSystem.hpp"
+#include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
+#include "Evolution/Initialization/Domain.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Initialization/Interface.hpp"
+#include "Evolution/Initialization/Limiter.hpp"
+#include "Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp"
+#include "Evolution/Systems/NewtonianEuler/System.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "IO/Observer/Actions.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/RegisterObservers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Actions/MutateApply.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/ChangeStepSize.hpp"
+#include "Time/Actions/RecordTimeStepperData.hpp"
+#include "Time/Actions/SelfStartActions.hpp"
+#include "Time/Actions/UpdateU.hpp"
+#include "Time/StepChoosers/Cfl.hpp"
+#include "Time/StepChoosers/Constant.hpp"
+#include "Time/StepChoosers/Increase.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/StepControllers/StepController.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Time/Triggers/TimeTriggers.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+namespace Parallel {
+template <typename Metavariables>
+class CProxy_ConstGlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+template <size_t Dim>
+struct EvolutionMetavars {
+  using analytic_solution = NewtonianEuler::Solutions::IsentropicVortex<Dim>;
+
+  using domain_creator_tag = OptionTags::DomainCreator<Dim, Frame::Inertial>;
+
+  using system = NewtonianEuler::System<
+      Dim, typename analytic_solution::equation_of_state_type>;
+
+  using temporal_id = Tags::TimeId;
+  static constexpr bool local_time_stepping = false;
+
+  using analytic_solution_tag = OptionTags::AnalyticSolution<analytic_solution>;
+  using boundary_condition_tag = analytic_solution_tag;
+  using analytic_variables_tags =
+      typename system::primitive_variables_tag::tags_list;
+
+  using equation_of_state_tag = hydro::Tags::EquationOfState<
+      typename analytic_solution_tag::type::equation_of_state_type>;
+
+  using normal_dot_numerical_flux = OptionTags::NumericalFlux<
+      dg::NumericalFluxes::LocalLaxFriedrichs<system>>;
+
+  using limiter = OptionTags::Limiter<Limiters::Minmod<
+      Dim, tmpl::list<NewtonianEuler::Tags::MassDensityCons<DataVector>,
+                      NewtonianEuler::Tags::MomentumDensity<DataVector, Dim,
+                                                            Frame::Inertial>,
+                      NewtonianEuler::Tags::EnergyDensity<DataVector>>>>;
+
+  using events = tmpl::list<
+      dg::Events::Registrars::ObserveErrorNorms<Dim, analytic_variables_tags>,
+      dg::Events::Registrars::ObserveFields<
+          Dim,
+          tmpl::append<
+              db::get_variables_tags_list<typename system::variables_tag>,
+              db::get_variables_tags_list<
+                  typename system::primitive_variables_tag>>,
+          analytic_variables_tags>>;
+  using triggers = Triggers::time_triggers;
+
+  using step_choosers =
+      tmpl::list<StepChoosers::Registrars::Cfl<Dim, Frame::Inertial>,
+                 StepChoosers::Registrars::Constant,
+                 StepChoosers::Registrars::Increase>;
+
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      typename Event<events>::creatable_classes>;
+
+  using compute_rhs = tmpl::flatten<tmpl::list<
+      Actions::ComputeVolumeFluxes,
+      dg::Actions::SendDataForFluxes<EvolutionMetavars>,
+      Actions::ComputeTimeDerivative,
+      dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
+      dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
+      tmpl::conditional_t<local_time_stepping, tmpl::list<>,
+                          dg::Actions::ApplyFluxes>,
+      Actions::RecordTimeStepperData>>;
+
+  // Conservative `UpdatePrimitives` expects system to possess
+  // list of recovery schemes so we use `MutateApply` instead.
+  using update_variables = tmpl::flatten<tmpl::list<
+      tmpl::conditional_t<local_time_stepping,
+                          dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
+                          tmpl::list<>>,
+      Actions::UpdateU, Limiters::Actions::SendData<EvolutionMetavars>,
+      Limiters::Actions::Limit<EvolutionMetavars>,
+      Actions::MutateApply<typename system::primitive_from_conservative>>>;
+
+  enum class Phase {
+    Initialization,
+    InitializeTimeStepperHistory,
+    RegisterWithObserver,
+    Evolve,
+    Exit
+  };
+
+  using initialization_actions = tmpl::list<
+      Initialization::Actions::Domain<Dim>,
+      Initialization::Actions::ConservativeSystem,
+      Initialization::Actions::AddComputeTags<
+          tmpl::list<NewtonianEuler::Tags::SoundSpeedSquaredCompute<DataVector>,
+                     NewtonianEuler::Tags::SoundSpeedCompute<DataVector>>>,
+      Actions::UpdateConservatives,
+      Initialization::Actions::Interface<
+          system,
+          Initialization::slice_tags_to_face<
+              typename system::variables_tag,
+              typename system::primitive_variables_tag,
+              NewtonianEuler::Tags::SoundSpeed<DataVector>>,
+          Initialization::slice_tags_to_exterior<
+              typename system::primitive_variables_tag,
+              NewtonianEuler::Tags::SoundSpeed<DataVector>>>,
+      Initialization::Actions::Evolution<system>,
+      Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
+      Initialization::Actions::Minmod<Dim>,
+      Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+
+  using component_list = tmpl::list<
+      observers::Observer<EvolutionMetavars>,
+      observers::ObserverWriter<EvolutionMetavars>,
+      DgElementArray<
+          EvolutionMetavars,
+          tmpl::list<
+              Parallel::PhaseActions<Phase, Phase::Initialization,
+                                     initialization_actions>,
+
+              Parallel::PhaseActions<
+                  Phase, Phase::InitializeTimeStepperHistory,
+                  tmpl::flatten<tmpl::list<SelfStart::self_start_procedure<
+                      compute_rhs, update_variables>>>>,
+
+              Parallel::PhaseActions<
+                  Phase, Phase::RegisterWithObserver,
+                  tmpl::list<observers::Actions::RegisterWithObservers<
+                                 observers::RegisterObservers<
+                                     element_observation_type>>,
+                             Parallel::Actions::TerminatePhase>>,
+
+              Parallel::PhaseActions<
+                  Phase, Phase::Evolve,
+                  tmpl::flatten<tmpl::list<
+                      Actions::UpdateConservatives,
+                      Actions::RunEventsAndTriggers,
+                      tmpl::conditional_t<
+                          local_time_stepping,
+                          Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
+                      compute_rhs, update_variables, Actions::AdvanceTime>>>>,
+          Parallel::ForwardAllOptionsToDataBox<
+              Initialization::option_tags<initialization_actions>>>>;
+
+  using const_global_cache_tag_list =
+      tmpl::list<analytic_solution_tag,
+                 OptionTags::TypedTimeStepper<tmpl::conditional_t<
+                     local_time_stepping, LtsTimeStepper, TimeStepper>>,
+                 OptionTags::EventsAndTriggers<events, triggers>>;
+
+  static constexpr OptionString help{
+      "Evolve the Newtonian Euler system in conservative form.\n\n"};
+
+  static Phase determine_next_phase(
+      const Phase& current_phase,
+      const Parallel::CProxy_ConstGlobalCache<
+          EvolutionMetavars>& /*cache_proxy*/) noexcept {
+    switch (current_phase) {
+      case Phase::Initialization:
+        return Phase::InitializeTimeStepperHistory;
+      case Phase::InitializeTimeStepperHistory:
+        return Phase::RegisterWithObserver;
+      case Phase::RegisterWithObserver:
+        return Phase::Evolve;
+      case Phase::Evolve:
+        return Phase::Exit;
+      case Phase::Exit:
+        ERROR(
+            "Should never call determine_next_phase with the current phase "
+            "being 'Exit'");
+      default:
+        ERROR(
+            "Unknown type of phase. Did you static_cast<Phase> to an integral "
+            "value?");
+    }
+  }
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling,
+    &domain::creators::register_derived_with_charm,
+    &Parallel::register_derived_classes_with_charm<
+        Event<metavariables::events>>,
+    &Parallel::register_derived_classes_with_charm<
+        StepChooser<metavariables::step_choosers>>,
+    &Parallel::register_derived_classes_with_charm<StepController>,
+    &Parallel::register_derived_classes_with_charm<TimeStepper>,
+    &Parallel::register_derived_classes_with_charm<
+        Trigger<metavariables::triggers>>};
+
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEulerFwd.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEulerFwd.hpp
@@ -1,0 +1,9 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+template <size_t Dim>
+struct EvolutionMetavars;

--- a/src/Evolution/Systems/NewtonianEuler/System.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/System.hpp
@@ -5,15 +5,64 @@
 
 #include <cstddef>
 
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Conservative/ConservativeDuDt.hpp"
+#include "Evolution/Systems/NewtonianEuler/Characteristics.hpp"
+#include "Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/NewtonianEuler/Fluxes.hpp"
+#include "Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Tags {
+template <class>
+class Variables;
+}  // namespace Tags
+/// \endcond
+
 /// \ingroup EvolutionSystemsGroup
 /// \brief Items related to evolving the Newtonian Euler system
 namespace NewtonianEuler {
 
-template <size_t Dim>
+template <size_t Dim, typename EquationOfStateType>
 struct System {
   static constexpr bool is_in_flux_conservative_form = true;
   static constexpr bool has_primitive_and_conservative_vars = true;
   static constexpr size_t volume_dim = Dim;
+  static constexpr size_t thermodynamic_dim =
+      EquationOfStateType::thermodynamic_dim;
+
+  // Compute item for pressure not currently implemented in SpECTRE,
+  // so its simple tag is passed along with the primitive variables.
+  using primitive_variables_tag = ::Tags::Variables<tmpl::list<
+      Tags::MassDensity<DataVector>, Tags::Velocity<DataVector, Dim>,
+      Tags::SpecificInternalEnergy<DataVector>, Tags::Pressure<DataVector>>>;
+
+  using variables_tag =
+      ::Tags::Variables<tmpl::list<Tags::MassDensityCons<DataVector>,
+                                   Tags::MomentumDensity<DataVector, Dim>,
+                                   Tags::EnergyDensity<DataVector>>>;
+
+  template <typename Tag>
+  using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;
+
+  using char_speeds_tag = Tags::CharacteristicSpeedsCompute<Dim>;
+  using compute_largest_characteristic_speed =
+      ComputeLargestCharacteristicSpeed<Dim>;
+
+  using conservative_from_primitive = ConservativeFromPrimitive<Dim>;
+  using primitive_from_conservative =
+      PrimitiveFromConservative<Dim, thermodynamic_dim>;
+
+  using volume_fluxes = ComputeFluxes<Dim>;
+
+  using compute_time_derivative = ConservativeDuDt<System>;
+
+  // The sources for this system vanish.
+  using sourced_variables = tmpl::list<>;
 };
 
 }  // namespace NewtonianEuler

--- a/src/ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp
+++ b/src/ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace Initialization {
+namespace Actions {
+/*!
+ * \ingroup ActionsGroup
+ *
+ * \brief Initialize the list of compute tags in `ComputeTagsList`
+ *
+ * Uses: nothing
+ *
+ * DataBox changes:
+ * - Adds:
+ *   - Each compute tag in the list `ComputeTagsList`
+ * - Removes:
+ *   - nothing
+ * - Modifies:
+ *   - nothing
+ */
+template <typename ComputeTagsList>
+struct AddComputeTags {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    return std::make_tuple(
+        merge_into_databox<AddComputeTags, db::AddSimpleTags<>,
+                           db::AddComputeTags<ComputeTagsList>>(
+            std::move(box)));
+  }
+};
+}  // namespace Actions
+}  // namespace Initialization

--- a/tests/InputFiles/NewtonianEuler/NewtonianEuler2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/NewtonianEuler2D.yaml
@@ -1,0 +1,55 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveNewtonianEuler2D
+# Check: execute
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.0001
+  TimeStepper:
+    AdamsBashforthN:
+      Order: 3
+
+DomainCreator:
+  Rectangle:
+    LowerBound: [-1.0, -1.0]
+    UpperBound: [1.0, 1.0]
+    IsPeriodicIn: [false, false]
+    InitialRefinement: [1, 1]
+    InitialGridPoints: [5, 5]
+
+AnalyticSolution:
+  IsentropicVortex:
+    AdiabaticIndex: 1.4
+    Center: [0.0, 0.0]
+    MeanVelocity: [1.0, 1.0]
+    PerturbAmplitude: 0.0
+    Strength: 5.0
+
+NumericalFlux:
+  LocalLaxFriedrichs:
+
+Limiter:
+  Minmod:
+    # Uncomment line below to turn off the limiter:
+    # DisableForDebugging: True
+    Type: LambdaPiN
+    # Recommended value from minmod papers:
+    TvbmConstant: 50.0
+
+EventsAndTriggers:
+  # ? EveryNSlabs:
+  #     N: 100
+  #     Offset: 0
+  # : - ObserveErrorNorms
+  #   - ObserveFields:
+  #       VariablesToObserve: [MassDensity]
+  # ? PastTime: 1.0001
+  ? SpecifiedSlabs:
+      Slabs: [10]
+  : - Completion
+
+Observers:
+  VolumeFileName: "./NewtonianEulerVolume"
+  ReductionFileName: "./NewtonianEulerReductions"

--- a/tests/InputFiles/NewtonianEuler/NewtonianEuler3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/NewtonianEuler3D.yaml
@@ -1,0 +1,55 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveNewtonianEuler3D
+# Check: execute
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.0001
+  TimeStepper:
+    AdamsBashforthN:
+      Order: 3
+
+DomainCreator:
+  Brick:
+    LowerBound: [-1.0, -1.0, 0.0]
+    UpperBound: [1.0, 1.0, 1.0]
+    IsPeriodicIn: [false, false, false]
+    InitialRefinement: [1, 1, 0]
+    InitialGridPoints: [5, 5, 5]
+
+AnalyticSolution:
+  IsentropicVortex:
+    AdiabaticIndex: 1.4
+    Center: [0.0, 0.0, 0.0]
+    MeanVelocity: [1.0, 1.0, 0.0]
+    PerturbAmplitude: 0.0
+    Strength: 5.0
+
+NumericalFlux:
+  LocalLaxFriedrichs:
+
+Limiter:
+  Minmod:
+    # Uncomment line below to turn off the limiter:
+    # DisableForDebugging: True
+    Type: LambdaPiN
+    # Recommended value from minmod papers:
+    TvbmConstant: 50.0
+
+EventsAndTriggers:
+  # ? EveryNSlabs:
+  #     N: 100
+  #     Offset: 0
+  # : - ObserveErrorNorms
+  #   - ObserveFields:
+  #       VariablesToObserve: [MassDensity]
+  # ? PastTime: 1.0001
+  ? SpecifiedSlabs:
+      Slabs: [10]
+  : - Completion
+
+Observers:
+  VolumeFileName: "./NewtonianEulerVolume"
+  ReductionFileName: "./NewtonianEulerReductions"

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/CMakeLists.txt
@@ -1,17 +1,16 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY "Test_Initialization")
+set(LIBRARY "Test_InitializationActions")
 
 set(LIBRARY_SOURCES
-  Test_MergeIntoDataBox.cpp
+  Test_AddComputeTags.cpp
+  Test_RemoveOptionsAndTerminatePhase.cpp
   )
-
-add_subdirectory(Actions)
 
 add_test_library(
   ${LIBRARY}
-  "ParallelAlgorithms/Initialization/"
+  "ParallelAlgorithms/Initialization/Actions"
   "${LIBRARY_SOURCES}"
   "DataStructures;ErrorHandling;Utilities"
   )

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddComputeTags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddComputeTags.cpp
@@ -1,0 +1,185 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <random>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Initialization/Tags.hpp"
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace {
+struct TemporalId {};
+
+struct Var1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "Var1"; }
+};
+
+template <size_t Dim>
+struct Var2 : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim, Frame::Inertial>;
+  static std::string name() noexcept { return "Var2"; }
+};
+
+template <size_t Dim>
+struct Var3 : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+  static std::string name() noexcept { return "Var3"; }
+};
+
+struct Var4 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "Var4"; }
+};
+
+template <size_t Dim>
+struct Var4Compute : Var4, db::ComputeTag {
+  static Scalar<DataVector> function(
+      const Scalar<DataVector>& var_1, const tnsr::I<DataVector, Dim>& var_2,
+      const tnsr::i<DataVector, Dim>& var_3) noexcept {
+    return Scalar<DataVector>{square(get(var_1)) +
+                              get(dot_product(var_2, var_3))};
+  }
+
+  using argument_tags = tmpl::list<Var1, Var2<Dim>, Var3<Dim>>;
+};
+
+template <size_t Dim>
+struct InitializeVars {
+  using initialization_option_tags =
+      tmpl::list<Initialization::Tags::InitialTime>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::list_contains_v<
+                DbTagsList, Initialization::Tags::InitialTime>> = nullptr>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    MAKE_GENERATOR(generator);
+    std::uniform_real_distribution<> distribution(0.0, 1.0);
+    const auto nn_generator = make_not_null(&generator);
+    const auto nn_distribution = make_not_null(&distribution);
+
+    const DataVector used_for_size(5);
+    auto var_1 = make_with_random_values<Scalar<DataVector>>(
+        nn_generator, nn_distribution, used_for_size);
+    auto var_2 = make_with_random_values<tnsr::I<DataVector, Dim>>(
+        nn_generator, nn_distribution, used_for_size);
+    auto var_3 = make_with_random_values<tnsr::i<DataVector, Dim>>(
+        nn_generator, nn_distribution, used_for_size);
+
+    using simple_tags =
+        db::AddSimpleTags<tmpl::list<Var1, Var2<Dim>, Var3<Dim>>>;
+    return std::make_tuple(
+        Initialization::merge_into_databox<InitializeVars, simple_tags>(
+            std::move(box), std::move(var_1), std::move(var_2),
+            std::move(var_3)));
+  }
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<not tmpl::list_contains_v<
+                DbTagsList, Initialization::Tags::InitialTime>> = nullptr>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    return {std::move(box)};
+  }
+};
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  static constexpr size_t dim = metavariables::dim;
+
+  using initialization_actions =
+      tmpl::list<InitializeVars<dim>,
+                 Initialization::Actions::AddComputeTags<Var4Compute<dim>>,
+                 Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+
+  using add_options_to_databox = Parallel::ForwardAllOptionsToDataBox<
+      Initialization::option_tags<initialization_actions>>;
+
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        initialization_actions>>;
+};
+
+template <size_t Dim>
+struct Metavariables {
+  using component_list = tmpl::list<Component<Metavariables>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using temporal_id = TemporalId;
+
+  static constexpr size_t dim = Dim;
+
+  enum class Phase { Initialization, Exit };
+};
+
+template <size_t Dim>
+void test_add_compute_tag() noexcept {
+  using MockRuntimeSystem =
+      ActionTesting::MockRuntimeSystem<Metavariables<Dim>>;
+  using component = Component<Metavariables<Dim>>;
+
+  MockRuntimeSystem runner{{}};
+  const double initial_time = 12.20;
+  ActionTesting::emplace_component<component>(&runner, 0, initial_time);
+  runner.set_phase(Metavariables<Dim>::Phase::Initialization);
+  // Initialize simple tags
+  runner.template next_action<component>(0);
+  // Initialize compute tags
+  runner.template next_action<component>(0);
+
+  const Scalar<DataVector> expected_var_4(
+      square(get(ActionTesting::get_databox_tag<component, Var1>(runner, 0))) +
+      get(dot_product(
+          ActionTesting::get_databox_tag<component, Var2<Dim>>(runner, 0),
+          ActionTesting::get_databox_tag<component, Var3<Dim>>(runner, 0))));
+  CHECK(ActionTesting::get_databox_tag<component, Var4>(runner, 0) ==
+        expected_var_4);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Initialization.AddComputeTags",
+                  "[Unit][ParallelAlgorithms]") {
+  test_add_compute_tag<1>();
+  test_add_compute_tag<2>();
+  test_add_compute_tag<3>();
+}

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
@@ -122,8 +122,9 @@ struct Metavariables {
 };
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Evolution.Initialization.RemoveOptionsFromDataBox",
-                  "[Unit][Evolution]") {
+SPECTRE_TEST_CASE(
+    "Unit.ParallelAlgorithms.Initialization.RemoveOptionsFromDataBox",
+    "[Unit][ParallelAlgorithms]") {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using component = Component<Metavariables>;
 

--- a/tests/Unit/ParallelAlgorithms/Initialization/Test_MergeIntoDataBox.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Test_MergeIntoDataBox.cpp
@@ -113,8 +113,8 @@ void test_failure_value() {
 }
 }  // namespace TestAddToBox_detail
 
-SPECTRE_TEST_CASE("Unit.Evolution.Initialization.AddToDataBox",
-                  "[Unit][Evolution]") {
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Initialization.AddToDataBox",
+                  "[Unit][ParallelAlgorithms]") {
   TestAddToBox_detail::test();
 }
 
@@ -122,8 +122,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Initialization.AddToDataBox",
 // we found that the value being set by the action
 // TestAddToBox_detail::FakeAction is not the same as what is already in the
 // DataBox. The value in the DataBox is: 2 while the value being added is 3]]
-SPECTRE_TEST_CASE("Unit.Evolution.Initialization.AddToDataBox.Error",
-                  "[Unit][Evolution]") {
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Initialization.AddToDataBox.Error",
+                  "[Unit][ParallelAlgorithms]") {
   ERROR_TEST();
   TestAddToBox_detail::test_failure_value();
 }


### PR DESCRIPTION
## Proposed changes

The order is

- Add missing members to `NewtonianEuler` system.
- Add NewtonianEuler Initializer. 
  This commit adds two "new" files that should be replaced by something that doesn't duplicate code:
  + `src/Evolution/Conservative/UpdatePrimitivesNoRecovery.hpp`, which should be deleted in favor of making `UpdatePrimitives.hpp`handle systems without a list of prim from cons recovery methods.
  + `src/Evolution/Initialization/InterfaceNewtonianEuler.hpp`, which should be deleted in favor of making  `Interface.hpp` handle systems without GR variables, as well as making it capable of initializing system-specific compute items on the interface.

  In addition, `src/Evolution/Systems/NewtonianEuler/Initialize.hpp`  is also mostly a copy-paste of other systems, so we should somehow factor that out too (maybe in a future PR in order to deal with all systems at once).
- Add EvolveNewtonianEuler Executable.
 (2-3D for now because there is no 1D initial data in develop yet!!!)

Any suggestions to deal with the code duplication in the initialization would be appreciated!

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
