### PR TITLE
Add initial data for an advecting magnetic field loop

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -238,6 +238,22 @@
   url      = "https://doi.org/10.1086/374594",
 }
 
+@article{Gardiner2005hy,
+      author         = "Gardiner, Thomas A. and Stone, James M.",
+      title          = "{An Unsplit Godunov method for ideal MHD via constrained
+                        transport}",
+      journal        = "J. Comput. Phys.",
+      volume         = "205",
+      year           = "2005",
+      pages          = "509-539",
+      doi            = "10.1016/j.jcp.2004.11.016",
+      url            = "https://10.1016/j.jcp.2004.11.016",
+      eprint         = "astro-ph/0501557",
+      archivePrefix  = "arXiv",
+      primaryClass   = "astro-ph",
+      SLACcitation   = "%%CITATION = ASTRO-PH/0501557;%%"
+}
+
 @article{Goldberg1966uu,
   author   = "Goldberg, J. N. and MacFarlane, A. J. and Newman, E. T.
               and Rohrlich, F. and Sudarshan, E. C. G.",
@@ -469,6 +485,22 @@
   pages   = "153--160",
   doi     = "10.1007/BF00649949",
   url     = "https://doi.org/10.1007/BF00649949"
+}
+
+@article{Mignone2010br,
+      author         = "Mignone, A. and Tzeferacos, P. and Bodo, G.",
+      title          = "{High-order conservative finite difference GLM-MHD
+                        schemes for cell-centered MHD}",
+      journal        = "J. Comput. Phys.",
+      volume         = "229",
+      year           = "2010",
+      pages          = "5896-5920",
+      doi            = "10.1016/j.jcp.2010.04.013",
+      url            = "https://doi.org/10.1016/j.jcp.2010.04.013",
+      eprint         = "1001.2832",
+      archivePrefix  = "arXiv",
+      primaryClass   = "astro-ph.HE",
+      SLACcitation   = "%%CITATION = ARXIV:1001.2832;%%"
 }
 
 @article{Minerbo1978,

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY GrMhdAnalyticData)
 set(LIBRARY_SOURCES
   BondiHoyleAccretion.cpp
   CylindricalBlastWave.cpp
+  MagneticFieldLoop.cpp
   MagneticRotor.cpp
   MagnetizedFmDisk.cpp
   OrszagTangVortex.cpp

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.cpp
@@ -1,0 +1,225 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp"
+
+#include <cmath>  // IWYU pragma: keep
+#include <cstddef>
+#include <ostream>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "PointwiseFunctions/Hydro/LorentzFactor.hpp"
+#include "Utilities/ConstantExpressions.hpp"  // IWYU pragma: keep
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Math.hpp"  // IWYU pragma: keep
+#include "Utilities/StdArrayHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+// IWYU pragma: no_include <complex>
+
+/// \cond
+namespace grmhd {
+namespace AnalyticData {
+
+MagneticFieldLoop::MagneticFieldLoop(
+    const double pressure, const double rest_mass_density,
+    const double adiabatic_index,
+    const std::array<double, 3>& advection_velocity,
+    const double magnetic_field_magnitude, const double inner_radius,
+    const double outer_radius, const OptionContext& context)
+    : pressure_(pressure),
+      rest_mass_density_(rest_mass_density),
+      adiabatic_index_(adiabatic_index),
+      advection_velocity_(advection_velocity),
+      magnetic_field_magnitude_(magnetic_field_magnitude),
+      inner_radius_(inner_radius),
+      outer_radius_(outer_radius),
+      equation_of_state_{adiabatic_index_} {
+  if (magnitude(advection_velocity) >= 1.0) {
+    PARSE_ERROR(context, "MagneticFieldLoop: superluminal AdvectionVelocity = "
+                             << advection_velocity);
+  }
+  if (inner_radius >= outer_radius) {
+    PARSE_ERROR(context, "MagneticFieldLoop: InnerRadius of "
+                             << inner_radius
+                             << " is not less than OuterRadius of "
+                             << outer_radius);
+  }
+}
+
+void MagneticFieldLoop::pup(PUP::er& p) noexcept {
+  p | pressure_;
+  p | rest_mass_density_;
+  p | adiabatic_index_;
+  p | advection_velocity_;
+  p | magnetic_field_magnitude_;
+  p | inner_radius_;
+  p | outer_radius_;
+  p | equation_of_state_;
+  p | background_spacetime_;
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>
+MagneticFieldLoop::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const
+    noexcept {
+  return {make_with_value<Scalar<DataType>>(x, rest_mass_density_)};
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>
+MagneticFieldLoop::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/) const
+    noexcept {
+  auto result = make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(x, 0.0);
+  get<0>(result) = advection_velocity_[0];
+  get<1>(result) = advection_velocity_[1];
+  get<2>(result) = advection_velocity_[2];
+  return {std::move(result)};
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>
+MagneticFieldLoop::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
+    noexcept {
+  return equation_of_state_.specific_internal_energy_from_density_and_pressure(
+      get<hydro::Tags::RestMassDensity<DataType>>(
+          variables(x, tmpl::list<hydro::Tags::RestMassDensity<DataType>>{})),
+      get<hydro::Tags::Pressure<DataType>>(
+          variables(x, tmpl::list<hydro::Tags::Pressure<DataType>>{})));
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>
+MagneticFieldLoop::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const noexcept {
+  return {make_with_value<Scalar<DataType>>(x, pressure_)};
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>
+MagneticFieldLoop::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
+    noexcept {
+  auto result = make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(x, 0.0);
+  const DataType cylindrical_radius =
+      sqrt(square(get<0>(x)) + square(get<1>(x)));
+  for (size_t s = 0; s < get_size(cylindrical_radius); ++s) {
+    const double current_radius = get_element(cylindrical_radius, s);
+    // The data is ill-posed at the origin, so it is not clear what to do...
+    if (current_radius <= outer_radius_ and current_radius > inner_radius_) {
+      get_element(get<0>(result), s) = -magnetic_field_magnitude_ *
+                                       get_element(get<1>(x), s) /
+                                       current_radius;
+      get_element(get<1>(result), s) = magnetic_field_magnitude_ *
+                                       get_element(get<0>(x), s) /
+                                       current_radius;
+    }
+    if (current_radius <= inner_radius_) {
+      get_element(get<0>(result), s) = -magnetic_field_magnitude_ *
+                                       get_element(get<1>(x), s) /
+                                       inner_radius_;
+      get_element(get<1>(result), s) =
+          magnetic_field_magnitude_ * get_element(get<0>(x), s) / inner_radius_;
+    }
+  }
+  return {std::move(result)};
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>
+MagneticFieldLoop::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const
+    noexcept {
+  return {make_with_value<Scalar<DataType>>(x, 0.0)};
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>
+MagneticFieldLoop::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const noexcept {
+  using velocity_tag = hydro::Tags::SpatialVelocity<DataType, 3>;
+  const auto velocity =
+      get<velocity_tag>(variables(x, tmpl::list<velocity_tag>{}));
+  return {hydro::lorentz_factor(dot_product(velocity, velocity))};
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>
+MagneticFieldLoop::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
+    noexcept {
+  return equation_of_state_.specific_enthalpy_from_density_and_energy(
+      get<hydro::Tags::RestMassDensity<DataType>>(
+          variables(x, tmpl::list<hydro::Tags::RestMassDensity<DataType>>{})),
+      get<hydro::Tags::SpecificInternalEnergy<DataType>>(variables(
+          x, tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>>{})));
+}
+
+bool operator==(const MagneticFieldLoop& lhs,
+                const MagneticFieldLoop& rhs) noexcept {
+  // there is no comparison operator for the EoS, but should be okay as
+  // the adiabatic_indexs are compared
+  return lhs.pressure_ == rhs.pressure_ and
+         lhs.rest_mass_density_ == rhs.rest_mass_density_ and
+         lhs.adiabatic_index_ == rhs.adiabatic_index_ and
+         lhs.advection_velocity_ == rhs.advection_velocity_ and
+         lhs.magnetic_field_magnitude_ == rhs.magnetic_field_magnitude_ and
+         lhs.inner_radius_ == rhs.inner_radius_ and
+         lhs.outer_radius_ == rhs.outer_radius_ and
+         lhs.background_spacetime_ == rhs.background_spacetime_;
+}
+
+bool operator!=(const MagneticFieldLoop& lhs,
+                const MagneticFieldLoop& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define TAG(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE_SCALARS(_, data)                         \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>>     \
+      MagneticFieldLoop::variables(                          \
+          const tnsr::I<DTYPE(data), 3, Frame::Inertial>& x, \
+          tmpl::list<TAG(data) < DTYPE(data)>> /*meta*/) const noexcept;
+
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE_SCALARS, (double, DataVector),
+    (hydro::Tags::RestMassDensity, hydro::Tags::SpecificInternalEnergy,
+     hydro::Tags::Pressure, hydro::Tags::DivergenceCleaningField,
+     hydro::Tags::LorentzFactor, hydro::Tags::SpecificEnthalpy))
+
+#define INSTANTIATE_VECTORS(_, data)                                         \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>>                  \
+      MagneticFieldLoop::variables(                                          \
+          const tnsr::I<DTYPE(data), 3, Frame::Inertial>& x,                 \
+          tmpl::list<TAG(data) < DTYPE(data), 3, Frame::Inertial>> /*meta*/) \
+          const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
+                        (hydro::Tags::SpatialVelocity,
+                         hydro::Tags::MagneticField))
+
+#undef DTYPE
+#undef TAG
+#undef INSTANTIATE_SCALARS
+#undef INSTANTIATE_VECTORS
+}  // namespace AnalyticData
+}  // namespace grmhd
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp
@@ -1,0 +1,242 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <limits>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/MakeArray.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+// IWYU pragma:  no_include <pup.h>
+
+/// \cond
+namespace PUP {
+class er;  // IWYU pragma: keep
+}  // namespace PUP
+/// \endcond
+
+namespace grmhd {
+namespace AnalyticData {
+
+/*!
+ * \brief Analytic initial data for an advecting magnetic field loop.
+ *
+ * This test, originally proposed in \cite Gardiner2005hy and presented in a
+ * slightly modified form by \cite Mignone2010br, a region with annular
+ * cross section with the specified `InnerRadius` and `OuterRadius` is given a
+ * non-zero azimuthal magnetic field of constant magnitude `MagFieldStrength`
+ * with zero magnetic field outside the loop.  Inside the `InnerRadius` the
+ * magnetic field strength falls to zero quadratically. The loop is embedded in
+ * an ideal fluid with the given `AdiabaticIndex`, `RestMassDensity` and
+ * `Pressure` with a uniform `AdvectionVelocity`.  The magnetic field loop
+ * should advect across the grid, maintaining its shape and strength, as long
+ * as the magnetic pressure is negligible compared to the thermal pressure.
+ *
+ * This test diagnoses how well the evolution scheme preserves the no-monopole
+ * condition, as well as the diffusivity of the scheme.
+ *
+ * The standard test setup is done on \f$x \in [-1,1]\f$, \f$y \in [-0.5,
+ * 0.5]\f$, with periodic boundary conditions and with the following values
+ * given for the options:
+ * -  InnerRadius: 0.06
+ * -  OuterRadius: 0.3
+ * -  RestMassDensity: 1.0
+ * -  Pressure: 1.0
+ * -  AdvectionVelocity: [0.08164965809277261, 0.040824829046386304, 0.0]
+ * -  MagFieldStrength: 0.001
+ * -  AdiabaticIndex: 1.66666666666666667
+ *
+ */
+class MagneticFieldLoop {
+ public:
+  using equation_of_state_type = EquationsOfState::IdealFluid<true>;
+
+  /// The pressure throughout the fluid.
+  struct Pressure {
+    using type = double;
+    static constexpr OptionString help = {
+        "The constant pressure throughout the fluid."};
+    static type lower_bound() { return 0.0; }
+  };
+
+  /// The rest mass density throughout the fluid.
+  struct RestMassDensity {
+    using type = double;
+    static constexpr OptionString help = {
+        "The constant density throughout the fluid."};
+    static type lower_bound() { return 0.0; }
+  };
+
+  /// The adiabatic index for the ideal fluid.
+  struct AdiabaticIndex {
+    using type = double;
+    static constexpr OptionString help = {
+        "The adiabatic index for the ideal fluid."};
+    static type lower_bound() { return 1.0; }
+  };
+
+  /// The fluid velocity.
+  struct AdvectionVelocity {
+    using type = std::array<double, 3>;
+    static constexpr OptionString help = {"The advection velocity."};
+    static type lower_bound() { return {{-1.0, -1.0, -1.0}}; }
+    static type upper_bound() { return {{1.0, 1.0, 1.0}}; }
+  };
+
+  /// The strength of the magnetic field.
+  struct MagFieldStrength {
+    using type = double;
+    static constexpr OptionString help = {
+        "The magnitude of the magnetic field."};
+    static type lower_bound() { return 0.0; }
+  };
+
+  /// The inner radius of the magnetic loop.
+  struct InnerRadius {
+    using type = double;
+    static constexpr OptionString help = {
+        "The inner radius of the magnetic loop."};
+    static type lower_bound() { return 0.0; }
+  };
+
+  /// The outer radius of the magnetic loop.
+  struct OuterRadius {
+    using type = double;
+    static constexpr OptionString help = {
+        "The outer radius of the magnetic loop."};
+    static type lower_bound() { return 0.0; }
+  };
+
+  using options =
+      tmpl::list<Pressure, RestMassDensity, AdiabaticIndex, AdvectionVelocity,
+                 MagFieldStrength, InnerRadius, OuterRadius>;
+  static constexpr OptionString help = {
+      "Periodic advection of a magnetic field loop in Minkowski."};
+
+  MagneticFieldLoop() = default;
+  MagneticFieldLoop(const MagneticFieldLoop& /*rhs*/) = delete;
+  MagneticFieldLoop& operator=(const MagneticFieldLoop& /*rhs*/) = delete;
+  MagneticFieldLoop(MagneticFieldLoop&& /*rhs*/) noexcept = default;
+  MagneticFieldLoop& operator=(MagneticFieldLoop&& /*rhs*/) noexcept = default;
+  ~MagneticFieldLoop() = default;
+
+  MagneticFieldLoop(double pressure, double rest_mass_density,
+                    double adiabatic_index,
+                    const std::array<double, 3>& advection_velocity,
+                    double magnetic_field_magnitude, double inner_radius,
+                    double outer_radius, const OptionContext& context = {});
+
+  explicit MagneticFieldLoop(CkMigrateMessage* /*unused*/) noexcept {}
+
+  // @{
+  /// Retrieve the GRMHD variables at a given position.
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
+      noexcept
+      -> tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::SpatialVelocity<
+                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<
+          hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::MagneticField<
+                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<
+          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const
+      noexcept
+      -> tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
+  // @}
+
+  /// Retrieve a collection of hydrodynamic variables at position x
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<Tags...> /*meta*/) const noexcept {
+    static_assert(sizeof...(Tags) > 1,
+                  "The generic template will recurse infinitely if only one "
+                  "tag is being retrieved.");
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  /// Retrieve the metric variables
+  template <typename DataType, typename Tag>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, 3>& x,
+                                     tmpl::list<Tag> /*meta*/) const noexcept {
+    constexpr double dummy_time = 0.0;
+    return background_spacetime_.variables(x, dummy_time, tmpl::list<Tag>{});
+  }
+
+  const EquationsOfState::IdealFluid<true>& equation_of_state() const noexcept {
+    return equation_of_state_;
+  }
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
+
+ private:
+  double pressure_ = std::numeric_limits<double>::signaling_NaN();
+  double rest_mass_density_ = std::numeric_limits<double>::signaling_NaN();
+  double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();
+  std::array<double, 3> advection_velocity_ =
+      make_array<3>(std::numeric_limits<double>::signaling_NaN());
+  double magnetic_field_magnitude_ =
+      std::numeric_limits<double>::signaling_NaN();
+  double inner_radius_ = std::numeric_limits<double>::signaling_NaN();
+  double outer_radius_ = std::numeric_limits<double>::signaling_NaN();
+
+  EquationsOfState::IdealFluid<true> equation_of_state_{};
+  gr::Solutions::Minkowski<3> background_spacetime_{};
+
+  friend bool operator==(const MagneticFieldLoop& lhs,
+                         const MagneticFieldLoop& rhs) noexcept;
+
+  friend bool operator!=(const MagneticFieldLoop& lhs,
+                         const MagneticFieldLoop& rhs) noexcept;
+};
+
+}  // namespace AnalyticData
+}  // namespace grmhd

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_GrMhdAnalyticData")
 set(LIBRARY_SOURCES
   Test_BondiHoyleAccretion.cpp
   Test_CylindricalBlastWave.cpp
+  Test_MagneticFieldLoop.cpp
   Test_MagneticRotor.cpp
   Test_MagnetizedFmDisk.cpp
   Test_OrszagTangVortex.cpp

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.py
@@ -1,0 +1,80 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def compute_rest_mass_density(x, pressure, rest_mass_density, adiabatic_index,
+                              advection_velocity, magnetic_field_strength,
+                              inner_radius, outer_radius):
+    return rest_mass_density
+
+
+def compute_pressure(x, pressure, rest_mass_density,
+                     adiabatic_index, advection_velocity,
+                     magnetic_field_strength, inner_radius, outer_radius):
+    return pressure
+
+
+def specific_internal_energy(x, pressure, rest_mass_density, adiabatic_index,
+                             advection_velocity, magnetic_field_strength,
+                             inner_radius, outer_radius):
+    return (1.0 / (adiabatic_index - 1.0) *
+            compute_pressure(x, pressure, rest_mass_density, adiabatic_index,
+                             advection_velocity, magnetic_field_strength,
+                             inner_radius, outer_radius) /
+            compute_rest_mass_density(x, pressure, rest_mass_density,
+                                      adiabatic_index, advection_velocity,
+                                      magnetic_field_strength,
+                                      inner_radius, outer_radius))
+
+
+def spatial_velocity(x, pressure, rest_mass_density, adiabatic_index,
+                     advection_velocity, magnetic_field_strength,
+                     inner_radius, outer_radius):
+    return np.array(advection_velocity)
+
+
+def lorentz_factor(x, pressure, rest_mass_density, adiabatic_index,
+                   advection_velocity, magnetic_field_strength,
+                   inner_radius, outer_radius):
+    v = spatial_velocity(x, pressure, rest_mass_density, adiabatic_index,
+                         advection_velocity, magnetic_field_strength,
+                         inner_radius, outer_radius)
+    return 1. / np.sqrt(1. - np.dot(v, v))
+
+
+def specific_enthalpy(x, pressure, rest_mass_density, adiabatic_index,
+                      advection_velocity, magnetic_field_strength,
+                      inner_radius, outer_radius):
+    return (1. + specific_internal_energy(x, pressure, rest_mass_density,
+                                          adiabatic_index, advection_velocity,
+                                          magnetic_field_strength,
+                                          inner_radius, outer_radius)
+            + compute_pressure(x, pressure, rest_mass_density, adiabatic_index,
+                               advection_velocity, magnetic_field_strength,
+                               inner_radius, outer_radius) /
+            compute_rest_mass_density(x, pressure, rest_mass_density,
+                                      adiabatic_index, advection_velocity,
+                                      magnetic_field_strength,
+                                      inner_radius, outer_radius))
+
+
+def magnetic_field(x, pressure, rest_mass_density, adiabatic_index,
+                   advection_velocity, magnetic_field_strength,
+                   inner_radius, outer_radius):
+    radius = np.sqrt(np.square(x[0]) + np.square(x[1]))
+    if (radius > outer_radius):
+        return np.array([0.0, 0.0, 0.0])
+    if (radius < inner_radius):
+        return np.array([-magnetic_field_strength * x[1]/inner_radius,
+        magnetic_field_strength * x[0] / inner_radius, 0.])
+    return np.array([
+        -magnetic_field_strength * x[1]/radius,
+        magnetic_field_strength * x[0] / radius, 0.])
+
+
+def divergence_cleaning_field(x, pressure, rest_mass_density, adiabatic_index,
+                              advection_velocity, magnetic_field_strength,
+                              inner_radius, outer_radius):
+    return 0.

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticFieldLoop.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticFieldLoop.cpp
@@ -1,0 +1,159 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <tuple>
+
+#include "DataStructures/DataBox/Prefixes.hpp"    // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"          // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
+#include "ErrorHandling/Error.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+
+struct MagneticFieldLoopProxy : grmhd::AnalyticData::MagneticFieldLoop {
+  using grmhd::AnalyticData::MagneticFieldLoop::MagneticFieldLoop;
+
+  template <typename DataType>
+  using hydro_variables_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataType>,
+                 hydro::Tags::SpatialVelocity<DataType, 3>,
+                 hydro::Tags::SpecificInternalEnergy<DataType>,
+                 hydro::Tags::Pressure<DataType>,
+                 hydro::Tags::LorentzFactor<DataType>,
+                 hydro::Tags::SpecificEnthalpy<DataType>>;
+
+  template <typename DataType>
+  using grmhd_variables_tags =
+      tmpl::push_back<hydro_variables_tags<DataType>,
+                      hydro::Tags::MagneticField<DataType, 3>,
+                      hydro::Tags::DivergenceCleaningField<DataType>>;
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<hydro_variables_tags<DataType>>
+  hydro_variables(const tnsr::I<DataType, 3, Frame::Inertial>& x) const
+      noexcept {
+    return variables(x, hydro_variables_tags<DataType>{});
+  }
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<grmhd_variables_tags<DataType>>
+  grmhd_variables(const tnsr::I<DataType, 3, Frame::Inertial>& x) const
+      noexcept {
+    return variables(x, grmhd_variables_tags<DataType>{});
+  }
+};
+
+void test_create_from_options() noexcept {
+  const auto magnetic_field_loop =
+      test_creation<grmhd::AnalyticData::MagneticFieldLoop>(
+          "  Pressure: 3.0\n"
+          "  RestMassDensity: 1.0\n"
+          "  AdiabaticIndex: 1.66666666666666667\n"
+          "  AdvectionVelocity: [0.5, 0.04166666666666667, 0.0]\n"
+          "  MagFieldStrength: 0.001\n"
+          "  InnerRadius: 0.06\n"
+          "  OuterRadius: 0.3\n");
+  CHECK(magnetic_field_loop ==
+        grmhd::AnalyticData::MagneticFieldLoop(
+            3.0, 1.0, 1.66666666666666667,
+            std::array<double, 3>{{0.5, 0.04166666666666667, 0.0}}, 0.001, 0.06,
+            0.3));
+}
+
+void test_move() noexcept {
+  grmhd::AnalyticData::MagneticFieldLoop magnetic_field_loop(
+      3.0, 1.0, 1.66666666666666667,
+      std::array<double, 3>{{0.5, 0.04166666666666667, 0.0}}, 0.001, 0.06, 0.3);
+  grmhd::AnalyticData::MagneticFieldLoop magnetic_field_loop_copy(
+      3.0, 1.0, 1.66666666666666667,
+      std::array<double, 3>{{0.5, 0.04166666666666667, 0.0}}, 0.001, 0.06, 0.3);
+  test_move_semantics(std::move(magnetic_field_loop),
+                      magnetic_field_loop_copy);  //  NOLINT
+}
+
+void test_serialize() noexcept {
+  grmhd::AnalyticData::MagneticFieldLoop magnetic_field_loop(
+      3.0, 1.0, 1.66666666666666667,
+      std::array<double, 3>{{0.5, 0.04166666666666667, 0.0}}, 0.001, 0.06, 0.3);
+  test_serialization(magnetic_field_loop);
+}
+
+template <typename DataType>
+void test_variables(const DataType& used_for_size) noexcept {
+  const double pressure = 3.0;
+  const double rest_mass_density = 1.0;
+  const double adiabatic_index = 1.6666666666666666;
+  const std::array<double, 3> advection_velocity{
+      {0.5, 0.04166666666666667, 0.0}};
+  const double magnetic_field_magnitude = 0.001;
+  const double inner_radius = 0.06;
+  const double outer_radius = 0.3;
+
+  const auto member_variables = std::make_tuple(
+      pressure, rest_mass_density, adiabatic_index, advection_velocity,
+      magnetic_field_magnitude, inner_radius, outer_radius);
+
+  MagneticFieldLoopProxy magnetic_field_loop(
+      pressure, rest_mass_density, adiabatic_index, advection_velocity,
+      magnetic_field_magnitude, inner_radius, outer_radius);
+
+  pypp::check_with_random_values<
+      1, MagneticFieldLoopProxy::hydro_variables_tags<DataType>>(
+      &MagneticFieldLoopProxy::hydro_variables<DataType>, magnetic_field_loop,
+      "MagneticFieldLoop",
+      {"compute_rest_mass_density", "spatial_velocity",
+       "specific_internal_energy", "compute_pressure", "lorentz_factor",
+       "specific_enthalpy"},
+      {{{-1.0, 1.0}}}, member_variables, used_for_size);
+
+  pypp::check_with_random_values<
+      1, MagneticFieldLoopProxy::grmhd_variables_tags<DataType>>(
+      &MagneticFieldLoopProxy::grmhd_variables<DataType>, magnetic_field_loop,
+      "MagneticFieldLoop",
+      {"compute_rest_mass_density", "spatial_velocity",
+       "specific_internal_energy", "compute_pressure", "lorentz_factor",
+       "specific_enthalpy", "magnetic_field", "divergence_cleaning_field"},
+      {{{-1.0, 1.0}}}, member_variables, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagneticFieldLoop",
+    "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticData/GrMhd"};
+
+  test_create_from_options();
+  test_serialize();
+  test_move();
+
+  test_variables(std::numeric_limits<double>::signaling_NaN());
+  test_variables(DataVector(5));
+}
+
+// [[OutputRegex, MagneticFieldLoop: superluminal AdvectionVelocity]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagneticFieldLoopBadVelocity",
+    "[Unit][PointwiseFunctions]") {
+  ERROR_TEST();
+  grmhd::AnalyticData::MagneticFieldLoop magnetic_loop(
+      3.0, 1.0, 1.66666666666666667,
+      std::array<double, 3>{{0.5, 0.04166666666666667, -0.9}}, 0.001, 0.06,
+      0.3);
+  ERROR("Failed to trigger PARSE_ERROR in a parse error test");
+}


### PR DESCRIPTION
This is another standard GRMHD test problem.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
