### PR TITLE
Update the stages in BuildLinux.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,15 @@
 #
 # Cron Jobs:
 # - Branch: develop, Interval: daily, Options: Always run
+#
+# Updating or adding new stages:
+# - Make sure all stages are specified in the `stages:` section below that
+#   defines the order of the stages.
+# - Make sure the stage names in the `jobs` section (using the `stage:` label)
+#   match exactly the names of the stages in the stage order section.
+# - Make sure that all stages are accounted for in the `.travis/BuildLinux.sh`
+#   file. Note that the `${TRAVIS_BUILD_STAGE_NAME}` capitalizes only the first
+#   letter regardless of how you capitalize your stage names.
 
 language: cpp
 
@@ -49,7 +58,8 @@ services:
 stages:
   - Build stage 1
   - Build stage 2
-  - Build stage 3, ClangTidy, and Doxygen
+  - Build stage 3
+  - Build stage 4, ClangTidy, and Doxygen
 
 # Set up travis configurations of Linux and macOS.
 #
@@ -58,7 +68,7 @@ stages:
 jobs:
   fast_finish: true
   include:
-  - stage: Build stage 3, ClangTidy, and Doxygen
+  - stage: Build stage 4, ClangTidy, and Doxygen
     os: linux
     dist: trusty
     env: CHECK_COMMITS=true
@@ -206,9 +216,26 @@ jobs:
   - <<: *Clang8Debug
   - <<: *Clang8Release
 
-  # Last stage: Build stage 3, clang tidy, and docs.
+  # Build stage 3
   - <<: *Gcc6Debug
-    stage: Build stage 3, ClangTidy, and Doxygen
+    stage: Build stage 3
+  - <<: *Gcc6Release
+  - <<: *Gcc7Debug
+  - <<: *Gcc7Release
+  - <<: *Gcc8Debug
+  - <<: *Gcc8Release
+  - <<: *Gcc9Debug
+  - <<: *Gcc9Release
+  - <<: *Clang4Debug
+  - <<: *Clang4Release
+  - <<: *Clang5Debug
+  - <<: *Clang5Release
+  - <<: *Clang8Debug
+  - <<: *Clang8Release
+
+  # Last stage: Build stage 4, clang tidy, and docs.
+  - <<: *Gcc6Debug
+    stage: Build stage 4, ClangTidy, and Doxygen
   - <<: *Gcc6Release
   - <<: *Gcc7Debug
   - <<: *Gcc7Release

--- a/.travis/BuildLinux.sh
+++ b/.travis/BuildLinux.sh
@@ -44,14 +44,14 @@ touch ${SPECTRE_BUILD_DIR}/tmp/coverage.info
 if [ -z "${RUN_CLANG_TIDY}" ] \
     && [ -z "${RUN_IWYU}" ] \
     && [ -z "${BUILD_DOC}" ]; then
-    if [[ ${TRAVIS_BUILD_STAGE_NAME} = "Build libraries" ]]; then
+    if [[ ${TRAVIS_BUILD_STAGE_NAME} = "Build stage 1" ]]; then
         time make libs -j2
         time make test-libs-domain -j2
         time make test-libs-elliptic -j2
         time make test-libs-evolution -j2
     fi
 
-    if [[ ${TRAVIS_BUILD_STAGE_NAME} = "Build test libraries" ]]; then
+    if [[ ${TRAVIS_BUILD_STAGE_NAME} = "Build stage 2" ]]; then
         time make test-libs-numerical-algorithms -j2
         # Build DataStructures in serial because the DataVector tests
         # are very memory intensive to compile
@@ -59,10 +59,13 @@ if [ -z "${RUN_CLANG_TIDY}" ] \
         time make test-libs-pointwise-functions -j2
     fi
 
-    if [[ ${TRAVIS_BUILD_STAGE_NAME} = \
-          "Build executables, run tests, clangtidy, and doxygen" ]]; then
+    if [[ ${TRAVIS_BUILD_STAGE_NAME} = "Build stage 3" ]]; then
         time make test-libs-other -j2
         time make -j2
+    fi
+
+    if [[ ${TRAVIS_BUILD_STAGE_NAME} = \
+          "Build stage 4, clangtidy, and doxygen" ]]; then
         # Build major executables in serial to avoid hitting memory limits.
         time make test-executables -j1
         time ctest --output-on-failure -j2


### PR DESCRIPTION
## Proposed changes

In the previous travis change (#1623) changing the stage names in the `BuildLinux.sh` was missed. This PR corrects that and adds another stage because I noticed that on my fork one of the builds ran to 57 min out of the allotted 50 min (Travis seems to not cut off my fork at 50 min consistently :man_shrugging: ). This PR also adds instructions to the `.travis.yml` file that explains how to add a new stage or change the names of stages.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
