### PR TITLE
Remove unused variables

### DIFF
--- a/tests/Unit/DataStructures/Test_ComplexDataVectorBinaryOperations.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexDataVectorBinaryOperations.cpp
@@ -22,8 +22,6 @@
 
 void test_complex_data_vector_multiple_operand_math() noexcept {
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
-  const TestHelpers::VectorImpl::Bound mone_one{{-1.0, 1.0}};
-  const TestHelpers::VectorImpl::Bound gt_one{{1.0, 100.0}};
   const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
 
   const auto binary_ops = std::make_tuple(

--- a/tests/Unit/DataStructures/Test_ComplexModalVector.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexModalVector.cpp
@@ -56,7 +56,6 @@
 
 void test_complex_modal_vector_math() noexcept {
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
-  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
 
   const auto unary_ops = std::make_tuple(
       std::make_tuple(funcl::Conj<>{}, std::make_tuple(generic)),

--- a/tests/Unit/DataStructures/Test_DataVectorBinaryOperations.cpp
+++ b/tests/Unit/DataStructures/Test_DataVectorBinaryOperations.cpp
@@ -21,8 +21,6 @@
 
 void test_data_vector_multiple_operand_math() noexcept {
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
-  const TestHelpers::VectorImpl::Bound mone_one{{-1.0, 1.0}};
-  const TestHelpers::VectorImpl::Bound gt_one{{1.0, 100.0}};
   const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
 
   const auto binary_ops = std::make_tuple(

--- a/tests/Unit/DataStructures/Test_ModalVector.cpp
+++ b/tests/Unit/DataStructures/Test_ModalVector.cpp
@@ -54,7 +54,6 @@
 
 void test_modal_vector_math() noexcept {
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
-  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
 
   const auto unary_ops = std::make_tuple(
       std::make_tuple(funcl::Abs<>{}, std::make_tuple(generic)));

--- a/tests/Unit/DataStructures/Test_MoreComplexDiagonalModalOperatorMath.cpp
+++ b/tests/Unit/DataStructures/Test_MoreComplexDiagonalModalOperatorMath.cpp
@@ -23,7 +23,6 @@
 
 void test_additional_complex_diagonal_modal_operator_math() noexcept {
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
-  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
 
   const auto acting_on_modal_vector = std::make_tuple(std::make_tuple(
       funcl::Multiplies<>{}, std::make_tuple(generic, generic)));


### PR DESCRIPTION
## Proposed changes

 Removes unused variables that are warned about building RunTests. 

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
