### PR TITLE
Fix undefined behavior in various RNG tests

### DIFF
--- a/tests/Unit/DataStructures/VectorImplTestHelper.hpp
+++ b/tests/Unit/DataStructures/VectorImplTestHelper.hpp
@@ -515,12 +515,12 @@ void test_function_on_vector_operands(
   const size_t size = size_distribution(generator);
   // using each distribution, generate a value for the appropriate operand type
   // and put it in a tuple.
-  auto operand_values = std::make_tuple(make_with_random_values<Operands>(
+  std::tuple<Operands...> operand_values{make_with_random_values<Operands>(
       make_not_null(&generator),
       UniformCustomDistribution<
           tt::get_fundamental_type_t<get_vector_element_type_t<Operands>>>{
           std::get<Is>(bounds)},
-      size)...);
+      size)...};
   // wrap the tuple of random values according to the passed in `Wraps`
   auto wrapped_operands = wrap_tuple<Wraps...>(
       operand_values, std::make_index_sequence<sizeof...(Bounds)>{});

--- a/tests/Unit/Utilities/Test_Functional.cpp
+++ b/tests/Unit/Utilities/Test_Functional.cpp
@@ -32,45 +32,48 @@ using std::min;
 
 // clang-tidy : suppress warning from no-paren on macro parameter, macro doesn't
 // work when it's in parens. Same for all subsequent macros.
-#define MAKE_UNARY_TEST(STRUCTNAME, FUNC)                                  \
-  struct TestFuncEval##STRUCTNAME {                                        \
-    template <typename T, typename DistT, typename UniformGen>             \
-    void operator()(UniformGen gen, UniformCustomDistribution<DistT> dist, \
-                    T /*meta*/) noexcept {                                 \
-      auto val = make_with_random_values<typename T::type>(                \
-          make_not_null(&gen), make_not_null(&dist));                      \
-      CHECK(STRUCTNAME<>{}(val) == FUNC(val)); /*NOLINT*/                  \
-    }                                                                      \
+#define MAKE_UNARY_TEST(STRUCTNAME, FUNC)                      \
+  struct TestFuncEval##STRUCTNAME {                            \
+    template <typename T, typename DistT, typename UniformGen> \
+    void operator()(const gsl::not_null<UniformGen*> gen,      \
+                    UniformCustomDistribution<DistT> dist,     \
+                    T /*meta*/) noexcept {                     \
+      auto val = make_with_random_values<typename T::type>(    \
+          gen, make_not_null(&dist));                          \
+      CHECK(STRUCTNAME<>{}(val) == FUNC(val)); /*NOLINT*/      \
+    }                                                          \
   }
 
-#define MAKE_BINARY_TEST(STRUCTNAME, FUNC)                                   \
-  struct TestFuncEval##STRUCTNAME {                                          \
-    template <typename T1, typename T2, typename DistT1, typename DistT2,    \
-              typename UniformGen>                                           \
-    void operator()(UniformGen gen, UniformCustomDistribution<DistT1> dist1, \
-                    UniformCustomDistribution<DistT2> dist2, T1 /*meta*/,    \
-                    T2 /*meta*/) noexcept {                                  \
-      auto val1 = make_with_random_values<typename T1::type>(                \
-          make_not_null(&gen), make_not_null(&dist1));                       \
-      auto val2 = make_with_random_values<typename T2::type>(                \
-          make_not_null(&gen), make_not_null(&dist2));                       \
-      CHECK(STRUCTNAME<>{}(val1, val2) == FUNC(val1, val2)); /*NOLINT*/      \
-    }                                                                        \
+#define MAKE_BINARY_TEST(STRUCTNAME, FUNC)                                \
+  struct TestFuncEval##STRUCTNAME {                                       \
+    template <typename T1, typename T2, typename DistT1, typename DistT2, \
+              typename UniformGen>                                        \
+    void operator()(const gsl::not_null<UniformGen*> gen,                 \
+                    UniformCustomDistribution<DistT1> dist1,              \
+                    UniformCustomDistribution<DistT2> dist2, T1 /*meta*/, \
+                    T2 /*meta*/) noexcept {                               \
+      auto val1 = make_with_random_values<typename T1::type>(             \
+          gen, make_not_null(&dist1));                                    \
+      auto val2 = make_with_random_values<typename T2::type>(             \
+          gen, make_not_null(&dist2));                                    \
+      CHECK(STRUCTNAME<>{}(val1, val2) == FUNC(val1, val2)); /*NOLINT*/   \
+    }                                                                     \
   }
 
