### PR TITLE
Split `Normalized` into a simple tag + an inheriting compute tag

### DIFF
--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -38,8 +38,7 @@ Scalar<DataType> magnitude(
     const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector,
     const Tensor<DataType, Symmetry<1, 1>,
                  index_list<change_index_up_lo<Index>,
-                            change_index_up_lo<Index>>>&
-        metric) noexcept {
+                            change_index_up_lo<Index>>>& metric) noexcept {
   return Scalar<DataType>{sqrt(get(dot_product(vector, vector, metric)))};
 }
 
@@ -90,10 +89,22 @@ struct NonEuclideanMagnitude : Magnitude<Tag>, db::ComputeTag {
 ///
 /// \snippet Test_Magnitude.cpp normalized_name
 template <typename Tag>
-struct Normalized : db::ComputeTag {
+struct Normalized : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
     return "Normalized(" + Tag::name() + ")";
   }
+  using tag = Tag;
+  using type = db::item_type<Tag>;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup DataStructuresGroup
+/// Normalizes the (co)vector represented by Tag
+///
+/// This tag inherits from `Tags::Normalized<Tag>`
+template <typename Tag>
+struct NormalizedCompute : Normalized<Tag>, db::ComputeTag {
+  using base = Normalized<Tag>;
   static constexpr auto function(
       const db::item_type<Tag>&
           vector_in,  // Compute items need to take const references

--- a/src/Elliptic/Initialization/Interface.hpp
+++ b/src/Elliptic/Initialization/Interface.hpp
@@ -83,7 +83,7 @@ struct Interface {
                                      Tags::UnnormalizedFaceNormal<volume_dim>>>,
       Tags::InterfaceComputeItem<
           Directions,
-          Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>>;
+          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<volume_dim>>>>;
 
   using exterior_face_tags = tmpl::list<
       Tags::BoundaryDirectionsExterior<volume_dim>,
@@ -107,7 +107,7 @@ struct Interface {
                                      Tags::UnnormalizedFaceNormal<volume_dim>>>,
       Tags::InterfaceComputeItem<
           Tags::BoundaryDirectionsExterior<volume_dim>,
-          Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>>;
+          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<volume_dim>>>>;
 
   using simple_tags = db::AddSimpleTags<
       // We rely on the variable data on exterior faces being updated manually.

--- a/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
@@ -110,9 +110,8 @@ struct InitializeElement {
 
   // Items related to the basic structure of the domain
   struct DomainTags {
-    using simple_tags =
-        db::AddSimpleTags<Tags::Mesh<Dim>, Tags::Element<Dim>,
-                          Tags::ElementMap<Dim>>;
+    using simple_tags = db::AddSimpleTags<Tags::Mesh<Dim>, Tags::Element<Dim>,
+                                          Tags::ElementMap<Dim>>;
 
     using compute_tags = db::AddComputeTags<
         Tags::LogicalCoordinates<Dim>,
@@ -229,7 +228,8 @@ struct InitializeElement {
                                    typename System::template magnitude_tag<
                                        Tags::UnnormalizedFaceNormal<Dim>>>,
         Tags::InterfaceComputeItem<
-            Directions, Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
+            Directions,
+            Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>>;
 
     using ext_tags = tmpl::list<
         Tags::BoundaryDirectionsExterior<Dim>,
@@ -246,7 +246,7 @@ struct InitializeElement {
                                        Tags::UnnormalizedFaceNormal<Dim>>>,
         Tags::InterfaceComputeItem<
             Tags::BoundaryDirectionsExterior<Dim>,
-            Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
+            Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>>;
 
     using compute_tags =
         tmpl::append<face_tags<Tags::InternalDirections<Dim>>,
@@ -448,8 +448,8 @@ struct InitializeElement {
       }
 
       for (const auto& direction : element.external_boundaries()) {
-        const auto mortar_id = std::make_pair(
-            direction, ElementId<Dim>::external_boundary_id());
+        const auto mortar_id =
+            std::make_pair(direction, ElementId<Dim>::external_boundary_id());
         mortar_data[mortar_id];
         // Since no communication needs to happen for boundary conditions,
         // the temporal id is not advanced on the boundary, so we set it equal
@@ -477,8 +477,7 @@ struct InitializeElement {
                   LocalSystem::is_in_flux_conservative_form>
     struct Impl {
       using simple_tags = db::AddSimpleTags<
-          mortar_data_tag,
-          Tags::Mortars<Tags::Next<temporal_id_tag>, Dim>,
+          mortar_data_tag, Tags::Mortars<Tags::Next<temporal_id_tag>, Dim>,
           Tags::Mortars<Tags::Mesh<Dim - 1>, Dim>,
           Tags::Mortars<Tags::MortarSize<Dim - 1>, Dim>,
           interface_tag<typename flux_comm_types::normal_dot_fluxes_tag>,
@@ -573,8 +572,8 @@ struct InitializeElement {
               typename LocalSystem::variables_tag, Dim, Frame::Inertial>>,
           Tags::Slice<Tags::BoundaryDirectionsInterior<Dim>,
                       db::add_tag_prefix<Tags::Flux,
-                                           typename LocalSystem::variables_tag,
-                                           tmpl::size_t<Dim>, Frame::Inertial>>,
+                                         typename LocalSystem::variables_tag,
+                                         tmpl::size_t<Dim>, Frame::Inertial>>,
           boundary_interior_compute_tag<Tags::ComputeNormalDotFlux<
               typename LocalSystem::variables_tag, Dim, Frame::Inertial>>,
           Tags::Slice<Tags::BoundaryDirectionsExterior<Dim>,

--- a/src/Evolution/Initialization/Interface.hpp
+++ b/src/Evolution/Initialization/Interface.hpp
@@ -54,7 +54,8 @@ struct Interface {
                                  typename System::template magnitude_tag<
                                      Tags::UnnormalizedFaceNormal<dim>>>,
       Tags::InterfaceComputeItem<
-          Directions, Tags::Normalized<Tags::UnnormalizedFaceNormal<dim>>>>;
+          Directions,
+          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<dim>>>>;
 
   using ext_tags = tmpl::list<
       Tags::BoundaryDirectionsExterior<dim>,
@@ -75,7 +76,7 @@ struct Interface {
                                      Tags::UnnormalizedFaceNormal<dim>>>,
       Tags::InterfaceComputeItem<
           Tags::BoundaryDirectionsExterior<dim>,
-          Tags::Normalized<Tags::UnnormalizedFaceNormal<dim>>>>;
+          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<dim>>>>;
 
   using compute_tags =
       tmpl::append<face_tags<Tags::InternalDirections<dim>>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
@@ -264,15 +264,13 @@ void ComputeNormalDotFluxes<Dim>::apply(
     const tnsr::i<DataVector, Dim>& unit_normal) noexcept {
   const auto shift_dot_normal = get(dot_product(shift, unit_normal));
 
-  auto normal_dot_phi =
-      make_with_value<tnsr::aa<DataVector, Dim>>(gamma1, 0.);
+  auto normal_dot_phi = make_with_value<tnsr::aa<DataVector, Dim>>(gamma1, 0.);
   for (size_t mu = 0; mu < Dim + 1; ++mu) {
     for (size_t nu = mu; nu < Dim + 1; ++nu) {
       for (size_t i = 0; i < Dim; ++i) {
         for (size_t j = 0; j < Dim; ++j) {
           normal_dot_phi.get(mu, nu) += inverse_spatial_metric.get(i, j) *
-                                              unit_normal.get(j) *
-                                              phi.get(i, mu, nu);
+                                        unit_normal.get(j) * phi.get(i, mu, nu);
         }
       }
     }

--- a/tests/Unit/DataStructures/Tensor/EagerMath/Test_Magnitude.cpp
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/Test_Magnitude.cpp
@@ -155,8 +155,8 @@ void test_magnitude_tags() {
       db::create<db::AddSimpleTags<Vector, Covector<2>>,
                  db::AddComputeTags<Tags::EuclideanMagnitude<Vector>,
                                     Tags::EuclideanMagnitude<Covector<2>>,
-                                    Tags::Normalized<Vector>,
-                                    Tags::Normalized<Covector<2>>>>(
+                                    Tags::NormalizedCompute<Vector>,
+                                    Tags::NormalizedCompute<Covector<2>>>>(
           db::item_type<Vector>({{{1., 2.}, {2., 3.}, {2., 6.}}}),
           db::item_type<Covector<2>>({{{3., 5.}, {4., 12.}}}));
 
@@ -219,8 +219,9 @@ void test_general_magnitude_tags() {
                  db::AddComputeTags<
                      Tags::NonEuclideanMagnitude<Vector, Metric>,
                      Tags::NonEuclideanMagnitude<Covector<3>, InverseMetric>,
-                     Tags::Normalized<Vector>, Tags::Normalized<Covector<3>>>>(
-          vector, covector, metric, inv_metric);
+                     Tags::NormalizedCompute<Vector>,
+                     Tags::NormalizedCompute<Covector<3>>>>(vector, covector,
+                                                            metric, inv_metric);
 
   CHECK_ITERABLE_APPROX(get(db::get<Tags::Magnitude<Vector>>(box)),
                         (DataVector{npts, sqrt(778.0)}));

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
@@ -204,7 +204,8 @@ struct ElementArray {
       boundary_compute_tag<Tags::UnnormalizedFaceNormal<Dim>>,
       boundary_compute_tag<
           Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
-      boundary_compute_tag<Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>,
+      boundary_compute_tag<
+          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>,
       Tags::BoundaryDirectionsExterior<Dim>,
       exterior_boundary_compute_tag<Tags::Direction<Dim>>,
       exterior_boundary_compute_tag<Tags::InterfaceMesh<Dim>>,
@@ -213,7 +214,7 @@ struct ElementArray {
       exterior_boundary_compute_tag<
           Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
       exterior_boundary_compute_tag<
-          Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
+          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>>;
 
   using initial_databox =
       db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;

--- a/tests/Unit/Elliptic/Initialization/Test_BoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_BoundaryConditions.cpp
@@ -106,7 +106,7 @@ using arguments_compute_tags = db::AddComputeTags<
         Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
     Tags::InterfaceComputeItem<
         Tags::BoundaryDirectionsInterior<Dim>,
-        Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
+        Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>>;
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.BoundaryConditions",

--- a/tests/Unit/Evolution/Conservative/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Conservative/Test_Tags.cpp
@@ -121,14 +121,15 @@ void check() {
       Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim, Frame>>;
   const auto magnitude_normal = magnitude_normal_tag::function(normal);
   using normalized_normal_tag =
-      Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim, Frame>>;
+      Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim, Frame>>;
   const auto normalized_normal =
       normalized_normal_tag::function(normal, magnitude_normal);
   using compute_n_dot_f =
       Tags::ComputeNormalDotFlux<variables_tag<Dim, Frame>, Dim, Frame>;
   static_assert(
       cpp17::is_same_v<typename compute_n_dot_f::argument_tags,
-                       tmpl::list<flux_tag<Dim, Frame>, normalized_normal_tag>>,
+                       tmpl::list<flux_tag<Dim, Frame>,
+                                  typename normalized_normal_tag::base>>,
       "Wrong argument tags");
   const auto result = compute_n_dot_f::function(fluxes, normalized_normal);
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -120,7 +120,8 @@ struct component {
       interface_compute_tag<Tags::UnnormalizedFaceNormal<2>>,
       interface_compute_tag<
           Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<2>>>,
-      interface_compute_tag<Tags::Normalized<Tags::UnnormalizedFaceNormal<2>>>>;
+      interface_compute_tag<
+          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<2>>>>;
   using initial_databox =
       db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;
 };
@@ -198,8 +199,9 @@ SPECTRE_TEST_CASE("Unit.DG.Actions.ComputeNonconservativeBoundaryFluxes",
 
   auto box = run_action(element, vars, other_arg);
 
-  const auto& unit_face_normal = db::get<interface_tag<Tags::Normalized<
-      Tags::UnnormalizedFaceNormal<2>>>>(box);
+  const auto& unit_face_normal =
+      db::get<interface_tag<Tags::Normalized<Tags::UnnormalizedFaceNormal<2>>>>(
+          box);
   const auto& n_dot_f = db::get<n_dot_f_tag>(box);
 
   std::unordered_map<Direction<2>,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -46,7 +46,6 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
@@ -180,7 +179,7 @@ struct component {
       interface_compute_tag<
           Dim, Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
       interface_compute_tag<
-          Dim, Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
+          Dim, Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>>;
 
   using initial_databox =
       db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -174,7 +174,7 @@ struct lts_component {
       interface_compute_tag<
           Dim, Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
       interface_compute_tag<
-          Dim, Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
+          Dim, Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>>;
 
   using initial_databox =
       db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -234,7 +234,8 @@ struct component {
       boundary_compute_tag<Tags::UnnormalizedFaceNormal<Dim>>,
       boundary_compute_tag<
           Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
-      boundary_compute_tag<Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>,
+      boundary_compute_tag<
+          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>,
       Tags::BoundaryDirectionsExterior<Dim>,
       external_boundary_compute_tag<Tags::Direction<Dim>>,
       external_boundary_compute_tag<Tags::InterfaceMesh<Dim>>,
@@ -243,7 +244,7 @@ struct component {
       external_boundary_compute_tag<
           Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
       external_boundary_compute_tag<
-          Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
+          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>>;
 
   using initial_databox =
       db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;


### PR DESCRIPTION
## Proposed changes

Here we replace the compute tag `Normalized` with a compute tag `NormalizedCompute` that derives off a simple tag `Normalized`..



### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).