### PR TITLE
Ignore warning for AppleClang

### DIFF
--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -240,18 +240,14 @@ void test_variables_construction_and_access() noexcept {
   CHECK(get_output(filled_variables) == expected_output);
 
   // Check self-assignment
-#ifndef __APPLE__
 #if defined(__clang__) && __clang_major__ > 6
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
 #endif  // defined(__clang__) && __clang_major__ > 6
-#endif  // ! __APPLE__
   filled_variables = filled_variables;  // NOLINT
-#ifndef __APPLE__
 #if defined(__clang__) && __clang_major__ > 6
 #pragma GCC diagnostic pop
 #endif  // defined(__clang__) && __clang_major__ > 6
-#endif  // ! __APPLE__
   CHECK(filled_variables == another_filled_variables);
 
   CHECK(

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_ComplexDataView.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_ComplexDataView.cpp
@@ -142,18 +142,14 @@ void test_view() noexcept {
   }
 
   // check self-assignment from the referenced vector
-#ifndef __APPLE__
 #if defined(__clang__) && __clang_major__ > 6
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
 #endif  // defined(__clang__) && __clang_major__ > 6
-#endif  // ! __APPLE__
   assign_vec_1 = assign_vec_1;
-#ifndef __APPLE__
 #if defined(__clang__) && __clang_major__ > 6
 #pragma GCC diagnostic pop
 #endif  // defined(__clang__) && __clang_major__ > 6
-#endif  // ! __APPLE__
   for (size_t i = 0; i < view_size; i++) {
     CHECK(real(assign_vec_1[i]) == real(source_vec[i + offset]));
     CHECK(imag(assign_vec_1[i]) == imag(assign_vec_1[i]));
@@ -180,22 +176,18 @@ void test_view() noexcept {
   }
 
   // check self-assignment from the view
-#ifndef __APPLE__
 #if defined(__clang__) && __clang_major__ > 6
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
 #endif  // defined(__clang__) && __clang_major__ > 6
-#endif  // ! __APPLE__
   // clang-tidy and gcc ignore for allowing the intentional self-assignment
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wextra"
   vector_view = vector_view; // NOLINT
 #pragma GCC diagnostic pop
-#ifndef __APPLE__
 #if defined(__clang__) && __clang_major__ > 6
 #pragma GCC diagnostic pop
 #endif  // defined(__clang__) && __clang_major__ > 6
-#endif  // ! __APPLE__
   for (size_t i = 0; i < view_size; i++) {
     CHECK(source_vec[i + offset] == assign_view_source[i]);
   }

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -91,19 +91,15 @@ void test_copy_semantics(const T& a) {
   // constructor
   const T c(a);  // NOLINT
   CHECK(c == a);
-#ifndef __APPLE__
 #if defined(__clang__) && __clang_major__ > 6
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
 #endif  // defined(__clang__) && __clang_major__ > 6
-#endif  // ! __APPLE__
   // clang-tidy: self-assignment
   b = b;  // NOLINT
-#ifndef __APPLE__
 #if defined(__clang__) && __clang_major__ > 6
 #pragma GCC diagnostic pop
 #endif  // defined(__clang__) && __clang_major__ > 6
-#endif  // ! __APPLE__
   CHECK(b == a);
 }
 


### PR DESCRIPTION
The self-assign-overloaded warning is now recognized by AppleClang, so
it can be now appear in a diagnostic ignored pragma

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
