### PR TITLE
Add importer for numeric initial data

### DIFF
--- a/docs/DevGuide/DevGuide.md
+++ b/docs/DevGuide/DevGuide.md
@@ -9,6 +9,7 @@ See LICENSE.txt for details.
   unit tests, and executables.
 - \ref dev_guide_creating_executables "Executables and how to add them"
 - \ref dev_guide_option_parsing "Option parsing" to get options from input files
+- \ref dev_guide_importing "Importing" data from files
 - \ref profiling_with_projections "Profiling With Charm++ Projections" and PAPI
   for optimizing performance
 - \ref spectre_writing_python_bindings "Writing Python Bindings" to use

--- a/docs/DevGuide/ImportingData.md
+++ b/docs/DevGuide/ImportingData.md
@@ -1,0 +1,69 @@
+\cond NEVER
+Distributed under the MIT License.
+See LICENSE.txt for details.
+\endcond
+# Importing data {#dev_guide_importing}
+
+The `importers` namespace holds functionality for importing data into SpECTRE.
+We currently support loading volume data files in the same format that is
+written by the `observers`.
+
+## Importing volume data
+
+The `importers::VolumeDataReader` parallel component is responsible for loading
+volume data and distributing it to elements of one or multiple array parallel
+components. As a first step, make sure you have added the
+`importers::VolumeDataReader` to your `Metavariables::component_list`. Also make
+sure you have a `Metavariables::Phase` in which you will perform registration
+with the importer, and another for loading the data. Here's an example for such
+`Metavariables`:
+
+\snippet Test_VolumeDataReaderAlgorithm.hpp metavars
+
+To register elements of your array parallel component for receiving volume data,
+invoke the `importers::Actions::RegisterWithVolumeDataReader` action in the
+`phase_dependent_action_list`. Here's an example:
+
+\snippet Test_VolumeDataReaderAlgorithm.hpp register_action
+
+Now you're all set to load a data file. To do so, invoke the
+`importers::ThreadedActions::ReadVolumeData` action on the
+`importers::VolumeDataReader`. A good place for this is the `execute_next_phase`
+function of the array parallel component:
+
+\snippet Test_VolumeDataReaderAlgorithm.hpp read_data_action
+
+\snippet Test_VolumeDataReaderAlgorithm.hpp invoke_readvoldata
+
+In the first snippet the `read_element_data_action` type alias is set to a
+specialization of the `importers::ThreadedActions::ReadVolumeData` template.
+Its first template parameter specifies an option group that determines the data
+file to load, the second parameter is a typelist of the tags to import and fill
+with the volume data, the third parameter is the action that is called upon
+receiving the data on the array elements, and the last template parameter is the
+parallel component on which the callback action will be invoked. See the
+documentation of the `importers::ThreadedActions::ReadVolumeData` action for
+details on these parameters. Here is more information on the parameters used in
+the example above:
+
+- The `VolumeDataOptions` in this example is an option group that supplies
+  information such as the file name. You provide an option group that represents
+  the data you want to import. For example, we have the
+  `evolution::OptionTags::NumericInitialData` that represents numeric initial
+  data for an evolution. In our example, we created a new class like this:
+
+  \snippet Test_VolumeDataReaderAlgorithm.hpp option_group
+
+  This results in a section in the input file that may look like this:
+
+  \snippet Test_VolumeDataReaderAlgorithm2D.yaml importer_options
+
+- The `::Actions::SetData` callback action in the example will be invoked to
+  receive the data on each element. You can use this particular action to move
+  the received data directly into the DataBox, but it's generally better to
+  write a new action that does a few consistency checks on the data before
+  moving it into the DataBox.
+
+When the `importers::ThreadedActions::ReadVolumeData` is invoked, the data file
+will be read and its data distributed to all elements of the array that have
+been registered.

--- a/src/IO/Importers/ElementActions.hpp
+++ b/src/IO/Importers/ElementActions.hpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/ElementId.hpp"
+#include "IO/Importers/VolumeDataReader.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/Requires.hpp"
+
+namespace importers {
+namespace Actions {
+
+/// \cond
+struct RegisterElementWithSelf;
+/// \endcond
+
+/*!
+ * \brief Register an element with the volume data reader component.
+ *
+ * Invoke this action on each element of an array parallel component to register
+ * them for receiving imported volume data.
+ */
+struct RegisterWithVolumeDataReader {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ElementIndex<Dim>& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const std::string element_name = MakeString{}
+                                     << ElementId<Dim>(array_index);
+    auto& local_reader_component =
+        *Parallel::get_parallel_component<
+             importers::VolumeDataReader<Metavariables>>(cache)
+             .ckLocalBranch();
+    Parallel::simple_action<importers::Actions::RegisterElementWithSelf>(
+        local_reader_component,
+        observers::ArrayComponentId(
+            std::add_pointer_t<ParallelComponent>{nullptr},
+            Parallel::ArrayIndex<ElementIndex<Dim>>(array_index)),
+        element_name);
+    return {std::move(box)};
+  }
+};
+
+}  // namespace Actions
+}  // namespace importers

