### PR TITLE
compute item to get L2-norm of tensors

### DIFF
--- a/src/DataStructures/Tensor/EagerMath/Norms.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Norms.hpp
@@ -1,0 +1,151 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace L2Norm_detail {
+template <typename DataType, typename Symm, typename IndexList>
+Scalar<DataType> pointwise_l2_norm_square(
+    const Tensor<DataType, Symm, IndexList>& tensor) noexcept {
+  auto pointwise_l2_normsq = make_with_value<Scalar<DataType>>(tensor, 0.);
+  for (auto tensor_element = tensor.begin(); tensor_element != tensor.end();
+       ++tensor_element) {
+    // In order to handle tensory symmetries, we multiply the square of each
+    // stored component with its multiplicity
+    get(pointwise_l2_normsq) +=
+        tensor.multiplicity(tensor_element) * square(*tensor_element);
+  }
+  return pointwise_l2_normsq;
+}
+}  // namespace L2Norm_detail
+
+/*!
+ * \ingroup TensorGroup
+ * \brief Compute point-wise Euclidean \f$L^2\f$-norm of arbitrary Tensors.
+ *
+ * \details
+ * At each grid point \f$p\f$ in the element, this function computes the
+ * point-wise Frobenius norm of a given Tensor with arbitrary rank. If the
+ * Tensor \f$A\f$ has rank \f$n\f$ and dimensionality \f$D\f$, then its
+ * Frobenius norm at point \f$p\f$ is computed as:
+ *
+ * \f{equation}
+ * ||A||_2(p) =
+ *    \left(\sum^{D-1}_{i_1=0}\sum^{D-1}_{i_2=0}\cdots \sum^{D-1}_{i_n=0}
+ *          |A_{i_1 i_2 \cdots i_n}(p)|^2 \right)^{1/2},
+ * \f}
+ *
+ * where both contra-variant and co-variant indices are shown as lower indices.
+ */
+template <typename DataType, typename Symm, typename IndexList>
+Scalar<DataType> pointwise_l2_norm(
+    const Tensor<DataType, Symm, IndexList>& tensor) noexcept {
+  return Scalar<DataType>{
+      sqrt(get(L2Norm_detail::pointwise_l2_norm_square(tensor)))};
+}
+
+// @{
+/*!
+ * \ingroup TensorGroup
+ * \brief Compute Euclidean \f$L^2\f$-norm of arbitrary Tensors reduced over an
+ * element.
+ *
+ * \details
+ * Computes the RMS value of the point-wise Frobenius norm of a given Tensor
+ * with arbitrary rank over all grid points in an element. If the Tensor \f$A\f$
+ * has rank \f$n\f$ and dimensionality \f$D\f$, and the element (of order
+ * \f$N\f$) has \f$N+1\f$ points, then its element-reduced Frobenius norm is
+ * computed as:
+ *
+ * \f{equation}
+ *  ||A||_2 =
+ *     \left(\frac{1}{N+1}\sum^{N}_{p=0}
+ *          \left(\sum^{D-1}_{i_1=0}\sum^{D-1}_{i_2=0}\cdots
+ *                \sum^{D-1}_{i_n=0} |A^p_{i_1 i_2 \cdots i_n}|^2 \right)
+ * \right)^{1/2},
+ * \f}
+ *
+ * where both contra-variant and co-variant indices are shown as lower indices,
+ * and \f$p\f$ indexes grid points in the element.
+ *
+ * \warning This function reduces the Frobenius norm over the element, not the
+ * whole domain.
+ */
+template <typename DataType, typename Symm, typename IndexList>
+double l2_norm(const Tensor<DataType, Symm, IndexList>& tensor) noexcept {
+  const auto pointwise_l2_normsq =
+      L2Norm_detail::pointwise_l2_norm_square(tensor);
+  using Plus = funcl::Plus<funcl::Identity>;
+  return sqrt(alg::accumulate(get(pointwise_l2_normsq), 0., Plus{}) /
+              tensor.begin()->size());
+}
+
+namespace Tags {
+/*!
+ * \ingroup DataBoxTagsGroup
+ * \ingroup DataStructuresGroup
+ * Point-wise Euclidean \f$L^2\f$-norm of a Tensor.
+ * \see `pointwise_l2_norm()` for details.
+ */
+template <typename Tag>
+struct PointwiseL2Norm : db::SimpleTag {
+  using type = Scalar<typename Tag::type::type>;
+  static std::string name() noexcept {
+    return "PointwiseL2Norm(" + db::tag_name<Tag>() + ")";
+  }
+};
+
+/*!
+ * \ingroup DataBoxTagsGroup
+ * \ingroup DataStructuresGroup
+ * Computes the point-wise Euclidean \f$L^2\f$-norm of a Tensor.
+ * \see `pointwise_l2_norm()` for details.
+ */
+template <typename Tag>
+struct PointwiseL2NormCompute : PointwiseL2Norm<Tag>, db::ComputeTag {
+  using base = PointwiseL2Norm<Tag>;
+  static constexpr db::item_type<PointwiseL2Norm<Tag>> (*function)(
+      const db::item_type<Tag>&) = pointwise_l2_norm;
+  using argument_tags = tmpl::list<Tag>;
+};
+
+/*!
+ * \ingroup DataBoxTagsGroup
+ * \ingroup DataStructuresGroup
+ * Euclidean \f$L^2\f$-norm of a Tensor, RMS over grid points in element.
+ * \see `l2_norm()` for details.
+ */
+template <typename Tag>
+struct L2Norm : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept {
+    return "L2Norm(" + db::tag_name<Tag>() + ")";
+  }
+};
+
+/*!
+ * \ingroup DataBoxTagsGroup
+ * \ingroup DataStructuresGroup
+ * Computes the Euclidean \f$L^2\f$-norm of a Tensor, RMS over grid points in
+ * element. \see `l2_norm()` for details.
+ *
+ * \warning This compute tag reduces the Frobenius norm over the element, not
+ * the whole domain.
+ */
+template <typename Tag>
+struct L2NormCompute : L2Norm<Tag>, db::ComputeTag {
+  using base = L2Norm<Tag>;
+  static constexpr db::item_type<L2Norm<Tag>> (*function)(
+      const db::item_type<Tag>&) = l2_norm;
+  using argument_tags = tmpl::list<Tag>;
+};
+}  // namespace Tags

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -353,7 +353,7 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   ///
   /// \see TensorMetafunctions::compute_multiplicity
   SPECTRE_ALWAYS_INLINE constexpr size_t multiplicity(
-      const iterator& iter) const noexcept {
+      const const_iterator& iter) const noexcept {
     return structure::multiplicity(static_cast<size_t>(iter - begin()));
   }
   SPECTRE_ALWAYS_INLINE static constexpr size_t multiplicity(

--- a/tests/Unit/DataStructures/Tensor/EagerMath/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_DivideBy.cpp
   Test_DotProduct.cpp
   Test_Magnitude.cpp
+  Test_Norms.cpp
   )
 
 add_test_library(

--- a/tests/Unit/DataStructures/Tensor/EagerMath/Test_Norms.cpp
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/Test_Norms.cpp
@@ -1,0 +1,264 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/Norms.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+struct MyScalar : db::SimpleTag {
+  static std::string name() noexcept { return "MyScalar"; }
+  using type = Scalar<DataVector>;
+};
+template <size_t Dim, typename Frame>
+struct Vector : db::SimpleTag {
+  static std::string name() noexcept { return "Vector"; }
+  using type = tnsr::I<DataVector, Dim, Frame>;
+};
+template <size_t Dim, typename Frame>
+struct Covector : db::SimpleTag {
+  static std::string name() noexcept { return "Covector"; }
+  using type = tnsr::i<DataVector, Dim, Frame>;
+};
+template <size_t Dim, typename Frame>
+struct Metric : db::SimpleTag {
+  static std::string name() noexcept { return "Metric"; }
+  using type = tnsr::ii<DataVector, Dim, Frame>;
+};
+template <size_t Dim, typename Frame>
+struct InverseMetric : db::SimpleTag {
+  static std::string name() noexcept { return "InverseMetric"; }
+  using type = tnsr::II<DataVector, Dim, Frame>;
+};
+
+template <typename Frame>
+void test_l2_norm_tag() {
+  constexpr size_t npts = 5;
+
+  const DataVector one(npts, 1.);
+  const DataVector two(npts, 2.);
+  const DataVector minus_three(npts, -3.);
+  const DataVector four(npts, 4.);
+  const DataVector minus_five(npts, -5.);
+  const DataVector twelve(npts, 12.);
+  const auto mixed = []() {
+    DataVector tmp(npts, 0.);
+    for (size_t i = 0; i < npts; ++i) {
+      if (i % 2) {
+        tmp[i] = 3.5;
+      } else {
+        tmp[i] = 4.5;
+      }
+    }
+    return tmp;
+  }();
+
+  // create test tensors
+  const auto psi_1d = [&npts, &minus_five]() {
+    db::item_type<Metric<1, Frame>> tmp{npts};
+    get<0, 0>(tmp) = minus_five;
+    return tmp;
+  }();
+  const auto psi_2d = [&npts, &one, &two]() {
+    db::item_type<Metric<2, Frame>> tmp{npts};
+    get<0, 0>(tmp) = two;
+    get<0, 1>(tmp) = two;
+    get<1, 0>(tmp) = two;
+    get<1, 1>(tmp) = one;
+    return tmp;
+  }();
+  const auto psi_3d = [&npts, &one, &two, &minus_three]() {
+    db::item_type<Metric<3, Frame>> tmp{npts};
+    get<0, 0>(tmp) = one;
+    get<0, 1>(tmp) = two;
+    get<0, 2>(tmp) = minus_three;
+    get<1, 1>(tmp) = two;
+    get<1, 2>(tmp) = two;
+    get<2, 2>(tmp) = one;
+    return tmp;
+  }();
+
+  const auto box = db::create<
+      db::AddSimpleTags<MyScalar, Vector<1, Frame>, Vector<2, Frame>,
+                        Vector<3, Frame>, Covector<1, Frame>,
+                        Covector<2, Frame>, Covector<3, Frame>,
+                        Metric<1, Frame>, Metric<2, Frame>, Metric<3, Frame>,
+                        InverseMetric<1, Frame>, InverseMetric<2, Frame>,
+                        InverseMetric<3, Frame>>,
+      db::AddComputeTags<Tags::PointwiseL2NormCompute<MyScalar>,
+                         Tags::PointwiseL2NormCompute<Vector<1, Frame>>,
+                         Tags::PointwiseL2NormCompute<Vector<2, Frame>>,
+                         Tags::PointwiseL2NormCompute<Vector<3, Frame>>,
+                         Tags::PointwiseL2NormCompute<Covector<1, Frame>>,
+                         Tags::PointwiseL2NormCompute<Covector<2, Frame>>,
+                         Tags::PointwiseL2NormCompute<Covector<3, Frame>>,
+                         Tags::PointwiseL2NormCompute<Metric<1, Frame>>,
+                         Tags::PointwiseL2NormCompute<Metric<2, Frame>>,
+                         Tags::PointwiseL2NormCompute<Metric<3, Frame>>,
+                         Tags::PointwiseL2NormCompute<InverseMetric<1, Frame>>,
+                         Tags::PointwiseL2NormCompute<InverseMetric<2, Frame>>,
+                         Tags::PointwiseL2NormCompute<InverseMetric<3, Frame>>,
+                         Tags::L2NormCompute<MyScalar>,
+                         Tags::L2NormCompute<Vector<1, Frame>>,
+                         Tags::L2NormCompute<Vector<2, Frame>>,
+                         Tags::L2NormCompute<Vector<3, Frame>>,
+                         Tags::L2NormCompute<Covector<1, Frame>>,
+                         Tags::L2NormCompute<Covector<2, Frame>>,
+                         Tags::L2NormCompute<Covector<3, Frame>>,
+                         Tags::L2NormCompute<Metric<1, Frame>>,
+                         Tags::L2NormCompute<Metric<2, Frame>>,
+                         Tags::L2NormCompute<Metric<3, Frame>>,
+                         Tags::L2NormCompute<InverseMetric<1, Frame>>,
+                         Tags::L2NormCompute<InverseMetric<2, Frame>>,
+                         Tags::L2NormCompute<InverseMetric<3, Frame>>>>(
+      db::item_type<MyScalar>{{{minus_three}}},
+      db::item_type<Vector<1, Frame>>{{{mixed}}},
+      db::item_type<Vector<2, Frame>>{{{minus_three, mixed}}},
+      db::item_type<Vector<3, Frame>>{{{minus_three, mixed, four}}},
+      db::item_type<Covector<1, Frame>>{{{four}}},
+      db::item_type<Covector<2, Frame>>{{{four, two}}},
+      db::item_type<Covector<3, Frame>>{{{four, two, twelve}}}, psi_1d, psi_2d,
+      psi_3d, determinant_and_inverse(psi_1d).second,
+      determinant_and_inverse(psi_2d).second,
+      determinant_and_inverse(psi_3d).second);
+
+  // Test point-wise L2-norm against precomputed values
+  // rank 0
+  CHECK_ITERABLE_APPROX(get(db::get<Tags::PointwiseL2Norm<MyScalar>>(box)),
+                        DataVector(npts, 3.));
+  // rank (1, 0)
+  const auto verification_vec_1d = []() {
+    DataVector tmp(npts, 0.);
+    for (size_t i = 0; i < npts; ++i) {
+      if (i % 2) {
+        tmp[i] = 3.5;
+      } else {
+        tmp[i] = 4.5;
+      }
+    }
+    return tmp;
+  }();
+  const auto verification_vec_2d = []() {
+    DataVector tmp(npts, 0.);
+    for (size_t i = 0; i < npts; ++i) {
+      if (i % 2) {
+        tmp[i] = 4.6097722286464435;
+      } else {
+        tmp[i] = 5.408326913195984;
+      }
+    }
+    return tmp;
+  }();
+  const auto verification_vec_3d = []() {
+    DataVector tmp(npts, 0.);
+    for (size_t i = 0; i < npts; ++i) {
+      if (i % 2) {
+        tmp[i] = 6.103277807866851;
+      } else {
+        tmp[i] = 6.726812023536855;
+      }
+    }
+    return tmp;
+  }();
+  CHECK_ITERABLE_APPROX(
+      get(db::get<Tags::PointwiseL2Norm<Vector<1, Frame>>>(box)),
+      verification_vec_1d);
+  CHECK_ITERABLE_APPROX(
+      get(db::get<Tags::PointwiseL2Norm<Vector<2, Frame>>>(box)),
+      verification_vec_2d);
+  CHECK_ITERABLE_APPROX(
+      get(db::get<Tags::PointwiseL2Norm<Vector<3, Frame>>>(box)),
+      verification_vec_3d);
+  // rank (0, 1)
+  CHECK_ITERABLE_APPROX(
+      get(db::get<Tags::PointwiseL2Norm<Covector<1, Frame>>>(box)),
+      DataVector(npts, 4.));
+  CHECK_ITERABLE_APPROX(
+      get(db::get<Tags::PointwiseL2Norm<Covector<2, Frame>>>(box)),
+      DataVector(npts, 4.47213595499958));
+  CHECK_ITERABLE_APPROX(
+      get(db::get<Tags::PointwiseL2Norm<Covector<3, Frame>>>(box)),
+      DataVector(npts, 12.806248474865697));
+  // rank (0, 2)
+  CHECK_ITERABLE_APPROX(
+      get(db::get<Tags::PointwiseL2Norm<Metric<1, Frame>>>(box)),
+      DataVector(npts, 5.));
+  CHECK_ITERABLE_APPROX(
+      get(db::get<Tags::PointwiseL2Norm<Metric<2, Frame>>>(box)),
+      DataVector(npts, 3.605551275463989));
+  CHECK_ITERABLE_APPROX(
+      get(db::get<Tags::PointwiseL2Norm<Metric<3, Frame>>>(box)),
+      DataVector(npts, 6.324555320336759));
+  // rank (2, 0)
+  CHECK_ITERABLE_APPROX(
+      get(db::get<Tags::PointwiseL2Norm<InverseMetric<1, Frame>>>(box)),
+      DataVector(npts, 0.2));
+  CHECK_ITERABLE_APPROX(
+      get(db::get<Tags::PointwiseL2Norm<InverseMetric<2, Frame>>>(box)),
+      DataVector(npts, 1.8027756377319946));
+  CHECK_ITERABLE_APPROX(
+      get(db::get<Tags::PointwiseL2Norm<InverseMetric<3, Frame>>>(box)),
+      DataVector(npts, 0.4787135538781691));
+
+  // Test L2-norm reduced over domain, against precomputed values
+  // rank 0
+  CHECK(db::get<Tags::L2Norm<MyScalar>>(box) == approx(3.));
+  // rank (1, 0)
+  CHECK(db::get<Tags::L2Norm<Vector<1, Frame>>>(box) ==
+        approx(4.129164564412516));
+  CHECK(db::get<Tags::L2Norm<Vector<2, Frame>>>(box) ==
+        approx(5.103920062069938));
+  CHECK(db::get<Tags::L2Norm<Vector<3, Frame>>>(box) ==
+        approx(6.48459713474939));
+  // rank (0, 1)
+  CHECK(db::get<Tags::L2Norm<Covector<1, Frame>>>(box) == approx(4.));
+  CHECK(db::get<Tags::L2Norm<Covector<2, Frame>>>(box) ==
+        approx(4.47213595499958));
+  CHECK(db::get<Tags::L2Norm<Covector<3, Frame>>>(box) ==
+        approx(12.806248474865697));
+  // rank (0, 2)
+  CHECK(db::get<Tags::L2Norm<Metric<1, Frame>>>(box) == approx(5.));
+  CHECK(db::get<Tags::L2Norm<Metric<2, Frame>>>(box) ==
+        approx(3.605551275463989));
+  CHECK(db::get<Tags::L2Norm<Metric<3, Frame>>>(box) ==
+        approx(6.324555320336759));
+  // rank (2, 0)
+  CHECK(db::get<Tags::L2Norm<InverseMetric<1, Frame>>>(box) == approx(0.2));
+  CHECK(db::get<Tags::L2Norm<InverseMetric<2, Frame>>>(box) ==
+        approx(1.8027756377319946));
+  CHECK(db::get<Tags::L2Norm<InverseMetric<3, Frame>>>(box) ==
+        approx(0.4787135538781691));
+
+  // Check tag names
+  using Tag = MyScalar;
+  CHECK(Tags::PointwiseL2Norm<Tag>::name() ==
+        "PointwiseL2Norm(" + db::tag_name<Tag>() + ")");
+  CHECK(Tags::PointwiseL2NormCompute<Tag>::name() ==
+        "PointwiseL2Norm(" + db::tag_name<Tag>() + ")");
+  CHECK(Tags::L2Norm<Tag>::name() == "L2Norm(" + db::tag_name<Tag>() + ")");
+  CHECK(Tags::L2NormCompute<Tag>::name() ==
+        "L2Norm(" + db::tag_name<Tag>() + ")");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Norms",
+                  "[DataStructures][Unit]") {
+  test_l2_norm_tag<Frame::Grid>();
+  test_l2_norm_tag<Frame::Inertial>();
+}

--- a/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
@@ -1150,7 +1150,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Multiplicity",
       tensor;
 
   // Test multiplicity by iterator
-  for (auto it = tensor.begin(); it != tensor.end(); ++it) {
+  for (auto it = tensor.cbegin(); it != tensor.cend(); ++it) {
     const auto& indices = tensor.get_tensor_index(it);
     const size_t multiplicity = (indices[1] == indices[2] ? 1 : 2);
     CHECK(multiplicity == tensor.multiplicity(it));


### PR DESCRIPTION
## Proposed changes

Added a compute item to get L2-norm of tensors. This would be useful for observing constraints



### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
