### PR TITLE
Add GCC9 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,18 @@ jobs:
     dist: trusty
     env: BUILD_TYPE=Release COMPILER=gcc-8
     name: gcc-8 release
+  - &Gcc9Debug
+    os: linux
+    compiler: gcc-9
+    dist: trusty
+    env: BUILD_TYPE=Debug COMPILER=gcc-9
+    name: gcc-9 debug
+  - &Gcc9Release
+    os: linux
+    compiler: gcc-9
+    dist: trusty
+    env: BUILD_TYPE=Release COMPILER=gcc-9
+    name: gcc-9 release
   - &ClangDebug
     os: linux
     compiler: clang
@@ -161,6 +173,8 @@ jobs:
   - <<: *Gcc7Release
   - <<: *Gcc8Debug
   - <<: *Gcc8Release
+  - <<: *Gcc9Debug
+  - <<: *Gcc9Release
   - <<: *ClangDebug
   - <<: *ClangRelease
 
@@ -172,6 +186,8 @@ jobs:
   - <<: *Gcc7Release
   - <<: *Gcc8Debug
   - <<: *Gcc8Release
+  - <<: *Gcc9Debug
+  - <<: *Gcc9Release
   - <<: *ClangDebug
   - <<: *ClangRelease
 

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -18,11 +18,17 @@ FROM ubuntu:18.04
 ARG PARALLEL_MAKE_ARG=-j2
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Add ubuntu test repo for GCC9
+RUN apt-get update -y \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository ppa:ubuntu-toolchain-r/test
+
 # Install required packages for SpECTRE
 RUN apt-get update -y \
     && apt-get install -y gcc-6 g++-6 gfortran-6 \
                           gcc-7 g++-7 gfortran-7 \
                           gcc-8 g++-8 gfortran-8 \
+                          gcc-9 g++-9 gfortran-9 \
                           gdb git cmake \
                           libopenblas-dev liblapack-dev \
                           libhdf5-dev hdf5-tools \


### PR DESCRIPTION
## Proposed changes

- Frontera has GCC9, so we should be able to compile with it.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