--- a/src/IO/Importers/Tags.hpp
+++ b/src/IO/Importers/Tags.hpp
@@ -1,0 +1,147 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "Options/Options.hpp"
+
+/// Items related to loading data from files
+namespace importers {
+
+/// The input file options associated with the data importer
+namespace OptionTags {
+
+/*!
+ * \ingroup OptionGroupsGroup
+ * \brief Groups the data importer configurations in the input file
+ */
+struct Group {
+  static std::string name() noexcept { return "Importers"; }
+  static constexpr OptionString help = "Options for loading data files";
+};
+
+/*!
+ * \brief The file to read data from.
+ */
+template <typename ImporterOptionsGroup>
+struct FileName {
+  static_assert(
+      cpp17::is_same_v<typename ImporterOptionsGroup::group, Group>,
+      "The importer options should be placed in the 'Importers' option "
+      "group. Add a type alias `using group = importers::OptionTags::Group`.");
+  using type = std::string;
+  static constexpr OptionString help = "Path to the data file";
+  using group = ImporterOptionsGroup;
+};
+
+/*!
+ * \brief The subgroup within the file to read data from.
+ *
+ * This subgroup should conform to the `h5::VolumeData` format.
+ */
+template <typename ImporterOptionsGroup>
+struct Subgroup {
+  static_assert(
+      cpp17::is_same_v<typename ImporterOptionsGroup::group, Group>,
+      "The importer options should be placed in the 'Importers' option "
+      "group. Add a type alias `using group = importers::OptionTags::Group`.");
+  using type = std::string;
+  static constexpr OptionString help =
+      "The subgroup within the file, excluding extensions";
+  using group = ImporterOptionsGroup;
+};
+
+/*!
+ * \brief The observation value at which to read data from the file.
+ */
+template <typename ImporterOptionsGroup>
+struct ObservationValue {
+  static_assert(
+      cpp17::is_same_v<typename ImporterOptionsGroup::group, Group>,
+      "The importer options should be placed in the 'Importers' option "
+      "group. Add a type alias `using group = importers::OptionTags::Group`.");
+  using type = double;
+  static constexpr OptionString help =
+      "The observation value at which to read data";
+  using group = ImporterOptionsGroup;
+};
+
+}  // namespace OptionTags
+
+/// The \ref DataBoxGroup tags associated with the data importer
+namespace Tags {
+
+/*!
+ * \brief The file to read data from.
+ */
+template <typename ImporterOptionsGroup>
+struct FileName : db::SimpleTag {
+  static std::string name() noexcept {
+    return "FileName(" + option_name<ImporterOptionsGroup>() + ")";
+  }
+  using type = std::string;
+  using option_tags = tmpl::list<OptionTags::FileName<ImporterOptionsGroup>>;
+
+  template <typename Metavariables>
+  static type create_from_options(const type& file_name) noexcept {
+    return file_name;
+  }
+};
+
+/*!
+ * \brief The subgroup within the file to read data from.
+ *
+ * This subgroup should conform to the `h5::VolumeData` format.
+ */
+template <typename ImporterOptionsGroup>
+struct Subgroup : db::SimpleTag {
+  static std::string name() noexcept {
+    return "Subgroup(" + option_name<ImporterOptionsGroup>() + ")";
+  }
+  using type = std::string;
+  using option_tags = tmpl::list<OptionTags::Subgroup<ImporterOptionsGroup>>;
+
+  template <typename Metavariables>
+  static type create_from_options(const type& subgroup) noexcept {
+    return subgroup;
+  }
+};
+
+/*!
+ * \brief The observation value at which to read data from the file.
+ */
+template <typename ImporterOptionsGroup>
+struct ObservationValue : db::SimpleTag {
+  static std::string name() noexcept {
+    return "ObservationValue(" + option_name<ImporterOptionsGroup>() + ")";
+  }
+  using type = double;
+  using option_tags =
+      tmpl::list<OptionTags::ObservationValue<ImporterOptionsGroup>>;
+
+  template <typename Metavariables>
+  static type create_from_options(const type& observation_value) noexcept {
+    return observation_value;
+  }
+};
+
+/*!
+ * \brief The elements that will receive data from the importer.
+ *
+ * \details Identifiers for elements from multiple parallel components can be
+ * stored. Each element is identified by an `observers::ArrayComponentId` and
+ * also needs to provide the `std::string` that identifies it in the data file.
+ */
+struct RegisteredElements : db::SimpleTag {
+  using type = std::unordered_map<observers::ArrayComponentId, std::string>;
+};
+
+}  // namespace Tags
+
+}  // namespace importers

--- a/src/IO/Importers/VolumeDataReader.hpp
+++ b/src/IO/Importers/VolumeDataReader.hpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "AlgorithmNodegroup.hpp"
+#include "IO/Importers/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+
+namespace importers {
+
+namespace detail {
+struct InitializeVolumeDataReader;
+}  // namespace detail
+
+/*!
+ * \brief A nodegroup parallel component that reads in a volume data file and
+ * distributes its data to elements of an array parallel component.
+ *
+ * Each element of the array parallel component must register itself before
+ * data can be sent to it. To do so, invoke
+ * `importers::Actions::RegisterWithVolumeDataReader` on each element. In a
+ * subsequent phase you can then invoke
+ * `importers::ThreadedActions::ReadVolumeData` on the `VolumeDataReader`
+ * component to read in the file and distribute its data to the registered
+ * elements.
+ */
+template <typename Metavariables>
+struct VolumeDataReader {
+  using chare_type = Parallel::Algorithms::Nodegroup;
+  using metavariables = Metavariables;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<detail::InitializeVolumeDataReader>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void initialize(Parallel::CProxy_ConstGlobalCache<
+                         Metavariables>& /*global_cache*/) noexcept {}
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    Parallel::get_parallel_component<VolumeDataReader>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+
+namespace detail {
+struct InitializeVolumeDataReader {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using simple_tags = db::AddSimpleTags<Tags::RegisteredElements>;
+    using compute_tags = db::AddComputeTags<>;
+
+    return std::make_tuple(
+        ::Initialization::merge_into_databox<InitializeVolumeDataReader,
+                                             simple_tags, compute_tags>(
+            std::move(box), db::item_type<Tags::RegisteredElements>{}),
+        true);
+  }
+};
+}  // namespace detail
+
+}  // namespace importers

