### PR TITLE
Fix ActionTesting::InitializeDatabox for when a tag is removed

### DIFF
--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -163,7 +163,7 @@ struct InitializeDataBox<tmpl::list<SimpleTags...>, ComputeTagsList> {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent,
             typename ArrayIndex,
-            Requires<not tmpl2::flat_all_v<
+            Requires<not tmpl2::flat_any_v<
                 tmpl::list_contains_v<DbTagsList, SimpleTags>...>> = nullptr>
   static auto apply(db::DataBox<DbTagsList>& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
@@ -187,15 +187,18 @@ struct InitializeDataBox<tmpl::list<SimpleTags...>, ComputeTagsList> {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent,
             typename ArrayIndex,
-            Requires<tmpl2::flat_all_v<
+            Requires<tmpl2::flat_any_v<
                 tmpl::list_contains_v<DbTagsList, SimpleTags>...>> = nullptr>
   static std::tuple<db::DataBox<DbTagsList>&&> apply(
-      db::DataBox<DbTagsList>& box,
+      db::DataBox<DbTagsList>& /*box*/,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
       const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
-    return {std::move(box)};
+    ERROR(
+        "Tried to apply ActionTesting::InitializeDataBox even though one or "
+        "more of its tags are already in the DataBox. Did you call next_action "
+        "too many times in the initialization phase?");
   }
 
   /// Sets the initial values of simple tags in the DataBox.

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -157,7 +157,7 @@ using MockRuntimeSystem =
     ActionTesting::MockRuntimeSystem<Metavariables<HasPrimitives>>;
 
 template <bool HasPrimitives = false>
-void emplace_component(
+void emplace_component_and_initialize(
     const gsl::not_null<MockRuntimeSystem<HasPrimitives>*> runner,
     const bool forward_in_time, const Time& initial_time,
     const TimeDelta& initial_time_step, const size_t order,
@@ -171,7 +171,7 @@ void emplace_component(
 }
 
 template <>
-void emplace_component<true>(
+void emplace_component_and_initialize<true>(
     const gsl::not_null<MockRuntimeSystem<true>*> runner,
     const bool forward_in_time, const Time& initial_time,
     const TimeDelta& initial_time_step, const size_t order,
@@ -252,11 +252,10 @@ void test_actions(const size_t order, const bool forward_in_time) noexcept {
 
   MockRuntimeSystem<> runner{
       {std::make_unique<TimeSteppers::AdamsBashforthN>(order)}};
-  emplace_component(make_not_null(&runner), forward_in_time, initial_time,
-                    initial_time_step, order, initial_value);
+  emplace_component_and_initialize(make_not_null(&runner), forward_in_time,
+                                   initial_time, initial_time_step, order,
+                                   initial_value);
 
-  runner.set_phase(Metavariables<>::Phase::Initialization);
-  runner.next_action<Component<Metavariables<>>>(0);
   runner.set_phase(Metavariables<>::Phase::Testing);
 
   {
@@ -373,9 +372,9 @@ double error_in_step(const size_t order, const double step) noexcept {
   using component = Component<Metavariables<TestPrimitives>>;
   MockRuntimeSystem<TestPrimitives> runner{
       {std::make_unique<TimeSteppers::AdamsBashforthN>(order)}};
-  emplace_component<TestPrimitives>(make_not_null(&runner), forward_in_time,
-                                    initial_time, initial_time_step, order,
-                                    initial_value);
+  emplace_component_and_initialize<TestPrimitives>(
+      make_not_null(&runner), forward_in_time, initial_time, initial_time_step,
+      order, initial_value);
   runner.set_phase(Metavariables<TestPrimitives>::Phase::Testing);
 
   run_past<std::is_same<SelfStart::Actions::Cleanup, tmpl::_1>,


### PR DESCRIPTION
## Proposed changes

This previously failed to compile when one of the tags was removed during initialization.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
