### PR TITLE
Add limiter test helper to reduce code duplication

### DIFF
--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/TestHelpers.hpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/TestHelpers.hpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <unordered_set>
+
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/Neighbors.hpp"
+#include "Domain/OrientationMap.hpp"
+
+namespace TestHelpers {
+namespace SlopeLimiters {
+
+// Construct a Neighbors object with one neighboring element.
+template <size_t VolumeDim>
+Neighbors<VolumeDim> make_neighbor_with_id(const size_t id) noexcept {
+  return {std::unordered_set<ElementId<VolumeDim>>{ElementId<VolumeDim>(id)},
+          OrientationMap<VolumeDim>{}};
+}
+
+// Construct an Element with one neighboring element in each direction.
+//
+// The optional argument specifies directions to external boundaries, i.e.,
+// directions where there is no neighboring element.
+template <size_t VolumeDim>
+Element<VolumeDim> make_element(
+    const std::unordered_set<Direction<VolumeDim>>&
+        directions_of_external_boundaries = {}) noexcept {
+  typename Element<VolumeDim>::Neighbors_t neighbors;
+  for (const auto dir : Direction<VolumeDim>::all_directions()) {
+    // Element has neighbors in directions with internal boundaries
+    if (directions_of_external_boundaries.count(dir) == 0) {
+      const size_t index =
+          1 + 2 * dir.dimension() + (dir.side() == Side::Upper ? 1 : 0);
+      neighbors[dir] = make_neighbor_with_id<VolumeDim>(index);
+    }
+  }
+  return Element<VolumeDim>{ElementId<VolumeDim>{0}, neighbors};
+}
+
+}  // namespace SlopeLimiters
+}  // namespace TestHelpers

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
@@ -34,6 +34,7 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/TestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
@@ -90,49 +91,6 @@ void test_minmod_serialization() noexcept {
   test_serialization(minmod);
 }
 
-template <size_t VolumeDim>
-Neighbors<VolumeDim> make_neighbor_with_id(const size_t id) noexcept {
-  return {std::unordered_set<ElementId<VolumeDim>>{ElementId<VolumeDim>(id)},
-          OrientationMap<VolumeDim>{}};
-}
-
-// Construct an element with one neighbor in each direction.
-template <size_t VolumeDim>
-Element<VolumeDim> make_element() noexcept;
-
-template <>
-Element<1> make_element() noexcept {
-  return Element<1>{
-      ElementId<1>{0},
-      Element<1>::Neighbors_t{
-          {Direction<1>::lower_xi(), make_neighbor_with_id<1>(1)},
-          {Direction<1>::upper_xi(), make_neighbor_with_id<1>(2)}}};
-}
-
-template <>
-Element<2> make_element() noexcept {
-  return Element<2>{
-      ElementId<2>{0},
-      Element<2>::Neighbors_t{
-          {Direction<2>::lower_xi(), make_neighbor_with_id<2>(1)},
-          {Direction<2>::upper_xi(), make_neighbor_with_id<2>(2)},
-          {Direction<2>::lower_eta(), make_neighbor_with_id<2>(3)},
-          {Direction<2>::upper_eta(), make_neighbor_with_id<2>(4)}}};
-}
-
-template <>
-Element<3> make_element() noexcept {
-  return Element<3>{
-      ElementId<3>{0},
-      Element<3>::Neighbors_t{
-          {Direction<3>::lower_xi(), make_neighbor_with_id<3>(1)},
-          {Direction<3>::upper_xi(), make_neighbor_with_id<3>(2)},
-          {Direction<3>::lower_eta(), make_neighbor_with_id<3>(3)},
-          {Direction<3>::upper_eta(), make_neighbor_with_id<3>(4)},
-          {Direction<3>::lower_zeta(), make_neighbor_with_id<3>(5)},
-          {Direction<3>::upper_zeta(), make_neighbor_with_id<3>(6)}}};
-}
-
 // Test that the limiter activates in the x-direction only. Domain quantities
 // and input Scalar may be of higher dimension VolumeDim.
 template <size_t VolumeDim>