--- a/src/IO/Importers/VolumeDataReaderActions.hpp
+++ b/src/IO/Importers/VolumeDataReaderActions.hpp
@@ -1,0 +1,196 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "IO/Importers/Tags.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace importers {
+/// Actions related to importers
+namespace Actions {
+
+/*!
+ * \brief Invoked on the `importers::VolumeDataReader` component to store the
+ * registered data.
+ *
+ * The `importers::Actions::RegisterWithVolumeDataReader` action, which is
+ * performed on each element of an array parallel component, invokes this action
+ * on the `importers::VolumeDataReader` component.
+ */
+struct RegisterElementWithSelf {
+  template <
+      typename ParallelComponent, typename DbTagsList, typename Metavariables,
+      typename ArrayIndex, typename DataBox = db::DataBox<DbTagsList>,
+      Requires<db::tag_is_retrievable_v<Tags::RegisteredElements, DataBox>> =
+          nullptr>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const observers::ArrayComponentId& array_component_id,
+                    const std::string& grid_name) noexcept {
+    db::mutate<Tags::RegisteredElements>(
+        make_not_null(&box),
+        [&array_component_id, &grid_name](
+            const gsl::not_null<db::item_type<Tags::RegisteredElements>*>
+                registered_elements) noexcept {
+          (*registered_elements)[array_component_id] = grid_name;
+        });
+  }
+};
+
+}  // namespace Actions
+
+/// Threaded actions related to importers
+namespace ThreadedActions {
+
+/*!
+ * \brief Read a volume data file and distribute the data to the registered
+ * elements.
+ *
+ * This action can be invoked on the `importers::VolumeDataReader` component
+ * once all elements have been registered with it. It opens the data file, reads
+ * the data for each registered element and calls the `CallbackAction` on each
+ * element providing the data.
+ *
+ * - The `ImporterOptionsGroup` parameter specifies the \ref OptionGroupsGroup
+ * "options group" in the input file that provides the following run-time
+ * options:
+ *   - `importers::OptionTags::FileName`
+ *   - `importers::OptionTags::Subgroup`
+ *   - `importers::OptionTags::ObservationValue`
+ * - The `FieldTagsList` parameter specifies a typelist of tensor tags that
+ * are read from the file and provided to each element. It is assumed that the
+ * tensor data is stored in datasets named `db::tag_name<Tag>() + suffix`, where
+ * the `suffix` is empty for scalars or `"_"` followed by the
+ * `Tensor::component_name` for each independent tensor component.
+ * - The `CallbackAction` is invoked on each registered element of the
+ * `CallbackComponent` with a
+ * `tuples::tagged_tuple_from_typelist<FieldTagsList>` containing the
+ * tensor data for that element. Use `Actions::SetData` to write the data
+ * directly into their respective tags in the DataBox. The `CallbackComponent`
+ * must the the same that was encoded into the `observers::ArrayComponentId`
+ * used to register the elements.
+ */
+template <typename ImporterOptionsGroup, typename FieldTagsList,
+          typename CallbackAction, typename CallbackComponent>
+struct ReadVolumeData {
+  using const_global_cache_tags =
+      tmpl::list<Tags::FileName<ImporterOptionsGroup>,
+                 Tags::Subgroup<ImporterOptionsGroup>,
+                 Tags::ObservationValue<ImporterOptionsGroup>>;
+
+  template <typename ParallelComponent, typename DataBox,
+            typename Metavariables, typename ArrayIndex,
+            Requires<db::tag_is_retrievable_v<Tags::RegisteredElements,
+                                              DataBox>> = nullptr>
+  static void apply(DataBox& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const gsl::not_null<CmiNodeLock*> node_lock) noexcept {
+    Parallel::lock(node_lock);
+    {
+      // The scoping is to close the file before unlocking
+      h5::H5File<h5::AccessType::ReadOnly> h5file(
+          Parallel::get<Tags::FileName<ImporterOptionsGroup>>(cache));
+      constexpr size_t version_number = 0;
+      const auto& volume_file = h5file.get<h5::VolumeData>(
+          "/" + Parallel::get<Tags::Subgroup<ImporterOptionsGroup>>(cache),
+          version_number);
+      const auto observation_id = volume_file.find_observation_id(
+          Parallel::get<Tags::ObservationValue<ImporterOptionsGroup>>(cache));
+      // Read the tensor data for all elements at once, since that's how it's
+      // stored in the file
+      tuples::tagged_tuple_from_typelist<FieldTagsList> all_tensor_data{};
+      tmpl::for_each<FieldTagsList>([
+        &all_tensor_data, &volume_file, &observation_id
+      ](auto field_tag_v) noexcept {
+        using field_tag = tmpl::type_from<decltype(field_tag_v)>;
+        auto& tensor_data = get<field_tag>(all_tensor_data);
+        for (size_t i = 0; i < tensor_data.size(); i++) {
+          tensor_data[i] = volume_file.get_tensor_component(
+              observation_id,
+              db::tag_name<field_tag>() + tensor_data.component_suffix(
+                                              tensor_data.get_tensor_index(i)));
+        }
+      });
+      // Retrieve the information needed to reconstruct which element the data
+      // belongs to
+      const auto all_grid_names = volume_file.get_grid_names(observation_id);
+      const auto all_extents = volume_file.get_extents(observation_id);
+      // Distribute the tensor data to the registered elements
+      for (auto& element_and_name : get<Tags::RegisteredElements>(box)) {
+        const CkArrayIndex& raw_element_index =
+            element_and_name.first.array_index();
+        // Check if the parallel component of the registered element matches the
+        // callback, because it's possible that elements from other components
+        // with the same index are also registered.
+        // Since the way the component is encoded in `ArrayComponentId` is
+        // private to that class, we construct one and compare.
+        if (element_and_name.first !=
+            observers::ArrayComponentId(
+                std::add_pointer_t<CallbackComponent>{nullptr},
+                raw_element_index)) {
+          continue;
+        }
+        // Find the data offset that corresponds to this element
+        const auto element_data_offset_and_length =
+            h5::offset_and_length_for_grid(element_and_name.second,
+                                           all_grid_names, all_extents);
+        // Extract this element's data from the read-in dataset
+        tuples::tagged_tuple_from_typelist<FieldTagsList> element_data{};
+        tmpl::for_each<FieldTagsList>([
+          &element_data, &element_data_offset_and_length, &all_tensor_data
+        ](auto field_tag_v) noexcept {
+          using field_tag = tmpl::type_from<decltype(field_tag_v)>;
+          auto& element_tensor_data = get<field_tag>(element_data);
+          // Iterate independent components of the tensor
+          for (size_t i = 0; i < element_tensor_data.size(); i++) {
+            const DataVector& data_tensor_component =
+                get<field_tag>(all_tensor_data)[i];
+            DataVector element_tensor_component{
+                element_data_offset_and_length.second};
+            // Retrieve data from slice of the contigious dataset
+            for (size_t j = 0; j < element_tensor_component.size(); j++) {
+              element_tensor_component[j] =
+                  data_tensor_component[element_data_offset_and_length.first +
+                                        j];
+            }
+            element_tensor_data[i] = element_tensor_component;
+          }
+        });
+        // Pass the data to the element in a simple action
+        const auto element_index =
+            Parallel::ArrayIndex<typename CallbackComponent::array_index>(
+                raw_element_index)
+                .get_index();
+        Parallel::simple_action<CallbackAction>(
+            Parallel::get_parallel_component<CallbackComponent>(
+                cache)[element_index],
+            std::move(element_data));
+      }
+    }
+    Parallel::unlock(node_lock);
+  }
+};
+
+}  // namespace ThreadedActions
+}  // namespace importers