-#define MAKE_BINARY_OP_TEST(STRUCTNAME, OP)                                  \
-  struct TestFuncEval##STRUCTNAME {                                          \
-    template <typename T1, typename T2, typename DistT1, typename DistT2,    \
-              typename UniformGen>                                           \
-    void operator()(UniformGen gen, UniformCustomDistribution<DistT1> dist1, \
-                    UniformCustomDistribution<DistT2> dist2, T1 /*meta*/,    \
-                    T2 /*meta*/) noexcept {                                  \
-      auto val1 = make_with_random_values<typename T1::type>(                \
-          make_not_null(&gen), make_not_null(&dist1));                       \
-      auto val2 = make_with_random_values<typename T2::type>(                \
-          make_not_null(&gen), make_not_null(&dist2));                       \
-      CHECK(STRUCTNAME<>{}(val1, val2) == val1 OP val2); /*NOLINT*/          \
-    }                                                                        \
+#define MAKE_BINARY_OP_TEST(STRUCTNAME, OP)                               \
+  struct TestFuncEval##STRUCTNAME {                                       \
+    template <typename T1, typename T2, typename DistT1, typename DistT2, \
+              typename UniformGen>                                        \
+    void operator()(const gsl::not_null<UniformGen*> gen,                 \
+                    UniformCustomDistribution<DistT1> dist1,              \
+                    UniformCustomDistribution<DistT2> dist2, T1 /*meta*/, \
+                    T2 /*meta*/) noexcept {                               \
+      auto val1 = make_with_random_values<typename T1::type>(             \
+          gen, make_not_null(&dist1));                                    \
+      auto val2 = make_with_random_values<typename T2::type>(             \
+          gen, make_not_null(&dist2));                                    \
+      CHECK(STRUCTNAME<>{}(val1, val2) == val1 OP val2); /*NOLINT*/       \
+    }                                                                     \
   }
 
 #define MAKE_BINARY_INPLACE_TEST(STRUCTNAME, OP, TESTOP)                       \
@@ -81,13 +84,14 @@ using std::min;
                   typename T1::type,                                           \
                   decltype(std::declval<typename T1::type>() TESTOP            \
                                std::declval<typename T2::type>())>> = nullptr> \
-    void operator()(UniformGen gen, UniformCustomDistribution<DistT1> dist1,   \
+    void operator()(const gsl::not_null<UniformGen*> gen,                      \
+                    UniformCustomDistribution<DistT1> dist1,                   \
                     UniformCustomDistribution<DistT2> dist2, T1 /*meta*/,      \
                     T2 /*meta*/) noexcept {                                    \
       auto val1 = make_with_random_values<typename T1::type>(                  \
-          make_not_null(&gen), make_not_null(&dist1));                         \
+          gen, make_not_null(&dist1));                                         \
       auto val2 = make_with_random_values<typename T2::type>(                  \
-          make_not_null(&gen), make_not_null(&dist2));                         \
+          gen, make_not_null(&dist2));                                         \
       auto val1_copy = val1;                                                   \
       auto result = val1_copy TESTOP val2;                                     \
       STRUCTNAME<>{}(val1, val2); /*NOLINT*/                                   \
@@ -102,7 +106,7 @@ using std::min;
                   typename T1::type,                                           \
                   decltype(std::declval<typename T1::type>() TESTOP            \
                                std::declval<typename T2::type>())>> = nullptr> \
