### PR TITLE
Add Python Wrapper to Access Build Info Available Before Linking

### DIFF
--- a/cmake/SetupBuildInfo.cmake
+++ b/cmake/SetupBuildInfo.cmake
@@ -4,8 +4,14 @@
 find_package(Git REQUIRED)
 
 configure_file(
-  ${CMAKE_SOURCE_DIR}/src/Informer/InfoFromBuild.cpp
-  ${CMAKE_BINARY_DIR}/Informer/InfoFromBuild.cpp
+  ${CMAKE_SOURCE_DIR}/src/Informer/InfoAtLink.cpp
+  ${CMAKE_BINARY_DIR}/Informer/InfoAtLink.cpp
+  )
+# Configure info from build to give access to unit test path,
+# SpECTRE version, etc. (things known at CMake time)
+configure_file(
+  ${CMAKE_SOURCE_DIR}/src/Informer/InfoAtCompile.cpp
+  ${CMAKE_BINARY_DIR}/Informer/InfoAtCompile.cpp
   )
 
 # APPLE instead of ${APPLE} is intentional

--- a/src/Executables/Examples/HelloWorldNoCharm/CMakeLists.txt
+++ b/src/Executables/Examples/HelloWorldNoCharm/CMakeLists.txt
@@ -12,6 +12,7 @@ add_spectre_executable(
 target_link_libraries(
   ${EXECUTABLE}
   DataStructures
+  Informer
   ${YAMLCPP_LIBRARIES}
   )
 

--- a/src/Executables/ParallelInfo/CMakeLists.txt
+++ b/src/Executables/ParallelInfo/CMakeLists.txt
@@ -24,4 +24,5 @@ add_dependencies(
 target_link_libraries(
   ${EXECUTABLE}
   ErrorHandling
+  Informer
   )

--- a/src/Informer/CMakeLists.txt
+++ b/src/Informer/CMakeLists.txt
@@ -5,7 +5,9 @@ set(LIBRARY Informer)
 
 set(LIBRARY_SOURCES
     Informer.cpp
-    Verbosity.cpp)
+    Verbosity.cpp
+    ${CMAKE_BINARY_DIR}/Informer/InfoAtCompile.cpp
+    )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
@@ -13,3 +15,7 @@ target_link_libraries(
   ${LIBRARY}
   INTERFACE ErrorHandling
   )
+
+if(BUILD_PYTHON_BINDINGS)
+  add_subdirectory(Python)
+endif()

--- a/src/Informer/InfoAtCompile.cpp
+++ b/src/Informer/InfoAtCompile.cpp
@@ -1,0 +1,16 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "@CMAKE_SOURCE_DIR@/src/Informer/InfoFromBuild.hpp"
+
+std::string spectre_version() { return std::string("@SpECTRE_VERSION@"); }
+
+int spectre_major_version() { return @SpECTRE_VERSION_MAJOR@; }
+
+int spectre_minor_version() { return @SpECTRE_VERSION_MINOR@; }
+
+int spectre_patch_version() { return @SpECTRE_VERSION_PATCH@; }
+
+std::string unit_test_path() noexcept {
+  return "@CMAKE_SOURCE_DIR@/tests/Unit/";
+}

--- a/src/Informer/InfoAtLink.cpp
+++ b/src/Informer/InfoAtLink.cpp
@@ -16,14 +16,6 @@ std::string git_commit_hash() {
 std::string git_branch() { return std::string(BOOST_PP_STRINGIZE(GIT_BRANCH)); }
 }  // namespace
 
-std::string spectre_version() { return std::string("@SpECTRE_VERSION@"); }
-
-int spectre_major_version() { return @SpECTRE_VERSION_MAJOR@; }
-
-int spectre_minor_version() { return @SpECTRE_VERSION_MINOR@; }
-
-int spectre_patch_version() { return @SpECTRE_VERSION_PATCH@; }
-
 std::string info_from_build() {
   static const std::string info = [] {
     std::ostringstream os;
@@ -38,8 +30,4 @@ std::string info_from_build() {
     return os.str();
   }();
   return info;
-}
-
-std::string unit_test_path() noexcept {
-  return "@CMAKE_SOURCE_DIR@/tests/Unit/";
 }

--- a/src/Informer/Python/Bindings.cpp
+++ b/src/Informer/Python/Bindings.cpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <boost/python.hpp>
+
+namespace py_bindings {
+void bind_info_at_compile();
+}  // namespace py_bindings
+
+BOOST_PYTHON_MODULE(_Informer) {
+  Py_Initialize();
+  py_bindings::bind_info_at_compile();
+}

--- a/src/Informer/Python/CMakeLists.txt
+++ b/src/Informer/Python/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PyInformer")
+
+spectre_python_add_module(
+  Informer
+  SOURCES
+  Bindings.cpp
+  InfoAtCompile.cpp
+)
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC Informer
+  ${SPECTRE_LINK_PYBINDINGS}
+  )

--- a/src/Informer/Python/InfoAtCompile.cpp
+++ b/src/Informer/Python/InfoAtCompile.cpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <boost/python.hpp>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include "Informer/InfoFromBuild.hpp"
+#include "Utilities/GetOutput.hpp"
+namespace bp = boost::python;
+
+namespace py_bindings {
+void bind_info_at_compile() {
+  // Wrapper to make Build Info available from python
+  bp::def("spectre_version", &spectre_version);
+  bp::def("spectre_major_version", &spectre_major_version);
+  bp::def("spectre_minor_version", &spectre_minor_version);
+  bp::def("spectre_patch_version", &spectre_patch_version);
+  bp::def("unit_test_path", &unit_test_path);
+}
+}  // namespace py_bindings

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -88,7 +88,7 @@ if(COVERAGE)
       TESTRUNNER_ARGS
       "--output-on-failure"
       IGNORE_COV
-      '${CMAKE_BINARY_DIR}/Informer/InfoFromBuild.cpp'
+      '${CMAKE_BINARY_DIR}/Informer/InfoAtLink.cpp'
       '${CMAKE_SOURCE_DIR}/tests/*'
   )
 endif()

