### PR TITLE
Add tests for simple tags in gr and GH namespaces, resolve #1493

### DIFF
--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_Constraints.cpp
   Test_DuDt.cpp
   Test_Fluxes.cpp
+  Test_Tags.cpp
   Test_UpwindFlux.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Tags.cpp
@@ -1,0 +1,81 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+
+namespace {
+struct ArbitraryFrame;
+}  // namespace
+
+template <size_t Dim, typename Frame>
+void test_simple_tags() {
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::Pi<Dim, Frame>>() == "Pi");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::Phi<Dim, Frame>>() == "Phi");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::ConstraintGamma0>() ==
+        "ConstraintGamma0");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::ConstraintGamma1>() ==
+        "ConstraintGamma1");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::ConstraintGamma2>() ==
+        "ConstraintGamma2");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::GaugeH<Dim, Frame>>() ==
+        "GaugeH");
+  CHECK(db::tag_name<
+            GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<Dim, Frame>>() ==
+        "SpacetimeDerivGaugeH");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, Frame>>() ==
+        "InitialGaugeH");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::UPsi<Dim, Frame>>() == "UPsi");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::UZero<Dim, Frame>>() ==
+        "UZero");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::UPlus<Dim, Frame>>() ==
+        "UPlus");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::UMinus<Dim, Frame>>() ==
+        "UMinus");
+  CHECK(db::tag_name<
+            GeneralizedHarmonic::Tags::CharacteristicSpeeds<Dim, Frame>>() ==
+        "CharacteristicSpeeds");
+  CHECK(db::tag_name<
+            GeneralizedHarmonic::Tags::CharacteristicFields<Dim, Frame>>() ==
+        "CharacteristicFields");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::
+                         EvolvedFieldsFromCharacteristicFields<Dim, Frame>>() ==
+        "EvolvedFieldsFromCharacteristicFields");
+  CHECK(
+      db::tag_name<GeneralizedHarmonic::Tags::GaugeConstraint<Dim, Frame>>() ==
+      "GaugeConstraint");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::FConstraint<Dim, Frame>>() ==
+        "FConstraint");
+  CHECK(db::tag_name<
+            GeneralizedHarmonic::Tags::TwoIndexConstraint<Dim, Frame>>() ==
+        "TwoIndexConstraint");
+  CHECK(db::tag_name<
+            GeneralizedHarmonic::Tags::ThreeIndexConstraint<Dim, Frame>>() ==
+        "ThreeIndexConstraint");
+  CHECK(db::tag_name<
+            GeneralizedHarmonic::Tags::FourIndexConstraint<Dim, Frame>>() ==
+        "FourIndexConstraint");
+  CHECK(
+      db::tag_name<GeneralizedHarmonic::Tags::ConstraintEnergy<Dim, Frame>>() ==
+      "ConstraintEnergy");
+  CHECK(
+      db::tag_name<GeneralizedHarmonic::OptionTags::GaugeHRollOnStartTime>() ==
+      "GaugeHRollOnStartT");
+  CHECK(
+      db::tag_name<GeneralizedHarmonic::OptionTags::GaugeHRollOnTimeWindow>() ==
+      "GaugeHRollOnTWindow");
+  CHECK(db::tag_name<GeneralizedHarmonic::OptionTags::
+                         GaugeHSpatialWeightDecayWidth<Frame>>() ==
+        "GaugeHDecayWidth");
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.Tags",
+                  "[Unit][Evolution]") {
+  test_simple_tags<1, ArbitraryFrame>();
+  test_simple_tags<2, ArbitraryFrame>();
+  test_simple_tags<3, ArbitraryFrame>();
+}

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
@@ -5,11 +5,67 @@
 
 #include <string>
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
-struct DataVector;
+namespace {
+struct ArbitraryFrame;
+struct ArbitraryType;
+}  // namespace
+
+template <size_t Dim, typename Frame, typename Type>
+void test_simple_tags() {
+  CHECK(db::tag_name<gr::Tags::SpacetimeMetric<Dim, Frame, Type>>() ==
+        "SpacetimeMetric");
+  CHECK(db::tag_name<gr::Tags::InverseSpacetimeMetric<Dim, Frame, Type>>() ==
+        "InverseSpacetimeMetric");
+  CHECK(db::tag_name<gr::Tags::InverseSpatialMetric<Dim, Frame, Type>>() ==
+        "InverseSpatialMetric");
+  CHECK(db::tag_name<gr::Tags::DetSpatialMetric<Type>>() == "DetSpatialMetric");
+  CHECK(db::tag_name<gr::Tags::SqrtDetSpatialMetric<Type>>() ==
+        "SqrtDetSpatialMetric");
+  CHECK(db::tag_name<gr::Tags::Shift<Dim, Frame, Type>>() == "Shift");
+  CHECK(db::tag_name<gr::Tags::Lapse<Type>>() == "Lapse");
+  CHECK(db::tag_name<gr::Tags::DerivSpacetimeMetric<Dim, Frame, Type>>() ==
+        "DerivSpacetimeMetric");
+  CHECK(db::tag_name<
+            gr::Tags::DerivativesOfSpacetimeMetric<Dim, Frame, Type>>() ==
+        "DerivativesOfSpacetimeMetric");
+  CHECK(db::tag_name<
+            gr::Tags::SpacetimeChristoffelFirstKind<Dim, Frame, Type>>() ==
+        "SpacetimeChristoffelFirstKind");
+  CHECK(db::tag_name<
+            gr::Tags::SpacetimeChristoffelSecondKind<Dim, Frame, Type>>() ==
+        "SpacetimeChristoffelSecondKind");
+  CHECK(
+      db::tag_name<gr::Tags::SpatialChristoffelFirstKind<Dim, Frame, Type>>() ==
+      "SpatialChristoffelFirstKind");
+  CHECK(db::tag_name<
+            gr::Tags::SpatialChristoffelSecondKind<Dim, Frame, Type>>() ==
+        "SpatialChristoffelSecondKind");
+  CHECK(db::tag_name<gr::Tags::SpacetimeNormalOneForm<Dim, Frame, Type>>() ==
+        "SpacetimeNormalOneForm");
+  CHECK(db::tag_name<gr::Tags::SpacetimeNormalVector<Dim, Frame, Type>>() ==
+        "SpacetimeNormalVector");
+  CHECK(db::tag_name<
+            gr::Tags::TraceSpacetimeChristoffelFirstKind<Dim, Frame, Type>>() ==
+        "TraceSpacetimeChristoffelFirstKind");
+  CHECK(db::tag_name<
+            gr::Tags::TraceSpatialChristoffelFirstKind<Dim, Frame, Type>>() ==
+        "TraceSpatialChristoffelFirstKind");
+  CHECK(db::tag_name<
+            gr::Tags::TraceSpatialChristoffelSecondKind<Dim, Frame, Type>>() ==
+        "TraceSpatialChristoffelSecondKind");
+  CHECK(db::tag_name<gr::Tags::ExtrinsicCurvature<Dim, Frame, Type>>() ==
+        "ExtrinsicCurvature");
+  CHECK(db::tag_name<gr::Tags::TraceExtrinsicCurvature<Type>>() ==
+        "TraceExtrinsicCurvature");
+  CHECK(db::tag_name<gr::Tags::EnergyDensity<Type>>() == "EnergyDensity");
+}
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Tags",
                   "[Unit][PointwiseFunctions]") {
-  CHECK(gr::Tags::EnergyDensity<DataVector>::name() == "EnergyDensity");
+  test_simple_tags<1, ArbitraryFrame, ArbitraryType>();
+  test_simple_tags<2, ArbitraryFrame, ArbitraryType>();
+  test_simple_tags<3, ArbitraryFrame, ArbitraryType>();
 }


### PR DESCRIPTION
## Proposed changes

Currently, while ComputeTags in `gr` and `GeneralizedHarmonic` namespaces are tested, SimpleTags are not tested. This PR fixes this issue (raised in #1493).

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
