### PR TITLE
Fix magnetic field term in BondiMichel

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
@@ -287,7 +287,8 @@ BondiMichel::variables(
     const IntermediateVars<DataType>& vars) const noexcept {
   auto result = make_with_value<tnsr::I<DataType, 3>>(x, 0.0);
   const DataType mag_field_strength_factor =
-      mag_field_strength_ / (cube(vars.radius) * sqrt(1.0 + 2.0 / vars.radius));
+      mag_field_strength_ * square(mass_) /
+      (cube(vars.radius) * sqrt(1.0 + 2.0 * mass_ / vars.radius));
   result.get(0) = mag_field_strength_factor * x.get(0);
   result.get(1) = mag_field_strength_factor * x.get(1);
   result.get(2) = mag_field_strength_factor * x.get(2);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/TestFunctions.py
@@ -352,7 +352,7 @@ def bondi_michel_divergence_cleaning_field(x, mass, sonic_radius, sonic_density,
 def bondi_michel_magnetic_field(x, mass, sonic_radius, sonic_density,
                                 adiabatic_exponent, magnetic_field):
     r = np.sqrt(x[0]**2 + x[1]**2 + x[2]**2)
-    m = magnetic_field / (r**3 * np.sqrt(1.0 + 2.0/r))
+    m = magnetic_field * mass**2 / (r**3 * np.sqrt(1.0 + 2.0 * mass / r))
     return np.array([m * x[0], m * x[1], m * x[2]])
 
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
@@ -123,7 +123,7 @@ void test_variables(const DataType& used_for_size) {
 }
 
 void test_solution() noexcept {
-  grmhd::Solutions::BondiMichel solution(1.0, 50.0, 1.3, 1.5, 0.24);
+  grmhd::Solutions::BondiMichel solution(1.1, 50.0, 1.3, 1.5, 0.24);
   const std::array<double, 3> x{{4.0, 4.0, 4.0}};
   const std::array<double, 3> dx{{1.e-3, 1.e-3, 1.e-3}};
 


### PR DESCRIPTION
## Proposed changes

The magnetic field terms in the BondiMichel accretion solution do not include any mass terms, so this solution currently only works for M=1. This PR fixes that.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
