### PR TITLE
Add option groups

### DIFF
--- a/docs/DevGuide/OptionParsing.md
+++ b/docs/DevGuide/OptionParsing.md
@@ -13,13 +13,13 @@ are declared in `Options/Options.hpp`.
 
 ## General option format
 
-An option is defined by an "option struct".  At minimum, the struct
-must declare the type of the object to be parsed and provide a brief
+An option is defined by an "option tag", represented by a `struct`.  At minimum,
+the struct must declare the type of the object to be parsed and provide a brief
 description of the meaning.  The name of the option in the input file
 defaults to the name of the struct (excluding any template parameters
 and scope information), but can be overridden by providing a static
 `name()` function.  Several other pieces of information, such as
-defaults and limits, may be provided if desired.  This information is
+defaults, limits and grouping, may be provided if desired.  This information is
 all included in the generated help output.
 
 Examples:
@@ -32,6 +32,13 @@ The option type can be any type understood natively by yaml-cpp
 types SpECTRE adds support for.  SpECTRE adds `std::unordered_map`
 (but only with ordered keys), and various classes marked as
 constructible in their declarations.
+
+An option tag can be placed in a group by adding a `group` type alias to the
+struct. The alias should refer to a type that, like option tags, defines a help
+string and may override a static `name()` function.
+
+Example:
+\snippet Test_Options.cpp options_example_group
 
 ## Constructible classes
 

--- a/src/Options/OptionsDetails.hpp
+++ b/src/Options/OptionsDetails.hpp
@@ -78,13 +78,15 @@ struct yaml_type<std::array<T, N>> {
 template <typename K, typename V, typename C>
 struct yaml_type<std::map<K, V, C>> {
   static std::string value() noexcept {
-    return "{" + yaml_type<K>::value() + ": " + yaml_type<V>::value() + "}"; }
+    return "{" + yaml_type<K>::value() + ": " + yaml_type<V>::value() + "}";
+  }
 };
 
 template <typename K, typename V, typename H, typename E>
 struct yaml_type<std::unordered_map<K, V, H, E>> {
   static std::string value() noexcept {
-    return "{" + yaml_type<K>::value() + ": " + yaml_type<V>::value() + "}"; }
+    return "{" + yaml_type<K>::value() + ": " + yaml_type<V>::value() + "}";
+  }
 };
 
 template <typename T, typename U>
