### PR TITLE
Add GeneralizedHarmonic executable

### DIFF
--- a/src/Evolution/Executables/CMakeLists.txt
+++ b/src/Evolution/Executables/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Burgers)
+add_subdirectory(GeneralizedHarmonic)
 add_subdirectory(GrMhd)
 add_subdirectory(NewtonianEuler)
 add_subdirectory(ScalarWave)

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBS_TO_LINK
+    CoordinateMaps
+    DiscontinuousGalerkin
+    Domain
+    DomainCreators
+    GeneralRelativity
+    GeneralRelativitySolutions
+    GeneralizedHarmonic
+    GeneralizedHarmonicGaugeSourceFunctions
+    IO
+    Informer
+    LinearOperators
+    MathFunctions
+    Time
+    Utilities
+    ${SPECTRE_LIBRARIES}
+  )
+
+add_spectre_parallel_executable(
+  EvolveGeneralizedHarmonic
+  EvolveGeneralizedHarmonic
+  Evolution/Executables/GeneralizedHarmonic
+  EvolutionMetavars
+  "${LIBS_TO_LINK}"
+)

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -1,0 +1,271 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "Evolution/Actions/ComputeTimeDerivative.hpp"
+#include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
+#include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Initialization/NonconservativeSystem.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Initialize.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "IO/Observer/Actions.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/RegisterObservers.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp"
+#include "ParallelAlgorithms/Events/ObserveErrorNorms.hpp"
+#include "ParallelAlgorithms/Events/ObserveFields.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/ChangeStepSize.hpp"
+#include "Time/Actions/RecordTimeStepperData.hpp"
+#include "Time/Actions/SelfStartActions.hpp"
+#include "Time/Actions/UpdateU.hpp"
+#include "Time/StepChoosers/Cfl.hpp"
+#include "Time/StepChoosers/Constant.hpp"
+#include "Time/StepChoosers/Increase.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/StepControllers/StepController.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Time/Triggers/TimeTriggers.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Frame {
+// IWYU pragma: no_forward_declare MathFunction
+struct Inertial;
+}  // namespace Frame
+namespace Parallel {
+template <typename Metavariables>
+class CProxy_ConstGlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+struct EvolutionMetavars {
+  static constexpr int volume_dim = 3;
+  using frame = Frame::Inertial;
+  using system = GeneralizedHarmonic::System<volume_dim>;
+  using temporal_id = Tags::TimeStepId;
+  static constexpr bool local_time_stepping = false;
+  using initial_data_tag = Tags::AnalyticSolution<
+      GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>>;
+  using boundary_condition_tag = initial_data_tag;
+  using normal_dot_numerical_flux =
+      Tags::NumericalFlux<GeneralizedHarmonic::UpwindFlux<volume_dim>>;
+  using events = tmpl::list<
+      dg::Events::Registrars::ObserveErrorNorms<
+          volume_dim, typename system::variables_tag::tags_list>,
+      dg::Events::Registrars::ObserveFields<
+          volume_dim,
+          tmpl::append<
+              typename system::variables_tag::tags_list,
+              tmpl::list<::Tags::PointwiseL2Norm<
+                             GeneralizedHarmonic::Tags::GaugeConstraint<
+                                 volume_dim, frame>>,
+                         ::Tags::PointwiseL2Norm<
+                             GeneralizedHarmonic::Tags::ThreeIndexConstraint<
+                                 volume_dim, frame>>,
+                         ::Tags::PointwiseL2Norm<
+                             GeneralizedHarmonic::Tags::FourIndexConstraint<
+                                 volume_dim, frame>>>>,
+          typename system::variables_tag::tags_list>>;
+  using triggers = Triggers::time_triggers;
+
+  // A tmpl::list of tags to be added to the ConstGlobalCache by the
+  // metavariables
+  using const_global_cache_tags = tmpl::list<
+      initial_data_tag, Tags::TimeStepper<TimeStepper>,
+      GeneralizedHarmonic::Tags::GaugeHRollOnStartTime,
+      GeneralizedHarmonic::Tags::GaugeHRollOnTimeWindow,
+      GeneralizedHarmonic::Tags::GaugeHSpatialWeightDecayWidth<frame>,
+      Tags::EventsAndTriggers<events, triggers>>;
+
+  using step_choosers =
+      tmpl::list<StepChoosers::Registrars::Cfl<volume_dim, frame>,
+                 StepChoosers::Registrars::Constant,
+                 StepChoosers::Registrars::Increase>;
+
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
+  using observed_reduction_data_tags =
+      observers::collect_reduction_data_tags<Event<events>::creatable_classes>;
+
+  using compute_rhs = tmpl::flatten<tmpl::list<
+      dg::Actions::ComputeNonconservativeBoundaryFluxes<
+          Tags::InternalDirections<volume_dim>>,
+      dg::Actions::SendDataForFluxes<EvolutionMetavars>,
+      Actions::ComputeTimeDerivative,
+      dg::Actions::ComputeNonconservativeBoundaryFluxes<
+          Tags::BoundaryDirectionsInterior<volume_dim>>,
+      dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
+      dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
+      dg::Actions::ApplyFluxes, Actions::RecordTimeStepperData>>;
+  using update_variables = tmpl::flatten<tmpl::list<Actions::UpdateU>>;
+
+  enum class Phase {
+    Initialization,
+    InitializeTimeStepperHistory,
+    RegisterWithObserver,
+    Evolve,
+    Exit
+  };
+
+  using initialization_actions = tmpl::list<
+      dg::Actions::InitializeDomain<volume_dim>,
+      Initialization::Actions::NonconservativeSystem,
+      GeneralizedHarmonic::Actions::InitializeGhAnd3Plus1Variables<volume_dim>,
+      dg::Actions::InitializeInterfaces<
+          system,
+          dg::Initialization::slice_tags_to_face<
+              typename system::variables_tag,
+              gr::Tags::SpatialMetric<volume_dim, frame, DataVector>,
+              gr::Tags::DetAndInverseSpatialMetricCompute<volume_dim, frame,
+                                                          DataVector>,
+              gr::Tags::Shift<volume_dim, frame, DataVector>,
+              gr::Tags::Lapse<DataVector>>,
+          dg::Initialization::slice_tags_to_exterior<
+              gr::Tags::SpatialMetric<volume_dim, frame, DataVector>,
+              gr::Tags::DetAndInverseSpatialMetricCompute<volume_dim, frame,
+                                                          DataVector>,
+              gr::Tags::Shift<volume_dim, frame, DataVector>,
+              gr::Tags::Lapse<DataVector>>,
+          dg::Initialization::face_compute_tags<
+              ::Tags::BoundaryCoordinates<volume_dim, frame>,
+              GeneralizedHarmonic::Tags::ConstraintGamma0Compute<volume_dim,
+                                                                 frame>,
+              GeneralizedHarmonic::Tags::ConstraintGamma1Compute<volume_dim,
+                                                                 frame>,
+              GeneralizedHarmonic::Tags::ConstraintGamma2Compute<volume_dim,
+                                                                 frame>,
+              GeneralizedHarmonic::CharacteristicFieldsCompute<volume_dim,
+                                                               frame>,
+              GeneralizedHarmonic::CharacteristicSpeedsCompute<volume_dim,
+                                                               frame>>,
+          dg::Initialization::exterior_compute_tags<
+              GeneralizedHarmonic::Tags::ConstraintGamma0Compute<volume_dim,
+                                                                 frame>,
+              GeneralizedHarmonic::Tags::ConstraintGamma1Compute<volume_dim,
+                                                                 frame>,
+              GeneralizedHarmonic::Tags::ConstraintGamma2Compute<volume_dim,
+                                                                 frame>,
+              GeneralizedHarmonic::CharacteristicFieldsCompute<volume_dim,
+                                                               frame>,
+              GeneralizedHarmonic::CharacteristicSpeedsCompute<volume_dim,
+                                                               frame>>>,
+      Initialization::Actions::Evolution<EvolutionMetavars>,
+      GeneralizedHarmonic::Actions::InitializeGauge<volume_dim>,
+      GeneralizedHarmonic::Actions::InitializeConstraints<volume_dim>,
+      dg::Actions::InitializeMortars<EvolutionMetavars, true>,
+      Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
+      Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+
+  using component_list = tmpl::list<
+      observers::Observer<EvolutionMetavars>,
+      observers::ObserverWriter<EvolutionMetavars>,
+      DgElementArray<
+          EvolutionMetavars,
+          tmpl::list<
+              Parallel::PhaseActions<Phase, Phase::Initialization,
+                                     initialization_actions>,
+              Parallel::PhaseActions<
+                  Phase, Phase::InitializeTimeStepperHistory,
+                  tmpl::flatten<tmpl::list<SelfStart::self_start_procedure<
+                      compute_rhs, update_variables>>>>,
+              Parallel::PhaseActions<
+                  Phase, Phase::RegisterWithObserver,
+                  tmpl::list<observers::Actions::RegisterWithObservers<
+                                 observers::RegisterObservers<
+                                     element_observation_type>>,
+                             Parallel::Actions::TerminatePhase>>,
+              Parallel::PhaseActions<
+                  Phase, Phase::Evolve,
+                  tmpl::flatten<
+                      tmpl::list<Actions::RunEventsAndTriggers, compute_rhs,
+                                 update_variables, Actions::AdvanceTime>>>>>>;
+
+  static constexpr OptionString help{
+      "Evolve a generalized harmonic analytic solution.\n\n"
+      "The analytic solution is: KerrSchild\n"
+      "The numerical flux is:    UpwindFlux\n"};
+
+  static Phase determine_next_phase(
+      const Phase& current_phase,
+      const Parallel::CProxy_ConstGlobalCache<
+          EvolutionMetavars>& /*cache_proxy*/) noexcept {
+    switch (current_phase) {
+      case Phase::Initialization:
+        return Phase::InitializeTimeStepperHistory;
+      case Phase::InitializeTimeStepperHistory:
+        return Phase::RegisterWithObserver;
+      case Phase::RegisterWithObserver:
+        return Phase::Evolve;
+      case Phase::Evolve:
+        return Phase::Exit;
+      case Phase::Exit:
+        ERROR(
+            "Should never call determine_next_phase with the current phase "
+            "being 'Exit'");
+      default:
+        ERROR(
+            "Unknown type of phase. Did you static_cast<Phase> an integral "
+            "value?");
+    }
+  }
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling,
+    &domain::creators::register_derived_with_charm,
+    &Parallel::register_derived_classes_with_charm<
+        Event<metavariables::events>>,
+    &Parallel::register_derived_classes_with_charm<
+        StepChooser<metavariables::step_choosers>>,
+    &Parallel::register_derived_classes_with_charm<StepController>,
+    &Parallel::register_derived_classes_with_charm<TimeStepper>,
+    &Parallel::register_derived_classes_with_charm<
+        Trigger<metavariables::triggers>>};
+
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicFwd.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicFwd.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+struct EvolutionMetavars;

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -321,11 +321,9 @@ spacetime_deriv_of_power_log_factor_metric_lapse(
 // contain the temporal and spatial roll-on functions.
 template <size_t SpatialDim, typename Frame>
 void damped_harmonic_h(
-    const gsl::not_null<
-        typename db::item_type<Tags::GaugeH<SpatialDim, Frame>>*>
+    const gsl::not_null<db::item_type<Tags::GaugeH<SpatialDim, Frame>>*>
         gauge_h,
-    const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
-        gauge_h_init,
+    const db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>& gauge_h_init,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, SpatialDim, Frame>& shift,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
@@ -338,8 +336,8 @@ void damped_harmonic_h(
     const double sigma_t_L2, const double t_start_S, const double sigma_t_S,
     const double sigma_r) noexcept {
   if (UNLIKELY(get_size(get<0>(*gauge_h)) != get_size(get(lapse)))) {
-    *gauge_h = typename db::item_type<Tags::GaugeH<SpatialDim, Frame>>(
-        get_size(get(lapse)));
+    *gauge_h =
+        db::item_type<Tags::GaugeH<SpatialDim, Frame>>(get_size(get(lapse)));
   }
   // Use a TempBuffer to reduce total number of allocations. This is especially
   // important in a multithreaded environment.
@@ -401,33 +399,6 @@ void damped_harmonic_h(
   }
 }
 
-template <size_t SpatialDim, typename Frame>
-typename db::item_type<Tags::GaugeH<SpatialDim, Frame>>
-DampedHarmonicHCompute<SpatialDim, Frame>::function(
-    const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
-        gauge_h_init,
-    const Scalar<DataVector>& lapse,
-    const tnsr::I<DataVector, SpatialDim, Frame>& shift,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
-    const double& time, const double& t_start, const double& sigma_t,
-    const tnsr::I<DataVector, SpatialDim, Frame>& coords,
-    const double& sigma_r) noexcept {
-  typename db::item_type<Tags::GaugeH<SpatialDim, Frame>> gauge_h{
-      get_size(get(lapse))};
-  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame>(
-      make_not_null(&gauge_h), gauge_h_init, lapse, shift,
-      sqrt_det_spatial_metric, spacetime_metric, time, coords, 1., 1.,
-      1.,                // amp_coef_{L1, L2, S}
-      4, 4, 4,           // exp_{L1, L2, S}
-      t_start, sigma_t,  // _h_init
-      t_start, sigma_t,  // _L1
-      t_start, sigma_t,  // _L2
-      t_start, sigma_t,  // _S
-      sigma_r);
-  return gauge_h;
-}
-
 // Spacetime derivatives of the damped harmonic gauge source function.
 //
 // The following functions and struct compute spacetime derivatives, i.e.
@@ -446,12 +417,11 @@ DampedHarmonicHCompute<SpatialDim, Frame>::function(
 template <size_t SpatialDim, typename Frame>
 void spacetime_deriv_damped_harmonic_h(
     const gsl::not_null<
-        typename db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>*>
+        db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>*>
         d4_gauge_h,
-    const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
-        gauge_h_init,
-    const typename db::item_type<
-        Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>& dgauge_h_init,
+    const db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>& gauge_h_init,
+    const db::item_type<Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>&
+        dgauge_h_init,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, SpatialDim, Frame>& shift,
     const tnsr::a<DataVector, SpatialDim, Frame>&
@@ -469,9 +439,8 @@ void spacetime_deriv_damped_harmonic_h(
     const double sigma_t_L2, const double t_start_S, const double sigma_t_S,
     const double sigma_r) noexcept {
   if (UNLIKELY(get_size(get<0, 0>(*d4_gauge_h)) != get_size(get(lapse)))) {
-    *d4_gauge_h =
-        typename db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>(
-            get(lapse));
+    *d4_gauge_h = db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>(
+        get(lapse));
   }
   // Use a TempBuffer to reduce total number of allocations. This is especially
   // important in a multithreaded environment.
@@ -751,41 +720,6 @@ void spacetime_deriv_damped_harmonic_h(
     }
   }
 }
-
-template <size_t SpatialDim, typename Frame>
-typename db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>
-SpacetimeDerivDampedHarmonicHCompute<SpatialDim, Frame>::function(
-    const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
-        gauge_h_init,
-    const typename db::item_type<
-        Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>& dgauge_h_init,
-    const Scalar<DataVector>& lapse,
-    const tnsr::I<DataVector, SpatialDim, Frame>& shift,
-    const tnsr::a<DataVector, SpatialDim, Frame>&
-        spacetime_unit_normal_one_form,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
-    const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
-    const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
-    const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const double& time,
-    const double& t_start, const double& sigma_t,
-    const tnsr::I<DataVector, SpatialDim, Frame>& coords,
-    const double& sigma_r) noexcept {
-  typename db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>
-      d4_gauge_h{get_size(get(lapse))};
-  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h(
-      make_not_null(&d4_gauge_h), gauge_h_init, dgauge_h_init, lapse, shift,
-      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
-      inverse_spatial_metric, spacetime_metric, pi, phi, time, coords,
-      1., 1., 1.,        // amp_coef_{L1, L2, S}
-      4, 4, 4,           // exp_{L1, L2, S}
-      t_start, sigma_t,  // _h_init
-      t_start, sigma_t,  // _L1
-      t_start, sigma_t,  // _L2
-      t_start, sigma_t,  // _S
-      sigma_r);
-  return d4_gauge_h;
-}
 }  // namespace GeneralizedHarmonic
 
 // Explicit Instantiations
@@ -877,6 +811,58 @@ SpacetimeDerivDampedHarmonicHCompute<SpatialDim, Frame>::function(
           const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,          \
           const double g_exponent, const int exponent) noexcept;
 
+#define INSTANTIATE_DV_FUNC(_, data)                                           \
+  template void GeneralizedHarmonic::damped_harmonic_h(                        \
+      const gsl::not_null<db::item_type<                                       \
+          GeneralizedHarmonic::Tags::GaugeH<DIM(data), FRAME(data)>>*>         \
+          gauge_h,                                                             \
+      const db::item_type<                                                     \
+          GeneralizedHarmonic::Tags::InitialGaugeH<DIM(data), FRAME(data)>>&   \
+          gauge_h_init,                                                        \
+      const Scalar<DataVector>& lapse,                                         \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,                \
+      const Scalar<DataVector>& sqrt_det_spatial_metric,                       \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& spacetime_metric,    \
+      const double time,                                                       \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& coords,               \
+      const double amp_coef_L1, const double amp_coef_L2,                      \
+      const double amp_coef_S, const int exp_L1, const int exp_L2,             \
+      const int exp_S, const double t_start_h_init,                            \
+      const double sigma_t_h_init, const double t_start_L1,                    \
+      const double sigma_t_L1, const double t_start_L2,                        \
+      const double sigma_t_L2, const double t_start_S, const double sigma_t_S, \
+      const double sigma_r) noexcept;                                          \
+  template void GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h(        \
+      const gsl::not_null<                                                     \
+          db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<       \
+              DIM(data), FRAME(data)>>*>                                       \
+          d4_gauge_h,                                                          \
+      const db::item_type<                                                     \
+          GeneralizedHarmonic::Tags::InitialGaugeH<DIM(data), FRAME(data)>>&   \
+          gauge_h_init,                                                        \
+      const db::item_type<                                                     \
+          GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<              \
+              DIM(data), FRAME(data)>>& dgauge_h_init,                         \
+      const Scalar<DataVector>& lapse,                                         \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,                \
+      const tnsr::a<DataVector, DIM(data), FRAME(data)>&                       \
+          spacetime_unit_normal_one_form,                                      \
+      const Scalar<DataVector>& sqrt_det_spatial_metric,                       \
+      const tnsr::II<DataVector, DIM(data), FRAME(data)>&                      \
+          inverse_spatial_metric,                                              \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& spacetime_metric,    \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& pi,                  \
+      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& phi,                \
+      const double time,                                                       \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& coords,               \
+      const double amp_coef_L1, const double amp_coef_L2,                      \
+      const double amp_coef_S, const int exp_L1, const int exp_L2,             \
+      const int exp_S, const double t_start_h_init,                            \
+      const double sigma_t_h_init, const double t_start_L1,                    \
+      const double sigma_t_L1, const double t_start_L2,                        \
+      const double sigma_t_L2, const double t_start_S, const double sigma_t_S, \
+      const double sigma_r) noexcept;
+
 #define INSTANTIATE_SCALAR_FUNC(_, data)                                    \
   template void                                                             \
   GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse( \
@@ -890,25 +876,19 @@ SpacetimeDerivDampedHarmonicHCompute<SpatialDim, Frame>::function(
       const Scalar<DTYPE_SCAL(data)>& sqrt_det_spatial_metric,              \
       const double exponent) noexcept;
 
-#define INSTANTIATE_COMPUTE_ITEM(_, data)                                    \
-  template struct GeneralizedHarmonic::DampedHarmonicHCompute<DIM(data),     \
-                                                              FRAME(data)>;  \
-  template struct GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute< \
-      DIM(data), FRAME(data)>;
-
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
                         (Frame::Inertial))
 
-GENERATE_INSTANTIATIONS(INSTANTIATE_SCALAR_FUNC, (double, DataVector))
-
-GENERATE_INSTANTIATIONS(INSTANTIATE_COMPUTE_ITEM, (1, 2, 3), (DataVector),
+GENERATE_INSTANTIATIONS(INSTANTIATE_DV_FUNC, (1, 2, 3), (DataVector),
                         (Frame::Inertial))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_SCALAR_FUNC, (double, DataVector))
 
 #undef DIM
 #undef DTYPE
 #undef FRAME
 #undef DTYPE_SCAL
 #undef INSTANTIATE
+#undef INSTANTIATE_DV_FUNC
 #undef INSTANTIATE_SCALAR_FUNC
-#undef INSTANTIATE_COMPUTE_ITEM
 /// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -15,6 +15,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "Time/Tags.hpp"
+#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -42,35 +43,6 @@ class not_null;
 // IWYU pragma: no_forward_declare gr::Tags::SqrtDetSpatialMetric
 
 namespace GeneralizedHarmonic {
-/*!
- * \brief Damped harmonic gauge source function.
- *
- * \details See damped_harmonic_h() for details.
- */
-template <size_t SpatialDim, typename Frame>
-struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
-                                db::ComputeTag {
-  using argument_tags = tmpl::list<
-      Tags::InitialGaugeH<SpatialDim, Frame>, ::gr::Tags::Lapse<DataVector>,
-      ::gr::Tags::Shift<SpatialDim, Frame, DataVector>,
-      ::gr::Tags::SqrtDetSpatialMetric<DataVector>,
-      ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>, ::Tags::Time,
-      OptionTags::GaugeHRollOnStartTime, OptionTags::GaugeHRollOnTimeWindow,
-      ::Tags::Coordinates<SpatialDim, Frame>,
-      OptionTags::GaugeHSpatialWeightDecayWidth<Frame>>;
-
-  static typename db::item_type<Tags::GaugeH<SpatialDim, Frame>> function(
-      const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
-          gauge_h_init,
-      const Scalar<DataVector>& lapse,
-      const tnsr::I<DataVector, SpatialDim, Frame>& shift,
-      const Scalar<DataVector>& sqrt_det_spatial_metric,
-      const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
-      const double& time, const double& t_start, const double& sigma_t,
-      const tnsr::I<DataVector, SpatialDim, Frame>& coords,
-      const double& sigma_r) noexcept;
-};
-
 /*!
  * \brief Damped harmonic gauge source function.
  *
@@ -126,10 +98,8 @@ struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
  */
 template <size_t SpatialDim, typename Frame>
 void damped_harmonic_h(
-    gsl::not_null<typename db::item_type<Tags::GaugeH<SpatialDim, Frame>>*>
-        gauge_h,
-    const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
-        gauge_h_init,
+    gsl::not_null<db::item_type<Tags::GaugeH<SpatialDim, Frame>>*> gauge_h,
+    const db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>& gauge_h_init,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, SpatialDim, Frame>& shift,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
@@ -147,46 +117,45 @@ void damped_harmonic_h(
     double sigma_r) noexcept;
 
 /*!
- * \brief Spacetime derivatives of the damped harmonic gauge source function.
+ * \brief Damped harmonic gauge source function.
  *
- * \details See spacetime_deriv_damped_harmonic_h() for details.
+ * \details See damped_harmonic_h() for details.
  */
 template <size_t SpatialDim, typename Frame>
-struct SpacetimeDerivDampedHarmonicHCompute
-    : Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>,
-      db::ComputeTag {
+struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
+                                db::ComputeTag {
   using argument_tags = tmpl::list<
-      Tags::InitialGaugeH<SpatialDim, Frame>,
-      Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>,
-      ::gr::Tags::Lapse<DataVector>,
+      Tags::InitialGaugeH<SpatialDim, Frame>, ::gr::Tags::Lapse<DataVector>,
       ::gr::Tags::Shift<SpatialDim, Frame, DataVector>,
-      ::gr::Tags::SpacetimeNormalOneForm<SpatialDim, Frame, DataVector>,
       ::gr::Tags::SqrtDetSpatialMetric<DataVector>,
-      ::gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
-      ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>,
-      Tags::Pi<SpatialDim, Frame>, Tags::Phi<SpatialDim, Frame>, ::Tags::Time,
-      OptionTags::GaugeHRollOnStartTime, OptionTags::GaugeHRollOnTimeWindow,
+      ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>, ::Tags::Time,
+      Tags::GaugeHRollOnStartTime, Tags::GaugeHRollOnTimeWindow,
       ::Tags::Coordinates<SpatialDim, Frame>,
-      OptionTags::GaugeHSpatialWeightDecayWidth<Frame>>;
+      Tags::GaugeHSpatialWeightDecayWidth<Frame>>;
 
-  static typename db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>
-  function(
-      const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
-          gauge_h_init,
-      const typename db::item_type<
-          Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>& dgauge_h_init,
+  static constexpr db::item_type<Tags::GaugeH<SpatialDim, Frame>> function(
+      const db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>& gauge_h_init,
       const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, SpatialDim, Frame>& shift,
-      const tnsr::a<DataVector, SpatialDim, Frame>&
-          spacetime_unit_normal_one_form,
       const Scalar<DataVector>& sqrt_det_spatial_metric,
-      const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
       const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
-      const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
-      const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const double& time,
-      const double& t_start, const double& sigma_t,
+      const double& time, const double& t_start, const double& sigma_t,
       const tnsr::I<DataVector, SpatialDim, Frame>& coords,
-      const double& sigma_r) noexcept;
+      const double& sigma_r) noexcept {
+    db::item_type<Tags::GaugeH<SpatialDim, Frame>> gauge_h{
+        get_size(get(lapse))};
+    GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame>(
+        make_not_null(&gauge_h), gauge_h_init, lapse, shift,
+        sqrt_det_spatial_metric, spacetime_metric, time, coords, 1., 1.,
+        1.,                // amp_coef_{L1, L2, S}
+        4, 4, 4,           // exp_{L1, L2, S}
+        t_start, sigma_t,  // _h_init
+        t_start, sigma_t,  // _L1
+        t_start, sigma_t,  // _L2
+        t_start, sigma_t,  // _S
+        sigma_r);
+    return gauge_h;
+  }
 };
 
 /*!
@@ -259,13 +228,11 @@ struct SpacetimeDerivDampedHarmonicHCompute
  */
 template <size_t SpatialDim, typename Frame>
 void spacetime_deriv_damped_harmonic_h(
-    gsl::not_null<
-        typename db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>*>
+    gsl::not_null<db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>*>
         d4_gauge_h,
-    const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
-        gauge_h_init,
-    const typename db::item_type<
-        Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>& dgauge_h_init,
+    const db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>& gauge_h_init,
+    const db::item_type<Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>&
+        dgauge_h_init,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, SpatialDim, Frame>& shift,
     const tnsr::a<DataVector, SpatialDim, Frame>&
@@ -286,4 +253,61 @@ void spacetime_deriv_damped_harmonic_h(
     double sigma_t_S,
     // weight function
     double sigma_r) noexcept;
+
+/*!
+ * \brief Spacetime derivatives of the damped harmonic gauge source function.
+ *
+ * \details See spacetime_deriv_damped_harmonic_h() for details.
+ */
+template <size_t SpatialDim, typename Frame>
+struct SpacetimeDerivDampedHarmonicHCompute
+    : Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<
+      Tags::InitialGaugeH<SpatialDim, Frame>,
+      Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>,
+      ::gr::Tags::Lapse<DataVector>,
+      ::gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+      ::gr::Tags::SpacetimeNormalOneForm<SpatialDim, Frame, DataVector>,
+      ::gr::Tags::SqrtDetSpatialMetric<DataVector>,
+      ::gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
+      ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>,
+      Tags::Pi<SpatialDim, Frame>, Tags::Phi<SpatialDim, Frame>, ::Tags::Time,
+      Tags::GaugeHRollOnStartTime, Tags::GaugeHRollOnTimeWindow,
+      ::Tags::Coordinates<SpatialDim, Frame>,
+      Tags::GaugeHSpatialWeightDecayWidth<Frame>>;
+
+  static constexpr db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>
+  function(
+      const db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>& gauge_h_init,
+      const db::item_type<Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>&
+          dgauge_h_init,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+      const tnsr::a<DataVector, SpatialDim, Frame>&
+          spacetime_unit_normal_one_form,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
+      const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+      const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const double& time,
+      const double& t_start, const double& sigma_t,
+      const tnsr::I<DataVector, SpatialDim, Frame>& coords,
+      const double& sigma_r) noexcept {
+    db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>> d4_gauge_h{
+        get_size(get(lapse))};
+    GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h(
+        make_not_null(&d4_gauge_h), gauge_h_init, dgauge_h_init, lapse, shift,
+        spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
+        inverse_spatial_metric, spacetime_metric, pi, phi, time, coords, 1., 1.,
+        1.,                // amp_coef_{L1, L2, S}
+        4, 4, 4,           // exp_{L1, L2, S}
+        t_start, sigma_t,  // _h_init
+        t_start, sigma_t,  // _L1
+        t_start, sigma_t,  // _L2
+        t_start, sigma_t,  // _S
+        sigma_r);
+    return d4_gauge_h;
+  }
+};
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -1,0 +1,215 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <utility>  // IWYU pragma: keep
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Norms.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace GeneralizedHarmonic {
+namespace Actions {
+template <size_t Dim>
+struct InitializeConstraints {
+  using frame = Frame::Inertial;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using compute_tags = db::AddComputeTags<
+        GeneralizedHarmonic::Tags::GaugeConstraintCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::FourIndexConstraintCompute<Dim, frame>,
+        // following tags added to observe constraints
+        ::Tags::PointwiseL2NormCompute<
+            GeneralizedHarmonic::Tags::GaugeConstraint<Dim, frame>>,
+        ::Tags::PointwiseL2NormCompute<
+            GeneralizedHarmonic::Tags::ThreeIndexConstraint<Dim, frame>>,
+        ::Tags::PointwiseL2NormCompute<
+            GeneralizedHarmonic::Tags::FourIndexConstraint<Dim, frame>>>;
+
+    return std::make_tuple(
+        Initialization::merge_into_databox<InitializeConstraints,
+                                           db::AddSimpleTags<>, compute_tags>(
+            std::move(box)));
+  }
+};
+
+template <size_t Dim>
+struct InitializeGhAnd3Plus1Variables {
+  using frame = Frame::Inertial;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using compute_tags = db::AddComputeTags<
+        gr::Tags::SpatialMetricCompute<Dim, frame, DataVector>,
+        gr::Tags::DetAndInverseSpatialMetricCompute<Dim, frame, DataVector>,
+        gr::Tags::ShiftCompute<Dim, frame, DataVector>,
+        gr::Tags::LapseCompute<Dim, frame, DataVector>,
+        gr::Tags::SqrtDetSpatialMetricCompute<Dim, frame, DataVector>,
+        gr::Tags::SpacetimeNormalOneFormCompute<Dim, frame, DataVector>,
+        gr::Tags::SpacetimeNormalVectorCompute<Dim, frame, DataVector>,
+        gr::Tags::InverseSpacetimeMetricCompute<Dim, frame, DataVector>,
+        GeneralizedHarmonic::Tags::DerivSpatialMetricCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::DerivLapseCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::DerivShiftCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::TimeDerivSpatialMetricCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::TimeDerivLapseCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::TimeDerivShiftCompute<Dim, frame>,
+        gr::Tags::DerivativesOfSpacetimeMetricCompute<Dim, frame>,
+        gr::Tags::DerivSpacetimeMetricCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<Dim, frame>,
+        gr::Tags::SpacetimeChristoffelFirstKindCompute<Dim, frame, DataVector>,
+        gr::Tags::SpacetimeChristoffelSecondKindCompute<Dim, frame, DataVector>,
+        gr::Tags::TraceSpacetimeChristoffelFirstKindCompute<Dim, frame,
+                                                            DataVector>,
+        gr::Tags::SpatialChristoffelFirstKindCompute<Dim, frame, DataVector>,
+        gr::Tags::SpatialChristoffelSecondKindCompute<Dim, frame, DataVector>,
+        gr::Tags::TraceSpatialChristoffelFirstKindCompute<Dim, frame,
+                                                          DataVector>,
+        GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::ConstraintGamma0Compute<Dim, frame>,
+        GeneralizedHarmonic::Tags::ConstraintGamma1Compute<Dim, frame>,
+        GeneralizedHarmonic::Tags::ConstraintGamma2Compute<Dim, frame>>;
+
+    return std::make_tuple(
+        Initialization::merge_into_databox<InitializeGhAnd3Plus1Variables,
+                                           db::AddSimpleTags<>, compute_tags>(
+            std::move(box)));
+  }
+};
+
+template <size_t Dim>
+struct InitializeGauge {
+  using frame = Frame::Inertial;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    // compute initial-gauge related quantities
+    const auto& mesh = db::get<::Tags::Mesh<Dim>>(box);
+    const size_t num_grid_points = mesh.number_of_grid_points();
+    const auto& lapse = get<gr::Tags::Lapse<DataVector>>(box);
+    const auto& dt_lapse = get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(box);
+    const auto& deriv_lapse = get<
+        ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>, frame>>(
+        box);
+    const auto& shift = get<gr::Tags::Shift<Dim, frame, DataVector>>(box);
+    const auto& dt_shift =
+        get<::Tags::dt<gr::Tags::Shift<Dim, frame, DataVector>>>(box);
+    const auto& deriv_shift =
+        get<::Tags::deriv<gr::Tags::Shift<Dim, frame, DataVector>,
+                          tmpl::size_t<Dim>, frame>>(box);
+    const auto& spatial_metric =
+        get<gr::Tags::SpatialMetric<Dim, frame, DataVector>>(box);
+    const auto& trace_extrinsic_curvature =
+        get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(box);
+    const auto& trace_christoffel_last_indices =
+        get<gr::Tags::TraceSpatialChristoffelFirstKind<Dim, frame, DataVector>>(
+            box);
+
+    // compute the initial gauge source function
+    auto initial_gauge_h = GeneralizedHarmonic::gauge_source<Dim, frame>(
+        lapse, dt_lapse, deriv_lapse, shift, dt_shift, deriv_shift,
+        spatial_metric, trace_extrinsic_curvature,
+        trace_christoffel_last_indices);
+    // set time derivatives of InitialGaugeH = 0
+    // NOTE: this will need to be generalized to handle numerical initial data
+    // and analytic initial data whose gauge is not initially stationary.
+    auto dt_initial_gauge_source =
+        make_with_value<tnsr::a<DataVector, Dim, frame>>(lapse, 0.);
+
+    // compute spatial derivatives of InitialGaugeH
+    // The `partial_derivatives` function does not support single Tensor input,
+    // and so we must store the tensor in a Variables first.
+    using InitialGaugeHVars = ::Variables<
+        tmpl::list<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>>>;
+    InitialGaugeHVars initial_gauge_h_vars{num_grid_points};
+
+    get<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>>(
+        initial_gauge_h_vars) = initial_gauge_h;
+    const auto& inverse_jacobian = db::get<
+        ::Tags::InverseJacobian<::Tags::ElementMap<Dim, frame>,
+                                ::Tags::Coordinates<Dim, Frame::Logical>>>(box);
+    auto d_initial_gauge_source =
+        get<::Tags::deriv<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>,
+                          tmpl::size_t<Dim>, frame>>(
+            partial_derivatives<typename InitialGaugeHVars::tags_list>(
+                initial_gauge_h_vars, mesh, inverse_jacobian));
+
+    // compute spacetime derivatives of InitialGaugeH
+    auto initial_d4_gauge_h =
+        GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<
+            Dim, frame>::function(std::move(dt_initial_gauge_source),
+                                  std::move(d_initial_gauge_source));
+    // Add gauge tags
+    using compute_tags = db::AddComputeTags<
+        GeneralizedHarmonic::DampedHarmonicHCompute<Dim, frame>,
+        GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<Dim, frame>>;
+
+    // Finally, insert gauge related quantities to the box
+    return std::make_tuple(
+        Initialization::merge_into_databox<
+            InitializeGauge,
+            db::AddSimpleTags<
+                GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>,
+                GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<Dim,
+                                                                       frame>>,
+            compute_tags>(std::move(box), std::move(initial_gauge_h),
+                          std::move(initial_d4_gauge_h)));
+  }
+};
+
+}  // namespace Actions
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
+#include "Evolution/Tags.hpp"
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 
@@ -53,6 +54,65 @@ struct ConstraintGamma1 : db::SimpleTag {
 struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() noexcept { return "ConstraintGamma2"; }
+};
+
+/*!
+ * \brief Gauge control parameter determining when to start rolling-on the
+ * evolution gauge.
+ *
+ * \details The evolution gauge is gradually transitioned to (or
+ * *rolled-on* to) at the beginning of an evolution. This parameter sets
+ * the coordinate time at which roll-on begins.
+ */
+struct GaugeHRollOnStartTime : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "GaugeHRollOnStartTime"; }
+  using option_tags = tmpl::list<OptionTags::GaugeHRollOnStart>;
+  static double create_from_options(
+      const double gauge_roll_on_start_time) noexcept {
+    return gauge_roll_on_start_time;
+  }
+};
+
+/*!
+ * \brief Gauge control parameter determining how long the transition to
+ * the evolution gauge should take at the start of an evolution.
+ *
+ * \details The evolution gauge is gradually transitioned to (or
+ * *rolled-on* to) at the beginning of an evolution. This parameter sets
+ * the width of the coordinate time window during which roll-on happens.
+ */
+struct GaugeHRollOnTimeWindow : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "GaugeHRollOnTimeWindow"; }
+  using option_tags = tmpl::list<OptionTags::GaugeHRollOnWindow>;
+  static double create_from_options(
+      const double gauge_roll_on_window) noexcept {
+    return gauge_roll_on_window;
+  }
+};
+
+/*!
+ * \brief Gauge control parameter to specify the spatial weighting function
+ * that enters damped harmonic gauge source function.
+ *
+ * \details The evolution gauge source function is multiplied by a spatial
+ * weight function which controls where and how much it sources the damped
+ * harmonic gauge equation. The weight function is:
+ * \f$ W(x^i) = \exp[-(r/\sigma_r)^2] \f$.
+ * This weight function can be written with an extra factor inside the exponent
+ * in literature, e.g. \cite Deppe2018uye. We will absorb it here in
+ * \f$\sigma_r\f$. The parameter this tag tags is \f$ \sigma_r \f$.
+ */
+template <typename Frame>
+struct GaugeHSpatialWeightDecayWidth : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "GaugeHSpatialWeightDecayWidth"; }
+  using option_tags = tmpl::list<OptionTags::GaugeHSpatialDecayWidth<Frame>>;
+  static double create_from_options(
+      const double gauge_spatial_decay_width) noexcept {
+    return gauge_spatial_decay_width;
+  }
 };
 
 /*!
@@ -214,6 +274,26 @@ struct ConstraintEnergy : db::SimpleTag {
 
 namespace OptionTags {
 /*!
+ * \ingroup OptionGroupsGroup
+ * Groups option tags related to the GeneralizedHarmonic evolution system.
+ */
+struct Group {
+  static std::string name() noexcept { return "GeneralizedHarmonic"; }
+  static constexpr OptionString help{"Options for the GH evolution system"};
+  using group = evolution::OptionTags::SystemGroup;
+};
+
+/*!
+ * \ingroup OptionGroupsGroup
+ * Gauge-related option tags for the GeneralizedHarmonic evolution system.
+ */
+struct GaugeGroup {
+  static std::string name() noexcept { return "Gauge"; }
+  static constexpr OptionString help{
+      "Gauge-specific options for the GH evolution system"};
+  using group = GeneralizedHarmonic::OptionTags::Group;
+};
+/*!
  * \ingroup OptionTagsGroup
  * \brief Gauge control parameter determining when to start rolling-on the
  * evolution gauge.
@@ -222,11 +302,12 @@ namespace OptionTags {
  * *rolled-on* to) at the beginning of an evolution. This parameter sets
  * the coordinate time at which roll-on begins.
  */
