### PR TITLE
Add ability to compute a derived quantity from an input option to be added to the global cache

### DIFF
--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -44,7 +44,21 @@ template <size_t Dim, typename TargetFrame>
 struct DomainCreator {
   using type = std::unique_ptr<::DomainCreator<Dim, TargetFrame>>;
   static constexpr OptionString help = {"The domain to create initially"};
+
+  using const_global_cache_type = ::Domain<Dim, TargetFrame>;
+  template <typename Metavariables>
+  static const_global_cache_type convert_for_global_cache(
+      const type& option_data) noexcept {
+    return option_data->create_domain();
+  }
 };
+
+/// \ingroup OptionTagsGroup
+/// Tag to be used when storing the `Domain` in the `ConstGlobalCache`.
+///
+/// Added to the cache by the  evolution `DgElementArray` be default.
+template <size_t Dim, typename TargetFrame>
+using Domain = DomainCreator<Dim, TargetFrame>;
 }  // namespace OptionTags
 
 namespace Tags {

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -14,6 +14,7 @@
 #include "Domain/ElementId.hpp"                     // IWYU pragma: keep
 #include "Domain/ElementIndex.hpp"
 #include "Domain/InitialElementIds.hpp"
+#include "Domain/Tags.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "IO/Observer/ObservationId.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"
@@ -46,8 +47,9 @@ struct DgElementArray {
   using phase_dependent_action_list = PhaseDepActionList;
   using array_index = ElementIndex<volume_dim>;
 
-  using const_global_cache_tag_list =
-      Parallel::get_const_global_cache_tags_from_pdal<PhaseDepActionList>;
+  using const_global_cache_tag_list = tmpl::push_back<
+      Parallel::get_const_global_cache_tags_from_pdal<PhaseDepActionList>,
+      OptionTags::Domain<volume_dim, Frame::Inertial>>;
 
   using options = tmpl::flatten<tmpl::list<
       typename Metavariables::domain_creator_tag, OptionTags::InitialTime,

--- a/src/Parallel/ConstGlobalCacheHelper.hpp
+++ b/src/Parallel/ConstGlobalCacheHelper.hpp
@@ -7,17 +7,43 @@
 #pragma once
 
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
 
 namespace Parallel {
+template <typename Tag>
+struct GlobalCacheTag {
+  static constexpr auto help = Tag::help;
+  using type = typename Tag::const_global_cache_type;
+};
+
 namespace ConstGlobalCache_detail {
+template <typename Tag, typename = cpp17::void_t<>>
+struct GlobalCacheTagsImpl {
+  using type = Tag;
+};
+template <typename Tag>
+struct GlobalCacheTagsImpl<
+    Tag, cpp17::void_t<typename Tag::const_global_cache_type>> {
+  using type = GlobalCacheTag<Tag>;
+};
+
+template <typename Tag>
+using GlobalCacheTagsImpl_t = typename GlobalCacheTagsImpl<Tag>::type;
+
 template <typename Component>
 using parallel_component_cache_tags =
     typename Component::const_global_cache_tag_list;
+
 template <typename Metavariables>
-using make_tag_list = tmpl::remove_duplicates<
+using make_option_tag_list = tmpl::remove_duplicates<
     tmpl::append<typename Metavariables::const_global_cache_tag_list,
                  tmpl::join<tmpl::transform<
                      typename Metavariables::component_list,
                      tmpl::bind<parallel_component_cache_tags, tmpl::_1>>>>>;
+
+template <typename Metavariables>
+using make_tag_list =
+    tmpl::transform<make_option_tag_list<Metavariables>,
+                    ConstGlobalCache_detail::GlobalCacheTagsImpl<tmpl::_1>>;
 }  // namespace ConstGlobalCache_detail
 }  // namespace Parallel


### PR DESCRIPTION
## Proposed changes

- Add ability to compute a derived quantity from an input option to be added to the global cache
- Have DgElementArray for evolution add Domain to the cache

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
