### PR TITLE
Compute items for SpacetimeNormal{OneForm, Vector}

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -203,6 +203,39 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
 
 namespace Tags {
 /*!
+ * \brief Compute item for spacetime normal oneform \f$n_a\f$ from
+ * the lapse \f$N\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::SpacetimeNormalOneForm`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpacetimeNormalOneFormCompute
+    : SpacetimeNormalOneForm<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<Lapse<DataType>>;
+  static constexpr auto function =
+      &spacetime_normal_one_form<SpatialDim, Frame, DataType>;
+  using base = SpacetimeNormalOneForm<SpatialDim, Frame, DataType>;
+};
+
+/*!
+ * \brief Compute item for spacetime normal vector \f$n^a\f$ from
+ * the lapse \f$N\f$ and the shift \f$N^i\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::SpacetimeNormalVector`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpacetimeNormalVectorCompute
+    : SpacetimeNormalVector<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<Lapse<DataType>, Shift<SpatialDim, Frame, DataType>>;
+  static constexpr auto function =
+      &spacetime_normal_vector<SpatialDim, Frame, DataType>;
+  using base = SpacetimeNormalVector<SpatialDim, Frame, DataType>;
+};
+
+/*!
  * \brief Compute item for spacetime metric \f$\psi_{ab}\f$ from the
  * lapse \f$N\f$, shift \f$N^i\f$, and spatial metric \f$g_{ij}\f$.
  *

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -156,6 +156,12 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
 
   // Check that compute items work correctly in the DataBox
   // First, check that the names are correct
+  CHECK(gr::Tags::SpacetimeNormalOneFormCompute<3, Frame::Inertial,
+                                                DataVector>::name() ==
+        "SpacetimeNormalOneForm");
+  CHECK(gr::Tags::SpacetimeNormalVectorCompute<3, Frame::Inertial,
+                                               DataVector>::name() ==
+        "SpacetimeNormalVector");
   CHECK(gr::Tags::SpacetimeMetricCompute<3, Frame::Inertial,
                                          DataVector>::name() ==
         "SpacetimeMetric");
@@ -226,7 +232,11 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
           gr::Tags::ShiftCompute<3, Frame::Inertial, DataVector>,
           gr::Tags::LapseCompute<3, Frame::Inertial, DataVector>,
           gr::Tags::InverseSpacetimeMetricCompute<3, Frame::Inertial,
-                                                  DataVector>>>(
+                                                  DataVector>,
+          gr::Tags::SpacetimeNormalOneFormCompute<3, Frame::Inertial,
+                                                  DataVector>,
+          gr::Tags::SpacetimeNormalVectorCompute<3, Frame::Inertial,
+                                                 DataVector>>>(
       expected_spacetime_metric);
   CHECK(db::get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(box) ==
         expected_spatial_metric);
@@ -242,6 +252,16 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
   CHECK(
       db::get<gr::Tags::InverseSpacetimeMetric<3, Frame::Inertial, DataVector>>(
           box) == expected_inverse_spacetime_metric);
+  CHECK(
+      db::get<gr::Tags::SpacetimeNormalOneForm<3, Frame::Inertial, DataVector>>(
+          box) ==
+      gr::spacetime_normal_one_form<3, Frame::Inertial, DataVector>(
+          expected_lapse));
+  CHECK(
+      db::get<gr::Tags::SpacetimeNormalVector<3, Frame::Inertial, DataVector>>(
+          box) ==
+      gr::spacetime_normal_vector<3, Frame::Inertial, DataVector>(
+          expected_lapse, expected_shift));
 
   // Now let's put the lapse, shift, and spatial metric into the databox
   // and test that we can compute the correct spacetime metric


### PR DESCRIPTION
## Proposed changes

Adds compute tags for SpacetimeNormal{OneForm, Vector}. This PR includes changes added in #1468 , #1469 and #1470 as the first three commits. Therefore, please review the **most recent** commit only.


**Edit**: Dependencies of this PR have merged, and this rebased on them.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).