--- a/src/ParallelAlgorithms/Actions/SetData.hpp
+++ b/src/ParallelAlgorithms/Actions/SetData.hpp
@@ -1,0 +1,58 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+struct ConstGlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace Actions {
+
+/*!
+ * \ingroup ActionsGroup
+ * \brief Mutate the DataBox tags in `TagsList` according to the `data`.
+ *
+ * An example use case for this action is as the callback for the
+ * `importers::ThreadedActions::ReadVolumeData`.
+ *
+ * DataBox changes:
+ * - Modifies:
+ *   - All tags in `TagsList`
+ */
+template <typename TagsList>
+struct SetData;
+
+/// \cond
+template <typename... Tags>
+struct SetData<tmpl::list<Tags...>> {
+  template <
+      typename ParallelComponent, typename DataBox, typename Metavariables,
+      typename ArrayIndex,
+      Requires<cpp17::conjunction_v<db::tag_is_retrievable<Tags, DataBox>...>> =
+          nullptr>
+  static void apply(DataBox& box,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    tuples::TaggedTuple<Tags...> data) noexcept {
+    tmpl::for_each<tmpl::list<Tags...>>([&box, &data](auto tag_v) noexcept {
+      using tag = tmpl::type_from<decltype(tag_v)>;
+      db::mutate<tag>(
+          make_not_null(&box),
+          [&data](const gsl::not_null<db::item_type<tag>*> value) noexcept {
+            *value = std::move(tuples::get<tag>(data));
+          });
+    });
+  }
+};
+/// \endcond
+
+}  // namespace Actions

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Importers)
+
 set(LIBRARY "Test_IO")
 
 set(LIBRARY_SOURCES

--- a/tests/Unit/IO/Importers/CMakeLists.txt
+++ b/tests/Unit/IO/Importers/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_DataImporter")
+
+set(LIBRARY_SOURCES
+  Test_Tags.cpp
+  Test_VolumeDataReaderActions.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "IO/Importers"
+  "${LIBRARY_SOURCES}"
+  "IO"
+  )
+
+add_dependencies(
+  ${LIBRARY}
+  module_ConstGlobalCache
+  )
+
+function(add_algorithm_test TEST_NAME DIM)
+  set(HPP_NAME Test_${TEST_NAME})
+  set(EXECUTABLE_NAME ${HPP_NAME}${DIM}D)
+  set(TEST_IDENTIFIER Integration.Importers.${TEST_NAME}${DIM}D)
+
+  add_spectre_parallel_executable(
+    ${EXECUTABLE_NAME}
+    ${HPP_NAME}
+    tests/Unit/IO/Importers
+    Metavariables<${DIM}>
+    "DataStructures;Domain;ErrorHandling;Informer;IO"
+    )
+
+  add_dependencies(test-executables ${EXECUTABLE_NAME})
+
+  add_test(
+    NAME "\"${TEST_IDENTIFIER}\""
+    COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file
+    ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}.yaml
+    )
+
+  set_tests_properties(
+    "\"${TEST_IDENTIFIER}\""
+    PROPERTIES
+    TIMEOUT 5
+    LABELS "integration"
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+endfunction()
+
+add_algorithm_test("VolumeDataReaderAlgorithm" 1)
+add_algorithm_test("VolumeDataReaderAlgorithm" 2)
+add_algorithm_test("VolumeDataReaderAlgorithm" 3)

--- a/tests/Unit/IO/Importers/Test_Tags.cpp
+++ b/tests/Unit/IO/Importers/Test_Tags.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "IO/Importers/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+
+namespace {
+struct ExampleVolumeData {
+  using group = importers::OptionTags::Group;
+  static constexpr OptionString help = "Example volume data";
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.IO.Importers.Tags", "[Unit][IO]") {
+  CHECK(db::tag_name<importers::Tags::RegisteredElements>() ==
+        "RegisteredElements");
+  CHECK(db::tag_name<importers::Tags::FileName<ExampleVolumeData>>() ==
+        "FileName(ExampleVolumeData)");
+  CHECK(db::tag_name<importers::Tags::Subgroup<ExampleVolumeData>>() ==
+        "Subgroup(ExampleVolumeData)");
+  CHECK(db::tag_name<importers::Tags::ObservationValue<ExampleVolumeData>>() ==
+        "ObservationValue(ExampleVolumeData)");
+
+  Options<
+      tmpl::list<importers::OptionTags::FileName<ExampleVolumeData>,
+                 importers::OptionTags::Subgroup<ExampleVolumeData>,
+                 importers::OptionTags::ObservationValue<ExampleVolumeData>>>
+      opts("");
+  opts.parse(
+      "Importers:\n"
+      "  ExampleVolumeData:\n"
+      "    FileName: File.name\n"
+      "    Subgroup: data.group\n"
+      "    ObservationValue: 1.");
+  CHECK(opts.get<importers::OptionTags::FileName<ExampleVolumeData>>() ==
+        "File.name");
+  CHECK(opts.get<importers::OptionTags::Subgroup<ExampleVolumeData>>() ==
+        "data.group");
+  CHECK(
+      opts.get<importers::OptionTags::ObservationValue<ExampleVolumeData>>() ==
+      1.);
+}

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
@@ -1,0 +1,198 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "IO/Importers/ElementActions.hpp"
+#include "IO/Importers/Tags.hpp"
+#include "IO/Importers/VolumeDataReader.hpp"
+#include "IO/Importers/VolumeDataReaderActions.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace {
+
+struct VectorTag : db::SimpleTag {
+  using type = tnsr::I<DataVector, 2>;
+  static std::string name() noexcept { return "V"; }
+};
+
+struct TensorTag : db::SimpleTag {
+  using type = tnsr::ij<DataVector, 2>;
+  static std::string name() noexcept { return "T"; }
+};
+
+using import_tags_list = tmpl::list<VectorTag, TensorTag>;
+
+struct TestVolumeData {
+  using group = importers::OptionTags::Group;
+};
+
+using ElementIndexType = ElementIndex<2>;
+
+template <typename Metavariables>
+struct MockElementArray {
+  using component_being_mocked = void;  // Not needed
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndexType;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<import_tags_list>,
+                 importers::Actions::RegisterWithVolumeDataReader>>>;
+};
+
+template <typename Metavariables>
+struct MockVolumeDataReader {
+  using component_being_mocked = importers::VolumeDataReader<Metavariables>;
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<importers::detail::InitializeVolumeDataReader>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<MockElementArray<Metavariables>,
+                                    MockVolumeDataReader<Metavariables>>;
+  using const_global_cache_tags =
+      tmpl::list<importers::Tags::FileName<TestVolumeData>,
+                 importers::Tags::Subgroup<TestVolumeData>,
+                 importers::Tags::ObservationValue<TestVolumeData>>;
+  enum class Phase { Initialization, Testing };
+};
+
+struct TestCallback {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename DataBox = db::DataBox<DbTagsList>,
+            Requires<db::tag_is_retrievable_v<VectorTag, DataBox>> = nullptr>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ElementIndexType& /*array_index*/,
+                    tuples::tagged_tuple_from_typelist<import_tags_list>
+                        tensor_data) noexcept {
+    CHECK(get<VectorTag>(tensor_data) == get<VectorTag>(box));
+    CHECK(get<TensorTag>(tensor_data) == get<TensorTag>(box));
+  }
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.IO.Importers.VolumeDataReaderActions", "[Unit][IO]") {
+  using reader_component = MockVolumeDataReader<Metavariables>;
+  using element_array = MockElementArray<Metavariables>;
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      {"TestVolumeData.h5", "element_data", 0.}};
+
+  // Setup mock data file reader
+  ActionTesting::emplace_component<reader_component>(make_not_null(&runner), 0);
+  ActionTesting::next_action<reader_component>(make_not_null(&runner), 0);
+
+  // Create a few elements with sample data
+  // Specific IDs have no significance, just need different IDs.
+  const std::vector<ElementId<2>> element_ids{{1, {{{1, 0}, {1, 0}}}},
+                                              {1, {{{1, 1}, {1, 0}}}},
+                                              {1, {{{1, 0}, {2, 3}}}},
+                                              {1, {{{1, 0}, {5, 4}}}},
+                                              {0, {{{1, 0}, {1, 0}}}}};
+  for (const auto& id : element_ids) {
+    const auto hashed_id = static_cast<double>(std::hash<ElementId<2>>{}(id));
+    const size_t num_points = 4;
+    db::item_type<VectorTag> vector{num_points};
+    get<0>(vector) = DataVector{0.5 * hashed_id, 1.0 * hashed_id,
+                                3.0 * hashed_id, -2.0 * hashed_id};
+    get<1>(vector) = DataVector{-0.5 * hashed_id, -1.0 * hashed_id,
+                                -3.0 * hashed_id, 2.0 * hashed_id};
+    db::item_type<TensorTag> tensor{num_points};
+    get<0, 0>(tensor) = DataVector{10.5 * hashed_id, 11.0 * hashed_id,
+                                   13.0 * hashed_id, -22.0 * hashed_id};
+    get<0, 1>(tensor) = DataVector{10.5 * hashed_id, -11.0 * hashed_id,
+                                   -13.0 * hashed_id, -22.0 * hashed_id};
+    get<1, 0>(tensor) = DataVector{-10.5 * hashed_id, 11.0 * hashed_id,
+                                   13.0 * hashed_id, 22.0 * hashed_id};
+    get<1, 1>(tensor) = DataVector{-10.5 * hashed_id, -11.0 * hashed_id,
+                                   -13.0 * hashed_id, 22.0 * hashed_id};
+    ActionTesting::emplace_component_and_initialize<element_array>(
+        make_not_null(&runner), ElementIndexType{id},
+        {std::move(vector), std::move(tensor)});
+
+    // Register element
+    ActionTesting::next_action<element_array>(make_not_null(&runner), id);
+    // Invoke the simple_action RegisterElementWithSelf that was called on the
+    // reader component by the RegisterWithVolumeDataReader action.
+    runner.invoke_queued_simple_action<reader_component>(0);
+  }
+
+  const auto get_element_tag =
+      [&runner](auto tag_v, const ElementId<2>& local_id) -> decltype(auto) {
+    using tag = std::decay_t<decltype(tag_v)>;
+    return ActionTesting::get_databox_tag<element_array, tag>(runner, local_id);
+  };
+
+  // Collect the sample data from all elements
+  std::vector<ExtentsAndTensorVolumeData> all_element_data{};
+  for (const auto& id : element_ids) {
+    const std::string element_name = MakeString{} << id << '/';
+    std::vector<TensorComponent> tensor_data(6);
+    const auto& vector = get_element_tag(VectorTag{}, id);
+    tensor_data[0] = TensorComponent(element_name + "V_x"s, get<0>(vector));
+    tensor_data[1] = TensorComponent(element_name + "V_y"s, get<1>(vector));
+    const auto& tensor = get_element_tag(TensorTag{}, id);
+    tensor_data[2] = TensorComponent(element_name + "T_xx"s, get<0, 0>(tensor));
+    tensor_data[3] = TensorComponent(element_name + "T_xy"s, get<0, 1>(tensor));
+    tensor_data[4] = TensorComponent(element_name + "T_yx"s, get<1, 0>(tensor));
+    tensor_data[5] = TensorComponent(element_name + "T_yy"s, get<1, 1>(tensor));
+    all_element_data.push_back({{2, 2}, tensor_data});
+  }
+  // Write the sample data into an H5 file
+  const std::string h5_file_name = "TestVolumeData.h5";
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+  h5::H5File<h5::AccessType::ReadWrite> h5_file{h5_file_name, false};
+  auto& volume_data = h5_file.insert<h5::VolumeData>("/element_data", 0);
+  volume_data.write_volume_data(0, 0., all_element_data);
+
+  runner.set_phase(Metavariables::Phase::Testing);
+
+  // Have the importer read the file and pass it to the callback
+  runner.algorithms<reader_component>()
+      .at(0)
+      .template threaded_action<importers::ThreadedActions::ReadVolumeData<
+          TestVolumeData, import_tags_list, TestCallback, element_array>>();
+  runner.invoke_queued_threaded_action<reader_component>(0);
+
+  // Invoke the queued callbacks on the elements that test if the data is
+  // correct
+  for (const auto& id : element_ids) {
+    runner.invoke_queued_simple_action<element_array>(id);
+  }
+
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+}

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -71,6 +71,7 @@ constexpr size_t number_of_elements = 2;
 template <>
 constexpr size_t number_of_elements<Grid::Coarse> = 1;
 
