### PR TITLE
Add db::apply overload that uses argument_tags

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1645,16 +1645,16 @@ constexpr bool has_argument_tags_v = has_argument_tags<F>::value;
 template <typename TagsList, typename F, typename BoxTags, typename... Args,
           Requires<not DataBox_detail::has_argument_tags_v<std::decay_t<F>>> =
               nullptr>
-inline constexpr auto apply(F&& f, const DataBox<BoxTags>& box,
-                            Args&&... args) noexcept {
+SPECTRE_ALWAYS_INLINE constexpr auto apply(F&& f, const DataBox<BoxTags>& box,
+                                           Args&&... args) noexcept {
   return DataBox_detail::Apply<TagsList>::apply(std::forward<F>(f), box,
                                                 std::forward<Args>(args)...);
 }
 
 template <typename F, typename BoxTags, typename... Args,
           typename ArgumentTags = typename std::decay_t<F>::argument_tags>
-inline constexpr auto apply(F&& f, const DataBox<BoxTags>& box,
-                            Args&&... args) noexcept {
+SPECTRE_ALWAYS_INLINE constexpr auto apply(F&& f, const DataBox<BoxTags>& box,
+                                           Args&&... args) noexcept {
   return DataBox_detail::Apply<ArgumentTags>::apply(
       std::forward<F>(f), box, std::forward<Args>(args)...);
 }
@@ -1680,8 +1680,8 @@ inline constexpr auto apply(F&& f, const DataBox<BoxTags>& box,
  * DataBox, `box`
  */
 template <typename F, typename BoxTags, typename... Args>
-inline constexpr auto apply(const DataBox<BoxTags>& box,
-                            Args&&... args) noexcept {
+SPECTRE_ALWAYS_INLINE constexpr auto apply(const DataBox<BoxTags>& box,
+                                           Args&&... args) noexcept {
   static_assert(
       DataBox_detail::has_argument_tags_v<F>,
       "The stateless invokable does not specify an 'argument_tags' type "
@@ -1698,7 +1698,7 @@ template <typename... ReturnTags, typename... ArgumentTags, typename F,
               const std::add_lvalue_reference_t<
                   db::item_type<ArgumentTags, BoxTags>>...,
               Args...>> = nullptr>
-inline constexpr auto mutate_apply(
+SPECTRE_ALWAYS_INLINE constexpr auto mutate_apply(
     F&& /*f*/, const gsl::not_null<db::DataBox<BoxTags>*> box,
     tmpl::list<ReturnTags...> /*meta*/, tmpl::list<ArgumentTags...> /*meta*/,
     Args&&... args) noexcept {
@@ -1727,7 +1727,7 @@ template <typename... ReturnTags, typename... ArgumentTags, typename F,
               const std::add_lvalue_reference_t<
                   db::item_type<ArgumentTags, BoxTags>>...,
               Args...>> = nullptr>
-inline constexpr auto mutate_apply(
+SPECTRE_ALWAYS_INLINE constexpr auto mutate_apply(
     F&& f, const gsl::not_null<db::DataBox<BoxTags>*> box,
     tmpl::list<ReturnTags...> /*meta*/, tmpl::list<ArgumentTags...> /*meta*/,
     Args&&... args) noexcept {
@@ -1772,7 +1772,7 @@ template <
                 const std::add_lvalue_reference_t<
                     db::item_type<ArgumentTags, BoxTags>>...,
                 Args...>)> = nullptr>
-inline constexpr auto mutate_apply(
+SPECTRE_ALWAYS_INLINE constexpr auto mutate_apply(
     F /*f*/, const gsl::not_null<db::DataBox<BoxTags>*> /*box*/,
     tmpl::list<ReturnTags...> /*meta*/, tmpl::list<ArgumentTags...> /*meta*/,
     Args&&... /*args*/) noexcept {
@@ -1868,7 +1868,7 @@ template <typename MutateTags, typename ArgumentTags, typename F,
           typename BoxTags, typename... Args,
           Requires<not DataBox_detail::has_return_tags_and_argument_tags_v<
               std::decay_t<F>>> = nullptr>
-inline constexpr auto mutate_apply(
+SPECTRE_ALWAYS_INLINE constexpr auto mutate_apply(
     F&& f, const gsl::not_null<DataBox<BoxTags>*> box,
     Args&&... args) noexcept(DataBox_detail::
                                  check_mutate_apply_mutate_tags(
@@ -1894,7 +1894,7 @@ template <typename F, typename BoxTags, typename... Args,
               std::decay_t<F>>> = nullptr,
           typename MutateTags = typename std::decay_t<F>::return_tags,
           typename ArgumentTags = typename std::decay_t<F>::argument_tags>
-inline constexpr auto mutate_apply(
+SPECTRE_ALWAYS_INLINE constexpr auto mutate_apply(
     F&& f, const gsl::not_null<DataBox<BoxTags>*> box,
     Args&&... args) noexcept(DataBox_detail::
                                  check_mutate_apply_mutate_tags(
@@ -1939,8 +1939,8 @@ inline constexpr auto mutate_apply(
  * DataBox, `box`
  */
 template <typename F, typename BoxTags, typename... Args>
-inline constexpr auto mutate_apply(const gsl::not_null<DataBox<BoxTags>*> box,
-                                   Args&&... args) noexcept {
+SPECTRE_ALWAYS_INLINE constexpr auto mutate_apply(
+    const gsl::not_null<DataBox<BoxTags>*> box, Args&&... args) noexcept {
   static_assert(
       DataBox_detail::has_return_tags_and_argument_tags_v<F>,
       "The stateless mutator does not specify both 'argument_tags' and "

--- a/src/Evolution/EventsAndTriggers/Event.hpp
+++ b/src/Evolution/EventsAndTriggers/Event.hpp
@@ -54,11 +54,8 @@ class Event : public PUP::able {
            const ArrayIndex& array_index,
            const ComponentPointer /*meta*/) noexcept {
     call_with_dynamic_type<void, creatable_classes>(
-        this,
-        [&box, &cache, &array_index](auto* const event) noexcept {
-          using EventType = std::decay_t<decltype(*event)>;
-          db::apply<typename EventType::argument_tags>(
-              *event, box, cache, array_index, ComponentPointer{});
+        this, [&box, &cache, &array_index ](auto* const event) noexcept {
+          db::apply(*event, box, cache, array_index, ComponentPointer{});
         });
   }
 };

--- a/src/Evolution/EventsAndTriggers/Trigger.hpp
+++ b/src/Evolution/EventsAndTriggers/Trigger.hpp
@@ -57,11 +57,8 @@ class Trigger : public PUP::able {
   template <typename DbTags>
   bool is_triggered(const db::DataBox<DbTags>& box) noexcept {
     return call_with_dynamic_type<bool, creatable_classes>(
-        this,
-        [&box](auto* const trigger) noexcept {
-          using TriggerType = std::decay_t<decltype(*trigger)>;
-          return db::apply<typename TriggerType::argument_tags>(
-              *trigger, box);
+        this, [&box](auto* const trigger) noexcept {
+          return db::apply(*trigger, box);
         });
   }
 };

--- a/src/Time/StepChoosers/Cfl.hpp
+++ b/src/Time/StepChoosers/Cfl.hpp
@@ -70,9 +70,7 @@ class Cfl : public StepChooser<StepChooserRegistrars> {
       const Parallel::ConstGlobalCache<Metavariables>& cache) const noexcept {
     using compute_largest_characteristic_speed =
         typename Metavariables::system::compute_largest_characteristic_speed;
-    const double speed =
-        db::apply<typename compute_largest_characteristic_speed::argument_tags>(
-            compute_largest_characteristic_speed{}, box);
+    const double speed = db::apply<compute_largest_characteristic_speed>(box);
     const double time_stepper_stability_factor =
         Parallel::get<Tags::TimeStepperBase>(cache).stable_step();
 

--- a/src/Time/StepChoosers/StepChooser.hpp
+++ b/src/Time/StepChoosers/StepChooser.hpp
@@ -64,10 +64,8 @@ class StepChooser : public PUP::able {
       const db::DataBox<DbTags>& box,
       const Parallel::ConstGlobalCache<Metavariables>& cache) const noexcept {
     const auto result = call_with_dynamic_type<double, creatable_classes>(
-        this, [&box, &cache](const auto* const chooser) noexcept {
-          using ChooserType = std::decay_t<decltype(*chooser)>;
-          return db::apply<typename ChooserType::argument_tags>(*chooser, box,
-                                                                cache);
+        this, [&box, &cache ](const auto* const chooser) noexcept {
+          return db::apply(*chooser, box, cache);
         });
     ASSERT(
         result > 0.,

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -537,6 +537,23 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.apply",
       tmpl::list<test_databox_tags::Tag2Base, test_databox_tags::ComputeTag1>>(
       ApplyCallable{}, original_box,
       db::get<test_databox_tags::Tag1>(original_box));
+  /// [apply_stateless_struct_example]
+  struct StatelessApplyCallable {
+    using argument_tags =
+        tmpl::list<test_databox_tags::Tag2, test_databox_tags::ComputeTag1>;
+    static void apply(const std::string& sample_string,
+                      const std::string& computed_string,
+                      const std::vector<double>& vector) noexcept {
+      CHECK(sample_string == "My Sample String"s);
+      CHECK(computed_string == "My Sample String6.28"s);
+      CHECK(vector == (std::vector<double>{8.7, 93.2, 84.7}));
+    }
+  };
+  db::apply<StatelessApplyCallable>(
+      original_box, db::get<test_databox_tags::Tag1>(original_box));
+  /// [apply_stateless_struct_example]
+  db::apply(StatelessApplyCallable{}, original_box,
+            db::get<test_databox_tags::Tag1>(original_box));
 }
 
 // [[OutputRegex, Could not find the tag named "TagTensor__" in the DataBox]]


### PR DESCRIPTION
## Proposed changes

This PR extends the functionality introduced for `db::mutate_apply` in #1413 to `db::apply`.

The new overload checks if the class that is applied has an argument_tags typelist and uses that instead of an explicitly specified template parameter. Another new overload does the same for applying a stateless class (i.e. given as a template parameter instead of as an instantiated object).

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
