### PR TITLE
Compute items for SqrtDetSpatialMetric

### DIFF
--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -42,6 +42,17 @@ Scalar<DataType> magnitude(
   return Scalar<DataType>{sqrt(get(dot_product(vector, vector, metric)))};
 }
 
+/// \ingroup TensorGroup
+/// \brief Compute square root of the Euclidean magnitude of a rank-0 tensor
+///
+/// \details
+/// Computes the square root of the absolute value of the scalar.
+template <typename DataType>
+Scalar<DataType> sqrt_magnitude(
+    const Scalar<DataType>& input) noexcept {
+  return Scalar<DataType>{sqrt(abs(get(input)))};
+}
+
 namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup DataStructuresGroup
@@ -116,5 +127,18 @@ struct NormalizedCompute : Normalized<Tag>, db::ComputeTag {
     return vector;
   }
   using argument_tags = tmpl::list<Tag, Magnitude<Tag>>;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup DataStructuresGroup
+/// The square root of a scalar
+///
+/// \snippet Test_Magnitude.cpp sqrt_name
+template <typename Tag>
+struct Sqrt : db::ComputeTag {
+  static std::string name() noexcept { return "Sqrt(" + Tag::name() + ")"; }
+  static constexpr Scalar<DataVector> (*function)(const db::item_type<Tag>&) =
+      sqrt_magnitude;
+  using argument_tags = tmpl::list<Tag>;
 };
 }  // namespace Tags

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -321,5 +321,21 @@ struct DerivSpacetimeMetricCompute
   }
   using base = gr::Tags::DerivSpacetimeMetric<SpatialDim, Frame, DataVector>;
 };
+
+/*!
+ * \brief Compute item to get the square root of the determinant of the spatial
+ * metric \f$\sqrt{g}\f$ via `gr::Tags::DetAndInverseSpatialMetric`.
+ *
+ * \details Can be retrieved using `gr::Tags::SqrtDetSpatialMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SqrtDetSpatialMetricCompute : SqrtDetSpatialMetric<DataType>,
+                                     db::ComputeTag {
+  using argument_tags = tmpl::list<DetSpatialMetric<DataType>>;
+  static Scalar<DataType> function(const Scalar<DataType>& det_spatial_metric) {
+    return Scalar<DataType>{sqrt(get(det_spatial_metric))};
+  }
+  using base = SqrtDetSpatialMetric<DataType>;
+};
 }  // namespace Tags
 }  // namespace gr

--- a/tests/Unit/DataStructures/Tensor/EagerMath/Test_Magnitude.cpp
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/Test_Magnitude.cpp
@@ -241,6 +241,26 @@ void test_general_magnitude_tags() {
   CHECK_ITERABLE_APPROX(get<2>(db::get<Tags::Normalized<Covector<3>>>(box)),
                         get<2>(covector) / sqrt(778.0));
 }
+
+struct MyScalar : db::SimpleTag {
+  static std::string name() noexcept { return "MyScalar"; }
+  using type = Scalar<DataVector>;
+};
+void test_root_tags() {
+  constexpr size_t npts = 5;
+  const Scalar<DataVector> my_scalar{DataVector{npts, -3.0}};
+
+  const auto box =
+      db::create<db::AddSimpleTags<MyScalar>,
+                 db::AddComputeTags<Tags::Sqrt<MyScalar>>>(my_scalar);
+
+  CHECK(get(db::get<Tags::Sqrt<MyScalar>>(box)) == DataVector{npts, sqrt(3.0)});
+
+  using Tag = MyScalar;
+  /// [sqrt_name]
+  CHECK(Tags::Sqrt<Tag>::name() == "Sqrt(" + Tag::name() + ")");
+  /// [sqrt_name]
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
@@ -249,4 +269,5 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
   test_magnitude();
   test_magnitude_tags();
   test_general_magnitude_tags();
+  test_root_tags();
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -162,6 +162,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
   CHECK(
       gr::Tags::SpatialMetricCompute<3, Frame::Inertial, DataVector>::name() ==
       "SpatialMetric");
+  CHECK(gr::Tags::SqrtDetSpatialMetricCompute<3, Frame::Inertial,
+                                              DataVector>::name() ==
+        "SqrtDetSpatialMetric");
   CHECK(gr::Tags::DetAndInverseSpatialMetricCompute<3, Frame::Inertial,
                                                     DataVector>::name() ==
         "Variables(DetSpatialMetric,InverseSpatialMetric)");
@@ -178,7 +181,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
   MAKE_GENERATOR(generator);
   std::uniform_real_distribution<> distribution(-0.1, 0.1);
 
-  const auto expected_spacetime_metric = [&]() {
+  const auto expected_spacetime_metric = [&generator, &distribution,
+                                          &used_for_size]() {
     auto spacetime_metric_l =
         make_with_random_values<tnsr::aa<DataVector, 3, Frame::Inertial>>(
             make_not_null(&generator), make_not_null(&distribution),
@@ -205,7 +209,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
       db::AddComputeTags<
           gr::Tags::SpatialMetricCompute<3, Frame::Inertial, DataVector>,
           gr::Tags::DetAndInverseSpatialMetricCompute<3, Frame::Inertial,
-                                                      DataVector>>>(
+                                                      DataVector>,
+          gr::Tags::SqrtDetSpatialMetricCompute<3, Frame::Inertial,
+                                                DataVector>>>(
       expected_spacetime_metric);
   CHECK(db::get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(box) ==
         expected_spatial_metric);
@@ -213,6 +219,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
         expected_det_and_inverse_spatial_metric.first);
   CHECK(db::get<gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>>(
             box) == expected_det_and_inverse_spatial_metric.second);
+  CHECK(get(db::get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(box)) ==
+        sqrt(get(expected_det_and_inverse_spatial_metric.first)));
 
   // Now let's put the lapse, shift, and spatial metric into the databox
   // and test that we can compute the correct spacetime metric


### PR DESCRIPTION
## Proposed changes
**Edit**: after merging #1468, this PR has been updated to:
 - add a compute tag that returns the `sqrt` of the determinant of 3-metric;
 - add a generic `Sqrt` compute tag that can be used on `Scalar<>`.

**Previous description** (before merging #1468):
Adds compute tags for Det of SpatialMetric, SqrtDet of SpatialMetric, and InverseSpatialMetric. This PR includes changes added in #1468 as the first commit. Therefore, please review the **most recent** commit only.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).