### PR TITLE
Add WeylElectric

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -100,6 +100,17 @@
   url            = "https://doi.org/10.1103/PhysRevD.56.6298",
 }
 
+@article{Boyle2019kee,
+      author         = "Boyle, Michael and others",
+      title          = "{The SXS Collaboration catalog of binary black hole
+                        simulations}",
+      year           = "2019",
+      eprint         = "1904.04831",
+      archivePrefix  = "arXiv",
+      primaryClass   = "gr-qc",
+      SLACcitation   = "%%CITATION = ARXIV:1904.04831;%%"
+}
+
 @book{Cockburn1999,
   author     = "Cockburn, Bernardo",
   editor     = "Barth, Timothy J. and Deconinck, Herman",

--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
     IndexManipulation.cpp
     KerrSchildCoords.cpp
     Ricci.cpp
+    WeylElectric.cpp
     )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
 namespace gr {
 
@@ -29,4 +30,23 @@ tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
     const tnsr::aBcc<DataType, SpatialDim, Frame, Index>&
         d_christoffel_2nd_kind) noexcept;
 
+namespace Tags {
+/// Compute item for spatial Ricci tensor \f$R_{ij}\f$
+/// computed from SpatialChristoffelSecondKind and its spatial derivatives.
+///
+/// Can be retrieved using `gr::Tags::RicciTensor`
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct RicciTensorCompute : RicciTensor<SpatialDim, Frame, DataType>,
+                            db::ComputeTag {
+  using argument_tags = tmpl::list<
+      gr::Tags::SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>,
+      ::Tags::deriv<
+          gr::Tags::SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>,
+          tmpl::size_t<SpatialDim>, Frame>>;
+  static constexpr tnsr::ii<DataType, SpatialDim, Frame> (*function)(
+      const tnsr::Ijj<DataType, SpatialDim, Frame>&,
+      const tnsr::iJkk<DataType, SpatialDim, Frame>&) =
+      &ricci_tensor<SpatialDim, Frame, IndexType::Spatial, DataType>;
+};
+}  // namespace Tags
 } // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -156,6 +156,17 @@ struct TraceExtrinsicCurvature : db::SimpleTag {
 };
 
 /*!
+ * \brief Computes Ricci tensor from the (spatial or spacetime)
+ * Christoffel symbol of the second kind and its derivative.
+ */
+
+template <size_t Dim, typename Frame, typename DataType>
+struct RicciTensor : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+  static std::string name() noexcept { return "RicciTensor"; }
+};
+
+/*!
  * \brief The energy density \f$E=t_a t_b T^{ab}\f$, where \f$t_a\f$ denotes the
  * normal to the spatial hypersurface
  */
