### PR TITLE
Add StrahlkorperGr::euclidean_surface_integral_of_vector

### DIFF
--- a/src/ApparentHorizons/StrahlkorperGr.cpp
+++ b/src/ApparentHorizons/StrahlkorperGr.cpp
@@ -565,6 +565,18 @@ double surface_integral_of_scalar(
 }
 
 template <typename Frame>
+double euclidean_surface_integral_of_vector(
+    const Scalar<DataVector>& area_element,
+    const tnsr::I<DataVector, 3, Frame>& vector,
+    const tnsr::i<DataVector, 3, Frame>& normal_one_form,
+    const Strahlkorper<Frame>& strahlkorper) noexcept {
+  const DataVector integrand =
+      get(area_element) * get(dot_product(vector, normal_one_form)) /
+      sqrt(get(dot_product(normal_one_form, normal_one_form)));
+  return strahlkorper.ylm_spherepack().definite_integral(integrand.data());
+}
+
+template <typename Frame>
 Scalar<DataVector> spin_function(
     const StrahlkorperTags::aliases::Jacobian<Frame>& tangents,
     const YlmSpherepack& ylm,
@@ -753,6 +765,13 @@ StrahlkorperGr::euclidean_area_element<Frame::Inertial>(
 
 template double StrahlkorperGr::surface_integral_of_scalar(
     const Scalar<DataVector>& area_element, const Scalar<DataVector>& scalar,
+    const Strahlkorper<Frame::Inertial>& strahlkorper) noexcept;
+
+template
+double StrahlkorperGr::euclidean_surface_integral_of_vector(
+    const Scalar<DataVector>& area_element,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& vector,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_one_form,
     const Strahlkorper<Frame::Inertial>& strahlkorper) noexcept;
 
 template Scalar<DataVector> StrahlkorperGr::spin_function<Frame::Inertial>(

--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -209,6 +209,27 @@ double surface_integral_of_scalar(
 
 /*!
  * \ingroup SurfacesGroup
+ * \brief Euclidean surface integral of a vector on a 2D `Strahlkorper`
+ *
+ * \details Computes the surface integral
+ * \f$\oint V^i s_i (s_j s_k \delta^{jk})^{-1/2} d^2S\f$ for a
+ * vector \f$V^i\f$ on a `Strahlkorper` with area element \f$d^2S\f$ and
+ * normal one-form \f$s_i\f$.  Here \f$\delta^{ij}\f$ is the Euclidean
+ * metric (i.e. the Kronecker delta). Note that the input `normal_one_form`
+ * is not assumed to be normalized; the denominator of the integrand
+ * effectively normalizes it using the Euclidean metric.
+ * The area element can be computed via
+ * `StrahlkorperGr::euclidean_area_element()`.
+ */
+template <typename Frame>
+double euclidean_surface_integral_of_vector(
+    const Scalar<DataVector>& area_element,
+    const tnsr::I<DataVector, 3, Frame>& vector,
+    const tnsr::i<DataVector, 3, Frame>& normal_one_form,
+    const Strahlkorper<Frame>& strahlkorper) noexcept;
+
+/*!
+ * \ingroup SurfacesGroup
  * \brief Spin function of a 2D `Strahlkorper`.
  *
  * \details See Eqs. (2) and (10)

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -239,6 +239,24 @@ struct EuclideanSurfaceIntegral : db::ComputeTag {
                                    StrahlkorperTags::Strahlkorper<Frame>>;
 };
 
+/// Computes the Euclidean-space integral of a vector over a
+/// Strahlkorper, \f$\oint V^i s_i (s_j s_k \delta^{jk})^{-1/2} d^2 S\f$,
+/// where \f$s_i\f$ is the Strahlkorper surface unit normal and
+/// \f$\delta^{ij}\f$ is the Kronecker delta.  Note that \f$s_i\f$ is
+/// not assumed to be normalized; the denominator of the integrand
+/// effectively normalizes it using the Euclidean metric.
+template <typename IntegrandTag, typename Frame>
+struct EuclideanSurfaceIntegralVector : db::ComputeTag {
+  static std::string name() noexcept {
+    return "EuclideanSurfaceIntegralVector(" + IntegrandTag::name() + ")";
+  }
+  static constexpr auto function =
+      ::StrahlkorperGr::euclidean_surface_integral_of_vector<Frame>;
+  using argument_tags = tmpl::list<EuclideanAreaElement<Frame>, IntegrandTag,
+                                   StrahlkorperTags::NormalOneForm<Frame>,
+                                   StrahlkorperTags::Strahlkorper<Frame>>;
+};
+
 template <typename Frame>
 using items_tags = tmpl::list<Strahlkorper<Frame>>;
 

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -253,6 +253,99 @@ void test_area_element(const Solution& solution, const double& surface_radius,
   CHECK_ITERABLE_APPROX(get(area_element), expected(get(area_element).size()));
 }
 
+void test_euclidean_surface_integral_of_vector(
+    const Strahlkorper<Frame::Inertial>& strahlkorper) noexcept {
+  const auto box = db::create<
+      db::AddSimpleTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
+      db::AddComputeTags<
+          StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(strahlkorper);
+
+  const auto& normal_one_form =
+      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box);
+  const auto& r_hat = db::get<StrahlkorperTags::Rhat<Frame::Inertial>>(box);
+  const auto& radius = db::get<StrahlkorperTags::Radius<Frame::Inertial>>(box);
+  const auto& jacobian =
+      db::get<StrahlkorperTags::Jacobian<Frame::Inertial>>(box);
+
+  const auto euclidean_area_element = StrahlkorperGr::euclidean_area_element(
+      jacobian, normal_one_form, radius, r_hat);
+
+  // Create arbitrary vector
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> dist(-1., 1.);
+  const auto test_vector = make_with_random_values<tnsr::I<DataVector, 3>>(
+      make_not_null(&generator), make_not_null(&dist), radius);
+
+  // Test against integrating this scalar.
+  const auto scalar = Scalar<DataVector>(
+      get(dot_product(test_vector, normal_one_form)) /
+      sqrt(get(dot_product(normal_one_form, normal_one_form))));
+
+  const auto integral_1 = StrahlkorperGr::surface_integral_of_scalar(
+      euclidean_area_element, scalar, strahlkorper);
+  const auto integral_2 = StrahlkorperGr::euclidean_surface_integral_of_vector(
+      euclidean_area_element, test_vector, normal_one_form, strahlkorper);
+
+  CHECK(integral_1 == approx(integral_2));
+}
+
+template <typename Solution, typename Frame>
+void test_euclidean_surface_integral_of_vector_2(
+    const Solution& solution, const Strahlkorper<Frame>& strahlkorper,
+    double expected_area) noexcept {
+  // Another test:  Integrate (assuming Euclidean metric) the vector
+  // V^i = s_j \delta^{ij} (s_k s_l \delta^{kl})^{-1/2} A A_euclid^{-1}
+  // where s_j is the unnormalized Strahlkorper normal one-form,
+  // A is the correct (curved) area element in Kerr,
+  // and A_euclid is the euclidean area element.
+  // This integral should give the area of the horizon, which is
+  // 16 pi M_irr^2 = 8 pi M^2 (1 + sqrt(1-chi^2))
+
+  const auto box = db::create<
+      db::AddSimpleTags<StrahlkorperTags::items_tags<Frame>>,
+      db::AddComputeTags<StrahlkorperTags::compute_items_tags<Frame>>>(
+      strahlkorper);
+
+  // Get spatial metric
+  const double t = 0.0;
+  const auto& cart_coords =
+      db::get<StrahlkorperTags::CartesianCoords<Frame>>(box);
+  const auto vars = solution.variables(
+      cart_coords, t, typename Solution::template tags<DataVector>{});
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<3, Frame, DataVector>>(vars);
+
+  // Get everything we need for the integral
+  const auto& normal_one_form =
+      db::get<StrahlkorperTags::NormalOneForm<Frame>>(box);
+  const auto& r_hat = db::get<StrahlkorperTags::Rhat<Frame>>(box);
+  const auto& radius = db::get<StrahlkorperTags::Radius<Frame>>(box);
+  const auto& jacobian = db::get<StrahlkorperTags::Jacobian<Frame>>(box);
+  const auto euclidean_area_element = StrahlkorperGr::euclidean_area_element(
+      jacobian, normal_one_form, radius, r_hat);
+
+  // Make the test vector
+  // V^i = s_j \delta^{ij} (s_k s_l \delta^{kl})^{-1/2} A A_euclid^{-1}
+  // where A is the area element and A_euclid is the euclidean area element.
+  const auto area_element = StrahlkorperGr::area_element(
+      spatial_metric, jacobian, normal_one_form, radius, r_hat);
+  const auto test_vector_factor = Scalar<DataVector>(
+      get(area_element) / get(euclidean_area_element) /
+      sqrt(get(dot_product(normal_one_form, normal_one_form))));
+  auto test_vector = make_with_value<tnsr::I<DataVector, 3, Frame>>(r_hat, 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    test_vector.get(i) = normal_one_form.get(i) * get(test_vector_factor);
+  }
+
+  const auto area_integral =
+      StrahlkorperGr::euclidean_surface_integral_of_vector(
+          euclidean_area_element, test_vector, normal_one_form, strahlkorper);
+
+  // approx here because we are integrating over a Strahlkorper
+  // at finite resolution.
+  CHECK(area_integral == approx(expected_area));
+}
+
 void test_euclidean_area_element(
     const Strahlkorper<Frame::Inertial>& strahlkorper) noexcept {
   const auto box = db::create<
@@ -794,6 +887,11 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.AreaElement",
                                inside_kerr_horizon);
   test_integral_correspondence(gr::Solutions::KerrSchild{mass, spin, center},
                                outside_kerr_horizon);
+
+  test_euclidean_surface_integral_of_vector(kerr_horizon);
+  test_euclidean_surface_integral_of_vector_2(
+      gr::Solutions::KerrSchild{mass, spin, center}, kerr_horizon,
+      expected_area);
 }
 
 SPECTRE_TEST_CASE(


### PR DESCRIPTION
Add a new function and compute item that, given some vector `V^i`, computes the integral
of `V^i s_i` over a Strahlkorper, where the integral assumes flat space (but an arbitrarily-shaped Strahlkorper), and `s_i` is the unit normal to the Strahlkorper normalized with the Euclidean metric.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
