### PR TITLE
Fix Doxygen group names

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -40,7 +40,7 @@ class DataBox;
 
 // @{
 /*!
- * \ingroup TypeTraitsGroup DataBox
+ * \ingroup TypeTraitsGroup DataBoxGroup
  * \brief Determines if a type `T` is as db::DataBox
  *
  * \effects Inherits from std::true_type if `T` is a specialization of

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -112,7 +112,7 @@ TensorIndex<static_cast<size_t>(I + 1000)> ti_contracted();
 
 namespace tt {
 /*!
- * \ingroup TypeTraitsGroup TensorExpressions
+ * \ingroup TypeTraitsGroup TensorExpressionsGroup
  * \brief Check if a type `T` is a TensorIndex used in TensorExpressions
  */
 template <typename T>

--- a/src/DataStructures/Tensor/IndexType.hpp
+++ b/src/DataStructures/Tensor/IndexType.hpp
@@ -200,7 +200,7 @@ using SpacetimeIndex =
 
 namespace tt {
 // @{
-/// \ingroup TensorGroup TypeTraits
+/// \ingroup TensorGroup TypeTraitsGroup
 /// Inherits from std::true_type if T is a \ref SpacetimeIndex
 /// "TensorIndexType"
 /// \tparam T the type to check

--- a/src/Domain/CoordinateMaps/ProductMaps.hpp
+++ b/src/Domain/CoordinateMaps/ProductMaps.hpp
@@ -218,7 +218,7 @@ bool operator!=(const ProductOf2Maps<Map1, Map2>& lhs,
   return not(lhs == rhs);
 }
 
-/// \ingroup CoordinateMaps
+/// \ingroup CoordinateMapsGroup
 /// \brief Product of three one-dimensional CoordinateMaps.
 template <typename Map1, typename Map2, typename Map3>
 class ProductOf3Maps {

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -61,8 +61,8 @@ tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
 // @}
 
 namespace Tags {
-/// \ingroup DataBoxTags
-/// \ingroup ComputationalDomain
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
 /// The unnormalized face normal one form
 template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
 struct UnnormalizedFaceNormal : db::ComputeTag {

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -18,7 +18,7 @@
 #include "Options/Options.hpp"
 
 namespace Tags {
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// \ingroup DiscontinuousGalerkinGroup
 /// \brief Simple boundary communication data
 template <typename TemporalId, typename LocalData, typename RemoteData>

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -52,7 +52,7 @@ struct Time : db::ComputeTag {
   using argument_tags = tmpl::list<TimeId>;
 };
 
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
 /// \brief Prefix for TimeStepper history
 ///

--- a/src/Utilities/TmplDebugging.hpp
+++ b/src/Utilities/TmplDebugging.hpp
@@ -9,7 +9,7 @@
 #include "Utilities/TMPL.hpp"
 
 /*!
- * \ingroup UtilitiesGroup TypeTraits
+ * \ingroup UtilitiesGroup TypeTraitsGroup
  * \brief Get compiler error with type of template parameter
  *
  * The compiler error generated when using an object of type

--- a/src/Utilities/TypeTraits.hpp
+++ b/src/Utilities/TypeTraits.hpp
@@ -368,14 +368,14 @@ constexpr bool is_fundamental_v = std::is_fundamental<T>::value;
 /// \ingroup TypeTraitsGroup
 /// C++ STL code present in C++20
 namespace cpp20 {
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 struct remove_cvref {
   // clang-tidy use using instead of typedef
   typedef std::remove_cv_t<std::remove_reference_t<T>> type;  // NOLINT
 };
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 using remove_cvref_t = typename remove_cvref<T>::type;
 }  // namespace cpp20


### PR DESCRIPTION
Append missing "Group" suffixes

I didn't change instances of `\ingroup GeneralizedHarmonic` because it seems this group doesn't actually exist...

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
