### PR TITLE
Make 'parse' an explicit input file test

### DIFF
--- a/cmake/AddInputFileTests.cmake
+++ b/cmake/AddInputFileTests.cmake
@@ -62,7 +62,7 @@ endfunction()
 # '# Executable: EvolveScalarWave1D'
 # with the name of the executable that should be able to parse and run
 # using the input file, and a line of the form:
-# '# Check: execute'
+# '# Check: parse;execute'
 # OR
 # '# Check:'
 # If 'execute' is present then the input file will not just be parsed,
@@ -87,16 +87,32 @@ function(add_input_file_tests INPUT_FILE_DIR)
       INPUT_FILE_EXECUTABLE "${INPUT_FILE_EXECUTABLE}")
     string(STRIP "${INPUT_FILE_EXECUTABLE}" INPUT_FILE_EXECUTABLE)
 
-    # Read what tests to do. Currently only "execute" is available
-    # "parse" is ignored because it's always run, empty is accepted.
+    # Read what tests to do. Currently "execute" and "parse" are available.
     string(REGEX MATCH "#[ ]*Check:[^\n]+"
       INPUT_FILE_CHECKS "${INPUT_FILE_CONTENTS}")
     # Extract list of checks to perform
     string(REGEX REPLACE "#[ ]*Check:[ ]*" ""
       INPUT_FILE_CHECKS "${INPUT_FILE_CHECKS}")
     string(STRIP "${INPUT_FILE_CHECKS}" INPUT_FILE_CHECKS)
-    set(INPUT_FILE_CHECKS "parse;${INPUT_FILE_CHECKS}")
+    set(INPUT_FILE_CHECKS "${INPUT_FILE_CHECKS}")
     list(REMOVE_DUPLICATES "INPUT_FILE_CHECKS")
+    # Convert all the checks to lower case to make life easier.
+    string(TOLOWER "${INPUT_FILE_CHECKS}" INPUT_FILE_CHECKS)
+
+    # Make sure that the 'parse' check is listed. If not, print an
+    # error message that explains that it's needed and why.
+    list(FIND "INPUT_FILE_CHECKS" "parse" FOUND_PARSE)
+    if (${FOUND_PARSE} EQUAL -1)
+      message(FATAL_ERROR
+        "The input file: "
+        "'${INPUT_FILE}' "
+        "does not specify the 'parse' check. All input file tests must"
+        " specify the 'parse' check which runs the executable passing"
+        " the '--check-options' flag. With this flag the executable"
+        " should check that the input file parses correctly and that"
+        " the values specified in the input file do not violate any"
+        " bounds or sanity checks.")
+    endif (${FOUND_PARSE} EQUAL -1)
 
     # Read the timeout duration specified in input file, empty is accepted.
     # The default duration is 2 seconds.

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveBurgers
-# Check: execute
+# Check: parse;execute
 
 AnalyticSolution:
   Step:

--- a/tests/InputFiles/ExampleExecutables/HelloWorldNoCharm.yaml
+++ b/tests/InputFiles/ExampleExecutables/HelloWorldNoCharm.yaml
@@ -2,4 +2,4 @@
 # See LICENSE.txt for details.
 
 # Executable: HelloWorldNoCharm
-# Check: execute
+# Check: parse;execute

--- a/tests/InputFiles/ExampleExecutables/SingletonHelloWorld.yaml
+++ b/tests/InputFiles/ExampleExecutables/SingletonHelloWorld.yaml
@@ -2,6 +2,6 @@
 # See LICENSE.txt for details.
 
 # Executable: SingletonHelloWorld
-# Check: execute
+# Check: parse;execute
 
 Name: Albert Einstein

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: ExportCoordinates1D
-# Check: execute
+# Check: parse;execute
 # ExpectedOutput:
 #   ExportCoordinates1DVolume0.h5
 

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: ExportCoordinates2D
-# Check: execute
+# Check: parse;execute
 # ExpectedOutput:
 #   ExportCoordinates2DVolume0.h5
 

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: ExportCoordinates3D
-# Check: execute
+# Check: parse;execute
 # ExpectedOutput:
 #   ExportCoordinates3DVolume0.h5
 

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveGeneralizedHarmonic
-# Check: execute
+# Check: parse;execute
 # Timeout: 8
 # ExpectedOutput:
 #   GhKerrSchildReductionData.h5

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveCylindricalBlastWave
-# Check: execute
+# Check: parse;execute
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveFishboneMoncriefDisk
-# Check: execute
+# Check: parse;execute
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveRiemannProblem1D
-# Check: execute
+# Check: parse;execute
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveRiemannProblem2D
-# Check: execute
+# Check: parse;execute
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveRiemannProblem3D
-# Check: execute
+# Check: parse;execute
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/Poisson/Input1D.yaml
+++ b/tests/InputFiles/Poisson/Input1D.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: SolvePoissonProblem1D
-# Check: execute
+# Check: parse;execute
 # ExpectedOutput:
 #   Poisson1DReductions.h5
 #   Poisson1DVolume0.h5

--- a/tests/InputFiles/Poisson/Input2D.yaml
+++ b/tests/InputFiles/Poisson/Input2D.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: SolvePoissonProblem2D
-# Check: execute
+# Check: parse;execute
 # ExpectedOutput:
 #   Poisson2DReductions.h5
 #   Poisson2DVolume0.h5

--- a/tests/InputFiles/Poisson/Input3D.yaml
+++ b/tests/InputFiles/Poisson/Input3D.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: SolvePoissonProblem3D
-# Check: execute
+# Check: parse;execute
 # ExpectedOutput:
 #   Poisson3DReductions.h5
 #   Poisson3DVolume0.h5

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveStandaloneM1
-# Check: execute
+# Check: parse;execute
 # ExpectedOutput:
 #   M1Reductions.h5
 

--- a/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveScalarWave1D
-# Check: execute
+# Check: parse;execute
 
 AnalyticSolution:
   PlaneWave:

--- a/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveScalarWave2D
-# Check: execute
+# Check: parse;execute
 
 AnalyticSolution:
   PlaneWave:

--- a/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveScalarWave3D
-# Check: execute
+# Check: parse;execute
 
 AnalyticSolution:
   PlaneWave:

--- a/tests/InputFiles/ScalarWave/ObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/ObserveExample.yaml
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveScalarWave1D
+# Check: parse
 
 AnalyticSolution:
   PlaneWave:


### PR DESCRIPTION
## Proposed changes

Rather than implicitly adding `parse` to all input file checks, require they be added explicitly. This is an issue for PR #1611 

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