-struct GaugeHRollOnStartTime : db::SimpleTag {
+struct GaugeHRollOnStart {
   using type = double;
-  static std::string name() noexcept { return "GaugeHRollOnStartT"; }
+  static std::string name() noexcept { return "RollOnStartTime"; }
   static constexpr OptionString help{
       "Simulation time to start rolling-on evolution gauge"};
+  using group = GaugeGroup;
 };
 
 /*!
@@ -238,11 +319,12 @@ struct GaugeHRollOnStartTime : db::SimpleTag {
  * *rolled-on* to) at the beginning of an evolution. This parameter sets
  * the width of the coordinate time window during which roll-on happens.
  */
-struct GaugeHRollOnTimeWindow : db::SimpleTag {
+struct GaugeHRollOnWindow {
   using type = double;
-  static std::string name() noexcept { return "GaugeHRollOnTWindow"; }
+  static std::string name() noexcept { return "RollOnTimeWindow"; }
   static constexpr OptionString help{
       "Duration of gauge roll-on in simulation time"};
+  using group = GaugeGroup;
 };
 
 /*!
@@ -259,11 +341,12 @@ struct GaugeHRollOnTimeWindow : db::SimpleTag {
  * \f$\sigma_r\f$. The parameter this tag tags is \f$ \sigma_r \f$.
  */
 template <typename Frame>
-struct GaugeHSpatialWeightDecayWidth : db::SimpleTag {
+struct GaugeHSpatialDecayWidth {
   using type = double;
-  static std::string name() noexcept { return "GaugeHDecayWidth"; }
+  static std::string name() noexcept { return "SpatialDecayWidth"; }
   static constexpr OptionString help{
       "Spatial width of weighting factor in evolution gauge"};
+  using group = GaugeGroup;
 };
 }  // namespace OptionTags
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
@@ -19,6 +19,10 @@ struct Phi;
 struct ConstraintGamma0;
 struct ConstraintGamma1;
 struct ConstraintGamma2;
+struct GaugeHRollOnStartTime;
+struct GaugeHRollOnTimeWindow;
+template <typename Frame>
+struct GaugeHSpatialWeightDecayWidth;
 template <size_t Dim, typename Frame = Frame::Inertial>
 struct InitialGaugeH;
 template <size_t Dim, typename Frame = Frame::Inertial>
@@ -60,9 +64,11 @@ struct ConstraintEnergy;
 
 /// \brief Input option tags for the generalized harmonic evolution system
 namespace OptionTags {
-struct GaugeHRollOnStartTime;
-struct GaugeHRollOnTimeWindow;
+struct Group;
+struct GaugeGroup;
+struct GaugeHRollOnStart;
+struct GaugeHRollOnWindow;
 template <typename Frame>
-struct GaugeHSpatialWeightDecayWidth;
+struct GaugeHSpatialDecayWidth;
 }  // namespace OptionTags
 }  // namespace GeneralizedHarmonic

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -1,0 +1,54 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveGeneralizedHarmonic
+# Check: execute
+# Timeout: 5
+# ExpectedOutput:
+#   GhKerrSchildReductionData.h5
+#   GhKerrSchildVolumeData0.h5
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.01
+  TimeStepper: RungeKutta3
+
+DomainCreator:
+    Brick:
+      LowerBound: [4.0, -0.5, -0.5]
+      UpperBound: [5.0, 0.5, 0.5]
+      InitialRefinement: [1, 1, 1]
+      InitialGridPoints: [5, 5, 5]
+      IsPeriodicIn: [false, false, false]
+
+AnalyticSolution:
+  KerrSchild:
+    Mass: 1.0
+    Spin: [0.0, 0.0, 0.4]
+    Center: [0.0, 0.0, 0.0]
+
+EvolutionSystem:
+  GeneralizedHarmonic:
+    Gauge:
+      RollOnStartTime: 100000.0
+      RollOnTimeWindow: 100.0
+      SpatialDecayWidth: 50.0
+
+NumericalFlux:
+  UpwindFlux:
+
+EventsAndTriggers:
+  ? EveryNSlabs:
+      N: 2
+      Offset: 0
+  : - ObserveErrorNorms
+  ? EveryNSlabs:
+      N: 5
+      Offset: 0
+  : - ObserveFields
+  ? PastTime: 0.03
+  : - Completion
+
+Observers:
+  VolumeFileName: "GhKerrSchildVolumeData"
+  ReductionFileName: "GhKerrSchildReductionData"

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Tags.cpp
@@ -62,15 +62,14 @@ void test_simple_tags() {
   CHECK(
       db::tag_name<GeneralizedHarmonic::Tags::ConstraintEnergy<Dim, Frame>>() ==
       "ConstraintEnergy");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::GaugeHRollOnStartTime>() ==
+        "GaugeHRollOnStartTime");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::GaugeHRollOnTimeWindow>() ==
+        "GaugeHRollOnTimeWindow");
   CHECK(
-      db::tag_name<GeneralizedHarmonic::OptionTags::GaugeHRollOnStartTime>() ==
-      "GaugeHRollOnStartT");
-  CHECK(
-      db::tag_name<GeneralizedHarmonic::OptionTags::GaugeHRollOnTimeWindow>() ==
-      "GaugeHRollOnTWindow");
-  CHECK(db::tag_name<GeneralizedHarmonic::OptionTags::
-                         GaugeHSpatialWeightDecayWidth<Frame>>() ==
-        "GaugeHDecayWidth");
+      db::tag_name<
+          GeneralizedHarmonic::Tags::GaugeHSpatialWeightDecayWidth<Frame>>() ==
+      "GaugeHSpatialWeightDecayWidth");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.Tags",


