### PR TITLE
Expand spin weighted utilities

### DIFF
--- a/src/DataStructures/ComplexDataVector.hpp
+++ b/src/DataStructures/ComplexDataVector.hpp
@@ -101,22 +101,32 @@ struct MapTrait<ComplexDataVector, blaze::Abs> {
 #endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
 
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDataVector, DataVector,
-                                               AddTrait);
+                                               AddTrait, ComplexDataVector);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDataVector, DataVector,
-                                               DivTrait);
+                                               DivTrait, ComplexDataVector);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDataVector, DataVector,
-                                               MultTrait);
+                                               MultTrait, ComplexDataVector);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDataVector, DataVector,
-                                               SubTrait);
+                                               SubTrait, ComplexDataVector);
 
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDataVector, double,
-                                               AddTrait);
+                                               AddTrait, ComplexDataVector);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDataVector, double,
-                                               DivTrait);
+                                               DivTrait, ComplexDataVector);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDataVector, double,
-                                               MultTrait);
+                                               MultTrait, ComplexDataVector);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDataVector, double,
-                                               SubTrait);
+                                               SubTrait, ComplexDataVector);
+
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(DataVector, std::complex<double>,
+                                               AddTrait, ComplexDataVector);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(DataVector, std::complex<double>,
+                                               DivTrait, ComplexDataVector);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(DataVector, std::complex<double>,
+                                               MultTrait, ComplexDataVector);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(DataVector, std::complex<double>,
+                                               SubTrait, ComplexDataVector);
+
 
 #if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
 template <typename Operator>

--- a/src/DataStructures/ComplexDiagonalModalOperator.hpp
+++ b/src/DataStructures/ComplexDiagonalModalOperator.hpp
@@ -68,30 +68,50 @@ namespace blaze {
 VECTOR_BLAZE_TRAIT_SPECIALIZE_ARITHMETIC_TRAITS(ComplexDiagonalModalOperator);
 
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
-                                               DiagonalModalOperator, AddTrait);
+                                               DiagonalModalOperator, AddTrait,
+                                               ComplexDiagonalModalOperator);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
-                                               DiagonalModalOperator, DivTrait);
+                                               DiagonalModalOperator, DivTrait,
+                                               ComplexDiagonalModalOperator);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
-                                               DiagonalModalOperator,
-                                               MultTrait);
+                                               DiagonalModalOperator, MultTrait,
+                                               ComplexDiagonalModalOperator);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
-                                               DiagonalModalOperator, SubTrait);
+                                               DiagonalModalOperator, SubTrait,
+                                               ComplexDiagonalModalOperator);
 
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
-                                               double, AddTrait);
+                                               double, AddTrait,
+                                               ComplexDiagonalModalOperator);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
-                                               double, DivTrait);
+                                               double, DivTrait,
+                                               ComplexDiagonalModalOperator);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
-                                               double, MultTrait);
+                                               double, MultTrait,
+                                               ComplexDiagonalModalOperator);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
-                                               double, SubTrait);
+                                               double, SubTrait,
+                                               ComplexDiagonalModalOperator);
+
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(DiagonalModalOperator,
+                                               std::complex<double>, AddTrait,
+                                               ComplexDiagonalModalOperator);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(DiagonalModalOperator,
+                                               std::complex<double>, DivTrait,
+                                               ComplexDiagonalModalOperator);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(DiagonalModalOperator,
+                                               std::complex<double>, MultTrait,
+                                               ComplexDiagonalModalOperator);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(DiagonalModalOperator,
+                                               std::complex<double>, SubTrait,
+                                               ComplexDiagonalModalOperator);
 
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexModalVector,
                                                DiagonalModalOperator,
-                                               MultTrait);
+                                               MultTrait, ComplexModalVector);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexModalVector,
                                                ComplexDiagonalModalOperator,
-                                               MultTrait);
+                                               MultTrait, ComplexModalVector);
 template <>
 struct MultTrait<ModalVector, ComplexDiagonalModalOperator> {
   using Type = ComplexModalVector;
@@ -108,7 +128,7 @@ struct UnaryMapTrait<ComplexDiagonalModalOperator, Operator> {
   static_assert(
       tmpl::list_contains_v<
           tmpl::list<
-              blaze::Conj,
+              blaze::Conj, blaze::Sqrt,
               // these traits are required for operators acting with doubles
               blaze::AddScalar<ComplexDiagonalModalOperator::ElementType>,
               blaze::SubScalarRhs<ComplexDiagonalModalOperator::ElementType>,
@@ -118,8 +138,7 @@ struct UnaryMapTrait<ComplexDiagonalModalOperator, Operator> {
               blaze::AddScalar<DiagonalModalOperator::ElementType>,
               blaze::SubScalarRhs<DiagonalModalOperator::ElementType>,
               blaze::SubScalarLhs<DiagonalModalOperator::ElementType>,
-              blaze::DivideScalarByVector<
-                  ComplexDiagonalModalOperator::ElementType>>,
+              blaze::DivideScalarByVector<DiagonalModalOperator::ElementType>>,
           Operator>,
       "This unary operation is not permitted on a "
       "ComplexDiagonalModalOperator");
@@ -160,7 +179,7 @@ struct MapTrait<ComplexDiagonalModalOperator, Operator> {
   static_assert(
       tmpl::list_contains_v<
           tmpl::list<
-              blaze::Conj,
+              blaze::Conj, blaze::Sqrt,
               // these traits are required for operators acting with doubles
               blaze::AddScalar<ComplexDiagonalModalOperator::ElementType>,
               blaze::SubScalarRhs<ComplexDiagonalModalOperator::ElementType>,
@@ -170,8 +189,7 @@ struct MapTrait<ComplexDiagonalModalOperator, Operator> {
               blaze::AddScalar<DiagonalModalOperator::ElementType>,
               blaze::SubScalarRhs<DiagonalModalOperator::ElementType>,
               blaze::SubScalarLhs<DiagonalModalOperator::ElementType>,
-              blaze::DivideScalarByVector<
-                  ComplexDiagonalModalOperator::ElementType>>,
+              blaze::DivideScalarByVector<DiagonalModalOperator::ElementType>>,
           Operator>,
       "This unary operation is not permitted on a "
       "ComplexDiagonalModalOperator");

--- a/src/DataStructures/ComplexModalVector.hpp
+++ b/src/DataStructures/ComplexModalVector.hpp
@@ -57,17 +57,21 @@ struct AddTrait<ComplexModalVector, ComplexModalVector> {
   using Type = ComplexModalVector;
 };
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexModalVector, ModalVector,
-                                               AddTrait);
+                                               AddTrait, ComplexModalVector);
 template <>
 struct SubTrait<ComplexModalVector, ComplexModalVector> {
   using Type = ComplexModalVector;
 };
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexModalVector, ModalVector,
-                                               SubTrait);
+                                               SubTrait, ComplexModalVector);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexModalVector,
-                                               std::complex<double>, MultTrait);
+                                               std::complex<double>, MultTrait,
+                                               ComplexModalVector);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ModalVector,
+                                               std::complex<double>, MultTrait,
+                                               ComplexModalVector);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexModalVector, double,
-                                               MultTrait);
+                                               MultTrait, ComplexModalVector);
 template <>
 struct DivTrait<ComplexModalVector, std::complex<double>> {
   using Type = ComplexModalVector;
@@ -88,7 +92,9 @@ struct UnaryMapTrait<ComplexModalVector, Operator> {
                      // (-) w/doubles
                      blaze::AddScalar<ComplexModalVector::ElementType>,
                      blaze::SubScalarRhs<ComplexModalVector::ElementType>,
-                     blaze::SubScalarLhs<ComplexModalVector::ElementType>>,
+                     blaze::SubScalarLhs<ComplexModalVector::ElementType>,
+                     blaze::AddScalar<double>, blaze::SubScalarRhs<double>,
+                     blaze::SubScalarLhs<double>>,
           Operator>,
       "Only unary operations permitted on a ComplexModalVector are:"
       " conj, imag, and real");
@@ -134,7 +140,9 @@ struct MapTrait<ComplexModalVector, Operator> {
                      // (-) w/doubles
                      blaze::AddScalar<ComplexModalVector::ElementType>,
                      blaze::SubScalarRhs<ComplexModalVector::ElementType>,
-                     blaze::SubScalarLhs<ComplexModalVector::ElementType>>,
+                     blaze::SubScalarLhs<ComplexModalVector::ElementType>,
+                     blaze::AddScalar<double>, blaze::SubScalarRhs<double>,
+                     blaze::SubScalarLhs<double>>,
           Operator>,
       "Only unary operations permitted on a ComplexModalVector are:"
       " conj, imag, and real");

--- a/src/DataStructures/DiagonalModalOperator.hpp
+++ b/src/DataStructures/DiagonalModalOperator.hpp
@@ -48,7 +48,7 @@ namespace blaze {
 VECTOR_BLAZE_TRAIT_SPECIALIZE_ARITHMETIC_TRAITS(DiagonalModalOperator);
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ModalVector,
                                                DiagonalModalOperator,
-                                               MultTrait);
+                                               MultTrait, ModalVector);
 
 #if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
 template <typename Operator>
