### PR TITLE
Compute items for Lapse, Shift and InverseSpacetimeMetric

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -222,6 +222,25 @@ struct SpacetimeMetricCompute : SpacetimeMetric<SpatialDim, Frame, DataType>,
 };
 
 /*!
+ * \brief Compute item for inverse spacetime metric \f$\psi^{ab}\f$
+ * in terms of the lapse \f$N\f$, shift \f$N^i\f$, and inverse
+ * spatial metric \f$g^{ij}\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::InverseSpacetimeMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct InverseSpacetimeMetricCompute
+    : InverseSpacetimeMetric<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<Lapse<DataType>, Shift<SpatialDim, Frame, DataType>,
+                 InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static constexpr auto function =
+      &inverse_spacetime_metric<SpatialDim, Frame, DataType>;
+  using base = InverseSpacetimeMetric<SpatialDim, Frame, DataType>;
+};
+
+/*!
  * \brief Compute item for spatial metric \f$g_{ij}\f$ from the
  * spacetime metric \f$\psi_{ab}\f$.
  *
@@ -240,7 +259,8 @@ struct SpatialMetricCompute : SpatialMetric<SpatialDim, Frame, DataType>,
  * \brief Compute item for spatial metric determinant \f$g\f$
  * and inverse \f$g^{ij}\f$ in terms of the spatial metric \f$g_{ij}\f$.
  *
- * \details Can be retrieved using `gr::Tags::DetAndInverseSpatialMetric`.
+ * \details Can be retrieved using `gr::Tags::DetSpatialMetric` and
+ * `gr::Tags::InverseSpatialMetric`.
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
 struct DetAndInverseSpatialMetricCompute
@@ -336,6 +356,36 @@ struct SqrtDetSpatialMetricCompute : SqrtDetSpatialMetric<DataType>,
     return Scalar<DataType>{sqrt(get(det_spatial_metric))};
   }
   using base = SqrtDetSpatialMetric<DataType>;
+};
+
+/*!
+ * \brief Compute item for shift \f$N^i\f$ from the spacetime metric
+ * \f$\psi_{ab}\f$ and the inverse spatial metric \f$g^{ij}\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::Shift`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct ShiftCompute : Shift<SpatialDim, Frame, DataType>, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<SpacetimeMetric<SpatialDim, Frame, DataType>,
+                 InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static constexpr auto function = &shift<SpatialDim, Frame, DataType>;
+  using base = Shift<SpatialDim, Frame, DataType>;
+};
+
+/*!
+ * \brief Compute item for lapse \f$N\f$ from the spacetime metric
+ * \f$\psi_{ab}\f$ and the shift \f$N^i\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::Lapse`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct LapseCompute : Lapse<DataType>, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<Shift<SpatialDim, Frame, DataType>,
+                 SpacetimeMetric<SpatialDim, Frame, DataType>>;
+  static constexpr auto function = &lapse<SpatialDim, Frame, DataType>;
+  using base = Lapse<DataType>;
 };
 }  // namespace Tags
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -27,6 +27,9 @@ struct SpatialMetric : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
   static std::string name() noexcept { return "SpatialMetric"; }
 };
+/*!
+ * \brief Inverse of the spatial metric.
+ */
 template <size_t Dim, typename Frame, typename DataType>
 struct InverseSpatialMetric : db::SimpleTag {
   using type = tnsr::II<DataType, Dim, Frame>;

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -23,6 +23,9 @@ template <size_t Dim, typename Frame = Frame::Inertial,
 struct SpatialMetric;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
+struct DetAndInverseSpatialMetric;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct InverseSpatialMetric;
 template <typename DataType = DataVector>
 struct DetSpatialMetric;


### PR DESCRIPTION
## Proposed changes

Adds compute tags for Lapse, Shift and InverseSpacetimeMetric. This PR includes changes added in #1468 and #1469 as the first two commits. Therefore, please review the **most recent** commit only.


**Edit**: All dependencies of this PR have been merged, and rebased upon. This PR is now ready for merge.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).