### PR TITLE
Observe MassFlux in EvolveValenciaDivClean

### DIFF
--- a/cmake/AddSpectreExecutable.cmake
+++ b/cmake/AddSpectreExecutable.cmake
@@ -66,6 +66,7 @@ function(
 
   target_link_libraries(
     ${EXECUTABLE_NAME}
+    PUBLIC
     ${LINK_LIBS}
     ${SPECTRE_LIBRARIES}
     )

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -443,6 +443,43 @@ class Variables<tmpl::list<Tags...>> {
   tuples::TaggedTuple<Tags...> reference_variable_data_;
 };
 
+// The above Variables implementation doesn't work for an empty parameter pack,
+// so specialize here.
+template<>
+class Variables<tmpl::list<>> {
+ public:
+  Variables() noexcept = default;
+  explicit Variables(const size_t /*number_of_grid_points*/) noexcept {};
+  static constexpr size_t size() noexcept { return 0; }
+};
+
+// gcc8 screams when the empty Variables has pup as a member function, so we
+// declare pup as a free function here.
+// clang-tidy: runtime-references
+SPECTRE_ALWAYS_INLINE void pup(
+    PUP::er& /*p*/,                                    // NOLINT
+    Variables<tmpl::list<>>& /* unused */) noexcept {  // NOLINT
+}
+SPECTRE_ALWAYS_INLINE void operator|(
+    PUP::er& /*p*/, Variables<tmpl::list<>>& /* unused */) noexcept {  // NOLINT
+}
+
+SPECTRE_ALWAYS_INLINE bool operator==(
+    const Variables<tmpl::list<>>& /*lhs*/,
+    const Variables<tmpl::list<>>& /*rhs*/) noexcept {
+  return true;
+}
+SPECTRE_ALWAYS_INLINE bool operator!=(
+    const Variables<tmpl::list<>>& /*lhs*/,
+    const Variables<tmpl::list<>>& /*rhs*/) noexcept {
+  return false;
+}
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const Variables<tmpl::list<>>& /*d*/) noexcept {
+  return os << "{}";
+}
+
 template <typename... Tags>
 Variables<tmpl::list<Tags...>>::Variables() noexcept {
   // This makes an assertion trigger if one tries to assign to

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -32,7 +32,13 @@ endfunction(add_grmhd_executable)
 
 add_grmhd_executable(
   FishboneMoncriefDisk
-  RelativisticEuler::Solutions::FishboneMoncriefDisk
+  RelativisticEuler::Solutions::FishboneMoncriefDisk,Horizon
+  )
+target_link_libraries(
+  EvolveFishboneMoncriefDisk
+  PUBLIC
+  ApparentHorizons
+  Interpolation
   )
 
 add_grmhd_executable(

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanFwd.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanFwd.hpp
@@ -35,6 +35,7 @@ class OrszagTangVortex;
 }  // namespace AnalyticData
 }  // namespace grmhd
 
-template <typename InitialData>
+struct Horizon;
+template <typename InitialData, typename...InterpolationTargetTags>
 struct EvolutionMetavars;
 /// \endcond

--- a/src/NumericalAlgorithms/Interpolation/Interpolate.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Interpolate.hpp
@@ -92,6 +92,7 @@ class Interpolate<VolumeDim, tmpl::list<Tensors...>, EventRegistrars>
       get<tensor_tag>(interp_vars) = tensor;
       return 0;
     };
+    (void) copy_to_variables; // GCC warns unused variable if Tensors is empty.
     expand_pack(copy_to_variables(tmpl::type_<Tensors>{}, tensors)...);
 
     // Send volume data to the Interpolator, to trigger interpolation.

--- a/src/ParallelAlgorithms/EventsAndTriggers/Tags.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Tags.hpp
@@ -35,6 +35,13 @@ template <typename EventRegistrars, typename TriggerRegistrars>
 struct EventsAndTriggers {
   using type = ::EventsAndTriggers<EventRegistrars, TriggerRegistrars>;
   static constexpr OptionString help = "Events to run at triggers";
+  // When the template arguments to this struct are sufficiently
+  // complicated, pretty_type::short_name() run on this struct returns
+  // something that is neither pretty nor short, and leads to an
+  // OptionParser run-time error saying that an option name is greater
+  // than 21 characters.  Adding the name() function below bypasses
+  // pretty_type::short_name().
+  static std::string name() noexcept { return "EventsAndTriggers"; }
 };
 }  // namespace OptionTags
 

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -85,3 +85,10 @@ EventsAndTriggers:
 Observers:
   VolumeFileName: "GrMhdVolume"
   ReductionFileName: "GrMhdReductions"
+
+InterpolationTargets:
+  Horizon:
+    Lmax: 10
+    Center: [0.0, 0.0, 0.0]
+    Mass: 1.0
+    DimensionlessSpin: [0.0, 0.0, 0.9375]

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -54,6 +54,25 @@ std::string repeat_string_with_commas(const std::string& str,
   return t;
 }
 
+// An empty Variables is a separate implementation, so we put tests
+// for it in a separate function here.
+void test_empty_variables() noexcept {
+  Variables<tmpl::list<>> empty_vars;
+  auto serialized_empty_vars = serialize_and_deserialize(empty_vars);
+  CHECK(serialized_empty_vars == empty_vars);
+
+  // The following test with a std::tuple<Variables<tmpl::list<>>>
+  // revealed a gcc8 bug that passed the above test (the one that
+  // serializes/deserializes a Variables<tmpl::list<>>).
+  std::tuple<int, std::string, Variables<tmpl::list<>>> tuple_with_empty_vars{
+      3, "hello", {}};
+  auto serialized_tuple_with_empty_vars =
+      serialize_and_deserialize(tuple_with_empty_vars);
+  CHECK(serialized_tuple_with_empty_vars == tuple_with_empty_vars);
+
+  CHECK(get_output(tuple_with_empty_vars) == "(3,hello,{})");
+}
+
 template <typename VectorType>
 void test_variables_construction_and_access() noexcept {
   using value_type = typename VectorType::value_type;
@@ -854,6 +873,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
     // test_variables_from_tagged_tuple<ModalVector>();
   }
   TestHelpers::db::test_simple_tag<Tags::TempScalar<1>>("TempTensor1");
+
+  SECTION("Test empty variables") {
+    test_empty_variables();
+  }
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

Adds the interpolator to EvolveValenciaDivClean.

FishboneMoncriefDisk now observes MassFlux.

The other EvolveValenciaDivClean executables do not currently have interpolators,
but there is an easy mechanism for adding them.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
