### PR TITLE
Add documentation for create_initial_element

### DIFF
--- a/src/Domain/CreateInitialElement.hpp
+++ b/src/Domain/CreateInitialElement.hpp
@@ -17,6 +17,13 @@ class ElementId;
 /*!
  * \ingroup ComputationalDomainGroup
  * \brief Creates an initial element of a Block.
+ *
+ * \details This function creates an element at the refinement level and
+ * position specified by the `element_id` within the `block`. It assumes
+ * that all of its neighboring elements are at the same refinement level. Thus,
+ * the created element's `neighbors` has one neighbor per direction (or zero on
+ * an external boundary), with each neighbor at the same refinement level as the
+ * element.
  */
 template <size_t VolumeDim, typename TargetFrame>
 Element<VolumeDim> create_initial_element(


### PR DESCRIPTION
## Proposed changes

A suggestion to resolve #1556, which came up in the review of #1615. @kidder please suggest wording if you want to comment on the more subtle part of this function (or, feel free to take over this issue).

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->