### PR TITLE
Improve damped harmonic gauge, add ability to reproduce SpEC

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -119,9 +119,10 @@ struct EvolutionMetavars {
       Tags::NumericalFlux<GeneralizedHarmonic::UpwindFlux<volume_dim>>;
 
   using step_choosers_common =
-      tmpl::list<//StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial>,
-                 StepChoosers::Registrars::Constant,
-                 StepChoosers::Registrars::Increase>;
+      tmpl::list<  // StepChoosers::Registrars::Cfl<volume_dim,
+                   // Frame::Inertial>,
+          StepChoosers::Registrars::Constant,
+          StepChoosers::Registrars::Increase>;
   using step_choosers_for_step_only =
       tmpl::list<StepChoosers::Registrars::PreventRapidIncrease>;
   using step_choosers_for_slab_only =
@@ -211,6 +212,7 @@ struct EvolutionMetavars {
       GeneralizedHarmonic::Tags::GaugeHRollOnStartTime,
       GeneralizedHarmonic::Tags::GaugeHRollOnTimeWindow,
       GeneralizedHarmonic::Tags::GaugeHSpatialWeightDecayWidth<frame>,
+      GeneralizedHarmonic::Tags::UseSpecStyleRollOn,
       Tags::EventsAndTriggers<events, triggers>>;
 
   struct ObservationType {};
@@ -300,27 +302,26 @@ struct EvolutionMetavars {
       intrp::InterpolationTarget<EvolutionMetavars, Horizon>,
       DgElementArray<
           EvolutionMetavars,
-          tmpl::list<
-              Parallel::PhaseActions<Phase, Phase::Initialization,
-                                     initialization_actions>,
+          tmpl::list<Parallel::PhaseActions<Phase, Phase::Initialization,
+                                            initialization_actions>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::InitializeTimeStepperHistory,
-                  SelfStart::self_start_procedure<step_actions>>,
+                     Parallel::PhaseActions<
+                         Phase, Phase::InitializeTimeStepperHistory,
+                         SelfStart::self_start_procedure<step_actions>>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::Register,
-                  tmpl::flatten<tmpl::list<
+                     Parallel::PhaseActions<
+                         Phase, Phase::Register,
+                         tmpl::flatten<tmpl::list<
                              intrp::Actions::RegisterElementWithInterpolator,
                              observers::Actions::RegisterWithObservers<
                                  observers::RegisterObservers<
                                      Tags::Time, element_observation_type>>,
                              Parallel::Actions::TerminatePhase>>>,
-              Parallel::PhaseActions<
-                  Phase, Phase::Evolve,
-                  tmpl::list<Actions::RunEventsAndTriggers,
-                             Actions::ChangeSlabSize,
-                             step_actions, Actions::AdvanceTime>>>>>;
+                     Parallel::PhaseActions<
+                         Phase, Phase::Evolve,
+                         tmpl::list<Actions::RunEventsAndTriggers,
+                                    Actions::ChangeSlabSize, step_actions,
+                                    Actions::AdvanceTime>>>>>;
 
   static constexpr OptionString help{
       "Evolve a generalized harmonic analytic solution.\n\n"

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -391,10 +391,10 @@ void damped_harmonic_h(
   const auto roll_on_h_init = [&time, &t_start_h_init, &sigma_t_h_init]() {
     auto x = DampedHarmonicGauge_detail::roll_on_function(time, t_start_h_init,
                                                           sigma_t_h_init);
-    if (abs(x) < std::numeric_limits<double>::epsilon()) {
-      return 0.;
-    } else {
+    if (UNLIKELY(abs(1. - x) > 10. * std::numeric_limits<double>::epsilon())) {
       return x;
+    } else {
+      return 0.;
     }
   }();
 
@@ -562,10 +562,10 @@ void spacetime_deriv_damped_harmonic_h(
   const auto roll_on_h_init = [&time, &t_start_h_init, &sigma_t_h_init]() {
     auto x = DampedHarmonicGauge_detail::roll_on_function(time, t_start_h_init,
                                                           sigma_t_h_init);
-    if (abs(x) < std::numeric_limits<double>::epsilon()) {
-      return 0.;
-    } else {
+    if (UNLIKELY(abs(1. - x) > 10. * std::numeric_limits<double>::epsilon())) {
       return x;
+    } else {
+      return 0.;
     }
   }();
   const auto roll_on_L1 = DampedHarmonicGauge_detail::roll_on_function(
@@ -594,10 +594,10 @@ void spacetime_deriv_damped_harmonic_h(
   const auto d0_roll_on_h_init = [&time, &t_start_h_init, &sigma_t_h_init]() {
     auto x = DampedHarmonicGauge_detail::time_deriv_of_roll_on_function(
         time, t_start_h_init, sigma_t_h_init);
-    if (abs(x) < std::numeric_limits<double>::epsilon()) {
-      return 0.;
-    } else {
+    if (UNLIKELY(abs(1. - x) > 10. * std::numeric_limits<double>::epsilon())) {
       return x;
+    } else {
+      return 0.;
     }
   }();
   const auto d0_roll_on_L1 =

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -391,7 +391,7 @@ void damped_harmonic_h(
   const auto roll_on_h_init = [&time, &t_start_h_init, &sigma_t_h_init]() {
     auto x = DampedHarmonicGauge_detail::roll_on_function(time, t_start_h_init,
                                                           sigma_t_h_init);
-    if (UNLIKELY(abs(1. - x) > 10. * std::numeric_limits<double>::epsilon())) {
+    if (UNLIKELY(abs(1. - x) > 100. * std::numeric_limits<double>::epsilon())) {
       return x;
     } else {
       return 0.;
@@ -403,7 +403,7 @@ void damped_harmonic_h(
     gauge_h->get(a) = (1. - roll_on_h_init) * gauge_h_init.get(a) +
                       get(h_prefac1) * spacetime_unit_normal_one_form.get(a);
     // In case we want SpEC-style roll-on of gauge
-    if (UNLIKELY(use_spec_style_rollon)) {
+    if (use_spec_style_rollon) {
       gauge_h->get(a) += (roll_on_h_init - 1.) * get(h_prefac1) *
                          spacetime_unit_normal_one_form.get(a);
     }
@@ -411,7 +411,7 @@ void damped_harmonic_h(
       gauge_h->get(a) +=
           get(h_prefac2) * spacetime_metric.get(a, i + 1) * shift.get(i);
       // In case we want SpEC-style roll-on of gauge
-      if (UNLIKELY(use_spec_style_rollon)) {
+      if (use_spec_style_rollon) {
         gauge_h->get(a) += (roll_on_h_init - 1.) * get(h_prefac2) *
                            spacetime_metric.get(a, i + 1) * shift.get(i);
       }
@@ -562,7 +562,7 @@ void spacetime_deriv_damped_harmonic_h(
   const auto roll_on_h_init = [&time, &t_start_h_init, &sigma_t_h_init]() {
     auto x = DampedHarmonicGauge_detail::roll_on_function(time, t_start_h_init,
                                                           sigma_t_h_init);
-    if (UNLIKELY(abs(1. - x) > 10. * std::numeric_limits<double>::epsilon())) {
+    if (UNLIKELY(abs(1. - x) > 100. * std::numeric_limits<double>::epsilon())) {
       return x;
     } else {
       return 0.;
@@ -594,7 +594,7 @@ void spacetime_deriv_damped_harmonic_h(
   const auto d0_roll_on_h_init = [&time, &t_start_h_init, &sigma_t_h_init]() {
     auto x = DampedHarmonicGauge_detail::time_deriv_of_roll_on_function(
         time, t_start_h_init, sigma_t_h_init);
-    if (UNLIKELY(abs(1. - x) > 10. * std::numeric_limits<double>::epsilon())) {
+    if (UNLIKELY(abs(1. - x) > 100. * std::numeric_limits<double>::epsilon())) {
       return x;
     } else {
       return 0.;
@@ -755,14 +755,15 @@ void spacetime_deriv_damped_harmonic_h(
   }
 
   // In case we want SpEC-style roll-on of gauge
-  if (UNLIKELY(use_spec_style_rollon)) {
+  if (use_spec_style_rollon) {
     // Calculate T2 + T3
-    typename db::item_type<Tags::GaugeH<SpatialDim, Frame>> _T2_plus_T3{
+    db::item_type<Tags::GaugeH<SpatialDim, Frame>> T2_plus_T3{
         get_size(get(lapse))};
-    const auto _zero_h_init = make_with_value<
-        typename db::item_type<Tags::GaugeH<SpatialDim, Frame>>>(lapse, 0.);
+    const auto zero_h_init =
+        make_with_value<db::item_type<Tags::GaugeH<SpatialDim, Frame>>>(lapse,
+                                                                        0.);
     GeneralizedHarmonic::damped_harmonic_h(
-        make_not_null(&_T2_plus_T3), _zero_h_init, lapse, shift,
+        make_not_null(&T2_plus_T3), zero_h_init, lapse, shift,
         sqrt_det_spatial_metric, spacetime_metric, time, coords, amp_coef_L1,
         amp_coef_L2, amp_coef_S, exp_L1, exp_L2, exp_S, t_start_h_init,
         sigma_t_h_init, t_start_L1, sigma_t_L1, t_start_L2, sigma_t_L2,
@@ -771,7 +772,7 @@ void spacetime_deriv_damped_harmonic_h(
     //                         + R_H0 (T2_{ab} + T3_{ab})
     // \f]
     for (size_t a = 0; a < SpatialDim + 1; ++a) {
-      d4_gauge_h->get(0, a) += d0_roll_on_h_init * _T2_plus_T3.get(a);
+      d4_gauge_h->get(0, a) += d0_roll_on_h_init * T2_plus_T3.get(a);
       for (size_t b = 0; b < SpatialDim + 1; ++b) {
         d4_gauge_h->get(a, b) +=
             (roll_on_h_init - 1.) * (dT2.get(a, b) + dT3.get(a, b));

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
+#include <limits>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/TempBuffer.hpp"
@@ -386,8 +387,15 @@ void damped_harmonic_h(
   get(h_prefac1) = get(mu_L1) * get(log_fac_1) + get(mu_L2) * get(log_fac_2);
   get(h_prefac2) = -get(mu_S) / get(lapse);
 
-  const double roll_on_h_init = DampedHarmonicGauge_detail::roll_on_function(
-      time, t_start_h_init, sigma_t_h_init);
+  const auto roll_on_h_init = [&time, &t_start_h_init, &sigma_t_h_init]() {
+    auto x = DampedHarmonicGauge_detail::roll_on_function(time, t_start_h_init,
+                                                          sigma_t_h_init);
+    if (abs(x) < std::numeric_limits<double>::epsilon()) {
+      return 0.;
+    } else {
+      return x;
+    }
+  }();
 
   // Calculate H_a
   for (size_t a = 0; a < SpatialDim + 1; ++a) {
@@ -540,8 +548,15 @@ void spacetime_deriv_damped_harmonic_h(
       make_not_null(&log_fac_2), lapse, sqrt_det_spatial_metric, exp_fac_2);
 
   // Tempering functions
-  const auto roll_on_h_init = DampedHarmonicGauge_detail::roll_on_function(
-      time, t_start_h_init, sigma_t_h_init);
+  const auto roll_on_h_init = [&time, &t_start_h_init, &sigma_t_h_init]() {
+    auto x = DampedHarmonicGauge_detail::roll_on_function(time, t_start_h_init,
+                                                          sigma_t_h_init);
+    if (abs(x) < std::numeric_limits<double>::epsilon()) {
+      return 0.;
+    } else {
+      return x;
+    }
+  }();
   const auto roll_on_L1 = DampedHarmonicGauge_detail::roll_on_function(
       time, t_start_L1, sigma_t_L1);
   const auto roll_on_L2 = DampedHarmonicGauge_detail::roll_on_function(
@@ -565,9 +580,15 @@ void spacetime_deriv_damped_harmonic_h(
   // Calc \f$ \mu_2 = \mu_{L2} log(1/N) = R W log(1/N)^5\f$
   get(mu2) = get(mu_L2) * get(log_fac_2);
 
-  const auto d0_roll_on_h_init =
-      DampedHarmonicGauge_detail::time_deriv_of_roll_on_function(
-          time, t_start_h_init, sigma_t_h_init);
+  const auto d0_roll_on_h_init = [&time, &t_start_h_init, &sigma_t_h_init]() {
+    auto x = DampedHarmonicGauge_detail::time_deriv_of_roll_on_function(
+        time, t_start_h_init, sigma_t_h_init);
+    if (abs(x) < std::numeric_limits<double>::epsilon()) {
+      return 0.;
+    } else {
+      return x;
+    }
+  }();
   const auto d0_roll_on_L1 =
       DampedHarmonicGauge_detail::time_deriv_of_roll_on_function(
           time, t_start_L1, sigma_t_L1);

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -95,6 +95,14 @@ namespace GeneralizedHarmonic {
  *   - Exponents \f$ e_X\f$ are input as exp\_X.
  *   - The spatial weight function is specified completely by \f$\{\f$sigma\_r
  * \f$\}\f$.
+ *
+ * Note on comparison with SpEC:
+ *   - To reproduce the gauge roll-on of SpEC, use
+ *          `use_spec_style_rollon = true`
+ *          (here, and when calling spacetime_deriv_damped_harmonic_h())
+ *   - This will replace: \f$\mu_X \rightarrow
+ *                           R_{H_\mathrm{init}}(t) \times\mu_X\f$
+ *          for \f$ X=\{L1, L2, S\}\f$ in \f$ H_a\f$.
  */
 template <size_t SpatialDim, typename Frame>
 void damped_harmonic_h(
@@ -115,7 +123,11 @@ void damped_harmonic_h(
     double sigma_t_L1, double t_start_L2, double sigma_t_L2, double t_start_S,
     double sigma_t_S,
     // weight function
-    double sigma_r) noexcept;
+    double sigma_r,
+    // toggle the switch below to change
+    // H = (1 - R0) H0 + mu1 T1 + mu2 T2 + muS TS, to
+    // H = (1 - R0) H0 + R0 (mu1 T1 + mu2 T2 + muS TS)
+    bool use_spec_style_rollon = false) noexcept;
 
 /*!
  * \brief Damped harmonic gauge source function.
@@ -136,16 +148,15 @@ struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
       Tags::GaugeHSpatialWeightDecayWidth<Frame>>;
 
   static constexpr db::const_item_type<Tags::GaugeH<SpatialDim, Frame>>
-  function(
-      const db::const_item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
-          gauge_h_init,
-      const Scalar<DataVector>& lapse,
-      const tnsr::I<DataVector, SpatialDim, Frame>& shift,
-      const Scalar<DataVector>& sqrt_det_spatial_metric,
-      const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
-      const double& time, const double& t_start, const double& sigma_t,
-      const tnsr::I<DataVector, SpatialDim, Frame>& coords,
-      const double& sigma_r) noexcept {
+  function(const db::const_item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+               gauge_h_init,
+           const Scalar<DataVector>& lapse,
+           const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+           const Scalar<DataVector>& sqrt_det_spatial_metric,
+           const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+           const double& time, const double& t_start, const double& sigma_t,
+           const tnsr::I<DataVector, SpatialDim, Frame>& coords,
+           const double& sigma_r) noexcept {
     db::item_type<Tags::GaugeH<SpatialDim, Frame>> gauge_h{
         get_size(get(lapse))};
     GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame>(
@@ -229,6 +240,15 @@ struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
  * [\mathrm{log}(\sqrt{g}/N)^{e_S}] \\
  *                  +& A_S \mathrm{log}(\sqrt{g} / N)^{e_S} \partial_a [R_S(t)
  * W(x^i)]. \f}
+ *
+ * Note on comparison with SpEC:
+ *   - To reproduce the gauge roll-on of SpEC, use
+ *          `use_spec_style_rollon = true`
+ *          (here, and when calling damped_harmonic_h())
+ *   - This will replace: \f$\mu_X \rightarrow
+ *                           R_{H_\mathrm{init}}(t) \times\mu_X\f$
+ *          for \f$ X=\{L1, L2, S\}\f$ in \f$ H_a\f$
+ *          (before taking its partial derivative).
  */
 template <size_t SpatialDim, typename Frame>
 void spacetime_deriv_damped_harmonic_h(
@@ -257,7 +277,11 @@ void spacetime_deriv_damped_harmonic_h(
     double sigma_t_L1, double t_start_L2, double sigma_t_L2, double t_start_S,
     double sigma_t_S,
     // weight function
-    double sigma_r) noexcept;
+    double sigma_r,
+    // toggle the switch below to change
+    // H = (1 - R0) H0 + mu1 T1 + mu2 T2 + muS TS, to
+    // H = (1 - R0) H0 + R0 (mu1 T1 + mu2 T2 + muS TS)
+    bool use_spec_style_rollon = false) noexcept;
 
 /*!
  * \brief Spacetime derivatives of the damped harmonic gauge source function.

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -143,7 +143,7 @@ struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
       ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>, ::Tags::Time,
       Tags::GaugeHRollOnStartTime, Tags::GaugeHRollOnTimeWindow,
       ::Tags::Coordinates<SpatialDim, Frame>,
-      Tags::GaugeHSpatialWeightDecayWidth<Frame>>;
+      Tags::GaugeHSpatialWeightDecayWidth<Frame>, Tags::UseSpecStyleRollOn>;
 
   static constexpr db::const_item_type<Tags::GaugeH<SpatialDim, Frame>>
   function(const db::const_item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
@@ -154,7 +154,7 @@ struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
            const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
            const double& time, const double& t_start, const double& sigma_t,
            const tnsr::I<DataVector, SpatialDim, Frame>& coords,
-           const double& sigma_r) noexcept {
+           const double& sigma_r, const bool& use_spec_style_rollon) noexcept {
     db::item_type<Tags::GaugeH<SpatialDim, Frame>> gauge_h{
         get_size(get(lapse))};
     GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame>(
@@ -166,7 +166,7 @@ struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
         t_start, sigma_t,  // _L1
         t_start, sigma_t,  // _L2
         t_start, sigma_t,  // _S
-        sigma_r);
+        sigma_r, use_spec_style_rollon);
     return gauge_h;
   }
 };
@@ -301,7 +301,7 @@ struct SpacetimeDerivDampedHarmonicHCompute
       Tags::Pi<SpatialDim, Frame>, Tags::Phi<SpatialDim, Frame>, ::Tags::Time,
       Tags::GaugeHRollOnStartTime, Tags::GaugeHRollOnTimeWindow,
       ::Tags::Coordinates<SpatialDim, Frame>,
-      Tags::GaugeHSpatialWeightDecayWidth<Frame>>;
+      Tags::GaugeHSpatialWeightDecayWidth<Frame>, Tags::UseSpecStyleRollOn>;
 
   static constexpr db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>
   function(
@@ -319,7 +319,7 @@ struct SpacetimeDerivDampedHarmonicHCompute
       const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const double& time,
       const double& t_start, const double& sigma_t,
       const tnsr::I<DataVector, SpatialDim, Frame>& coords,
-      const double& sigma_r) noexcept {
+      const double& sigma_r, const bool& use_spec_style_rollon) noexcept {
     db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>> d4_gauge_h{
         get_size(get(lapse))};
     GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h(
@@ -332,7 +332,7 @@ struct SpacetimeDerivDampedHarmonicHCompute
         t_start, sigma_t,  // _L1
         t_start, sigma_t,  // _L2
         t_start, sigma_t,  // _S
-        sigma_r);
+        sigma_r, use_spec_style_rollon);
     return d4_gauge_h;
   }
 };

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -96,8 +96,8 @@ namespace GeneralizedHarmonic {
  *   - The spatial weight function is specified completely by \f$\{\f$sigma\_r
  * \f$\}\f$.
  *
- * Note on comparison with SpEC:
- *   - To reproduce the gauge roll-on of SpEC, use
+ * \note On comparison with SpEC:
+ *   - To reproduce the gauge roll-on of SpEC, toggle
  *          `use_spec_style_rollon = true`
  *          (here, and when calling spacetime_deriv_damped_harmonic_h())
  *   - This will replace: \f$\mu_X \rightarrow
@@ -124,9 +124,7 @@ void damped_harmonic_h(
     double sigma_t_S,
     // weight function
     double sigma_r,
-    // toggle the switch below to change
-    // H = (1 - R0) H0 + mu1 T1 + mu2 T2 + muS TS, to
-    // H = (1 - R0) H0 + R0 (mu1 T1 + mu2 T2 + muS TS)
+    // toggle the switch below to change to spec-style roll-on
     bool use_spec_style_rollon = false) noexcept;
 
 /*!
@@ -241,8 +239,8 @@ struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
  *                  +& A_S \mathrm{log}(\sqrt{g} / N)^{e_S} \partial_a [R_S(t)
  * W(x^i)]. \f}
  *
- * Note on comparison with SpEC:
- *   - To reproduce the gauge roll-on of SpEC, use
+ * \note On comparison with SpEC:
+ *   - To reproduce the gauge roll-on of SpEC, toggle
  *          `use_spec_style_rollon = true`
  *          (here, and when calling damped_harmonic_h())
  *   - This will replace: \f$\mu_X \rightarrow
@@ -278,9 +276,7 @@ void spacetime_deriv_damped_harmonic_h(
     double sigma_t_S,
     // weight function
     double sigma_r,
-    // toggle the switch below to change
-    // H = (1 - R0) H0 + mu1 T1 + mu2 T2 + muS TS, to
-    // H = (1 - R0) H0 + R0 (mu1 T1 + mu2 T2 + muS TS)
+    // toggle the switch below to change to spec-style roll-on
     bool use_spec_style_rollon = false) noexcept;
 
 /*!

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -114,6 +114,21 @@ struct GaugeHSpatialWeightDecayWidth : db::SimpleTag {
 };
 
 /*!
+ * \brief Enable SpEC-style roll-on of gauge and its derivatives.
+ *
+ * \details This option defaults to false
+ */
+struct UseSpecStyleRollOn : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<OptionTags::UseSpecStyleRollOn>;
+
+  template <typename Metavariables>
+  static bool create_from_options(const bool flag) noexcept {
+    return flag;
+  }
+};
+
+/*!
  * \brief Gauge source function for the generalized harmonic system.
  *
  * \details In the generalized / damped harmonic gauge, unlike the simple
@@ -325,6 +340,20 @@ struct GaugeHSpatialDecayWidth {
   static std::string name() noexcept { return "SpatialDecayWidth"; }
   static constexpr OptionString help{
       "Spatial width of weighting factor in evolution gauge"};
+  using group = GaugeGroup;
+};
+
+/*!
+ * \brief Enable SpEC-style roll-on of gauge and its derivatives
+ *
+ * \details This option defaults to false
+ */
+struct UseSpecStyleRollOn {
+  using type = bool;
+  static type default_value() noexcept { return false; }
+  static std::string name() noexcept { return "UseSpecStyleRollOn"; }
+  static constexpr OptionString help{
+      "Enable SpEC-style roll-on of gauge and its derivatives"};
   using group = GaugeGroup;
 };
 }  // namespace OptionTags

--- a/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
@@ -23,6 +23,7 @@ struct GaugeHRollOnStartTime;
 struct GaugeHRollOnTimeWindow;
 template <typename Frame>
 struct GaugeHSpatialWeightDecayWidth;
+struct UseSpecStyleRollOn;
 template <size_t Dim, typename Frame = Frame::Inertial>
 struct InitialGaugeH;
 template <size_t Dim, typename Frame = Frame::Inertial>
@@ -70,5 +71,6 @@ struct GaugeHRollOnStart;
 struct GaugeHRollOnWindow;
 template <typename Frame>
 struct GaugeHSpatialDecayWidth;
+struct UseSpecStyleRollOn;
 }  // namespace OptionTags
 }  // namespace GeneralizedHarmonic

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.py
@@ -29,14 +29,18 @@ def spacetime_deriv_weight_function(coords, r_max):
 def roll_on_function(time, t_start, sigma_t):
     if time < t_start:
         return 0.
-    return 1. - np.exp(- ((time - t_start) / sigma_t)**4)
+    x = 1. - np.exp(- ((time - t_start) / sigma_t)**4)
+    if abs(x) > 1.e-14: return x
+    return 0
 
 
 def time_deriv_roll_on_function(time, t_start, sigma_t):
     if time < t_start:
         return 0.
     tnrm = (time - t_start) / sigma_t
-    return np.exp(- tnrm**4) * 4 * tnrm**3 / sigma_t
+    x = np.exp(- tnrm**4) * 4 * tnrm**3 / sigma_t
+    if abs(x) > 1.e-14: return x
+    return 0
 
 
 def log_fac(lapse, sqrt_det_spatial_metric, exponent):

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -152,7 +152,8 @@ void test_options() noexcept {
   Options<tmpl::list<
       GeneralizedHarmonic::OptionTags::GaugeHRollOnStart,
       GeneralizedHarmonic::OptionTags::GaugeHRollOnWindow,
-      GeneralizedHarmonic::OptionTags::GaugeHSpatialDecayWidth<Frame>>>
+      GeneralizedHarmonic::OptionTags::GaugeHSpatialDecayWidth<Frame>,
+      GeneralizedHarmonic::OptionTags::UseSpecStyleRollOn>>
       opts("");
   opts.parse(
       "EvolutionSystem:\n"
@@ -160,7 +161,8 @@ void test_options() noexcept {
       "    Gauge:\n"
       "      RollOnStartTime : 0.\n"
       "      RollOnTimeWindow : 100.\n"
-      "      SpatialDecayWidth : 50.\n");
+      "      SpatialDecayWidth : 50.\n"
+      "      UseSpecStyleRollOn : true\n");
   CHECK(
       opts.template get<GeneralizedHarmonic::OptionTags::GaugeHRollOnStart>() ==
       0.);
@@ -170,6 +172,8 @@ void test_options() noexcept {
       opts.template get<
           GeneralizedHarmonic::OptionTags::GaugeHSpatialDecayWidth<Frame>>() ==
       50.);
+  CHECK(opts.template get<
+            GeneralizedHarmonic::OptionTags::UseSpecStyleRollOn>() == true);
 }
 
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -268,7 +272,7 @@ wrap_DampedHarmonicHCompute(
   return GeneralizedHarmonic::DampedHarmonicHCompute<
       SpatialDim, Frame>::function(gauge_h_init, lapse, shift,
                                    sqrt_det_spatial_metric, spacetime_metric, t,
-                                   t_start, sigma_t, coords, sigma_r);
+                                   t_start, sigma_t, coords, sigma_r, false);
 }
 
 // Compare with Python implementation
@@ -1085,7 +1089,8 @@ wrap_SpacetimeDerivDampedHarmonicHCompute(
                                    spacetime_unit_normal_one_form,
                                    sqrt_det_spatial_metric,
                                    inverse_spatial_metric, spacetime_metric, pi,
-                                   phi, t, t_start, sigma_t, coords, sigma_r);
+                                   phi, t, t_start, sigma_t, coords, sigma_r,
+                                   false);
 }
 // Compare with Python implementation
 template <size_t SpatialDim, typename Frame>
@@ -2956,15 +2961,16 @@ void test_damped_harmonic_compute_tags(const size_t grid_size_each_dimension,
           GeneralizedHarmonic::Tags::GaugeHRollOnStartTime,
           GeneralizedHarmonic::Tags::GaugeHRollOnTimeWindow,
           GeneralizedHarmonic::Tags::GaugeHSpatialWeightDecayWidth<
-              Frame::Inertial>>,
+              Frame::Inertial>,
+          GeneralizedHarmonic::Tags::UseSpecStyleRollOn>,
       db::AddComputeTags<
           GeneralizedHarmonic::DampedHarmonicHCompute<3, Frame::Inertial>,
           GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<
-              3, Frame::Inertial>>>(gauge_h_init, d4_gauge_h_init, lapse, shift,
-                                    spacetime_unit_normal_one_form,
-                                    sqrt_det_spatial_metric,
-                                    inverse_spatial_metric, spacetime_metric,
-                                    pi, phi, t, x, t_start_S, sigma_t_S, r_max);
+              3, Frame::Inertial>>>(
+      gauge_h_init, d4_gauge_h_init, lapse, shift,
+      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, t, x, t_start_S,
+      sigma_t_S, r_max, false);
 
   // Verify that locally computed H_a matches the same obtained through its
   // ComputeTag from databox


### PR DESCRIPTION
## Proposed changes

Resolve outstanding issues #1515 and #1516 for the damped harmonic gauge. Two changes are made in this PR:
 - Removed the long-term dependence of evolutions on the initial gauge.
 - Include a switch to revert to SpEC-style gauge roll-on. The new roll-on functions are cleaner, but this switch will be useful for comparisons with SpEC.


### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
