### PR TITLE
Constraint-preserving BCs for GH

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -532,6 +532,19 @@
   volume         = "335",
 }
 
+@article{Kidder:2001tz,
+    author = "Kidder, Lawrence E. and Scheel, Mark A. and Teukolsky, Saul A.",
+    title = "{Extending the lifetime of 3-D black hole computations with a new
+             hyperbolic system of evolution equations}",
+    eprint = "gr-qc/0105031",
+    archivePrefix = "arXiv",
+    doi = "10.1103/PhysRevD.64.064017",
+    journal = "Phys. Rev. D",
+    volume = "64",
+    pages = "064017",
+    year = "2001"
+}
+
 @article{Komissarov1999,
   author   = "Komissarov, S. S.",
   title    = "A {Godunov}-type scheme for relativistic magnetohydrodynamics",

--- a/src/DataStructures/Tags/TempTensor.hpp
+++ b/src/DataStructures/Tags/TempTensor.hpp
@@ -97,6 +97,12 @@ template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
 using Tempijj = TempTensor<N, tnsr::ijj<DataType, SpatialDim, Fr>>;
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
           typename DataType = DataVector>
+using TempIjj = TempTensor<N, tnsr::Ijj<DataType, SpatialDim, Fr>>;
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+          typename DataType = DataVector>
+using Tempijk = TempTensor<N, tnsr::ijk<DataType, SpatialDim, Fr>>;
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+          typename DataType = DataVector>
 using Tempiaa = TempTensor<N, tnsr::iaa<DataType, SpatialDim, Fr>>;
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
           typename DataType = DataVector>
@@ -110,5 +116,10 @@ using Tempabb = TempTensor<N, tnsr::abb<DataType, SpatialDim, Fr>>;
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
           typename DataType = DataVector>
 using TempabC = TempTensor<N, tnsr::abC<DataType, SpatialDim, Fr>>;
+
+// Rank 4
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+          typename DataType = DataVector>
+using Tempijaa = TempTensor<N, tnsr::ijaa<DataType, SpatialDim, Fr>>;
 // @}
 }  // namespace Tags

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -22,12 +22,12 @@ set(LIBS_TO_LINK
   )
 
 function(add_generalized_harmonic_executable
-    INITIAL_DATA_NAME INITIAL_DATA BOUNDARY_CONDITIONS)
+    INITIAL_DATA_NAME INITIAL_DATA BOUNDARY_CONDITIONS BJORHUS)
   add_spectre_parallel_executable(
     "EvolveGh${INITIAL_DATA_NAME}"
     EvolveGeneralizedHarmonic
     Evolution/Executables/GeneralizedHarmonic
-    "EvolutionMetavars<${INITIAL_DATA}, ${BOUNDARY_CONDITIONS}>"
+    "EvolutionMetavars<${INITIAL_DATA}, ${BOUNDARY_CONDITIONS}, ${BJORHUS}>"
     "${LIBS_TO_LINK}"
     )
 endfunction(add_generalized_harmonic_executable)
