### PR TITLE
Add assertions against Elements having too many neighbors

### DIFF
--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -189,15 +189,15 @@ class Variables<tmpl::list<Tags...>> {
                 db::remove_all_prefixes<Tags>>::value...>::value> = nullptr>
   explicit Variables(Variables<tmpl::list<WrappedTags...>>&& rhs) noexcept;
   template <typename... WrappedTags,
-            Requires<tmpl2::flat_all_v<std::is_same<
+            Requires<tmpl2::flat_all<std::is_same<
                 db::remove_all_prefixes<WrappedTags>,
-                db::remove_all_prefixes<Tags>>::value...>> = nullptr>
+                db::remove_all_prefixes<Tags>>::value...>::value> = nullptr>
   Variables& operator=(Variables<tmpl::list<WrappedTags...>>&& rhs) noexcept;
 
   template <typename... WrappedTags,
-            Requires<tmpl2::flat_all_v<std::is_same<
+            Requires<tmpl2::flat_all<std::is_same<
                 db::remove_all_prefixes<WrappedTags>,
-                db::remove_all_prefixes<Tags>>::value...>> = nullptr>
+                db::remove_all_prefixes<Tags>>::value...>::value> = nullptr>
   explicit Variables(const Variables<tmpl::list<WrappedTags...>>& rhs) noexcept;
   template <typename... WrappedTags,
             Requires<tmpl2::flat_all_v<std::is_same<
@@ -564,9 +564,9 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
 
 template <typename... Tags>
 template <typename... WrappedTags,
-          Requires<tmpl2::flat_all_v<
+          Requires<tmpl2::flat_all<
               std::is_same<db::remove_all_prefixes<WrappedTags>,
-                           db::remove_all_prefixes<Tags>>::value...>>>
+                           db::remove_all_prefixes<Tags>>::value...>::value>>
 Variables<tmpl::list<Tags...>>::Variables(
     const Variables<tmpl::list<WrappedTags...>>& rhs) noexcept
     : size_(rhs.size_), number_of_grid_points_(rhs.number_of_grid_points()) {
@@ -621,9 +621,9 @@ Variables<tmpl::list<Tags...>>::Variables(
 
 template <typename... Tags>
 template <typename... WrappedTags,
-          Requires<tmpl2::flat_all_v<
+          Requires<tmpl2::flat_all<
               std::is_same<db::remove_all_prefixes<WrappedTags>,
-                           db::remove_all_prefixes<Tags>>::value...>>>
+                           db::remove_all_prefixes<Tags>>::value...>::value>>
 Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
     Variables<tmpl::list<WrappedTags...>>&& rhs) noexcept {
   variable_data_impl_ = std::move(rhs.variable_data_impl_);

--- a/src/Domain/Element.cpp
+++ b/src/Domain/Element.cpp
@@ -6,6 +6,8 @@
 #include <ostream>
 #include <pup.h>  // IWYU pragma: keep
 
+#include "Domain/MaxNumberOfNeighbors.hpp"
+#include "ErrorHandling/Assert.hpp"
 #include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
@@ -30,7 +32,12 @@ Element<VolumeDim>::Element(ElementId<VolumeDim> id,
           external_boundaries.erase(neighbor_direction.first);
         }
         return external_boundaries;
-      }()) {}
+      }()) {
+  // Assuming a maximum 2-to-1 refinement between neighboring elements:
+  ASSERT(number_of_neighbors_ <= maximum_number_of_neighbors(VolumeDim),
+         "Can't have " << number_of_neighbors_ << " neighbors in " << VolumeDim
+                       << " dimensions");
+}
 
 template <size_t VolumeDim>
 void Element<VolumeDim>::pup(PUP::er& p) noexcept {

--- a/src/Domain/MaxNumberOfNeighbors.hpp
+++ b/src/Domain/MaxNumberOfNeighbors.hpp
@@ -23,3 +23,17 @@ constexpr size_t maximum_number_of_neighbors(const size_t dim) {
       throw "Invalid dim specified";
   };
 }
+
+/// \ingroup ComputationalDomainGroup
+/// Returns the maximum number of neighbors in each direction an element can
+/// have in `dim` dimensions.
+///
+/// \note Assumes a maximum 2-to-1 refinement between two adjacent Elements.
+constexpr size_t maximum_number_of_neighbors_per_direction(const size_t dim) {
+  switch (dim) {
+    case 0:
+      return 0;
+    default:
+      return two_to_the(dim - 1);
+  };
+}

