### PR TITLE
Lazy static cache

### DIFF
--- a/src/NumericalAlgorithms/Spectral/Projection.cpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.cpp
@@ -18,65 +18,40 @@
 
 namespace Spectral {
 
-namespace {
-constexpr auto supported_quadratures = {Quadrature::Gauss,
-                                        Quadrature::GaussLobatto};
-
-size_t encode_quadrature(const Quadrature quadrature) noexcept {
-  return static_cast<size_t>(std::find(supported_quadratures.begin(),
-                                       supported_quadratures.end(),
-                                       quadrature) -
-                             supported_quadratures.begin());
-}
-
-Quadrature decode_quadrature(const size_t encoded) noexcept {
-  return *(supported_quadratures.begin() + encoded);
-}
-
-void check_quadrature_supported(const Quadrature quadrature) noexcept {
-  ASSERT(std::find(supported_quadratures.begin(), supported_quadratures.end(),
-                   quadrature) != supported_quadratures.end(),
-         "Unsupported quadrature: " << quadrature);
-}
-}  // namespace
-
 const Matrix& projection_matrix_mortar_to_element(
     const MortarSize size, const Mesh<1>& element_mesh,
     const Mesh<1>& mortar_mesh) noexcept {
   ASSERT(element_mesh.basis(0) == Basis::Legendre and
              mortar_mesh.basis(0) == Basis::Legendre,
          "Projections only implemented on Legendre basis");
-  check_quadrature_supported(element_mesh.quadrature(0));
-  check_quadrature_supported(mortar_mesh.quadrature(0));
   ASSERT(
       element_mesh.extents(0) <= maximum_number_of_points<Basis::Legendre> and
           mortar_mesh.extents(0) <= maximum_number_of_points<Basis::Legendre>,
       "Mesh has more points than supported by its quadrature.");
   ASSERT(element_mesh.extents(0) <= mortar_mesh.extents(0),
          "Requested projection matrix from mortar with fewer points ("
-         << mortar_mesh.extents(0) << ") than the element ("
-         << element_mesh.extents(0) << ")");
+             << mortar_mesh.extents(0) << ") than the element ("
+             << element_mesh.extents(0) << ")");
 
   switch (size) {
     case MortarSize::Full: {
       const static auto cache = make_static_cache<
-          CacheRange<0, supported_quadratures.size()>,
+          CacheEnumeration<Quadrature, Quadrature::Gauss,
+                           Quadrature::GaussLobatto>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
-          CacheRange<0, supported_quadratures.size()>,
+          CacheEnumeration<Quadrature, Quadrature::Gauss,
+                           Quadrature::GaussLobatto>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>(
-          [](const size_t encoded_quadrature_element,
-             const size_t extents_element,
-             const size_t encoded_quadrature_mortar,
+          [](const Quadrature quadrature_element, const size_t extents_element,
+             const Quadrature quadrature_mortar,
              const size_t extents_mortar) noexcept {
             if (extents_element > extents_mortar) {
               return Matrix{};
             }
-            const Mesh<1> mesh_element(
-                extents_element, Basis::Legendre,
-                decode_quadrature(encoded_quadrature_element));
-            const Mesh<1> mesh_mortar(
-                extents_mortar, Basis::Legendre,
-                decode_quadrature(encoded_quadrature_mortar));
+            const Mesh<1> mesh_element(extents_element, Basis::Legendre,
+                                       quadrature_element);
+            const Mesh<1> mesh_mortar(extents_mortar, Basis::Legendre,
+                                      quadrature_mortar);
 
             // The projection in spectral space is just a truncation
             // of the modes.
@@ -96,134 +71,123 @@ const Matrix& projection_matrix_mortar_to_element(
 
             return projection;
           });
-      return cache(encode_quadrature(element_mesh.quadrature(0)),
-                   element_mesh.extents(0),
-                   encode_quadrature(mortar_mesh.quadrature(0)),
-                   mortar_mesh.extents(0));
+      return cache(element_mesh.quadrature(0), element_mesh.extents(0),
+                   mortar_mesh.quadrature(0), mortar_mesh.extents(0));
     }
 
     case MortarSize::UpperHalf: {
       const static auto cache = make_static_cache<
-          CacheRange<0, supported_quadratures.size()>,
+          CacheEnumeration<Quadrature, Quadrature::Gauss,
+                           Quadrature::GaussLobatto>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
-          CacheRange<0, supported_quadratures.size()>,
-          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>(
-          [](const size_t encoded_quadrature_element,
-             const size_t extents_element,
-             const size_t encoded_quadrature_mortar,
-             const size_t extents_mortar) noexcept {
-            if (extents_element > extents_mortar) {
-              return Matrix{};
-            }
-            const Mesh<1> mesh_element(
-                extents_element, Basis::Legendre,
-                decode_quadrature(encoded_quadrature_element));
-            const Mesh<1> mesh_mortar(
-                extents_mortar, Basis::Legendre,
-                decode_quadrature(encoded_quadrature_mortar));
+          CacheEnumeration<Quadrature, Quadrature::Gauss,
+                           Quadrature::GaussLobatto>,
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>([](
+          const Quadrature quadrature_element, const size_t extents_element,
+          const Quadrature quadrature_mortar,
+          const size_t extents_mortar) noexcept {
+        if (extents_element > extents_mortar) {
+          return Matrix{};
+        }
+        const Mesh<1> mesh_element(extents_element, Basis::Legendre,
+                                   quadrature_element);
+        const Mesh<1> mesh_mortar(extents_mortar, Basis::Legendre,
+                                  quadrature_mortar);
 
-            // The transformation from the small interval to the large
-            // interval in spectral space.  This is a rearranged
-            // version of the equation given in the header.  This form
-            // was easier to code.
-            const auto spectral_transformation = [](
-                const size_t large_index, const size_t small_index) noexcept {
-              ASSERT(large_index >= small_index,
-                     "Above-diagonal entries are zero.  Don't use them.");
-              double result = 1.;
-              for (size_t i = (large_index - small_index) / 2; i > 0; --i) {
-                result = 1 - result *
-                                 ((large_index + small_index + 3 - 2 * i) *
-                                  (large_index + small_index + 2 - 2 * i) *
-                                  (large_index - small_index + 2 - 2 * i) *
-                                  (large_index - small_index + 1 - 2 * i)) /
-                                 (2 * i * (2 * large_index + 1 - 2 * i) *
-                                  (large_index + 2 - 2 * i) *
-                                  (large_index + 1 - 2 * i));
-              }
+        // The transformation from the small interval to the large
+        // interval in spectral space.  This is a rearranged
+        // version of the equation given in the header.  This form
+        // was easier to code.
+        const auto spectral_transformation =
+            [](const size_t large_index, const size_t small_index) noexcept {
+          ASSERT(large_index >= small_index,
+                 "Above-diagonal entries are zero.  Don't use them.");
+          double result = 1.;
+          for (size_t i = (large_index - small_index) / 2; i > 0; --i) {
+            result =
+                1 - result *
+                        ((large_index + small_index + 3 - 2 * i) *
+                         (large_index + small_index + 2 - 2 * i) *
+                         (large_index - small_index + 2 - 2 * i) *
+                         (large_index - small_index + 1 - 2 * i)) /
+                        (2 * i * (2 * large_index + 1 - 2 * i) *
+                         (large_index + 2 - 2 * i) * (large_index + 1 - 2 * i));
+          }
 
-              for (size_t i = 1; i <= large_index - small_index; ++i) {
-                result *= 1. + (large_index + small_index + 1.) / i;
-              }
-              result /= pow(2., large_index + 1);
-              return result;
-            };
+          for (size_t i = 1; i <= large_index - small_index; ++i) {
+            result *= 1. + (large_index + small_index + 1.) / i;
+          }
+          result /= pow(2., large_index + 1);
+          return result;
+        };
 
-            const auto& spectral_to_grid_element =
-                modal_to_nodal_matrix(mesh_element);
-            const auto& grid_to_spectral_mortar =
-                nodal_to_modal_matrix(mesh_mortar);
+        const auto& spectral_to_grid_element =
+            modal_to_nodal_matrix(mesh_element);
+        const auto& grid_to_spectral_mortar =
+            nodal_to_modal_matrix(mesh_mortar);
 
-            Matrix temp(extents_element, extents_element, 0.);
-            for (size_t j = 0; j < extents_element; ++j) {
-              for (size_t k = j; k < extents_element; ++k) {
-                const double transformation_entry =
-                    spectral_transformation(k, j);
-                for (size_t i = 0; i < extents_element; ++i) {
-                  temp(i, j) +=
-                      spectral_to_grid_element(i, k) * transformation_entry;
-                }
-              }
-            }
-
-            Matrix projection(extents_element, extents_mortar, 0.);
+        Matrix temp(extents_element, extents_element, 0.);
+        for (size_t j = 0; j < extents_element; ++j) {
+          for (size_t k = j; k < extents_element; ++k) {
+            const double transformation_entry = spectral_transformation(k, j);
             for (size_t i = 0; i < extents_element; ++i) {
-              for (size_t j = 0; j < extents_mortar; ++j) {
-                for (size_t k = 0; k < extents_element; ++k) {
-                  projection(i, j) +=
-                      temp(i, k) * grid_to_spectral_mortar(k, j);
-                }
-              }
+              temp(i, j) +=
+                  spectral_to_grid_element(i, k) * transformation_entry;
             }
+          }
+        }
 
-            return projection;
-          });
-      return cache(encode_quadrature(element_mesh.quadrature(0)),
-                   element_mesh.extents(0),
-                   encode_quadrature(mortar_mesh.quadrature(0)),
-                   mortar_mesh.extents(0));
+        Matrix projection(extents_element, extents_mortar, 0.);
+        for (size_t i = 0; i < extents_element; ++i) {
+          for (size_t j = 0; j < extents_mortar; ++j) {
+            for (size_t k = 0; k < extents_element; ++k) {
+              projection(i, j) += temp(i, k) * grid_to_spectral_mortar(k, j);
+            }
+          }
+        }
+
+        return projection;
+      });
+      return cache(element_mesh.quadrature(0), element_mesh.extents(0),
+                   mortar_mesh.quadrature(0), mortar_mesh.extents(0));
     }
 
     case MortarSize::LowerHalf: {
       const static auto cache = make_static_cache<
-          CacheRange<0, supported_quadratures.size()>,
+          CacheEnumeration<Quadrature, Quadrature::Gauss,
+                           Quadrature::GaussLobatto>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
-          CacheRange<0, supported_quadratures.size()>,
-          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>(
-          [](const size_t encoded_quadrature_element,
-             const size_t extents_element,
-             const size_t encoded_quadrature_mortar,
-             const size_t extents_mortar) noexcept {
-            if (extents_element > extents_mortar) {
-              return Matrix{};
-            }
-            const Mesh<1> mesh_element(
-                extents_element, Basis::Legendre,
-                decode_quadrature(encoded_quadrature_element));
-            const Mesh<1> mesh_mortar(
-                extents_mortar, Basis::Legendre,
-                decode_quadrature(encoded_quadrature_mortar));
+          CacheEnumeration<Quadrature, Quadrature::Gauss,
+                           Quadrature::GaussLobatto>,
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>([](
+          const Quadrature quadrature_element, const size_t extents_element,
+          const Quadrature quadrature_mortar,
+          const size_t extents_mortar) noexcept {
+        if (extents_element > extents_mortar) {
+          return Matrix{};
+        }
+        const Mesh<1> mesh_element(extents_element, Basis::Legendre,
+                                   quadrature_element);
+        const Mesh<1> mesh_mortar(extents_mortar, Basis::Legendre,
+                                  quadrature_mortar);
 
-            // The lower-half matrices are generated from the upper-half
-            // matrices using symmetry.
-            const auto& projection_upper_half =
-                projection_matrix_mortar_to_element(MortarSize::UpperHalf,
-                                                    mesh_element, mesh_mortar);
+        // The lower-half matrices are generated from the upper-half
+        // matrices using symmetry.
+        const auto& projection_upper_half = projection_matrix_mortar_to_element(
+            MortarSize::UpperHalf, mesh_element, mesh_mortar);
 
-            Matrix projection_lower_half(extents_element, extents_mortar);
-            for (size_t i = 0; i < extents_element; ++i) {
-              for (size_t j = 0; j < extents_mortar; ++j) {
-                projection_lower_half(i, j) = projection_upper_half(
-                    extents_element - i - 1, extents_mortar - j - 1);
-              }
-            }
+        Matrix projection_lower_half(extents_element, extents_mortar);
+        for (size_t i = 0; i < extents_element; ++i) {
+          for (size_t j = 0; j < extents_mortar; ++j) {
+            projection_lower_half(i, j) = projection_upper_half(
+                extents_element - i - 1, extents_mortar - j - 1);
+          }
+        }
 
-            return projection_lower_half;
-          });
-      return cache(encode_quadrature(element_mesh.quadrature(0)),
-                   element_mesh.extents(0),
-                   encode_quadrature(mortar_mesh.quadrature(0)),
-                   mortar_mesh.extents(0));
+        return projection_lower_half;
+      });
+      return cache(element_mesh.quadrature(0), element_mesh.extents(0),
+                   mortar_mesh.quadrature(0), mortar_mesh.extents(0));
     }
 
     default:
@@ -237,31 +201,28 @@ const Matrix& projection_matrix_element_to_mortar(
   ASSERT(mortar_mesh.basis(0) == Basis::Legendre and
              element_mesh.basis(0) == Basis::Legendre,
          "Projections only implemented on Legendre basis");
-  check_quadrature_supported(mortar_mesh.quadrature(0));
-  check_quadrature_supported(element_mesh.quadrature(0));
   ASSERT(
       mortar_mesh.extents(0) <= maximum_number_of_points<Basis::Legendre> and
           element_mesh.extents(0) <= maximum_number_of_points<Basis::Legendre>,
       "Mesh has more points than supported by its quadrature.");
   ASSERT(mortar_mesh.extents(0) >= element_mesh.extents(0),
          "Requested projection matrix to mortar with fewer points ("
-         << mortar_mesh.extents(0) << ") than the element ("
-         << element_mesh.extents(0) << ")");
+             << mortar_mesh.extents(0) << ") than the element ("
+             << element_mesh.extents(0) << ")");
 
   // Element-to-mortar projections are always interpolations.
   const auto make_interpolators = [](auto interval_transform) noexcept {
     return [interval_transform = std::move(interval_transform)](
-        const size_t encoded_quadrature_mortar,
-        const size_t extents_mortar,
-        const size_t encoded_quadrature_element,
+        const Quadrature quadrature_mortar, const size_t extents_mortar,
+        const Quadrature quadrature_element,
         const size_t extents_element) noexcept {
       if (extents_mortar < extents_element) {
         return Matrix{};
       }
       const Mesh<1> mesh_element(extents_element, Basis::Legendre,
-                                 decode_quadrature(encoded_quadrature_element));
+                                 quadrature_element);
       const Mesh<1> mesh_mortar(extents_mortar, Basis::Legendre,
-                                decode_quadrature(encoded_quadrature_mortar));
+                                quadrature_mortar);
       return interpolation_matrix(
           mesh_element, interval_transform(collocation_points(mesh_mortar)));
     };
@@ -270,45 +231,45 @@ const Matrix& projection_matrix_element_to_mortar(
   switch (size) {
     case MortarSize::Full: {
       const static auto cache = make_static_cache<
-          CacheRange<0, supported_quadratures.size()>,
+          CacheEnumeration<Quadrature, Quadrature::Gauss,
+                           Quadrature::GaussLobatto>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
-          CacheRange<0, supported_quadratures.size()>,
+          CacheEnumeration<Quadrature, Quadrature::Gauss,
+                           Quadrature::GaussLobatto>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>(
           make_interpolators([](const DataVector& x) noexcept { return x; }));
-      return cache(encode_quadrature(mortar_mesh.quadrature(0)),
-                   mortar_mesh.extents(0),
-                   encode_quadrature(element_mesh.quadrature(0)),
-                   element_mesh.extents(0));
+      return cache(mortar_mesh.quadrature(0), mortar_mesh.extents(0),
+                   element_mesh.quadrature(0), element_mesh.extents(0));
     }
 
     case MortarSize::UpperHalf: {
       const static auto cache = make_static_cache<
-          CacheRange<0, supported_quadratures.size()>,
+          CacheEnumeration<Quadrature, Quadrature::Gauss,
+                           Quadrature::GaussLobatto>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
-          CacheRange<0, supported_quadratures.size()>,
+          CacheEnumeration<Quadrature, Quadrature::Gauss,
+                           Quadrature::GaussLobatto>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>(
           make_interpolators([](const DataVector& x) noexcept {
             return DataVector(0.5 * (x + 1.));
           }));
-      return cache(encode_quadrature(mortar_mesh.quadrature(0)),
-                   mortar_mesh.extents(0),
-                   encode_quadrature(element_mesh.quadrature(0)),
-                   element_mesh.extents(0));
+      return cache(mortar_mesh.quadrature(0), mortar_mesh.extents(0),
+                   element_mesh.quadrature(0), element_mesh.extents(0));
     }
 
     case MortarSize::LowerHalf: {
       const static auto cache = make_static_cache<
-          CacheRange<0, supported_quadratures.size()>,
+          CacheEnumeration<Quadrature, Quadrature::Gauss,
+                           Quadrature::GaussLobatto>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
-          CacheRange<0, supported_quadratures.size()>,
+          CacheEnumeration<Quadrature, Quadrature::Gauss,
+                           Quadrature::GaussLobatto>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>(
           make_interpolators([](const DataVector& x) noexcept {
             return DataVector(0.5 * (x - 1.));
           }));
-      return cache(encode_quadrature(mortar_mesh.quadrature(0)),
-                   mortar_mesh.extents(0),
-                   encode_quadrature(element_mesh.quadrature(0)),
-                   element_mesh.extents(0));
+      return cache(mortar_mesh.quadrature(0), mortar_mesh.extents(0),
+                   element_mesh.quadrature(0), element_mesh.extents(0));
     }
 
     default:

--- a/src/NumericalAlgorithms/Spectral/Projection.cpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.cpp
@@ -59,15 +59,15 @@ const Matrix& projection_matrix_mortar_to_element(
 
   switch (size) {
     case MortarSize::Full: {
-      const static StaticCache<
-          Matrix, CacheRange<0, supported_quadratures.size()>,
+      const static auto cache = make_static_cache<
+          CacheRange<0, supported_quadratures.size()>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
           CacheRange<0, supported_quadratures.size()>,
-          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>
-          cache([](const size_t encoded_quadrature_element,
-                   const size_t extents_element,
-                   const size_t encoded_quadrature_mortar,
-                   const size_t extents_mortar) noexcept {
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>(
+          [](const size_t encoded_quadrature_element,
+             const size_t extents_element,
+             const size_t encoded_quadrature_mortar,
+             const size_t extents_mortar) noexcept {
             if (extents_element > extents_mortar) {
               return Matrix{};
             }
@@ -103,15 +103,15 @@ const Matrix& projection_matrix_mortar_to_element(
     }
 
     case MortarSize::UpperHalf: {
-      const static StaticCache<
-          Matrix, CacheRange<0, supported_quadratures.size()>,
+      const static auto cache = make_static_cache<
+          CacheRange<0, supported_quadratures.size()>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
           CacheRange<0, supported_quadratures.size()>,
-          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>
-          cache([](const size_t encoded_quadrature_element,
-                   const size_t extents_element,
-                   const size_t encoded_quadrature_mortar,
-                   const size_t extents_mortar) noexcept {
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>(
+          [](const size_t encoded_quadrature_element,
+             const size_t extents_element,
+             const size_t encoded_quadrature_mortar,
+             const size_t extents_mortar) noexcept {
             if (extents_element > extents_mortar) {
               return Matrix{};
             }
@@ -185,15 +185,15 @@ const Matrix& projection_matrix_mortar_to_element(
     }
 
     case MortarSize::LowerHalf: {
-      const static StaticCache<
-          Matrix, CacheRange<0, supported_quadratures.size()>,
+      const static auto cache = make_static_cache<
+          CacheRange<0, supported_quadratures.size()>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
           CacheRange<0, supported_quadratures.size()>,
-          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>
-          cache([](const size_t encoded_quadrature_element,
-                   const size_t extents_element,
-                   const size_t encoded_quadrature_mortar,
-                   const size_t extents_mortar) noexcept {
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>(
+          [](const size_t encoded_quadrature_element,
+             const size_t extents_element,
+             const size_t encoded_quadrature_mortar,
+             const size_t extents_mortar) noexcept {
             if (extents_element > extents_mortar) {
               return Matrix{};
             }
@@ -269,14 +269,12 @@ const Matrix& projection_matrix_element_to_mortar(
 
   switch (size) {
     case MortarSize::Full: {
-      const static StaticCache<
-          Matrix, CacheRange<0, supported_quadratures.size()>,
+      const static auto cache = make_static_cache<
+          CacheRange<0, supported_quadratures.size()>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
           CacheRange<0, supported_quadratures.size()>,
-          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>
-          cache(make_interpolators([](const DataVector& x) noexcept {
-            return x;
-          }));
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>(
+          make_interpolators([](const DataVector& x) noexcept { return x; }));
       return cache(encode_quadrature(mortar_mesh.quadrature(0)),
                    mortar_mesh.extents(0),
                    encode_quadrature(element_mesh.quadrature(0)),
@@ -284,12 +282,12 @@ const Matrix& projection_matrix_element_to_mortar(
     }
 
     case MortarSize::UpperHalf: {
-      const static StaticCache<
-          Matrix, CacheRange<0, supported_quadratures.size()>,
+      const static auto cache = make_static_cache<
+          CacheRange<0, supported_quadratures.size()>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
           CacheRange<0, supported_quadratures.size()>,
-          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>
-          cache(make_interpolators([](const DataVector& x) noexcept {
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>(
+          make_interpolators([](const DataVector& x) noexcept {
             return DataVector(0.5 * (x + 1.));
           }));
       return cache(encode_quadrature(mortar_mesh.quadrature(0)),
@@ -299,12 +297,12 @@ const Matrix& projection_matrix_element_to_mortar(
     }
 
     case MortarSize::LowerHalf: {
-      const static StaticCache<
-          Matrix, CacheRange<0, supported_quadratures.size()>,
+      const static auto cache = make_static_cache<
+          CacheRange<0, supported_quadratures.size()>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
           CacheRange<0, supported_quadratures.size()>,
-          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>
-          cache(make_interpolators([](const DataVector& x) noexcept {
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>(
+          make_interpolators([](const DataVector& x) noexcept {
             return DataVector(0.5 * (x - 1.));
           }));
       return cache(encode_quadrature(mortar_mesh.quadrature(0)),

--- a/src/NumericalAlgorithms/Spectral/SwshCoefficients.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCoefficients.cpp
@@ -15,6 +15,7 @@
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/StaticCache.hpp"
 
 // IWYU pragma: no_forward_declare SpinWeighted
 
@@ -28,39 +29,14 @@ CoefficientsMetadata::CoefficientsMetadata(const size_t l_max) noexcept
   alm_info_.reset(alm_to_initialize);
 }
 
-namespace {
-template <size_t I>
-const CoefficientsMetadata& coefficients_cache_impl() noexcept {
-  static const CoefficientsMetadata precomputed_coefficients{I};
-  return precomputed_coefficients;
-}
-
-template <size_t... Is>
-SPECTRE_ALWAYS_INLINE const CoefficientsMetadata&
-precomputed_static_coefficients_impl(
-    const size_t index, std::index_sequence<Is...> /*meta*/) noexcept {
-  if (UNLIKELY(index > collocation_maximum_l_max)) {
-    ERROR("The provided l_max "
-          << index
-          << " is not below the maximum l_max to cache, which is currently "
-          << detail::coefficients_maximum_l_max
-          << ". Either "
-             "construct the CoefficientsMetadata manually, or consider (with "
-             "caution) "
-             "increasing `coefficients_maximum_l_max`.");
-  }
-
-  static const std::array<const CoefficientsMetadata& (*)(), sizeof...(Is)>
-      cache{{&coefficients_cache_impl<Is>...}};
-  return gsl::at(cache, index)();
-}
-
-}  // namespace
-
 const CoefficientsMetadata& cached_coefficients_metadata(
     const size_t l_max) noexcept {
-  return precomputed_static_coefficients_impl(
-      l_max, std::make_index_sequence<detail::coefficients_maximum_l_max>{});
+  const static auto lazy_coefficients_cache =
+      make_static_cache<CacheRange<0, detail::coefficients_maximum_l_max>>(
+          [](const size_t generator_l_max) noexcept {
+            return CoefficientsMetadata{generator_l_max};
+          });
+  return lazy_coefficients_cache(l_max);
 }
 
 template <int Spin>

--- a/src/Utilities/StaticCache.hpp
+++ b/src/Utilities/StaticCache.hpp
@@ -13,15 +13,54 @@
 #include "Utilities/TypeTraits.hpp"
 
 /// \ingroup UtilitiesGroup
+/// Range of values for StaticCache indices.  The `Start` is inclusive
+/// and the `End` is exclusive.  The range must not be empty.
+template <size_t Start, size_t End>
+struct CacheRange {
+  static_assert(Start < End, "CacheRange must include at least one value");
+  constexpr static size_t start = Start;
+  constexpr static size_t end = End;
+  constexpr static size_t size = end - start;
+  using value_type = size_t;
+};
+
+/// \ingroup UtilitiesGroup
+/// Possible enumeration values for the StaticCache. Only values specified here
+/// are retrievable.
+///
+/// \note The `EnumerationType` must be streamable.
+template <typename EnumerationType, EnumerationType... Enums>
+struct CacheEnumeration {
+  constexpr static size_t size = sizeof...(Enums);
+  using value_type = EnumerationType;
+};
+
+/// \ingroup UtilitiesGroup
 /// A cache of objects intended to be stored in a static variable.
 ///
-/// Objects can be accessed using several `size_t` arguments in the
-/// ranges specified as template parameters.  The CacheRange template
-/// parameters give first and one-past-last values for the valid
-/// ranges for each argument.
+/// Objects can be accessed via a combination of several `size_t` and `enum`
+/// arguments. The range of each `size_t` argument is specified via a template
+/// parameter of type `CacheRange<start, end>`, giving the first and
+/// one-past-last values for the range. Each `enum` argument is specified by a
+/// template parameter of type `CacheEnumeration<EnumerationType, Members...>`
+/// giving the enumeration type and an explicit set of every enum member to be
+/// cached.
 ///
 /// \example
+/// A cache with only numeric indices:
 /// \snippet Test_StaticCache.cpp static_cache
+///
+/// \example
+/// A cache with enumeration indices:
+/// \snippet Test_StaticCache.cpp static_cache_with_enum
+///
+/// \example
+/// A cache with mixed numeric and enumeration indices:
+/// \snippet Test_StaticCache.cpp static_cache_with_enum_and_numeric
+///
+/// \example
+/// A cache with no arguments at all (caching only a single object)
+/// \snippet Test_StaticCache.cpp static_cache_no_args
 ///
 /// \see make_static_cache
 ///
@@ -30,27 +69,48 @@
 template <typename Generator, typename T, typename... Ranges>
 class StaticCache {
  public:
-  explicit StaticCache(Generator&& generator) : generator_{generator} {}
+  template <typename Gen>
+  // NOLINTNEXTLINE(misc-forwarding-reference-overload)
+  explicit StaticCache(Gen&& generator) noexcept
+      : generator_{std::forward<Gen>(generator)} {}
 
   template <typename... Args>
   const T& operator()(const Args... parameters) const noexcept {
     static_assert(sizeof...(parameters) == sizeof...(Ranges),
                   "Number of arguments must match number of ranges.");
-    return unwrap_cache(
-        std::make_tuple(static_cast<size_t>(parameters),
-                        std::integral_constant<size_t, Ranges::start>{},
-                        std::make_index_sequence<Ranges::size>{})...);
+    return unwrap_cache(generate_tuple<Ranges>(parameters)...);
   }
 
  private:
-  template <size_t... Indices>
+  template <typename Range, typename T1,
+            Requires<not std::is_enum<T1>::value> = nullptr>
+  auto generate_tuple(const T1 parameter) const noexcept {
+    static_assert(
+        tt::is_integer_v<std::decay_t<T1>>,
+        "The parameter passed for a CacheRange must be an integer type.");
+    return std::make_tuple(static_cast<size_t>(parameter),
+                           std::integral_constant<size_t, Range::start>{},
+                           std::make_index_sequence<Range::size>{});
+  }
+
+  template <typename Range, typename T1,
+            Requires<std::is_enum<T1>::value> = nullptr>
+  std::tuple<std::decay_t<T1>, Range> generate_tuple(const T1 parameter) const
+      noexcept {
+    static_assert(
+        std::is_same<typename Range::value_type, std::decay_t<T1>>::value,
+        "Mismatched enum parameter type and cached type.");
+    return {parameter, Range{}};
+  }
+
+  template <typename... IntegralConstantValues>
   const T& unwrap_cache() const noexcept {
-    static const T cached_object = generator_(Indices...);
+    static const T cached_object = generator_(IntegralConstantValues::value...);
     return cached_object;
   }
 
-  template <size_t... Indices, size_t IndexOffset, size_t... Is,
-            typename... Args>
+  template <typename... IntegralConstantValues, size_t IndexOffset,
+            size_t... Is, typename... Args>
   const T& unwrap_cache(
       std::tuple<size_t, std::integral_constant<size_t, IndexOffset>,
                  std::index_sequence<Is...>>
@@ -68,10 +128,45 @@ class StaticCache {
         const T& (StaticCache<Generator, T, Ranges...>::*)(Args...) const,
         sizeof...(Is)>
         cache{{&StaticCache<Generator, T, Ranges...>::unwrap_cache<
-            Indices..., Is + IndexOffset>...}};
+            IntegralConstantValues...,
+            std::integral_constant<size_t, Is + IndexOffset>>...}};
+    // The array `cache` holds pointers to member functions, so we dereference
+    // the pointer and invoke it on `this`.
     return (this->*gsl::at(cache, std::get<0>(parameter0) - IndexOffset))(
         parameters...);
   }
+
+  template <typename... IntegralConstantValues, typename EnumType,
+            EnumType... EnumValues, typename... Args>
+  const T& unwrap_cache(
+      std::tuple<EnumType, CacheEnumeration<EnumType, EnumValues...>>
+          parameter0,
+      Args... parameters) const noexcept {
+    size_t array_location = std::numeric_limits<size_t>::max();
+    static const std::array<EnumType, sizeof...(EnumValues)> values{
+        {EnumValues...}};
+    for (size_t i = 0; i < sizeof...(EnumValues); ++i) {
+      if (std::get<0>(parameter0) == gsl::at(values, i)) {
+        array_location = i;
+        break;
+      }
+    }
+    if (UNLIKELY(array_location == std::numeric_limits<size_t>::max())) {
+      ERROR("Uncached enumeration value: " << std::get<0>(parameter0));
+    }
+    // note that the act of assigning to the specified function pointer type
+    // fixes the template arguments that need to be inferred.
+    static const std::array<
+        const T& (StaticCache<Generator, T, Ranges...>::*)(Args...) const,
+        sizeof...(EnumValues)>
+        cache{{&StaticCache<Generator, T, Ranges...>::unwrap_cache<
+            IntegralConstantValues...,
+            std::integral_constant<EnumType, EnumValues>>...}};
+    // The array `cache` holds pointers to member functions, so we dereference
+    // the pointer and invoke it on `this`.
+    return (this->*gsl::at(cache, array_location))(parameters...);
+  }
+
   const Generator generator_;
 };
 
@@ -79,18 +174,8 @@ class StaticCache {
 /// Create a StaticCache, inferring the cached type from the generator.
 template <typename... Ranges, typename Generator>
 auto make_static_cache(Generator&& generator) noexcept {
-  using CachedType = std::decay_t<decltype(generator((Ranges{}, size_t{})...))>;
-  return StaticCache<Generator, CachedType, Ranges...>(
+  using CachedType = std::decay_t<decltype(
+      generator(std::declval<typename Ranges::value_type>()...))>;
+  return StaticCache<std::decay_t<Generator>, CachedType, Ranges...>(
       std::forward<Generator>(generator));
 }
-
-/// \ingroup UtilitiesGroup
-/// Range of values for StaticCache indices.  The `Start` is inclusive
-/// and the `End` is exclusive.  The range must not be empty.
-template <size_t Start, size_t End>
-struct CacheRange {
-  static_assert(Start < End, "CacheRange must include at least one value");
-  constexpr static size_t start = Start;
-  constexpr static size_t end = End;
-  constexpr static size_t size = end - start;
-};

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCoefficients.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCoefficients.cpp
@@ -263,7 +263,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshCoefficients",
   }
 }
 
-// [[OutputRegex, is not below the maximum l_max]]
+// [[OutputRegex, Index out of range]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.NumericalAlgorithms.Spectral.SwshCoefficients.PrecomputationOverrun",
     "[Unit][NumericalAlgorithms]") {

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCollocation.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCollocation.cpp
@@ -137,7 +137,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshCollocation",
   }
 }
 
-// [[OutputRegex, is not below the maximum l_max]]
+// [[OutputRegex, Index out of range]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.NumericalAlgorithms.Spectral.SwshCollocation.PrecomputationOverrun",
     "[Unit][NumericalAlgorithms]") {

--- a/tests/Unit/Utilities/Test_StaticCache.cpp
+++ b/tests/Unit/Utilities/Test_StaticCache.cpp
@@ -9,13 +9,46 @@
 #include <vector>
 
 #include "ErrorHandling/Error.hpp"
+#include "Utilities/MakeString.hpp"
 #include "Utilities/StaticCache.hpp"
+
+namespace {
+enum class Color { Red, Green, Purple };
+
+std::ostream& operator<<(std::ostream& os, Color t) noexcept {
+  switch (t) {
+    case Color::Red:
+      return os << "Red";
+    case Color::Green:
+      return os << "Green";
+    case Color::Purple:
+      return os << "Purple";
+    default:
+      ERROR("Unknown color");
+  }
+}
+
+enum class Animal { Goldendoodle, Labradoodle, Poodle };
+
+std::ostream& operator<<(std::ostream& os, Animal t) noexcept {
+  switch (t) {
+    case Animal::Goldendoodle:
+      return os << "Goldendoodle";
+    case Animal::Labradoodle:
+      return os << "Labradoodle";
+    case Animal::Poodle:
+      return os << "Poodle";
+    default:
+      ERROR("Unknown Animal");
+  }
+}
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
   /// [static_cache]
   const static auto cache =
-      make_static_cache<CacheRange<0, 3>, CacheRange<3, 5>>([](
-          const size_t a, const size_t b) noexcept { return a + b; });
+      make_static_cache<CacheRange<0, 3>, CacheRange<3, 5>>(
+          [](const size_t a, const size_t b) noexcept { return a + b; });
   CHECK(cache(0, 3) == 3);  // smallest entry
   CHECK(cache(2, 4) == 6);  // largest entry
   /// [static_cache]
@@ -28,7 +61,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
         return a + b;
       });
   // cache is lazy, shouldn't have called at all before retrieving
-  CHECK(calls.size() == 0);
+  CHECK(calls.empty());
 
   // explicitly call the cache creation to check its contents
   cache2(0, 3);
@@ -62,6 +95,93 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
   CHECK(small_calls == 0);
   CHECK(small_cache() == 5);
   CHECK(small_calls == 1);
+
+  /// [static_cache_no_args]
+  const auto simple_small_cache =
+      make_static_cache([]() noexcept { return size_t{10}; });
+  CHECK(simple_small_cache() == 10);
+  /// [static_cache_no_args]
+
+  // check enum caching functionality
+  const auto enum_generator_tuple =
+      [](const Color& color, const size_t value = 5,
+         const Animal animal = Animal::Goldendoodle) noexcept {
+    size_t offset_animal = 0;
+    switch (animal) {
+      case Animal::Goldendoodle:
+        offset_animal = 3;
+        break;
+      case Animal::Labradoodle:
+        offset_animal = 2;
+        break;
+      case Animal::Poodle:
+        offset_animal = 1;
+        break;
+    };
+
+    switch (color) {
+      case Color::Red:
+        return std::make_tuple(offset_animal, 1, value);
+      case Color::Green:
+        return std::make_tuple(offset_animal, 2, value);
+      case Color::Purple:
+        return std::make_tuple(offset_animal, 3, value);
+    };
+  };
+  /// [static_cache_with_enum]
+  const auto simple_enum_cache = make_static_cache<
+      CacheEnumeration<Color, Color::Red, Color::Green, Color::Purple>>([
+  ](const Color color) noexcept { return std::string{MakeString{} << color}; });
+  CHECK(simple_enum_cache(Color::Red) == "Red");
+  /// [static_cache_with_enum]
+  const auto enum_cache = make_static_cache<
+      CacheEnumeration<Color, Color::Red, Color::Green, Color::Purple>>(
+      enum_generator_tuple);
+  for (const auto color : {Color::Red, Color::Green, Color::Purple}) {
+    CHECK(enum_cache(color) ==
+          std::make_tuple(3, static_cast<size_t>(color) + 1, 5));
+  }
+
+  const auto enum_size_t_cache = make_static_cache<
+      CacheEnumeration<Color, Color::Red, Color::Green, Color::Purple>,
+      CacheRange<3, 5>>(enum_generator_tuple);
+  for (const auto color : {Color::Red, Color::Green, Color::Purple}) {
+    CHECK(enum_size_t_cache(color, 3) ==
+          std::make_tuple(3, static_cast<size_t>(color) + 1, 3));
+    CHECK(enum_size_t_cache(color, 4) ==
+          std::make_tuple(3, static_cast<size_t>(color) + 1, 4));
+  }
+
+  /// [static_cache_with_enum_and_numeric]
+  const auto simple_enum_size_t_enum_cache = make_static_cache<
+      CacheEnumeration<Color, Color::Red, Color::Green, Color::Purple>,
+      CacheRange<3, 5>,
+      CacheEnumeration<Animal, Animal::Goldendoodle, Animal::Labradoodle,
+                       Animal::Poodle>>(
+      [](const Color color, const size_t value, const Animal animal) noexcept {
+        return std::string{MakeString{} << color << value << animal};
+      });
+  CHECK(simple_enum_size_t_enum_cache(Color::Red, 3, Animal::Labradoodle) ==
+        "Red3Labradoodle");
+  CHECK(simple_enum_size_t_enum_cache(Color::Purple, 4, Animal::Poodle) ==
+        "Purple4Poodle");
+  /// [static_cache_with_enum_and_numeric]
+  const auto enum_size_t_enum_cache = make_static_cache<
+      CacheEnumeration<Color, Color::Red, Color::Green, Color::Purple>,
+      CacheRange<3, 5>,
+      CacheEnumeration<Animal, Animal::Goldendoodle, Animal::Labradoodle,
+                       Animal::Poodle>>(enum_generator_tuple);
+  for (const auto color : {Color::Red, Color::Green, Color::Purple}) {
+    for (const auto animal :
+         {Animal::Goldendoodle, Animal::Labradoodle, Animal::Poodle}) {
+      CHECK(enum_size_t_enum_cache(color, 3, animal) ==
+            std::make_tuple(3 - static_cast<size_t>(animal),
+                            static_cast<size_t>(color) + 1, 3));
+      CHECK(enum_size_t_enum_cache(color, 4, animal) ==
+            std::make_tuple(3 - static_cast<size_t>(animal),
+                            static_cast<size_t>(color) + 1, 4));
+    }
+  }
 }
 
 // [[OutputRegex, Index out of range: 3 <= 2 < 5]]
@@ -69,8 +189,8 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
                                "[Utilities][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  const auto cache = make_static_cache<CacheRange<3, 5>>([](
-      const size_t x) noexcept { return x; });
+  const auto cache = make_static_cache<CacheRange<3, 5>>(
+      [](const size_t x) noexcept { return x; });
   cache(2);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
@@ -81,8 +201,8 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
                                "[Utilities][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  const auto cache = make_static_cache<CacheRange<3, 5>>([](
-      const size_t x) noexcept { return x; });
+  const auto cache = make_static_cache<CacheRange<3, 5>>(
+      [](const size_t x) noexcept { return x; });
   cache(5);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif

--- a/tests/Unit/Utilities/Test_StaticCache.cpp
+++ b/tests/Unit/Utilities/Test_StaticCache.cpp
@@ -117,6 +117,9 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
       case Animal::Poodle:
         offset_animal = 1;
         break;
+      default:
+        offset_animal = std::numeric_limits<size_t>::max();
+        break;
     };
 
     switch (color) {
@@ -126,6 +129,9 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
         return std::make_tuple(offset_animal, 2, value);
       case Color::Purple:
         return std::make_tuple(offset_animal, 3, value);
+      default:
+        return std::make_tuple(offset_animal, std::numeric_limits<int>::max(),
+                               value);
     };
   };
   /// [static_cache_with_enum]

--- a/tests/Unit/Utilities/Test_StaticCache.cpp
+++ b/tests/Unit/Utilities/Test_StaticCache.cpp
@@ -27,9 +27,25 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
         calls.emplace_back(a, b);
         return a + b;
       });
+  // cache is lazy, shouldn't have called at all before retrieving
+  CHECK(calls.size() == 0);
+
+  // explicitly call the cache creation to check its contents
+  cache2(0, 3);
+  cache2(0, 4);
+  cache2(1, 3);
+  CHECK(calls.size() == 3);
+
+  cache2(0, 4);
+  cache2(1, 3);
+  cache2(1, 3);
+  CHECK(calls.size() == 3);
+
+  cache2(1, 4);
+  cache2(2, 3);
+  cache2(2, 4);
   CHECK(calls.size() == 6);
-  // Creation order is not specified.
-  std::sort(calls.begin(), calls.end());
+
   const decltype(calls) expected_calls{{0, 3}, {0, 4}, {1, 3},
                                        {1, 4}, {2, 3}, {2, 4}};
   CHECK(calls == expected_calls);
@@ -43,7 +59,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
     ++small_calls;
     return size_t{5};
   });
-  CHECK(small_calls == 1);
+  CHECK(small_calls == 0);
   CHECK(small_cache() == 5);
   CHECK(small_calls == 1);
 }


### PR DESCRIPTION
## Proposed changes

Generalize that increasingly frequently used technique of a lazy static cache using a function pointer table. I think we have enough of them piling up to justify a general tool.
This PR also immediately replaces those caches in Swsh... utilities which previously had their own implementation of the technique.

I have a draft sitting around for generalizing this to take extra arguments, as are currently used in the similar implementations for filtering and in PR #1456, but I figured I'd get opinions on the simple version to begin with.

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code

