### PR TITLE
Use .clang-format style for git-clang-format

### DIFF
--- a/tools/Hooks/ClangFormat.py
+++ b/tools/Hooks/ClangFormat.py
@@ -62,8 +62,8 @@ if (int(clang_format_version.group(1)) < 4 and
               (clang_format_version.group(1), clang_format_version.group(2)))
     sys.exit(0)
 
-output = subprocess.check_output([git_executable, clang_format, "--diff"
-                                  ]).decode('ascii')
+output = subprocess.check_output([git_executable, clang_format, "--style=file",
+                                  "--diff"]).decode('ascii')
 
 if output not in ['\n', '', 'no modified files to format\n',
                   'clang-format did not modify any files\n']:


### PR DESCRIPTION
## Proposed changes

I occasionally had git-clang-format report differences when committing, although I ran clang-format over the code. I think that's because git-clang-format wasn't set up to use the `.clang-format` style file. Perhaps this fixes that issue.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->