### PR TITLE
Fix sign of communicated speeds in HLL

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Hll.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Hll.hpp
@@ -166,9 +166,9 @@ struct Hll {
           std::numeric_limits<double>::signaling_NaN());
       for (size_t s = 0; s < min_signal_speed.begin()->size(); ++s) {
         get(min_signal_speed)[s] = std::min(get(min_signal_speed_interior)[s],
-                                            get(min_signal_speed_exterior)[s]);
+                                            -get(max_signal_speed_exterior)[s]);
         get(max_signal_speed)[s] = std::max(get(max_signal_speed_interior)[s],
-                                            get(max_signal_speed_exterior)[s]);
+                                            -get(min_signal_speed_exterior)[s]);
       }
       const DataVector one_over_cp_minus_cm =
           1.0 / (get(max_signal_speed) - get(min_signal_speed));

--- a/tests/Unit/DataStructures/Test_MoreDiagonalModalOperatorMath.cpp
+++ b/tests/Unit/DataStructures/Test_MoreDiagonalModalOperatorMath.cpp
@@ -21,7 +21,6 @@
 
 void test_additional_diagonal_modal_operator_math() noexcept {
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
-  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
 
   const auto acting_on_modal_vector = std::make_tuple(std::make_tuple(
       funcl::Multiplies<>{}, std::make_tuple(generic, generic)));

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestFunctions.py
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestFunctions.py
@@ -23,7 +23,8 @@ def apply_var_1_hll_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
                          minus_ndotf_3_ext, minus_ndotf_4_ext,
                          var_1_ext, var_2_ext, var_3_ext, var_4_ext):
     char_speeds = (characteristic_speeds(var_1_int, var_2_int, var_3_int) +
-                   characteristic_speeds(var_1_ext, var_2_ext, var_3_ext) +
+                   [-c for c in
+                    characteristic_speeds(var_1_ext, var_2_ext, var_3_ext)] +
                    [0.0])
     return hll_flux(ndotf_1_int, minus_ndotf_1_ext, var_1_int, var_1_ext,
                     min(char_speeds), max(char_speeds))
@@ -35,7 +36,8 @@ def apply_var_2_hll_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
                          minus_ndotf_3_ext, minus_ndotf_4_ext,
                          var_1_ext, var_2_ext, var_3_ext, var_4_ext):
     char_speeds = (characteristic_speeds(var_1_int, var_2_int, var_3_int) +
-                   characteristic_speeds(var_1_ext, var_2_ext, var_3_ext) +
+                   [-c for c in
+                    characteristic_speeds(var_1_ext, var_2_ext, var_3_ext)] +
                    [0.0])
     return hll_flux(ndotf_2_int, minus_ndotf_2_ext, var_2_int, var_2_ext,
                     min(char_speeds), max(char_speeds))
@@ -47,7 +49,8 @@ def apply_var_3_hll_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
                          minus_ndotf_3_ext, minus_ndotf_4_ext,
                          var_1_ext, var_2_ext, var_3_ext, var_4_ext):
     char_speeds = (characteristic_speeds(var_1_int, var_2_int, var_3_int) +
-                   characteristic_speeds(var_1_ext, var_2_ext, var_3_ext) +
+                   [-c for c in
+                    characteristic_speeds(var_1_ext, var_2_ext, var_3_ext)] +
                    [0.0])
     return hll_flux(ndotf_3_int, minus_ndotf_3_ext, var_3_int, var_3_ext,
                     min(char_speeds), max(char_speeds))
@@ -59,7 +62,8 @@ def apply_var_4_hll_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
                          minus_ndotf_3_ext, minus_ndotf_4_ext,
                          var_1_ext, var_2_ext, var_3_ext, var_4_ext):
     char_speeds = (characteristic_speeds(var_1_int, var_2_int, var_3_int) +
-                   characteristic_speeds(var_1_ext, var_2_ext, var_3_ext) +
+                   [-c for c in
+                    characteristic_speeds(var_1_ext, var_2_ext, var_3_ext)] +
                    [0.0])
     return hll_flux(ndotf_4_int, minus_ndotf_4_ext, var_4_int, var_4_ext,
                     min(char_speeds), max(char_speeds))

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Test_Hll.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Test_Hll.cpp
@@ -137,6 +137,12 @@ void test_hll_flux(const DataVector& used_for_size) noexcept {
       used_for_size);
 }
 
+template <size_t Dim>
+void test_conservation(const DataVector& used_for_size) noexcept {
+  TestHelpers::NumericalFluxes::test_conservation<Dim>(
+      dg::NumericalFluxes::Hll<TestHelpers::NumericalFluxes::System<Dim>>{},
+      used_for_size);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Fluxes.Hll",
@@ -148,4 +154,5 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Fluxes.Hll",
 
   GENERATE_UNINITIALIZED_DATAVECTOR;
   CHECK_FOR_DATAVECTORS(test_hll_flux, (1, 2, 3))
+  CHECK_FOR_DATAVECTORS(test_conservation, (1, 2, 3))
 }

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Test_LocalLaxFriedrichs.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Test_LocalLaxFriedrichs.cpp
@@ -137,6 +137,13 @@ void test_llf_flux(const DataVector& used_for_size) noexcept {
       used_for_size);
 }
 
+template <size_t Dim>
+void test_conservation(const DataVector& used_for_size) noexcept {
+  TestHelpers::NumericalFluxes::test_conservation<Dim>(
+      dg::NumericalFluxes::LocalLaxFriedrichs<
+          TestHelpers::NumericalFluxes::System<Dim>>{},
+      used_for_size);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Fluxes.LocalLaxFriedrichs",
@@ -148,4 +155,5 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Fluxes.LocalLaxFriedrichs",
 
   GENERATE_UNINITIALIZED_DATAVECTOR;
   CHECK_FOR_DATAVECTORS(test_llf_flux, (1, 2, 3))
+  CHECK_FOR_DATAVECTORS(test_conservation, (1, 2, 3))
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
