### PR TITLE
Add RegisterElementWithInterpolator.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp
@@ -5,16 +5,32 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp" // IWYU pragma: keep
 #include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace db {
+template <typename TagsList>
+class DataBox;
+}  // namespace db
+namespace intrp {
+template <typename Metavariables>
+struct Interpolator;
+}  // namespace intrp
+/// \endcond
 
 namespace intrp {
 namespace Actions {
 
 /// \ingroup ActionsGroup
-/// \brief Called by each local Element to register itself with an Interpolator.
+/// \brief Invoked on the `Interpolator` ParallelComponent to register an
+/// element with the `Interpolator`.
+///
+/// This is called by `RegisterElementWithInterpolator` below.
 ///
 /// Uses: nothing
 ///
@@ -24,7 +40,7 @@ namespace Actions {
 /// - Modifies:
 ///   - `Tags::NumberOfElements`
 ///
-/// For requirements on Metavariables, see InterpolationTarget.
+/// For requirements on Metavariables, see `InterpolationTarget`.
 struct RegisterElement {
   template <
       typename ParallelComponent, typename DbTags, typename Metavariables,
@@ -39,6 +55,36 @@ struct RegisterElement {
                                     num_elements) noexcept {
           ++(*num_elements);
         });
+  }
+};
+
+/// \ingroup ActionsGroup
+/// \brief Invoked on `DgElementArray` to register all its elements with the
+/// `Interpolator`.
+///
+/// Uses: nothing
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies: nothing
+///
+struct RegisterElementWithInterpolator {
+  template <typename DbTagList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagList>&&> apply(
+      db::DataBox<DbTagList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    auto& interpolator =
+        *Parallel::get_parallel_component<::intrp::Interpolator<Metavariables>>(
+             cache)
+             .ckLocalBranch();
+    Parallel::simple_action<RegisterElement>(interpolator);
+    return {std::move(box)};
   }
 };
 


### PR DESCRIPTION
New Action to be invoked on DgElementArray.

Every element must call this if it is to interpolate later.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
