### PR TITLE
Update GH `System` with tags needed for evolution

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
@@ -3,17 +3,18 @@
 
 #pragma once
 
-#include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
-#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
-namespace brigand {
-template <class...>
-struct list;
-}  // namespace brigand
+class DataVector;
 
+namespace Tags {
 template <class>
 class Variables;
+}  // namespace Tags
 /// \endcond
 
 /*!
@@ -28,10 +29,22 @@ struct System {
   static constexpr size_t volume_dim = Dim;
   static constexpr bool is_euclidean = false;
 
-  using variables_tags = brigand::list<gr::Tags::SpacetimeMetric<Dim>,
-                                       Tags::Pi<Dim>, Tags::Phi<Dim>>;
-  using gradient_tags = variables_tags;
+  using variables_tag = ::Tags::Variables<tmpl::list<
+      gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>,
+      Tags::Pi<Dim, Frame::Inertial>, Tags::Phi<Dim, Frame::Inertial>>>;
+  using gradients_tags =
+      tmpl::list<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>,
+                 Tags::Pi<Dim, Frame::Inertial>,
+                 Tags::Phi<Dim, Frame::Inertial>>;
 
-  using Variables = ::Variables<variables_tags>;
+  using compute_time_derivative = ComputeDuDt<Dim>;
+  using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;
+  using char_speeds_tag = CharacteristicSpeedsCompute<Dim, Frame::Inertial>;
+  using compute_largest_characteristic_speed =
+      ComputeLargestCharacteristicSpeed<Dim, Frame::Inertial>;
+
+  template <typename Tag>
+  using magnitude_tag = ::Tags::NonEuclideanMagnitude<
+      Tag, gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>;
 };
 }  // namespace GeneralizedHarmonic


### PR DESCRIPTION
## Proposed changes

Add members to GeneralizedHarmonic's `System` struct that will be needed to evolve the system. These are used to specify evolution / gradient variables, computation of fluxes, gauge determination etc.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
