### PR TITLE
Update swsh transform utils

### DIFF
--- a/src/DataStructures/SpinWeighted.hpp
+++ b/src/DataStructures/SpinWeighted.hpp
@@ -122,6 +122,10 @@ struct SpinWeighted<T, Spin, true> {
     data_.set_data_ref(start, set_size);
   }
 
+  void destructive_resize(const size_t new_size) noexcept {
+    data_.destructive_resize(new_size);
+  }
+
   SpinWeighted() = default;
   SpinWeighted(const SpinWeighted&) noexcept = default;
   SpinWeighted(SpinWeighted&&) noexcept = default;

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
     SwshCoefficients.cpp
     SwshCollocation.cpp
     SwshTags.cpp
+    SwshTransform.cpp
     )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/NumericalAlgorithms/Spectral/SwshCoefficients.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCoefficients.cpp
@@ -11,12 +11,14 @@
 #include "ErrorHandling/Error.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "Utilities/ForceInline.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace Spectral {
 namespace Swsh {
-namespace detail {
-Coefficients::Coefficients(const size_t l_max) noexcept : l_max_(l_max) {
+
+CoefficientsMetadata::CoefficientsMetadata(const size_t l_max) noexcept
+    : l_max_(l_max) {
   sharp_alm_info* alm_to_initialize;
   sharp_make_triangular_alm_info(l_max, l_max, 1, &alm_to_initialize);
   alm_info_.reset(alm_to_initialize);
@@ -24,36 +26,37 @@ Coefficients::Coefficients(const size_t l_max) noexcept : l_max_(l_max) {
 
 namespace {
 template <size_t I>
-const Coefficients& coefficients_cache_impl() noexcept {
-  static const Coefficients precomputed_coefficients{I};
+const CoefficientsMetadata& coefficients_cache_impl() noexcept {
+  static const CoefficientsMetadata precomputed_coefficients{I};
   return precomputed_coefficients;
 }
 
 template <size_t... Is>
-SPECTRE_ALWAYS_INLINE const Coefficients& precomputed_static_coefficients_impl(
+SPECTRE_ALWAYS_INLINE const CoefficientsMetadata&
+precomputed_static_coefficients_impl(
     const size_t index, std::index_sequence<Is...> /*meta*/) noexcept {
   if (UNLIKELY(index > collocation_maximum_l_max)) {
     ERROR("The provided l_max "
           << index
           << " is not below the maximum l_max to cache, which is currently "
-          << coefficients_maximum_l_max
+          << detail::coefficients_maximum_l_max
           << ". Either "
-             "construct the Coefficients manually, or consider (with caution) "
+             "construct the CoefficientsMetadata manually, or consider (with "
+             "caution) "
              "increasing `coefficients_maximum_l_max`.");
   }
 
-  static const std::array<const Coefficients& (*)(), sizeof...(Is)> cache{
-      {&coefficients_cache_impl<Is>...}};
+  static const std::array<const CoefficientsMetadata& (*)(), sizeof...(Is)>
+      cache{{&coefficients_cache_impl<Is>...}};
   return gsl::at(cache, index)();
 }
 
 }  // namespace
 
-const Coefficients& precomputed_coefficients(const size_t l_max) noexcept {
+const CoefficientsMetadata& cached_coefficients_metadata(
+    const size_t l_max) noexcept {
   return precomputed_static_coefficients_impl(
-      l_max, std::make_index_sequence<coefficients_maximum_l_max>{});
+      l_max, std::make_index_sequence<detail::coefficients_maximum_l_max>{});
 }
-
-}  // namespace detail
 }  // namespace Swsh
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SwshCoefficients.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCoefficients.cpp
@@ -4,15 +4,19 @@
 #include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
 
 #include <array>
+#include <cmath>
 #include <ostream>
 #include <sharp_cxx.h>
 #include <utility>
 
+#include "DataStructures/SpinWeighted.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+
+// IWYU pragma: no_forward_declare SpinWeighted
 
 namespace Spectral {
 namespace Swsh {
@@ -58,5 +62,193 @@ const CoefficientsMetadata& cached_coefficients_metadata(
   return precomputed_static_coefficients_impl(
       l_max, std::make_index_sequence<detail::coefficients_maximum_l_max>{});
 }
+
+template <int Spin>
+std::complex<double> libsharp_mode_to_goldberg_plus_m(
+    const LibsharpCoefficientInfo& coefficient_info,
+    const SpinWeighted<ComplexModalVector, Spin>& libsharp_modes,
+    const size_t radial_offset) noexcept {
+  return sharp_swsh_sign(Spin, coefficient_info.m, true) *
+             libsharp_modes
+                 .data()[radial_offset * size_of_libsharp_coefficient_vector(
+                                             coefficient_info.l_max) +
+                         coefficient_info.transform_of_real_part_offset] +
+         std::complex<double>(0.0, 1.0) *
+             sharp_swsh_sign(Spin, coefficient_info.m, false) *
+             libsharp_modes
+                 .data()[radial_offset * size_of_libsharp_coefficient_vector(
+                                             coefficient_info.l_max) +
+                         coefficient_info.transform_of_imag_part_offset];
+}
+
+template <int Spin>
+std::complex<double> libsharp_mode_to_goldberg_minus_m(
+    const LibsharpCoefficientInfo& coefficient_info,
+    const SpinWeighted<ComplexModalVector, Spin>& libsharp_modes,
+    const size_t radial_offset) noexcept {
+  return sharp_swsh_sign(Spin, -static_cast<int>(coefficient_info.m), true) *
+             conj(libsharp_modes
+                      .data()[radial_offset *
+                                  size_of_libsharp_coefficient_vector(
+                                      coefficient_info.l_max) +
+                              coefficient_info.transform_of_real_part_offset]) +
+         std::complex<double>(0.0, 1.0) *
+             sharp_swsh_sign(Spin, -static_cast<int>((coefficient_info.m)),
+                             false) *
+             conj(libsharp_modes
+                      .data()[radial_offset *
+                                  size_of_libsharp_coefficient_vector(
+                                      coefficient_info.l_max) +
+                              coefficient_info.transform_of_imag_part_offset]);
+}
+
+template <int Spin>
+std::complex<double> libsharp_mode_to_goldberg(
+    const size_t l, const int m, const size_t l_max,
+    const SpinWeighted<ComplexModalVector, Spin>& libsharp_modes,
+    const size_t radial_offset) noexcept {
+  const CoefficientsMetadata::CoefficientsIndexIterator coefficients_iterator{
+      l_max, l, static_cast<size_t>(abs(m))};
+  if (m >= 0) {
+    return libsharp_mode_to_goldberg_plus_m(*coefficients_iterator,
+                                            libsharp_modes, radial_offset);
+  } else {
+    return libsharp_mode_to_goldberg_minus_m(*coefficients_iterator,
+                                             libsharp_modes, radial_offset);
+  }
+}
+
+template <int Spin>
+void goldberg_modes_to_libsharp_modes_single_pair(
+    const LibsharpCoefficientInfo& coefficient_info,
+    const gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*> libsharp_modes,
+    const size_t radial_offset,
+    const std::complex<double> goldberg_plus_m_mode_value,
+    std::complex<double> goldberg_minus_m_mode_value) noexcept {
+  const auto sign_determinant = static_cast<double>(
+      sharp_swsh_sign(Spin, coefficient_info.m, true) *
+          sharp_swsh_sign(Spin, -static_cast<int>(coefficient_info.m), false) +
+      sharp_swsh_sign(Spin, coefficient_info.m, false) *
+          sharp_swsh_sign(Spin, -static_cast<int>(coefficient_info.m), true));
+  const auto i = std::complex<double>(0.0, 1.0);
+  if (coefficient_info.m == 0) {
+    goldberg_minus_m_mode_value = goldberg_plus_m_mode_value;
+  }
+  libsharp_modes->data()[radial_offset * size_of_libsharp_coefficient_vector(
+                                             coefficient_info.l_max) +
+                         coefficient_info.transform_of_real_part_offset] =
+      (sharp_swsh_sign(Spin, -static_cast<int>(coefficient_info.m), false) *
+           goldberg_plus_m_mode_value +
+       sharp_swsh_sign(Spin, coefficient_info.m, false) *
+           conj(goldberg_minus_m_mode_value)) /
+      sign_determinant;
+
+  libsharp_modes->data()[radial_offset * size_of_libsharp_coefficient_vector(
+                                             coefficient_info.l_max) +
+                         coefficient_info.transform_of_imag_part_offset] =
+      (-i * sharp_swsh_sign(Spin, -static_cast<int>(coefficient_info.m), true) *
+           goldberg_plus_m_mode_value +
+       i * sharp_swsh_sign(Spin, coefficient_info.m, true) *
+           conj(goldberg_minus_m_mode_value)) /
+      sign_determinant;
+}
+
+template <int Spin>
+void goldberg_modes_to_libsharp_modes_single_pair(
+    const size_t l, const int m, const size_t l_max,
+    const gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*> libsharp_modes,
+    const size_t radial_offset,
+    const std::complex<double> goldberg_plus_m_mode_value,
+    const std::complex<double> goldberg_minus_m_mode_value) noexcept {
+  CoefficientsMetadata::CoefficientsIndexIterator coefficients_iterator{
+      l_max, l, static_cast<size_t>(abs(m))};
+  goldberg_modes_to_libsharp_modes_single_pair(
+      *coefficients_iterator, libsharp_modes, radial_offset,
+      goldberg_plus_m_mode_value, goldberg_minus_m_mode_value);
+}
+
+template <int Spin>
+void libsharp_to_goldberg_modes(
+    const gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*> goldberg_modes,
+    const SpinWeighted<ComplexModalVector, Spin>& libsharp_modes,
+    const size_t l_max) noexcept {
+  const size_t number_of_radial_grid_points =
+      libsharp_modes.data().size() / size_of_libsharp_coefficient_vector(l_max);
+
+  goldberg_modes->destructive_resize(square(1 + l_max) *
+                                     number_of_radial_grid_points);
+
+  const auto& coefficients_metadata = cached_coefficients_metadata(l_max);
+  for (size_t i = 0; i < number_of_radial_grid_points; ++i) {
+    for (const auto& coefficient_info : coefficients_metadata) {
+      goldberg_modes->data()[goldberg_mode_index(
+          coefficient_info.l_max, coefficient_info.l,
+          static_cast<int>(coefficient_info.m), i)] =
+          libsharp_mode_to_goldberg_plus_m(coefficient_info, libsharp_modes, i);
+      goldberg_modes->data()[goldberg_mode_index(
+          coefficient_info.l_max, coefficient_info.l,
+          -static_cast<int>(coefficient_info.m), i)] =
+          libsharp_mode_to_goldberg_minus_m(coefficient_info, libsharp_modes,
+                                            i);
+    }
+  }
+}
+
+template <int Spin>
+SpinWeighted<ComplexModalVector, Spin> libsharp_to_goldberg_modes(
+    const SpinWeighted<ComplexModalVector, Spin>& libsharp_modes,
+    const size_t l_max) noexcept {
+  const size_t number_of_radial_grid_points =
+      libsharp_modes.data().size() / size_of_libsharp_coefficient_vector(l_max);
+  SpinWeighted<ComplexModalVector, Spin> result{square(1 + l_max) *
+                                                number_of_radial_grid_points};
+  libsharp_to_goldberg_modes(make_not_null(&result), libsharp_modes, l_max);
+  return result;
+}
+
+#define GET_SPIN(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define LIBSHARP_TO_GOLDBERG_INSTANTIATION(r, data)                           \
+  template std::complex<double> libsharp_mode_to_goldberg_plus_m(             \
+      const LibsharpCoefficientInfo& coefficient_info,                        \
+      const SpinWeighted<ComplexModalVector, GET_SPIN(data)>& libsharp_modes, \
+      const size_t radial_offset) noexcept;                                   \
+  template std::complex<double> libsharp_mode_to_goldberg_minus_m(            \
+      const LibsharpCoefficientInfo& coefficient_info,                        \
+      const SpinWeighted<ComplexModalVector, GET_SPIN(data)>& libsharp_modes, \
+      const size_t radial_offset) noexcept;                                   \
+  template std::complex<double> libsharp_mode_to_goldberg(                    \
+      const size_t l, const int m, const size_t l_max,                        \
+      const SpinWeighted<ComplexModalVector, GET_SPIN(data)>& libsharp_modes, \
+      const size_t radial_offset) noexcept;                                   \
+  template void goldberg_modes_to_libsharp_modes_single_pair(                 \
+      const LibsharpCoefficientInfo& coefficient_info,                        \
+      const gsl::not_null<SpinWeighted<ComplexModalVector, GET_SPIN(data)>*>  \
+          libsharp_modes,                                                     \
+      const size_t radial_offset,                                             \
+      const std::complex<double> goldberg_plus_m_mode_value,                  \
+      const std::complex<double> goldberg_minus_m_mode_value) noexcept;       \
+  template void goldberg_modes_to_libsharp_modes_single_pair(                 \
+      const size_t l, const int m, const size_t l_max,                        \
+      const gsl::not_null<SpinWeighted<ComplexModalVector, GET_SPIN(data)>*>  \
+          libsharp_modes,                                                     \
+      const size_t radial_offset,                                             \
+      const std::complex<double> goldberg_plus_m_mode_value,                  \
+      const std::complex<double> goldberg_minus_m_mode_value) noexcept;       \
+  template void libsharp_to_goldberg_modes(                                   \
+      const gsl::not_null<SpinWeighted<ComplexModalVector, GET_SPIN(data)>*>  \
+          goldberg_modes,                                                     \
+      const SpinWeighted<ComplexModalVector, GET_SPIN(data)>& libsharp_modes, \
+      const size_t l_max) noexcept;                                           \
+  template SpinWeighted<ComplexModalVector, GET_SPIN(data)>                   \
+  libsharp_to_goldberg_modes(                                                 \
+      const SpinWeighted<ComplexModalVector, GET_SPIN(data)>& libsharp_modes, \
+      const size_t l_max) noexcept;
+
+GENERATE_INSTANTIATIONS(LIBSHARP_TO_GOLDBERG_INSTANTIATION, (-2, -1, 0, 1, 2))
+
+#undef LIBSHARP_TO_GOLDBERG_INSTANTIATION
+#undef GET_SPIN
+
 }  // namespace Swsh
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SwshCollocation.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCollocation.hpp
@@ -51,9 +51,9 @@ number_of_swsh_phi_collocation_points(const size_t l_max) noexcept {
 
 // In the static caching mechanism, we permit an l_max up to this macro
 // value. Higher l_max values may still be created manually using the
-// `Collocation` constructor. If l_max's are used several times at higher value,
-// consider increasing this value, but only after memory costs have been
-// evaluated.
+// `CollocationMetadata` constructor. If l_max's are used several times at
+// higher value, consider increasing this value, but only after memory costs
+// have been evaluated.
 constexpr size_t collocation_maximum_l_max = 200;
 
 namespace detail {
@@ -76,7 +76,7 @@ struct LibsharpCollocationPoint {
 /// \brief A wrapper class for the spherical harmonic library collocation data
 ///
 /// \details The currently chosen library for spin-weighted spherical harmonic
-/// transforms is libsharp. The `Collocation` class stores the
+/// transforms is libsharp. The `CollocationMetadata` class stores the
 /// libsharp `sharp_geom_info` object, which contains data about
 /// 1. The angular collocation points used in spin-weighted spherical harmonic
 /// transforms
@@ -86,16 +86,17 @@ struct LibsharpCollocationPoint {
 /// \tparam Representation the ComplexRepresentation, either
 /// `ComplexRepresentation::Interleaved` or
 /// `ComplexRepresentation::RealsThenImags` compatible with the generated
-/// `Collocation` - this is necessary because the stored libsharp type contains
-/// memory stride information.
+/// `CollocationMetadata` - this is necessary because the stored libsharp type
+/// contains memory stride information.
 template <ComplexRepresentation Representation>
-class Collocation {
+class CollocationMetadata {
  public:
   class CollocationConstIterator {
    public:
     /// create a new iterator. defaults to the start of the supplied object
     explicit CollocationConstIterator(
-        const gsl::not_null<const Collocation<Representation>*> collocation,
+        const gsl::not_null<const CollocationMetadata<Representation>*>
+            collocation,
         const size_t start_index = 0) noexcept
         : index_{start_index}, collocation_{collocation} {}
 
@@ -140,7 +141,7 @@ class Collocation {
 
    private:
     size_t index_;
-    const Collocation<Representation>* const collocation_;
+    const CollocationMetadata<Representation>* const collocation_;
   };
 
   /// The representation of the block of complex values, which sets the stride
@@ -154,15 +155,15 @@ class Collocation {
   /// \note If you will potentially use the same `l_max` collocation set more
   /// than once, it is probably better to use the
   /// `precomputed_spherical_harmonic_collocation` function
-  explicit Collocation(size_t l_max) noexcept;
+  explicit CollocationMetadata(size_t l_max) noexcept;
 
   /// default constructor required for iterator use
-  ~Collocation() = default;
-  Collocation() = default;
-  Collocation(const Collocation&) = default;
-  Collocation(Collocation&&) = default;
-  Collocation& operator=(Collocation&) = default;
-  Collocation& operator=(Collocation&&) = default;
+  ~CollocationMetadata() = default;
+  CollocationMetadata() = default;
+  CollocationMetadata(const CollocationMetadata&) = default;
+  CollocationMetadata(CollocationMetadata&&) = default;
+  CollocationMetadata& operator=(CollocationMetadata&) = default;
+  CollocationMetadata& operator=(CollocationMetadata&&) = default;
 
   /// retrieve the `sharp_geom_info*` stored. This should largely be used only
   /// for passing to other libsharp functions. Otherwise, access elements
@@ -190,10 +191,11 @@ class Collocation {
   /// Get a bidirectional iterator to the start of the grid. `operator*` for
   /// that iterator gives a `LibsharpCollocationPoint` with members `offset`,
   /// `theta`, and `phi`
-  Collocation<Representation>::CollocationConstIterator begin() const noexcept {
+  CollocationMetadata<Representation>::CollocationConstIterator begin() const
+      noexcept {
     return CollocationConstIterator{make_not_null(this), 0};
   }
-  Collocation<Representation>::CollocationConstIterator cbegin() const
+  CollocationMetadata<Representation>::CollocationConstIterator cbegin() const
       noexcept {
     return begin();
   }
@@ -202,10 +204,12 @@ class Collocation {
   /// Get a bidirectional iterator to the end of the grid. `operator*` for
   /// that iterator gives a `LibsharpCollocationPoint` with members `offset`,
   /// `theta`, and `phi`
-  Collocation<Representation>::CollocationConstIterator end() const noexcept {
+  CollocationMetadata<Representation>::CollocationConstIterator end() const
+      noexcept {
     return CollocationConstIterator{make_not_null(this), size()};
   }
-  Collocation<Representation>::CollocationConstIterator cend() const noexcept {
+  CollocationMetadata<Representation>::CollocationConstIterator cend() const
+      noexcept {
     return end();
   }
   // @}
@@ -226,7 +230,7 @@ class Collocation {
 /// generated, it's returned by reference. Otherwise, the new grid is generated
 /// and put in the lookup table before it is returned by reference.
 template <ComplexRepresentation Representation>
-const Collocation<Representation>& precomputed_collocation(
+const CollocationMetadata<Representation>& cached_collocation_metadata(
     size_t l_max) noexcept;
 }  // namespace Swsh
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SwshCollocation.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCollocation.hpp
@@ -23,6 +23,32 @@ number_of_swsh_collocation_points(const size_t l_max) noexcept {
   return (l_max + 1) * (2 * l_max + 1);
 }
 
+/// \ingroup SwshGroup
+/// \brief Returns the number of spin-weighted spherical harmonic collocation
+/// values in \f$\theta\f$ for a libsharp-compatible set of collocation
+/// points.
+///
+/// \details The full number of collocation points is the product of the number
+/// of \f$\theta\f$ points and the number of \f$\phi\f$ points (a 'rectangular'
+/// grid).
+constexpr SPECTRE_ALWAYS_INLINE size_t
+number_of_swsh_theta_collocation_points(const size_t l_max) noexcept {
+  return (l_max + 1);
+}
+
+/// \ingroup SwshGroup
+/// \brief Returns the number of spin-weighted spherical harmonic collocation
+/// values in \f$\phi\f$ for a libsharp-compatible set of collocation
+/// points.
+///
+/// \details The full number of collocation points is the product of the number
+/// of \f$\theta\f$ points and the number of \f$\phi\f$ points (a 'rectangular'
+/// grid).
+constexpr SPECTRE_ALWAYS_INLINE size_t
+number_of_swsh_phi_collocation_points(const size_t l_max) noexcept {
+  return (2 * l_max + 1);
+}
+
 // In the static caching mechanism, we permit an l_max up to this macro
 // value. Higher l_max values may still be created manually using the
 // `Collocation` constructor. If l_max's are used several times at higher value,
@@ -87,7 +113,7 @@ class Collocation {
     };
     /// advance the iterator by one position (postfix)
     // clang-tidy wants this to return a const iterator
-    CollocationConstIterator operator++(int)noexcept {  // NOLINT
+    CollocationConstIterator operator++(int) noexcept {  // NOLINT
       return CollocationConstIterator(collocation_, index_++);
     }
 
@@ -98,7 +124,7 @@ class Collocation {
     };
     /// retreat the iterator by one position (prefix)
     // clang-tidy wants this to return a const iterator
-    CollocationConstIterator operator--(int)noexcept {  // NOLINT
+    CollocationConstIterator operator--(int) noexcept {  // NOLINT
       return CollocationConstIterator(collocation_, index_--);
     }
 
@@ -163,7 +189,7 @@ class Collocation {
   // @{
   /// Get a bidirectional iterator to the start of the grid. `operator*` for
   /// that iterator gives a `LibsharpCollocationPoint` with members `offset`,
-  /// `theta`, and `phi` with operator *
+  /// `theta`, and `phi`
   Collocation<Representation>::CollocationConstIterator begin() const noexcept {
     return CollocationConstIterator{make_not_null(this), 0};
   }
@@ -175,7 +201,7 @@ class Collocation {
   // @{
   /// Get a bidirectional iterator to the end of the grid. `operator*` for
   /// that iterator gives a `LibsharpCollocationPoint` with members `offset`,
-  /// `theta`, and `phi` with operator *
+  /// `theta`, and `phi`
   Collocation<Representation>::CollocationConstIterator end() const noexcept {
     return CollocationConstIterator{make_not_null(this), size()};
   }

--- a/src/NumericalAlgorithms/Spectral/SwshTransform.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTransform.cpp
@@ -104,13 +104,12 @@ void execute_libsharp_transform_set(
 }  // namespace detail
 
 template <ComplexRepresentation Representation, int Spin>
-void swsh_transform(
-    const gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*>
-        libsharp_coefficients,
-    const gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> collocation,
-    const size_t l_max) noexcept {
+void swsh_transform(const gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*>
+                        libsharp_coefficients,
+                    const SpinWeighted<ComplexDataVector, Spin>& collocation,
+                    const size_t l_max) noexcept {
   size_t number_of_radial_points =
-      collocation->data().size() / number_of_swsh_collocation_points(l_max);
+      collocation.data().size() / number_of_swsh_collocation_points(l_max);
 
   // append a list of pointers into the collocation point data. This is
   // required because libsharp expects pointers to pointers.
@@ -130,7 +129,11 @@ void swsh_transform(
 
   detail::append_libsharp_collocation_pointers(
       make_not_null(&pre_transform_collocation_data),
-      make_not_null(&pre_transform_views), make_not_null(&collocation->data()),
+      make_not_null(&pre_transform_views),
+      make_not_null(
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+          &const_cast<SpinWeighted<ComplexDataVector, Spin>&>(collocation)
+               .data()),
       l_max, Spin >= 0);
 
   if (libsharp_coefficients->data().size() !=
@@ -158,7 +161,7 @@ void swsh_transform(
 
 template <ComplexRepresentation Representation, int Spin>
 SpinWeighted<ComplexModalVector, Spin> swsh_transform(
-    const gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> collocation,
+    const SpinWeighted<ComplexDataVector, Spin>& collocation,
     const size_t l_max) noexcept {
   SpinWeighted<ComplexModalVector, Spin> result_vector{};
   swsh_transform<Representation, Spin>(make_not_null(&result_vector),
@@ -169,11 +172,10 @@ SpinWeighted<ComplexModalVector, Spin> swsh_transform(
 template <ComplexRepresentation Representation, int Spin>
 void inverse_swsh_transform(
     const gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> collocation,
-    const gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*>
-        libsharp_coefficients,
+    const SpinWeighted<ComplexModalVector, Spin>& libsharp_coefficients,
     const size_t l_max) noexcept {
   const size_t number_of_radial_points =
-      libsharp_coefficients->data().size() /
+      libsharp_coefficients.data().size() /
       (size_of_libsharp_coefficient_vector(l_max));
 
   const auto* collocation_metadata =
@@ -186,7 +188,11 @@ void inverse_swsh_transform(
 
   detail::append_libsharp_coefficient_pointers(
       make_not_null(&pre_transform_coefficient_data),
-      make_not_null(&libsharp_coefficients->data()), l_max);
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+      make_not_null(&const_cast<SpinWeighted<ComplexModalVector, Spin>&>(
+                         libsharp_coefficients)
+                         .data()),
+      l_max);
 
   std::vector<detail::ComplexDataView<Representation>> post_transform_views;
   post_transform_views.reserve(number_of_radial_points);
@@ -224,8 +230,7 @@ void inverse_swsh_transform(
 
 template <ComplexRepresentation Representation, int Spin>
 SpinWeighted<ComplexDataVector, Spin> inverse_swsh_transform(
-    const gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*>
-        libsharp_coefficients,
+    const SpinWeighted<ComplexModalVector, Spin>& libsharp_coefficients,
     const size_t l_max) noexcept {
   SpinWeighted<ComplexDataVector, Spin> result_vector{};
   inverse_swsh_transform<Representation, Spin>(make_not_null(&result_vector),
@@ -240,24 +245,22 @@ SpinWeighted<ComplexDataVector, Spin> inverse_swsh_transform(
   template void swsh_transform<GET_REPRESENTATION(data), GET_SPIN(data)>(    \
       const gsl::not_null<SpinWeighted<ComplexModalVector, GET_SPIN(data)>*> \
           libsharp_coefficients,                                             \
-      const gsl::not_null<SpinWeighted<ComplexDataVector, GET_SPIN(data)>*>  \
-          collocation,                                                       \
+      const SpinWeighted<ComplexDataVector, GET_SPIN(data)>& collocation,    \
       const size_t l_max) noexcept;                                          \
   template SpinWeighted<ComplexModalVector, GET_SPIN(data)>                  \
   swsh_transform<GET_REPRESENTATION(data), GET_SPIN(data)>(                  \
-      const gsl::not_null<SpinWeighted<ComplexDataVector, GET_SPIN(data)>*>  \
-          collocation,                                                       \
+      const SpinWeighted<ComplexDataVector, GET_SPIN(data)>& collocation,    \
       const size_t l_max) noexcept;                                          \
   template void                                                              \
   inverse_swsh_transform<GET_REPRESENTATION(data), GET_SPIN(data)>(          \
       const gsl::not_null<SpinWeighted<ComplexDataVector, GET_SPIN(data)>*>  \
           collocation,                                                       \
-      const gsl::not_null<SpinWeighted<ComplexModalVector, GET_SPIN(data)>*> \
+      const SpinWeighted<ComplexModalVector, GET_SPIN(data)>&                \
           libsharp_coefficients,                                             \
       const size_t l_max) noexcept;                                          \
   template SpinWeighted<ComplexDataVector, GET_SPIN(data)>                   \
   inverse_swsh_transform<GET_REPRESENTATION(data), GET_SPIN(data)>(          \
-      const gsl::not_null<SpinWeighted<ComplexModalVector, GET_SPIN(data)>*> \
+      const SpinWeighted<ComplexModalVector, GET_SPIN(data)>&                \
           libsharp_coefficients,                                             \
       const size_t l_max) noexcept;
 

--- a/src/NumericalAlgorithms/Spectral/SwshTransform.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTransform.cpp
@@ -45,7 +45,7 @@ void append_libsharp_coefficient_pointers(
     const gsl::not_null<ComplexModalVector*> vector,
     const size_t l_max) noexcept {
   const size_t number_of_coefficients =
-      Spectral::Swsh::number_of_swsh_coefficients(l_max) * 2;
+      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max);
   const size_t number_of_radial_points =
       vector->size() / number_of_coefficients;
 
@@ -122,7 +122,7 @@ void swsh_transform(
   const auto* collocation_metadata =
       &precomputed_collocation<Representation>(l_max);
   const auto* alm_info =
-      detail::precomputed_coefficients(l_max).get_sharp_alm_info();
+      cached_coefficients_metadata(l_max).get_sharp_alm_info();
 
   // libsharp considers two arrays per transform when spin is not zero.
   const size_t num_transforms =
@@ -134,11 +134,11 @@ void swsh_transform(
       l_max, Spin >= 0);
 
   if (libsharp_coefficients->data().size() !=
-      2 * number_of_radial_points *
-          Spectral::Swsh::number_of_swsh_coefficients(l_max)) {
-    libsharp_coefficients->data() =
-        ComplexModalVector{2 * number_of_radial_points *
-                           Spectral::Swsh::number_of_swsh_coefficients(l_max)};
+      number_of_radial_points *
+          Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)) {
+    libsharp_coefficients->data() = ComplexModalVector{
+        number_of_radial_points *
+        Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
   }
 
   std::vector<std::complex<double>*> post_transform_coefficient_data;
@@ -174,12 +174,12 @@ void inverse_swsh_transform(
     const size_t l_max) noexcept {
   const size_t number_of_radial_points =
       libsharp_coefficients->data().size() /
-      (number_of_swsh_coefficients(l_max) * 2);
+      (size_of_libsharp_coefficient_vector(l_max));
 
   const auto* collocation_metadata =
       &precomputed_collocation<Representation>(l_max);
   const auto* alm_info =
-      detail::precomputed_coefficients(l_max).get_sharp_alm_info();
+      cached_coefficients_metadata(l_max).get_sharp_alm_info();
 
   std::vector<std::complex<double>*> pre_transform_coefficient_data;
   pre_transform_coefficient_data.reserve(2 * number_of_radial_points);

--- a/src/NumericalAlgorithms/Spectral/SwshTransform.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTransform.cpp
@@ -1,0 +1,298 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+
+#include <cmath>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"  // IWYU pragma: keep
+#include "Utilities/GenerateInstantiations.hpp"
+
+// IWYU pragma: no_forward_declare SpinWeighted
+
+namespace Spectral {
+namespace Swsh {
+
+namespace detail {
+template <ComplexRepresentation Representation>
+void append_libsharp_collocation_pointers(
+    const gsl::not_null<std::vector<double*>*> collocation_data,
+    const gsl::not_null<std::vector<ComplexDataView<Representation>>*>
+        collocation_views,
+    const gsl::not_null<ComplexDataVector*> vector, const size_t l_max,
+    const bool positive_spin) noexcept {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  const size_t number_of_radial_points =
+      vector->size() / number_of_angular_points;
+
+  for (size_t i = 0; i < number_of_radial_points; ++i) {
+    collocation_views->push_back(detail::ComplexDataView<Representation>{
+        vector, number_of_angular_points, i * number_of_angular_points});
+    collocation_data->push_back(collocation_views->back().real_data());
+    // alteration needed because libsharp doesn't support negative spins
+    if (not positive_spin) {
+      collocation_views->back().conjugate();
+    }
+    collocation_data->push_back(collocation_views->back().imag_data());
+  }
+}
+
+void append_libsharp_coefficient_pointers(
+    const gsl::not_null<std::vector<std::complex<double>*>*> coefficient_data,
+    const gsl::not_null<ComplexModalVector*> vector,
+    const size_t l_max) noexcept {
+  const size_t number_of_coefficients =
+      Spectral::Swsh::number_of_swsh_coefficients(l_max) * 2;
+  const size_t number_of_radial_points =
+      vector->size() / number_of_coefficients;
+
+  for (size_t i = 0; i < number_of_radial_points; ++i) {
+    // coefficients associated with the real part
+    coefficient_data->push_back(vector->data() + i * number_of_coefficients);
+    // coefficients associated with the imaginary part
+    coefficient_data->push_back(vector->data() +
+                                (2 * i + 1) * (number_of_coefficients / 2));
+  }
+}
+
+template <ComplexRepresentation Representation>
+void execute_libsharp_transform_set(
+    const sharp_jobtype& jobtype, const int spin,
+    const gsl::not_null<std::vector<std::complex<double>*>*> coefficient_data,
+    const gsl::not_null<std::vector<double*>*> collocation_data,
+    const gsl::not_null<const Collocation<Representation>*>
+        collocation_metadata,
+    const sharp_alm_info* alm_info, const size_t num_transforms) noexcept {
+  // libsharp considers two arrays per transform when spin is not zero.
+  const size_t number_of_arrays_per_transform = (spin == 0 ? 1 : 2);
+  // libsharp has an internal flag for the maximum number of transforms, so if
+  // we have more than max_libsharp_transforms, we have to do them in chunks
+  // of max_libsharp_transforms.
+  for (size_t transform_block = 0;
+       transform_block <
+       (num_transforms + max_libsharp_transforms - 1) / max_libsharp_transforms;
+       ++transform_block) {
+    if (transform_block < (num_transforms / max_libsharp_transforms)) {
+      // clang-tidy cppcoreguidelines-pro-bounds-pointer-arithmetic
+      sharp_execute(jobtype, abs(spin),
+                    coefficient_data->data() +  // NOLINT
+                        number_of_arrays_per_transform *
+                            max_libsharp_transforms * transform_block,
+                    collocation_data->data() +  // NOLINT
+                        number_of_arrays_per_transform *
+                            max_libsharp_transforms * transform_block,
+                    collocation_metadata->get_sharp_geom_info(), alm_info,
+                    max_libsharp_transforms, SHARP_DP, nullptr, nullptr);
+    } else {
+      // clang-tidy cppcoreguidelines-pro-bounds-pointer-arithmetic
+      sharp_execute(jobtype, abs(spin),
+                    coefficient_data->data() +  // NOLINT
+                        number_of_arrays_per_transform *
+                            max_libsharp_transforms * transform_block,
+                    collocation_data->data() +  // NOLINT
+                        number_of_arrays_per_transform *
+                            max_libsharp_transforms * transform_block,
+                    collocation_metadata->get_sharp_geom_info(), alm_info,
+                    num_transforms % max_libsharp_transforms, SHARP_DP, nullptr,
+                    nullptr);
+    }
+  }
+}
+}  // namespace detail
+
+template <ComplexRepresentation Representation, int Spin>
+void swsh_transform(
+    const gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*>
+        libsharp_coefficients,
+    const gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> collocation,
+    const size_t l_max) noexcept {
+  size_t number_of_radial_points =
+      collocation->data().size() / number_of_swsh_collocation_points(l_max);
+
+  // append a list of pointers into the collocation point data. This is
+  // required because libsharp expects pointers to pointers.
+  std::vector<detail::ComplexDataView<Representation>> pre_transform_views;
+  pre_transform_views.reserve(number_of_radial_points);
+  std::vector<double*> pre_transform_collocation_data;
+  pre_transform_collocation_data.reserve(2 * number_of_radial_points);
+
+  const auto* collocation_metadata =
+      &precomputed_collocation<Representation>(l_max);
+  const auto* alm_info =
+      detail::precomputed_coefficients(l_max).get_sharp_alm_info();
+
+  // libsharp considers two arrays per transform when spin is not zero.
+  const size_t num_transforms =
+      (Spin == 0 ? 2 * number_of_radial_points : number_of_radial_points);
+
+  detail::append_libsharp_collocation_pointers(
+      make_not_null(&pre_transform_collocation_data),
+      make_not_null(&pre_transform_views), make_not_null(&collocation->data()),
+      l_max, Spin >= 0);
+
+  if (libsharp_coefficients->data().size() !=
+      2 * number_of_radial_points *
+          Spectral::Swsh::number_of_swsh_coefficients(l_max)) {
+    libsharp_coefficients->data() =
+        ComplexModalVector{2 * number_of_radial_points *
+                           Spectral::Swsh::number_of_swsh_coefficients(l_max)};
+  }
+
+  std::vector<std::complex<double>*> post_transform_coefficient_data;
+  post_transform_coefficient_data.reserve(2 * number_of_radial_points);
+
+  detail::append_libsharp_coefficient_pointers(
+      make_not_null(&post_transform_coefficient_data),
+      make_not_null(&libsharp_coefficients->data()), l_max);
+
+  detail::execute_libsharp_transform_set(
+      SHARP_MAP2ALM, Spin, make_not_null(&post_transform_coefficient_data),
+      make_not_null(&pre_transform_collocation_data),
+      make_not_null(collocation_metadata), alm_info, num_transforms);
+
+  detail::conjugate_views<Spin>(make_not_null(&pre_transform_views));
+}
+
+template <ComplexRepresentation Representation, int Spin>
+SpinWeighted<ComplexModalVector, Spin> swsh_transform(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> collocation,
+    const size_t l_max) noexcept {
+  SpinWeighted<ComplexModalVector, Spin> result_vector{};
+  swsh_transform<Representation, Spin>(make_not_null(&result_vector),
+                                       collocation, l_max);
+  return result_vector;
+}
+
+template <ComplexRepresentation Representation, int Spin>
+void inverse_swsh_transform(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> collocation,
+    const gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*>
+        libsharp_coefficients,
+    const size_t l_max) noexcept {
+  const size_t number_of_radial_points =
+      libsharp_coefficients->data().size() /
+      (number_of_swsh_coefficients(l_max) * 2);
+
+  const auto* collocation_metadata =
+      &precomputed_collocation<Representation>(l_max);
+  const auto* alm_info =
+      detail::precomputed_coefficients(l_max).get_sharp_alm_info();
+
+  std::vector<std::complex<double>*> pre_transform_coefficient_data;
+  pre_transform_coefficient_data.reserve(2 * number_of_radial_points);
+
+  detail::append_libsharp_coefficient_pointers(
+      make_not_null(&pre_transform_coefficient_data),
+      make_not_null(&libsharp_coefficients->data()), l_max);
+
+  std::vector<detail::ComplexDataView<Representation>> post_transform_views;
+  post_transform_views.reserve(number_of_radial_points);
+  std::vector<double*> post_transform_collocation_data;
+  post_transform_collocation_data.reserve(2 * number_of_radial_points);
+
+  if (collocation->data().size() !=
+      number_of_radial_points *
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max)) {
+    collocation->data() = ComplexDataVector{
+        number_of_radial_points *
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  }
+  // libsharp considers two arrays per transform when spin is not zero.
+  const size_t num_transforms = (Spin == 0 ? 2 : 1) * number_of_radial_points;
+
+  detail::append_libsharp_collocation_pointers(
+      make_not_null(&post_transform_collocation_data),
+      make_not_null(&post_transform_views), make_not_null(&collocation->data()),
+      l_max, true);
+  detail::execute_libsharp_transform_set(
+      SHARP_ALM2MAP, Spin, make_not_null(&pre_transform_coefficient_data),
+      make_not_null(&post_transform_collocation_data),
+      make_not_null(collocation_metadata), alm_info, num_transforms);
+
+  detail::conjugate_views<Spin>(make_not_null(&post_transform_views));
+
+  // The inverse transformed collocation data has just been placed in the
+  // memory blocks controlled by the `ComplexDataView`s. Finally, that data
+  // must be flushed back to the input vector.
+  for (auto& view : post_transform_views) {
+    view.copy_back_to_source();
+  }
+}
+
+template <ComplexRepresentation Representation, int Spin>
+SpinWeighted<ComplexDataVector, Spin> inverse_swsh_transform(
+    const gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*>
+        libsharp_coefficients,
+    const size_t l_max) noexcept {
+  SpinWeighted<ComplexDataVector, Spin> result_vector{};
+  inverse_swsh_transform<Representation, Spin>(make_not_null(&result_vector),
+                                               libsharp_coefficients, l_max);
+  return result_vector;
+}
+
+#define GET_REPRESENTATION(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define GET_SPIN(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define SWSH_TRANSFORM_INSTANTIATION(r, data)                                \
+  template void swsh_transform<GET_REPRESENTATION(data), GET_SPIN(data)>(    \
+      const gsl::not_null<SpinWeighted<ComplexModalVector, GET_SPIN(data)>*> \
+          libsharp_coefficients,                                             \
+      const gsl::not_null<SpinWeighted<ComplexDataVector, GET_SPIN(data)>*>  \
+          collocation,                                                       \
+      const size_t l_max) noexcept;                                          \
+  template SpinWeighted<ComplexModalVector, GET_SPIN(data)>                  \
+  swsh_transform<GET_REPRESENTATION(data), GET_SPIN(data)>(                  \
+      const gsl::not_null<SpinWeighted<ComplexDataVector, GET_SPIN(data)>*>  \
+          collocation,                                                       \
+      const size_t l_max) noexcept;                                          \
+  template void                                                              \
+  inverse_swsh_transform<GET_REPRESENTATION(data), GET_SPIN(data)>(          \
+      const gsl::not_null<SpinWeighted<ComplexDataVector, GET_SPIN(data)>*>  \
+          collocation,                                                       \
+      const gsl::not_null<SpinWeighted<ComplexModalVector, GET_SPIN(data)>*> \
+          libsharp_coefficients,                                             \
+      const size_t l_max) noexcept;                                          \
+  template SpinWeighted<ComplexDataVector, GET_SPIN(data)>                   \
+  inverse_swsh_transform<GET_REPRESENTATION(data), GET_SPIN(data)>(          \
+      const gsl::not_null<SpinWeighted<ComplexModalVector, GET_SPIN(data)>*> \
+          libsharp_coefficients,                                             \
+      const size_t l_max) noexcept;
+
+#define SWSH_TRANSFORM_UTILITIES_INSTANTIATION(r, data)                   \
+  template void append_libsharp_collocation_pointers(                     \
+      const gsl::not_null<std::vector<double*>*> collocation_data,        \
+      const gsl::not_null<                                                \
+          std::vector<ComplexDataView<GET_REPRESENTATION(data)>>*>        \
+          collocation_views,                                              \
+      const gsl::not_null<ComplexDataVector*> vector, const size_t l_max, \
+      const bool positive_spin) noexcept;                                 \
+  template void execute_libsharp_transform_set(                           \
+      const sharp_jobtype& jobtype, const int spin,                       \
+      const gsl::not_null<std::vector<std::complex<double>*>*>            \
+          coefficient_data,                                               \
+      const gsl::not_null<std::vector<double*>*> collocation_data,        \
+      const gsl::not_null<const Collocation<GET_REPRESENTATION(data)>*>   \
+          collocation_metadata,                                           \
+      const sharp_alm_info* alm_info, const size_t num_transforms) noexcept;
+
+namespace detail {
+GENERATE_INSTANTIATIONS(SWSH_TRANSFORM_UTILITIES_INSTANTIATION,
+                        (ComplexRepresentation::Interleaved,
+                         ComplexRepresentation::RealsThenImags))
+}  // namespace detail
+
+GENERATE_INSTANTIATIONS(SWSH_TRANSFORM_INSTANTIATION,
+                        (ComplexRepresentation::Interleaved,
+                         ComplexRepresentation::RealsThenImags),
+                        (-2, -1, 0, 1, 2))
+
+#undef GET_REPRESENTATION
+#undef GET_SPIN
+#undef SWSH_TRANSFORM_INSTANTIATION
+#undef SWSH_TRANSFORM_UTILITIES_INSTANTIATION
+
+}  // namespace Swsh
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SwshTransform.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTransform.cpp
@@ -63,7 +63,7 @@ void execute_libsharp_transform_set(
     const sharp_jobtype& jobtype, const int spin,
     const gsl::not_null<std::vector<std::complex<double>*>*> coefficient_data,
     const gsl::not_null<std::vector<double*>*> collocation_data,
-    const gsl::not_null<const Collocation<Representation>*>
+    const gsl::not_null<const CollocationMetadata<Representation>*>
         collocation_metadata,
     const sharp_alm_info* alm_info, const size_t num_transforms) noexcept {
   // libsharp considers two arrays per transform when spin is not zero.
@@ -120,7 +120,7 @@ void swsh_transform(
   pre_transform_collocation_data.reserve(2 * number_of_radial_points);
 
   const auto* collocation_metadata =
-      &precomputed_collocation<Representation>(l_max);
+      &cached_collocation_metadata<Representation>(l_max);
   const auto* alm_info =
       cached_coefficients_metadata(l_max).get_sharp_alm_info();
 
@@ -177,7 +177,7 @@ void inverse_swsh_transform(
       (size_of_libsharp_coefficient_vector(l_max));
 
   const auto* collocation_metadata =
-      &precomputed_collocation<Representation>(l_max);
+      &cached_collocation_metadata<Representation>(l_max);
   const auto* alm_info =
       cached_coefficients_metadata(l_max).get_sharp_alm_info();
 
@@ -274,7 +274,8 @@ SpinWeighted<ComplexDataVector, Spin> inverse_swsh_transform(
       const gsl::not_null<std::vector<std::complex<double>*>*>            \
           coefficient_data,                                               \
       const gsl::not_null<std::vector<double*>*> collocation_data,        \
-      const gsl::not_null<const Collocation<GET_REPRESENTATION(data)>*>   \
+      const gsl::not_null<                                                \
+          const CollocationMetadata<GET_REPRESENTATION(data)>*>           \
           collocation_metadata,                                           \
       const sharp_alm_info* alm_info, const size_t num_transforms) noexcept;
 

--- a/src/NumericalAlgorithms/Spectral/SwshTransform.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTransform.hpp
@@ -217,7 +217,7 @@ class TransformJob {
   size_t number_of_radial_grid_points_;
   size_t l_max_;
   sharp_alm_info* alm_info_;
-  const Collocation<Representation>* collocation_metadata_;
+  const CollocationMetadata<Representation>* collocation_metadata_;
 };
 
 namespace detail {
@@ -269,7 +269,8 @@ void execute_libsharp_transform_set(
     const sharp_jobtype& jobtype, int spin,
     gsl::not_null<std::vector<std::complex<double>*>*> coefficient_data,
     gsl::not_null<std::vector<double*>*> collocation_data,
-    gsl::not_null<const Collocation<Representation>*> collocation_metadata,
+    gsl::not_null<const CollocationMetadata<Representation>*>
+        collocation_metadata,
     const sharp_alm_info* alm_info, size_t num_transforms) noexcept;
 }  // namespace detail
 
@@ -278,7 +279,8 @@ TransformJob<Spin, Representation, TagList>::TransformJob(
     const size_t l_max, const size_t number_of_radial_grid_points) noexcept
     : number_of_radial_grid_points_{number_of_radial_grid_points},
       l_max_{l_max},
-      collocation_metadata_{&precomputed_collocation<Representation>(l_max_)} {
+      collocation_metadata_{
+          &cached_collocation_metadata<Representation>(l_max_)} {
   alm_info_ = cached_coefficients_metadata(l_max_).get_sharp_alm_info();
 }
 

--- a/src/NumericalAlgorithms/Spectral/SwshTransform.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTransform.hpp
@@ -3,14 +3,15 @@
 
 #pragma once
 
-#include <cmath>
 #include <complex>
 #include <cstddef>
 #include <sharp_cxx.h>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Variables.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"  // IWYU pragma: keep
@@ -21,9 +22,19 @@
 
 // IWYU pragma: no_forward_declare Variables
 // IWYU pragma: no_forward_declare Coefficients
+// IWYU pragma: no_forward_declare SpinWeighted
+
+class ComplexDataVector;
+class ComplexModalVector;
 
 namespace Spectral {
 namespace Swsh {
+
+namespace detail {
+// libsharp has an internal maximum number of transforms that is not in the
+// public interface, so we must hard-code its value here
+static const size_t max_libsharp_transforms = 100;
+}  // namespace detail
 
 /*!
  * \ingroup SwshGroup
@@ -208,6 +219,59 @@ class TransformJob {
   const Collocation<Representation>* collocation_metadata_;
 };
 
+namespace detail {
+// appends to a vector of pointers `collocation_data` the set of pointers
+// associated with angular views of the provided collocation data `vector`. The
+// associated views are appended into `collocation_views`. If `positive_spin` is
+// false, this function will conjugate the views, and therefore potentially
+// conjugate (depending on `Representation`) the input data `vectors`. This
+// behavior is chosen to avoid frequent copies of the input data `vector` for
+// optimization. The conjugation must be undone after the call to libsharp
+// transforms using `conjugate_views` to restore the input data to its original
+// state.
+template <ComplexRepresentation Representation>
+void append_libsharp_collocation_pointers(
+    gsl::not_null<std::vector<double*>*> collocation_data,
+    gsl::not_null<std::vector<ComplexDataView<Representation>>*>
+        collocation_views,
+    gsl::not_null<ComplexDataVector*> vector, size_t l_max,
+    bool positive_spin) noexcept;
+
+// Perform a conjugation on a vector of `ComplexDataView`s if `Spin` < 0. This
+// is used for undoing the conjugation described in the code comment for
+// `append_libsharp_collocation_pointers`
+template <int Spin, ComplexRepresentation Representation>
+SPECTRE_ALWAYS_INLINE void conjugate_views(
+    gsl::not_null<std::vector<ComplexDataView<Representation>>*>
+        collocation_views) noexcept {
+  if (Spin < 0) {
+    for (auto& view : *collocation_views) {
+      view.conjugate();
+    }
+  }
+}
+
+// appends to a vector of pointers the set of pointers associated with
+// angular views of the provided coefficient vector. When working with the
+// libsharp coefficient representation, note the intricacies mentioned in
+// the documentation for `TransformJob`.
+void append_libsharp_coefficient_pointers(
+    gsl::not_null<std::vector<std::complex<double>*>*> coefficient_data,
+    gsl::not_null<ComplexModalVector*> vector, size_t l_max) noexcept;
+
+// perform the actual libsharp execution calls on an input and output set of
+// pointers. This function handles the complication of a limited maximum number
+// of simultaneous transforms, performing multiple execution calls on pointer
+// blocks if necessary.
+template <ComplexRepresentation Representation>
+void execute_libsharp_transform_set(
+    const sharp_jobtype& jobtype, int spin,
+    gsl::not_null<std::vector<std::complex<double>*>*> coefficient_data,
+    gsl::not_null<std::vector<double*>*> collocation_data,
+    gsl::not_null<const Collocation<Representation>*> collocation_metadata,
+    const sharp_alm_info* alm_info, size_t num_transforms) noexcept;
+}  // namespace detail
+
 template <int Spin, ComplexRepresentation Representation, typename TagList>
 TransformJob<Spin, Representation, TagList>::TransformJob(
     const size_t l_max, const size_t number_of_radial_grid_points) noexcept
@@ -227,75 +291,42 @@ void TransformJob<Spin, Representation, TagList>::execute_transform(
   std::vector<detail::ComplexDataView<Representation>> pre_transform_views;
   pre_transform_views.reserve(number_of_radial_grid_points_ *
                               tmpl::size<TagList>::value);
-  std::vector<const double*> pre_transform_collocation_data;
+  std::vector<double*> pre_transform_collocation_data;
   pre_transform_collocation_data.reserve(2 * number_of_radial_grid_points_ *
                                          tmpl::size<TagList>::value);
 
-  // for each Tag and each slice block in the radial direction, construct a
-  // ComplexDataView at the appropriate locations, then retrieve its real
-  // and imaginary data and put it in subsequent slots in the
-  // pre_transform_collocation_data.
-  size_t num_transforms = 0;
-  tmpl::for_each<TagList>([
-    &pre_transform_collocation_data, &pre_transform_views, &num_transforms,
-    &input, this
-  ](auto x) noexcept {
-    using transform_var_tag = typename decltype(x)::type;
-    decltype(auto) input_vector = get(get<transform_var_tag>(*input)).data();
-    for (size_t i = 0; i < number_of_radial_grid_points_; ++i) {
-      pre_transform_views.push_back(detail::ComplexDataView<Representation>{
-          make_not_null(&input_vector), collocation_metadata_->size(),
-          i * collocation_metadata_->size()});
-      pre_transform_collocation_data.push_back(
-          pre_transform_views.back().real_data());
-      // alteration needed because libsharp doesn't support negative spins
-      if (spin < 0) {
-        pre_transform_views.back().conjugate();
-      }
-      pre_transform_collocation_data.push_back(
-          pre_transform_views.back().imag_data());
-      // libsharp considers two arrays per transform when spin is not zero.
-      num_transforms += (spin == 0 ? 2 : 1);
-    }
-  });
-
+  // libsharp considers two arrays per transform when spin is not zero.
+  const size_t num_transforms = (Spin == 0 ? 2 : 1) *
+                                number_of_radial_grid_points_ *
+                                tmpl::size<TagList>::value;
+  tmpl::for_each<TagList>(
+      [&pre_transform_collocation_data, &pre_transform_views, &input,
+       this ](auto tag_v) noexcept {
+        using tag = typename decltype(tag_v)::type;
+        detail::append_libsharp_collocation_pointers(
+            make_not_null(&pre_transform_collocation_data),
+            make_not_null(&pre_transform_views),
+            make_not_null(&get(get<tag>(*input)).data()), l_max_, Spin >= 0);
+      });
   std::vector<std::complex<double>*> post_transform_coefficient_data;
   post_transform_coefficient_data.reserve(2 * number_of_radial_grid_points_ *
                                           tmpl::size<TagList>::value);
 
-  // assemble list of locations in the output Variables for the destinations
-  // of the coefficient data
   tmpl::for_each<CoefficientTagList>([
     &post_transform_coefficient_data, &output, this
   ](auto x) noexcept {
-    using coefficient_var_tag = typename decltype(x)::type;
-    decltype(auto) output_vector =
-        get(get<coefficient_var_tag>(*output)).data();
-    for (size_t i = 0; i < number_of_radial_grid_points_; ++i) {
-      // coefficients associated with the real part
-      post_transform_coefficient_data.push_back(
-          output_vector.data() + 2 * i * number_of_swsh_coefficients(l_max_));
-      // coefficients associated with the imaginary part
-      post_transform_coefficient_data.push_back(
-          output_vector.data() +
-          (2 * i + 1) * number_of_swsh_coefficients(l_max_));
-    }
+    detail::append_libsharp_coefficient_pointers(
+        make_not_null(&post_transform_coefficient_data),
+        make_not_null(&get(get<typename decltype(x)::type>(*output)).data()),
+        l_max_);
   });
 
-  sharp_execute(SHARP_MAP2ALM, abs(spin),
-                post_transform_coefficient_data.data(),
-                pre_transform_collocation_data.data(),
-                collocation_metadata_->get_sharp_geom_info(), alm_info_,
-                num_transforms, SHARP_DP, nullptr, nullptr);
+  detail::execute_libsharp_transform_set(
+      SHARP_MAP2ALM, spin, make_not_null(&post_transform_coefficient_data),
+      make_not_null(&pre_transform_collocation_data),
+      make_not_null(collocation_metadata_), alm_info_, num_transforms);
 
-  // libsharp only has the ability to transform positive spins, so we have to
-  // perform conjugation to deal with negative spins.
-  if (spin < 0) {
-    // fix the conjugation performed prior to transformation.
-    for (auto& view : pre_transform_views) {
-      view.conjugate();
-    }
-  }
+  detail::conjugate_views<Spin>(make_not_null(&pre_transform_views));
 }
 
 template <int Spin, ComplexRepresentation Representation, typename TagList>
@@ -306,60 +337,41 @@ void TransformJob<Spin, Representation, TagList>::execute_inverse_transform(
   std::vector<std::complex<double>*> pre_transform_coefficient_data;
   pre_transform_coefficient_data.reserve(2 * number_of_radial_grid_points_ *
                                          tmpl::size<CoefficientTagList>::value);
-  // assemble list of locations in the input Variables for the locations
-  // of the coefficient data
-  tmpl::for_each<CoefficientTagList>([&pre_transform_coefficient_data, &input,
-                                      this](auto x) {
-    using coefficient_var_tag = typename decltype(x)::type;
-    decltype(auto) input_vector = get(get<coefficient_var_tag>(*input)).data();
-    for (size_t i = 0; i < number_of_radial_grid_points_; ++i) {
-      pre_transform_coefficient_data.push_back(
-          input_vector.data() + 2 * i * number_of_swsh_coefficients(l_max_));
-      pre_transform_coefficient_data.push_back(
-          input_vector.data() +
-          (2 * i + 1) * number_of_swsh_coefficients(l_max_));
-    }
-  });
+  tmpl::for_each<CoefficientTagList>(
+      [&pre_transform_coefficient_data, &input, this](auto x) {
+        detail::append_libsharp_coefficient_pointers(
+            make_not_null(&pre_transform_coefficient_data),
+            make_not_null(&get(get<typename decltype(x)::type>(*input)).data()),
+            l_max_);
+      });
 
   std::vector<detail::ComplexDataView<Representation>> post_transform_views;
   post_transform_views.reserve(number_of_radial_grid_points_ *
                                tmpl::size<TagList>::value);
-  std::vector<const double*> post_transform_collocation_data;
+  std::vector<double*> post_transform_collocation_data;
   post_transform_collocation_data.reserve(2 * number_of_radial_grid_points_ *
                                           tmpl::size<TagList>::value);
 
-  // for each tag in `TagList`, construct a ComplexDataView at the
-  // appropriate locations, then retrieve its real and imaginary data and put
-  // it in subsequent slots in the pre_transform_collocation_data
-  size_t num_transforms = 0;
-  tmpl::for_each<TagList>([&post_transform_collocation_data, &num_transforms,
+  // libsharp considers two arrays per transform when spin is not zero.
+  const size_t num_transforms = (Spin == 0 ? 2 : 1) *
+                                number_of_radial_grid_points_ *
+                                tmpl::size<TagList>::value;
+
+  tmpl::for_each<TagList>([&post_transform_collocation_data,
                            &post_transform_views, &output, this](auto x) {
-    using transform_var_tag = typename decltype(x)::type;
-    decltype(auto) output_vector = get(get<transform_var_tag>(*output)).data();
-    for (size_t i = 0; i < number_of_radial_grid_points_; ++i) {
-      post_transform_views.push_back(detail::ComplexDataView<Representation>{
-          make_not_null(&output_vector), collocation_metadata_->size(),
-          i * collocation_metadata_->size()});
-      post_transform_collocation_data.push_back(
-          post_transform_views.back().real_data());
-      post_transform_collocation_data.push_back(
-          post_transform_views.back().imag_data());
-      // libsharp considers two arrays per transform when spin is not zero.
-      num_transforms += (spin == 0 ? 2 : 1);
-    }
+    detail::append_libsharp_collocation_pointers(
+        make_not_null(&post_transform_collocation_data),
+        make_not_null(&post_transform_views),
+        make_not_null(&get(get<typename decltype(x)::type>(*output)).data()),
+        l_max_, true);
   });
 
-  sharp_execute(SHARP_ALM2MAP, abs(spin), pre_transform_coefficient_data.data(),
-                post_transform_collocation_data.data(),
-                collocation_metadata_->get_sharp_geom_info(), alm_info_,
-                num_transforms, SHARP_DP, nullptr, nullptr);
+  detail::execute_libsharp_transform_set(
+      SHARP_ALM2MAP, spin, make_not_null(&pre_transform_coefficient_data),
+      make_not_null(&post_transform_collocation_data),
+      make_not_null(collocation_metadata_), alm_info_, num_transforms);
 
-  if (spin < 0) {
-    // the conjugate is needed because libsharp doesn't handle negative spins.
-    for (auto& view : post_transform_views) {
-      view.conjugate();
-    }
-  }
+  detail::conjugate_views<Spin>(make_not_null(&post_transform_views));
 
   // The inverse transformed collocation data has just been placed in the
   // memory blocks controlled by the `ComplexDataView`s. Finally, that data
@@ -368,6 +380,95 @@ void TransformJob<Spin, Representation, TagList>::execute_inverse_transform(
     view.copy_back_to_source();
   }
 }
+
+// @{
+/*!
+ * \ingroup SwshGroup
+ * \brief Perform a forward libsharp spin-weighted spherical harmonic transform
+ * on a supplied `SpinWeighted<ComplexDataVector, Spin>`.
+ *
+ * \details This function places the result in a
+ * `SpinWeighted<ComplexModalVector, Spin>` either returned via the provided
+ * pointer or by value (causing an allocation) if no pointer is provided. This
+ * is a simpler interface to the same functionality as `TransformJob`. This
+ * function is most suitable if only a small number of quantities will be
+ * transformed. If many quantities are simultaneously transformed and
+ * performance is desired, consider creating a `TransformJob`, or set of
+ * `TransformJob`s from a tag list, potentially using `make_transform_job_list`.
+ *
+ * template parameters:
+ * - `Representation`: Either `ComplexRepresentation::Interleaved` or
+ * `ComplexRepresentation::RealsThenImags`, indicating the representation for
+ * intermediate steps of the transformation. The two representations will give
+ * identical results but may help or hurt performance depending on the task.
+ * If unspecified, defaults to `ComplexRepresentation::Interleaved`.
+ * - `Spin`: The spin-weight of the quantity being transformed.
+ *
+ * The result is a set of libsharp-compatible coefficients.
+ * \see TransformJob for more details on the mathematics of the libsharp
+ * data structures.
+ */
+template <
+    ComplexRepresentation Representation = ComplexRepresentation::Interleaved,
+    int Spin>
+void swsh_transform(
+    gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*>
+        libsharp_coefficients,
+    gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> collocation,
+    size_t l_max) noexcept;
+
+template <
+    ComplexRepresentation Representation = ComplexRepresentation::Interleaved,
+    int Spin>
+SpinWeighted<ComplexModalVector, Spin> swsh_transform(
+    gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> collocation,
+    size_t l_max) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup SwshGroup
+ * \brief Perform an inverse libsharp spin-weighted spherical harmonic transform
+ * on a supplied `SpinWeighted<ComplexModalVector, Spin>`.
+ *
+ * \details This function places the result in a
+ * `SpinWeighted<ComplexDataVector, Spin>` either returned via the provided
+ * pointer or by value (causing an allocation) if no pointer is provided. This
+ * is a simpler interface to the same functionality as `TransformJob`. This
+ * function is most suitable if only a small number of quantities will be
+ * transformed. If many quantities are simultaneously transformed and
+ * performance is desired, consider creating a `TransformJob`, or set of
+ * `TransformJob`s from a tag list, potentially using `make_transform_job_list`.
+ *
+ * template parameters:
+ * - `Representation`: Either `ComplexRepresentation::Interleaved` or
+ * `ComplexRepresentation::RealsThenImags`, indicating the representation for
+ * intermediate steps of the transformation. The two representations will give
+ * identical results but may help or hurt performance depending on the task.
+ * If unspecified, defaults to `ComplexRepresentation::Interleaved`.
+ * - `Spin`: The spin-weight of the quantity being transformed.
+ *
+ * The result is a set of libsharp-compatible collocation values.
+ * \see TransformJob for more details on the mathematics of the libsharp
+ * data structures.
+ */
+template <
+    ComplexRepresentation Representation = ComplexRepresentation::Interleaved,
+    int Spin>
+void inverse_swsh_transform(
+    gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> collocation,
+    gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*>
+        libsharp_coefficients,
+    size_t l_max) noexcept;
+
+template <
+    ComplexRepresentation Representation = ComplexRepresentation::Interleaved,
+    int Spin>
+SpinWeighted<ComplexDataVector, Spin> inverse_swsh_transform(
+    gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*>
+        libsharp_coefficients,
+    size_t l_max) noexcept;
+// @}
 
 namespace detail {
 template <typename Job>
@@ -379,12 +480,12 @@ struct transform_job_is_not_empty<
 
 template <int MinSpin, ComplexRepresentation Representation, typename TagList,
           typename IndexSequence>
-struct make_swsh_transform_job_list_impl;
+struct make_transform_job_list_impl;
 
 template <int MinSpin, ComplexRepresentation Representation, typename TagList,
           int... Is>
-struct make_swsh_transform_job_list_impl<MinSpin, Representation, TagList,
-                                         std::integer_sequence<int, Is...>> {
+struct make_transform_job_list_impl<MinSpin, Representation, TagList,
+                                    std::integer_sequence<int, Is...>> {
   using type = tmpl::filter<
       tmpl::list<TransformJob<Is + MinSpin, Representation,
                               get_tags_with_spin<Is + MinSpin, TagList>>...>,
@@ -398,17 +499,16 @@ struct make_swsh_transform_job_list_impl<MinSpin, Representation, TagList,
 /// `ComplexRepresentation` to use for the transformations.
 ///
 /// \details Up to five `TransformJob` will be returned, corresponding to
-/// the possible spin values. Any number of transformations are aggregated into
-/// that set of `TransformJob`s. The number of transforms is up to five because
-/// the libsharp utility only has capability to perform spin-weighted spherical
-/// harmonic transforms for integer spin-weights from -2 to 2.
+/// the possible spin values. Any number of transformations are aggregated
+/// into that set of `TransformJob`s. The number of transforms is up to five
+/// because the libsharp utility only has capability to perform spin-weighted
+/// spherical harmonic transforms for integer spin-weights from -2 to 2.
 ///
-/// \snippet Test_SwshTransformJob.cpp make_swsh_transform_job_list
+/// \snippet Test_SwshTransform.cpp make_transform_job_list
 template <ComplexRepresentation Representation, typename TagList>
-using make_swsh_transform_job_list =
-    typename detail::make_swsh_transform_job_list_impl<
-        -2, Representation, TagList,
-        decltype(std::make_integer_sequence<int, 5>{})>::type;
+using make_transform_job_list = typename detail::make_transform_job_list_impl<
+    -2, Representation, TagList,
+    decltype(std::make_integer_sequence<int, 5>{})>::type;
 
 /// \ingroup SpectralGroup
 /// \brief Assemble a `tmpl::list` of `TransformJob`s given a list of
@@ -420,10 +520,10 @@ using make_swsh_transform_job_list =
 /// derivative routine, where one transforms the set of fields for which
 /// derivatives are required.
 ///
-/// \snippet Test_SwshTransformJob.cpp make_swsh_transform_from_derivative_tags
+/// \snippet Test_SwshTransform.cpp make_transform_from_derivative_tags
 template <ComplexRepresentation Representation, typename DerivativeTagList>
-using make_swsh_transform_job_list_from_derivative_tags =
-    typename detail::make_swsh_transform_job_list_impl<
+using make_transform_job_list_from_derivative_tags =
+    typename detail::make_transform_job_list_impl<
         -2, Representation,
         tmpl::transform<DerivativeTagList,
                         tmpl::bind<db::remove_tag_prefix, tmpl::_1>>,

--- a/tests/Unit/DataStructures/Test_SpinWeighted.cpp
+++ b/tests/Unit/DataStructures/Test_SpinWeighted.cpp
@@ -192,6 +192,18 @@ SPECTRE_TEST_CASE("Unit.DataStructures.SpinWeighted",
   CHECK(size_and_value_created_spin_weight_m2.data() ==
         ComplexDataVector{5, 4.0});
   CHECK(size_and_value_created_spin_weight_m2.size() == 5);
+
+  // test destructive resize for vector type
+  SpinWeighted<ComplexDataVector, 2> destructive_resize_check{5, 4.0};
+  const SpinWeighted<ComplexDataVector, 2> destructive_resize_copy =
+      destructive_resize_check;
+  // check unchanged if no resize
+  destructive_resize_check.destructive_resize(5);
+  CHECK(destructive_resize_check == destructive_resize_copy);
+  // check resize occurs if appropriate
+  destructive_resize_check.destructive_resize(6);
+  CHECK(destructive_resize_check != destructive_resize_copy);
+  CHECK(destructive_resize_check.size() == destructive_resize_copy.size() + 1);
 }
 
 /// \cond HIDDEN_SYMBOLS

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -18,7 +18,7 @@ set(LIBRARY_SOURCES
   Test_SwshCollocation.cpp
   Test_SwshTags.cpp
   Test_SwshTestHelpers.cpp
-  Test_SwshTransformJob.cpp
+  Test_SwshTransform.cpp
   )
 
 add_test_library(

--- a/tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp
@@ -127,7 +127,7 @@ void swsh_collocation_from_coefficients_and_basis_func(
     const size_t l_max, const size_t number_of_radial_points,
     const BasisFunction basis_function) noexcept {
   auto& spherical_harmonic_collocation =
-      precomputed_collocation<Representation>(l_max);
+      cached_collocation_metadata<Representation>(l_max);
   auto spherical_harmonic_lm =
       cached_coefficients_metadata(l_max).get_sharp_alm_info();
 

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCoefficients.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCoefficients.cpp
@@ -172,8 +172,7 @@ void check_goldberg_mode_conversion() {
   }
 
   SpinWeighted<ComplexModalVector, Spin> test_modes =
-      swsh_transform<Representation>(
-          make_not_null(&goldberg_collocation_points), l_max);
+      swsh_transform<Representation>(goldberg_collocation_points, l_max);
 
   Approx swsh_approx =
       Approx::custom()
@@ -243,7 +242,7 @@ void check_goldberg_mode_conversion() {
   }
 
   const auto inverse_transform_set_from_goldberg =
-      inverse_swsh_transform<Representation>(make_not_null(&test_modes), l_max);
+      inverse_swsh_transform<Representation>(test_modes, l_max);
   CHECK_ITERABLE_CUSTOM_APPROX(inverse_transform_set_from_goldberg.data(),
                                goldberg_collocation_points.data(), swsh_approx);
 }

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCoefficients.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCoefficients.cpp
@@ -3,12 +3,24 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <complex>
 #include <cstddef>
+#include <limits>
 #include <random>
 #include <sharp_cxx.h>
 
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
 #include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 #include "tests/Utilities/MakeWithRandomValues.hpp"
 
@@ -16,72 +28,103 @@ namespace Spectral {
 namespace Swsh {
 namespace {
 
-SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshCoefficients",
-                  "[Unit][NumericalAlgorithms]") {
+void test_swsh_coefficients_class_interface() noexcept {
   MAKE_GENERATOR(gen);
   UniformCustomDistribution<size_t> sdist{8, 64};
   const size_t l_max = sdist(gen);
 
   CAPTURE(l_max);
-  const detail::Coefficients& precomputed_coefficients =
-      detail::precomputed_coefficients(l_max);
+  const CoefficientsMetadata& precomputed_libsharp_lm =
+      cached_coefficients_metadata(l_max);
 
-  const detail::Coefficients& another_precomputed_coefficients =
-      detail::precomputed_coefficients(l_max);
+  const CoefficientsMetadata& another_precomputed_libsharp_lm =
+      cached_coefficients_metadata(l_max);
 
   // checks that the same pointer is in both
-  CHECK(precomputed_coefficients.get_sharp_alm_info() ==
-        another_precomputed_coefficients.get_sharp_alm_info());
+  CHECK(precomputed_libsharp_lm.get_sharp_alm_info() ==
+        another_precomputed_libsharp_lm.get_sharp_alm_info());
 
-  const detail::Coefficients computed_coefficients{l_max};
+  const CoefficientsMetadata computed_coefficients{l_max};
 
-  CHECK(precomputed_coefficients.l_max() == l_max);
+  CHECK(precomputed_libsharp_lm.l_max() == l_max);
   CHECK(computed_coefficients.l_max() == l_max);
 
-  sharp_alm_info* manual_sai;
-  sharp_make_triangular_alm_info(l_max, l_max, 1, &manual_sai);
+  sharp_alm_info* expected_sharp_alm_info;
+  sharp_make_triangular_alm_info(l_max, l_max, 1, &expected_sharp_alm_info);
 
   // check that all of the precomputed coefficients, the directly constructed
   // coefficients, and the manually created sharp_alm_info* all contain the same
   // data
-  CHECK(precomputed_coefficients.get_sharp_alm_info()->lmax ==
+  CHECK(precomputed_libsharp_lm.get_sharp_alm_info()->lmax ==
         computed_coefficients.get_sharp_alm_info()->lmax);
-  CHECK(precomputed_coefficients.get_sharp_alm_info()->lmax ==
-        manual_sai->lmax);
-  CHECK(precomputed_coefficients.get_sharp_alm_info()->lmax ==
+  CHECK(precomputed_libsharp_lm.get_sharp_alm_info()->lmax ==
+        expected_sharp_alm_info->lmax);
+  CHECK(precomputed_libsharp_lm.get_sharp_alm_info()->lmax ==
         computed_coefficients.l_max());
 
-  CHECK(precomputed_coefficients.get_sharp_alm_info()->nm ==
+  CHECK(precomputed_libsharp_lm.get_sharp_alm_info()->nm ==
         computed_coefficients.get_sharp_alm_info()->nm);
-  CHECK(precomputed_coefficients.get_sharp_alm_info()->nm == manual_sai->nm);
+  CHECK(precomputed_libsharp_lm.get_sharp_alm_info()->nm ==
+        expected_sharp_alm_info->nm);
 
-  CHECK(precomputed_coefficients.get_sharp_alm_info()->flags ==
+  CHECK(precomputed_libsharp_lm.get_sharp_alm_info()->flags ==
         computed_coefficients.get_sharp_alm_info()->flags);
-  CHECK(precomputed_coefficients.get_sharp_alm_info()->flags ==
-        manual_sai->flags);
+  CHECK(precomputed_libsharp_lm.get_sharp_alm_info()->flags ==
+        expected_sharp_alm_info->flags);
 
-  CHECK(precomputed_coefficients.get_sharp_alm_info()->stride ==
+  CHECK(precomputed_libsharp_lm.get_sharp_alm_info()->stride ==
         computed_coefficients.get_sharp_alm_info()->stride);
-  CHECK(precomputed_coefficients.get_sharp_alm_info()->stride ==
-        manual_sai->stride);
+  CHECK(precomputed_libsharp_lm.get_sharp_alm_info()->stride ==
+        expected_sharp_alm_info->stride);
 
   for (size_t m_index = 0;
        m_index <
-       static_cast<size_t>(precomputed_coefficients.get_sharp_alm_info()->nm);
+       static_cast<size_t>(precomputed_libsharp_lm.get_sharp_alm_info()->nm);
        ++m_index) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    CHECK(precomputed_coefficients.get_sharp_alm_info()->mval[m_index] ==
+    CHECK(precomputed_libsharp_lm.get_sharp_alm_info()->mval[m_index] ==
           computed_coefficients.get_sharp_alm_info()->mval[m_index]);
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    CHECK(precomputed_coefficients.get_sharp_alm_info()->mval[m_index] ==
-          manual_sai->mval[m_index]);
+    CHECK(precomputed_libsharp_lm.get_sharp_alm_info()->mval[m_index] ==
+          expected_sharp_alm_info->mval[m_index]);
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    CHECK(precomputed_coefficients.get_sharp_alm_info()->mvstart[m_index] ==
+    CHECK(precomputed_libsharp_lm.get_sharp_alm_info()->mvstart[m_index] ==
           computed_coefficients.get_sharp_alm_info()->mvstart[m_index]);
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    CHECK(precomputed_coefficients.get_sharp_alm_info()->mvstart[m_index] ==
-          manual_sai->mvstart[m_index]);
+    CHECK(precomputed_libsharp_lm.get_sharp_alm_info()->mvstart[m_index] ==
+          expected_sharp_alm_info->mvstart[m_index]);
+  }
+
+  CHECK(precomputed_libsharp_lm.begin() == precomputed_libsharp_lm.cbegin());
+  CHECK(precomputed_libsharp_lm.end() == precomputed_libsharp_lm.cend());
+  CHECK(precomputed_libsharp_lm.begin() != precomputed_libsharp_lm.end());
+
+  size_t offset_counter = 0;
+  size_t expected_l = 0;
+  size_t expected_m = 0;
+  for (const auto& coefficient_info : precomputed_libsharp_lm) {
+    CHECK(coefficient_info.transform_of_real_part_offset == offset_counter);
+    CHECK(coefficient_info.transform_of_imag_part_offset -
+              coefficient_info.transform_of_real_part_offset ==
+          size_of_libsharp_coefficient_vector(l_max) / 2);
+    CHECK(coefficient_info.l == expected_l);
+    CHECK(coefficient_info.m == expected_m);
+    ++offset_counter;
+    if (expected_l == l_max) {
+      ++expected_m;
+      expected_l = expected_m;
+    } else {
+      ++expected_l;
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshCoefficients",
+                  "[Unit][NumericalAlgorithms]") {
+  {
+    INFO("Checking Coefficients for libsharp interoperability");
+    test_swsh_coefficients_class_interface();
   }
 }
 
@@ -90,7 +133,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshCoefficients",
     "Unit.NumericalAlgorithms.Spectral.SwshCoefficients.PrecomputationOverrun",
     "[Unit][NumericalAlgorithms]") {
   ERROR_TEST();
-  detail::precomputed_coefficients(detail::coefficients_maximum_l_max + 1);
+  cached_coefficients_metadata(detail::coefficients_maximum_l_max + 1);
   ERROR("Failed to trigger ERROR in an error test");
 }
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCollocation.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCollocation.cpp
@@ -28,17 +28,17 @@ void test_spherical_harmonic_collocation() noexcept {
   const size_t l_max = sdist(gen);
 
   CAPTURE(l_max);
-  const Collocation<Representation>& precomputed_collocation_value =
-      precomputed_collocation<Representation>(l_max);
+  const CollocationMetadata<Representation>& precomputed_collocation_value =
+      cached_collocation_metadata<Representation>(l_max);
 
-  const Collocation<Representation>& another_precomputed_collocation =
-      precomputed_collocation<Representation>(l_max);
+  const CollocationMetadata<Representation>& another_precomputed_collocation =
+      cached_collocation_metadata<Representation>(l_max);
 
   // checks that the same pointer is in both
   CHECK(precomputed_collocation_value.get_sharp_geom_info() ==
         another_precomputed_collocation.get_sharp_geom_info());
 
-  const Collocation<Representation> computed_collocation{l_max};
+  const CollocationMetadata<Representation> computed_collocation{l_max};
 
   CHECK(precomputed_collocation_value.l_max() == l_max);
   CHECK(computed_collocation.l_max() == l_max);
@@ -125,13 +125,13 @@ void test_spherical_harmonic_collocation() noexcept {
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshCollocation",
                   "[Unit][NumericalAlgorithms]") {
   {
-    INFO("Collocation based on contiguous complex data (Interleaved)");
+    INFO("CollocationMetadata based on contiguous complex data (Interleaved)");
     test_spherical_harmonic_collocation<ComplexRepresentation::Interleaved>();
   }
   {
     INFO(
-        "Collocation based on a pair of contiguous blocks representing complex "
-        "data (RealsThenImags)");
+        "CollocationMetadata based on a pair of contiguous blocks representing "
+        "complex data (RealsThenImags)");
     test_spherical_harmonic_collocation<
         ComplexRepresentation::RealsThenImags>();
   }
@@ -142,7 +142,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshCollocation",
     "Unit.NumericalAlgorithms.Spectral.SwshCollocation.PrecomputationOverrun",
     "[Unit][NumericalAlgorithms]") {
   ERROR_TEST();
-  precomputed_collocation<ComplexRepresentation::RealsThenImags>(
+  cached_collocation_metadata<ComplexRepresentation::RealsThenImags>(
       collocation_maximum_l_max + 1);
   ERROR("Failed to trigger ERROR in an error test");
 }

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransform.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransform.cpp
@@ -124,7 +124,7 @@ void test_transform_and_inverse_transform() noexcept {
   Variables<tmpl::list<Tags::SwshTransform<ExpectedTestTag<S>>,
                        Tags::SwshTransform<TestTag<S>>>>
       coefficient_data{
-          number_of_swsh_coefficients(l_max) * 2 * number_of_radial_points,
+          size_of_libsharp_coefficient_vector(l_max) * number_of_radial_points,
           0.0};
 
   // randomly generate the mode coefficients

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransform.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransform.cpp
@@ -149,8 +149,7 @@ void test_transform_and_inverse_transform() noexcept {
   const TransformJob<S, Representation, JobTags> job{l_max,
                                                      number_of_radial_points};
   const auto test_collocation_copy = test_collocation;
-  job.execute_transform(make_not_null(&coefficient_data),
-                        make_not_null(&collocation_data));
+  job.execute_transform(make_not_null(&coefficient_data), collocation_data);
 
   // approximation needs to be a little loose to consistently accommodate
   // the ratios of factorials in the analytic form
@@ -173,8 +172,8 @@ void test_transform_and_inverse_transform() noexcept {
                                transform_approx);
 
   SpinWeighted<ComplexModalVector, S> modes_from_function_call =
-      swsh_transform<Representation>(
-          make_not_null(&get(get<TestTag<S>>(collocation_data))), l_max);
+      swsh_transform<Representation>(get(get<TestTag<S>>(collocation_data)),
+                                     l_max);
   CHECK_ITERABLE_CUSTOM_APPROX(modes_from_function_call.data(), generated_modes,
                                transform_approx);
 
@@ -183,12 +182,10 @@ void test_transform_and_inverse_transform() noexcept {
   const TransformJob<S, Representation, InverseJobTags> inverse_job{
       l_max, number_of_radial_points};
   inverse_job.execute_inverse_transform(make_not_null(&collocation_data),
-                                        make_not_null(&coefficient_data));
+                                        coefficient_data);
   SpinWeighted<ComplexDataVector, S> collocation_values_from_function_call =
       inverse_swsh_transform<Representation>(
-          make_not_null(
-              &get(get<Tags::SwshTransform<TestTag<S>>>(coefficient_data))),
-          l_max);
+          get(get<Tags::SwshTransform<TestTag<S>>>(coefficient_data)), l_max);
   CHECK_ITERABLE_CUSTOM_APPROX(test_collocation, expected_collocation,
                                transform_approx);
 }

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransform.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransform.cpp
@@ -19,7 +19,7 @@
 #include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"  // IWYU pragma: keep
-#include "NumericalAlgorithms/Spectral/SwshTransformJob.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
@@ -54,7 +54,7 @@ using TestDerivativeTagList =
                Tags::Derivative<ExpectedTestTag<-1>, Tags::EthEthbar>,
                Tags::Derivative<TestTag<2>, Tags::EthbarEthbar>>;
 
-/// [make_swsh_transform_job_list]
+/// [make_transform_job_list]
 using ExpectedInverseJobs = tmpl::list<
     TransformJob<
         -1, ComplexRepresentation::RealsThenImags,
@@ -66,13 +66,13 @@ using ExpectedInverseJobs = tmpl::list<
 
 static_assert(
     cpp17::is_same_v<
-        make_swsh_transform_job_list<ComplexRepresentation::RealsThenImags,
+        make_transform_job_list<ComplexRepresentation::RealsThenImags,
                                      TestDerivativeTagList>,
         ExpectedInverseJobs>,
-    "failed testing make_swsh_transform_job_list");
-/// [make_swsh_transform_job_list]
+    "failed testing make_transform_job_list");
+/// [make_transform_job_list]
 
-/// [make_swsh_transform_from_derivative_tags]
+/// [make_transform_from_derivative_tags]
 using ExpectedJobs =
     tmpl::list<TransformJob<-1, ComplexRepresentation::Interleaved,
                             tmpl::list<TestTag<-1>, ExpectedTestTag<-1>>>,
@@ -81,11 +81,11 @@ using ExpectedJobs =
 
 static_assert(
     cpp17::is_same_v<
-        make_swsh_transform_job_list_from_derivative_tags<
+        make_transform_job_list_from_derivative_tags<
             ComplexRepresentation::Interleaved, TestDerivativeTagList>,
         ExpectedJobs>,
-    "failed testing make_swsh_transform_job_list_from_derivative_tags");
-/// [make_swsh_transform_from_derivative_tags]
+    "failed testing make_transform_job_list_from_derivative_tags");
+/// [make_transform_from_derivative_tags]
 
 static_assert(
     cpp17::is_same_v<
@@ -152,8 +152,8 @@ void test_transform_and_inverse_transform() noexcept {
   job.execute_transform(make_not_null(&coefficient_data),
                         make_not_null(&collocation_data));
 
-  // approximation needs to be a little loose to consistently accommodate the
-  // ratios of factorials in the analytic form
+  // approximation needs to be a little loose to consistently accommodate
+  // the ratios of factorials in the analytic form
   Approx transform_approx =
       Approx::custom()
           .epsilon(std::numeric_limits<double>::epsilon() * 1.0e6)
@@ -172,18 +172,28 @@ void test_transform_and_inverse_transform() noexcept {
   CHECK_ITERABLE_CUSTOM_APPROX(transformed_modes, generated_modes,
                                transform_approx);
 
+  SpinWeighted<ComplexModalVector, S> modes_from_function_call =
+      swsh_transform<Representation>(
+          make_not_null(&get(get<TestTag<S>>(collocation_data))), l_max);
+  CHECK_ITERABLE_CUSTOM_APPROX(modes_from_function_call.data(), generated_modes,
+                               transform_approx);
+
   // create the inverse transformation job and execute
   using InverseJobTags = tmpl::list<TestTag<S>>;
   const TransformJob<S, Representation, InverseJobTags> inverse_job{
       l_max, number_of_radial_points};
   inverse_job.execute_inverse_transform(make_not_null(&collocation_data),
                                         make_not_null(&coefficient_data));
-
+  SpinWeighted<ComplexDataVector, S> collocation_values_from_function_call =
+      inverse_swsh_transform<Representation>(
+          make_not_null(
+              &get(get<Tags::SwshTransform<TestTag<S>>>(coefficient_data))),
+          l_max);
   CHECK_ITERABLE_CUSTOM_APPROX(test_collocation, expected_collocation,
                                transform_approx);
 }
 
-SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.Transform",
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshTransform",
                   "[Unit][NumericalAlgorithms]") {
   {
     INFO("Testing with ComplexRepresentation::Interleaved");

--- a/tests/Unit/TestingFramework.hpp
+++ b/tests/Unit/TestingFramework.hpp
@@ -103,6 +103,31 @@ static Approx approx =                                          // NOLINT
 /*!
  * \ingroup TestingFrameworkGroup
  * \brief A wrapper around Catch's CHECK macro that checks approximate
+ * equality of the two entries in a std::complex. For efficiency, no function
+ * forwarding is performed, just a pair of `CHECK`s inline
+ */
+#define CHECK_COMPLEX_APPROX(a, b)                                     \
+  do {                                                                 \
+    INFO(__FILE__ ":" + std::to_string(__LINE__) + ": " #a " == " #b); \
+    CHECK(approx(real(a)) == real(b));                                 \
+    CHECK(approx(imag(a)) == imag(b));                                 \
+  } while (false)
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Same as `CHECK_COMPLEX_APPROX` with user-defined Approx.
+ *  The third argument should be of type `Approx`.
+ */
+#define CHECK_COMPLEX_CUSTOM_APPROX(a, b, appx)                        \
+  do {                                                                 \
+    INFO(__FILE__ ":" + std::to_string(__LINE__) + ": " #a " == " #b); \
+    CHECK(appx(real(a)) == real(b));                                   \
+    CHECK(appx(imag(a)) == imag(b));                                   \
+  } while (false)
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief A wrapper around Catch's CHECK macro that checks approximate
  * equality of entries in iterable containers.  For maplike
  * containers, keys are checked for strict equality and values are
  * checked for approximate equality.


### PR DESCRIPTION
## Proposed changes

Updates to the spin-weighted spherical harmonic transform utilities. These include putting in a public coefficients interface, creating an easy method of converting between libsharp coefficients and more traditional methods, and refactoring the transformation functions.



### Types of changes:

- [ ] New feature

### Component:

- [ ] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies
 - [x] #1522 