@@ -36,6 +36,7 @@ add_generalized_harmonic_executable(
   KerrSchild
   GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
   GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
+  false
 )
 target_link_libraries(
   EvolveGhKerrSchild
@@ -44,12 +45,61 @@ target_link_libraries(
   )
 
 add_generalized_harmonic_executable(
+  KerrSchildCPBjorhus
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
+  GeneralizedHarmonic::BoundaryConditions::Bjorhus::ConstraintPreserving
+  true
+)
+target_link_libraries(
+  EvolveGhKerrSchildCPBjorhus
+  PRIVATE
+  GeneralRelativitySolutions
+  )
+
+add_generalized_harmonic_executable(
+  KerrSchildCPPBjorhus
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
+  GeneralizedHarmonic::BoundaryConditions::Bjorhus::ConstraintPreservingPhysical
+  true
+)
+target_link_libraries(
+  EvolveGhKerrSchildCPPBjorhus
+  PRIVATE
+  GeneralRelativitySolutions
+  )
+
+add_generalized_harmonic_executable(
   KerrSchildNumericInitialData
   evolution::NumericInitialData<GeneralizedHarmonic::System<3>>
   GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
+  false
 )
 target_link_libraries(
   EvolveGhKerrSchildNumericInitialData
+  PRIVATE
+  GeneralRelativitySolutions
+  )
+
+add_generalized_harmonic_executable(
+  KerrSchildNumericInitialDataCPBjorhus
+  evolution::NumericInitialData<GeneralizedHarmonic::System<3>>
+  GeneralizedHarmonic::BoundaryConditions::Bjorhus::ConstraintPreserving
+  true
+)
+target_link_libraries(
+  EvolveGhKerrSchildNumericInitialDataCPBjorhus
+  PRIVATE
+  GeneralRelativitySolutions
+  )
+
+add_generalized_harmonic_executable(
+  KerrSchildNumericInitialDataCPPBjorhus
+  evolution::NumericInitialData<GeneralizedHarmonic::System<3>>
+  GeneralizedHarmonic::BoundaryConditions::Bjorhus::ConstraintPreservingPhysical
+  true
+)
+target_link_libraries(
+  EvolveGhKerrSchildNumericInitialDataCPPBjorhus
   PRIVATE
   GeneralRelativitySolutions
   )

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicFwd.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicFwd.hpp
@@ -13,6 +13,13 @@ namespace Solutions {
 template <typename GrSolution>
 struct WrappedGr;
 }  // namespace Solutions
+namespace BoundaryConditions {
+namespace Bjorhus {
+struct Freezing;
+struct ConstraintPreserving;
+struct ConstraintPreservingPhysical;
+}  // namespace Bjorhus
+}  // namespace BoundaryConditions
 }  // namespace GeneralizedHarmonic
 namespace gr {
 namespace Solutions {
@@ -24,6 +31,7 @@ template <typename System>
 struct NumericInitialData;
 }  // namespace evolution
 
-template <typename InitialData, typename BoundaryConditions>
+template <typename InitialData, typename BoundaryConditions,
+          bool BjorhusExternalBoundary>
 struct EvolutionMetavars;
 /// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp
@@ -1,0 +1,311 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/DataOnSlice.hpp"
+#include "DataStructures/SliceVariables.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Structure/IndexToSliceAt.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryConditions.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace GeneralizedHarmonic {
+namespace Actions {
+namespace BoundaryConditions_detail {}  // namespace BoundaryConditions_detail
+
+/// \ingroup ActionsGroup
+/// \brief Computes contributions on the interior side from the volume, and
+/// imposes constraint preserving boundary conditions on the exterior side.
+///
+/// With:
+/// - Boundary<Tag> =
+///   Tags::Interface<Tags::BoundaryDirections<volume_dim>, Tag>
+/// - External<Tag> =
+///   Tags::Interface<Tags::ExternalBoundaryDirections<volume_dim>, Tag>
+///
+/// Uses:
+/// - GlobalCache:
+///   - Metavariables::normal_dot_numerical_flux
+///   - Metavariables::boundary_condition
+/// - DataBox:
+///   - Tags::Element<volume_dim>
+///   - Boundary<Metavariables::normal_dot_numerical_flux::type::argument_tags>
+///   - External<Metavariables::normal_dot_numerical_flux::type::argument_tags>
+///   - Boundary<Tags::Mesh<volume_dim - 1>>
+///   - External<Tags::Mesh<volume_dim - 1>>
+///   - Boundary<Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>,
+///   - External<Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>,
+///   - Boundary<Tags::BoundaryCoordinates<volume_dim>>,
+///   - Metavariables::temporal_id
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///      - External<Tags::dt<typename system::variables_tag>>
+///
+template <typename Metavariables>
+struct ImposeBjorhusBoundaryConditions {
+ public:
+  using const_global_cache_tags =
+      tmpl::list<typename Metavariables::normal_dot_numerical_flux,
+                 typename Metavariables::boundary_condition_tag>;
+
+ private:
+  // {VSpacetimeMetric,VZero,VPlus,VMinus}BcMethod enumerate available
+  // choices for boundary condition. The choice is made in the `apply`
+  // method below.
+  using VSpacetimeMetricBcMethod =
+      BoundaryConditions_detail::VSpacetimeMetricBcMethod;
+  using VZeroBcMethod = BoundaryConditions_detail::VZeroBcMethod;
+  using VPlusBcMethod = BoundaryConditions_detail::VPlusBcMethod;
+  using VMinusBcMethod = BoundaryConditions_detail::VMinusBcMethod;
+
+  template <size_t VolumeDim, VSpacetimeMetricBcMethod VSpacetimeMetricMethod,
+            VZeroBcMethod VZeroMethod, VPlusBcMethod VPlusMethod,
+            VMinusBcMethod VMinusMethod, typename DbTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent,
+            typename... InboxTags>
+  struct apply_impl {
+    static std::tuple<db::DataBox<DbTags>&&> function_impl(
+        db::DataBox<DbTags>& box,
+        tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+        Parallel::GlobalCache<Metavariables>& cache,
+        const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+        const ParallelComponent* const /*meta*/) noexcept {
+      // Get information about system:
+      // tags for evolved variables and their time derivatives
+      using system = typename Metavariables::system;
+      using variables_tag = typename system::variables_tag;
+      using dt_variables_tag =
+          db::add_tag_prefix<Metavariables::temporal_id::template step_prefix,
+                             variables_tag>;
+      constexpr const size_t number_of_independent_components =
+          dt_variables_tag::type::number_of_independent_components;
+
+      const db::item_type<domain::Tags::Mesh<VolumeDim>>& mesh =
+          db::get<domain::Tags::Mesh<VolumeDim>>(box);
+      const size_t volume_grid_points = mesh.extents().product();
+      const auto& unit_normal_one_forms = db::get<domain::Tags::Interface<
+          domain::Tags::BoundaryDirectionsInterior<VolumeDim>,
+          ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<
+              VolumeDim, Frame::Inertial>>>>(box);
+      const auto& volume_all_vars = db::get<variables_tag>(box);
+      const auto& volume_all_dt_vars = db::get<dt_variables_tag>(box);
+      const auto& external_bdry_char_speeds = db::get<domain::Tags::Interface<
+          domain::Tags::BoundaryDirectionsInterior<VolumeDim>,
+          Tags::CharacteristicSpeeds<VolumeDim, Frame::Inertial>>>(box);
+      const auto& external_bdry_inertial_coords =
+          db::get<domain::Tags::Interface<
+              domain::Tags::BoundaryDirectionsInterior<VolumeDim>,
+              domain::Tags::Coordinates<VolumeDim, Frame::Inertial>>>(box);
+
+      // Apply boundary condition:
+      // Loop over external boundaries and set dt_volume_vars on them
+      for (auto& external_direction_and_normals : unit_normal_one_forms) {
+        const auto& direction = external_direction_and_normals.first;
+        const size_t dimension = direction.dimension();
+        const auto& unit_normal_one_form =
+            external_direction_and_normals.second;
+        const size_t slice_grid_points =
+            mesh.extents().slice_away(dimension).product();
+        // Get U on this slice
+        const auto vars =
+            data_on_slice(volume_all_vars, mesh.extents(), dimension,
+                          index_to_slice_at(mesh.extents(), direction));
+        ASSERT(vars.number_of_grid_points() == slice_grid_points,
+               "vars_on_slice has wrong number of grid points.  "
+               "Expected "
+                   << slice_grid_points << ", got "
+                   << vars.number_of_grid_points());
+        // Get dt<U> on this slice
+        const auto dt_vars =
+            data_on_slice(volume_all_dt_vars, mesh.extents(), dimension,
+                          index_to_slice_at(mesh.extents(), direction));
+        // Get characteristic speeds
+        const auto& char_speeds = external_bdry_char_speeds.at(direction);
+        // For external boundaries that are within a horizon,
+        // all characteristic fields are outgoing (toward the singularity)
+        if (BoundaryConditions_detail::min_characteristic_speed<VolumeDim>(
+                char_speeds) >= 0.) {
+          continue;
+        }
+        // Get boundary coordinates
+        const auto& inertial_coords =
+            external_bdry_inertial_coords.at(direction);
+
+        // Create and store all temporaries needed here and elsewhere
+        BoundaryConditions_detail::BjorhusIntermediatesComputer intermediates(
+            slice_grid_points);
+        intermediates.compute_vars(box, direction, dimension, mesh, vars,
+                                   dt_vars, unit_normal_one_form, char_speeds);
+
+        db::mutate<dt_variables_tag>(
+            make_not_null(&box),
+            // Function that applies bdry conditions to dt<variables>
+            [
+              &volume_grid_points, &slice_grid_points, &mesh, &dimension,
+              &direction, &intermediates, &vars, &dt_vars,
+              &unit_normal_one_form, &inertial_coords, &char_speeds
+            ](const gsl::not_null<db::item_type<dt_variables_tag>*>
+                  volume_dt_vars,
+              const double /* time */, const auto& /* boundary_condition */
+              ) noexcept {
+              // Preliminaries
+              ASSERT(
+                  volume_dt_vars->number_of_grid_points() == volume_grid_points,
+                  "volume_dt_vars has wrong number of grid points.  Expected "
+                      << volume_grid_points << ", got "
+                      << volume_dt_vars->number_of_grid_points());
+              // Compute desired values of dt_volume_vars and set it.
+              // At all points on the interface where the char speed of
+              // given characteristic field is positive, we "do nothing", and
+              // when its negative, we apply Bjorhus BCs. This is achieved
+              // through `set_bc_when_char_speed_is_negative`.
+              const auto bc_dt_u_psi =
+                  BoundaryConditions_detail::set_bc_when_char_speed_is_negative(
+                      intermediates.get_var(
+                          Tags::VSpacetimeMetric<VolumeDim, Frame::Inertial>{}),
+                      BoundaryConditions_detail::set_dt_v_psi<
+                          typename Tags::VSpacetimeMetric<
+                              VolumeDim, Frame::Inertial>::type,
+                          VolumeDim>::apply(VSpacetimeMetricMethod,
+                                            make_not_null(&intermediates), vars,
+                                            dt_vars, unit_normal_one_form),
+                      char_speeds.at(0));
+              const auto bc_dt_u_zero =
+                  BoundaryConditions_detail::set_bc_when_char_speed_is_negative(
+                      intermediates.get_var(
+                          Tags::VZero<VolumeDim, Frame::Inertial>{}),
+                      BoundaryConditions_detail::set_dt_v_zero<
+                          typename Tags::VZero<VolumeDim,
+                                               Frame::Inertial>::type,
+                          VolumeDim>::apply(VZeroMethod,
+                                            make_not_null(&intermediates), vars,
+                                            dt_vars, unit_normal_one_form),
+                      char_speeds.at(1));
+              const auto bc_dt_u_plus =
+                  BoundaryConditions_detail::set_bc_when_char_speed_is_negative(
+                      intermediates.get_var(
+                          Tags::VPlus<VolumeDim, Frame::Inertial>{}),
+                      BoundaryConditions_detail::set_dt_v_plus<
+                          typename Tags::VPlus<VolumeDim,
+                                               Frame::Inertial>::type,
+                          VolumeDim>::apply(VPlusMethod,
+                                            make_not_null(&intermediates), vars,
+                                            dt_vars, unit_normal_one_form),
+                      char_speeds.at(2));
+              const auto bc_dt_u_minus =
+                  BoundaryConditions_detail::set_bc_when_char_speed_is_negative(
+                      intermediates.get_var(
+                          Tags::VMinus<VolumeDim, Frame::Inertial>{}),
+                      BoundaryConditions_detail::set_dt_v_minus<
+                          typename Tags::VMinus<VolumeDim,
+                                                Frame::Inertial>::type,
+                          VolumeDim>::apply(VMinusMethod,
+                                            make_not_null(&intermediates), vars,
+                                            dt_vars, inertial_coords,
+                                            unit_normal_one_form),
+                      char_speeds.at(3));
+              // Convert them to desired values on dt<U>
+              const auto bc_dt_all_u =
+                  evolved_fields_from_characteristic_fields(
+                      intermediates.get_var(Tags::ConstraintGamma2{}),
+                      bc_dt_u_psi, bc_dt_u_zero, bc_dt_u_plus, bc_dt_u_minus,
+                      unit_normal_one_form);
+              // Now store final values of dt<U> in suitable data structure
+              // FIXME: Can we extract this list of dt<U> tags directly from
+              // `dt_variables_tag`?
+              const tuples::TaggedTuple<
+                  db::add_tag_prefix<
+                      Metavariables::temporal_id::template step_prefix,
+                      gr::Tags::SpacetimeMetric<VolumeDim, Frame::Inertial,
+                                                DataVector>>,
+                  db::add_tag_prefix<
+                      Metavariables::temporal_id::template step_prefix,
+                      Tags::Pi<VolumeDim, Frame::Inertial>>,
+                  db::add_tag_prefix<
+                      Metavariables::temporal_id::template step_prefix,
+                      Tags::Phi<VolumeDim, Frame::Inertial>>>
+                  bc_dt_tuple(
+                      std::move(get<gr::Tags::SpacetimeMetric<
+                                    VolumeDim, Frame::Inertial, DataVector>>(
+                          bc_dt_all_u)),
+                      std::move(get<Tags::Pi<VolumeDim, Frame::Inertial>>(
+                          bc_dt_all_u)),
+                      std::move(get<Tags::Phi<VolumeDim, Frame::Inertial>>(
+                          bc_dt_all_u)));
+              const auto slice_data_ = variables_from_tagged_tuple(bc_dt_tuple);
+              const auto* slice_data = slice_data_.data();
+
+              // Assign BC values of dt_volume_vars on external boundary
+              // slices of volume variables
+              auto* const volume_dt_data = volume_dt_vars->data();
+              for (SliceIterator si(
+                       mesh.extents(), dimension,
+                       index_to_slice_at(mesh.extents(), direction));
+                   si; ++si) {
+                for (size_t i = 0; i < number_of_independent_components; ++i) {
+                  // clang-tidy: do not use pointer arithmetic
+                  volume_dt_data[si.volume_offset() +       // NOLINT
+                                 i * volume_grid_points] =  // NOLINT
+                      slice_data[si.slice_offset() +        // NOLINT
+                                 i * slice_grid_points];    // NOLINT
+                }
+              }
+            },
+            db::get<::Tags::Time>(box),
+            get<typename Metavariables::boundary_condition_tag>(cache));
+      }
+
+      return std::forward_as_tuple(std::move(box));
+    }
+  };
+
+ public:
+  template <typename DbTags, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTags>&&> apply(
+      db::DataBox<DbTags>& box, tuples::TaggedTuple<InboxTags...>& inboxes,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ActionList action_list,
+      const ParallelComponent* const parallel_component) noexcept {
+    return apply_impl<Metavariables::system::volume_dim,
+                      // BC choice for U_\Psi
+                      Metavariables::boundary_conditions::v_spacetime_bc_method,
+                      // BC choice for U_0
+                      Metavariables::boundary_conditions::v_zero_bc_method,
+                      // BC choice for U_+
+                      Metavariables::boundary_conditions::v_plus_bc_method,
+                      // BC choice for U_-
+                      Metavariables::boundary_conditions::v_minus_bc_method,
+                      DbTags, ArrayIndex, ActionList, ParallelComponent,
+                      InboxTags...>::function_impl(box, inboxes, cache,
+                                                   array_index, action_list,
+                                                   parallel_component);
+  }
+};
+
+}  // namespace Actions
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusHelpers.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusHelpers.hpp
@@ -1,0 +1,152 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace GeneralizedHarmonic {
+namespace Actions {
+namespace BoundaryConditions_detail {
+template <size_t VolumeDim>
+double min_characteristic_speed(
+    const std::array<DataVector, 4>& char_speeds) noexcept {
+  std::array<double, 4> min_speeds{
+      {min(char_speeds.at(0)), min(char_speeds.at(1)), min(char_speeds.at(2)),
+       min(char_speeds.at(3))}};
+  return *std::min_element(min_speeds.begin(), min_speeds.end());
+}
+
+template <typename T, typename DataType>
+T set_bc_when_char_speed_is_negative(const T& rhs_char_dt_u,
+                                     const T& desired_bc_dt_u,
+                                     const DataType& char_speed_u) noexcept {
+  auto bc_dt_u = rhs_char_dt_u;
+  auto it1 = bc_dt_u.begin();
+  auto it2 = desired_bc_dt_u.begin();
+  for (; it2 != desired_bc_dt_u.end(); ++it1, ++it2) {
+    for (size_t i = 0; i < it1->size(); ++i) {
+      if (char_speed_u[i] < 0.) {
+        (*it1)[i] = (*it2)[i];
+      }
+    }
+  }
+  return bc_dt_u;
+}
+}  // namespace BoundaryConditions_detail
+}  // namespace Actions
+
+// Spatial projection tensors
+template <size_t VolumeDim, typename Frame, typename DataType, typename RetType>
+void spatial_projection_tensor(
+    const gsl::not_null<RetType*> projection_tensor,
+    const tnsr::II<DataType, VolumeDim, Frame>& inverse_spatial_metric,
+    const tnsr::A<DataType, VolumeDim, Frame>& normal_vector) noexcept {
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {
+      projection_tensor->get(i, j) =
+          inverse_spatial_metric.get(i, j) -
+          normal_vector.get(i + 1) * normal_vector.get(j + 1);
+    }
+  }
+}
+template <size_t VolumeDim, typename Frame, typename DataType, typename RetType>
+void spatial_projection_tensor(
+    const gsl::not_null<RetType*> projection_tensor,
+    const tnsr::ii<DataType, VolumeDim, Frame>& spatial_metric,
+    const tnsr::a<DataType, VolumeDim, Frame>& normal_one_form) noexcept {
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {
+      projection_tensor->get(i, j) =
+          spatial_metric.get(i, j) -
+          normal_one_form.get(i + 1) * normal_one_form.get(j + 1);
+    }
+  }
+}
+template <size_t VolumeDim, typename Frame, typename DataType, typename RetType>
+void spatial_projection_tensor(
+    const gsl::not_null<RetType*> projection_tensor,
+    const tnsr::A<DataType, VolumeDim, Frame>& normal_vector,
+    const tnsr::a<DataType, VolumeDim, Frame>& normal_one_form) noexcept {
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      projection_tensor->get(i, j) =
+          -normal_vector.get(i + 1) * normal_one_form.get(j + 1);
+    }
+    projection_tensor->get(i, i) += 1.;
+  }
+}
+
+// This computes U8(+/-)_{ij} = [P^(a_i P^b)_j - (1/2) P_{ij} P^{ab}] *
+//                              [E_{ab} -/+ \epsilon_{a}{}^{cd} n_d B_{cb}]
+//
+// Note that U8+_{ij} is proportional to the Newman-Penrose Psi4
+//       and U8-_{ij} is proportional to the Newman-Penrose Psi0
+//
+// Here
+// U8(a,b)     = U8_{ab}
+// ni(a)       = n_a      (unit normal)
+// nI(a)       = n^a
+// PIJ(a,b)    = P^{ab}   (projection operator = g^{ab} - n^a n^b)
+// Pij(a,b)    = P_{ab}   (projection operator = g_{ab} - n_a n_b)
+// PIj(a,b)    = P^a_b    (projection operator = g^a_b  - n^a n_b)
+// K(a,b)      = K_{ab}
+// Ricci(a,b)  = Ricci_{ab}
+// Invg(a,b)   = g^{ab}
+// CdK(a,b)(c) = \nabla_c K_{ab}
+template <size_t VolumeDim, typename Frame, typename DataType, typename RetType>
+void weyl_propagating(
+    const gsl::not_null<RetType*> U8,
+    const tnsr::ii<DataType, VolumeDim, Frame>& ricci,
+    const tnsr::ii<DataType, VolumeDim, Frame>& extrinsic_curvature,
+    const tnsr::II<DataType, VolumeDim, Frame>& inverse_spatial_metric,
+    const tnsr::ijj<DataType, VolumeDim, Frame>& CdK,
+    const tnsr::A<DataType, VolumeDim, Frame>& unit_interface_normal_vector,
+    const tnsr::II<DataType, VolumeDim, Frame>& projection_IJ,
+    const tnsr::ii<DataType, VolumeDim, Frame>& projection_ij,
+    const tnsr::Ij<DataType, VolumeDim, Frame>& projection_Ij,
+    const int sign) noexcept {
+  // Fill temp with unprojected quantity
+  tnsr::ii<DataType, VolumeDim, Frame> temp(
+      get_size(get<0>(unit_interface_normal_vector)));
+  for (size_t a = 0; a < VolumeDim; ++a) {
+    for (size_t b = a; b < VolumeDim; ++b) {  // Symmetry
+      temp.get(a, b) = ricci.get(a, b);
+      for (size_t c = 0; c < VolumeDim; ++c) {
+        temp.get(a, b) -=
+            sign * unit_interface_normal_vector.get(1 + c) *
+            (CdK.get(c, a, b) - 0.5 * (CdK.get(b, a, c) + CdK.get(a, b, c)));
+
+        for (size_t d = 0; d < VolumeDim; ++d) {
+          temp.get(a, b) +=
+              inverse_spatial_metric.get(c, d) *
+              (extrinsic_curvature.get(a, b) * extrinsic_curvature.get(c, d) -
+               extrinsic_curvature.get(a, c) * extrinsic_curvature.get(d, b));
+        }
+      }
+    }
+  }
+
+  // Now project
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {  // Symmetry
+      U8->get(i, j) = 0.;
+      for (size_t a = 0; a < VolumeDim; ++a) {
+        for (size_t b = 0; b < VolumeDim; ++b) {
+          U8->get(i, j) +=
+              (projection_Ij.get(a, i) * projection_Ij.get(b, j) -
+               0.5 * projection_IJ.get(a, b) * projection_ij.get(i, j)) *
+              temp.get(a, b);
+        }
+      }
+    }
+  }
+}
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
@@ -1,0 +1,881 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/LeviCivitaIterator.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusHelpers.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusInternals.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryConditions.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace GeneralizedHarmonic {
+namespace Actions {
+
+namespace BoundaryConditions_detail {}  // namespace BoundaryConditions_detail
+
+namespace BoundaryConditions_detail {
+using BoundaryConditions::Bjorhus::VMinusBcMethod;
+using BoundaryConditions::Bjorhus::VPlusBcMethod;
+using BoundaryConditions::Bjorhus::VSpacetimeMetricBcMethod;
+using BoundaryConditions::Bjorhus::VZeroBcMethod;
+
+// \brief This struct sets boundary condition on dt<VSpacetimeMetric>
+template <typename ReturnType, size_t VolumeDim>
+struct set_dt_v_psi {
+  template <typename VarsTagsList, typename DtVarsTagsList>
+  static ReturnType apply(
+      const VSpacetimeMetricBcMethod Method,
+      const gsl::not_null<BjorhusIntermediatesComputer*> intermediates,
+      const Variables<VarsTagsList>& /* vars */,
+      const Variables<DtVarsTagsList>& /* dt_vars */,
+      const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+      /* unit_normal_one_form */) noexcept {
+    const auto three_index_constraint = intermediates->get_var(
+        Tags::ThreeIndexConstraint<VolumeDim, Frame::Inertial>{});
+    const auto unit_interface_normal_vector = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::interface_normal_vector<
+            VolumeDim, DataVector>{});
+    const auto char_projected_rhs_dt_u_psi = intermediates->get_var(
+        Tags::VSpacetimeMetric<VolumeDim, Frame::Inertial>{});
+    const std::array<DataVector, 4> char_speeds{
+        {get(intermediates->get_var(
+             BjorhusIntermediatesComputer::internal_tags::char_speed_vpsi<
+                 DataVector>{})),
+         get(intermediates->get_var(
+             BjorhusIntermediatesComputer::internal_tags::char_speed_vzero<
+                 DataVector>{})),
+         get(intermediates->get_var(
+             BjorhusIntermediatesComputer::internal_tags::char_speed_vplus<
+                 DataVector>{})),
+         get(intermediates->get_var(
+             BjorhusIntermediatesComputer::internal_tags::char_speed_vminus<
+                 DataVector>{}))}};
+
+    // Memory allocated for return type
+    ReturnType& bc_dt_u_psi = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::bc_dt_u_psi<VolumeDim,
+                                                                 DataVector>{});
+    std::fill(bc_dt_u_psi.begin(), bc_dt_u_psi.end(), 0.);
+    // Switch on prescribed boundary condition method
+    switch (Method) {
+      case VSpacetimeMetricBcMethod::Freezing:
+        return bc_dt_u_psi;
+      case VSpacetimeMetricBcMethod::ConstraintPreserving:
+        return apply_bjorhus_constraint_preserving(
+            make_not_null(&bc_dt_u_psi), unit_interface_normal_vector,
+            three_index_constraint, char_projected_rhs_dt_u_psi, char_speeds);
+      case VSpacetimeMetricBcMethod::Unknown:
+      default:
+        ASSERT(false,
+               "Requested BC method fo VSpacetimeMetric not implemented!");
+    }
+    // dummy return to suppress compiler warning
+    return ReturnType{};
+  }
+
+ private:
+  static ReturnType apply_bjorhus_constraint_preserving(
+      gsl::not_null<ReturnType*> bc_dt_u_psi,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_vector,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+          three_index_constraint,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+          char_projected_rhs_dt_u_psi,
+      const std::array<DataVector, 4>& char_speeds) noexcept;
+};
+
+template <typename ReturnType, size_t VolumeDim>
+ReturnType
+set_dt_v_psi<ReturnType, VolumeDim>::apply_bjorhus_constraint_preserving(
+    const gsl::not_null<ReturnType*> bc_dt_u_psi,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_vector,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+        three_index_constraint,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_u_psi,
+    const std::array<DataVector, 4>& char_speeds) noexcept {
+  ASSERT(get_size(get<0, 0>(*bc_dt_u_psi)) ==
+             get_size(get<0>(unit_interface_normal_vector)),
+         "Size of input variables and temporary memory do not match: "
+             << get_size(get<0, 0>(*bc_dt_u_psi)) << ","
+             << get_size(get<0>(unit_interface_normal_vector)));
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      bc_dt_u_psi->get(a, b) += char_projected_rhs_dt_u_psi.get(a, b);
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        bc_dt_u_psi->get(a, b) += char_speeds.at(0) *
+                                  unit_interface_normal_vector.get(i + 1) *
+                                  three_index_constraint.get(i, a, b);
+      }
+    }
+  }
+  return *bc_dt_u_psi;
+}
+
+// \brief This struct sets boundary condition on dt<VZero>
+template <typename ReturnType, size_t VolumeDim>
+struct set_dt_v_zero {
+  template <typename VarsTagsList, typename DtVarsTagsList>
+  static ReturnType apply(
+      const VZeroBcMethod Method,
+      const gsl::not_null<BjorhusIntermediatesComputer*> intermediates,
+      const Variables<VarsTagsList>& /* vars */,
+      const Variables<DtVarsTagsList>& /* dt_vars */,
+      const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+      /* unit_normal_one_form */) noexcept {
+    // Not using auto below to enforce a loose test on the quantity being
+    // fetched from the buffer
+    const auto unit_interface_normal_vector = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::interface_normal_vector<
+            VolumeDim, DataVector>{});
+    const auto four_index_constraint = intermediates->get_var(
+        Tags::FourIndexConstraint<VolumeDim, Frame::Inertial>{});
+    const auto char_projected_rhs_dt_u_zero =
+        intermediates->get_var(Tags::VZero<VolumeDim, Frame::Inertial>{});
+    const std::array<DataVector, 4> char_speeds{
+        {get(intermediates->get_var(
+             BjorhusIntermediatesComputer::internal_tags::char_speed_vpsi<
+                 DataVector>{})),
+         get(intermediates->get_var(
+             BjorhusIntermediatesComputer::internal_tags::char_speed_vzero<
+                 DataVector>{})),
+         get(intermediates->get_var(
+             BjorhusIntermediatesComputer::internal_tags::char_speed_vplus<
+                 DataVector>{})),
+         get(intermediates->get_var(
+             BjorhusIntermediatesComputer::internal_tags::char_speed_vminus<
+                 DataVector>{}))}};
+
+    // Memory allocated for return type
+    ReturnType& bc_dt_u_zero = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::bc_dt_u_zero<
+            VolumeDim, DataVector>{});
+    std::fill(bc_dt_u_zero.begin(), bc_dt_u_zero.end(), 0.);
+    // Switch on prescribed boundary condition method
+    switch (Method) {
+      case VZeroBcMethod::Freezing:
+        return bc_dt_u_zero;
+      case VZeroBcMethod::ConstraintPreserving:
+        return apply_bjorhus_constraint_preserving(
+            make_not_null(&bc_dt_u_zero), unit_interface_normal_vector,
+            four_index_constraint, char_projected_rhs_dt_u_zero, char_speeds);
+      case VZeroBcMethod::Unknown:
+      default:
+        ASSERT(false, "Requested BC method fo VZero not implemented!");
+    }
+    // dummy return to suppress compiler warning
+    return ReturnType{};
+  }
+
+ private:
+  static ReturnType apply_bjorhus_constraint_preserving(
+      gsl::not_null<ReturnType*> bc_dt_u_zero,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_vector,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+          four_index_constraint,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+          char_projected_rhs_dt_u_zero,
+      const std::array<DataVector, 4>& char_speeds) noexcept;
+};
+
+template <typename ReturnType, size_t VolumeDim>
+ReturnType
+set_dt_v_zero<ReturnType, VolumeDim>::apply_bjorhus_constraint_preserving(
+    const gsl::not_null<ReturnType*> bc_dt_u_zero,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_vector,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+        four_index_constraint,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_u_zero,
+    const std::array<DataVector, 4>& char_speeds) noexcept {
+  ASSERT(get_size(get<0, 0, 0>(*bc_dt_u_zero)) ==
+             get_size(get<0>(unit_interface_normal_vector)),
+         "Size of input variables and temporary memory do not match: "
+             << get_size(get<0, 0, 0>(*bc_dt_u_zero)) << ","
+             << get_size(get<0>(unit_interface_normal_vector)));
+
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        bc_dt_u_zero->get(i, a, b) += char_projected_rhs_dt_u_zero.get(i, a, b);
+      }
+      // Lets say this term is T2_{kab} := - n_l N^l n^j C_{jkab}.
+      // But we store C4_{iab} = LeviCivita^{ijk} dphi_{jkab},
+      // which means  C_{jkab} = LeviCivita^{ijk} C4_{iab}
+      // where C4 is `four_index_constraint`.
+      // therefore, T2_{iab} =  char_speed<VZero> n^j C_{jiab}
+      // (since char_speed<VZero> = - n_l N^l), and therefore:
+      // T2_{iab} = char_speed<VZero> n^k LeviCivita^{ijk} C4_{jab}.
+      // Let LeviCivitaIterator be indexed by
+      // it[0] <--> i,
+      // it[1] <--> j,
+      // it[2] <--> k, then
+      // T2_{it[0], ab} += char_speed<VZero> n^it[2] it.sign() C4_{it[1], ab};
+      for (LeviCivitaIterator<VolumeDim> it; it; ++it) {
+        bc_dt_u_zero->get(it[0], a, b) +=
+            it.sign() * char_speeds.at(1) *
+            unit_interface_normal_vector.get(it[2] + 1) *
+            four_index_constraint.get(it[1], a, b);
+      }
+    }
+  }
+  return *bc_dt_u_zero;
+}
+
+// \brief This struct sets boundary condition on dt<VPlus>
+template <typename ReturnType, size_t VolumeDim>
+struct set_dt_v_plus {
+  template <typename VarsTagsList, typename DtVarsTagsList>
+  static ReturnType apply(
+      const VPlusBcMethod Method,
+      const gsl::not_null<BjorhusIntermediatesComputer*> intermediates,
+      const Variables<VarsTagsList>& /* vars */,
+      const Variables<DtVarsTagsList>& /* dt_vars */,
+      const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+      /* unit_normal_one_form */) noexcept {
+    // Memory allocated for return type
+    ReturnType& bc_dt_u_plus = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::bc_dt_u_plus<
+            VolumeDim, DataVector>{});
+    std::fill(bc_dt_u_plus.begin(), bc_dt_u_plus.end(), 0.);
+    // Switch on prescribed boundary condition method
+    switch (Method) {
+      case VPlusBcMethod::Freezing:
+        return bc_dt_u_plus;
+      case VPlusBcMethod::Unknown:
+      default:
+        ASSERT(false, "Requested BC method fo VPlus not implemented!");
+    }
+    // dummy return to suppress compiler warning
+    return ReturnType{};
+  }
+
+ private:
+};
+
+// \brief This struct sets boundary condition on dt<VMinus>
+template <typename ReturnType, size_t VolumeDim>
+struct set_dt_v_minus {
+  template <typename VarsTagsList, typename DtVarsTagsList>
+  static ReturnType apply(
+      const VMinusBcMethod Method,
+      const gsl::not_null<BjorhusIntermediatesComputer*> intermediates,
+      const Variables<VarsTagsList>& vars,
+      const Variables<DtVarsTagsList>& /* dt_vars */,
+      const typename domain::Tags::Coordinates<
+          VolumeDim, Frame::Inertial>::type& inertial_coords,
+      const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+      /* unit_normal_one_form */) noexcept {
+    // Not using auto below to enforce a loose test on the quantity being
+    // fetched from the buffer
+    const auto constraint_gamma2 =
+        intermediates->get_var(Tags::ConstraintGamma2{});
+    const auto three_index_constraint = intermediates->get_var(
+        Tags::ThreeIndexConstraint<VolumeDim, Frame::Inertial>{});
+    const auto unit_interface_normal_one_form = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::interface_normal_one_form<
+            VolumeDim, DataVector>{});
+    const auto unit_interface_normal_vector = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::interface_normal_vector<
+            VolumeDim, DataVector>{});
+    const auto spacetime_unit_normal_vector = intermediates->get_var(
+        gr::Tags::SpacetimeNormalVector<VolumeDim, Frame::Inertial,
+                                        DataVector>{});
+
+    const auto char_projected_rhs_dt_u_psi = intermediates->get_var(
+        Tags::VSpacetimeMetric<VolumeDim, Frame::Inertial>{});
+    const auto char_projected_rhs_dt_u_minus =
+        intermediates->get_var(Tags::VMinus<VolumeDim, Frame::Inertial>{});
+    const std::array<DataVector, 4> char_speeds{
+        {get(intermediates->get_var(
+             BjorhusIntermediatesComputer::internal_tags::char_speed_vpsi<
+                 DataVector>{})),
+         get(intermediates->get_var(
+             BjorhusIntermediatesComputer::internal_tags::char_speed_vzero<
+                 DataVector>{})),
+         get(intermediates->get_var(
+             BjorhusIntermediatesComputer::internal_tags::char_speed_vplus<
+                 DataVector>{})),
+         get(intermediates->get_var(
+             BjorhusIntermediatesComputer::internal_tags::char_speed_vminus<
+                 DataVector>{}))}};
+
+    // timelike and spacelike SPACETIME vectors, l^a and k^a
+    const auto& outgoing_null_one_form = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::outgoing_null_one_form<
+            VolumeDim, DataVector>{});
+    const auto& incoming_null_one_form = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::incoming_null_one_form<
+            VolumeDim, DataVector>{});
+    // timelike and spacelike SPACETIME oneforms, l_a and k_a
+    const auto& outgoing_null_vector = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::outgoing_null_vector<
+            VolumeDim, DataVector>{});
+    const auto& incoming_null_vector = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::incoming_null_vector<
+            VolumeDim, DataVector>{});
+    // spacetime projection operator P_ab, P^ab, and P^a_b
+    const auto& projection_AB = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::projection_AB<
+            VolumeDim, DataVector>{});
+    const auto& projection_ab = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::projection_ab<
+            VolumeDim, DataVector>{});
+    const auto& projection_Ab = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::projection_Ab<
+            VolumeDim, DataVector>{});
+    // constraint characteristics
+    const auto& constraint_char_zero_minus = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::constraint_char_zero_minus<
+            VolumeDim, DataVector>{});
+    const auto& constraint_char_zero_plus = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::constraint_char_zero_plus<
+            VolumeDim, DataVector>{});
+
+    const auto& inverse_spatial_metric = intermediates->get_var(
+        gr::Tags::InverseSpatialMetric<VolumeDim, Frame::Inertial,
+                                       DataVector>{});
+    const auto& extrinsic_curvature = intermediates->get_var(
+        gr::Tags::ExtrinsicCurvature<VolumeDim, Frame::Inertial, DataVector>{});
+    const auto& inverse_spacetime_metric = intermediates->get_var(
+        gr::Tags::InverseSpacetimeMetric<VolumeDim, Frame::Inertial,
+                                         DataVector>{});
+
+    const typename gr::Tags::SpacetimeMetric<
+        VolumeDim, Frame::Inertial, DataVector>::type& spacetime_metric =
+        get<gr::Tags::SpacetimeMetric<VolumeDim, Frame::Inertial, DataVector>>(
+            vars);
+    const typename Tags::Phi<VolumeDim, Frame::Inertial>::type& phi =
+        get<Tags::Phi<VolumeDim, Frame::Inertial>>(vars);
+    const auto& d_pi = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::deriv_pi<VolumeDim,
+                                                              DataVector>{});
+    const auto& d_phi = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::deriv_phi<VolumeDim,
+                                                               DataVector>{});
+    // Memory allocated for return type
+    ReturnType& bc_dt_u_minus = intermediates->get_var(
+        BjorhusIntermediatesComputer::internal_tags::bc_dt_u_minus<
+            VolumeDim, DataVector>{});
+    std::fill(bc_dt_u_minus.begin(), bc_dt_u_minus.end(), 0.);
+    // Switch on prescribed boundary condition method
+    switch (Method) {
+      case VMinusBcMethod::Freezing:
+        return apply_gauge_sommerfeld(
+            make_not_null(&bc_dt_u_minus), constraint_gamma2, inertial_coords,
+            incoming_null_one_form, outgoing_null_one_form,
+            incoming_null_vector, outgoing_null_vector, projection_Ab,
+            char_projected_rhs_dt_u_psi);
+      case VMinusBcMethod::ConstraintPreserving:
+        apply_bjorhus_constraint_preserving(
+            make_not_null(&bc_dt_u_minus), incoming_null_one_form,
+            outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
+            projection_ab, projection_Ab, projection_AB,
+            constraint_char_zero_plus, constraint_char_zero_minus,
+            char_projected_rhs_dt_u_minus, char_speeds);
+        return apply_gauge_sommerfeld(
+            make_not_null(&bc_dt_u_minus), constraint_gamma2, inertial_coords,
+            incoming_null_one_form, outgoing_null_one_form,
+            incoming_null_vector, outgoing_null_vector, projection_Ab,
+            char_projected_rhs_dt_u_psi);
+      case VMinusBcMethod::ConstraintPreservingPhysical:
+        apply_bjorhus_constraint_preserving(
+            make_not_null(&bc_dt_u_minus), incoming_null_one_form,
+            outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
+            projection_ab, projection_Ab, projection_AB,
+            constraint_char_zero_plus, constraint_char_zero_minus,
+            char_projected_rhs_dt_u_minus, char_speeds);
+        apply_bjorhus_constraint_preserving_physical(
+            make_not_null(&bc_dt_u_minus), constraint_gamma2,
+            unit_interface_normal_one_form, unit_interface_normal_vector,
+            spacetime_unit_normal_vector, projection_ab, projection_Ab,
+            projection_AB, inverse_spatial_metric, extrinsic_curvature,
+            spacetime_metric, inverse_spacetime_metric, three_index_constraint,
+            char_projected_rhs_dt_u_minus, phi, d_phi, d_pi, char_speeds);
+        return apply_gauge_sommerfeld(
+            make_not_null(&bc_dt_u_minus), constraint_gamma2, inertial_coords,
+            incoming_null_one_form, outgoing_null_one_form,
+            incoming_null_vector, outgoing_null_vector, projection_Ab,
+            char_projected_rhs_dt_u_psi);
+      case VMinusBcMethod::Unknown:
+      default:
+        ASSERT(false, "Requested BC method fo VMinus not implemented!");
+    }
+    // dummy return to suppress compiler warning
+    return ReturnType{};
+  }
+
+ private:
+  static ReturnType apply_bjorhus_constraint_preserving(
+      gsl::not_null<ReturnType*> bc_dt_u_minus,
+      const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+          incoming_null_one_form,
+      const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+          outgoing_null_one_form,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          incoming_null_vector,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          outgoing_null_vector,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& projection_ab,
+      const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+      const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>& projection_AB,
+      const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+          constraint_char_zero_plus,
+      const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+          constraint_char_zero_minus,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+          char_projected_rhs_dt_u_minus,
+      const std::array<DataVector, 4>& char_speeds) noexcept;
+  static ReturnType apply_bjorhus_constraint_preserving_physical(
+      gsl::not_null<ReturnType*> bc_dt_u_minus,
+      const Scalar<DataVector>& gamma2,
+      const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_one_form,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_vector,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          spacetime_unit_normal_vector,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& projection_ab,
+      const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+      const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>& projection_AB,
+      const tnsr::II<DataVector, VolumeDim, Frame::Inertial>&
+          inverse_spatial_metric,
+      const tnsr::ii<DataVector, VolumeDim, Frame::Inertial>&
+          extrinsic_curvature,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& spacetime_metric,
+      const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>&
+          inverse_spacetime_metric,
+      const typename Tags::ThreeIndexConstraint<
+          VolumeDim, Frame::Inertial>::type& three_index_constraint,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+          char_projected_rhs_dt_u_minus,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& phi,
+      const tnsr::ijaa<DataVector, VolumeDim, Frame::Inertial>& d_phi,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& d_pi,
+      const std::array<DataVector, 4>& char_speeds) noexcept;
+  static ReturnType apply_gauge_sommerfeld(
+      gsl::not_null<ReturnType*> bc_dt_u_minus,
+      const Scalar<DataVector>& gamma2,
+      const typename domain::Tags::Coordinates<
+          VolumeDim, Frame::Inertial>::type& inertial_coords,
+      const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+          incoming_null_one_form,
+      const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+          outgoing_null_one_form,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          incoming_null_vector,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          outgoing_null_vector,
+      const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+          char_projected_rhs_dt_u_psi) noexcept;
+};
+
+template <typename ReturnType, size_t VolumeDim>
+ReturnType
+set_dt_v_minus<ReturnType, VolumeDim>::apply_bjorhus_constraint_preserving(
+    const gsl::not_null<ReturnType*> bc_dt_u_minus,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        incoming_null_one_form,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        outgoing_null_one_form,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_plus,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_minus,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_u_minus,
+    const std::array<DataVector, 4>& char_speeds) noexcept {
+  ASSERT(get_size(get<0, 0>(*bc_dt_u_minus)) ==
+             get_size(get<0>(incoming_null_one_form)),
+         "Size of input variables and temporary memory do not match: "
+             << get_size(get<0, 0>(*bc_dt_u_minus)) << ","
+             << get_size(get<0>(incoming_null_one_form)));
+  const double mMu = 0.;  // hard-coded value from SpEC Bbh input file Mu = 0
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      for (size_t c = 0; c <= VolumeDim; ++c) {
+        for (size_t d = 0; d <= VolumeDim; ++d) {
+          bc_dt_u_minus->get(a, b) +=
+              0.25 *
+              (incoming_null_vector.get(c) * incoming_null_vector.get(d) *
+                   outgoing_null_one_form.get(a) *
+                   outgoing_null_one_form.get(b) -
+               incoming_null_vector.get(c) * projection_Ab.get(d, a) *
+                   outgoing_null_one_form.get(b) -
+               incoming_null_vector.get(c) * projection_Ab.get(d, b) *
+                   outgoing_null_one_form.get(a) -
+               incoming_null_vector.get(d) * projection_Ab.get(c, a) *
+                   outgoing_null_one_form.get(b) -
+               incoming_null_vector.get(d) * projection_Ab.get(c, b) *
+                   outgoing_null_one_form.get(a) +
+               2.0 * projection_AB.get(c, d) * projection_ab.get(a, b)) *
+              char_projected_rhs_dt_u_minus.get(c, d);
+        }
+      }
+      for (size_t c = 0; c <= VolumeDim; ++c) {
+        bc_dt_u_minus->get(a, b) +=
+            0.5 * char_speeds.at(3) *
+            (constraint_char_zero_minus.get(c) -
+             mMu * constraint_char_zero_plus.get(c)) *
+            (0.5 * outgoing_null_one_form.get(a) *
+                 outgoing_null_one_form.get(b) * incoming_null_vector.get(c) +
+             projection_ab.get(a, b) * outgoing_null_vector.get(c) -
+             projection_Ab.get(c, b) * outgoing_null_one_form.get(a) -
+             projection_Ab.get(c, a) * outgoing_null_one_form.get(b));
+      }
+    }
+  }
+  return *bc_dt_u_minus;
+}
+
+template <typename ReturnType, size_t VolumeDim>
+ReturnType set_dt_v_minus<ReturnType, VolumeDim>::
+    apply_bjorhus_constraint_preserving_physical(
+        const gsl::not_null<ReturnType*> bc_dt_u_minus,
+        const Scalar<DataVector>& gamma2,
+        const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+            unit_interface_normal_one_form,
+        const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+            unit_interface_normal_vector,
+        const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+            spacetime_unit_normal_vector,
+        const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& projection_ab,
+        const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+        const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>& projection_AB,
+        const tnsr::II<DataVector, VolumeDim, Frame::Inertial>&
+            inverse_spatial_metric,
+        const tnsr::ii<DataVector, VolumeDim, Frame::Inertial>&
+            extrinsic_curvature,
+        const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+            spacetime_metric,
+        const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>&
+            inverse_spacetime_metric,
+        const typename Tags::ThreeIndexConstraint<
+            VolumeDim, Frame::Inertial>::type& three_index_constraint,
+        const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+            char_projected_rhs_dt_u_minus,
+        const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& phi,
+        const tnsr::ijaa<DataVector, VolumeDim, Frame::Inertial>& d_phi,
+        const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& d_pi,
+        const std::array<DataVector, 4>& char_speeds) noexcept {
+  ASSERT(get_size(get<0, 0>(*bc_dt_u_minus)) == get_size(get(gamma2)),
+         "Size of input variables and temporary memory do not match: "
+             << get_size(get<0, 0>(*bc_dt_u_minus)) << ","
+             << get_size(get(gamma2)));
+  // hard-coded value from SpEC Bbh input file Mu = MuPhys = 0
+  const double mMuPhys = 0.;
+  const bool mAdjustPhysUsingC4 = true;
+  const bool mGamma2InPhysBc = true;
+
+  // In what follows, we use the notation of Kidder, Scheel & Teukolsky
+  // (2001) https://arxiv.org/pdf/gr-qc/0105031.pdf. We will refer to this
+  // article as KST henceforth, and use the abbreviation in variable names
+  // to disambiguate their origin.
+  auto U8p = make_with_value<tnsr::ii<DataVector, VolumeDim, Frame::Inertial>>(
+      unit_interface_normal_vector, 0.);
+  auto U8m = make_with_value<tnsr::ii<DataVector, VolumeDim, Frame::Inertial>>(
+      unit_interface_normal_vector, 0.);
+  {
+    // D_(k,i,j) = (1/2) \partial_k g_(ij) and its derivative
+    tnsr::ijj<DataVector, VolumeDim, Frame::Inertial> spatial_phi(
+        get_size(get(gamma2)));
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = i; j < VolumeDim; ++j) {
+        for (size_t k = 0; k < VolumeDim; ++k) {
+          spatial_phi.get(k, i, j) = phi.get(k, i + 1, j + 1);
+        }
+      }
+    }
+
+    // Compute spatial Ricci tensor
+    auto ricci_3 = GeneralizedHarmonic::spatial_ricci_tensor(
+        phi, d_phi, inverse_spatial_metric);
+    tnsr::ijj<DataVector, VolumeDim, Frame::Inertial> CdK(
+        get_size(get(gamma2)));
+    {
+      const auto christoffel_first_kind =
+          gr::christoffel_first_kind(spatial_phi);
+      const auto christoffel_second_kind = raise_or_lower_first_index(
+          christoffel_first_kind, inverse_spatial_metric);
+
+      // Ordinary derivative first
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        for (size_t j = i; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            CdK.get(k, i, j) = 0.5 * d_pi.get(k, i + 1, j + 1);
+            for (size_t a = 0; a <= VolumeDim; ++a) {
+              CdK.get(k, i, j) +=
+                  0.5 *
+                  (d_phi.get(k, i, j + 1, a) + d_phi.get(k, j, i + 1, a)) *
+                  spacetime_unit_normal_vector.get(a);
+              for (size_t b = 0; b <= VolumeDim; ++b) {
+                for (size_t c = 0; c <= VolumeDim; ++c) {
+                  CdK.get(k, i, j) -=
+                      0.5 * (phi.get(i, j + 1, a) + phi.get(j, i + 1, a)) *
+                      spacetime_unit_normal_vector.get(b) *
+                      (inverse_spacetime_metric.get(c, a) +
+                       0.5 * spacetime_unit_normal_vector.get(c) *
+                           spacetime_unit_normal_vector.get(a)) *
+                      phi.get(k, c, b);
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Now add gamma terms
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        for (size_t j = i; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            for (size_t l = 0; l < VolumeDim; ++l) {
+              CdK.get(k, i, j) -= christoffel_second_kind.get(l, i, k) *
+                                      extrinsic_curvature.get(l, j) +
+                                  christoffel_second_kind.get(l, j, k) *
+                                      extrinsic_curvature.get(l, i);
+            }
+          }
+        }
+      }
+    }
+
+    if (mAdjustPhysUsingC4) {
+      // This adds 4-index constraint terms to 3Ricci so as to cancel
+      // out normal derivatives from the final expression for U8.
+      // It is much easier to add them here than to recalculate U8
+      // from scratch.
+
+      // Add some 4-index constraint terms to 3Ricci.
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        for (size_t j = i; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            for (size_t l = 0; l < VolumeDim; ++l) {
+              ricci_3.get(i, j) += 0.25 * inverse_spatial_metric.get(k, l) *
+                                   (d_phi.get(i, k, 1 + l, 1 + j) -
+                                    d_phi.get(k, i, 1 + l, 1 + j) +
+                                    d_phi.get(j, k, 1 + l, 1 + i) -
+                                    d_phi.get(k, j, 1 + l, 1 + i));
+            }
+          }
+        }
+      }
+
+      // Add more 4-index constraint terms to 3Ricci
+      // These compensate for some of the CdK terms.
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        for (size_t j = i; j < VolumeDim; ++j) {
+          for (size_t a = 0; a <= VolumeDim; ++a) {
+            for (size_t k = 0; k < VolumeDim; ++k) {
+              ricci_3.get(i, j) +=
+                  0.5 * unit_interface_normal_vector.get(k + 1) *
+                  spacetime_unit_normal_vector.get(a) *
+                  (d_phi.get(i, k, j + 1, a) - d_phi.get(k, i, j + 1, a) +
+                   d_phi.get(j, k, i + 1, a) - d_phi.get(k, j, i + 1, a));
+            }
+          }
+        }
+      }
+    }
+
+    TempBuffer<tmpl::list<
+        // spatial projection operators P_ij, P^ij, and P^i_j
+        ::Tags::TempII<0, VolumeDim, Frame::Inertial, DataVector>,
+        ::Tags::Tempii<1, VolumeDim, Frame::Inertial, DataVector>,
+        ::Tags::TempIj<2, VolumeDim, Frame::Inertial, DataVector>>>
+        local_buffer(get_size(get<0>(unit_interface_normal_vector)));
+    auto& spatial_projection_IJ =
+        get<::Tags::TempII<0, VolumeDim, Frame::Inertial, DataVector>>(
+            local_buffer);
+    auto& spatial_projection_ij =
+        get<::Tags::Tempii<1, VolumeDim, Frame::Inertial, DataVector>>(
+            local_buffer);
+    auto& spatial_projection_Ij =
+        get<::Tags::TempIj<2, VolumeDim, Frame::Inertial, DataVector>>(
+            local_buffer);
+
+    // Make spatial projection operators
+    GeneralizedHarmonic::spatial_projection_tensor(
+        make_not_null(&spatial_projection_IJ), inverse_spatial_metric,
+        unit_interface_normal_vector);
+
+    const auto spatial_metric = [&spacetime_metric]() noexcept {
+      tnsr::ii<DataVector, VolumeDim, Frame::Inertial> tmp_metric(
+          get_size(get<0, 0>(spacetime_metric)));
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        for (size_t k = j; k < VolumeDim; ++k) {
+          tmp_metric.get(j, k) = spacetime_metric.get(1 + j, 1 + k);
+        }
+      }
+      return tmp_metric;
+    }
+    ();
+    GeneralizedHarmonic::spatial_projection_tensor(
+        make_not_null(&spatial_projection_ij), spatial_metric,
+        unit_interface_normal_one_form);
+
+    GeneralizedHarmonic::spatial_projection_tensor(
+        make_not_null(&spatial_projection_Ij), unit_interface_normal_vector,
+        unit_interface_normal_one_form);
+
+    GeneralizedHarmonic::weyl_propagating(
+        make_not_null(&U8p), ricci_3, extrinsic_curvature,
+        inverse_spatial_metric, CdK, unit_interface_normal_vector,
+        spatial_projection_IJ, spatial_projection_ij, spatial_projection_Ij, 1);
+    GeneralizedHarmonic::weyl_propagating(
+        make_not_null(&U8m), ricci_3, extrinsic_curvature,
+        inverse_spatial_metric, CdK, unit_interface_normal_vector,
+        spatial_projection_IJ, spatial_projection_ij, spatial_projection_Ij,
+        -1);
+  }
+
+  auto U3p = make_with_value<tnsr::aa<DataVector, VolumeDim, Frame::Inertial>>(
+      unit_interface_normal_vector, 0.);
+  auto U3m = make_with_value<tnsr::aa<DataVector, VolumeDim, Frame::Inertial>>(
+      unit_interface_normal_vector, 0.);
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        for (size_t j = 0; j < VolumeDim; ++j) {
+          U3p.get(a, b) += 2.0 * projection_Ab.get(i + 1, a) *
+                           projection_Ab.get(j + 1, b) * U8p.get(i, j);
+          U3m.get(a, b) += 2.0 * projection_Ab.get(i + 1, a) *
+                           projection_Ab.get(j + 1, b) * U8m.get(i, j);
+        }
+      }
+    }
+  }
+
+  // Impose physical boundary condition
+  if (mGamma2InPhysBc) {
+    DataVector tmp(get_size(get<0>(unit_interface_normal_vector)));
+    for (size_t c = 0; c <= VolumeDim; ++c) {
+      for (size_t d = c; d <= VolumeDim; ++d) {
+        for (size_t a = 0; a <= VolumeDim; ++a) {
+          for (size_t b = 0; b <= VolumeDim; ++b) {
+            tmp = 0.;
+            for (size_t i = 0; i < VolumeDim; ++i) {
+              tmp += unit_interface_normal_vector.get(i + 1) *
+                     three_index_constraint.get(i, a, b);
+            }
+            tmp *= get(gamma2);
+            bc_dt_u_minus->get(c, d) +=
+                (projection_Ab.get(a, c) * projection_Ab.get(b, d) -
+                 0.5 * projection_ab.get(c, d) * projection_AB.get(a, b)) *
+                (char_projected_rhs_dt_u_minus.get(a, b) +
+                 char_speeds.at(3) *
+                     (U3m.get(a, b) - tmp - mMuPhys * U3p.get(a, b)));
+          }
+        }
+      }
+    }
+  } else {
+    for (size_t c = 0; c <= VolumeDim; ++c) {
+      for (size_t d = c; d <= VolumeDim; ++d) {
+        for (size_t a = 0; a <= VolumeDim; ++a) {
+          for (size_t b = 0; b <= VolumeDim; ++b) {
+            bc_dt_u_minus->get(c, d) +=
+                (projection_Ab.get(a, c) * projection_Ab.get(b, d) -
+                 0.5 * projection_ab.get(c, d) * projection_AB.get(a, b)) *
+                (char_projected_rhs_dt_u_minus.get(a, b) +
+                 char_speeds.at(3) * (U3m.get(a, b) - mMuPhys * U3p.get(a, b)));
+          }
+        }
+      }
+    }
+  }
+
+  return *bc_dt_u_minus;
+}
+
+template <typename ReturnType, size_t VolumeDim>
+ReturnType set_dt_v_minus<ReturnType, VolumeDim>::apply_gauge_sommerfeld(
+    const gsl::not_null<ReturnType*> bc_dt_u_minus,
+    const Scalar<DataVector>& gamma2,
+    const typename domain::Tags::Coordinates<VolumeDim, Frame::Inertial>::type&
+        inertial_coords,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        incoming_null_one_form,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        outgoing_null_one_form,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_u_psi) noexcept {
+  ASSERT(get_size(get<0, 0>(*bc_dt_u_minus)) ==
+             get_size(get<0>(incoming_null_one_form)),
+         "Size of input variables and temporary memory do not match: "
+             << get_size(get<0, 0>(*bc_dt_u_minus)) << ","
+             << get_size(get<0>(incoming_null_one_form)));
+  // gauge_bc_coeff below is hard-coded here to its default value in SpEC
+  constexpr double gauge_bc_coeff = 1.;
+
+  DataVector inertial_radius(get_size(get<0>(inertial_coords)), 0.);
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    inertial_radius += square(inertial_coords.get(i));
+  }
+  inertial_radius = sqrt(inertial_radius);
+
+  // add in gauge BC
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      for (size_t c = 0; c <= VolumeDim; ++c) {
+        for (size_t d = 0; d <= VolumeDim; ++d) {
+          bc_dt_u_minus->get(a, b) +=
+              0.5 *
+              (incoming_null_one_form.get(a) * projection_Ab.get(c, b) *
+                   outgoing_null_vector.get(d) +
+               incoming_null_one_form.get(b) * projection_Ab.get(c, a) *
+                   outgoing_null_vector.get(d) -
+               0.5 * incoming_null_one_form.get(a) *
+                   outgoing_null_one_form.get(b) * incoming_null_vector.get(c) *
+                   outgoing_null_vector.get(d) -
+               0.5 * incoming_null_one_form.get(b) *
+                   outgoing_null_one_form.get(a) * incoming_null_vector.get(c) *
+                   outgoing_null_vector.get(d) -
+               0.5 * incoming_null_one_form.get(a) *
+                   incoming_null_one_form.get(b) * outgoing_null_vector.get(c) *
+                   outgoing_null_vector.get(d)) *
+              (get(gamma2) - gauge_bc_coeff * (1. / inertial_radius)) *
+              char_projected_rhs_dt_u_psi.get(c, d);
+        }
+      }
+    }
+  }
+
+  return *bc_dt_u_minus;
+}
+
+}  // namespace BoundaryConditions_detail
+}  // namespace Actions
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusInternals.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusInternals.hpp
@@ -1,0 +1,439 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/DataOnSlice.hpp"
+#include "DataStructures/SliceVariables.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+
+/// \cond
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace GeneralizedHarmonic {
+namespace Actions {
+namespace BoundaryConditions_detail {
+class BjorhusIntermediatesComputer {
+ public:
+  struct internal_tags {
+    // null vectors and forms
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using outgoing_null_one_form =
+        ::Tags::Tempa<0, VolumeDim, Frame::Inertial, DataType>;
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using incoming_null_one_form =
+        ::Tags::Tempa<1, VolumeDim, Frame::Inertial, DataType>;
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using outgoing_null_vector =
+        ::Tags::TempA<2, VolumeDim, Frame::Inertial, DataType>;
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using incoming_null_vector =
+        ::Tags::TempA<3, VolumeDim, Frame::Inertial, DataType>;
+    // boundary normals
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using interface_normal_one_form =
+        ::Tags::Tempa<4, VolumeDim, Frame::Inertial, DataType>;
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using interface_normal_vector =
+        ::Tags::TempA<5, VolumeDim, Frame::Inertial, DataType>;
+    template <typename DataType = DataVector>
+    using interface_normal_dot_shift = ::Tags::TempScalar<8, DataType>;
+    // projection tensors
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using projection_AB =
+        ::Tags::TempAA<9, VolumeDim, Frame::Inertial, DataType>;
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using projection_ab =
+        ::Tags::Tempaa<10, VolumeDim, Frame::Inertial, DataType>;
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using projection_Ab =
+        ::Tags::TempAb<11, VolumeDim, Frame::Inertial, DataType>;
+    // Characteristics
+    template <typename DataType = DataVector>
+    using char_speed_vpsi = ::Tags::TempScalar<12, DataType>;
+    template <typename DataType = DataVector>
+    using char_speed_vzero = ::Tags::TempScalar<13, DataType>;
+    template <typename DataType = DataVector>
+    using char_speed_vplus = ::Tags::TempScalar<14, DataType>;
+    template <typename DataType = DataVector>
+    using char_speed_vminus = ::Tags::TempScalar<15, DataType>;
+    // Constraints
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using constraint_char_zero_minus =
+        ::Tags::Tempa<16, VolumeDim, Frame::Inertial, DataType>;
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using constraint_char_zero_plus =
+        ::Tags::Tempa<34, VolumeDim, Frame::Inertial, DataType>;
+    // Memory for BCs
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using bc_dt_u_psi =
+        ::Tags::Tempaa<27, VolumeDim, Frame::Inertial, DataType>;
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using bc_dt_u_zero =
+        ::Tags::Tempiaa<28, VolumeDim, Frame::Inertial, DataType>;
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using bc_dt_u_plus =
+        ::Tags::Tempaa<29, VolumeDim, Frame::Inertial, DataType>;
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using bc_dt_u_minus =
+        ::Tags::Tempaa<30, VolumeDim, Frame::Inertial, DataType>;
+    // Derivs of evolved vars
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using deriv_spacetime_metric =
+        ::Tags::Tempiaa<31, VolumeDim, Frame::Inertial, DataType>;
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using deriv_pi = ::Tags::Tempiaa<32, VolumeDim, Frame::Inertial, DataType>;
+    template <size_t VolumeDim, typename DataType = DataVector>
+    using deriv_phi =
+        ::Tags::Tempijaa<33, VolumeDim, Frame::Inertial, DataType>;
+  };
+
+  template <size_t VolumeDim>
+  using intermediate_vars = tmpl::list<
+      internal_tags::outgoing_null_one_form<VolumeDim, DataVector>,
+      internal_tags::incoming_null_one_form<VolumeDim, DataVector>,
+      internal_tags::outgoing_null_vector<VolumeDim, DataVector>,
+      internal_tags::incoming_null_vector<VolumeDim, DataVector>,
+      internal_tags::interface_normal_one_form<VolumeDim, DataVector>,
+      internal_tags::interface_normal_vector<VolumeDim, DataVector>,
+      gr::Tags::SpacetimeNormalOneForm<VolumeDim, Frame::Inertial, DataVector>,
+      gr::Tags::SpacetimeNormalVector<VolumeDim, Frame::Inertial, DataVector>,
+      internal_tags::interface_normal_dot_shift<DataVector>,
+      internal_tags::projection_AB<VolumeDim, DataVector>,
+      internal_tags::projection_ab<VolumeDim, DataVector>,
+      internal_tags::projection_Ab<VolumeDim, DataVector>,
+      internal_tags::char_speed_vpsi<DataVector>,
+      internal_tags::char_speed_vzero<DataVector>,
+      internal_tags::char_speed_vplus<DataVector>,
+      internal_tags::char_speed_vminus<DataVector>,
+      internal_tags::constraint_char_zero_minus<VolumeDim, DataVector>,
+      internal_tags::constraint_char_zero_plus<VolumeDim, DataVector>,
+      Tags::ThreeIndexConstraint<VolumeDim, Frame::Inertial>,
+      Tags::FourIndexConstraint<VolumeDim, Frame::Inertial>,
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<VolumeDim, Frame::Inertial, DataVector>,
+      gr::Tags::ExtrinsicCurvature<VolumeDim, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpacetimeMetric<VolumeDim, Frame::Inertial, DataVector>,
+      Tags::VSpacetimeMetric<VolumeDim, Frame::Inertial>,
+      Tags::VZero<VolumeDim, Frame::Inertial>,
+      Tags::VPlus<VolumeDim, Frame::Inertial>,
+      Tags::VMinus<VolumeDim, Frame::Inertial>, Tags::ConstraintGamma2,
+      internal_tags::bc_dt_u_psi<VolumeDim, DataVector>,
+      internal_tags::bc_dt_u_zero<VolumeDim, DataVector>,
+      internal_tags::bc_dt_u_plus<VolumeDim, DataVector>,
+      internal_tags::bc_dt_u_minus<VolumeDim, DataVector>,
+      internal_tags::deriv_spacetime_metric<VolumeDim, DataVector>,
+      internal_tags::deriv_pi<VolumeDim, DataVector>,
+      internal_tags::deriv_phi<VolumeDim, DataVector>,
+      domain::Tags::Coordinates<VolumeDim, Frame::Inertial>>;
+
+ private:
+  TempBuffer<intermediate_vars<3>> buffer_;
+
+ public:
+  explicit BjorhusIntermediatesComputer(size_t used_for_size) noexcept
+      : buffer_(used_for_size) {}
+
+  template <typename Tag>
+  const typename Tag::type& get_var(const Tag& /* tag */) const noexcept {
+    return get<Tag>(buffer_);
+  }
+
+  template <typename Tag>
+  typename Tag::type& get_var(const Tag& /* tag */) noexcept {
+    return get<Tag>(buffer_);
+  }
+
+  template <typename Tag>
+  void set_var(const typename Tag::type& var_data,
+               const Tag& /* tag */) noexcept {
+    get<Tag>(buffer_) = var_data;
+  }
+
+  SPECTRE_ALWAYS_INLINE decltype(buffer_)& get_buffer() noexcept {
+    return buffer_;
+  }
+
+  // \brief This function computes intermediate variables needed for
+  // Bjorhus-type constraint preserving boundary conditions for the
+  // GeneralizedHarmonic system
+  template <size_t VolumeDim, typename DbTags, typename VarsTagsList,
+            typename DtVarsTagsList>
+  void compute_vars(
+      const db::DataBox<DbTags>& box, const Direction<VolumeDim>& direction,
+      const size_t& dimension,
+      const typename domain::Tags::Mesh<VolumeDim>::type& mesh,
+      const Variables<VarsTagsList>& /* vars */,
+      const Variables<DtVarsTagsList>& dt_vars,
+      const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_one_form,
+      const typename Tags::CharacteristicSpeeds<
+          VolumeDim, Frame::Inertial>::type& char_speeds) noexcept {
+    //
+    // NOTE: variable names below closely follow \cite Lindblom2005qh
+    //
+    // 1) Extract quantities from databox that are needed to compute
+    // intermediate variables
+    using tags_needed_on_slice = tmpl::list<
+        gr::Tags::Lapse<DataVector>,
+        gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>,
+        gr::Tags::SpatialMetric<VolumeDim, Frame::Inertial, DataVector>,
+        gr::Tags::InverseSpatialMetric<VolumeDim, Frame::Inertial, DataVector>,
+        gr::Tags::SpacetimeNormalOneForm<VolumeDim, Frame::Inertial,
+                                         DataVector>,
+        gr::Tags::SpacetimeNormalVector<VolumeDim, Frame::Inertial, DataVector>,
+        gr::Tags::SpacetimeMetric<VolumeDim, Frame::Inertial, DataVector>,
+        gr::Tags::InverseSpacetimeMetric<VolumeDim, Frame::Inertial,
+                                         DataVector>,
+        gr::Tags::ExtrinsicCurvature<VolumeDim, Frame::Inertial, DataVector>,
+        ::Tags::deriv<gr::Tags::SpacetimeMetric<VolumeDim, Frame::Inertial>,
+                      tmpl::size_t<VolumeDim>, Frame::Inertial>,
+        ::Tags::deriv<Tags::Pi<VolumeDim, Frame::Inertial>,
+                      tmpl::size_t<VolumeDim>, Frame::Inertial>,
+        ::Tags::deriv<Tags::Phi<VolumeDim, Frame::Inertial>,
+                      tmpl::size_t<VolumeDim>, Frame::Inertial>,
+        Tags::ConstraintGamma2,
+        Tags::TwoIndexConstraint<VolumeDim, Frame::Inertial>,
+        Tags::ThreeIndexConstraint<VolumeDim, Frame::Inertial>,
+        Tags::FourIndexConstraint<VolumeDim, Frame::Inertial>,
+        Tags::FConstraint<VolumeDim, Frame::Inertial>,
+        domain::Tags::Coordinates<VolumeDim, Frame::Inertial>>;
+    const auto vars_on_this_slice = db::data_on_slice(
+        box, mesh.extents(), dimension,
+        index_to_slice_at(mesh.extents(), direction), tags_needed_on_slice{});
+
+    // 2) name quantities as its just easier
+    const auto& shift =
+        get<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>>(
+            vars_on_this_slice);
+    const auto& inverse_spatial_metric = get<
+        gr::Tags::InverseSpatialMetric<VolumeDim, Frame::Inertial, DataVector>>(
+        vars_on_this_slice);
+    const auto& spacetime_normal_one_form =
+        get<gr::Tags::SpacetimeNormalOneForm<VolumeDim, Frame::Inertial,
+                                             DataVector>>(vars_on_this_slice);
+    const auto& spacetime_normal_vector =
+        get<gr::Tags::SpacetimeNormalVector<VolumeDim, Frame::Inertial,
+                                            DataVector>>(vars_on_this_slice);
+    const auto& spacetime_metric =
+        get<gr::Tags::SpacetimeMetric<VolumeDim, Frame::Inertial, DataVector>>(
+            vars_on_this_slice);
+    const auto& inverse_spacetime_metric =
+        get<gr::Tags::InverseSpacetimeMetric<VolumeDim, Frame::Inertial,
+                                             DataVector>>(vars_on_this_slice);
+
+    const auto& gamma2 = get<Tags::ConstraintGamma2>(vars_on_this_slice);
+    const auto& two_index_constraint =
+        get<Tags::TwoIndexConstraint<VolumeDim, Frame::Inertial>>(
+            vars_on_this_slice);
+    const auto& f_constraint =
+        get<Tags::FConstraint<VolumeDim, Frame::Inertial>>(vars_on_this_slice);
+    // storage for DT<UChar> = CharProjection(dt<U>)
+    const auto& rhs_dt_psi = get<::Tags::dt<
+        gr::Tags::SpacetimeMetric<VolumeDim, Frame::Inertial, DataVector>>>(
+        dt_vars);
+    const auto& rhs_dt_pi =
+        get<::Tags::dt<Tags::Pi<VolumeDim, Frame::Inertial>>>(dt_vars);
+    const auto& rhs_dt_phi =
+        get<::Tags::dt<Tags::Phi<VolumeDim, Frame::Inertial>>>(dt_vars);
+    const auto char_projected_dt_u = characteristic_fields(
+        gamma2, inverse_spatial_metric, rhs_dt_psi, rhs_dt_pi, rhs_dt_phi,
+        unit_interface_normal_one_form);
+
+    // 3) Extract variable storage out of the buffer now
+    // timelike and spacelike SPACETIME vectors, l^a and k^a
+    auto& local_outgoing_null_one_form =
+        get<internal_tags::outgoing_null_one_form<VolumeDim, DataVector>>(
+            buffer_);
+    auto& local_incoming_null_one_form =
+        get<internal_tags::incoming_null_one_form<VolumeDim, DataVector>>(
+            buffer_);
+    // timelike and spacelike SPACETIME oneforms, l_a and k_a
+    auto& local_outgoing_null_vector =
+        get<internal_tags::outgoing_null_vector<VolumeDim, DataVector>>(
+            buffer_);
+    auto& local_incoming_null_vector =
+        get<internal_tags::incoming_null_vector<VolumeDim, DataVector>>(
+            buffer_);
+    // SPACETIME form of interface normal (vector and oneform)
+    auto& local_interface_normal_one_form =
+        get<internal_tags::interface_normal_one_form<VolumeDim, DataVector>>(
+            buffer_);
+    auto& local_interface_normal_vector =
+        get<internal_tags::interface_normal_vector<VolumeDim, DataVector>>(
+            buffer_);
+    // spacetime null form t_a and vector t^a
+    get<gr::Tags::SpacetimeNormalOneForm<VolumeDim, Frame::Inertial,
+                                         DataVector>>(buffer_) =
+        get<gr::Tags::SpacetimeNormalOneForm<VolumeDim, Frame::Inertial,
+                                             DataVector>>(vars_on_this_slice);
+    get<gr::Tags::SpacetimeNormalVector<VolumeDim, Frame::Inertial,
+                                        DataVector>>(buffer_) =
+        get<gr::Tags::SpacetimeNormalVector<VolumeDim, Frame::Inertial,
+                                            DataVector>>(vars_on_this_slice);
+    // interface normal dot shift: n_k N^k
+    auto& interface_normal_dot_shift =
+        get<internal_tags::interface_normal_dot_shift<DataVector>>(buffer_);
+    // spacetime projection operator P_ab, P^ab, and P^a_b
+    auto& local_projection_AB =
+        get<internal_tags::projection_AB<VolumeDim, DataVector>>(buffer_);
+    auto& local_projection_ab =
+        get<internal_tags::projection_ab<VolumeDim, DataVector>>(buffer_);
+    auto& local_projection_Ab =
+        get<internal_tags::projection_Ab<VolumeDim, DataVector>>(buffer_);
+    // 4.4) Characteristic speeds
+    get(get<internal_tags::char_speed_vpsi<DataVector>>(buffer_)) =
+        char_speeds.at(0);
+    get(get<internal_tags::char_speed_vzero<DataVector>>(buffer_)) =
+        char_speeds.at(1);
+    get(get<internal_tags::char_speed_vplus<DataVector>>(buffer_)) =
+        char_speeds.at(2);
+    get(get<internal_tags::char_speed_vminus<DataVector>>(buffer_)) =
+        char_speeds.at(3);
+    // constraint characteristics
+    auto& local_constraint_char_zero_minus =
+        get<internal_tags::constraint_char_zero_minus<VolumeDim, DataVector>>(
+            buffer_);
+    auto& local_constraint_char_zero_plus =
+        get<internal_tags::constraint_char_zero_plus<VolumeDim, DataVector>>(
+            buffer_);
+    // 4.6) c^\hat{3}_{jab} = C_{jab} = \partial_j\psi_{ab} - \Phi_{jab}
+    get<Tags::ThreeIndexConstraint<VolumeDim, Frame::Inertial>>(buffer_) =
+        get<Tags::ThreeIndexConstraint<VolumeDim, Frame::Inertial>>(
+            vars_on_this_slice);
+    // 4.7) c^\hat{4}_{ijab} = C_{ijab}
+    get<Tags::FourIndexConstraint<VolumeDim, Frame::Inertial>>(buffer_) =
+        get<Tags::FourIndexConstraint<VolumeDim, Frame::Inertial>>(
+            vars_on_this_slice);
+    // lapse, shift and inverse spatial_metric
+    get<gr::Tags::Lapse<DataVector>>(buffer_) =
+        get<gr::Tags::Lapse<DataVector>>(vars_on_this_slice);
+    get<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>>(buffer_) =
+        get<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>>(
+            vars_on_this_slice);
+    get<gr::Tags::InverseSpatialMetric<VolumeDim, Frame::Inertial, DataVector>>(
+        buffer_) =
+        get<gr::Tags::InverseSpatialMetric<VolumeDim, Frame::Inertial,
+                                           DataVector>>(vars_on_this_slice);
+    get<gr::Tags::ExtrinsicCurvature<VolumeDim, Frame::Inertial, DataVector>>(
+        buffer_) =
+        get<gr::Tags::ExtrinsicCurvature<VolumeDim, Frame::Inertial,
+                                         DataVector>>(vars_on_this_slice);
+    get<gr::Tags::InverseSpacetimeMetric<VolumeDim, Frame::Inertial,
+                                         DataVector>>(buffer_) =
+        get<gr::Tags::InverseSpacetimeMetric<VolumeDim, Frame::Inertial,
+                                             DataVector>>(vars_on_this_slice);
+    // Characteristic projected time derivatives of evolved fields
+    get<Tags::VSpacetimeMetric<VolumeDim, Frame::Inertial>>(buffer_) =
+        get<Tags::VSpacetimeMetric<VolumeDim, Frame::Inertial>>(
+            char_projected_dt_u);
+    get<Tags::VZero<VolumeDim, Frame::Inertial>>(buffer_) =
+        get<Tags::VZero<VolumeDim, Frame::Inertial>>(char_projected_dt_u);
+    get<Tags::VPlus<VolumeDim, Frame::Inertial>>(buffer_) =
+        get<Tags::VPlus<VolumeDim, Frame::Inertial>>(char_projected_dt_u);
+    get<Tags::VMinus<VolumeDim, Frame::Inertial>>(buffer_) =
+        get<Tags::VMinus<VolumeDim, Frame::Inertial>>(char_projected_dt_u);
+    // Spatial derivatives of evolved variables: Psi, Pi and Phi
+    get<internal_tags::deriv_spacetime_metric<VolumeDim, DataVector>>(buffer_) =
+        get<::Tags::deriv<gr::Tags::SpacetimeMetric<VolumeDim, Frame::Inertial>,
+                          tmpl::size_t<VolumeDim>, Frame::Inertial>>(
+            vars_on_this_slice);
+    get<internal_tags::deriv_pi<VolumeDim, DataVector>>(buffer_) =
+        get<::Tags::deriv<Tags::Pi<VolumeDim, Frame::Inertial>,
+                          tmpl::size_t<VolumeDim>, Frame::Inertial>>(
+            vars_on_this_slice);
+    get<internal_tags::deriv_phi<VolumeDim, DataVector>>(buffer_) =
+        get<::Tags::deriv<Tags::Phi<VolumeDim, Frame::Inertial>,
+                          tmpl::size_t<VolumeDim>, Frame::Inertial>>(
+            vars_on_this_slice);
+    // Constraint damping parameters
+    get<Tags::ConstraintGamma2>(buffer_) =
+        get<Tags::ConstraintGamma2>(vars_on_this_slice);
+
+    // Coordinates
+    get<domain::Tags::Coordinates<VolumeDim, Frame::Inertial>>(buffer_) =
+        get<domain::Tags::Coordinates<VolumeDim, Frame::Inertial>>(
+            vars_on_this_slice);
+
+    // 4) Compute intermediate variables now
+    // 4.1) Spacetime form of interface normal (vector and oneform)
+    const auto unit_interface_normal_vector = raise_or_lower_index(
+        unit_interface_normal_one_form, inverse_spatial_metric);
+    get<0>(local_interface_normal_one_form) = 0.;
+    get<0>(local_interface_normal_vector) = 0.;
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      local_interface_normal_one_form.get(1 + i) =
+          unit_interface_normal_one_form.get(i);
+      local_interface_normal_vector.get(1 + i) =
+          unit_interface_normal_vector.get(i);
+    }
+    // 4.2) timelike and spacelike SPACETIME vectors, l^a and k^a,
+    //      without (1/sqrt(2))
+    for (size_t a = 0; a < VolumeDim + 1; ++a) {
+      local_outgoing_null_one_form.get(a) =
+          spacetime_normal_one_form.get(a) +
+          local_interface_normal_one_form.get(a);
+      local_incoming_null_one_form.get(a) =
+          spacetime_normal_one_form.get(a) -
+          local_interface_normal_one_form.get(a);
+      local_outgoing_null_vector.get(a) =
+          spacetime_normal_vector.get(a) + local_interface_normal_vector.get(a);
+      local_incoming_null_vector.get(a) =
+          spacetime_normal_vector.get(a) - local_interface_normal_vector.get(a);
+    }
+    //       interface_normal_dot_shift = n_i N^i
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      get(interface_normal_dot_shift) =
+          shift.get(i) * local_interface_normal_one_form.get(i + 1);
+    }
+    // 4.3) Spacetime projection operators P_ab, P^ab and P^a_b
+    for (size_t a = 0; a < VolumeDim + 1; ++a) {
+      for (size_t b = 0; b < VolumeDim + 1; ++b) {
+        local_projection_ab.get(a, b) =
+            spacetime_metric.get(a, b) +
+            spacetime_normal_one_form.get(a) *
+                spacetime_normal_one_form.get(b) -
+            local_interface_normal_one_form.get(a) *
+                local_interface_normal_one_form.get(b);
+        local_projection_Ab.get(a, b) =
+            spacetime_normal_one_form.get(a) * spacetime_normal_vector.get(b) -
+            local_interface_normal_one_form.get(a) *
+                local_interface_normal_vector.get(b);
+        if (UNLIKELY(a == b)) {
+          local_projection_Ab.get(a, b) += 1.;
+        }
+        local_projection_AB.get(a, b) =
+            inverse_spacetime_metric.get(a, b) +
+            spacetime_normal_vector.get(a) * spacetime_normal_vector.get(b) -
+            local_interface_normal_vector.get(a) *
+                local_interface_normal_vector.get(b);
+      }
+    }
+    // 4.5) c^{\hat{0}-}_a = F_a + n^k C_{ka}
+    for (size_t a = 0; a < VolumeDim + 1; ++a) {
+      local_constraint_char_zero_minus.get(a) = f_constraint.get(a);
+      local_constraint_char_zero_plus.get(a) = f_constraint.get(a);
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        local_constraint_char_zero_minus.get(a) +=
+            unit_interface_normal_vector.get(i) *
+            two_index_constraint.get(i, a);
+        local_constraint_char_zero_plus.get(a) -=
+            unit_interface_normal_vector.get(i) *
+            two_index_constraint.get(i, a);
+      }
+    }
+  }
+};
+}  // namespace BoundaryConditions_detail
+}  // namespace Actions
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryConditions.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryConditions.hpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace GeneralizedHarmonic {
+namespace BoundaryConditions {}  // namespace BoundaryConditions
+
+namespace BoundaryConditions {
+namespace Bjorhus {}  // namespace Bjorhus
+
+namespace Bjorhus {
+enum class VSpacetimeMetricBcMethod { Freezing, ConstraintPreserving, Unknown };
+enum class VZeroBcMethod { Freezing, ConstraintPreserving, Unknown };
+enum class VPlusBcMethod { Freezing, Unknown };
+enum class VMinusBcMethod {
+  Freezing,
+  ConstraintPreserving,
+  ConstraintPreservingPhysical,
+  Unknown
+};
+
+struct Freezing {
+  static const VSpacetimeMetricBcMethod v_spacetime_bc_method =
+      VSpacetimeMetricBcMethod::Freezing;
+  static const VZeroBcMethod v_zero_bc_method = VZeroBcMethod::Freezing;
+  static const VPlusBcMethod v_plus_bc_method = VPlusBcMethod::Freezing;
+  static const VMinusBcMethod v_minus_bc_method = VMinusBcMethod::Freezing;
+};
+
+struct ConstraintPreserving {
+  static const VSpacetimeMetricBcMethod v_spacetime_bc_method =
+      VSpacetimeMetricBcMethod::ConstraintPreserving;
+  static const VZeroBcMethod v_zero_bc_method =
+      VZeroBcMethod::ConstraintPreserving;
+  // (This field is never incoming, which is why we use Freezing)
+  static const VPlusBcMethod v_plus_bc_method = VPlusBcMethod::Freezing;
+  static const VMinusBcMethod v_minus_bc_method =
+      VMinusBcMethod::ConstraintPreserving;
+};
+
+struct ConstraintPreservingPhysical {
+  static const VSpacetimeMetricBcMethod v_spacetime_bc_method =
+      VSpacetimeMetricBcMethod::ConstraintPreserving;
+  static const VZeroBcMethod v_zero_bc_method =
+      VZeroBcMethod::ConstraintPreserving;
+  // (This field is never incoming, which is why we use Freezing)
+  static const VPlusBcMethod v_plus_bc_method = VPlusBcMethod::Freezing;
+  static const VMinusBcMethod v_minus_bc_method =
+      VMinusBcMethod::ConstraintPreservingPhysical;
+};
+}  // namespace Bjorhus
+}  // namespace BoundaryConditions
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
@@ -100,10 +100,10 @@ void two_index_constraint_add_term_4_of_11(
 template <size_t SpatialDim, typename Frame, typename DataType>
 void two_index_constraint_add_term_5_of_11(
     const gsl::not_null<tnsr::ia<DataType, SpatialDim, Frame>*> constraint,
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function) noexcept {
+    const tnsr::ab<DataType, SpatialDim, Frame>& d_gauge_function) noexcept {
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t a = 0; a < SpatialDim + 1; ++a) {
-      constraint->get(i, a) += d_gauge_function.get(i, a);
+      constraint->get(i, a) += d_gauge_function.get(i + 1, a);
     }
   }
 }
