### PR TITLE
Reset fast flow

### DIFF
--- a/src/ApparentHorizons/FastFlow.hpp
+++ b/src/ApparentHorizons/FastFlow.hpp
@@ -179,6 +179,9 @@ class FastFlow {
   /// Resets the finder.
   SPECTRE_ALWAYS_INLINE void reset_for_next_find() noexcept {
     current_iter_ = 0;
+    previous_residual_mesh_norm_ = 0.0;
+    min_residual_mesh_norm_ = std::numeric_limits<double>::max();
+    iter_at_min_residual_mesh_norm_ = 0;
   }
 
  private:


### PR DESCRIPTION
## Proposed changes

Fix a bug in resetting FastFlow from one completed horizon find to the next.

Add a test that fails before the bug fix and succeeds after it.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