### PR DESCRIPTION
## Proposed changes

This PR adds the executable for the `GeneralizedHarmonic` system, which evolves 3D `AnalyticSolution` initial data. It also adds an observer to write out constraints and errors in evolved tensors (against the analytic solution). 

**CURRENT:**

- All dependencies merged

_______________________________________________
**EDIT (08/12/2019):**

- Once #1633 is merged, I'll replace the observer coded up here with generic observers. The output with generic observers (using compute tags from #1633) should remain identical to what it is now with the temporary observer. Please consider (`Observe.hpp`) as only serving to help characterize the actual evolution at the moment and review rest of the PR.

_______________________________________________

**EDIT (06/24/2019):**

This PR has been rebased onto PDALs (#1535), and now uses them. It **still** depends on:
- #1322 (first commit of this PR)

**Please review more recent commits than this only.**

_______________________________________________

**EDIT (06/06/2019):**

After rebase with current develop, this PR now depends only on:
- #1322 (first commit of this PR)

**Please review more recent commits than this only.**

_______________________________________________

**EDIT (05/22/2019):**

After rebase with current develop, this PR now depends only on:
- #1444 (first commit of this PR)
- #1499 (second commit of this PR)
- #1322 (third commit of this PR)

**Please review more recent commits than these only.**

_______________________________________________

All code for this PR is in the **most recent commit**. It depends on other PRs, whose contents have been committed as **6** previous commits. They are, in chronological order:

- 1st commit contains code from #1468 , #1469 , #1470 , #1471 , #1473 , #1474 , #1475 , #1476 , #1477  and #1478
- 2nd commit contains code from #1444 
- 3rd commit contains code from #1499 
- 4th commit contains code from #1497 
- 5th commit contains code from #1322 
- 6th commit contains code from #1496 .

Therefore: **please review the most recent commit only**.


### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
