### PR TITLE
Fix script that builds docs for a PR

### DIFF
--- a/tools/pr-docs
+++ b/tools/pr-docs
@@ -25,7 +25,7 @@ pr=$1
 outdir=$2
 
 # Linux || OSX
-tmpdir=$(mktemp -d --tmpdir 2>/dev/null || mkdir -d -t spectre-doc)
+tmpdir=$(mktemp -d --tmpdir 2>/dev/null || mktemp -d -t spectre-doc)
 trap 'rm -rf "${tmpdir}"' EXIT
 
 spectre=$(git rev-parse --show-toplevel 2>/dev/null) || {


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
