### PR TITLE
Interpolator can deal with points outside of the Domain.

### DIFF
--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -17,8 +17,8 @@
 namespace {
 // Define this alias so we don't need to keep typing this monster.
 template <size_t Dim>
-using block_logical_coord_holder =
-    IdPair<domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>;
+using block_logical_coord_holder = boost::optional<
+    IdPair<domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>>;
 }  // namespace
 
 template <size_t Dim, typename Frame>
@@ -27,18 +27,16 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
     const tnsr::I<DataVector, Dim, Frame>& x) noexcept {
   const size_t num_pts = get<0>(x).size();
   std::vector<block_logical_coord_holder<Dim>> block_coord_holders(num_pts);
-  std::vector<tnsr::I<double, Dim, Frame>> points_with_no_block;
   for (size_t s = 0; s < num_pts; ++s) {
     tnsr::I<double, Dim, Frame> x_frame(0.0);
     for (size_t d = 0; d < Dim; ++d) {
       x_frame.get(d) = x.get(d)[s];
     }
-    auto& x_logical = block_coord_holders[s].data;
+    tnsr::I<double, Dim, typename ::Frame::Logical> x_logical{};
     // Check which block this point is in. Each point will be in one
     // and only one block, unless it is on a shared boundary.  In that
     // case, choose the first matching block (and this block will have
     // the smallest block_id).
-    bool found_block = false;
     for (const auto& block : domain.blocks()) {
       const auto inv = block.coordinate_map().inverse(x_frame);
       if(inv) {
@@ -56,18 +54,11 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
       if (is_contained) {
         // Point is in this block.  Don't bother checking subsequent
         // blocks.
-        block_coord_holders[s].id = domain::BlockId(block.id());
-        found_block = true;
+        block_coord_holders[s] =
+            make_id_pair(domain::BlockId(block.id()), std::move(x_logical));
         break;
       }
     }
-    if (not found_block) {
-      points_with_no_block.emplace_back(std::move(x_frame));
-    }
-  }
-  if (not points_with_no_block.empty()) {
-    ERROR("Found points that are not in any block\n: x_frame = "
-          << points_with_no_block);
   }
   return block_coord_holders;
 }

--- a/src/Domain/BlockLogicalCoordinates.hpp
+++ b/src/Domain/BlockLogicalCoordinates.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <vector>
 
@@ -24,11 +25,12 @@ class IdPair;
 /// Computes the block logical coordinates and the containing `BlockId`
 /// of a set of points, given coordinates in the `Frame` frame.
 ///
-/// \details Returns a std::vector<IdPair<BlockId,coords>>, where the
-/// vector runs over the points and is indexed in the same order as
+/// \details Returns a std::vector<boost::optional<IdPair<BlockId,coords>>>,
+/// where the vector runs over the points and is indexed in the same order as
 /// the input coordinates `x`. For each point, the `IdPair` holds the
 /// block logical coords of that point and the `BlockId` of the `Block` that
 /// contains that point.
+/// The boost::optional is empty if the point is not in any Block.
 /// If a point is on a shared boundary of two or more `Block`s, it is
 /// returned only once, and is considered to belong to the `Block`
 /// with the smaller `BlockId`.
@@ -36,5 +38,5 @@ template <size_t Dim, typename Frame>
 auto block_logical_coordinates(
     const Domain<Dim, Frame>& domain,
     const tnsr::I<DataVector, Dim, Frame>& x) noexcept
-    -> std::vector<IdPair<domain::BlockId,
-                          tnsr::I<double, Dim, typename ::Frame::Logical>>>;
+    -> std::vector<boost::optional<IdPair<
+        domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>>>;

--- a/src/Domain/ElementLogicalCoordinates.cpp
+++ b/src/Domain/ElementLogicalCoordinates.cpp
@@ -22,8 +22,8 @@
 namespace {
 // Define this alias so we don't need to keep typing this monster.
 template <size_t Dim>
-using block_logical_coord_holder =
-    IdPair<domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>;
+using block_logical_coord_holder = boost::optional<
+    IdPair<domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>>;
 }  // namespace
 
 template <size_t Dim>
@@ -40,8 +40,13 @@ element_logical_coordinates(const std::vector<ElementId<Dim>>& element_ids,
 
   // Loop over points
   for (size_t offset = 0; offset < block_coord_holders.size(); ++offset) {
-    const auto& block_id = block_coord_holders[offset].id;
-    const auto& x_block_logical = block_coord_holders[offset].data;
+    // Skip points that are not in any block.
+    if (not block_coord_holders[offset]) {
+      continue;
+    }
+
+    const auto& block_id = block_coord_holders[offset].get().id;
+    const auto& x_block_logical = block_coord_holders[offset].get().data;
     // Need to loop over elements, because the block doesn't know
     // things like the refinement_level of each element.
     for (size_t index = 0; index < element_ids.size(); ++index) {

--- a/src/Domain/ElementLogicalCoordinates.hpp
+++ b/src/Domain/ElementLogicalCoordinates.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <unordered_map>
 #include <vector>
@@ -87,7 +88,7 @@ struct ElementLogicalCoordHolder {
 template <size_t Dim>
 auto element_logical_coordinates(
     const std::vector<ElementId<Dim>>& element_ids,
-    const std::vector<
-        IdPair<domain::BlockId, tnsr::I<double, Dim, typename Frame::Logical>>>&
+    const std::vector<boost::optional<IdPair<
+        domain::BlockId, tnsr::I<double, Dim, typename Frame::Logical>>>>&
         block_coord_holders) noexcept
     -> std::unordered_map<ElementId<Dim>, ElementLogicalCoordHolder<Dim>>;

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
@@ -85,6 +85,15 @@ struct FindApparentHorizon {
       const gsl::not_null<db::DataBox<DbTags>*> box,
       const gsl::not_null<Parallel::ConstGlobalCache<Metavariables>*> cache,
       const typename Metavariables::temporal_id::type& temporal_id) noexcept {
+
+    // Before doing anything else, deal with the possibility that some
+    // of the points might be outside of the Domain.
+    const auto num_invalid_pts =
+        db::get<Tags::IndicesOfInvalidInterpPoints>(*box).size();
+    if(num_invalid_pts > 0) {
+      ERROR("FindApparentHorizon: Found points that are not in any block");
+    }
+
     const auto& verbosity = db::get<::Tags::Verbosity>(*box);
     const auto& inv_g =
         db::get<::gr::Tags::InverseSpatialMetric<3, Frame::Inertial>>(*box);

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
@@ -92,6 +92,9 @@ struct ObserveTimeSeriesOnSurface {
       tmpl::list<typename detail::reduction_data_type<TagsToObserve>::type>>;
   using observation_types = tmpl::list<ObservationType>;
 
+  static constexpr double fill_invalid_points_with =
+      std::numeric_limits<double>::quiet_NaN();
+
   template <typename DbTags, typename Metavariables>
   static void apply(
       const db::DataBox<DbTags>& box,

--- a/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
@@ -89,6 +89,7 @@ auto make_initial_box(
 /// DataBox changes:
 /// - Adds:
 ///   - `Tags::IndicesOfFilledInterpPoints`
+///   - `Tags::IndicesOfInvalidInterpPoints`
 ///   - `Tags::TemporalIds<Metavariables>`
 ///   - `Tags::CompletedTemporalIds<Metavariables>`
 ///   - `::Tags::Variables<typename
@@ -100,7 +101,8 @@ auto make_initial_box(
 template <typename Metavariables, typename InterpolationTargetTag>
 struct InitializeInterpolationTarget {
   using return_tag_list_initial = tmpl::list<
-      Tags::IndicesOfFilledInterpPoints, Tags::TemporalIds<Metavariables>,
+      Tags::IndicesOfFilledInterpPoints, Tags::IndicesOfInvalidInterpPoints,
+      Tags::TemporalIds<Metavariables>,
       Tags::CompletedTemporalIds<Metavariables>,
       ::Tags::Variables<
           typename InterpolationTargetTag::vars_to_interpolate_to_target>>;
@@ -124,6 +126,7 @@ struct InitializeInterpolationTarget {
         db::create_from<db::RemoveTags<>,
                         db::get_items<return_tag_list_initial>>(
             std::move(box), db::item_type<Tags::IndicesOfFilledInterpPoints>{},
+            db::item_type<Tags::IndicesOfInvalidInterpPoints>{},
             db::item_type<Tags::TemporalIds<Metavariables>>{},
             db::item_type<Tags::CompletedTemporalIds<Metavariables>>{},
             db::item_type<

--- a/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <unordered_map>
 #include <unordered_set>
@@ -44,8 +45,8 @@ struct Info {
   /// `block_coord_holders` even after all `Element`s have sent their
   /// data (this is because this `Info` lives only on a single core,
   /// and this core will have access only to the local `Element`s).
-  std::vector<IdPair<domain::BlockId,
-                     tnsr::I<double, VolumeDim, typename ::Frame::Logical>>>
+  std::vector<boost::optional<IdPair<
+      domain::BlockId, tnsr::I<double, VolumeDim, typename ::Frame::Logical>>>>
       block_coord_holders;
   /// `vars` holds the interpolated `Variables` on some subset of the
   /// points in `block_coord_holders`.  The grid points inside vars

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -89,6 +89,12 @@ namespace intrp {
 ///      needs the volume data at this temporal_id (such as another iteration of
 ///      the horizon finder).
 ///
+///      post_interpolation_callback can optionally have a static constexpr
+///      double called `fill_invalid_points_with`.  Any points outside the
+///      Domain will be filled with this value. If this variable is not defined,
+///      then the `apply` function must check for invalid points,
+///      and should typically exit with an error message if it finds any.
+///
 /// `Metavariables` must contain the following type aliases:
 /// - interpolator_source_vars:
 ///      A `tmpl::list` of tags that define a `Variables` sent from all

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -111,6 +111,7 @@ namespace Actions {
 /// - Removes: nothing
 /// - Modifies:
 ///   - `Tags::IndicesOfFilledInterpPoints`
+///   - `Tags::IndicesOfInvalidInterpPoints`
 ///   - `::Tags::Variables<typename
 ///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
 ///

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
@@ -230,12 +230,13 @@ struct InterpolationTargetReceiveVars {
           }
         });
 
-    if (db::get<Tags::IndicesOfFilledInterpPoints>(box).size() ==
+    if (db::get<Tags::IndicesOfFilledInterpPoints>(box).size() +
+            db::get<Tags::IndicesOfInvalidInterpPoints>(box).size() ==
         db::get<::Tags::Variables<
             typename InterpolationTargetTag::vars_to_interpolate_to_target>>(
             box)
             .number_of_grid_points()) {
-      // All the points have been interpolated.
+      // All the valid points have been interpolated.
       InterpolationTarget_detail::callback_and_cleanup<InterpolationTargetTag>(
           make_not_null(&box), make_not_null(&cache));
     }

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
@@ -17,6 +17,7 @@
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits.hpp"
 
 /// \cond
 // IWYU pragma: no_forward_declare db::DataBox
@@ -74,6 +75,61 @@ auto apply_callback(
   return true;
 }
 
+// type trait testing if the class has a fill_invalid_points_with member.
+template <typename T, typename = void>
+struct has_fill_invalid_points_with : std::false_type {};
+
+template <typename T>
+struct has_fill_invalid_points_with<
+    T, cpp17::void_t<decltype(
+           T::post_interpolation_callback::fill_invalid_points_with)>>
+    : std::true_type {};
+
+template <typename T>
+constexpr bool has_fill_invalid_points_with_v =
+    has_fill_invalid_points_with<T>::value;
+
+// Fills invalid points with some constant value.
+template <typename InterpolationTargetTag, typename DbTags,
+          Requires<not has_fill_invalid_points_with_v<InterpolationTargetTag>> =
+              nullptr>
+void fill_invalid_points(
+    const gsl::not_null<db::DataBox<DbTags>*> /*box*/) noexcept {}
+
+template <
+    typename InterpolationTargetTag, typename DbTags,
+    Requires<has_fill_invalid_points_with_v<InterpolationTargetTag>> = nullptr>
+void fill_invalid_points(
+    const gsl::not_null<db::DataBox<DbTags>*> box) noexcept {
+  if (not db::get<Tags::IndicesOfInvalidInterpPoints>(*box).empty()) {
+    db::mutate<
+        Tags::IndicesOfInvalidInterpPoints,
+        ::Tags::Variables<
+            typename InterpolationTargetTag::vars_to_interpolate_to_target>>(
+        box, [](const gsl::not_null<
+                    db::item_type<Tags::IndicesOfInvalidInterpPoints>*>
+                    indices_of_invalid_points,
+                const gsl::not_null<db::item_type<
+                    ::Tags::Variables<typename InterpolationTargetTag::
+                                          vars_to_interpolate_to_target>>*>
+                    vars_dest) noexcept {
+          const size_t npts_dest = vars_dest->number_of_grid_points();
+          const size_t nvars = vars_dest->number_of_independent_components;
+          for (auto index : *indices_of_invalid_points) {
+            for (size_t v = 0; v < nvars; ++v) {
+              // clang-tidy: no pointer arithmetic
+              vars_dest->data()[index + v * npts_dest] =  // NOLINT
+                  InterpolationTargetTag::post_interpolation_callback::
+                      fill_invalid_points_with;
+            }
+          }
+          // Further functions may test if there are invalid points.
+          // Clear the invalid points now, since we have filled them.
+          indices_of_invalid_points->clear();
+        });
+  }
+}
+
 /// Calls the callback function, tells interpolators to clean up the current
 /// temporal_id, and then if there are more temporal_ids to be interpolated,
 /// starts the next one.
@@ -85,6 +141,10 @@ void callback_and_cleanup(
         cache) noexcept {
   const auto temporal_id =
       db::get<Tags::TemporalIds<Metavariables>>(*box).front();
+
+  // Before doing anything else, deal with the possibility that some
+  // of the points might be outside of the Domain.
+  fill_invalid_points<InterpolationTargetTag>(box);
 
   // apply_callback should return true if we are done with this
   // temporal_id.  It should return false only if the callback
@@ -117,7 +177,7 @@ void callback_and_cleanup(
         // large, so we limit its size.  We assume that
         // asynchronous calls to AddTemporalIdsToInterpolationTarget do not span
         // more than 10 temporal_ids.
-        if(completed_ids->size() > 10) {
+        if (completed_ids->size() > 10) {
           completed_ids->pop_front();
         }
       });

--- a/src/NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <utility>
 #include <vector>
@@ -70,8 +71,9 @@ struct ReceivePoints {
       Parallel::ConstGlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/,
       const typename Metavariables::temporal_id::type& temporal_id,
-      std::vector<IdPair<domain::BlockId, tnsr::I<double, VolumeDim,
-                                                  typename ::Frame::Logical>>>&&
+      std::vector<boost::optional<
+          IdPair<domain::BlockId,
+                 tnsr::I<double, VolumeDim, typename ::Frame::Logical>>>>&&
           block_logical_coords) noexcept {
     db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(
         make_not_null(&box),

--- a/src/NumericalAlgorithms/Interpolation/Tags.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Tags.hpp
@@ -33,6 +33,17 @@ struct IndicesOfFilledInterpPoints : db::SimpleTag {
   using type = std::unordered_set<size_t>;
 };
 
+/// Keeps track of points that cannot be filled with interpolated data.
+///
+/// The InterpolationTarget can decide what to do with these points.
+/// In most cases the correct action is to throw an error, but in other
+/// cases one might wish to fill these points with a default value or
+/// take some other action.
+struct IndicesOfInvalidInterpPoints : db::SimpleTag {
+  static std::string name() noexcept { return "IndicesOfInvalidInterpPoints"; }
+  using type = std::unordered_set<size_t>;
+};
+
 /// `temporal_id`s on which to interpolate.
 template <typename Metavariables>
 struct TemporalIds : db::SimpleTag {

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -486,7 +486,7 @@ void test_radial_block_layers(const double inner_radius,
   const auto blogical_coords =
       block_logical_coordinates(domain, interior_inertial_coords);
   for (size_t s = 0; s < expected_block_ids.size(); ++s) {
-    CHECK(blogical_coords[s].id.get_index() == expected_block_ids[s]);
+    CHECK(blogical_coords[s].get().id.get_index() == expected_block_ids[s]);
   }
   size_t element_count = 0;
   for (const auto& block : domain.blocks()) {

--- a/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -5,6 +5,7 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <utility>
 #include <vector>
@@ -90,8 +91,9 @@ struct MockReceivePoints {
       Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/,
       const typename Metavariables::temporal_id::type& temporal_id,
-      std::vector<IdPair<domain::BlockId,
-                         tnsr::I<double, VolumeDim, typename Frame::Logical>>>&&
+      std::vector<boost::optional<
+          IdPair<domain::BlockId,
+                 tnsr::I<double, VolumeDim, typename Frame::Logical>>>>&&
           block_coord_holders) noexcept {
     db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(
         make_not_null(&box),
@@ -204,9 +206,10 @@ void test_interpolation_target(
   CHECK(block_coord_holders.size() == number_of_points);
 
   for (size_t i = 0; i < number_of_points; ++i) {
-    CHECK(block_coord_holders[i].id == expected_block_coord_holders[i].id);
-    CHECK_ITERABLE_APPROX(block_coord_holders[i].data,
-                          expected_block_coord_holders[i].data);
+    CHECK(block_coord_holders[i].get().id ==
+          expected_block_coord_holders[i].get().id);
+    CHECK_ITERABLE_APPROX(block_coord_holders[i].get().data,
+                          expected_block_coord_holders[i].get().data);
   }
 
   // Call again at a different temporal_id
@@ -223,9 +226,10 @@ void test_interpolation_target(
   const auto& new_block_coord_holders =
       vars_infos.at(new_temporal_id).block_coord_holders;
   for (size_t i = 0; i < number_of_points; ++i) {
-    CHECK(new_block_coord_holders[i].id == expected_block_coord_holders[i].id);
-    CHECK_ITERABLE_APPROX(new_block_coord_holders[i].data,
-                          expected_block_coord_holders[i].data);
+    CHECK(new_block_coord_holders[i].get().id ==
+          expected_block_coord_holders[i].get().id);
+    CHECK_ITERABLE_APPROX(new_block_coord_holders[i].get().data,
+                          expected_block_coord_holders[i].get().data);
   }
 }
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -108,9 +108,11 @@ struct MockCleanUpInterpolator {
     // this function was called.  This isn't the usual usage of
     // NumberOfElements.
     db::mutate<intrp::Tags::NumberOfElements>(
-        make_not_null(&box),
-        [](const gsl::not_null<db::item_type<intrp::Tags::NumberOfElements>*>
-               number_of_elements) noexcept { ++(*number_of_elements); });
+        make_not_null(&box), [](const gsl::not_null<
+                                 db::item_type<intrp::Tags::NumberOfElements>*>
+                                    number_of_elements) noexcept {
+          ++(*number_of_elements);
+        });
   }
 };
 
@@ -130,10 +132,11 @@ struct MockComputeTargetPoints {
     // whether this function was called.  This isn't the usual usage
     // of IndicesOfFilledInterpPoints; this is done only for the test.
     db::mutate<intrp::Tags::IndicesOfFilledInterpPoints>(
-        make_not_null(&box),
-        [](const gsl::not_null<
-            db::item_type<intrp::Tags::IndicesOfFilledInterpPoints>*>
-               indices) noexcept { indices->insert(indices->size() + 1); });
+        make_not_null(&box), [](const gsl::not_null<db::item_type<
+                                    intrp::Tags::IndicesOfFilledInterpPoints>*>
+                                    indices) noexcept {
+          indices->insert(indices->size() + 1);
+        });
   }
 };
 
@@ -192,6 +195,32 @@ struct MockPostInterpolationCallbackNoCleanup {
   }
 };
 
+template <size_t NumberOfInvalidInterpolationPoints>
+struct MockPostInterpolationCallbackWithInvalidPoints {
+  static constexpr double fill_invalid_points_with = 15.0;
+
+  template <typename DbTags, typename Metavariables>
+  static void apply(
+      const db::DataBox<DbTags>& box,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const typename Metavariables::temporal_id::type& temporal_id) noexcept {
+    Slab slab(0.0, 1.0);
+    CHECK(temporal_id == TimeStepId(true, 0, Time(slab, Rational(13, 15))));
+
+    // The result should be the square of the first 10 integers, in
+    // a Scalar<DataVector>, followed by several 225s.
+    DataVector expected_dv(NumberOfInvalidInterpolationPoints + 10);
+    for (size_t i = 0; i < 10; ++i) {
+      expected_dv[i] = double(i * i);
+    }
+    for (size_t i = 10; i < 10 + NumberOfInvalidInterpolationPoints; ++i) {
+      expected_dv[i] = 225.0;
+    }
+    const Scalar<DataVector> expected{expected_dv};
+    CHECK_ITERABLE_APPROX(expected, db::get<Tags::Square>(box));
+  }
+};
+
 template <typename Metavariables>
 struct mock_interpolator {
   using metavariables = Metavariables;
@@ -234,7 +263,8 @@ struct MockMetavariables {
   enum class Phase { Initialization, Testing, Exit };
 };
 
-template <typename MockCallbackType, size_t NumberOfExpectedCleanUpActions>
+template <typename MockCallbackType, size_t NumberOfExpectedCleanUpActions,
+          size_t NumberOfInvalidPointsToAdd>
 void test_interpolation_target_receive_vars() noexcept {
   using metavars = MockMetavariables<MockCallbackType>;
   using interp_component = mock_interpolator<metavars>;
@@ -247,6 +277,13 @@ void test_interpolation_target_receive_vars() noexcept {
   Slab slab(0.0, 1.0);
   const size_t num_points = 10;
 
+  // Add indices of invalid points (if there are any) at the end.
+  std::unordered_set<size_t> invalid_indices{};
+  for (size_t index = num_points;
+       index < num_points + NumberOfInvalidPointsToAdd; ++index) {
+    invalid_indices.insert(index);
+  }
+
   ActionTesting::MockRuntimeSystem<metavars> runner{
       {domain_creator.create_domain()}};
   ActionTesting::emplace_component<interp_component>(&runner, 0);
@@ -254,13 +291,15 @@ void test_interpolation_target_receive_vars() noexcept {
   ActionTesting::emplace_component_and_initialize<target_component>(
       &runner, 0,
       {db::item_type<intrp::Tags::IndicesOfFilledInterpPoints>{},
+       db::item_type<intrp::Tags::IndicesOfInvalidInterpPoints>{
+           invalid_indices},
        db::item_type<typename intrp::Tags::TemporalIds<metavars>>{
            TimeStepId(true, 0, Time(slab, Rational(13, 15))),
            TimeStepId(true, 0, Time(slab, Rational(14, 15)))},
        db::item_type<typename intrp::Tags::CompletedTemporalIds<metavars>>{},
        db::item_type<::Tags::Variables<typename metavars::InterpolationTargetA::
                                            vars_to_interpolate_to_target>>{
-           num_points}});
+           num_points + NumberOfInvalidPointsToAdd}});
   runner.set_phase(metavars::Phase::Testing);
 
   // Now set up the vars.
@@ -432,8 +471,10 @@ void test_interpolation_target_receive_vars() noexcept {
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.ReceiveVars",
                   "[Unit]") {
-  test_interpolation_target_receive_vars<MockPostInterpolationCallback, 1>();
+  test_interpolation_target_receive_vars<MockPostInterpolationCallback, 1, 0>();
   test_interpolation_target_receive_vars<MockPostInterpolationCallbackNoCleanup,
-                                         0>();
+                                         0, 0>();
+  test_interpolation_target_receive_vars<
+      MockPostInterpolationCallbackWithInvalidPoints<3>, 1, 3>();
 }
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -4,6 +4,7 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
+#include <boost/optional/optional_io.hpp>
 #include <cstddef>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
## Proposed changes
This is a change to the parallel interpolator.

Previously, if there was an interpolation point that was not in any Block, an error was
thrown at a low level.

Now, invalid interpolation points (i.e. points outside of all blocks) are allowed at a low level and dealt with at a higher level.  The post_interpolation_callback deals with these points as it sees fit.  This is usually by throwing an error, but now there are other possibilities. For instance, there is now an easy mechanism for the post_interpolation_callback to fill invalid interpolation points with a specified double (for instance, a quiet NaN).

This change will be useful for (at least) two things:
1.  Observing on a subset of points (say the x-y plane) that includes the interior of one or more excision regions.  Typically the user will want to fill these points with quiet NaNs and have the visualization software ignore these points. No further changes are needed for this functionality (other than writing the InterpolationTargets that specify the desired subset of points).
2.  The horizon finder needs to detect if the trial AH surface passes inside an excision region, and if so, adjust the trial surface accordingly instead of simply throwing an error.  This will require a future PR that depends on this one.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
