### PR TITLE
Allow installing Python bindings with pip

### DIFF
--- a/cmake/SpectreSetupPython.cmake
+++ b/cmake/SpectreSetupPython.cmake
@@ -28,6 +28,11 @@ if(NOT EXISTS "${SPECTRE_PYTHON_PREFIX}/__init__.py")
     "__all__ = []")
 endif()
 
+# Write a file for installing the Python modules
+configure_file(
+  "${CMAKE_SOURCE_DIR}/src/PythonBindings/setup.py"
+  "${SPECTRE_PYTHON_PREFIX_PARENT}/setup.py")
+
 # Write a file to be able to set up the new python path.
 file(WRITE
   "${CMAKE_BINARY_DIR}/tmp/LoadPython.sh"

--- a/docs/Tutorials/Python.md
+++ b/docs/Tutorials/Python.md
@@ -2,12 +2,25 @@
 Distributed under the MIT License.
 See LICENSE.txt for details.
 \endcond
-# Using SpECTRE's Python Modules {#spectre_using_python}
+# Using SpECTRE's Python modules {#spectre_using_python}
 
-## Prepending to Python Path
 Some classes and functions from SpECTRE have Python bindings to make it easier
 to visualize data, write test code, and provide an introduction to numerical
-relativity without needing to delve into C++. Currently the way to get access to
-the SpECTRE python package is to prefix  `BUILD_DIR/bin/python` to your
-`PYTHONPATH`. This is done automatically by sourcing the `LoadPython.sh` file by
-running `. BUILD_DIR/bin/LoadPython.sh`.
+relativity without needing to delve into C++.
+
+## Installing the SpECTRE Python modules
+
+First, build SpECTRE with Python bindings enabled by appending the
+`-D BUILD_PYTHON_BINDINGS=ON` flag to the `cmake` command. You will find that
+a `BUILD_DIR/bin/python` directory is created that contains the Python modules.
+Then, you can install the modules into your Python environment in
+_development mode_, which means they are symlinked so that changes to the
+modules will be reflected in your Python environment, with the command
+`pip install -e path/to/bin/python`. Alternatively, remove the `-e` flag to
+install the modules normally. You can do this in any Python environment that
+supports `pip`, for instance in a
+[`virtualenv`/`venv`](https://docs.python.org/3/tutorial/venv.html) or in an
+[Anaconda](https://www.anaconda.com/distribution/) environment. You can also get
+access to the SpECTRE Python modules by adding  `BUILD_DIR/bin/python` to your
+`PYTHONPATH`. This is done automatically by sourcing the `LoadPython.sh` file
+with the command `. BUILD_DIR/bin/LoadPython.sh`.

--- a/src/PythonBindings/setup.py
+++ b/src/PythonBindings/setup.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from distutils.core import setup
+
+setup(
+    name='spectre',
+    version='${SpECTRE_VERSION}',
+    description="Python bindings for SpECTRE",
+    author="SXS collaboration",
+    url="https://spectre-code.org",
+    packages=['spectre'],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+)


### PR DESCRIPTION
## Proposed changes

This PR replaces the script that appends the Python modules to the `PYTHONPATH` with functionality that allows installing them with `pip`. The modules can be installed into a Python environment in _development mode_, which means they are symlinked so that changes to the modules will be reflected in the Python environment, with the command `pip install -e path/to/bin/python`.

For those working on Python code for SpECTRE, I would like to note the following (unrelated to this PR):

Once the modules are installed in the Python environment, they can also be run directly from the command line with the command `python -m the_module [args]`. This runs a `__main__.py` script in the package directory or the specific module file as `__main__`. See e.g. https://docs.python.org/3.7/library/__main__.html. We can use this functionality to write Python modules that both provide functions to use e.g. in a Jupyter notebook _and_ expose a CLI, e.g. to make visualisations.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->