### PR TITLE
Remove DomainCreatorsGroup

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -33,8 +33,8 @@
  *
  * ### Description
  * The VolumeDim-dimensional computational Domain is constructed from a set of
- * non-overlapping Block%s. Each Block is a distorted VolumeDim-dimensional
- * hyperrcube  Each codimension-1 boundary of a Block is either part of the
+ * non-overlapping Block%s.  Each Block is a distorted VolumeDim-dimensional
+ * hypercube.  Each codimension-1 boundary of a Block is either part of the
  * external boundary of the computational domain, or is identical to a boundary
  * of one other Block.  Each Block is subdivided into one or more Element%s
  * that may be changed dynamically if AMR is enabled.

--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -384,12 +384,6 @@
  */
 
 /*!
- * \defgroup DomainCreatorsGroup Domain Creators
- * A collection of domain creators for specifying the initial computational
- * domain geometry.
- */
-
-/*!
  * \defgroup EllipticSystemsGroup Elliptic Systems
  * \brief All available elliptic systems and information on how to implement
  * elliptic systems

--- a/src/Domain/Creators/AlignedLattice.hpp
+++ b/src/Domain/Creators/AlignedLattice.hpp
@@ -18,7 +18,6 @@
 namespace domain {
 namespace creators {
 
-/// \ingroup DomainCreatorsGroup
 /// \brief Create a Domain consisting of multiple aligned Blocks arrayed in a
 /// lattice.
 ///

--- a/src/Domain/Creators/Brick.hpp
+++ b/src/Domain/Creators/Brick.hpp
@@ -23,7 +23,6 @@ class DomainCreator;  // IWYU pragma: keep
 namespace domain {
 namespace creators {
 
-/// \ingroup DomainCreatorsGroup
 /// Create a 3D Domain consisting of a single Block.
 template <typename TargetFrame>
 class Brick : public DomainCreator<3, TargetFrame> {

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -19,7 +19,6 @@ class DomainCreator;  // IWYU pragma: keep
 namespace domain {
 namespace creators {
 
-/// \ingroup DomainCreatorsGroup
 /// Create a 3D Domain in the shape of a cylinder where the cross-section
 /// is a square surrounded by four two-dimensional wedges (see Wedge2D).
 ///

--- a/src/Domain/Creators/Disk.hpp
+++ b/src/Domain/Creators/Disk.hpp
@@ -19,7 +19,6 @@ class DomainCreator;  // IWYU pragma: keep
 namespace domain {
 namespace creators {
 
-/// \ingroup DomainCreatorsGroup
 /// Create a 2D Domain in the shape of a disk from a square surrounded by four
 /// wedges.
 template <typename TargetFrame>

--- a/src/Domain/Creators/DomainCreator.hpp
+++ b/src/Domain/Creators/DomainCreator.hpp
@@ -25,7 +25,8 @@ class Domain;
 /// \endcond
 
 namespace domain {
-/// Defines classes that create Domains.
+/// \ingroup ComputationalDomainGroup
+/// \brief Defines classes that create Domains.
 namespace creators {
 /// \cond
 template <size_t VolumeDim, typename TargetFrame>
@@ -86,7 +87,8 @@ struct domain_creators<3> {
 };
 }  // namespace DomainCreators_detail
 
-/// Base class for creating Domains from an option string.
+/// \ingroup ComputationalDomainGroup
+/// \brief Base class for creating Domains from an option string.
 template <size_t VolumeDim, typename TargetFrame>
 class DomainCreator {
  public:

--- a/src/Domain/Creators/FrustalCloak.hpp
+++ b/src/Domain/Creators/FrustalCloak.hpp
@@ -22,7 +22,6 @@ class DomainCreator;  // IWYU pragma: keep
 namespace domain {
 namespace creators {
 
-/// \ingroup DomainCreatorsGroup
 /// Create a 3D cubical domain with two equal-sized abutting excised cubes in
 /// the center. This is done by combining ten frusta.
 template <typename TargetFrame>

--- a/src/Domain/Creators/Interval.hpp
+++ b/src/Domain/Creators/Interval.hpp
@@ -23,7 +23,6 @@ class DomainCreator;  // IWYU pragma: keep
 namespace domain {
 namespace creators {
 
-/// \ingroup DomainCreatorsGroup
 /// Create a 1D Domain consisting of a single Block.
 template <typename TargetFrame>
 class Interval : public DomainCreator<1, TargetFrame> {

--- a/src/Domain/Creators/Rectangle.hpp
+++ b/src/Domain/Creators/Rectangle.hpp
@@ -23,7 +23,6 @@ class DomainCreator;  // IWYU pragma: keep
 namespace domain {
 namespace creators {
 
-/// \ingroup DomainCreatorsGroup
 /// Create a 2D Domain consisting of a single Block.
 template <typename TargetFrame>
 class Rectangle : public DomainCreator<2, TargetFrame> {

--- a/src/Domain/Creators/RotatedBricks.hpp
+++ b/src/Domain/Creators/RotatedBricks.hpp
@@ -16,7 +16,6 @@
 namespace domain {
 namespace creators {
 
-/// \ingroup DomainCreatorsGroup
 /// Create a 3D Domain consisting of eight rotated Blocks.
 ///
 /// \image html eightcubes_rotated_exploded.png

--- a/src/Domain/Creators/RotatedIntervals.hpp
+++ b/src/Domain/Creators/RotatedIntervals.hpp
@@ -23,7 +23,6 @@ class DomainCreator;  // IWYU pragma: keep
 namespace domain {
 namespace creators {
 
-/// \ingroup DomainCreatorsGroup
 /// Create a 1D Domain consisting of two rotated Blocks.
 /// The left block has its logical \f$\xi\f$-axis aligned with the grid x-axis.
 /// The right block has its logical \f$\xi\f$-axis opposite to the grid x-axis.

--- a/src/Domain/Creators/RotatedRectangles.hpp
+++ b/src/Domain/Creators/RotatedRectangles.hpp
@@ -16,7 +16,6 @@
 namespace domain {
 namespace creators {
 
-/// \ingroup DomainCreatorsGroup
 /// Create a 2D Domain consisting of four rotated Blocks.
 /// - The lower left block has its logical \f$\xi\f$-axis aligned with
 /// the grid x-axis.

--- a/src/Domain/Creators/Shell.hpp
+++ b/src/Domain/Creators/Shell.hpp
@@ -21,8 +21,6 @@ namespace domain {
 namespace creators {
 
 /*!
- * \ingroup DomainCreatorsGroup
- *
  * \brief Creates a 3D Domain in the shape of a hollow spherical shell
  * consisting of six wedges.
  *

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -25,7 +25,6 @@ class DomainCreator;  // IWYU pragma: keep
 namespace domain {
 namespace creators {
 
-/// \ingroup DomainCreatorsGroup
 /// Create a 3D Domain in the shape of a sphere consisting of six wedges
 /// and a central cube. For an image showing how the wedges are aligned in
 /// this Domain, see the documentation for Shell.

--- a/src/Domain/OrientationMap.hpp
+++ b/src/Domain/OrientationMap.hpp
@@ -19,7 +19,7 @@ class er;
 }  // namespace PUP
 
 /*!
- * \ingroup DomainCreatorsGroup
+ * \ingroup ComputationalDomainGroup
  * \brief A mapping of the logical coordinate axes of a host to the logical
  * coordinate axes of a neighbor of the host.
  * \usage Given a `size_t dimension`, a `Direction`, or a `SegmentId` of the
@@ -120,7 +120,7 @@ std::array<T, VolumeDim> OrientationMap<VolumeDim>::permute_from_neighbor(
   return result;
 }
 
-/// \ingroup DomainCreatorsGroup
+/// \ingroup ComputationalDomainGroup
 /// `OrientationMap`s define an active rotation of the logical axes that bring
 /// the axes of a host block into alignment with the logical axes of the
 /// neighbor block. `discrete_rotation` applies this active rotation on the


### PR DESCRIPTION
## Proposed changes

Use `ComputationalDomainGroup` instead.
Also adds namespace `domain::creators` to the `ComputationalDomainGroup`.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