--- a/tests/Unit/Informer/CMakeLists.txt
+++ b/tests/Unit/Informer/CMakeLists.txt
@@ -13,3 +13,7 @@ add_test_library(
   "${LIBRARY_SOURCES}"
   "Informer;Utilities"
   )
+spectre_add_python_test(
+  "Unit.Informer.Python"
+  "Test_InfoAtCompile.py"
+  "Unit;Informer;Python")

--- a/tests/Unit/Informer/Test_InfoAtCompile.py
+++ b/tests/Unit/Informer/Test_InfoAtCompile.py
@@ -1,0 +1,21 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre import Informer as Info
+import unittest
+
+
+class TestInformer(unittest.TestCase):
+    def test_spectre_version(self):
+        num_ver = str(Info.spectre_major_version()) + "." + \
+            str(Info.spectre_minor_version()) + "." + \
+            str(Info.spectre_patch_version())
+        self.assertEqual(num_ver, Info.spectre_version())
+    # The unit test path is unpredictable, but the last 12 characters must be
+    # '/tests/Unit/'
+    def test_unit_test_path(self):
+        self.assertEqual(Info.unit_test_path()[-12:], '/tests/Unit/')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -53,6 +53,7 @@ add_dependencies(
 target_link_libraries(
   Test_ConstGlobalCache
   ErrorHandling
+  Informer
   ${SPECTRE_LIBRARIES}
   )
 

--- a/tools/WrapLinker.sh
+++ b/tools/WrapLinker.sh
@@ -8,7 +8,7 @@ git_commit_hash=`@GIT_EXECUTABLE@ describe --abbrev=0 --always --tags`
 git_branch=`@GIT_EXECUTABLE@ rev-parse --abbrev-ref HEAD`
 popd >/dev/null
 
-# Create a copy of InfoFromBuild.cpp based on the output filename.
+# Create a copy of InfoAtLink.cpp based on the output filename.
 # When compiling an executable from a cpp file, charmc writes a
 # temporary file called ${basename}.o to the current directory, so we
 # need all the compilations that might run in parallel in one
@@ -24,22 +24,22 @@ if [ -z "${oindex}" ] ; then
 fi
 # Construct a filename from the next argument
 let ++oindex
-InfoFromBuild_file=@CMAKE_BINARY_DIR@/tmp/\
-$(basename "${!oindex}")_InfoFromBuild.cpp
-cp @CMAKE_BINARY_DIR@/Informer/InfoFromBuild.cpp "${InfoFromBuild_file}"
+InfoAtLink_file=@CMAKE_BINARY_DIR@/tmp/\
+$(basename "${!oindex}")_InfoAtLink.cpp
+cp @CMAKE_BINARY_DIR@/Informer/InfoAtLink.cpp "${InfoAtLink_file}"
 
 # Formaline through the linker doesn't work on macOS and since we won't
 # be doing production runs on macOS we disable it.
 if [ -f @CMAKE_BINARY_DIR@/tmp/Formaline.sh ]; then
     . @CMAKE_BINARY_DIR@/tmp/Formaline.sh $(basename "${!oindex}")
     "$@" -DGIT_COMMIT_HASH=$git_commit_hash -DGIT_BRANCH=$git_branch \
-         "${InfoFromBuild_file}" "${formaline_output}" \
+         "${InfoAtLink_file}" "${formaline_output}" \
          ${formaline_object_output}
     rm ${formaline_output}
     rm ${formaline_object_output}
 else
     "$@" -DGIT_COMMIT_HASH=$git_commit_hash -DGIT_BRANCH=$git_branch \
-         "${InfoFromBuild_file}"
+         "${InfoAtLink_file}"
 fi
 
-rm ${InfoFromBuild_file}
+rm ${InfoAtLink_file}


### PR DESCRIPTION


## Proposed changes
This pull request splits the `InfoFromBuild.cpp` into two new `.cpp` files, `InfoFromBuild.cpp` and `MakeTimeInfoFromBuild.cpp` which distinguish between Information which is made available at link time, which cannot be linked into a library, and information which is available at CMake time, which can be (open for suggestions on naming improvements).  The `MakeTimeInfoFromBuild.cpp`, accessing info available after "cmaking" is then  compiled and linked into the library `Informer`, and the functions in it can then be given python wrappers which allow the cmake info to be accessed from python.   This information is important because 1: it allows python tests have access to the `unit_test_path()` function and 2:  in the future it will allow more transparency as the version of the `spectre` python modules will be available in python.  


### Types of changes:

- [ ] Bugfix
- [ x] New feature

### Component:

- [ x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
