### PR TITLE
Fix building without python bindings

### DIFF
--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -29,4 +29,6 @@ target_link_libraries(
   INTERFACE Utilities
   )
 
-add_subdirectory(H5/Python)
+if(BUILD_PYTHON_BINDINGS)
+  add_subdirectory(H5/Python)
+endif()


### PR DESCRIPTION
I still have local issues building *with* python bindings, but that appears to predate recent changes.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
