### PR TITLE
Add compute items for trace of ExtrinsicCurvature and derivatives of SpacetimeMetric

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -620,5 +620,30 @@ struct ExtrinsicCurvatureCompute
       &extrinsic_curvature<SpatialDim, Frame, DataVector>;
   using base = gr::Tags::ExtrinsicCurvature<SpatialDim, Frame, DataVector>;
 };
+
+/*!
+ * \brief Compute item to get the trace of extrinsic curvature from generalized
+ * harmonic variables and the spacetime normal vector.
+ *
+ * \details See `extrinsic_curvature()` for how the extrinsic curvature
+ * \f$ K_{ij}\f$ is computed. Its trace is taken as
+ * \f{align}
+ *     tr(K) &= g^{ij} K_{ij}.
+ * \f}
+ *
+ * Can be retrieved using `gr::Tags::TraceExtrinsicCurvature`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct TraceExtrinsicCurvatureCompute
+    : gr::Tags::TraceExtrinsicCurvature<DataVector>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<gr::Tags::ExtrinsicCurvature<SpatialDim, Frame, DataVector>,
+                 gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>>;
+  static constexpr Scalar<DataVector> (*function)(
+      const tnsr::ii<DataVector, SpatialDim, Frame>&,
+      const tnsr::II<DataVector, SpatialDim, Frame>&) = &trace;
+  using base = gr::Tags::TraceExtrinsicCurvature<DataVector>;
+};
 }  // namespace Tags
 }  // namespace GeneralizedHarmonic

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -58,6 +58,18 @@ struct Lapse : db::SimpleTag {
 /*!
  * \brief Spacetime derivatives of the spacetime metric
  *
+ * \details Spatial derivatives of the spacetime metric
+ * \f$\partial_i \psi_{bc}\f$ assembled from the spatial
+ * derivatives of evolved 3+1 variables.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct DerivSpacetimeMetric : db::SimpleTag {
+  using type = tnsr::iaa<DataType, Dim, Frame>;
+  static std::string name() noexcept { return "DerivSpacetimeMetric"; }
+};
+/*!
+ * \brief Spacetime derivatives of the spacetime metric
+ *
  * \details Spacetime derivatives of the spacetime metric
  * \f$\partial_a \psi_{bc}\f$ assembled from the spatial and temporal
  * derivatives of evolved 3+1 variables.

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -35,6 +35,9 @@ template <typename DataType = DataVector>
 struct Lapse;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
+struct DerivSpacetimeMetric;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct DerivativesOfSpacetimeMetric;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -602,6 +602,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
         "Pi");
   CHECK(GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<
             3, Frame::Inertial>::name() == "ExtrinsicCurvature");
+  CHECK(GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
+            3, Frame::Inertial>::name() == "TraceExtrinsicCurvature");
 
   // Check that the compute items return the correct values
   MAKE_GENERATOR(generator);
@@ -668,6 +670,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
   const auto expected_extrinsic_curvature =
       GeneralizedHarmonic::extrinsic_curvature(spacetime_normal_vector,
                                                expected_pi, expected_phi);
+  const auto expected_trace_extrinsic_curvature =
+      trace(expected_extrinsic_curvature, inverse_spatial_metric);
 
   const auto other_box = db::create<
       db::AddSimpleTags<
@@ -714,7 +718,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
       db::AddComputeTags<
           GeneralizedHarmonic::Tags::PhiCompute<3, Frame::Inertial>,
           GeneralizedHarmonic::Tags::PiCompute<3, Frame::Inertial>,
-          GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<
+          GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<3,
+                                                               Frame::Inertial>,
+          GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
               3, Frame::Inertial>>>(
       spatial_metric, lapse, shift,
       spacetime_normal_vector, inverse_spatial_metric, deriv_spatial_metric,
@@ -727,4 +733,6 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
             ghvars_box) == expected_pi);
   CHECK(db::get<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>(
             ghvars_box) == expected_extrinsic_curvature);
+  CHECK(db::get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(ghvars_box) ==
+        expected_trace_extrinsic_curvature);
 }


### PR DESCRIPTION
## Proposed changes

Add compute items for the trace of ExtrinsicCurvature, spacetime / spatial derivatives of SpacetimeMetric. This PR includes changes added in #1473  as the first commit. Therefore, please review the most recent commit only.

**Edit:** #1473 has merged into develop, and this PR has been rebased on it.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
