### PR TITLE
Missing includes and better error message in db::first_matching_tag

### DIFF
--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -160,8 +160,24 @@ using list_of_matching_tags = tmpl::conditional_t<
     cpp17::is_same_v<Tag, ::Tags::DataBox>, tmpl::list<::Tags::DataBox>,
     tmpl::filter<TagList, std::is_base_of<tmpl::pin<Tag>, tmpl::_1>>>;
 
+template <typename Tag, typename TagList,
+          typename MatchingTagsList = list_of_matching_tags<TagList, Tag>>
+struct first_matching_tag_impl {
+  using type = tmpl::front<MatchingTagsList>;
+};
+
+template <typename Tag, typename TagList>
+struct first_matching_tag_impl<Tag, TagList, tmpl::list<>> {
+  static_assert(std::is_same<Tag, NoSuchType>::value,
+                "Could not find the DataBox tag in the list of DataBox tags. "
+                "The first template parameter of 'first_matching_tag_impl' is "
+                "the tag that cannot be found and the second is the list of "
+                "tags being searched.");
+  using type = NoSuchType;
+};
+
 template <typename TagList, typename Tag>
-using first_matching_tag = tmpl::front<list_of_matching_tags<TagList, Tag>>;
+using first_matching_tag = typename first_matching_tag_impl<Tag, TagList>::type;
 
 template <typename TagList, typename Tag>
 constexpr auto number_of_matching_tags =

--- a/src/Domain/MaxNumberOfNeighbors.hpp
+++ b/src/Domain/MaxNumberOfNeighbors.hpp
@@ -5,6 +5,8 @@
 
 #include <cstddef>
 
+#include "Utilities/ConstantExpressions.hpp"
+
 /// \ingroup ComputationalDomainGroup
 /// Returns the maximum number of neighbors an element can have in `dim`
 /// dimensions.

--- a/src/Evolution/Initialization/ConservativeSystem.hpp
+++ b/src/Evolution/Initialization/ConservativeSystem.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
 
 /// \cond
 namespace Frame {

--- a/src/Evolution/Initialization/Interface.hpp
+++ b/src/Evolution/Initialization/Interface.hpp
@@ -8,6 +8,9 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 


### PR DESCRIPTION
## Proposed changes

- Add a few missing includes in different places
- Add a check in `first_matching_tag` that causes a static_assert to be hit that explains the error rather than a backtrace into Brigand code that's basically undecipherable.

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