@@ -163,6 +174,18 @@ template <typename DataType>
 struct EnergyDensity : db::SimpleTag {
   using type = Scalar<DataType>;
   static std::string name() noexcept { return "EnergyDensity"; }
+};
+
+/*!
+ * \brief Computes the electric part of the Weyl tensor in vacuum
+ * as: \f$ E_{ij} = R_{ij} + KK_{ij} - K^m_{i}K_{mj}\f$ where \f$R_{ij}\f$ is
+ * the spatial Ricci tensor, \f$K_{ij}\f$ is the extrinsic curvature, and
+ * \f$K\f$ is the trace of \f$K_{ij}\f$.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct WeylElectric : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+  static std::string name() noexcept { return "WeylElectric"; }
 };
 }  // namespace Tags
 

--- a/src/PointwiseFunctions/GeneralRelativity/WeylElectric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylElectric.cpp
@@ -1,0 +1,82 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/VectorImpl.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace gr {
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> weyl_electric(
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_ricci,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>&
+        inverse_spatial_metric) noexcept {
+  tnsr::ii<DataType, SpatialDim, Frame> weyl_electric_part{};
+  weyl_electric<SpatialDim, Frame, DataType>(
+      make_not_null(&weyl_electric_part), spatial_ricci,
+      extrinsic_curvature, inverse_spatial_metric);
+  return weyl_electric_part;
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void weyl_electric(
+    const gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*>
+        weyl_electric_part,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_ricci,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>&
+        inverse_spatial_metric) noexcept {
+  *weyl_electric_part = spatial_ricci;
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      for (size_t k = 0; k < SpatialDim; ++k) {
+        for (size_t l = 0; l < SpatialDim; ++l) {
+          weyl_electric_part->get(i, j) +=
+              extrinsic_curvature.get(k, l) *
+                  (inverse_spatial_metric.get(k, l)) *
+                  extrinsic_curvature.get(i, j) -
+              extrinsic_curvature.get(i, l) *
+                  (inverse_spatial_metric.get(k, l)) *
+                  extrinsic_curvature.get(k, j);
+        }
+      }
+    }
+  }
+}
+}  // namespace gr
+
+// Explicit Instantiations
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                                \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)> gr::weyl_electric( \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_ricci,   \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          extrinsic_curvature,                                              \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          inverse_spatial_metric) noexcept;                                 \
+  template void gr::weyl_electric(                                          \
+      const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*>   \
+          weyl_electric_part,                                               \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_ricci,   \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          extrinsic_curvature,                                              \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          inverse_spatial_metric) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/WeylElectric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylElectric.hpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+
+#include "Utilities/Gsl.hpp"
+
+namespace gr {
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the electric part of the Weyl tensor in vacuum.
+ *
+ * \details Computes the electric part of the Weyl tensor in vacuum \f$E_{ij}\f$
+ * as: \f$ E_{ij} = R_{ij} + KK_{ij} - K^m_{i}K_{mj}\f$ where \f$R_{ij}\f$ is
+ * the spatial Ricci tensor, \f$K_{ij}\f$ is the extrinsic curvature, and
+ * \f$K\f$ is the trace of \f$K_{ij}\f$. An additional definition is \f$E_{ij} =
+ * n^a n^b C_{a i b j}\f$, where \f$n\f$ is the unit-normal to the hypersurface
+ * and \f$C\f$ is the Weyl tensor consistent with the conventions
+ * in \cite Boyle2019kee.
+ * \note This needs additional terms for computations in a non-vacuum.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> weyl_electric(
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_ricci,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>&
+        inverse_spatial_metric) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void weyl_electric(
+    gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*>
+        weyl_electric_part,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_ricci,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>&
+        inverse_spatial_metric) noexcept;
+
+namespace Tags {
+/// Compute item for the electric part of the weyl tensor in vacuum
+/// Computed from the RicciTensor, ExtrinsicCurvature, and InverseSpatialMetric
+///
+/// Can be retrieved using gr::Tags::WeylElectric
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct WeylElectricCompute : WeylElectric<SpatialDim, Frame, DataType>,
+                             db::ComputeTag {
+  static constexpr tnsr::ii<DataType, SpatialDim, Frame> (*function)(
+      const tnsr::ii<DataType, SpatialDim, Frame>&,
+      const tnsr::ii<DataType, SpatialDim, Frame>&,
+      const tnsr::II<DataType, SpatialDim, Frame>&) =
+          &weyl_electric<SpatialDim, Frame, DataType>;
+  using argument_tags = tmpl::list<
+      gr::Tags::RicciTensor<SpatialDim, Frame, DataType>,
+      gr::Tags::ExtrinsicCurvature<SpatialDim, Frame, DataType>,
+      gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+};
+}  // namespace Tags
+}  // namespace gr

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_KerrSchildCoords.cpp
   Test_Ricci.cpp
   Test_Tags.cpp
+  Test_WeylElectric.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylElectric.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylElectric.cpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+// IWYU pragma: no_include <boost/preprocessor/arithmetic/dec.hpp>
+// IWYU pragma: no_include <boost/preprocessor/repetition/enum.hpp>
+// IWYU pragma: no_include <boost/preprocessor/tuple/reverse.hpp>
+
+namespace {
+template <size_t SpatialDim, typename DataType>
+void test_weyl_electric(const DataType& used_for_size) {
+  tnsr::ii<DataType, SpatialDim, Frame::Inertial> (*f)(
+      const tnsr::ii<DataType, SpatialDim, Frame::Inertial>&,
+      const tnsr::ii<DataType, SpatialDim, Frame::Inertial>&,
+      const tnsr::II<DataType, SpatialDim, Frame::Inertial>&) =
+      &gr::weyl_electric<SpatialDim, Frame::Inertial, DataType>;
+  pypp::check_with_random_values<1>(f, "WeylElectric", "weyl_electric_tensor",
+                                    {{{-1., 1.}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.WeylElectric",
+                  "[PointwiseFunctions][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/GeneralRelativity/");
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_weyl_electric, (1, 2, 3));
+}

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/WeylElectric.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/WeylElectric.py
@@ -1,0 +1,14 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def weyl_electric_tensor(spatial_ricci, extrinsic_curvature,
+                         inverse_spatial_metric):
+    return (np.einsum("ij", spatial_ricci) +
+           np.einsum("kl,kl,ij", extrinsic_curvature,
+           inverse_spatial_metric, extrinsic_curvature) -
+           np.einsum("il,kl,kj",
+           extrinsic_curvature, inverse_spatial_metric,
+           extrinsic_curvature))


### PR DESCRIPTION
## Proposed changes
Add code to compute the electric part of the Weyl tensor.

### Types of changes:

- [ ] Bugfix
- [x ] New feature

### Component:

- [ x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->