### PR TITLE
Rename grid_points_to_spectral_matrix and inverse

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/CoefficientTransforms.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/CoefficientTransforms.cpp
@@ -23,8 +23,8 @@ void transform_impl_helper(double* const output_coeffs,
   for (StripeIterator stripe_it(mesh.extents(), dim); stripe_it; ++stripe_it) {
     const Matrix& transformation_matrix =
         nodal_to_modal
-            ? Spectral::grid_points_to_spectral_matrix(mesh.slice_through(dim))
-            : Spectral::spectral_to_grid_points_matrix(mesh.slice_through(dim));
+            ? Spectral::nodal_to_modal_matrix(mesh.slice_through(dim))
+            : Spectral::modal_to_nodal_matrix(mesh.slice_through(dim));
     dgemv_('N', mesh.extents()[dim], mesh.extents()[dim], 1.0,
            transformation_matrix.data(), mesh.extents()[dim],
            input_coeffs + stripe_it.offset(), stripe_it.stride(),  // NOLINT

--- a/src/NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp
@@ -22,7 +22,7 @@ class not_null;
  * \ingroup SpectralGroup
  * \brief Compute the modal coefficients from the nodal coefficients
  *
- * \see Spectral::grid_points_to_spectral_matrix
+ * \see Spectral::nodal_to_modal_matrix
  */
 template <size_t Dim>
 void to_modal_coefficients(gsl::not_null<ModalVector*> modal_coefficients,
@@ -39,7 +39,7 @@ ModalVector to_modal_coefficients(const DataVector& nodal_coefficients,
  * \ingroup SpectralGroup
  * \brief Compute the nodal coefficients from the modal coefficients
  *
- * \see Spectral::spectral_to_grid_points_matrix
+ * \see Spectral::modal_to_nodal_matrix
  */
 template <size_t Dim>
 void to_nodal_coefficients(gsl::not_null<DataVector*> nodal_coefficients,

--- a/src/NumericalAlgorithms/Spectral/Projection.cpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.cpp
@@ -81,9 +81,9 @@ const Matrix& projection_matrix_mortar_to_element(
             // The projection in spectral space is just a truncation
             // of the modes.
             const auto& spectral_to_grid_element =
-                spectral_to_grid_points_matrix(mesh_element);
+                modal_to_nodal_matrix(mesh_element);
             const auto& grid_to_spectral_mortar =
-                grid_points_to_spectral_matrix(mesh_mortar);
+                nodal_to_modal_matrix(mesh_mortar);
             Matrix projection(extents_element, extents_mortar, 0.);
             for (size_t i = 0; i < extents_element; ++i) {
               for (size_t j = 0; j < extents_mortar; ++j) {
@@ -150,9 +150,9 @@ const Matrix& projection_matrix_mortar_to_element(
             };
 
             const auto& spectral_to_grid_element =
-                spectral_to_grid_points_matrix(mesh_element);
+                modal_to_nodal_matrix(mesh_element);
             const auto& grid_to_spectral_mortar =
-                grid_points_to_spectral_matrix(mesh_mortar);
+                nodal_to_modal_matrix(mesh_mortar);
 
             Matrix temp(extents_element, extents_element, 0.);
             for (size_t j = 0; j < extents_element; ++j) {

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -369,18 +369,18 @@ Matrix interpolation_matrix(const Mesh<1>& mesh,
  *
  * \param num_points The number of collocation points
 
- * \see grid_points_to_spectral_matrix(size_t)
+ * \see nodal_to_modal_matrix(size_t)
  */
 template <Basis BasisType, Quadrature QuadratureType>
-const Matrix& spectral_to_grid_points_matrix(size_t num_points) noexcept;
+const Matrix& modal_to_nodal_matrix(size_t num_points) noexcept;
 
 /*!
  * \brief Transformation matrix from modal to nodal coefficients for a
  * one-dimensional mesh.
  *
- * \see spectral_to_grid_points_matrix(size_t)
+ * \see modal_to_nodal_matrix(size_t)
  */
-const Matrix& spectral_to_grid_points_matrix(const Mesh<1>& mesh) noexcept;
+const Matrix& modal_to_nodal_matrix(const Mesh<1>& mesh) noexcept;
 
 /*!
  * \brief %Matrix used to transform from the nodal coefficients of a function to
@@ -388,7 +388,7 @@ const Matrix& spectral_to_grid_points_matrix(const Mesh<1>& mesh) noexcept;
  * _Vandermonde matrix_.
  *
  * \details This is the inverse to the Vandermonde matrix \f$\mathcal{V}\f$
- * computed in spectral_to_grid_points_matrix(size_t). It can be computed
+ * computed in modal_to_nodal_matrix(size_t). It can be computed
  * analytically for Gauss quadrature by evaluating
  * \f$\sum_j\mathcal{V}^{-1}_{ij}u_j=\widetilde{u}_i=
  * \frac{(u,\Phi_i)}{\gamma_i}\f$
@@ -399,18 +399,18 @@ const Matrix& spectral_to_grid_points_matrix(const Mesh<1>& mesh) noexcept;
  *
  * \param num_points The number of collocation points
  *
- * \see spectral_to_grid_points_matrix(size_t)
+ * \see modal_to_nodal_matrix(size_t)
  */
 template <Basis BasisType, Quadrature QuadratureType>
-const Matrix& grid_points_to_spectral_matrix(size_t num_points) noexcept;
+const Matrix& nodal_to_modal_matrix(size_t num_points) noexcept;
 
 /*!
  * \brief Transformation matrix from nodal to modal coefficients for a
  * one-dimensional mesh.
  *
- * \see grid_points_to_spectral_matrix(size_t)
+ * \see nodal_to_modal_matrix(size_t)
  */
-const Matrix& grid_points_to_spectral_matrix(const Mesh<1>& mesh) noexcept;
+const Matrix& nodal_to_modal_matrix(const Mesh<1>& mesh) noexcept;
 
 /*!
  * \brief %Matrix used to linearize a function.
@@ -418,12 +418,12 @@ const Matrix& grid_points_to_spectral_matrix(const Mesh<1>& mesh) noexcept;
  * \details Filters out all except the lowest two modes by applying
  * \f$\mathcal{V}^{-1}\cdot\mathrm{diag}(1,1,0,0,...)\cdot\mathcal{V}\f$ to the
  * nodal coefficients, where \f$\mathcal{V}\f$ is the Vandermonde matrix
- * computed in `spectral_to_grid_points_matrix(size_t)`.
+ * computed in `modal_to_nodal_matrix(size_t)`.
  *
  * \param num_points The number of collocation points
  *
- * \see spectral_to_grid_points_matrix(size_t)
- * \see grid_points_to_spectral_matrix(size_t)
+ * \see modal_to_nodal_matrix(size_t)
+ * \see nodal_to_modal_matrix(size_t)
  */
 template <Basis BasisType, Quadrature QuadratureType>
 const Matrix& linear_filter_matrix(size_t num_points) noexcept;

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
@@ -41,7 +41,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Linearize",
         for (size_t d = 0; d < 3; ++d) {
           for (StripeIterator s(mesh.extents(), d); s; ++s) {
             const Matrix& inv_v =
-                Spectral::grid_points_to_spectral_matrix(mesh.slice_through(d));
+                Spectral::nodal_to_modal_matrix(mesh.slice_through(d));
             const auto slice_points = mesh.extents(d);
             DataVector u_s(slice_points);
             dgemv_('N', slice_points, slice_points, 1., inv_v.data(),
@@ -108,7 +108,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LinearizeInOneDim",
           DataVector u_lin = linearize(u, mesh, d);
           for (StripeIterator s(mesh.extents(), d); s; ++s) {
             const Matrix& inv_v =
-                Spectral::grid_points_to_spectral_matrix(mesh.slice_through(d));
+                Spectral::nodal_to_modal_matrix(mesh.slice_through(d));
             const auto slice_points = mesh.extents(d);
             DataVector u_s(slice_points);
             dgemv_('N', slice_points, slice_points, 1., inv_v.data(),

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_LegendreGauss.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_LegendreGauss.cpp
@@ -128,32 +128,30 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGauss.DiffMatrix",
 
 namespace {
 
-void test_spectral_to_grid_points_matrix(const size_t num_points,
-                                         const Matrix& expected_matrix) {
-  const auto& matrix = Spectral::spectral_to_grid_points_matrix<
-      Spectral::Basis::Legendre, Spectral::Quadrature::Gauss>(num_points);
+void test_modal_to_nodal_matrix(const size_t num_points,
+                                const Matrix& expected_matrix) {
+  const auto& matrix =
+      Spectral::modal_to_nodal_matrix<Spectral::Basis::Legendre,
+                                      Spectral::Quadrature::Gauss>(num_points);
   CHECK_MATRIX_APPROX(expected_matrix, matrix);
 }
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGauss.SpectralToGridPoints",
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGauss.ModalToNodal",
                   "[NumericalAlgorithms][Spectral][Unit]") {
-  SECTION("Check 1 point") {
-    test_spectral_to_grid_points_matrix(1, Matrix(1, 1, 1.));
-  }
+  SECTION("Check 1 point") { test_modal_to_nodal_matrix(1, Matrix(1, 1, 1.)); }
   SECTION("Check 2 points") {
-    test_spectral_to_grid_points_matrix(
+    test_modal_to_nodal_matrix(
         2, Matrix({{1., -0.5773502691896258}, {1., 0.5773502691896258}}));
   }
   SECTION("Check 3 points") {
-    test_spectral_to_grid_points_matrix(
-        3, Matrix({{1., -0.7745966692414830, 0.4},
-                   {1., 0., -0.5},
-                   {1., 0.7745966692414830, 0.4}}));
+    test_modal_to_nodal_matrix(3, Matrix({{1., -0.7745966692414830, 0.4},
+                                          {1., 0., -0.5},
+                                          {1., 0.7745966692414830, 0.4}}));
   }
   SECTION("Check 4 points") {
-    test_spectral_to_grid_points_matrix(
+    test_modal_to_nodal_matrix(
         4,
         Matrix(
             {{1., -0.8611363115940530, 0.6123336207187148, -0.3047469849552077},
@@ -163,7 +161,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGauss.SpectralToGridPoints",
               0.3047469849552077}}));
   }
   SECTION("Check 5 points") {
-    test_spectral_to_grid_points_matrix(
+    test_modal_to_nodal_matrix(
         5, Matrix({{1., -0.9061798459386637, 0.7317428697781310,
                     -0.5010311710446620, 0.2457354590949121},
                    {1., -0.5384693101056831, -0.06507620311146464,
@@ -178,33 +176,32 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGauss.SpectralToGridPoints",
 
 namespace {
 
-void test_grid_points_to_spectral_matrix(const size_t num_points,
-                                         const Matrix& expected_matrix) {
-  const auto& matrix = Spectral::grid_points_to_spectral_matrix<
-      Spectral::Basis::Legendre, Spectral::Quadrature::Gauss>(num_points);
+void test_nodal_to_modal_matrix(const size_t num_points,
+                                const Matrix& expected_matrix) {
+  const auto& matrix =
+      Spectral::nodal_to_modal_matrix<Spectral::Basis::Legendre,
+                                      Spectral::Quadrature::Gauss>(num_points);
   CHECK_MATRIX_APPROX(expected_matrix, matrix);
 }
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGauss.GridPointsToSpectral",
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGauss.NodalToModal",
                   "[NumericalAlgorithms][Spectral][Unit]") {
-  SECTION("Check 1 point") {
-    test_grid_points_to_spectral_matrix(1, Matrix(1, 1, 1.));
-  }
+  SECTION("Check 1 point") { test_nodal_to_modal_matrix(1, Matrix(1, 1, 1.)); }
   SECTION("Check 2 points") {
-    test_grid_points_to_spectral_matrix(
+    test_nodal_to_modal_matrix(
         2, Matrix({{0.5, 0.5}, {-0.8660254037844385, 0.8660254037844385}}));
   }
   SECTION("Check 3 points") {
-    test_grid_points_to_spectral_matrix(
+    test_nodal_to_modal_matrix(
         3,
         Matrix({{0.2777777777777781, 0.4444444444444438, 0.2777777777777781},
                 {-0.6454972243679031, 0, 0.6454972243679031},
                 {0.5555555555555561, -1.111111111111112, 0.5555555555555561}}));
   }
   SECTION("Check 4 points") {
-    test_grid_points_to_spectral_matrix(
+    test_nodal_to_modal_matrix(
         4, Matrix({{0.1739274225687268, 0.3260725774312732, 0.3260725774312732,
                     0.1739274225687269},
                    {-0.4493256574676805, -0.3325754854784655,
@@ -215,7 +212,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGauss.GridPointsToSpectral",
                     -0.9397724703777526, 0.3710270034019466}}));
   }
   SECTION("Check 5 points") {
-    test_grid_points_to_spectral_matrix(
+    test_nodal_to_modal_matrix(
         5,
         Matrix({{0.1184634425280945, 0.2393143352496832, 0.2844444444444443,
                  0.2393143352496832, 0.1184634425280947},

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_LegendreGaussLobatto.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_LegendreGaussLobatto.cpp
@@ -249,35 +249,35 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGaussLobatto.DiffMatrix",
 
 namespace {
 
-void test_spectral_to_grid_points_matrix(const size_t num_points,
-                                         const Matrix& expected_matrix) {
-  const auto& matrix = Spectral::spectral_to_grid_points_matrix<
-      Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>(
-      num_points);
+void test_modal_to_nodal_matrix(const size_t num_points,
+                                const Matrix& expected_matrix) {
+  const auto& matrix =
+      Spectral::modal_to_nodal_matrix<Spectral::Basis::Legendre,
+                                      Spectral::Quadrature::GaussLobatto>(
+          num_points);
   CHECK_MATRIX_APPROX(expected_matrix, matrix);
 }
 
 }  // namespace
 
-SPECTRE_TEST_CASE(
-    "Unit.Numerical.Spectral.LegendreGaussLobatto.SpectralToGridPoints",
-    "[NumericalAlgorithms][Spectral][Unit]") {
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGaussLobatto.ModalToNodal",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
   SECTION("Check 2 points") {
-    test_spectral_to_grid_points_matrix(2, Matrix({{1., -1.}, {1., 1.}}));
+    test_modal_to_nodal_matrix(2, Matrix({{1., -1.}, {1., 1.}}));
   }
   SECTION("Check 3 points") {
-    test_spectral_to_grid_points_matrix(
+    test_modal_to_nodal_matrix(
         3, Matrix({{1., -1., 1.}, {1., 0., -0.5}, {1., 1., 1.}}));
   }
   SECTION("Check 4 points") {
-    test_spectral_to_grid_points_matrix(
+    test_modal_to_nodal_matrix(
         4, Matrix({{1., -1., 1., -1.},
                    {1., -0.4472135954999579, -0.2, 0.4472135954999580},
                    {1., 0.4472135954999579, -0.2, -0.4472135954999580},
                    {1., 1., 1., 1.}}));
   }
   SECTION("Check 5 points") {
-    test_spectral_to_grid_points_matrix(
+    test_modal_to_nodal_matrix(
         5, Matrix({{1., -1., 1., -1., 1.},
                    {1., -0.6546536707079772, 0.1428571428571430,
                     0.2805658588748472, -0.4285714285714287},
@@ -287,7 +287,7 @@ SPECTRE_TEST_CASE(
                    {1., 1., 1., 1., 1.}}));
   }
   SECTION("Check 6 points") {
-    test_spectral_to_grid_points_matrix(
+    test_modal_to_nodal_matrix(
         6,
         Matrix(
             {{1., -1., 1., -1., 1., -1.},
@@ -302,7 +302,7 @@ SPECTRE_TEST_CASE(
              {1., 1., 1., 1., 1., 1.}}));
   }
   SECTION("Check 10 points") {
-    test_spectral_to_grid_points_matrix(
+    test_modal_to_nodal_matrix(
         10,
         Matrix(
             {{1., -1., 1., -1., 1., -1., 1., -1., 1., -1.},
@@ -336,30 +336,29 @@ SPECTRE_TEST_CASE(
 
 namespace {
 
-void test_grid_points_to_spectral_matrix(const size_t num_points,
-                                         const Matrix& expected_matrix) {
-  const auto& matrix = Spectral::grid_points_to_spectral_matrix<
-      Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>(
-      num_points);
+void test_nodal_to_modal_matrix(const size_t num_points,
+                                const Matrix& expected_matrix) {
+  const auto& matrix =
+      Spectral::nodal_to_modal_matrix<Spectral::Basis::Legendre,
+                                      Spectral::Quadrature::GaussLobatto>(
+          num_points);
   CHECK_MATRIX_APPROX(expected_matrix, matrix);
 }
 
 }  // namespace
 
-SPECTRE_TEST_CASE(
-    "Unit.Numerical.Spectral.LegendreGaussLobatto.GridPointsToSpectral",
-    "[NumericalAlgorithms][Spectral][Unit]") {
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGaussLobatto.NodalToModal",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
   SECTION("Check 2 points") {
-    test_grid_points_to_spectral_matrix(2, Matrix({{0.5, 0.5}, {-0.5, 0.5}}));
+    test_nodal_to_modal_matrix(2, Matrix({{0.5, 0.5}, {-0.5, 0.5}}));
   }
   SECTION("Check 3 points") {
-    test_grid_points_to_spectral_matrix(3,
-                                        Matrix({{1. / 6., 2. / 3., 1. / 6.},
-                                                {-1. / 2., 0., 1. / 2.},
-                                                {1. / 3., -2. / 3., 1. / 3.}}));
+    test_nodal_to_modal_matrix(3, Matrix({{1. / 6., 2. / 3., 1. / 6.},
+                                          {-1. / 2., 0., 1. / 2.},
+                                          {1. / 3., -2. / 3., 1. / 3.}}));
   }
   SECTION("Check 4 points") {
-    test_grid_points_to_spectral_matrix(
+    test_nodal_to_modal_matrix(
         4, Matrix({{0.08333333333333320, 0.4166666666666668, 0.4166666666666666,
                     0.08333333333333337},
                    {-0.25, -0.5590169943749476, 0.5590169943749476, 0.25},
@@ -368,7 +367,7 @@ SPECTRE_TEST_CASE(
                    {-0.25, 0.5590169943749476, -0.5590169943749476, 0.25}}));
   }
   SECTION("Check 5 points") {
-    test_grid_points_to_spectral_matrix(
+    test_nodal_to_modal_matrix(
         5, Matrix({{0.05, 0.2722222222222222, 0.3555555555555557,
                     0.2722222222222221, 0.05},
                    {-0.15, -0.5346338310781814, 0., 0.5346338310781813, 0.15},
@@ -379,7 +378,7 @@ SPECTRE_TEST_CASE(
                     -0.4666666666666665, 0.2}}));
   }
   SECTION("Check 6 points") {
-    test_grid_points_to_spectral_matrix(
+    test_nodal_to_modal_matrix(
         6,
         Matrix(
             {{0.03333333333333338, 0.1892374781489234, 0.2774291885177432,
@@ -396,7 +395,7 @@ SPECTRE_TEST_CASE(
               0.4808232423993798, -0.3971119470091983, 0.1666666666666666}}));
   }
   SECTION("Check 10 points") {
-    test_grid_points_to_spectral_matrix(
+    test_nodal_to_modal_matrix(
         10,
         Matrix(
             {{0.01111111111111113, 0.06665299542553522, 0.1124446710315631,

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -111,8 +111,8 @@ void test_linear_filter() {
        n <= Spectral::maximum_number_of_points<BasisType>; n++) {
     const auto& filter_matrix =
         Spectral::linear_filter_matrix<BasisType, QuadratureType>(n);
-    const auto& grid_points_to_spectral_matrix =
-        Spectral::grid_points_to_spectral_matrix<BasisType, QuadratureType>(n);
+    const auto& nodal_to_modal_matrix =
+        Spectral::nodal_to_modal_matrix<BasisType, QuadratureType>(n);
     const auto& collocation_pts =
         Spectral::collocation_points<BasisType, QuadratureType>(n);
     const DataVector u = exp(collocation_pts);
@@ -120,8 +120,8 @@ void test_linear_filter() {
     dgemv_('N', n, n, 1.0, filter_matrix.data(), n, u.data(), 1, 0.0,
            u_filtered.data(), 1);
     DataVector u_filtered_spectral(n);
-    dgemv_('N', n, n, 1.0, grid_points_to_spectral_matrix.data(), n,
-           u_filtered.data(), 1, 0.0, u_filtered_spectral.data(), 1);
+    dgemv_('N', n, n, 1.0, nodal_to_modal_matrix.data(), n, u_filtered.data(),
+           1, 0.0, u_filtered_spectral.data(), 1);
     for (size_t s = 2; s < n; ++s) {
       CHECK(0.0 == approx(u_filtered_spectral[s]));
     }
@@ -389,15 +389,11 @@ void test_spectral_quantities_for_mesh(const Mesh<1>& slice) {
   CHECK(Spectral::interpolation_matrix(slice, target_points) ==
         expected_interp_matrix_points);
   const auto& expected_vand_matrix =
-      Spectral::spectral_to_grid_points_matrix<BasisType, QuadratureType>(
-          num_points);
-  CHECK(Spectral::spectral_to_grid_points_matrix(slice) ==
-        expected_vand_matrix);
+      Spectral::modal_to_nodal_matrix<BasisType, QuadratureType>(num_points);
+  CHECK(Spectral::modal_to_nodal_matrix(slice) == expected_vand_matrix);
   const auto& expected_inv_vand_matrix =
-      Spectral::grid_points_to_spectral_matrix<BasisType, QuadratureType>(
-          num_points);
-  CHECK(Spectral::grid_points_to_spectral_matrix(slice) ==
-        expected_inv_vand_matrix);
+      Spectral::nodal_to_modal_matrix<BasisType, QuadratureType>(num_points);
+  CHECK(Spectral::nodal_to_modal_matrix(slice) == expected_inv_vand_matrix);
   const auto& expected_lin_matrix =
       Spectral::linear_filter_matrix<BasisType, QuadratureType>(num_points);
   CHECK(Spectral::linear_filter_matrix(slice) == expected_lin_matrix);


### PR DESCRIPTION
## Proposed changes

- Rename `grid_points_to_spectral_matrix` to `nodal_to_modal_matrix`
- Rename `spectral_to_grid_points_matrix` to `modal_to_nodal_matrix`

The wording is clearer and consistent with what we've been doing elsewhere in the code recently.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