--- a/src/Domain/Neighbors.cpp
+++ b/src/Domain/Neighbors.cpp
@@ -6,7 +6,9 @@
 #include <ostream>
 #include <pup.h>  // IWYU pragma: keep
 
-#include "Domain/ElementId.hpp"      // IWYU pragma: keep
+#include "Domain/ElementId.hpp"  // IWYU pragma: keep
+#include "Domain/MaxNumberOfNeighbors.hpp"
+#include "ErrorHandling/Assert.hpp"
 #include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
@@ -14,7 +16,12 @@
 template <size_t VolumeDim>
 Neighbors<VolumeDim>::Neighbors(std::unordered_set<ElementId<VolumeDim>> ids,
                                 OrientationMap<VolumeDim> orientation) noexcept
-    : ids_(std::move(ids)), orientation_(std::move(orientation)) {}
+    : ids_(std::move(ids)), orientation_(std::move(orientation)) {
+  // Assuming a maximum 2-to-1 refinement between neighboring elements:
+  ASSERT(ids_.size() <= maximum_number_of_neighbors_per_direction(VolumeDim),
+         "Can't have " << ids_.size() << " neighbors in " << VolumeDim
+                       << " dimensions");
+}
 
 template <size_t VolumeDim>
 void Neighbors<VolumeDim>::add_ids(
@@ -22,6 +29,10 @@ void Neighbors<VolumeDim>::add_ids(
   for (const auto& id : additional_ids) {
     ids_.insert(id);
   }
+  // Assuming a maximum 2-to-1 refinement between neighboring elements:
+  ASSERT(ids_.size() <= maximum_number_of_neighbors_per_direction(VolumeDim),
+         "Can't have " << ids_.size() << " neighbors in " << VolumeDim
+                       << " dimensions");
 }
 
 template <size_t VolumeDim>

--- a/tests/Unit/Domain/Test_Element.cpp
+++ b/tests/Unit/Domain/Test_Element.cpp
@@ -4,6 +4,7 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <cstddef>
+#include <functional>
 #include <unordered_set>
 
 #include "Domain/Direction.hpp"
@@ -11,6 +12,7 @@
 #include "Domain/ElementId.hpp"
 #include "Domain/Neighbors.hpp"
 #include "Domain/OrientationMap.hpp"
+#include "Domain/Side.hpp"
 #include "Domain/Tags.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
@@ -18,37 +20,33 @@
 
 namespace {
 template <size_t VolumeDim>
-void check_element() {
+void check_element_work(const typename Element<VolumeDim>::Neighbors_t&
+                            neighbors_in_largest_dimension,
+                        const size_t expected_number_of_neighbors) {
   const ElementId<VolumeDim> id{5};
-
-  const Neighbors<VolumeDim> neighbors(
-      std::unordered_set<ElementId<VolumeDim>>{ElementId<VolumeDim>(7),
-                                               ElementId<VolumeDim>(4)},
-      OrientationMap<VolumeDim>{});
-  const typename Element<VolumeDim>::Neighbors_t two_neighbors{
-    {Direction<VolumeDim>::lower_xi(), neighbors},
-    {Direction<VolumeDim>::upper_xi(), neighbors}};
-
-  const Element<VolumeDim> element(id, two_neighbors);
+  const Element<VolumeDim> element(id, neighbors_in_largest_dimension);
 
   CHECK(element.id() == id);
-  CHECK(element.neighbors() == two_neighbors);
-  CHECK(element.number_of_neighbors() == 4);
+  CHECK(element.neighbors() == neighbors_in_largest_dimension);
+  CHECK(element.number_of_neighbors() == expected_number_of_neighbors);
   for (const auto& direction : Direction<VolumeDim>::all_directions()) {
-    // Either a xi direction or an external boundary, but not both.
-    CHECK((direction.axis() == Direction<VolumeDim>::Axis::Xi) !=
+    // The highest spatial dimension has neighbors; else, external boundary.
+    CHECK((direction.dimension() == VolumeDim - 1) !=
           (element.external_boundaries().count(direction) == 1));
   }
-
   CHECK(element == element);
   CHECK_FALSE(element != element);
+
   const Element<VolumeDim> element_diff_id(ElementId<VolumeDim>(3),
-                                           two_neighbors);
+                                           neighbors_in_largest_dimension);
   CHECK(element != element_diff_id);
   CHECK_FALSE(element == element_diff_id);
+
   const Element<VolumeDim> element_diff_neighbors(
       id, typename Element<VolumeDim>::Neighbors_t{
-        {Direction<VolumeDim>::lower_xi(), neighbors}});
+              {Direction<VolumeDim>::lower_xi(),
+               neighbors_in_largest_dimension.at(
+                   Direction<VolumeDim>(VolumeDim - 1, Side::Upper))}});
   CHECK(element != element_diff_neighbors);
   CHECK_FALSE(element == element_diff_neighbors);
 
@@ -62,10 +60,50 @@ void check_element() {
 
   CHECK(Tags::Element<VolumeDim>::name() == "Element");
 }
+
+void check_element_1d() {
+  const Neighbors<1> neighbors_lower_xi(
+      std::unordered_set<ElementId<1>>{ElementId<1>(7)}, OrientationMap<1>{});
+  const Neighbors<1> neighbors_upper_xi(
+      std::unordered_set<ElementId<1>>{ElementId<1>(7)}, OrientationMap<1>{});
+  const typename Element<1>::Neighbors_t xi_neighbors{
+      {Direction<1>::lower_xi(), neighbors_lower_xi},
+      {Direction<1>::upper_xi(), neighbors_upper_xi}};
+  check_element_work<1>(xi_neighbors, 2);
+}
+
+void check_element_2d() {
+  const Neighbors<2> neighbors_lower_eta(
+      std::unordered_set<ElementId<2>>{ElementId<2>(7), ElementId<2>(4)},
+      OrientationMap<2>{});
+  const Neighbors<2> neighbors_upper_eta(
+      std::unordered_set<ElementId<2>>{ElementId<2>(7), ElementId<2>(4)},
+      OrientationMap<2>{});
+  const typename Element<2>::Neighbors_t eta_neighbors{
+      {Direction<2>::lower_eta(), neighbors_lower_eta},
+      {Direction<2>::upper_eta(), neighbors_upper_eta}};
+  check_element_work<2>(eta_neighbors, 4);
+}
+
+void check_element_3d() {
+  const Neighbors<3> neighbors_lower_zeta(
+      std::unordered_set<ElementId<3>>{ElementId<3>(7), ElementId<3>(4),
+                                       ElementId<3>(9), ElementId<3>(2)},
+      OrientationMap<3>{});
+  const Neighbors<3> neighbors_upper_zeta(
+      std::unordered_set<ElementId<3>>{ElementId<3>(7), ElementId<3>(4),
+                                       ElementId<3>(9), ElementId<3>(2)},
+      OrientationMap<3>{});
+  const typename Element<3>::Neighbors_t zeta_neighbors{
+      {Direction<3>::lower_zeta(), neighbors_lower_zeta},
+      {Direction<3>::upper_zeta(), neighbors_upper_zeta}};
+  check_element_work<3>(zeta_neighbors, 8);
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Element", "[Domain][Unit]") {
-  check_element<1>();
-  check_element<2>();
-  check_element<3>();
+  check_element_1d();
+  check_element_2d();
+  check_element_3d();
 }

--- a/tests/Unit/Domain/Test_Neighbors.cpp
+++ b/tests/Unit/Domain/Test_Neighbors.cpp
@@ -25,41 +25,25 @@ SPECTRE_TEST_CASE("Unit.Domain.Neighbors.1d", "[Domain][Unit]") {
   // Test constructor:
   OrientationMap<1> custom_orientation(
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}});
-
-  const std::unordered_set<ElementId<1>> custom_ids = []() {
-    std::unordered_set<ElementId<1>> temp;
-    std::array<SegmentId, 1> segment1_ids{{SegmentId(2, 3)}};
-    ElementId<1> element1_id(2, segment1_ids);
-    temp.insert(element1_id);
-    std::array<SegmentId, 1> segment2_ids{{SegmentId(2, 2)}};
-    ElementId<1> element2_id(3, segment2_ids);
-    temp.insert(element2_id);
-    std::array<SegmentId, 1> segment3_ids{{SegmentId(2, 1)}};
-    ElementId<1> element3_id(1, segment3_ids);
-    temp.insert(element3_id);
-    return temp;
-  }();
-
-  Neighbors<1> custom_neighbors(custom_ids, custom_orientation);
+  const std::unordered_set<ElementId<1>> custom_id{
+      ElementId<1>(2, {{SegmentId(2, 3)}})};
+  Neighbors<1> custom_neighbors(custom_id, custom_orientation);
 
   // Test size
-  CHECK(custom_neighbors.size() == 3);
+  CHECK(custom_neighbors.size() == 1);
 
-  const std::unordered_set<ElementId<1>> more_custom_ids = []() {
-    std::unordered_set<ElementId<1>> temp;
-    std::array<SegmentId, 1> segment4_ids{{SegmentId(2, 3)}};
-    ElementId<1> element4_id(0, segment4_ids);
-    temp.insert(element4_id);
-    return temp;
-  }();
-
-  // Test add_ids:
-  custom_neighbors.add_ids(more_custom_ids);
-  CHECK(custom_neighbors.size() == 4);
+  // In 1D, cannot have more than 1 neighbor.
+  // Test add_ids using an empty default-constructed Neighbors object:
+  Neighbors<1> empty_neighbors;
+  CHECK(empty_neighbors.size() == 0);
+  empty_neighbors.add_ids(custom_id);
+  CHECK(empty_neighbors.size() == 1);
 
   // Test set_ids_to:
-  custom_neighbors.set_ids_to(custom_ids);
-  CHECK(custom_neighbors.size() == 3);
+  const std::unordered_set<ElementId<1>> other_custom_id{
+      ElementId<1>(0, {{SegmentId(2, 1)}})};
+  custom_neighbors.set_ids_to(other_custom_id);
+  CHECK(custom_neighbors.size() == 1);
 
   // Test serialization:
   test_serialization(custom_neighbors);
@@ -81,41 +65,22 @@ SPECTRE_TEST_CASE("Unit.Domain.Neighbors.2d", "[Domain][Unit]") {
   // Test constructor:
   OrientationMap<2> custom_orientation(std::array<Direction<2>, 2>{
       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}});
-
-  const std::unordered_set<ElementId<2>> custom_ids = []() {
-    std::unordered_set<ElementId<2>> temp;
-    std::array<SegmentId, 2> segment1_ids{{SegmentId(2, 3), SegmentId(1, 0)}};
-    ElementId<2> element1_id(2, segment1_ids);
-    temp.insert(element1_id);
-    std::array<SegmentId, 2> segment2_ids{{SegmentId(2, 2), SegmentId(1, 1)}};
-    ElementId<2> element2_id(3, segment2_ids);
-    temp.insert(element2_id);
-    std::array<SegmentId, 2> segment3_ids{{SegmentId(2, 1), SegmentId(1, 0)}};
-    ElementId<2> element3_id(1, segment3_ids);
-    temp.insert(element3_id);
-    return temp;
-  }();
-
-  Neighbors<2> custom_neighbors(custom_ids, custom_orientation);
+  const std::unordered_set<ElementId<2>> custom_id{
+      ElementId<2>(2, {{SegmentId(2, 3), SegmentId(1, 0)}})};
+  Neighbors<2> custom_neighbors(custom_id, custom_orientation);
 
   // Test size
-  CHECK(custom_neighbors.size() == 3);
-
-  const std::unordered_set<ElementId<2>> more_custom_ids = []() {
-    std::unordered_set<ElementId<2>> temp;
-    std::array<SegmentId, 2> segment4_ids{{SegmentId(2, 3), SegmentId(1, 0)}};
-    ElementId<2> element4_id(0, segment4_ids);
-    temp.insert(element4_id);
-    return temp;
-  }();
+  CHECK(custom_neighbors.size() == 1);
 
   // Test add_ids:
-  custom_neighbors.add_ids(more_custom_ids);
-  CHECK(custom_neighbors.size() == 4);
+  const std::unordered_set<ElementId<2>> other_custom_id{
+      ElementId<2>(0, {{SegmentId(2, 3), SegmentId(1, 0)}})};
+  custom_neighbors.add_ids(other_custom_id);
+  CHECK(custom_neighbors.size() == 2);
 
   // Test set_ids_to:
-  custom_neighbors.set_ids_to(custom_ids);
-  CHECK(custom_neighbors.size() == 3);
+  custom_neighbors.set_ids_to(custom_id);
+  CHECK(custom_neighbors.size() == 1);
 
   // Test serialization:
   test_serialization(custom_neighbors);
@@ -143,24 +108,10 @@ SPECTRE_TEST_CASE("Unit.Domain.Neighbors.3d", "[Domain][Unit]") {
   OrientationMap<3> custom_orientation(std::array<Direction<3>, 3>{
       {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
        Direction<3>::upper_xi()}});
-
-  const std::unordered_set<ElementId<3>> custom_ids = []() {
-    std::unordered_set<ElementId<3>> temp;
-    std::array<SegmentId, 3> segment1_ids{
-        {SegmentId(2, 3), SegmentId(1, 0), SegmentId(1, 1)}};
-    ElementId<3> element1_id(2, segment1_ids);
-    temp.insert(element1_id);
-    std::array<SegmentId, 3> segment2_ids{
-        {SegmentId(2, 2), SegmentId(1, 1), SegmentId(1, 0)}};
-    ElementId<3> element2_id(3, segment2_ids);
-    temp.insert(element2_id);
-    std::array<SegmentId, 3> segment3_ids{
-        {SegmentId(2, 1), SegmentId(1, 0), SegmentId(1, 1)}};
-    ElementId<3> element3_id(1, segment3_ids);
-    temp.insert(element3_id);
-    return temp;
-  }();
-
+  const std::unordered_set<ElementId<3>> custom_ids{
+      ElementId<3>(2, {{SegmentId(2, 3), SegmentId(1, 0), SegmentId(1, 1)}}),
+      ElementId<3>(3, {{SegmentId(2, 2), SegmentId(1, 1), SegmentId(1, 0)}}),
+      ElementId<3>(1, {{SegmentId(2, 1), SegmentId(1, 0), SegmentId(1, 1)}})};
   Neighbors<3> custom_neighbors(custom_ids, custom_orientation);
 
   // Test size
@@ -173,17 +124,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Neighbors.3d", "[Domain][Unit]") {
         "orientation = (+1, +2, +0)");
 
   // Test add_ids
-
-  const std::unordered_set<ElementId<3>> more_custom_ids = []() {
-    std::unordered_set<ElementId<3>> temp;
-    std::array<SegmentId, 3> segment4_ids{
-        {SegmentId(2, 3), SegmentId(1, 0), SegmentId(1, 1)}};
-    ElementId<3> element4_id(0, segment4_ids);
-    temp.insert(element4_id);
-    return temp;
-  }();
-
-  custom_neighbors.add_ids(more_custom_ids);
+  const std::unordered_set<ElementId<3>> other_custom_id{
+      ElementId<3>(0, {{SegmentId(2, 3), SegmentId(1, 0), SegmentId(1, 1)}})};
+  custom_neighbors.add_ids(other_custom_id);
   CHECK(custom_neighbors.size() == 4);
 
   CHECK(get_output(custom_neighbors) ==

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
@@ -227,29 +227,26 @@ void test_minmod_limiter_two_lower_xi_neighbors() noexcept {
                               1.05 / 0.875);
 }
 
-// See above, but with 4 upper_xi neighbors. Note that in 2D we are unlikely to
-// want domains that have more than 2 neighbors across a face; however, because
-// the multi-neighbor averaging is dimension-agnostic, this also can represent a
-// 3D test.
+// See above, but in 3D and with 4 upper_xi neighbors
 void test_minmod_limiter_four_upper_xi_neighbors() noexcept {
-  const auto element = Element<2>{
-      ElementId<2>{0},
-      Element<2>::Neighbors_t{
-          {Direction<2>::lower_xi(), make_neighbor_with_id<2>(1)},
-          {Direction<2>::upper_xi(),
-           {std::unordered_set<ElementId<2>>{ElementId<2>(2), ElementId<2>(7),
-                                             ElementId<2>(8), ElementId<2>(9)},
-            OrientationMap<2>{}}},
+  const auto element = Element<3>{
+      ElementId<3>{0},
+      Element<3>::Neighbors_t{
+          {Direction<3>::lower_xi(), make_neighbor_with_id<3>(1)},
+          {Direction<3>::upper_xi(),
+           {std::unordered_set<ElementId<3>>{ElementId<3>(2), ElementId<3>(7),
+                                             ElementId<3>(8), ElementId<3>(9)},
+            OrientationMap<3>{}}},
       }};
   const auto mesh =
-      Mesh<2>(3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
+      Mesh<3>(3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
   const double dx = 1.0;
-  const auto element_size = make_array<2>(dx);
+  const auto element_size = make_array<3>(dx);
 
   const auto mean = 2.0;
   const auto func = [&mean](
-      const tnsr::I<DataVector, 2, Frame::Logical>& coords) noexcept {
+      const tnsr::I<DataVector, 3, Frame::Logical>& coords) noexcept {
     return mean + 1.2 * get<0>(coords);
   };
   const auto input = ScalarTag::type(func(logical_coords));
@@ -259,29 +256,29 @@ void test_minmod_limiter_four_upper_xi_neighbors() noexcept {
       const double right3, const double right4, const double right1_size,
       const double right2_size, const double right3_size,
       const double right4_size) noexcept {
-    using Pack = SlopeLimiters::Minmod<2, tmpl::list<ScalarTag>>::PackagedData;
+    using Pack = SlopeLimiters::Minmod<3, tmpl::list<ScalarTag>>::PackagedData;
     return std::unordered_map<
-        std::pair<Direction<2>, ElementId<2>>, Pack,
-        boost::hash<std::pair<Direction<2>, ElementId<2>>>>{
+        std::pair<Direction<3>, ElementId<3>>, Pack,
+        boost::hash<std::pair<Direction<3>, ElementId<3>>>>{
         std::make_pair(
-            std::make_pair(Direction<2>::lower_xi(), ElementId<2>(1)),
-            Pack{Scalar<double>(left), make_array<2>(dx)}),
+            std::make_pair(Direction<3>::lower_xi(), ElementId<3>(1)),
+            Pack{Scalar<double>(left), make_array<3>(dx)}),
         std::make_pair(
-            std::make_pair(Direction<2>::upper_xi(), ElementId<2>(2)),
-            Pack{Scalar<double>(right1), make_array(right1_size, dx)}),
+            std::make_pair(Direction<3>::upper_xi(), ElementId<3>(2)),
+            Pack{Scalar<double>(right1), make_array(right1_size, dx, dx)}),
         std::make_pair(
-            std::make_pair(Direction<2>::upper_xi(), ElementId<2>(7)),
-            Pack{Scalar<double>(right2), make_array(right2_size, dx)}),
+            std::make_pair(Direction<3>::upper_xi(), ElementId<3>(7)),
+            Pack{Scalar<double>(right2), make_array(right2_size, dx, dx)}),
         std::make_pair(
-            std::make_pair(Direction<2>::upper_xi(), ElementId<2>(8)),
-            Pack{Scalar<double>(right3), make_array(right3_size, dx)}),
+            std::make_pair(Direction<3>::upper_xi(), ElementId<3>(8)),
+            Pack{Scalar<double>(right3), make_array(right3_size, dx, dx)}),
         std::make_pair(
-            std::make_pair(Direction<2>::upper_xi(), ElementId<2>(9)),
-            Pack{Scalar<double>(right4), make_array(right4_size, dx)}),
+            std::make_pair(Direction<3>::upper_xi(), ElementId<3>(9)),
+            Pack{Scalar<double>(right4), make_array(right4_size, dx, dx)}),
     };
   };
 
-  const SlopeLimiters::Minmod<2, tmpl::list<ScalarTag>> minmod(
+  const SlopeLimiters::Minmod<3, tmpl::list<ScalarTag>> minmod(
       SlopeLimiters::MinmodType::LambdaPi1);
 
   // Make four right neighbors with different mean values
@@ -710,11 +707,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.Minmod",
     INFO("Test Minmod limiter in 2d");
     test_minmod_limiter_2d();
     test_minmod_limiter_two_lower_xi_neighbors();
-    test_minmod_limiter_four_upper_xi_neighbors();
   }
 
   {
     INFO("Test Minmod limiter in 3d");
     test_minmod_limiter_3d();
+    test_minmod_limiter_four_upper_xi_neighbors();
   }
 }


### PR DESCRIPTION
## Proposed changes

Adds assertions to Element and Neighbor to guard against constructing with (or adding) more neighbors than `maximum_number_of_neighbors(dim)`.

The tests for Element and Neighbor are adjusted to remove cases of a 1D test creating more than one neighbor per side.

Fixes #551 

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