+/// [option_group]
 template <Grid TheGrid>
 struct VolumeDataOptions {
   using group = importers::OptionTags::Group;
@@ -79,6 +80,7 @@ struct VolumeDataOptions {
   }
   static constexpr OptionString help = "Numeric volume data";
 };
+/// [option_group]
 
 template <Grid TheGrid>
 struct TestVolumeData {
@@ -295,20 +297,23 @@ struct ElementArray {
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Initialization,
                              tmpl::list<InitializeElement<Dim>>>,
-
+      /// [register_action]
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Register,
           tmpl::list<importers::Actions::RegisterWithVolumeDataReader,
                      Parallel::Actions::TerminatePhase>>,
-
+      /// [register_action]
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::TestResult,
                              tmpl::list<TestResult<Dim, TheGrid>>>>;
 
+  /// [read_data_action]
   using import_fields = tmpl::list<ScalarFieldTag, VectorFieldTag<Dim>>;
+
   using read_element_data_action = importers::ThreadedActions::ReadVolumeData<
       VolumeDataOptions<TheGrid>, import_fields,
       ::Actions::SetData<import_fields>, ElementArray>;
+  /// [read_data_action]
 
   using const_global_cache_tags =
       typename read_element_data_action::const_global_cache_tags;
@@ -332,6 +337,7 @@ struct ElementArray {
     array_proxy.doneInserting();
   }
 
+  /// [invoke_readvoldata]
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
@@ -345,8 +351,10 @@ struct ElementArray {
               importers::VolumeDataReader<Metavariables>>(local_cache));
     }
   }
