### PR TITLE
compute item to get L2-norm of tensors

### DIFF
--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -9,6 +9,8 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Numeric.hpp"
 #include "Utilities/TMPL.hpp"
 
 /*!
@@ -48,10 +50,37 @@ Scalar<DataType> magnitude(
 /// \details
 /// Computes the square root of the absolute value of the scalar.
 template <typename DataType>
-Scalar<DataType> sqrt_magnitude(
-    const Scalar<DataType>& input) noexcept {
+Scalar<DataType> sqrt_magnitude(const Scalar<DataType>& input) noexcept {
   return Scalar<DataType>{sqrt(abs(get(input)))};
 }
+
+/// @{
+/// \ingroup TensorGroup
+/// \brief Compute $\\ell^2$ (Frobenius) norm of a tensor
+///
+/// \details
+/// Computes the Frobenius norm of a given tensor of arbitrary rank.
+template <typename DataType, typename Symm, typename IndexList>
+Scalar<DataType> l2_norm(
+    const Tensor<DataType, Symm, IndexList>& tensor) noexcept {
+  auto& input = const_cast<Tensor<DataType, Symm, IndexList>&>(tensor);
+  DataType sum(tensor.begin()->size(), 0.);
+  for (auto it = input.begin(); it != input.end(); ++it) {
+    sum += input.multiplicity(it) * square(*it);
+  }
+  return Scalar<DataType>{sqrt(sum)};
+}
+template <typename DataType, typename Symm, typename IndexList>
+double l2_norm(const Tensor<DataType, Symm, IndexList>& tensor) noexcept {
+  auto& input = const_cast<Tensor<DataType, Symm, IndexList>&>(tensor);
+  DataType sum(tensor.begin()->size(), 0.);
+  for (auto it = input.begin(); it != input.end(); ++it) {
+    sum += input.multiplicity(it) * square(*it);
+  }
+  using PlusSquare = funcl::Plus<funcl::Identity, funcl::Square<>>;
+  return alg::accumulate(sqrt(sum), 0., PlusSquare{});
+}
+/// @}
 
 namespace Tags {
 /// \ingroup DataBoxTagsGroup
@@ -139,6 +168,19 @@ struct Sqrt : db::ComputeTag {
   static std::string name() noexcept { return "Sqrt(" + Tag::name() + ")"; }
   static constexpr Scalar<DataVector> (*function)(const db::item_type<Tag>&) =
       sqrt_magnitude;
+  using argument_tags = tmpl::list<Tag>;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup DataStructuresGroup
+/// The L2 norm of a tensor
+///
+/// \snippet Test_Magnitude.cpp sqrt_name
+template <typename Tag, bool Accumulate = false>
+struct L2Norm : db::ComputeTag {
+  static std::string name() noexcept { return "L2Norm(" + Tag::name() + ")"; }
+  static constexpr tmpl::conditional_t<Accumulate, double, Scalar<DataVector>> (
+      *function)(const db::item_type<Tag>&) = l2_norm;
   using argument_tags = tmpl::list<Tag>;
 };
 }  // namespace Tags


### PR DESCRIPTION
## Proposed changes

Added a compute item to get L2-norm of tensors. This would be useful for observing constraints

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
