### PR TITLE
Use another build stage for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,19 +48,17 @@ services:
 # Specify the order of stages.
 stages:
   - Build Libraries
-  - Build and Run Tests, ClangTidy, IWYU, and Doxygen
+  - Build Test Libraries
+  - Build Executables, Run Tests, ClangTidy, IWYU, and Doxygen
 
 # Set up travis configurations of Linux and macOS.
 #
 # We also have separate targets for running shell scripts that enforce what
 # would normally be done as pre-push hooks, CHECK_COMMITS and CHECK_FILES
-#
-# NOTE: The static analysis targets are run first since these are typically
-#       fast to run and provide the most useful feedback.
 jobs:
   fast_finish: true
   include:
-  - stage: Build and Run Tests, ClangTidy, IWYU, and Doxygen
+  - stage: Build Executables, Run Tests, ClangTidy, IWYU, and Doxygen
     os: linux
     dist: trusty
     env: CHECK_COMMITS=true
@@ -97,32 +95,32 @@ jobs:
     compiler: clang
     name: test check files
 
-  # Run full builds after static analysis
-  - &Gcc7Debug
-    os: linux
-    compiler: gcc
-    dist: trusty
-    env: BUILD_TYPE=Debug COVERAGE=OFF COMPILER=gcc-7
-    name: gcc-7 debug
-    stage: Build Libraries
-  - &Gcc7Release
-    os: linux
-    compiler: gcc
-    dist: trusty
-    env: BUILD_TYPE=Release COMPILER=gcc-7
-    name: gcc-7 release
+  # First stage: build libraries
   - &Gcc6Debug
     os: linux
     compiler: gcc-6
     dist: trusty
     env: BUILD_TYPE=Debug COMPILER=gcc-6
     name: gcc-6 debug
+    stage: Build Libraries
   - &Gcc6Release
     os: linux
     compiler: gcc-6
     dist: trusty
     env: BUILD_TYPE=Release COMPILER=gcc-6
     name: gcc-6 release
+  - &Gcc7Debug
+    os: linux
+    compiler: gcc
+    dist: trusty
+    env: BUILD_TYPE=Debug COVERAGE=OFF COMPILER=gcc-7
+    name: gcc-7 debug
+  - &Gcc7Release
+    os: linux
+    compiler: gcc
+    dist: trusty
+    env: BUILD_TYPE=Release COMPILER=gcc-7
+    name: gcc-7 release
   - &Gcc8Debug
     os: linux
     compiler: gcc-8
@@ -160,18 +158,27 @@ jobs:
   #   compiler: clang
   #   name: osx xcode 9.2 release
 
-  # Build and run tests, clang tidy, IWYU, and docs.
-  - <<: *Gcc7Debug
-    stage: Build and Run Tests, ClangTidy, IWYU, and Doxygen
-  - <<: *Gcc7Release
-  - <<: *ClangDebug
-  - <<: *ClangRelease
+  # Build test libraries
   - <<: *Gcc6Debug
+    stage: Build Test Libraries
   - <<: *Gcc6Release
+  - <<: *Gcc7Debug
+  - <<: *Gcc7Release
   - <<: *Gcc8Debug
   - <<: *Gcc8Release
-  # - <<: *MacOsDebug9_2
-  # - <<: *MacOsRelease9_2
+  - <<: *ClangDebug
+  - <<: *ClangRelease
+
+  # Last stage: Build test executables, run tests, clang tidy, IWYU, and docs.
+  - <<: *Gcc6Debug
+    stage: Build Executables, Run Tests, ClangTidy, IWYU, and Doxygen
+  - <<: *Gcc6Release
+  - <<: *Gcc7Debug
+  - <<: *Gcc7Release
+  - <<: *Gcc8Debug
+  - <<: *Gcc8Release
+  - <<: *ClangDebug
+  - <<: *ClangRelease
 
 
 # Travis allows caching of data between builds to reduce build times or perform

--- a/.travis/BuildLinux.sh
+++ b/.travis/BuildLinux.sh
@@ -57,12 +57,22 @@ if [ -z "${RUN_CLANG_TIDY}" ] \
     && [ -z "${RUN_IWYU}" ] \
     && [ -z "${BUILD_DOC}" ]; then
     if [[ ${TRAVIS_BUILD_STAGE_NAME} = "Build libraries" ]]; then
