### PR TITLE
Add compute items for spatial Christoffels

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
@@ -8,7 +8,14 @@
 
 #include <cstddef>
 
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
 /// \cond
 namespace gsl {
@@ -38,4 +45,65 @@ template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
 tnsr::abb<DataType, SpatialDim, Frame, Index> christoffel_first_kind(
     const tnsr::abb<DataType, SpatialDim, Frame, Index>& d_metric) noexcept;
 // @}
-} // namespace gr
+namespace Tags {
+/// Compute item for spatial Christoffel symbols of the first kind
+/// \f$\Gamma_{ijk}\f$ computed from the first derivative of the
+/// spatial metric.
+///
+/// Can be retrieved using `gr::Tags::SpatialChristoffelFirstKind`
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpatialChristoffelFirstKindCompute
+    : SpatialChristoffelFirstKind<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<
+      ::Tags::deriv<gr::Tags::SpatialMetric<SpatialDim, Frame, DataType>,
+                    tmpl::size_t<SpatialDim>, Frame>>;
+  static constexpr tnsr::ijj<DataType, SpatialDim, Frame> (*function)(
+      const tnsr::ijj<DataType, SpatialDim, Frame>&) =
+      &christoffel_first_kind<SpatialDim, Frame, IndexType::Spatial, DataType>;
+  using base = SpatialChristoffelFirstKind<SpatialDim, Frame, DataType>;
+};
+
+/// Compute item for spatial Christoffel symbols of the second kind
+/// \f$\Gamma^i_{jk}\f$ computed from the Christoffel symbols of the
+/// first kind and the inverse spatial metric.
+///
+/// Can be retrieved using `gr::Tags::SpatialChristoffelSecondKind`
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpatialChristoffelSecondKindCompute
+    : SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<SpatialChristoffelFirstKind<SpatialDim, Frame, DataType>,
+                 InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static constexpr tnsr::Ijj<DataType, SpatialDim, Frame> (*function)(
+      const tnsr::ijj<DataType, SpatialDim, Frame>&,
+      const tnsr::II<DataType, SpatialDim, Frame>&) =
+      &raise_or_lower_first_index<DataType,
+                                  SpatialIndex<SpatialDim, UpLo::Lo, Frame>,
+                                  SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
+  using base = SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>;
+};
+
+/// Compute item for the trace of the spatial Christoffel symbols
+/// of the first kind
+/// \f$\Gamma_{i} = \Gamma_{ijk}g^{jk}\f$ computed from the
+/// Christoffel symbols of the first kind and the inverse spatial metric.
+///
+/// Can be retrieved using `gr::Tags::TraceSpatialChristoffelFirstKind`
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct TraceSpatialChristoffelFirstKindCompute
+    : TraceSpatialChristoffelFirstKind<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<SpatialChristoffelFirstKind<SpatialDim, Frame, DataType>,
+                 InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static constexpr tnsr::i<DataType, SpatialDim, Frame> (*function)(
+      const tnsr::ijj<DataType, SpatialDim, Frame>&,
+      const tnsr::II<DataType, SpatialDim, Frame>&) =
+      &trace_last_indices<DataType, SpatialIndex<SpatialDim, UpLo::Lo, Frame>,
+                          SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
+  using base = TraceSpatialChristoffelFirstKind<SpatialDim, Frame, DataType>;
+};
+}  // namespace Tags
+}  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -85,6 +85,19 @@ struct TraceSpacetimeChristoffelFirstKind : db::SimpleTag {
     return "TraceSpacetimeChristoffelFirstKind";
   }
 };