-    void operator()(UniformGen /*gen*/,                                        \
+    void operator()(const gsl::not_null<UniformGen*> /*gen*/,                  \
                     UniformCustomDistribution<DistT1> /*dist1*/,               \
                     UniformCustomDistribution<DistT2> /*dist2*/, T1 /*meta*/,  \
                     T2 /*meta*/) noexcept {}                                   \
@@ -144,10 +148,10 @@ MAKE_UNARY_TEST(Tanh, tanh);
 template <int N>
 struct TestFuncEvalUnaryPow {
   template <typename T, typename DistT, typename UniformGen>
-  void operator()(UniformGen gen, UniformCustomDistribution<DistT> dist,
-                  T /*meta*/) noexcept {
-    auto val = make_with_random_values<typename T::type>(make_not_null(&gen),
-                                                         make_not_null(&dist));
+  void operator()(const gsl::not_null<UniformGen*> gen,
+                  UniformCustomDistribution<DistT> dist, T /*meta*/) noexcept {
+    auto val =
+        make_with_random_values<typename T::type>(gen, make_not_null(&dist));
     CHECK(UnaryPow<N>{}(val) == pow<N>(val)); /*NOLINT*/
   }
 };
@@ -177,14 +181,14 @@ using Bound = std::array<double, 2>;
 template <typename C, typename ValType, typename Func, typename Gen,
           size_t... Is>
 void test_functional_against_function(
-    const Func func, Gen& gen, const Bound& bounds,
+    const Func func, const gsl::not_null<Gen*> gen, const Bound& bounds,
     const std::index_sequence<Is...> /*meta*/) noexcept {
   static_assert(sizeof...(Is) == C::arity,
                 "test was passed incorrect number of arguments");
   UniformCustomDistribution<typename tt::get_fundamental_type_t<ValType>> dist{
       bounds};
   const auto args = make_with_random_values<std::array<ValType, sizeof...(Is)>>(
-      make_not_null(&gen), make_not_null(&dist));
+      gen, make_not_null(&dist));
   if (cpp17::is_same_v<ValType, typename tt::get_fundamental_type_t<ValType>>) {
     CHECK_ITERABLE_APPROX(C{}(args[Is]...), func(args[Is]...));
   } else {
@@ -217,7 +221,7 @@ void test_get_argument() noexcept {
 void test_assert_equal() noexcept { CHECK(AssertEqual<>{}(7, 7) == 7); }
 
 template <typename Gen>
-void test_functional_combinations(Gen& gen) noexcept {
+void test_functional_combinations(const gsl::not_null<Gen*> gen) noexcept {
   const Bound generic{{-50.0, 50.0}};
   const Bound small{{-5.0, 5.0}};
 
@@ -260,7 +264,7 @@ void test_functional_combinations(Gen& gen) noexcept {
 }
 
 template <typename Gen>
-void test_generic_unaries(Gen& gen) noexcept {
+void test_generic_unaries(const gsl::not_null<Gen*> gen) noexcept {
   const Bound generic{{-50.0, 50.0}};
   const Bound gt_one{{1.0, 100.0}};
   const Bound mone_one{{-1.0, 1.0}};
@@ -308,7 +312,7 @@ void test_generic_unaries(Gen& gen) noexcept {
 }
 
 template <typename Gen>
-void test_floating_point_functions(Gen& gen) noexcept {
+void test_floating_point_functions(const gsl::not_null<Gen*> gen) noexcept {
   const Bound generic{{-50.0, 50.0}};
   const Bound gt_one{{1.0, 100.0}};
   const Bound positive{{.001, 100.0}};
@@ -365,7 +369,7 @@ void test_floating_point_functions(Gen& gen) noexcept {
 }
 
 template <typename Gen>
-void test_real_functions(Gen& gen) noexcept {
+void test_real_functions(const gsl::not_null<Gen*> gen) noexcept {
   const Bound generic{{-50.0, 50.0}};
   const Bound gt_one{{1.0, 100.0}};
   const Bound positive{{.001, 100.0}};
@@ -447,10 +451,10 @@ void test_real_functions(Gen& gen) noexcept {
 
 SPECTRE_TEST_CASE("Unit.Utilities.Functional", "[Utilities][Unit]") {
   MAKE_GENERATOR(generator);
-  test_generic_unaries(generator);
-  test_floating_point_functions(generator);
-  test_real_functions(generator);
-  test_functional_combinations(generator);
+  test_generic_unaries(make_not_null(&generator));
+  test_floating_point_functions(make_not_null(&generator));
+  test_real_functions(make_not_null(&generator));
+  test_functional_combinations(make_not_null(&generator));
   test_assert_equal();
   test_get_argument();
 }

--- a/tests/Utilities/MakeWithRandomValues.hpp
+++ b/tests/Utilities/MakeWithRandomValues.hpp
@@ -92,10 +92,11 @@ struct FillWithRandomValuesImpl<Variables<tmpl::list<Tags...>>,
       const gsl::not_null<Variables<tmpl::list<Tags...>>*> data,
       const gsl::not_null<UniformRandomBitGenerator*> generator,
       const gsl::not_null<RandomNumberDistribution*> distribution) noexcept {
-    expand_pack(
-        (FillWithRandomValuesImpl<std::decay_t<decltype(get<Tags>(*data))>>::
-             apply(&get<Tags>(*data), generator, distribution),
-         cpp17::void_type{})...);
+    EXPAND_PACK_LEFT_TO_RIGHT(
+        FillWithRandomValuesImpl<
+            std::decay_t<decltype(get<Tags>(*data))>>::apply(&get<Tags>(*data),
+                                                             generator,
+                                                             distribution));
   }
 };
 /// \endcond


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
