### PR TITLE
Remove StrahlkorperGr::unit_normal_one_form()

### DIFF
--- a/src/ApparentHorizons/FastFlow.cpp
+++ b/src/ApparentHorizons/FastFlow.cpp
@@ -17,6 +17,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DivideBy.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "ErrorHandling/Error.hpp"
@@ -124,9 +125,9 @@ FastFlow::iterate_horizon_finder(
       magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame>>(box),
                 upper_spatial_metric);
   const DataVector one_over_one_form_magnitude = 1.0 / get(one_form_magnitude);
-  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
-      db::get<StrahlkorperTags::NormalOneForm<Frame>>(box),
-      one_over_one_form_magnitude);
+  const auto unit_normal_one_form =
+      divide_by(db::get<StrahlkorperTags::NormalOneForm<Frame>>(box),
+                get(one_form_magnitude));
   const auto inverse_surface_metric = StrahlkorperGr::inverse_surface_metric(
       raise_or_lower_index(unit_normal_one_form, upper_spatial_metric),
       upper_spatial_metric);

--- a/src/ApparentHorizons/StrahlkorperGr.cpp
+++ b/src/ApparentHorizons/StrahlkorperGr.cpp
@@ -360,17 +360,6 @@ double get_spin_magnitude(const std::array<DataVector, 3>& potentials,
 namespace StrahlkorperGr {
 
 template <typename Frame>
-tnsr::i<DataVector, 3, Frame> unit_normal_one_form(
-    const tnsr::i<DataVector, 3, Frame>& normal_one_form,
-    const DataVector& one_over_one_form_magnitude) noexcept {
-  auto unit_normal_one_form = normal_one_form;
-  for (size_t i = 0; i < 3; ++i) {
-    unit_normal_one_form.get(i) *= one_over_one_form_magnitude;
-  }
-  return unit_normal_one_form;
-}
-
-template <typename Frame>
 tnsr::ii<DataVector, 3, Frame> grad_unit_normal_one_form(
     const tnsr::i<DataVector, 3, Frame>& r_hat, const DataVector& radius,
     const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
@@ -696,11 +685,6 @@ double christodoulou_mass(const double dimensionful_spin_magnitude,
                                           (4.0 * square(irreducible_mass))));
 }
 }  // namespace StrahlkorperGr
