### PR TITLE
Horizon finder size fix

### DIFF
--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -13,6 +13,7 @@
 #include "ApparentHorizons/ComputeItems.hpp"  // IWYU pragma: keep
 #include "ApparentHorizons/FastFlow.hpp"
 #include "ApparentHorizons/Strahlkorper.hpp"
+#include "ApparentHorizons/YlmSpherepack.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"  // IWYU pragma: keep
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -106,6 +107,17 @@ struct TestSchwarzschildHorizon {
     Approx custom_approx = Approx::custom().epsilon(1.e-2).scale(1.0);
     CHECK_ITERABLE_CUSTOM_APPROX(horizon_radius, expected_radius,
                                  custom_approx);
+
+    // Test that InverseSpatialMetric can be retrieved from the
+    // DataBox and that its number of grid points is the same
+    // as that of the strahlkorper.
+    const auto& strahlkorper =
+        get<StrahlkorperTags::Strahlkorper<Frame::Inertial>>(box);
+    const auto& inv_metric =
+        get<gr::Tags::InverseSpatialMetric<3, Frame::Inertial>>(box);
+    CHECK(strahlkorper.ylm_spherepack().physical_size() ==
+          get<0,0>(inv_metric).size());
+
     ++test_schwarzschild_horizon_called;
   }
 };
@@ -132,6 +144,15 @@ struct TestKerrHorizon {
     Approx custom_approx = Approx::custom().epsilon(1.e-3).scale(1.0);
     CHECK_ITERABLE_CUSTOM_APPROX(horizon_radius, get(expected_radius),
                                  custom_approx);
+
+    // Test that InverseSpatialMetric can be retrieved from the
+    // DataBox and that its number of grid points is the same
+    // as that of the strahlkorper.
+    const auto& inv_metric =
+        get<gr::Tags::InverseSpatialMetric<3, Frame::Inertial>>(box);
+    CHECK(strahlkorper.ylm_spherepack().physical_size() ==
+          get<0,0>(inv_metric).size());
+
     ++test_kerr_horizon_called;
   }
 };

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -845,7 +845,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.AreaElement",
       2.0, [](const size_t size) noexcept { return DataVector(size, 4.0); });
 
   // Check the area of a Kerr horizon
-  constexpr int l_max = 20;
+  constexpr int l_max = 22;
   const double mass = 4.444;
   const std::array<double, 3> spin{{0.4, 0.33, 0.22}};
   const std::array<double, 3> center{{0.0, 0.0, 0.0}};


### PR DESCRIPTION
## Proposed changes

Fix bug where the horizon finder doesn't re-evaluate interpolated quantities
onto the correct-size Strahlkorper after finder converges.

Add test that checks for this bug.

## Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
