### PR TITLE
Expose floating-point time in the DataBox

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -460,7 +460,7 @@
  *
  * - `system`: See above.
  * - `temporal_id`: A DataBox tag that identifies steps in the algorithm.
- * Generally use `Tags::TimeId`.
+ * Generally use `Tags::TimeStepId`.
  */
 
 /*!

--- a/src/Evolution/DiscontinuousGalerkin/ObserveErrorNorms.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/ObserveErrorNorms.hpp
@@ -22,7 +22,6 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Reduction.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
-#include "Time/Time.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/Numeric.hpp"
@@ -34,7 +33,7 @@ namespace Frame {
 struct Inertial;
 }  // namespace Frame
 namespace Tags {
-struct SubstepTime;
+struct Time;
 }  // namespace Tags
 /// \endcond
 
@@ -120,12 +119,11 @@ class ObserveErrorNorms<VolumeDim, tmpl::list<Tensors...>, EventRegistrars>
   using observed_reduction_data_tags =
       observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
 
-  using argument_tags =
-      tmpl::list<::Tags::SubstepTime, coordinates_tag, Tensors...>;
+  using argument_tags = tmpl::list<::Tags::Time, coordinates_tag, Tensors...>;
 
   template <typename Metavariables, typename ArrayIndex,
             typename ParallelComponent>
-  void operator()(const Time& time,
+  void operator()(const double time,
                   const db::item_type<coordinates_tag>& inertial_coordinates,
                   const db::item_type<Tensors>&... tensors,
                   Parallel::ConstGlobalCache<Metavariables>& cache,
@@ -133,7 +131,7 @@ class ObserveErrorNorms<VolumeDim, tmpl::list<Tensors...>, EventRegistrars>
                   const ParallelComponent* const /*meta*/) const noexcept {
     const auto analytic_solution =
         Parallel::get<Tags::AnalyticSolutionBase>(cache).variables(
-            inertial_coordinates, time.value(), tmpl::list<Tensors...>{});
+            inertial_coordinates, time, tmpl::list<Tensors...>{});
 
     tuples::TaggedTuple<LocalSquareError<Tensors>...> local_square_errors;
     const auto record_errors = [&analytic_solution, &local_square_errors](
@@ -159,12 +157,12 @@ class ObserveErrorNorms<VolumeDim, tmpl::list<Tensors...>, EventRegistrars>
     Parallel::simple_action<observers::Actions::ContributeReductionData>(
         local_observer,
         observers::ObservationId(
-            time.value(), typename Metavariables::element_observation_type{}),
+            time, typename Metavariables::element_observation_type{}),
         std::string{"/element_data"},
         std::vector<std::string>{"Time", "NumberOfPoints",
                                  ("Error(" + Tensors::name() + ")")...},
         ReductionData{
-            time.value(), num_points,
+            time, num_points,
             std::move(get<LocalSquareError<Tensors>>(local_square_errors))...});
   }
 };

--- a/src/Evolution/DiscontinuousGalerkin/ObserveErrorNorms.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/ObserveErrorNorms.hpp
@@ -34,7 +34,7 @@ namespace Frame {
 struct Inertial;
 }  // namespace Frame
 namespace Tags {
-struct Time;
+struct SubstepTime;
 }  // namespace Tags
 /// \endcond
 
@@ -120,7 +120,8 @@ class ObserveErrorNorms<VolumeDim, tmpl::list<Tensors...>, EventRegistrars>
   using observed_reduction_data_tags =
       observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
 
-  using argument_tags = tmpl::list<::Tags::Time, coordinates_tag, Tensors...>;
+  using argument_tags =
+      tmpl::list<::Tags::SubstepTime, coordinates_tag, Tensors...>;
 
   template <typename Metavariables, typename ArrayIndex,
             typename ParallelComponent>

--- a/src/Evolution/DiscontinuousGalerkin/ObserveFields.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/ObserveFields.hpp
@@ -43,7 +43,7 @@ namespace Frame {
 struct Inertial;
 }  // namespace Frame
 namespace Tags {
-struct Time;
+struct SubstepTime;
 }  // namespace Tags
 /// \endcond
 
@@ -160,7 +160,7 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
   }
 
   using argument_tags =
-      tmpl::list<::Tags::Time, ::Tags::Mesh<VolumeDim>, coordinates_tag,
+      tmpl::list<::Tags::SubstepTime, ::Tags::Mesh<VolumeDim>, coordinates_tag,
                  AnalyticSolutionTensors..., NonSolutionTensors...>;
 
   template <typename Metavariables, typename ParallelComponent>

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -76,7 +76,7 @@ class CProxy_ConstGlobalCache;
 struct EvolutionMetavars {
   static constexpr size_t volume_dim = 1;
   using system = Burgers::System;
-  using temporal_id = Tags::TimeId;
+  using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = false;
   using initial_data_tag =
       Tags::AnalyticSolution<Burgers::Solutions::Step>;

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -109,7 +109,7 @@ struct EvolutionMetavars {
   using equation_of_state_type = typename initial_data::equation_of_state_type;
   using system = grmhd::ValenciaDivClean::System<equation_of_state_type>;
   static constexpr size_t thermodynamic_dim = system::thermodynamic_dim;
-  using temporal_id = Tags::TimeId;
+  using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = false;
   using initial_data_tag =
       tmpl::conditional_t<evolution::is_analytic_solution_v<initial_data>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -89,7 +89,7 @@ struct EvolutionMetavars {
 
   using system = NewtonianEuler::System<Dim, equation_of_state_type>;
 
-  using temporal_id = Tags::TimeId;
+  using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = false;
 
   using initial_data_tag = Tags::AnalyticSolution<initial_data>;

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -80,7 +80,7 @@ struct EvolutionMetavars {
   static constexpr size_t volume_dim = Dim;
   // Customization/"input options" to simulation
   using system = ScalarWave::System<Dim>;
-  using temporal_id = Tags::TimeId;
+  using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = true;
   using initial_data_tag =
       Tags::AnalyticSolution<ScalarWave::Solutions::PlaneWave<Dim>>;

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -90,7 +90,7 @@ struct Evolution {
                                  System::is_in_flux_conservative_form>
   struct ComputeTags {
     using type = db::AddComputeTags<
-        ::Tags::Time,
+        ::Tags::SubstepTime,
         ::Tags::DerivCompute<
             variables_tag,
             ::Tags::InverseJacobian<::Tags::ElementMap<dim>,
@@ -101,7 +101,7 @@ struct Evolution {
   template <typename System>
   struct ComputeTags<System, true> {
     using type = db::AddComputeTags<
-        ::Tags::Time,
+        ::Tags::SubstepTime,
         ::Tags::DivCompute<
             db::add_tag_prefix<::Tags::Flux, variables_tag, tmpl::size_t<dim>,
                                Frame::Inertial>,

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -22,7 +22,7 @@
 #include "Time/StepControllers/StepController.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -59,13 +59,13 @@ namespace Actions {
 /// \brief Initialize items related to time-evolution of the system
 ///
 /// Since we have not started the evolution yet, we initialize the state
-/// _before_ the initial time. So `Tags::TimeId` is undefined at this point,
-/// and `Tags::Next<Tags::TimeId>` is the initial time.
+/// _before_ the initial time. So `Tags::TimeStepId` is undefined at this point,
+/// and `Tags::Next<Tags::TimeStepId>` is the initial time.
 ///
 /// DataBox changes:
 /// - Adds:
-///   * Tags::TimeId
-///   * `Tags::Next<Tags::TimeId>`
+///   * Tags::TimeStepId
+///   * `Tags::Next<Tags::TimeStepId>`
 ///   * Tags::TimeStep
 ///   * `db::add_tag_prefix<Tags::dt, variables_tag>`
 ///   * `Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>`
@@ -150,7 +150,7 @@ struct Evolution {
     // proper starts with slab 0.
     const auto& time_stepper = Parallel::get<::Tags::TimeStepperBase>(cache);
 
-    const TimeId time_id(
+    const TimeStepId time_id(
         time_runs_forward,
         -static_cast<int64_t>(time_stepper.number_of_past_steps()),
         initial_time);
@@ -160,15 +160,16 @@ struct Evolution {
     return std::make_tuple(
         merge_into_databox<
             Evolution,
-            db::AddSimpleTags<::Tags::TimeId, ::Tags::Next<::Tags::TimeId>,
-                              ::Tags::Time, ::Tags::TimeStep, dt_variables_tag,
+            db::AddSimpleTags<::Tags::TimeStepId,
+                              ::Tags::Next<::Tags::TimeStepId>, ::Tags::Time,
+                              ::Tags::TimeStep, dt_variables_tag,
                               ::Tags::HistoryEvolvedVariables<
                                   variables_tag, dt_variables_tag>>,
             compute_tags>(
             std::move(box),
             // At this point we have not started evolution yet, so the current
             // time is undefined and _next_ is the initial time.
-            TimeId{}, time_id, std::numeric_limits<double>::signaling_NaN(),
+            TimeStepId{}, time_id, std::numeric_limits<double>::signaling_NaN(),
             initial_dt, std::move(dt_vars), std::move(history)));
   }
 

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -161,15 +161,15 @@ struct Evolution {
         merge_into_databox<
             Evolution,
             db::AddSimpleTags<::Tags::TimeId, ::Tags::Next<::Tags::TimeId>,
-                              ::Tags::TimeStep, dt_variables_tag,
+                              ::Tags::Time, ::Tags::TimeStep, dt_variables_tag,
                               ::Tags::HistoryEvolvedVariables<
                                   variables_tag, dt_variables_tag>>,
             compute_tags>(
             std::move(box),
             // At this point we have not started evolution yet, so the current
             // time is undefined and _next_ is the initial time.
-            TimeId{}, time_id, initial_dt, std::move(dt_vars),
-            std::move(history)));
+            TimeId{}, time_id, std::numeric_limits<double>::signaling_NaN(),
+            initial_dt, std::move(dt_vars), std::move(history)));
   }
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -14,7 +14,6 @@
 #include "DataStructures/Variables.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
-#include "Time/Time.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -411,14 +410,14 @@ DampedHarmonicHCompute<SpatialDim, Frame>::function(
     const tnsr::I<DataVector, SpatialDim, Frame>& shift,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
-    const Time& time, const double& t_start, const double& sigma_t,
+    const double& time, const double& t_start, const double& sigma_t,
     const tnsr::I<DataVector, SpatialDim, Frame>& coords,
     const double& sigma_r) noexcept {
   typename db::item_type<Tags::GaugeH<SpatialDim, Frame>> gauge_h{
       get_size(get(lapse))};
   GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame>(
       make_not_null(&gauge_h), gauge_h_init, lapse, shift,
-      sqrt_det_spatial_metric, spacetime_metric, time.value(), coords, 1., 1.,
+      sqrt_det_spatial_metric, spacetime_metric, time, coords, 1., 1.,
       1.,                // amp_coef_{L1, L2, S}
       4, 4, 4,           // exp_{L1, L2, S}
       t_start, sigma_t,  // _h_init
@@ -768,7 +767,7 @@ SpacetimeDerivDampedHarmonicHCompute<SpatialDim, Frame>::function(
     const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
     const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
     const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
-    const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const Time& time,
+    const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const double& time,
     const double& t_start, const double& sigma_t,
     const tnsr::I<DataVector, SpatialDim, Frame>& coords,
     const double& sigma_r) noexcept {
@@ -777,7 +776,7 @@ SpacetimeDerivDampedHarmonicHCompute<SpatialDim, Frame>::function(
   GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h(
       make_not_null(&d4_gauge_h), gauge_h_init, dgauge_h_init, lapse, shift,
       spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
-      inverse_spatial_metric, spacetime_metric, pi, phi, time.value(), coords,
+      inverse_spatial_metric, spacetime_metric, pi, phi, time, coords,
       1., 1., 1.,        // amp_coef_{L1, L2, S}
       4, 4, 4,           // exp_{L1, L2, S}
       t_start, sigma_t,  // _h_init

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -23,10 +23,11 @@ namespace gsl {
 template <class T>
 class not_null;
 }  // namespace gsl
-class Time;
 /// \endcond
 
-// IWYU pragma: no_forward_declare Tags::SubstepTime
+// IWYU pragma: no_include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+
+// IWYU pragma: no_forward_declare Tags::Time
 // IWYU pragma: no_forward_declare Tags::Coordinates
 // IWYU pragma: no_forward_declare Tags::deriv
 // IWYU pragma: no_forward_declare Tensor
@@ -53,8 +54,7 @@ struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
       Tags::InitialGaugeH<SpatialDim, Frame>, ::gr::Tags::Lapse<DataVector>,
       ::gr::Tags::Shift<SpatialDim, Frame, DataVector>,
       ::gr::Tags::SqrtDetSpatialMetric<DataVector>,
-      ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>,
-      ::Tags::SubstepTime,
+      ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>, ::Tags::Time,
       OptionTags::GaugeHRollOnStartTime, OptionTags::GaugeHRollOnTimeWindow,
       ::Tags::Coordinates<SpatialDim, Frame>,
       OptionTags::GaugeHSpatialWeightDecayWidth<Frame>>;
@@ -66,7 +66,7 @@ struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
       const tnsr::I<DataVector, SpatialDim, Frame>& shift,
       const Scalar<DataVector>& sqrt_det_spatial_metric,
       const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
-      const Time& time, const double& t_start, const double& sigma_t,
+      const double& time, const double& t_start, const double& sigma_t,
       const tnsr::I<DataVector, SpatialDim, Frame>& coords,
       const double& sigma_r) noexcept;
 };
@@ -164,8 +164,7 @@ struct SpacetimeDerivDampedHarmonicHCompute
       ::gr::Tags::SqrtDetSpatialMetric<DataVector>,
       ::gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
       ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>,
-      Tags::Pi<SpatialDim, Frame>, Tags::Phi<SpatialDim, Frame>,
-      ::Tags::SubstepTime,
+      Tags::Pi<SpatialDim, Frame>, Tags::Phi<SpatialDim, Frame>, ::Tags::Time,
       OptionTags::GaugeHRollOnStartTime, OptionTags::GaugeHRollOnTimeWindow,
       ::Tags::Coordinates<SpatialDim, Frame>,
       OptionTags::GaugeHSpatialWeightDecayWidth<Frame>>;
@@ -184,7 +183,7 @@ struct SpacetimeDerivDampedHarmonicHCompute
       const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
       const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
       const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
-      const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const Time& time,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const double& time,
       const double& t_start, const double& sigma_t,
       const tnsr::I<DataVector, SpatialDim, Frame>& coords,
       const double& sigma_r) noexcept;

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -26,7 +26,7 @@ class not_null;
 class Time;
 /// \endcond
 
-// IWYU pragma: no_forward_declare Tags::Time
+// IWYU pragma: no_forward_declare Tags::SubstepTime
 // IWYU pragma: no_forward_declare Tags::Coordinates
 // IWYU pragma: no_forward_declare Tags::deriv
 // IWYU pragma: no_forward_declare Tensor
@@ -53,7 +53,8 @@ struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
       Tags::InitialGaugeH<SpatialDim, Frame>, ::gr::Tags::Lapse<DataVector>,
       ::gr::Tags::Shift<SpatialDim, Frame, DataVector>,
       ::gr::Tags::SqrtDetSpatialMetric<DataVector>,
-      ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>, ::Tags::Time,
+      ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>,
+      ::Tags::SubstepTime,
       OptionTags::GaugeHRollOnStartTime, OptionTags::GaugeHRollOnTimeWindow,
       ::Tags::Coordinates<SpatialDim, Frame>,
       OptionTags::GaugeHSpatialWeightDecayWidth<Frame>>;
@@ -163,7 +164,8 @@ struct SpacetimeDerivDampedHarmonicHCompute
       ::gr::Tags::SqrtDetSpatialMetric<DataVector>,
       ::gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
       ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>,
-      Tags::Pi<SpatialDim, Frame>, Tags::Phi<SpatialDim, Frame>, ::Tags::Time,
+      Tags::Pi<SpatialDim, Frame>, Tags::Phi<SpatialDim, Frame>,
+      ::Tags::SubstepTime,
       OptionTags::GaugeHRollOnStartTime, OptionTags::GaugeHRollOnTimeWindow,
       ::Tags::Coordinates<SpatialDim, Frame>,
       OptionTags::GaugeHSpatialWeightDecayWidth<Frame>>;

--- a/src/IO/Observer/RegisterObservers.hpp
+++ b/src/IO/Observer/RegisterObservers.hpp
@@ -20,9 +20,7 @@ struct RegisterObservers {
   register_info(const db::DataBox<DbTagsList>& box,
                 const ArrayIndex& /*array_index*/) noexcept {
     return {observers::TypeOfObservation::ReductionAndVolume,
-            observers::ObservationId{
-                static_cast<double>(db::get<::Tags::SubstepTime>(box).value()),
-                ObsType{}}};
+            observers::ObservationId{db::get<::Tags::Time>(box), ObsType{}}};
   }
 };
 }  // namespace observers

--- a/src/IO/Observer/RegisterObservers.hpp
+++ b/src/IO/Observer/RegisterObservers.hpp
@@ -21,7 +21,7 @@ struct RegisterObservers {
                 const ArrayIndex& /*array_index*/) noexcept {
     return {observers::TypeOfObservation::ReductionAndVolume,
             observers::ObservationId{
-                static_cast<double>(db::get<::Tags::Time>(box).value()),
+                static_cast<double>(db::get<::Tags::SubstepTime>(box).value()),
                 ObsType{}}};
   }
 };

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
@@ -186,7 +186,7 @@ struct ImposeDirichletBoundaryConditions {
                 typename system::variables_tag::type::tags_list{}));
           }
         },
-        make_not_null(&box), db::get<Tags::Time>(box).value(),
+        make_not_null(&box), db::get<Tags::SubstepTime>(box).value(),
         get<typename Metavariables::boundary_condition_tag>(cache),
         db::get<Tags::Interface<Tags::BoundaryDirectionsExterior<VolumeDim>,
                                 Tags::Coordinates<VolumeDim, Frame::Inertial>>>(
@@ -251,7 +251,7 @@ struct ImposeDirichletBoundaryConditions {
                 tmpl::list<system>{});
           }
         },
-        make_not_null(&box), db::get<Tags::Time>(box).value(),
+        make_not_null(&box), db::get<Tags::SubstepTime>(box).value(),
         get<typename Metavariables::boundary_condition_tag>(cache),
         db::get<Tags::Interface<Tags::BoundaryDirectionsExterior<VolumeDim>,
                                 Tags::Coordinates<VolumeDim, Frame::Inertial>>>(

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
@@ -186,7 +186,7 @@ struct ImposeDirichletBoundaryConditions {
                 typename system::variables_tag::type::tags_list{}));
           }
         },
