### PR TITLE
Add filtering framework and exponential filter

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Filtering.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Filtering.hpp
@@ -1,0 +1,334 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/LinearOperators/ApplyMatrices.hpp"
+#include "NumericalAlgorithms/Spectral/Filtering.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace dg {
+namespace Actions {
+namespace ExponentialFilter_detail {
+template <bool SameSize, bool SameList>
+struct FilterAllEvolvedVars {
+  template <typename EvolvedVarsTagList, typename... FilterTags>
+  using f = std::integral_constant<bool, false>;
+};
+
+template <>
+struct FilterAllEvolvedVars<true, false> {
+  template <typename EvolvedVarsTagList, typename... FilterTags>
+  using f =
+      std::integral_constant<bool, tmpl2::flat_all_v<tmpl::list_contains_v<
+                                       EvolvedVarsTagList, FilterTags>...>>;
+};
+
+template <>
+struct FilterAllEvolvedVars<true, true> {
+  template <typename EvolvedVarsTagList, typename... FilterTags>
+  using f = std::integral_constant<bool, true>;
+};
+}  // namespace ExponentialFilter_detail
+
+/// \cond
+template <size_t FilterIndex, typename TagsToFilterList>
+struct ExponentialFilter;
+/// \endcond
+
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief Applies an exponential filter to the specified tags.
+ *
+ * Applies an exponential filter in each logical direction to each component of
+ * the tensors `TagsToFilter`. The exponential filter rescales the 1d modal
+ * coefficients \f$c_i\f$ as:
+ *
+ * \f{align*}{
+ *  c_i\to c_i \exp\left[-\alpha_{\mathrm{ef}}
+ *   \left(\frac{i}{N}\right)^{2\beta_{\mathrm{ef}}}\right]
+ * \f}
+ *
+ * where \f$N\f$ is the basis order, \f$\alpha_{\mathrm{ef}}\f$ determines how
+ * much the coefficients are rescaled, and \f$\beta_{\mathrm{ef}}\f$ (given by
+ * the `HalfPower` option) determines how aggressive/broad the filter is (lower
+ * values means filtering more coefficients). Setting
+ * \f$\alpha_{\mathrm{ef}}=36\f$ results in effectively zeroing the highest
+ * coefficient (in practice it gets rescaled by machine epsilon). The same
+ * \f$\alpha_{\mathrm{ef}}\f$ and \f$\beta_{\mathrm{ef}}\f$ are used in each
+ * logical direction. For a discussion of filtering see section 5.3 of
+ * \cite HesthavenWarburton.
+ *
+ * If different `Alpha` or `HalfPower` parameters are desired for different tags
+ * then multiple `ExponentialFilter` actions must be inserted into the action
+ * list with different `FilterIndex` values. In the input file these will be
+ * specified as `ExpFilterFILTER_INDEX`, e.g. `ExpFilter0` and `ExpFilter1`.
+ * Below is an example of an action list with two different exponential filters:
+ *
+ * \snippet DiscontinuousGalerkin/Test_Filtering.cpp action_list_example
+ *
+ * #### Action properties
+ *
+ * Uses:
+ * - ConstGlobalCache:
+ *   - `ExponentialFilter`
+ * - DataBox:
+ *   - `Tags::Mesh`
+ * - DataBox changes:
+ *   - Adds: nothing
+ *   - Removes: nothing
+ *   - Modifies:
+ *     - `TagsToFilter`
+ * - System:
+ *   - `volume_dim`
+ *   - `variables_tag`
+ *
+ * #### Design decision:
+ *
+ * - The reason for the `size_t` template parameter is to allow for different
+ * `Alpha` and `HalfPower` parameters for different tensors while still being
+ * able to cache the matrices.
+ */
+template <size_t FilterIndex, typename... TagsToFilter>
+class ExponentialFilter<FilterIndex, tmpl::list<TagsToFilter...>> {
+ public:
+  using const_global_cache_tags = tmpl::list<ExponentialFilter>;
+
+  /// \brief The value of `exp(-alpha)` is what the highest modal coefficient is
+  /// rescaled by.
+  struct Alpha {
+    using type = double;
+    static constexpr OptionString help =
+        "exp(-alpha) is rescaling of highest coefficient";
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  /*!
+   * \brief Half of the exponent in the exponential.
+   *
+   * \f{align*}{
+   *  c_i\to c_i \exp\left[-\alpha \left(\frac{i}{N}\right)^{2m}\right]
+   * \f}
+   */
+  struct HalfPower {
+    using type = unsigned;
+    static constexpr OptionString help =
+        "Half of the exponent in the generalized Gaussian";
+    static type lower_bound() noexcept { return 1; }
+  };
+  /// \brief Turn the filter off
+  ///
+  /// This option exists to temporarily disable the filter for debugging
+  /// purposes. For problems where filtering is not needed, the preferred
+  /// approach is to not compile the filter into the executable.
+  struct DisableForDebugging {
+    using type = bool;
+    static type default_value() noexcept { return false; }
+    static constexpr OptionString help = {"Disable the filter"};
+  };
+
+  using type = ExponentialFilter;
+  static std::string name() noexcept {
+    return "ExpFilter" + std::to_string(FilterIndex);
+  }
+
+  using options = tmpl::list<Alpha, HalfPower, DisableForDebugging>;
+  static constexpr OptionString help = {"An exponential filter."};
+
+  ExponentialFilter() = default;
+
+  ExponentialFilter(double alpha, unsigned half_power,
+                    bool disable_for_debugging) noexcept;
+
+  // Action part of the class
+  template <typename DbTags, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent,
+            typename Metavariables>
+  static std::tuple<db::DataBox<DbTags>&&> apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    constexpr size_t volume_dim = Metavariables::system::volume_dim;
+    using evolved_vars_tag = typename Metavariables::system::variables_tag;
+    using evolved_vars_tags_list = typename evolved_vars_tag::tags_list;
+    const ExponentialFilter& filter_helper =
+        Parallel::get<ExponentialFilter>(cache);
+    if (UNLIKELY(filter_helper.disable_for_debugging_)) {
+      return {std::move(box)};
+    }
+    const Mesh<volume_dim> mesh = db::get<::Tags::Mesh<volume_dim>>(box);
+    const Matrix empty{};
+    auto filter = make_array<volume_dim>(std::cref(empty));
+    for (size_t d = 0; d < volume_dim; d++) {
+      gsl::at(filter, d) =
+          std::cref(filter_helper.filter_matrix(mesh.slice_through(d)));
+    }
+
+    // In the case that the tags we are filtering are all the evolved variables
+    // we filter the entire Variables at once to be more efficient. This case is
+    // the first branch of the `if-else`.
+    if (ExponentialFilter_detail::FilterAllEvolvedVars<
+            sizeof...(TagsToFilter) ==
+                tmpl::size<evolved_vars_tags_list>::value,
+            cpp17::is_same_v<evolved_vars_tags_list,
+                             tmpl::list<TagsToFilter...>>>::
+            template f<evolved_vars_tags_list, TagsToFilter...>::value) {
+      db::mutate<typename Metavariables::system::variables_tag>(
+          make_not_null(&box),
+          [&filter](
+              const gsl::not_null<
+                  db::item_type<typename Metavariables::system::variables_tag>*>
+                  vars,
+              const auto& local_mesh) noexcept {
+            *vars = apply_matrices(filter, *vars, local_mesh.extents());
+          },
+          mesh);
+    } else {
+      db::mutate<TagsToFilter...>(
+          make_not_null(&box),
+          [&filter](const gsl::not_null<
+                        db::item_type<TagsToFilter>*>... tensors_to_filter,
+                    const auto& local_mesh) noexcept {
+            DataVector temp(local_mesh.number_of_grid_points(), 0.0);
+            const auto helper =
+                [&local_mesh, &filter, &temp ](const auto tensor) noexcept {
+              for (auto& component : *tensor) {
+                temp = 0.0;
+                apply_matrices(make_not_null(&temp), filter, component,
+                               local_mesh.extents());
+                component = temp;
+              }
+            };
+            EXPAND_PACK_LEFT_TO_RIGHT(helper(tensors_to_filter));
+          },
+          mesh);
+    }
+    return {std::move(box)};
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept;
+
+  bool operator==(const ExponentialFilter& rhs) const noexcept;
+
+ private:
+  const Matrix& filter_matrix(const Mesh<1>& mesh) const noexcept {
+    // All these switch gymnastics are to translate the runtime mesh values into
+    // compile time template parameters. This is used so we have a sparse lazy
+    // cache where we only cache matrices that we actually need for the meshes
+    // used in the simulation.
+    switch (mesh.basis(0)) {
+      case Spectral::Basis::Legendre:
+        switch (mesh.quadrature(0)) {
+          case Spectral::Quadrature::Gauss:
+            return filter_matrix_impl<Spectral::Basis::Legendre,
+                                      Spectral::Quadrature::Gauss>(
+                mesh,
+                std::make_index_sequence<Spectral::maximum_number_of_points<
+                    Spectral::Basis::Legendre>>{});
+          case Spectral::Quadrature::GaussLobatto:
+            return filter_matrix_impl<Spectral::Basis::Legendre,
+                                      Spectral::Quadrature::GaussLobatto>(
+                mesh,
+                std::make_index_sequence<Spectral::maximum_number_of_points<
+                    Spectral::Basis::Legendre>>{});
+          default:
+            ERROR("Missing quadrature in exponential filter matrix action.");
+        }
+      case Spectral::Basis::Chebyshev:
+        switch (mesh.quadrature(0)) {
+          case Spectral::Quadrature::Gauss:
+            return filter_matrix_impl<Spectral::Basis::Chebyshev,
+                                      Spectral::Quadrature::Gauss>(
+                mesh,
+                std::make_index_sequence<Spectral::maximum_number_of_points<
+                    Spectral::Basis::Chebyshev>>{});
+          case Spectral::Quadrature::GaussLobatto:
+            return filter_matrix_impl<Spectral::Basis::Chebyshev,
+                                      Spectral::Quadrature::GaussLobatto>(
+                mesh.slice_through(0),
+                std::make_index_sequence<Spectral::maximum_number_of_points<
+                    Spectral::Basis::Chebyshev>>{});
+          default:
+            ERROR("Missing quadrature in exponential filter matrix action.");
+        }
+      default:
+        ERROR("Missing basis in exponential filter matrix action.");
+    };
+  }
+
+  template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType,
+            size_t I>
+  static const Matrix& filter_matrix_cache(const Mesh<1>& mesh,
+                                           const double alpha,
+                                           const unsigned half_power) noexcept {
+    static Matrix matrix =
+        Spectral::filtering::exponential_filter(mesh, alpha, half_power);
+    return matrix;
+  }
+
+  template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType,
+            size_t... Is>
+  const Matrix& filter_matrix_impl(const Mesh<1>& mesh,
+                                   std::index_sequence<Is...> /*meta*/) const
+      noexcept {
+    static const std::array<const Matrix& (*)(const Mesh<1>&, double, unsigned),
+                            sizeof...(Is)>
+        cache{{&filter_matrix_cache<BasisType, QuadratureType, Is>...}};
+    return gsl::at(cache, mesh.extents(0))(mesh, alpha_, half_power_);
+  }
+
+  double alpha_{36.0};
+  unsigned half_power_{16};
+  bool disable_for_debugging_{false};
+};
+
+template <size_t FilterIndex, typename... TagsToFilter>
+ExponentialFilter<FilterIndex, tmpl::list<TagsToFilter...>>::ExponentialFilter(
+    const double alpha, const unsigned half_power,
+    const bool disable_for_debugging) noexcept
+    : alpha_(alpha),
+      half_power_(half_power),
+      disable_for_debugging_(disable_for_debugging) {}
+
+template <size_t FilterIndex, typename... TagsToFilter>
+void ExponentialFilter<FilterIndex, tmpl::list<TagsToFilter...>>::pup(
+    PUP::er& p) noexcept {
+  p | alpha_;
+  p | half_power_;
+  p | disable_for_debugging_;
+}
+
+template <size_t FilterIndex, typename... TagsToFilter>
+bool ExponentialFilter<FilterIndex, tmpl::list<TagsToFilter...>>::operator==(
+    const ExponentialFilter& rhs) const noexcept {
+  return alpha_ == rhs.alpha_ and half_power_ == rhs.half_power_ and
+         disable_for_debugging_ == rhs.disable_for_debugging_;
+}
+
+template <size_t FilterIndex, typename TagsToFilterList>
+bool operator!=(
+    const ExponentialFilter<FilterIndex, TagsToFilterList>& lhs,
+    const ExponentialFilter<FilterIndex, TagsToFilterList>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace Actions
+}  // namespace dg

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -12,6 +12,7 @@
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"  // IWYU pragma: keep
+#include "Evolution/DiscontinuousGalerkin/Filtering.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/InitializeElement.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/ObserveErrorNorms.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/ObserveFields.hpp"  // IWYU pragma: keep
@@ -118,6 +119,12 @@ struct EvolutionMetavars {
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,
                           dg::Actions::ApplyFluxes>,
       Actions::RecordTimeStepperData>>;
+  // To add filtering to the executable add the action:
+  //
+  // dg::Actions::ExponentialFilter<0,
+  //        tmpl::list<ScalarWave::Pi, ScalarWave::Psi, ScalarWave::Phi<Dim>>>
+  //
+  // to the end of `update_variables` so it is after `Actions::UpdateU`.
   using update_variables = tmpl::flatten<tmpl::list<
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY Spectral)
 set(LIBRARY_SOURCES
     Chebyshev.cpp
     ComplexDataView.cpp
+    Filtering.cpp
     Legendre.cpp
     Projection.cpp
     Spectral.cpp

--- a/src/NumericalAlgorithms/Spectral/Filtering.cpp
+++ b/src/NumericalAlgorithms/Spectral/Filtering.cpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/Filtering.hpp"
+
+#include <cmath>
+
+#include "DataStructures/Matrix.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Spectral {
+namespace filtering {
+Matrix exponential_filter(const Mesh<1>& mesh, const double alpha,
+                          const unsigned half_power) noexcept {
+  if (UNLIKELY(mesh.number_of_grid_points() == 1)) {
+    return Matrix(1, 1, 1.0);
+  }
+  const Matrix& nodal_to_modal = Spectral::nodal_to_modal_matrix(mesh);
+  const Matrix& modal_to_nodal = Spectral::modal_to_nodal_matrix(mesh);
+  Matrix filter_matrix(mesh.number_of_grid_points(),
+                       mesh.number_of_grid_points(), 0.0);
+  const double order = mesh.number_of_grid_points() - 1.0;
+  for (size_t i = 0; i < mesh.number_of_grid_points(); ++i) {
+    filter_matrix(i, i) = exp(-alpha * pow(i / order, 2 * half_power));
+  }
+  return modal_to_nodal * filter_matrix * nodal_to_modal;
+}
+}  // namespace filtering
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/Filtering.hpp
+++ b/src/NumericalAlgorithms/Spectral/Filtering.hpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \cond
+class Matrix;
+template <size_t>
+class Mesh;
+/// \endcond
+
+namespace Spectral {
+/*!
+ * \ingroup SpectralGroup
+ * \brief Matrices for filtering spectral coefficients.
+ */
+namespace filtering {
+/*!
+ * \brief Returns a `Matrix` by which to multiply the nodal coefficients to
+ * apply a stable exponential filter.
+ *
+ * The exponential filter rescales the modal coefficients according to:
+ *
+ * \f{align*}{
+ *  c_i\to c_i \exp\left[-\alpha \left(\frac{i}{N}\right)^{2m}\right]
+ * \f}
+ *
+ * where \f$c_i\f$ are the zero-indexed modal coefficients, \f$N\f$ is the basis
+ * order, \f$\alpha\f$ determines how much the coefficients are rescaled, and
+ * \f$m\f$ determines how aggressive/broad the filter is (lower values means
+ * filtering more coefficients). Setting \f$\alpha=36\f$ results in setting the
+ * highest coefficient to machine precision, effectively zeroing it out.
+ *
+ * \note The filter matrix is not cached by the function because it depends on a
+ * double, an integer, and the mesh, which could make caching very memory
+ * intensive. The caller of this function is responsible for determining whether
+ * or not the matrix should be cached.
+ */
+Matrix exponential_filter(const Mesh<1>& mesh, double alpha,
+                          unsigned half_power) noexcept;
+}  // namespace filtering
+}  // namespace Spectral

--- a/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
@@ -39,6 +39,11 @@ StepChoosers:
   - Cfl:
       SafetyFactor: 0.2
 
+# If filtering is enabled in the executable the filter can be controlled using:
+# ExpFilter0:
+#   Alpha: 12
+#   HalfPower: 32
+
 NumericalFluxParams:
 
 EventsAndTriggers:

--- a/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
@@ -39,6 +39,11 @@ StepChoosers:
   - Cfl:
       SafetyFactor: 0.2
 
+# If filtering is enabled in the executable the filter can be controlled using:
+# ExpFilter0:
+#   Alpha: 12
+#   HalfPower: 32
+
 NumericalFluxParams:
 
 EventsAndTriggers:

--- a/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
@@ -39,6 +39,11 @@ StepChoosers:
   - Cfl:
       SafetyFactor: 0.2
 
+# If filtering is enabled in the executable the filter can be controlled using:
+# ExpFilter0:
+#   Alpha: 12
+#   HalfPower: 32
+
 NumericalFluxParams:
 
 EventsAndTriggers:

--- a/tests/InputFiles/ScalarWave/ObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/ObserveExample.yaml
@@ -38,6 +38,11 @@ StepChoosers:
   - Cfl:
       SafetyFactor: 0.2
 
+# If filtering is enabled in the executable the filter can be controlled using:
+# ExpFilter0:
+#   Alpha: 12
+#   HalfPower: 32
+
 NumericalFluxParams:
 
 # [observe_event_trigger]

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_EvolutionDiscontinuousGalerkin")
 
 set(LIBRARY_SOURCES
+  Test_Filtering.cpp
   Test_InitializeElement.cpp
   Test_ObserveErrorNorms.cpp
   Test_ObserveFields.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_Filtering.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_Filtering.cpp
@@ -1,0 +1,261 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesHelpers.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"  // IWYU pragma: keep
+#include "Evolution/DiscontinuousGalerkin/Filtering.hpp"
+#include "NumericalAlgorithms/LinearOperators/ApplyMatrices.hpp"
+#include "NumericalAlgorithms/Spectral/Filtering.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestCreation.hpp"
+
+// IWYU pragma: no_forward_declare dg::Actions::ExponentialFilter
+
+namespace {
+namespace Tags {
+struct ScalarVar : db::SimpleTag {
+  static std::string name() noexcept { return "Scalar"; }
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct VectorVar : db::SimpleTag {
+  static std::string name() noexcept { return "Vector"; }
+  using type = tnsr::I<DataVector, Dim>;
+};
+}  // namespace Tags
+
+template <size_t Dim>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+  using variables_tag =
+      ::Tags::Variables<tmpl::list<Tags::ScalarVar, Tags::VectorVar<Dim>>>;
+};
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  static constexpr size_t dim = metavariables::system::volume_dim;
+
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  /// [action_list_example]
+  using action_list = tmpl::conditional_t<
+      metavariables::filter_individually,
+      tmpl::list<
+          dg::Actions::ExponentialFilter<0, tmpl::list<Tags::ScalarVar>>,
+          dg::Actions::ExponentialFilter<1, tmpl::list<Tags::VectorVar<dim>>>>,
+      tmpl::list<dg::Actions::ExponentialFilter<
+          0, tmpl::list<Tags::VectorVar<dim>, Tags::ScalarVar>>>>;
+  /// [action_list_example]
+  using const_global_cache_tag_list =
+      Parallel::get_const_global_cache_tags<action_list>;
+  using simple_tags =
+      db::AddSimpleTags<::Tags::Mesh<dim>,
+                        typename metavariables::system::variables_tag>;
+  using initial_databox = db::compute_databox_type<simple_tags>;
+};
+
+template <size_t Dim, bool FilterIndividually>
+struct Metavariables {
+  static constexpr bool filter_individually = FilterIndividually;
+
+  using system = System<Dim>;
+  static constexpr bool local_time_stepping = true;
+  using component_list = tmpl::list<Component<Metavariables>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+};
+
+template <typename Metavariables,
+          Requires<Metavariables::filter_individually> = nullptr>
+typename ActionTesting::MockRuntimeSystem<Metavariables>::CacheTuple
+create_cache_tuple(const double alpha, const unsigned half_power,
+                   const bool disable_for_debugging) noexcept {
+  constexpr size_t dim = Metavariables::system::volume_dim;
+  return {dg::Actions::ExponentialFilter<0, tmpl::list<Tags::ScalarVar>>{
+              alpha, half_power, disable_for_debugging},
+          dg::Actions::ExponentialFilter<1, tmpl::list<Tags::VectorVar<dim>>>{
+              2.0 * alpha, 2 * half_power, disable_for_debugging}};
+}
+
+template <typename Metavariables,
+          Requires<not Metavariables::filter_individually> = nullptr>
+typename ActionTesting::MockRuntimeSystem<Metavariables>::CacheTuple
+create_cache_tuple(const double alpha, const unsigned half_power,
+                   const bool disable_for_debugging) noexcept {
+  constexpr size_t dim = Metavariables::system::volume_dim;
+  return {dg::Actions::ExponentialFilter<
+      0, tmpl::list<Tags::VectorVar<dim>, Tags::ScalarVar>>{
+      alpha, half_power, disable_for_debugging}};
+}
+
+template <size_t Dim, Spectral::Basis BasisType,
+          Spectral::Quadrature QuadratureType, bool FilterIndividually>
+void test_exponential_filter_action(const double alpha,
+                                    const unsigned half_power,
+                                    const bool disable_for_debugging) noexcept {
+  CAPTURE(BasisType);
+  CAPTURE(QuadratureType);
+  CAPTURE(disable_for_debugging);
+
+  using metavariables = Metavariables<Dim, FilterIndividually>;
+  using component = Component<metavariables>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
+  using MockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<component>;
+
+  for (size_t num_pts =
+           Spectral::minimum_number_of_points<BasisType, QuadratureType>;
+       num_pts < Spectral::maximum_number_of_points<BasisType>; ++num_pts) {
+    CAPTURE(num_pts);
+    const Mesh<Dim> mesh(num_pts, BasisType, QuadratureType);
+
+    typename MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+
+    Variables<tmpl::list<Tags::ScalarVar, Tags::VectorVar<Dim>>> initial_vars(
+        mesh.number_of_grid_points());
+    for (size_t i = 0; i < mesh.number_of_grid_points(); ++i) {
+      get(get<Tags::ScalarVar>(initial_vars))[i] = pow(i, num_pts) * 0.5;
+      for (size_t d = 0; d < Dim; ++d) {
+        get<Tags::VectorVar<Dim>>(initial_vars).get(d)[i] =
+            d + pow(i, num_pts) * 0.75;
+      }
+    }
+
+    tuples::get<MockDistributedObjectsTag>(dist_objects)
+        .emplace(0, ActionTesting::MockDistributedObject<component>{
+                        db::create<typename component::simple_tags>(
+                            mesh, initial_vars)});
+
+    MockRuntimeSystem runner(create_cache_tuple<metavariables>(
+                                 alpha, half_power, disable_for_debugging),
+                             std::move(dist_objects));
+
+    auto& box =
+        runner.template algorithms<component>()
+            .at(0)
+            .template get_databox<typename component::initial_databox>();
+
+    runner.template next_action<component>(0);
+    if (FilterIndividually) {
+      runner.template next_action<component>(0);
+    }
+
+    std::array<Matrix, Dim> filter_scalar{};
+    std::array<Matrix, Dim> filter_vector{};
+    for (size_t d = 0; d < Dim; d++) {
+      if (disable_for_debugging) {
+        gsl::at(filter_scalar, d) = Matrix{};
+        gsl::at(filter_vector, d) = Matrix{};
+      } else {
+        gsl::at(filter_scalar, d) = Spectral::filtering::exponential_filter(
+            mesh.slice_through(d), alpha, half_power);
+        if (FilterIndividually) {
+          gsl::at(filter_vector, d) = Spectral::filtering::exponential_filter(
+              mesh.slice_through(d), 2.0 * alpha, 2 * half_power);
+        } else {
+          gsl::at(filter_vector, d) = gsl::at(filter_scalar, d);
+        }
+      }
+    }
+
+    Scalar<DataVector> expected_scalar(mesh.number_of_grid_points(), 0.0);
+    tnsr::I<DataVector, Dim> expected_vector(mesh.number_of_grid_points(), 0.0);
+    apply_matrices(&get(expected_scalar), filter_scalar,
+                   get(get<Tags::ScalarVar>(initial_vars)), mesh.extents());
+    for (size_t d = 0; d < Dim; d++) {
+      apply_matrices(&expected_vector.get(d), filter_vector,
+                     get<Tags::VectorVar<Dim>>(initial_vars).get(d),
+                     mesh.extents());
+    }
+    CHECK_ITERABLE_APPROX(expected_scalar, db::get<Tags::ScalarVar>(box));
+    CHECK_ITERABLE_APPROX(expected_vector, db::get<Tags::VectorVar<Dim>>(box));
+  }
+}
+
+template <size_t Dim, bool FilterIndividually>
+void invoke_test_exponential_filter_action(
+    const double alpha, const unsigned half_power,
+    const bool disable_for_debugging) noexcept {
+  test_exponential_filter_action<1, Spectral::Basis::Legendre,
+                                 Spectral::Quadrature::GaussLobatto,
+                                 FilterIndividually>(alpha, half_power,
+                                                     disable_for_debugging);
+  test_exponential_filter_action<1, Spectral::Basis::Legendre,
+                                 Spectral::Quadrature::Gauss,
+                                 FilterIndividually>(alpha, half_power,
+                                                     disable_for_debugging);
+  test_exponential_filter_action<1, Spectral::Basis::Chebyshev,
+                                 Spectral::Quadrature::GaussLobatto,
+                                 FilterIndividually>(alpha, half_power,
+                                                     disable_for_debugging);
+  test_exponential_filter_action<1, Spectral::Basis::Chebyshev,
+                                 Spectral::Quadrature::Gauss,
+                                 FilterIndividually>(alpha, half_power,
+                                                     disable_for_debugging);
+}
+
+template <size_t Dim>
+void test_exponential_filter_creation() noexcept {
+  using Filter = dg::Actions::ExponentialFilter<
+      0, tmpl::list<Tags::ScalarVar, Tags::VectorVar<Dim>>>;
+
+  const Filter filter = test_creation<Filter>(
+      "  Alpha: 36\n"
+      "  HalfPower: 32\n");
+
+  CHECK(filter == Filter{36.0, 32, false});
+  CHECK_FALSE(filter == Filter{35.0, 32, false});
+  CHECK_FALSE(filter == Filter{36.0, 33, false});
+  CHECK_FALSE(filter == Filter{36.0, 32, true});
+
+  CHECK_FALSE(filter != Filter{36.0, 32, false});
+  CHECK(filter != Filter{35.0, 32, false});
+  CHECK(filter != Filter{36.0, 33, false});
+  CHECK(filter != Filter{36.0, 32, true});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.dG.ExponentialFilter", "[Unit][Evolution]") {
+  // Can't do a loop over different alpha and half_power values because matrices
+  // are cached in the action.
+  const double alpha = 10.0;
+  const unsigned half_power = 16;
+  invoke_test_exponential_filter_action<1, true>(alpha, half_power, false);
+  invoke_test_exponential_filter_action<2, true>(alpha, half_power, false);
+  invoke_test_exponential_filter_action<3, true>(alpha, half_power, false);
+  invoke_test_exponential_filter_action<1, false>(alpha, half_power, false);
+  invoke_test_exponential_filter_action<2, false>(alpha, half_power, false);
+  invoke_test_exponential_filter_action<3, false>(alpha, half_power, false);
+
+  invoke_test_exponential_filter_action<1, true>(alpha, half_power, true);
+  invoke_test_exponential_filter_action<2, true>(alpha, half_power, true);
+  invoke_test_exponential_filter_action<3, true>(alpha, half_power, true);
+  invoke_test_exponential_filter_action<1, false>(alpha, half_power, true);
+  invoke_test_exponential_filter_action<2, false>(alpha, half_power, true);
+  invoke_test_exponential_filter_action<3, false>(alpha, half_power, true);
+
+  test_exponential_filter_creation<1>();
+  test_exponential_filter_creation<2>();
+  test_exponential_filter_creation<3>();
+}

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_ChebyshevGauss.cpp
   Test_ChebyshevGaussLobatto.cpp
   Test_ComplexDataView.cpp
+  Test_Filtering.cpp
   Test_IndefiniteIntegral.cpp
   Test_LegendreGauss.cpp
   Test_LegendreGaussLobatto.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Filtering.cpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp"
+#include "NumericalAlgorithms/Spectral/Filtering.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Blas.hpp"
+
+namespace {
+
+template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
+void test_exponential_filter(const double alpha, const unsigned half_power,
+                             const double eps) noexcept {
+  Approx local_approx = Approx::custom().epsilon(eps).scale(1.0);
+  CAPTURE(BasisType);
+  CAPTURE(QuadratureType);
+  CAPTURE(eps);
+  for (size_t num_pts =
+           Spectral::minimum_number_of_points<BasisType, QuadratureType>;
+       num_pts < Spectral::maximum_number_of_points<BasisType>; ++num_pts) {
+    CAPTURE(num_pts);
+    const Mesh<1> mesh{num_pts, BasisType, QuadratureType};
+    ModalVector initial_modal_coeffs(num_pts);
+    for (size_t i = 0; i < num_pts; ++i) {
+      initial_modal_coeffs = i + 1.0;
+    }
+    const DataVector initial_nodal_coeffs =
+        to_nodal_coefficients(initial_modal_coeffs, mesh);
+    DataVector filtered_nodal_coeffs(num_pts);
+    const Matrix filter_matrix =
+        Spectral::filtering::exponential_filter(mesh, alpha, half_power);
+    dgemv_('N', num_pts, num_pts, 1., filter_matrix.data(), num_pts,
+           initial_nodal_coeffs.data(), 1, 0.0, filtered_nodal_coeffs.data(),
+           1);
+    const ModalVector filtered_modal_coeffs =
+        to_modal_coefficients(filtered_nodal_coeffs, mesh);
+    const double basis_order = num_pts - 1;
+    for (size_t i = 0; i < num_pts; ++i) {
+      CAPTURE(i);
+      if (num_pts == 1) {
+        // In the case of only 1 coefficient there should be no filtering.
+        CHECK(filtered_modal_coeffs[i] == initial_modal_coeffs[i]);
+      } else {
+        CHECK(filtered_modal_coeffs[i] ==
+              local_approx(initial_modal_coeffs[i] *
+                           exp(-alpha * pow(i / basis_order, 2 * half_power))));
+      }
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExponentialFilter",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  const std::vector<double> alphas{10.0, 20.0, 30.0, 40.0};
+  const std::vector<unsigned> half_powers{2, 4, 8, 16};
+  for (const double alpha : alphas) {
+    for (const unsigned half_power : half_powers) {
+      test_exponential_filter<Spectral::Basis::Legendre,
+                              Spectral::Quadrature::GaussLobatto>(
+          alpha, half_power, 2.0e-14);
+      test_exponential_filter<Spectral::Basis::Legendre,
+                              Spectral::Quadrature::Gauss>(alpha, half_power,
+                                                           1.0e-12);
+      test_exponential_filter<Spectral::Basis::Chebyshev,
+                              Spectral::Quadrature::GaussLobatto>(
+          alpha, half_power, 2.0e-14);
+      test_exponential_filter<Spectral::Basis::Chebyshev,
+                              Spectral::Quadrature::Gauss>(alpha, half_power,
+                                                           1.0e-12);
+    }
+  }
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

- Adds a function compute an exponential filter.
- Adds an action to apply the exponential filter to specific tags.

This was needed to get spherical Bondi accretion stable using a spherical shell domain. Here is a plot of the errors to show this stabilizes the scheme:

![plot](https://user-images.githubusercontent.com/13531030/56505732-65874700-64ea-11e9-989a-1738a3a0ec27.png)


Depends loosely on:
- [x] #1489 

The commits that are *NOT* to be reviewed as part of this PR are:
- Remove break statements that don't do anything
- Fix TensorExpressions linking errors with lld 8
- Rename grid_points_to_spectral_matrix and inverse functions

The order of commits that *are* part of this PR:
1. Add function to compute exponential filter matrix
2. Add exponential filter action

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
