### PR TITLE
Speed up GH.ConstraintComputeTags test

### DIFF
--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -1207,19 +1207,16 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.ConstraintEnergy",
       std::numeric_limits<double>::signaling_NaN());
 }
 
-// [[TimeOut, 9]]
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.GeneralizedHarmonic.ConstraintComputeTags",
     "[Unit][Evolution]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{
-      "Evolution/Systems/GeneralizedHarmonic/"};
   // Test the F constraint against Kerr Schild
   const double mass = 1.4;
   const std::array<double, 3> dimensionless_spin{{0.4, 0.3, 0.2}};
   const std::array<double, 3> center{{0.2, 0.3, 0.4}};
   const gr::Solutions::KerrSchild solution(mass, dimensionless_spin, center);
 
-  const size_t grid_size = 8;
+  const size_t grid_size = 3;
   const std::array<double, 3> upper_bound{{0.82, 1.24, 1.32}};
   const std::array<double, 3> lower_bound{{0.8, 1.22, 1.30}};
 


### PR DESCRIPTION
pypp::SetupLocalPythonEnvironment takes about 0.1 seconds and was
unnecessary.

The test is checking that the free functions and compute items give
the same results.  There is no need to compute these results to high
accuracy.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