-        make_not_null(&box), db::get<Tags::SubstepTime>(box).value(),
+        make_not_null(&box), db::get<Tags::Time>(box),
         get<typename Metavariables::boundary_condition_tag>(cache),
         db::get<Tags::Interface<Tags::BoundaryDirectionsExterior<VolumeDim>,
                                 Tags::Coordinates<VolumeDim, Frame::Inertial>>>(
@@ -251,7 +251,7 @@ struct ImposeDirichletBoundaryConditions {
                 tmpl::list<system>{});
           }
         },
-        make_not_null(&box), db::get<Tags::SubstepTime>(box).value(),
+        make_not_null(&box), db::get<Tags::Time>(box),
         get<typename Metavariables::boundary_condition_tag>(cache),
         db::get<Tags::Interface<Tags::BoundaryDirectionsExterior<VolumeDim>,
                                 Tags::Coordinates<VolumeDim, Frame::Inertial>>>(

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
@@ -104,10 +104,11 @@ struct ObserveTimeSeriesOnSurface {
     // always guaranteed to be present.
     Parallel::threaded_action<observers::ThreadedActions::WriteReductionData>(
         proxy[0],
-        observers::ObservationId(temporal_id.time().value(), ObservationType{}),
+        observers::ObservationId(temporal_id.substep_time().value(),
+                                 ObservationType{}),
         std::string{"/" + pretty_type::short_name<InterpolationTargetTag>()},
         detail::make_legend(TagsToObserve{}),
-        detail::make_reduction_data(box, temporal_id.time().value(),
+        detail::make_reduction_data(box, temporal_id.substep_time().value(),
                                     TagsToObserve{}));
   }
 };

--- a/src/NumericalAlgorithms/Interpolation/Interpolate.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Interpolate.hpp
@@ -17,9 +17,9 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class TimeId;
+class TimeStepId;
 namespace Tags {
-struct TimeId;
+struct TimeStepId;
 template <size_t VolumeDim>
 struct Mesh;
 template <typename TagsList>
@@ -71,10 +71,10 @@ class Interpolate<VolumeDim, tmpl::list<Tensors...>, EventRegistrars>
   Interpolate() = default;
 
   using argument_tags =
-      tmpl::list<::Tags::TimeId, ::Tags::Mesh<VolumeDim>, Tensors...>;
+      tmpl::list<::Tags::TimeStepId, ::Tags::Mesh<VolumeDim>, Tensors...>;
 
   template <typename Metavariables, typename ParallelComponent>
-  void operator()(const TimeId& time_id, const Mesh<VolumeDim>& mesh,
+  void operator()(const TimeStepId& time_id, const Mesh<VolumeDim>& mesh,
                   const db::item_type<Tensors>&... tensors,
                   Parallel::ConstGlobalCache<Metavariables>& cache,
                   const ElementIndex<VolumeDim>& array_index,

--- a/src/Time/Actions/AdvanceTime.hpp
+++ b/src/Time/Actions/AdvanceTime.hpp
@@ -57,7 +57,7 @@ struct AdvanceTime {
           const auto& time_stepper =
               Parallel::get<Tags::TimeStepperBase>(cache);
           *time_id = *next_time_id;
-          *time_step = time_step->with_slab(time_id->time().slab());
+          *time_step = time_step->with_slab(time_id->step_time().slab());
           *next_time_id = time_stepper.next_time_id(*next_time_id, *time_step);
         });
 

--- a/src/Time/Actions/AdvanceTime.hpp
+++ b/src/Time/Actions/AdvanceTime.hpp
@@ -11,7 +11,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -20,7 +20,7 @@ namespace Tags {
 template <typename Tag>
 struct Next;
 struct Time;
-struct TimeId;
+struct TimeStepId;
 struct TimeStep;
 struct TimeStepperBase;
 }  // namespace Tags
@@ -34,15 +34,15 @@ namespace Actions {
 ///
 /// Uses:
 /// - ConstGlobalCache: OptionTags::TimeStepper
-/// - DataBox: Tags::TimeId, Tags::TimeStep
+/// - DataBox: Tags::TimeStepId, Tags::TimeStep
 ///
 /// DataBox changes:
 /// - Adds: nothing
 /// - Removes: nothing
 /// - Modifies:
-///   - Tags::Next<Tags::TimeId>
+///   - Tags::Next<Tags::TimeStepId>
 ///   - Tags::Time
-///   - Tags::TimeId
+///   - Tags::TimeStepId
 ///   - Tags::TimeStep
 struct AdvanceTime {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
@@ -53,13 +53,13 @@ struct AdvanceTime {
       const Parallel::ConstGlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {  // NOLINT const
-    db::mutate<Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep,
+    db::mutate<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
                Tags::Time>(
-        make_not_null(&box), [&cache](const gsl::not_null<TimeId*> time_id,
-                                      const gsl::not_null<TimeId*> next_time_id,
-                                      const gsl::not_null<TimeDelta*> time_step,
-                                      const gsl::not_null<double*>
-                                          time) noexcept {
+        make_not_null(&box), [&cache](
+                                 const gsl::not_null<TimeStepId*> time_id,
+                                 const gsl::not_null<TimeStepId*> next_time_id,
+                                 const gsl::not_null<TimeDelta*> time_step,
+                                 const gsl::not_null<double*> time) noexcept {
           const auto& time_stepper =
               Parallel::get<Tags::TimeStepperBase>(cache);
           *time_id = *next_time_id;

--- a/src/Time/Actions/ChangeStepSize.hpp
+++ b/src/Time/Actions/ChangeStepSize.hpp
@@ -18,7 +18,7 @@
 
 /// \cond
 class TimeDelta;
-class TimeId;
+class TimeStepId;
 // IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
 
@@ -34,13 +34,13 @@ namespace Actions {
 ///   - Tags::TimeStepperBase
 /// - DataBox:
 ///   - Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>
-///   - Tags::TimeId
+///   - Tags::TimeStepId
 ///   - Tags::TimeStep
 ///
 /// DataBox changes:
 /// - Adds: nothing
 /// - Removes: nothing
-/// - Modifies: Tags::Next<Tags::TimeId>, Tags::TimeStep
+/// - Modifies: Tags::Next<Tags::TimeStepId>, Tags::TimeStep
 template <typename StepChooserRegistrars>
 struct ChangeStepSize {
   using step_choosers_tag = Tags::StepChoosers<StepChooserRegistrars>;
@@ -66,7 +66,7 @@ struct ChangeStepSize {
     const auto& step_choosers = Parallel::get<step_choosers_tag>(cache);
     const auto& step_controller = Parallel::get<Tags::StepController>(cache);
 
-    const auto& time_id = db::get<Tags::TimeId>(box);
+    const auto& time_id = db::get<Tags::TimeStepId>(box);
 
     if (not time_stepper.can_change_step_size(
             time_id,
@@ -96,10 +96,10 @@ struct ChangeStepSize {
       const auto new_next_time_id =
           time_stepper.next_time_id(time_id, new_step);
 
-      db::mutate<Tags::Next<Tags::TimeId>, Tags::TimeStep>(
+      db::mutate<Tags::Next<Tags::TimeStepId>, Tags::TimeStep>(
           make_not_null(&box),
           [&new_next_time_id, &new_step](
-              const gsl::not_null<TimeId*> next_time_id,
+              const gsl::not_null<TimeStepId*> next_time_id,
               const gsl::not_null<TimeDelta*> time_step) noexcept {
             *next_time_id = new_next_time_id;
             *time_step = new_step;

--- a/src/Time/Actions/ChangeStepSize.hpp
+++ b/src/Time/Actions/ChangeStepSize.hpp
@@ -91,7 +91,7 @@ struct ChangeStepSize {
     }
 
     const auto new_step =
-        step_controller.choose_step(time_id.time(), desired_step);
+        step_controller.choose_step(time_id.step_time(), desired_step);
     if (new_step != current_step) {
       const auto new_next_time_id =
           time_stepper.next_time_id(time_id, new_step);

--- a/src/Time/Actions/RecordTimeStepperData.hpp
+++ b/src/Time/Actions/RecordTimeStepperData.hpp
@@ -65,10 +65,10 @@ struct RecordTimeStepperData {
         [](const gsl::not_null<db::item_type<dt_variables_tag>*> dt_vars,
            const gsl::not_null<db::item_type<history_tag>*> history,
            const db::item_type<variables_tag>& vars,
-           const db::item_type<Tags::Time>& time) noexcept {
+           const db::item_type<Tags::SubstepTime>& time) noexcept {
           history->insert(time, vars, std::move(*dt_vars));
         },
-        db::get<variables_tag>(box), db::get<Tags::Time>(box));
+        db::get<variables_tag>(box), db::get<Tags::SubstepTime>(box));
 
     return std::forward_as_tuple(std::move(box));
   }

--- a/src/Time/Actions/SelfStartActions.hpp
+++ b/src/Time/Actions/SelfStartActions.hpp
@@ -260,7 +260,7 @@ struct CheckForCompletion {
 /// - ConstGlobalCache: nothing
 /// - DataBox:
 ///   - Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>
-///   - Tags::Time
+///   - Tags::SubstepTime
 ///   - Tags::TimeId
 ///   - Tags::TimeStep
 ///
@@ -280,7 +280,7 @@ struct CheckForOrderIncrease {
       const ParallelComponent* const /*meta*/) noexcept {  // NOLINT const
     using variables_tag = typename Metavariables::system::variables_tag;
 
-    const auto& time = db::get<::Tags::Time>(box);
+    const auto& time = db::get<::Tags::SubstepTime>(box);
     const auto& time_step = db::get<::Tags::TimeStep>(box);
     const auto& history = db::get<::Tags::HistoryEvolvedVariables<
         variables_tag, db::add_tag_prefix<::Tags::dt, variables_tag>>>(box);

--- a/src/Time/Actions/SelfStartActions.hpp
+++ b/src/Time/Actions/SelfStartActions.hpp
@@ -296,7 +296,7 @@ struct CheckForOrderIncrease {
           [](const gsl::not_null<db::item_type<::Tags::Next<::Tags::TimeId>>*>
                  next_time_id,
              const db::item_type<::Tags::TimeId>& current_time_id) noexcept {
-            const Slab slab = current_time_id.time().slab();
+            const Slab slab = current_time_id.step_time().slab();
             *next_time_id =
                 TimeId(current_time_id.time_runs_forward(),
                        current_time_id.slab_number() + 1,

--- a/src/Time/BoundaryHistory.hpp
+++ b/src/Time/BoundaryHistory.hpp
@@ -16,7 +16,7 @@
 #include "ErrorHandling/Assert.hpp"
 #include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
 #include "Time/Time.hpp"  // IWYU pragma: keep
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -49,10 +49,10 @@ class BoundaryHistory {
 
   /// Add a new value to the end of the history of the indicated side.
   //@{
-  void local_insert(const TimeId& time_id, LocalVars vars) noexcept {
+  void local_insert(const TimeStepId& time_id, LocalVars vars) noexcept {
     local_data_.emplace_back(time_id.substep_time(), std::move(vars));
   }
-  void remote_insert(const TimeId& time_id, RemoteVars vars) noexcept {
+  void remote_insert(const TimeStepId& time_id, RemoteVars vars) noexcept {
     remote_data_.emplace_back(time_id.substep_time(), std::move(vars));
   }
   //@}
@@ -60,10 +60,12 @@ class BoundaryHistory {
   /// Add a new value to the front of the history of the indicated
   /// side.  This is often convenient for setting initial data.
   //@{
-  void local_insert_initial(const TimeId& time_id, LocalVars vars) noexcept {
+  void local_insert_initial(const TimeStepId& time_id,
+                            LocalVars vars) noexcept {
     local_data_.emplace_front(time_id.substep_time(), std::move(vars));
   }
-  void remote_insert_initial(const TimeId& time_id, RemoteVars vars) noexcept {
+  void remote_insert_initial(const TimeStepId& time_id,
+                             RemoteVars vars) noexcept {
     remote_data_.emplace_front(time_id.substep_time(), std::move(vars));
   }
   //@}

--- a/src/Time/BoundaryHistory.hpp
+++ b/src/Time/BoundaryHistory.hpp
@@ -50,10 +50,10 @@ class BoundaryHistory {
   /// Add a new value to the end of the history of the indicated side.
   //@{
   void local_insert(const TimeId& time_id, LocalVars vars) noexcept {
-    local_data_.emplace_back(time_id.time(), std::move(vars));
+    local_data_.emplace_back(time_id.substep_time(), std::move(vars));
   }
   void remote_insert(const TimeId& time_id, RemoteVars vars) noexcept {
-    remote_data_.emplace_back(time_id.time(), std::move(vars));
+    remote_data_.emplace_back(time_id.substep_time(), std::move(vars));
   }
   //@}
 
@@ -61,10 +61,10 @@ class BoundaryHistory {
   /// side.  This is often convenient for setting initial data.
   //@{
   void local_insert_initial(const TimeId& time_id, LocalVars vars) noexcept {
-    local_data_.emplace_front(time_id.time(), std::move(vars));
+    local_data_.emplace_front(time_id.substep_time(), std::move(vars));
   }
   void remote_insert_initial(const TimeId& time_id, RemoteVars vars) noexcept {
-    remote_data_.emplace_front(time_id.time(), std::move(vars));
+    remote_data_.emplace_front(time_id.substep_time(), std::move(vars));
   }
   //@}
 

--- a/src/Time/CMakeLists.txt
+++ b/src/Time/CMakeLists.txt
@@ -6,7 +6,7 @@ set(LIBRARY Time)
 set(LIBRARY_SOURCES
     Slab.cpp
     Time.cpp
-    TimeId.cpp
+    TimeStepId.cpp
     )
 
 add_subdirectory(StepChoosers)

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -57,6 +57,14 @@ struct SubstepTime : db::ComputeTag {
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
+/// \brief Tag for the current time as a double
+struct Time : db::SimpleTag {
+  static std::string name() noexcept { return "Time"; }
+  using type = double;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup TimeGroup
 /// \brief Prefix for TimeStepper history
 ///
 /// \tparam Tag tag for the variables

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -49,7 +49,9 @@ struct TimeStep : db::SimpleTag {
 /// \brief Tag for compute item for ::Time of the current substep (from TimeId)
 struct SubstepTime : db::ComputeTag {
   static std::string name() noexcept { return "SubstepTime"; }
-  static auto function(const ::TimeId& id) noexcept { return id.time(); }
+  static auto function(const ::TimeId& id) noexcept {
+    return id.substep_time();
+  }
   using argument_tags = tmpl::list<TimeId>;
 };
 

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -21,17 +21,17 @@
 #include "Time/StepChoosers/StepChooser.hpp"        // IWYU pragma: keep
 #include "Time/StepControllers/StepController.hpp"  // IWYU pragma: keep
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Tags {
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
-/// \brief Tag for ::TimeId for the algorithm state
-struct TimeId : db::SimpleTag {
-  static std::string name() noexcept { return "TimeId"; }
-  using type = ::TimeId;
+/// \brief Tag for ::TimeStepId for the algorithm state
+struct TimeStepId : db::SimpleTag {
+  static std::string name() noexcept { return "TimeStepId"; }
+  using type = ::TimeStepId;
   template <typename Tag>
   using step_prefix = typename Tags::dt<Tag>;
 };
@@ -46,13 +46,14 @@ struct TimeStep : db::SimpleTag {
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
-/// \brief Tag for compute item for ::Time of the current substep (from TimeId)
+/// \brief Tag for compute item for ::Time of the current substep (from
+/// TimeStepId)
 struct SubstepTime : db::ComputeTag {
   static std::string name() noexcept { return "SubstepTime"; }
-  static auto function(const ::TimeId& id) noexcept {
+  static auto function(const ::TimeStepId& id) noexcept {
     return id.substep_time();
   }
-  using argument_tags = tmpl::list<TimeId>;
+  using argument_tags = tmpl::list<TimeStepId>;
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -46,9 +46,9 @@ struct TimeStep : db::SimpleTag {
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
-/// \brief Tag for compute item for current ::Time (from TimeId)
-struct Time : db::ComputeTag {
-  static std::string name() noexcept { return "Time"; }
+/// \brief Tag for compute item for ::Time of the current substep (from TimeId)
+struct SubstepTime : db::ComputeTag {
+  static std::string name() noexcept { return "SubstepTime"; }
   static auto function(const ::TimeId& id) noexcept { return id.time(); }
   using argument_tags = tmpl::list<TimeId>;
 };

--- a/src/Time/TimeId.cpp
+++ b/src/Time/TimeId.cpp
@@ -15,11 +15,11 @@ void TimeId::canonicalize() noexcept {
                          : step_time_.is_at_slab_start()) {
     ASSERT(substep_ == 0,
            "Time needs to be advanced, but step already started");
-    const Slab new_slab =
-        time_runs_forward_ ? time_.slab().advance() : time_.slab().retreat();
+    const Slab new_slab = time_runs_forward_ ? substep_time_.slab().advance()
+                                             : substep_time_.slab().retreat();
     ++slab_number_;
-    time_ = time_.with_slab(new_slab);
-    step_time_ = time_;
+    substep_time_ = substep_time_.with_slab(new_slab);
+    step_time_ = substep_time_;
   }
 }
 
@@ -28,7 +28,7 @@ void TimeId::pup(PUP::er& p) noexcept {
   p | slab_number_;
   p | step_time_;
   p | substep_;
-  p | time_;
+  p | substep_time_;
 }
 
 bool operator==(const TimeId& a, const TimeId& b) noexcept {
@@ -40,7 +40,7 @@ bool operator==(const TimeId& a, const TimeId& b) noexcept {
   // This could happen if we have a local-time-stepping substep
   // method.  If we implement any of those the comparison operators
   // for TimeId will have to be revisited.
-  ASSERT(not equal or a.time() == b.time(),
+  ASSERT(not equal or a.substep_time() == b.substep_time(),
          "IDs at same step and substep but different times");
   return equal;
 }
@@ -70,7 +70,7 @@ bool operator>=(const TimeId& a, const TimeId& b) noexcept {
 
 std::ostream& operator<<(std::ostream& s, const TimeId& id) noexcept {
   return s << id.slab_number() << ':' << id.step_time() << ':' << id.substep()
-           << ':' << id.time();
+           << ':' << id.substep_time();
 }
 
 size_t hash_value(const TimeId& id) noexcept {
@@ -78,7 +78,7 @@ size_t hash_value(const TimeId& id) noexcept {
   boost::hash_combine(h, id.slab_number());
   boost::hash_combine(h, id.step_time());
   boost::hash_combine(h, id.substep());
-  boost::hash_combine(h, id.time());
+  boost::hash_combine(h, id.substep_time());
   return h;
 }
 

--- a/src/Time/TimeId.hpp
+++ b/src/Time/TimeId.hpp
@@ -34,20 +34,20 @@ class TimeId {
         slab_number_(slab_number),
         step_time_(time),
         substep_(0),
-        time_(time) {
+        substep_time_(time) {
     canonicalize();
   }
-  /// Create a TimeId at a substep at time `time` in a step starting
-  /// at time `step_time`.
+  /// Create a TimeId at a substep at time `substep_time` in a step
+  /// starting at time `step_time`.
   TimeId(const bool time_runs_forward, const int64_t slab_number,
          const Time& step_time, const uint64_t substep,
-         const Time& time) noexcept
+         const Time& substep_time) noexcept
       : time_runs_forward_(time_runs_forward),
         slab_number_(slab_number),
         step_time_(step_time),
         substep_(substep),
-        time_(time) {
-    ASSERT(substep_ != 0 or step_time_ == time_,
+        substep_time_(substep_time) {
+    ASSERT(substep_ != 0 or step_time_ == substep_time_,
            "Initial substep must align with the step.");
     canonicalize();
   }
@@ -58,10 +58,10 @@ class TimeId {
   const Time& step_time() const noexcept { return step_time_; }
   uint64_t substep() const noexcept { return substep_; }
   /// Time of the current substep
-  const Time& time() const noexcept { return time_; }
+  const Time& substep_time() const noexcept { return substep_time_; }
 
   bool is_at_slab_boundary() const noexcept {
-    return substep_ == 0 and time_.is_at_slab_boundary();
+    return substep_ == 0 and substep_time_.is_at_slab_boundary();
   }
 
   // clang-tidy: google-runtime-references
@@ -74,7 +74,7 @@ class TimeId {
   int64_t slab_number_{0};
   Time step_time_{};
   uint64_t substep_{0};
-  Time time_{};
+  Time substep_time_{};
 };
 
 bool operator==(const TimeId& a, const TimeId& b) noexcept;

--- a/src/Time/TimeStepId.cpp
+++ b/src/Time/TimeStepId.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 
 #include <boost/functional/hash.hpp>
 #include <ostream>
@@ -10,7 +10,7 @@
 #include "Time/EvolutionOrdering.hpp"
 #include "Time/Slab.hpp"
 
-void TimeId::canonicalize() noexcept {
+void TimeStepId::canonicalize() noexcept {
   if (time_runs_forward_ ? step_time_.is_at_slab_end()
                          : step_time_.is_at_slab_start()) {
     ASSERT(substep_ == 0,
@@ -23,7 +23,7 @@ void TimeId::canonicalize() noexcept {
   }
 }
 
-void TimeId::pup(PUP::er& p) noexcept {
+void TimeStepId::pup(PUP::er& p) noexcept {
   p | time_runs_forward_;
   p | slab_number_;
   p | step_time_;
@@ -31,7 +31,7 @@ void TimeId::pup(PUP::er& p) noexcept {
   p | substep_time_;
 }
 
-bool operator==(const TimeId& a, const TimeId& b) noexcept {
+bool operator==(const TimeStepId& a, const TimeStepId& b) noexcept {
   ASSERT(a.time_runs_forward() == b.time_runs_forward(),
          "Time is not running in a consistent direction");
   const bool equal = a.slab_number() == b.slab_number() and
@@ -39,17 +39,17 @@ bool operator==(const TimeId& a, const TimeId& b) noexcept {
                      a.substep() == b.substep();
   // This could happen if we have a local-time-stepping substep
   // method.  If we implement any of those the comparison operators
-  // for TimeId will have to be revisited.
+  // for TimeStepId will have to be revisited.
   ASSERT(not equal or a.substep_time() == b.substep_time(),
          "IDs at same step and substep but different times");
   return equal;
 }
 
-bool operator!=(const TimeId& a, const TimeId& b) noexcept {
+bool operator!=(const TimeStepId& a, const TimeStepId& b) noexcept {
   return not(a == b);
 }
 
-bool operator<(const TimeId& a, const TimeId& b) noexcept {
+bool operator<(const TimeStepId& a, const TimeStepId& b) noexcept {
   ASSERT(a.time_runs_forward() == b.time_runs_forward(),
          "Time is not running in a consistent direction");
   return a.slab_number() < b.slab_number() or
@@ -58,22 +58,22 @@ bool operator<(const TimeId& a, const TimeId& b) noexcept {
                                                        b.step_time()) or
            (a.step_time() == b.step_time() and a.substep() < b.substep())));
 }
-bool operator<=(const TimeId& a, const TimeId& b) noexcept {
+bool operator<=(const TimeStepId& a, const TimeStepId& b) noexcept {
   return not(b < a);
 }
-bool operator>(const TimeId& a, const TimeId& b) noexcept {
+bool operator>(const TimeStepId& a, const TimeStepId& b) noexcept {
   return b < a;
 }
-bool operator>=(const TimeId& a, const TimeId& b) noexcept {
+bool operator>=(const TimeStepId& a, const TimeStepId& b) noexcept {
   return not(a < b);
 }
 
-std::ostream& operator<<(std::ostream& s, const TimeId& id) noexcept {
+std::ostream& operator<<(std::ostream& s, const TimeStepId& id) noexcept {
   return s << id.slab_number() << ':' << id.step_time() << ':' << id.substep()
            << ':' << id.substep_time();
 }
 
-size_t hash_value(const TimeId& id) noexcept {
+size_t hash_value(const TimeStepId& id) noexcept {
   size_t h = 0;
   boost::hash_combine(h, id.slab_number());
   boost::hash_combine(h, id.step_time());
@@ -84,7 +84,7 @@ size_t hash_value(const TimeId& id) noexcept {
 
 // clang-tidy: do not modify std namespace (okay for hash)
 namespace std {  // NOLINT
-size_t hash<TimeId>::operator()(const TimeId& id) const noexcept {
-  return boost::hash<TimeId>{}(id);
+size_t hash<TimeStepId>::operator()(const TimeStepId& id) const noexcept {
+  return boost::hash<TimeStepId>{}(id);
 }
 }  // namespace std

--- a/src/Time/TimeStepId.hpp
+++ b/src/Time/TimeStepId.hpp
@@ -2,7 +2,7 @@
 // See LICENSE.txt for details.
 
 /// \file
-/// Defines class TimeId.
+/// Defines class TimeStepId.
 
 #pragma once
 
@@ -22,14 +22,14 @@ class er;
 ///
 /// A unique identifier for the temporal state of an integrated
 /// system.
-class TimeId {
+class TimeStepId {
  public:
-  TimeId() = default;
-  /// Create a TimeId at the start of a step.  If that step is at the
-  /// (evolution-defined) end of the slab the TimeId will be advanced
+  TimeStepId() = default;
+  /// Create a TimeStepId at the start of a step.  If that step is at the
+  /// (evolution-defined) end of the slab the TimeStepId will be advanced
   /// to the next slab.
-  TimeId(const bool time_runs_forward, const int64_t slab_number,
-         const Time& time) noexcept
+  TimeStepId(const bool time_runs_forward, const int64_t slab_number,
+             const Time& time) noexcept
       : time_runs_forward_(time_runs_forward),
         slab_number_(slab_number),
         step_time_(time),
@@ -37,11 +37,11 @@ class TimeId {
         substep_time_(time) {
     canonicalize();
   }
-  /// Create a TimeId at a substep at time `substep_time` in a step
+  /// Create a TimeStepId at a substep at time `substep_time` in a step
   /// starting at time `step_time`.
-  TimeId(const bool time_runs_forward, const int64_t slab_number,
-         const Time& step_time, const uint64_t substep,
-         const Time& substep_time) noexcept
+  TimeStepId(const bool time_runs_forward, const int64_t slab_number,
+             const Time& step_time, const uint64_t substep,
+             const Time& substep_time) noexcept
       : time_runs_forward_(time_runs_forward),
         slab_number_(slab_number),
         step_time_(step_time),
@@ -77,20 +77,20 @@ class TimeId {
   Time substep_time_{};
 };
 
-bool operator==(const TimeId& a, const TimeId& b) noexcept;
-bool operator!=(const TimeId& a, const TimeId& b) noexcept;
-bool operator<(const TimeId& a, const TimeId& b) noexcept;
-bool operator<=(const TimeId& a, const TimeId& b) noexcept;
-bool operator>(const TimeId& a, const TimeId& b) noexcept;
-bool operator>=(const TimeId& a, const TimeId& b) noexcept;
+bool operator==(const TimeStepId& a, const TimeStepId& b) noexcept;
+bool operator!=(const TimeStepId& a, const TimeStepId& b) noexcept;
+bool operator<(const TimeStepId& a, const TimeStepId& b) noexcept;
+bool operator<=(const TimeStepId& a, const TimeStepId& b) noexcept;
+bool operator>(const TimeStepId& a, const TimeStepId& b) noexcept;
+bool operator>=(const TimeStepId& a, const TimeStepId& b) noexcept;
 
-std::ostream& operator<<(std::ostream& s, const TimeId& id) noexcept;
+std::ostream& operator<<(std::ostream& s, const TimeStepId& id) noexcept;
 
-size_t hash_value(const TimeId& id) noexcept;
+size_t hash_value(const TimeStepId& id) noexcept;
 
 namespace std {
 template <>
-struct hash<TimeId> {
-  size_t operator()(const TimeId& id) const noexcept;
+struct hash<TimeStepId> {
+  size_t operator()(const TimeStepId& id) const noexcept;
 };
 }  // namespace std

--- a/src/Time/TimeSteppers/AdamsBashforthN.cpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.cpp
@@ -43,7 +43,7 @@ TimeId AdamsBashforthN::next_time_id(
     const TimeDelta& time_step) const noexcept {
   ASSERT(current_id.substep() == 0, "Adams-Bashforth should not have substeps");
   return {current_id.time_runs_forward(), current_id.slab_number(),
-          current_id.time() + time_step};
+          current_id.step_time() + time_step};
 }
 
 std::vector<double> AdamsBashforthN::get_coefficients_impl(

--- a/src/Time/TimeSteppers/AdamsBashforthN.cpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.cpp
@@ -5,7 +5,7 @@
 
 #include <algorithm>
 
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 
 namespace TimeSteppers {
 
@@ -38,8 +38,8 @@ double AdamsBashforthN::stable_step() const noexcept {
   return 1. / invstep;
 }
 
-TimeId AdamsBashforthN::next_time_id(
-    const TimeId& current_id,
+TimeStepId AdamsBashforthN::next_time_id(
+    const TimeStepId& current_id,
     const TimeDelta& time_step) const noexcept {
   ASSERT(current_id.substep() == 0, "Adams-Bashforth should not have substeps");
   return {current_id.time_runs_forward(), current_id.slab_number(),

--- a/src/Time/TimeSteppers/AdamsBashforthN.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.hpp
@@ -695,7 +695,7 @@ bool AdamsBashforthN::can_change_step_size(
   // "real" values.
   const evolution_less<Time> less{time_id.time_runs_forward()};
   return history.size() == 0 or
-         (less(history.back(), time_id.time()) and
+         (less(history.back(), time_id.step_time()) and
           std::is_sorted(history.begin(), history.end(), less));
 }
 

--- a/src/Time/TimeSteppers/AdamsBashforthN.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.hpp
@@ -25,7 +25,7 @@
 #include "Parallel/CharmPupable.hpp"
 #include "Time/EvolutionOrdering.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"  // IWYU pragma: keep
 #include "Utilities/CachedFunction.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -216,12 +216,12 @@ class AdamsBashforthN : public LtsTimeStepper::Inherit {
 
   double stable_step() const noexcept override;
 
-  TimeId next_time_id(const TimeId& current_id,
-                      const TimeDelta& time_step) const noexcept override;
+  TimeStepId next_time_id(const TimeStepId& current_id,
+                          const TimeDelta& time_step) const noexcept override;
 
   template <typename Vars, typename DerivVars>
   bool can_change_step_size(
-      const TimeId& time_id,
+      const TimeStepId& time_id,
       const TimeSteppers::History<Vars, DerivVars>& history) const noexcept;
 
   WRAPPED_PUPable_decl_template(AdamsBashforthN);  // NOLINT
@@ -686,7 +686,7 @@ AdamsBashforthN::boundary_impl(
 
 template <typename Vars, typename DerivVars>
 bool AdamsBashforthN::can_change_step_size(
-    const TimeId& time_id,
+    const TimeStepId& time_id,
     const TimeSteppers::History<Vars, DerivVars>& history) const noexcept {
   // We need to forbid local time-stepping before initialization is
   // complete.  The self-start procedure itself should never consider

--- a/src/Time/TimeSteppers/RungeKutta3.cpp
+++ b/src/Time/TimeSteppers/RungeKutta3.cpp
@@ -6,7 +6,7 @@
 #include <cmath>
 
 #include "ErrorHandling/Assert.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 
 namespace TimeSteppers {
 
@@ -23,8 +23,9 @@ double RungeKutta3::stable_step() const noexcept {
   return 0.5 * (1. + cbrt(4. + sqrt(17.)) - 1. / cbrt(4. + sqrt(17.)));
 }
 
-TimeId RungeKutta3::next_time_id(const TimeId& current_id,
-                                 const TimeDelta& time_step) const noexcept {
+TimeStepId RungeKutta3::next_time_id(
+    const TimeStepId& current_id,
+    const TimeDelta& time_step) const noexcept {
   switch (current_id.substep()) {
     case 0:
       ASSERT(current_id.substep_time() == current_id.step_time(),

--- a/src/Time/TimeSteppers/RungeKutta3.cpp
+++ b/src/Time/TimeSteppers/RungeKutta3.cpp
@@ -27,18 +27,20 @@ TimeId RungeKutta3::next_time_id(const TimeId& current_id,
                                  const TimeDelta& time_step) const noexcept {
   switch (current_id.substep()) {
     case 0:
-      ASSERT(current_id.time() == current_id.step_time(), "Wrong substep time");
+      ASSERT(current_id.substep_time() == current_id.step_time(),
+             "Wrong substep time");
       return {current_id.time_runs_forward(), current_id.slab_number(),
               current_id.step_time(), 1, current_id.step_time() + time_step};
     case 1:
-      ASSERT(current_id.time() == current_id.step_time() + time_step,
+      ASSERT(current_id.substep_time() == current_id.step_time() + time_step,
              "Wrong substep time");
       return {current_id.time_runs_forward(), current_id.slab_number(),
               current_id.step_time(), 2,
               current_id.step_time() + time_step / 2};
     case 2:
-      ASSERT(current_id.time() == current_id.step_time() + time_step / 2,
-             "Wrong substep time");
+      ASSERT(
+          current_id.substep_time() == current_id.step_time() + time_step / 2,
+          "Wrong substep time");
       return {current_id.time_runs_forward(), current_id.slab_number(),
               current_id.step_time() + time_step};
     default:

--- a/src/Time/TimeSteppers/RungeKutta3.hpp
+++ b/src/Time/TimeSteppers/RungeKutta3.hpp
@@ -22,7 +22,7 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-struct TimeId;
+struct TimeStepId;
 namespace TimeSteppers {
 template <typename Vars, typename DerivVars>
 class History;
@@ -65,8 +65,8 @@ class RungeKutta3 : public TimeStepper::Inherit {
 
   double stable_step() const noexcept override;
 
-  TimeId next_time_id(const TimeId& current_id,
-                      const TimeDelta& time_step) const noexcept override;
+  TimeStepId next_time_id(const TimeStepId& current_id,
+                          const TimeDelta& time_step) const noexcept override;
 
   WRAPPED_PUPable_decl_template(RungeKutta3);  // NOLINT
 

--- a/src/Time/TimeSteppers/TimeStepper.hpp
+++ b/src/Time/TimeSteppers/TimeStepper.hpp
@@ -9,7 +9,7 @@
 #include <type_traits>
 
 #include "Parallel/CharmPupable.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/FakeVirtual.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -83,9 +83,10 @@ class TimeStepper : public PUP::able {
   /// stably as a multiple of the step for Euler's method.
   virtual double stable_step() const noexcept = 0;
 
-  /// The TimeId after the current substep
-  virtual TimeId next_time_id(const TimeId& current_id,
-                              const TimeDelta& time_step) const noexcept = 0;
+  /// The TimeStepId after the current substep
+  virtual TimeStepId next_time_id(
+      const TimeStepId& current_id,
+      const TimeDelta& time_step) const noexcept = 0;
 };
 
 // LtsTimeStepper cannot be split out into its own file because the
@@ -157,7 +158,7 @@ class LtsTimeStepper : public TimeStepper::Inherit {
   /// boundaries.
   template <typename Vars, typename DerivVars>
   bool can_change_step_size(
-      const TimeId& time_id,
+      const TimeStepId& time_id,
       const TimeSteppers::History<Vars, DerivVars>& history) const noexcept {
     return LtsTimeStepper_detail::fake_virtual_can_change_step_size<
         creatable_classes>(this, time_id, history);

--- a/src/Time/Triggers/EveryNSlabs.hpp
+++ b/src/Time/Triggers/EveryNSlabs.hpp
@@ -9,13 +9,13 @@
 #include "Evolution/EventsAndTriggers/Trigger.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/Registration.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
 namespace Tags {
-struct TimeId;
+struct TimeStepId;
 }  // namespace Tags
 /// \endcond
 
@@ -58,9 +58,9 @@ class EveryNSlabs : public Trigger<TriggerRegistrars> {
   EveryNSlabs(const uint64_t interval, const uint64_t offset) noexcept
       : interval_(interval), offset_(offset) {}
 
-  using argument_tags = tmpl::list<Tags::TimeId>;
+  using argument_tags = tmpl::list<Tags::TimeStepId>;
 
-  bool operator()(const TimeId& time_id) const noexcept {
+  bool operator()(const TimeStepId& time_id) const noexcept {
     if (not time_id.is_at_slab_boundary()) {
       return false;
     }

--- a/src/Time/Triggers/PastTime.hpp
+++ b/src/Time/Triggers/PastTime.hpp
@@ -17,7 +17,7 @@
 
 /// \cond
 namespace Tags {
-struct SubstepTime;
+struct Time;
 struct TimeId;
 }  // namespace Tags
 /// \endcond
@@ -51,14 +51,14 @@ class PastTime : public Trigger<TriggerRegistrars> {
   explicit PastTime(const double trigger_time) noexcept
       : trigger_time_(trigger_time) {}
 
-  using argument_tags = tmpl::list<Tags::SubstepTime, Tags::TimeId>;
+  using argument_tags = tmpl::list<Tags::Time, Tags::TimeId>;
 
-  bool operator()(const Time& time, const TimeId& time_id) const noexcept {
+  bool operator()(const double time, const TimeId& time_id) const noexcept {
     if (not time_id.is_at_slab_boundary()) {
       return false;
     }
     return evolution_greater<double>{time_id.time_runs_forward()}(
-        time.value(), trigger_time_);
+        time, trigger_time_);
   }
 
   // clang-tidy: google-runtime-references

--- a/src/Time/Triggers/PastTime.hpp
+++ b/src/Time/Triggers/PastTime.hpp
@@ -17,7 +17,7 @@
 
 /// \cond
 namespace Tags {
-struct Time;
+struct SubstepTime;
 struct TimeId;
 }  // namespace Tags
 /// \endcond
@@ -51,7 +51,7 @@ class PastTime : public Trigger<TriggerRegistrars> {
   explicit PastTime(const double trigger_time) noexcept
       : trigger_time_(trigger_time) {}
 
-  using argument_tags = tmpl::list<Tags::Time, Tags::TimeId>;
+  using argument_tags = tmpl::list<Tags::SubstepTime, Tags::TimeId>;
 
   bool operator()(const Time& time, const TimeId& time_id) const noexcept {
     if (not time_id.is_at_slab_boundary()) {

--- a/src/Time/Triggers/PastTime.hpp
+++ b/src/Time/Triggers/PastTime.hpp
@@ -11,14 +11,14 @@
 #include "Parallel/CharmPupable.hpp"
 #include "Time/EvolutionOrdering.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/Registration.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
 namespace Tags {
 struct Time;
-struct TimeId;
+struct TimeStepId;
 }  // namespace Tags
 /// \endcond
 
@@ -51,9 +51,9 @@ class PastTime : public Trigger<TriggerRegistrars> {
   explicit PastTime(const double trigger_time) noexcept
       : trigger_time_(trigger_time) {}
 
-  using argument_tags = tmpl::list<Tags::Time, Tags::TimeId>;
+  using argument_tags = tmpl::list<Tags::Time, Tags::TimeStepId>;
 
-  bool operator()(const double time, const TimeId& time_id) const noexcept {
+  bool operator()(const double time, const TimeStepId& time_id) const noexcept {
     if (not time_id.is_at_slab_boundary()) {
       return false;
     }

--- a/src/Time/Triggers/SpecifiedSlabs.hpp
+++ b/src/Time/Triggers/SpecifiedSlabs.hpp
@@ -11,13 +11,13 @@
 #include "Evolution/EventsAndTriggers/Trigger.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/Registration.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
 namespace Tags {
-struct TimeId;
+struct TimeStepId;
 }  // namespace Tags
 /// \endcond
 
@@ -56,9 +56,9 @@ class SpecifiedSlabs : public Trigger<TriggerRegistrars> {
   explicit SpecifiedSlabs(const std::vector<uint64_t>& slabs) noexcept
       : slabs_(slabs.begin(), slabs.end()) {}
 
-  using argument_tags = tmpl::list<Tags::TimeId>;
+  using argument_tags = tmpl::list<Tags::TimeStepId>;
 
-  bool operator()(const TimeId& time_id) const noexcept {
+  bool operator()(const TimeStepId& time_id) const noexcept {
     if (not time_id.is_at_slab_boundary()) {
       return false;
     }

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -54,7 +54,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -211,7 +211,7 @@ struct MockMetavariables {
                  GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
                  GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>;
   using interpolation_target_tags = tmpl::list<AhA>;
-  using temporal_id  = ::Tags::TimeId;
+  using temporal_id  = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
   using component_list =
       tmpl::list<mock_interpolation_target<MockMetavariables, AhA>,
@@ -268,7 +268,7 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
   runner.set_phase(metavars::Phase::Registration);
 
   Slab slab(0.0, 1.0);
-  TimeId temporal_id(true, 0, Time(slab, 0));
+  TimeStepId temporal_id(true, 0, Time(slab, 0));
 
   // Create element_ids.
   std::vector<ElementId<3>> element_ids{};
@@ -294,7 +294,7 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
   ActionTesting::simple_action<
       target_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                             typename metavars::AhA>>(
-      make_not_null(&runner), 0, std::vector<TimeId>{temporal_id});
+      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
 
   // Create volume data and send it to the interpolator.
   for (const auto& element_id : element_ids) {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ObserveErrorNorms.cpp
@@ -26,10 +26,7 @@
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"  // IWYU pragma: keep
-#include "Time/Slab.hpp"
 #include "Time/Tags.hpp"  // IWYU pragma: keep
-#include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
@@ -251,10 +248,9 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   ActionTesting::emplace_component<observer_component>(&runner, 0);
 
   const auto box = db::create<
-      db::AddSimpleTags<Tags::TimeId,
-                        Tags::Variables<typename decltype(vars)::tags_list>>,
-      db::AddComputeTags<Tags::SubstepTime>>(
-      TimeId(true, 0, Slab(0., observation_time).end()), vars);
+      db::AddSimpleTags<Tags::Time,
+                        Tags::Variables<typename decltype(vars)::tags_list>>>(
+      observation_time, vars);
 
   observe->run(box, runner.cache(), array_index,
                std::add_pointer_t<element_component>{});

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ObserveErrorNorms.cpp
@@ -253,7 +253,7 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   const auto box = db::create<
       db::AddSimpleTags<Tags::TimeId,
                         Tags::Variables<typename decltype(vars)::tags_list>>,
-      db::AddComputeTags<Tags::Time>>(
+      db::AddComputeTags<Tags::SubstepTime>>(
       TimeId(true, 0, Slab(0., observation_time).end()), vars);
 
   observe->run(box, runner.cache(), array_index,

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ObserveFields.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ObserveFields.cpp
@@ -323,7 +323,7 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   const auto box = db::create<
       db::AddSimpleTags<Tags::TimeId, Tags::Mesh<volume_dim>,
                         Tags::Variables<typename decltype(vars)::tags_list>>,
-      db::AddComputeTags<Tags::Time>>(
+      db::AddComputeTags<Tags::SubstepTime>>(
       TimeId(true, 0, Slab(0., observation_time).end()), mesh, vars);
 
   observe->run(box, runner.cache(), array_index,

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ObserveFields.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ObserveFields.cpp
@@ -32,10 +32,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"  // IWYU pragma: keep
-#include "Time/Slab.hpp"
 #include "Time/Tags.hpp"  // IWYU pragma: keep
-#include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
@@ -321,10 +318,9 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   ActionTesting::emplace_component<observer_component>(&runner, 0);
 
   const auto box = db::create<
-      db::AddSimpleTags<Tags::TimeId, Tags::Mesh<volume_dim>,
-                        Tags::Variables<typename decltype(vars)::tags_list>>,
-      db::AddComputeTags<Tags::SubstepTime>>(
-      TimeId(true, 0, Slab(0., observation_time).end()), mesh, vars);
+      db::AddSimpleTags<Tags::Time, Tags::Mesh<volume_dim>,
+                        Tags::Variables<typename decltype(vars)::tags_list>>>(
+      observation_time, mesh, vars);
 
   observe->run(box, runner.cache(), array_index,
                std::add_pointer_t<element_component>{});

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -2987,14 +2987,6 @@ void test_damped_harmonic_compute_tags(const size_t grid_size_each_dimension,
 
   // Verify that locally computed H_a matches the same obtained through its
   // ComputeTag from databox
-  CHECK(db::get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(box) == shift);
-  CHECK(db::get<::Tags::Time>(box) == current_time);
-  CHECK(db::get<GeneralizedHarmonic::OptionTags::GaugeHRollOnStartTime>(box) ==
-        t_start_S);
-  CHECK(db::get<GeneralizedHarmonic::OptionTags::GaugeHRollOnTimeWindow>(box) ==
-        sigma_t_S);
-  CHECK(db::get<GeneralizedHarmonic::OptionTags::GaugeHSpatialWeightDecayWidth<
-            Frame::Inertial>>(box) == r_max);
   CHECK(db::get<GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>>(box) ==
         gauge_h_expected);
   CHECK(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -2976,7 +2976,7 @@ void test_damped_harmonic_compute_tags(const size_t grid_size_each_dimension,
           GeneralizedHarmonic::OptionTags::GaugeHSpatialWeightDecayWidth<
               Frame::Inertial>>,
       db::AddComputeTags<
-          ::Tags::Time,
+          ::Tags::SubstepTime,
           GeneralizedHarmonic::DampedHarmonicHCompute<3, Frame::Inertial>,
           GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<
               3, Frame::Inertial>>>(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -31,14 +31,10 @@
 #include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
-#include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
-#include "Utilities/Rational.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
@@ -260,14 +256,10 @@ wrap_DampedHarmonicHCompute(
     const double t, const double t_start, const double sigma_t,
     const tnsr::I<DataVector, SpatialDim, Frame>& coords,
     const double sigma_r) noexcept {
-  const Slab slab(0, t);
-  const Rational frac(1);
-  const Time current_time(slab, frac);
   return GeneralizedHarmonic::DampedHarmonicHCompute<
       SpatialDim, Frame>::function(gauge_h_init, lapse, shift,
                                    sqrt_det_spatial_metric, spacetime_metric,
-                                   current_time, t_start, sigma_t, coords,
-                                   sigma_r);
+                                   t, t_start, sigma_t, coords, sigma_r);
 }
 
 // Compare with Python implementation
@@ -1085,16 +1077,12 @@ wrap_SpacetimeDerivDampedHarmonicHCompute(
     const double t_start, const double sigma_t,
     const tnsr::I<DataVector, SpatialDim, Frame>& coords,
     const double sigma_r) noexcept {
-  const Slab slab(0, t);
-  const Rational frac(1);
-  const Time current_time(slab, frac);
   return GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<
       SpatialDim, Frame>::function(gauge_h_init, dgauge_h_init, lapse, shift,
                                    spacetime_unit_normal_one_form,
                                    sqrt_det_spatial_metric,
                                    inverse_spatial_metric, spacetime_metric, pi,
-                                   phi, current_time, t_start, sigma_t, coords,
-                                   sigma_r);
+                                   phi, t, t_start, sigma_t, coords, sigma_r);
 }
 // Compare with Python implementation
 template <size_t SpatialDim, typename Frame>
@@ -2853,10 +2841,6 @@ void test_damped_harmonic_compute_tags(const size_t grid_size_each_dimension,
   const auto x = coord_map(x_logical);
   // Arbitrary time for time-independent solution.
   const double t = pdist(generator) * 0.4;
-  const Slab slab(0, t);
-  const Rational frac(1);
-  const Time current_time(slab, frac);
-  const TimeId current_time_id(true, 0, current_time);
 
   // Randomized 3 + 1 quantities
   // Note: Ranges from which random numbers are drawn to populate 3+1 tensors
@@ -2969,20 +2953,19 @@ void test_damped_harmonic_compute_tags(const size_t grid_size_each_dimension,
           gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
           gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>,
           GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
-          GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>, ::Tags::TimeId,
+          GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>, ::Tags::Time,
           ::Tags::Coordinates<3, Frame::Inertial>,
           GeneralizedHarmonic::OptionTags::GaugeHRollOnStartTime,
           GeneralizedHarmonic::OptionTags::GaugeHRollOnTimeWindow,
           GeneralizedHarmonic::OptionTags::GaugeHSpatialWeightDecayWidth<
               Frame::Inertial>>,
       db::AddComputeTags<
-          ::Tags::SubstepTime,
           GeneralizedHarmonic::DampedHarmonicHCompute<3, Frame::Inertial>,
           GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<
               3, Frame::Inertial>>>(
       gauge_h_init, d4_gauge_h_init, lapse, shift,
       spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
-      inverse_spatial_metric, spacetime_metric, pi, phi, current_time_id, x,
+      inverse_spatial_metric, spacetime_metric, pi, phi, t, x,
       t_start_S, sigma_t_S, r_max);
 
   // Verify that locally computed H_a matches the same obtained through its

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
@@ -32,7 +32,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"  // IWYU pragma: keep
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Time/TimeSteppers/AdamsBashforthN.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -104,7 +104,7 @@ struct Component {
 struct Metavariables {
   using system = System;
   using component_list = tmpl::list<Component<Metavariables>>;
-  using temporal_id = TimeId;
+  using temporal_id = TimeStepId;
   static constexpr bool local_time_stepping = true;
   using const_global_cache_tag_list = tmpl::list<>;
 
@@ -166,16 +166,16 @@ SPECTRE_TEST_CASE("Unit.DG.Actions.ApplyBoundaryFluxesLocalTimeStepping",
   using mortar_data_tag =
       typename flux_comm_types::local_time_stepping_mortar_data_tag;
   typename mortar_data_tag::type mortar_data;
-  mortar_data[slow_mortar].local_insert(TimeId(true, 0, now),
+  mortar_data[slow_mortar].local_insert(TimeStepId(true, 0, now),
                                         gsl::at(local_data, 0));
-  mortar_data[fast_mortar].local_insert(TimeId(true, 0, now),
+  mortar_data[fast_mortar].local_insert(TimeStepId(true, 0, now),
                                         gsl::at(local_data, 1));
-  mortar_data[slow_mortar].remote_insert(TimeId(true, 0, now - time_step / 2),
-                                         gsl::at(remote_data, 0));
-  mortar_data[fast_mortar].remote_insert(TimeId(true, 0, now),
+  mortar_data[slow_mortar].remote_insert(
+      TimeStepId(true, 0, now - time_step / 2), gsl::at(remote_data, 0));
+  mortar_data[fast_mortar].remote_insert(TimeStepId(true, 0, now),
                                          gsl::at(remote_data, 1));
-  mortar_data[fast_mortar].remote_insert(TimeId(true, 0, now + time_step / 3),
-                                         gsl::at(remote_data, 2));
+  mortar_data[fast_mortar].remote_insert(
+      TimeStepId(true, 0, now + time_step / 3), gsl::at(remote_data, 2));
 
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
       {std::make_unique<TimeSteppers::AdamsBashforthN>(1), NumericalFlux{}}};

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -199,14 +199,14 @@ struct component {
   using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
 
   using simple_tags = db::AddSimpleTags<
-      TemporalId, Tags::Mesh<Dim>, Tags::Element<Dim>, Tags::ElementMap<Dim>,
-      bdry_normal_dot_fluxes_tag<flux_comm_types>, bdry_other_data_tag,
-      external_bdry_normal_dot_fluxes_tag<flux_comm_types>,
+      TemporalId, Tags::Time, Tags::Mesh<Dim>, Tags::Element<Dim>,
+      Tags::ElementMap<Dim>, bdry_normal_dot_fluxes_tag<flux_comm_types>,
+      bdry_other_data_tag, external_bdry_normal_dot_fluxes_tag<flux_comm_types>,
       external_bdry_other_data_tag, external_bdry_vars_tag,
       mortar_data_tag<flux_comm_types>>;
 
   using compute_tags = db::AddComputeTags<
-      Tags::SubstepTime, Tags::BoundaryDirectionsInterior<Dim>,
+      Tags::BoundaryDirectionsInterior<Dim>,
       boundary_compute_tag<Tags::Direction<Dim>>,
       boundary_compute_tag<Tags::InterfaceMesh<Dim>>,
       boundary_compute_tag<Tags::UnnormalizedFaceNormalCompute<Dim>>,
@@ -358,7 +358,7 @@ void run_test() {
 
     ActionTesting::emplace_component_and_initialize<my_component>(
         &runner, self_id,
-        {initial_time, mesh, element, std::move(map),
+        {initial_time, start.value(), mesh, element, std::move(map),
          std::move(bdry_normal_dot_fluxes), std::move(bdry_other_data),
          std::move(external_bdry_normal_dot_fluxes),
          std::move(external_bdry_other_data), std::move(external_bdry_vars),

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -31,11 +31,8 @@
 #include "Domain/FaceNormal.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
-#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
-#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Time/Slab.hpp"
@@ -58,7 +55,6 @@
 // IWYU pragma: no_forward_declare Tensor
 // IWYU pragma: no_forward_declare Variables
 // IWYU pragma: no_forward_declare dg::Actions::ImposeDirichletBoundaryConditions
-// IWYU pragma: no_forward_declare dg::Actions::ReceiveDataForFluxes
 
 namespace {
 constexpr size_t Dim = 2;
@@ -120,11 +116,11 @@ struct BoundaryCondition {
     return tuples::TaggedTuple<Var>{Scalar<DataVector>{{{{30., 40., 50.}}}}};
   }
 
-  tuples::TaggedTuple<Var> variables(const tnsr::I<DataVector, Dim>& /*x*/,
-                                     double /*t*/,
-                                     tmpl::list<PrimitiveVar> /*meta*/) const
-      noexcept {
-    return tuples::TaggedTuple<Var>{Scalar<DataVector>{{{{15., 20., 25.}}}}};
+  tuples::TaggedTuple<PrimitiveVar> variables(
+      const tnsr::I<DataVector, Dim>& /*x*/, double /*t*/,
+      tmpl::list<PrimitiveVar> /*meta*/) const noexcept {
+    return tuples::TaggedTuple<PrimitiveVar>{
+        Scalar<DataVector>{{{{15., 20., 25.}}}}};
   }
   // clang-tidy: do not use references
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
@@ -158,12 +154,6 @@ struct System {
 };
 
 template <typename Tag>
-using interface_tag = Tags::Interface<Tags::InternalDirections<Dim>, Tag>;
-template <typename Tag>
-using interface_compute_tag =
-    Tags::InterfaceComputeItem<Tags::InternalDirections<Dim>, Tag>;
-
-template <typename Tag>
 using boundary_tag =
     Tags::Interface<Tags::BoundaryDirectionsInterior<Dim>, Tag>;
 template <typename Tag>
@@ -184,9 +174,6 @@ using LocalMortarData = typename FluxCommTypes::LocalMortarData;
 template <typename FluxCommTypes>
 using PackagedData = typename FluxCommTypes::PackagedData;
 template <typename FluxCommTypes>
-using normal_dot_fluxes_tag =
-    interface_tag<typename FluxCommTypes::normal_dot_fluxes_tag>;
-template <typename FluxCommTypes>
 using bdry_normal_dot_fluxes_tag =
     boundary_tag<typename FluxCommTypes::normal_dot_fluxes_tag>;
 template <typename FluxCommTypes>
@@ -197,17 +184,10 @@ using bdry_vars_tag = boundary_tag<Tags::Variables<tmpl::list<Var>>>;
 using external_bdry_vars_tag =
     external_boundary_tag<Tags::Variables<tmpl::list<Var>>>;
 
-template <typename FluxCommTypes>
-using fluxes_tag = typename FluxCommTypes::FluxesTag;
-
-using other_data_tag = interface_tag<Tags::Variables<tmpl::list<OtherData>>>;
 using bdry_other_data_tag =
     boundary_tag<Tags::Variables<tmpl::list<OtherData>>>;
 using external_bdry_other_data_tag =
     external_boundary_tag<Tags::Variables<tmpl::list<OtherData>>>;
-using mortar_next_temporal_ids_tag = Tags::Mortars<Tags::Next<TemporalId>, Dim>;
-using mortar_meshes_tag = Tags::Mortars<Tags::Mesh<Dim - 1>, Dim>;
-using mortar_sizes_tag = Tags::Mortars<Tags::MortarSize<Dim - 1>, Dim>;
 
 template <typename Metavariables>
 struct component {
@@ -219,12 +199,11 @@ struct component {
   using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
 
   using simple_tags = db::AddSimpleTags<
-      TemporalId, Tags::Next<TemporalId>, Tags::Mesh<Dim>, Tags::Element<Dim>,
-      Tags::ElementMap<Dim>, bdry_normal_dot_fluxes_tag<flux_comm_types>,
-      bdry_other_data_tag, external_bdry_normal_dot_fluxes_tag<flux_comm_types>,
+      TemporalId, Tags::Mesh<Dim>, Tags::Element<Dim>, Tags::ElementMap<Dim>,
+      bdry_normal_dot_fluxes_tag<flux_comm_types>, bdry_other_data_tag,
+      external_bdry_normal_dot_fluxes_tag<flux_comm_types>,
       external_bdry_other_data_tag, external_bdry_vars_tag,
-      mortar_data_tag<flux_comm_types>, mortar_next_temporal_ids_tag,
-      mortar_meshes_tag, mortar_sizes_tag>;
+      mortar_data_tag<flux_comm_types>>;
 
   using compute_tags = db::AddComputeTags<
       Tags::Time, Tags::BoundaryDirectionsInterior<Dim>,
@@ -253,8 +232,7 @@ struct component {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
           tmpl::list<
-              dg::Actions::ImposeDirichletBoundaryConditions<Metavariables>,
-              dg::Actions::ReceiveDataForFluxes<Metavariables>>>>;
+              dg::Actions::ImposeDirichletBoundaryConditions<Metavariables>>>>;
 };
 
 template <bool HasPrimitiveAndConservativeVars>
@@ -270,30 +248,16 @@ struct Metavariables {
   enum class Phase { Initialization, Testing, Exit };
 };
 
-template <typename Component>
-using compute_items = typename Component::compute_tags;
-
 template <bool HasConservativeAndPrimitiveVars>
 void run_test() {
   using metavariables = Metavariables<HasConservativeAndPrimitiveVars>;
   using flux_comm_types = typename component<metavariables>::flux_comm_types;
   using my_component = component<metavariables>;
-  using simple_tags = typename my_component::simple_tags;
-  using compute_tags = typename my_component::compute_tags;
   const Mesh<2> mesh{3, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto};
 
-  //      xi      Block       +- xi
-  //      |     0   |   1     |
-  // eta -+ +-------+-+-+---+ eta
-  //        |       |X| |   |
-  //        |       +-+-+   |
-  //        |       | | |   |
-  //        +-------+-+-+---+
-  // We run the actions on the indicated element.
   const ElementId<2> self_id(1, {{{2, 0}, {1, 0}}});
   const ElementId<2> west_id(0);
-  const ElementId<2> east_id(1, {{{2, 1}, {1, 0}}});
   const ElementId<2> south_id(1, {{{2, 0}, {1, 1}}});
 
   using Affine = domain::CoordinateMaps::Affine;
@@ -343,7 +307,7 @@ void run_test() {
 
     auto map = ElementMap<2, Frame::Inertial>(self_id, coordmap->get_clone());
 
-    db::item_type<normal_dot_fluxes_tag<flux_comm_types>>
+    db::item_type<bdry_normal_dot_fluxes_tag<flux_comm_types>>
         bdry_normal_dot_fluxes;
     for (const auto& direction : external_directions) {
       auto& flux_vars = bdry_normal_dot_fluxes[direction];
@@ -351,14 +315,14 @@ void run_test() {
       get<Tags::NormalDotFlux<Var>>(flux_vars) = data.bdry_fluxes.at(direction);
     }
 
-    db::item_type<other_data_tag> bdry_other_data;
+    db::item_type<bdry_other_data_tag> bdry_other_data;
     for (const auto& direction : external_directions) {
       auto& other_data_vars = bdry_other_data[direction];
       other_data_vars.initialize(3);
       get<OtherData>(other_data_vars) = data.bdry_other_data.at(direction);
     }
 
-    db::item_type<normal_dot_fluxes_tag<flux_comm_types>>
+    db::item_type<external_bdry_normal_dot_fluxes_tag<flux_comm_types>>
         external_bdry_normal_dot_fluxes;
     for (const auto& direction : external_directions) {
       auto& flux_vars = external_bdry_normal_dot_fluxes[direction];
@@ -367,7 +331,7 @@ void run_test() {
           data.external_bdry_fluxes.at(direction);
     }
 
-    db::item_type<other_data_tag> external_bdry_other_data;
+    db::item_type<external_bdry_other_data_tag> external_bdry_other_data;
     for (const auto& direction : external_directions) {
       auto& other_data_vars = external_bdry_other_data[direction];
       other_data_vars.initialize(3);
@@ -384,35 +348,26 @@ void run_test() {
 
     const Slab slab(1.2, 3.4);
     const Time start = slab.start();
-    const Time end = slab.end();
 
     TimeId initial_time(true, 4, start);
-    TimeId next_time(true, 4, end);
 
     db::item_type<mortar_data_tag<flux_comm_types>> mortar_history{};
-    db::item_type<mortar_next_temporal_ids_tag> mortar_next_temporal_ids{};
-    db::item_type<mortar_meshes_tag> mortar_meshes{};
-    db::item_type<mortar_sizes_tag> mortar_sizes{};
     for (const auto& mortar_id : external_mortar_ids) {
       mortar_history.insert({mortar_id, {}});
-      mortar_next_temporal_ids.insert({mortar_id, initial_time});
-      mortar_meshes.insert({mortar_id, mesh.slice_away(0)});
-      mortar_sizes.insert({mortar_id, {{Spectral::MortarSize::Full}}});
     }
 
     ActionTesting::emplace_component_and_initialize<my_component>(
         &runner, self_id,
-        {initial_time, next_time, mesh, element, std::move(map),
+        {initial_time, mesh, element, std::move(map),
          std::move(bdry_normal_dot_fluxes), std::move(bdry_other_data),
          std::move(external_bdry_normal_dot_fluxes),
          std::move(external_bdry_other_data), std::move(external_bdry_vars),
-         std::move(mortar_history), std::move(mortar_next_temporal_ids),
-         std::move(mortar_meshes), std::move(mortar_sizes)});
+         std::move(mortar_history)});
   }
   runner.set_phase(metavariables::Phase::Testing);
 
-  ActionTesting::next_action<my_component>(make_not_null(&runner), self_id);
   CHECK(ActionTesting::is_ready<my_component>(runner, self_id));
+  ActionTesting::next_action<my_component>(make_not_null(&runner), self_id);
 
   // Check that BC's were indeed applied.
   const auto& external_vars =
@@ -429,15 +384,10 @@ void run_test() {
       Scalar<DataVector>({{{30., 40., 50.}}});
   CHECK(external_vars == expected_vars);
 
-  // ReceiveDataForFluxes
-  ActionTesting::next_action<my_component>(make_not_null(&runner), self_id);
-  const auto& self_box =
-      ActionTesting::get_databox<my_component,
-                                 tmpl::append<simple_tags, compute_tags>>(
-          runner, self_id);
-
   auto mortar_history = serialize_and_deserialize(
-      db::get<mortar_data_tag<flux_comm_types>>(self_box));
+      ActionTesting::get_databox_tag<my_component,
+                                     mortar_data_tag<flux_comm_types>>(
+          runner, self_id));
   CHECK(mortar_history.size() == 2);
   const auto check_mortar = [&mortar_history](
       const std::pair<Direction<2>, ElementId<2>>& mortar_id,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -38,7 +38,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -59,7 +59,7 @@
 namespace {
 constexpr size_t Dim = 2;
 
-using TemporalId = Tags::TimeId;
+using TemporalId = Tags::TimeStepId;
 
 struct Var : db::SimpleTag {
   static std::string name() noexcept { return "Var"; }
@@ -349,7 +349,7 @@ void run_test() {
     const Slab slab(1.2, 3.4);
     const Time start = slab.start();
 
-    TimeId initial_time(true, 4, start);
+    TimeStepId initial_time(true, 4, start);
 
     db::item_type<mortar_data_tag<flux_comm_types>> mortar_history{};
     for (const auto& mortar_id : external_mortar_ids) {

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -206,7 +206,7 @@ struct component {
       mortar_data_tag<flux_comm_types>>;
 
   using compute_tags = db::AddComputeTags<
-      Tags::Time, Tags::BoundaryDirectionsInterior<Dim>,
+      Tags::SubstepTime, Tags::BoundaryDirectionsInterior<Dim>,
       boundary_compute_tag<Tags::Direction<Dim>>,
       boundary_compute_tag<Tags::InterfaceMesh<Dim>>,
       boundary_compute_tag<Tags::UnnormalizedFaceNormalCompute<Dim>>,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -20,7 +20,7 @@
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -160,7 +160,7 @@ void test_interpolation_target(
   runner.set_phase(metavars::Phase::Testing);
 
   Slab slab(0.0, 1.0);
-  TimeId temporal_id(true, 0, Time(slab, 0));
+  TimeStepId temporal_id(true, 0, Time(slab, 0));
 
   ActionTesting::simple_action<
       target_component,
@@ -210,7 +210,7 @@ void test_interpolation_target(
   }
 
   // Call again at a different temporal_id
-  TimeId new_temporal_id(true, 0, Time(slab, 1));
+  TimeStepId new_temporal_id(true, 0, Time(slab, 1));
   ActionTesting::simple_action<
       target_component,
       typename metavars::InterpolationTargetA::compute_target_points>(

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -20,7 +20,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Rational.hpp"
 #include "Utilities/Requires.hpp"
@@ -74,7 +74,7 @@ struct MockComputeTargetPoints {
       const ArrayIndex& /*array_index*/,
       const typename Metavariables::temporal_id::type& temporal_id) noexcept {
     Slab slab(0.0, 1.0);
-    CHECK(temporal_id == TimeId(true, 0, Time(slab, 0)));
+    CHECK(temporal_id == TimeStepId(true, 0, Time(slab, 0)));
     // Put something in IndicesOfFilledInterpPts so we can check later whether
     // this function was called.  This isn't the usual usage of
     // IndicesOfFilledInterpPoints.
@@ -92,7 +92,7 @@ struct MockMetavariables {
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_target_points = MockComputeTargetPoints;
   };
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
 
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>>;
@@ -121,9 +121,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.AddTemporalIds",
             .empty());
 
   Slab slab(0.0, 1.0);
-  const std::vector<TimeId> temporal_ids = {
-      TimeId(true, 0, Time(slab, 0)),
-      TimeId(true, 0, Time(slab, Rational(1, 3)))};
+  const std::vector<TimeStepId> temporal_ids = {
+      TimeStepId(true, 0, Time(slab, 0)),
+      TimeStepId(true, 0, Time(slab, Rational(1, 3)))};
 
   runner.simple_action<target_component,
                        ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
@@ -132,7 +132,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.AddTemporalIds",
   CHECK(ActionTesting::get_databox_tag<target_component,
                                        ::intrp::Tags::TemporalIds<metavars>>(
             runner, 0) ==
-        std::deque<TimeId>(temporal_ids.begin(), temporal_ids.end()));
+        std::deque<TimeStepId>(temporal_ids.begin(), temporal_ids.end()));
 
   // Add the same temporal_ids again, which should do nothing...
   runner.simple_action<target_component,
@@ -142,7 +142,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.AddTemporalIds",
   CHECK(ActionTesting::get_databox_tag<target_component,
                                        ::intrp::Tags::TemporalIds<metavars>>(
             runner, 0) ==
-        std::deque<TimeId>(temporal_ids.begin(), temporal_ids.end()));
+        std::deque<TimeStepId>(temporal_ids.begin(), temporal_ids.end()));
 
   runner.invoke_queued_simple_action<target_component>(0);
 
@@ -153,9 +153,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.AddTemporalIds",
             .size() == 1);
 
   // Call again; it should not call MockComputeTargetPoints this time.
-  const std::vector<TimeId> temporal_ids_2 = {
-      TimeId(true, 0, Time(slab, Rational(2, 3))),
-      TimeId(true, 0, Time(slab, Rational(3, 3)))};
+  const std::vector<TimeStepId> temporal_ids_2 = {
+      TimeStepId(true, 0, Time(slab, Rational(2, 3))),
+      TimeStepId(true, 0, Time(slab, Rational(3, 3)))};
   runner.simple_action<target_component,
                        ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
                            metavars::InterpolationTargetA>>(0, temporal_ids_2);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
@@ -20,7 +20,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/Rational.hpp"
@@ -68,7 +68,7 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags =
@@ -84,7 +84,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.CleanUp", "[Unit]") {
   using interp_component = mock_interpolator<metavars>;
 
   Slab slab(0.0, 1.0);
-  TimeId temporal_id(true, 0, Time(slab, Rational(12, 13)));
+  TimeStepId temporal_id(true, 0, Time(slab, Rational(12, 13)));
 
   // Make a VolumeVarsInfo that contains a single temporal_id but
   // no data (since we don't need data for this test).

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -52,7 +52,7 @@ struct Metavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
 
   using component_list = tmpl::list<
       mock_interpolation_target<Metavariables, InterpolationTargetA>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
@@ -42,7 +42,7 @@ struct Metavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolatorTargetA>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -25,7 +25,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
@@ -64,7 +64,7 @@ struct Lapse : db::SimpleTag {
 struct MockInterpolatorReceiveVolumeData {
   struct Results {
     // Hardcode expected types here.
-    db::item_type<::Tags::TimeId> temporal_id{};
+    db::item_type<::Tags::TimeStepId> temporal_id{};
     ElementId<3> element_id{};
     Mesh<3> mesh{};
     Variables<tmpl::list<Tags::Lapse>> vars{};
@@ -128,7 +128,7 @@ struct MockMetavariables {
   struct InterpolatorTargetA {
     using vars_to_interpolate_to_target = tmpl::list<Tags::Lapse>;
   };
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<Tags::Lapse>;
   using interpolation_target_tags = tmpl::list<InterpolatorTargetA>;
@@ -167,7 +167,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
   const auto box = db::create<db::AddSimpleTags<
       metavars::temporal_id, ::Tags::Mesh<metavars::volume_dim>,
       ::Tags::Variables<typename decltype(vars)::tags_list>>>(
-      TimeId(true, 0, Slab(0., observation_time).end()), mesh, vars);
+      TimeStepId(true, 0, Slab(0., observation_time).end()), mesh, vars);
 
   intrp::Events::Interpolate<metavars::volume_dim,
                              metavars::interpolator_source_vars> event{};

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -183,7 +183,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
   CHECK(runner.is_simple_action_queue_empty<elem_component>(array_index));
 
   const auto& results = MockInterpolatorReceiveVolumeData::results;
-  CHECK(results.temporal_id.time().value() == observation_time);
+  CHECK(results.temporal_id.substep_time().value() == observation_time);
   CHECK(results.element_id == element_id);
   CHECK(results.mesh == mesh);
   CHECK(results.vars == vars);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -37,7 +37,7 @@ struct MockMetavariables {
                                           ::Frame::Inertial>;
     using type = compute_target_points::options_type;
   };
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -33,7 +33,7 @@ struct MockMetavariables {
         ::intrp::Actions::KerrHorizon<InterpolationTargetA, ::Frame::Inertial>;
     using type = compute_target_points::options_type;
   };
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -29,7 +29,7 @@ struct MockMetavariables {
         ::intrp::Actions::LineSegment<InterpolationTargetA, 3>;
     using type = compute_target_points::options_type;
   };
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -26,7 +26,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -101,7 +101,7 @@ struct MockCleanUpInterpolator {
       const ArrayIndex& /*array_index*/,
       const typename Metavariables::temporal_id::type& temporal_id) noexcept {
     Slab slab(0.0, 1.0);
-    CHECK(temporal_id == TimeId(true, 0, Time(slab, Rational(13, 15))));
+    CHECK(temporal_id == TimeStepId(true, 0, Time(slab, Rational(13, 15))));
     // Put something in NumberOfElements so we can check later whether
     // this function was called.  This isn't the usual usage of
     // NumberOfElements.
@@ -123,7 +123,7 @@ struct MockComputeTargetPoints {
       const ArrayIndex& /*array_index*/,
       const typename Metavariables::temporal_id::type& temporal_id) noexcept {
     Slab slab(0.0, 1.0);
-    CHECK(temporal_id == TimeId(true, 0, Time(slab, Rational(14, 15))));
+    CHECK(temporal_id == TimeStepId(true, 0, Time(slab, Rational(14, 15))));
     // Increment IndicesOfFilledInterpPoints so we can check later
     // whether this function was called.  This isn't the usual usage
     // of IndicesOfFilledInterpPoints; this is done only for the test.
@@ -156,7 +156,7 @@ template <typename DbTags, typename TemporalId>
 void callback_impl(const db::DataBox<DbTags>& box,
                    const TemporalId& temporal_id) noexcept {
   Slab slab(0.0, 1.0);
-  CHECK(temporal_id == TimeId(true, 0, Time(slab, Rational(13, 15))));
+  CHECK(temporal_id == TimeStepId(true, 0, Time(slab, Rational(13, 15))));
   // The result should be the square of the first 10 integers, in
   // a Scalar<DataVector>.
   const Scalar<DataVector> expected{
@@ -222,7 +222,7 @@ struct MockMetavariables {
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
 
   using component_list = tmpl::list<
@@ -253,8 +253,8 @@ void test_interpolation_target_receive_vars() noexcept {
       &runner, 0,
       {db::item_type<intrp::Tags::IndicesOfFilledInterpPoints>{},
        db::item_type<typename intrp::Tags::TemporalIds<metavars>>{
-           TimeId(true, 0, Time(slab, Rational(13, 15))),
-           TimeId(true, 0, Time(slab, Rational(14, 15)))},
+           TimeStepId(true, 0, Time(slab, Rational(13, 15))),
+           TimeStepId(true, 0, Time(slab, Rational(14, 15)))},
        db::item_type<typename intrp::Tags::CompletedTemporalIds<metavars>>{},
        db::item_type<::Tags::Variables<typename metavars::InterpolationTargetA::
                                            vars_to_interpolate_to_target>>{
@@ -405,7 +405,7 @@ void test_interpolation_target_receive_vars() noexcept {
     CHECK(ActionTesting::get_databox_tag<
               target_component, intrp::Tags::CompletedTemporalIds<metavars>>(
               runner, 0)
-              .front() == TimeId(true, 0, Time(slab, Rational(13, 15))));
+              .front() == TimeStepId(true, 0, Time(slab, Rational(13, 15))));
 
     // And there is yet one more simple action, compute_target_points,
     // which here we mock just to check that it is called.

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -31,7 +31,7 @@ struct MockMetavariables {
         ::intrp::Actions::WedgeSectionTorus<InterpolationTargetA>;
     using type = compute_target_points::options_type;
   };
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -30,7 +30,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Rational.hpp"
 #include "Utilities/Requires.hpp"
@@ -151,7 +151,7 @@ struct Metavariables {
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
   using component_list =
       tmpl::list<mock_interpolation_target<Metavariables, InterpolationTargetA>,
@@ -197,7 +197,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceivePoints",
   }
   ();
   Slab slab(0.0, 1.0);
-  TimeId temporal_id(true, 0, Time(slab, Rational(11, 15)));
+  TimeStepId temporal_id(true, 0, Time(slab, Rational(11, 15)));
 
   runner.simple_action<
       mock_interpolator<metavars>,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -44,7 +44,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
@@ -148,7 +148,7 @@ struct MockInterpolationTargetReceiveVars {
     // This is not the usual usage of Tags::TemporalIds; this is done just
     // for the test.
     Slab slab(0.0, 1.0);
-    TimeId temporal_id(true, 0, Time(slab, Rational(111, 135)));
+    TimeStepId temporal_id(true, 0, Time(slab, Rational(111, 135)));
     db::mutate<intrp::Tags::TemporalIds<Metavariables>>(
         make_not_null(&box), [&temporal_id](
                                  const gsl::not_null<db::item_type<
@@ -233,7 +233,7 @@ struct MockMetavariables {
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
@@ -254,7 +254,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceiveVolumeData",
       domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{7, 7}}, false);
   const auto domain = domain_creator.create_domain();
   Slab slab(0.0, 1.0);
-  TimeId temporal_id(true, 0, Time(slab, Rational(11, 15)));
+  TimeStepId temporal_id(true, 0, Time(slab, Rational(11, 15)));
   auto vars_holders = [&domain, &temporal_id]() {
     const size_t n_pts = 15;
     tnsr::I<DataVector, 3, Frame::Inertial> points(n_pts);
@@ -354,7 +354,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceiveVolumeData",
                                        intrp::Tags::TemporalIds<metavars>>(
             runner, 0)
             .front() ==
-        TimeId(true, 0, Time(Slab(0.0, 1.0), Rational(111, 135))));
+        TimeStepId(true, 0, Time(Slab(0.0, 1.0), Rational(111, 135))));
 
   // No more queued simple actions.
   CHECK(runner.is_simple_action_queue_empty<target_component>(0));

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -67,7 +67,7 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolatorTargetA>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -56,7 +56,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
@@ -269,7 +269,7 @@ struct MockMetavariables {
       tmpl::list<Tags::TestSolution,
                  gr::Tags::SpatialMetric<3, Frame::Inertial>>;
   using interpolation_target_tags = tmpl::list<SurfaceA, SurfaceB, SurfaceC>;
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
   using component_list =
       tmpl::list<MockObserverWriter<MockMetavariables>,
@@ -331,7 +331,7 @@ SPECTRE_TEST_CASE(
   runner.set_phase(metavars::Phase::Registration);
 
   Slab slab(0.0, 1.0);
-  TimeId temporal_id(true, 0, Time(slab, 0));
+  TimeStepId temporal_id(true, 0, Time(slab, 0));
   const auto domain = domain_creator.create_domain();
 
   // Create element_ids.
@@ -361,15 +361,15 @@ SPECTRE_TEST_CASE(
   ActionTesting::simple_action<
       target_a_component,
       intrp::Actions::AddTemporalIdsToInterpolationTarget<metavars::SurfaceA>>(
-      make_not_null(&runner), 0, std::vector<TimeId>{temporal_id});
+      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
   ActionTesting::simple_action<
       target_b_component,
       intrp::Actions::AddTemporalIdsToInterpolationTarget<metavars::SurfaceB>>(
-      make_not_null(&runner), 0, std::vector<TimeId>{temporal_id});
+      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
   ActionTesting::simple_action<
       target_c_component,
       intrp::Actions::AddTemporalIdsToInterpolationTarget<metavars::SurfaceC>>(
-      make_not_null(&runner), 0, std::vector<TimeId>{temporal_id});
+      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
 
   // There should be three queued simple actions (registration), so invoke
   // them and check that there are no more.

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -44,7 +44,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
@@ -249,7 +249,7 @@ struct MockMetavariables {
   using interpolation_target_tags =
       tmpl::list<InterpolationTargetA, InterpolationTargetB,
                  InterpolationTargetC>;
-  using temporal_id = ::Tags::TimeId;
+  using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
@@ -302,7 +302,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
   runner.set_phase(metavars::Phase::Registration);
 
   Slab slab(0.0, 1.0);
-  TimeId temporal_id(true, 0, Time(slab, 0));
+  TimeStepId temporal_id(true, 0, Time(slab, 0));
   const auto domain = domain_creator.create_domain();
 
   // Create Element_ids.
@@ -327,15 +327,15 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
   ActionTesting::simple_action<
       target_a_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               metavars::InterpolationTargetA>>(
-      make_not_null(&runner), 0, std::vector<TimeId>{temporal_id});
+      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
   ActionTesting::simple_action<
       target_b_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               metavars::InterpolationTargetB>>(
-      make_not_null(&runner), 0, std::vector<TimeId>{temporal_id});
+      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
   ActionTesting::simple_action<
       target_c_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               metavars::InterpolationTargetC>>(
-      make_not_null(&runner), 0, std::vector<TimeId>{temporal_id});
+      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
 
   // Create volume data and send it to the interpolator.
   for (const auto& element_id : element_ids) {
@@ -384,7 +384,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
   ActionTesting::simple_action<
       target_a_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               metavars::InterpolationTargetA>>(
-      make_not_null(&runner), 0, std::vector<TimeId>{temporal_id});
+      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
   // ...so make sure it was ignored by checking that there isn't anything
   // else in the simple_action queue of the target or the interpolator.
   CHECK(ActionTesting::is_simple_action_queue_empty<target_a_component>(runner,

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -89,7 +89,7 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
           runner, 0);
   const auto& final_time_id = db::get<Tags::TimeId>(box);
   const auto expected_slab = start.slab().advance_towards(time_step);
-  CHECK(final_time_id.time().slab() == expected_slab);
+  CHECK(final_time_id.step_time().slab() == expected_slab);
   CHECK(final_time_id ==
         TimeId(time_step.is_positive(), 8, start + 2 * time_step));
   CHECK(db::get<Tags::TimeStep>(box) == time_step.with_slab(expected_slab));
@@ -121,7 +121,7 @@ void check_abn(const Time& start, const TimeDelta& time_step) {
           runner, 0);
   const auto& final_time_id = db::get<Tags::TimeId>(box);
   const auto expected_slab = start.slab().advance_towards(time_step);
-  CHECK(final_time_id.time().slab() == expected_slab);
+  CHECK(final_time_id.step_time().slab() == expected_slab);
   CHECK(final_time_id ==
         TimeId(time_step.is_positive(), 8, start + 2 * time_step));
   CHECK(db::get<Tags::TimeStep>(box) == time_step.with_slab(expected_slab));

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -37,8 +37,8 @@ struct Component {
   using const_global_cache_tag_list =
       tmpl::list<Tags::TimeStepper<TimeStepper>>;
 
-  using simple_tags =
-      db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep>;
+  using simple_tags = db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>,
+                                        Tags::TimeStep, Tags::Time>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -67,7 +67,7 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
       &runner, 0,
       {TimeId(time_step.is_positive(), 8, start),
        TimeId(time_step.is_positive(), 8, start, 1, start + substep_offsets[1]),
-       time_step});
+       time_step, start.value()});
   runner.set_phase(Metavariables::Phase::Testing);
 
   for (const auto& step_start : {start, start + time_step}) {
@@ -76,10 +76,13 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
           ActionTesting::get_databox<component,
                                      typename component::simple_tags>(runner,
                                                                       0);
+      const Time substep_time = step_start + gsl::at(substep_offsets, substep);
       CHECK(db::get<Tags::TimeId>(box) ==
             TimeId(time_step.is_positive(), 8, step_start, substep,
-                   step_start + gsl::at(substep_offsets, substep)));
+                   substep_time));
       CHECK(db::get<Tags::TimeStep>(box) == time_step);
+      CHECK(db::get<Tags::Time>(box) ==
+            db::get<Tags::TimeId>(box).substep_time().value());
       runner.next_action<component>(0);
     }
   }
@@ -92,6 +95,7 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
   CHECK(final_time_id.step_time().slab() == expected_slab);
   CHECK(final_time_id ==
         TimeId(time_step.is_positive(), 8, start + 2 * time_step));
+  CHECK(db::get<Tags::Time>(box) == final_time_id.substep_time().value());
   CHECK(db::get<Tags::TimeStep>(box) == time_step.with_slab(expected_slab));
 }
 
@@ -103,7 +107,8 @@ void check_abn(const Time& start, const TimeDelta& time_step) {
   ActionTesting::emplace_component_and_initialize<component>(
       &runner, 0,
       {TimeId(time_step.is_positive(), 8, start),
-       TimeId(time_step.is_positive(), 8, start + time_step), time_step});
+       TimeId(time_step.is_positive(), 8, start + time_step), time_step,
+       start.value()});
   runner.set_phase(Metavariables::Phase::Testing);
 
   for (const auto& step_start : {start, start + time_step}) {
@@ -113,6 +118,8 @@ void check_abn(const Time& start, const TimeDelta& time_step) {
     CHECK(db::get<Tags::TimeId>(box) ==
           TimeId(time_step.is_positive(), 8, step_start));
     CHECK(db::get<Tags::TimeStep>(box) == time_step);
+    CHECK(db::get<Tags::Time>(box) ==
+          db::get<Tags::TimeId>(box).substep_time().value());
     runner.next_action<component>(0);
   }
 
@@ -124,6 +131,7 @@ void check_abn(const Time& start, const TimeDelta& time_step) {
   CHECK(final_time_id.step_time().slab() == expected_slab);
   CHECK(final_time_id ==
         TimeId(time_step.is_positive(), 8, start + 2 * time_step));
+  CHECK(db::get<Tags::Time>(box) == final_time_id.substep_time().value());
   CHECK(db::get<Tags::TimeStep>(box) == time_step.with_slab(expected_slab));
 }
 }  // namespace

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -14,7 +14,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"  // IWYU pragma: keep
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Time/TimeSteppers/AdamsBashforthN.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Utilities/Gsl.hpp"
@@ -37,8 +37,9 @@ struct Component {
   using const_global_cache_tag_list =
       tmpl::list<Tags::TimeStepper<TimeStepper>>;
 
-  using simple_tags = db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>,
-                                        Tags::TimeStep, Tags::Time>;
+  using simple_tags =
+      db::AddSimpleTags<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>,
+                        Tags::TimeStep, Tags::Time>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -65,8 +66,9 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
   MockRuntimeSystem runner{{std::make_unique<TimeSteppers::RungeKutta3>()}};
   ActionTesting::emplace_component_and_initialize<component>(
       &runner, 0,
-      {TimeId(time_step.is_positive(), 8, start),
-       TimeId(time_step.is_positive(), 8, start, 1, start + substep_offsets[1]),
+      {TimeStepId(time_step.is_positive(), 8, start),
+       TimeStepId(time_step.is_positive(), 8, start, 1,
+                  start + substep_offsets[1]),
        time_step, start.value()});
   runner.set_phase(Metavariables::Phase::Testing);
 
@@ -77,12 +79,12 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
                                      typename component::simple_tags>(runner,
                                                                       0);
       const Time substep_time = step_start + gsl::at(substep_offsets, substep);
-      CHECK(db::get<Tags::TimeId>(box) ==
-            TimeId(time_step.is_positive(), 8, step_start, substep,
-                   substep_time));
+      CHECK(db::get<Tags::TimeStepId>(box) ==
+            TimeStepId(time_step.is_positive(), 8, step_start, substep,
+                       substep_time));
       CHECK(db::get<Tags::TimeStep>(box) == time_step);
       CHECK(db::get<Tags::Time>(box) ==
-            db::get<Tags::TimeId>(box).substep_time().value());
+            db::get<Tags::TimeStepId>(box).substep_time().value());
       runner.next_action<component>(0);
     }
   }
@@ -90,11 +92,11 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
   const auto& box =
       ActionTesting::get_databox<component, typename component::simple_tags>(
           runner, 0);
-  const auto& final_time_id = db::get<Tags::TimeId>(box);
+  const auto& final_time_id = db::get<Tags::TimeStepId>(box);
   const auto expected_slab = start.slab().advance_towards(time_step);
   CHECK(final_time_id.step_time().slab() == expected_slab);
   CHECK(final_time_id ==
-        TimeId(time_step.is_positive(), 8, start + 2 * time_step));
+        TimeStepId(time_step.is_positive(), 8, start + 2 * time_step));
   CHECK(db::get<Tags::Time>(box) == final_time_id.substep_time().value());
   CHECK(db::get<Tags::TimeStep>(box) == time_step.with_slab(expected_slab));
 }
@@ -106,8 +108,8 @@ void check_abn(const Time& start, const TimeDelta& time_step) {
       {std::make_unique<TimeSteppers::AdamsBashforthN>(1)}};
   ActionTesting::emplace_component_and_initialize<component>(
       &runner, 0,
-      {TimeId(time_step.is_positive(), 8, start),
-       TimeId(time_step.is_positive(), 8, start + time_step), time_step,
+      {TimeStepId(time_step.is_positive(), 8, start),
+       TimeStepId(time_step.is_positive(), 8, start + time_step), time_step,
        start.value()});
   runner.set_phase(Metavariables::Phase::Testing);
 
@@ -115,22 +117,22 @@ void check_abn(const Time& start, const TimeDelta& time_step) {
     const auto& box =
         ActionTesting::get_databox<component, typename component::simple_tags>(
             runner, 0);
-    CHECK(db::get<Tags::TimeId>(box) ==
-          TimeId(time_step.is_positive(), 8, step_start));
+    CHECK(db::get<Tags::TimeStepId>(box) ==
+          TimeStepId(time_step.is_positive(), 8, step_start));
     CHECK(db::get<Tags::TimeStep>(box) == time_step);
     CHECK(db::get<Tags::Time>(box) ==
-          db::get<Tags::TimeId>(box).substep_time().value());
+          db::get<Tags::TimeStepId>(box).substep_time().value());
     runner.next_action<component>(0);
   }
 
   const auto& box =
       ActionTesting::get_databox<component, typename component::simple_tags>(
           runner, 0);
-  const auto& final_time_id = db::get<Tags::TimeId>(box);
+  const auto& final_time_id = db::get<Tags::TimeStepId>(box);
   const auto expected_slab = start.slab().advance_towards(time_step);
   CHECK(final_time_id.step_time().slab() == expected_slab);
   CHECK(final_time_id ==
-        TimeId(time_step.is_positive(), 8, start + 2 * time_step));
+        TimeStepId(time_step.is_positive(), 8, start + 2 * time_step));
   CHECK(db::get<Tags::Time>(box) == final_time_id.substep_time().value());
   CHECK(db::get<Tags::TimeStep>(box) == time_step.with_slab(expected_slab));
 }

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -19,7 +19,7 @@
 #include "Time/StepControllers/BinaryFraction.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Time/TimeSteppers/AdamsBashforthN.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Gsl.hpp"
@@ -54,7 +54,7 @@ struct Component {
   using array_index = int;
   using const_global_cache_tag_list =
       tmpl::list<Tags::TimeStepper<LtsTimeStepper>>;
-  using simple_tags = tmpl::list<Tags::TimeId, Tags::Next<Tags::TimeId>,
+  using simple_tags = tmpl::list<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>,
                                  Tags::TimeStep, history_tag>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -97,10 +97,11 @@ void check(const bool time_runs_forward,
   // Initialize the component
   ActionTesting::emplace_component_and_initialize<component>(
       &runner, 0,
-      {TimeId(time_runs_forward, 0, time),
-       TimeId(time_runs_forward, 0,
-              (time_runs_forward ? time.slab().start() : time.slab().end()) +
-                  initial_step_size),
+      {TimeStepId(time_runs_forward, 0, time),
+       TimeStepId(
+           time_runs_forward, 0,
+           (time_runs_forward ? time.slab().start() : time.slab().end()) +
+               initial_step_size),
        initial_step_size, db::item_type<history_tag>{}});
 
   runner.set_phase(Metavariables::Phase::Testing);
@@ -110,8 +111,8 @@ void check(const bool time_runs_forward,
           runner, 0);
 
   CHECK(db::get<Tags::TimeStep>(box) == expected_step);
-  CHECK(db::get<Tags::Next<Tags::TimeId>>(box) ==
-        TimeId(time_runs_forward, 0, time + expected_step));
+  CHECK(db::get<Tags::Next<Tags::TimeStepId>>(box) ==
+        TimeStepId(time_runs_forward, 0, time + expected_step));
 }
 }  // namespace
 

--- a/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
+++ b/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
@@ -14,7 +14,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
@@ -46,7 +46,7 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
   using const_global_cache_tag_list = tmpl::list<>;
-  using simple_tags = db::AddSimpleTags<Tags::TimeId, variables_tag,
+  using simple_tags = db::AddSimpleTags<Tags::TimeStepId, variables_tag,
                                         dt_variables_tag, history_tag>;
   using compute_tags = db::AddComputeTags<Tags::SubstepTime>;
   using phase_dependent_action_list = tmpl::list<
@@ -70,7 +70,7 @@ struct Metavariables {
 SPECTRE_TEST_CASE("Unit.Time.Actions.RecordTimeStepperData",
                   "[Unit][Time][Actions]") {
   const Slab slab(1., 3.);
-  const TimeId time_id(true, 8, slab.start());
+  const TimeStepId time_id(true, 8, slab.start());
 
   history_tag::type history{};
   history.insert(slab.end(), 2., 3.);

--- a/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
+++ b/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
@@ -48,7 +48,7 @@ struct Component {
   using const_global_cache_tag_list = tmpl::list<>;
   using simple_tags = db::AddSimpleTags<Tags::TimeId, variables_tag,
                                         dt_variables_tag, history_tag>;
-  using compute_tags = db::AddComputeTags<Tags::Time>;
+  using compute_tags = db::AddComputeTags<Tags::SubstepTime>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>  // IWYU pragma: keep
+#include <limits>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -126,7 +127,8 @@ struct Component {
       typename metavariables::system::test_primitive_variables_tags,
       db::add_tag_prefix<Tags::dt,
                          typename metavariables::system::variables_tag>,
-      history_tag, Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep>>;
+      history_tag, Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep,
+      Tags::Time>>;
   using compute_tags = db::AddComputeTags<Tags::SubstepTime>;
 
   static constexpr bool has_primitives = Metavariables::has_primitives;
@@ -165,7 +167,7 @@ void emplace_component_and_initialize(
       runner, 0,
       {initial_value, 0., db::item_type<history_tag>{}, TimeId{},
        TimeId(forward_in_time, 1 - static_cast<int64_t>(order), initial_time),
-       initial_time_step});
+       initial_time_step, std::numeric_limits<double>::signaling_NaN()});
 }
 
 template <>
@@ -179,7 +181,7 @@ void emplace_component_and_initialize<true>(
       runner, 0,
       {initial_value, initial_value, 0., db::item_type<history_tag>{}, TimeId{},
        TimeId(forward_in_time, 1 - static_cast<int64_t>(order), initial_time),
-       initial_time_step});
+       initial_time_step, std::numeric_limits<double>::signaling_NaN()});
 }
 
 namespace detail {

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -303,7 +303,7 @@ void test_actions(const size_t order, const bool forward_in_time) noexcept {
         const auto next_time =
             ActionTesting::get_databox_tag<Component<Metavariables<>>,
                                            Tags::Next<Tags::TimeId>>(runner, 0)
-                .time();
+                .step_time();
         CHECK((next_time == initial_time) == last_point);
       }
       {

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -127,7 +127,7 @@ struct Component {
       db::add_tag_prefix<Tags::dt,
                          typename metavariables::system::variables_tag>,
       history_tag, Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep>>;
-  using compute_tags = db::AddComputeTags<Tags::Time>;
+  using compute_tags = db::AddComputeTags<Tags::SubstepTime>;
 
   static constexpr bool has_primitives = Metavariables::has_primitives;
 
@@ -298,7 +298,7 @@ void test_actions(const size_t order, const bool forward_in_time) noexcept {
             not_self_start_action>(make_not_null(&runner));
         CHECK(not jumped);
         CHECK(abs(ActionTesting::get_databox_tag<Component<Metavariables<>>,
-                                                 Tags::Time>(runner, 0) -
+                                                 Tags::SubstepTime>(runner, 0) -
                   initial_time) < abs(initial_time_step));
         const auto next_time =
             ActionTesting::get_databox_tag<Component<Metavariables<>>,

--- a/tests/Unit/Time/CMakeLists.txt
+++ b/tests/Unit/Time/CMakeLists.txt
@@ -11,7 +11,7 @@ set(LIBRARY_SOURCES
   Test_Slab.cpp
   Test_SpecifiedSlabs.cpp
   Test_Time.cpp
-  Test_TimeId.cpp
+  Test_TimeStepId.cpp
   )
 
 add_subdirectory(Actions)

--- a/tests/Unit/Time/Test_EveryNSlabs.cpp
+++ b/tests/Unit/Time/Test_EveryNSlabs.cpp
@@ -14,7 +14,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Time/Triggers/EveryNSlabs.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -35,21 +35,21 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.EveryNSlabs", "[Unit][Time]") {
   const auto sent_trigger = serialize_and_deserialize(trigger);
 
   const Slab slab(0., 1.);
-  auto box = db::create<db::AddSimpleTags<Tags::TimeId>>(
-      TimeId(true, 0, slab.start()));
+  auto box = db::create<db::AddSimpleTags<Tags::TimeStepId>>(
+      TimeStepId(true, 0, slab.start()));
   for (const bool expected :
        {false, false, false, false, false, true, false, false, true, false}) {
     CHECK(sent_trigger->is_triggered(box) == expected);
-    db::mutate<Tags::TimeId>(
-        make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {
-          *time_id = TimeId(true, time_id->slab_number(), time_id->step_time(),
+    db::mutate<Tags::TimeStepId>(make_not_null(&box), [
+    ](const gsl::not_null<TimeStepId*> time_id) noexcept {
+      *time_id = TimeStepId(true, time_id->slab_number(), time_id->step_time(),
                             1, time_id->step_time());
-        });
+    });
     CHECK_FALSE(sent_trigger->is_triggered(box));
-    db::mutate<Tags::TimeId>(
-        make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {
-          *time_id =
-              TimeId(true, time_id->slab_number() + 1, time_id->step_time());
-        });
+    db::mutate<Tags::TimeStepId>(make_not_null(&box), [
+    ](const gsl::not_null<TimeStepId*> time_id) noexcept {
+      *time_id =
+          TimeStepId(true, time_id->slab_number() + 1, time_id->step_time());
+    });
   }
 }

--- a/tests/Unit/Time/Test_EveryNSlabs.cpp
+++ b/tests/Unit/Time/Test_EveryNSlabs.cpp
@@ -42,13 +42,14 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.EveryNSlabs", "[Unit][Time]") {
     CHECK(sent_trigger->is_triggered(box) == expected);
     db::mutate<Tags::TimeId>(
         make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {
-          *time_id = TimeId(true, time_id->slab_number(), time_id->time(), 1,
-                            time_id->time());
+          *time_id = TimeId(true, time_id->slab_number(), time_id->step_time(),
+                            1, time_id->step_time());
         });
     CHECK_FALSE(sent_trigger->is_triggered(box));
     db::mutate<Tags::TimeId>(
         make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {
-          *time_id = TimeId(true, time_id->slab_number() + 1, time_id->time());
+          *time_id =
+              TimeId(true, time_id->slab_number() + 1, time_id->step_time());
         });
   }
 }

--- a/tests/Unit/Time/Test_History.cpp
+++ b/tests/Unit/Time/Test_History.cpp
@@ -14,7 +14,7 @@
 #include "Time/History.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -22,7 +22,9 @@
 namespace {
 Time make_time(const double t) noexcept { return Slab(t, t + 0.5).start(); }
 
-TimeId make_time_id(const double t) noexcept { return {true, 0, make_time(t)}; }
+TimeStepId make_time_id(const double t) noexcept {
+  return {true, 0, make_time(t)};
+}
 
 // Requires `it` to point at 0. in the sequence of times -1., 0., 1., 2.
 template <typename Iterator>

--- a/tests/Unit/Time/Test_PastTime.cpp
+++ b/tests/Unit/Time/Test_PastTime.cpp
@@ -43,7 +43,7 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.PastTime", "[Unit][Time]") {
         make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {
           *time_id =
               TimeId(time_id->time_runs_forward(), time_id->slab_number(),
-                     time_id->time(), 1, time_id->time());
+                     time_id->step_time(), 1, time_id->step_time());
         });
     CHECK_FALSE(sent_trigger->is_triggered(box));
   };

--- a/tests/Unit/Time/Test_PastTime.cpp
+++ b/tests/Unit/Time/Test_PastTime.cpp
@@ -32,12 +32,11 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.PastTime", "[Unit][Time]") {
 
   const Slab slab(-10., 10.);
 
-  const auto check = [&sent_trigger](const Time& time,
-                                     const bool time_runs_forward,
-                                     const bool expected) noexcept {
-    auto box = db::create<db::AddSimpleTags<Tags::TimeId>,
-                          db::AddComputeTags<Tags::SubstepTime>>(
-        TimeId(time_runs_forward, 0, time));
+  const auto check = [&sent_trigger, &slab](const Time& time,
+                                            const bool time_runs_forward,
+                                            const bool expected) noexcept {
+    auto box = db::create<db::AddSimpleTags<Tags::TimeId, Tags::Time>>(
+        TimeId(time_runs_forward, 0, slab.start()), time.value());
     CHECK(sent_trigger->is_triggered(box) == expected);
     db::mutate<Tags::TimeId>(
         make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {

--- a/tests/Unit/Time/Test_PastTime.cpp
+++ b/tests/Unit/Time/Test_PastTime.cpp
@@ -36,7 +36,7 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.PastTime", "[Unit][Time]") {
                                      const bool time_runs_forward,
                                      const bool expected) noexcept {
     auto box = db::create<db::AddSimpleTags<Tags::TimeId>,
-                          db::AddComputeTags<Tags::Time>>(
+                          db::AddComputeTags<Tags::SubstepTime>>(
         TimeId(time_runs_forward, 0, time));
     CHECK(sent_trigger->is_triggered(box) == expected);
     db::mutate<Tags::TimeId>(

--- a/tests/Unit/Time/Test_PastTime.cpp
+++ b/tests/Unit/Time/Test_PastTime.cpp
@@ -13,7 +13,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Time/Triggers/PastTime.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -35,15 +35,15 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.PastTime", "[Unit][Time]") {
   const auto check = [&sent_trigger, &slab](const Time& time,
                                             const bool time_runs_forward,
                                             const bool expected) noexcept {
-    auto box = db::create<db::AddSimpleTags<Tags::TimeId, Tags::Time>>(
-        TimeId(time_runs_forward, 0, slab.start()), time.value());
+    auto box = db::create<db::AddSimpleTags<Tags::TimeStepId, Tags::Time>>(
+        TimeStepId(time_runs_forward, 0, slab.start()), time.value());
     CHECK(sent_trigger->is_triggered(box) == expected);
-    db::mutate<Tags::TimeId>(
-        make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {
-          *time_id =
-              TimeId(time_id->time_runs_forward(), time_id->slab_number(),
+    db::mutate<Tags::TimeStepId>(make_not_null(&box), [
+    ](const gsl::not_null<TimeStepId*> time_id) noexcept {
+      *time_id =
+          TimeStepId(time_id->time_runs_forward(), time_id->slab_number(),
                      time_id->step_time(), 1, time_id->step_time());
-        });
+    });
     CHECK_FALSE(sent_trigger->is_triggered(box));
   };
   check(slab.start(), true, false);

--- a/tests/Unit/Time/Test_SpecifiedSlabs.cpp
+++ b/tests/Unit/Time/Test_SpecifiedSlabs.cpp
@@ -41,13 +41,14 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.SpecifiedSlabs", "[Unit][Time]") {
     CHECK(sent_trigger->is_triggered(box) == expected);
     db::mutate<Tags::TimeId>(
         make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {
-          *time_id = TimeId(true, time_id->slab_number(), time_id->time(), 1,
-                            time_id->time());
+          *time_id = TimeId(true, time_id->slab_number(), time_id->step_time(),
+                            1, time_id->step_time());
         });
     CHECK_FALSE(sent_trigger->is_triggered(box));
     db::mutate<Tags::TimeId>(
         make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {
-          *time_id = TimeId(true, time_id->slab_number() + 1, time_id->time());
+          *time_id =
+              TimeId(true, time_id->slab_number() + 1, time_id->step_time());
         });
   }
 }

--- a/tests/Unit/Time/Test_SpecifiedSlabs.cpp
+++ b/tests/Unit/Time/Test_SpecifiedSlabs.cpp
@@ -14,7 +14,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Time/Triggers/SpecifiedSlabs.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -34,21 +34,21 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.SpecifiedSlabs", "[Unit][Time]") {
   const auto sent_trigger = serialize_and_deserialize(trigger);
 
   const Slab slab(0., 1.);
-  auto box = db::create<db::AddSimpleTags<Tags::TimeId>>(
-      TimeId(true, 0, slab.start()));
+  auto box = db::create<db::AddSimpleTags<Tags::TimeStepId>>(
+      TimeStepId(true, 0, slab.start()));
   for (const bool expected :
        {false, false, false, true, false, false, true, false, true, false}) {
     CHECK(sent_trigger->is_triggered(box) == expected);
-    db::mutate<Tags::TimeId>(
-        make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {
-          *time_id = TimeId(true, time_id->slab_number(), time_id->step_time(),
+    db::mutate<Tags::TimeStepId>(make_not_null(&box), [
+    ](const gsl::not_null<TimeStepId*> time_id) noexcept {
+      *time_id = TimeStepId(true, time_id->slab_number(), time_id->step_time(),
                             1, time_id->step_time());
-        });
+    });
     CHECK_FALSE(sent_trigger->is_triggered(box));
-    db::mutate<Tags::TimeId>(
-        make_not_null(&box), [](const gsl::not_null<TimeId*> time_id) noexcept {
-          *time_id =
-              TimeId(true, time_id->slab_number() + 1, time_id->step_time());
-        });
+    db::mutate<Tags::TimeStepId>(make_not_null(&box), [
+    ](const gsl::not_null<TimeStepId*> time_id) noexcept {
+      *time_id =
+          TimeStepId(true, time_id->slab_number() + 1, time_id->step_time());
+    });
   }
 }

--- a/tests/Unit/Time/Test_TimeId.cpp
+++ b/tests/Unit/Time/Test_TimeId.cpp
@@ -43,9 +43,9 @@ void check(const bool time_runs_forward) noexcept {
   CHECK(TimeId(time_runs_forward, 4, end).is_at_slab_boundary());
 
   CHECK(TimeId(time_runs_forward, 5, start).slab_number() == 5);
-  CHECK(TimeId(time_runs_forward, 5, start).time().slab() == slab);
+  CHECK(TimeId(time_runs_forward, 5, start).substep_time().slab() == slab);
   CHECK(TimeId(time_runs_forward, 5, end).slab_number() == 6);
-  CHECK(TimeId(time_runs_forward, 5, end).time().slab() ==
+  CHECK(TimeId(time_runs_forward, 5, end).substep_time().slab() ==
         slab.advance_towards(step));
 
   const TimeId id(time_runs_forward, 4, start + step / 3, 2, start + step / 2);
@@ -54,14 +54,16 @@ void check(const bool time_runs_forward) noexcept {
   CHECK_FALSE(id != id);
   CHECK(id == TimeId(id));
 
-  const auto check_comparisons =
-      [&id](const int64_t slab_delta, const TimeDelta& step_time_delta,
-            const int64_t substep_delta, const TimeDelta& time_delta) noexcept {
+  const auto check_comparisons = [&id](
+      const int64_t slab_delta,
+      const TimeDelta& step_time_delta,
+      const int64_t substep_delta,
+      const TimeDelta& substep_time_delta) noexcept {
     const TimeId id2(id.time_runs_forward(),
                      id.slab_number() + slab_delta,
                      id.step_time() + step_time_delta,
                      id.substep() + static_cast<uint64_t>(substep_delta),
-                     id.time() + time_delta);
+                     id.substep_time() + substep_time_delta);
     check_cmp(id, id2);
     CHECK(Hash{}(id) != Hash{}(id2));
   };
@@ -79,8 +81,8 @@ void check(const bool time_runs_forward) noexcept {
 
   test_serialization(id);
 
-  CHECK(get_output(id) ==
-        "4:" + get_output(id.step_time()) + ":2:" + get_output(id.time()));
+  CHECK(get_output(id) == "4:" + get_output(id.step_time()) +
+                              ":2:" + get_output(id.substep_time()));
 }
 }  // namespace
 

--- a/tests/Unit/Time/Test_TimeStepId.cpp
+++ b/tests/Unit/Time/Test_TimeStepId.cpp
@@ -9,61 +9,63 @@
 
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 namespace {
 void check(const bool time_runs_forward) noexcept {
-  using Hash = std::hash<TimeId>;
+  using Hash = std::hash<TimeStepId>;
 
   const Slab slab(1.2, 3.4);
   const Time start = time_runs_forward ? slab.start() : slab.end();
   const Time end = time_runs_forward ? slab.end() : slab.start();
   const TimeDelta step = end - start;
 
-  CHECK(TimeId(time_runs_forward, 4, start + step / 3) ==
-        TimeId(time_runs_forward, 4, start + step / 3, 0, start + step / 3));
+  CHECK(TimeStepId(time_runs_forward, 4, start + step / 3) ==
+        TimeStepId(time_runs_forward, 4, start + step / 3, 0,
+                   start + step / 3));
 
   CHECK_FALSE(
-      TimeId(time_runs_forward, 4, start + step / 3, 2, start + step / 2)
+      TimeStepId(time_runs_forward, 4, start + step / 3, 2, start + step / 2)
           .is_at_slab_boundary());
-  CHECK_FALSE(TimeId(time_runs_forward, 4, start + step / 3, 2, start)
+  CHECK_FALSE(TimeStepId(time_runs_forward, 4, start + step / 3, 2, start)
                   .is_at_slab_boundary());
-  CHECK_FALSE(TimeId(time_runs_forward, 4, start + step / 3, 2, end)
+  CHECK_FALSE(TimeStepId(time_runs_forward, 4, start + step / 3, 2, end)
                   .is_at_slab_boundary());
   CHECK_FALSE(
-      TimeId(time_runs_forward, 4, start + step / 3, 0, start + step / 3)
+      TimeStepId(time_runs_forward, 4, start + step / 3, 0, start + step / 3)
           .is_at_slab_boundary());
   CHECK_FALSE(
-      TimeId(time_runs_forward, 4, start, 1, start).is_at_slab_boundary());
+      TimeStepId(time_runs_forward, 4, start, 1, start).is_at_slab_boundary());
   CHECK_FALSE(
-      TimeId(time_runs_forward, 4, start, 1, end).is_at_slab_boundary());
-  CHECK(TimeId(time_runs_forward, 4, start).is_at_slab_boundary());
-  CHECK(TimeId(time_runs_forward, 4, end).is_at_slab_boundary());
+      TimeStepId(time_runs_forward, 4, start, 1, end).is_at_slab_boundary());
+  CHECK(TimeStepId(time_runs_forward, 4, start).is_at_slab_boundary());
+  CHECK(TimeStepId(time_runs_forward, 4, end).is_at_slab_boundary());
 
-  CHECK(TimeId(time_runs_forward, 5, start).slab_number() == 5);
-  CHECK(TimeId(time_runs_forward, 5, start).substep_time().slab() == slab);
-  CHECK(TimeId(time_runs_forward, 5, end).slab_number() == 6);
-  CHECK(TimeId(time_runs_forward, 5, end).substep_time().slab() ==
+  CHECK(TimeStepId(time_runs_forward, 5, start).slab_number() == 5);
+  CHECK(TimeStepId(time_runs_forward, 5, start).substep_time().slab() == slab);
+  CHECK(TimeStepId(time_runs_forward, 5, end).slab_number() == 6);
+  CHECK(TimeStepId(time_runs_forward, 5, end).substep_time().slab() ==
         slab.advance_towards(step));
 
-  const TimeId id(time_runs_forward, 4, start + step / 3, 2, start + step / 2);
+  const TimeStepId id(time_runs_forward, 4, start + step / 3, 2,
+                      start + step / 2);
 
   CHECK(id == id);
   CHECK_FALSE(id != id);
-  CHECK(id == TimeId(id));
+  CHECK(id == TimeStepId(id));
 
   const auto check_comparisons = [&id](
       const int64_t slab_delta,
       const TimeDelta& step_time_delta,
       const int64_t substep_delta,
       const TimeDelta& substep_time_delta) noexcept {
-    const TimeId id2(id.time_runs_forward(),
-                     id.slab_number() + slab_delta,
-                     id.step_time() + step_time_delta,
-                     id.substep() + static_cast<uint64_t>(substep_delta),
-                     id.substep_time() + substep_time_delta);
+    const TimeStepId id2(id.time_runs_forward(),
+                         id.slab_number() + slab_delta,
+                         id.step_time() + step_time_delta,
+                         id.substep() + static_cast<uint64_t>(substep_delta),
+                         id.substep_time() + substep_time_delta);
     check_cmp(id, id2);
     CHECK(Hash{}(id) != Hash{}(id2));
   };
@@ -86,7 +88,7 @@ void check(const bool time_runs_forward) noexcept {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Time.TimeId", "[Unit][Time]") {
+SPECTRE_TEST_CASE("Unit.Time.TimeStepId", "[Unit][Time]") {
   check(true);
   check(false);
 }

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -405,7 +405,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Boundary.Reversal",
   const Slab slab(0., 1.);
   TimeSteppers::BoundaryHistory<double, double, double> history{};
   const auto add_history = [&df, &history](const TimeId& time_id) noexcept {
-    history.local_insert(time_id, df(time_id.time().value()));
+    history.local_insert(time_id, df(time_id.step_time().value()));
     history.remote_insert(time_id, 0.);
   };
   add_history(TimeId(true, 0, slab.start()));

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -16,7 +16,7 @@
 #include "Time/History.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Time/TimeSteppers/AdamsBashforthN.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/ForceInline.hpp"
@@ -51,7 +51,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN", "[Unit][Time]") {
     TimeSteppers::History<double, double> history;
     history.insert(first, 0., 0.);
     history.insert(second, 0., 0.);
-    return stepper.can_change_step_size(TimeId(true, 0, now), history);
+    return stepper.can_change_step_size(TimeStepId(true, 0, now), history);
   };
   CHECK(can_change(start, mid, end));
   CHECK_FALSE(can_change(start, end, mid));
@@ -110,7 +110,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Backwards",
     TimeSteppers::History<double, double> history;
     history.insert(first, 0., 0.);
     history.insert(second, 0., 0.);
-    return stepper.can_change_step_size(TimeId(false, 0, now), history);
+    return stepper.can_change_step_size(TimeStepId(false, 0, now), history);
   };
   CHECK_FALSE(can_change(start, mid, end));
   CHECK_FALSE(can_change(start, end, mid));
@@ -199,7 +199,7 @@ void do_lts_test(const std::array<TimeDelta, 2>& dt) noexcept {
   };
 
   const auto make_time_id = [forward_in_time](const Time& t) noexcept {
-    return TimeId(forward_in_time, 0, t);
+    return TimeStepId(forward_in_time, 0, t);
   };
 
   const Slab slab = dt[0].slab();
@@ -260,7 +260,7 @@ void check_lts_vts() noexcept {
   const Slab slab(0., 1.);
 
   const auto make_time_id = [](const Time& t) noexcept {
-    return TimeId(true, 0, t);
+    return TimeStepId(true, 0, t);
   };
 
   Time t = slab.start();
@@ -404,13 +404,13 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Boundary.Reversal",
 
   const Slab slab(0., 1.);
   TimeSteppers::BoundaryHistory<double, double, double> history{};
-  const auto add_history = [&df, &history](const TimeId& time_id) noexcept {
+  const auto add_history = [&df, &history](const TimeStepId& time_id) noexcept {
     history.local_insert(time_id, df(time_id.step_time().value()));
     history.remote_insert(time_id, 0.);
   };
-  add_history(TimeId(true, 0, slab.start()));
-  add_history(TimeId(true, 0, slab.end()));
-  add_history(TimeId(true, 1, slab.start() + slab.duration() / 3));
+  add_history(TimeStepId(true, 0, slab.start()));
+  add_history(TimeStepId(true, 0, slab.end()));
+  add_history(TimeStepId(true, 1, slab.start() + slab.duration() / 3));
   double y = f(1. / 3.);
   y += ab3.compute_boundary_delta(
       [](const double local, const double /*remote*/) noexcept {

--- a/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.cpp
+++ b/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.cpp
@@ -17,7 +17,7 @@
 #include "Time/History.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
@@ -33,7 +33,7 @@ void take_step(
     const TimeStepper& stepper,
     F&& rhs,
     const TimeDelta& step_size) noexcept {
-  TimeId time_id(step_size.is_positive(), 0, *time);
+  TimeStepId time_id(step_size.is_positive(), 0, *time);
   for (uint64_t substep = 0;
        substep < stepper.number_of_substeps();
        ++substep) {
@@ -204,7 +204,7 @@ void equal_rate_boundary(const LtsTimeStepper& stepper,
   const Slab slab(0.875, 1.);
   const TimeDelta step_size = (forward ? 1 : -1) * slab.duration() / num_steps;
 
-  TimeId time_id(forward, 0, forward ? slab.start() : slab.end());
+  TimeStepId time_id(forward, 0, forward ? slab.start() : slab.end());
   double y = analytic(time_id.substep_time().value());
   TimeSteppers::History<double, double> volume_history;
   TimeSteppers::BoundaryHistory<double, double, double> boundary_history;
@@ -226,10 +226,10 @@ void equal_rate_boundary(const LtsTimeStepper& stepper,
       history_time -= history_step_size;
       volume_history.insert_initial(history_time,
                                     analytic(history_time.value()), 0.);
-      boundary_history.local_insert_initial(TimeId(forward, 0, history_time),
-                                            unused_local_deriv);
-      boundary_history.remote_insert_initial(TimeId(forward, 0, history_time),
-                                             driver(history_time.value()));
+      boundary_history.local_insert_initial(
+          TimeStepId(forward, 0, history_time), unused_local_deriv);
+      boundary_history.remote_insert_initial(
+          TimeStepId(forward, 0, history_time), driver(history_time.value()));
     }
   }
 
@@ -288,7 +288,7 @@ void check_dense_output(const TimeStepper& stepper,
                         const int expected_order) noexcept {
   const auto get_dense = [&stepper](TimeDelta step_size,
                                     const double time) noexcept {
-    TimeId time_id(true, 0, step_size.slab().start());
+    TimeStepId time_id(true, 0, step_size.slab().start());
     double y = 1.;
     TimeSteppers::History<double, double> history;
     initialize_history(time_id.substep_time(), &history,
@@ -363,7 +363,7 @@ void check_boundary_dense_output(const LtsTimeStepper& stepper) noexcept {
   };
 
   const auto make_time_id = [](const Time& t) noexcept {
-    return TimeId(true, 0, t);
+    return TimeStepId(true, 0, t);
   };
 
   TimeSteppers::BoundaryHistory<double, double, double> history;


### PR DESCRIPTION
This will be necessary for dense output, but is also more convenient than the `Time` objects for most uses.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
