### PR TITLE
Add 1D data visualization tool

### DIFF
--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -35,6 +35,7 @@ installation_on_clusters "Installation on clusters" page.
 * [Python](https://www.python.org/) 2.7, or 3.5 or later
 * [NumPy](http://www.numpy.org/) 1.10 or later
 * [SciPy](https://www.scipy.org)
+* [matplotlib](https://matplotlib.org/)
 
 #### Optional:
 * [Pybind11](https://pybind11.readthedocs.io) for SpECTRE Python bindings

--- a/src/Visualization/Python/CMakeLists.txt
+++ b/src/Visualization/Python/CMakeLists.txt
@@ -7,9 +7,15 @@ spectre_python_add_module(
   Visualization
   PYTHON_FILES
   Visualization/Python/GenerateXdmf.py
+  Visualization/Python/Render1D.py
   )
 
 spectre_python_add_executable(
   GenerateXdmf
   Visualization/GenerateXdmf.py
+)
+
+spectre_python_add_executable(
+  Render1D
+  Visualization/Render1D.py
 )

--- a/src/Visualization/Python/Render1D.py
+++ b/src/Visualization/Python/Render1D.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import glob
+import h5py
+import argparse
+import sys
+import os
+import numpy as np
+import logging
+import matplotlib as mpl
+
+
+def find_extrema_over_data_set(arr):
+    '''
+    Find max and min over a range of number arrays
+    :param arr: the array over which to find the max and min
+    '''
+
+    return (np.nanmin(arr), np.nanmax(arr))
+
+
+def parse_cmd_line():
+    '''
+    parse command-line arguments
+    :return: dictionary of the command-line args, dashes are underscores
+    '''
+
+    parser = argparse.ArgumentParser(
+        description='Render 1-dimensional data',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    group_files = parser.add_mutually_exclusive_group(required=True)
+    group_files.add_argument(
+        '--file-prefix',
+        type=str,
+        help="Common prefix of all h5 files being used "
+        "in the case of a single h5 file, it is the file name "
+        "without the .h5 extension")
+    group_files.add_argument('--filename-list',
+                             type=str,
+                             nargs='+',
+                             help="List of all files if they do not "
+                             "have same file prefix. You must include '.h5' "
+                             "extension ")
+    parser.add_argument('--subfile-name',
+                        type=str,
+                        required=True,
+                        help="Name of subfile within h5 file containing "
+                        "volume data to be rendered. You must include the "
+                        "'.vol' suffix.")
+    group_vars = parser.add_mutually_exclusive_group(required=True)
+    group_vars.add_argument('--var',
+                            type=str,
+                            help="Name of variable to render. E.g. 'Psi' "
+                            "or 'Error(Psi)'")
+    group_vars.add_argument(
+        '--list-vars',
+        action='store_true',
+        help="Print to screen variables in h5 file and exit")
+    parser.add_argument(
+        '--time',
+        type=int,
+        required=False,
+        help="If specified, renders the integer observation step "
+        "instead of an animation")
+    parser.add_argument('-o',
+                        '--output',
+                        type=str,
+                        required=False,
+                        help="Set the name of the output file you want "
+                        "written. For animations this saves an mp4 file and "
+                        "for stills a pdf. Name of file should not include "
+                        "file extension.")
+    group_anim = parser.add_mutually_exclusive_group(required=False)
+    group_anim.add_argument(
+        '--fps',
+        type=float,
+        default=5,
+        help="Set the number of frames per second when writing "
+        "an animation to disk.")
+    group_anim.add_argument('--interval',
+                            type=float,
+                            help="Delay between frames in  milliseconds")
+    args = parser.parse_args()
+    # Print error message if '.h5' suffix is used in '--file-prefix' argument
+    assert args.file_prefix is None or not args.file_prefix.endswith('.h5'),\
+    "Retry without .h5 extension on 'file-prefix'"
+
+    return vars(args)
+
+
+def get_h5_files(files):
+    '''
+    Get a list of the h5 files containing the data
+    :param: list of h5 filenames or common file prefix
+    :return: list of h5 files containing volume data
+    '''
+
+    h5_files = []
+    if isinstance(files, str):
+        h5_file_names = glob.glob(files + "*.h5")
+        assert len(h5_file_names) > 0,\
+            "Found no files with prefix {} in directory {}"\
+            .format(files, os.getcwd())
+        h5_files = [h5py.File(file_name, 'r') for file_name in h5_file_names]
+
+    else:
+        for file_name in files:
+            try:
+                h5_files.append(h5py.File(file_name, 'r'))
+            except IOError as err:
+                sys.exit("Could not find file '{}' in directory {}: {}".format(
+                    file_name, os.getcwd(), err))
+    return h5_files
+
+
+def print_var_names(files, subfile_name):
+    '''
+    Print all available variables to screen
+    :param files: list of h5 filenames or common file prefix
+    :param subfile_name: name of .vol subfile in h5 file(s)
+    :return: None
+    '''
+
+    h5files = get_h5_files(files)
+    volfile = h5files[0][subfile_name]
+    obs_id_0 = next(iter(volfile))
+    variables = list(volfile[obs_id_0].keys())
+    variables.remove("connectivity")
+    variables.remove("InertialCoordinates_x")
+    variables.remove("total_extents")
+    variables.remove("grid_names")
+    variables.remove("bases")
+    variables.remove("quadratures")
+    print("Variables in H5 file:\n{}".format(list(map(str, variables))))
+    for h5_file in h5files:
+        h5_file.close()
+
+
+def get_data(files, subfile_name, var_name):
+    '''
+    Get the data to be plotted
+    :param files: list of h5 filenames or common file prefix
+    :param subfile_name: name of .vol subfile in h5 file(s)
+    :param var_name: name of variable to render
+    :return: the list of time, coords and data
+    '''
+
+    time = []
+    coords = []
+    data = []
+    h5files = get_h5_files(files)
+    volfiles = [h5file[subfile_name] for h5file in h5files]
+    # Get a list of times from the first vol file
+    ids_times = [(obs_id, volfiles[0][obs_id].attrs['observation_value'])
+                 for obs_id in volfiles[0].keys()]
+    ids_times.sort(key=lambda pair: pair[1])
+    for obs_id, local_time in ids_times:
+        local_coords = []
+        local_data = []
+        for volfile in volfiles:
+            try:
+                local_data = (local_data + list(volfile[obs_id][var_name]))
+            except KeyError:
+                print("The variable name {} is not a valid variable. "
+                      "Use '--list-vars' to see the list of variable names in "
+                      "the file(s) \n{}".format(var_name,
+                                                list(map(str, h5files))))
+                sys.exit(1)
+            local_coords = (local_coords +
+                            list(volfile[obs_id]['InertialCoordinates_x']))
+        ordering = np.argsort(local_coords)
+        coords.append(np.array(local_coords)[ordering])
+        data.append(np.array(local_data)[ordering])
+        time.append(local_time)
+
+    for h5file in h5files:
+        h5file.close()
+    return time, coords, data
+
+
+def render_single_time(var_name, time_slice, output_prefix, time, coords,
+                       data):
+    '''
+    Renders image at a single time step
+    :param var_name: name of variable to render
+    :param time_slice: the integer observation step to render
+    :param output_prefix: name of output file
+    :param time: list of time steps
+    :param coords: list of coordinates to plot
+    :param data: list of variable data to plot
+    :return: None
+    '''
+    import matplotlib.pyplot as plt
+
+    plt.xlabel("x")
+    plt.ylabel(var_name)
+    try:
+        plt.title("t = {:.5f}".format(time[time_slice]))
+        plt.plot(coords[time_slice], data[time_slice], 'o')
+    except IndexError:
+        sys.exit("The integer time step provided {} is outside the range of "
+                 "allowed time steps. The range of allowed integer time steps "
+                 "in the files provided is 0-{}".format(
+                     time_slice,
+                     len(time) - 1))
+    if output_prefix:
+        logging.info("Writing still to file {}.pdf".format(output_prefix))
+        plt.savefig(output_prefix + ".pdf", format='pdf')
+    else:
+        plt.show()
+
+
+def render_animation(var_name, output_prefix, interval, time, coords, data):
+    '''
+    Render an animation of the data
+    :param var_name: name of variable to render
+    :param output_prefix: name of output file
+    :param interval: delay between frames for animation
+    :param time: list of time steps
+    :param coords: list of coordinates to plot
+    :param data: list of variable data to plot
+    :return: None
+    '''
+    import matplotlib.pyplot as plt
+    import matplotlib.animation as animation
+    fig = plt.figure()
+    ax = plt.axes(xlim=(find_extrema_over_data_set(coords)),
+                  ylim=(find_extrema_over_data_set(data)))
+    line, = ax.plot([], [], 'o', lw=2)
+    ax.set_xlabel('x')
+    ax.set_ylabel(var_name)
+    title = ax.set_title("")
+
+    def init():
+        '''
+        Initialize the animation canvas
+        :return: empty line and title info
+        '''
+        line.set_data([], [])
+        title.set_text("")
+        return line, title
+
+    def animate(iteration):
+        '''
+        Update the animation canvas
+        :return: line and title info for particular time step
+        '''
+        title.set_text("t = {:.5f}".format(time[iteration]))
+        line.set_data(coords[iteration], data[iteration])
+        return line, title
+
+    anim = animation.FuncAnimation(fig,
+                                   animate,
+                                   init_func=init,
+                                   frames=len(time),
+                                   interval=interval)
+    if output_prefix:
+        fps = 1000.0 / interval
+        logging.info(
+            "Writing animation to file {}.mp4 at {} frames per second".format(
+                output_prefix, fps))
+        anim.save(output_prefix + ".mp4", writer='ffmpeg')
+    else:
+        plt.show()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    args = parse_cmd_line()
+    if args['output'] is not None:
+        mpl.use("Agg")
+    if args['file_prefix'] is not None:
+        files = args['file_prefix']
+    else:
+        files = args['filename_list']
+    subfile_name = args['subfile_name']
+    if args['list_vars']:
+        print_var_names(files, subfile_name)
+        sys.exit(0)
+    time, coords, data = get_data(files, subfile_name, args['var'])
+    if args['interval'] is None:
+        interval = 1000.0 / args['fps']
+    else:
+        interval = args['interval']
+    if args['time'] is None:
+        render_animation(args['var'], args['output'], interval, time, coords,
+                         data)
+    else:
+        render_single_time(args['var'], args['time'], args['output'], time,
+                           coords, data)

--- a/tests/Unit/Visualization/Python/CMakeLists.txt
+++ b/tests/Unit/Visualization/Python/CMakeLists.txt
@@ -1,7 +1,12 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-spectre_add_python_bindings_test(
+spectre_add_python_test(
   "Unit.Visualization.Python.GenerateXdmf"
   Test_GenerateXdmf.py
+  "unit;visualization;python")
+
+spectre_add_python_test(
+  "Unit.Visualization.Python.Render1D"
+  Test_Render1D.py
   "unit;visualization;python")

--- a/tests/Unit/Visualization/Python/CMakeLists.txt
+++ b/tests/Unit/Visualization/Python/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-spectre_add_python_test(
+spectre_add_python_bindings_test(
   "Unit.Visualization.Python.GenerateXdmf"
   Test_GenerateXdmf.py
   "unit;visualization;python")

--- a/tests/Unit/Visualization/Python/Test_Render1D.py
+++ b/tests/Unit/Visualization/Python/Test_Render1D.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.Visualization.Render1D import (find_extrema_over_data_set,
+                                            render_single_time)
+
+import unittest
+import os
+import numpy as np
+import matplotlib as mpl
+mpl.use('agg')
+
+
+class TestRender1D(unittest.TestCase):
+    def test_find_extrema_over_data_set(self):
+        test_array = np.array([1.1, 6.45, 0.34, 2.3])
+        expected_vals = (0.34, 6.45)
+        self.assertEqual(find_extrema_over_data_set(test_array), expected_vals)
+
+    def test_render_single_time(self):
+        var_name = "Variable Test"
+        time_slice = 1
+        output_prefix = "TestRenderSingleTime"
+        time = [0.0, 0.1]
+        coords = [[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]]
+        data = [[5.2, 4.5, 9.0, 2.0, 8.0], [1.1, 4.0, 6.0, 5.3, 3.0]]
+        # test whether a pdf file is saved when run
+        render_single_time(var_name, time_slice, output_prefix, time, coords,
+                           data)
+        self.assertTrue(os.path.isfile(output_prefix + '.pdf'))
+        os.remove(output_prefix + '.pdf')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes
The python file contains code to visualize 1D data using matplotlib and saves the animation to mpeg file.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
