### PR TITLE
Add dependency in Limiters CMake

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
@@ -19,5 +19,6 @@ target_link_libraries(
   ${LIBRARY}
   INTERFACE DataStructures
   INTERFACE Domain
+  INTERFACE Interpolation  # for WENO
   INTERFACE LinearOperators
   )


### PR DESCRIPTION
## Proposed changes

Make it possible to switch the various evolution executables from Minmod to Weno without needing to modify the executables' LIBS_TO_LINK

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

