### PR TITLE
Remove Travis build of IWYU

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ At a high level, describe what this PR does.
 
 ### Code review checklist
 
-- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
+- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
   For instructions on how to perform the CI checks locally refer to the [Dev
   guide on the Travis CI](https://spectre-code.org/travis_guide.html).
 - [ ] The code is documented and the documentation renders correctly. Run

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ services:
 stages:
   - Build Libraries
   - Build Test Libraries
-  - Build Executables, Run Tests, ClangTidy, IWYU, and Doxygen
+  - Build Executables, Run Tests, ClangTidy, and Doxygen
 
 # Set up travis configurations of Linux and macOS.
 #
@@ -58,7 +58,7 @@ stages:
 jobs:
   fast_finish: true
   include:
-  - stage: Build Executables, Run Tests, ClangTidy, IWYU, and Doxygen
+  - stage: Build Executables, Run Tests, ClangTidy, and Doxygen
     os: linux
     dist: trusty
     env: CHECK_COMMITS=true
@@ -79,11 +79,6 @@ jobs:
     env: RUN_CLANG_TIDY=true BUILD_TYPE=Debug
     compiler: clang
     name: clang-tidy debug
-  - os: linux
-    dist: trusty
-    env: RUN_IWYU=true BUILD_TYPE=Debug
-    compiler: clang
-    name: include what you use
   - os: linux
     dist: trusty
     env: BUILD_DOC=true BUILD_TYPE=Debug
@@ -169,9 +164,9 @@ jobs:
   - <<: *ClangDebug
   - <<: *ClangRelease
 
-  # Last stage: Build test executables, run tests, clang tidy, IWYU, and docs.
+  # Last stage: Build test executables, run tests, clang tidy, and docs.
   - <<: *Gcc6Debug
-    stage: Build Executables, Run Tests, ClangTidy, IWYU, and Doxygen
+    stage: Build Executables, Run Tests, ClangTidy, and Doxygen
   - <<: *Gcc6Release
   - <<: *Gcc7Debug
   - <<: *Gcc7Release
@@ -220,6 +215,7 @@ before_install:
   - export CHARM_PATCH=v6.8.patch
   - export CHARM_CC=${CC}
   - export FC=gfortran-8
+  - export USE_PCH=ON;
   - if [[ ${COMPILER} =~ (gcc|clang)-([0-9\.]+) ]]; then
       CC=${BASH_REMATCH[1]}-${BASH_REMATCH[2]};
       if [[ ${BASH_REMATCH[1]} = gcc ]]; then
@@ -228,11 +224,6 @@ before_install:
       else
           CXX=clang++-${BASH_REMATCH[2]};
       fi
-    fi
-  - if [ ${RUN_IWYU} ]; then
-        export USE_PCH=OFF;
-    else
-        export USE_PCH=ON;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       ./.travis/MacOsBuildDependencies.sh;
@@ -316,7 +307,6 @@ script:
         --build-arg GH_PAGES_SOURCE_BRANCH=${GH_PAGES_SOURCE_BRANCH}
         --build-arg COVERALLS_TOKEN=${COVERALLS_TOKEN}
         --build-arg RUN_CLANG_TIDY=${RUN_CLANG_TIDY}
-        --build-arg RUN_IWYU=${RUN_IWYU}
         --build-arg BUILD_DOC=${BUILD_DOC}
         --build-arg USE_PCH=${USE_PCH}
         --build-arg UPSTREAM_REPO=${UPSTREAM_REPO}

--- a/.travis/BuildLinux.sh
+++ b/.travis/BuildLinux.sh
@@ -72,7 +72,7 @@ if [ -z "${RUN_CLANG_TIDY}" ] \
     fi
 
     if [[ ${TRAVIS_BUILD_STAGE_NAME} = \
-          "Build executables, run tests, clangtidy, iwyu, and doxygen" ]]; then
+          "Build executables, run tests, clangtidy, and doxygen" ]]; then
         # Build major executables in serial to avoid hitting memory limits.
         time make test-executables -j1
         time ctest --output-on-failure -j2

--- a/docs/DevGuide/Travis.md
+++ b/docs/DevGuide/Travis.md
@@ -97,11 +97,6 @@ useful to perform at least the following tests locally:
   pull request, `make clang-tidy-hash HASH=UPSTREAM_HEAD` where `UPSTREAM_HEAD`
   is the hash of the commit that your pull request is based on, usually the
   `HEAD` of the `upstream/develop` branch.
-- **IWYU:** Also just for the changed files in a pull request run `make
-  iwyu-hash HASH=UPSTREAM_HEAD`. Since IWYU requires `USE_PCH=OFF` you can
-  create a separate build directory and append `-D USE_PCH=OFF` to the usual
-  `cmake` call. Note that it is very easy to incorrectly install IWYU (if not
-  using the Docker container) and generate nonsense errors.
 - **Documentation:** To render the documentation for the current state
   of the source tree the command `make doc` (or `make doc-check` to
   highlight warnings) can be used, placing its result in the `docs`
@@ -111,6 +106,20 @@ useful to perform at least the following tests locally:
   `index.html` file in the `html` subdirectory in a browser. Some functionality
   requires a web server (e.g. citation popovers), so just run a
   `python3 -m http.server` in the `html` directory to enable this.
+- **IWYU:** We experimented for a time using IWYU (include what you
+  use) as an automated check for correct includes and forward
+  declarations.  Unfortunately it gave many incorrect suggestions.  We
+  have decided to no longer have a IWYU check for Travis, but have
+  left support for IWYU so that it can be used locally.  To do so just
+  for the changed files in a pull request run `make iwyu-hash
+  HASH=UPSTREAM_HEAD`. Since IWYU requires `USE_PCH=OFF` you can
+  create a separate build directory and append `-D USE_PCH=OFF` to the
+  usual `cmake` call. Note that it is very easy to incorrectly install
+  IWYU (if not using the Docker container) and generate nonsense
+  errors.  Note that we have left IWYU pragmas in the code, but no
+  longer require they be added so that IWYU gives no errors when run.
+  As IWYU is still under development, we plan to investigate using it
+  again in the future.
 
 ## Travis setup {#travis-setup}
 


### PR DESCRIPTION
We have experimented with IWYU for over a year, and it gives more incorrect
suggestions that require pragmas than correct suggestions.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
