### PR TITLE
Add Function to List Subgroups of an H5 File

### DIFF
--- a/src/IO/H5/File.hpp
+++ b/src/IO/H5/File.hpp
@@ -21,6 +21,7 @@
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/CheckH5.hpp"
 #include "IO/H5/Header.hpp"  // IWYU pragma: keep
+#include "IO/H5/Helpers.hpp"
 #include "IO/H5/Object.hpp"
 #include "IO/H5/OpenGroup.hpp"
 #include "Utilities/FileSystem.hpp"
@@ -88,6 +89,11 @@ class H5File {
 
   /// Get name of the H5 file
   const std::string& name() const noexcept { return file_name_; }
+
+  /// Get a std::vector of the names of all immediate subgroups of the file
+  const std::vector<std::string> groups() const noexcept {
+    return h5::get_group_names(file_id_, "/");
+  }
 
   // @{
   /*!
@@ -223,8 +229,7 @@ const ObjectType& H5File<Access_t>::get(const std::string& path,
 
 template <AccessType Access_t>
 template <typename ObjectType, typename... Args>
-ObjectType& H5File<Access_t>::insert(const std::string& path,
-                                     Args&&... args) {
+ObjectType& H5File<Access_t>::insert(const std::string& path, Args&&... args) {
   static_assert(AccessType::ReadWrite == Access_t,
                 "Can only insert into ReadWrite access H5 files.");
   current_object_ = nullptr;

--- a/src/IO/H5/Python/File.cpp
+++ b/src/IO/H5/Python/File.cpp
@@ -13,6 +13,7 @@
 #include "IO/H5/Dat.hpp"
 #include "IO/H5/File.hpp"
 #include "IO/H5/Header.hpp"
+#include "IO/H5/Helpers.hpp"
 #include "IO/H5/OpenGroup.hpp"
 #include "IO/H5/Type.hpp"
 #include "IO/H5/Version.hpp"
@@ -44,8 +45,12 @@ void bind_h5file() {
                                py_list_to_std_vector<std::string>(legend),
                                version);
            })
-      .def("close", +[](const h5::H5File<h5::AccessType::ReadWrite>& f) {
-        f.close_current_object();
+      .def("close",
+           +[](const h5::H5File<h5::AccessType::ReadWrite>& f) {
+             f.close_current_object();
+           })
+      .def("groups", +[](h5::H5File<h5::AccessType::ReadWrite>& f) {
+        return std_vector_to_py_list<std::string>(f.groups());
       });
 }
 }  // namespace py_bindings

--- a/tests/Unit/IO/Test_H5.py
+++ b/tests/Unit/IO/Test_H5.py
@@ -2,11 +2,12 @@
 # See LICENSE.txt for details.
 
 from spectre import DataStructures
-import  spectre.IO.H5 as spectre_h5
+import spectre.IO.H5 as spectre_h5
 import unittest
 import numpy as np
 import os
 import numpy.testing as npt
+
 
 class TestIOH5File(unittest.TestCase):
     # Test Fixtures
@@ -19,11 +20,9 @@ class TestIOH5File(unittest.TestCase):
         if os.path.isfile(self.file_name):
             os.remove(self.file_name)
 
-
     def tearDown(self):
         if os.path.isfile(self.file_name):
             os.remove(self.file_name)
-
 
     # Test whether an H5 file is created correctly,
     def test_name(self):
@@ -78,6 +77,18 @@ class TestIOH5File(unittest.TestCase):
         datfile = file_spec.get_dat("/element_data")
         self.assertEqual(datfile.get_header()[0:16], "#\n# File created")
         file_spec.close()
+
+    def test_groups(self):
+        file_spec = spectre_h5.H5File(self.file_name, 1)
+        file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
+        file_spec.insert_dat("/element_position", ["x", "y", "z"], 0)
+        file_spec.insert_dat("/element_size", ["Time", "Size"], 0)
+        groups_spec = ["element_data.dat", "element_position.dat",
+                       "element_size.dat", "src.tar.gz"]
+        for group_name in groups_spec:
+            self.assertTrue(group_name in file_spec.groups())
+        file_spec.close()
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

This pull request adds a getter function for the subgroups of a c++ `h5::H5File` object, as well as a python wrapper for this function. 

### Types of changes:

- [ ] Bugfix
- [ x] New feature

### Component:

- [ x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
