### PR TITLE
Make interface compute items work with cache tags

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Filtering.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Filtering.hpp
@@ -118,7 +118,8 @@ struct ExponentialFilter;
  * able to cache the matrices.
  */
 template <size_t FilterIndex, typename... TagsToFilter>
-class ExponentialFilter<FilterIndex, tmpl::list<TagsToFilter...>> {
+class ExponentialFilter<FilterIndex, tmpl::list<TagsToFilter...>>
+    : db::SimpleTag {
  public:
   using const_global_cache_tags = tmpl::list<ExponentialFilter>;
 
@@ -159,6 +160,7 @@ class ExponentialFilter<FilterIndex, tmpl::list<TagsToFilter...>> {
     return "ExpFilter" + std::to_string(FilterIndex);
   }
   using group = ::OptionTags::FilteringGroup;
+  using container_tag = ExponentialFilter;
 
   using options = tmpl::list<Alpha, HalfPower, DisableForDebugging>;
   static constexpr OptionString help = {"An exponential filter."};

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp
@@ -5,6 +5,21 @@
 
 #include "Options/Options.hpp"
 
+namespace Tags {
+/*!
+ * \brief The limiter in the DataBox
+ *
+ * \see OptionTags::Limiter
+ */
+template <typename LimiterType>
+struct Limiter : db::SimpleTag {
+  static std::string name() noexcept {
+    return "Limiter(" + pretty_type::short_name<LimiterType>() + ")";
+  }
+  using type = LimiterType;
+};
+}  // namespace Tags
+
 namespace OptionTags {
 /*!
  * \ingroup OptionGroupsGroup
@@ -26,5 +41,6 @@ struct Limiter {
   static constexpr OptionString help = "Options for the limiter";
   using type = LimiterType;
   using group = LimiterGroup;
+  using container_tag = Tags::Limiter<LimiterType>;
 };
 }  // namespace OptionTags

--- a/src/Evolution/EventsAndTriggers/Tags.hpp
+++ b/src/Evolution/EventsAndTriggers/Tags.hpp
@@ -9,6 +9,19 @@
 #include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"
 #include "Options/Options.hpp"
 
+namespace Tags {
+/// \cond
+struct EventsAndTriggersTagBase : db::BaseTag {};
+/// \endcond
+
+/// The `OptionTags::EventsAndTriggers` in the DataBox
+template <typename EventRegistrars, typename TriggerRegistrars>
+struct EventsAndTriggers : EventsAndTriggersTagBase, db::SimpleTag {
+  static std::string name() noexcept { return "EventsAndTriggers"; }
+  using type = ::EventsAndTriggers<EventRegistrars, TriggerRegistrars>;
+};
+}  // namespace Tags
+
 namespace OptionTags {
 /// \cond
 struct EventsAndTriggersTagBase {};
@@ -38,5 +51,7 @@ template <typename EventRegistrars, typename TriggerRegistrars>
 struct EventsAndTriggers : EventsAndTriggersTagBase {
   using type = ::EventsAndTriggers<EventRegistrars, TriggerRegistrars>;
   static constexpr OptionString help = "Events to run at triggers";
+  using container_tag =
+      Tags::EventsAndTriggers<EventRegistrars, TriggerRegistrars>;
 };
 }  // namespace OptionTags

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
@@ -82,12 +82,13 @@ struct ValenciaDivCleanGroup {
 };
 
 /// \brief The constraint damping parameter
-struct DampingParameter : Tags::ConstraintDampingParameter {
+struct DampingParameter {
   static std::string name() noexcept { return "DampingParameter"; }
   using type = double;
   static constexpr OptionString help{
       "Constraint damping parameter for divergence cleaning"};
   using group = ValenciaDivCleanGroup;
+  using container_tag = Tags::ConstraintDampingParameter;
 };
 }  // namespace OptionTags
 }  // namespace ValenciaDivClean

--- a/src/Evolution/VariableFixing/Tags.hpp
+++ b/src/Evolution/VariableFixing/Tags.hpp
@@ -6,6 +6,22 @@
 #include "Options/Options.hpp"
 #include "Utilities/PrettyType.hpp"
 
+namespace Tags {
+/*!
+ * \brief The variable fixer in the DataBox
+ *
+ * \see OptionTags::VariableFixer
+ */
+template <typename VariableFixerType>
+struct VariableFixer : db::SimpleTag {
+  using type = VariableFixerType;
+  static std::string name() noexcept {
+    return "VariableFixer(" + pretty_type::short_name<VariableFixerType>() +
+           ")";
+  }
+};
+}  // namespace Tags
+
 namespace OptionTags {
 /*!
  * \ingroup OptionGroupsGroup
@@ -29,5 +45,6 @@ struct VariableFixer {
     return pretty_type::short_name<VariableFixerType>();
   }
   using group = VariableFixingGroup;
+  using container_tag = Tags::VariableFixer<VariableFixerType>;
 };
 }  // namespace OptionTags

--- a/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
+++ b/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
@@ -18,10 +18,17 @@
 /// [executable_example_includes]
 
 /// [executable_example_options]
+namespace Tags {
+struct Name : db::SimpleTag {
+  static std::string name() noexcept { return "Name"; }
+  using type = std::string;
+};
+}  // namespace Tags
 namespace OptionTags {
 struct Name {
   using type = std::string;
   static constexpr OptionString help{"A name"};
+  using container_tag = Tags::Name;
 };
 }  // namespace OptionTags
 /// [executable_example_options]

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -131,6 +131,23 @@ struct H5FileLock : db::SimpleTag {
   static std::string name() noexcept { return "H5FileLock"; }
   using type = CmiNodeLock;
 };
+
+/// The name of the H5 file on disk to which all volume data is written.
+///
+/// \see observers::OptionTags::VolumeFileName
+struct VolumeFileName : db::SimpleTag {
+  static std::string name() { return "ObserversVolumeFileName"; }
+  using type = std::string;
+};
+
+/// The name of the H5 file on disk to which all reduction data is written.
+///
+/// \see observers::OptionTags::ReductionFileName
+struct ReductionFileName : db::SimpleTag {
+  static std::string name() { return "ObserversReductionFileName"; }
+  using type = std::string;
+};
+
 }  // namespace Tags
 
 /// \ingroup ObserversGroup
@@ -150,6 +167,7 @@ struct VolumeFileName {
   static constexpr OptionString help = {
       "Name of the volume data file without extension"};
   using group = Group;
+  using container_tag = Tags::VolumeFileName;
 };
 
 /// \ingroup ObserversGroup
@@ -159,6 +177,7 @@ struct ReductionFileName {
   static constexpr OptionString help = {
       "Name of the reduction data file without extension"};
   using group = Group;
+  using container_tag = Tags::ReductionFileName;
 };
 }  // namespace OptionTags
 }  // namespace observers

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -47,6 +47,19 @@ struct MortarSize : db::SimpleTag {
   static std::string name() noexcept { return "MortarSize"; }
   using type = std::array<Spectral::MortarSize, Dim>;
 };
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup DiscontinuousGalerkinGroup
+/// The object that computes numerical fluxes for a DG scheme
+template <typename NumericalFluxType>
+struct NormalDotNumericalFluxComputer : db::SimpleTag {
+  static std::string name() noexcept {
+    return "NormalDotNumericalFluxComputer(" +
+           pretty_type::short_name<NumericalFluxType>() + ")";
+  }
+  using type = NumericalFluxType;
+};
+
 }  // namespace Tags
 
 namespace OptionTags {
@@ -72,5 +85,6 @@ struct NumericalFlux {
   static constexpr OptionString help = "Options for the numerical flux";
   using type = NumericalFluxType;
   using group = NumericalFluxGroup;
+  using container_tag = Tags::NormalDotNumericalFluxComputer<NumericalFluxType>;
 };
 }  // namespace OptionTags

--- a/src/NumericalAlgorithms/LinearSolver/Tags.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Tags.hpp
@@ -19,14 +19,6 @@
 #include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits.hpp"
 
-/// \cond
-namespace LinearSolver {
-namespace OptionTags {
-struct ConvergenceCriteria;
-}  // namespace OptionTags
-}  // namespace LinearSolver
-/// \endcond
-
 /*!
  * \ingroup LinearSolverGroup
  * \brief Functionality for solving linear systems of equations
@@ -204,6 +196,18 @@ struct HasConverged : db::SimpleTag {
   using type = Convergence::HasConverged;
 };
 
+/*!
+ * \brief `Convergence::Criteria` that determine the linear solve has converged
+ *
+ * \see LinearSolver::OptionTags::ConvergenceCriteria
+ */
+struct ConvergenceCriteria : db::SimpleTag {
+  static std::string name() noexcept {
+    return "LinearSolverConvergenceCriteria";
+  }
+  using type = Convergence::Criteria;
+};
+
 /*
  * \brief Employs the `LinearSolver::OptionTags::ConvergenceCriteria` to
  * determine the linear solver has converged.
@@ -219,7 +223,7 @@ struct HasConvergedCompute : LinearSolver::Tags::HasConverged, db::ComputeTag {
 
  public:
   using argument_tags =
-      tmpl::list<LinearSolver::OptionTags::ConvergenceCriteria,
+      tmpl::list<LinearSolver::Tags::ConvergenceCriteria,
                  LinearSolver::Tags::IterationId, residual_magnitude_tag,
                  initial_residual_magnitude_tag>;
   static db::item_type<LinearSolver::Tags::HasConverged> function(
@@ -230,6 +234,16 @@ struct HasConvergedCompute : LinearSolver::Tags::HasConverged, db::ComputeTag {
                                      residual_magnitude,
                                      initial_residual_magnitude);
   }
+};
+
+/*!
+ * \brief Logging verbosity of the linear solver
+ *
+ * \see LinearSolver::OptionTags::Verbosity
+ */
+struct Verbosity : db::SimpleTag {
+  using type = ::Verbosity;
+  static std::string name() noexcept { return "LinearSolverVerbosity"; }
 };
 
 }  // namespace Tags
@@ -271,20 +285,20 @@ struct Group {
  * remain. Therefore, ideally choose the absolute or relative residual criteria
  * based on an estimate of the discretization residual.
  */
-struct ConvergenceCriteria : db::SimpleTag {
+struct ConvergenceCriteria {
   static constexpr OptionString help =
       "Determine convergence of the linear solve";
   using type = Convergence::Criteria;
   using group = Group;
-  // We need a `name()` so that this can be placed in the DataBox. Can be
-  // removed once we can retrieve cache tags through the DataBox.
-  static std::string name() noexcept { return "ConvergenceCriteria"; }
+  using container_tag = LinearSolver::Tags::ConvergenceCriteria;
 };
 
+/// Logging verbosity of the linear solver
 struct Verbosity {
   using type = ::Verbosity;
   static constexpr OptionString help = "Logging verbosity";
   using group = Group;
+  using container_tag = LinearSolver::Tags::Verbosity;
   static type default_value() { return ::Verbosity::Quiet; }
 };
 

--- a/src/PointwiseFunctions/AnalyticData/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Tags.hpp
@@ -5,6 +5,23 @@
 
 #include "Options/Options.hpp"
 
+namespace Tags {
+/// Can be used to retrieve the analytic data computer from the DataBox without
+/// having to know the template parameters of AnalyticDataComputer.
+struct AnalyticDataComputerBase {};
+
+/// The analytic data computer, with the type of the analytic data set as the
+/// template parameter
+template <typename SolutionType>
+struct AnalyticDataComputer : AnalyticDataComputerBase, db::SimpleTag {
+  static std::string name() noexcept {
+    return "AnalyticDataComputer(" + pretty_type::short_name<SolutionType>() +
+           ")";
+  }
+  using type = SolutionType;
+};
+}  // namespace Tags
+
 namespace OptionTags {
 /// \ingroup OptionGroupsGroup
 /// Holds the `OptionTags::AnalyticData` option in the input file
@@ -28,5 +45,6 @@ struct AnalyticData : AnalyticDataBase {
   static constexpr OptionString help = "Options for the analytic data";
   using type = SolutionType;
   using group = AnalyticDataGroup;
+  using container_tag = Tags::AnalyticDataComputer<SolutionType>;
 };
 }  // namespace OptionTags

--- a/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
@@ -5,6 +5,23 @@
 
 #include "Options/Options.hpp"
 
+namespace Tags {
+/// Can be used to retrieve the analytic solution computer from the DataBox
+/// without having to know the template parameters of AnalyticSolutionComputer.
+struct AnalyticSolutionComputerBase : db::BaseTag {};
+
+/// The analytic solution, with the type of the analytic solution set as the
+/// template parameter
+template <typename SolutionType>
+struct AnalyticSolutionComputer : AnalyticSolutionComputerBase, db::SimpleTag {
+  static std::string name() noexcept {
+    return "AnalyticSolutionComputer(" +
+           pretty_type::short_name<SolutionType>() + ")";
+  }
+  using type = SolutionType;
+};
+}  // namespace Tags
+
 namespace OptionTags {
 /// \ingroup OptionGroupsGroup
 /// Holds the `OptionTags::AnalyticSolution` option in the input file
@@ -32,6 +49,7 @@ struct AnalyticSolution : AnalyticSolutionBase {
   static constexpr OptionString help = "Options for the analytic solution";
   using type = SolutionType;
   using group = AnalyticSolutionGroup;
+  using container_tag = Tags::AnalyticSolutionComputer<SolutionType>;
 };
 /// \ingroup OptionTagsGroup
 /// The boundary condition to be applied at all external boundaries.

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -75,6 +75,32 @@ struct BoundaryHistory : db::SimpleTag {
       TimeSteppers::BoundaryHistory<LocalVars, RemoteVars, CouplingResult>;
 };
 
+/// The ::TimeStepper
+struct TimeStepper : db::BaseTag {};
+
+/// The ::TimeStepper, specifying a (base) type.
+template <typename StepperType>
+struct TypedTimeStepper : TimeStepper, db::SimpleTag {
+  static std::string name() noexcept {
+    return "TimeStepper(" + pretty_type::short_name<StepperType>() + ")";
+  }
+  using type = StepperType;
+};
+
+/// \ingroup TimeGroup
+/// Limits on LTS step size
+template <typename Registrars>
+struct StepChoosers : db::SimpleTag {
+  static std::string name() noexcept { return "StepChoosers"; }
+  using type = std::vector<std::unique_ptr<::StepChooser<Registrars>>>;
+};
+
+/// \ingroup TimeGroup
+/// The LTS step controller
+struct StepController : db::SimpleTag {
+  static std::string name() noexcept { return "StepChoosers"; }
+  using type = ::StepController;
+};
 }  // namespace Tags
 
 namespace OptionTags {
@@ -94,6 +120,7 @@ struct TypedTimeStepper : TimeStepper {
   static constexpr OptionString help{"The time stepper"};
   using type = std::unique_ptr<StepperType>;
   using group = EvolutionGroup;
+  using container_tag = Tags::TypedTimeStepper<StepperType>;
 };
 
 /// \ingroup OptionTagsGroup
@@ -104,6 +131,7 @@ struct StepChoosers {
   using type = std::vector<std::unique_ptr<::StepChooser<Registrars>>>;
   static size_t lower_bound_on_size() noexcept { return 1; }
   using group = EvolutionGroup;
+  using container_tag = Tags::StepChoosers<Registrars>;
 };
 
 /// \ingroup OptionTagsGroup
@@ -112,6 +140,7 @@ struct StepController {
   static constexpr OptionString help{"The LTS step controller"};
   using type = std::unique_ptr<::StepController>;
   using group = EvolutionGroup;
+  using container_tag = Tags::StepController;
 };
 
 /// \ingroup OptionTagsGroup

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -193,7 +193,7 @@ struct mock_interpolator {
 
 template <typename PostHorizonFindCallback>
 struct MockMetavariables {
-  struct AhA {
+  struct AhA : db::SimpleTag {
     using compute_items_on_source = tmpl::list<
         ah::Tags::InverseSpatialMetricCompute<3, Frame::Inertial>,
         ah::Tags::ExtrinsicCurvatureCompute<3, Frame::Inertial>,
@@ -210,6 +210,8 @@ struct MockMetavariables {
     using post_horizon_find_callback = PostHorizonFindCallback;
     // This `type` is so this tag can be used to read options.
     using type = typename compute_target_points::options_type;
+    using container_tag = AhA;
+    static std::string name() noexcept { return "AhA"; }
   };
   using interpolator_source_vars =
       tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
@@ -114,8 +114,10 @@ class NumericalFlux {
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 };
 
-struct NumericalFluxTag {
+struct NumericalFluxTag : db::SimpleTag {
   using type = NumericalFlux;
+  using container_tag = NumericalFluxTag;
+  static std::string name() noexcept { return "NumericalFluxTag"; }
 };
 
 struct System {

--- a/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
@@ -121,8 +121,10 @@ struct AnalyticSolution {
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 };
 
-struct AnalyticSolutionTag {
+struct AnalyticSolutionTag : db::SimpleTag {
   using type = AnalyticSolution;
+  using container_tag = AnalyticSolutionTag;
+  static std::string name() noexcept { return "AnalyticSolutionTag"; }
 };
 
 struct Metavariables {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
@@ -96,8 +96,10 @@ class DummyLimiterForTest {
   void pup(const PUP::er& /*p*/) const noexcept {}
 };
 
-struct LimiterTag {
+struct LimiterTag : db::SimpleTag {
   using type = DummyLimiterForTest;
+  using container_tag = LimiterTag;
+  static std::string name() noexcept { return "LimiterTag"; }
 };
 
 template <size_t Dim, typename Metavariables>

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
@@ -57,8 +57,10 @@ struct System {
   using variables_tag = Tags::Variables<tmpl::list<Var>>;
 };
 
-struct LimiterTag {
+struct LimiterTag : db::SimpleTag {
   using type = Limiters::Minmod<2, tmpl::list<Var>>;
+  using container_tag = LimiterTag;
+  static std::string name() noexcept { return "LimiterTag"; }
 };
 
 template <size_t Dim, typename Metavariables>

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
@@ -71,8 +71,10 @@ class NumericalFlux {
   void pup(PUP::er& /*p*/) noexcept {}
 };
 
-struct NumericalFluxTag {
+struct NumericalFluxTag : db::SimpleTag {
   using type = NumericalFlux;
+  using container_tag = NumericalFluxTag;
+  static std::string name() noexcept { return "NumericalFluxTag"; }
 };
 
 struct System {

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyFluxes.cpp
@@ -89,8 +89,10 @@ class NumericalFlux {
 };
 
 template <typename Flux>
-struct NumericalFluxTag {
+struct NumericalFluxTag : db::SimpleTag {
   using type = Flux;
+  using container_tag = NumericalFluxTag;
+  static std::string name() noexcept { return "NumericalFluxTag"; }
 };
 
 template <size_t Dim>

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -114,8 +114,10 @@ class NumericalFlux {
 };
 
 template <size_t Dim>
-struct NumericalFluxTag {
+struct NumericalFluxTag : db::SimpleTag {
   using type = NumericalFlux<Dim>;
+  using container_tag = NumericalFluxTag;
+  static std::string name() noexcept { return "NumericalFluxTag"; }
 };
 
 template <size_t Dim>

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -107,8 +107,10 @@ class NumericalFlux {
 };
 
 template <size_t Dim>
-struct NumericalFluxTag {
+struct NumericalFluxTag : db::SimpleTag {
   using type = NumericalFlux<Dim>;
+  using container_tag = NumericalFluxTag;
+  static std::string name() noexcept { return "NumericalFluxTag"; }
 };
 
 template <size_t Dim>

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -110,8 +110,10 @@ class NumericalFlux {
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 };
 
-struct NumericalFluxTag {
+struct NumericalFluxTag : db::SimpleTag {
   using type = NumericalFlux;
+  using container_tag = NumericalFluxTag;
+  static std::string name() noexcept { return "NumericalFluxTag"; }
 };
 
 struct BoundaryCondition {
@@ -131,8 +133,10 @@ struct BoundaryCondition {
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 };
 
-struct BoundaryConditionTag {
+struct BoundaryConditionTag : db::SimpleTag {
   using type = BoundaryCondition;
+  using container_tag = BoundaryConditionTag;
+  static std::string name() noexcept { return "BoundaryConditionTag"; }
 };
 
 template <bool HasPrimitiveAndConservativeVars>

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -29,13 +29,15 @@
 
 namespace {
 struct MockMetavariables {
-  struct InterpolationTargetA {
+  struct InterpolationTargetA : db::SimpleTag {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_target_points =
         ::intrp::Actions::ApparentHorizon<InterpolationTargetA,
                                           ::Frame::Inertial>;
     using type = compute_target_points::options_type;
+    using container_tag = InterpolationTargetA;
+    static std::string name() noexcept { return "InterpolationTargetA"; }
   };
   using temporal_id = ::Tags::TimeId;
   using domain_frame = Frame::Inertial;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -26,12 +26,14 @@
 
 namespace {
 struct MockMetavariables {
-  struct InterpolationTargetA {
+  struct InterpolationTargetA : db::SimpleTag {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_target_points =
         ::intrp::Actions::KerrHorizon<InterpolationTargetA, ::Frame::Inertial>;
     using type = compute_target_points::options_type;
+    using container_tag = InterpolationTargetA;
+    static std::string name() noexcept { return "InterpolationTargetA"; }
   };
   using temporal_id = ::Tags::TimeId;
   using domain_frame = Frame::Inertial;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -22,12 +22,14 @@
 
 namespace {
 struct MockMetavariables {
-  struct InterpolationTargetA {
+  struct InterpolationTargetA : db::SimpleTag {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_target_points =
         ::intrp::Actions::LineSegment<InterpolationTargetA, 3>;
     using type = compute_target_points::options_type;
+    using container_tag = InterpolationTargetA;
+    static std::string name() noexcept { return "InterpolationTargetA"; }
   };
   using temporal_id = ::Tags::TimeId;
   using domain_frame = Frame::Inertial;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -216,12 +216,14 @@ struct mock_interpolator {
 
 template <typename MockCallBackType>
 struct MockMetavariables {
-  struct InterpolationTargetA {
+  struct InterpolationTargetA : db::SimpleTag {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_target_points = MockComputeTargetPoints;
     using post_interpolation_callback = MockCallBackType;
     using compute_items_on_target = tmpl::list<Tags::SquareComputeItem>;
+    using container_tag = InterpolationTargetA;
+    static std::string name() noexcept { return "InterpolationTargetA"; }
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -24,12 +24,14 @@
 
 namespace {
 struct MockMetavariables {
-  struct InterpolationTargetA {
+  struct InterpolationTargetA : db::SimpleTag {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_target_points =
         ::intrp::Actions::WedgeSectionTorus<InterpolationTargetA>;
     using type = compute_target_points::options_type;
+    using container_tag = InterpolationTargetA;
+    static std::string name() noexcept { return "InterpolationTargetA"; }
   };
   using temporal_id = ::Tags::TimeId;
   using domain_frame = Frame::Inertial;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -202,7 +202,7 @@ struct MockInterpolator {
 };
 
 struct MockMetavariables {
-  struct SurfaceA {
+  struct SurfaceA : db::SimpleTag {
     using compute_items_on_source = tmpl::list<>;
     using vars_to_interpolate_to_target =
         tmpl::list<Tags::TestSolution,
@@ -220,8 +220,10 @@ struct MockMetavariables {
             SurfaceA, SurfaceA>;
     // This `type` is so this tag can be used to read options.
     using type = typename compute_target_points::options_type;
+    using container_tag = SurfaceA;
+    static std::string name() noexcept { return "SurfaceA"; }
   };
-  struct SurfaceB {
+  struct SurfaceB : db::SimpleTag {
     using compute_items_on_source = tmpl::list<>;
     using vars_to_interpolate_to_target =
         tmpl::list<Tags::TestSolution,
@@ -242,8 +244,10 @@ struct MockMetavariables {
             SurfaceB, SurfaceB>;
     // This `type` is so this tag can be used to read options.
     using type = typename compute_target_points::options_type;
+    using container_tag = SurfaceB;
+    static std::string name() noexcept { return "SurfaceB"; }
   };
-  struct SurfaceC {
+  struct SurfaceC : db::SimpleTag {
     using compute_items_on_source = tmpl::list<>;
     using vars_to_interpolate_to_target =
         tmpl::list<Tags::TestSolution,
@@ -261,6 +265,8 @@ struct MockMetavariables {
             SurfaceC, SurfaceC>;
     // This `type` is so this tag can be used to read options.
     using type = typename compute_target_points::options_type;
+    using container_tag = SurfaceC;
+    static std::string name() noexcept { return "SurfaceC"; }
   };
 
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -216,7 +216,7 @@ struct mock_interpolator {
 };
 
 struct MockMetavariables {
-  struct InterpolationTargetA {
+  struct InterpolationTargetA : db::SimpleTag {
     using compute_items_on_source = tmpl::list<Tags::SquareComputeItem>;
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
     using compute_items_on_target = tmpl::list<>;
@@ -225,8 +225,10 @@ struct MockMetavariables {
     using post_interpolation_callback =
         TestFunction<InterpolationTargetA, Tags::Square>;
     using type = typename compute_target_points::options_type;
+    using container_tag = InterpolationTargetA;
+    static std::string name() noexcept { return "InterpolationTargetA"; }
   };
-  struct InterpolationTargetB {
+  struct InterpolationTargetB : db::SimpleTag {
     using compute_items_on_source = tmpl::list<Tags::SquareComputeItem>;
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
     using compute_items_on_target = tmpl::list<Tags::NegateComputeItem>;
@@ -235,8 +237,10 @@ struct MockMetavariables {
     using post_interpolation_callback =
         TestFunction<InterpolationTargetB, Tags::Negate>;
     using type = typename compute_target_points::options_type;
+    using container_tag = InterpolationTargetB;
+    static std::string name() noexcept { return "InterpolationTargetB"; }
   };
-  struct InterpolationTargetC {
+  struct InterpolationTargetC : db::SimpleTag {
     using compute_items_on_source = tmpl::list<>;
     using vars_to_interpolate_to_target = tmpl::list<Tags::TestSolution>;
     using compute_items_on_target = tmpl::list<Tags::SquareComputeItem>;
@@ -245,6 +249,8 @@ struct MockMetavariables {
     using post_interpolation_callback = TestKerrHorizonIntegral;
     // This `type` is so this tag can be used to read options.
     using type = typename compute_target_points::options_type;
+    using container_tag = InterpolationTargetC;
+    static std::string name() noexcept { return "InterpolationTargetC"; }
   };
 
   using interpolator_source_vars = tmpl::list<Tags::TestSolution>;

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -54,19 +54,25 @@ struct NumberOfElements {
 // Therefore, this option specifies a (N*M,N*M) matrix that has its columns
 // split over all elements. In a context where the linear operator represents a
 // DG discretization, M is the number of collocation points per element.
-struct LinearOperator {
+struct LinearOperator : db::SimpleTag {
   static constexpr OptionString help = "The linear operator A to invert.";
   using type = std::vector<DenseMatrix<double, blaze::columnMajor>>;
+  using container_tag = LinearOperator;
+  static std::string name() noexcept { return "LinearOperator"; }
 };
 // Both of the following options expect a list of N vectors that have a size of
 // M each, so that they constitute a vector of total size N*M (see above).
-struct Source {
+struct Source : db::SimpleTag {
   static constexpr OptionString help = "The source b in the equation Ax=b.";
   using type = std::vector<DenseVector<double>>;
+  using container_tag = Source;
+  static std::string name() noexcept { return "Source"; }
 };
-struct ExpectedResult {
+struct ExpectedResult : db::SimpleTag {
   static constexpr OptionString help = "The solution x in the equation Ax=b";
   using type = std::vector<DenseVector<double>>;
+  using container_tag = ExpectedResult;
+  static std::string name() noexcept { return "ExpectedResult"; }
 };
 
 // The vector `x` we want to solve for

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -34,21 +34,29 @@
 
 namespace LinearSolverAlgorithmTestHelpers {
 
-struct LinearOperator {
+struct LinearOperator : db::SimpleTag {
   static constexpr OptionString help = "The linear operator A to invert.";
   using type = DenseMatrix<double>;
+  using container_tag = LinearOperator;
+  static std::string name() noexcept { return "LinearOperator"; }
 };
-struct Source {
+struct Source : db::SimpleTag {
   static constexpr OptionString help = "The source b in the equation Ax=b.";
   using type = DenseVector<double>;
+  using container_tag = Source;
+  static std::string name() noexcept { return "Source"; }
 };
-struct InitialGuess {
+struct InitialGuess : db::SimpleTag {
   static constexpr OptionString help = "The initial guess for the vector x.";
   using type = DenseVector<double>;
+  using container_tag = InitialGuess;
+  static std::string name() noexcept { return "InitialGuess"; }
 };
-struct ExpectedResult {
+struct ExpectedResult : db::SimpleTag {
   static constexpr OptionString help = "The solution x in the equation Ax=b";
   using type = DenseVector<double>;
+  using container_tag = ExpectedResult;
+  static std::string name() noexcept { return "ExpectedResult"; }
 };
 
 // The vector `x` we want to solve for

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Tags.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Tags.cpp
@@ -44,15 +44,16 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Tags",
         "LinearOrthogonalizationHistory(Tag)");
   CHECK(LinearSolver::Tags::KrylovSubspaceBasis<Tag>::name() ==
         "KrylovSubspaceBasis(Tag)");
-  CHECK(LinearSolver::OptionTags::ConvergenceCriteria::name() ==
-        "ConvergenceCriteria");
+  CHECK(LinearSolver::Tags::ConvergenceCriteria::name() ==
+        "LinearSolverConvergenceCriteria");
+  CHECK(LinearSolver::Tags::Verbosity::name() == "LinearSolverVerbosity");
 
   {
     INFO("HasConvergedCompute");
     CHECK(LinearSolver::Tags::HasConvergedCompute<Tag>::name() ==
           "LinearSolverHasConverged");
     const auto box = db::create<
-        db::AddSimpleTags<LinearSolver::OptionTags::ConvergenceCriteria,
+        db::AddSimpleTags<LinearSolver::Tags::ConvergenceCriteria,
                           LinearSolver::Tags::IterationId,
                           residual_magnitude_tag,
                           initial_residual_magnitude_tag>,
@@ -68,7 +69,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Tags",
     // A vanishing initial residual should work because the absolute residual
     // condition takes precedence so that no FPE occurs
     const auto box = db::create<
-        db::AddSimpleTags<LinearSolver::OptionTags::ConvergenceCriteria,
+        db::AddSimpleTags<LinearSolver::Tags::ConvergenceCriteria,
                           LinearSolver::Tags::IterationId,
                           residual_magnitude_tag,
                           initial_residual_magnitude_tag>,

--- a/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
@@ -41,16 +41,22 @@ struct RegistrationHelper;
 
 namespace {
 
-struct name {
+struct Name : db::SimpleTag {
   using type = std::string;
+  using container_tag = Name;
+  static std::string name() noexcept { return "Name"; }
 };
 
-struct age {
+struct Age : db::SimpleTag {
   using type = int;
+  using container_tag = Age;
+  static std::string name() noexcept { return "Age"; }
 };
 
-struct height {
+struct Height : db::SimpleTag {
   using type = double;
+  using container_tag = Height;
+  static std::string name() noexcept { return "Height"; }
 };
 
 #pragma GCC diagnostic push
@@ -86,16 +92,18 @@ class Square : public Shape {
 };
 #pragma GCC diagnostic pop
 
-struct shape_of_nametag_base {};
+struct ShapeOfNametagBase {};
 
-struct shape_of_nametag : shape_of_nametag_base {
+struct ShapeOfNametag : ShapeOfNametagBase, db::SimpleTag {
   using type = std::unique_ptr<Shape>;
+  using container_tag = ShapeOfNametag;
+  static std::string name() noexcept { return "ShapeOfNametag"; }
 };
 
 template <class Metavariables>
 struct SingletonParallelComponent {
   using chare_type = Parallel::Algorithms::Singleton;
-  using const_global_cache_tag_list = tmpl::list<name, age, height>;
+  using const_global_cache_tag_list = tmpl::list<Name, Age, Height>;
   using options = tmpl::list<>;
   using metavariables = Metavariables;
   using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
@@ -107,7 +115,7 @@ struct SingletonParallelComponent {
 template <class Metavariables>
 struct ArrayParallelComponent {
   using chare_type = Parallel::Algorithms::Array;
-  using const_global_cache_tag_list = tmpl::list<height, shape_of_nametag>;
+  using const_global_cache_tag_list = tmpl::list<Height, ShapeOfNametag>;
   using array_index = int;
   using options = tmpl::list<>;
   using metavariables = Metavariables;
@@ -120,7 +128,7 @@ struct ArrayParallelComponent {
 template <class Metavariables>
 struct GroupParallelComponent {
   using chare_type = Parallel::Algorithms::Group;
-  using const_global_cache_tag_list = tmpl::list<name>;
+  using const_global_cache_tag_list = tmpl::list<Name>;
   using options = tmpl::list<>;
   using metavariables = Metavariables;
   using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
@@ -132,7 +140,7 @@ struct GroupParallelComponent {
 template <class Metavariables>
 struct NodegroupParallelComponent {
   using chare_type = Parallel::Algorithms::Nodegroup;
-  using const_global_cache_tag_list = tmpl::list<height>;
+  using const_global_cache_tag_list = tmpl::list<Height>;
   using options = tmpl::list<>;
   using metavariables = Metavariables;
   using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
@@ -159,18 +167,18 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCache", "[Unit][Parallel]") {
         TestMetavariables>;
     static_assert(
         cpp17::is_same_v<tag_list,
-                         tmpl::list<name, age, height, shape_of_nametag>>,
+                         tmpl::list<Name, Age, Height, ShapeOfNametag>>,
         "Wrong tag_list in ConstGlobalCache test");
 
     tuples::tagged_tuple_from_typelist<tag_list> const_data_to_be_cached(
         "Nobody", 178, 2.2, std::make_unique<Square>());
     Parallel::ConstGlobalCache<TestMetavariables> cache(
         std::move(const_data_to_be_cached));
-    CHECK("Nobody" == Parallel::get<name>(cache));
-    CHECK(178 == Parallel::get<age>(cache));
-    CHECK(2.2 == Parallel::get<height>(cache));
-    CHECK(4 == Parallel::get<shape_of_nametag>(cache).number_of_sides());
-    CHECK(4 == Parallel::get<shape_of_nametag_base>(cache).number_of_sides());
+    CHECK("Nobody" == Parallel::get<Name>(cache));
+    CHECK(178 == Parallel::get<Age>(cache));
+    CHECK(2.2 == Parallel::get<Height>(cache));
+    CHECK(4 == Parallel::get<ShapeOfNametag>(cache).number_of_sides());
+    CHECK(4 == Parallel::get<ShapeOfNametagBase>(cache).number_of_sides());
   }
 
   {
@@ -178,7 +186,7 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCache", "[Unit][Parallel]") {
         TestMetavariables>;
     static_assert(
         cpp17::is_same_v<tag_list,
-                         tmpl::list<name, age, height, shape_of_nametag>>,
+                         tmpl::list<Name, Age, Height, ShapeOfNametag>>,
         "Wrong tag_list in ConstGlobalCache test");
 
     tuples::tagged_tuple_from_typelist<tag_list> const_data_to_be_cached(
@@ -189,12 +197,12 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCache", "[Unit][Parallel]") {
             Parallel::CProxy_ConstGlobalCache<TestMetavariables>::ckNew(
                 const_data_to_be_cached);
     const auto& local_cache = *const_global_cache_proxy.ckLocalBranch();
-    CHECK("Nobody" == Parallel::get<name>(local_cache));
-    CHECK(178 == Parallel::get<age>(local_cache));
-    CHECK(2.2 == Parallel::get<height>(local_cache));
-    CHECK(4 == Parallel::get<shape_of_nametag>(local_cache).number_of_sides());
+    CHECK("Nobody" == Parallel::get<Name>(local_cache));
+    CHECK(178 == Parallel::get<Age>(local_cache));
+    CHECK(2.2 == Parallel::get<Height>(local_cache));
+    CHECK(4 == Parallel::get<ShapeOfNametag>(local_cache).number_of_sides());
     CHECK(4 ==
-          Parallel::get<shape_of_nametag_base>(local_cache).number_of_sides());
+          Parallel::get<ShapeOfNametagBase>(local_cache).number_of_sides());
   }
 }
 

--- a/tests/Unit/Parallel/Test_ConstGlobalCacheDataBox.cpp
+++ b/tests/Unit/Parallel/Test_ConstGlobalCacheDataBox.cpp
@@ -18,15 +18,28 @@
 #include "Utilities/TaggedTuple.hpp"
 
 namespace Parallel {
-namespace OptionTags {
-struct IntegerList : db::BaseTag {
+namespace Tags {
+struct IntegerList : db::SimpleTag {
   using type = std::array<int, 3>;
-  static constexpr OptionString help = {"Help"};
+  static std::string name() noexcept { return "IntegerList"; }
 };
 
-struct UniquePtrIntegerList : db::BaseTag {
+struct UniquePtrIntegerList : db::SimpleTag {
+  using type = std::array<int, 3>;
+  static std::string name() noexcept { return "UniquePtrIntegerList"; }
+};
+}  // namespace Tags
+namespace OptionTags {
+struct IntegerList {
+  using type = std::array<int, 3>;
+  static constexpr OptionString help = {"Help"};
+  using container_tag = Tags::IntegerList;
+};
+
+struct UniquePtrIntegerList {
   using type = std::unique_ptr<std::array<int, 3>>;
   static constexpr OptionString help = {"Help"};
+  using container_tag = Tags::UniquePtrIntegerList;
 };
 }  // namespace OptionTags
 
@@ -52,14 +65,13 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCacheDataBox", "[Unit][Parallel]") {
           Tags::FromConstGlobalCache<OptionTags::UniquePtrIntegerList>>>(
       &cpp17::as_const(cache));
   CHECK(db::get<Tags::ConstGlobalCache>(box) == &cache);
-  CHECK(std::array<int, 3>{{-1, 3, 7}} ==
-        db::get<OptionTags::IntegerList>(box));
+  CHECK(std::array<int, 3>{{-1, 3, 7}} == db::get<Tags::IntegerList>(box));
   CHECK(std::array<int, 3>{{1, 5, -8}} ==
-        db::get<OptionTags::UniquePtrIntegerList>(box));
+        db::get<Tags::UniquePtrIntegerList>(box));
   CHECK(&Parallel::get<OptionTags::IntegerList>(cache) ==
-        &db::get<OptionTags::IntegerList>(box));
+        &db::get<Tags::IntegerList>(box));
   CHECK(&Parallel::get<OptionTags::UniquePtrIntegerList>(cache) ==
-        &db::get<OptionTags::UniquePtrIntegerList>(box));
+        &db::get<Tags::UniquePtrIntegerList>(box));
 
   tuples::TaggedTuple<OptionTags::IntegerList, OptionTags::UniquePtrIntegerList>
       tuple2{};
@@ -76,18 +88,12 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCacheDataBox", "[Unit][Parallel]") {
       });
 
   CHECK(db::get<Tags::ConstGlobalCache>(box) == &cache2);
-  CHECK(std::array<int, 3>{{10, -3, 700}} ==
-        db::get<OptionTags::IntegerList>(box));
+  CHECK(std::array<int, 3>{{10, -3, 700}} == db::get<Tags::IntegerList>(box));
   CHECK(std::array<int, 3>{{100, -7, -300}} ==
-        db::get<OptionTags::UniquePtrIntegerList>(box));
+        db::get<Tags::UniquePtrIntegerList>(box));
   CHECK(&Parallel::get<OptionTags::IntegerList>(cache2) ==
-        &db::get<OptionTags::IntegerList>(box));
+        &db::get<Tags::IntegerList>(box));
   CHECK(&Parallel::get<OptionTags::UniquePtrIntegerList>(cache2) ==
-        &db::get<OptionTags::UniquePtrIntegerList>(box));
-
-  CHECK(Tags::FromConstGlobalCache<OptionTags::IntegerList>::name() ==
-        "FromConstGlobalCache(IntegerList)");
-  CHECK(Tags::FromConstGlobalCache<OptionTags::UniquePtrIntegerList>::name() ==
-        "FromConstGlobalCache(UniquePtrIntegerList)");
+        &db::get<Tags::UniquePtrIntegerList>(box));
 }
 }  // namespace Parallel


### PR DESCRIPTION
## Proposed changes

Tags from the ConstGlobalCache are now available through the DataBox,
but `db::item_type` didn't work for them. Since `Tags::InterfaceComputeItem`
needs `db::item_type`, this restriction prohibited cache tags from being used as
argument tags.

### Types of changes:

- [x] Bugfix

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
