### PR TITLE
Add MassFlux

### DIFF
--- a/src/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   EquationsOfState/IdealFluid.cpp
   EquationsOfState/PolytropicFluid.cpp
   LorentzFactor.cpp
+  MassFlux.cpp
   SpecificEnthalpy.cpp
   )
 

--- a/src/PointwiseFunctions/Hydro/MassFlux.cpp
+++ b/src/PointwiseFunctions/Hydro/MassFlux.cpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "MassFlux.hpp"
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+/// \cond
+namespace hydro {
+
+template <typename DataType, size_t Dim, typename Frame>
+tnsr::I<DataType, Dim, Frame> mass_flux(
+    const Scalar<DataType>& rest_mass_density,
+    const tnsr::I<DataType, Dim, Frame>& spatial_velocity,
+    const Scalar<DataType>& lorentz_factor, const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, Dim, Frame>& shift,
+    const Scalar<DataType>& sqrt_det_spatial_metric) noexcept {
+  auto result =
+      make_with_value<tnsr::I<DataType, Dim, Frame>>(rest_mass_density, 0.0);
+  for (size_t i = 0; i < Dim; ++i) {
+    result.get(i) = get(rest_mass_density) * get(lorentz_factor) *
+                    get(sqrt_det_spatial_metric) *
+                    (get(lapse) * spatial_velocity.get(i) - shift.get(i));
+  }
+  return result;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define INSTANTIATE(_, data)                                                \
+  template tnsr::I<DTYPE(data), DIM(data), FRAME(data)> mass_flux(   \
+      const Scalar<DTYPE(data)>& rest_mass_density,                         \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& spatial_velocity, \
+      const Scalar<DTYPE(data)>& lorentz_factor,                            \
+      const Scalar<DTYPE(data)>& lapse,                                     \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,            \
+      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+}  // namespace hydro
+/// \endcond

--- a/src/PointwiseFunctions/Hydro/MassFlux.hpp
+++ b/src/PointwiseFunctions/Hydro/MassFlux.hpp
@@ -1,0 +1,64 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp" // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp" // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_forward_declare gr::Tags::Lapse
+// IWYU pragma: no_forward_declare gr::Tags::Shift
+// IWYU pragma: no_forward_declare gr::Tags::SqrtDetSpatialMetric
+// IWYU pragma: no_forward_declare hydro::Tags::LorentzFactor
+// IWYU pragma: no_forward_declare hydro::Tags::RestMassDensity
+// IWYU pragma: no_forward_declare hydro::Tags::SpatialVelocity
+
+namespace hydro {
+/// Computes the vector \f$J^i\f$ in \f$\dot{M} = -\int J^i s_i d^2S\f$,
+/// representing the mass flux through a surface with normal \f$s_i\f$.
+///
+/// Note that the integral is understood
+/// as a flat-space integral: all metric factors are included in \f$J^i\f$.
+/// In particular, if the integral is done over a Strahlkorper, the
+/// `StrahlkorperGr::euclidean_area_element` of the Strahlkorper should be used,
+/// and \f$s_i\f$ is
+/// the normal one-form to the Strahlkorper normalized with the flat metric,
+/// \f$s_is_j\delta^{ij}=1\f$.
+///
+/// The formula is
+/// \f$ J^i = \rho W \sqrt{\gamma}(\alpha v^i-\beta^i)\f$,
+/// where \f$\rho\f$ is the mass density, \f$W\f$ is the Lorentz factor,
+/// \f$v^i\f$ is the spatial velocity of the fluid,
+/// \f$\gamma\f$ is the determinant of the 3-metric \f$\gamma_{ij}\f$,
+/// \f$\alpha\f$ is the lapse, and \f$\beta^i\f$ is the shift.
+template <typename DataType, size_t Dim, typename Frame>
+tnsr::I<DataType, Dim, Frame> mass_flux(
+    const Scalar<DataType>& rest_mass_density,
+    const tnsr::I<DataType, Dim, Frame>& spatial_velocity,
+    const Scalar<DataType>& lorentz_factor, const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, Dim, Frame>& shift,
+    const Scalar<DataType>& sqrt_det_spatial_metric) noexcept;
+
+namespace Tags {
+/// Compute item for mass flux vector \f$J^i\f$.
+///
+/// Can be retrieved using `hydro::Tags::MassFlux`
+template <typename DataType, size_t Dim, typename Frame>
+struct MassFluxCompute : MassFlux<DataType, Dim, Frame>,
+                               db::ComputeTag {
+  static constexpr auto function = &mass_flux<DataType, Dim, Frame>;
+  using argument_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataType>,
+                 hydro::Tags::SpatialVelocity<DataType, Dim, Frame>,
+                 hydro::Tags::LorentzFactor<DataType>,
+                 ::gr::Tags::Lapse<DataType>,
+                 ::gr::Tags::Shift<Dim, Frame, DataType>,
+                 ::gr::Tags::SqrtDetSpatialMetric<DataType>>;
+};
+}  // namespace Tags
+}  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 
@@ -191,6 +192,30 @@ struct SpecificInternalEnergy : db::SimpleTag {
   static std::string name() noexcept { return "SpecificInternalEnergy"; }
 };
 
+/// The vector \f$J^i\f$ in \f$\dot{M} = -\int J^i s_i d^2S\f$,
+/// representing the mass flux through a surface with normal \f$s_i\f$.
+///
+/// Note that the integral is understood
+/// as a flat-space integral: all metric factors are included in \f$J^i\f$.
+/// In particular, if the integral is done over a Strahlkorper, the
+/// `StrahlkorperGr::euclidean_area_element` of the Strahlkorper should be used,
+/// and \f$s_i\f$ is
+/// the normal one-form to the Strahlkorper normalized with the flat metric,
+/// \f$s_is_j\delta^{ij}=1\f$.
+///
+/// The formula is
+/// \f$ J^i = \rho W \sqrt{\gamma}(\alpha v^i-\beta^i)\f$,
+/// where \f$\rho\f$ is the mass density, \f$W\f$ is the Lorentz factor,
+/// \f$v^i\f$ is the spatial velocity of the fluid,
+/// \f$\gamma\f$ is the determinant of the 3-metric \f$\gamma_{ij}\f$,
+/// \f$\alpha\f$ is the lapse, and \f$\beta^i\f$ is the shift.
+template <typename DataType, size_t Dim, typename Fr>
+struct MassFlux : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, Fr>;
+  static std::string name() noexcept {
+    return Frame::prefix<Fr>() + "MassFlux";
+  }
+};
 }  // namespace Tags
 
 /// The tags for the primitive variables for GRMHD.

