### PR TITLE
Add compute items for spacetime Christoffels

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
@@ -45,6 +45,7 @@ template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
 tnsr::abb<DataType, SpatialDim, Frame, Index> christoffel_first_kind(
     const tnsr::abb<DataType, SpatialDim, Frame, Index>& d_metric) noexcept;
 // @}
+
 namespace Tags {
 /// Compute item for spatial Christoffel symbols of the first kind
 /// \f$\Gamma_{ijk}\f$ computed from the first derivative of the
@@ -104,6 +105,67 @@ struct TraceSpatialChristoffelFirstKindCompute
       &trace_last_indices<DataType, SpatialIndex<SpatialDim, UpLo::Lo, Frame>,
                           SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
   using base = TraceSpatialChristoffelFirstKind<SpatialDim, Frame, DataType>;
+};
+
+/// Compute item for spacetime Christoffel symbols of the first kind
+/// \f$\Gamma_{abc}\f$ computed from the first derivative of the
+/// spacetime metric.
+///
+/// Can be retrieved using `gr::Tags::SpacetimeChristoffelFirstKind`
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpacetimeChristoffelFirstKindCompute
+    : SpacetimeChristoffelFirstKind<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<DerivativesOfSpacetimeMetric<SpatialDim, Frame, DataType>>;
+  static constexpr tnsr::abb<DataType, SpatialDim, Frame,
+                             IndexType::Spacetime> (*function)(
+      const tnsr::abb<DataType, SpatialDim, Frame, IndexType::Spacetime>&) =
+      &christoffel_first_kind<SpatialDim, Frame, IndexType::Spacetime,
+                              DataType>;
+  using base = SpacetimeChristoffelFirstKind<SpatialDim, Frame, DataType>;
+};
+
+/// Compute item for spacetime Christoffel symbols of the second kind
+/// \f$\Gamma^a_{bc}\f$ computed from the Christoffel symbols of the
+/// first kind and the inverse spacetime metric.
+///
+/// Can be retrieved using `gr::Tags::SpacetimeChristoffelSecondKind`
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpacetimeChristoffelSecondKindCompute
+    : SpacetimeChristoffelSecondKind<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<SpacetimeChristoffelFirstKind<SpatialDim, Frame, DataType>,
+                 InverseSpacetimeMetric<SpatialDim, Frame, DataType>>;
+  static constexpr tnsr::Abb<DataType, SpatialDim, Frame> (*function)(
+      const tnsr::abb<DataType, SpatialDim, Frame>&,
+      const tnsr::AA<DataType, SpatialDim, Frame>&) =
+      &raise_or_lower_first_index<DataType,
+                                  SpacetimeIndex<SpatialDim, UpLo::Lo, Frame>,
+                                  SpacetimeIndex<SpatialDim, UpLo::Lo, Frame>>;
+  using base = SpacetimeChristoffelSecondKind<SpatialDim, Frame, DataType>;
+};
+
+/// Compute item for the trace of the spacetime Christoffel symbols
+/// of the first kind
+/// \f$\Gamma_{a} = \Gamma_{abc}g^{bc}\f$ computed from the
+/// Christoffel symbols of the first kind and the inverse spacetime metric.
+///
+/// Can be retrieved using `gr::Tags::TraceSpacetimeChristoffelFirstKind`
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct TraceSpacetimeChristoffelFirstKindCompute
+    : TraceSpacetimeChristoffelFirstKind<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<SpacetimeChristoffelFirstKind<SpatialDim, Frame, DataType>,
+                 InverseSpacetimeMetric<SpatialDim, Frame, DataType>>;
+  static constexpr tnsr::a<DataType, SpatialDim, Frame> (*function)(
+      const tnsr::abb<DataType, SpatialDim, Frame>&,
+      const tnsr::AA<DataType, SpatialDim, Frame>&) =
+      &trace_last_indices<DataType, SpacetimeIndex<SpatialDim, UpLo::Lo, Frame>,
+                          SpacetimeIndex<SpatialDim, UpLo::Lo, Frame>>;
+  using base = TraceSpacetimeChristoffelFirstKind<SpatialDim, Frame, DataType>;
 };
 }  // namespace Tags
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -55,6 +55,18 @@ struct Lapse : db::SimpleTag {
   using type = Scalar<DataType>;
   static std::string name() noexcept { return "Lapse"; }
 };
