### PR TITLE
Support Clang 8 and add clang4 and clang8 as Travis targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ services:
 
 # Specify the order of stages.
 stages:
-  - Build Libraries
-  - Build Test Libraries
-  - Build Executables, Run Tests, ClangTidy, and Doxygen
+  - Build stage 1
+  - Build stage 2
+  - Build stage 3, ClangTidy, and Doxygen
 
 # Set up travis configurations of Linux and macOS.
 #
@@ -58,7 +58,7 @@ stages:
 jobs:
   fast_finish: true
   include:
-  - stage: Build Executables, Run Tests, ClangTidy, and Doxygen
+  - stage: Build stage 3, ClangTidy, and Doxygen
     os: linux
     dist: trusty
     env: CHECK_COMMITS=true
@@ -90,14 +90,14 @@ jobs:
     compiler: clang
     name: test check files
 
-  # First stage: build libraries
+  # Build stage 1
   - &Gcc6Debug
     os: linux
     compiler: gcc-6
     dist: trusty
     env: BUILD_TYPE=Debug COMPILER=gcc-6
     name: gcc-6 debug
-    stage: Build Libraries
+    stage: Build stage 1
   - &Gcc6Release
     os: linux
     compiler: gcc-6
@@ -140,18 +140,42 @@ jobs:
     dist: trusty
     env: BUILD_TYPE=Release COMPILER=gcc-9
     name: gcc-9 release
-  - &ClangDebug
+  - &Clang4Debug
     os: linux
-    compiler: clang
+    compiler: clang-4.0
     dist: trusty
-    env: BUILD_TYPE=Debug
-    name: clang debug
-  - &ClangRelease
+    env: BUILD_TYPE=Debug COMPILER=clang-4.0
+    name: clang-4 debug
+  - &Clang4Release
     os: linux
-    compiler: clang
+    compiler: clang-4.0
     dist: trusty
-    env: BUILD_TYPE=Release
-    name: clang release
+    env: BUILD_TYPE=Release COMPILER=clang-4.0
+    name: clang-4 release
+  - &Clang5Debug
+    os: linux
+    compiler: clang-5.0
+    dist: trusty
+    env: BUILD_TYPE=Debug COMPILER=clang-5.0
+    name: clang-5 debug
+  - &Clang5Release
+    os: linux
+    compiler: clang-5.0
+    dist: trusty
+    env: BUILD_TYPE=Release COMPILER=clang-5.0
+    name: clang-5 release
+  - &Clang8Debug
+    os: linux
+    compiler: clang-8
+    dist: trusty
+    env: BUILD_TYPE=Debug COMPILER=clang-8
+    name: clang-8 debug
+  - &Clang8Release
+    os: linux
+    compiler: clang-8
+    dist: trusty
+    env: BUILD_TYPE=Release COMPILER=clang-8
+    name: clang-8 release
   # - &MacOsDebug9_2
   #   os: osx
   #   env: BUILD_TYPE=Debug
@@ -165,9 +189,9 @@ jobs:
   #   compiler: clang
   #   name: osx xcode 9.2 release
 
-  # Build test libraries
+  # Build stage 2
   - <<: *Gcc6Debug
-    stage: Build Test Libraries
+    stage: Build stage 2
   - <<: *Gcc6Release
   - <<: *Gcc7Debug
   - <<: *Gcc7Release
@@ -175,12 +199,16 @@ jobs:
   - <<: *Gcc8Release
   - <<: *Gcc9Debug
   - <<: *Gcc9Release
-  - <<: *ClangDebug
-  - <<: *ClangRelease
+  - <<: *Clang4Debug
+  - <<: *Clang4Release
+  - <<: *Clang5Debug
+  - <<: *Clang5Release
+  - <<: *Clang8Debug
+  - <<: *Clang8Release
 
-  # Last stage: Build test executables, run tests, clang tidy, and docs.
+  # Last stage: Build stage 3, clang tidy, and docs.
   - <<: *Gcc6Debug
-    stage: Build Executables, Run Tests, ClangTidy, and Doxygen
+    stage: Build stage 3, ClangTidy, and Doxygen
   - <<: *Gcc6Release
   - <<: *Gcc7Debug
   - <<: *Gcc7Release
@@ -188,8 +216,12 @@ jobs:
   - <<: *Gcc8Release
   - <<: *Gcc9Debug
   - <<: *Gcc9Release
-  - <<: *ClangDebug
-  - <<: *ClangRelease
+  - <<: *Clang4Debug
+  - <<: *Clang4Release
+  - <<: *Clang5Debug
+  - <<: *Clang5Release
+  - <<: *Clang8Debug
+  - <<: *Clang8Release
 
 
 # Travis allows caching of data between builds to reduce build times or perform

