### PR TITLE
Fix HWENO fitting bug

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/HwenoModifiedSolution.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/HwenoModifiedSolution.cpp
@@ -239,7 +239,7 @@ const Matrix& ConstrainedFitCache<VolumeDim>::retrieve_inverse_a_matrix(
     return inverse_a_matrices.at(primary_direction).at(primary_direction);
   } else {
     ERROR(
-        "Logic error: asked to retrieve a cached A^{-1} matrix for a\n"
+        "Cache misuse error: asked to retrieve a cached A^{-1} matrix for a\n"
         "configuration where multiple neighboring elements are excluded from\n"
         "the HWENO fit. Because this case is so rare, it is not handled by\n"
         "the cache. The caller should check for multiple neighbors being\n"


### PR DESCRIPTION
## Proposed changes

The recently-merged HWENO fitting code has a bug: it is possible to flag the primary neighbor for the fit as needing to be excluded from the fit. Oops.

This PR fixes the bug and adds a test case that would have caught the bug.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