@@ -193,12 +195,9 @@ struct print {
     ss << "  " << std::setw(max_label_size_) << std::left << name<T>()
        << yaml_type<typename T::type>::value();
     std::string limits;
-    for (const auto& limit : {
-        print_default<T>(),
-        print_lower_bound<T>(),
-        print_upper_bound<T>(),
-        print_lower_bound_on_size<T>(),
-        print_upper_bound_on_size<T>() }) {
+    for (const auto& limit :
+         {print_default<T>(), print_lower_bound<T>(), print_upper_bound<T>(),
+          print_lower_bound_on_size<T>(), print_upper_bound_on_size<T>()}) {
       if (not limits.empty() and not limit.empty()) {
         limits += ", ";
       }
@@ -353,13 +352,12 @@ struct wrap_create_types_impl<std::array<T, N>> {
   }
 
   template <size_t... Is>
-  static auto unwrap_helper(
-      std::array<T, N> wrapped,
-      std::integer_sequence<size_t, Is...> /*meta*/) {
+  static auto unwrap_helper(std::array<T, N> wrapped,
+                            std::integer_sequence<size_t, Is...> /*meta*/) {
     using UnwrappedT = decltype(unwrap_create_types<T>(std::declval<T>()));
     static_cast<void>(wrapped);  // Work around broken GCC warning
     return std::array<UnwrappedT, N>{
-      {unwrap_create_types<T>(std::move(wrapped[Is]))...}};
+        {unwrap_create_types<T>(std::move(wrapped[Is]))...}};
   }
 };
 

--- a/src/Options/OptionsDetails.hpp
+++ b/src/Options/OptionsDetails.hpp
@@ -42,6 +42,45 @@ std::string name() noexcept {
   return name_helper<T>::name();
 }
 
+// Traverses the group hierarchy of `Tag`, returning the topmost group that is
+// a subgroup of `Root`. Directly returns `Tag` if it has no group.
+// This means that the returned type is always the direct child node of `Root`
+// that contains `Tag` in its hierarchy.
+// If `Root` is not in the group hierarchy of `Tag`, this function returns the
+// topmost group of `Tag` (meaning that `Root` is treated as the root of its
+// group hierarchy).
+template <typename Tag, typename Root, typename = cpp17::void_t<>>
+struct find_subgroup {
+  using type = Tag;
+};
+
+template <typename Tag>
+struct find_subgroup<Tag, typename Tag::group,
+                     cpp17::void_t<typename Tag::group>> {
+  using type = Tag;
+};
+
+template <typename Tag, typename Root>
+struct find_subgroup<Tag, Root, cpp17::void_t<typename Tag::group>> {
+  using type = typename find_subgroup<typename Tag::group, Root>::type;
+};
+
+/// Checks if `Tag` is within the group hierarchy of `Group`.
+template <typename Tag, typename Group, typename = cpp17::void_t<>>
+struct is_in_group : std::false_type {};
+
+template <typename Tag>
+struct is_in_group<Tag, typename Tag::group, cpp17::void_t<typename Tag::group>>
+    : std::true_type {};
+
+template <typename Tag, typename Group>
+struct is_in_group<Tag, Group, cpp17::void_t<typename Tag::group>>
+    : is_in_group<typename Tag::group, Group> {};
+
+/// The subset of tags in `OptionList` that are in the hierarchy of `Group`
+template <typename OptionList, typename Group>
+using options_in_group = tmpl::filter<OptionList, is_in_group<tmpl::_1, Group>>;
+
 // Display a type in a pseudo-YAML form, leaving out likely irrelevant
 // information.
 template <typename T>
@@ -131,73 +170,88 @@ struct has_upper_bound_on_size<
     S, cpp17::void_t<decltype(std::declval<S>().upper_bound_on_size())>>
     : std::true_type {};
 
-struct print {
-  explicit print(const int max_label_size) noexcept
-      : max_label_size_(max_label_size) {}
+template <typename Group, typename OptionList, typename = std::nullptr_t>
+struct print_impl {
+  static std::string apply(const int max_label_size) noexcept {
+    std::ostringstream ss;
+    ss << "  " << std::setw(max_label_size + 2) << std::left << name<Group>()
+       << Group::help << "\n\n";
+    return ss.str();
+  }
+};
 
-  using value_type = std::string;
-  template <typename T, Requires<has_default<T>::value> = nullptr>
+template <typename Tag, typename OptionList>
+struct print_impl<Tag, OptionList,
+                  Requires<tmpl::list_contains_v<OptionList, Tag>>> {
+  template <typename LocalTag, Requires<has_default<LocalTag>::value> = nullptr>
   static std::string print_default() noexcept {
     std::ostringstream ss;
-    ss << "default=" << std::boolalpha << T::default_value();
+    ss << "default=" << std::boolalpha << LocalTag::default_value();
     return ss.str();
   }
-  template <typename T, Requires<not has_default<T>::value> = nullptr>
+  template <typename LocalTag,
+            Requires<not has_default<LocalTag>::value> = nullptr>
   static std::string print_default() noexcept {
     return "";
   }
-  template <typename T, Requires<has_lower_bound<T>::value> = nullptr>
+  template <typename LocalTag,
+            Requires<has_lower_bound<LocalTag>::value> = nullptr>
   static std::string print_lower_bound() noexcept {
     std::ostringstream ss;
-    ss << "min=" << T::lower_bound();
+    ss << "min=" << LocalTag::lower_bound();
     return ss.str();
   }
-  template <typename T, Requires<not has_lower_bound<T>::value> = nullptr>
+  template <typename LocalTag,
+            Requires<not has_lower_bound<LocalTag>::value> = nullptr>
   static std::string print_lower_bound() noexcept {
     return "";
   }
-  template <typename T, Requires<has_upper_bound<T>::value> = nullptr>
+  template <typename LocalTag,
+            Requires<has_upper_bound<LocalTag>::value> = nullptr>
   static std::string print_upper_bound() noexcept {
     std::ostringstream ss;
-    ss << "max=" << T::upper_bound();
+    ss << "max=" << LocalTag::upper_bound();
     return ss.str();
   }
-  template <typename T, Requires<not has_upper_bound<T>::value> = nullptr>
+  template <typename LocalTag,
+            Requires<not has_upper_bound<LocalTag>::value> = nullptr>
   static std::string print_upper_bound() noexcept {
     return "";
   }
-  template <typename T, Requires<has_lower_bound_on_size<T>::value> = nullptr>
+  template <typename LocalTag,
+            Requires<has_lower_bound_on_size<LocalTag>::value> = nullptr>
   static std::string print_lower_bound_on_size() noexcept {
     std::ostringstream ss;
-    ss << "min size=" << T::lower_bound_on_size();
+    ss << "min size=" << LocalTag::lower_bound_on_size();
     return ss.str();
   }
-  template <typename T,
-            Requires<not has_lower_bound_on_size<T>::value> = nullptr>
+  template <typename LocalTag,
+            Requires<not has_lower_bound_on_size<LocalTag>::value> = nullptr>
   static std::string print_lower_bound_on_size() noexcept {
     return "";
   }
-  template <typename T, Requires<has_upper_bound_on_size<T>::value> = nullptr>
+  template <typename LocalTag,
+            Requires<has_upper_bound_on_size<LocalTag>::value> = nullptr>
   static std::string print_upper_bound_on_size() noexcept {
     std::ostringstream ss;
-    ss << "max size=" << T::upper_bound_on_size();
+    ss << "max size=" << LocalTag::upper_bound_on_size();
     return ss.str();
   }
-  template <typename T,
-            Requires<not has_upper_bound_on_size<T>::value> = nullptr>
+  template <typename LocalTag,
+            Requires<not has_upper_bound_on_size<LocalTag>::value> = nullptr>
   static std::string print_upper_bound_on_size() noexcept {
     return "";
   }
 
-  template <typename T>
-  void operator()(tmpl::type_<T> /*meta*/) noexcept {
+  static std::string apply(const int max_label_size) noexcept {
     std::ostringstream ss;
-    ss << "  " << std::setw(max_label_size_) << std::left << name<T>()
-       << yaml_type<typename T::type>::value();
+    ss << "  " << std::setw(max_label_size + 2) << std::left << name<Tag>()
+       << yaml_type<typename Tag::type>::value();
     std::string limits;
     for (const auto& limit :
-         {print_default<T>(), print_lower_bound<T>(), print_upper_bound<T>(),
-          print_lower_bound_on_size<T>(), print_upper_bound_on_size<T>()}) {
+         {print_default<Tag>(), print_lower_bound<Tag>(),
+          print_upper_bound<Tag>(), print_lower_bound_on_size<Tag>(),
+          print_upper_bound_on_size<Tag>()}) {
       if (not limits.empty() and not limit.empty()) {
         limits += ", ";
       }
@@ -206,10 +260,20 @@ struct print {
     if (not limits.empty()) {
       ss << " [" << limits << "]";
     }
-    ss << "\n" << std::setw(max_label_size_ + 2) << "" << T::help << "\n\n";
-    value += ss.str();
+    ss << "\n" << std::setw(max_label_size + 4) << "" << Tag::help << "\n\n";
+    return ss.str();
   }
+};
 
+template <typename OptionList>
+struct print {
+  explicit print(const int max_label_size) noexcept
+      : max_label_size_(max_label_size) {}
+  using value_type = std::string;
+  template <typename Tag>
+  void operator()(tmpl::type_<Tag> /*meta*/) noexcept {
+    value += print_impl<Tag, OptionList>::apply(max_label_size_);
+  }
   value_type value{};
 
  private:

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -39,15 +39,15 @@
 // include this file.)
 
 inline Option::Option(YAML::Node node, OptionContext context) noexcept
-  // clang-tidy: YAML::Node not movable (as of yaml-cpp-0.5.3)
-  : node_(std::make_unique<YAML::Node>(std::move(node))),
-    context_(std::move(context)) {  // NOLINT
-    context_.line = node.Mark().line;
-    context_.column = node.Mark().column;
-  }
+    // clang-tidy: YAML::Node not movable (as of yaml-cpp-0.5.3)
+    : node_(std::make_unique<YAML::Node>(std::move(node))),
+      context_(std::move(context)) {  // NOLINT
+  context_.line = node.Mark().line;
+  context_.column = node.Mark().column;
+}
 
 inline Option::Option(OptionContext context) noexcept
-  : node_(std::make_unique<YAML::Node>()), context_(std::move(context)) {}
+    : node_(std::make_unique<YAML::Node>()), context_(std::move(context)) {}
 
 inline const YAML::Node& Option::node() const noexcept { return *node_; }
 inline const OptionContext& Option::context() const noexcept {
@@ -80,10 +80,8 @@ T Option::parse_as() const {
   } catch (const YAML::BadConversion& e) {
     // This happens when trying to parse an empty value as a container
     // with no entries.
-    if ((tt::is_a_v<std::vector, T> or
-         tt::is_std_array_of_size_v<0, T> or
-         tt::is_maplike_v<T>) and
-        node().IsNull()) {
+    if ((tt::is_a_v<std::vector, T> or tt::is_std_array_of_size_v<0, T> or
+         tt::is_maplike_v<T>) and node().IsNull()) {
       return T{};
     }
     OptionContext error_context = context();
@@ -91,8 +89,7 @@ T Option::parse_as() const {
     error_context.column = e.mark.column;
     std::ostringstream ss;
     ss << "Failed to convert value to type "
-       << Options_detail::yaml_type<T>::value()
-       << ":";
+       << Options_detail::yaml_type<T>::value() << ":";
 
     const std::string value_text = YAML::Dump(node());
     if (value_text.find('\n') == std::string::npos) {
@@ -110,10 +107,10 @@ T Option::parse_as() const {
 
     if (tt::is_a_v<std::vector, T> or tt::is_std_array_v<T>) {
       ss << "\n\nNote: For sequences this can happen because the length of the "
-          "sequence specified\nin the input file is not equal to the length "
-          "expected by the code. Sequences in\nfiles can be denoted either as "
-          "a bracket enclosed list ([foo, bar]) or with each\nentry on a "
-          "separate line, indented and preceeded by a dash (  - foo).";
+            "sequence specified\nin the input file is not equal to the length "
+            "expected by the code. Sequences in\nfiles can be denoted either "
+            "as a bracket enclosed list ([foo, bar]) or with each\nentry on a "
+            "separate line, indented and preceeded by a dash (  - foo).";
     }
     PARSE_ERROR(error_context, ss.str());
   } catch (const Options_detail::propagate_context& e) {
@@ -194,17 +191,17 @@ class Options {
   ///
   /// \tparam T the option struct
   /// \param t the value of the read in option
-  template <typename T,
-            Requires<Options_detail::has_lower_bound_on_size<T>::value> =
-                nullptr>
+  template <
+      typename T,
+      Requires<Options_detail::has_lower_bound_on_size<T>::value> = nullptr>
   void check_lower_bound_on_size(const typename T::type& t,
                                  const OptionContext& context) const;
-  template <typename T,
-            Requires<not Options_detail::has_lower_bound_on_size<T>::value> =
-                nullptr>
+  template <
+      typename T,
+      Requires<not Options_detail::has_lower_bound_on_size<T>::value> = nullptr>
   constexpr void check_lower_bound_on_size(
-      const typename T::type& /*t*/,
-      const OptionContext& /*context*/) const noexcept {}
+      const typename T::type& /*t*/, const OptionContext& /*context*/) const
+      noexcept {}
   //@}
 
   //@{
@@ -212,17 +209,17 @@ class Options {
   ///
   /// \tparam T the option struct
   /// \param t the value of the read in option
-  template <typename T,
-            Requires<Options_detail::has_upper_bound_on_size<T>::value> =
-                nullptr>
+  template <
+      typename T,
+      Requires<Options_detail::has_upper_bound_on_size<T>::value> = nullptr>
   void check_upper_bound_on_size(const typename T::type& t,
                                  const OptionContext& context) const;
-  template <typename T,
-            Requires<not Options_detail::has_upper_bound_on_size<T>::value> =
-                nullptr>
+  template <
+      typename T,
+      Requires<not Options_detail::has_upper_bound_on_size<T>::value> = nullptr>
   constexpr void check_upper_bound_on_size(
-      const typename T::type& /*t*/,
-      const OptionContext& /*context*/) const noexcept {}
+      const typename T::type& /*t*/, const OptionContext& /*context*/) const
+      noexcept {}
   //@}
 
   //@{
@@ -240,9 +237,9 @@ class Options {
   template <typename T,
             Requires<not Options_detail::has_default<T>::value> = nullptr>
   [[noreturn]] typename T::type get_default() const {
-    PARSE_ERROR(context_,
-                "You did not specify the option '" << Options_detail::name<T>()
-                << "'.\n" << help());
+    PARSE_ERROR(context_, "You did not specify the option '"
+                              << Options_detail::name<T>() << "'.\n"
+                              << help());
   }
   //@}
 
@@ -258,9 +255,9 @@ class Options {
                          const OptionContext& context) const;
   template <typename T,
             Requires<not Options_detail::has_lower_bound<T>::value> = nullptr>
-  constexpr void check_lower_bound(
-      const typename T::type& /*t*/,
-      const OptionContext& /*context*/) const noexcept {}
+  constexpr void check_lower_bound(const typename T::type& /*t*/,
+                                   const OptionContext& /*context*/) const
+      noexcept {}
   //@}
 
   //@{
@@ -269,16 +266,15 @@ class Options {
   /// Note: Upper bounds are <=, not just <.
   /// \tparam T the option struct
   /// \param t the value of the read in option
-  template <
-      typename T,
-      Requires<Options_detail::has_upper_bound<T>::value> = nullptr>
+  template <typename T,
+            Requires<Options_detail::has_upper_bound<T>::value> = nullptr>
   void check_upper_bound(const typename T::type& t,
                          const OptionContext& context) const;
   template <typename T,
             Requires<not Options_detail::has_upper_bound<T>::value> = nullptr>
-  constexpr void check_upper_bound(
-      const typename T::type& /*t*/,
-      const OptionContext& /*context*/) const noexcept {}
+  constexpr void check_upper_bound(const typename T::type& /*t*/,
+                                   const OptionContext& /*context*/) const
+      noexcept {}
   //@}
 
   //@{
@@ -322,15 +318,17 @@ Options<OptionList>::Options(std::string help_text) noexcept
     using T = typename decltype(t)::type;
     const std::string label = Options_detail::name<T>();
     ASSERT(label.size() < max_label_size_,
-           "The option name " << label << " is too long for nice formatting, "
-           "please shorten the name to be under " << max_label_size_
-           << " characters");
+           "The option name " << label
+                              << " is too long for nice formatting, "
+                                 "please shorten the name to be under "
+                              << max_label_size_ << " characters");
     ASSERT(std::strlen(T::help) > 0,
            "You must supply a help string of non-zero length for " << label);
     ASSERT(std::strlen(T::help) < max_help_size_,
            "Option help strings should be short and to the point.  "
-           "The help string for " << label << " should be less than "
-           << max_help_size_ << " characters long.");
+           "The help string for "
+               << label << " should be less than " << max_help_size_
+               << " characters long.");
   });
 }
 
@@ -365,9 +363,8 @@ void Options<OptionList>::parse(const Option& options) {
 template <typename OptionList>
 void Options<OptionList>::parse(const YAML::Node& node) {
   if (not(node.IsMap() or node.IsNull())) {
-    PARSE_ERROR(context_,
-                "'" << node << "' does not look like options.\n"
-                << help());
+    PARSE_ERROR(context_, "'" << node << "' does not look like options.\n"
+                              << help());
   }
   for (const auto& name_and_value : node) {
     const auto& name = name_and_value.first.as<std::string>();
@@ -378,16 +375,14 @@ void Options<OptionList>::parse(const YAML::Node& node) {
 
     // Check for invalid key
     if (1 != valid_names_.count(name)) {
-      PARSE_ERROR(context,
-                  "Option '" << name << "' is not a valid option.\n"
-                  << parsing_help(node));
+      PARSE_ERROR(context, "Option '" << name << "' is not a valid option.\n"
+                                      << parsing_help(node));
     }
 
     // Check for duplicate key
     if (0 != parsed_options_.count(name)) {
-      PARSE_ERROR(context,
-                  "Option '" << name << "' specified twice.\n"
-                  << parsing_help(node));
+      PARSE_ERROR(context, "Option '" << name << "' specified twice.\n"
+                                      << parsing_help(node));
     }
     parsed_options_.emplace(name, value);
   }
@@ -463,10 +458,10 @@ void Options<OptionList>::check_lower_bound_on_size(
   static_assert(cpp17::is_same_v<decltype(T::lower_bound_on_size()), size_t>,
                 "lower_bound_on_size() is not a size_t.");
   if (t.size() < T::lower_bound_on_size()) {
-    PARSE_ERROR(context,
-                "Value must have at least " << T::lower_bound_on_size()
-                << " entries, but " << t.size() << " were given.\n"
-                << help());
+    PARSE_ERROR(context, "Value must have at least "
+                             << T::lower_bound_on_size() << " entries, but "
+                             << t.size() << " were given.\n"
+                             << help());
   }
 }
 
@@ -478,10 +473,10 @@ void Options<OptionList>::check_upper_bound_on_size(
   static_assert(cpp17::is_same_v<decltype(T::upper_bound_on_size()), size_t>,
                 "upper_bound_on_size() is not a size_t.");
   if (t.size() > T::upper_bound_on_size()) {
-    PARSE_ERROR(context,
-                "Value must have at most " << T::upper_bound_on_size()
-                << " entries, but " << t.size() << " were given.\n"
-                << help());
+    PARSE_ERROR(context, "Value must have at most "
+                             << T::upper_bound_on_size() << " entries, but "
+                             << t.size() << " were given.\n"
+                             << help());
   }
 }
 
@@ -494,10 +489,9 @@ inline void Options<OptionList>::check_lower_bound(
   static_assert(not cpp17::is_same_v<typename T::type, bool>,
                 "Cannot set a lower bound for a bool.");
   if (t < T::lower_bound()) {
-    PARSE_ERROR(context,
-                "Value " << t << " is below the lower bound of "
-                << T::lower_bound() << ".\n"
-                << help());
+    PARSE_ERROR(context, "Value " << t << " is below the lower bound of "
+                                  << T::lower_bound() << ".\n"
+                                  << help());
   }
 }
 
@@ -510,16 +504,15 @@ inline void Options<OptionList>::check_upper_bound(
   static_assert(not cpp17::is_same_v<typename T::type, bool>,
                 "Cannot set an upper bound for a bool.");
   if (t > T::upper_bound()) {
-    PARSE_ERROR(context,
-                "Value " << t << " is above the upper bound of "
-                << T::upper_bound() << ".\n"
-                << help());
+    PARSE_ERROR(context, "Value " << t << " is above the upper bound of "
+                                  << T::upper_bound() << ".\n"
+                                  << help());
   }
 }
 
 template <typename OptionList>
-std::string Options<OptionList>::parsing_help(
-    const YAML::Node& options) const noexcept {
+std::string Options<OptionList>::parsing_help(const YAML::Node& options) const
+    noexcept {
   std::ostringstream os;
   // At top level this would dump the entire input file, which is very
   // verbose and not very informative.  At lower levels the result
@@ -541,12 +534,14 @@ template <typename OptionList>
   // Inline the top_level branch of PARSE_ERROR to avoid warning that
   // the other branch would call terminate.  (Parser errors can only
   // be generated at top level.)
-  ERROR("\n" << context <<
-        "Unable to correctly parse the input file because of a syntax error.\n"
-        "This is often due to placing a suboption on the same line as an "
-        "option, e.g.:\nDomainCreator: CreateInterval:\n  IsPeriodicIn: "
-        "[false]\n\nShould be:\nDomainCreator:\n  CreateInterval:\n    "
-        "IsPeriodicIn: [true]\n\nSee an example input file for help.");
+  ERROR(
+      "\n"
+      << context
+      << "Unable to correctly parse the input file because of a syntax error.\n"
+         "This is often due to placing a suboption on the same line as an "
+         "option, e.g.:\nDomainCreator: CreateInterval:\n  IsPeriodicIn: "
+         "[false]\n\nShould be:\nDomainCreator:\n  CreateInterval:\n    "
+         "IsPeriodicIn: [true]\n\nSee an example input file for help.");
 }
 
 template <typename T>

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -48,8 +48,9 @@ SPECTRE_TEST_CASE("Unit.Options.Empty.not_map", "[Unit][Options]") {
 SPECTRE_TEST_CASE("Unit.Options.syntax_error", "[Unit][Options]") {
   ERROR_TEST();
   Options<tmpl::list<>> opts("");
-  opts.parse("DomainCreator: CreateInterval:\n"
-             "  IsPeriodicIn: [false]");
+  opts.parse(
+      "DomainCreator: CreateInterval:\n"
+      "  IsPeriodicIn: [false]");
 }
 
 struct Simple {
@@ -80,8 +81,9 @@ void test_options_simple_success() {
 SPECTRE_TEST_CASE("Unit.Options.Simple.duplicate", "[Unit][Options]") {
   ERROR_TEST();
   Options<tmpl::list<Simple>> opts("");
-  opts.parse("Simple: -4\n"
-             "Simple: -3");
+  opts.parse(
+      "Simple: -4\n"
+      "Simple: -3");
   opts.get<Simple>();
 }
 
@@ -90,8 +92,9 @@ SPECTRE_TEST_CASE("Unit.Options.Simple.duplicate", "[Unit][Options]") {
 SPECTRE_TEST_CASE("Unit.Options.NamedSimple.duplicate", "[Unit][Options]") {
   ERROR_TEST();
   Options<tmpl::list<NamedSimple>> opts("");
-  opts.parse("SomeName: -4\n"
-             "SomeName: -3");
+  opts.parse(
+      "SomeName: -4\n"
+      "SomeName: -3");
   opts.get<NamedSimple>();
 }
 
@@ -151,7 +154,7 @@ SPECTRE_TEST_CASE("Unit.Options.NamedSimple.invalid", "[Unit][Options]") {
 struct Bounded {
   using type = int;
   static constexpr OptionString help = {
-    "Option with bounds and a default value"};
+      "Option with bounds and a default value"};
   // These are optional
   static type default_value() noexcept { return 3; }
   static type lower_bound() noexcept { return 2; }
@@ -164,7 +167,7 @@ void test_options_default_specified() {
   Options<tmpl::list<Bounded>> opts("Overall help text");
   opts.parse("Bounded: 8");
   CHECK(opts.get<Bounded>() == 8);
-/// [options_example_scalar_parse]
+  /// [options_example_scalar_parse]
 }
 
 void test_options_default_defaulted() {
@@ -322,11 +325,12 @@ SPECTRE_TEST_CASE("Unit.Options.Array.too_long", "[Unit][Options]") {
 SPECTRE_TEST_CASE("Unit.Options.Array.too_long.formatting", "[Unit][Options]") {
   ERROR_TEST();
   Options<tmpl::list<Array>> opts("");
-  opts.parse("Array:\n"
-             "  - 1\n"
-             "  - 2\n"
-             "  - 3\n"
-             "  - 4");
+  opts.parse(
+      "Array:\n"
+      "  - 1\n"
+      "  - 2\n"
+      "  - 3\n"
+      "  - 4");
   opts.get<Array>();
 }
 
@@ -360,9 +364,10 @@ struct Map {
 
 void test_options_map_success() {
   Options<tmpl::list<Map>> opts("");
-  opts.parse("Map:\n"
-             "  A: 3\n"
-             "  Z: 2");
+  opts.parse(
+      "Map:\n"
+      "  A: 3\n"
+      "  Z: 2");
   std::map<std::string, int> expected;
   expected.emplace("A", 3);
   expected.emplace("Z", 2);
@@ -389,8 +394,9 @@ SPECTRE_TEST_CASE("Unit.Options.Map.invalid", "[Unit][Options]") {
 SPECTRE_TEST_CASE("Unit.Options.Map.invalid_entry", "[Unit][Options]") {
   ERROR_TEST();
   Options<tmpl::list<Map>> opts("");
-  opts.parse("Map:\n"
-             "  A: string");
+  opts.parse(
+      "Map:\n"
+      "  A: string");
   opts.get<Map>();
 }
 
@@ -401,9 +407,10 @@ struct UnorderedMap {
 
 void test_options_unordered_map_success() {
   Options<tmpl::list<UnorderedMap>> opts("");
-  opts.parse("UnorderedMap:\n"
-             "  A: 3\n"
-             "  Z: 2");
+  opts.parse(
+      "UnorderedMap:\n"
+      "  A: 3\n"
+      "  Z: 2");
   std::unordered_map<std::string, int> expected;
   expected.emplace("A", 3);
   expected.emplace("Z", 2);
@@ -415,10 +422,10 @@ struct Wrapped {
   T data;
 };
 
-#define FORWARD_OP(op)                                          \
-  template <typename T>                                         \
-  bool operator op(const Wrapped<T>& a, const Wrapped<T>& b) {  \
-    return a.data op b.data;                                    \
+#define FORWARD_OP(op)                                         \
+  template <typename T>                                        \
+  bool operator op(const Wrapped<T>& a, const Wrapped<T>& b) { \
+    return a.data op b.data;                                   \
   }
 FORWARD_OP(==)
 FORWARD_OP(!=)
@@ -471,24 +478,25 @@ struct WrapUnorderedMap {
 
 void test_options_complex_containers() {
   Options<tmpl::list<WrapMap, WrapVector, WrapList, WrapArray, WrapPair,
-                     WrapUnorderedMap>> opts("");
-  opts.parse("WrapMap: {1: A, 2: B}\n"
-             "WrapVector: [1, 2, 3]\n"
-             "WrapList: [1, 2, 3]\n"
-             "WrapArray: [1, 2]\n"
-             "WrapPair: [1, X]\n"
-             "WrapUnorderedMap: {1: A, 2: B}\n");
-  CHECK(opts.get<WrapMap>() ==
-        (std::map<Wrapped<int>, Wrapped<std::string>>{
-          {{1}, {"A"}}, {{2}, {"B"}}}));
+                     WrapUnorderedMap>>
+      opts("");
+  opts.parse(
+      "WrapMap: {1: A, 2: B}\n"
+      "WrapVector: [1, 2, 3]\n"
+      "WrapList: [1, 2, 3]\n"
+      "WrapArray: [1, 2]\n"
+      "WrapPair: [1, X]\n"
+      "WrapUnorderedMap: {1: A, 2: B}\n");
+  CHECK(opts.get<WrapMap>() == (std::map<Wrapped<int>, Wrapped<std::string>>{
+                                   {{1}, {"A"}}, {{2}, {"B"}}}));
   CHECK(opts.get<WrapVector>() == (std::vector<Wrapped<int>>{{1}, {2}, {3}}));
   CHECK(opts.get<WrapList>() == (std::list<Wrapped<int>>{{1}, {2}, {3}}));
   CHECK(opts.get<WrapArray>() == (std::array<Wrapped<int>, 2>{{{1}, {2}}}));
   CHECK(opts.get<WrapPair>() ==
         (std::pair<Wrapped<int>, Wrapped<std::string>>{{1}, {"X"}}));
   CHECK(opts.get<WrapUnorderedMap>() ==
-        (std::unordered_map<Wrapped<int>, Wrapped<std::string>>{
-          {{1}, {"A"}}, {{2}, {"B"}}}));
+        (std::unordered_map<Wrapped<int>, Wrapped<std::string>>{{{1}, {"A"}},
+                                                                {{2}, {"B"}}}));
 }
 
 #ifdef SPECTRE_DEBUG
@@ -497,7 +505,7 @@ struct Duplicate {
   static constexpr OptionString help = {"halp"};
 };
 struct NamedDuplicate {
-    using type = int;
+  using type = int;
   static std::string name() noexcept { return "Duplicate"; }
   static constexpr OptionString help = {"halp"};
 };
@@ -534,13 +542,13 @@ struct NamedNoHelp {
 struct TooLongHelp {
   using type = int;
   static constexpr OptionString help = {
-    "halp halp halp halp halp halp halp halp halp halp halp halp"};
+      "halp halp halp halp halp halp halp halp halp halp halp halp"};
 };
 struct NamedTooLongHelp {
   using type = int;
   static std::string name() noexcept { return "TooLongHelp"; }
   static constexpr OptionString help = {
-    "halp halp halp halp halp halp halp halp halp halp halp halp"};
+      "halp halp halp halp halp halp halp halp halp halp halp halp"};
 };
 #endif  // SPECTRE_DEBUG
 
@@ -616,17 +624,17 @@ struct Apply3 {
 
 void test_options_apply() {
   Options<tmpl::list<Apply1, Apply2, Apply3>> opts("");
-  opts.parse("Apply1: 2\n"
-             "Apply2: str\n"
-             "Apply3: [1, 2, 3]");
+  opts.parse(
+      "Apply1: 2\n"
+      "Apply2: str\n"
+      "Apply3: [1, 2, 3]");
   // We do the checks outside the lambda to make sure it actually gets called.
   std::vector<int> arg1;
   int arg2;
-  opts.apply<tmpl::list<Apply3, Apply1>>(
-      [&](const auto& a, auto b) {
-        arg1 = a;
-        arg2 = b;
-      });
+  opts.apply<tmpl::list<Apply3, Apply1>>([&](const auto& a, auto b) {
+    arg1 = a;
+    arg2 = b;
+  });
   CHECK(arg1 == (std::vector<int>{1, 2, 3}));
   CHECK(arg2 == 2);
 }


### PR DESCRIPTION
## Proposed changes

This PR adds the option group functionality that we discussed in #1362. It allows the following:

```cpp
// In Observer/Tags.hpp
struct Group {
  static std::string option_name() { return "Observers"; }
  static constexpr OptionString help = {"Options for recording data"};
};
struct ReductionFileName {
  using type = std::string;
  static constexpr OptionString help = {
      "Name of the reduction data file without extension"};
  using group = Group;
};
```

```yaml
# In the input file
Observers:
  VolumeFileName: "Volume"
  ReductionFileName: "Reductions"
```

```cpp
// In the source code
get<observers::OptionTags::ReductionFileName>(cache)
```

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