+/*!
+ * \brief Trace of the spatial Christoffel symbols of the first kind
+ * \f$\Gamma_{i} = \Gamma_{ijk}g^{jk}\f$, where \f$\Gamma_{ijk}\f$ are
+ * Christoffel symbols of the first kind and \f$g^{jk}\f$ is the
+ * inverse spatial metric.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct TraceSpatialChristoffelFirstKind : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+  static std::string name() noexcept {
+    return "TraceSpatialChristoffelFirstKind";
+  }
+};
 template <size_t Dim, typename Frame, typename DataType>
 struct TraceSpatialChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
@@ -92,6 +105,7 @@ struct TraceSpatialChristoffelSecondKind : db::SimpleTag {
     return "TraceSpatialChristoffelSecondKind";
   }
 };
+
 template <size_t Dim, typename Frame, typename DataType>
 struct ExtrinsicCurvature : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
@@ -112,6 +126,5 @@ struct EnergyDensity : db::SimpleTag {
   using type = Scalar<DataType>;
   static std::string name() noexcept { return "EnergyDensity"; }
 };
-
 }  // namespace Tags
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -31,7 +31,6 @@ template <size_t Dim, typename Frame = Frame::Inertial,
 struct Shift;
 template <typename DataType = DataVector>
 struct Lapse;
-
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct SpacetimeChristoffelFirstKind;
@@ -53,6 +52,9 @@ struct SpacetimeNormalVector;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct TraceSpacetimeChristoffelFirstKind;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct TraceSpatialChristoffelFirstKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct TraceSpatialChristoffelSecondKind;

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
@@ -3,13 +3,36 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <array>
 #include <cstddef>
+#include <random>
+#include <string>
+#include <utility>
 
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+/// \cond
+namespace Tags {
+template <typename Tag, typename Dim, typename Frame, typename>
+struct deriv;
+}  // namespace Tags
+template <typename X, typename Symm, typename IndexList>
+class Tensor;
+/// \endcond
 
 namespace {
 template <size_t Dim, IndexType Index, typename DataType>
@@ -18,11 +41,11 @@ void test_christoffel(const DataType& used_for_size) {
       const tnsr::abb<DataType, Dim, Frame::Inertial, Index>&) =
       &gr::christoffel_first_kind<Dim, Frame::Inertial, Index, DataType>;
   pypp::check_with_random_values<1>(f, "Christoffel", "christoffel_first_kind",
-                                    {{{-10.0, 10.0}}}, used_for_size);
+                                    {{{-10., 10.}}}, used_for_size);
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Christoffel.",
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Christoffel",
                   "[PointwiseFunctions][Unit]") {
   pypp::SetupLocalPythonEnvironment local_python_env(
       "PointwiseFunctions/GeneralRelativity/");
@@ -39,4 +62,83 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Christoffel.",
   test_christoffel<1, IndexType::Spacetime>(0.);
   test_christoffel<2, IndexType::Spacetime>(0.);
   test_christoffel<3, IndexType::Spacetime>(0.);
+
+  // Check that compute items work correctly in the DataBox
+  // First, check that the names are correct
+  CHECK(gr::Tags::SpatialChristoffelFirstKind<3, Frame::Inertial,
+                                              DataVector>::name() ==
+        "SpatialChristoffelFirstKind");
+  CHECK(gr::Tags::TraceSpatialChristoffelFirstKind<3, Frame::Inertial,
+                                                   DataVector>::name() ==
+        "TraceSpatialChristoffelFirstKind");
+  CHECK(gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial,
+                                               DataVector>::name() ==
+        "SpatialChristoffelSecondKind");
+  CHECK(gr::Tags::TraceSpatialChristoffelSecondKind<3, Frame::Inertial,
+                                                    DataVector>::name() ==
+        "TraceSpatialChristoffelSecondKind");
+
+  CHECK(gr::Tags::SpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                     DataVector>::name() ==
+        "SpatialChristoffelFirstKind");
+  CHECK(gr::Tags::TraceSpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                          DataVector>::name() ==
+        "TraceSpatialChristoffelFirstKind");
+  CHECK(gr::Tags::SpatialChristoffelSecondKindCompute<3, Frame::Inertial,
+                                                      DataVector>::name() ==
+        "SpatialChristoffelSecondKind");
+
+  // Check that the compute items return correct values
+  const DataVector used_for_size{3., 4., 5.};
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(-0.2, 0.2);
+
+  auto spacetime_metric =
+      make_with_random_values<tnsr::aa<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&distribution),
+          used_for_size);
+  get<0, 0>(spacetime_metric) += -1.;
+  for (size_t i = 1; i <= 3; ++i) {
+    spacetime_metric.get(i, i) += 1.;
+  }
+
+  const auto deriv_spatial_metric =
+      make_with_random_values<tnsr::ijj<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&distribution),
+          used_for_size);
+
+  const auto spatial_metric = gr::spatial_metric(spacetime_metric);
+  const auto det_and_inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric);
+  const auto& inverse_spatial_metric = det_and_inverse_spatial_metric.second;
+
+  const auto spatial_christoffel_first_kind =
+      gr::christoffel_first_kind(deriv_spatial_metric);
+  const auto trace_spatial_christoffel_first_kind = trace_last_indices(
+      spatial_christoffel_first_kind, inverse_spatial_metric);
+  const auto spatial_christoffel_second_kind = raise_or_lower_first_index(
+      spatial_christoffel_first_kind, inverse_spatial_metric);
+
+  const auto box = db::create<
+      db::AddSimpleTags<
+          gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+          ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>>,
+      db::AddComputeTags<gr::Tags::SpatialChristoffelFirstKindCompute<
+                             3, Frame::Inertial, DataVector>,
+                         gr::Tags::TraceSpatialChristoffelFirstKindCompute<
+                             3, Frame::Inertial, DataVector>,
+                         gr::Tags::SpatialChristoffelSecondKindCompute<
+                             3, Frame::Inertial, DataVector>>>(
+      inverse_spatial_metric, deriv_spatial_metric);
+
+  CHECK(db::get<gr::Tags::SpatialChristoffelFirstKind<3, Frame::Inertial,
+                                                      DataVector>>(box) ==
+        spatial_christoffel_first_kind);
+  CHECK(db::get<gr::Tags::TraceSpatialChristoffelFirstKind<3, Frame::Inertial,
+                                                           DataVector>>(box) ==
+        trace_spatial_christoffel_first_kind);
+  CHECK(db::get<gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial,
+                                                       DataVector>>(box) ==
+        spatial_christoffel_second_kind);
 }


### PR DESCRIPTION
## Proposed changes

Add compute items for spatial Christoffels for first and second kind, and the trace of the first.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).