@@ -173,7 +131,8 @@ void test_minmod_limiter_two_lower_xi_neighbors() noexcept {
           {Direction<2>::lower_xi(),
            {std::unordered_set<ElementId<2>>{ElementId<2>(1), ElementId<2>(7)},
             OrientationMap<2>{}}},
-          {Direction<2>::upper_xi(), make_neighbor_with_id<2>(2)}}};
+          {Direction<2>::upper_xi(),
+           TestHelpers::SlopeLimiters::make_neighbor_with_id<2>(2)}}};
   const auto mesh =
       Mesh<2>(3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
@@ -232,7 +191,8 @@ void test_minmod_limiter_four_upper_xi_neighbors() noexcept {
   const auto element = Element<3>{
       ElementId<3>{0},
       Element<3>::Neighbors_t{
-          {Direction<3>::lower_xi(), make_neighbor_with_id<3>(1)},
+          {Direction<3>::lower_xi(),
+           TestHelpers::SlopeLimiters::make_neighbor_with_id<3>(1)},
           {Direction<3>::upper_xi(),
            {std::unordered_set<ElementId<3>>{ElementId<3>(2), ElementId<3>(7),
                                              ElementId<3>(8), ElementId<3>(9)},
@@ -373,7 +333,7 @@ void test_work(
   auto scalar_to_limit = input_scalar;
   auto vector_to_limit = input_vector;
 
-  const auto element = make_element<VolumeDim>();
+  const auto element = TestHelpers::SlopeLimiters::make_element<VolumeDim>();
   const SlopeLimiters::Minmod<VolumeDim,
                               tmpl::list<ScalarTag, VectorTag<VolumeDim>>>
       minmod(SlopeLimiters::MinmodType::LambdaPi1);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_WenoGridHelpers.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_WenoGridHelpers.cpp
@@ -6,7 +6,6 @@
 #include <array>
 #include <cstddef>
 #include <functional>
-#include <unordered_set>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -21,6 +20,7 @@
 #include "Evolution/DiscontinuousGalerkin/SlopeLimiters/WenoGridHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/Gsl.hpp"
+#include "tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/TestHelpers.hpp"
 
 namespace {
 
@@ -65,49 +65,6 @@ void test_check_element_no_href() {
   CHECK_FALSE(SlopeLimiters::Weno_detail::
                   check_element_has_one_similar_neighbor_in_direction(
                       element, Direction<2>::upper_eta()));
-}
-
-template <size_t VolumeDim>
-Neighbors<VolumeDim> make_neighbor_with_id(const size_t id) noexcept {
-  return {std::unordered_set<ElementId<VolumeDim>>{ElementId<VolumeDim>(id)},
-          OrientationMap<VolumeDim>{}};
-}
-
-// Construct an element with one neighbor in each direction.
-template <size_t VolumeDim>
-Element<VolumeDim> make_element() noexcept;
-
-template <>
-Element<1> make_element() noexcept {
-  return Element<1>{
-      ElementId<1>{0},
-      Element<1>::Neighbors_t{
-          {Direction<1>::lower_xi(), make_neighbor_with_id<1>(1)},
-          {Direction<1>::upper_xi(), make_neighbor_with_id<1>(2)}}};
-}
-
-template <>
-Element<2> make_element() noexcept {
-  return Element<2>{
-      ElementId<2>{0},
-      Element<2>::Neighbors_t{
-          {Direction<2>::lower_xi(), make_neighbor_with_id<2>(1)},
-          {Direction<2>::upper_xi(), make_neighbor_with_id<2>(2)},
-          {Direction<2>::lower_eta(), make_neighbor_with_id<2>(3)},
-          {Direction<2>::upper_eta(), make_neighbor_with_id<2>(4)}}};
-}
-
-template <>
-Element<3> make_element() noexcept {
-  return Element<3>{
-      ElementId<3>{0},
-      Element<3>::Neighbors_t{
-          {Direction<3>::lower_xi(), make_neighbor_with_id<3>(1)},
-          {Direction<3>::upper_xi(), make_neighbor_with_id<3>(2)},
-          {Direction<3>::lower_eta(), make_neighbor_with_id<3>(3)},
-          {Direction<3>::upper_eta(), make_neighbor_with_id<3>(4)},
-          {Direction<3>::lower_zeta(), make_neighbor_with_id<3>(5)},
-          {Direction<3>::upper_zeta(), make_neighbor_with_id<3>(6)}}};
 }
 
 template <size_t VolumeDim>
@@ -168,7 +125,7 @@ void check_grid_point_transform_no_href(
 
 void test_grid_helpers_1d() {
   INFO("Testing WENO grid helpers in 1D");
-  const auto element = make_element<1>();
+  const auto element = TestHelpers::SlopeLimiters::make_element<1>();
   const Mesh<1> mesh({{6}}, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   check_grid_point_transform_no_href(mesh, mesh, element);
@@ -180,7 +137,7 @@ void test_grid_helpers_1d() {
 
 void test_grid_helpers_2d() {
   INFO("Testing WENO grid helpers in 2D");
-  const auto element = make_element<2>();
+  const auto element = TestHelpers::SlopeLimiters::make_element<2>();
   const Mesh<2> mesh({{5, 6}}, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   check_grid_point_transform_no_href(mesh, mesh, element);
@@ -192,7 +149,7 @@ void test_grid_helpers_2d() {
 
 void test_grid_helpers_3d() {
   INFO("Testing WENO grid helpers in 3D");
-  const auto element = make_element<3>();
+  const auto element = TestHelpers::SlopeLimiters::make_element<3>();
   const Mesh<3> mesh({{4, 5, 6}}, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   check_grid_point_transform_no_href(mesh, mesh, element);


### PR DESCRIPTION
## Proposed changes

Gather duplicated code into a test helper.

Depends on #1456, but only in the sense that they conflict -- I can easily reverse the dependency if we want to merge this shorter PR sooner. Only commit "Add helpers for shared limiter test code" is new.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