--- a/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
@@ -58,6 +58,8 @@ template <typename DataType>
 struct SpecificEnthalpyCompute;
 template <typename DataType>
 struct SpecificInternalEnergy;
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct MassFlux;
 }  // namespace Tags
 }  // namespace hydro
 /// \endcond

--- a/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   EquationsOfState/Test_IdealFluid.cpp
   EquationsOfState/Test_PolytropicFluid.cpp
   Test_LorentzFactor.cpp
+  Test_MassFlux.cpp
   Test_SpecificEnthalpy.cpp
   Test_Tags.cpp
   )

--- a/tests/Unit/PointwiseFunctions/Hydro/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/TestFunctions.py
@@ -13,6 +13,17 @@ def lorentz_factor(spatial_velocity, spatial_velocity_one_form):
 
 # End functions for testing LorentzFactor.cpp
 
+# Functions for testing MassFlux.cpp
+
+
+def mass_flux(rest_mass_density, spatial_velocity,
+              lorentz_factor, lapse, shift, sqrt_det_spatial_metric):
+    return rest_mass_density * lorentz_factor * sqrt_det_spatial_metric * \
+        (lapse * spatial_velocity - shift)
+
+
+# End functions for testing MassFlux.cpp
+
 # Functions for testing SpecificEnthalpy.cpp
 
 

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_MassFlux.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_MassFlux.cpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/MassFlux.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+namespace hydro {
+namespace {
+template <size_t Dim, typename Frame, typename DataType>
+void test_mass_flux(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(&mass_flux<DataType, Dim, Frame>,
+                                    "TestFunctions", "mass_flux",
+                                    {{{-10.0, 10.0}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.MassFlux",
+                  "[Unit][Hydro]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/Hydro/");
+  const DataVector dv(5);
+  test_mass_flux<1, Frame::Inertial>(dv);
+  test_mass_flux<1, Frame::Grid>(dv);
+  test_mass_flux<2, Frame::Inertial>(dv);
+  test_mass_flux<2, Frame::Grid>(dv);
+  test_mass_flux<3, Frame::Inertial>(dv);
+  test_mass_flux<3, Frame::Grid>(dv);
+
+  test_mass_flux<1, Frame::Inertial>(0.0);
+  test_mass_flux<1, Frame::Grid>(0.0);
+  test_mass_flux<2, Frame::Inertial>(0.0);
+  test_mass_flux<2, Frame::Grid>(0.0);
+  test_mass_flux<3, Frame::Inertial>(0.0);
+  test_mass_flux<3, Frame::Grid>(0.0);
+
+  // Check compute item works correctly in DataBox
+  CHECK(Tags::MassFluxCompute<DataVector, 2, Frame::Inertial>::name() ==
+        "MassFlux");
+  Scalar<DataVector> rho{{{DataVector{5, 1.0}}}};
+  tnsr::I<DataVector, 3> velocity{
+      {{DataVector{5, 0.25}, DataVector{5, 0.1}, DataVector{5, 0.35}}}};
+  Scalar<DataVector> lorentz{{{DataVector{5, 0.2}}}};
+  Scalar<DataVector> lapse{{{DataVector{5, 0.3}}}};
+  tnsr::I<DataVector, 3> shift{
+      {{DataVector{5, 0.1}, DataVector{5, 0.2}, DataVector{5, 0.3}}}};
+  Scalar<DataVector> sqrt_det_g{{{DataVector{5, 0.25}}}};
+  const auto box = db::create<
+      db::AddSimpleTags<Tags::RestMassDensity<DataVector>,
+                        Tags::SpatialVelocity<DataVector, 3, Frame::Inertial>,
+                        Tags::LorentzFactor<DataVector>,
+                        ::gr::Tags::Lapse<DataVector>,
+                        ::gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                        ::gr::Tags::SqrtDetSpatialMetric<DataVector>>,
+      db::AddComputeTags<
+          Tags::MassFluxCompute<DataVector, 3, Frame::Inertial>>>(
+      rho, velocity, lorentz, lapse, shift, sqrt_det_g);
+  CHECK(db::get<Tags::MassFlux<DataVector, 3, Frame::Inertial>>(box) ==
+        mass_flux(rho, velocity, lorentz, lapse, shift, sqrt_det_g));
+}
+}  // namespace hydro

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
@@ -70,4 +70,6 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.Tags", "[Unit][Hydro]") {
         "SpecificInternalEnergy");
   CHECK(hydro::Tags::SpecificInternalEnergy<DataVector>::name() ==
         "SpecificInternalEnergy");
+  CHECK(hydro::Tags::MassFlux<DataVector, 3, Frame::Inertial>::name() ==
+        "MassFlux");
 }


### PR DESCRIPTION
## Proposed changes

Adds a function and compute item to compute `J^i`,  the mass flux vector, 
defined so that the flat-space integral of `J^i s_i` over a surface with (Euclidean-normalized) unit normal `s_i` is the mass flux through that surface.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