-
-template tnsr::i<DataVector, 3, Frame::Inertial>
-StrahlkorperGr::unit_normal_one_form<Frame::Inertial>(
-    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_one_form,
-    const DataVector& one_over_one_form_magnitude) noexcept;
 
 template tnsr::ii<DataVector, 3, Frame::Inertial>
 StrahlkorperGr::grad_unit_normal_one_form<Frame::Inertial>(

--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -22,19 +22,6 @@ class Tensor;
 namespace StrahlkorperGr {
 
 /// \ingroup SurfacesGroup
-/// \brief Computes normalized unit normal one-form to a Strahlkorper.
-///
-/// \details The input argument `normal_one_form` \f$n_i\f$ is the
-/// unnormalized surface one-form; it depends on a Strahlkorper but
-/// not on a metric.  The input argument `one_over_one_form_magnitude`
-/// is \f$1/\sqrt{g^{ij}n_i n_j}\f$, which can be computed using (one
-/// over) the `magnitude` function.
-template <typename Frame>
-tnsr::i<DataVector, 3, Frame> unit_normal_one_form(
-    const tnsr::i<DataVector, 3, Frame>& normal_one_form,
-    const DataVector& one_over_one_form_magnitude) noexcept;
-
-/// \ingroup SurfacesGroup
 /// \brief Computes 3-covariant gradient \f$D_i S_j\f$ of a
 /// Strahlkorper's normal.
 ///

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -17,6 +17,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/DivideBy.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"   // IWYU prgma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -68,13 +69,13 @@ void test_expansion(const Solution& solution,
   const auto inverse_spatial_metric =
       determinant_and_inverse(spatial_metric).second;
 
-  const DataVector one_over_one_form_magnitude =
-      1.0 / get(magnitude(
-                db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+  const DataVector one_form_magnitude = get(
+      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
                 inverse_spatial_metric));
-  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
-      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-      one_over_one_form_magnitude);
+  const DataVector one_over_one_form_magnitude = 1.0 / one_form_magnitude;
+  const auto unit_normal_one_form =
+      divide_by(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                one_form_magnitude);
   const auto grad_unit_normal_one_form =
       StrahlkorperGr::grad_unit_normal_one_form(
           db::get<StrahlkorperTags::Rhat<Frame::Inertial>>(box),
@@ -136,13 +137,13 @@ void test_minkowski() {
               tmpl::list<gr::Tags::InverseSpatialMetric<3, Frame::Inertial,
                                                         DataVector>>{}));
 
-  const DataVector one_over_one_form_magnitude =
-      1.0 / get(magnitude(
-                db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+  const DataVector one_form_magnitude = get(
+      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
                 inverse_spatial_metric));
-  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
-      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-      one_over_one_form_magnitude);
+  const DataVector one_over_one_form_magnitude = 1.0 / one_form_magnitude;
+  const auto unit_normal_one_form =
+      divide_by(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                one_form_magnitude);
   const auto grad_unit_normal_one_form =
       StrahlkorperGr::grad_unit_normal_one_form(
           db::get<StrahlkorperTags::Rhat<Frame::Inertial>>(box),
@@ -192,13 +193,13 @@ void test_ricci_scalar(const Solution& solution,
   const auto inverse_spatial_metric =
       determinant_and_inverse(spatial_metric).second;
 
-  const DataVector one_over_one_form_magnitude =
-      1.0 / get(magnitude(
-                db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+  const DataVector one_form_magnitude = get(
+      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
                 inverse_spatial_metric));
-  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
-      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-      one_over_one_form_magnitude);
+  const DataVector one_over_one_form_magnitude = 1.0 / one_form_magnitude;
+  const auto unit_normal_one_form =
+      divide_by(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                one_form_magnitude);
   const auto grad_unit_normal_one_form =
       StrahlkorperGr::grad_unit_normal_one_form(
           db::get<StrahlkorperTags::Rhat<Frame::Inertial>>(box),
@@ -470,13 +471,14 @@ void test_spin_function(const Solution& solution,
 
   const auto& normal_one_form =
       db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box);
-  const DataVector one_over_one_form_magnitude =
-      1.0 / get(magnitude(
-                db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+
+  const DataVector one_form_magnitude = get(
+      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
                 inverse_spatial_metric));
-  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
-      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-      one_over_one_form_magnitude);
+  const DataVector one_over_one_form_magnitude = 1.0 / one_form_magnitude;
+  const auto unit_normal_one_form =
+      divide_by(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                one_form_magnitude);
   const auto unit_normal_vector =
       raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
 
@@ -543,13 +545,13 @@ void test_dimensionful_spin_magnitude(
 
   const auto& normal_one_form =
       db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box);
-  const DataVector one_over_one_form_magnitude =
-      1.0 / get(magnitude(
-                db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+  const DataVector one_form_magnitude = get(
+      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
                 inverse_spatial_metric));
-  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
-      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-      one_over_one_form_magnitude);
+  const DataVector one_over_one_form_magnitude = 1.0 / one_form_magnitude;
+  const auto unit_normal_one_form =
+      divide_by(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                one_form_magnitude);
   const auto unit_normal_vector =
       raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
 
@@ -628,13 +630,13 @@ void test_spin_vector(
 
   const auto& normal_one_form =
       db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box);
-  const DataVector one_over_one_form_magnitude =
-      1.0 / get(magnitude(
-                db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+  const DataVector one_form_magnitude = get(
+      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
                 inverse_spatial_metric));
-  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
-      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-      one_over_one_form_magnitude);
+  const DataVector one_over_one_form_magnitude = 1.0 / one_form_magnitude;
+  const auto unit_normal_one_form =
+      divide_by(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                one_form_magnitude);
   const auto unit_normal_vector =
       raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
 


### PR DESCRIPTION
## Proposed changes

StrahlkorperGr::unit_normal_one_form() simply divides a one form by its magnitude, but DataStructures/Tensor/EagerMath/DivideBy.hpp does the same thing more generically.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->