### PR TITLE
Small cleanups

### DIFF
--- a/src/ApparentHorizons/StrahlkorperGr.cpp
+++ b/src/ApparentHorizons/StrahlkorperGr.cpp
@@ -636,11 +636,11 @@ double dimensionful_spin_magnitude(
     const YlmSpherepack& ylm, const Scalar<DataVector>& area_element) noexcept {
   const Scalar<DataVector> sin_theta{sin(ylm.theta_phi_points()[0])};
 
-  const auto& surface_metric =
+  const auto surface_metric =
       get_surface_metric(spatial_metric, tangents, sin_theta);
-  const auto& inverse_surface_metric =
+  const auto inverse_surface_metric =
       determinant_and_inverse(surface_metric).second;
-  const auto& trace_christoffel_second_kind = get_trace_christoffel_second_kind(
+  const auto trace_christoffel_second_kind = get_trace_christoffel_second_kind(
       surface_metric, inverse_surface_metric, sin_theta, ylm);
 
   const size_t matrix_dimension = get_matrix_dimension(ylm);
@@ -662,7 +662,7 @@ double dimensionful_spin_magnitude(
 
   // Get normalized potentials (Kerr normalization) corresponding to the
   // eigenvectors with three smallest-magnitude eigenvalues.
-  const auto& potentials =
+  const auto potentials =
       get_normalized_spin_potentials(smallest_eigenvectors, ylm, area_element);
 
   return get_spin_magnitude(potentials, spin_function, area_element, ylm);

--- a/src/ApparentHorizons/YlmSpherepack.cpp
+++ b/src/ApparentHorizons/YlmSpherepack.cpp
@@ -421,7 +421,7 @@ const std::vector<double>& YlmSpherepack::phi_points() const noexcept {
 }
 
 void YlmSpherepack::second_derivative(
-    const std::array<double*, 2>& df, gsl::not_null<SecondDeriv*> ddf,
+    const std::array<double*, 2>& df, const gsl::not_null<SecondDeriv*> ddf,
     const gsl::not_null<const double*> collocation_values,
     const size_t physical_stride, const size_t physical_offset) const noexcept {
   // Initialize trig functions at collocation points

--- a/src/ControlSystem/FunctionOfTimeUpdater.cpp
+++ b/src/ControlSystem/FunctionOfTimeUpdater.cpp
@@ -19,14 +19,15 @@ FunctionOfTimeUpdater<DerivOrder>::FunctionOfTimeUpdater(
 
 template <size_t DerivOrder>
 void FunctionOfTimeUpdater<DerivOrder>::measure(
-    double time, const DataVector& raw_q) noexcept {
+    const double time, const DataVector& raw_q) noexcept {
   averager_.update(time, raw_q, timescale_tuner_.current_timescale());
 }
 
 template <size_t DerivOrder>
 void FunctionOfTimeUpdater<DerivOrder>::modify(
-    gsl::not_null<FunctionsOfTime::PiecewisePolynomial<DerivOrder>*> f_of_t,
-    double time) noexcept {
+    const gsl::not_null<FunctionsOfTime::PiecewisePolynomial<DerivOrder>*>
+        f_of_t,
+    const double time) noexcept {
   if (averager_(time)) {
     std::array<DataVector, DerivOrder + 1> q_and_derivs = averager_(time).get();
     // get the time offset due to averaging

--- a/src/ControlSystem/PiecewisePolynomial.cpp
+++ b/src/ControlSystem/PiecewisePolynomial.cpp
@@ -18,7 +18,7 @@
 
 template <size_t MaxDeriv>
 FunctionsOfTime::PiecewisePolynomial<MaxDeriv>::PiecewisePolynomial(
-    double t, value_type initial_func_and_derivs) noexcept
+    const double t, value_type initial_func_and_derivs) noexcept
     : deriv_info_at_update_times_{{t, std::move(initial_func_and_derivs)}} {}
 
 template <size_t MaxDeriv>
@@ -79,8 +79,8 @@ void FunctionsOfTime::PiecewisePolynomial<MaxDeriv>::update(
 
 template <size_t MaxDeriv>
 FunctionsOfTime::PiecewisePolynomial<MaxDeriv>::DerivInfo::DerivInfo(
-    double t, value_type deriv) noexcept : time(t),
-                                           derivs_coefs(std::move(deriv)) {
+    const double t, value_type deriv) noexcept
+    : time(t), derivs_coefs(std::move(deriv)) {
   // convert derivs to coefficients for polynomial evaluation.
   // the coefficient of x^N is the Nth deriv rescaled by 1/factorial(N)
   double fact = 1.0;

--- a/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
@@ -407,7 +407,7 @@ auto determinant_and_inverse(
                 "Taking the inverse of a mixed Spatial and Spacetime index "
                 "Tensor is not allowed since it's not clear what that means.");
   static_assert(not std::is_integral<T>::value, "Can't invert a Tensor<int>.");
-  const auto& det_and_inv_pair =
+  const auto det_and_inv_pair =
       determinant_and_inverse_detail::DetAndInverseImpl<Symm, Index0,
                                                         Index1>::apply(tensor);
   tuples::TaggedTuple<DetTag, InvTag> det_and_inv_tupl;

--- a/src/DataStructures/Tensor/Structure.hpp
+++ b/src/DataStructures/Tensor/Structure.hpp
@@ -281,7 +281,7 @@ struct ComponentNameImpl {
     }
     // Create string labeling get_tensor_index
     std::stringstream ss;
-    const auto& canonical_tensor_index =
+    const auto canonical_tensor_index =
         Structure::get_canonical_tensor_index(storage_index);
     for (size_t r = 0; r < Structure::rank(); ++r) {
       ss << gsl::at(labels, r)[gsl::at(canonical_tensor_index, r)];

--- a/src/Domain/Amr/UpdateAmrDecision.cpp
+++ b/src/Domain/Amr/UpdateAmrDecision.cpp
@@ -19,7 +19,7 @@ namespace amr {
 
 template <size_t VolumeDim>
 bool update_amr_decision(
-    gsl::not_null<std::array<amr::Flag, VolumeDim>*> my_current_amr_flags,
+    const gsl::not_null<std::array<amr::Flag, VolumeDim>*> my_current_amr_flags,
     const Element<VolumeDim>& element, const ElementId<VolumeDim>& neighbor_id,
     const std::array<amr::Flag, VolumeDim>& neighbor_amr_flags) noexcept {
   const auto& element_id = element.id();
@@ -105,11 +105,12 @@ bool update_amr_decision(
 /// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                 \
-  template bool update_amr_decision(                                         \
-      gsl::not_null<std::array<amr::Flag, DIM(data)>*> my_current_amr_flags, \
-      const Element<DIM(data)>& element,                                     \
-      const ElementId<DIM(data)>& neighbor_id,                               \
+#define INSTANTIATE(_, data)                                 \
+  template bool update_amr_decision(                         \
+      const gsl::not_null<std::array<amr::Flag, DIM(data)>*> \
+          my_current_amr_flags,                              \
+      const Element<DIM(data)>& element,                     \
+      const ElementId<DIM(data)>& neighbor_id,               \
       const std::array<amr::Flag, DIM(data)>& neighbor_amr_flags) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -273,7 +273,7 @@ void set_cartesian_periodic_boundaries(
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks,
-    gsl::not_null<
+    const gsl::not_null<
         std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks) noexcept {
   ASSERT(orientations_of_all_blocks.size() == corners_of_all_blocks.size(),
@@ -369,7 +369,7 @@ template <size_t VolumeDim>
 void set_internal_boundaries(
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
-    gsl::not_null<
+    const gsl::not_null<
         std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks) noexcept {
   for (size_t block1_index = 0; block1_index < corners_of_all_blocks.size();
@@ -401,7 +401,7 @@ void set_identified_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
-    gsl::not_null<
+    const gsl::not_null<
         std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks) noexcept {
   for (const auto& pair : identifications) {
@@ -1008,7 +1008,7 @@ Domain<VolumeDim, TargetFrame> rectilinear_domain(
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks,
     const std::array<bool, VolumeDim>& dimension_is_periodic,
     const std::vector<PairOfFaces>& identifications,
-    bool use_equiangular_map) noexcept {
+    const bool use_equiangular_map) noexcept {
   std::vector<Block<VolumeDim, TargetFrame>> blocks{};
   auto corners_of_all_blocks =
       corners_for_rectilinear_domains(domain_extents, block_indices_to_exclude);
@@ -1073,31 +1073,31 @@ ShellWedges create_from_yaml<ShellWedges>::create<void>(const Option& options) {
 
 template void set_internal_boundaries(
     const std::vector<std::array<size_t, 2>>& corners_of_all_blocks,
-    gsl::not_null<std::vector<DirectionMap<1, BlockNeighbor<1>>>*>
+    const gsl::not_null<std::vector<DirectionMap<1, BlockNeighbor<1>>>*>
         neighbors_of_all_blocks) noexcept;
 template void set_internal_boundaries(
     const std::vector<std::array<size_t, 4>>& corners_of_all_blocks,
-    gsl::not_null<std::vector<DirectionMap<2, BlockNeighbor<2>>>*>
+    const gsl::not_null<std::vector<DirectionMap<2, BlockNeighbor<2>>>*>
         neighbors_of_all_blocks) noexcept;
 template void set_internal_boundaries(
     const std::vector<std::array<size_t, 8>>& corners_of_all_blocks,
-    gsl::not_null<std::vector<DirectionMap<3, BlockNeighbor<3>>>*>
+    const gsl::not_null<std::vector<DirectionMap<3, BlockNeighbor<3>>>*>
         neighbors_of_all_blocks) noexcept;
 
 template void set_identified_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, 2>>& corners_of_all_blocks,
-    gsl::not_null<std::vector<DirectionMap<1, BlockNeighbor<1>>>*>
+    const gsl::not_null<std::vector<DirectionMap<1, BlockNeighbor<1>>>*>
         neighbors_of_all_blocks) noexcept;
 template void set_identified_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, 4>>& corners_of_all_blocks,
-    gsl::not_null<std::vector<DirectionMap<2, BlockNeighbor<2>>>*>
+    const gsl::not_null<std::vector<DirectionMap<2, BlockNeighbor<2>>>*>
         neighbors_of_all_blocks) noexcept;
 template void set_identified_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, 8>>& corners_of_all_blocks,
-    gsl::not_null<std::vector<DirectionMap<3, BlockNeighbor<3>>>*>
+    const gsl::not_null<std::vector<DirectionMap<3, BlockNeighbor<3>>>*>
         neighbors_of_all_blocks) noexcept;
 template std::vector<std::array<size_t, 2>> corners_for_rectilinear_domains(
     const Index<1>& domain_extents,
@@ -1176,7 +1176,7 @@ frustum_coordinate_maps(const double length_inner_cube,
           orientations_of_all_blocks,                                       \
       const std::array<bool, DIM(data)>& dimension_is_periodic,             \
       const std::vector<PairOfFaces>& identifications,                      \
-      bool use_equiangular_map) noexcept;
+      const bool use_equiangular_map) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial))
 

--- a/src/Evolution/Systems/Burgers/Equations.cpp
+++ b/src/Evolution/Systems/Burgers/Equations.cpp
@@ -19,7 +19,7 @@
 
 namespace Burgers {
 void LocalLaxFriedrichsFlux::package_data(
-    gsl::not_null<Variables<package_tags>*> packaged_data,
+    const gsl::not_null<Variables<package_tags>*> packaged_data,
     const Scalar<DataVector>& normal_dot_flux_u,
     const Scalar<DataVector>& u) const noexcept {
   get<Tags::U>(*packaged_data) = u;
@@ -27,7 +27,7 @@ void LocalLaxFriedrichsFlux::package_data(
 }
 
 void LocalLaxFriedrichsFlux::operator()(
-    gsl::not_null<Scalar<DataVector>*> normal_dot_numerical_flux_u,
+    const gsl::not_null<Scalar<DataVector>*> normal_dot_numerical_flux_u,
     const Scalar<DataVector>& normal_dot_flux_u_interior,
     const Scalar<DataVector>& u_interior,
     const Scalar<DataVector>& minus_normal_dot_flux_u_exterior,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
@@ -1139,7 +1139,7 @@ tnsr::a<DataType, SpatialDim, Frame> f_constraint(
 
 template <size_t SpatialDim, typename Frame, typename DataType>
 void f_constraint(
-    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
     const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
     const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
@@ -1248,7 +1248,7 @@ Scalar<DataType> constraint_energy(
 
 template <size_t SpatialDim, typename Frame, typename DataType>
 void constraint_energy(
-    gsl::not_null<Scalar<DataType>*> energy,
+    const gsl::not_null<Scalar<DataType>*> energy,
     const tnsr::a<DataType, SpatialDim, Frame>& gauge_constraint,
     const tnsr::a<DataType, SpatialDim, Frame>& f_constraint,
     const tnsr::ia<DataType, SpatialDim, Frame>& two_index_constraint,
@@ -1308,7 +1308,7 @@ void constraint_energy(
           d_spacetime_metric,                                                \
       const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;   \
   template void GeneralizedHarmonic::three_index_constraint(                 \
-      gsl::not_null<tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>*>         \
+      const gsl::not_null<tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>*>   \
           constraint,                                                        \
       const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>&                  \
           d_spacetime_metric,                                                \
@@ -1433,7 +1433,7 @@ void constraint_energy(
       double three_index_constraint_multiplier,                              \
       double four_index_constraint_multiplier) noexcept;                     \
   template void GeneralizedHarmonic::constraint_energy(                      \
-      gsl::not_null<Scalar<DTYPE(data)>*> energy,                            \
+      const gsl::not_null<Scalar<DTYPE(data)>*> energy,                      \
       const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>& gauge_constraint,  \
       const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>& f_constraint,      \
       const tnsr::ia<DTYPE(data), DIM(data), FRAME(data)>&                   \

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
@@ -461,22 +461,22 @@ void UpwindFlux<Dim>::operator()(
   const Scalar<DataVector> gamma2_avg{0.5 *
                                       (get(gamma2_int) + get(gamma2_ext))};
 
-  const auto& char_fields_int = characteristic_fields(
+  const auto char_fields_int = characteristic_fields(
       gamma2_avg, inverse_spatial_metric_int, spacetime_metric_int, pi_int,
       phi_int, interface_unit_normal_int);
-  const auto& char_speeds_int = characteristic_speeds(
+  const auto char_speeds_int = characteristic_speeds(
       gamma1_avg, lapse_int, shift_int, interface_unit_normal_int);
-  const auto& char_fields_ext = characteristic_fields(
+  const auto char_fields_ext = characteristic_fields(
       gamma2_avg, inverse_spatial_metric_ext, spacetime_metric_ext, pi_ext,
       phi_ext, interface_unit_normal_int);
-  const auto& char_speeds_ext = characteristic_speeds(
+  const auto char_speeds_ext = characteristic_speeds(
       gamma1_avg, lapse_ext, shift_ext, interface_unit_normal_int);
 
-  const auto& weighted_char_fields =
+  const auto weighted_char_fields =
       GeneralizedHarmonic_detail::weight_char_fields<Dim>(
           char_fields_int, char_speeds_int, char_fields_ext, char_speeds_ext);
 
-  const auto& weighted_evolved_fields =
+  const auto weighted_evolved_fields =
       evolved_fields_from_characteristic_fields(
           gamma2_avg,
           get<Tags::UPsi<Dim, Frame::Inertial>>(weighted_char_fields),

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
@@ -403,7 +403,7 @@ void ComputeNormalDotFluxes<Dim>::apply(
 
 template <size_t Dim>
 void UpwindFlux<Dim>::package_data(
-    gsl::not_null<Variables<package_tags>*> packaged_data,
+    const gsl::not_null<Variables<package_tags>*> packaged_data,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
     const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
@@ -430,11 +430,11 @@ void UpwindFlux<Dim>::package_data(
 
 template <size_t Dim>
 void UpwindFlux<Dim>::operator()(
-    gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+    const gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
         psi_normal_dot_numerical_flux,
-    gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+    const gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
         pi_normal_dot_numerical_flux,
-    gsl::not_null<tnsr::iaa<DataVector, Dim, Frame::Inertial>*>
+    const gsl::not_null<tnsr::iaa<DataVector, Dim, Frame::Inertial>*>
         phi_normal_dot_numerical_flux,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric_int,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi_int,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -38,7 +38,7 @@ void weight_function(const gsl::not_null<Scalar<DataType>*> weight,
   if (UNLIKELY(get_size(get(*weight)) != get_size(get<0>(coords)))) {
     *weight = Scalar<DataType>(get_size(get<0>(coords)));
   }
-  const auto& r_squared = dot_product(coords, coords);
+  const auto r_squared = dot_product(coords, coords);
   get(*weight) = exp(-get(r_squared) / pow<2>(sigma_r));
 }
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.cpp
@@ -48,7 +48,7 @@ void densitized_stress(
   dot_product(make_not_null(&magnetic_field_dot_spatial_velocity),
               magnetic_field_oneform, spatial_velocity);
   // not const to save an allocation below
-  Scalar<DataVector>  magnetic_field_squared{};
+  Scalar<DataVector> magnetic_field_squared{};
   get(magnetic_field_squared)
       .set_data_ref(temp_buffer_for_magnetic_field_squared);
   dot_product(make_not_null(&magnetic_field_squared), magnetic_field,
@@ -99,10 +99,12 @@ namespace grmhd {
 namespace ValenciaDivClean {
 
 void ComputeSources::apply(
-    gsl::not_null<Scalar<DataVector>*> source_tilde_tau,
-    gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> source_tilde_s,
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> source_tilde_b,
-    gsl::not_null<Scalar<DataVector>*> source_tilde_phi,
+    const gsl::not_null<Scalar<DataVector>*> source_tilde_tau,
+    const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
+        source_tilde_s,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        source_tilde_b,
+    const gsl::not_null<Scalar<DataVector>*> source_tilde_phi,
     const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
     const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,

--- a/src/Evolution/VariableFixing/FixToAtmosphere.cpp
+++ b/src/Evolution/VariableFixing/FixToAtmosphere.cpp
@@ -40,12 +40,13 @@ void FixToAtmosphere<ThermodynamicDim>::pup(PUP::er& p) noexcept {  // NOLINT
 
 template <>
 void FixToAtmosphere<1>::operator()(
-    gsl::not_null<Scalar<DataVector>*> rest_mass_density,
-    gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> spatial_velocity,
-    gsl::not_null<Scalar<DataVector>*> lorentz_factor,
-    gsl::not_null<Scalar<DataVector>*> pressure,
-    gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+    const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+    const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        spatial_velocity,
+    const gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+    const gsl::not_null<Scalar<DataVector>*> pressure,
+    const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
     const EquationsOfState::EquationOfState<true, 1>& equation_of_state) const
     noexcept {
   for (size_t i = 0; i < rest_mass_density->get().size(); i++) {
@@ -69,12 +70,13 @@ void FixToAtmosphere<1>::operator()(
 
 template <>
 void FixToAtmosphere<2>::operator()(
-    gsl::not_null<Scalar<DataVector>*> rest_mass_density,
-    gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> spatial_velocity,
-    gsl::not_null<Scalar<DataVector>*> lorentz_factor,
-    gsl::not_null<Scalar<DataVector>*> pressure,
-    gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+    const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+    const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        spatial_velocity,
+    const gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+    const gsl::not_null<Scalar<DataVector>*> pressure,
+    const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
     const EquationsOfState::EquationOfState<true, 2>& equation_of_state) const
     noexcept {
   for (size_t i = 0; i < rest_mass_density->get().size(); i++) {

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.cpp
@@ -134,7 +134,7 @@ WrappedGr<SolutionType>::variables(
       get<typename WrappedGr<SolutionType>::DerivSpatialMetric>(
           intermediate_vars);
 
-  const auto& phi =
+  const auto phi =
       GeneralizedHarmonic::phi(lapse, deriv_lapse, shift, deriv_shift,
                                spatial_metric, deriv_spatial_metric);
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.cpp
@@ -66,7 +66,7 @@ template <>
 tuples::TaggedTuple<::Tags::Source<Field>> Moustache<1>::variables(
     const tnsr::I<DataVector, 1>& x,
     tmpl::list<::Tags::Source<Field>> /*meta*/) const noexcept {
-  const auto& x1 = get<0>(x) - 0.5;
+  const auto x1 = get<0>(x) - 0.5;
   // This polynomial is minus the laplacian of the 1D solution
   Scalar<DataVector> field_source(abs(x1) * (20. * square(x1) - 1.5));
   return {std::move(field_source)};
@@ -76,8 +76,8 @@ template <>
 tuples::TaggedTuple<::Tags::Source<Field>> Moustache<2>::variables(
     const tnsr::I<DataVector, 2>& x,
     tmpl::list<::Tags::Source<Field>> /*meta*/) const noexcept {
-  const auto& x1 = get<0>(x) - 0.5;
-  const auto& x2 = get<1>(x) - 0.5;
+  const auto x1 = get<0>(x) - 0.5;
+  const auto x2 = get<1>(x) - 0.5;
   const auto x1_square = square(x1);
   const auto x2_square = square(x2);
   const auto norm_square = x1_square + x2_square;

--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
@@ -53,7 +53,7 @@ tnsr::abb<DataType, SpatialDim, Frame, Index> christoffel_first_kind(
       const tnsr::abb<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>& \
           d_metric) noexcept;                                                \
   template void gr::christoffel_first_kind(                                  \
-      gsl::not_null<                                                         \
+      const gsl::not_null<                                                   \
           tnsr::abb<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>*>  \
           christoffel,                                                       \
       const tnsr::abb<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>& \

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
@@ -137,7 +137,7 @@ Scalar<DataType> horizon_ricci_scalar(
 
   // Get the theta and phi points on the original Strahlkorper, where the
   // spin is not on the z axis
-  const auto& theta_phi_points = ylm.theta_phi_points();
+  const auto theta_phi_points = ylm.theta_phi_points();
 
   // Loop over collocation points, rotating each point
   std::vector<std::array<double, 2>> points;

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -585,7 +585,7 @@ void test_spin_function(const Solution& solution,
   const auto& deriv_spatial_metric =
       get<Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
                       tmpl::size_t<3>, Frame::Inertial>>(vars);
-  const auto& extrinsic_curvature = gr::extrinsic_curvature(
+  const auto extrinsic_curvature = gr::extrinsic_curvature(
       get<gr::Tags::Lapse<DataVector>>(vars),
       get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
       get<Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
@@ -598,7 +598,7 @@ void test_spin_function(const Solution& solution,
   const auto& tangents =
       db::get<StrahlkorperTags::Tangents<Frame::Inertial>>(box);
 
-  const auto& spin_function = StrahlkorperGr::spin_function(
+  const auto spin_function = StrahlkorperGr::spin_function(
       tangents, ylm, unit_normal_vector, area_element, extrinsic_curvature);
 
   auto integrand = spin_function;
@@ -658,7 +658,7 @@ void test_dimensionful_spin_magnitude(
   const auto& deriv_spatial_metric =
       get<Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
                       tmpl::size_t<3>, Frame::Inertial>>(vars);
-  const auto& extrinsic_curvature = gr::extrinsic_curvature(
+  const auto extrinsic_curvature = gr::extrinsic_curvature(
       get<gr::Tags::Lapse<DataVector>>(vars),
       get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
       get<Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
@@ -743,7 +743,7 @@ void test_spin_vector(
   const auto& deriv_spatial_metric =
       get<Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
                       tmpl::size_t<3>, Frame::Inertial>>(vars);
-  const auto& extrinsic_curvature = gr::extrinsic_curvature(
+  const auto extrinsic_curvature = gr::extrinsic_curvature(
       get<gr::Tags::Lapse<DataVector>>(vars),
       get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
       get<Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
@@ -756,7 +756,7 @@ void test_spin_vector(
   const auto& tangents =
       db::get<StrahlkorperTags::Tangents<Frame::Inertial>>(box);
 
-  const auto& spin_function = StrahlkorperGr::spin_function(
+  const auto spin_function = StrahlkorperGr::spin_function(
       tangents, ylm, unit_normal_vector, area_element, extrinsic_curvature);
 
   const auto ricci_scalar = TestHelpers::Kerr::horizon_ricci_scalar(

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -56,7 +56,7 @@ void test_radius_and_derivs() {
       create_strahlkorper_y11(y11_amplitude, radius, center);
 
   // Now construct a Y00 + Im(Y11) surface by hand.
-  const auto& theta_phi = strahlkorper.ylm_spherepack().theta_phi_points();
+  const auto theta_phi = strahlkorper.ylm_spherepack().theta_phi_points();
   const auto& theta_points = strahlkorper.ylm_spherepack().theta_points();
   const auto& phi_points = strahlkorper.ylm_spherepack().phi_points();
   const auto n_pts = theta_phi[0].size();
@@ -168,7 +168,7 @@ void test_normals() {
   const auto strahlkorper =
       create_strahlkorper_y11(y11_amplitude, radius, center);
 
-  const auto& theta_phi = strahlkorper.ylm_spherepack().theta_phi_points();
+  const auto theta_phi = strahlkorper.ylm_spherepack().theta_phi_points();
   const auto n_pts = theta_phi[0].size();
 
   // Test surface_tangents
@@ -278,7 +278,7 @@ void test_normals() {
         square(r);
     return sqrt(normsquared);
   }();
-  const auto& normal_mag = magnitude(normal_one_form, invg);
+  const auto normal_mag = magnitude(normal_one_form, invg);
   CHECK_ITERABLE_APPROX(expected_normal_mag, get(normal_mag));
 }
 }  // namespace

--- a/tests/Unit/ApparentHorizons/Test_YlmSpherepack.cpp
+++ b/tests/Unit/ApparentHorizons/Test_YlmSpherepack.cpp
@@ -160,7 +160,7 @@ void test_theta_phi_points(
   DataVector u(ylm_spherepack.physical_size());
   func.func(&u, 1, 0, theta, phi);
 
-  const auto& theta_phi = ylm_spherepack.theta_phi_points();
+  const auto theta_phi = ylm_spherepack.theta_phi_points();
   DataVector u_test(ylm_spherepack.physical_size());
   // fill pointwise using offset
   for (size_t s = 0; s < ylm_spherepack.physical_size(); ++s) {

--- a/tests/Unit/ControlSystem/FoTUpdater_Helper.cpp
+++ b/tests/Unit/ControlSystem/FoTUpdater_Helper.cpp
@@ -23,9 +23,9 @@ Translation<DerivOrder>::Translation(DataVector target_coords) noexcept
 
 template <size_t DerivOrder>
 void Translation<DerivOrder>::operator()(
-    gsl::not_null<FunctionOfTimeUpdater<DerivOrder>*> updater,
-    const FunctionsOfTime::PiecewisePolynomial<DerivOrder>& f_of_t, double time,
-    const DataVector& coords) noexcept {
+    const gsl::not_null<FunctionOfTimeUpdater<DerivOrder>*> updater,
+    const FunctionsOfTime::PiecewisePolynomial<DerivOrder>& f_of_t,
+    const double time, const DataVector& coords) noexcept {
   const DataVector q = coords - target_coords_ - f_of_t.func(time)[0];
   updater->measure(time, q);
 }

--- a/tests/Unit/ControlSystem/Test_Controller.cpp
+++ b/tests/Unit/ControlSystem/Test_Controller.cpp
@@ -49,7 +49,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller", "[ControlSystem][Unit]") {
         {{std::sin(freq * t)},
          {freq * std::cos(freq * t)},
          {-square(freq) * std::sin(freq * t)}}};
-    const auto& lambda = f_of_t.func_and_2_derivs(t);
+    const auto lambda = f_of_t.func_and_2_derivs(t);
     // check that the error is within the specified tolerance, which is
     // maintained by the TimescaleTuner adjusting the damping time
     CHECK(fabs(target_func[0][0] - lambda[0][0]) <
@@ -112,7 +112,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets",
         {{std::sin(freq * t)},
          {freq * std::cos(freq * t)},
          {-square(freq) * std::sin(freq * t)}}};
-    const auto& lambda = f_of_t.func_and_2_derivs(t);
+    const auto lambda = f_of_t.func_and_2_derivs(t);
     // check that the error is within the specified tolerance, which is
     // maintained by the TimescaleTuner adjusting the damping time
     CHECK(fabs(target_func[0][0] - lambda[0][0]) <
@@ -189,7 +189,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets_DontAverageQ",
         {{std::sin(freq * t)},
          {freq * std::cos(freq * t)},
          {-square(freq) * std::sin(freq * t)}}};
-    const auto& lambda = f_of_t.func_and_2_derivs(t);
+    const auto lambda = f_of_t.func_and_2_derivs(t);
     // check that the error is within the specified tolerance, which is
     // maintained by the TimescaleTuner adjusting the damping time
     CHECK(fabs(target_func[0][0] - lambda[0][0]) <

--- a/tests/Unit/ControlSystem/Test_PiecewisePolynomial.cpp
+++ b/tests/Unit/ControlSystem/Test_PiecewisePolynomial.cpp
@@ -26,7 +26,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial",
   FunctionOfTime& f_of_t = f_of_t_derived;
 
   while (t < final_time) {
-    const auto& lambdas0 = f_of_t.func_and_2_derivs(t);
+    const auto lambdas0 = f_of_t.func_and_2_derivs(t);
     CHECK(approx(lambdas0[0][0]) == cube(t));
     CHECK(approx(lambdas0[0][1]) == square(t));
     CHECK(approx(lambdas0[1][0]) == 3.0 * square(t));
@@ -34,13 +34,13 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial",
     CHECK(approx(lambdas0[2][0]) == 6.0 * t);
     CHECK(approx(lambdas0[2][1]) == 2.0);
 
-    const auto& lambdas1 = f_of_t.func_and_deriv(t);
+    const auto lambdas1 = f_of_t.func_and_deriv(t);
     CHECK(approx(lambdas1[0][0]) == cube(t));
     CHECK(approx(lambdas1[0][1]) == square(t));
     CHECK(approx(lambdas1[1][0]) == 3.0 * square(t));
     CHECK(approx(lambdas1[1][1]) == 2.0 * t);
 
-    const auto& lambdas2 = f_of_t.func(t);
+    const auto lambdas2 = f_of_t.func(t);
     CHECK(approx(lambdas2[0][0]) == cube(t));
     CHECK(approx(lambdas2[0][1]) == square(t));
 
@@ -48,7 +48,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial",
     f_of_t_derived.update(t, {6.0, 0.0});
   }
   // test time_bounds function
-  const auto& t_bounds = f_of_t.time_bounds();
+  const auto t_bounds = f_of_t.time_bounds();
   CHECK(t_bounds[0] == 0.0);
   CHECK(t_bounds[1] == 4.2);
 }
@@ -72,14 +72,14 @@ SPECTRE_TEST_CASE(
     t += dt;
     f_of_t_derived.update(t, {3.0 + t});
   }
-  const auto& lambdas0 = f_of_t.func_and_2_derivs(t);
+  const auto lambdas0 = f_of_t.func_and_2_derivs(t);
   CHECK(approx(lambdas0[0][0]) == 33.948);
   CHECK(approx(lambdas0[1][0]) == 19.56);
   CHECK(approx(lambdas0[2][0]) == 7.2);
-  const auto& lambdas1 = f_of_t.func_and_deriv(t);
+  const auto lambdas1 = f_of_t.func_and_deriv(t);
   CHECK(approx(lambdas1[0][0]) == 33.948);
   CHECK(approx(lambdas1[1][0]) == 19.56);
-  const auto& lambdas2 = f_of_t.func(t);
+  const auto lambdas2 = f_of_t.func(t);
   CHECK(approx(lambdas2[0][0]) == 33.948);
 
   CHECK(lambdas0.size() == 3);
@@ -96,19 +96,19 @@ SPECTRE_TEST_CASE(
   FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(1.0, init_func);
   f_of_t.update(2.0, {6.0, 0.0});
 
-  const auto& lambdas0 = f_of_t.func_and_2_derivs(1.0 - 5.0e-16);
+  const auto lambdas0 = f_of_t.func_and_2_derivs(1.0 - 5.0e-16);
   CHECK(approx(lambdas0[0][0]) == 1.0);
   CHECK(approx(lambdas0[1][0]) == 3.0);
   CHECK(approx(lambdas0[2][0]) == 6.0);
   CHECK(approx(lambdas0[0][1]) == 1.0);
   CHECK(approx(lambdas0[1][1]) == 2.0);
   CHECK(approx(lambdas0[2][1]) == 2.0);
-  const auto& lambdas1 = f_of_t.func_and_deriv(1.0 - 5.0e-16);
+  const auto lambdas1 = f_of_t.func_and_deriv(1.0 - 5.0e-16);
   CHECK(approx(lambdas1[0][0]) == 1.0);
   CHECK(approx(lambdas1[1][0]) == 3.0);
   CHECK(approx(lambdas1[0][1]) == 1.0);
   CHECK(approx(lambdas1[1][1]) == 2.0);
-  const auto& lambdas2 = f_of_t.func(1.0 - 5.0e-16);
+  const auto lambdas2 = f_of_t.func(1.0 - 5.0e-16);
   CHECK(approx(lambdas2[0][0]) == 1.0);
   CHECK(approx(lambdas2[0][1]) == 1.0);
 }

--- a/tests/Unit/ControlSystem/Test_SettleToConstant.cpp
+++ b/tests/Unit/ControlSystem/Test_SettleToConstant.cpp
@@ -28,32 +28,32 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.SettleToConstant",
   const FunctionOfTime& f_of_t = f_of_t_derived;
 
   // check that values agree at the matching time
-  const auto& lambdas0 = f_of_t.func_and_2_derivs(match_time);
+  const auto lambdas0 = f_of_t.func_and_2_derivs(match_time);
   CHECK(approx(lambdas0[0][0]) == f_t0);
   CHECK(approx(lambdas0[1][0]) == dtf_t0);
   CHECK(approx(lambdas0[2][0]) == d2tf_t0);
 
-  const auto& lambdas1 = f_of_t.func_and_deriv(match_time);
+  const auto lambdas1 = f_of_t.func_and_deriv(match_time);
   CHECK(approx(lambdas1[0][0]) == f_t0);
   CHECK(approx(lambdas1[1][0]) == dtf_t0);
 
-  const auto& lambdas2 = f_of_t.func(match_time);
+  const auto lambdas2 = f_of_t.func(match_time);
   CHECK(approx(lambdas2[0][0]) == f_t0);
 
   // check that asymptotic values approach f = A = const.
-  const auto& lambdas3 = f_of_t.func_and_2_derivs(1.0e5);
+  const auto lambdas3 = f_of_t.func_and_2_derivs(1.0e5);
   CHECK(approx(lambdas3[0][0]) == A);
   CHECK(approx(lambdas3[1][0]) == 0.0);
   CHECK(approx(lambdas3[2][0]) == 0.0);
 
-  const auto& lambdas4 = f_of_t.func_and_deriv(1.0e5);
+  const auto lambdas4 = f_of_t.func_and_deriv(1.0e5);
   CHECK(approx(lambdas4[0][0]) == A);
   CHECK(approx(lambdas4[1][0]) == 0.0);
 
-  const auto& lambdas5 = f_of_t.func(1.0e5);
+  const auto lambdas5 = f_of_t.func(1.0e5);
   CHECK(approx(lambdas5[0][0]) == A);
 
   // test time_bounds function
-  const auto& t_bounds = f_of_t.time_bounds();
+  const auto t_bounds = f_of_t.time_bounds();
   CHECK(t_bounds[0] == 10.0);
 }

--- a/tests/Unit/DataStructures/Test_FixedHashMap.cpp
+++ b/tests/Unit/DataStructures/Test_FixedHashMap.cpp
@@ -329,11 +329,13 @@ void test_repeated_key() {
   CHECK(cpp17::as_const(map).find(1) != map.end());
   CHECK(cpp17::as_const(map).find(2) == map.end());
 
-  make_overloader([](gsl::not_null<CopyableKeyMapType*>
-                         local_map) noexcept { (*local_map)[2] = 12; },
-                  [](gsl::not_null<NonCopyableKeyMapType*> local_map) noexcept {
-                    local_map->insert({2, 12});
-                  })(make_not_null(&map));
+  make_overloader(
+      [](const gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
+        (*local_map)[2] = 12;
+      },
+      [](const gsl::not_null<NonCopyableKeyMapType*> local_map) noexcept {
+        local_map->insert({2, 12});
+      })(make_not_null(&map));
   CHECK(map.size() == 2);
   CHECK_FALSE(map.empty());
   CHECK(map.at(2) == 12);
@@ -356,10 +358,11 @@ void test_repeated_key() {
   CHECK(map.at(3) == 13);
   CHECK(cpp17::as_const(map).at(3) == 13);
   make_overloader(
-      [](gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
+      [](const gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
         CHECK((*local_map)[3] == 13);
       },
-      [](gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
+      [
+      ](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
       make_not_null(&map));
   CHECK(map.count(1) == 1);
   CHECK(map.count(2) == 1);
@@ -407,17 +410,20 @@ void test_repeated_key() {
   CHECK(map.at(4) == 14);
   CHECK(cpp17::as_const(map).at(4) == 14);
   make_overloader(
-      [](gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
+      [](const gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
         CHECK((*local_map)[4] == 14);
       },
-      [](gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
+      [
+      ](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
       make_not_null(&map));
 
-  make_overloader([](gsl::not_null<CopyableKeyMapType*>
-                         local_map) noexcept { (*local_map)[5] = 15; },
-                  [](gsl::not_null<NonCopyableKeyMapType*> local_map) noexcept {
-                    local_map->insert_or_assign(5, 15);
-                  })(make_not_null(&map));
+  make_overloader(
+      [](const gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
+        (*local_map)[5] = 15;
+      },
+      [](const gsl::not_null<NonCopyableKeyMapType*> local_map) noexcept {
+        local_map->insert_or_assign(5, 15);
+      })(make_not_null(&map));
   CHECK(map.size() == 4);
   CHECK_FALSE(map.empty());
   CHECK(map.count(1) == 1);
@@ -435,10 +441,11 @@ void test_repeated_key() {
   CHECK(map.at(5) == 15);
   CHECK(cpp17::as_const(map).at(5) == 15);
   make_overloader(
-      [](gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
+      [](const gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
         CHECK((*local_map)[5] == 15);
       },
-      [](gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
+      [
+      ](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
       make_not_null(&map));
 
   map.erase(4);
@@ -458,10 +465,11 @@ void test_repeated_key() {
   CHECK(map.at(5) == 15);
   CHECK(cpp17::as_const(map).at(5) == 15);
   make_overloader(
-      [](gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
+      [](const gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
         CHECK((*local_map)[5] == 15);
       },
-      [](gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
+      [
+      ](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
       make_not_null(&map));
 
   const auto check_4 = [](
@@ -487,15 +495,17 @@ void test_repeated_key() {
     CHECK(check_4_local_map->at(4) == expected);
     CHECK(cpp17::as_const(*check_4_local_map).at(4) == expected);
     make_overloader(
-        [expected](gsl::not_null<CopyableKeyMapType*> more_local_map) noexcept {
+        [expected](
+            const gsl::not_null<CopyableKeyMapType*> more_local_map) noexcept {
           CHECK((*more_local_map)[4] == expected);
         },
-        [](gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
+        [](const gsl::not_null<
+            NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
         check_4_local_map);
   };
 
   make_overloader(
-      [&check_4](gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
+      [&check_4](const gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
         // Test serialization and that FixedHashMap works correctly after.
         test_serialization(*local_map);
 
@@ -525,7 +535,8 @@ void test_repeated_key() {
         check_4(after_map.insert_or_assign(key_4, 34), 34, true, &after_map);
         check_4(after_map.insert_or_assign(key_4, 44), 44, false, &after_map);
       },
-      [&check_4](gsl::not_null<NonCopyableKeyMapType*> local_map) noexcept {
+      [&check_4](
+          const gsl::not_null<NonCopyableKeyMapType*> local_map) noexcept {
         check_4(local_map->insert_or_assign(4, 14), 14, true, local_map);
         check_4(local_map->insert_or_assign(4, 24), 24, false, local_map);
 
@@ -537,12 +548,13 @@ void test_repeated_key() {
 
   test_iterators(map);
   make_overloader(
-      [](gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
+      [](const gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
         test_copy_semantics(*local_map);
         const auto map2 = *local_map;
         test_move_semantics(std::move(*local_map), map2);
       },
-      [](gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
+      [
+      ](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
       make_not_null(&map));
 }
 

--- a/tests/Unit/Elliptic/Initialization/Test_BoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_BoundaryConditions.cpp
@@ -66,7 +66,7 @@ struct AnalyticSolution {
 template <size_t Dim>
 struct NumericalFlux {
   void compute_dirichlet_boundary(
-      gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
+      const gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
       const Scalar<DataVector>& field,
       const tnsr::i<DataVector, Dim,
                     Frame::Inertial>& /*interface_unit_normal*/) const

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -342,10 +342,9 @@ void test_damped_harmonic_h_function_term_1_of_4(
   }
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
+  const auto det_spatial_metric = determinant_and_inverse(spatial_metric).first;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
 
   // Initialize settings
@@ -433,13 +432,12 @@ void test_damped_harmonic_h_function_term_2_of_4(
   }
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& spacetime_unit_normal_one_form =
+  const auto spacetime_unit_normal_one_form =
       gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
           lapse);
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
+  const auto det_spatial_metric = determinant_and_inverse(spatial_metric).first;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
 
   // Initialize settings
@@ -450,11 +448,11 @@ void test_damped_harmonic_h_function_term_2_of_4(
   const double sigma_t_L1 = pdist(generator) * 0.2;
   const double r_max = pdist(generator) * 0.7;
 
-  const auto& log_fac_1 = log(get(sqrt_det_spatial_metric) / get(lapse));
+  const auto log_fac_1 = log(get(sqrt_det_spatial_metric) / get(lapse));
   const double roll_on_L1 =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L1, sigma_t_L1);
-  const auto& weight =
+  const auto weight =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
 
@@ -536,13 +534,12 @@ void test_damped_harmonic_h_function_term_3_of_4(
   }
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& spacetime_unit_normal_one_form =
+  const auto spacetime_unit_normal_one_form =
       gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
           lapse);
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
+  const auto det_spatial_metric = determinant_and_inverse(spatial_metric).first;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
 
   // Initialize settings
@@ -555,11 +552,11 @@ void test_damped_harmonic_h_function_term_3_of_4(
   const double roll_on_L2 =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L2, sigma_t_L2);
-  const auto& weight =
+  const auto weight =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
 
-  const auto& log_fac_2 = log(1. / get(lapse));
+  const auto log_fac_2 = log(1. / get(lapse));
   const auto h_prefac1 = amp_coef_L2 * roll_on_L2 * get(weight) *
                          pow(log_fac_2, exp_L2) * log_fac_2;
 
@@ -638,12 +635,11 @@ void test_damped_harmonic_h_function_term_4_of_4(
   }
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
+  const auto det_spatial_metric = determinant_and_inverse(spatial_metric).first;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
-  const auto& one_over_lapse = 1. / get(lapse);
+  const auto one_over_lapse = 1. / get(lapse);
 
   // Initialize settings
   const double amp_coef_S = pdist(generator);
@@ -655,11 +651,11 @@ void test_damped_harmonic_h_function_term_4_of_4(
   const double roll_on_S =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_S, sigma_t_S);
-  const auto& weight =
+  const auto weight =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
 
-  const auto& log_fac_1 = log(get(sqrt_det_spatial_metric) * one_over_lapse);
+  const auto log_fac_1 = log(get(sqrt_det_spatial_metric) * one_over_lapse);
   const auto h_prefac2 = -amp_coef_S * roll_on_S * get(weight) *
                          pow(log_fac_1, exp_S) * one_over_lapse;
 
@@ -730,10 +726,9 @@ void test_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
   const auto& spatial_metric = get<gr::Tags::SpatialMetric<SpatialDim>>(vars);
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
+  const auto det_spatial_metric = determinant_and_inverse(spatial_metric).first;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
 
   // Initialize settings
@@ -746,7 +741,7 @@ void test_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
   const double roll_on_L1 =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L1, sigma_t_L1);
-  const auto& weight =
+  const auto weight =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
 
@@ -794,16 +789,16 @@ void test_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
       }
     }
   }
-  const auto& spacetime_unit_normal_one_form_ab_initio =
+  const auto spacetime_unit_normal_one_form_ab_initio =
       gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
           lapse_ab_initio);
-  const auto& det_spatial_metric_ab_initio =
+  const auto det_spatial_metric_ab_initio =
       determinant_and_inverse(spatial_metric_ab_initio).first;
   Scalar<DataVector> sqrt_det_spatial_metric_ab_initio(
       sqrt(get(det_spatial_metric_ab_initio)));
 
   // compute GR dependent terms
-  const auto& log_fac_1 =
+  const auto log_fac_1 =
       log(get(sqrt_det_spatial_metric_ab_initio) / get(lapse_ab_initio));
 
   const auto h_prefac1 = amp_coef_L1 * roll_on_L1 * get(weight) *
@@ -857,10 +852,9 @@ void test_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
   const auto& spatial_metric = get<gr::Tags::SpatialMetric<SpatialDim>>(vars);
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
+  const auto det_spatial_metric = determinant_and_inverse(spatial_metric).first;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
 
   // Initialize settings
@@ -872,7 +866,7 @@ void test_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
   const double roll_on_L2 =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L2, sigma_t_L2);
-  const auto& weight =
+  const auto weight =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
 
@@ -909,12 +903,12 @@ void test_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
   // 3) compute lapse
   const Scalar<DataVector> lapse_ab_initio{sqrt(1. / (1. + H2))};
 
-  const auto& spacetime_unit_normal_one_form_ab_initio =
+  const auto spacetime_unit_normal_one_form_ab_initio =
       gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
           lapse_ab_initio);
 
   // compute GR dependent terms
-  const auto& log_fac_2 = log(1. / get(lapse_ab_initio));
+  const auto log_fac_2 = log(1. / get(lapse_ab_initio));
 
   // compute other terms
   const auto h_prefac1 = amp_coef_L2 * roll_on_L2 * get(weight) *
@@ -968,10 +962,9 @@ void test_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
   const auto& spatial_metric = get<gr::Tags::SpatialMetric<SpatialDim>>(vars);
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
+  const auto det_spatial_metric = determinant_and_inverse(spatial_metric).first;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
 
   // Initialize settings
@@ -983,7 +976,7 @@ void test_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
   const double roll_on_S =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_S, sigma_t_S);
-  const auto& weight =
+  const auto weight =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
 
@@ -1037,15 +1030,15 @@ void test_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
       }
     }
   }
-  const auto& spacetime_metric_ab_initio = gr::spacetime_metric(
+  const auto spacetime_metric_ab_initio = gr::spacetime_metric(
       lapse_ab_initio, shift_ab_initio, spatial_metric_ab_initio);
-  const auto& det_spatial_metric_ab_initio =
+  const auto det_spatial_metric_ab_initio =
       determinant_and_inverse(spatial_metric_ab_initio).first;
   Scalar<DataVector> sqrt_det_spatial_metric_ab_initio(
       sqrt(get(det_spatial_metric_ab_initio)));
 
   // compute GR dependent terms
-  const auto& log_fac_1 =
+  const auto log_fac_1 =
       log(get(sqrt_det_spatial_metric_ab_initio) / get(lapse_ab_initio));
 
   const auto h_prefac2 = -amp_coef_S * roll_on_S * get(weight) *
@@ -1202,15 +1195,14 @@ void test_deriv_damped_harmonic_h_function_term_1_of_4(
       make_not_null(&generator), make_not_null(&dist2), used_for_size);
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& spacetime_unit_normal_one_form =
+  const auto spacetime_unit_normal_one_form =
       gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
           lapse);
-  const auto& inverse_spatial_metric =
-      determinant_and_inverse(spatial_metric).second;
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
+  const auto det_and_inv = determinant_and_inverse(spatial_metric);
+  const auto& det_spatial_metric = det_and_inv.first;
+  const auto& inverse_spatial_metric = det_and_inv.second;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
   const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
                                             spatial_metric, d_spatial_metric);
@@ -1337,21 +1329,20 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4(
       make_not_null(&generator), make_not_null(&dist2), used_for_size);
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& spacetime_unit_normal_one_form =
+  const auto spacetime_unit_normal_one_form =
       gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
           lapse);
   const auto spacetime_unit_normal =
       gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
           lapse, shift);
-  const auto& inverse_spatial_metric =
-      determinant_and_inverse(spatial_metric).second;
+  const auto det_and_inv = determinant_and_inverse(spatial_metric);
+  const auto& det_spatial_metric = det_and_inv.first;
+  const auto& inverse_spatial_metric = det_and_inv.second;
   const auto inverse_spacetime_metric =
       gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
           lapse, shift, inverse_spatial_metric);
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
   const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
                                             spatial_metric, d_spatial_metric);
@@ -1360,7 +1351,7 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4(
 
   // commonly used terms
   const auto exp_fac_1 = 1. / 2.;
-  const auto& log_fac_1 =
+  const auto log_fac_1 =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
           DataVector>(lapse, sqrt_det_spatial_metric, exp_fac_1);
 
@@ -1377,7 +1368,7 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4(
           t, t_start_L1, sigma_t_L1);
   const auto d0_roll_on_L1 = GeneralizedHarmonic::DampedHarmonicGauge_detail::
       time_deriv_of_roll_on_function(t, t_start_L1, sigma_t_L1);
-  const auto& weight =
+  const auto weight =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
   auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
@@ -1403,7 +1394,7 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4(
       make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
           get(lapse), 0.);
   {
-    const auto& d4_log_fac_mu1 =
+    const auto d4_log_fac_mu1 =
         GeneralizedHarmonic::DampedHarmonicGauge_detail ::
             spacetime_deriv_of_power_log_factor_metric_lapse<
                 SpatialDim, Frame::Inertial, DataVector>(
@@ -1542,21 +1533,20 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4(
       make_not_null(&generator), make_not_null(&dist2), used_for_size);
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& spacetime_unit_normal_one_form =
+  const auto spacetime_unit_normal_one_form =
       gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
           lapse);
   const auto spacetime_unit_normal =
       gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
           lapse, shift);
-  const auto& inverse_spatial_metric =
-      determinant_and_inverse(spatial_metric).second;
+  const auto det_and_inv = determinant_and_inverse(spatial_metric);
+  const auto& det_spatial_metric = det_and_inv.first;
+  const auto& inverse_spatial_metric = det_and_inv.second;
   const auto inverse_spacetime_metric =
       gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
           lapse, shift, inverse_spatial_metric);
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
   const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
                                             spatial_metric, d_spatial_metric);
@@ -1565,7 +1555,7 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4(
 
   // commonly used terms
   const auto exp_fac_2 = 0.;
-  const auto& log_fac_2 =
+  const auto log_fac_2 =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
           DataVector>(lapse, sqrt_det_spatial_metric, exp_fac_2);
 
@@ -1583,7 +1573,7 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4(
           t, t_start_L2, sigma_t_L2);
   const auto d0_roll_on_L2 = GeneralizedHarmonic::DampedHarmonicGauge_detail::
       time_deriv_of_roll_on_function(t, t_start_L2, sigma_t_L2);
-  const auto& weight =
+  const auto weight =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
   auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
@@ -1609,7 +1599,7 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4(
       make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
           get(lapse), 0.);
   {
-    const auto& d4_log_fac_mu2 =
+    const auto d4_log_fac_mu2 =
         GeneralizedHarmonic::DampedHarmonicGauge_detail ::
             spacetime_deriv_of_power_log_factor_metric_lapse<
                 SpatialDim, Frame::Inertial, DataVector>(
@@ -1748,21 +1738,20 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4(
       make_not_null(&generator), make_not_null(&dist2), used_for_size);
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& spacetime_unit_normal_one_form =
+  const auto spacetime_unit_normal_one_form =
       gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
           lapse);
   const auto spacetime_unit_normal =
       gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
           lapse, shift);
-  const auto& inverse_spatial_metric =
-      determinant_and_inverse(spatial_metric).second;
+  const auto det_and_inv = determinant_and_inverse(spatial_metric);
+  const auto& det_spatial_metric = det_and_inv.first;
+  const auto& inverse_spatial_metric = det_and_inv.second;
   const auto inverse_spacetime_metric =
       gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
           lapse, shift, inverse_spatial_metric);
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
   const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
                                             spatial_metric, d_spatial_metric);
@@ -1774,8 +1763,8 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4(
 
   // commonly used terms
   const auto exp_fac_1 = 1. / 2.;
-  const auto& one_over_lapse = 1. / get(lapse);
-  const auto& log_fac_1 =
+  const auto one_over_lapse = 1. / get(lapse);
+  const auto log_fac_1 =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
           DataVector>(lapse, sqrt_det_spatial_metric, exp_fac_1);
 
@@ -1792,7 +1781,7 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4(
           t, t_start_S, sigma_t_S);
   const auto d0_roll_on_S = GeneralizedHarmonic::DampedHarmonicGauge_detail::
       time_deriv_of_roll_on_function(t, t_start_S, sigma_t_S);
-  const auto& weight =
+  const auto weight =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
   auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
@@ -1816,7 +1805,7 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4(
       make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
           get(lapse), 0.);
   {
-    const auto& d4_log_fac_muS =
+    const auto d4_log_fac_muS =
         GeneralizedHarmonic::DampedHarmonicGauge_detail ::
             spacetime_deriv_of_power_log_factor_metric_lapse<
                 SpatialDim, Frame::Inertial, DataVector>(
@@ -1958,21 +1947,20 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
       get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& spacetime_unit_normal_one_form =
+  const auto spacetime_unit_normal_one_form =
       gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
           lapse);
   const auto spacetime_unit_normal =
       gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
           lapse, shift);
-  const auto& inverse_spatial_metric =
-      determinant_and_inverse(spatial_metric).second;
+  const auto det_and_inv = determinant_and_inverse(spatial_metric);
+  const auto& det_spatial_metric = det_and_inv.first;
+  const auto& inverse_spatial_metric = det_and_inv.second;
   const auto inverse_spacetime_metric =
       gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
           lapse, shift, inverse_spatial_metric);
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
   const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
                                             spatial_metric, d_spatial_metric);
@@ -2015,7 +2003,7 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
           t, t_start_L1, sigma_t_L1);
   const auto d0_roll_on_L1 = GeneralizedHarmonic::DampedHarmonicGauge_detail::
       time_deriv_of_roll_on_function(t, t_start_L1, sigma_t_L1);
-  const auto& weight =
+  const auto weight =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
   auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
@@ -2113,19 +2101,19 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
     }
   }
 
-  const auto& spacetime_unit_normal_one_form_ab_initio =
+  const auto spacetime_unit_normal_one_form_ab_initio =
       gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
           lapse_ab_initio);
   const auto spacetime_unit_normal_ab_initio =
       gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
           lapse_ab_initio, shift_ab_initio);
-  const auto& inverse_spatial_metric_ab_initio =
-      determinant_and_inverse(spatial_metric_ab_initio).second;
+  const auto det_and_inv_ab_initio =
+      determinant_and_inverse(spatial_metric_ab_initio);
+  const auto& det_spatial_metric_ab_initio = det_and_inv_ab_initio.first;
+  const auto& inverse_spatial_metric_ab_initio = det_and_inv_ab_initio.second;
   const auto inverse_spacetime_metric_ab_initio =
       gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
           lapse_ab_initio, shift_ab_initio, inverse_spatial_metric_ab_initio);
-  const auto& det_spatial_metric_ab_initio =
-      determinant_and_inverse(spatial_metric_ab_initio).first;
   Scalar<DataVector> sqrt_det_spatial_metric_ab_initio(
       sqrt(get(det_spatial_metric_ab_initio)));
   const auto phi_ab_initio = GeneralizedHarmonic::phi(
@@ -2137,7 +2125,7 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
 
   // commonly used terms
   const auto exp_fac_1 = 1. / 2.;
-  const auto& log_fac_1 =
+  const auto log_fac_1 =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
           DataVector>(lapse_ab_initio, sqrt_det_spatial_metric_ab_initio,
                       exp_fac_1);
@@ -2162,7 +2150,7 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
       make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
           get(lapse), 0.);
   {
-    const auto& d4_log_fac_mu1 =
+    const auto d4_log_fac_mu1 =
         GeneralizedHarmonic::DampedHarmonicGauge_detail ::
             spacetime_deriv_of_power_log_factor_metric_lapse<
                 SpatialDim, Frame::Inertial, DataVector>(
@@ -2259,21 +2247,20 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
       get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& spacetime_unit_normal_one_form =
+  const auto spacetime_unit_normal_one_form =
       gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
           lapse);
   const auto spacetime_unit_normal =
       gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
           lapse, shift);
-  const auto& inverse_spatial_metric =
-      determinant_and_inverse(spatial_metric).second;
+  const auto det_and_inv = determinant_and_inverse(spatial_metric);
+  const auto& det_spatial_metric = det_and_inv.first;
+  const auto& inverse_spatial_metric = det_and_inv.second;
   const auto inverse_spacetime_metric =
       gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
           lapse, shift, inverse_spatial_metric);
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
   const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
                                             spatial_metric, d_spatial_metric);
@@ -2317,7 +2304,7 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
           t, t_start_L2, sigma_t_L2);
   const auto d0_roll_on_L2 = GeneralizedHarmonic::DampedHarmonicGauge_detail::
       time_deriv_of_roll_on_function(t, t_start_L2, sigma_t_L2);
-  const auto& weight =
+  const auto weight =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
   auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
@@ -2415,19 +2402,19 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
     }
   }
 
-  const auto& spacetime_unit_normal_one_form_ab_initio =
+  const auto spacetime_unit_normal_one_form_ab_initio =
       gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
           lapse_ab_initio);
   const auto spacetime_unit_normal_ab_initio =
       gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
           lapse_ab_initio, shift_ab_initio);
-  const auto& inverse_spatial_metric_ab_initio =
-      determinant_and_inverse(spatial_metric_ab_initio).second;
+  const auto det_and_inv_ab_initio =
+      determinant_and_inverse(spatial_metric_ab_initio);
+  const auto& det_spatial_metric_ab_initio = det_and_inv_ab_initio.first;
+  const auto& inverse_spatial_metric_ab_initio = det_and_inv_ab_initio.second;
   const auto inverse_spacetime_metric_ab_initio =
       gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
           lapse_ab_initio, shift_ab_initio, inverse_spatial_metric_ab_initio);
-  const auto& det_spatial_metric_ab_initio =
-      determinant_and_inverse(spatial_metric_ab_initio).first;
   Scalar<DataVector> sqrt_det_spatial_metric_ab_initio(
       sqrt(get(det_spatial_metric_ab_initio)));
   const auto phi_ab_initio = GeneralizedHarmonic::phi(
@@ -2439,7 +2426,7 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
 
   // commonly used terms
   const auto exp_fac_2 = 0.;
-  const auto& log_fac_2 =
+  const auto log_fac_2 =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
           DataVector>(lapse_ab_initio, sqrt_det_spatial_metric_ab_initio,
                       exp_fac_2);
@@ -2463,7 +2450,7 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
       make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
           get(lapse_ab_initio), 0.);
   {
-    const auto& d4_log_fac_mu2 =
+    const auto d4_log_fac_mu2 =
         GeneralizedHarmonic::DampedHarmonicGauge_detail ::
             spacetime_deriv_of_power_log_factor_metric_lapse<
                 SpatialDim, Frame::Inertial, DataVector>(
@@ -2560,21 +2547,20 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
       get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& spacetime_unit_normal_one_form =
+  const auto spacetime_unit_normal_one_form =
       gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
           lapse);
   const auto spacetime_unit_normal =
       gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
           lapse, shift);
-  const auto& inverse_spatial_metric =
-      determinant_and_inverse(spatial_metric).second;
+  const auto det_and_inv = determinant_and_inverse(spatial_metric);
+  const auto& det_spatial_metric = det_and_inv.first;
+  const auto& inverse_spatial_metric = det_and_inv.second;
   const auto inverse_spacetime_metric =
       gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
           lapse, shift, inverse_spatial_metric);
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
   const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
                                             spatial_metric, d_spatial_metric);
@@ -2620,7 +2606,7 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
           t, t_start_S, sigma_t_S);
   const auto d0_roll_on_S = GeneralizedHarmonic::DampedHarmonicGauge_detail::
       time_deriv_of_roll_on_function(t, t_start_S, sigma_t_S);
-  const auto& weight =
+  const auto weight =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
   auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
@@ -2718,18 +2704,18 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
     }
   }
 
-  const auto& spacetime_metric_ab_initio = gr::spacetime_metric(
+  const auto spacetime_metric_ab_initio = gr::spacetime_metric(
       lapse_ab_initio, shift_ab_initio, spatial_metric_ab_initio);
   const auto spacetime_unit_normal_ab_initio =
       gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
           lapse_ab_initio, shift_ab_initio);
-  const auto& inverse_spatial_metric_ab_initio =
-      determinant_and_inverse(spatial_metric_ab_initio).second;
+  const auto det_and_inv_ab_initio =
+      determinant_and_inverse(spatial_metric_ab_initio);
+  const auto& det_spatial_metric_ab_initio = det_and_inv_ab_initio.first;
+  const auto& inverse_spatial_metric_ab_initio = det_and_inv_ab_initio.second;
   const auto inverse_spacetime_metric_ab_initio =
       gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
           lapse_ab_initio, shift_ab_initio, inverse_spatial_metric_ab_initio);
-  const auto& det_spatial_metric_ab_initio =
-      determinant_and_inverse(spatial_metric_ab_initio).first;
   Scalar<DataVector> sqrt_det_spatial_metric_ab_initio(
       sqrt(get(det_spatial_metric_ab_initio)));
   const auto phi_ab_initio = GeneralizedHarmonic::phi(
@@ -2741,8 +2727,8 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
 
   // commonly used terms
   const auto exp_fac_1 = 1. / 2.;
-  const auto& one_over_lapse = 1. / get(lapse_ab_initio);
-  const auto& log_fac_1 =
+  const auto one_over_lapse = 1. / get(lapse_ab_initio);
+  const auto log_fac_1 =
       GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
           DataVector>(lapse_ab_initio, sqrt_det_spatial_metric_ab_initio,
                       exp_fac_1);
@@ -2764,7 +2750,7 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
       make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
           get(lapse_ab_initio), 0.);
   {
-    const auto& d4_log_fac_muS =
+    const auto d4_log_fac_muS =
         GeneralizedHarmonic::DampedHarmonicGauge_detail ::
             spacetime_deriv_of_power_log_factor_metric_lapse<
                 SpatialDim, Frame::Inertial, DataVector>(
@@ -2914,21 +2900,20 @@ void test_damped_harmonic_compute_tags(const size_t grid_size_each_dimension,
       make_not_null(&generator), make_not_null(&dist2), used_for_size);
 
   // Get ingredients
-  const auto& spacetime_metric =
+  const auto spacetime_metric =
       gr::spacetime_metric(lapse, shift, spatial_metric);
-  const auto& spacetime_unit_normal_one_form =
+  const auto spacetime_unit_normal_one_form =
       gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
           lapse);
   const auto spacetime_unit_normal =
       gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
           lapse, shift);
-  const auto& inverse_spatial_metric =
-      determinant_and_inverse(spatial_metric).second;
+  const auto det_and_inv = determinant_and_inverse(spatial_metric);
+  const auto& det_spatial_metric = det_and_inv.first;
+  const auto& inverse_spatial_metric = det_and_inv.second;
   const auto inverse_spacetime_metric =
       gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
           lapse, shift, inverse_spatial_metric);
-  const auto& det_spatial_metric =
-      determinant_and_inverse(spatial_metric).first;
   Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
   const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
                                             spatial_metric, d_spatial_metric);

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -121,10 +121,10 @@ void test_characteristic_speeds_analytic(
 
   // Get generalized harmonic characteristic speeds locally
   const auto shift_dot_normal = dot_product(shift, unit_normal_one_form);
-  const auto& upsi_speed = -(1. + get(gamma_1)) * get(shift_dot_normal);
-  const auto& uzero_speed = -get(shift_dot_normal);
-  const auto& uplus_speed = -get(shift_dot_normal) + get(lapse);
-  const auto& uminus_speed = -get(shift_dot_normal) - get(lapse);
+  const auto upsi_speed = -(1. + get(gamma_1)) * get(shift_dot_normal);
+  const auto uzero_speed = -get(shift_dot_normal);
+  const auto uplus_speed = -get(shift_dot_normal) + get(lapse);
+  const auto uminus_speed = -get(shift_dot_normal) - get(lapse);
 
   // Check that locally computed fields match returned ones
   const auto char_speeds_from_func =

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -118,24 +118,24 @@ void test_gauge_constraint_analytic(
       get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
 
   // Get ingredients for computing the gauge constraint
-  const auto& inverse_spatial_metric =
+  const auto inverse_spatial_metric =
       determinant_and_inverse(spatial_metric).second;
-  const auto& inverse_spacetime_metric =
+  const auto inverse_spacetime_metric =
       gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
-  const auto& gauge_function = GeneralizedHarmonic::gauge_source(
+  const auto gauge_function = GeneralizedHarmonic::gauge_source(
       lapse, dt_lapse, d_lapse, shift, dt_shift, d_shift, spatial_metric,
       trace(gr::extrinsic_curvature(lapse, shift, d_shift, spatial_metric,
                                     dt_spatial_metric, d_spatial_metric),
             inverse_spatial_metric),
       trace_last_indices(gr::christoffel_first_kind(d_spatial_metric),
                          inverse_spatial_metric));
-  const auto& phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
-                                             spatial_metric, d_spatial_metric);
-  const auto& pi = GeneralizedHarmonic::pi(
+  const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
+                                            spatial_metric, d_spatial_metric);
+  const auto pi = GeneralizedHarmonic::pi(
       lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
-  const auto& normal_one_form =
+  const auto normal_one_form =
       gr::spacetime_normal_one_form<3, Frame::Inertial>(lapse);
-  const auto& normal_vector = gr::spacetime_normal_vector(lapse, shift);
+  const auto normal_vector = gr::spacetime_normal_vector(lapse, shift);
 
   // Get the constraint, and check that it vanishes
   auto constraint =
@@ -229,16 +229,16 @@ void test_two_index_constraint_analytic(
       get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
 
   // Compute quantities from variables for the two-index constraint
-  const auto& inverse_spatial_metric =
+  const auto inverse_spatial_metric =
       determinant_and_inverse(spatial_metric).second;
-  const auto& inverse_spacetime_metric =
+  const auto inverse_spacetime_metric =
       gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
-  const auto& normal_one_form =
+  const auto normal_one_form =
       gr::spacetime_normal_one_form<3, Frame::Inertial>(lapse);
-  const auto& normal_vector = gr::spacetime_normal_vector(lapse, shift);
+  const auto normal_vector = gr::spacetime_normal_vector(lapse, shift);
 
   // Arbitrary choice for gamma2
-  const auto& gamma2 = make_with_value<Scalar<DataVector>>(x, 4.0);
+  const auto gamma2 = make_with_value<Scalar<DataVector>>(x, 4.0);
 
   // Compute derivatives d_psi, d_phi, d_pi, and d_gauge_function numerically
   Variables<VariablesTags> gh_vars(data_size);
@@ -274,7 +274,7 @@ void test_two_index_constraint_analytic(
       get<Tags::deriv<GaugeH, tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
 
   // Compute the three-index constraint
-  const auto& three_index_constraint =
+  const auto three_index_constraint =
       GeneralizedHarmonic::three_index_constraint(d_spacetime_metric, phi);
 
   // Get the constraint, and check that it vanishes to error_tolerance
@@ -458,16 +458,16 @@ void test_f_constraint_analytic(const Solution& solution,
       get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
 
   // Compute quantities from variables for the two-index constraint
-  const auto& inverse_spatial_metric =
+  const auto inverse_spatial_metric =
       determinant_and_inverse(spatial_metric).second;
-  const auto& inverse_spacetime_metric =
+  const auto inverse_spacetime_metric =
       gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
-  const auto& normal_one_form =
+  const auto normal_one_form =
       gr::spacetime_normal_one_form<3, Frame::Inertial>(lapse);
-  const auto& normal_vector = gr::spacetime_normal_vector(lapse, shift);
+  const auto normal_vector = gr::spacetime_normal_vector(lapse, shift);
 
   // Arbitrary choice for gamma2
-  const auto& gamma2 = make_with_value<Scalar<DataVector>>(x, 4.0);
+  const auto gamma2 = make_with_value<Scalar<DataVector>>(x, 4.0);
 
   // Compute derivatives d_psi, d_phi, d_pi, and d_gauge_function numerically
   Variables<VariablesTags> gh_vars(data_size);
@@ -503,7 +503,7 @@ void test_f_constraint_analytic(const Solution& solution,
       get<Tags::deriv<GaugeH, tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
 
   // Compute the three-index constraint
-  const auto& three_index_constraint =
+  const auto three_index_constraint =
       GeneralizedHarmonic::three_index_constraint(d_spacetime_metric, phi);
 
   // Get the constraint, and check that it vanishes to error_tolerance
@@ -596,17 +596,17 @@ void test_constraint_energy_analytic(const Solution& solution,
   const auto& dt_spatial_metric =
       get<Tags::dt<gr::Tags::SpatialMetric<3>>>(vars);
 
-  const auto& determinant_and_inverse_spatial_metric =
+  const auto determinant_and_inverse_spatial_metric =
       determinant_and_inverse(spatial_metric);
   const auto& determinant_spatial_metric =
       determinant_and_inverse_spatial_metric.first;
   const auto& inverse_spatial_metric =
       determinant_and_inverse_spatial_metric.second;
-  const auto& inverse_spacetime_metric =
+  const auto inverse_spacetime_metric =
       gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
-  const auto& normal_one_form =
+  const auto normal_one_form =
       gr::spacetime_normal_one_form<3, Frame::Inertial>(lapse);
-  const auto& normal_vector = gr::spacetime_normal_vector(lapse, shift);
+  const auto normal_vector = gr::spacetime_normal_vector(lapse, shift);
 
   // Compute derivative d_phi numerically
   Variables<VariablesTags> gh_vars(data_size);
@@ -642,21 +642,21 @@ void test_constraint_energy_analytic(const Solution& solution,
       get<Tags::deriv<GaugeH, tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
 
   // Arbitrary choice for gamma2
-  const auto& gamma2 = make_with_value<Scalar<DataVector>>(x, 4.0);
+  const auto gamma2 = make_with_value<Scalar<DataVector>>(x, 4.0);
 
   // Get the constraints
-  const auto& gauge_constraint = GeneralizedHarmonic::gauge_constraint(
+  const auto gauge_constraint = GeneralizedHarmonic::gauge_constraint(
       gauge_function, normal_one_form, normal_vector, inverse_spatial_metric,
       inverse_spacetime_metric, pi, phi);
-  const auto& three_index_constraint =
+  const auto three_index_constraint =
       GeneralizedHarmonic::three_index_constraint(d_spacetime_metric, phi);
-  const auto& four_index_constraint =
+  const auto four_index_constraint =
       GeneralizedHarmonic::four_index_constraint(d_phi);
-  const auto& two_index_constraint = GeneralizedHarmonic::two_index_constraint(
+  const auto two_index_constraint = GeneralizedHarmonic::two_index_constraint(
       d_gauge_function, normal_one_form, normal_vector, inverse_spatial_metric,
       inverse_spacetime_metric, pi, phi, d_pi, d_phi, gamma2,
       three_index_constraint);
-  const auto& f_constraint = GeneralizedHarmonic::f_constraint(
+  const auto f_constraint = GeneralizedHarmonic::f_constraint(
       gauge_function, d_gauge_function, normal_one_form, normal_vector,
       inverse_spatial_metric, inverse_spacetime_metric, pi, phi, d_pi, d_phi,
       gamma2, three_index_constraint);
@@ -748,9 +748,9 @@ void test_constraint_compute_items(
       gr::spacetime_normal_vector(lapse, shift);
   const auto spacetime_normal_one_form =
       gr::spacetime_normal_one_form<3, Frame::Inertial, DataVector>(lapse);
-  const auto inverse_spatial_metric =
-      determinant_and_inverse(spatial_metric).second;
-  const auto det_spatial_metric = determinant_and_inverse(spatial_metric).first;
+  const auto det_and_inv = determinant_and_inverse(spatial_metric);
+  const auto& det_spatial_metric = det_and_inv.first;
+  const auto& inverse_spatial_metric = det_and_inv.second;
   const auto inverse_spacetime_metric =
       gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_UpwindFlux.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_UpwindFlux.cpp
@@ -111,7 +111,7 @@ void test_upwind_flux_random() noexcept {
       tnsr::aa<DataVector, spatial_dim, Frame::Inertial>>(
       nn_generator, nn_dist_pert, used_for_size);
 
-  const auto& spatial_metric_int = gr::spatial_metric(spacetime_metric_int);
+  const auto spatial_metric_int = gr::spatial_metric(spacetime_metric_int);
   const auto inverse_spatial_metric_int =
       determinant_and_inverse(spatial_metric_int).second;
   const tnsr::i<DataVector, spatial_dim, Frame::Inertial>
@@ -128,7 +128,7 @@ void test_upwind_flux_random() noexcept {
       gr::shift(spacetime_metric_int, inverse_spatial_metric_int);
   const auto lapse_int = gr::lapse(shift_int, spacetime_metric_int);
 
-  const auto& spatial_metric_ext = gr::spatial_metric(spacetime_metric_ext);
+  const auto spatial_metric_ext = gr::spatial_metric(spacetime_metric_ext);
   const auto inverse_spatial_metric_ext =
       determinant_and_inverse(spatial_metric_ext).second;
   const DataVector one_form_magnitude_ext =
@@ -254,5 +254,5 @@ void test_upwind_flux_random() noexcept {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.UpwindFlux",
                   "[Unit][Evolution]") {
-    test_upwind_flux_random();
+  test_upwind_flux_random();
 }

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_PrimitiveFromConservative.cpp
@@ -22,10 +22,10 @@ namespace {
 template <size_t Dim>
 struct PrimitiveFromConservativeProxyThermoDim1 {
   static void apply_helper(
-      gsl::not_null<Scalar<DataVector>*> mass_density,
-      gsl::not_null<tnsr::I<DataVector, Dim>*> velocity,
-      gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
-      gsl::not_null<Scalar<DataVector>*> pressure,
+      const gsl::not_null<Scalar<DataVector>*> mass_density,
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> velocity,
+      const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+      const gsl::not_null<Scalar<DataVector>*> pressure,
       const Scalar<DataVector>& mass_density_cons,
       const tnsr::I<DataVector, Dim>& momentum_density,
       const Scalar<DataVector>& energy_density) noexcept {
@@ -39,10 +39,10 @@ struct PrimitiveFromConservativeProxyThermoDim1 {
 template <size_t Dim>
 struct PrimitiveFromConservativeProxyThermoDim2 {
   static void apply_helper(
-      gsl::not_null<Scalar<DataVector>*> mass_density,
-      gsl::not_null<tnsr::I<DataVector, Dim>*> velocity,
-      gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
-      gsl::not_null<Scalar<DataVector>*> pressure,
+      const gsl::not_null<Scalar<DataVector>*> mass_density,
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> velocity,
+      const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+      const gsl::not_null<Scalar<DataVector>*> pressure,
       const Scalar<DataVector>& mass_density_cons,
       const tnsr::I<DataVector, Dim>& momentum_density,
       const Scalar<DataVector>& energy_density) noexcept {

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -90,7 +90,7 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
       ActionTesting::get_databox<component, typename component::simple_tags>(
           runner, 0);
   const auto& final_time_id = db::get<Tags::TimeId>(box);
-  const auto& expected_slab = start.slab().advance_towards(time_step);
+  const auto expected_slab = start.slab().advance_towards(time_step);
   CHECK(final_time_id.time().slab() == expected_slab);
   CHECK(final_time_id ==
         TimeId(time_step.is_positive(), 8, start + 2 * time_step));
@@ -122,7 +122,7 @@ void check_abn(const Time& start, const TimeDelta& time_step) {
       ActionTesting::get_databox<component, typename component::simple_tags>(
           runner, 0);
   const auto& final_time_id = db::get<Tags::TimeId>(box);
-  const auto& expected_slab = start.slab().advance_towards(time_step);
+  const auto expected_slab = start.slab().advance_towards(time_step);
   CHECK(final_time_id.time().slab() == expected_slab);
   CHECK(final_time_id ==
         TimeId(time_step.is_positive(), 8, start + 2 * time_step));

--- a/tests/Unit/Time/Test_History.cpp
+++ b/tests/Unit/Time/Test_History.cpp
@@ -170,7 +170,8 @@ using BoundaryHistoryType =
     TimeSteppers::BoundaryHistory<std::string, std::vector<int>, double>;
 
 // Must take a non-const arg for coupling caching
-size_t check_boundary_state(gsl::not_null<BoundaryHistoryType*> hist) noexcept {
+size_t check_boundary_state(
+    const gsl::not_null<BoundaryHistoryType*> hist) noexcept {
   CHECK(hist->local_size() == 4);
   {
     auto it = hist->local_begin();
@@ -196,7 +197,7 @@ size_t check_boundary_state(gsl::not_null<BoundaryHistoryType*> hist) noexcept {
   std::string local_arg;
   std::vector<int> remote_arg;
   double coupling_return;
-  const auto coupling = [&local_arg, &remote_arg, &coupling_return](
+  const auto coupling = [&local_arg, &remote_arg, &coupling_return ](
       const std::string& local, const std::vector<int>& remote) noexcept {
     local_arg = local;
     remote_arg = remote;
@@ -205,8 +206,8 @@ size_t check_boundary_state(gsl::not_null<BoundaryHistoryType*> hist) noexcept {
 
   size_t coupling_calls = 0;
   coupling_return = 3.5;
-  CHECK(3.5 == hist->coupling(coupling, hist->local_begin(),
-                             hist->remote_begin()));
+  CHECK(3.5 ==
+        hist->coupling(coupling, hist->local_begin(), hist->remote_begin()));
   if (local_arg.empty()) {
     CHECK(remote_arg.empty());
   } else {
@@ -219,7 +220,7 @@ size_t check_boundary_state(gsl::not_null<BoundaryHistoryType*> hist) noexcept {
 
   coupling_return = 6.5;
   CHECK(6.5 == hist->coupling(coupling, hist->local_begin() + 3,
-                             hist->remote_begin() + 2));
+                              hist->remote_begin() + 2));
   if (local_arg.empty()) {
     CHECK(remote_arg.empty());
   } else {

--- a/tests/Unit/Utilities/Test_Tuple.cpp
+++ b/tests/Unit/Utilities/Test_Tuple.cpp
@@ -189,7 +189,7 @@ struct negate {
 struct negate_if_sum_less {
   template <typename T, typename Index, typename S>
   void operator()(const T& element, Index /*index*/, S& second_tuple_element,
-                  gsl::not_null<double*> state,
+                  const gsl::not_null<double*> state,
                   const std::string& test_sentence,
                   const std::string& test_sentence2) const noexcept(false) {
     CHECK(test_sentence == "test sentence");


### PR DESCRIPTION
Cleans some instances of,
- missing consts, especially in in function arguments
- references to temporaries, in `const auto&`. The standard permits assigning temporaries to const references in this way, but the code is more readable when references are used to denote actual references to data owned by another object.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