@@ -368,13 +368,13 @@ void f_constraint_add_term_5_of_25(
     const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function) noexcept {
+    const tnsr::ab<DataType, SpatialDim, Frame>& d_gauge_function) noexcept {
   for (size_t a = 0; a < SpatialDim + 1; ++a) {
     for (size_t i = 0; i < SpatialDim; ++i) {
       for (size_t j = 0; j < SpatialDim; ++j) {
         constraint->get(a) += spacetime_normal_one_form.get(a) *
                               inverse_spatial_metric.get(i, j) *
-                              d_gauge_function.get(i, j + 1);
+                              d_gauge_function.get(i + 1, j + 1);
       }
     }
   }
@@ -461,18 +461,18 @@ void f_constraint_add_term_8_of_25(
     const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function) noexcept {
+    const tnsr::ab<DataType, SpatialDim, Frame>& d_gauge_function) noexcept {
   for (size_t a = 0; a < SpatialDim + 1; ++a) {
     for (size_t b = 0; b < SpatialDim + 1; ++b) {
       if (a > 0) {
         constraint->get(a) -=
-            spacetime_normal_vector.get(b) * d_gauge_function.get(a - 1, b);
+            spacetime_normal_vector.get(b) * d_gauge_function.get(a, b);
       }
       for (size_t i = 0; i < SpatialDim; ++i) {
         constraint->get(a) -= spacetime_normal_one_form.get(a) *
                               spacetime_normal_vector.get(i + 1) *
                               spacetime_normal_vector.get(b) *
-                              d_gauge_function.get(i, b);
+                              d_gauge_function.get(i + 1, b);
       }
     }
   }
@@ -1012,7 +1012,7 @@ void gauge_constraint(
 
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ia<DataType, SpatialDim, Frame> two_index_constraint(
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::ab<DataType, SpatialDim, Frame>& d_gauge_function,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
@@ -1036,7 +1036,7 @@ tnsr::ia<DataType, SpatialDim, Frame> two_index_constraint(
 template <size_t SpatialDim, typename Frame, typename DataType>
 void two_index_constraint(
     const gsl::not_null<tnsr::ia<DataType, SpatialDim, Frame>*> constraint,
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::ab<DataType, SpatialDim, Frame>& d_gauge_function,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
@@ -1121,7 +1121,7 @@ void four_index_constraint(
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::a<DataType, SpatialDim, Frame> f_constraint(
     const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::ab<DataType, SpatialDim, Frame>& d_gauge_function,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
@@ -1146,7 +1146,7 @@ template <size_t SpatialDim, typename Frame, typename DataType>
 void f_constraint(
     const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
     const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::ab<DataType, SpatialDim, Frame>& d_gauge_function,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
@@ -1347,7 +1347,7 @@ void constraint_energy(
       const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;   \
   template tnsr::ia<DTYPE(data), DIM(data), FRAME(data)>                     \
   GeneralizedHarmonic::two_index_constraint(                                 \
-      const tnsr::ia<DTYPE(data), DIM(data), FRAME(data)>& d_gauge_function, \
+      const tnsr::ab<DTYPE(data), DIM(data), FRAME(data)>& d_gauge_function, \
       const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                    \
           spacetime_normal_one_form,                                         \
       const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                    \
@@ -1366,7 +1366,7 @@ void constraint_energy(
   template void GeneralizedHarmonic::two_index_constraint(                   \
       const gsl::not_null<tnsr::ia<DTYPE(data), DIM(data), FRAME(data)>*>    \
           constraint,                                                        \
-      const tnsr::ia<DTYPE(data), DIM(data), FRAME(data)>& d_gauge_function, \
+      const tnsr::ab<DTYPE(data), DIM(data), FRAME(data)>& d_gauge_function, \
       const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                    \
           spacetime_normal_one_form,                                         \
       const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                    \
@@ -1385,7 +1385,7 @@ void constraint_energy(
   template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                      \
   GeneralizedHarmonic::f_constraint(                                         \
       const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>& gauge_function,    \
-      const tnsr::ia<DTYPE(data), DIM(data), FRAME(data)>& d_gauge_function, \
+      const tnsr::ab<DTYPE(data), DIM(data), FRAME(data)>& d_gauge_function, \
       const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                    \
           spacetime_normal_one_form,                                         \
       const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                    \
@@ -1405,7 +1405,7 @@ void constraint_energy(
       const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>     \
           constraint,                                                        \
       const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>& gauge_function,    \
-      const tnsr::ia<DTYPE(data), DIM(data), FRAME(data)>& d_gauge_function, \
+      const tnsr::ab<DTYPE(data), DIM(data), FRAME(data)>& d_gauge_function, \
       const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                    \
           spacetime_normal_one_form,                                         \
       const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                    \

--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
@@ -122,7 +122,7 @@ void gauge_constraint(
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ia<DataType, SpatialDim, Frame> two_index_constraint(
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::ab<DataType, SpatialDim, Frame>& d_gauge_function,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
@@ -138,7 +138,7 @@ tnsr::ia<DataType, SpatialDim, Frame> two_index_constraint(
 template <size_t SpatialDim, typename Frame, typename DataType>
 void two_index_constraint(
     gsl::not_null<tnsr::ia<DataType, SpatialDim, Frame>*> constraint,
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::ab<DataType, SpatialDim, Frame>& d_gauge_function,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
@@ -245,7 +245,7 @@ void four_index_constraint(
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::a<DataType, SpatialDim, Frame> f_constraint(
     const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::ab<DataType, SpatialDim, Frame>& d_gauge_function,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
@@ -262,7 +262,7 @@ template <size_t SpatialDim, typename Frame, typename DataType>
 void f_constraint(
     gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
     const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::ab<DataType, SpatialDim, Frame>& d_gauge_function,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
@@ -538,8 +538,7 @@ struct GaugeConstraintCompute : GaugeConstraint<SpatialDim, Frame>,
 template <size_t SpatialDim, typename Frame>
 struct FConstraintCompute : FConstraint<SpatialDim, Frame>, db::ComputeTag {
   using argument_tags = tmpl::list<
-      GaugeH<SpatialDim, Frame>,
-      ::Tags::deriv<GaugeH<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
+      GaugeH<SpatialDim, Frame>, SpacetimeDerivGaugeH<SpatialDim, Frame>,
       gr::Tags::SpacetimeNormalOneForm<SpatialDim, Frame, DataVector>,
       gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
       gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
@@ -554,7 +553,7 @@ struct FConstraintCompute : FConstraint<SpatialDim, Frame>, db::ComputeTag {
   static constexpr auto function = static_cast<void (*)(
       gsl::not_null<tnsr::a<DataVector, SpatialDim, Frame>*>,
       const tnsr::a<DataVector, SpatialDim, Frame>&,
-      const tnsr::ia<DataVector, SpatialDim, Frame>&,
+      const tnsr::ab<DataVector, SpatialDim, Frame>&,
       const tnsr::a<DataVector, SpatialDim, Frame>&,
       const tnsr::A<DataVector, SpatialDim, Frame>&,
       const tnsr::II<DataVector, SpatialDim, Frame>&,
@@ -581,7 +580,7 @@ template <size_t SpatialDim, typename Frame>
 struct TwoIndexConstraintCompute : TwoIndexConstraint<SpatialDim, Frame>,
                                    db::ComputeTag {
   using argument_tags = tmpl::list<
-      ::Tags::deriv<GaugeH<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
+      SpacetimeDerivGaugeH<SpatialDim, Frame>,
       gr::Tags::SpacetimeNormalOneForm<SpatialDim, Frame, DataVector>,
       gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
       gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
@@ -595,7 +594,7 @@ struct TwoIndexConstraintCompute : TwoIndexConstraint<SpatialDim, Frame>,
 
   static constexpr auto function = static_cast<void (*)(
       gsl::not_null<tnsr::ia<DataVector, SpatialDim, Frame>*>,
-      const tnsr::ia<DataVector, SpatialDim, Frame>&,
+      const tnsr::ab<DataVector, SpatialDim, Frame>&,
       const tnsr::a<DataVector, SpatialDim, Frame>&,
       const tnsr::A<DataVector, SpatialDim, Frame>&,
       const tnsr::II<DataVector, SpatialDim, Frame>&,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -70,19 +70,28 @@ struct InitializeConstraints {
                     const ParallelComponent* const /*meta*/) noexcept {
     using compute_tags = tmpl::flatten<db::AddComputeTags<
         GeneralizedHarmonic::Tags::GaugeConstraintCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::FConstraintCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<Dim, frame>,
         // following tags added to observe constraints
         ::Tags::PointwiseL2NormCompute<
             GeneralizedHarmonic::Tags::GaugeConstraint<Dim, frame>>,
+        ::Tags::PointwiseL2NormCompute<
+            GeneralizedHarmonic::Tags::FConstraint<Dim, frame>>,
+        ::Tags::PointwiseL2NormCompute<
+            GeneralizedHarmonic::Tags::TwoIndexConstraint<Dim, frame>>,
         ::Tags::PointwiseL2NormCompute<
             GeneralizedHarmonic::Tags::ThreeIndexConstraint<Dim, frame>>,
         // The 4-index constraint is only implemented in 3d
         tmpl::conditional_t<
             Dim == 3,
-            tmpl::list<GeneralizedHarmonic::Tags::FourIndexConstraintCompute<
-                           Dim, frame>,
-                       ::Tags::PointwiseL2NormCompute<
-                           GeneralizedHarmonic::Tags::FourIndexConstraint<
-                               Dim, frame>>>,
+            tmpl::list<
+                GeneralizedHarmonic::Tags::FourIndexConstraintCompute<Dim,
+                                                                      frame>,
+                GeneralizedHarmonic::Tags::ConstraintEnergyCompute<Dim, frame>,
+                ::Tags::PointwiseL2NormCompute<
+                    GeneralizedHarmonic::Tags::FourIndexConstraint<Dim, frame>>,
+                ::Tags::PointwiseL2NormCompute<
+                    GeneralizedHarmonic::Tags::ConstraintEnergy<Dim, frame>>>,
             tmpl::list<>>>>;
 
     return std::make_tuple(
@@ -115,6 +124,7 @@ struct InitializeGhAnd3Plus1Variables {
         gr::Tags::SpacetimeNormalVectorCompute<Dim, frame, DataVector>,
         gr::Tags::InverseSpacetimeMetricCompute<Dim, frame, DataVector>,
         GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<Dim, frame>,
         GeneralizedHarmonic::Tags::ConstraintGamma0Compute<Dim, frame>,
         GeneralizedHarmonic::Tags::ConstraintGamma1Compute<Dim, frame>,
         GeneralizedHarmonic::Tags::ConstraintGamma2Compute<Dim, frame>>;

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   GaugeSource.cpp
   Phi.cpp
   Pi.cpp
+  Ricci.cpp
   SpacetimeDerivOfDetSpatialMetric.cpp
   SpacetimeDerivOfNormOfShift.cpp
   SpacetimeDerivativeOfSpacetimeMetric.cpp
@@ -31,6 +32,7 @@ spectre_target_headers(
   GaugeSource.hpp
   Phi.hpp
   Pi.hpp
+  Ricci.hpp
   SpacetimeDerivOfDetSpatialMetric.hpp
   SpacetimeDerivOfNormOfShift.hpp
   SpacetimeDerivativeOfSpacetimeMetric.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.cpp
@@ -1,0 +1,163 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp"
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+/// \cond
+namespace GeneralizedHarmonic {
+template <size_t VolumeDim, typename Frame, typename DataType>
+void spatial_ricci_tensor(
+    const gsl::not_null<tnsr::ii<DataType, VolumeDim, Frame>*> ricci,
+    const tnsr::iaa<DataType, VolumeDim, Frame>& phi,
+    const tnsr::ijaa<DataType, VolumeDim, Frame>& deriv_phi,
+    const tnsr::II<DataType, VolumeDim, Frame>&
+        inverse_spatial_metric) noexcept {
+  if (UNLIKELY(get_size(get<0, 0>(*ricci)) != get_size(get<0, 0, 0>(phi)))) {
+    *ricci = tnsr::ii<DataType, VolumeDim, Frame>(get_size(get<0, 0, 0>(phi)));
+  }
+
+  TempBuffer<tmpl::list<::Tags::TempIjj<0, VolumeDim, Frame, DataType>,
+                        ::Tags::Tempijk<0, VolumeDim, Frame, DataType>,
+                        ::Tags::Tempi<0, VolumeDim, Frame, DataType>,
+                        ::Tags::Tempi<1, VolumeDim, Frame, DataType>,
+                        ::Tags::TempI<0, VolumeDim, Frame, DataType>,
+                        ::Tags::TempI<1, VolumeDim, Frame, DataType>>>
+      local_buffer(get_size(get<0, 0>(inverse_spatial_metric)));
+
+  // New variable to avoid recomputing in nested loops
+  auto& phi_uplolo =
+      get<::Tags::TempIjj<0, VolumeDim, Frame, DataType>>(local_buffer);
+  for (size_t k = 0; k < VolumeDim; ++k) {
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = i; j < VolumeDim; ++j) {  // Symmetry
+        phi_uplolo.get(k, i, j) = 0.;
+        for (size_t l = 0; l < VolumeDim; ++l) {
+          phi_uplolo.get(k, i, j) +=
+              0.5 * inverse_spatial_metric.get(k, l) * phi.get(l, 1 + i, 1 + j);
+        }
+      }
+    }
+  }
+
+  // New variable to avoid recomputing in nested loops
+  auto& phi_loloup =
+      get<::Tags::Tempijk<0, VolumeDim, Frame, DataType>>(local_buffer);
+  for (size_t k = 0; k < VolumeDim; ++k) {
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        phi_loloup.get(i, j, k) = 0.;
+        for (size_t l = 0; l < VolumeDim; ++l) {
+          phi_loloup.get(i, j, k) +=
+              0.5 * inverse_spatial_metric.get(k, l) * phi.get(i, 1 + j, 1 + l);
+        }
+      }
+    }
+  }
+
+  // New variable to avoid recomputing in nested loops
+  auto& phi_trace1 =
+      get<::Tags::Tempi<0, VolumeDim, Frame, DataType>>(local_buffer);
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    phi_trace1.get(i) = 0.;
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      phi_trace1.get(i) += phi_loloup.get(i, j, j);
+    }
+  }
+  auto& phi_trace2 =
+      get<::Tags::Tempi<1, VolumeDim, Frame, DataType>>(local_buffer);
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    phi_trace2.get(i) = 0.;
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      phi_trace2.get(i) += phi_uplolo.get(j, j, i);
+    }
+  }
+
+  auto& phi_trace1_up =
+      get<::Tags::TempI<0, VolumeDim, Frame, DataType>>(local_buffer);
+  auto& phi_trace2_up =
+      get<::Tags::TempI<1, VolumeDim, Frame, DataType>>(local_buffer);
+
+  raise_or_lower_index(make_not_null(&phi_trace1_up), phi_trace1,
+                       inverse_spatial_metric);
+  raise_or_lower_index(make_not_null(&phi_trace2_up), phi_trace2,
+                       inverse_spatial_metric);
+
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {  // Symmetry
+      ricci->get(i, j) = 0.;
+      for (size_t p = 0; p < VolumeDim; ++p) {
+        ricci->get(i, j) +=
+            0.5 *
+            (phi.get(p, 1 + i, 1 + j) - phi.get(i, 1 + j, 1 + p) -
+             phi.get(j, 1 + i, 1 + p)) *
+            (2.0 * phi_trace2_up.get(p) - phi_trace1_up.get(p));
+        for (size_t q = 0; q < VolumeDim; ++q) {
+          ricci->get(i, j) +=
+              0.25 * inverse_spatial_metric.get(p, q) *
+                  (deriv_phi.get(j, q, 1 + p, 1 + i) +
+                   deriv_phi.get(i, q, 1 + p, 1 + j) -
+                   deriv_phi.get(j, i, 1 + p, 1 + q) -
+                   deriv_phi.get(i, j, 1 + p, 1 + q) +
+                   deriv_phi.get(p, i, 1 + q, 1 + j) +
+                   deriv_phi.get(p, j, 1 + q, 1 + i) -
+                   2.0 * deriv_phi.get(q, p, 1 + i, 1 + j)) +
+              phi_loloup.get(i, p, q) * phi_loloup.get(j, q, p) +
+              2.0 * phi_uplolo.get(p, i, q) * phi_loloup.get(p, j, q) -
+              2.0 * phi_uplolo.get(p, q, i) * phi_uplolo.get(q, p, j);
+        }
+      }
+    }
+  }
+}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::ii<DataType, VolumeDim, Frame> spatial_ricci_tensor(
+    const tnsr::iaa<DataType, VolumeDim, Frame>& phi,
+    const tnsr::ijaa<DataType, VolumeDim, Frame>& deriv_phi,
+    const tnsr::II<DataType, VolumeDim, Frame>&
+        inverse_spatial_metric) noexcept {
+  tnsr::ii<DataType, VolumeDim, Frame> ricci{};
+  GeneralizedHarmonic::spatial_ricci_tensor<VolumeDim, Frame, DataType>(
+      make_not_null(&ricci), phi, deriv_phi, inverse_spatial_metric);
+  return ricci;
+}
+}  // namespace GeneralizedHarmonic
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                              \
+  template void GeneralizedHarmonic::spatial_ricci_tensor(                \
+      const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*> \
+          ricci,                                                          \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,          \
+      const tnsr::ijaa<DTYPE(data), DIM(data), FRAME(data)>& deriv_phi,   \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
+          inverse_spatial_metric) noexcept;                               \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>                  \
+  GeneralizedHarmonic::spatial_ricci_tensor(                              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,          \
+      const tnsr::ijaa<DTYPE(data), DIM(data), FRAME(data)>& deriv_phi,   \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
+          inverse_spatial_metric) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+///\file
+/// Declares function templates to calculate the Ricci tensor
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace GeneralizedHarmonic {
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute spatial Ricci tensor using evolved variables and
+ * their first derivatives.
+ *
+ * \details Compute \f$R_{ij}\f$ as:
+ *
+ * \f{align}
+ * R_{i j} =& \case{1}{2} g^{a b} \left( \partial_{(i} d_{a b j)}
+ *            + \partial_a d_{(i j) b} - \partial_a d_{b i j}
+ *            - \partial_{(i} d_{j) a b} \right) \\
+ *          &+ \case{1}{2} b^a d_{a i j} - \case{1}{4} d^a d_{a i j}
+ *            - b^a d_{(i j) a} - \case{1}{2} d_{a j}^{~ ~ b} d_{b i}^{~ ~ a}\\
+ *          &+ \case{1}{2} d^a d_{(i j) a} + \case{1}{4} d_i^{~ a b} d_{j a b}
+ *            + \case{1}{2} d_{~ ~ i}^{a b} d_{a b j},
+ * \f}
+ *
+ * using the variable \f$d_{kij} \equiv \partial_k g_{ij}\f$ defined and
+ * used in equations (2.13) - (2.20) of \cite Kidder:2001tz to derive
+ * the equation above.
+ */
+template <size_t VolumeDim, typename Frame, typename DataType>
+void spatial_ricci_tensor(
+    gsl::not_null<tnsr::ii<DataType, VolumeDim, Frame>*> ricci,
+    const tnsr::iaa<DataType, VolumeDim, Frame>& phi,
+    const tnsr::ijaa<DataType, VolumeDim, Frame>& deriv_phi,
+    const tnsr::II<DataType, VolumeDim, Frame>&
+        inverse_spatial_metric) noexcept;
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::ii<DataType, VolumeDim, Frame> spatial_ricci_tensor(
+    const tnsr::iaa<DataType, VolumeDim, Frame>& phi,
+    const tnsr::ijaa<DataType, VolumeDim, Frame>& deriv_phi,
+    const tnsr::II<DataType, VolumeDim, Frame>&
+        inverse_spatial_metric) noexcept;
+// @}
+}  // namespace GeneralizedHarmonic

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(GaugeSourceFunctions)
 set(LIBRARY "Test_GeneralizedHarmonic")
 
 set(LIBRARY_SOURCES
+  Test_BoundaryConditions.cpp
   Test_Characteristics.cpp
   Test_Constraints.cpp
   Test_DuDt.cpp

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
@@ -58,7 +58,7 @@ def two_index_constraint_term_4_of_11(spacetime_normal_one_form,
 
 
 def two_index_constraint_term_5_of_11(d_gauge_function):
-    return d_gauge_function
+    return d_gauge_function[1:, :]
 
 
 def two_index_constraint_term_6_of_11(spacetime_normal_vector,
@@ -287,7 +287,7 @@ def f_constraint_term_4_of_25(spacetime_normal_one_form,
 
 def f_constraint_term_5_of_25(spacetime_normal_one_form,
                               inverse_spatial_metric, d_gauge_function):
-    d_gauge_function_ij = d_gauge_function[:, 1:]
+    d_gauge_function_ij = d_gauge_function[1:, 1:]
     return np.einsum("a,ij,ij", spacetime_normal_one_form,
                      inverse_spatial_metric, d_gauge_function_ij)
 
@@ -324,14 +324,12 @@ def f_constraint_term_7_of_25(spacetime_normal_one_form,
 
 def f_constraint_term_8_of_25(spacetime_normal_one_form,
                               spacetime_normal_vector, d_gauge_function):
-    d_gauge_function_ab = np.pad(d_gauge_function, ((1, 0), (0, 0)),
-                                 'constant')
+    d_gauge_function[0, :] = 0
     spacetime_normal_vector_I = spacetime_normal_vector[1:]
-    term = -1.0 * np.einsum("b,ab", spacetime_normal_vector,
-                            d_gauge_function_ab)
+    term = -1.0 * np.einsum("b,ab", spacetime_normal_vector, d_gauge_function)
     return term - np.einsum("a,i,b,ib", spacetime_normal_one_form,
                             spacetime_normal_vector_I, spacetime_normal_vector,
-                            d_gauge_function)
+                            d_gauge_function[1:, :])
 
 
 def f_constraint_term_9_of_25(inverse_spatial_metric, phi,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_BoundaryConditions.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_BoundaryConditions.cpp
@@ -1,0 +1,2643 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+#include <random>
+#include <string>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Options/ParseOptions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+using Affine = domain::CoordinateMaps::Affine;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+using frame = Frame::Inertial;
+constexpr size_t VolumeDim = 3;
+
+// Test boundary conditions on dt<VSpacetimeMetric>
+template <GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+              VSpacetimeMetricBcMethod BcMethod>
+void test_constraint_preserving_bjorhus_u_psi(
+    size_t grid_size_each_dimension, const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept;
+
+template <>
+void test_constraint_preserving_bjorhus_u_psi<
+    GeneralizedHarmonic::BoundaryConditions::Bjorhus::VSpacetimeMetricBcMethod::
+        ConstraintPreserving>(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Setup grid
+  Mesh<VolumeDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  const Direction<VolumeDim> direction(1, Side::Upper);  // +y direction
+  const size_t slice_grid_points =
+      mesh.extents().slice_away(direction.dimension()).product();
+  // Storage for intermediate vars
+  GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+      BjorhusIntermediatesComputer intermediate_vars(slice_grid_points);
+  auto& buffer = intermediate_vars.get_buffer();
+  // Also create local variables and their time derivatives, both of which we
+  // will populate as needed
+  db::item_type<GeneralizedHarmonic::System<VolumeDim>::variables_tag>
+      local_vars(slice_grid_points, 0.);
+  Variables<db::wrap_tags_in<
+      ::Tags::dt, GeneralizedHarmonic::System<VolumeDim>::gradients_tags>>
+      local_dt_vars(slice_grid_points, 0.);
+  tnsr::i<DataVector, VolumeDim, frame> local_unit_normal_one_form(
+      slice_grid_points, 0.);
+
+  {
+    // POPULATE various tensors needed to compute BcDtVSpacetimeMetric
+    // EXACTLY as done in SpEC
+    auto& local_three_index_constraint =
+        get<GeneralizedHarmonic::Tags::ThreeIndexConstraint<VolumeDim,
+                                                            Frame::Inertial>>(
+            buffer);
+    auto& local_unit_interface_normal_vector =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    interface_normal_vector<VolumeDim, DataVector>>(buffer);
+    auto& local_lapse = get<gr::Tags::Lapse<DataVector>>(buffer);
+    auto& local_shift =
+        get<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>>(buffer);
+
+    auto& local_pi =
+        get<GeneralizedHarmonic::Tags::Pi<VolumeDim, frame>>(local_vars);
+    auto& local_phi =
+        get<GeneralizedHarmonic::Tags::Phi<VolumeDim, frame>>(local_vars);
+
+    auto& local_char_projected_rhs_dt_u_psi =
+        get<GeneralizedHarmonic::Tags::VSpacetimeMetric<VolumeDim,
+                                                        Frame::Inertial>>(
+            buffer);
+    auto& local_char_speeds_0 =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::char_speed_vpsi<
+                    DataVector>>(buffer);
+    auto& local_char_speeds_1 =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::char_speed_vzero<
+                    DataVector>>(buffer);
+
+    // Setting 3idxConstraint
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = 0; b <= VolumeDim; ++b) {
+          local_three_index_constraint.get(0, a, b)[i] = 11. - 3.;
+          local_three_index_constraint.get(1, a, b)[i] = 13. - 5.;
+          local_three_index_constraint.get(2, a, b)[i] = 17. - 7.;
+        }
+      }
+    }
+    // Setting unit_interface_normal_Vector
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      local_unit_interface_normal_vector.get(0)[i] = 1.e300;
+      local_unit_interface_normal_vector.get(1)[i] = -1.;
+      local_unit_interface_normal_vector.get(2)[i] = 0.;
+      local_unit_interface_normal_vector.get(3)[i] = 0.;
+    }
+    // Setting local_lapse
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      get(local_lapse)[i] = 2.;
+    }
+    // Setting shift
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      local_shift.get(0)[i] = 1.;
+      local_shift.get(1)[i] = 2.;
+      local_shift.get(2)[i] = 3.;
+    }
+    // Setting pi AND phi
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = 0; b <= VolumeDim; ++b) {
+          local_pi.get(a, b)[i] = 1.;
+          local_phi.get(0, a, b)[i] = 3.;
+          local_phi.get(1, a, b)[i] = 5.;
+          local_phi.get(2, a, b)[i] = 7.;
+        }
+      }
+    }
+    // Setting local_RhsVSpacetimeMetric
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_char_projected_rhs_dt_u_psi.get(0, a)[i] = 23.;
+        local_char_projected_rhs_dt_u_psi.get(1, a)[i] = 29.;
+        local_char_projected_rhs_dt_u_psi.get(2, a)[i] = 31.;
+        local_char_projected_rhs_dt_u_psi.get(3, a)[i] = 37.;
+      }
+    }
+    // Setting char speeds
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      get(local_char_speeds_0)[i] = -0.3;
+      get(local_char_speeds_1)[i] = -0.1;
+    }
+    // Setting unit normal one_form
+    get<1>(local_unit_normal_one_form) = 1.;
+  }
+
+  // Compute return value from Action
+  auto local_bc_dt_u_psi =
+      GeneralizedHarmonic::Actions::BoundaryConditions_detail::set_dt_v_psi<
+          typename GeneralizedHarmonic::Tags::VSpacetimeMetric<VolumeDim,
+                                                               frame>::type,
+          VolumeDim>::apply(GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+                                VSpacetimeMetricBcMethod::ConstraintPreserving,
+                            make_not_null(&intermediate_vars), local_vars,
+                            local_dt_vars, local_unit_normal_one_form);
+
+  // Initialize with values from SpEC
+  auto spec_bd_dt_u_psi = local_bc_dt_u_psi;
+  for (size_t i = 0; i < slice_grid_points; ++i) {
+    get<0, 0>(spec_bd_dt_u_psi)[i] = 25.4;
+    get<0, 1>(spec_bd_dt_u_psi)[i] = 25.4;
+    get<0, 2>(spec_bd_dt_u_psi)[i] = 25.4;
+    get<0, 3>(spec_bd_dt_u_psi)[i] = 25.4;
+    get<1, 1>(spec_bd_dt_u_psi)[i] = 31.4;
+    get<1, 2>(spec_bd_dt_u_psi)[i] = 31.4;
+    get<1, 3>(spec_bd_dt_u_psi)[i] = 31.4;
+    get<2, 2>(spec_bd_dt_u_psi)[i] = 33.4;
+    get<2, 3>(spec_bd_dt_u_psi)[i] = 33.4;
+    get<3, 3>(spec_bd_dt_u_psi)[i] = 39.4;
+  }
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_bc_dt_u_psi, spec_bd_dt_u_psi);
+
+  // Test for another set of values
+  {
+    auto& local_unit_interface_normal_vector =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    interface_normal_vector<VolumeDim, DataVector>>(buffer);
+    // Setting unit_interface_normal_Vector
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      local_unit_interface_normal_vector.get(0)[i] = 1.e300;
+      local_unit_interface_normal_vector.get(1)[i] = -1.;
+      local_unit_interface_normal_vector.get(2)[i] = 1.;
+      local_unit_interface_normal_vector.get(3)[i] = 1.;
+    }
+  }
+  // Compute return value from Action
+  local_bc_dt_u_psi =
+      GeneralizedHarmonic::Actions::BoundaryConditions_detail::set_dt_v_psi<
+          typename GeneralizedHarmonic::Tags::VSpacetimeMetric<VolumeDim,
+                                                               frame>::type,
+          VolumeDim>::apply(GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+                                VSpacetimeMetricBcMethod::ConstraintPreserving,
+                            make_not_null(&intermediate_vars), local_vars,
+                            local_dt_vars, local_unit_normal_one_form);
+  // Initialize with values from SpEC
+  for (size_t i = 0; i < slice_grid_points; ++i) {
+    get<0, 0>(spec_bd_dt_u_psi)[i] = 20.;
+    get<0, 1>(spec_bd_dt_u_psi)[i] = 20.;
+    get<0, 2>(spec_bd_dt_u_psi)[i] = 20.;
+    get<0, 3>(spec_bd_dt_u_psi)[i] = 20.;
+    get<1, 1>(spec_bd_dt_u_psi)[i] = 26.;
+    get<1, 2>(spec_bd_dt_u_psi)[i] = 26.;
+    get<1, 3>(spec_bd_dt_u_psi)[i] = 26.;
+    get<2, 2>(spec_bd_dt_u_psi)[i] = 28.;
+    get<2, 3>(spec_bd_dt_u_psi)[i] = 28.;
+    get<3, 3>(spec_bd_dt_u_psi)[i] = 34.;
+  }
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_bc_dt_u_psi, spec_bd_dt_u_psi);
+}
+
+// Test boundary conditions on dt<VZero>
+template <
+    GeneralizedHarmonic::BoundaryConditions::Bjorhus::VZeroBcMethod BcMethod>
+void test_constraint_preserving_bjorhus_u_zero(
+    size_t grid_size_each_dimension, const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept;
+
+template <>
+void test_constraint_preserving_bjorhus_u_zero<
+    GeneralizedHarmonic::BoundaryConditions::Bjorhus::VZeroBcMethod::
+        ConstraintPreserving>(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Setup grid
+  Mesh<VolumeDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  const Direction<VolumeDim> direction(1, Side::Upper);  // +y direction
+  const size_t slice_grid_points =
+      mesh.extents().slice_away(direction.dimension()).product();
+  // Storage for intermediate vars
+  GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+      BjorhusIntermediatesComputer intermediate_vars(slice_grid_points);
+  auto& buffer = intermediate_vars.get_buffer();
+  // Also create local variables and their time derivatives, both of which we
+  // will populate as needed
+  db::item_type<GeneralizedHarmonic::System<VolumeDim>::variables_tag>
+      local_vars(slice_grid_points, 0.);
+  Variables<db::wrap_tags_in<
+      ::Tags::dt, GeneralizedHarmonic::System<VolumeDim>::gradients_tags>>
+      local_dt_vars(slice_grid_points, 0.);
+  tnsr::i<DataVector, VolumeDim, frame> local_unit_normal_one_form(
+      slice_grid_points, 0.);
+
+  {
+    // POPULATE various tensors needed to compute BcDtVSpacetimeMetric
+    // EXACTLY as done in SpEC
+    auto& local_four_index_constraint =
+        get<GeneralizedHarmonic::Tags::FourIndexConstraint<VolumeDim,
+                                                           Frame::Inertial>>(
+            buffer);
+    auto& local_unit_interface_normal_vector =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    interface_normal_vector<VolumeDim, DataVector>>(buffer);
+    auto& local_lapse = get<gr::Tags::Lapse<DataVector>>(buffer);
+    auto& local_shift =
+        get<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>>(buffer);
+
+    auto& local_pi =
+        get<GeneralizedHarmonic::Tags::Pi<VolumeDim, frame>>(local_vars);
+    auto& local_phi =
+        get<GeneralizedHarmonic::Tags::Phi<VolumeDim, frame>>(local_vars);
+
+    auto& local_char_projected_rhs_dt_u_zero =
+        get<GeneralizedHarmonic::Tags::VZero<VolumeDim, Frame::Inertial>>(
+            buffer);
+    auto& local_char_speeds_0 =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::char_speed_vpsi<
+                    DataVector>>(buffer);
+    auto& local_char_speeds_1 =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::char_speed_vzero<
+                    DataVector>>(buffer);
+
+    // Setting 4idxConstraint:
+    // initialize dPhi (with same values as for SpEC) and compute C4 from it
+    auto local_dphi =
+        make_with_value<tnsr::ijaa<DataVector, VolumeDim, Frame::Inertial>>(
+            local_lapse, 0.);
+    for (size_t a = 0; a <= VolumeDim; ++a) {
+      for (size_t b = 0; b <= VolumeDim; ++b) {
+        for (size_t i = 0; i < slice_grid_points; ++i) {
+          local_dphi.get(0, 0, a, b)[i] = 3.;
+          local_dphi.get(0, 1, a, b)[i] = 5.;
+          local_dphi.get(0, 2, a, b)[i] = 7.;
+          local_dphi.get(1, 0, a, b)[i] = 59.;
+          local_dphi.get(1, 1, a, b)[i] = 61.;
+          local_dphi.get(1, 2, a, b)[i] = 67.;
+          local_dphi.get(2, 0, a, b)[i] = 73.;
+          local_dphi.get(2, 1, a, b)[i] = 79.;
+          local_dphi.get(2, 2, a, b)[i] = 83.;
+        }
+      }
+    }
+    // C4_{iab} = LeviCivita^{ijk} dphi_{jkab}
+    local_four_index_constraint =
+        GeneralizedHarmonic::four_index_constraint<VolumeDim, Frame::Inertial,
+                                                   DataVector>(local_dphi);
+
+    // Setting unit_interface_normal_Vector
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      local_unit_interface_normal_vector.get(0)[i] = 1.e300;
+      local_unit_interface_normal_vector.get(1)[i] = -1.;
+      local_unit_interface_normal_vector.get(2)[i] = 1.;
+      local_unit_interface_normal_vector.get(3)[i] = 1.;
+    }
+    // Setting lapse
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      get(local_lapse)[i] = 2.;
+    }
+    // Setting shift
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      local_shift.get(0)[i] = 1.;
+      local_shift.get(1)[i] = 2.;
+      local_shift.get(2)[i] = 3.;
+    }
+    // Setting pi AND phi
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = 0; b <= VolumeDim; ++b) {
+          local_pi.get(a, b)[i] = 1.;
+          local_phi.get(0, a, b)[i] = 3.;
+          local_phi.get(1, a, b)[i] = 5.;
+          local_phi.get(2, a, b)[i] = 7.;
+        }
+      }
+    }
+    // Setting local_RhsU0
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          local_char_projected_rhs_dt_u_zero.get(0, a, b)[i] = 91.;
+          local_char_projected_rhs_dt_u_zero.get(1, a, b)[i] = 97.;
+          local_char_projected_rhs_dt_u_zero.get(2, a, b)[i] = 101.;
+        }
+      }
+    }
+    // Setting char speeds
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      get(local_char_speeds_0)[i] = -0.3;
+      get(local_char_speeds_1)[i] = -0.1;
+    }
+    // Setting unit normal one_form
+    get<1>(local_unit_normal_one_form) = 1.;
+  }
+  // Compute return value from Action
+  auto local_bc_dt_u_zero =
+      GeneralizedHarmonic::Actions::BoundaryConditions_detail::set_dt_v_zero<
+          typename GeneralizedHarmonic::Tags::VZero<VolumeDim, frame>::type,
+          VolumeDim>::apply(GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+                                VZeroBcMethod::ConstraintPreserving,
+                            make_not_null(&intermediate_vars), local_vars,
+                            local_dt_vars, local_unit_normal_one_form);
+
+  // Initialize with values from SpEC
+  auto spec_bc_dt_u_zero = local_bc_dt_u_zero;
+  for (size_t i = 0; i < slice_grid_points; ++i) {
+    get<0, 0, 0>(spec_bc_dt_u_zero)[i] = 79.;
+    get<0, 0, 1>(spec_bc_dt_u_zero)[i] = 79.;
+    get<0, 0, 2>(spec_bc_dt_u_zero)[i] = 79.;
+    get<0, 0, 3>(spec_bc_dt_u_zero)[i] = 79.;
+    get<1, 0, 0>(spec_bc_dt_u_zero)[i] = 90.4;
+    get<1, 0, 1>(spec_bc_dt_u_zero)[i] = 90.4;
+    get<1, 0, 2>(spec_bc_dt_u_zero)[i] = 90.4;
+    get<1, 0, 3>(spec_bc_dt_u_zero)[i] = 90.4;
+    get<2, 0, 3>(spec_bc_dt_u_zero)[i] = 95.6;
+    get<2, 0, 0>(spec_bc_dt_u_zero)[i] = 95.6;
+    get<2, 0, 1>(spec_bc_dt_u_zero)[i] = 95.6;
+    get<2, 0, 2>(spec_bc_dt_u_zero)[i] = 95.6;
+
+    get<0, 1, 1>(spec_bc_dt_u_zero)[i] = 79.;
+    get<0, 1, 2>(spec_bc_dt_u_zero)[i] = 79.;
+    get<0, 1, 3>(spec_bc_dt_u_zero)[i] = 79.;
+    get<1, 1, 1>(spec_bc_dt_u_zero)[i] = 90.4;
+    get<1, 1, 2>(spec_bc_dt_u_zero)[i] = 90.4;
+    get<1, 1, 3>(spec_bc_dt_u_zero)[i] = 90.4;
+    get<2, 1, 1>(spec_bc_dt_u_zero)[i] = 95.6;
+    get<2, 1, 2>(spec_bc_dt_u_zero)[i] = 95.6;
+    get<2, 1, 3>(spec_bc_dt_u_zero)[i] = 95.6;
+
+    get<0, 2, 2>(spec_bc_dt_u_zero)[i] = 79.;
+    get<0, 2, 3>(spec_bc_dt_u_zero)[i] = 79.;
+    get<1, 2, 2>(spec_bc_dt_u_zero)[i] = 90.4;
+    get<1, 2, 3>(spec_bc_dt_u_zero)[i] = 90.4;
+    get<2, 2, 2>(spec_bc_dt_u_zero)[i] = 95.6;
+    get<2, 2, 3>(spec_bc_dt_u_zero)[i] = 95.6;
+
+    get<0, 3, 3>(spec_bc_dt_u_zero)[i] = 79.;
+    get<1, 3, 3>(spec_bc_dt_u_zero)[i] = 90.4;
+    get<2, 3, 3>(spec_bc_dt_u_zero)[i] = 95.6;
+  }
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_bc_dt_u_zero, spec_bc_dt_u_zero);
+
+  // Test for another set of values
+  {
+    auto& local_unit_interface_normal_vector =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    interface_normal_vector<VolumeDim, DataVector>>(buffer);
+    // Setting unit_interface_normal_Vector
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      local_unit_interface_normal_vector.get(0)[i] = 1.e300;
+      local_unit_interface_normal_vector.get(1)[i] = -1.;
+      local_unit_interface_normal_vector.get(2)[i] = 0.;
+      local_unit_interface_normal_vector.get(3)[i] = 0.;
+    }
+  }
+  // Compute return value from Action
+  local_bc_dt_u_zero =
+      GeneralizedHarmonic::Actions::BoundaryConditions_detail::set_dt_v_zero<
+          typename GeneralizedHarmonic::Tags::VZero<VolumeDim, frame>::type,
+          VolumeDim>::apply(GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+                                VZeroBcMethod::ConstraintPreserving,
+                            make_not_null(&intermediate_vars), local_vars,
+                            local_dt_vars, local_unit_normal_one_form);
+
+  // Initialize with values from SpEC
+  for (size_t i = 0; i < slice_grid_points; ++i) {
+    get<0, 0, 0>(spec_bc_dt_u_zero)[i] = 91.;
+    get<0, 0, 1>(spec_bc_dt_u_zero)[i] = 91.;
+    get<0, 0, 2>(spec_bc_dt_u_zero)[i] = 91.;
+    get<0, 0, 3>(spec_bc_dt_u_zero)[i] = 91.;
+    get<1, 0, 0>(spec_bc_dt_u_zero)[i] = 91.6;
+    get<1, 0, 1>(spec_bc_dt_u_zero)[i] = 91.6;
+    get<1, 0, 2>(spec_bc_dt_u_zero)[i] = 91.6;
+    get<1, 0, 3>(spec_bc_dt_u_zero)[i] = 91.6;
+    get<2, 0, 3>(spec_bc_dt_u_zero)[i] = 94.4;
+    get<2, 0, 0>(spec_bc_dt_u_zero)[i] = 94.4;
+    get<2, 0, 1>(spec_bc_dt_u_zero)[i] = 94.4;
+    get<2, 0, 2>(spec_bc_dt_u_zero)[i] = 94.4;
+
+    get<0, 1, 1>(spec_bc_dt_u_zero)[i] = 91.;
+    get<0, 1, 2>(spec_bc_dt_u_zero)[i] = 91.;
+    get<0, 1, 3>(spec_bc_dt_u_zero)[i] = 91.;
+    get<1, 1, 1>(spec_bc_dt_u_zero)[i] = 91.6;
+    get<1, 1, 2>(spec_bc_dt_u_zero)[i] = 91.6;
+    get<1, 1, 3>(spec_bc_dt_u_zero)[i] = 91.6;
+    get<2, 1, 1>(spec_bc_dt_u_zero)[i] = 94.4;
+    get<2, 1, 2>(spec_bc_dt_u_zero)[i] = 94.4;
+    get<2, 1, 3>(spec_bc_dt_u_zero)[i] = 94.4;
+
+    get<0, 2, 2>(spec_bc_dt_u_zero)[i] = 91.;
+    get<0, 2, 3>(spec_bc_dt_u_zero)[i] = 91.;
+    get<1, 2, 2>(spec_bc_dt_u_zero)[i] = 91.6;
+    get<1, 2, 3>(spec_bc_dt_u_zero)[i] = 91.6;
+    get<2, 2, 2>(spec_bc_dt_u_zero)[i] = 94.4;
+    get<2, 2, 3>(spec_bc_dt_u_zero)[i] = 94.4;
+
+    get<0, 3, 3>(spec_bc_dt_u_zero)[i] = 91.;
+    get<1, 3, 3>(spec_bc_dt_u_zero)[i] = 91.6;
+    get<2, 3, 3>(spec_bc_dt_u_zero)[i] = 94.4;
+  }
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_bc_dt_u_zero, spec_bc_dt_u_zero);
+}
+
+// Test boundary conditions on dt<VMinus>
+template <
+    GeneralizedHarmonic::BoundaryConditions::Bjorhus::VMinusBcMethod BcMethod>
+void test_constraint_preserving_bjorhus_u_minus(
+    size_t grid_size_each_dimension, const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept;
+
+// Test the boundary condition imposed on VMinus when
+// option `Freezing` is specified. Only the gauge portion of the RHS is set.
+template <>
+void test_constraint_preserving_bjorhus_u_minus<
+    GeneralizedHarmonic::BoundaryConditions::Bjorhus::VMinusBcMethod::Freezing>(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Setup grid
+  Mesh<VolumeDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  const Direction<VolumeDim> direction(1, Side::Upper);  // +y direction
+  const size_t slice_grid_points =
+      mesh.extents().slice_away(direction.dimension()).product();
+  const auto inertial_coords = [&slice_grid_points, &lower_bound]() {
+    tnsr::I<DataVector, VolumeDim, frame> tmp(slice_grid_points, 0.);
+    // +y direction
+    get<1>(tmp) = 0.5;
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        get<0>(tmp)[i * VolumeDim + j] =
+            lower_bound[0] + 0.5 * static_cast<double>(i);
+        get<2>(tmp)[i * VolumeDim + j] =
+            lower_bound[2] + 0.5 * static_cast<double>(j);
+      }
+    }
+    return tmp;
+  }();
+  // Storage for intermediate vars
+  GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+      BjorhusIntermediatesComputer intermediate_vars(slice_grid_points);
+  auto& buffer = intermediate_vars.get_buffer();
+  // Also create local variables and their time derivatives, both of which we
+  // will populate as needed
+  db::item_type<GeneralizedHarmonic::System<VolumeDim>::variables_tag>
+      local_vars(slice_grid_points, 0.);
+  Variables<db::wrap_tags_in<
+      ::Tags::dt, GeneralizedHarmonic::System<VolumeDim>::gradients_tags>>
+      local_dt_vars(slice_grid_points, 0.);
+  tnsr::i<DataVector, VolumeDim, frame> local_unit_normal_one_form(
+      slice_grid_points, 0.);
+
+  {
+    // POPULATE various tensors needed to compute BcDtVSpacetimeMetric
+    // EXACTLY as done in SpEC
+    auto& local_inertial_coords =
+        get<domain::Tags::Coordinates<VolumeDim, Frame::Inertial>>(buffer);
+    auto& local_constraint_gamma2 =
+        get<GeneralizedHarmonic::Tags::ConstraintGamma2>(buffer);
+    // timelike and spacelike SPACETIME vectors, l^a and k^a
+    auto& local_outgoing_null_one_form =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    outgoing_null_one_form<VolumeDim, DataVector>>(buffer);
+    auto& local_incoming_null_one_form =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    incoming_null_one_form<VolumeDim, DataVector>>(buffer);
+    // timelike and spacelike SPACETIME oneforms, l_a and k_a
+    auto& local_outgoing_null_vector =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    outgoing_null_vector<VolumeDim, DataVector>>(buffer);
+    auto& local_incoming_null_vector =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    incoming_null_vector<VolumeDim, DataVector>>(buffer);
+    // projection Ab
+    auto& local_projection_Ab =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::projection_Ab<
+                    VolumeDim, DataVector>>(buffer);
+    // RhsVSpacetimeMetric and RhsVMinus
+    auto& local_char_projected_rhs_dt_u_psi =
+        get<GeneralizedHarmonic::Tags::VSpacetimeMetric<VolumeDim,
+                                                        Frame::Inertial>>(
+            buffer);
+    auto& local_char_projected_rhs_dt_u_zero =
+        get<GeneralizedHarmonic::Tags::VZero<VolumeDim, Frame::Inertial>>(
+            buffer);
+    auto& local_char_projected_rhs_dt_u_minus =
+        get<GeneralizedHarmonic::Tags::VMinus<VolumeDim, Frame::Inertial>>(
+            buffer);
+
+    auto& local_unit_interface_normal_vector =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    interface_normal_vector<VolumeDim, DataVector>>(buffer);
+
+    auto& local_pi =
+        get<GeneralizedHarmonic::Tags::Pi<VolumeDim, frame>>(local_vars);
+    auto& local_phi =
+        get<GeneralizedHarmonic::Tags::Phi<VolumeDim, frame>>(local_vars);
+
+    auto& local_char_speeds_0 =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::char_speed_vpsi<
+                    DataVector>>(buffer);
+    auto& local_char_speeds_1 =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::char_speed_vzero<
+                    DataVector>>(buffer);
+    auto& local_char_speeds_3 =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::char_speed_vminus<
+                    DataVector>>(buffer);
+
+    // Setting coords
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      local_inertial_coords.get(i) = inertial_coords.get(i);
+    }
+    // Setting constraint_gamma2
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      get(local_constraint_gamma2)[i] = 113.;
+    }
+    // Setting incoming null one_form: ui
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_incoming_null_one_form.get(0)[i] = -2.;
+      local_incoming_null_one_form.get(1)[i] = 5.;
+      local_incoming_null_one_form.get(2)[i] = 3.;
+      local_incoming_null_one_form.get(3)[i] = 7.;
+    }
+    // Setting incoming null vector: uI
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_incoming_null_vector.get(0)[i] = -1.;
+      local_incoming_null_vector.get(1)[i] = 13.;
+      local_incoming_null_vector.get(2)[i] = 17.;
+      local_incoming_null_vector.get(3)[i] = 19.;
+    }
+    // Setting outgoing null one_form: vi
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_outgoing_null_one_form.get(0)[i] = -1.;
+      local_outgoing_null_one_form.get(1)[i] = 3.;
+      local_outgoing_null_one_form.get(2)[i] = 2.;
+      local_outgoing_null_one_form.get(3)[i] = 5.;
+    }
+    // Setting outgoing null vector: vI
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_outgoing_null_vector.get(0)[i] = -1.;
+      local_outgoing_null_vector.get(1)[i] = 2.;
+      local_outgoing_null_vector.get(2)[i] = 3.;
+      local_outgoing_null_vector.get(3)[i] = 5.;
+    }
+    // Setting projection Ab
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_projection_Ab.get(0, a)[i] = 233.;
+        local_projection_Ab.get(1, a)[i] = 239.;
+        local_projection_Ab.get(2, a)[i] = 241.;
+        local_projection_Ab.get(3, a)[i] = 251.;
+      }
+    }
+    // Setting local_RhsVSpacetimeMetric
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_char_projected_rhs_dt_u_psi.get(0, a)[i] = 23.;
+        local_char_projected_rhs_dt_u_psi.get(1, a)[i] = 29.;
+        local_char_projected_rhs_dt_u_psi.get(2, a)[i] = 31.;
+        local_char_projected_rhs_dt_u_psi.get(3, a)[i] = 37.;
+      }
+    }
+    // Setting RhsVMinus
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_char_projected_rhs_dt_u_minus.get(0, a)[i] = 331.;
+        local_char_projected_rhs_dt_u_minus.get(1, a)[i] = 337.;
+        local_char_projected_rhs_dt_u_minus.get(2, a)[i] = 347.;
+        local_char_projected_rhs_dt_u_minus.get(3, a)[i] = 349.;
+      }
+    }
+
+    // Setting unit_interface_normal_Vector
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      local_unit_interface_normal_vector.get(0)[i] = 1.e300;
+      local_unit_interface_normal_vector.get(1)[i] = -1.;
+      local_unit_interface_normal_vector.get(2)[i] = 1.;
+      local_unit_interface_normal_vector.get(3)[i] = 1.;
+    }
+    // Setting pi AND phi
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = 0; b <= VolumeDim; ++b) {
+          local_pi.get(a, b)[i] = 1.;
+          local_phi.get(0, a, b)[i] = 3.;
+          local_phi.get(1, a, b)[i] = 5.;
+          local_phi.get(2, a, b)[i] = 7.;
+        }
+      }
+    }
+    // Setting local_RhsU0
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          local_char_projected_rhs_dt_u_zero.get(0, a, b)[i] = 91.;
+          local_char_projected_rhs_dt_u_zero.get(1, a, b)[i] = 97.;
+          local_char_projected_rhs_dt_u_zero.get(2, a, b)[i] = 101.;
+        }
+      }
+    }
+    // Setting char speeds
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      get(local_char_speeds_0)[i] = -0.3;
+      get(local_char_speeds_1)[i] = -0.1;
+      get(local_char_speeds_3)[i] = -0.2;
+    }
+  }
+
+  // Compute return value from Action
+  auto local_bc_dt_u_minus =
+      GeneralizedHarmonic::Actions::BoundaryConditions_detail::set_dt_v_minus<
+          typename GeneralizedHarmonic::Tags::VMinus<VolumeDim, frame>::type,
+          VolumeDim>::apply(GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+                                VMinusBcMethod::Freezing,
+                            make_not_null(&intermediate_vars), local_vars,
+                            local_dt_vars, inertial_coords,
+                            local_unit_normal_one_form);
+
+  // Initialize with values from SpEC
+  auto spec_bc_dt_u_minus = local_bc_dt_u_minus;
+  for (size_t i = 0; i < slice_grid_points; ++i) {
+    if (get<0>(inertial_coords)[i] == 299. and
+        get<1>(inertial_coords)[i] == 0.5 and
+        get<2>(inertial_coords)[i] == -0.5) {
+      std::array<double, 16> spec_vals = {
+          {-60383491.77088407, 48998513.74318591, 17859686.38943806,
+           80929560.64883879, 48998513.74318591, 132404254.8520959,
+           108291107.5524412, 154536853.2719879, 17859686.38943806,
+           108291107.5524412, 82283797.31617498, 133110088.4608499,
+           80929560.64883879, 154536853.2719879, 133110088.4608499,
+           173190849.6514583}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299.5 and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == -0.5) {
+      std::array<double, 16> spec_vals = {
+          {-60383494.75455543, 48998516.16430231, 17859687.27192156,
+           80929564.64773327, 48998516.16430231, 132404261.3944599,
+           108291112.9033255, 154536860.9079687, 17859687.27192156,
+           108291112.9033255, 82283801.38198504, 133110095.0380906,
+           80929564.64773327, 154536860.9079687, 133110095.0380906,
+           173190858.2091711}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 300. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == -0.5) {
+      std::array<double, 16> spec_vals = {
+          {-60383497.7282813, 48998518.5773484, 17859688.15146346,
+           80929568.63329825, 48998518.5773484, 132404267.9150162,
+           108291118.2363736, 154536868.5184965, 17859688.15146346,
+           108291118.2363736, 82283805.43424253, 133110101.5934074,
+           80929568.63329825, 154536868.5184965, 133110101.5934074,
+           173190866.7383583}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.) {
+      std::array<double, 16> spec_vals = {
+          {-60383491.76838519, 48998513.74115818, 17859686.38869897,
+           80929560.64548963, 48998513.74115818, 132404254.8466165,
+           108291107.5479597, 154536853.2655927, 17859686.38869897,
+           108291107.5479597, 82283797.31276976, 133110088.4553414,
+           80929560.64548963, 154536853.2655927, 133110088.4553414,
+           173190849.644291}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299.5 and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.) {
+      std::array<double, 16> spec_vals = {
+          {-60383494.75206903, 48998516.16228471, 17859687.27118616,
+           80929564.64440086, 48998516.16228471, 132404261.3890079,
+           108291112.8988664, 154536860.9016054, 17859687.27118616,
+           108291112.8988664, 82283801.37859686, 133110095.0326096,
+           80929564.64440086, 154536860.9016054, 133110095.0326096,
+           173190858.2020396}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 300. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.) {
+      std::array<double, 16> spec_vals = {
+          {-60383497.72580732, 48998518.57534086, 17859688.15073173,
+           80929568.62998244, 48998518.57534086, 132404267.9095915,
+           108291118.2319368, 154536868.5121649, 17859688.15073173,
+           108291118.2319368, 82283805.43087126, 133110101.5879537,
+           80929568.62998244, 154536868.5121649, 133110101.5879537,
+           173190866.7312625}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.5) {
+      std::array<double, 16> spec_vals = {
+          {-60383491.77088407, 48998513.74318591, 17859686.38943806,
+           80929560.64883879, 48998513.74318591, 132404254.8520959,
+           108291107.5524412, 154536853.2719879, 17859686.38943806,
+           108291107.5524412, 82283797.31617498, 133110088.4608499,
+           80929560.64883879, 154536853.2719879, 133110088.4608499,
+           173190849.6514583}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299.5 and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.5) {
+      std::array<double, 16> spec_vals = {
+          {-60383494.75455543, 48998516.16430231, 17859687.27192156,
+           80929564.64773327, 48998516.16430231, 132404261.3944599,
+           108291112.9033255, 154536860.9079687, 17859687.27192156,
+           108291112.9033255, 82283801.38198504, 133110095.0380906,
+           80929564.64773327, 154536860.9079687, 133110095.0380906,
+           173190858.2091711}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 300. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.5) {
+      std::array<double, 16> spec_vals = {
+          {-60383497.7282813, 48998518.5773484, 17859688.15146346,
+           80929568.63329825, 48998518.5773484, 132404267.9150162,
+           108291118.2363736, 154536868.5184965, 17859688.15146346,
+           108291118.2363736, 82283805.43424253, 133110101.5934074,
+           80929568.63329825, 154536868.5184965, 133110101.5934074,
+           173190866.7383583}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else {
+      ASSERT(false,
+             "Not checking the correct face, coordinates not recognized");
+    }
+  }
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_bc_dt_u_minus, spec_bc_dt_u_minus);
+}
+
+// Test the boundary condition imposed on VMinus when
+// option `ConstraintPreserving` is specified.
+template <>
+void test_constraint_preserving_bjorhus_u_minus<
+    GeneralizedHarmonic::BoundaryConditions::Bjorhus::VMinusBcMethod::
+        ConstraintPreserving>(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Setup grid
+  Mesh<VolumeDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  const Direction<VolumeDim> direction(1, Side::Upper);  // +y direction
+  const size_t slice_grid_points =
+      mesh.extents().slice_away(direction.dimension()).product();
+  const auto inertial_coords = [&slice_grid_points, &lower_bound]() {
+    tnsr::I<DataVector, VolumeDim, frame> tmp(slice_grid_points, 0.);
+    // +y direction
+    get<1>(tmp) = 0.5;
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        get<0>(tmp)[i * VolumeDim + j] =
+            lower_bound[0] + 0.5 * static_cast<double>(i);
+        get<2>(tmp)[i * VolumeDim + j] =
+            lower_bound[2] + 0.5 * static_cast<double>(j);
+      }
+    }
+    return tmp;
+  }();
+  // Storage for intermediate vars
+  GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+      BjorhusIntermediatesComputer intermediate_vars(slice_grid_points);
+  auto& buffer = intermediate_vars.get_buffer();
+  // Also create local variables and their time derivatives, both of which we
+  // will populate as needed
+  db::item_type<GeneralizedHarmonic::System<VolumeDim>::variables_tag>
+      local_vars(slice_grid_points, 0.);
+  Variables<db::wrap_tags_in<
+      ::Tags::dt, GeneralizedHarmonic::System<VolumeDim>::gradients_tags>>
+      local_dt_vars(slice_grid_points, 0.);
+  tnsr::i<DataVector, VolumeDim, frame> local_unit_normal_one_form(
+      slice_grid_points, 0.);
+
+  {
+    // POPULATE various tensors needed to compute BcDtVSpacetimeMetric
+    // EXACTLY as done in SpEC
+    auto& local_inertial_coords =
+        get<domain::Tags::Coordinates<VolumeDim, Frame::Inertial>>(buffer);
+    auto& local_constraint_gamma2 =
+        get<GeneralizedHarmonic::Tags::ConstraintGamma2>(buffer);
+    // timelike and spacelike SPACETIME vectors, l^a and k^a
+    auto& local_outgoing_null_one_form =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    outgoing_null_one_form<VolumeDim, DataVector>>(buffer);
+    auto& local_incoming_null_one_form =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    incoming_null_one_form<VolumeDim, DataVector>>(buffer);
+    // timelike and spacelike SPACETIME oneforms, l_a and k_a
+    auto& local_outgoing_null_vector =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    outgoing_null_vector<VolumeDim, DataVector>>(buffer);
+    auto& local_incoming_null_vector =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    incoming_null_vector<VolumeDim, DataVector>>(buffer);
+    // spacetime projection operator P_ab, P^ab, and P^a_b
+    auto& local_projection_AB =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::projection_AB<
+                    VolumeDim, DataVector>>(buffer);
+    auto& local_projection_ab =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::projection_ab<
+                    VolumeDim, DataVector>>(buffer);
+    auto& local_projection_Ab =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::projection_Ab<
+                    VolumeDim, DataVector>>(buffer);
+    // constraint characteristics
+    auto& local_constraint_char_zero_minus =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    constraint_char_zero_minus<VolumeDim, DataVector>>(buffer);
+    auto& local_constraint_char_zero_plus =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    constraint_char_zero_plus<VolumeDim, DataVector>>(buffer);
+    // RhsVSpacetimeMetric and RhsVMinus
+    auto& local_char_projected_rhs_dt_u_psi =
+        get<GeneralizedHarmonic::Tags::VSpacetimeMetric<VolumeDim,
+                                                        Frame::Inertial>>(
+            buffer);
+    auto& local_char_projected_rhs_dt_u_minus =
+        get<GeneralizedHarmonic::Tags::VMinus<VolumeDim, Frame::Inertial>>(
+            buffer);
+
+    auto& local_unit_interface_normal_vector =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    interface_normal_vector<VolumeDim, DataVector>>(buffer);
+
+    auto& local_pi =
+        get<GeneralizedHarmonic::Tags::Pi<VolumeDim, frame>>(local_vars);
+    auto& local_phi =
+        get<GeneralizedHarmonic::Tags::Phi<VolumeDim, frame>>(local_vars);
+
+    auto& local_char_speeds_0 =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::char_speed_vpsi<
+                    DataVector>>(buffer);
+    auto& local_char_speeds_1 =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::char_speed_vzero<
+                    DataVector>>(buffer);
+    auto& local_char_speeds_3 =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::char_speed_vminus<
+                    DataVector>>(buffer);
+
+    // Setting coords
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      local_inertial_coords.get(i) = inertial_coords.get(i);
+    }
+    // Setting constraint_gamma2
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      get(local_constraint_gamma2)[i] = 113.;
+    }
+    // Setting incoming null one_form: ui
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_incoming_null_one_form.get(0)[i] = -2.;
+      local_incoming_null_one_form.get(1)[i] = 5.;
+      local_incoming_null_one_form.get(2)[i] = 3.;
+      local_incoming_null_one_form.get(3)[i] = 7.;
+    }
+    // Setting incoming null vector: uI
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_incoming_null_vector.get(0)[i] = -1.;
+      local_incoming_null_vector.get(1)[i] = 13.;
+      local_incoming_null_vector.get(2)[i] = 17.;
+      local_incoming_null_vector.get(3)[i] = 19.;
+    }
+    // Setting outgoing null one_form: vi
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_outgoing_null_one_form.get(0)[i] = -1.;
+      local_outgoing_null_one_form.get(1)[i] = 3.;
+      local_outgoing_null_one_form.get(2)[i] = 2.;
+      local_outgoing_null_one_form.get(3)[i] = 5.;
+    }
+    // Setting outgoing null vector: vI
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_outgoing_null_vector.get(0)[i] = -1.;
+      local_outgoing_null_vector.get(1)[i] = 2.;
+      local_outgoing_null_vector.get(2)[i] = 3.;
+      local_outgoing_null_vector.get(3)[i] = 5.;
+    }
+    // Setting projection Ab
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_projection_Ab.get(0, a)[i] = 233.;
+        local_projection_Ab.get(1, a)[i] = 239.;
+        local_projection_Ab.get(2, a)[i] = 241.;
+        local_projection_Ab.get(3, a)[i] = 251.;
+      }
+    }
+    // Setting projection ab
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_projection_ab.get(0, a)[i] = 379.;
+        local_projection_ab.get(1, a)[i] = 383.;
+        local_projection_ab.get(2, a)[i] = 389.;
+        local_projection_ab.get(3, a)[i] = 397.;
+      }
+    }
+    // Setting projection AB
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_projection_AB.get(0, a)[i] = 353.;
+        local_projection_AB.get(1, a)[i] = 359.;
+        local_projection_AB.get(2, a)[i] = 367.;
+        local_projection_AB.get(3, a)[i] = 373.;
+      }
+    }
+    // Setting local_RhsVSpacetimeMetric
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_char_projected_rhs_dt_u_psi.get(0, a)[i] = 23.;
+        local_char_projected_rhs_dt_u_psi.get(1, a)[i] = 29.;
+        local_char_projected_rhs_dt_u_psi.get(2, a)[i] = 31.;
+        local_char_projected_rhs_dt_u_psi.get(3, a)[i] = 37.;
+      }
+    }
+    // Setting RhsVMinus
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_char_projected_rhs_dt_u_minus.get(0, a)[i] = 331.;
+        local_char_projected_rhs_dt_u_minus.get(1, a)[i] = 337.;
+        local_char_projected_rhs_dt_u_minus.get(2, a)[i] = 347.;
+        local_char_projected_rhs_dt_u_minus.get(3, a)[i] = 349.;
+      }
+    }
+
+    // Setting unit_interface_normal_Vector
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      local_unit_interface_normal_vector.get(0)[i] = 1.e300;
+      local_unit_interface_normal_vector.get(1)[i] = -1.;
+      local_unit_interface_normal_vector.get(2)[i] = 1.;
+      local_unit_interface_normal_vector.get(3)[i] = 1.;
+    }
+    // Setting pi AND phi
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = 0; b <= VolumeDim; ++b) {
+          local_pi.get(a, b)[i] = 1.;
+          local_phi.get(0, a, b)[i] = 3.;
+          local_phi.get(1, a, b)[i] = 5.;
+          local_phi.get(2, a, b)[i] = 7.;
+        }
+      }
+    }
+    // Setting char speeds
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      get(local_char_speeds_0)[i] = -0.3;
+      get(local_char_speeds_1)[i] = -0.1;
+      get(local_char_speeds_3)[i] = -0.2;
+    }
+    // Setting constraint_char_zero_plus AND constraint_char_zero_minus
+    // ONLY ON THE +Y AXIS (Y = +0.5) -- FIXME
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      if (get<0>(inertial_coords)[i] == 299. and
+          get<1>(inertial_coords)[i] == 0.5 and
+          get<2>(inertial_coords)[i] == -0.5) {
+        std::array<double, 4> spec_vals = {
+            {3722388974.799386, -16680127.68747905, -22991565.68745775,
+             -29394198.68743645}};
+        std::array<double, 4> spec_vals2 = {
+            {3866802572.424386, -19802442.06247905, -19496408.06245775,
+             -19257249.06243645}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 299.5 and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == -0.5) {
+        std::array<double, 4> spec_vals = {
+            {1718287695.133032, -35082292.16184025, -44420849.32723039,
+             -53850596.45928719}};
+        std::array<double, 4> spec_vals2 = {
+            {1866652790.548975, -38170999.90741873, -40892085.07280888,
+             -43680040.20486567}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 300. and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == -0.5) {
+        std::array<double, 4> spec_vals = {
+            {1718299060.415949, -35082089.27527188, -44420613.14790046,
+             -53850326.98725116}};
+        std::array<double, 4> spec_vals2 = {
+            {1866664134.129611, -38170797.39904065, -40891849.27166924,
+             -43679771.11101994}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 299. and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == 0.) {
+        std::array<double, 4> spec_vals = {
+            {1718276282.501221, -35082495.89577083, -44421086.49296889,
+             -53850867.05677793}};
+        std::array<double, 4> spec_vals2 = {
+            {1866641399.709844, -38171203.26157932, -40892321.85877737,
+             -43680310.4225864}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 299.5 and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == 0.) {
+        std::array<double, 4> spec_vals = {
+            {1718287685.660846, -35082292.33093269, -44420849.52407002,
+             -53850596.68387395}};
+        std::array<double, 4> spec_vals2 = {
+            {1866652781.094877, -38171000.07619599, -40892085.26933331,
+             -43680040.42913724}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 300. and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == 0.) {
+        std::array<double, 4> spec_vals = {
+            {1718299050.990844, -35082089.44352208, -44420613.34375966,
+             -53850327.21071925}};
+        std::array<double, 4> spec_vals2 = {
+            {1866664124.722503, -38170797.56697725, -40891849.46721483,
+             -43679771.33417442}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 299. and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == 0.5) {
+        std::array<double, 4> spec_vals = {
+            {1718276292.082241, -35082495.72473276, -44421086.29386414,
+             -53850866.82960649}};
+        std::array<double, 4> spec_vals2 = {
+            {1866641409.272568, -38171203.09086005, -40892321.65999144,
+             -43680310.19573379}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 299.5 and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == 0.5) {
+        std::array<double, 4> spec_vals = {
+            {1718287695.194063, -35082292.16074976, -44420849.32596073,
+             -53850596.45783833}};
+        std::array<double, 4> spec_vals2 = {
+            {1866652790.609889, -38170999.90633029, -40892085.07154126,
+             -43680040.20341886}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 300. and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == 0.5) {
+        std::array<double, 4> spec_vals = {
+            {1718299060.476573, -35082089.27418864, -44420613.14663924,
+             -53850326.98581193}};
+        std::array<double, 4> spec_vals2 = {
+            {1866664134.190119, -38170797.39795944, -40891849.27041004,
+             -43679771.10958273}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else {
+        // When applying BCs to various faces, only one face (i.e. the +y side)
+        // will be set here, others can be set however...
+        ASSERT(false,
+               "Not checking the correct face, coordinates not recognized");
+      }
+    }
+  }
+
+  // Compute return value from Action
+  auto local_bc_dt_u_minus =
+      GeneralizedHarmonic::Actions::BoundaryConditions_detail::set_dt_v_minus<
+          typename GeneralizedHarmonic::Tags::VMinus<VolumeDim, frame>::type,
+          VolumeDim>::apply(GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+                                VMinusBcMethod::ConstraintPreserving,
+                            make_not_null(&intermediate_vars), local_vars,
+                            local_dt_vars, inertial_coords,
+                            local_unit_normal_one_form);
+
+  // Initialize with values from SpEC
+  auto spec_bc_dt_u_minus = local_bc_dt_u_minus;
+  for (size_t i = 0; i < slice_grid_points; ++i) {
+    if (get<0>(inertial_coords)[i] == 299. and
+        get<1>(inertial_coords)[i] == 0.5 and
+        get<2>(inertial_coords)[i] == -0.5) {
+      std::array<double, 16> spec_vals = {
+          {-22857869555.93848, 330934979077.5689, 242482973593.2169,
+           507808643438.4713, 330934979077.5689, 690190606335.8783,
+           600780523621.8837, 868984678067.689, 242482973593.2169,
+           600780523621.8837, 514052337348.0055, 781537245156.9633,
+           507808643438.4713, 868984678067.689, 781537245156.9633,
+           1054439575483.625}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299.5 and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == -0.5) {
+      std::array<double, 16> spec_vals = {
+          {6085210488.394159, 167380193629.8459, 127052654518.3203,
+           248004925243.5957, 167380193629.8459, 332680231531.8318,
+           291581334988.8124, 414851930920.4022, 127052654518.3203,
+           291581334988.8124, 252051387928.7005, 374742777072.0203,
+           248004925243.5957, 414851930920.4022, 374742777072.0203,
+           501009779843.9042}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 300. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == -0.5) {
+      std::array<double, 16> spec_vals = {
+          {6084984067.712499, 167381093626.4053, 127053272910.3827,
+           248006388447.6548, 167381093626.4053, 332682261170.2852,
+           291583083105.2007, 414854523601.7003, 127053272910.3827,
+           291583083105.2007, 252052859833.8237, 374745093603.8436,
+           248006388447.6548, 414854523601.7003, 374745093603.8436,
+           501012947925.7576}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.) {
+      std::array<double, 16> spec_vals = {
+          {6085437853.704128, 167379289884.4027, 127052033550.7529,
+           248003455943.9015, 167379289884.4027, 332678193437.6569,
+           291579579589.7132, 414849327437.366, 127052033550.7529,
+           291579579589.7132, 252049909891.7733, 374740450889.0901,
+           248003455943.9015, 414849327437.366, 374740450889.0901,
+           501006598562.8735}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299.5 and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.) {
+      std::array<double, 16> spec_vals = {
+          {6085210677.100476, 167380192879.7604, 127052654002.9328,
+           248004924024.1152, 167380192879.7604, 332680229840.2671,
+           291581333531.8772, 414851928759.5795, 127052654002.9328,
+           291581333531.8772, 252051386701.9684, 374742775141.3494,
+           248004924024.1152, 414851928759.5795, 374742775141.3494,
+           501009777203.5247}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 300. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.) {
+      std::array<double, 16> spec_vals = {
+          {6084984255.479748, 167381092880.0475, 127053272397.5563,
+           248006387234.2355, 167381092880.0475, 332682259487.1282,
+           291583081655.5068, 414854521451.6181, 127053272397.5563,
+           291583081655.5068, 252052858613.1887, 374745091682.769,
+           248006387234.2355, 414854521451.6181, 374745091682.769,
+           501012945298.5021}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.5) {
+      std::array<double, 16> spec_vals = {
+          {6085437662.827703, 167379290643.1056, 127052034072.0609,
+           248003457177.3931, 167379290643.1056, 332678195148.6575,
+           291579581063.3884, 414849329623.0162, 127052034072.0609,
+           291579581063.3884, 252049911132.6, 374740452841.9442,
+           248003457177.3931, 414849329623.0162, 374740452841.9442,
+           501006601233.5914}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299.5 and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.5) {
+      std::array<double, 16> spec_vals = {
+          {6085210487.177534, 167380193634.6784, 127052654521.6405,
+           248004925251.4529, 167380193634.6784, 332680231542.7307,
+           291581334998.1996, 414851930934.3248, 127052654521.6405,
+           291581334998.1996, 252051387936.6043, 374742777084.4599,
+           248004925251.4529, 414851930934.3248, 374742777084.4599,
+           501009779860.9169}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 300. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.5) {
+      std::array<double, 16> spec_vals = {
+          {6084984066.503965, 167381093631.2057, 127053272913.6808,
+           248006388455.4596, 167381093631.2057, 332682261181.1116,
+           291583083114.5252, 414854523615.53, 127053272913.6808,
+           291583083114.5252, 252052859841.6748, 374745093616.2003,
+           248006388455.4596, 414854523615.53, 374745093616.2003,
+           501012947942.6568}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else {
+      ASSERT(false,
+             "Not checking the correct face, coordinates not recognized");
+    }
+  }
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_bc_dt_u_minus, spec_bc_dt_u_minus);
+}
+
+// Test the boundary condition imposed on VMinus when
+// option `ConstraintPreserving` is specified.
+template <>
+void test_constraint_preserving_bjorhus_u_minus<
+    GeneralizedHarmonic::BoundaryConditions::Bjorhus::VMinusBcMethod::
+        ConstraintPreservingPhysical>(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Setup grid
+  Mesh<VolumeDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  const Direction<VolumeDim> direction(1, Side::Upper);  // +y direction
+  const size_t slice_grid_points =
+      mesh.extents().slice_away(direction.dimension()).product();
+  const auto inertial_coords = [&slice_grid_points, &lower_bound]() {
+    tnsr::I<DataVector, VolumeDim, frame> tmp(slice_grid_points, 0.);
+    // +y direction
+    get<1>(tmp) = 0.5;
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        get<0>(tmp)[i * VolumeDim + j] =
+            lower_bound[0] + 0.5 * static_cast<double>(i);
+        get<2>(tmp)[i * VolumeDim + j] =
+            lower_bound[2] + 0.5 * static_cast<double>(j);
+      }
+    }
+    return tmp;
+  }();
+  // Storage for intermediate vars
+  GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+      BjorhusIntermediatesComputer intermediate_vars(slice_grid_points);
+  auto& buffer = intermediate_vars.get_buffer();
+  // Also create local variables and their time derivatives, both of which we
+  // will populate as needed
+  db::item_type<GeneralizedHarmonic::System<VolumeDim>::variables_tag>
+      local_vars(slice_grid_points, 0.);
+  Variables<db::wrap_tags_in<
+      ::Tags::dt, GeneralizedHarmonic::System<VolumeDim>::gradients_tags>>
+      local_dt_vars(slice_grid_points, 0.);
+  tnsr::i<DataVector, VolumeDim, frame> local_unit_normal_one_form(
+      slice_grid_points, 0.);
+
+  {
+    // POPULATE various tensors needed to compute BcDtVSpacetimeMetric
+    // EXACTLY as done in SpEC
+    auto& local_inertial_coords =
+        get<domain::Tags::Coordinates<VolumeDim, Frame::Inertial>>(buffer);
+    auto& local_constraint_gamma2 =
+        get<GeneralizedHarmonic::Tags::ConstraintGamma2>(buffer);
+    auto& local_three_index_constraint =
+        get<GeneralizedHarmonic::Tags::ThreeIndexConstraint<VolumeDim,
+                                                            Frame::Inertial>>(
+            buffer);
+    // timelike and spacelike SPACETIME vectors, l^a and k^a
+    auto& local_outgoing_null_one_form =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    outgoing_null_one_form<VolumeDim, DataVector>>(buffer);
+    auto& local_incoming_null_one_form =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    incoming_null_one_form<VolumeDim, DataVector>>(buffer);
+    // timelike and spacelike SPACETIME oneforms, l_a and k_a
+    auto& local_outgoing_null_vector =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    outgoing_null_vector<VolumeDim, DataVector>>(buffer);
+    auto& local_incoming_null_vector =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    incoming_null_vector<VolumeDim, DataVector>>(buffer);
+    // spacetime projection operator P_ab, P^ab, and P^a_b
+    auto& local_projection_AB =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::projection_AB<
+                    VolumeDim, DataVector>>(buffer);
+    auto& local_projection_ab =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::projection_ab<
+                    VolumeDim, DataVector>>(buffer);
+    auto& local_projection_Ab =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::projection_Ab<
+                    VolumeDim, DataVector>>(buffer);
+    // constraint characteristics
+    auto& local_constraint_char_zero_minus =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    constraint_char_zero_minus<VolumeDim, DataVector>>(buffer);
+    auto& local_constraint_char_zero_plus =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    constraint_char_zero_plus<VolumeDim, DataVector>>(buffer);
+    // RhsVSpacetimeMetric and RhsVMinus
+    auto& local_char_projected_rhs_dt_u_psi =
+        get<GeneralizedHarmonic::Tags::VSpacetimeMetric<VolumeDim,
+                                                        Frame::Inertial>>(
+            buffer);
+    auto& local_char_projected_rhs_dt_u_minus =
+        get<GeneralizedHarmonic::Tags::VMinus<VolumeDim, Frame::Inertial>>(
+            buffer);
+
+    auto& local_unit_interface_normal_one_form =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    interface_normal_one_form<VolumeDim, DataVector>>(buffer);
+    auto& local_unit_interface_normal_vector =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::
+                    interface_normal_vector<VolumeDim, DataVector>>(buffer);
+    auto& local_spacetime_unit_normal_vector =
+        get<gr::Tags::SpacetimeNormalVector<VolumeDim, Frame::Inertial,
+                                            DataVector>>(buffer);
+
+    auto& local_inverse_spatial_metric = get<
+        gr::Tags::InverseSpatialMetric<VolumeDim, Frame::Inertial, DataVector>>(
+        buffer);
+    auto& local_extrinsic_curvature = get<
+        gr::Tags::ExtrinsicCurvature<VolumeDim, Frame::Inertial, DataVector>>(
+        buffer);
+    auto& local_inverse_spacetime_metric =
+        get<gr::Tags::InverseSpacetimeMetric<VolumeDim, Frame::Inertial,
+                                             DataVector>>(buffer);
+
+    auto& local_phi =
+        get<GeneralizedHarmonic::Tags::Phi<VolumeDim, frame>>(local_vars);
+    auto& local_spacetime_metric =
+        get<gr::Tags::SpacetimeMetric<VolumeDim, frame, DataVector>>(
+            local_vars);
+    auto& local_d_pi =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::deriv_pi<
+                    VolumeDim, DataVector>>(buffer);
+    auto& local_d_phi =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::deriv_phi<
+                    VolumeDim, DataVector>>(buffer);
+
+    auto& local_char_speeds_0 =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::char_speed_vpsi<
+                    DataVector>>(buffer);
+    auto& local_char_speeds_1 =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::char_speed_vzero<
+                    DataVector>>(buffer);
+    auto& local_char_speeds_3 =
+        get<GeneralizedHarmonic::Actions::BoundaryConditions_detail::
+                BjorhusIntermediatesComputer::internal_tags::char_speed_vminus<
+                    DataVector>>(buffer);
+
+    // Setting coords
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      local_inertial_coords.get(i) = inertial_coords.get(i);
+    }
+    // Setting local_spacetime_unit_normal_vector
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_spacetime_unit_normal_vector.get(0)[i] = -1.;
+      local_spacetime_unit_normal_vector.get(1)[i] = -3.;
+      local_spacetime_unit_normal_vector.get(2)[i] = -5.;
+      local_spacetime_unit_normal_vector.get(3)[i] = -7.;
+    }
+    // Setting local_unit_interface_normal_one_form
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_unit_interface_normal_one_form.get(0)[i] = 1.e300;
+      local_unit_interface_normal_one_form.get(1)[i] = -1.;
+      local_unit_interface_normal_one_form.get(2)[i] = 1.;
+      local_unit_interface_normal_one_form.get(3)[i] = 1.;
+    }
+    // Setting unit_interface_normal_Vector
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_unit_interface_normal_vector.get(0)[i] = 1.e300;
+      local_unit_interface_normal_vector.get(1)[i] = -1.;
+      local_unit_interface_normal_vector.get(2)[i] = 1.;
+      local_unit_interface_normal_vector.get(3)[i] = 1.;
+    }
+    // Setting lapse
+    // for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+    // get(local_lapse)[i] = 2.;
+    //}
+    // Setting shift
+    // for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+    // local_shift.get(0)[i] = 1.;
+    // local_shift.get(1)[i] = 2.;
+    // local_shift.get(2)[i] = 3.;
+    //}
+    // Setting local_inverse_spatial_metric
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        local_inverse_spatial_metric.get(0, j)[i] = 41.;
+        local_inverse_spatial_metric.get(1, j)[i] = 43.;
+        local_inverse_spatial_metric.get(2, j)[i] = 47.;
+      }
+    }
+    // Setting local_spacetime_metric
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_spacetime_metric.get(0, a)[i] = 257.;
+        local_spacetime_metric.get(1, a)[i] = 263.;
+        local_spacetime_metric.get(2, a)[i] = 269.;
+        local_spacetime_metric.get(3, a)[i] = 271.;
+      }
+    }
+    // Setting local_inverse_spacetime_metric
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_inverse_spacetime_metric.get(0, a)[i] =
+            -277.;  // needs to be < 0 for lapse
+        local_inverse_spacetime_metric.get(1, a)[i] = 281.;
+        local_inverse_spacetime_metric.get(2, a)[i] = 283.;
+        local_inverse_spacetime_metric.get(3, a)[i] = 293.;
+      }
+    }
+    // Setting local_extrinsic_curvature
+    // ONLY ON THE +Y AXIS (Y = +0.5) -- FIXME
+    //
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      if (get<0>(local_inertial_coords)[i] == 299. and
+          get<1>(local_inertial_coords)[i] == 0.5 and
+          get<2>(local_inertial_coords)[i] == -0.5) {
+        std::array<double, 9> spec_vals = {
+            {200.2198037251189, 266.7930716334918, 333.3663395418648,
+             266.7930716334918, 333.3663395418648, 399.9396074502377,
+             333.3663395418648, 399.9396074502377, 466.5128753586106}};
+        for (size_t j = 0; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            local_extrinsic_curvature.get(j, k)[i] =
+                gsl::at(spec_vals, j * (0 + VolumeDim) + k);
+          }
+        }
+      } else if (get<0>(local_inertial_coords)[i] == 299.5 and
+                 get<1>(local_inertial_coords)[i] == 0.5 and
+                 get<2>(local_inertial_coords)[i] == -0.5) {
+        std::array<double, 9> spec_vals = {
+            {200.2198037251189, 266.7930716334918, 333.3663395418648,
+             266.7930716334918, 333.3663395418648, 399.9396074502377,
+             333.3663395418648, 399.9396074502377, 466.5128753586106}};
+        for (size_t j = 0; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            local_extrinsic_curvature.get(j, k)[i] =
+                gsl::at(spec_vals, j * (0 + VolumeDim) + k);
+          }
+        }
+      } else if (get<0>(local_inertial_coords)[i] == 300. and
+                 get<1>(local_inertial_coords)[i] == 0.5 and
+                 get<2>(local_inertial_coords)[i] == -0.5) {
+        std::array<double, 9> spec_vals = {
+            {200.2198037251189, 266.7930716334918, 333.3663395418648,
+             266.7930716334918, 333.3663395418648, 399.9396074502377,
+             333.3663395418648, 399.9396074502377, 466.5128753586106}};
+        for (size_t j = 0; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            local_extrinsic_curvature.get(j, k)[i] =
+                gsl::at(spec_vals, j * (0 + VolumeDim) + k);
+          }
+        }
+      } else if (get<0>(local_inertial_coords)[i] == 299. and
+                 get<1>(local_inertial_coords)[i] == 0.5 and
+                 get<2>(local_inertial_coords)[i] == 0.) {
+        std::array<double, 9> spec_vals = {
+            {200.2198037251189, 266.7930716334918, 333.3663395418648,
+             266.7930716334918, 333.3663395418648, 399.9396074502377,
+             333.3663395418648, 399.9396074502377, 466.5128753586106}};
+        for (size_t j = 0; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            local_extrinsic_curvature.get(j, k)[i] =
+                gsl::at(spec_vals, j * (0 + VolumeDim) + k);
+          }
+        }
+      } else if (get<0>(local_inertial_coords)[i] == 299.5 and
+                 get<1>(local_inertial_coords)[i] == 0.5 and
+                 get<2>(local_inertial_coords)[i] == 0.) {
+        std::array<double, 9> spec_vals = {
+            {200.2198037251189, 266.7930716334918, 333.3663395418648,
+             266.7930716334918, 333.3663395418648, 399.9396074502377,
+             333.3663395418648, 399.9396074502377, 466.5128753586106}};
+        for (size_t j = 0; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            local_extrinsic_curvature.get(j, k)[i] =
+                gsl::at(spec_vals, j * (0 + VolumeDim) + k);
+          }
+        }
+      } else if (get<0>(local_inertial_coords)[i] == 300. and
+                 get<1>(local_inertial_coords)[i] == 0.5 and
+                 get<2>(local_inertial_coords)[i] == 0.) {
+        std::array<double, 9> spec_vals = {
+            {200.2198037251189, 266.7930716334918, 333.3663395418648,
+             266.7930716334918, 333.3663395418648, 399.9396074502377,
+             333.3663395418648, 399.9396074502377, 466.5128753586106}};
+        for (size_t j = 0; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            local_extrinsic_curvature.get(j, k)[i] =
+                gsl::at(spec_vals, j * (0 + VolumeDim) + k);
+          }
+        }
+      } else if (get<0>(local_inertial_coords)[i] == 299. and
+                 get<1>(local_inertial_coords)[i] == 0.5 and
+                 get<2>(local_inertial_coords)[i] == 0.5) {
+        std::array<double, 9> spec_vals = {
+            {200.2198037251189, 266.7930716334918, 333.3663395418648,
+             266.7930716334918, 333.3663395418648, 399.9396074502377,
+             333.3663395418648, 399.9396074502377, 466.5128753586106}};
+        for (size_t j = 0; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            local_extrinsic_curvature.get(j, k)[i] =
+                gsl::at(spec_vals, j * (0 + VolumeDim) + k);
+          }
+        }
+      } else if (get<0>(local_inertial_coords)[i] == 299.5 and
+                 get<1>(local_inertial_coords)[i] == 0.5 and
+                 get<2>(local_inertial_coords)[i] == 0.5) {
+        std::array<double, 9> spec_vals = {
+            {200.2198037251189, 266.7930716334918, 333.3663395418648,
+             266.7930716334918, 333.3663395418648, 399.9396074502377,
+             333.3663395418648, 399.9396074502377, 466.5128753586106}};
+        for (size_t j = 0; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            local_extrinsic_curvature.get(j, k)[i] =
+                gsl::at(spec_vals, j * (0 + VolumeDim) + k);
+          }
+        }
+      } else if (get<0>(local_inertial_coords)[i] == 300. and
+                 get<1>(local_inertial_coords)[i] == 0.5 and
+                 get<2>(local_inertial_coords)[i] == 0.5) {
+        std::array<double, 9> spec_vals = {
+            {200.2198037251189, 266.7930716334918, 333.3663395418648,
+             266.7930716334918, 333.3663395418648, 399.9396074502377,
+             333.3663395418648, 399.9396074502377, 466.5128753586106}};
+        for (size_t j = 0; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            local_extrinsic_curvature.get(j, k)[i] =
+                gsl::at(spec_vals, j * (0 + VolumeDim) + k);
+          }
+        }
+      } else {
+        // When applying BCs to various faces, only one face (i.e. the +y side)
+        // will be set here, others can be set however...
+        // FIXME: Disabled
+        ASSERT(true,
+               "Not checking the correct face, coordinates not recognized");
+      }
+    }
+
+    // Setting pi AND phi
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = 0; b <= VolumeDim; ++b) {
+          // local_pi.get(a, b)[i] = 1.;
+          local_phi.get(0, a, b)[i] = 3.;
+          local_phi.get(1, a, b)[i] = 5.;
+          local_phi.get(2, a, b)[i] = 7.;
+        }
+      }
+    }
+    // Setting local_d_phi
+    // initialize dPhi (with same values as for SpEC)
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = 0; b <= VolumeDim; ++b) {
+          local_d_pi.get(0, a, b)[i] = 1.;
+          local_d_phi.get(0, 0, a, b)[i] = 3.;
+          local_d_phi.get(0, 1, a, b)[i] = 5.;
+          local_d_phi.get(0, 2, a, b)[i] = 7.;
+          local_d_pi.get(1, a, b)[i] = 53.;
+          local_d_phi.get(1, 0, a, b)[i] = 59.;
+          local_d_phi.get(1, 1, a, b)[i] = 61.;
+          local_d_phi.get(1, 2, a, b)[i] = 67.;
+          local_d_pi.get(2, a, b)[i] = 71.;
+          local_d_phi.get(2, 0, a, b)[i] = 73.;
+          local_d_phi.get(2, 1, a, b)[i] = 79.;
+          local_d_phi.get(2, 2, a, b)[i] = 83.;
+        }
+      }
+    }
+    // Setting char speeds
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      get(local_char_speeds_0)[i] = -0.3;
+      get(local_char_speeds_1)[i] = -0.1;
+      get(local_char_speeds_3)[i] = -0.2;
+    }
+    // Setting constraint_gamma2
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      get(local_constraint_gamma2)[i] = 113.;
+    }
+    // Setting incoming null one_form: ui
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_incoming_null_one_form.get(0)[i] = -2.;
+      local_incoming_null_one_form.get(1)[i] = 5.;
+      local_incoming_null_one_form.get(2)[i] = 3.;
+      local_incoming_null_one_form.get(3)[i] = 7.;
+    }
+    // Setting incoming null vector: uI
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_incoming_null_vector.get(0)[i] = -1.;
+      local_incoming_null_vector.get(1)[i] = 13.;
+      local_incoming_null_vector.get(2)[i] = 17.;
+      local_incoming_null_vector.get(3)[i] = 19.;
+    }
+    // Setting outgoing null one_form: vi
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_outgoing_null_one_form.get(0)[i] = -1.;
+      local_outgoing_null_one_form.get(1)[i] = 3.;
+      local_outgoing_null_one_form.get(2)[i] = 2.;
+      local_outgoing_null_one_form.get(3)[i] = 5.;
+    }
+    // Setting outgoing null vector: vI
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_outgoing_null_vector.get(0)[i] = -1.;
+      local_outgoing_null_vector.get(1)[i] = 2.;
+      local_outgoing_null_vector.get(2)[i] = 3.;
+      local_outgoing_null_vector.get(3)[i] = 5.;
+    }
+    // Setting projection Ab
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_projection_Ab.get(0, a)[i] = 233.;
+        local_projection_Ab.get(1, a)[i] = 239.;
+        local_projection_Ab.get(2, a)[i] = 241.;
+        local_projection_Ab.get(3, a)[i] = 251.;
+      }
+    }
+    // Setting projection ab
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_projection_ab.get(0, a)[i] = 379.;
+        local_projection_ab.get(1, a)[i] = 383.;
+        local_projection_ab.get(2, a)[i] = 389.;
+        local_projection_ab.get(3, a)[i] = 397.;
+      }
+    }
+    // Setting projection AB
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_projection_AB.get(0, a)[i] = 353.;
+        local_projection_AB.get(1, a)[i] = 359.;
+        local_projection_AB.get(2, a)[i] = 367.;
+        local_projection_AB.get(3, a)[i] = 373.;
+      }
+    }
+    // Setting 3idxConstraint
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = 0; b <= VolumeDim; ++b) {
+          local_three_index_constraint.get(0, a, b)[i] = 11. - 3.;
+          local_three_index_constraint.get(1, a, b)[i] = 13. - 5.;
+          local_three_index_constraint.get(2, a, b)[i] = 17. - 7.;
+        }
+      }
+    }
+    // Setting local_RhsVSpacetimeMetric
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_char_projected_rhs_dt_u_psi.get(0, a)[i] = 23.;
+        local_char_projected_rhs_dt_u_psi.get(1, a)[i] = 29.;
+        local_char_projected_rhs_dt_u_psi.get(2, a)[i] = 31.;
+        local_char_projected_rhs_dt_u_psi.get(3, a)[i] = 37.;
+      }
+    }
+    // Setting RhsVMinus
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_char_projected_rhs_dt_u_minus.get(0, a)[i] = 331.;
+        local_char_projected_rhs_dt_u_minus.get(1, a)[i] = 337.;
+        local_char_projected_rhs_dt_u_minus.get(2, a)[i] = 347.;
+        local_char_projected_rhs_dt_u_minus.get(3, a)[i] = 349.;
+      }
+    }
+    // Setting constraint_char_zero_plus AND constraint_char_zero_minus
+    // ONLY ON THE +Y AXIS (Y = +0.5) -- FIXME
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      if (get<0>(inertial_coords)[i] == 299. and
+          get<1>(inertial_coords)[i] == 0.5 and
+          get<2>(inertial_coords)[i] == -0.5) {
+        std::array<double, 4> spec_vals = {
+            {3722388974.799386, -16680127.68747905, -22991565.68745775,
+             -29394198.68743645}};
+        std::array<double, 4> spec_vals2 = {
+            {3866802572.424386, -19802442.06247905, -19496408.06245775,
+             -19257249.06243645}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 299.5 and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == -0.5) {
+        std::array<double, 4> spec_vals = {
+            {1718287695.133032, -35082292.16184025, -44420849.32723039,
+             -53850596.45928719}};
+        std::array<double, 4> spec_vals2 = {
+            {1866652790.548975, -38170999.90741873, -40892085.07280888,
+             -43680040.20486567}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 300. and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == -0.5) {
+        std::array<double, 4> spec_vals = {
+            {1718299060.415949, -35082089.27527188, -44420613.14790046,
+             -53850326.98725116}};
+        std::array<double, 4> spec_vals2 = {
+            {1866664134.129611, -38170797.39904065, -40891849.27166924,
+             -43679771.11101994}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 299. and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == 0.) {
+        std::array<double, 4> spec_vals = {
+            {1718276282.501221, -35082495.89577083, -44421086.49296889,
+             -53850867.05677793}};
+        std::array<double, 4> spec_vals2 = {
+            {1866641399.709844, -38171203.26157932, -40892321.85877737,
+             -43680310.4225864}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 299.5 and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == 0.) {
+        std::array<double, 4> spec_vals = {
+            {1718287685.660846, -35082292.33093269, -44420849.52407002,
+             -53850596.68387395}};
+        std::array<double, 4> spec_vals2 = {
+            {1866652781.094877, -38171000.07619599, -40892085.26933331,
+             -43680040.42913724}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 300. and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == 0.) {
+        std::array<double, 4> spec_vals = {
+            {1718299050.990844, -35082089.44352208, -44420613.34375966,
+             -53850327.21071925}};
+        std::array<double, 4> spec_vals2 = {
+            {1866664124.722503, -38170797.56697725, -40891849.46721483,
+             -43679771.33417442}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 299. and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == 0.5) {
+        std::array<double, 4> spec_vals = {
+            {1718276292.082241, -35082495.72473276, -44421086.29386414,
+             -53850866.82960649}};
+        std::array<double, 4> spec_vals2 = {
+            {1866641409.272568, -38171203.09086005, -40892321.65999144,
+             -43680310.19573379}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 299.5 and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == 0.5) {
+        std::array<double, 4> spec_vals = {
+            {1718287695.194063, -35082292.16074976, -44420849.32596073,
+             -53850596.45783833}};
+        std::array<double, 4> spec_vals2 = {
+            {1866652790.609889, -38170999.90633029, -40892085.07154126,
+             -43680040.20341886}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else if (get<0>(inertial_coords)[i] == 300. and
+                 get<1>(inertial_coords)[i] == 0.5 and
+                 get<2>(inertial_coords)[i] == 0.5) {
+        std::array<double, 4> spec_vals = {
+            {1718299060.476573, -35082089.27418864, -44420613.14663924,
+             -53850326.98581193}};
+        std::array<double, 4> spec_vals2 = {
+            {1866664134.190119, -38170797.39795944, -40891849.27041004,
+             -43679771.10958273}};
+        for (size_t j = 0; j <= VolumeDim; ++j) {
+          local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+          local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+        }
+      } else {
+        // When applying BCs to various faces, only one face (i.e. the +y side)
+        // will be set here, others can be set however...
+        ASSERT(false,
+               "Not checking the correct face, coordinates not recognized");
+      }
+    }
+  }
+
+  // Compute return value from Action
+  auto local_bc_dt_u_minus =
+      GeneralizedHarmonic::Actions::BoundaryConditions_detail::set_dt_v_minus<
+          typename GeneralizedHarmonic::Tags::VMinus<VolumeDim, frame>::type,
+          VolumeDim>::apply(GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+                                VMinusBcMethod::ConstraintPreservingPhysical,
+                            make_not_null(&intermediate_vars), local_vars,
+                            local_dt_vars, inertial_coords,
+                            local_unit_normal_one_form);
+
+  // Initialize with values from SpEC
+  auto spec_bc_dt_u_minus = local_bc_dt_u_minus;
+  for (size_t i = 0; i < slice_grid_points; ++i) {
+    if (get<0>(inertial_coords)[i] == 299. and
+        get<1>(inertial_coords)[i] == 0.5 and
+        get<2>(inertial_coords)[i] == -0.5) {
+      std::array<double, 16> spec_vals = {
+          {7.122948293721196e+19, 7.122948329100482e+19, 7.122948320255282e+19,
+           7.122948346787851e+19, 7.122948329100482e+19, 7.639071460057165e+19,
+           7.639071451116156e+19, 7.639071477936572e+19, 7.122948320255282e+19,
+           7.639071451116156e+19, 8.413256084990011e+19, 8.413256111738503e+19,
+           7.122948346787851e+19, 7.639071477936572e+19, 8.413256111738503e+19,
+           9.445502329090969e+19}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299.5 and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == -0.5) {
+      std::array<double, 16> spec_vals = {
+          {7.122948296615504e+19, 7.122948312745003e+19, 7.122948308712251e+19,
+           7.122948320807479e+19, 7.122948312745003e+19, 7.639071424306128e+19,
+           7.639071420196236e+19, 7.639071432523298e+19, 7.122948308712251e+19,
+           7.639071420196236e+19, 8.413256058789916e+19, 8.413256071059056e+19,
+           7.122948320807479e+19, 7.639071432523298e+19, 8.413256071059056e+19,
+           9.445502273747989e+19}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 300. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == -0.5) {
+      std::array<double, 16> spec_vals = {
+          {7.122948296615481e+19, 7.122948312745094e+19, 7.122948308712312e+19,
+           7.122948320807626e+19, 7.122948312745094e+19, 7.639071424306332e+19,
+           7.639071420196412e+19, 7.639071432523558e+19, 7.122948308712312e+19,
+           7.639071420196412e+19, 8.413256058790063e+19, 8.413256071059287e+19,
+           7.122948320807626e+19, 7.639071432523558e+19, 8.413256071059287e+19,
+           9.445502273748306e+19}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.) {
+      std::array<double, 16> spec_vals = {
+          {7.122948296615527e+19, 7.122948312744913e+19, 7.122948308712188e+19,
+           7.122948320807332e+19, 7.122948312744913e+19, 7.639071424305924e+19,
+           7.639071420196061e+19, 7.639071432523037e+19, 7.122948308712188e+19,
+           7.639071420196061e+19, 8.413256058789768e+19, 8.413256071058824e+19,
+           7.122948320807332e+19, 7.639071432523037e+19, 8.413256071058824e+19,
+           9.445502273747671e+19}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299.5 and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.) {
+      std::array<double, 16> spec_vals = {
+          {7.122948296615504e+19, 7.122948312745003e+19, 7.122948308712251e+19,
+           7.122948320807479e+19, 7.122948312745003e+19, 7.639071424306128e+19,
+           7.639071420196236e+19, 7.639071432523298e+19, 7.122948308712251e+19,
+           7.639071420196236e+19, 8.413256058789916e+19, 8.413256071059056e+19,
+           7.122948320807479e+19, 7.639071432523298e+19, 8.413256071059056e+19,
+           9.445502273747989e+19}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 300. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.) {
+      std::array<double, 16> spec_vals = {
+          {7.122948296615482e+19, 7.122948312745094e+19, 7.122948308712312e+19,
+           7.122948320807626e+19, 7.122948312745094e+19, 7.63907142430633e+19,
+           7.63907142019641e+19, 7.639071432523556e+19, 7.122948308712312e+19,
+           7.63907142019641e+19, 8.413256058790063e+19, 8.413256071059287e+19,
+           7.122948320807626e+19, 7.639071432523556e+19, 8.413256071059287e+19,
+           9.445502273748306e+19}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.5) {
+      std::array<double, 16> spec_vals = {
+          {7.122948296615527e+19, 7.122948312744913e+19, 7.122948308712188e+19,
+           7.122948320807332e+19, 7.122948312744913e+19, 7.639071424305924e+19,
+           7.639071420196061e+19, 7.639071432523039e+19, 7.122948308712188e+19,
+           7.639071420196061e+19, 8.413256058789768e+19, 8.413256071058824e+19,
+           7.122948320807332e+19, 7.639071432523039e+19, 8.413256071058824e+19,
+           9.445502273747671e+19}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 299.5 and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.5) {
+      std::array<double, 16> spec_vals = {
+          {7.122948296615504e+19, 7.122948312745003e+19, 7.122948308712251e+19,
+           7.122948320807479e+19, 7.122948312745003e+19, 7.639071424306128e+19,
+           7.639071420196236e+19, 7.639071432523298e+19, 7.122948308712251e+19,
+           7.639071420196236e+19, 8.413256058789916e+19, 8.413256071059056e+19,
+           7.122948320807479e+19, 7.639071432523298e+19, 8.413256071059056e+19,
+           9.445502273747989e+19}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else if (get<0>(inertial_coords)[i] == 300. and
+               get<1>(inertial_coords)[i] == 0.5 and
+               get<2>(inertial_coords)[i] == 0.5) {
+      std::array<double, 16> spec_vals = {
+          {7.122948296615481e+19, 7.122948312745094e+19, 7.122948308712312e+19,
+           7.122948320807626e+19, 7.122948312745094e+19, 7.639071424306332e+19,
+           7.639071420196412e+19, 7.639071432523558e+19, 7.122948308712312e+19,
+           7.639071420196412e+19, 8.413256058790063e+19, 8.413256071059287e+19,
+           7.122948320807626e+19, 7.639071432523558e+19, 8.413256071059287e+19,
+           9.445502273748306e+19}};
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_u_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    } else {
+      ASSERT(false,
+             "Not checking the correct face, coordinates not recognized");
+    }
+  }
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_bc_dt_u_minus, spec_bc_dt_u_minus);
+}
+
+// Test helper functions needed to set dt<VMinus>
+namespace {
+// Test GeneralizedHarmonic::spatial_projection_tensor (3 OVERLOADS)
+void test_spatial_projection_tensors(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Setup grid
+  Mesh<VolumeDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  const Direction<VolumeDim> direction(1, Side::Upper);  // +y direction
+  const size_t slice_grid_points =
+      mesh.extents().slice_away(direction.dimension()).product();
+  const auto inertial_coords = [&slice_grid_points, &lower_bound]() {
+    tnsr::I<DataVector, VolumeDim, frame> tmp(slice_grid_points, 0.);
+    // +y direction
+    get<1>(tmp) = 0.5;
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        get<0>(tmp)[i * VolumeDim + j] =
+            lower_bound[0] + 0.5 * static_cast<double>(i);
+        get<2>(tmp)[i * VolumeDim + j] =
+            lower_bound[2] + 0.5 * static_cast<double>(j);
+      }
+    }
+    return tmp;
+  }();
+
+  // 1. Projection IJ
+  auto local_inverse_spatial_metric =
+      make_with_value<tnsr::II<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_unit_interface_normal_vector =
+      make_with_value<tnsr::A<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_spatial_projection_IJ =
+      make_with_value<tnsr::II<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+
+  // Setting inverse_spatial_metric
+  for (size_t i = 0; i < get<0>(inertial_coords).size(); ++i) {
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      local_inverse_spatial_metric.get(0, j)[i] = 41.;
+      local_inverse_spatial_metric.get(1, j)[i] = 43.;
+      local_inverse_spatial_metric.get(2, j)[i] = 47.;
+    }
+  }
+  // Setting unit_interface_normal_Vector
+  get<0>(local_unit_interface_normal_vector) = 1.e300;
+  get<1>(local_unit_interface_normal_vector) = -1.;
+  get<2>(local_unit_interface_normal_vector) = 1.;
+  get<3>(local_unit_interface_normal_vector) = 1.;
+
+  // Call tested function
+  GeneralizedHarmonic::spatial_projection_tensor(
+      make_not_null(&local_spatial_projection_IJ), local_inverse_spatial_metric,
+      local_unit_interface_normal_vector);
+
+  // Initialize with values from SpEC
+  auto spec_spatial_projection_IJ = local_spatial_projection_IJ;
+  {
+    const std::array<double, 9> spec_vals = {
+        {40., 42., 42., 42., 42., 42., 42., 42., 46.}};
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      for (size_t k = j; k < VolumeDim; ++k) {
+        spec_spatial_projection_IJ.get(j, k) =
+            gsl::at(spec_vals, j * VolumeDim + k);
+      }
+    }
+  }
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_spatial_projection_IJ,
+                        spec_spatial_projection_IJ);
+
+  // 2. Projection ij
+  auto local_spatial_metric =
+      make_with_value<tnsr::ii<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_unit_interface_normal_one_form =
+      make_with_value<tnsr::a<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_spatial_projection_ij =
+      make_with_value<tnsr::ii<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+
+  // Setting inverse_spatial_metric
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    local_spatial_metric.get(0, i) = 263.;
+    local_spatial_metric.get(1, i) = 269.;
+    local_spatial_metric.get(2, i) = 271.;
+  }
+  // Setting unit_interface_normal_Vector
+  get<0>(local_unit_interface_normal_one_form) = 1.e300;
+  get<1>(local_unit_interface_normal_one_form) = -1.;
+  get<2>(local_unit_interface_normal_one_form) = 1.;
+  get<3>(local_unit_interface_normal_one_form) = 1.;
+
+  // Call tested function
+  GeneralizedHarmonic::spatial_projection_tensor(
+      make_not_null(&local_spatial_projection_ij), local_spatial_metric,
+      local_unit_interface_normal_one_form);
+
+  // Initialize with values from SpEC
+  auto spec_spatial_projection_ij = local_spatial_projection_ij;
+  {
+    const std::array<double, 9> spec_vals = {
+        {262., 264., 264., 264., 268., 268., 264., 268., 270.}};
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      for (size_t k = j; k < VolumeDim; ++k) {
+        spec_spatial_projection_ij.get(j, k) =
+            gsl::at(spec_vals, j * VolumeDim + k);
+      }
+    }
+  }
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_spatial_projection_ij,
+                        spec_spatial_projection_ij);
+
+  // 3. Projection Ij
+  auto local_spatial_projection_Ij =
+      make_with_value<tnsr::Ij<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+
+  // Call tested function
+  GeneralizedHarmonic::spatial_projection_tensor(
+      make_not_null(&local_spatial_projection_Ij),
+      local_unit_interface_normal_vector, local_unit_interface_normal_one_form);
+
+  // Initialize with values from SpEC
+  auto spec_spatial_projection_Ij = local_spatial_projection_Ij;
+  {
+    const std::array<double, 9> spec_vals = {
+        {0., 1., 1., 1., 0., -1., 1., -1., 0.}};
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      for (size_t k = j; k < VolumeDim; ++k) {
+        spec_spatial_projection_Ij.get(j, k) =
+            gsl::at(spec_vals, j * VolumeDim + k);
+      }
+    }
+  }
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_spatial_projection_Ij,
+                        spec_spatial_projection_Ij);
+}
+
+// Test GeneralizedHarmonic::weyl_propagating
+void test_weyl_propagating(const size_t grid_size_each_dimension,
+                           const std::array<double, 3>& lower_bound,
+                           const std::array<double, 3>& upper_bound) noexcept {
+  // Setup grid
+  Mesh<VolumeDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  const Direction<VolumeDim> direction(1, Side::Upper);  // +y direction
+  const size_t slice_grid_points =
+      mesh.extents().slice_away(direction.dimension()).product();
+  const auto inertial_coords = [&slice_grid_points, &lower_bound]() {
+    tnsr::I<DataVector, VolumeDim, frame> tmp(slice_grid_points, 0.);
+    // +y direction
+    get<1>(tmp) = 0.5;
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        get<0>(tmp)[i * VolumeDim + j] =
+            lower_bound[0] + 0.5 * static_cast<double>(i);
+        get<2>(tmp)[i * VolumeDim + j] =
+            lower_bound[2] + 0.5 * static_cast<double>(j);
+      }
+    }
+    return tmp;
+  }();
+
+  // for Projection IJ
+  auto local_inverse_spatial_metric =
+      make_with_value<tnsr::II<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_unit_interface_normal_vector =
+      make_with_value<tnsr::A<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_spatial_projection_IJ =
+      make_with_value<tnsr::II<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  // for Projection ij
+  auto local_spatial_metric =
+      make_with_value<tnsr::ii<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_unit_interface_normal_one_form =
+      make_with_value<tnsr::a<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_spatial_projection_ij =
+      make_with_value<tnsr::ii<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  // for Projection Ij
+  auto local_spatial_projection_Ij =
+      make_with_value<tnsr::Ij<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  // Ricci3
+  auto local_ricci_3 =
+      make_with_value<tnsr::ii<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  // Extrinsic curvature
+  auto local_extrinsic_curvature =
+      make_with_value<tnsr::ii<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  // CdK
+  auto local_CdK =
+      make_with_value<tnsr::ijj<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+
+  // Setting inverse_spatial_metric
+  for (size_t j = 0; j < VolumeDim; ++j) {
+    local_inverse_spatial_metric.get(0, j) = 41.;
+    local_inverse_spatial_metric.get(1, j) = 43.;
+    local_inverse_spatial_metric.get(2, j) = 47.;
+  }
+
+  // Setting unit_interface_normal_Vector
+  get<0>(local_unit_interface_normal_vector) = 1.e300;
+  get<1>(local_unit_interface_normal_vector) = -1.;
+  get<2>(local_unit_interface_normal_vector) = 1.;
+  get<3>(local_unit_interface_normal_vector) = 1.;
+
+  // Setting inverse_spatial_metric
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    local_spatial_metric.get(0, i) = 263.;
+    local_spatial_metric.get(1, i) = 269.;
+    local_spatial_metric.get(2, i) = 271.;
+  }
+  // Setting unit_interface_normal_Vector
+  get<0>(local_unit_interface_normal_one_form) = 1.e300;
+  get<1>(local_unit_interface_normal_one_form) = -1.;
+  get<2>(local_unit_interface_normal_one_form) = 1.;
+  get<3>(local_unit_interface_normal_one_form) = 1.;
+
+  // Compute patial_projection_IJ
+  GeneralizedHarmonic::spatial_projection_tensor(
+      make_not_null(&local_spatial_projection_IJ), local_inverse_spatial_metric,
+      local_unit_interface_normal_vector);
+
+  // Compute patial_projection_ij
+  GeneralizedHarmonic::spatial_projection_tensor(
+      make_not_null(&local_spatial_projection_ij), local_spatial_metric,
+      local_unit_interface_normal_one_form);
+
+  // Compute patial_projection_Ij
+  GeneralizedHarmonic::spatial_projection_tensor(
+      make_not_null(&local_spatial_projection_Ij),
+      local_unit_interface_normal_vector, local_unit_interface_normal_one_form);
+
+  {  // Setting Ricci3
+    const std::array<double, 9> spec_vals = {{147398., 4162.5, -142614.5,
+                                              4162.5, 6088., 3710., -142614.5,
+                                              3710., 146874.}};
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      for (size_t k = j; k < VolumeDim; ++k) {
+        local_ricci_3.get(j, k) = gsl::at(spec_vals, j * VolumeDim + k);
+      }
+    }
+  }
+
+  {  // Setting Kij
+    const std::array<double, 9> spec_vals = {
+        {200.2198037251189, 266.7930716334918, 333.3663395418648,
+         266.7930716334918, 333.3663395418648, 399.9396074502377,
+         333.3663395418648, 399.9396074502377, 466.5128753586106}};
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      for (size_t k = j; k < VolumeDim; ++k) {
+        local_extrinsic_curvature.get(j, k) =
+            gsl::at(spec_vals, j * VolumeDim + k);
+      }
+    }
+  }
+
+  {  // Setting CdK
+    const std::array<double, 27> spec_vals = {
+        {8823.321925408985,  -70195.04590349646, -149213.4137324019,
+         -70195.04590349646, -199942.2438785821, -329689.4418536677,
+         -149213.4137324019, -329689.4418536677, -510165.4699749335,
+         -125752.1709458457, -206582.9538478412, -287445.7367498368,
+         -206582.9538478412, -338142.566896017,  -469734.1799441926,
+         -287445.7367498368, -469734.1799441926, -652054.6231385486,
+         -259672.6638171005, -342347.8617921862, -425007.0597672717,
+         -342347.8617921862, -475751.8899134519, -609139.9180347177,
+         -425007.0597672717, -609139.9180347177, -793256.7763021636}};
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        for (size_t k = j; k < VolumeDim; ++k) {
+          local_CdK.get(i, j, k) =
+              gsl::at(spec_vals, i * VolumeDim * VolumeDim + j * VolumeDim + k);
+        }
+      }
+    }
+  }
+
+  // Call tested function
+  auto local_U8p =
+      make_with_value<tnsr::ii<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_U8m =
+      make_with_value<tnsr::ii<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  GeneralizedHarmonic::weyl_propagating(
+      make_not_null(&local_U8p), local_ricci_3, local_extrinsic_curvature,
+      local_inverse_spatial_metric, local_CdK,
+      local_unit_interface_normal_vector, local_spatial_projection_IJ,
+      local_spatial_projection_ij, local_spatial_projection_Ij, 1);
+  GeneralizedHarmonic::weyl_propagating(
+      make_not_null(&local_U8m), local_ricci_3, local_extrinsic_curvature,
+      local_inverse_spatial_metric, local_CdK,
+      local_unit_interface_normal_vector, local_spatial_projection_IJ,
+      local_spatial_projection_ij, local_spatial_projection_Ij, -1);
+  // Initialize with values from SpEC
+  auto spec_U8p = local_U8p;
+  {
+    const std::array<double, 9> spec_vals = {
+        {928952774.2567333, 940713877.3261309, 939182081.2010889,
+         940713877.3261309, 945884770.4041573, 948874196.5740113,
+         939182081.2010889, 948874196.5740113, 957472967.9928486}};
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      for (size_t k = j; k < VolumeDim; ++k) {
+        spec_U8p.get(j, k) = gsl::at(spec_vals, j * VolumeDim + k);
+      }
+    }
+  }
+  auto spec_U8m = local_U8m;
+  {
+    const std::array<double, 9> spec_vals = {
+        {2072462877.743262, 2092514290.673862, 2091092298.798905,
+         2092514290.673862, 2114969735.595836, 2118154795.425982,
+         2091092298.798905, 2118154795.425982, 2135578770.007146}};
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      for (size_t k = j; k < VolumeDim; ++k) {
+        spec_U8m.get(j, k) = gsl::at(spec_vals, j * VolumeDim + k);
+      }
+    }
+  }
+
+  // Compare value vs those from SpEC
+  Approx custom_approx = Approx::custom().epsilon(1.e-12).scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(local_U8p, spec_U8p, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(local_U8m, spec_U8m, custom_approx);
+}
+}  // namespace
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.VPsi",
+    "[Unit][Evolution]") {
+  // Piece-wise tests with SpEC output
+  const size_t grid_size = 3;
+  const std::array<double, 3> lower_bound{{299., -0.5, -0.5}};
+  const std::array<double, 3> upper_bound{{300., 0.5, 0.5}};
+
+  test_constraint_preserving_bjorhus_u_psi<
+      GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+          VSpacetimeMetricBcMethod::ConstraintPreserving>(
+      grid_size, lower_bound, upper_bound);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.VZero",
+    "[Unit][Evolution]") {
+  // Piece-wise tests with SpEC output
+  const size_t grid_size = 3;
+  const std::array<double, 3> lower_bound{{299., -0.5, -0.5}};
+  const std::array<double, 3> upper_bound{{300., 0.5, 0.5}};
+
+  test_constraint_preserving_bjorhus_u_zero<
+      GeneralizedHarmonic::BoundaryConditions::Bjorhus::VZeroBcMethod::
+          ConstraintPreserving>(grid_size, lower_bound, upper_bound);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Helpers",
+    "[Unit][Evolution]") {
+  // Piece-wise tests with SpEC output
+  // These only work with the grid specified below
+  const size_t grid_size = 3;
+  const std::array<double, 3> lower_bound{{299., -0.5, -0.5}};
+  const std::array<double, 3> upper_bound{{300., 0.5, 0.5}};
+
+  test_spatial_projection_tensors(grid_size, lower_bound, upper_bound);
+  test_weyl_propagating(grid_size, lower_bound, upper_bound);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.VMinus",
+    "[Unit][Evolution]") {
+  // Piece-wise tests with SpEC output
+  // These only work with the grid specified below
+  const size_t grid_size = 3;
+  const std::array<double, 3> lower_bound{{299., -0.5, -0.5}};
+  const std::array<double, 3> upper_bound{{300., 0.5, 0.5}};
+
+  test_constraint_preserving_bjorhus_u_minus<
+      GeneralizedHarmonic::BoundaryConditions::Bjorhus::VMinusBcMethod::
+          Freezing>(grid_size, lower_bound, upper_bound);
+  test_constraint_preserving_bjorhus_u_minus<
+      GeneralizedHarmonic::BoundaryConditions::Bjorhus::VMinusBcMethod::
+          ConstraintPreserving>(grid_size, lower_bound, upper_bound);
+  test_constraint_preserving_bjorhus_u_minus<
+      GeneralizedHarmonic::BoundaryConditions::Bjorhus::VMinusBcMethod::
+          ConstraintPreservingPhysical>(grid_size, lower_bound, upper_bound);
+}

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -167,7 +167,7 @@ template <size_t SpatialDim, typename Frame, typename DataType>
 void test_two_index_constraint_random(const DataType& used_for_size) noexcept {
   pypp::check_with_random_values<1>(
       static_cast<tnsr::ia<DataType, SpatialDim, Frame> (*)(
-          const tnsr::ia<DataType, SpatialDim, Frame>&,
+          const tnsr::ab<DataType, SpatialDim, Frame>&,
           const tnsr::a<DataType, SpatialDim, Frame>&,
           const tnsr::A<DataType, SpatialDim, Frame>&,
           const tnsr::II<DataType, SpatialDim, Frame>&,
@@ -282,6 +282,18 @@ void test_two_index_constraint_analytic(
   const auto& d_gauge_function =
       get<Tags::deriv<GaugeH, tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
 
+  // Populate spacetime derivative of gauge function
+  const auto d4_gauge_function = [&x, &d_gauge_function]() {
+    auto tmp =
+        make_with_value<tnsr::ab<DataVector, 3, Frame::Inertial>>(x, 0.0);
+    for (size_t i = 0; i < 3; ++i) {
+      for (size_t a = 0; a < 4; ++a) {
+        tmp.get(i + 1, a) = d_gauge_function.get(i, a);
+      }
+    }
+    return tmp;
+  }();
+
   // Compute the three-index constraint
   const auto three_index_constraint =
       GeneralizedHarmonic::three_index_constraint(d_spacetime_metric, phi);
@@ -291,7 +303,7 @@ void test_two_index_constraint_analytic(
       make_with_value<tnsr::ia<DataVector, 3, Frame::Inertial>>(
           x, std::numeric_limits<double>::signaling_NaN());
   GeneralizedHarmonic::two_index_constraint(
-      make_not_null(&two_index_constraint), d_gauge_function, normal_one_form,
+      make_not_null(&two_index_constraint), d4_gauge_function, normal_one_form,
       normal_vector, inverse_spatial_metric, inverse_spacetime_metric, pi, phi,
       d_pi, d_phi, gamma2, three_index_constraint);
 
@@ -394,7 +406,7 @@ void test_f_constraint_random(const DataType& used_for_size) noexcept {
   pypp::check_with_random_values<1>(
       static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
           const tnsr::a<DataType, SpatialDim, Frame>&,
-          const tnsr::ia<DataType, SpatialDim, Frame>&,
+          const tnsr::ab<DataType, SpatialDim, Frame>&,
           const tnsr::a<DataType, SpatialDim, Frame>&,
           const tnsr::A<DataType, SpatialDim, Frame>&,
           const tnsr::II<DataType, SpatialDim, Frame>&,
@@ -508,6 +520,18 @@ void test_f_constraint_analytic(const Solution& solution,
   const auto& d_gauge_function =
       get<Tags::deriv<GaugeH, tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
 
+  // Populate spacetime derivative of gauge function
+  const auto d4_gauge_function = [&x, &d_gauge_function]() {
+    auto tmp =
+        make_with_value<tnsr::ab<DataVector, 3, Frame::Inertial>>(x, 0.0);
+    for (size_t i = 0; i < 3; ++i) {
+      for (size_t a = 0; a < 4; ++a) {
+        tmp.get(i + 1, a) = d_gauge_function.get(i, a);
+      }
+    }
+    return tmp;
+  }();
+
   // Compute the three-index constraint
   const auto three_index_constraint =
       GeneralizedHarmonic::three_index_constraint(d_spacetime_metric, phi);
@@ -516,7 +540,7 @@ void test_f_constraint_analytic(const Solution& solution,
   auto f_constraint = make_with_value<tnsr::a<DataVector, 3, Frame::Inertial>>(
       x, std::numeric_limits<double>::signaling_NaN());
   GeneralizedHarmonic::f_constraint(
-      make_not_null(&f_constraint), gauge_function, d_gauge_function,
+      make_not_null(&f_constraint), gauge_function, d4_gauge_function,
       normal_one_form, normal_vector, inverse_spatial_metric,
       inverse_spacetime_metric, pi, phi, d_pi, d_phi, gamma2,
       three_index_constraint);
@@ -643,6 +667,18 @@ void test_constraint_energy_analytic(const Solution& solution,
   const auto& d_gauge_function =
       get<Tags::deriv<GaugeH, tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
 
+  // Populate spacetime derivative of gauge function
+  const auto d4_gauge_function = [&x, &d_gauge_function]() {
+    auto tmp =
+        make_with_value<tnsr::ab<DataVector, 3, Frame::Inertial>>(x, 0.0);
+    for (size_t i = 0; i < 3; ++i) {
+      for (size_t a = 0; a < 4; ++a) {
+        tmp.get(i + 1, a) = d_gauge_function.get(i, a);
+      }
+    }
+    return tmp;
+  }();
+
   // Arbitrary choice for gamma2
   const auto gamma2 = make_with_value<Scalar<DataVector>>(x, 4.0);
 
@@ -655,11 +691,11 @@ void test_constraint_energy_analytic(const Solution& solution,
   const auto four_index_constraint =
       GeneralizedHarmonic::four_index_constraint(d_phi);
   const auto two_index_constraint = GeneralizedHarmonic::two_index_constraint(
-      d_gauge_function, normal_one_form, normal_vector, inverse_spatial_metric,
+      d4_gauge_function, normal_one_form, normal_vector, inverse_spatial_metric,
       inverse_spacetime_metric, pi, phi, d_pi, d_phi, gamma2,
       three_index_constraint);
   const auto f_constraint = GeneralizedHarmonic::f_constraint(
-      gauge_function, d_gauge_function, normal_one_form, normal_vector,
+      gauge_function, d4_gauge_function, normal_one_form, normal_vector,
       inverse_spatial_metric, inverse_spacetime_metric, pi, phi, d_pi, d_phi,
       gamma2, three_index_constraint);
 
@@ -924,14 +960,14 @@ void test_constraint_compute_items(
   const auto three_index_constraint =
       GeneralizedHarmonic::three_index_constraint(deriv_spacetime_metric, phi);
   const auto two_index_constraint = GeneralizedHarmonic::two_index_constraint(
-      deriv_gauge_source, spacetime_normal_one_form, spacetime_normal_vector,
-      inverse_spatial_metric, inverse_spacetime_metric, pi, phi, deriv_pi,
-      deriv_phi, gamma2, three_index_constraint);
+      derivatives_of_gauge_source, spacetime_normal_one_form,
+      spacetime_normal_vector, inverse_spatial_metric, inverse_spacetime_metric,
+      pi, phi, deriv_pi, deriv_phi, gamma2, three_index_constraint);
   const auto gauge_constraint = GeneralizedHarmonic::gauge_constraint(
       gauge_source, spacetime_normal_one_form, spacetime_normal_vector,
       inverse_spatial_metric, inverse_spacetime_metric, pi, phi);
   const auto f_constraint = GeneralizedHarmonic::f_constraint(
-      gauge_source, deriv_gauge_source, spacetime_normal_one_form,
+      gauge_source, derivatives_of_gauge_source, spacetime_normal_one_form,
       spacetime_normal_vector, inverse_spatial_metric, inverse_spacetime_metric,
       pi, phi, deriv_pi, deriv_phi, gamma2, three_index_constraint);
   const auto constraint_energy = GeneralizedHarmonic::constraint_energy(

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -23,6 +23,8 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Side.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
@@ -42,6 +44,7 @@
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfDetSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfNormOfShift.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivativeOfSpacetimeMetric.hpp"
@@ -625,6 +628,115 @@ void test_spacetime_derivative_of_spacetime_metric(
   }
 }
 
+// Test GeneralizedHarmonic::ricci_tensor
+void test_spatial_ricci_tensor(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  using frame = Frame::Inertial;
+  constexpr size_t VolumeDim = 3;
+  // Setup grid
+  Mesh<VolumeDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  const Direction<VolumeDim> direction(1, Side::Upper);  // +y direction
+  const size_t slice_grid_points =
+      mesh.extents().slice_away(direction.dimension()).product();
+  const auto inertial_coords = [&slice_grid_points, &lower_bound]() {
+    tnsr::I<DataVector, VolumeDim, frame> tmp(slice_grid_points, 0.);
+    // +y direction
+    get<1>(tmp) = 0.5;
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        get<0>(tmp)[i * VolumeDim + j] =
+            lower_bound[0] + 0.5 * static_cast<double>(i);
+        get<2>(tmp)[i * VolumeDim + j] =
+            lower_bound[2] + 0.5 * static_cast<double>(j);
+      }
+    }
+    return tmp;
+  }();
+
+  auto local_inverse_spatial_metric =
+      make_with_value<tnsr::II<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_phi =
+      make_with_value<tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_d_pi =
+      make_with_value<tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_d_phi =
+      make_with_value<tnsr::ijaa<DataVector, VolumeDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+
+  // Setting inverse_spatial_metric
+  for (size_t i = 0; i < get<0>(inertial_coords).size(); ++i) {
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      local_inverse_spatial_metric.get(0, j)[i] = 41.;
+      local_inverse_spatial_metric.get(1, j)[i] = 43.;
+      local_inverse_spatial_metric.get(2, j)[i] = 47.;
+    }
+  }
+  // Setting pi AND phi
+  for (size_t i = 0; i < get<0>(inertial_coords).size(); ++i) {
+    for (size_t a = 0; a <= VolumeDim; ++a) {
+      for (size_t b = 0; b <= VolumeDim; ++b) {
+        // local_pi.get(a, b)[i] = 1.;
+        local_phi.get(0, a, b)[i] = 3.;
+        local_phi.get(1, a, b)[i] = 5.;
+        local_phi.get(2, a, b)[i] = 7.;
+      }
+    }
+  }
+  // Setting local_d_phi
+  // initialize dPhi (with same values as for SpEC)
+  for (size_t i = 0; i < get<0>(inertial_coords).size(); ++i) {
+    for (size_t a = 0; a <= VolumeDim; ++a) {
+      for (size_t b = 0; b <= VolumeDim; ++b) {
+        local_d_pi.get(0, a, b)[i] = 1.;
+        local_d_phi.get(0, 0, a, b)[i] = 3.;
+        local_d_phi.get(0, 1, a, b)[i] = 5.;
+        local_d_phi.get(0, 2, a, b)[i] = 7.;
+        local_d_pi.get(1, a, b)[i] = 53.;
+        local_d_phi.get(1, 0, a, b)[i] = 59.;
+        local_d_phi.get(1, 1, a, b)[i] = 61.;
+        local_d_phi.get(1, 2, a, b)[i] = 67.;
+        local_d_pi.get(2, a, b)[i] = 71.;
+        local_d_phi.get(2, 0, a, b)[i] = 73.;
+        local_d_phi.get(2, 1, a, b)[i] = 79.;
+        local_d_phi.get(2, 2, a, b)[i] = 83.;
+      }
+    }
+  }
+
+  // Call tested function
+  auto local_ricci_3 = GeneralizedHarmonic::spatial_ricci_tensor(
+      local_phi, local_d_phi, local_inverse_spatial_metric);
+
+  // Initialize with values from SpEC
+  auto spec_ricci_3 = local_ricci_3;
+  get<0, 0>(spec_ricci_3) = 153230.;
+  get<0, 1>(spec_ricci_3) = 5283.;
+  get<0, 2>(spec_ricci_3) = -142541.;
+  get<1, 0>(spec_ricci_3) = 5283.;
+  get<1, 1>(spec_ricci_3) = 2497.;
+  get<1, 2>(spec_ricci_3) = -928.;
+  get<2, 2>(spec_ricci_3) = 141189.;
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_ricci_3, spec_ricci_3);
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
@@ -702,6 +814,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
                                     upper_bound);
   test_shift_deriv_functions_analytic(solution, grid_size, lower_bound,
                                       upper_bound);
+  test_spatial_ricci_tensor(grid_size, lower_bound, upper_bound);
 
   // Check that compute items work correctly in the DataBox
   // First, check that the names are correct


### PR DESCRIPTION
## Proposed changes

We add here the infrastructure (an `Action`) to impose Bjorhus-type boundary conditions for the generalized harmonic evolution system. This action sets desired values for the characteristic projected time derivatives of the evolved fields on the outer domain boundary. In addition to the action, we also implements here the actual conditions imposed by `SpEC` on the outer boundary for GeneralizedHarmonic. These include:
 - constraint preserving boundary conditions on `dt<VPsi>`, `dt<VZero>` and `dt<VMinus>`,
 - physical boundary conditions on `dt<VMinus>`, which restrict its two physical degrees of freedom,
 - gauge-dependent boundary conditions on `dt<VMinus>`, which restrict the gauge d.o.f.

**Update 10/06/2020**:

This PR has been updated following the first round of review by @geoffrey4444 . Since the changes were major and the fundamental design was updated, all fixups have been squashed and the updated code been refactored into multiple commits. The first 3 commits are now also independent PRs #2527 #2528 and #2529 . Please review these 3 commits over there, so we can merge them first and separately.


### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
