### PR TITLE
Fix for #1308 #1315

### DIFF
--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -169,17 +169,26 @@ void test_characteristic_fields() noexcept {
   pypp::check_with_random_values<1>(
       field_with_tag<GeneralizedHarmonic::Tags::UZero<Dim, Frame>, Dim, Frame>,
       "TestFunctions", "char_field_uzero", {{{-100., 100.}}}, used_for_size,
-      1.e-10);
+      1.e-9);  // last argument loosens tolerance from
+               // default of 1.0e-12 to avoid occasional
+               // failures of this test, suspected from
+               // accumulated roundoff error
   // UPlus
   pypp::check_with_random_values<1>(
       field_with_tag<GeneralizedHarmonic::Tags::UPlus<Dim, Frame>, Dim, Frame>,
       "TestFunctions", "char_field_uplus", {{{-100., 100.}}}, used_for_size,
-      1.e-11);
+      1.e-10);  // last argument loosens tolerance from
+                // default of 1.0e-12 to avoid occasional
+                // failures of this test, suspected from
+                // accumulated roundoff error
   // UMinus
   pypp::check_with_random_values<1>(
       field_with_tag<GeneralizedHarmonic::Tags::UMinus<Dim, Frame>, Dim, Frame>,
       "TestFunctions", "char_field_uminus", {{{-100., 100.}}}, used_for_size,
-      1.e-10);
+      1.e-10);  // last argument loosens tolerance from
+                // default of 1.0e-12 to avoid occasional
+                // failures of this test, suspected from
+                // accumulated roundoff error
 }
 
 // Test return-by-reference GH char fields by comparing to Kerr-Schild

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -399,8 +399,8 @@ void test_f_constraint_random(const DataType& used_for_size) noexcept {
           const tnsr::iaa<DataType, SpatialDim, Frame>&)>(
           &GeneralizedHarmonic::f_constraint<SpatialDim, Frame, DataType>),
       "TestFunctions", "f_constraint", {{{-10.0, 10.0}}}, used_for_size,
-      1.0e-10);  // Loosen tolerance to avoid occasional failures of this test
-                 // (suspected accumulated roundoff error)
+      1.0e-9);  // Loosen tolerance to avoid occasional failures of this test
+                // (suspected accumulated roundoff error)
 }
 
 // Test the return-by-reference F constraint


### PR DESCRIPTION
## Proposed changes

Reduce tolerance of GH characteristics' and constraints' tests to stop roundoff failures. This should fix #1308 #1315 .

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
