### PR TITLE
Simplify InterpolationTarget::compute_items_on_target

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
@@ -78,6 +78,8 @@ namespace callbacks {
 /// see InterpolationTarget for a description of InterpolationTargetTag.
 template <typename InterpolationTargetTag>
 struct FindApparentHorizon {
+  using observation_types = typename InterpolationTargetTag::
+      post_horizon_find_callback::observation_types;
   template <typename DbTags, typename Metavariables>
   static bool apply(
       const gsl::not_null<db::DataBox<DbTags>*> box,

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
@@ -86,26 +86,13 @@ void callback_and_cleanup(
   const auto temporal_id =
       db::get<Tags::TemporalIds<Metavariables>>(*box).front();
 
-  // Add compute_items_on_target to the box.
-  auto box_with_more_items = db::create_from<
-      db::RemoveTags<>, db::AddSimpleTags<>,
-      db::AddComputeTags<
-          typename InterpolationTargetTag::compute_items_on_target>>(
-      std::move(*box));
-
   // apply_callback should return true if we are done with this
   // temporal_id.  It should return false only if the callback
   // calls another `intrp::Action` that needs the volume data at this
   // same temporal_id.  If it returns false, we exit here and do not
   // clean up.
-  const bool done_with_temporal_id = apply_callback<InterpolationTargetTag>(
-      make_not_null(&box_with_more_items), cache, temporal_id);
-
-  // Remove compute_items_on_target from the box.
-  *box = db::create_from<
-      db::RemoveTags<typename InterpolationTargetTag::compute_items_on_target>,
-      db::AddSimpleTags<>, db::AddComputeTags<>>(
-      std::move(box_with_more_items));
+  const bool done_with_temporal_id =
+      apply_callback<InterpolationTargetTag>(box, cache, temporal_id);
 
   if (not done_with_temporal_id) {
     return;

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -92,6 +92,7 @@ namespace {
 // Counter to ensure that this function is called
 size_t test_schwarzschild_horizon_called = 0;
 struct TestSchwarzschildHorizon {
+  using observation_types = tmpl::list<>;
   template <typename DbTags, typename Metavariables>
   static void apply(const db::DataBox<DbTags>& box,
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
@@ -124,6 +125,7 @@ struct TestSchwarzschildHorizon {
 // Counter to ensure that this function is called
 size_t test_kerr_horizon_called = 0;
 struct TestKerrHorizon {
+  using observation_types = tmpl::list<>;
   template <typename DbTags, typename Metavariables>
   static void apply(const db::DataBox<DbTags>& box,
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -90,6 +90,7 @@ struct MockMetavariables {
   struct InterpolationTargetA {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
+    using compute_items_on_target = tmpl::list<>;
     using compute_target_points = MockComputeTargetPoints;
   };
   using temporal_id = ::Tags::TimeId;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -51,6 +51,7 @@ struct Metavariables {
   struct InterpolationTargetA {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
+    using compute_items_on_target = tmpl::list<>;
   };
   using temporal_id = ::Tags::TimeId;
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -32,6 +32,7 @@ struct MockMetavariables {
   struct InterpolationTargetA {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
+    using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::Actions::ApparentHorizon<InterpolationTargetA,
                                           ::Frame::Inertial>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -29,6 +29,7 @@ struct MockMetavariables {
   struct InterpolationTargetA {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
+    using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::Actions::KerrHorizon<InterpolationTargetA, ::Frame::Inertial>;
     using type = compute_target_points::options_type;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -25,6 +25,7 @@ struct MockMetavariables {
   struct InterpolationTargetA {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
+    using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::Actions::LineSegment<InterpolationTargetA, 3>;
     using type = compute_target_points::options_type;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -84,7 +84,9 @@ struct mock_interpolation_target {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+          tmpl::list<ActionTesting::InitializeDataBox<
+              simple_tags,
+              typename InterpolationTargetTag::compute_items_on_target>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
 };

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -27,6 +27,7 @@ struct MockMetavariables {
   struct InterpolationTargetA {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
+    using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::Actions::WedgeSectionTorus<InterpolationTargetA>;
     using type = compute_target_points::options_type;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -148,6 +148,7 @@ struct Metavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_source = tmpl::list<>;
+    using compute_items_on_target = tmpl::list<>;
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -230,6 +230,7 @@ struct MockMetavariables {
   struct InterpolationTargetA {
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
     using compute_items_on_source = tmpl::list<Tags::SquareComputeItem>;
+    using compute_items_on_target = tmpl::list<>;
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -66,6 +66,7 @@ struct MockMetavariables {
   struct InterpolatorTargetA {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
+    using compute_items_on_target = tmpl::list<>;
   };
   using temporal_id = ::Tags::TimeId;
   static constexpr size_t volume_dim = 3;


### PR DESCRIPTION
## Proposed changes

The treatment of compute_items_on_target is now much cleaner than before.
Instead of adding and removing compute items from the databox at various times with complicated
logic, now simply adds those compute items during initialization.  After all, they are evaluated only if they are used.

This fixes a potential bug where a variable that has been std::moved out of can possibly be used.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
