### PR TITLE
Make types appear explicitly in input files

### DIFF
--- a/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
@@ -55,7 +55,7 @@ struct Metavariables {
   using temporal_id = LinearSolver::Tags::IterationId;
 
   // Parse numerical flux parameters from the input file to store in the cache.
-  using normal_dot_numerical_flux = OptionTags::NumericalFluxParams<
+  using normal_dot_numerical_flux = OptionTags::NumericalFlux<
       Poisson::FirstOrderInternalPenaltyFlux<Dim>>;
 
   // Set up the domain creator from the input file.

--- a/src/Elliptic/Systems/Poisson/Equations.hpp
+++ b/src/Elliptic/Systems/Poisson/Equations.hpp
@@ -128,6 +128,7 @@ struct FirstOrderInternalPenaltyFlux {
   using options = tmpl::list<PenaltyParameter>;
   static constexpr OptionString help = {
       "Computes the internal penalty flux for a Poisson system."};
+  static std::string name() noexcept { return "InternalPenalty"; }
 
   FirstOrderInternalPenaltyFlux() = default;
   explicit FirstOrderInternalPenaltyFlux(double penalty_parameter)

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Tags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Tags.hpp
@@ -7,13 +7,24 @@
 
 namespace OptionTags {
 /*!
+ * \ingroup OptionGroupsGroup
+ * \brief Holds the `OptionTags::SlopeLimiter` option in the input file
+ */
+struct SlopeLimiterGroup {
+  static std::string name() noexcept { return "SlopeLimiter"; }
+  static constexpr OptionString help = "Options for limiting troubled cells";
+};
+
+/*!
  * \ingroup OptionTagsGroup
  * \brief The global cache tag that retrieves the parameters for the slope
  * limiter from the input file
  */
 template <typename SlopeLimiterType>
 struct SlopeLimiter {
+  static std::string name() noexcept { return option_name<SlopeLimiterType>(); }
   static constexpr OptionString help = "Options for the slope limiter";
   using type = SlopeLimiterType;
+  using group = SlopeLimiterGroup;
 };
 }  // namespace OptionTags

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Tags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Tags.hpp
@@ -12,8 +12,8 @@ namespace OptionTags {
  * limiter from the input file
  */
 template <typename SlopeLimiterType>
-struct SlopeLimiterParams {
-  static constexpr OptionString help = "The options for the slope limiter";
+struct SlopeLimiter {
+  static constexpr OptionString help = "Options for the slope limiter";
   using type = SlopeLimiterType;
 };
 }  // namespace OptionTags

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -71,8 +71,8 @@ struct EvolutionMetavars {
       OptionTags::AnalyticSolution<Burgers::Solutions::Step>;
   using boundary_condition_tag = analytic_solution_tag;
   using normal_dot_numerical_flux =
-      OptionTags::NumericalFluxParams<Burgers::LocalLaxFriedrichsFlux>;
-  using limiter = OptionTags::SlopeLimiterParams<
+      OptionTags::NumericalFlux<Burgers::LocalLaxFriedrichsFlux>;
+  using limiter = OptionTags::SlopeLimiter<
       SlopeLimiters::Minmod<1, system::variables_tag::tags_list>>;
 
   // public for use by the Charm++ registration code

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -92,10 +92,10 @@ struct EvolutionMetavars {
       typename system::primitive_variables_tag::tags_list;
   using equation_of_state_tag = hydro::Tags::EquationOfState<
       typename analytic_solution_tag::type::equation_of_state_type>;
-  using normal_dot_numerical_flux = OptionTags::NumericalFluxParams<
+  using normal_dot_numerical_flux = OptionTags::NumericalFlux<
       dg::NumericalFluxes::LocalLaxFriedrichs<system>>;
   // Do not limit the divergence-cleaning field Phi
-  using limiter = OptionTags::SlopeLimiterParams<SlopeLimiters::Minmod<
+  using limiter = OptionTags::SlopeLimiter<SlopeLimiters::Minmod<
       3, tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,
                     grmhd::ValenciaDivClean::Tags::TildeTau,
                     grmhd::ValenciaDivClean::Tags::TildeS<Frame::Inertial>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanAnalyticData.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanAnalyticData.hpp
@@ -84,11 +84,11 @@ struct EvolutionMetavars {
       typename system::primitive_variables_tag::tags_list;
   using equation_of_state_tag = hydro::Tags::EquationOfState<
       typename analytic_data_tag::type::equation_of_state_type>;
-  using normal_dot_numerical_flux = OptionTags::NumericalFluxParams<
+  using normal_dot_numerical_flux = OptionTags::NumericalFlux<
       dg::NumericalFluxes::LocalLaxFriedrichs<system>>;
   // GRMHD is only implemented in 3D.
   // Do not limit the divergence-cleaning field Phi
-  using limiter = OptionTags::SlopeLimiterParams<SlopeLimiters::Minmod<
+  using limiter = OptionTags::SlopeLimiter<SlopeLimiters::Minmod<
       3, tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,
                     grmhd::ValenciaDivClean::Tags::TildeTau,
                     grmhd::ValenciaDivClean::Tags::TildeS<Frame::Inertial>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -75,7 +75,7 @@ struct EvolutionMetavars {
       OptionTags::AnalyticSolution<ScalarWave::Solutions::PlaneWave<Dim>>;
   using boundary_condition_tag = analytic_solution_tag;
   using normal_dot_numerical_flux =
-      OptionTags::NumericalFluxParams<ScalarWave::UpwindFlux<Dim>>;
+      OptionTags::NumericalFlux<ScalarWave::UpwindFlux<Dim>>;
 
   // public for use by the Charm++ registration code
   using events = tmpl::list<

--- a/src/Evolution/Systems/Burgers/Equations.hpp
+++ b/src/Evolution/Systems/Burgers/Equations.hpp
@@ -33,6 +33,7 @@ struct LocalLaxFriedrichsFlux {
   using options = tmpl::list<>;
   static constexpr OptionString help{
       "Computes the Local LF flux for the Burgers system."};
+  static std::string name() noexcept { return "LocalLaxFriedrichs"; }
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) noexcept {}

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
@@ -9,16 +9,26 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"
+#include "Evolution/Tags.hpp"
 #include "Options/Options.hpp"
 
 class DataVector;
 
 namespace OptionTags {
+/// \ingroup OptionGroupsGroup
+/// Groups option tags related to the ValenciaDivClean evolution system.
+struct ValenciaDivCleanGroup {
+  static std::string name() noexcept { return "ValenciaDivClean"; }
+  static constexpr OptionString help{"Options for the evolution system"};
+  using group = EvolutionSystemGroup;
+};
+
 /// \brief The constraint damping parameter
 struct DampingParameter {
   using type = double;
   static constexpr OptionString help{
-      "constraint damping parameter for divergence cleaning"};
+      "Constraint damping parameter for divergence cleaning"};
+  using group = ValenciaDivCleanGroup;
 };
 }  // namespace OptionTags
 

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -128,6 +128,7 @@ struct UpwindFlux {
   static constexpr OptionString help = {
       "Computes the upwind flux for a scalar wave system. It requires no "
       "options."};
+  static std::string name() noexcept { return "Upwind"; }
 
   // clang-tidy: non-const reference
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT

--- a/src/Evolution/Tags.hpp
+++ b/src/Evolution/Tags.hpp
@@ -19,4 +19,16 @@ struct EvolutionGroup {
   static constexpr OptionString help{"Options for the time evolution"};
 };
 
+/*!
+ * \ingroup OptionGroupsGroup
+ * \brief Groups option tags related to the evolution system.
+ *
+ * The option tags for the evolution system should be placed in a subgroup that
+ * carries the system name. See e.g. `OptionTags::ValenciaDivCleanGroup`.
+ */
+struct EvolutionSystemGroup {
+  static std::string name() noexcept { return "EvolutionSystem"; }
+  static constexpr OptionString help{"The system of hyperbolic PDEs"};
+};
+
 }  // namespace OptionTags

--- a/src/Evolution/VariableFixing/Actions.hpp
+++ b/src/Evolution/VariableFixing/Actions.hpp
@@ -42,7 +42,7 @@ namespace Actions {
 template <typename VariableFixer>
 struct FixVariables {
   using const_global_cache_tags =
-      tmpl::list<OptionTags::VariableFixerParams<VariableFixer>>;
+      tmpl::list<OptionTags::VariableFixer<VariableFixer>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -55,7 +55,7 @@ struct FixVariables {
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
     const auto& variable_fixer =
-        get<OptionTags::VariableFixerParams<VariableFixer>>(cache);
+        get<OptionTags::VariableFixer<VariableFixer>>(cache);
     db::mutate_apply(variable_fixer, make_not_null(&box));
     return std::forward_as_tuple(std::move(box));
   }

--- a/src/Evolution/VariableFixing/Tags.hpp
+++ b/src/Evolution/VariableFixing/Tags.hpp
@@ -22,7 +22,7 @@ struct VariableFixingGroup {
  * fixer from the input file.
  */
 template <typename VariableFixerType>
-struct VariableFixerParams {
+struct VariableFixer {
   static constexpr OptionString help = "Options for the variable fixer";
   using type = VariableFixerType;
   static std::string name() noexcept {

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -56,7 +56,7 @@ namespace OptionTags {
  * flux from the input file
  */
 template <typename NumericalFluxType>
-struct NumericalFluxParams {
+struct NumericalFlux {
   static constexpr OptionString help = "The options for the numerical flux";
   using type = NumericalFluxType;
 };

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -51,13 +51,26 @@ struct MortarSize : db::SimpleTag {
 
 namespace OptionTags {
 /*!
+ * \ingroup OptionGroupsGroup
+ * \brief Holds the `OptionTags::NumericalFlux` option in the input file
+ */
+struct NumericalFluxGroup {
+  static std::string name() noexcept { return "NumericalFlux"; }
+  static constexpr OptionString help = "The numerical flux scheme";
+};
+
+/*!
  * \ingroup OptionTagsGroup
  * \brief The global cache tag that retrieves the parameters for the numerical
  * flux from the input file
  */
 template <typename NumericalFluxType>
 struct NumericalFlux {
-  static constexpr OptionString help = "The options for the numerical flux";
+  static std::string name() noexcept {
+    return option_name<NumericalFluxType>();
+  }
+  static constexpr OptionString help = "Options for the numerical flux";
   using type = NumericalFluxType;
+  using group = NumericalFluxGroup;
 };
 }  // namespace OptionTags

--- a/src/Options/Options.hpp
+++ b/src/Options/Options.hpp
@@ -16,6 +16,8 @@
 
 #include "ErrorHandling/Error.hpp"
 #include "Utilities/NoSuchType.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
 namespace YAML {
@@ -145,3 +147,21 @@ struct create_from_yaml {
   template <typename Metavariables>
   static T create(const Option& options);
 };
+
+namespace Options_detail {
+template <typename T, typename = cpp17::void_t<>>
+struct name_helper {
+  static std::string name() noexcept { return pretty_type::short_name<T>(); }
+};
+
+template <typename T>
+struct name_helper<T, cpp17::void_t<decltype(T::name())>> {
+  static std::string name() noexcept { return T::name(); }
+};
+}  // namespace Options_detail
+
+// The name in the YAML file for a struct.
+template <typename T>
+std::string option_name() noexcept {
+  return Options_detail::name_helper<T>::name();
+}

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -256,9 +256,9 @@ class Options {
   template <typename T,
             Requires<not Options_detail::has_default<T>::value> = nullptr>
   [[noreturn]] typename T::type get_default() const {
-    PARSE_ERROR(context_, "You did not specify the option '"
-                              << Options_detail::name<T>() << "'.\n"
-                              << help());
+    PARSE_ERROR(context_, "You did not specify the option '" << option_name<T>()
+                                                             << "'.\n"
+                                                             << help());
   }
   //@}
 
@@ -304,7 +304,7 @@ class Options {
             Requires<Options_detail::has_default<T>::value> = nullptr>
   void validate_default() const {
     OptionContext context;
-    context.append("Checking DEFAULT value for " + Options_detail::name<T>());
+    context.append("Checking DEFAULT value for " + option_name<T>());
     const auto default_value = T::default_value();
     check_lower_bound_on_size<T>(default_value, context);
     check_upper_bound_on_size<T>(default_value, context);
@@ -336,7 +336,7 @@ Options<OptionList, Group>::Options(std::string help_text) noexcept
                        .value) {
   tmpl::for_each<tags_and_subgroups_list>([](auto t) noexcept {
     using T = typename decltype(t)::type;
-    const std::string label = Options_detail::name<T>();
+    const std::string label = option_name<T>();
     ASSERT(label.size() <= max_label_size_,
            "The option name " << label
                               << " is too long for nice formatting, "
@@ -418,7 +418,7 @@ struct get_impl {
         tmpl::list_contains_v<OptionList, Tag>,
         "Could not find requested option in the list of options provided. Did "
         "you forget to add the option tag to the OptionList?");
-    const std::string subgroup_label = name<Subgroup>();
+    const std::string subgroup_label = option_name<Subgroup>();
     if (0 == opts.parsed_options_.count(subgroup_label)) {
       PARSE_ERROR(opts.context_, "You did not specify the group '"
                                      << subgroup_label << "'.\n"
@@ -441,7 +441,7 @@ struct get_impl<Tag, Metavariables, Tag> {
         tmpl::list_contains_v<OptionList, Tag>,
         "Could not find requested option in the list of options provided. Did "
         "you forget to add the option tag to the OptionList?");
-    const std::string label = name<Tag>();
+    const std::string label = option_name<Tag>();
 
     opts.template validate_default<Tag>();
     if (0 == opts.parsed_options_.count(label)) {

--- a/src/PointwiseFunctions/AnalyticData/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Tags.hpp
@@ -6,6 +6,14 @@
 #include "Options/Options.hpp"
 
 namespace OptionTags {
+/// \ingroup OptionGroupsGroup
+/// Holds the `OptionTags::AnalyticData` option in the input file
+struct AnalyticDataGroup {
+  static std::string name() noexcept { return "AnalyticData"; }
+  static constexpr OptionString help =
+      "Analytic data used for the initial data";
+};
+
 /// \ingroup OptionTagsGroup
 /// Can be used to retrieve the analytic data from the cache without having
 /// to know the template parameters of AnalyticData.
@@ -16,8 +24,9 @@ struct AnalyticDataBase {};
 /// parameter
 template <typename SolutionType>
 struct AnalyticData : AnalyticDataBase {
-  static constexpr OptionString help =
-      "Analytic data used for the initial data";
+  static std::string name() noexcept { return option_name<SolutionType>(); }
+  static constexpr OptionString help = "Options for the analytic data";
   using type = SolutionType;
+  using group = AnalyticDataGroup;
 };
 }  // namespace OptionTags

--- a/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
@@ -6,6 +6,14 @@
 #include "Options/Options.hpp"
 
 namespace OptionTags {
+/// \ingroup OptionGroupsGroup
+/// Holds the `OptionTags::AnalyticSolution` option in the input file
+struct AnalyticSolutionGroup {
+  static std::string name() noexcept { return "AnalyticSolution"; }
+  static constexpr OptionString help =
+      "Analytic solution used for the initial data and errors";
+};
+
 /// \ingroup OptionTagsGroup
 /// Can be used to retrieve the analytic solution from the cache without having
 /// to know the template parameters of AnalyticSolution.
@@ -20,9 +28,10 @@ struct BoundaryConditionBase {};
 /// template parameter
 template <typename SolutionType>
 struct AnalyticSolution : AnalyticSolutionBase {
-  static constexpr OptionString help =
-      "Analytic solution used for the initial data and errors";
+  static std::string name() noexcept { return option_name<SolutionType>(); }
+  static constexpr OptionString help = "Options for the analytic solution";
   using type = SolutionType;
+  using group = AnalyticSolutionGroup;
 };
 /// \ingroup OptionTagsGroup
 /// The boundary condition to be applied at all external boundaries.

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -26,6 +26,7 @@ DomainCreator:
     InitialGridPoints: [7]
 
 NumericalFlux:
+  LocalLaxFriedrichs:
 
 SlopeLimiter:
   Minmod:

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -24,9 +24,9 @@ DomainCreator:
     InitialRefinement: [2]
     InitialGridPoints: [7]
 
-NumericalFluxParams:
+NumericalFlux:
 
-SlopeLimiterParams:
+SlopeLimiter:
   Type: LambdaPi1
 
 EventsAndTriggers:

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -28,7 +28,8 @@ DomainCreator:
 NumericalFlux:
 
 SlopeLimiter:
-  Type: LambdaPi1
+  Minmod:
+    Type: LambdaPi1
 
 EventsAndTriggers:
   ? PastTime: 0.1

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -5,9 +5,10 @@
 # Check: execute
 
 AnalyticSolution:
-  LeftValue: 2.
-  RightValue: 1.
-  InitialPosition: -0.5
+  Step:
+    LeftValue: 2.
+    RightValue: 1.
+    InitialPosition: -0.5
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -33,8 +33,9 @@ NumericalFlux:
 DampingParameter: 0.0
 
 SlopeLimiter:
-  Type: Muscl
-  TvbmConstant: 0
+  Minmod:
+    Type: Muscl
+    TvbmConstant: 0
 
 VariableFixing:
   FixConservatives:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -31,7 +31,9 @@ AnalyticData:
 NumericalFlux:
   LocalLaxFriedrichs:
 
-DampingParameter: 0.0
+EvolutionSystem:
+  ValenciaDivClean:
+    DampingParameter: 0.0
 
 SlopeLimiter:
   Minmod:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -27,11 +27,11 @@ AnalyticData:
   MagneticField: [0.1, 0.0, 0.0]
   AdiabaticIndex: 1.3333333333333333333
 
-NumericalFluxParams:
+NumericalFlux:
 
 DampingParameter: 0.0
 
-SlopeLimiterParams:
+SlopeLimiter:
   Type: Muscl
   TvbmConstant: 0
 

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -29,6 +29,7 @@ AnalyticData:
     AdiabaticIndex: 1.3333333333333333333
 
 NumericalFlux:
+  LocalLaxFriedrichs:
 
 DampingParameter: 0.0
 

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -18,14 +18,15 @@ DomainCreator:
     InitialGridPoints: [2, 2, 2]
 
 AnalyticData:
-  InnerRadius: 0.8
-  OuterRadius: 1.0
-  InnerDensity: 1.0e-2
-  OuterDensity: 1.0e-4
-  InnerPressure: 1.0
-  OuterPressure: 5.0e-4
-  MagneticField: [0.1, 0.0, 0.0]
-  AdiabaticIndex: 1.3333333333333333333
+  CylindricalBlastWave:
+    InnerRadius: 0.8
+    OuterRadius: 1.0
+    InnerDensity: 1.0e-2
+    OuterDensity: 1.0e-4
+    InnerPressure: 1.0
+    OuterPressure: 5.0e-4
+    MagneticField: [0.1, 0.0, 0.0]
+    AdiabaticIndex: 1.3333333333333333333
 
 NumericalFlux:
 

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
@@ -41,7 +41,9 @@ AnalyticSolution:
 NumericalFlux:
   LocalLaxFriedrichs:
 
-DampingParameter: 0.0
+EvolutionSystem:
+  ValenciaDivClean:
+    DampingParameter: 0.0
 
 SlopeLimiter:
   Minmod:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
@@ -30,12 +30,13 @@ DomainCreator:
     InitialGridPoints: [5, 5, 5]
 
 AnalyticSolution:
-  BhMass: 1.0
-  BhDimlessSpin: 0.9375
-  InnerEdgeRadius: 6.0
-  MaxPressureRadius: 12.0
-  PolytropicConstant: 0.001
-  PolytropicExponent: 1.3333333333333333333333
+  FishboneMoncriefDisk:
+    BhMass: 1.0
+    BhDimlessSpin: 0.9375
+    InnerEdgeRadius: 6.0
+    MaxPressureRadius: 12.0
+    PolytropicConstant: 0.001
+    PolytropicExponent: 1.3333333333333333333333
 
 NumericalFlux:
 

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
@@ -37,11 +37,11 @@ AnalyticSolution:
   PolytropicConstant: 0.001
   PolytropicExponent: 1.3333333333333333333333
 
-NumericalFluxParams:
+NumericalFlux:
 
 DampingParameter: 0.0
 
-SlopeLimiterParams:
+SlopeLimiter:
   # Uncomment line below to turn off the limiter:
   # DisableForDebugging: True
   Type: LambdaPiN

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
@@ -39,6 +39,7 @@ AnalyticSolution:
     PolytropicExponent: 1.3333333333333333333333
 
 NumericalFlux:
+  LocalLaxFriedrichs:
 
 DampingParameter: 0.0
 

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
@@ -43,11 +43,12 @@ NumericalFlux:
 DampingParameter: 0.0
 
 SlopeLimiter:
-  # Uncomment line below to turn off the limiter:
-  # DisableForDebugging: True
-  Type: LambdaPiN
-  # Recommended value from minmod papers:
-  TvbmConstant: 50.0
+  Minmod:
+    # Uncomment line below to turn off the limiter:
+    # DisableForDebugging: True
+    Type: LambdaPiN
+    # Recommended value from minmod papers:
+    TvbmConstant: 50.0
 
 VariableFixing:
   FixConservatives:

--- a/tests/InputFiles/Poisson/Input1D.yaml
+++ b/tests/InputFiles/Poisson/Input1D.yaml
@@ -8,6 +8,7 @@
 #   Poisson1DVolume0.h5
 
 AnalyticSolution:
+  ProductOfSinusoids:
     WaveNumbers: [1]
 
 DomainCreator:

--- a/tests/InputFiles/Poisson/Input1D.yaml
+++ b/tests/InputFiles/Poisson/Input1D.yaml
@@ -20,6 +20,7 @@ DomainCreator:
     InitialGridPoints: [3]
 
 NumericalFlux:
+  InternalPenalty:
     PenaltyParameter: 5.729577951308232 # p^2 / h
 
 Observers:

--- a/tests/InputFiles/Poisson/Input1D.yaml
+++ b/tests/InputFiles/Poisson/Input1D.yaml
@@ -18,7 +18,7 @@ DomainCreator:
     InitialRefinement: [1]
     InitialGridPoints: [3]
 
-NumericalFluxParams:
+NumericalFlux:
     PenaltyParameter: 5.729577951308232 # p^2 / h
 
 Observers:

--- a/tests/InputFiles/Poisson/Input2D.yaml
+++ b/tests/InputFiles/Poisson/Input2D.yaml
@@ -20,6 +20,7 @@ DomainCreator:
     InitialGridPoints: [3, 3]
 
 NumericalFlux:
+  InternalPenalty:
     PenaltyParameter: 5.729577951308232 # p^2 / h
 
 Observers:

--- a/tests/InputFiles/Poisson/Input2D.yaml
+++ b/tests/InputFiles/Poisson/Input2D.yaml
@@ -18,7 +18,7 @@ DomainCreator:
     InitialRefinement: [1, 1]
     InitialGridPoints: [3, 3]
 
-NumericalFluxParams:
+NumericalFlux:
     PenaltyParameter: 5.729577951308232 # p^2 / h
 
 Observers:

--- a/tests/InputFiles/Poisson/Input2D.yaml
+++ b/tests/InputFiles/Poisson/Input2D.yaml
@@ -8,6 +8,7 @@
 #   Poisson2DVolume0.h5
 
 AnalyticSolution:
+  ProductOfSinusoids:
     WaveNumbers: [1, 1]
 
 DomainCreator:

--- a/tests/InputFiles/Poisson/Input3D.yaml
+++ b/tests/InputFiles/Poisson/Input3D.yaml
@@ -18,7 +18,7 @@ DomainCreator:
     InitialRefinement: [1, 1, 1]
     InitialGridPoints: [2, 2, 2]
 
-NumericalFluxParams:
+NumericalFlux:
     PenaltyParameter: 2.5464790894703255 # p^2 / h
 
 Observers:

--- a/tests/InputFiles/Poisson/Input3D.yaml
+++ b/tests/InputFiles/Poisson/Input3D.yaml
@@ -20,6 +20,7 @@ DomainCreator:
     InitialGridPoints: [2, 2, 2]
 
 NumericalFlux:
+  InternalPenalty:
     PenaltyParameter: 2.5464790894703255 # p^2 / h
 
 Observers:

--- a/tests/InputFiles/Poisson/Input3D.yaml
+++ b/tests/InputFiles/Poisson/Input3D.yaml
@@ -8,6 +8,7 @@
 #   Poisson3DVolume0.h5
 
 AnalyticSolution:
+  ProductOfSinusoids:
     WaveNumbers: [1, 1, 1]
 
 DomainCreator:

--- a/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
@@ -5,13 +5,14 @@
 # Check: execute
 
 AnalyticSolution:
-  WaveVector: [1.0]
-  Center: [0.0]
-  Profile:
-    Sinusoid:
-      Amplitude: 1.0
-      Wavenumber: 1.0
-      Phase: 0.0
+  PlaneWave:
+    WaveVector: [1.0]
+    Center: [0.0]
+    Profile:
+      Sinusoid:
+        Amplitude: 1.0
+        Wavenumber: 1.0
+        Phase: 0.0
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
@@ -44,6 +44,7 @@ DomainCreator:
 #     HalfPower: 32
 
 NumericalFlux:
+  Upwind:
 
 EventsAndTriggers:
   ? SpecifiedSlabs:

--- a/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
@@ -42,7 +42,7 @@ DomainCreator:
 #     Alpha: 12
 #     HalfPower: 32
 
-NumericalFluxParams:
+NumericalFlux:
 
 EventsAndTriggers:
   ? SpecifiedSlabs:

--- a/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
@@ -44,6 +44,7 @@ DomainCreator:
 #     HalfPower: 32
 
 NumericalFlux:
+  Upwind:
 
 EventsAndTriggers:
   ? SpecifiedSlabs:

--- a/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
@@ -42,7 +42,7 @@ DomainCreator:
 #     Alpha: 12
 #     HalfPower: 32
 
-NumericalFluxParams:
+NumericalFlux:
 
 EventsAndTriggers:
   ? SpecifiedSlabs:

--- a/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
@@ -5,13 +5,14 @@
 # Check: execute
 
 AnalyticSolution:
-  WaveVector: [1.0, 1.0]
-  Center: [0.0, 0.0]
-  Profile:
-    Sinusoid:
-      Amplitude: 1.0
-      Wavenumber: 1.0
-      Phase: 0.0
+  PlaneWave:
+    WaveVector: [1.0, 1.0]
+    Center: [0.0, 0.0]
+    Profile:
+      Sinusoid:
+        Amplitude: 1.0
+        Wavenumber: 1.0
+        Phase: 0.0
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
@@ -5,13 +5,14 @@
 # Check: execute
 
 AnalyticSolution:
-  WaveVector: [1.0, 1.0, 1.0]
-  Center: [0.0, 0.0, 0.0]
-  Profile:
-    Sinusoid:
-      Amplitude: 1.0
-      Wavenumber: 1.0
-      Phase: 0.0
+  PlaneWave:
+    WaveVector: [1.0, 1.0, 1.0]
+    Center: [0.0, 0.0, 0.0]
+    Profile:
+      Sinusoid:
+        Amplitude: 1.0
+        Wavenumber: 1.0
+        Phase: 0.0
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
@@ -44,6 +44,7 @@ DomainCreator:
 #     HalfPower: 32
 
 NumericalFlux:
+  Upwind:
 
 EventsAndTriggers:
   ? SpecifiedSlabs:

--- a/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
@@ -42,7 +42,7 @@ DomainCreator:
 #     Alpha: 12
 #     HalfPower: 32
 
-NumericalFluxParams:
+NumericalFlux:
 
 EventsAndTriggers:
   ? SpecifiedSlabs:

--- a/tests/InputFiles/ScalarWave/ObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/ObserveExample.yaml
@@ -4,13 +4,14 @@
 # Executable: EvolveScalarWave1D
 
 AnalyticSolution:
-  WaveVector: [1.0]
-  Center: [0.0]
-  Profile:
-    Sinusoid:
-      Amplitude: 1.0
-      Wavenumber: 1.0
-      Phase: 0.0
+  PlaneWave:
+    WaveVector: [1.0]
+    Center: [0.0]
+    Profile:
+      Sinusoid:
+        Amplitude: 1.0
+        Wavenumber: 1.0
+        Phase: 0.0
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/ScalarWave/ObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/ObserveExample.yaml
@@ -42,6 +42,7 @@ DomainCreator:
 #   HalfPower: 32
 
 NumericalFlux:
+  Upwind:
 
 # [observe_event_trigger]
 EventsAndTriggers:

--- a/tests/InputFiles/ScalarWave/ObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/ObserveExample.yaml
@@ -40,7 +40,7 @@ DomainCreator:
 #   Alpha: 12
 #   HalfPower: 32
 
-NumericalFluxParams:
+NumericalFlux:
 
 # [observe_event_trigger]
 EventsAndTriggers:

--- a/tests/Unit/Elliptic/Initialization/Test_BoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_BoundaryConditions.cpp
@@ -84,7 +84,7 @@ struct Metavariables {
   using analytic_solution_tag =
       OptionTags::AnalyticSolution<AnalyticSolution<Dim>>;
   using normal_dot_numerical_flux =
-      OptionTags::NumericalFluxParams<NumericalFlux<Dim>>;
+      OptionTags::NumericalFlux<NumericalFlux<Dim>>;
   using component_list = tmpl::list<>;
   using const_global_cache_tag_list =
       tmpl::list<analytic_solution_tag, normal_dot_numerical_flux>;


### PR DESCRIPTION
## Proposed changes

This PR is a follow-up to #1483, making use of the new option groups feature to add more structure to our input files. Mainly, it proposes the following change to how options for classes chosen at compile-time appear in the input file:

**Old:**
```yaml
AnalyticSolution:
  BhMass: 1.0
  ...
```

**New:**
```yaml
AnalyticSolution:
  FishboneMoncriefDisk:
    BhMass: 1.0
    ...
```

Note that this is backwards-compatible: If we choose to allow specifying the analytic solution in the input file in the future, as we do for the time stepper, for instance, then no changes to the input file are needed. On the other hand, if the user tries to change the `FishboneMoncriefDisk` to something else without the executable supporting it, a standard parse error is shown.

The reason for this change I also commented on in https://github.com/sxs-collaboration/spectre/pull/1483#issuecomment-482456502.

- [x] Depends on #1483, so the first 7 commits are not part of this PR

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).