### PR TITLE
Restrict time triggers to slab boundaries

### DIFF
--- a/src/Time/Triggers/EveryNSlabs.hpp
+++ b/src/Time/Triggers/EveryNSlabs.hpp
@@ -61,6 +61,9 @@ class EveryNSlabs : public Trigger<TriggerRegistrars> {
   using argument_tags = tmpl::list<Tags::TimeId>;
 
   bool operator()(const TimeId& time_id) const noexcept {
+    if (not time_id.is_at_slab_boundary()) {
+      return false;
+    }
     const auto slab_number = static_cast<uint64_t>(time_id.slab_number());
     return slab_number >= offset_ and (slab_number - offset_) % interval_ == 0;
   }

--- a/src/Time/Triggers/PastTime.hpp
+++ b/src/Time/Triggers/PastTime.hpp
@@ -54,6 +54,9 @@ class PastTime : public Trigger<TriggerRegistrars> {
   using argument_tags = tmpl::list<Tags::Time, Tags::TimeId>;
 
   bool operator()(const Time& time, const TimeId& time_id) const noexcept {
+    if (not time_id.is_at_slab_boundary()) {
+      return false;
+    }
     return evolution_greater<double>{time_id.time_runs_forward()}(
         time.value(), trigger_time_);
   }

--- a/src/Time/Triggers/SpecifiedSlabs.hpp
+++ b/src/Time/Triggers/SpecifiedSlabs.hpp
@@ -59,6 +59,9 @@ class SpecifiedSlabs : public Trigger<TriggerRegistrars> {
   using argument_tags = tmpl::list<Tags::TimeId>;
 
   bool operator()(const TimeId& time_id) const noexcept {
+    if (not time_id.is_at_slab_boundary()) {
+      return false;
+    }
     return slabs_.count(static_cast<uint64_t>(time_id.slab_number())) == 1;
   }
 

--- a/tests/Unit/Time/Test_EveryNSlabs.cpp
+++ b/tests/Unit/Time/Test_EveryNSlabs.cpp
@@ -42,6 +42,12 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.EveryNSlabs", "[Unit][Time]") {
     CHECK(sent_trigger->is_triggered(box) == expected);
     db::mutate<Tags::TimeId>(
         make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {
+          *time_id = TimeId(true, time_id->slab_number(), time_id->time(), 1,
+                            time_id->time());
+        });
+    CHECK_FALSE(sent_trigger->is_triggered(box));
+    db::mutate<Tags::TimeId>(
+        make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {
           *time_id = TimeId(true, time_id->slab_number() + 1, time_id->time());
         });
   }

--- a/tests/Unit/Time/Test_SpecifiedSlabs.cpp
+++ b/tests/Unit/Time/Test_SpecifiedSlabs.cpp
@@ -41,6 +41,12 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.SpecifiedSlabs", "[Unit][Time]") {
     CHECK(sent_trigger->is_triggered(box) == expected);
     db::mutate<Tags::TimeId>(
         make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {
+          *time_id = TimeId(true, time_id->slab_number(), time_id->time(), 1,
+                            time_id->time());
+        });
+    CHECK_FALSE(sent_trigger->is_triggered(box));
+    db::mutate<Tags::TimeId>(
+        make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {
           *time_id = TimeId(true, time_id->slab_number() + 1, time_id->time());
         });
   }


### PR DESCRIPTION
Fixes #1465.

Modifying the triggers here will allow us to, at a later time, add debugging triggers that can trigger at substeps.  Putting a check at a higher level would prevent that from working.  The `Always` trigger (and forms of `Not`) still trigger at every substep.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