--- a/.travis/BuildLinux.sh
+++ b/.travis/BuildLinux.sh
@@ -3,18 +3,6 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Load what we need from `/root/.bashrc`
-. /etc/profile.d/lmod.sh
-export PATH=$PATH:/work/spack/bin
-. /work/spack/share/spack/setup-env.sh
-spack load benchmark
-spack load blaze
-spack load brigand
-spack load catch
-spack load gsl
-spack load libsharp
-spack load libxsmm
-spack load yaml-cpp
 export PATH=$PATH:/work/texlive/bin/x86_64-linux
 
 ccache -z
@@ -61,18 +49,20 @@ if [ -z "${RUN_CLANG_TIDY}" ] \
         time make test-libs-domain -j2
         time make test-libs-elliptic -j2
         time make test-libs-evolution -j2
-        time make test-libs-numerical-algorithms -j2
     fi
 
     if [[ ${TRAVIS_BUILD_STAGE_NAME} = "Build test libraries" ]]; then
-        time make test-libs-data-structures -j2
+        time make test-libs-numerical-algorithms -j2
+        # Build DataStructures in serial because the DataVector tests
+        # are very memory intensive to compile
+        time make test-libs-data-structures -j1
         time make test-libs-pointwise-functions -j2
-        time make test-libs-other -j2
-        time make -j2
     fi
 
     if [[ ${TRAVIS_BUILD_STAGE_NAME} = \
           "Build executables, run tests, clangtidy, and doxygen" ]]; then
+        time make test-libs-other -j2
+        time make -j2
         # Build major executables in serial to avoid hitting memory limits.
         time make test-executables -j1
         time ctest --output-on-failure -j2

--- a/.travis/RunClangTidy.sh
+++ b/.travis/RunClangTidy.sh
@@ -3,19 +3,6 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Setup lmod and spack to load dependencies
-. /etc/profile.d/lmod.sh
-export PATH=$PATH:/work/spack/bin
-. /work/spack/share/spack/setup-env.sh
-spack load benchmark
-spack load blaze
-spack load brigand
-spack load catch
-spack load gsl
-spack load libsharp
-spack load libxsmm
-spack load yaml-cpp
-
 BUILD_DIR=`pwd`
 git clone ${UPSTREAM_REPO} /work/spectre_upstream
 cd /work/spectre_upstream

