### PR TITLE
Make KerrSchild defaults agnostic to volume dim

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
@@ -219,13 +219,13 @@ class KerrSchild {
     using type = std::array<double, volume_dim>;
     static constexpr OptionString help = {
         "The [x,y,z] dimensionless spin of the black hole"};
-    static type default_value() noexcept { return {{0., 0., 0.}}; }
+    static type default_value() noexcept { return {{0.}}; }
   };
   struct Center {
     using type = std::array<double, volume_dim>;
     static constexpr OptionString help = {
         "The [x,y,z] center of the black hole"};
-    static type default_value() noexcept { return {{0., 0., 0.}}; }
+    static type default_value() noexcept { return {{0.}}; }
   };
   using options = tmpl::list<Mass, Spin, Center>;
   static constexpr OptionString help{"Black hole in Kerr-Schild coordinates"};
@@ -286,9 +286,8 @@ class KerrSchild {
   }
 
  private:
-  double mass_{1.0};
-  std::array<double, volume_dim> dimensionless_spin_{{0.0, 0.0, 0.0}},
-      center_{{0.0, 0.0, 0.0}};
+  double mass_{1.};
+  std::array<double, volume_dim> dimensionless_spin_{{0.}}, center_{{0.}};
 };
 
 SPECTRE_ALWAYS_INLINE bool operator==(const KerrSchild& lhs,


### PR DESCRIPTION
## Proposed changes

Make default-initialization of BH mass/spin agnostic to volume dimensions.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
