### PR TITLE
Add contiguous VolumeData class

### DIFF
--- a/src/IO/H5/VolumeData.cpp
+++ b/src/IO/H5/VolumeData.cpp
@@ -4,10 +4,12 @@
 #include "IO/H5/VolumeData.hpp"
 
 #include <algorithm>
+#include <boost/algorithm/string.hpp>
 #include <boost/iterator/transform_iterator.hpp>
 #include <hdf5.h>
 #include <memory>
 #include <ostream>
+#include <string>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TensorData.hpp"
@@ -18,10 +20,64 @@
 #include "IO/H5/Header.hpp"
 #include "IO/H5/Helpers.hpp"
 #include "IO/H5/Version.hpp"
-
+#include "Utilities/Numeric.hpp"
 /// \cond HIDDEN_SYMBOLS
 namespace h5 {
-VolumeData::VolumeData(const bool exists, detail::OpenGroup&& group,
+namespace {
+// Append the element extents and connectevity to the total extents and
+// connectivity
+void append_element_extents_and_connectivity(
+    const gsl::not_null<std::vector<size_t>*> total_extents,
+    const gsl::not_null<std::vector<int>*> total_connectivity,
+    const gsl::not_null<int*> total_points_so_far, const size_t dim,
+    const ExtentsAndTensorVolumeData& element) noexcept {
+  // Process the element extents
+  const auto& extents = element.extents;
+  if (extents.size() != dim) {
+    ERROR("Trying to write data of dimensionality"
+          << extents.size() << "but the VolumeData file has dimensionality"
+          << dim << ".");
+  }
+  total_extents->insert(total_extents->end(), extents.begin(), extents.end());
+  // Find the number of points in the local connectivity
+  const int element_num_points =
+      alg::accumulate(extents, 1, std::multiplies<>{});
+  // Generate the connectivity data for the element
+  // Possible optimization: local_connectivity.reserve(BLAH) if we can figure
+  // out size without computing all the connectivities.
+  const std::vector<int> connectivity =
+      [&extents, &total_points_so_far ]() noexcept {
+    std::vector<int> local_connectivity;
+    for (const auto& cell : vis::detail::compute_cells(extents)) {
+      for (const auto& bounding_indices : cell.bounding_indices) {
+        local_connectivity.emplace_back(*total_points_so_far +
+                                        static_cast<int>(bounding_indices));
+      }
+    }
+    return local_connectivity;
+  }
+  ();
+  *total_points_so_far += element_num_points;
+  total_connectivity->insert(total_connectivity->end(), connectivity.begin(),
+                             connectivity.end());
+}
+
+// Append the name of an element to the string of grid names
+void append_element_name(const gsl::not_null<std::string*> grid_names,
+                         const ExtentsAndTensorVolumeData& element) noexcept {
+  // Get the name of the element
+  const auto& first_tensor_name = element.tensor_components.front().name;
+  ASSERT(first_tensor_name.find_last_of('/') != std::string::npos,
+         "The expected format of the tensor component names is "
+         "'GROUP_NAME/COMPONENT_NAME' but could not find a '/' in '"
+             << first_tensor_name << "'.");
+  const auto spatial_name =
+      first_tensor_name.substr(0, first_tensor_name.find_last_of('/'));
+  *grid_names += spatial_name + VolumeData::separator();
+}
+}  // namespace
+
+VolumeData::VolumeData(const bool subfile_exists, detail::OpenGroup&& group,
                        const hid_t /*location*/, const std::string& name,
                        const uint32_t version) noexcept
     : group_(std::move(group)),
@@ -32,7 +88,7 @@ VolumeData::VolumeData(const bool exists, detail::OpenGroup&& group,
                 : name + extension()),
       version_(version),
       volume_data_group_(group_.id(), name_, h5::AccessType::ReadWrite) {
-  if (exists) {
+  if (subfile_exists) {
     // We treat this as an internal version for now. We'll need to deal with
     // proper versioning later.
     const Version open_version(true, detail::OpenGroup{},
@@ -42,9 +98,11 @@ VolumeData::VolumeData(const bool exists, detail::OpenGroup&& group,
                         "header");
     header_ = header.get_header();
   } else {  // file does not exist
+    // Subfiles are closed as they go out of scope, so we have the extra
+    // braces here to add the necessary scope
     {
-      Version open_version(false, detail::OpenGroup{},
-                           volume_data_group_.id(), "version", version_);
+      Version open_version(false, detail::OpenGroup{}, volume_data_group_.id(),
+                           "version", version_);
     }
     {
       Header header(false, detail::OpenGroup{}, volume_data_group_.id(),
@@ -54,66 +112,97 @@ VolumeData::VolumeData(const bool exists, detail::OpenGroup&& group,
   }
 }
 
-void VolumeData::insert_tensor_data(
+// Write Volume Data stored in a vector of `ExtentsAndTensorVolumeData` to
+// an `observation_group` in a `VolumeData` file.
+void VolumeData::write_volume_data(
     const size_t observation_id, const double observation_value,
-    const ExtentsAndTensorVolumeData& extents_and_tensors) noexcept {
+    const std::vector<ExtentsAndTensorVolumeData>& elements) noexcept {
   const std::string path = "ObservationId" + std::to_string(observation_id);
   detail::OpenGroup observation_group(volume_data_group_.id(), path,
                                       AccessType::ReadWrite);
-  if (not contains_attribute(observation_group.id(), "", "observation_value")) {
-    h5::write_to_attribute(observation_group.id(), "observation_value",
-                           observation_value);
+  if (contains_attribute(observation_group.id(), "", "observation_value")) {
+    ERROR("Trying to write ObservationId "
+          << std::to_string(observation_id) << " with observation_value "
+          << observation_group.id() << " which already exists in file at "
+          << path << ".");
   }
-  const auto& first_tensor_name =
-      extents_and_tensors.tensor_components.front().name;
-  ASSERT(first_tensor_name.find_last_of('/') != std::string::npos,
-         "The expected format of the tensor component names is "
-         "'GROUP_NAME/COMPONENT_NAME' but could not find a '/' in '"
-             << first_tensor_name << "'.");
-  const auto spatial_name =
-      first_tensor_name.substr(0, first_tensor_name.find_last_of('/'));
-  detail::OpenGroup spatial_group(observation_group.id(), spatial_name,
-                                  AccessType::ReadWrite);
-
-  // Write extents.
-  const auto& extents = extents_and_tensors.extents;
-  if (not contains_attribute(spatial_group.id(), "", "extents")) {
-    h5::write_to_attribute(spatial_group.id(), "extents", extents);
-  }
-
-  // Write the connectivity.
-  if (not h5::contains_dataset_or_group(spatial_group.id(), "",
-                                        "connectivity")) {
-    const std::vector<int> connectivity = [&extents]() noexcept {
-      std::vector<int> local_connectivity;
-      for (const auto& cell : vis::detail::compute_cells(extents)) {
-        for (const auto& bounding_indices : cell.bounding_indices) {
-          local_connectivity.emplace_back(bounding_indices);
-        }
-      }
-      return local_connectivity;
-    }();
-    h5::write_connectivity(spatial_group.id(), connectivity);
-  }
-
-  // Write the tensor components.
-  for (const auto& tensor_component : extents_and_tensors.tensor_components) {
-    ASSERT(tensor_component.name.find_last_of('/') != std::string::npos,
+  h5::write_to_attribute(observation_group.id(), "observation_value",
+                         observation_value);
+  // Get first element to extract the component names and dimension
+  const auto get_component_name = [](const auto& component) noexcept {
+    ASSERT(component.name.find_last_of('/') != std::string::npos,
            "The expected format of the tensor component names is "
            "'GROUP_NAME/COMPONENT_NAME' but could not find a '/' in '"
-               << tensor_component.name << "'.");
-    const auto component_name = tensor_component.name.substr(
-        tensor_component.name.find_last_of('/') + 1);
-    if (not h5::contains_dataset_or_group(spatial_group.id(), "",
-                                          component_name)) {
-      h5::write_data(spatial_group.id(), tensor_component.data, component_name);
-    } else {
+               << component.name << "'.");
+    return component.name.substr(component.name.find_last_of('/') + 1);
+  };
+  const std::vector<std::string> component_names(
+      boost::make_transform_iterator(elements.front().tensor_components.begin(),
+                                     get_component_name),
+      boost::make_transform_iterator(elements.front().tensor_components.end(),
+                                     get_component_name));
+
+  // The dimension of the grid is the number of extents per element.
+  // Only written once per VolumeData file, as if two observation id's
+  if (not contains_attribute(volume_data_group_.id(), "", "dimension")) {
+    h5::write_to_attribute(volume_data_group_.id(), "dimension",
+                           elements.front().extents.size());
+  }
+  const auto dim =
+      h5::read_value_attribute<size_t>(volume_data_group_.id(), "dimension");
+  // Extract Tensor Data one component at a time
+  std::vector<size_t> total_extents;
+  std::string grid_names;
+  std::vector<int> total_connectivity;
+  // We need to keep track the total number of points inserted into the
+  // connectivity after each iteration to be sure each point gets a
+  // unique representation in the topology data
+  int total_points_so_far = 0;
+  // Loop over tensor componenents
+  for (size_t i = 0; i < component_names.size(); i++) {
+    std::string component_name = component_names[i];
+
+    std::vector<double> contiguous_tensor_data{};
+    for (auto& element : elements) {
+      if (i == 0) {  // True if first tensor component being accessed
+        append_element_name(&grid_names, element);
+        append_element_extents_and_connectivity(
+            &total_extents, &total_connectivity, &total_points_so_far, dim,
+            element);
+      }
+      const DataVector& tensor_data_on_grid = element.tensor_components[i].data;
+      contiguous_tensor_data.insert(contiguous_tensor_data.end(),
+                                    tensor_data_on_grid.begin(),
+                                    tensor_data_on_grid.end());
+
+    }  // for each element
+
+    // Write the data for the tensor component
+    if (h5::contains_dataset_or_group(observation_group.id(), "",
+                                      component_name)) {
       ERROR("Trying to write tensor component '"
             << component_name
             << "' which already exists in HDF5 file in group '" << name_ << '/'
-            << path << '/' << spatial_name << "'.");
+            << "ObservationId" << std::to_string(observation_id) << "'");
     }
-  }
+
+    h5::write_data(observation_group.id(), contiguous_tensor_data,
+                   {contiguous_tensor_data.size()}, component_name);
+  }  // for each component
+
+  // Write the grid extents contiguously, the first `dim` belong to the
+  // First grid, the second `dim` belong to the second grid, and so on,
+  // Ordering is `x, y, z, ... `
+  h5::write_data(observation_group.id(), total_extents, {total_extents.size()},
+                 "total_extents");
+  // Write the names of the grids as vector of chars with individual names
+  // separated by `separator()`
+  std::vector<char> grid_names_as_chars(grid_names.begin(), grid_names.end());
+  h5::write_data(observation_group.id(), grid_names_as_chars,
+                 {grid_names_as_chars.size()}, "grid_names");
+  // Write the Connectivity
+  h5::write_data(observation_group.id(), total_connectivity,
+                 {total_connectivity.size()}, "connectivity");
 }
 
 std::vector<size_t> VolumeData::list_observation_ids() const noexcept {
@@ -134,36 +223,50 @@ double VolumeData::get_observation_value(const size_t observation_id) const
                                           "observation_value");
 }
 
-std::vector<std::string> VolumeData::list_grids(
-    const size_t observation_id) const noexcept {
-  detail::OpenGroup observation_group(
-      volume_data_group_.id(),
-      "ObservationId" + std::to_string(observation_id), AccessType::ReadOnly);
-  return get_group_names(observation_group.id(), "");
-}
-
 std::vector<std::string> VolumeData::list_tensor_components(
-    size_t observation_id, const std::string& grid_name) const noexcept {
-  detail::OpenGroup spatial_group(
-      volume_data_group_.id(),
-      "ObservationId" + std::to_string(observation_id) + "/" + grid_name,
-      AccessType::ReadOnly);
-  auto tensor_components = get_group_names(spatial_group.id(), "");
+    const size_t observation_id) const noexcept {
+  auto tensor_components =
+      get_group_names(volume_data_group_.id(),
+                      "ObservationId" + std::to_string(observation_id));
   std::remove(tensor_components.begin(), tensor_components.end(),
               "connectivity");
-  tensor_components.pop_back();
+  std::remove(tensor_components.begin(), tensor_components.end(),
+              "total_extents");
+  std::remove(tensor_components.begin(), tensor_components.end(), "grid_names");
+  // std::remove moves the element to the end of the vector, so we still need to
+  // actually erase it from the vector
+  tensor_components.erase(tensor_components.end() - 3, tensor_components.end());
+
   return tensor_components;
 }
 
+std::vector<std::string> VolumeData::get_grid_names(
+    const size_t observation_id) const noexcept {
+  const std::string path = "ObservationId" + std::to_string(observation_id);
+  detail::OpenGroup observation_group(volume_data_group_.id(), path,
+                                      AccessType::ReadOnly);
+  const std::vector<char> names =
+      h5::read_data<1, std::vector<char>>(observation_group.id(), "grid_names");
+  const std::string all_names(names.begin(), names.end());
+  std::vector<std::string> grid_names{};
+  boost::split(grid_names, all_names, [this](const char c) noexcept {
+    return c == this->separator();
+  });
+  // boost::split counts the last separator as a split even though there are no
+  // characters after it, so the last entry of the vector is empty
+  grid_names.pop_back();
+  return grid_names;
+}
+
 DataVector VolumeData::get_tensor_component(
-    size_t observation_id, const std::string& grid_name,
-    const std::string& tensor_component) const noexcept {
-  detail::OpenGroup spatial_group(
-      volume_data_group_.id(),
-      "ObservationId" + std::to_string(observation_id) + "/" + grid_name,
-      AccessType::ReadOnly);
+    const size_t observation_id, const std::string& tensor_component) const
+    noexcept {
+  const std::string path = "ObservationId" + std::to_string(observation_id);
+  detail::OpenGroup observation_group(volume_data_group_.id(), path,
+                                      AccessType::ReadOnly);
+
   const hid_t dataset_id =
-      h5::open_dataset(spatial_group.id(), tensor_component);
+      h5::open_dataset(observation_group.id(), tensor_component);
   const hid_t dataspace_id = h5::open_dataspace(dataset_id);
   const auto rank =
       static_cast<size_t>(H5Sget_simple_extent_ndims(dataspace_id));
@@ -171,24 +274,41 @@ DataVector VolumeData::get_tensor_component(
   h5::close_dataset(dataset_id);
   switch (rank) {
     case 1:
-      return h5::read_data<1, DataVector>(spatial_group.id(), tensor_component);
+      return h5::read_data<1, DataVector>(observation_group.id(),
+                                          tensor_component);
     case 2:
-      return h5::read_data<2, DataVector>(spatial_group.id(), tensor_component);
+      return h5::read_data<2, DataVector>(observation_group.id(),
+                                          tensor_component);
     case 3:
-      return h5::read_data<3, DataVector>(spatial_group.id(), tensor_component);
+      return h5::read_data<3, DataVector>(observation_group.id(),
+                                          tensor_component);
     default:
       ERROR("Rank must be 1, 2, or 3. Received data with Rank = " << rank);
   }
 }
 
-std::vector<size_t> VolumeData::get_extents(size_t observation_id,
-                                            const std::string& grid_name) const
-    noexcept {
-  detail::OpenGroup spatial_group(
-      volume_data_group_.id(),
-      "ObservationId" + std::to_string(observation_id) + "/" + grid_name,
-      AccessType::ReadOnly);
-  return h5::read_rank1_attribute<size_t>(spatial_group.id(), "extents");
+std::vector<std::vector<size_t>> VolumeData::get_extents(
+    const size_t observation_id) const noexcept {
+  const std::string path = "ObservationId" + std::to_string(observation_id);
+  detail::OpenGroup observation_group(volume_data_group_.id(), path,
+                                      AccessType::ReadOnly);
+  const auto dim =
+      h5::read_value_attribute<size_t>(volume_data_group_.id(), "dimension");
+  const auto extents_per_element = static_cast<long>(dim);
+  const auto total_extents = h5::read_data<1, std::vector<size_t>>(
+      observation_group.id(), "total_extents");
+  std::vector<std::vector<size_t>> individual_extents;
+  individual_extents.reserve(total_extents.size() / dim);
+  for (auto iter = total_extents.begin(); iter != total_extents.end();
+       iter += extents_per_element) {
+    individual_extents.emplace_back(iter, iter + extents_per_element);
+  }
+  return individual_extents;
 }
+
+size_t VolumeData::get_dimension() const noexcept {
+  return h5::read_value_attribute<double>(volume_data_group_.id(), "dimension");
+}
+
 }  // namespace h5
 /// \endcond HIDDEN_SYMBOLS

--- a/src/IO/H5/VolumeData.hpp
+++ b/src/IO/H5/VolumeData.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <hdf5.h>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "IO/H5/Object.hpp"
@@ -25,7 +26,7 @@ namespace h5 {
  * The volume data inside the subfile can be of any dimensionality greater than
  * zero. This means that in a 3D simulation, data on 2-dimensional surfaces are
  * written as a VolumeData subfile. Data can be written using the
- * `insert_tensor_data()` method. An integral observation id is used to keep
+ * `write_volume_data()` method. An integral observation id is used to keep
  * track of the observation instance at which the data is written, and
  * associated with it is a floating point observation value, such as the
  * simulation time at which the data was written. The observation id will
@@ -33,13 +34,25 @@ namespace h5 {
  * simulation.
  *
  * The data stored in the subfile are the tensor components passed to the
- * `insert_tensor_data()` method as a `ExtentsAndTensorVolumeData`. The name of
- * each tensor component must follow the format
+ * `write_volume_data()` method as a  `std::vector<ExtentsAndTensorVolumeData>`.
+ * The name of each tensor component must follow the format
  * `GRID_NAME/TENSOR_NAME_COMPONENT`, e.g. `Element0/T_xx`. Typically the
  * `GRID_NAME` should be the output of the stream operator of the spatial ID of
  * the parallel component element sending the data to be observed. For example,
  * in the case of a dG evolution where the spatial IDs are `ElementId`s, the
- * grid names would be of the form `[B0,(L2I3,L2I3,L2I3)]`.
+ * grid names would be of the form `[B0,(L2I3,L2I3,L2I3)]`.  The data are
+ * written contiguously inside of the H5 subfile, in that each tensor
+ * component has a single dataset which holds all of the data from
+ * all elements, e.g. a tensor component `T_xx` which is found on all grids
+ * appears in the path `H5_FILE_NAME/element_data.vol/T_xx` and that is where
+ * all of the `T_xx` data from all of the grids resides.  Note that coordinates
+ * must be written as tensors in order to visualize the data in ParaView,
+ * Visit, etc.   In order to reconstruct which data came from which grid,
+ * the `get_grid_names()`, and `get_extents()` methods list the grids
+ * and their extents in the order which they and the data were written.
+ * For example, if the first grid has name `GRID_NAME` with extents
+ * `{2, 2, 2}`, it was responsible for contributing the first 2*2*2 = 8 grid
+ * points worth of data in each tensor dataset.
  *
  * \warning Currently the topology of the grids is assumed to be tensor products
  * of lines, i.e. lines, quadrilaterals, and hexahedrons. However, this can be
@@ -50,7 +63,7 @@ class VolumeData : public h5::Object {
  public:
   static std::string extension() noexcept { return ".vol"; }
 
-  VolumeData(bool exists, detail::OpenGroup&& group, hid_t location,
+  VolumeData(bool subfile_exists, detail::OpenGroup&& group, hid_t location,
              const std::string& name, uint32_t version = 1) noexcept;
 
   VolumeData(const VolumeData& /*rhs*/) = delete;
@@ -78,9 +91,9 @@ class VolumeData : public h5::Object {
   ///
   /// \requires The names of the tensor components is of the form
   /// `GRID_NAME/TENSOR_NAME_COMPONENT`, e.g. `Element0/T_xx`
-  void insert_tensor_data(
+  void write_volume_data(
       size_t observation_id, double observation_value,
-      const ExtentsAndTensorVolumeData& extents_and_tensors) noexcept;
+      const std::vector<ExtentsAndTensorVolumeData>& elements) noexcept;
 
   /// List all the integral observation ids in the subfile
   std::vector<size_t> list_observation_ids() const noexcept;
@@ -89,26 +102,29 @@ class VolumeData : public h5::Object {
   /// subfile
   double get_observation_value(size_t observation_id) const noexcept;
 
-  /// List all the grid ids at the the integral observation id in the
-  /// subfile
-  std::vector<std::string> list_grids(size_t observation_id) const noexcept;
+  /// List all the tensor components at observation id `observation_id`
+  std::vector<std::string> list_tensor_components(size_t observation_id) const
+      noexcept;
 
-  /// List all the tensor components on the grid `grid_name` at observation id
-  /// `observation_id`
-  std::vector<std::string> list_tensor_components(
-      size_t observation_id, const std::string& grid_name) const noexcept;
+  /// List the names of all the grids at observation id `observation_id`
+  std::vector<std::string> get_grid_names(size_t observation_id) const noexcept;
 
-  /// Read a tensor component with name `tensor_component` from the grid
-  /// `grid_name` at the observation id `observation_id`
+  /// Read a tensor component with name `tensor_component` at observation id
+  /// `observation_id` from all grids in the file
   DataVector get_tensor_component(size_t observation_id,
-                                  const std::string& grid_name,
                                   const std::string& tensor_component) const
       noexcept;
 
-  /// Read the extents of the grid `grid_name` at the observation id
+  /// Read the extents of all the grids stored in the file at the observation id
   /// `observation_id`
-  std::vector<size_t> get_extents(size_t observation_id,
-                                  const std::string& grid_name) const noexcept;
+  std::vector<std::vector<size_t>> get_extents(size_t observation_id) const
+      noexcept;
+
+  /// Read the dimensionality of the grids.
+  size_t get_dimension() const noexcept;
+
+  /// Return the character used as a separator between grids in the subfile.
+  static char separator() noexcept { return ':'; }
 
  private:
   detail::OpenGroup group_{};

--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -74,8 +74,8 @@ struct ContributeVolumeData {
         make_not_null(&box),
         [
           &cache, &observation_id, &array_component_id, &received_extents,
-          received_tensor_data = std::move(in_received_tensor_data), &
-          subfile_name
+          received_tensor_data = std::move(in_received_tensor_data),
+          &subfile_name
         ](const gsl::not_null<db::item_type<Tags::TensorData>*> volume_data,
           const std::unordered_set<ArrayComponentId>&
               volume_component_ids) mutable noexcept {
@@ -142,11 +142,12 @@ struct ContributeVolumeDataToWriter {
     // This is the number of callers that have registered (that are associated
     // with the observation type of this observation_id).
     // We expect that this Action will be called once by each of them.
-    const auto expected_number_of_calls = [&box, &observation_id]() noexcept {
+    const auto expected_number_of_calls = [&box, &observation_id ]() noexcept {
       const auto hash = observation_id.observation_type_hash();
       const auto& registered = db::get<Tags::VolumeObserversRegistered>(box);
       return (registered.count(hash) == 1) ? registered.at(hash).size() : 0;
-    }();
+    }
+    ();
     db::mutate<Tags::TensorData, Tags::VolumeObserversContributed>(
         make_not_null(&box),
         [
@@ -233,11 +234,14 @@ struct WriteVolumeData {
       constexpr size_t version_number = 0;
       auto& volume_file =
           h5file.try_insert<h5::VolumeData>(subfile_name, version_number);
-      for (const auto& id_and_tensor_data_for_grid : volume_data) {
-        const auto& extents_and_tensors = id_and_tensor_data_for_grid.second;
-        volume_file.insert_tensor_data(
-            observation_id.hash(), observation_id.value(), extents_and_tensors);
+      std::vector<ExtentsAndTensorVolumeData> dg_elements;
+      dg_elements.reserve(volume_data.size());
+      for (auto id_and_element : volume_data) {
+        dg_elements.push_back(id_and_element.second);
       }
+      // Write the data to the file
+      volume_file.write_volume_data(observation_id.hash(),
+                                    observation_id.value(), dg_elements);
     }
     Parallel::unlock(&file_lock);
   }

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -3,7 +3,9 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <algorithm>
 #include <boost/iterator/transform_iterator.hpp>
+#include <boost/range/combine.hpp>
 #include <cstddef>
 #include <functional>
 #include <string>
@@ -90,7 +92,6 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
   if (file_system::check_if_file_exists(h5_file_name)) {
     file_system::rm(h5_file_name, true);
   }
-
   const auto make_fake_volume_data = [](const observers::ArrayComponentId& id,
                                         const std::string& element_name) {
     const auto hashed_id =
@@ -139,69 +140,108 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
             /* get<0> = index of dimensions */
             std::get<0>(volume_data_fakes));
   }
-  // Invoke the simple action 'ContributeVolumeDataToWriter' to move the volume
-  // data to the Writer parallel component.
+  // Invoke the simple action 'ContributeVolumeDataToWriter'
+  // to move the volume data to the Writer parallel component.
   runner.invoke_queued_simple_action<obs_writer>(0);
-  // Invoke the threaded action 'WriteVolumeData' to write the data to disk.
+  // Invoke the threaded action 'WriteVolumeData' to write the data
+  // to disk.
   runner.invoke_queued_threaded_action<obs_writer>(0);
 
   REQUIRE(file_system::check_if_file_exists(h5_file_name));
   // Check that the H5 file was written correctly.
-  {
-    h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
-    auto& volume_file = my_file.get<h5::VolumeData>("/element_data");
+  h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
+  auto& volume_file = my_file.get<h5::VolumeData>("/element_data");
 
-    const auto temporal_id =
-        observers::ObservationId(
-            3., typename TestObservers_detail::RegisterThisObsType<
-                    type_of_observation>::ElementObservationType{})
-            .hash();
-    CHECK(volume_file.list_observation_ids() ==
-          std::vector<size_t>{temporal_id});
-    const auto grids = volume_file.list_grids(temporal_id);
-    const std::vector<std::string> expected_grids(
-        boost::make_transform_iterator(element_ids.begin(),
-                                       get_output<ElementId<2>>),
-        boost::make_transform_iterator(element_ids.end(),
-                                       get_output<ElementId<2>>));
-    REQUIRE(alg::all_of(grids, [&expected_grids](const std::string& name) {
-      return alg::found(expected_grids, name);
-    }));
-    REQUIRE(alg::all_of(expected_grids, [&grids](const std::string& name) {
-      return alg::found(grids, name);
-    }));
+  const auto temporal_id =
+      observers::ObservationId(
+          3., typename TestObservers_detail::RegisterThisObsType<
+                  type_of_observation>::ElementObservationType{})
+          .hash();
+  CHECK(volume_file.list_observation_ids() == std::vector<size_t>{temporal_id});
 
-    for (const auto& element_id : element_ids) {
-      const std::string grid_name = MakeString{} << element_id;
-      const auto tensor_names =
-          volume_file.list_tensor_components(temporal_id, grid_name);
-      const std::vector<std::string> expected_tensor_names{
-          "T_x", "T_y", "S_xx", "S_yy", "S_xy", "S_yx"};
-      CAPTURE(element_id);
-      CAPTURE(tensor_names);
-      CAPTURE(expected_tensor_names);
-      REQUIRE(alg::all_of(tensor_names,
-                          [&expected_tensor_names](const std::string& name) {
-                            return alg::found(expected_tensor_names, name);
-                          }));
-      REQUIRE(alg::all_of(expected_tensor_names,
-                          [&tensor_names](const std::string& name) {
-                            return alg::found(tensor_names, name);
-                          }));
-      const observers::ArrayComponentId array_id(
-          std::add_pointer_t<element_comp>{nullptr},
-          Parallel::ArrayIndex<ElementIndex<2>>{ElementIndex<2>{element_id}});
-      const auto volume_data_fakes = make_fake_volume_data(array_id, "");
-      CHECK(std::vector<size_t>{std::get<0>(volume_data_fakes)[0],
-                                std::get<0>(volume_data_fakes)[1]} ==
-            volume_file.get_extents(temporal_id, grid_name));
-      for (const auto& tensor_component : std::get<1>(volume_data_fakes)) {
-        CHECK(tensor_component.data ==
-              volume_file.get_tensor_component(temporal_id, grid_name,
-                                               tensor_component.name));
-      }
-    }
+  const auto tensor_names = volume_file.list_tensor_components(temporal_id);
+  const std::vector<std::string> expected_tensor_names{"T_x",  "T_y",  "S_xx",
+                                                       "S_yy", "S_xy", "S_yx"};
+  CAPTURE(tensor_names);
+  CAPTURE(expected_tensor_names);
+  REQUIRE(alg::all_of(tensor_names,
+                      [&expected_tensor_names](const std::string& name) {
+                        return alg::found(expected_tensor_names, name);
+                      }));
+  REQUIRE(alg::all_of(expected_tensor_names,
+                      [&tensor_names](const std::string& name) {
+                        return alg::found(tensor_names, name);
+                      }));
+  const std::vector<std::string> grid_names =
+      volume_file.get_grid_names(temporal_id);
+  // A pair holds an element_id, and it's "place" in the string of grid names
+  std::vector<std::tuple<ElementId<2>, size_t>> pairs;
+  auto start = grid_names.begin();
+  auto end = grid_names.end();
+  for (const auto& element_id : element_ids) {
+    const auto place =
+        std::find(start, end, get_output<ElementId<2>>(element_id));
+    // Check that the grid was actually found
+    REQUIRE(place != end);
+    // Store a tuple of the element_id and its place
+    pairs.emplace_back(element_id, std::distance(start, place));
   }
+  // Sort element_ids by place, this is necessary because the elements are
+  // written to file in an unpredictable order, so to extract this order,
+  // we look at the string of grid names, as it is written in the same order as
+  // the elements.
+  std::sort(pairs.begin(), pairs.end(),
+            [](const std::tuple<ElementId<2>, size_t>& pair_1,
+               const std::tuple<ElementId<2>, size_t>& pair_2) {
+              return std::get<1>(pair_1) < std::get<1>(pair_2);
+            });
+  std::vector<ElementId<2>> sorted_element_ids;
+  sorted_element_ids.reserve(pairs.size());
+  for (const auto& pair : pairs) {
+    sorted_element_ids.push_back(std::get<0>(pair));
+  }
+  // Read the Tensor Data that was written to the file
+  std::unordered_map<std::string, DataVector> read_tensor_data;
+  for (const auto& tensor_name :
+       volume_file.list_tensor_components(temporal_id)) {
+    read_tensor_data[tensor_name] =
+        volume_file.get_tensor_component(temporal_id, tensor_name);
+  }
+  // Read the extents that were written to file
+  const std::vector<std::vector<size_t>> read_extents =
+      volume_file.get_extents(temporal_id);
+  // The data is stored contiguously, and each element has a subset of the
+  // data
+  size_t points_processed = 0;
+  for (size_t i = 0; i < sorted_element_ids.size(); i++) {
+    const auto& element_id = sorted_element_ids[i];
+    const std::string grid_name = MakeString{} << element_id;
+    const observers::ArrayComponentId array_id(
+        std::add_pointer_t<element_comp>{nullptr},
+        Parallel::ArrayIndex<ElementIndex<2>>{ElementIndex<2>{element_id}});
+    const auto volume_data_fakes = make_fake_volume_data(array_id, "");
+    // Each element contains as many data points as the product of its
+    // extents, compute this number
+    const size_t stride = [&volume_data_fakes]() {
+      size_t local_points = 1;
+      for (const auto& extent : std::get<0>(volume_data_fakes)) {
+        local_points *= extent;
+      }
+      return local_points;
+    }();
+    // Check that the extents and tensor data were correctly written
+    CHECK(std::vector<size_t>{std::get<0>(volume_data_fakes)[0],
+                              std::get<0>(volume_data_fakes)[1]} ==
+          read_extents[i]);
+    for (const auto& tensor_component : std::get<1>(volume_data_fakes)) {
+      CHECK(tensor_component.data ==
+            DataVector(
+                &(read_tensor_data[tensor_component.name][points_processed]),
+                stride));
+    }
+    points_processed += stride;
+  }
+
   if (file_system::check_if_file_exists(h5_file_name)) {
     file_system::rm(h5_file_name, true);
   }

--- a/tests/Unit/IO/Test_VolumeData.cpp
+++ b/tests/Unit/IO/Test_VolumeData.cpp
@@ -3,6 +3,7 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -16,6 +17,7 @@
 #include "IO/H5/VolumeData.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/FileSystem.hpp"
+#include "Utilities/Numeric.hpp"
 
 SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
   const std::string h5_file_name("Unit.IO.H5.VolumeData.h5");
@@ -35,91 +37,150 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
       {17.9, 27.6, 21.9, -28.1, -26.3, 32.7, 26.8, -30.2}};
   const std::vector<size_t> observation_ids{8435087234, size_t(-1)};
   const std::vector<double> observation_values{8.0, 2.3};
-  const std::vector<std::string> grids{"[[2,3,4]]", "[[7,3,8]]"};
+  const std::vector<std::string> grid_names{"[[2,3,4]]", "[[5,6,7]]"};
   {
     auto& volume_file =
         my_file.insert<h5::VolumeData>("/element_data", version_number);
     const auto write_to_file = [
-      &volume_file, &tensor_components_and_coords, &grids
+      &volume_file, &tensor_components_and_coords, &grid_names
     ](const size_t observation_id, const double observation_value) noexcept {
-      for (const auto& grid : grids) {
-        volume_file.insert_tensor_data(
-            observation_id, observation_value,
-            ExtentsAndTensorVolumeData(
-                {2, 2, 2},
-                {TensorComponent{
-                     grid + "/S",
-                     observation_value * tensor_components_and_coords[0]},
-                 TensorComponent{
-                     grid + "/x-coord",
-                     observation_value * tensor_components_and_coords[1]},
-                 TensorComponent{
-                     grid + "/y-coord",
-                     observation_value * tensor_components_and_coords[2]},
-                 TensorComponent{
-                     grid + "/z-coord",
-                     observation_value * tensor_components_and_coords[3]}}));
-
-        volume_file.insert_tensor_data(
-            observation_id, observation_value,
-            ExtentsAndTensorVolumeData(
-                {2, 2, 2},
-                {TensorComponent{
-                     grid + "/T_x",
-                     observation_value * tensor_components_and_coords[4]},
-                 TensorComponent{
-                     grid + "/T_y",
-                     observation_value * tensor_components_and_coords[5]},
-                 TensorComponent{
-                     grid + "/T_z",
-                     observation_value * tensor_components_and_coords[6]}}));
-      }
+      std::string first_grid = grid_names.front();
+      std::string last_grid = grid_names.back();
+      volume_file.write_volume_data(
+          observation_id, observation_value,
+          std::vector<ExtentsAndTensorVolumeData>{
+              {{2, 2, 2},
+               {TensorComponent{
+                    first_grid + "/S",
+                    observation_value * tensor_components_and_coords[0]},
+                TensorComponent{
+                    first_grid + "/x-coord",
+                    observation_value * tensor_components_and_coords[1]},
+                TensorComponent{
+                    first_grid + "/y-coord",
+                    observation_value * tensor_components_and_coords[2]},
+                TensorComponent{
+                    first_grid + "/z-coord",
+                    observation_value * tensor_components_and_coords[3]},
+                TensorComponent{
+                    first_grid + "/T_x",
+                    observation_value * tensor_components_and_coords[4]},
+                TensorComponent{
+                    first_grid + "/T_y",
+                    observation_value * tensor_components_and_coords[5]},
+                TensorComponent{
+                    first_grid + "/T_z",
+                    observation_value * tensor_components_and_coords[6]}}},
+              // Second Element Data
+              {{2, 2, 2},
+               {TensorComponent{
+                    last_grid + "/S",
+                    observation_value * tensor_components_and_coords[1]},
+                TensorComponent{
+                    last_grid + "/x-coord",
+                    observation_value * tensor_components_and_coords[0]},
+                TensorComponent{
+                    last_grid + "/y-coord",
+                    observation_value * tensor_components_and_coords[5]},
+                TensorComponent{
+                    last_grid + "/z-coord",
+                    observation_value * tensor_components_and_coords[3]},
+                TensorComponent{
+                    last_grid + "/T_x",
+                    observation_value * tensor_components_and_coords[6]},
+                TensorComponent{
+                    last_grid + "/T_y",
+                    observation_value * tensor_components_and_coords[4]},
+                TensorComponent{
+                    last_grid + "/T_z",
+                    observation_value * tensor_components_and_coords[2]}}}});
     };
     for (size_t i = 0; i < observation_ids.size(); ++i) {
       write_to_file(observation_ids[i], observation_values[i]);
     }
   }
-
+  // Open the read volume file and check that the observation id and values are
+  // correct.
   const auto& volume_file =
       my_file.get<h5::VolumeData>("/element_data", version_number);
   const auto read_observation_ids = volume_file.list_observation_ids();
   CHECK(alg::all_of(read_observation_ids, [&observation_ids](const size_t id) {
     return alg::found(observation_ids, id);
   }));
-
+  // Check that the volume data is correct
   const auto check_time = [
-    &volume_file, &tensor_components_and_coords, &grids
+    &volume_file, &tensor_components_and_coords, &grid_names
   ](const size_t observation_id, const double observation_value) noexcept {
-    const auto read_grids = volume_file.list_grids(observation_id);
-    CHECK(read_grids == grids);
-    for (const auto& grid : grids) {
-      CHECK(std::vector<size_t>{2, 2, 2} ==
-            volume_file.get_extents(observation_id, grid));
-      CHECK(volume_file.get_observation_value(observation_id) ==
-            observation_value);
-      const std::vector<std::string> expected_components{
-          "S", "T_x", "T_y", "T_z", "x-coord", "y-coord", "z-coord"};
-      const auto read_components =
-          volume_file.list_tensor_components(observation_id, grid);
-      CHECK(alg::all_of(read_components,
-                        [&expected_components](const std::string& id) {
-                          return alg::found(expected_components, id);
-                        }));
-      CHECK(volume_file.get_tensor_component(observation_id, grid, "S") ==
-            observation_value * tensor_components_and_coords[0]);
-      CHECK(volume_file.get_tensor_component(observation_id, grid, "x-coord") ==
-            observation_value * tensor_components_and_coords[1]);
-      CHECK(volume_file.get_tensor_component(observation_id, grid, "y-coord") ==
-            observation_value * tensor_components_and_coords[2]);
-      CHECK(volume_file.get_tensor_component(observation_id, grid, "z-coord") ==
-            observation_value * tensor_components_and_coords[3]);
-      CHECK(volume_file.get_tensor_component(observation_id, grid, "T_x") ==
-            observation_value * tensor_components_and_coords[4]);
-      CHECK(volume_file.get_tensor_component(observation_id, grid, "T_y") ==
-            observation_value * tensor_components_and_coords[5]);
-      CHECK(volume_file.get_tensor_component(observation_id, grid, "T_z") ==
-            observation_value * tensor_components_and_coords[6]);
-    }
+    CHECK(std::vector<std::vector<size_t>>{{2, 2, 2}, {2, 2, 2}} ==
+          volume_file.get_extents(observation_id));
+    CHECK(volume_file.get_observation_value(observation_id) ==
+          observation_value);
+    CHECK(volume_file.get_grid_names(observation_id) == grid_names);
+    const std::vector<std::string> expected_components{
+        "S", "T_x", "T_y", "T_z", "x-coord", "y-coord", "z-coord"};
+    const auto read_components =
+        volume_file.list_tensor_components(observation_id);
+    CHECK(alg::all_of(read_components,
+                      [&expected_components](const std::string& id) {
+                        return alg::found(expected_components, id);
+                      }));
+    // These lambdas are needed to get the data coming from the first and
+    // second element, they will hopefully soon be replaced by a general
+    // function to check volume data
+    const auto get_first = [&volume_file,
+                            &observation_id](DataVector all_data) {
+      return DataVector(&all_data[0],
+                        static_cast<size_t>(alg::accumulate(
+                            volume_file.get_extents(observation_id)[0], 1,
+                            std::multiplies<>{})));
+    };
+    const auto get_second = [&volume_file, &observation_id,
+                             &get_first](DataVector all_data) {
+      return DataVector(&all_data[get_first(all_data).size()],
+                        static_cast<size_t>(alg::accumulate(
+                            volume_file.get_extents(observation_id)[1], 1,
+                            std::multiplies<>{})));
+    };
+    CHECK(get_first(volume_file.get_tensor_component(observation_id, "S")) ==
+          observation_value * tensor_components_and_coords[0]);
+    CHECK(get_second(volume_file.get_tensor_component(observation_id, "S")) ==
+          observation_value * tensor_components_and_coords[1]);
+
+    CHECK(get_first(
+              volume_file.get_tensor_component(observation_id, "x-coord")) ==
+          observation_value * tensor_components_and_coords[1]);
+    CHECK(get_second(
+              volume_file.get_tensor_component(observation_id, "x-coord")) ==
+          observation_value * tensor_components_and_coords[0]);
+
+    CHECK(get_first(
+              volume_file.get_tensor_component(observation_id, "y-coord")) ==
+          observation_value * tensor_components_and_coords[2]);
+    CHECK(get_second(
+              volume_file.get_tensor_component(observation_id, "y-coord")) ==
+          observation_value * tensor_components_and_coords[5]);
+
+    CHECK(get_first(
+              volume_file.get_tensor_component(observation_id, "z-coord")) ==
+          observation_value * tensor_components_and_coords[3]);
+    CHECK(get_second(
+              volume_file.get_tensor_component(observation_id, "z-coord")) ==
+          observation_value * tensor_components_and_coords[3]);
+
+    CHECK(get_first(volume_file.get_tensor_component(observation_id, "T_x")) ==
+          observation_value * tensor_components_and_coords[4]);
+    CHECK(get_second(volume_file.get_tensor_component(observation_id, "T_x")) ==
+          observation_value * tensor_components_and_coords[6]);
+
+    CHECK(get_first(volume_file.get_tensor_component(observation_id, "T_y")) ==
+          observation_value * tensor_components_and_coords[5]);
+    CHECK(get_second(volume_file.get_tensor_component(observation_id, "T_y")) ==
+          observation_value * tensor_components_and_coords[4]);
+
+    CHECK(get_first(volume_file.get_tensor_component(observation_id, "T_z")) ==
+          observation_value * tensor_components_and_coords[6]);
+    CHECK(get_second(volume_file.get_tensor_component(observation_id, "T_z")) ==
+          observation_value * tensor_components_and_coords[2]);
   };
   for (size_t i = 0; i < observation_ids.size(); ++i) {
     check_time(observation_ids[i], observation_values[i]);
@@ -143,9 +204,9 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
   h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
   auto& volume_file =
       my_file.insert<h5::VolumeData>("/element_data", version_number);
-  volume_file.insert_tensor_data(
-      100, 10.0,
-      ExtentsAndTensorVolumeData({2}, {TensorComponent{"S", {1.0, 2.0}}}));
+  volume_file.write_volume_data(100, 10.0,
+                                std::vector<ExtentsAndTensorVolumeData>{
+                                    {{2}, {TensorComponent{"S", {1.0, 2.0}}}}});
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
   // clang-format off
@@ -153,7 +214,8 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
 
 // [[OutputRegex, The expected format of the tensor component names is
 // 'GROUP_NAME/COMPONENT_NAME' but could not find a '/' in]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData.ComponentFormat1",
+[[noreturn]]
+SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData.ComponentFormat1",
                                "[Unit][IO][H5]") {
   // clang-format on
   ASSERTION_TEST();
@@ -166,10 +228,11 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
   h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
   auto& volume_file =
       my_file.insert<h5::VolumeData>("/element_data", version_number);
-  volume_file.insert_tensor_data(
+  volume_file.write_volume_data(
       100, 10.0,
-      ExtentsAndTensorVolumeData({2}, {TensorComponent{"A/S", {1.0, 2.0}},
-                                       TensorComponent{"S", {1.0, 2.0}}}));
+      std::vector<ExtentsAndTensorVolumeData>{
+          ExtentsAndTensorVolumeData({2}, {TensorComponent{"A/S", {1.0, 2.0}},
+                                           TensorComponent{"S", {1.0, 2.0}}})});
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
   // clang-format off
@@ -177,7 +240,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
 
 
 // [[OutputRegex, Trying to write tensor component 'S' which already exists
-// in HDF5 file in group 'element_data.vol/ObservationId100/A']]
+// in HDF5 file in group 'element_data.vol/ObservationId100']]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData.WriteTwice",
                                "[Unit][IO][H5]") {
   // clang-format on
@@ -191,10 +254,11 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
   h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
   auto& volume_file =
       my_file.insert<h5::VolumeData>("/element_data", version_number);
-  volume_file.insert_tensor_data(
-      100, 10.0,
-      ExtentsAndTensorVolumeData({2}, {TensorComponent{"A/S", {1.0, 2.0}},
-                                       TensorComponent{"A/S", {1.0, 2.0}}}));
+  volume_file.write_volume_data(100, 10.0,
+                                std::vector<ExtentsAndTensorVolumeData>{
+                                    {{2},
+                                     {TensorComponent{"A/S", {1.0, 2.0}},
+                                      TensorComponent{"A/S", {1.0, 2.0}}}}});
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
   // clang-format off


### PR DESCRIPTION
## Proposed changes
This pull request adds classes and functions necessary to write Volume Data contiguously to an h5 file which would previously have been written in groups corresponding to computational elements.  This allows for significant speedups in both writing and reading data from disk.  These changes have been incorporated by making a dual `ContiguousVolumeData` class which mimics the `VolumeData` class in every way possible while still allowing for this contiguous writing in a way that makes sense.    

### Types of changes:

- [ ] Bugfix
- [ x] New feature

### Component:

- [x ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments
The current way data is written is difficult because it is very slow to access the file many times by creating individual groups for every computational element, and in addition this makes the h5 files larger than necessary as having many groups means storing more metadata.  The following table, with data gathered from running the `EvolveScalarWave3D` executable with 5 time steps, and initial refinement of 5x5x5,  with 3x3x3 coords per element demonstrates this.  

|Metric                                 |  Contiguous     | Elementwise | 
|--------------------------|---------------|--------------|
|  Wall time of Execution    | 33.3 s               | 202.3 s           |
|   Size of H5 files               |        90 MB        |  270 MB         |   

(These were run on 12 cores, so there were 12 H5 files in each case )
If more evidence of performance is required, I'd be happy to document more simulations.   On top of this, storing data in many groups means that for visualization purposes each element must be treated as a separate grid, and this structure needs to be explicitly stated in an XDMF file is going to be used to visualize the data in a software like Paraview.  When the number of computational elements is large, with the number of coordinates per element fixed, this means `.xmf` file size scales at the same rate as the `.h5` file size, which dramatically slows down visualization.  In my personal experience the speedups associated with this have been of around 60 to 100 times.  A few notes about implementation, it will probably be desirable in the near term to allow users to choose their preferred data writing format, but currently in the executables I have exchanged the instances of `VolumeData` with `ContiguousVolumeData` to show that it's very feasible to easily change formats, and the tests for these executables currently reflect the `ContiguousVolumeData` style of writing.  
