### PR TITLE
Remove check_tensor_doubles*equals_tensor_datavectors()

### DIFF
--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrSchild.cpp
@@ -184,66 +184,6 @@ void test_einstein_solution() noexcept {
       std::numeric_limits<double>::epsilon() * 1.e5);
 }
 
-void test_double_vs_datavector() noexcept {
-  // Parameters for KerrSchild solution
-  const double mass = 1.7;
-  const std::array<double, 3> spin{{0.1, 0.2, 0.3}};
-  const std::array<double, 3> center{{0.3, 0.2, 0.4}};
-  gr::Solutions::KerrSchild solution(mass, spin, center);
-
-  const double t = 1.3;
-  const auto x1 = spatial_coords(0.0);
-  const auto x2 = spatial_coords(DataVector{0.0, 0.0, 0.0});
-
-  const auto vars1 =
-      solution.variables(x1, t, gr::Solutions::KerrSchild::tags<double>{});
-  const auto& lapse1 = get<gr::Tags::Lapse<double>>(vars1);
-  const auto& dt_lapse1 = get<Tags::dt<gr::Tags::Lapse<double>>>(vars1);
-  const auto& d_lapse1 =
-      get<gr::Solutions::KerrSchild::DerivLapse<double>>(vars1);
-  const auto& shift1 = get<gr::Tags::Shift<3, Frame::Inertial, double>>(vars1);
-  const auto& d_shift1 =
-      get<gr::Solutions::KerrSchild::DerivShift<double>>(vars1);
-  const auto& dt_shift1 =
-      get<Tags::dt<gr::Tags::Shift<3, Frame::Inertial, double>>>(vars1);
-  const auto& g1 =
-      get<gr::Tags::SpatialMetric<3, Frame::Inertial, double>>(vars1);
-  const auto& dt_g1 =
-      get<Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, double>>>(vars1);
-  const auto& d_g1 =
-      get<gr::Solutions::KerrSchild::DerivSpatialMetric<double>>(vars1);
-
-  const auto vars2 =
-      solution.variables(x2, t, gr::Solutions::KerrSchild::tags<DataVector>{});
-  const auto& lapse2 = get<gr::Tags::Lapse<DataVector>>(vars2);
-  const auto& dt_lapse2 = get<Tags::dt<gr::Tags::Lapse<DataVector>>>(vars2);
-  const auto& d_lapse2 =
-      get<gr::Solutions::KerrSchild::DerivLapse<DataVector>>(vars2);
-  const auto& shift2 =
-      get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars2);
-  const auto& d_shift2 =
-      get<gr::Solutions::KerrSchild::DerivShift<DataVector>>(vars2);
-  const auto& dt_shift2 =
-      get<Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>>(vars2);
-  const auto& g2 =
-      get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(vars2);
-  const auto& dt_g2 =
-      get<Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>(
-          vars2);
-  const auto& d_g2 =
-      get<gr::Solutions::KerrSchild::DerivSpatialMetric<DataVector>>(vars2);
-
-  check_tensor_doubles_approx_equals_tensor_datavectors(lapse2, lapse1);
-  check_tensor_doubles_approx_equals_tensor_datavectors(shift2, shift1);
-  check_tensor_doubles_approx_equals_tensor_datavectors(g2, g1);
-  check_tensor_doubles_approx_equals_tensor_datavectors(dt_lapse2, dt_lapse1);
-  check_tensor_doubles_approx_equals_tensor_datavectors(dt_shift2, dt_shift1);
-  check_tensor_doubles_approx_equals_tensor_datavectors(dt_g2, dt_g1);
-  check_tensor_doubles_approx_equals_tensor_datavectors(d_lapse2, d_lapse1);
-  check_tensor_doubles_approx_equals_tensor_datavectors(d_shift2, d_shift1);
-  check_tensor_doubles_approx_equals_tensor_datavectors(d_g2, d_g1);
-}
-
 void test_serialize() noexcept {
   gr::Solutions::KerrSchild solution(3.0, {{0.2, 0.3, 0.2}}, {{0.0, 3.0, 4.0}});
   test_serialization(solution);
@@ -275,7 +215,6 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.KerrSchild",
   test_schwarzschild<DataVector>(DataVector{0.0, 0.0, 0.0});
   test_schwarzschild<double>(0.0);
   test_einstein_solution();
-  test_double_vs_datavector();
   test_copy_and_move();
   test_serialize();
   test_construct_from_options();

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp
@@ -20,34 +20,6 @@ template <typename X, typename Symm, typename IndexList>
 class Tensor;
 /// \endcond
 
-template <typename Symmetry, typename IndexList>
-void check_tensor_doubles_equals_tensor_datavectors(
-    const Tensor<DataVector, Symmetry, IndexList>& tensor_dv,
-    const Tensor<double, Symmetry, IndexList>& tensor_double) {
-  const size_t n_pts = tensor_dv.begin()->size();
-  for (decltype(auto) datavector_and_double_components :
-       boost::combine(tensor_dv, tensor_double)) {
-    for (size_t s = 0; s < n_pts; ++s) {
-      CHECK(boost::get<0>(datavector_and_double_components)[s] ==
-            boost::get<1>(datavector_and_double_components));
-    }
-  }
-}
-
-template <typename Symmetry, typename IndexList>
-void check_tensor_doubles_approx_equals_tensor_datavectors(
-    const Tensor<DataVector, Symmetry, IndexList>& tensor_dv,
-    const Tensor<double, Symmetry, IndexList>& tensor_double) {
-  const size_t n_pts = tensor_dv.begin()->size();
-  for (decltype(auto) datavector_and_double_components :
-       boost::combine(tensor_dv, tensor_double)) {
-    for (size_t s = 0; s < n_pts; ++s) {
-      CHECK(boost::get<0>(datavector_and_double_components)[s] ==
-            approx(boost::get<1>(datavector_and_double_components)));
-    }
-  }
-}
-
 template <typename DataType>
 Scalar<DataType> make_lapse(const DataType& used_for_size);
 


### PR DESCRIPTION
## Proposed changes

Fixes #548. 

I took a look at `Test_KerrSchild.cpp`. It has 5 test functions:
  * `test_schwarzschild()` is templated on `DataType` and tested for `DataVector` and `double` already
  * `test_einstein_solution()` tests only `DataVector`, because it uses `GeneralizedHarmonic` tags that were deliberately not templated on `DataType`, such as `GeneralizedHarmonic::Tags::Pi`.
  * `test_copy_and_move()`, `test_serialize()`, and `test_construct_from_options()`do not test the parts of the class that are templated on `DataType`
  * `test_double_vs_datavector()` creates a `KerrSchild` solution, evaluates lapse, shift, etc. on either a single point given as a double or on the same point given 3 times in a length-3 `DataVector`, and then tests using `double` or `DataVector` gives the same result.

I don't see what `test_double_vs_datavector()` adds over just testing Schwarzschild with `doubles` and `DataVectors`, so I suggest simply removing `test_double_vs_datavector()`.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->