+/*!
+ * \brief Spacetime derivatives of the spacetime metric
+ *
+ * \details Spacetime derivatives of the spacetime metric
+ * \f$\partial_a \psi_{bc}\f$ assembled from the spatial and temporal
+ * derivatives of evolved 3+1 variables.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct DerivativesOfSpacetimeMetric : db::SimpleTag {
+  using type = tnsr::abb<DataType, Dim, Frame>;
+  static std::string name() noexcept { return "DerivativesOfSpacetimeMetric"; }
+};
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::abb<DataType, Dim, Frame>;
@@ -63,7 +75,9 @@ struct SpacetimeChristoffelFirstKind : db::SimpleTag {
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::Abb<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "SpactimeChristoffelSecondKind"; }
+  static std::string name() noexcept {
+    return "SpacetimeChristoffelSecondKind";
+  }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SpatialChristoffelFirstKind : db::SimpleTag {

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -35,6 +35,9 @@ template <typename DataType = DataVector>
 struct Lapse;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
+struct DerivativesOfSpacetimeMetric;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct SpacetimeChristoffelFirstKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
@@ -87,58 +87,129 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Christoffel",
   CHECK(gr::Tags::SpatialChristoffelSecondKindCompute<3, Frame::Inertial,
                                                       DataVector>::name() ==
         "SpatialChristoffelSecondKind");
+  CHECK(gr::Tags::SpacetimeChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                       DataVector>::name() ==
+        "SpacetimeChristoffelFirstKind");
+  CHECK(
+      gr::Tags::TraceSpacetimeChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                          DataVector>::name() ==
+      "TraceSpacetimeChristoffelFirstKind");
+  CHECK(gr::Tags::SpacetimeChristoffelSecondKindCompute<3, Frame::Inertial,
+                                                        DataVector>::name() ==
+        "SpacetimeChristoffelSecondKind");
 
   // Check that the compute items return correct values
   const DataVector used_for_size{3., 4., 5.};
   MAKE_GENERATOR(generator);
   std::uniform_real_distribution<> distribution(-0.2, 0.2);
 
-  auto spacetime_metric =
-      make_with_random_values<tnsr::aa<DataVector, 3, Frame::Inertial>>(
-          make_not_null(&generator), make_not_null(&distribution),
-          used_for_size);
-  get<0, 0>(spacetime_metric) += -1.;
-  for (size_t i = 1; i <= 3; ++i) {
-    spacetime_metric.get(i, i) += 1.;
-  }
+  const auto spacetime_metric = [&]() {
+    auto spacetime_metric_l =
+        make_with_random_values<tnsr::aa<DataVector, 3, Frame::Inertial>>(
+            make_not_null(&generator), make_not_null(&distribution),
+            used_for_size);
+    // Make sure spacetime_metric isn't singular
+    get<0, 0>(spacetime_metric_l) += -1.;
+    for (size_t i = 1; i <= 3; ++i) {
+      spacetime_metric_l.get(i, i) += 1.;
+    }
+    return spacetime_metric_l;
+  }();
 
   const auto deriv_spatial_metric =
       make_with_random_values<tnsr::ijj<DataVector, 3, Frame::Inertial>>(
           make_not_null(&generator), make_not_null(&distribution),
           used_for_size);
+  const auto deriv_shift =
+      make_with_random_values<tnsr::iJ<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&distribution),
+          used_for_size);
+  const auto deriv_lapse =
+      make_with_random_values<tnsr::i<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&distribution),
+          used_for_size);
+
+  const auto dt_spatial_metric =
+      make_with_random_values<tnsr::ii<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&distribution),
+          used_for_size);
+  const auto dt_shift =
+      make_with_random_values<tnsr::I<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&distribution),
+          used_for_size);
+  const auto dt_lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&distribution), used_for_size);
 
   const auto spatial_metric = gr::spatial_metric(spacetime_metric);
   const auto det_and_inverse_spatial_metric =
       determinant_and_inverse(spatial_metric);
   const auto& inverse_spatial_metric = det_and_inverse_spatial_metric.second;
+  const auto shift = gr::shift(spacetime_metric, inverse_spatial_metric);
+  const auto lapse = gr::lapse(shift, spacetime_metric);
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
 
-  const auto spatial_christoffel_first_kind =
+  const auto derivatives_of_spacetime_metric =
+      gr::derivatives_of_spacetime_metric(
+          lapse, dt_lapse, deriv_lapse, shift, dt_shift, deriv_shift,
+          spatial_metric, dt_spatial_metric, deriv_spatial_metric);
+
+  const auto expected_spatial_christoffel_first_kind =
       gr::christoffel_first_kind(deriv_spatial_metric);
-  const auto trace_spatial_christoffel_first_kind = trace_last_indices(
-      spatial_christoffel_first_kind, inverse_spatial_metric);
-  const auto spatial_christoffel_second_kind = raise_or_lower_first_index(
-      spatial_christoffel_first_kind, inverse_spatial_metric);
+  const auto expected_trace_spatial_christoffel_first_kind = trace_last_indices(
+      expected_spatial_christoffel_first_kind, inverse_spatial_metric);
+  const auto expected_spatial_christoffel_second_kind =
+      raise_or_lower_first_index(expected_spatial_christoffel_first_kind,
+                                 inverse_spatial_metric);
+  const auto expected_spacetime_christoffel_first_kind =
+      gr::christoffel_first_kind(derivatives_of_spacetime_metric);
+  const auto expected_trace_spacetime_christoffel_first_kind =
+      trace_last_indices(expected_spacetime_christoffel_first_kind,
+                         inverse_spacetime_metric);
+  const auto expected_spacetime_christoffel_second_kind =
+      raise_or_lower_first_index(expected_spacetime_christoffel_first_kind,
+                                 inverse_spacetime_metric);
 
   const auto box = db::create<
       db::AddSimpleTags<
           gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
           ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
-                        tmpl::size_t<3>, Frame::Inertial>>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          gr::Tags::InverseSpacetimeMetric<3, Frame::Inertial, DataVector>,
+          gr::Tags::DerivativesOfSpacetimeMetric<3, Frame::Inertial,
+                                                 DataVector>>,
       db::AddComputeTags<gr::Tags::SpatialChristoffelFirstKindCompute<
                              3, Frame::Inertial, DataVector>,
                          gr::Tags::TraceSpatialChristoffelFirstKindCompute<
                              3, Frame::Inertial, DataVector>,
                          gr::Tags::SpatialChristoffelSecondKindCompute<
+                             3, Frame::Inertial, DataVector>,
+                         gr::Tags::SpacetimeChristoffelFirstKindCompute<
+                             3, Frame::Inertial, DataVector>,
+                         gr::Tags::TraceSpacetimeChristoffelFirstKindCompute<
+                             3, Frame::Inertial, DataVector>,
+                         gr::Tags::SpacetimeChristoffelSecondKindCompute<
                              3, Frame::Inertial, DataVector>>>(
-      inverse_spatial_metric, deriv_spatial_metric);
+      inverse_spatial_metric, deriv_spatial_metric, inverse_spacetime_metric,
+      derivatives_of_spacetime_metric);
 
   CHECK(db::get<gr::Tags::SpatialChristoffelFirstKind<3, Frame::Inertial,
                                                       DataVector>>(box) ==
-        spatial_christoffel_first_kind);
+        expected_spatial_christoffel_first_kind);
   CHECK(db::get<gr::Tags::TraceSpatialChristoffelFirstKind<3, Frame::Inertial,
                                                            DataVector>>(box) ==
-        trace_spatial_christoffel_first_kind);
+        expected_trace_spatial_christoffel_first_kind);
   CHECK(db::get<gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial,
                                                        DataVector>>(box) ==
-        spatial_christoffel_second_kind);
+        expected_spatial_christoffel_second_kind);
+
+  CHECK(db::get<gr::Tags::SpacetimeChristoffelFirstKind<3, Frame::Inertial,
+                                                        DataVector>>(box) ==
+        expected_spacetime_christoffel_first_kind);
+  CHECK(db::get<gr::Tags::TraceSpacetimeChristoffelFirstKind<3, Frame::Inertial,
+                                                             DataVector>>(
+            box) == expected_trace_spacetime_christoffel_first_kind);
+  CHECK(db::get<gr::Tags::SpacetimeChristoffelSecondKind<3, Frame::Inertial,
+                                                         DataVector>>(box) ==
+        expected_spacetime_christoffel_second_kind);
 }


### PR DESCRIPTION
## Proposed changes

Add compute items for spacetime Christoffels for first and second kind, and the trace of the first.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).