@@ -61,7 +61,16 @@ struct UnaryMapTrait<DiagonalModalOperator, Operator> {
               blaze::AddScalar<DiagonalModalOperator::ElementType>,
               blaze::SubScalarRhs<DiagonalModalOperator::ElementType>,
               blaze::SubScalarLhs<DiagonalModalOperator::ElementType>,
-              blaze::DivideScalarByVector<DiagonalModalOperator::ElementType>>,
+              blaze::DivideScalarByVector<DiagonalModalOperator::ElementType>,
+              // With these and the blaze traits in
+              // `ComplexDiagonalModalOperator.hpp`, the `DiagonalModalOperator`
+              // can be operated with a `std::complex<double>` to produce a
+              // `ComplexDiagonalModalOperator`, analogous to implicit casting
+              // in the standard library
+              blaze::AddScalar<std::complex<double>>,
+              blaze::SubScalarRhs<std::complex<double>>,
+              blaze::SubScalarLhs<std::complex<double>>,
+              blaze::DivideScalarByVector<std::complex<double>>>,
           Operator>,
       "This unary operation is not permitted on a DiagonalModalOperator");
   using Type = DiagonalModalOperator;
@@ -88,7 +97,16 @@ struct MapTrait<DiagonalModalOperator, Operator> {
               blaze::AddScalar<DiagonalModalOperator::ElementType>,
               blaze::SubScalarRhs<DiagonalModalOperator::ElementType>,
               blaze::SubScalarLhs<DiagonalModalOperator::ElementType>,
-              blaze::DivideScalarByVector<DiagonalModalOperator::ElementType>>,
+              blaze::DivideScalarByVector<DiagonalModalOperator::ElementType>,
+              // With these and the blaze traits in
+              // `ComplexDiagonalModalOperator.hpp`, the `DiagonalModalOperator`
+              // can be operated with a `std::complex<double>` to produce a
+              // `ComplexDiagonalModalOperator`, analogous to implicit casting
+              // in the standard library
+              blaze::AddScalar<std::complex<double>>,
+              blaze::SubScalarRhs<std::complex<double>>,
+              blaze::SubScalarLhs<std::complex<double>>,
+              blaze::DivideScalarByVector<std::complex<double>>>,
           Operator>,
       "This unary operation is not permitted on a DiagonalModalOperator");
   using Type = DiagonalModalOperator;

--- a/src/DataStructures/ModalVector.hpp
+++ b/src/DataStructures/ModalVector.hpp
@@ -50,7 +50,8 @@ template <>
 struct SubTrait<ModalVector, ModalVector> {
   using Type = ModalVector;
 };
-BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ModalVector, double, MultTrait);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ModalVector, double, MultTrait,
+                                               ModalVector);
 template <>
 struct DivTrait<ModalVector, double> {
   using Type = ModalVector;
@@ -60,16 +61,25 @@ struct DivTrait<ModalVector, double> {
 template <typename Operator>
 struct UnaryMapTrait<ModalVector, Operator> {
   // Selectively allow unary operations for spectral coefficients
-  static_assert(tmpl::list_contains_v<
-                    tmpl::list<blaze::Abs,
-                               // Following 3 reqd. by operator(+,+=), (-,-=),
-                               // (-) w/doubles
-                               blaze::AddScalar<ModalVector::ElementType>,
-                               blaze::SubScalarRhs<ModalVector::ElementType>,
-                               blaze::SubScalarLhs<ModalVector::ElementType>>,
-                    Operator>,
-                "Only unary operation permitted on a ModalVector are:"
-                " abs");
+  static_assert(
+      tmpl::list_contains_v<
+          tmpl::list<blaze::Abs,
+                     // Following 3 reqd. by operator(+,+=), (-,-=),
+                     // (-) w/doubles
+                     blaze::AddScalar<ModalVector::ElementType>,
+                     blaze::SubScalarRhs<ModalVector::ElementType>,
+                     blaze::SubScalarLhs<ModalVector::ElementType>,
+                     // With these and the blaze traits in
+                     // `ComplexModalVector.hpp`, the `ModalVector`
+                     // can be operated with a `std::complex<double>` to produce
+                     // a `ComplexModalVector`, analogous to implicit
+                     // casting in the standard library
+                     blaze::AddScalar<std::complex<double>>,
+                     blaze::SubScalarRhs<std::complex<double>>,
+                     blaze::SubScalarLhs<std::complex<double>>>,
+          Operator>,
+      "The only unary operation permitted on a ModalVector is:"
+      " abs");
   using Type = ModalVector;
 };
 
@@ -92,9 +102,17 @@ struct MapTrait<ModalVector, Operator> {
                                // (-) w/doubles
                                blaze::AddScalar<ModalVector::ElementType>,
                                blaze::SubScalarRhs<ModalVector::ElementType>,
-                               blaze::SubScalarLhs<ModalVector::ElementType>>,
+                               blaze::SubScalarLhs<ModalVector::ElementType>,
+                               // With these and the blaze traits in
+                               // `ComplexModalVector.hpp`, the `ModalVector`
+                               // can be operated with a `std::complex<double>`
+                               // to produce a `ComplexModalVector`, analogous
+                               // to implicit casting in the standard library
+                               blaze::AddScalar<std::complex<double>>,
+                               blaze::SubScalarRhs<std::complex<double>>,
+                               blaze::SubScalarLhs<std::complex<double>>>,
                     Operator>,
-                "Only unary operation permitted on a ModalVector are:"
+                "The only unary operation permitted on a ModalVector is:"
                 " abs.");
   using Type = ModalVector;
 };

--- a/src/DataStructures/SpinWeighted.hpp
+++ b/src/DataStructures/SpinWeighted.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits.hpp"
@@ -69,6 +70,28 @@ struct SpinWeighted<T, Spin, false> {
     return *this;
   }
 
+  template <typename Rhs>
+  auto& operator+=(const SpinWeighted<Rhs, Spin>& rhs) noexcept {
+    data_ += rhs.data();
+    return *this;
+  }
+
+  auto& operator+=(const T& rhs) noexcept {
+    data_ += rhs;
+    return *this;
+  }
+
+  template <typename Rhs>
+  auto& operator-=(const SpinWeighted<Rhs, Spin>& rhs) noexcept {
+    data_ -= rhs.data();
+    return *this;
+  }
+
+  auto& operator-=(const T& rhs) noexcept {
+    data_ -= rhs;
+    return *this;
+  }
+
   T& data() noexcept { return data_; }
   const T& data() const noexcept { return data_; }
 
@@ -81,7 +104,13 @@ struct SpinWeighted<T, Spin, true> {
   using value_type = T;
   constexpr static int spin = Spin;
 
-  void set_data_ref(gsl::not_null<T*> rhs) noexcept { data_.set_data_ref(rhs); }
+  void set_data_ref(const gsl::not_null<T*> rhs) noexcept {
+    data_.set_data_ref(rhs);
+  }
+
+  void set_data_ref(const gsl::not_null<SpinWeighted<T, spin>*> rhs) noexcept {
+    data_.set_data_ref(make_not_null(&(rhs->data_)));
+  }
 
   template <typename ValueType>
   void set_data_ref(ValueType* const start, const size_t set_size) noexcept {
@@ -126,6 +155,28 @@ struct SpinWeighted<T, Spin, true> {
   }
   SpinWeighted& operator=(T&& rhs) noexcept {
     data_ = std::move(rhs);
+    return *this;
+  }
+
+  template <typename Rhs>
+  auto& operator+=(const SpinWeighted<Rhs, Spin>& rhs) noexcept {
+    data_ += rhs.data();
+    return *this;
+  }
+
+  auto& operator+=(const T& rhs) noexcept {
+    data_ += rhs;
+    return *this;
+  }
+
+  template <typename Rhs>
+  auto& operator-=(const SpinWeighted<Rhs, Spin>& rhs) noexcept {
+    data_ -= rhs.data();
+    return *this;
+  }
+
+  auto& operator-=(const T& rhs) noexcept {
+    data_ -= rhs;
     return *this;
   }
 
@@ -273,6 +324,20 @@ operator-(const get_vector_element_type_t<T>& lhs,
   return {lhs - rhs.data()};
 }
 // @}
+
+/// Negation operator preserves spin
+template <typename T, int Spin>
+SPECTRE_ALWAYS_INLINE SpinWeighted<decltype(-std::declval<T>()), Spin>
+operator-(const SpinWeighted<T, Spin>& operand) noexcept {
+  return {-operand.data()};
+}
+
+/// Unary `+` operator preserves spin
+template <typename T, int Spin>
+SPECTRE_ALWAYS_INLINE SpinWeighted<decltype(+std::declval<T>()), Spin>
+operator+(const SpinWeighted<T, Spin>& operand) noexcept {
+  return {+operand.data()};
+}
 
 // @{
 /// \brief Multiply two spin-weighted quantities if the types are compatible and

--- a/src/DataStructures/SpinWeighted.hpp
+++ b/src/DataStructures/SpinWeighted.hpp
@@ -48,6 +48,9 @@ struct SpinWeighted<T, Spin, false> {
 
   SpinWeighted(const T& rhs) noexcept : data_{rhs} {}        // NOLINT
   SpinWeighted(T&& rhs) noexcept : data_{std::move(rhs)} {}  // NOLINT
+  explicit SpinWeighted(const size_t size) noexcept : data_{size} {}
+  template <typename U>
+  SpinWeighted(const size_t size, const U& val) noexcept : data_{size, val} {}
 
   template <typename Rhs>
   SpinWeighted& operator=(const SpinWeighted<Rhs, Spin>& rhs) noexcept {
@@ -136,6 +139,9 @@ struct SpinWeighted<T, Spin, true> {
 
   SpinWeighted(const T& rhs) noexcept : data_{rhs} {}        // NOLINT
   SpinWeighted(T&& rhs) noexcept : data_{std::move(rhs)} {}  // NOLINT
+  explicit SpinWeighted(const size_t size) noexcept : data_{size} {}
+  template <typename U>
+  SpinWeighted(const size_t size, const U& val) noexcept : data_{size, val} {}
 
   template <typename Rhs>
   SpinWeighted& operator=(const SpinWeighted<Rhs, Spin>& rhs) noexcept {

--- a/src/DataStructures/SpinWeighted.hpp
+++ b/src/DataStructures/SpinWeighted.hpp
@@ -98,6 +98,8 @@ struct SpinWeighted<T, Spin, false> {
   T& data() noexcept { return data_; }
   const T& data() const noexcept { return data_; }
 
+ size_t size() const noexcept { return data_.size(); }
+
  private:
   T data_;
 };
@@ -188,6 +190,8 @@ struct SpinWeighted<T, Spin, true> {
 
   T& data() noexcept { return data_; }
   const T& data() const noexcept { return data_; }
+
+  size_t size() const noexcept { return data_.size(); }
 
  private:
   T data_;

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -426,16 +426,19 @@ std::ostream& operator<<(std::ostream& os,
  *
  * \param BLAZE_MATH_TRAIT The blaze trait for which you want declare the Type
  * field (e.g. `AddTrait`)
+ *
+ * \param RESULT_TYPE The type which should be used as the 'return' type for the
+ * binary operation
  */
-#define BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT( \
-    VECTOR_TYPE, COMPATIBLE, BLAZE_MATH_TRAIT)          \
-  template <>                                           \
-  struct BLAZE_MATH_TRAIT<VECTOR_TYPE, COMPATIBLE> {    \
-    using Type = VECTOR_TYPE;                           \
-  };                                                    \
-  template <>                                           \
-  struct BLAZE_MATH_TRAIT<COMPATIBLE, VECTOR_TYPE> {    \
-    using Type = VECTOR_TYPE;                           \
+#define BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(     \
+    VECTOR_TYPE, COMPATIBLE, BLAZE_MATH_TRAIT, RESULT_TYPE) \
+  template <>                                               \
+  struct BLAZE_MATH_TRAIT<VECTOR_TYPE, COMPATIBLE> {        \
+    using Type = RESULT_TYPE;                               \
+  };                                                        \
+  template <>                                               \
+  struct BLAZE_MATH_TRAIT<COMPATIBLE, VECTOR_TYPE> {        \
+    using Type = RESULT_TYPE;                               \
   }
 
 /*!

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -229,6 +229,33 @@ class VectorImpl
   }
   // @}
 
+  /*!
+   * \brief A common operation for checking the size and resizing a memory
+   * buffer if needed to ensure that it has the desired size. This operation is
+   * not permitted on a non-owning vector.
+   *
+   * \note This utility should NOT be used when it is anticipated that the
+   *   supplied buffer will typically be the wrong size (in that case, suggest
+   *   either manual checking or restructuring so that resizing is less common).
+   *   This uses `UNLIKELY` to perform the check most quickly when the buffer
+   *   needs no resizing, but will be slower when resizing is common.
+   */
+  void SPECTRE_ALWAYS_INLINE
+  destructive_resize(const size_t new_size) noexcept {
+    if(UNLIKELY(size() != new_size)) {
+      if (owning_) {
+        owned_data_ = std::unique_ptr<value_type[], decltype(&free)>{
+            new_size > 0 ? static_cast<value_type*>(
+                               malloc(new_size * sizeof(value_type)))
+                         : nullptr,
+            &free};
+        reset_pointer_vector(new_size);
+      } else {
+        ERROR("may not destructively resize a non-owning vector");
+      }
+    }
+  }
+
   /// Returns true if the class owns the data
   bool is_owning() const noexcept { return owning_; }
 

--- a/src/Utilities/VectorAlgebra.hpp
+++ b/src/Utilities/VectorAlgebra.hpp
@@ -20,7 +20,7 @@ template <typename LhsVectorType, typename RhsVectorType,
 void outer_product(const gsl::not_null<ResultVectorType*> result,
                    const LhsVectorType& lhs,
                    const RhsVectorType& rhs) noexcept {
-  check_and_resize(result, lhs.size() * rhs.size());
+  result->destructive_resize(lhs.size() * rhs.size());
   for (size_t i = 0; i < rhs.size(); ++i) {
     ResultVectorType view{result->data() + i * lhs.size(), lhs.size()};
     view = rhs[i] * lhs;
@@ -52,7 +52,7 @@ template <typename VectorType>
 void repeat(const gsl::not_null<VectorType*> result,
             const VectorType& to_repeat,
             const size_t times_to_repeat) noexcept {
-  check_and_resize(result, to_repeat.size() * times_to_repeat);
+  result->destructive_resize(to_repeat.size() * times_to_repeat);
   for (size_t i = 0; i < times_to_repeat; ++i) {
     VectorType view{result->data() + i * to_repeat.size(), to_repeat.size()};
     view = to_repeat;

--- a/src/Utilities/VectorAlgebra.hpp
+++ b/src/Utilities/VectorAlgebra.hpp
@@ -1,0 +1,69 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/VectorImpl.hpp"
+#include "Utilities/Gsl.hpp"
+
+// @{
+/// \ingroup UtilitiesGroup
+/// \brief Computes the outer product between two vectors.
+/// \details For vectors \f$A\f$ and \f$B\f$, the resulting outer product is
+/// \f$\{A_1 B_1,\, A_2 B_1\, \dots\, A_N B_1,\, A_1 B_2\, \dots\, A_N B_M\}\f$.
+/// This is useful for generating separable volume data from its constituent
+/// inputs.
+template <typename LhsVectorType, typename RhsVectorType,
+          typename ResultVectorType =
+              typename blaze::MultTrait<LhsVectorType, RhsVectorType>::Type>
+void outer_product(const gsl::not_null<ResultVectorType*> result,
+                   const LhsVectorType& lhs,
+                   const RhsVectorType& rhs) noexcept {
+  check_and_resize(result, lhs.size() * rhs.size());
+  for (size_t i = 0; i < rhs.size(); ++i) {
+    ResultVectorType view{result->data() + i * lhs.size(), lhs.size()};
+    view = rhs[i] * lhs;
+  }
+}
+
+template <typename LhsVectorType, typename RhsVectorType,
+          typename ResultVectorType =
+              typename blaze::MultTrait<LhsVectorType, RhsVectorType>::Type>
+ResultVectorType outer_product(const LhsVectorType& lhs,
+                               const RhsVectorType& rhs) noexcept {
+  auto result = ResultVectorType{lhs.size() * rhs.size()};
+  outer_product(make_not_null(&result), lhs, rhs);
+  return result;
+}
+// @}
+
+// @{
+/// \ingroup UtilitiesGroup
+/// \brief Repeats a vector `times_to_repeat` times.
+/// \details This can be useful for generating data that consists of the same
+/// block of values duplicated a number of times. For instance, this can be used
+/// to create a vector representing three-dimensional volume data from a
+/// corresponding two-dimensional vector data, if the two-dimensional data
+/// corresponds to the two fastest-varying directions of the desired
+/// three-dimensional representation. The result would then be uniform in the
+/// slowest-varying direction of the three dimensional grid.
+template <typename VectorType>
+void repeat(const gsl::not_null<VectorType*> result,
+            const VectorType& to_repeat,
+            const size_t times_to_repeat) noexcept {
+  check_and_resize(result, to_repeat.size() * times_to_repeat);
+  for (size_t i = 0; i < times_to_repeat; ++i) {
+    VectorType view{result->data() + i * to_repeat.size(), to_repeat.size()};
+    view = to_repeat;
+  }
+}
+
+template <typename VectorType>
+VectorType repeat(const VectorType& to_repeat,
+                  const size_t times_to_repeat) noexcept {
+  auto result = VectorType{to_repeat.size() * times_to_repeat};
+  repeat(make_not_null(&result), to_repeat, times_to_repeat);
+  return result;
+}
+// @}

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -5,9 +5,12 @@ set(LIBRARY "Test_DataStructures")
 
 set(LIBRARY_SOURCES
   Test_ComplexDataVector.cpp
+  Test_ComplexDataVectorBinaryOperations.cpp
   Test_ComplexDiagonalModalOperator.cpp
   Test_ComplexModalVector.cpp
+  Test_ComplexModalVectorInhomogeneousOperations.cpp
   Test_DataVector.cpp
+  Test_DataVectorBinaryOperations.cpp
   Test_DenseMatrix.cpp
   Test_DenseVector.cpp
   Test_DiagonalModalOperator.cpp
@@ -18,6 +21,9 @@ set(LIBRARY_SOURCES
   Test_IndexIterator.cpp
   Test_LeviCivitaIterator.cpp
   Test_ModalVector.cpp
+  Test_ModalVectorInhomogeneousOperations.cpp
+  Test_MoreComplexDiagonalModalOperatorMath.cpp
+  Test_MoreDiagonalModalOperatorMath.cpp
   Test_SliceIterator.cpp
   Test_SpinWeighted.cpp
   Test_StripeIterator.cpp

--- a/tests/Unit/DataStructures/Test_ComplexDataVector.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexDataVector.cpp
@@ -3,7 +3,6 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <array>
 #include <complex>
 #include <tuple>
 
@@ -96,57 +95,10 @@ void test_complex_data_vector_math() noexcept {
   TestHelpers::VectorImpl::test_functions_with_vector_arguments<
       TestHelpers::VectorImpl::TestKind::Normal, DataVector>(real_unary_ops);
   /// [test_vector_math_usage]
-  const auto binary_ops = std::make_tuple(
-      std::make_tuple(funcl::Divides<>{}, std::make_tuple(generic, positive)),
-      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
-      std::make_tuple(funcl::Multiplies<>{}, std::make_tuple(generic, generic)),
-      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
 
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Normal, ComplexDataVector,
-      ComplexDataVector>(binary_ops);
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Normal, DataVector, ComplexDataVector>(
-      binary_ops);
-
-  const auto inplace_binary_ops = std::make_tuple(
-      std::make_tuple(funcl::DivAssign<>{}, std::make_tuple(generic, positive)),
-      std::make_tuple(funcl::MinusAssign<>{},
-                      std::make_tuple(generic, generic)),
-      std::make_tuple(funcl::MultAssign<>{}, std::make_tuple(generic, generic)),
-      std::make_tuple(funcl::PlusAssign<>{},
-                      std::make_tuple(generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Inplace, ComplexDataVector,
-      ComplexDataVector>(inplace_binary_ops);
-
-  const auto cascaded_ops = std::make_tuple(
-      std::make_tuple(funcl::Multiplies<funcl::Plus<>, funcl::Identity>{},
-                      std::make_tuple(generic, generic, generic)),
-      std::make_tuple(funcl::Multiplies<funcl::Exp<>, funcl::Sin<>>{},
-                      std::make_tuple(generic, generic, generic)),
-      std::make_tuple(
-          funcl::Plus<funcl::Atan<funcl::Tan<>>, funcl::Divides<>>{},
-          std::make_tuple(generic, generic, positive)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Strict, ComplexDataVector,
-      ComplexDataVector, ComplexDataVector>(cascaded_ops);
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Strict, ComplexDataVector, DataVector,
-      ComplexDataVector>(cascaded_ops);
-
-  const auto array_binary_ops = std::make_tuple(
-      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
-      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Strict,
-      std::array<ComplexDataVector, 2>, std::array<ComplexDataVector, 2>>(
-      array_binary_ops);
+  // Note that the binary operations have been moved to
+  // `Test_ComplexDataVectorBinaryOperations.cpp` in an effort to better
+  // parallelize the build.
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.ComplexDataVector",

--- a/tests/Unit/DataStructures/Test_ComplexDataVector.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexDataVector.cpp
@@ -107,7 +107,7 @@ void test_complex_data_vector_math() noexcept {
       ComplexDataVector>(binary_ops);
 
   TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Strict, DataVector, ComplexDataVector>(
+      TestHelpers::VectorImpl::TestKind::Normal, DataVector, ComplexDataVector>(
       binary_ops);
 
   const auto inplace_binary_ops = std::make_tuple(

--- a/tests/Unit/DataStructures/Test_ComplexDataVectorBinaryOperations.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexDataVectorBinaryOperations.cpp
@@ -1,0 +1,85 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// This file is separated from `Test_ComplexDataVector.cpp` in an effort to
+// parallelize the test builds.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <tuple>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "ErrorHandling/Error.hpp"           // IWYU pragma: keep
+#include "Utilities/DereferenceWrapper.hpp"  // IWYU pragma: keep
+#include "Utilities/Functional.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+#include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
+#include "tests/Unit/DataStructures/VectorImplTestHelper.hpp"
+
+// IWYU pragma: no_include "DataStructures/DenseMatrix.hpp"
+
+void test_complex_data_vector_multiple_operand_math() noexcept {
+  const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
+  const TestHelpers::VectorImpl::Bound mone_one{{-1.0, 1.0}};
+  const TestHelpers::VectorImpl::Bound gt_one{{1.0, 100.0}};
+  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
+
+  const auto binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Divides<>{}, std::make_tuple(generic, positive)),
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Multiplies<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Normal, ComplexDataVector,
+      ComplexDataVector>(binary_ops);
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Normal, DataVector, ComplexDataVector>(
+      binary_ops);
+
+  const auto inplace_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::DivAssign<>{}, std::make_tuple(generic, positive)),
+      std::make_tuple(funcl::MinusAssign<>{},
+                      std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::MultAssign<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::PlusAssign<>{},
+                      std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Inplace, ComplexDataVector,
+      ComplexDataVector>(inplace_binary_ops);
+
+  const auto cascaded_ops = std::make_tuple(
+      std::make_tuple(funcl::Multiplies<funcl::Plus<>, funcl::Identity>{},
+                      std::make_tuple(generic, generic, generic)),
+      std::make_tuple(funcl::Multiplies<funcl::Exp<>, funcl::Sin<>>{},
+                      std::make_tuple(generic, generic, generic)),
+      std::make_tuple(
+          funcl::Plus<funcl::Atan<funcl::Tan<>>, funcl::Divides<>>{},
+          std::make_tuple(generic, generic, positive)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, ComplexDataVector,
+      ComplexDataVector, ComplexDataVector>(cascaded_ops);
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, ComplexDataVector, DataVector,
+      ComplexDataVector>(cascaded_ops);
+
+  const auto array_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict,
+      std::array<ComplexDataVector, 2>, std::array<ComplexDataVector, 2>>(
+      array_binary_ops);
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.ComplexDataVector.MultipleOperands",
+                  "[DataStructures][Unit]") {
+    test_complex_data_vector_multiple_operand_math();
+}

--- a/tests/Unit/DataStructures/Test_ComplexDiagonalModalOperator.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexDiagonalModalOperator.cpp
@@ -3,13 +3,11 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <array>
 #include <complex>
 #include <tuple>
 
 #include "DataStructures/ComplexDiagonalModalOperator.hpp"
-#include "DataStructures/ComplexModalVector.hpp"
-#include "DataStructures/DiagonalModalOperator.hpp"
+#include "DataStructures/DiagonalModalOperator.hpp"  // IWYU pragma: keep
 #include "DataStructures/ModalVector.hpp"  // IWYU pragma: keep
 #include "ErrorHandling/Error.hpp"         // IWYU pragma: keep
 #include "Utilities/Functional.hpp"
@@ -17,6 +15,7 @@
 #include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
 #include "tests/Unit/DataStructures/VectorImplTestHelper.hpp"
 
+// IWYU pragma: no_forward_declare DiagonalModalOperator;
 // IWYU pragma: no_include <algorithm>
 
 // [[OutputRegex, Must copy into same size]]
@@ -98,50 +97,10 @@ void test_complex_diagonal_modal_operator_math() noexcept {
       TestHelpers::VectorImpl::TestKind::Inplace, ComplexDiagonalModalOperator,
       DiagonalModalOperator>(inplace_binary_ops);
 
-  const auto acting_on_modal_vector = std::make_tuple(std::make_tuple(
-      funcl::Multiplies<>{}, std::make_tuple(generic, generic)));
-
-  // the operation isn't really "inplace", but we carefully forbid the operation
-  // between two ModalVectors, which will be avoided in the inplace test case,
-  // which checks only combinations with the ComplexDiagonalModalOperator as the
-  // first argument.
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Inplace, ComplexDiagonalModalOperator,
-      ModalVector, ComplexModalVector>(acting_on_modal_vector);
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
-      DiagonalModalOperator, ComplexModalVector>(acting_on_modal_vector);
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
-      ComplexModalVector, DiagonalModalOperator>(acting_on_modal_vector);
-  // testing the other ordering
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, ModalVector,
-      ComplexDiagonalModalOperator>(acting_on_modal_vector);
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
-      ComplexModalVector, ComplexDiagonalModalOperator>(acting_on_modal_vector);
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
-      ComplexModalVector, DiagonalModalOperator>(acting_on_modal_vector);
-
-  const auto cascaded_ops = std::make_tuple(
-      std::make_tuple(funcl::Multiplies<funcl::Plus<>, funcl::Identity>{},
-                      std::make_tuple(generic, generic, generic)),
-      std::make_tuple(funcl::Minus<funcl::Plus<>, funcl::Identity>{},
-                      std::make_tuple(generic, generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Strict, ComplexDiagonalModalOperator,
-      DiagonalModalOperator>(cascaded_ops);
-
-  const auto array_binary_ops = std::make_tuple(
-      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
-      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Strict,
-      std::array<ComplexDiagonalModalOperator, 2>>(array_binary_ops);
+  // Note that a collection of additional operations that involve acting on
+  // complex modal vectors with complex diagonal modal operators have been moved
+  // to `Test_MoreComplexDiagonalModalOperatorMath.cpp` in an effort to better
+  // parallelize the build.
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.ComplexDiagonalModalOperator",

--- a/tests/Unit/DataStructures/Test_ComplexDiagonalModalOperator.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexDiagonalModalOperator.cpp
@@ -65,7 +65,8 @@ void test_complex_diagonal_modal_operator_math() noexcept {
   const auto unary_ops = std::make_tuple(
       std::make_tuple(funcl::Conj<>{}, std::make_tuple(generic)),
       std::make_tuple(funcl::Imag<>{}, std::make_tuple(generic)),
-      std::make_tuple(funcl::Real<>{}, std::make_tuple(generic)));
+      std::make_tuple(funcl::Real<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Sqrt<>{}, std::make_tuple(generic)));
 
   TestHelpers::VectorImpl::test_functions_with_vector_arguments<
       TestHelpers::VectorImpl::TestKind::Normal, ComplexDiagonalModalOperator>(
@@ -82,7 +83,7 @@ void test_complex_diagonal_modal_operator_math() noexcept {
       binary_ops);
 
   TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Strict, ComplexDiagonalModalOperator,
+      TestHelpers::VectorImpl::TestKind::Normal, ComplexDiagonalModalOperator,
       DiagonalModalOperator>(binary_ops);
 
   const auto inplace_binary_ops = std::make_tuple(

--- a/tests/Unit/DataStructures/Test_ComplexModalVector.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexModalVector.cpp
@@ -97,46 +97,10 @@ void test_complex_modal_vector_math() noexcept {
       TestHelpers::VectorImpl::TestKind::Strict,
       std::array<ComplexModalVector, 2>>(array_binary_ops);
 
-  const auto just_element_with_modal_vector_ops =
-      std::make_tuple(std::make_tuple(funcl::Multiplies<>{},
-                                      std::make_tuple(generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, double,
-      ComplexModalVector>(just_element_with_modal_vector_ops);
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
-      std::complex<double>, ComplexModalVector>(
-      just_element_with_modal_vector_ops);
-
-  const auto just_modal_vector_with_element_ops = std::make_tuple(
-      std::make_tuple(funcl::Multiplies<>{}, std::make_tuple(generic, generic)),
-      std::make_tuple(funcl::Divides<>{}, std::make_tuple(generic, positive)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
-      ComplexModalVector, double>(just_modal_vector_with_element_ops);
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
-      ComplexModalVector, std::complex<double>>(
-      just_modal_vector_with_element_ops);
-
-  const auto just_modal_vector_with_modal_vector_ops =
-      std::make_tuple(std::make_tuple(funcl::MinusAssign<>{},
-                                      std::make_tuple(generic, generic)),
-                      std::make_tuple(funcl::PlusAssign<>{},
-                                      std::make_tuple(generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
-      ComplexModalVector, ComplexModalVector>(
-      just_modal_vector_with_modal_vector_ops);
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
-      ComplexModalVector, ModalVector>(just_modal_vector_with_modal_vector_ops);
+  // Note that the binary operations that involve a complex modal vector and
+  // various scalar types have been moved to
+  // `Test_ComplexModalVectorInhomogeneousOperations.cpp` in an effort to better
+  // parallelize the build.
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.ComplexModalVector",

--- a/tests/Unit/DataStructures/Test_ComplexModalVector.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexModalVector.cpp
@@ -78,7 +78,7 @@ void test_complex_modal_vector_math() noexcept {
       std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
 
   TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Strict, ComplexModalVector,
+      TestHelpers::VectorImpl::TestKind::Normal, ComplexModalVector,
       ModalVector>(binary_ops);
 
   const auto cascaded_ops = std::make_tuple(

--- a/tests/Unit/DataStructures/Test_ComplexModalVectorInhomogeneousOperations.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexModalVectorInhomogeneousOperations.cpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// This file has been separated from `Test_ComplexModalVector.cpp` in an effort
+// to parallelize the test builds.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <complex>
+#include <tuple>
+
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "ErrorHandling/Error.hpp"           // IWYU pragma: keep
+#include "Utilities/DereferenceWrapper.hpp"  // IWYU pragma: keep
+#include "Utilities/Functional.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+#include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
+#include "tests/Unit/DataStructures/VectorImplTestHelper.hpp"
+
+// IWYU pragma: no_include <algorithm>
+
+void test_complex_modal_vector_inhomogeneous_binary_math() noexcept {
+  const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
+  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
+
+  const auto just_element_with_modal_vector_ops =
+      std::make_tuple(std::make_tuple(funcl::Multiplies<>{},
+                                      std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, double,
+      ComplexModalVector>(just_element_with_modal_vector_ops);
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      std::complex<double>, ComplexModalVector>(
+      just_element_with_modal_vector_ops);
+
+  const auto just_modal_vector_with_element_ops = std::make_tuple(
+      std::make_tuple(funcl::Multiplies<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Divides<>{}, std::make_tuple(generic, positive)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      ComplexModalVector, double>(just_modal_vector_with_element_ops);
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      ComplexModalVector, std::complex<double>>(
+      just_modal_vector_with_element_ops);
+
+  const auto just_modal_vector_with_modal_vector_ops =
+      std::make_tuple(std::make_tuple(funcl::MinusAssign<>{},
+                                      std::make_tuple(generic, generic)),
+                      std::make_tuple(funcl::PlusAssign<>{},
+                                      std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      ComplexModalVector, ComplexModalVector>(
+      just_modal_vector_with_modal_vector_ops);
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      ComplexModalVector, ModalVector>(just_modal_vector_with_modal_vector_ops);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.DataStructures.ComplexModalVector.InhomogeneousOperations",
+    "[DataStructures][Unit]") {
+  test_complex_modal_vector_inhomogeneous_binary_math();
+}

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -3,14 +3,13 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <array>
 #include <tuple>
 
-#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
-#include "ErrorHandling/Error.hpp"        // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
+#include "ErrorHandling/Error.hpp"           // IWYU pragma: keep
 #include "Utilities/DereferenceWrapper.hpp"  // IWYU pragma: keep
 #include "Utilities/Functional.hpp"
-#include "Utilities/Math.hpp"  // IWYU pragma: keep
+#include "Utilities/Math.hpp"        // IWYU pragma: keep
 #include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
 #include "tests/Unit/DataStructures/VectorImplTestHelper.hpp"
 
@@ -50,7 +49,7 @@
 #endif
 }
 
-void test_data_vector_math() noexcept {
+void test_data_vector_unary_math() noexcept {
   /// [test_functions_with_vector_arguments_example]
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
   const TestHelpers::VectorImpl::Bound mone_one{{-1.0, 1.0}};
@@ -91,58 +90,9 @@ void test_data_vector_math() noexcept {
       TestHelpers::VectorImpl::TestKind::Normal, DataVector>(unary_ops);
   /// [test_functions_with_vector_arguments_example]
 
-  const auto binary_ops = std::make_tuple(
-      std::make_tuple(funcl::Divides<>{}, std::make_tuple(generic, positive)),
-      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
-      std::make_tuple(funcl::Multiplies<>{}, std::make_tuple(generic, generic)),
-      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Normal, DataVector>(binary_ops);
-
-  const auto inplace_binary_ops = std::make_tuple(
-      std::make_tuple(funcl::DivAssign<>{}, std::make_tuple(generic, positive)),
-      std::make_tuple(funcl::MinusAssign<>{},
-                      std::make_tuple(generic, generic)),
-      std::make_tuple(funcl::MultAssign<>{}, std::make_tuple(generic, generic)),
-      std::make_tuple(funcl::PlusAssign<>{},
-                      std::make_tuple(generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Inplace, DataVector>(
-      inplace_binary_ops);
-
-  const auto strict_binary_ops = std::make_tuple(
-      std::make_tuple(funcl::Atan2<>{}, std::make_tuple(generic, positive)),
-      std::make_tuple(funcl::Hypot<>{}, std::make_tuple(generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Strict, DataVector>(strict_binary_ops);
-
-  const auto cascaded_ops = std::make_tuple(
-      std::make_tuple(funcl::Multiplies<funcl::Plus<>, funcl::Identity>{},
-                      std::make_tuple(generic, generic, generic)),
-      std::make_tuple(funcl::Multiplies<funcl::Exp<>, funcl::Sin<>>{},
-                      std::make_tuple(generic, generic)),
-      std::make_tuple(
-          funcl::Plus<funcl::Atan<funcl::Tan<>>, funcl::Divides<>>{},
-          std::make_tuple(generic, generic, positive)),
-      // step function with multiplication should be tested due to resolved
-      // [issue 1122](https://github.com/sxs-collaboration/spectre/issues/1122)
-      std::make_tuple(funcl::StepFunction<
-                          funcl::Plus<funcl::Multiplies<>, funcl::Identity>>{},
-                      std::make_tuple(generic, generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Strict, DataVector>(cascaded_ops);
-
-  const auto array_binary_ops = std::make_tuple(
-      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
-      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Strict, std::array<DataVector, 2>>(
-      array_binary_ops);
+  // Note that the binary operations have been moved to
+  // `Test_DataVectorBinaryOperations.cpp` in an effort to better parallelize
+  // the build.
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataVector", "[DataStructures][Unit]") {
@@ -165,6 +115,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector", "[DataStructures][Unit]") {
   }
   {
     INFO("test DataVector math operations");
-    test_data_vector_math();
+    test_data_vector_unary_math();
   }
 }

--- a/tests/Unit/DataStructures/Test_DataVectorBinaryOperations.cpp
+++ b/tests/Unit/DataStructures/Test_DataVectorBinaryOperations.cpp
@@ -1,0 +1,85 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// This file is separated from `Test_DataVector.cpp` in an effort to parallelize
+// the test builds.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <tuple>
+
+#include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
+#include "ErrorHandling/Error.hpp"           // IWYU pragma: keep
+#include "Utilities/DereferenceWrapper.hpp"  // IWYU pragma: keep
+#include "Utilities/Functional.hpp"
+#include "Utilities/Math.hpp"        // IWYU pragma: keep
+#include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
+#include "tests/Unit/DataStructures/VectorImplTestHelper.hpp"
+
+// IWYU pragma: no_include <algorithm>
+
+void test_data_vector_multiple_operand_math() noexcept {
+  const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
+  const TestHelpers::VectorImpl::Bound mone_one{{-1.0, 1.0}};
+  const TestHelpers::VectorImpl::Bound gt_one{{1.0, 100.0}};
+  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
+
+  const auto binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Divides<>{}, std::make_tuple(generic, positive)),
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Multiplies<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Normal, DataVector>(binary_ops);
+
+  const auto inplace_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::DivAssign<>{}, std::make_tuple(generic, positive)),
+      std::make_tuple(funcl::MinusAssign<>{},
+                      std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::MultAssign<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::PlusAssign<>{},
+                      std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Inplace, DataVector>(
+      inplace_binary_ops);
+
+  const auto strict_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Atan2<>{}, std::make_tuple(generic, positive)),
+      std::make_tuple(funcl::Hypot<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, DataVector>(strict_binary_ops);
+
+  const auto cascaded_ops = std::make_tuple(
+      std::make_tuple(funcl::Multiplies<funcl::Plus<>, funcl::Identity>{},
+                      std::make_tuple(generic, generic, generic)),
+      std::make_tuple(funcl::Multiplies<funcl::Exp<>, funcl::Sin<>>{},
+                      std::make_tuple(generic, generic)),
+      std::make_tuple(
+          funcl::Plus<funcl::Atan<funcl::Tan<>>, funcl::Divides<>>{},
+          std::make_tuple(generic, generic, positive)),
+      // step function with multiplication should be tested due to resolved
+      // [issue 1122](https://github.com/sxs-collaboration/spectre/issues/1122)
+      std::make_tuple(funcl::StepFunction<
+                          funcl::Plus<funcl::Multiplies<>, funcl::Identity>>{},
+                      std::make_tuple(generic, generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, DataVector>(cascaded_ops);
+
+  const auto array_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, std::array<DataVector, 2>>(
+      array_binary_ops);
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.MultipleOperands",
+                  "[DataStructures][Unit]") {
+  test_data_vector_multiple_operand_math();
+}

--- a/tests/Unit/DataStructures/Test_DiagonalModalOperator.cpp
+++ b/tests/Unit/DataStructures/Test_DiagonalModalOperator.cpp
@@ -3,7 +3,6 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <array>
 #include <tuple>
 
 #include "DataStructures/DiagonalModalOperator.hpp"
@@ -78,38 +77,10 @@ void test_diagonal_modal_operator_math() noexcept {
       TestHelpers::VectorImpl::TestKind::Inplace, DiagonalModalOperator>(
       inplace_binary_ops);
 
-  const auto acting_on_modal_vector = std::make_tuple(std::make_tuple(
-      funcl::Multiplies<>{}, std::make_tuple(generic, generic)));
-
-  // the operation isn't really "inplace", but we carefully forbid the operation
-  // between two ModalVectors, which will be avoided in the inplace test case,
-  // which checks only combinations with the DiagonalModalOperator as the first
-  // argument.
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Inplace, DiagonalModalOperator,
-      ModalVector>(acting_on_modal_vector);
-  // testing the other ordering
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, ModalVector,
-      DiagonalModalOperator>(acting_on_modal_vector);
-
-  const auto cascaded_ops = std::make_tuple(
-      std::make_tuple(funcl::Multiplies<funcl::Plus<>, funcl::Identity>{},
-                      std::make_tuple(generic, generic, generic)),
-      std::make_tuple(funcl::Minus<funcl::Plus<>, funcl::Identity>{},
-                      std::make_tuple(generic, generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Strict, DiagonalModalOperator>(
-      cascaded_ops);
-
-  const auto array_binary_ops = std::make_tuple(
-      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
-      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::Strict,
-      std::array<DiagonalModalOperator, 2>>(array_binary_ops);
+  // Note that a collection of additional operations that involve acting on
+  // modal vectors with diagonal modal operators have been moved to
+  // `Test_MoreDiagonalModalOperatorMath.cpp` in an effort to better
+  // parallelize the build.
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DiagonalModalOperator",

--- a/tests/Unit/DataStructures/Test_ModalVector.cpp
+++ b/tests/Unit/DataStructures/Test_ModalVector.cpp
@@ -84,31 +84,9 @@ void test_modal_vector_math() noexcept {
       TestHelpers::VectorImpl::TestKind::Strict, std::array<ModalVector, 2>>(
       array_binary_ops);
 
-  const auto just_double_with_modal_vector_ops =
-      std::make_tuple(std::make_tuple(funcl::Multiplies<>{},
-                                      std::make_tuple(generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, double,
-      ModalVector>(just_double_with_modal_vector_ops);
-
-  const auto just_modal_vector_with_double_ops = std::make_tuple(
-      std::make_tuple(funcl::Multiplies<>{}, std::make_tuple(generic, generic)),
-      std::make_tuple(funcl::Divides<>{}, std::make_tuple(generic, positive)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, ModalVector,
-      double>(just_modal_vector_with_double_ops);
-
-  const auto just_modal_vector_with_modal_vector_ops =
-      std::make_tuple(std::make_tuple(funcl::MinusAssign<>{},
-                                      std::make_tuple(generic, generic)),
-                      std::make_tuple(funcl::PlusAssign<>{},
-                                      std::make_tuple(generic, generic)));
-
-  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
-      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, ModalVector,
-      ModalVector>(just_modal_vector_with_modal_vector_ops);
+  // Note that the binary operations that involve a modal vector and a double
+  // have been moved to `Test_ModalVectorInhomogeneousOperations.cpp` in an
+  // effort to better parallelize the build.
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector", "[DataStructures][Unit]") {

--- a/tests/Unit/DataStructures/Test_ModalVectorInhomogeneousOperations.cpp
+++ b/tests/Unit/DataStructures/Test_ModalVectorInhomogeneousOperations.cpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// This file is separated from `Test_ModalVector.cpp` in an effort to
+// parallelize the test builds.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <tuple>
+
+#include "DataStructures/ModalVector.hpp"
+#include "ErrorHandling/Error.hpp"           // IWYU pragma: keep
+#include "Utilities/DereferenceWrapper.hpp"  // IWYU pragma: keep
+#include "Utilities/Functional.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+#include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
+#include "tests/Unit/DataStructures/VectorImplTestHelper.hpp"
+
+// IWYU pragma: no_include <algorithm>
+
+void test_modal_vector_inhomogeneous_binary_math() noexcept {
+  const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
+  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
+
+  const auto just_double_with_modal_vector_ops =
+      std::make_tuple(std::make_tuple(funcl::Multiplies<>{},
+                                      std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, double,
+      ModalVector>(just_double_with_modal_vector_ops);
+
+  const auto just_modal_vector_with_double_ops = std::make_tuple(
+      std::make_tuple(funcl::Multiplies<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Divides<>{}, std::make_tuple(generic, positive)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, ModalVector,
+      double>(just_modal_vector_with_double_ops);
+
+  const auto just_modal_vector_with_modal_vector_ops =
+      std::make_tuple(std::make_tuple(funcl::MinusAssign<>{},
+                                      std::make_tuple(generic, generic)),
+                      std::make_tuple(funcl::PlusAssign<>{},
+                                      std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, ModalVector,
+      ModalVector>(just_modal_vector_with_modal_vector_ops);
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector.InhomogeneousOperations",
+                  "[DataStructures][Unit]") {
+  test_modal_vector_inhomogeneous_binary_math();
+}

--- a/tests/Unit/DataStructures/Test_MoreComplexDiagonalModalOperatorMath.cpp
+++ b/tests/Unit/DataStructures/Test_MoreComplexDiagonalModalOperatorMath.cpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// This file is separated from `Test_ComplexDiagonalModalOperator.cpp` in an
+// effort to parallelize the test builds.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <tuple>
+
+#include "DataStructures/ComplexDiagonalModalOperator.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DiagonalModalOperator.hpp"
+#include "DataStructures/ModalVector.hpp"  // IWYU pragma: keep
+#include "ErrorHandling/Error.hpp"         // IWYU pragma: keep
+#include "Utilities/Functional.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+#include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
+#include "tests/Unit/DataStructures/VectorImplTestHelper.hpp"
+
+// IWYU pragma: no_include <algorithm>
+
+void test_additional_complex_diagonal_modal_operator_math() noexcept {
+  const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
+  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
+
+  const auto acting_on_modal_vector = std::make_tuple(std::make_tuple(
+      funcl::Multiplies<>{}, std::make_tuple(generic, generic)));
+
+  // the operation isn't really "inplace", but we carefully forbid the operation
+  // between two ModalVectors, which will be avoided in the inplace test case,
+  // which checks only combinations with the ComplexDiagonalModalOperator as the
+  // first argument.
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Inplace, ComplexDiagonalModalOperator,
+      ModalVector, ComplexModalVector>(acting_on_modal_vector);
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      DiagonalModalOperator, ComplexModalVector>(acting_on_modal_vector);
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      ComplexModalVector, DiagonalModalOperator>(acting_on_modal_vector);
+  // testing the other ordering
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, ModalVector,
+      ComplexDiagonalModalOperator>(acting_on_modal_vector);
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      ComplexModalVector, ComplexDiagonalModalOperator>(acting_on_modal_vector);
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      ComplexModalVector, DiagonalModalOperator>(acting_on_modal_vector);
+
+  const auto cascaded_ops = std::make_tuple(
+      std::make_tuple(funcl::Multiplies<funcl::Plus<>, funcl::Identity>{},
+                      std::make_tuple(generic, generic, generic)),
+      std::make_tuple(funcl::Minus<funcl::Plus<>, funcl::Identity>{},
+                      std::make_tuple(generic, generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, ComplexDiagonalModalOperator,
+      DiagonalModalOperator>(cascaded_ops);
+
+  const auto array_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict,
+      std::array<ComplexDiagonalModalOperator, 2>>(array_binary_ops);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.DataStructures.ComplexDiagonalModalOperator.AdditionalMath",
+    "[DataStructures][Unit]") {
+  test_additional_complex_diagonal_modal_operator_math();
+}

--- a/tests/Unit/DataStructures/Test_MoreDiagonalModalOperatorMath.cpp
+++ b/tests/Unit/DataStructures/Test_MoreDiagonalModalOperatorMath.cpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// This file is separated from `Test_DiagonalModalOperator.cpp` in an effort to
+// parallelize the test builds.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <tuple>
+
+#include "DataStructures/DiagonalModalOperator.hpp"
+#include "DataStructures/ModalVector.hpp"  // IWYU pragma: keep
+#include "ErrorHandling/Error.hpp"         // IWYU pragma: keep
+#include "Utilities/Functional.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+#include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
+#include "tests/Unit/DataStructures/VectorImplTestHelper.hpp"
+
+// IWYU pragma: no_include <algorithm>
+
+void test_additional_diagonal_modal_operator_math() noexcept {
+  const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
+  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
+
+  const auto acting_on_modal_vector = std::make_tuple(std::make_tuple(
+      funcl::Multiplies<>{}, std::make_tuple(generic, generic)));
+
+  // the operation isn't really "inplace", but we carefully forbid the operation
+  // between two ModalVectors, which will be avoided in the inplace test case,
+  // which checks only combinations with the DiagonalModalOperator as the first
+  // argument.
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Inplace, DiagonalModalOperator,
+      ModalVector>(acting_on_modal_vector);
+  // testing the other ordering
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, ModalVector,
+      DiagonalModalOperator>(acting_on_modal_vector);
+
+  const auto cascaded_ops = std::make_tuple(
+      std::make_tuple(funcl::Multiplies<funcl::Plus<>, funcl::Identity>{},
+                      std::make_tuple(generic, generic, generic)),
+      std::make_tuple(funcl::Minus<funcl::Plus<>, funcl::Identity>{},
+                      std::make_tuple(generic, generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, DiagonalModalOperator>(
+      cascaded_ops);
+
+  const auto array_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict,
+      std::array<DiagonalModalOperator, 2>>(array_binary_ops);
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.DiagonalModalOperator.AdditionalMath",
+                  "[DataStructures][Unit]") {
+  test_additional_diagonal_modal_operator_math();
+}

--- a/tests/Unit/DataStructures/Test_SpinWeighted.cpp
+++ b/tests/Unit/DataStructures/Test_SpinWeighted.cpp
@@ -166,8 +166,7 @@ void test_spinweights() {
   spin_weight_0 += spin_weight_0;
   CHECK(spin_weight_0 == sum);
 
-  SpinWeighted<SpinWeightedType, 0> difference =
-      spin_weight_0 - no_spin_weight;
+  SpinWeighted<SpinWeightedType, 0> difference = spin_weight_0 - no_spin_weight;
   spin_weight_0 -= no_spin_weight;
   CHECK(spin_weight_0 == difference);
 }
@@ -183,6 +182,14 @@ SPECTRE_TEST_CASE("Unit.DataStructures.SpinWeighted",
     using type_pair = typename decltype(x)::type;
     test_spinweights<tmpl::front<type_pair>, tmpl::back<type_pair>>();
   });
+
+  SpinWeighted<ComplexDataVector, 1> size_created_spin_weight_1{6};
+  CHECK(size_created_spin_weight_1.data().size() == 6);
+
+  SpinWeighted<ComplexDataVector, -2> size_and_value_created_spin_weight_m2{
+      6, 4.0};
+  CHECK(size_and_value_created_spin_weight_m2.data() ==
+        ComplexDataVector{6, 4.0});
 }
 
 /// \cond HIDDEN_SYMBOLS

--- a/tests/Unit/DataStructures/Test_SpinWeighted.cpp
+++ b/tests/Unit/DataStructures/Test_SpinWeighted.cpp
@@ -75,7 +75,7 @@ void test_spinweights() {
   UniformCustomDistribution<size_t> size_dist{5, 10};
   const size_t size = size_dist(gen);
 
-  const auto spin_weight_0 =
+  auto spin_weight_0 =
       make_with_random_values<SpinWeighted<SpinWeightedType, 0>>(
           make_not_null(&gen), make_not_null(&spin_weighted_dist), size);
   const auto spin_weight_1 =
@@ -157,6 +157,19 @@ void test_spinweights() {
         SpinWeighted<decltype(std::declval<SpinWeightedType>() /
                               std::declval<SpinWeightedType>()),
                      2>{no_spin_weight / spin_weight_m2.data()});
+  CHECK(-spin_weight_1 ==
+        SpinWeighted<SpinWeightedType, 1>(-spin_weight_1.data()));
+  CHECK(spin_weight_m2 ==
+        SpinWeighted<SpinWeightedType, -2>(spin_weight_m2.data()));
+
+  SpinWeighted<SpinWeightedType, 0> sum = spin_weight_0 + spin_weight_0;
+  spin_weight_0 += spin_weight_0;
+  CHECK(spin_weight_0 == sum);
+
+  SpinWeighted<SpinWeightedType, 0> difference =
+      spin_weight_0 - no_spin_weight;
+  spin_weight_0 -= no_spin_weight;
+  CHECK(spin_weight_0 == difference);
 }
 
 using SpinWeightedTypePairs =

--- a/tests/Unit/DataStructures/Test_SpinWeighted.cpp
+++ b/tests/Unit/DataStructures/Test_SpinWeighted.cpp
@@ -183,13 +183,15 @@ SPECTRE_TEST_CASE("Unit.DataStructures.SpinWeighted",
     test_spinweights<tmpl::front<type_pair>, tmpl::back<type_pair>>();
   });
 
-  SpinWeighted<ComplexDataVector, 1> size_created_spin_weight_1{6};
-  CHECK(size_created_spin_weight_1.data().size() == 6);
+  SpinWeighted<ComplexDataVector, 1> size_created_spin_weight_1{5};
+  CHECK(size_created_spin_weight_1.data().size() == 5);
+  CHECK(size_created_spin_weight_1.size() == 5);
 
   SpinWeighted<ComplexDataVector, -2> size_and_value_created_spin_weight_m2{
-      6, 4.0};
+      5, 4.0};
   CHECK(size_and_value_created_spin_weight_m2.data() ==
-        ComplexDataVector{6, 4.0});
+        ComplexDataVector{5, 4.0});
+  CHECK(size_and_value_created_spin_weight_m2.size() == 5);
 }
 
 /// \cond HIDDEN_SYMBOLS

--- a/tests/Unit/DataStructures/VectorImplTestHelper.hpp
+++ b/tests/Unit/DataStructures/VectorImplTestHelper.hpp
@@ -92,7 +92,7 @@ void vector_test_construct_and_assign(
   move_assignment_initialized = std::move(initializer_list_constructed_copy);
   CHECK(move_assignment_initialized.is_owning());
 
-  const VectorType move_constructed{std::move(move_assignment_initialized)};
+  VectorType move_constructed{std::move(move_assignment_initialized)};
   CHECK(move_constructed.is_owning());
   CHECK(move_constructed == pointer_size_constructed);
 
@@ -100,6 +100,14 @@ void vector_test_construct_and_assign(
   const VectorType copy_constructed{move_constructed};  // NOLINT
   CHECK(copy_constructed.is_owning());
   CHECK(copy_constructed == pointer_size_constructed);
+
+  // check the destructive resize utility
+  const VectorType destructive_resize_check_copy = move_constructed;
+  move_constructed.destructive_resize(move_constructed.size());
+  CHECK(move_constructed == destructive_resize_check_copy);
+  move_constructed.destructive_resize(move_constructed.size() + 1);
+  CHECK(move_constructed != destructive_resize_check_copy);
+  CHECK(move_constructed.size() == destructive_resize_check_copy.size() + 1);
 }
 
 /// \ingroup TestingFrameworkGroup

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -39,6 +39,7 @@ set(LIBRARY_SOURCES
   Test_TMPL.cpp
   Test_Tuple.cpp
   Test_TypeTraits.cpp
+  Test_VectorAlgebra.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Utilities/Test_VectorAlgebra.cpp
+++ b/tests/Unit/Utilities/Test_VectorAlgebra.cpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TypeTraits.hpp"
+#include "Utilities/VectorAlgebra.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+template <typename RhsVectorType, typename LhsVectorType>
+void test_outer_product() {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> size_distribution{5, 10};
+  UniformCustomDistribution<
+      tt::get_fundamental_type_t<get_vector_element_type_t<LhsVectorType>>>
+      lhs_distribution{-2.0, 2.0};
+  UniformCustomDistribution<
+      tt::get_fundamental_type_t<get_vector_element_type_t<RhsVectorType>>>
+      rhs_distribution{-2.0, 2.0};
+  const LhsVectorType lhs = make_with_random_values<LhsVectorType>(
+      make_not_null(&gen), make_not_null(&lhs_distribution),
+      size_distribution(gen));
+  const RhsVectorType rhs = make_with_random_values<RhsVectorType>(
+      make_not_null(&gen), make_not_null(&rhs_distribution),
+      size_distribution(gen));
+  const auto outer_test = outer_product(lhs, rhs);
+  size_t product_index = 0;
+  for (const auto& b : rhs) {
+    for (const auto& a : lhs) {
+      // Iterable approx has overloads for both real and complex types
+      CHECK_ITERABLE_APPROX(outer_test[product_index], a * b);
+      ++product_index;
+    }
+  }
+}
+
+template <typename VectorType>
+void test_repeat() {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> size_distribution{5, 10};
+  UniformCustomDistribution<
+      tt::get_fundamental_type_t<get_vector_element_type_t<VectorType>>>
+      element_distribution{-2.0, 2.0};
+  const VectorType to_repeat = make_with_random_values<VectorType>(
+      make_not_null(&gen), make_not_null(&element_distribution),
+      size_distribution(gen));
+  size_t repeats = size_distribution(gen);
+  const auto repeated = repeat(to_repeat, repeats);
+  for (size_t i = 0; i < repeats; ++i) {
+    for (size_t j = 0; j < to_repeat.size(); ++j) {
+      CHECK(to_repeat[j] == repeated[j + i * to_repeat.size()]);
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.VectorAlgebra",
+                  "[Unit][DataStructures]") {
+  test_outer_product<ComplexDataVector, ComplexDataVector>();
+  test_outer_product<DataVector, ComplexDataVector>();
+  test_outer_product<ComplexDataVector, DataVector>();
+  test_outer_product<DataVector, DataVector>();
+
+  test_repeat<DataVector>();
+  test_repeat<ComplexDataVector>();
+  test_repeat<ModalVector>();
+}


### PR DESCRIPTION
## Proposed changes

Several small changes to utilities related to Vectors and `SpinWeighted` which help in simplifying spin-weighted spherical harmonics and CCE evolution code.

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
