### PR TITLE
Move EventAndTriggers OptionTag into its own file

### DIFF
--- a/src/Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp
+++ b/src/Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp
@@ -6,7 +6,7 @@
 #include <tuple>
 
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"
+#include "Evolution/EventsAndTriggers/Tags.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Utilities/TaggedTuple.hpp"
 

--- a/src/Evolution/EventsAndTriggers/EventsAndTriggers.hpp
+++ b/src/Evolution/EventsAndTriggers/EventsAndTriggers.hpp
@@ -71,9 +71,3 @@ struct create_from_yaml<EventsAndTriggers<EventRegistrars, TriggerRegistrars>> {
     return type(options.parse_as<typename type::Storage>());
   }
 };
-
-namespace OptionTags {
-/// \cond
-struct EventsAndTriggersTagBase {};
-/// \endcond
-}  // namespace OptionTags

--- a/src/Evolution/EventsAndTriggers/Tags.hpp
+++ b/src/Evolution/EventsAndTriggers/Tags.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines tags related to Events and Triggers
+
+#pragma once
+
+#include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"
+#include "Options/Options.hpp"
+
+namespace OptionTags {
+/// \cond
+struct EventsAndTriggersTagBase {};
+/// \endcond
+
+/// \ingroup OptionTagsGroup
+/// \ingroup EventsAndTriggersGroup
+/// Contains the events and triggers
+///
+/// In yaml this is specified as a map of triggers to lists of events:
+/// \code{.yaml}
+/// EventsAndTriggers:
+///   ? TriggerA:
+///       OptionsForTriggerA
+///   : - Event1:
+///         OptionsForEvent1
+///     - Event2:
+///         OptionsForEvent2
+///   ? TriggerB:
+///       OptionsForTriggerB
+///   : - Event3:
+///         OptionsForEvent3
+///     - Event4:
+///         OptionsForEvent4
+/// \endcode
+template <typename EventRegistrars, typename TriggerRegistrars>
+struct EventsAndTriggers : EventsAndTriggersTagBase {
+  using type = ::EventsAndTriggers<EventRegistrars, TriggerRegistrars>;
+  static constexpr OptionString help = "Events to run at triggers";
+};
+}  // namespace OptionTags

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -20,6 +20,7 @@
 #include "Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"  // IWYU pragma: keep
 #include "Evolution/EventsAndTriggers/Event.hpp"
 #include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"  // IWYU pragma: keep
+#include "Evolution/EventsAndTriggers/Tags.hpp"
 #include "Evolution/Systems/Burgers/Equations.hpp"  // IWYU pragma: keep // for LocalLaxFriedrichsFlux
 #include "Evolution/Systems/Burgers/System.hpp"
 #include "IO/Observer/Actions.hpp"

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -22,6 +22,7 @@
 #include "Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"  // IWYU pragma: keep
 #include "Evolution/EventsAndTriggers/Event.hpp"
 #include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"  // IWYU pragma: keep
+#include "Evolution/EventsAndTriggers/Tags.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Initialize.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanAnalyticData.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanAnalyticData.hpp
@@ -21,6 +21,7 @@
 #include "Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"  // IWYU pragma: keep
 #include "Evolution/EventsAndTriggers/Event.hpp"
 #include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"  // IWYU pragma: keep
+#include "Evolution/EventsAndTriggers/Tags.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Initialize.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -19,6 +19,7 @@
 #include "Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"  // IWYU pragma: keep
 #include "Evolution/EventsAndTriggers/Event.hpp"
 #include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"  // IWYU pragma: keep
+#include "Evolution/EventsAndTriggers/Tags.hpp"
 #include "Evolution/Systems/ScalarWave/Equations.hpp"  // IWYU pragma: keep // for UpwindFlux
 #include "Evolution/Systems/ScalarWave/System.hpp"
 #include "IO/Observer/Actions.hpp"            // IWYU pragma: keep

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -13,7 +13,6 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
-#include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"
 #include "Evolution/Tags.hpp"
 #include "Options/Options.hpp"
 #include "Time/BoundaryHistory.hpp"
@@ -145,16 +144,5 @@ struct InitialSlabSize {
   static constexpr OptionString help = "The initial slab size";
   static type lower_bound() noexcept { return 0.; }
   using group = EvolutionGroup;
-};
-
-/// \ingroup OptionTagsGroup
-/// \ingroup EventsAndTriggersGroup
-/// \ingroup TimeGroup
-/// Contains the events and triggers
-template <typename EventRegistrars, typename TriggerRegistrars>
-struct EventsAndTriggers : EventsAndTriggersTagBase {
-  using type = ::EventsAndTriggers<EventRegistrars, TriggerRegistrars>;
-  static constexpr OptionString help =
-      "Events and triggers to run at slab boundaries";
 };
 }  // namespace OptionTags

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -17,9 +17,9 @@
 #include "Evolution/EventsAndTriggers/Event.hpp"
 #include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"
 #include "Evolution/EventsAndTriggers/LogicalTriggers.hpp"  // IWYU pragma: keep
+#include "Evolution/EventsAndTriggers/Tags.hpp"
 #include "Evolution/EventsAndTriggers/Trigger.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
-#include "Time/Tags.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"


### PR DESCRIPTION
This breaks a non-enforced dependency of libGaugeSourceFunctions upon
module_ConstGlobalCache, which can cause the build to fail.

Potential breaking change:  Executables that use EventsAndTriggers will need to 
`#include "Evolution/EventsAndTriggers/Tags.hpp`

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