--- a/.travis/RunIncludeWhatYouUse.sh
+++ b/.travis/RunIncludeWhatYouUse.sh
@@ -24,19 +24,6 @@ check_whitelist() {
 # if on travis
 if [ $# == 0 ]; then
 
-    # Setup lmod and spack to load dependencies
-    . /etc/profile.d/lmod.sh
-    export PATH=$PATH:/work/spack/bin
-    . /work/spack/share/spack/setup-env.sh
-    spack load benchmark
-    spack load blaze
-    spack load brigand
-    spack load catch
-    spack load gsl
-    spack load libsharp
-    spack load libxsmm
-    spack load yaml-cpp
-
     SOURCE_DIR="/work/spectre/"
     BUILD_DIR=`pwd`
     IWYU_TOOL=iwyu_tool.py

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -29,15 +29,19 @@ RUN apt-get update -y \
                           gcc-7 g++-7 gfortran-7 \
                           gcc-8 g++-8 gfortran-8 \
                           gcc-9 g++-9 gfortran-9 \
-                          gdb git cmake \
+                          gdb git cmake autoconf \
                           libopenblas-dev liblapack-dev \
                           libhdf5-dev hdf5-tools \
                           libgsl0-dev \
                           clang-5.0 clang-format-5.0 clang-tidy-5.0 \
                           libclang-5.0-dev wget libncurses-dev \
                           lcov cppcheck \
-                          libboost-all-dev \
-                          libssl-dev
+                          libboost-all-dev libssl-dev libbenchmark-dev
+
+# Add clang 4 and 8
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && apt-get update -y \
+    && apt-get install -y clang-4.0 clang-8
 
 # Update is needed to get libc++ correctly
 # Install jemalloc
@@ -66,52 +70,59 @@ RUN apt-get update -y \
     && printf "if [ -f /etc/bash_completion ] && ! shopt -oq posix; then\n\
     . /etc/bash_completion\nfi\n\n" >> /root/.bashrc
 
-# Install LMod which is needed by Spack and set it to load at login
-RUN apt-get update -y \
-    && apt-get install -y curl lmod \
-    && printf '. /etc/profile.d/lmod.sh\n' >> /root/.bashrc \
-    && . /etc/profile.d/lmod.sh
+# We install dependencies not available through apt manually rather than using
+# Spack since Spack ends up building a lot of dependencies from scratch
+# that we don't need. Thus, not building the deps with Spack reduces total
+# build time of the Docker image.
 
-# Install Spack to get remaining dependencies
-WORKDIR /work
-RUN git clone https://github.com/LLNL/spack.git
-WORKDIR /work/spack
-# Since spack/develop is rather unstable, we check out a commit we
-# know is stable. This should be updated periodically to update
-# installed packages.
-RUN git checkout 470a45c51659156e7d154ea890e798ce32b8767d
-WORKDIR /work
-
-# Spack needs to be pointed to the system OpenSSL to work properly, we add this
-# in the general configure script for Spack rather than a user-specific
-# configure script. The below code is documented in the Spack manual.
-RUN printf "\n  openssl:\n    paths:\n      openssl@1.0.2g: /usr\n\
-    buildable: False\n" >> /work/spack/etc/spack/defaults/packages.yaml
-
-# Add Spack to PATH and install required dependencies
-# The sed commands are necessary because spack fails to find the
-# fortran compilers for an unknown reason. We compile the libraries with GCC6
-# so that we do not need separate versions for GCC6 and GCC7.
-RUN echo "export PATH=\$PATH:/work/spack/bin" >> /root/.bashrc\
-    && echo '. /work/spack/share/spack/setup-env.sh' >> /root/.bashrc \
-    && export PATH=$PATH:/work/spack/bin \
-    && spack compiler find \
-    && sed -i 's@fc: null@fc: /usr/bin/gfortran@' \
-    /root/.spack/linux/compilers.yaml \
-    && sed -i 's@f77: null@f77: /usr/bin/gfortran@' \
-    /root/.spack/linux/compilers.yaml
-RUN /work/spack/bin/spack install cmake \
-    && /work/spack/bin/spack install --no-checksum catch@2.1.0 \
-    && /work/spack/bin/spack install brigand@master \
-    && /work/spack/bin/spack install blaze \
-    && /work/spack/bin/spack install gsl%gcc@6.5.0 \
-    && /work/spack/bin/spack install libsharp -openmp -mpi \
-    && /work/spack/bin/spack install libxsmm%gcc@6.5.0 \
-    && /work/spack/bin/spack install yaml-cpp@develop%gcc@6.5.0 \
-    && /work/spack/bin/spack install benchmark%gcc@6.5.0
+# Install blaze, brigand, catch2, libsharp, libxsmm, yaml-cpp in /usr/local
+RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.2.tar.gz -O blaze.tar.gz \
+    && tar -xzf blaze.tar.gz \
+    && mv blaze-* blaze \
+    && mv blaze/blaze /usr/local/include \
+    && rm -rf blaze* \
+    && git clone https://github.com/edouarda/brigand.git \
+    && mv brigand/include/brigand /usr/local/include \
+    && rm -rf brigand \
+    && wget https://github.com/catchorg/Catch2/releases/download/v2.2.1/catch.hpp -O catch.hpp \
+    && mv catch.hpp /usr/local/include \
+    && wget https://github.com/Libsharp/libsharp/archive/v1.0.0.tar.gz -O libsharp.tar.gz \
+    && tar -xzf libsharp.tar.gz \
+    && mv libsharp-* libsharp_build \
+    && cd libsharp_build \
+    && autoconf \
+    && ./configure --prefix=/usr/local --disable-openmp \
+    && make -j4 \
+    && mv auto/bin/* /usr/local/bin \
+    && mv auto/include/* /usr/local/include \
+    && mv auto/lib/* /usr/local/lib \
+    && cd ../ \
+    && rm -r libsharp* \
+    && wget https://github.com/hfp/libxsmm/archive/1.9.tar.gz -O libxsmm.tar.gz \
+    && tar -xzf libxsmm.tar.gz \
+    && mv libxsmm-* libxsmm \
+    && cd libxsmm \
+    && make $PARALLEL_MAKE_ARG PREFIX=/usr/local/ install \
+    && cd .. \
+    && rm -rf libxsmm libxsmm.tar.gz \
+    && wget https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.6.2.tar.gz -O yaml-cpp.tar.gz \
+    && tar -xzf yaml-cpp.tar.gz \
+    && mv yaml-cpp-* yaml-cpp-build \
+    && cd yaml-cpp-build \
+    && mkdir build \
+    && cd build \
+    && cmake -D CMAKE_BUILD_TYPE=Release -D YAML_CPP_BUILD_TESTS=OFF \
+             -D YAML_CPP_BUILD_CONTRIB=OFF \
+             -D YAML_CPP_BUILD_TOOLS=ON \
+             -D CMAKE_INSTALL_PREFIX=/usr/local/ .. \
+    && make -j4 \
+    && make install \
+    && cd ../.. \
+    && rm -rf yaml-cpp*
 
 # Install include-what-you-use
 # We patch it to allow cyclic includes in boost
+WORKDIR /work
 RUN wget https://github.com/include-what-you-use/include-what-you-use/archive/clang_5.0.tar.gz \
     && tar -xzf clang_5.0.tar.gz \
     && rm clang_5.0.tar.gz \
@@ -146,18 +157,6 @@ RUN git clone https://charm.cs.illinois.edu/gerrit/charm \
     && git apply /work/charm/v6.8.patch \
     && rm /work/charm/v6.8.patch
 
-WORKDIR /work
-
-# Load Spack dependencies at container load
-RUN echo 'spack load catch' >> /root/.bashrc \
-    && echo 'spack load brigand' >> /root/.bashrc \
-    && echo 'spack load blaze' >> /root/.bashrc \
-    && echo 'spack load gsl' >> /root/.bashrc \
-    && echo 'spack load libsharp' >> /root/.bashrc \
-    && echo 'spack load libxsmm' >> /root/.bashrc \
-    && echo 'spack load yaml-cpp' >> /root/.bashrc \
-    && echo 'spack load benchmark' >> /root/.bashrc
-
 # - Set the environment variable SPECTRE_CONTAINER so we can check if we are
 #   inside a container (0 is true in bash)
 # - The singularity containers work better if the locale is set properly
@@ -185,12 +184,3 @@ RUN wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz \
             >> /root/.bashrc \
     && /work/texlive/bin/x86_64-linux/tlmgr install bibtex
 WORKDIR /work
-
-# Work around posix rename bug:
-#   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=891541
-RUN ln -s /usr/lib/x86_64-linux-gnu/lua/5.1/posix_c.so \
-    /usr/lib/x86_64-linux-gnu/lua/5.1/posix.so \
-    && ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so \
-    /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so \
-    && ln -s /usr/lib/x86_64-linux-gnu/lua/5.3/posix_c.so \
-    /usr/lib/x86_64-linux-gnu/lua/5.3/posix.so

--- a/src/IO/H5/Version.hpp
+++ b/src/IO/H5/Version.hpp
@@ -39,8 +39,8 @@ class Version : public h5::Object {
   Version(const Version& /*rhs*/) = delete;
   Version& operator=(const Version& /*rhs*/) = delete;
 
-  Version(Version&& /*rhs*/) noexcept = default;             // NOLINT
-  Version& operator=(Version&& /*rhs*/) noexcept = default;  // NOLINT
+  Version(Version&& /*rhs*/) noexcept = delete;             // NOLINT
+  Version& operator=(Version&& /*rhs*/) noexcept = delete;  // NOLINT
   ~Version() override = default;
   /// \endcond
 

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -72,6 +72,18 @@ std::ostream& operator<<(std::ostream& os,
                          const Quadrature& quadrature) noexcept;
 /// \endcond
 
+namespace detail {
+constexpr size_t minimum_number_of_points(
+    const Basis /*basis*/, const Quadrature quadrature) noexcept {
+  if (quadrature == Quadrature::Gauss) {
+    return 1;
+  } else if (quadrature == Quadrature::GaussLobatto) {
+    return 2;
+  }
+  return std::numeric_limits<size_t>::max();
+}
+}  // namespace detail
+
 /*!
  * \brief Minimum number of possible collocation points for a quadrature type.
  *
@@ -79,16 +91,9 @@ std::ostream& operator<<(std::ostream& os,
  * it must have at least two collocation points. Gauss quadrature can have only
  * one collocation point.
  */
-template <Basis, Quadrature>
-constexpr size_t minimum_number_of_points{std::numeric_limits<size_t>::max()};
-/// \cond
-template <Basis BasisType>
-constexpr size_t minimum_number_of_points<BasisType, Quadrature::Gauss> = 1;
-template <Basis BasisType>
-constexpr size_t minimum_number_of_points<BasisType, Quadrature::GaussLobatto> =
-    2;
-/// \endcond
-
+template <Basis basis, Quadrature quadrature>
+constexpr size_t minimum_number_of_points =
+    detail::minimum_number_of_points(basis, quadrature);
 /*!
  * \brief Maximum number of allowed collocation points.
  */


### PR DESCRIPTION
## Proposed changes

- Work around a compiler bug in clang8
- Add clang4 and clang8 as Travis targets.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
