### PR TITLE
Fix ScalarWave notation

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
@@ -35,20 +35,20 @@ namespace CurvedScalarWave {
  * \cite Holst2004wt :
  *
  * \f{align}
- * \partial_t\psi = & (1 + \gamma_1) N^k \partial_k \psi - N \Pi - \gamma_1 N^k
+ * \partial_t\Psi = & (1 + \gamma_1) N^k \partial_k \Psi - N \Pi - \gamma_1 N^k
  * \Phi_k \\
  *
  * \partial_t\Pi = & - N g^{ij}\partial_i\Phi_j + N^k \partial_k \Pi + \gamma_1
- * \gamma_2 N^k \partial_k \psi  + N \Gamma^i - g^{ij} \Phi_i \partial_j N
+ * \gamma_2 N^k \partial_k \Psi  + N \Gamma^i - g^{ij} \Phi_i \partial_j N
  *  + N K \Pi - \gamma_1  \gamma_2 N^k \Phi_k\\
  *
  * \partial_t\Phi_i = & - N \partial_i \Pi  + N^k \partial_k \Phi + \gamma_2
- * N \partial_i \psi - \Pi
+ * N \partial_i \Psi - \Pi
  * \partial_i N + \Phi_k \partial_i N^j - \gamma_2 N \Phi_i\\
  * \f}
  *
- * where \f$\psi\f$ is the scalar field, \f$\Pi\f$ is the
- * conjugate momentum to \f$\psi\f$, \f$\Phi_i=\partial_i\psi\f$ is an
+ * where \f$\Psi\f$ is the scalar field, \f$\Pi\f$ is the
+ * conjugate momentum to \f$\Psi\f$, \f$\Phi_i=\partial_i\Psi\f$ is an
  * auxiliary variable, \f$N\f$ is the lapse, \f$N^k\f$ is the shift, \f$ g_{ij}
  * \f$ is the spatial metric, \f$ K \f$ is the trace of the extrinsic curvature,
  * and \f$ \Gamma^i \f$ is the trace of the Christoffel symbol of the second

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -51,13 +51,13 @@ namespace ScalarWave {
  *
  * The evolution equations for the first-order scalar wave system are given by:
  * \f{align}
- * \partial_t\psi = & -\pi \\
- * \partial_t\Phi_i = & -\partial_i \pi \\
- * \partial_t\pi = & - \delta^{ij}\partial_i\Phi_j
+ * \partial_t\Psi = & -\Pi \\
+ * \partial_t\Phi_i = & -\partial_i \Pi \\
+ * \partial_t\Pi = & - \delta^{ij}\partial_i\Phi_j
  * \f}
  *
- * where \f$\psi\f$ is the scalar field, \f$\pi=-\partial_t\psi\f$ is the
- * conjugate momentum to \f$\psi\f$, and \f$\Phi_i=\partial_i\psi\f$ is an
+ * where \f$\Psi\f$ is the scalar field, \f$\Pi=-\partial_t\Psi\f$ is the
+ * conjugate momentum to \f$\Psi\f$, and \f$\Phi_i=\partial_i\Psi\f$ is an
  * auxiliary variable.
  */
 template <size_t Dim>


### PR DESCRIPTION
## Proposed changes

Fixes #926 

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
