### PR TITLE
Move create_initial_element into domain::Initialization namespace

### DIFF
--- a/src/Domain/CreateInitialElement.cpp
+++ b/src/Domain/CreateInitialElement.cpp
@@ -23,6 +23,8 @@ struct Grid;      // IWYU pragma: keep
 struct Inertial;  // IWYU pragma: keep
 }  // namespace Frame
 
+namespace domain {
+namespace Initialization {
 template <size_t VolumeDim, typename TargetFrame>
 Element<VolumeDim> create_initial_element(
     const ElementId<VolumeDim>& element_id,
@@ -90,14 +92,17 @@ Element<VolumeDim> create_initial_element(
   return Element<VolumeDim>(ElementId<VolumeDim>(element_id),
                             std::move(neighbors_of_element));
 }
+}  // namespace Initialization
+}  // namespace domain
 
 /// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE(_, data)                                                  \
-  template Element<DIM(data)> create_initial_element<DIM(data), FRAME(data)>( \
-      const ElementId<DIM(data)>&,                                            \
+#define INSTANTIATE(_, data)                                              \
+  template Element<DIM(data)>                                             \
+  domain::Initialization::create_initial_element<DIM(data), FRAME(data)>( \
+      const ElementId<DIM(data)>&,                                        \
       const Block<DIM(data), FRAME(data)>&) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial))

--- a/src/Domain/CreateInitialElement.hpp
+++ b/src/Domain/CreateInitialElement.hpp
@@ -14,11 +14,15 @@ template <size_t Dim>
 class ElementId;
 /// \endcond
 
+namespace domain {
+namespace Initialization {
 /*!
- * \ingroup ComputationalDomainGroup
+ * \ingroup InitializationGroup
  * \brief Creates an initial element of a Block.
  */
 template <size_t VolumeDim, typename TargetFrame>
 Element<VolumeDim> create_initial_element(
     const ElementId<VolumeDim>& element_id,
     const Block<VolumeDim, TargetFrame>& block) noexcept;
+}  // namespace Initialization
+}  // namespace domain

--- a/src/Elliptic/Initialization/Domain.hpp
+++ b/src/Elliptic/Initialization/Domain.hpp
@@ -65,7 +65,8 @@ struct Domain {
     const auto& my_block = domain.blocks()[element_id.block_id()];
     Mesh<Dim> mesh =
         ::Initialization::element_mesh(initial_extents, element_id);
-    Element<Dim> element = create_initial_element(element_id, my_block);
+    Element<Dim> element =
+        domain::Initialization::create_initial_element(element_id, my_block);
     ElementMap<Dim, Frame::Inertial> map{element_id,
                                          my_block.coordinate_map().get_clone()};
 

--- a/src/Evolution/Initialization/Domain.hpp
+++ b/src/Evolution/Initialization/Domain.hpp
@@ -88,7 +88,8 @@ struct Domain {
     const ElementId<Dim> element_id{array_index};
     const auto& my_block = domain.blocks()[element_id.block_id()];
     Mesh<Dim> mesh = element_mesh(initial_extents, element_id);
-    Element<Dim> element = create_initial_element(element_id, my_block);
+    Element<Dim> element =
+        domain::Initialization::create_initial_element(element_id, my_block);
     ElementMap<Dim, Frame::Inertial> map{element_id,
                                          my_block.coordinate_map().get_clone()};
 

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -494,7 +494,8 @@ void test_radial_block_layers(const double inner_radius,
     const std::vector<ElementId<3>> element_ids =
         initial_element_ids(block.id(), initial_ref_levs);
     for (const auto& element_id : element_ids) {
-      const auto element = create_initial_element(element_id, block);
+      const auto element =
+          domain::Initialization::create_initial_element(element_id, block);
       // Creating elements through InitialRefinement creates Elements in all
       // three logical dimensions. It is sufficient to only check the elements
       // in the radial direction lying along a ray at a fixed angle.

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -343,9 +343,9 @@ void test_initial_domain(const Domain<VolumeDim, Frame>& domain,
   CHECK(blocks.size() == initial_refinement_levels.size());
   std::unordered_map<ElementId<VolumeDim>, Element<VolumeDim>> elements;
   for (const auto& element_id : element_ids) {
-    elements.emplace(
-        element_id,
-        create_initial_element(element_id, blocks[element_id.block_id()]));
+    elements.emplace(element_id,
+                     domain::Initialization::create_initial_element(
+                         element_id, blocks[element_id.block_id()]));
   }
   domain::test_domain_connectivity(domain, elements);
   domain::test_refinement_levels_of_neighbors<0>(elements);

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -26,7 +26,8 @@ namespace {
 void test_create_initial_element(
     const ElementId<2>& element_id, const Block<2, Frame::Inertial>& block,
     const DirectionMap<2, Neighbors<2>>& expected_neighbors) noexcept {
-  const auto created_element = create_initial_element(element_id, block);
+  const auto created_element =
+      domain::Initialization::create_initial_element(element_id, block);
   const Element<2> expected_element{element_id, expected_neighbors};
   CHECK(created_element == expected_element);
 }


### PR DESCRIPTION
## Proposed changes

Follow-up to #1607 to make `create_intial_element` consistent.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