+  /// [invoke_readvoldata]
 };
 
+/// [metavars]
 template <size_t Dim>
 struct Metavariables {
   using component_list =
@@ -376,6 +384,7 @@ struct Metavariables {
     }
   }
 };
+/// [metavars]
 
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling};

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -1,0 +1,383 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#define CATCH_CONFIG_RUNNER
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <ostream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "AlgorithmArray.hpp"
+#include "AlgorithmSingleton.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "IO/Importers/ElementActions.hpp"
+#include "IO/Importers/Tags.hpp"
+#include "IO/Importers/VolumeDataReader.hpp"
+#include "IO/Importers/VolumeDataReaderActions.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Main.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "ParallelAlgorithms/Actions/SetData.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TMPL.hpp"
+
+struct ScalarFieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "ScalarField"; }
+};
+
+template <size_t Dim>
+struct VectorFieldTag : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+  static std::string name() noexcept { return "VectorField"; }
+};
+
+enum class Grid { Fine, Coarse };
+
+std::ostream& operator<<(std::ostream& os, Grid grid) noexcept {
+  switch (grid) {
+    case Grid::Fine:
+      return os << "Fine";
+    case Grid::Coarse:
+      return os << "Coarse";
+    default:
+      ERROR("Missing case for grid");
+  }
+}
+
+template <Grid TheGrid>
+constexpr size_t number_of_elements = 2;
+template <>
+constexpr size_t number_of_elements<Grid::Coarse> = 1;
+
+template <Grid TheGrid>
+struct VolumeDataOptions {
+  using group = importers::OptionTags::Group;
+  static std::string name() noexcept {
+    return MakeString{} << TheGrid << "VolumeData";
+  }
+  static constexpr OptionString help = "Numeric volume data";
+};
+
+template <Grid TheGrid>
+struct TestVolumeData {
+  static constexpr size_t num_elements = number_of_elements<TheGrid>;
+  std::array<std::array<size_t, 3>, num_elements> extents;
+  std::array<DataVector, num_elements> scalar_field_data;
+  std::array<std::array<DataVector, 3>, num_elements> vector_field_data;
+};
+
+const TestVolumeData<Grid::Fine> fine_volume_data{
+    {{// Grid extents on first element
+      {{2, 1, 1}},
+      // Grid extents on second element
+      {{3, 1, 1}}}},
+    {{// Field on first element
+      {{1., 2.}},
+      // Field on second element
+      {{3., 4., 5.}}}},
+    {{// Vector components on first element
+      {{{{1., 2.}}, {{3., 4.}}, {{5., 6.}}}},
+      // Vector components on second element
+      {{{{7., 8., 9.}}, {{10., 11., 12.}}, {{13., 14., 16.}}}}}}};
+
+const TestVolumeData<Grid::Coarse> coarse_volume_data{
+    {{{{2, 1, 1}}}},
+    {{{{17., 18.}}}},
+    {{{{{{19., 20.}}, {{21., 22.}}, {{23., 24.}}}}}}};
+
+template <bool Check>
+void clean_test_data(const std::string& data_file_name) noexcept {
+  if (file_system::check_if_file_exists(data_file_name)) {
+    file_system::rm(data_file_name, true);
+  } else if (Check) {
+    ERROR("Expected test data file '" << data_file_name << "' does not exist");
+  }
+}
+
+template <size_t Dim, Grid TheGrid>
+void write_test_data(const std::string& data_file_name,
+                     const std::string& subgroup,
+                     const double observation_value,
+                     const TestVolumeData<TheGrid>& test_data) noexcept {
+  // Open file for test data
+  h5::H5File<h5::AccessType::ReadWrite> data_file{data_file_name, true};
+  auto& test_data_file = data_file.insert<h5::VolumeData>("/" + subgroup);
+
+  // Construct test data for all elements
+  std::vector<ExtentsAndTensorVolumeData> element_data{};
+  for (size_t i = 0; i < number_of_elements<TheGrid>; i++) {
+    const std::string element_name = MakeString{} << ElementId<Dim>{i};
+    std::vector<TensorComponent> tensor_components{};
+    std::vector<size_t> element_extents{};
+    tensor_components.push_back(
+        {element_name + "/ScalarField", test_data.scalar_field_data[i]});
+    for (size_t d = 0; d < Dim; d++) {
+      static const std::array<std::string, 3> dim_suffix{{"x", "y", "z"}};
+      tensor_components.push_back(
+          {element_name + "/VectorField_" + dim_suffix[d],
+           test_data.vector_field_data[i][d]});
+      element_extents.push_back(test_data.extents[i][d]);
+    }
+    element_data.push_back(
+        {std::move(element_extents), std::move(tensor_components)});
+  }
+  test_data_file.write_volume_data(0, observation_value,
+                                   std::move(element_data));
+}
+
+template <size_t Dim>
+struct WriteTestData {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    // The data may be in a shared file, so first clean both, then write both
+    clean_test_data<false>(
+        get<importers::Tags::FileName<VolumeDataOptions<Grid::Fine>>>(box));
+    clean_test_data<false>(
+        get<importers::Tags::FileName<VolumeDataOptions<Grid::Coarse>>>(box));
+    write_test_data<Dim>(
+        get<importers::Tags::FileName<VolumeDataOptions<Grid::Fine>>>(box),
+        get<importers::Tags::Subgroup<VolumeDataOptions<Grid::Fine>>>(box),
+        get<importers::Tags::ObservationValue<VolumeDataOptions<Grid::Fine>>>(
+            box),
+        fine_volume_data);
+    write_test_data<Dim>(
+        get<importers::Tags::FileName<VolumeDataOptions<Grid::Coarse>>>(box),
+        get<importers::Tags::Subgroup<VolumeDataOptions<Grid::Coarse>>>(box),
+        get<importers::Tags::ObservationValue<VolumeDataOptions<Grid::Coarse>>>(
+            box),
+        coarse_volume_data);
+    return {std::move(box), true};
+  }
+};
+
+struct CleanTestData {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    clean_test_data<true>(
+        get<importers::Tags::FileName<VolumeDataOptions<Grid::Fine>>>(box));
+    if (get<importers::Tags::FileName<VolumeDataOptions<Grid::Coarse>>>(box) !=
+        get<importers::Tags::FileName<VolumeDataOptions<Grid::Fine>>>(box)) {
+      clean_test_data<true>(
+          get<importers::Tags::FileName<VolumeDataOptions<Grid::Coarse>>>(box));
+    }
+    return {std::move(box), true};
+  }
+};
+
+template <size_t Dim, typename Metavariables>
+struct TestDataWriter {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using metavariables = Metavariables;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<WriteTestData<Dim>>>,
+
+                 Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::TestResult,
+                                        tmpl::list<CleanTestData>>>;
+  using initialization_tags = tmpl::list<>;
+
+  static void initialize(Parallel::CProxy_ConstGlobalCache<
+                         Metavariables>& /*global_cache*/) noexcept {}
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
+    auto& local_component = Parallel::get_parallel_component<TestDataWriter>(
+        *(global_cache.ckLocalBranch()));
+    local_component.start_phase(next_phase);
+  }
+};
+
+template <size_t Dim>
+struct InitializeElement {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ElementIndex<Dim>& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    return std::make_tuple(
+        ::Initialization::merge_into_databox<
+            InitializeElement,
+            db::AddSimpleTags<ScalarFieldTag, VectorFieldTag<Dim>>>(
+            std::move(box), Scalar<DataVector>{}, tnsr::I<DataVector, Dim>{}),
+        true);
+  }
+};
+
+template <size_t Dim, Grid TheGrid>
+void test_result(const ElementIndex<Dim>& element_index,
+                 const TestVolumeData<TheGrid>& test_data,
+                 const Scalar<DataVector>& scalar_field,
+                 const tnsr::I<DataVector, Dim>& vector_field) noexcept {
+  const size_t raw_element_index = ElementId<Dim>{element_index}.block_id();
+  Scalar<DataVector> expected_scalar_field{
+      test_data.scalar_field_data[raw_element_index]};
+  SPECTRE_PARALLEL_REQUIRE(scalar_field == expected_scalar_field);
+  tnsr::I<DataVector, Dim> expected_vector_field{};
+  for (size_t d = 0; d < Dim; d++) {
+    expected_vector_field[d] =
+        test_data.vector_field_data[raw_element_index][d];
+  }
+  SPECTRE_PARALLEL_REQUIRE(vector_field == expected_vector_field);
+}
+
+template <size_t Dim, Grid TheGrid>
+struct TestResult {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ElementIndex<Dim>& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    if (TheGrid == Grid::Fine) {
+      test_result(array_index, fine_volume_data, get<ScalarFieldTag>(box),
+                  get<VectorFieldTag<Dim>>(box));
+    } else {
+      test_result(array_index, coarse_volume_data, get<ScalarFieldTag>(box),
+                  get<VectorFieldTag<Dim>>(box));
+    }
+    return {std::move(box), true};
+  }
+};
+
+template <size_t Dim, Grid TheGrid, typename Metavariables>
+struct ElementArray {
+  using chare_type = Parallel::Algorithms::Array;
+  using array_index = ElementIndex<Dim>;
+  using metavariables = Metavariables;
+  using initialization_tags = tmpl::list<>;
+  using array_allocation_tags = tmpl::list<>;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             tmpl::list<InitializeElement<Dim>>>,
+
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Register,
+          tmpl::list<importers::Actions::RegisterWithVolumeDataReader,
+                     Parallel::Actions::TerminatePhase>>,
+
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::TestResult,
+                             tmpl::list<TestResult<Dim, TheGrid>>>>;
+
+  using import_fields = tmpl::list<ScalarFieldTag, VectorFieldTag<Dim>>;
+  using read_element_data_action = importers::ThreadedActions::ReadVolumeData<
+      VolumeDataOptions<TheGrid>, import_fields,
+      ::Actions::SetData<import_fields>, ElementArray>;
+
+  using const_global_cache_tags =
+      typename read_element_data_action::const_global_cache_tags;
+
+  static void allocate_array(
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+          initialization_items) noexcept {
+    auto& array_proxy = Parallel::get_parallel_component<ElementArray>(
+        *(global_cache.ckLocalBranch()));
+
+    for (size_t i = 0, which_proc = 0,
+                number_of_procs =
+                    static_cast<size_t>(Parallel::number_of_procs());
+         i < number_of_elements<TheGrid>; i++) {
+      ElementIndex<Dim> element_index{ElementId<Dim>{i}};
+      array_proxy[element_index].insert(global_cache, initialization_items,
+                                        which_proc);
+      which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
+    }
+    array_proxy.doneInserting();
+  }
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    Parallel::get_parallel_component<ElementArray>(local_cache)
+        .start_phase(next_phase);
+
+    if (next_phase == Metavariables::Phase::ImportData) {
+      Parallel::threaded_action<read_element_data_action>(
+          Parallel::get_parallel_component<
+              importers::VolumeDataReader<Metavariables>>(local_cache));
+    }
+  }
+};
+
+template <size_t Dim>
+struct Metavariables {
+  using component_list =
+      tmpl::list<ElementArray<Dim, Grid::Fine, Metavariables>,
+                 ElementArray<Dim, Grid::Coarse, Metavariables>,
+                 TestDataWriter<Dim, Metavariables>,
+                 importers::VolumeDataReader<Metavariables>>;
+
+  static constexpr const char* const help{"Test the volume data reader"};
+  static constexpr bool ignore_unrecognized_command_line_options = false;
+
+  enum class Phase { Initialization, Register, ImportData, TestResult, Exit };
+
+  static Phase determine_next_phase(
+      const Phase& current_phase,
+      const Parallel::CProxy_ConstGlobalCache<
+          Metavariables>& /*cache_proxy*/) noexcept {
+    switch (current_phase) {
+      case Phase::Initialization:
+        return Phase::Register;
+      case Phase::Register:
+        return Phase::ImportData;
+      case Phase::ImportData:
+        return Phase::TestResult;
+      default:
+        return Phase::Exit;
+    }
+  }
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm1D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm1D.yaml
@@ -1,0 +1,12 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Importers:
+  FineVolumeData:
+    FileName: "Test_DataImporterAlgorithm1D_fine_data.h5"
+    Subgroup: "test_data"
+    ObservationValue: 3.
+  CoarseVolumeData:
+    FileName: "Test_DataImporterAlgorithm1D_coarse_data.h5"
+    Subgroup: "test_data"
+    ObservationValue: 2.

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm2D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm2D.yaml
@@ -1,6 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+# [importer_options]
 Importers:
   FineVolumeData:
     FileName: "Test_DataImporterAlgorithm2D_shared.h5"
@@ -10,3 +11,4 @@ Importers:
     FileName: "Test_DataImporterAlgorithm2D_shared.h5"
     Subgroup: "coarse_data"
     ObservationValue: 2.
+# [importer_options]

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm2D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm2D.yaml
@@ -1,0 +1,12 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Importers:
+  FineVolumeData:
+    FileName: "Test_DataImporterAlgorithm2D_shared.h5"
+    Subgroup: "fine_data"
+    ObservationValue: 3.
+  CoarseVolumeData:
+    FileName: "Test_DataImporterAlgorithm2D_shared.h5"
+    Subgroup: "coarse_data"
+    ObservationValue: 2.

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
@@ -1,0 +1,12 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Importers:
+  FineVolumeData:
+    FileName: "Test_DataImporterAlgorithm3D_shared.h5"
+    Subgroup: "fine_data"
+    ObservationValue: 3.
+  CoarseVolumeData:
+    FileName: "Test_DataImporterAlgorithm3D_shared.h5"
+    Subgroup: "coarse_data"
+    ObservationValue: 2.

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithmFwd.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithmFwd.hpp
@@ -1,0 +1,9 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+template <size_t Dim>
+struct Metavariables;

--- a/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ParallelAlgorithmsActions")
 
 set(LIBRARY_SOURCES
   Test_MutateApply.cpp
+  Test_SetData.cpp
   )
 
 add_test_library(

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_SetData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_SetData.cpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Actions/SetData.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace {
+
+struct SomeNumber : db::SimpleTag {
+  using type = int;
+};
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<SomeNumber>>>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<Component<Metavariables>>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Actions.SetData", "[Unit][Actions]") {
+  using component = Component<Metavariables>;
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  ActionTesting::emplace_component_and_initialize<component>(&runner, 0, {0});
+
+  runner.set_phase(Metavariables::Phase::Testing);
+
+  ActionTesting::simple_action<component,
+                               Actions::SetData<tmpl::list<SomeNumber>>>(
+      make_not_null(&runner), 0, tuples::TaggedTuple<SomeNumber>{3});
+  CHECK(ActionTesting::get_databox_tag<component, SomeNumber>(runner, 0) == 3);
+}


### PR DESCRIPTION
## Proposed changes

This is a parallel component and associated actions that allow loading a volume data file from disk and distribute its tensor data to elements. It can be used to set numeric initial data for evolutions or a numeric initial guess for elliptic solves.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