-        time make libs test-libs-stage1 -j2
+        time make libs -j2
+        time make test-libs-domain -j2
+        time make test-libs-elliptic -j2
+        time make test-libs-evolution -j2
+        time make test-libs-numerical-algorithms -j2
+    fi
+
+    if [[ ${TRAVIS_BUILD_STAGE_NAME} = "Build test libraries" ]]; then
+        time make test-libs-data-structures -j2
+        time make test-libs-pointwise-functions -j2
+        time make test-libs-other -j2
+        time make -j2
     fi
 
     if [[ ${TRAVIS_BUILD_STAGE_NAME} = \
-          "Build and run tests, clangtidy, iwyu, and doxygen" ]]; then
-        time make -j2
+          "Build executables, run tests, clangtidy, iwyu, and doxygen" ]]; then
         # Build major executables in serial to avoid hitting memory limits.
         time make test-executables -j1
         time ctest --output-on-failure -j2
@@ -79,7 +89,7 @@ if [ -z "${RUN_CLANG_TIDY}" ] \
             fi
         fi
     fi
-    time ccache -s
+    ccache -s
 fi
 
 # Build documentation and doc coverage and deploy to GitHub pages.

--- a/cmake/SetupBuildStageTargets.cmake
+++ b/cmake/SetupBuildStageTargets.cmake
@@ -6,14 +6,30 @@
 # Generate a list of all the Test_ libraries
 get_target_property(LIBS_TO_LINK RunTests LINK_LIBRARIES)
 
-add_custom_target(test-libs-stage1)
-add_dependencies(test-libs-stage1
-  Test_ApparentHorizons
-  Test_ControlSystem
+add_custom_target(test-libs-data-structures)
+add_custom_target(test-libs-domain)
+add_custom_target(test-libs-elliptic)
+add_custom_target(test-libs-evolution)
+add_custom_target(test-libs-numerical-algorithms)
+add_custom_target(test-libs-pointwise-functions)
+add_custom_target(test-libs-other)
+
+add_dependencies(test-libs-data-structures
+  Test_DataStructures
+  Test_DataBox
+  Test_Tensor
+  Test_EagerMath
+  Test_Expressions
+  )
+
+add_dependencies(test-libs-domain
   Test_Domain
   Test_Amr
   Test_CoordinateMaps
   Test_DomainCreators
+  )
+
+add_dependencies(test-libs-elliptic
   Test_EllipticActions
   Test_EllipticDG
   Test_EllipticInitialization
@@ -21,7 +37,9 @@ add_dependencies(test-libs-stage1
   Test_Poisson
   Test_PoissonActions
   Test_Xcts
-  Test_ErrorHandling
+  )
+
+add_dependencies(test-libs-evolution
   Test_EvolutionActions
   Test_EvolutionConservative
   Test_EvolutionDiscontinuousGalerkin
@@ -38,8 +56,9 @@ add_dependencies(test-libs-stage1
   Test_Valencia
   Test_VariableFixing
   Test_ScalarWave
-  Test_IO
-  Test_Informer
+  )
+
+add_dependencies(test-libs-numerical-algorithms
   Test_Convergence
   Test_NumericalDiscontinuousGalerkin
   Test_NumericalFluxes
@@ -48,21 +67,37 @@ add_dependencies(test-libs-stage1
   Test_LinearOperators
   Test_LinearSolver
   Test_LinearSolverActions
-  Test_ConjugateGradientAlgorithm
-  Test_DistributedConjugateGradientAlgorithm
   Test_ConjugateGradient
-  Test_DistributedGmresAlgorithm
-  Test_GmresAlgorithm
   Test_Gmres
   Test_RootFinding
   Test_Spectral
-  Test_Options
+  )
+
+add_dependencies(test-libs-pointwise-functions
+  Test_GrMhdAnalyticData
   Test_BurgersSolutions
+  Test_ElasticitySolutions
+  Test_GeneralRelativitySolutions
+  Test_GrMhdSolutions
   Test_NewtonianEulerSolutions
   Test_PoissonSolutions
+  Test_M1GreySolutions
+  Test_RelativisticEulerSolutions
   Test_WaveEquation
+  Test_XctsSolutions
+  Test_ConstitutiveRelations
   Test_GeneralRelativity
+  Test_Hydro
   Test_MathFunctions
+  )
+
+add_dependencies(test-libs-other
+  Test_ApparentHorizons
+  Test_ControlSystem
+  Test_ErrorHandling
+  Test_IO
+  Test_Informer
+  Test_Options
   Test_Pypp
   Test_TestUtilities
   Test_Time


### PR DESCRIPTION
## Proposed changes

Need to use three stages instead of two to avoid timeouts

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
