### PR TITLE
Fix linear solvers for PDALs

### DIFF
--- a/cmake/SetupBuildStageTargets.cmake
+++ b/cmake/SetupBuildStageTargets.cmake
@@ -67,8 +67,8 @@ add_dependencies(test-libs-numerical-algorithms
   Test_LinearOperators
   Test_LinearSolver
   Test_LinearSolverActions
-  # Test_ConjugateGradient
-  # Test_Gmres
+  Test_ConjugateGradient
+  Test_Gmres
   Test_RootFinding
   Test_Spectral
   )

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -939,7 +939,18 @@ constexpr DataBox<tmpl::list<Tags...>>::DataBox(
   merge_old_box(std::forward<Box>(old_box), tmpl::list<KeepTags...>{});
 
   // Add in new simple and compute tags
+
+// Silence "maybe-uninitialized" warning for GCC-6. The warning only occurs in
+// Release mode.
+// Note that clang also defines `__GNUC__`, so we need to exclude it.
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 7
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 7
   std::tuple<Args...> args_tuple(std::forward<Args>(args)...);
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 7
+#pragma GCC diagnostic pop
+#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 7
   add_items_to_box<tmpl::list<Tags...>>(
       args_tuple, tmpl::list<AddTags...>{},
       std::make_index_sequence<sizeof...(AddTags)>{},

--- a/src/IO/Observer/Actions.hpp
+++ b/src/IO/Observer/Actions.hpp
@@ -298,13 +298,36 @@ struct RegisterWithObservers {
  *```
  *
  */
+template <typename RegisterHelper>
 struct RegisterSingletonWithObserverWriter {
-  template <typename ParallelComponent, typename DbTagList,
-            typename Metavariables, typename ArrayIndex>
-  static void apply(const db::DataBox<DbTagList>& /*box*/,
-                    Parallel::ConstGlobalCache<Metavariables>& cache,
-                    const ArrayIndex& /*array_index*/,
-                    const observers::ObservationId& observation_id) noexcept {
+  template <typename DbTagList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagList>&&, bool> apply(
+      db::DataBox<DbTagList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    std::pair<observers::TypeOfObservation, observers::ObservationId>
+        type_of_observation_and_observation_id_pair =
+            RegisterHelper::template register_info<ParallelComponent>(
+                box, array_index);
+
+    switch (type_of_observation_and_observation_id_pair.first) {
+      case TypeOfObservation::Reduction:
+        break;
+      case TypeOfObservation::ReductionAndVolume:
+      case TypeOfObservation::Volume:
+        ERROR(
+            "Registering volume observations is not supported for singletons. "
+            "The TypeOfObservation should be 'Reduction'.");
+      default:
+        ERROR(
+            "Registering an unknown TypeOfObservation. It should be "
+            "'Reduction' for singleton.");
+    };
+
     // The actual value of the processing element doesn't matter
     // here; it is used only to give an ObserverWriter a count of how many
     // times it will be called.
@@ -316,7 +339,10 @@ struct RegisterSingletonWithObserverWriter {
         Actions::RegisterReductionContributorWithObserverWriter>(
         Parallel::get_parallel_component<
             observers::ObserverWriter<Metavariables>>(cache)[0],
-        observation_id, fake_processing_element);
+        std::move(                                                // NOLINT
+            type_of_observation_and_observation_id_pair.second),  // NOLINT
+        fake_processing_element);
+    return {std::move(box), true};
   }
 };
 }  // namespace Actions

--- a/src/IO/Observer/ObservationId.hpp
+++ b/src/IO/Observer/ObservationId.hpp
@@ -83,7 +83,8 @@ class ObservationId {
 };
 
 template <typename ObservationType>
-ObservationId::ObservationId(const double t, const ObservationType& /*meta*/,
+ObservationId::ObservationId(const double t,  // NOLINT
+                             const ObservationType& /*meta*/,
                              const std::string& observation_subtype) noexcept
     : observation_type_hash_(std::hash<std::string>{}(
           pretty_type::get_name<ObservationType>() + observation_subtype)),

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
@@ -36,16 +36,18 @@ namespace cg_detail {
 
 template <typename BroadcastTarget>
 struct InitializeResidual {
-  template <typename... DbTags, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent,
-            Requires<sizeof...(DbTags) != 0> = nullptr>
-  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
-                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+  template <
+      typename ParallelComponent, typename DbTagsList, typename Metavariables,
+      typename ArrayIndex,
+      Requires<tmpl::list_contains_v<
+          DbTagsList,
+          db::add_tag_prefix<LinearSolver::Tags::MagnitudeSquare,
+                             db::add_tag_prefix<LinearSolver::Tags::Residual,
+                                                typename Metavariables::system::
+                                                    fields_tag>>>> = nullptr>
+  static auto apply(db::DataBox<DbTagsList>& box,
                     Parallel::ConstGlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,
-                    const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/,
                     const double residual_square) noexcept {
     using fields_tag = typename Metavariables::system::fields_tag;
     using residual_square_tag = db::add_tag_prefix<
@@ -95,16 +97,18 @@ struct InitializeResidual {
 
 template <typename BroadcastTarget>
 struct ComputeAlpha {
-  template <typename... DbTags, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent,
-            Requires<sizeof...(DbTags) != 0> = nullptr>
-  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
-                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+  template <
+      typename ParallelComponent, typename DbTagsList, typename Metavariables,
+      typename ArrayIndex,
+      Requires<tmpl::list_contains_v<
+          DbTagsList,
+          db::add_tag_prefix<LinearSolver::Tags::MagnitudeSquare,
+                             db::add_tag_prefix<LinearSolver::Tags::Residual,
+                                                typename Metavariables::system::
+                                                    fields_tag>>>> = nullptr>
+  static auto apply(db::DataBox<DbTagsList>& box,
                     Parallel::ConstGlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,
-                    const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/,
                     const double conj_grad_inner_product) noexcept {
     using fields_tag = typename Metavariables::system::fields_tag;
     using residual_square_tag = db::add_tag_prefix<
@@ -119,16 +123,18 @@ struct ComputeAlpha {
 
 template <typename BroadcastTarget>
 struct UpdateResidual {
-  template <typename... DbTags, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent,
-            Requires<sizeof...(DbTags) != 0> = nullptr>
-  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
-                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+  template <
+      typename ParallelComponent, typename DbTagsList, typename Metavariables,
+      typename ArrayIndex,
+      Requires<tmpl::list_contains_v<
+          DbTagsList,
+          db::add_tag_prefix<LinearSolver::Tags::MagnitudeSquare,
+                             db::add_tag_prefix<LinearSolver::Tags::Residual,
+                                                typename Metavariables::system::
+                                                    fields_tag>>>> = nullptr>
+  static auto apply(db::DataBox<DbTagsList>& box,
                     Parallel::ConstGlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,
-                    const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/,
                     const double residual_square) noexcept {
     using fields_tag = typename Metavariables::system::fields_tag;
     using residual_square_tag = db::add_tag_prefix<

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/ElementActions.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/ElementActions.hpp
@@ -37,11 +37,13 @@ namespace gmres_detail {
 
 struct NormalizeInitialOperand {
   template <
-      typename ParallelComponent, typename DbTagsList, typename Metavariables,
+      typename ParallelComponent, typename DataBox, typename Metavariables,
       typename ArrayIndex,
-      Requires<tmpl::list_contains_v<
-          DbTagsList, typename Metavariables::system::fields_tag>> = nullptr>
-  static void apply(db::DataBox<DbTagsList>& box,
+      Requires<db::tag_is_retrievable_v<
+                   typename Metavariables::system::fields_tag, DataBox> and
+               db::tag_is_retrievable_v<LinearSolver::Tags::HasConverged,
+                                        DataBox>> = nullptr>
+  static void apply(DataBox& box,
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     const double residual_magnitude,
@@ -70,14 +72,17 @@ struct NormalizeInitialOperand {
 };
 
 struct PerformStep {
-  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+  template <typename DataBox, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
-  static auto apply(db::DataBox<DbTagsList>& box,
-                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    const Parallel::ConstGlobalCache<Metavariables>& cache,
-                    const ArrayIndex& array_index, const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/) noexcept {
+  static std::tuple<DataBox&&, bool> apply(
+      DataBox& box, const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index,
+      // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
+      const ActionList /*meta*/,
+      // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
+      const ParallelComponent* const /*meta*/) noexcept {
     using fields_tag = typename Metavariables::system::fields_tag;
     using operand_tag =
         db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
@@ -103,17 +108,19 @@ struct PerformStep {
         Parallel::get_parallel_component<ResidualMonitor<Metavariables>>(
             cache));
 
-    return std::tuple<db::DataBox<DbTagsList>&&, bool>(std::move(box), true);
+    return {std::move(box), true};
   }
 };
 
 struct OrthogonalizeOperand {
   template <
-      typename ParallelComponent, typename DbTagsList, typename Metavariables,
+      typename ParallelComponent, typename DataBox, typename Metavariables,
       typename ArrayIndex,
-      Requires<tmpl::list_contains_v<
-          DbTagsList, typename Metavariables::system::fields_tag>> = nullptr>
-  static void apply(db::DataBox<DbTagsList>& box,
+      Requires<db::tag_is_retrievable_v<
+                   typename Metavariables::system::fields_tag, DataBox> and
+               db::tag_is_retrievable_v<LinearSolver::Tags::HasConverged,
+                                        DataBox>> = nullptr>
+  static void apply(DataBox& box,
                     const Parallel::ConstGlobalCache<Metavariables>& cache,
                     const ArrayIndex& array_index,
                     const double orthogonalization) noexcept {
@@ -172,11 +179,13 @@ struct OrthogonalizeOperand {
 
 struct NormalizeOperandAndUpdateField {
   template <
-      typename ParallelComponent, typename DbTagsList, typename Metavariables,
+      typename ParallelComponent, typename DataBox, typename Metavariables,
       typename ArrayIndex,
-      Requires<tmpl::list_contains_v<
-          DbTagsList, typename Metavariables::system::fields_tag>> = nullptr>
-  static void apply(db::DataBox<DbTagsList>& box,
+      Requires<db::tag_is_retrievable_v<
+                   typename Metavariables::system::fields_tag, DataBox> and
+               db::tag_is_retrievable_v<LinearSolver::Tags::HasConverged,
+                                        DataBox>> = nullptr>
+  static void apply(DataBox& box,
                     Parallel::ConstGlobalCache<Metavariables>& cache,
                     const ArrayIndex& array_index, const double normalization,
                     const DenseVector<double>& minres,
@@ -228,14 +237,8 @@ struct NormalizeOperandAndUpdateField {
         get<initial_fields_tag>(box));
 
     // Proceed with algorithm
-    // We use `ckLocal()` here since this is essentially retrieving "self",
-    // which is guaranteed to be on the local processor. This ensures the calls
-    // are evaluated in order.
     Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
-        .ckLocal()
-        ->set_terminate(false);
-    Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
-        .perform_algorithm();
+        .perform_algorithm(true);
   }
 };
 

--- a/src/NumericalAlgorithms/LinearSolver/Observe.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Observe.hpp
@@ -7,6 +7,7 @@
 #include "IO/Observer/ObservationId.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/ReductionActions.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
 #include "NumericalAlgorithms/LinearSolver/Tags.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Info.hpp"
@@ -23,6 +24,20 @@ using reduction_data = Parallel::ReductionData<
     Parallel::ReductionDatum<double, funcl::AssertEqual<>>>;
 
 struct ObservationType {};
+
+struct Registration {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename ArrayIndex>
+  static std::pair<observers::TypeOfObservation, observers::ObservationId>
+  register_info(const db::DataBox<DbTagsList>& /*box*/,
+                const ArrayIndex& /*array_index*/) noexcept {
+    observers::ObservationId fake_initial_observation_id{0., ObservationType{}};
+    return {
+        observers::TypeOfObservation::Reduction,
+        std::move(fake_initial_observation_id)  // NOLINT
+    };
+  }
+};
 
 /*!
  * \brief Contributes data from the residual monitor to the reduction observer

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -1127,6 +1127,7 @@ class MockArrayElementProxy {
   // Actions may call this, but since tests step through actions manually it has
   // no effect.
   void perform_algorithm() noexcept {}
+  void perform_algorithm(const bool /*restart_if_terminated*/) noexcept {}
 
   MockDistributedObject<Component>* ckLocal() { return &local_algorithm_; }
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
@@ -1,67 +1,67 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# set(LIBRARY "Test_ConjugateGradient")
+set(LIBRARY "Test_ConjugateGradient")
 
-# set(LIBRARY_SOURCES
-#   Test_ElementActions.cpp
-#   Test_ResidualMonitorActions.cpp
-#   )
+set(LIBRARY_SOURCES
+  Test_ElementActions.cpp
+  Test_ResidualMonitorActions.cpp
+  )
 
-# add_test_library(
-#   ${LIBRARY}
-#   "NumericalAlgorithms/LinearSolver/ConjugateGradient"
-#   "${LIBRARY_SOURCES}"
-#   "Convergence;DataStructures;IO"
-#   )
+add_test_library(
+  ${LIBRARY}
+  "NumericalAlgorithms/LinearSolver/ConjugateGradient"
+  "${LIBRARY_SOURCES}"
+  "Convergence;DataStructures;IO"
+  )
 
-# add_dependencies(
-#   ${LIBRARY}
-#   module_ConstGlobalCache
-#   )
+add_dependencies(
+  ${LIBRARY}
+  module_ConstGlobalCache
+  )
 
-# # This code is adapted from Parallel/CMakeLists.txt
+# This code is adapted from Parallel/CMakeLists.txt
 
-# function(add_algorithm_test TEST_NAME)
-#   set(EXECUTABLE_NAME Test_${TEST_NAME})
-#   set(TEST_IDENTIFIER Integration.LinearSolver.${TEST_NAME})
+function(add_algorithm_test TEST_NAME)
+  set(EXECUTABLE_NAME Test_${TEST_NAME})
+  set(TEST_IDENTIFIER Integration.LinearSolver.${TEST_NAME})
 
-#   add_spectre_executable(
-#     ${EXECUTABLE_NAME}
-#     ${EXECUTABLE_NAME}.cpp
-#     )
+  add_spectre_executable(
+    ${EXECUTABLE_NAME}
+    ${EXECUTABLE_NAME}.cpp
+    )
 
-#   add_dependencies(
-#     ${EXECUTABLE_NAME}
-#     module_ConstGlobalCache
-#     module_Main
-#     )
+  add_dependencies(
+    ${EXECUTABLE_NAME}
+    module_ConstGlobalCache
+    module_Main
+    )
 
-#   target_link_libraries(
-#     ${EXECUTABLE_NAME}
-#     Convergence
-#     DataStructures
-#     ErrorHandling
-#     Informer
-#     IO
-#     ${SPECTRE_LIBRARIES}
-#     )
+  target_link_libraries(
+    ${EXECUTABLE_NAME}
+    Convergence
+    DataStructures
+    ErrorHandling
+    Informer
+    IO
+    ${SPECTRE_LIBRARIES}
+    )
 
-#   add_dependencies(test-executables ${EXECUTABLE_NAME})
+  add_dependencies(test-executables ${EXECUTABLE_NAME})
 
-#   add_test(
-#     NAME "\"${TEST_IDENTIFIER}\""
-#     COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file
-#     ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}.yaml
-#     )
+  add_test(
+    NAME "\"${TEST_IDENTIFIER}\""
+    COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file
+    ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}.yaml
+    )
 
-#   set_tests_properties(
-#     "\"${TEST_IDENTIFIER}\""
-#     PROPERTIES
-#     TIMEOUT 5
-#     LABELS "integration"
-#     ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
-# endfunction()
+  set_tests_properties(
+    "\"${TEST_IDENTIFIER}\""
+    PROPERTIES
+    TIMEOUT 5
+    LABELS "integration"
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+endfunction()
 
-# add_algorithm_test("ConjugateGradientAlgorithm")
-# add_algorithm_test("DistributedConjugateGradientAlgorithm")
+add_algorithm_test("ConjugateGradientAlgorithm")
+add_algorithm_test("DistributedConjugateGradientAlgorithm")

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
@@ -40,6 +40,7 @@ struct Metavariables {
 
   enum class Phase {
     Initialization,
+    RegisterWithObserver,
     PerformLinearSolve,
     TestResult,
     CleanOutput,
@@ -52,6 +53,8 @@ struct Metavariables {
           Metavariables>& /*cache_proxy*/) noexcept {
     switch (current_phase) {
       case Phase::Initialization:
+        return Phase::RegisterWithObserver;
+      case Phase::RegisterWithObserver:
         return Phase::PerformLinearSolve;
       case Phase::PerformLinearSolve:
         return Phase::TestResult;

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
@@ -33,9 +33,6 @@ struct Metavariables {
                    typename linear_solver::component_list>;
   using const_global_cache_tag_list = tmpl::list<>;
 
-  struct ObservationType {};
-  using element_observation_type = ObservationType;
-
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;
 
@@ -46,6 +43,7 @@ struct Metavariables {
 
   enum class Phase {
     Initialization,
+    RegisterWithObserver,
     PerformLinearSolve,
     TestResult,
     CleanOutput,
@@ -58,6 +56,8 @@ struct Metavariables {
           Metavariables>& /*cache_proxy*/) noexcept {
     switch (current_phase) {
       case Phase::Initialization:
+        return Phase::RegisterWithObserver;
+      case Phase::RegisterWithObserver:
         return Phase::PerformLinearSolve;
       case Phase::PerformLinearSolve:
         return Phase::TestResult;

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/CMakeLists.txt
@@ -1,67 +1,67 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# set(LIBRARY "Test_Gmres")
+set(LIBRARY "Test_Gmres")
 
-# set(LIBRARY_SOURCES
-#   Test_ElementActions.cpp
-#   Test_ResidualMonitorActions.cpp
-#   )
+set(LIBRARY_SOURCES
+  Test_ElementActions.cpp
+  Test_ResidualMonitorActions.cpp
+  )
 
-# add_test_library(
-#   ${LIBRARY}
-#   "NumericalAlgorithms/LinearSolver/Gmres"
-#   "${LIBRARY_SOURCES}"
-#   "Convergence;DataStructures;IO"
-#   )
+add_test_library(
+  ${LIBRARY}
+  "NumericalAlgorithms/LinearSolver/Gmres"
+  "${LIBRARY_SOURCES}"
+  "Convergence;DataStructures;IO"
+  )
 
-# add_dependencies(
-#   ${LIBRARY}
-#   module_ConstGlobalCache
-#   )
+add_dependencies(
+  ${LIBRARY}
+  module_ConstGlobalCache
+  )
 
-# # This code is adapted from Parallel/CMakeLists.txt
+# This code is adapted from Parallel/CMakeLists.txt
 
-# function(add_algorithm_test TEST_NAME)
-#   set(EXECUTABLE_NAME Test_${TEST_NAME})
-#   set(TEST_IDENTIFIER Integration.LinearSolver.${TEST_NAME})
+function(add_algorithm_test TEST_NAME)
+  set(EXECUTABLE_NAME Test_${TEST_NAME})
+  set(TEST_IDENTIFIER Integration.LinearSolver.${TEST_NAME})
 
-#   add_spectre_executable(
-#     ${EXECUTABLE_NAME}
-#     ${EXECUTABLE_NAME}.cpp
-#     )
+  add_spectre_executable(
+    ${EXECUTABLE_NAME}
+    ${EXECUTABLE_NAME}.cpp
+    )
 
-#   add_dependencies(
-#     ${EXECUTABLE_NAME}
-#     module_ConstGlobalCache
-#     module_Main
-#     )
+  add_dependencies(
+    ${EXECUTABLE_NAME}
+    module_ConstGlobalCache
+    module_Main
+    )
 
-#   target_link_libraries(
-#     ${EXECUTABLE_NAME}
-#     Convergence
-#     DataStructures
-#     ErrorHandling
-#     Informer
-#     IO
-#     ${SPECTRE_LIBRARIES}
-#     )
+  target_link_libraries(
+    ${EXECUTABLE_NAME}
+    Convergence
+    DataStructures
+    ErrorHandling
+    Informer
+    IO
+    ${SPECTRE_LIBRARIES}
+    )
 
-#   add_dependencies(test-executables ${EXECUTABLE_NAME})
+  add_dependencies(test-executables ${EXECUTABLE_NAME})
 
-#   add_test(
-#     NAME "\"${TEST_IDENTIFIER}\""
-#     COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file
-#     ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}.yaml
-#     )
+  add_test(
+    NAME "\"${TEST_IDENTIFIER}\""
+    COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file
+    ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}.yaml
+    )
 
-#   set_tests_properties(
-#     "\"${TEST_IDENTIFIER}\""
-#     PROPERTIES
-#     TIMEOUT 5
-#     LABELS "integration"
-#     ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
-# endfunction()
+  set_tests_properties(
+    "\"${TEST_IDENTIFIER}\""
+    PROPERTIES
+    TIMEOUT 5
+    LABELS "integration"
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+endfunction()
 
-# add_algorithm_test("GmresAlgorithm")
-# add_algorithm_test("DistributedGmresAlgorithm")
+add_algorithm_test("GmresAlgorithm")
+add_algorithm_test("DistributedGmresAlgorithm")

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
@@ -33,9 +33,6 @@ struct Metavariables {
                    typename linear_solver::component_list>;
   using const_global_cache_tag_list = tmpl::list<>;
 
-  struct ObservationType {};
-  using element_observation_type = ObservationType;
-
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;
 
@@ -45,6 +42,7 @@ struct Metavariables {
 
   enum class Phase {
     Initialization,
+    RegisterWithObserver,
     PerformLinearSolve,
     TestResult,
     CleanOutput,
@@ -57,6 +55,8 @@ struct Metavariables {
           Metavariables>& /*cache_proxy*/) noexcept {
     switch (current_phase) {
       case Phase::Initialization:
+        return Phase::RegisterWithObserver;
+      case Phase::RegisterWithObserver:
         return Phase::PerformLinearSolve;
       case Phase::PerformLinearSolve:
         return Phase::TestResult;

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
@@ -16,6 +16,7 @@
 #include "NumericalAlgorithms/LinearSolver/Gmres/ElementActions.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/LinearSolver/Gmres/InitializeElement.hpp"
 #include "NumericalAlgorithms/LinearSolver/Tags.hpp"  // IWYU pragma: keep
+#include "Parallel/AddOptionsToDataBox.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -40,21 +41,20 @@ using orthogonalization_iteration_id_tag =
 using basis_history_tag = LinearSolver::Tags::KrylovSubspaceBasis<VectorTag>;
 
 template <typename Metavariables>
-using element_tags =
-    tmpl::append<tmpl::list<VectorTag, operand_tag>,
-                 typename LinearSolver::gmres_detail::InitializeElement<
-                     Metavariables>::simple_tags,
-                 typename LinearSolver::gmres_detail::InitializeElement<
-                     Metavariables>::compute_tags>;
-
-template <typename Metavariables>
 struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
   using const_global_cache_tag_list = tmpl::list<>;
-  using action_list = tmpl::list<>;
-  using initial_databox = db::compute_databox_type<element_tags<Metavariables>>;
+  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<
+          tmpl::append<tmpl::list<VectorTag, operand_tag>,
+                       typename LinearSolver::gmres_detail::InitializeElement<
+                           Metavariables>::simple_tags>,
+          typename LinearSolver::gmres_detail::InitializeElement<
+              Metavariables>::compute_tags>>>>;
 };
 
 struct System {
@@ -65,45 +65,39 @@ struct Metavariables {
   using component_list = tmpl::list<ElementArray<Metavariables>>;
   using system = System;
   using const_global_cache_tag_list = tmpl::list<>;
+  enum class Phase { Initialization, Testing, Exit };
 };
 
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ElementActions",
                   "[Unit][NumericalAlgorithms][LinearSolver][Actions]") {
-  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using MockDistributedObjectsTag =
-      MockRuntimeSystem::MockDistributedObjectsTag<ElementArray<Metavariables>>;
+  using element_array = ElementArray<Metavariables>;
 
-  const int self_id{0};
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
 
-  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
-  tuples::get<MockDistributedObjectsTag>(dist_objects)
-      .emplace(
-          self_id,
-          db::create<
-              tmpl::append<tmpl::list<VectorTag, operand_tag>,
-                           typename LinearSolver::gmres_detail::
-                               InitializeElement<Metavariables>::simple_tags>,
-              typename LinearSolver::gmres_detail::InitializeElement<
-                  Metavariables>::compute_tags>(
-              DenseVector<double>(3, 0.), DenseVector<double>(3, 2.), 0_st,
-              0_st, DenseVector<double>(3, -1.), 0_st,
-              std::vector<DenseVector<double>>{DenseVector<double>(3, 0.5),
-                                               DenseVector<double>(3, 1.5)},
-              db::item_type<LinearSolver::Tags::HasConverged>{}));
-  MockRuntimeSystem runner{{}, std::move(dist_objects)};
-  const auto get_box = [&runner, &self_id]() -> decltype(auto) {
-    return runner.algorithms<ElementArray<Metavariables>>()
-        .at(self_id)
-        .get_databox<ElementArray<Metavariables>::initial_databox>();
+  // Setup mock element array
+  ActionTesting::emplace_component_and_initialize<element_array>(
+      make_not_null(&runner), 0,
+      {DenseVector<double>(3, 0.), DenseVector<double>(3, 2.), 0_st, 0_st,
+       DenseVector<double>(3, -1.), 0_st,
+       std::vector<DenseVector<double>>{DenseVector<double>(3, 0.5),
+                                        DenseVector<double>(3, 1.5)},
+       db::item_type<LinearSolver::Tags::HasConverged>{}});
+
+  // DataBox shortcuts
+  const auto get_tag = [&runner](auto tag_v) -> decltype(auto) {
+    using tag = std::decay_t<decltype(tag_v)>;
+    return ActionTesting::get_databox_tag<element_array, tag>(runner, 0);
   };
+
+  runner.set_phase(Metavariables::Phase::Testing);
+
   {
-    const auto& box = get_box();
-    CHECK(db::get<LinearSolver::Tags::IterationId>(box) == 0);
-    CHECK(db::get<initial_fields_tag>(box) == DenseVector<double>(3, -1.));
-    CHECK(db::get<operand_tag>(box) == DenseVector<double>(3, 2.));
-    CHECK(db::get<basis_history_tag>(box).size() == 2);
+    CHECK(get_tag(LinearSolver::Tags::IterationId{}) == 0);
+    CHECK(get_tag(initial_fields_tag{}) == DenseVector<double>(3, -1.));
+    CHECK(get_tag(operand_tag{}) == DenseVector<double>(3, 2.));
+    CHECK(get_tag(basis_history_tag{}).size() == 2);
   }
 
   // Can't test the other element actions because reductions are not yet
@@ -112,34 +106,30 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ElementActions",
   // `Test_DistributedGmresAlgorithm.cpp`.
 
   SECTION("NormalizeInitialOperand") {
-    runner.simple_action<ElementArray<Metavariables>,
-                         LinearSolver::gmres_detail::NormalizeInitialOperand>(
-        self_id, 4.,
+    ActionTesting::simple_action<
+        element_array, LinearSolver::gmres_detail::NormalizeInitialOperand>(
+        make_not_null(&runner), 0, 4.,
         db::item_type<LinearSolver::Tags::HasConverged>{
             {1, 0., 0.}, 1, 0., 0.});
-    const auto& box = get_box();
-    CHECK_ITERABLE_APPROX(db::get<operand_tag>(box),
-                          DenseVector<double>(3, 0.5));
-    CHECK(db::get<basis_history_tag>(box).size() == 3);
-    CHECK(db::get<basis_history_tag>(box)[2] == db::get<operand_tag>(box));
-    CHECK(db::get<LinearSolver::Tags::HasConverged>(box));
+    CHECK_ITERABLE_APPROX(get_tag(operand_tag{}), DenseVector<double>(3, 0.5));
+    CHECK(get_tag(basis_history_tag{}).size() == 3);
+    CHECK(get_tag(basis_history_tag{})[2] == get_tag(operand_tag{}));
+    CHECK(get_tag(LinearSolver::Tags::HasConverged{}));
   }
   SECTION("NormalizeOperandAndUpdateField") {
-    runner.simple_action<
-        ElementArray<Metavariables>,
+    ActionTesting::simple_action<
+        element_array,
         LinearSolver::gmres_detail::NormalizeOperandAndUpdateField>(
-        self_id, 4., DenseVector<double>{2., 4.},
+        make_not_null(&runner), 0, 4., DenseVector<double>{2., 4.},
         db::item_type<LinearSolver::Tags::HasConverged>{
             {1, 0., 0.}, 1, 0., 0.});
-    const auto& box = get_box();
-    CHECK(db::get<LinearSolver::Tags::IterationId>(box) == 1);
-    CHECK(db::get<orthogonalization_iteration_id_tag>(box) == 0);
-    CHECK_ITERABLE_APPROX(db::get<operand_tag>(box),
-                          DenseVector<double>(3, 0.5));
-    CHECK(db::get<basis_history_tag>(box).size() == 3);
-    CHECK(db::get<basis_history_tag>(box)[2] == db::get<operand_tag>(box));
+    CHECK(get_tag(LinearSolver::Tags::IterationId{}) == 1);
+    CHECK(get_tag(orthogonalization_iteration_id_tag{}) == 0);
+    CHECK_ITERABLE_APPROX(get_tag(operand_tag{}), DenseVector<double>(3, 0.5));
+    CHECK(get_tag(basis_history_tag{}).size() == 3);
+    CHECK(get_tag(basis_history_tag{})[2] == get_tag(operand_tag{}));
     // minres * basis_history - initial = 2 * 0.5 + 4 * 1.5 - 1 = 6
-    CHECK_ITERABLE_APPROX(db::get<VectorTag>(box), DenseVector<double>(3, 6.));
-    CHECK(db::get<LinearSolver::Tags::HasConverged>(box));
+    CHECK_ITERABLE_APPROX(get_tag(VectorTag{}), DenseVector<double>(3, 6.));
+    CHECK(get_tag(LinearSolver::Tags::HasConverged{}));
   }
 }

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
@@ -31,9 +31,6 @@ struct Metavariables {
                    typename linear_solver::component_list>;
   using const_global_cache_tag_list = tmpl::list<>;
 
-  struct ObservationType {};
-  using element_observation_type = ObservationType;
-
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;
 
@@ -43,6 +40,7 @@ struct Metavariables {
 
   enum class Phase {
     Initialization,
+    RegisterWithObserver,
     PerformLinearSolve,
     TestResult,
     CleanOutput,
@@ -55,6 +53,8 @@ struct Metavariables {
           Metavariables>& /*cache_proxy*/) noexcept {
     switch (current_phase) {
       case Phase::Initialization:
+        return Phase::RegisterWithObserver;
+      case Phase::RegisterWithObserver:
         return Phase::PerformLinearSolve;
       case Phase::PerformLinearSolve:
         return Phase::TestResult;

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ResidualMonitorActionsTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ResidualMonitorActionsTestHelpers.hpp
@@ -48,15 +48,14 @@ using observer_writer_tags =
                CheckReductionNamesTag, CheckReductionDataTag>;
 
 struct MockWriteReductionData {
-  template <typename... InboxTags, typename Metavariables, typename ActionList,
-            typename ParallelComponent, typename ArrayIndex,
-            typename... ReductionDatums>
-  static void apply(db::DataBox<observer_writer_tags>& box,  // NOLINT
-                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex,
+            typename... ReductionDatums,
+            Requires<tmpl::list_contains_v<DbTagsList, CheckObservationIdTag>> =
+                nullptr>
+  static void apply(db::DataBox<DbTagsList>& box,  // NOLINT
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
-                    const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/,
                     const gsl::not_null<CmiNodeLock*> /*node_lock*/,
                     const observers::ObservationId& observation_id,
                     const std::string& subfile_name,
@@ -89,9 +88,11 @@ struct MockObserverWriter {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
   using const_global_cache_tag_list = tmpl::list<>;
-  using action_list = tmpl::list<>;
+  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<observer_writer_tags>>>>;
   using component_being_mocked = observers::ObserverWriter<Metavariables>;
-  using initial_databox = db::compute_databox_type<observer_writer_tags>;
 
   using replace_these_threaded_actions =
       tmpl::list<observers::ThreadedActions::WriteReductionData>;


### PR DESCRIPTION
## Proposed changes

Re-enables the linear solver tests that were deferred from #1535.

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
