### PR TITLE
Improve handling of options for initialization

### DIFF
--- a/cmake/SetupCharmAlgorithm.py
+++ b/cmake/SetupCharmAlgorithm.py
@@ -31,7 +31,8 @@ def create_interface_file(args):
               "Parallel::CProxy_ConstGlobalCache<\n" \
               "                      METAVARIABLES_FROM_COMPONENT>,\n" \
               "tuples::tagged_tuple_from_typelist<" \
-              "PARALLEL_COMPONENT_OPTIONS_SIMPLE_TAGS> options);\n" \
+              "PARALLEL_COMPONENT_INITIALIZATION_TAGS> initialization_items);" \
+              "\n" \
               "\n" \
               "    template <typename Action, typenameLDOTLDOTLDOT Args>\n" \
               "    entry void simple_action(\n" \

--- a/cmake/SetupCharmModuleFunctions.cmake
+++ b/cmake/SetupCharmModuleFunctions.cmake
@@ -133,16 +133,16 @@ function(generate_algorithms_impl ALGORITHM_NAME ALGORITHM_TYPE ALGORITHM_DIR)
              Algorithm${ALGORITHM_NAME}.decl.h \
      \
      \
-     && perl -pi -e 's/PARALLEL_COMPONENT_OPTIONS_SIMPLE_TAGS/typename ParallelComponent::add_options_to_databox::simple_tags/g' Algorithm${ALGORITHM_NAME}.decl.h \
-     && perl -pi -e 's/PARALLEL_COMPONENT_OPTIONS_SIMPLE_TAGS/typename ParallelComponent::add_options_to_databox::simple_tags/g' Algorithm${ALGORITHM_NAME}.def.h \
+     && perl -pi -e 's/PARALLEL_COMPONENT_INITIALIZATION_TAGS/typename ParallelComponent::initialization_tags/g' Algorithm${ALGORITHM_NAME}.decl.h \
+     && perl -pi -e 's/PARALLEL_COMPONENT_INITIALIZATION_TAGS/typename ParallelComponent::initialization_tags/g' Algorithm${ALGORITHM_NAME}.def.h \
      \
      \
      && perl -pi -e 's/TYPENAME_PHASE_TYPE/typename ParallelComponent::metavariables::Phase/g' Algorithm${ALGORITHM_NAME}.decl.h \
      && perl -pi -e 's/TYPENAME_PHASE_TYPE/typename ParallelComponent::metavariables::Phase/g' Algorithm${ALGORITHM_NAME}.def.h \
      \
      \
-     && perl -pi -e 's/impl_noname_0, options/impl_noname_0, std::move(options)/g' Algorithm${ALGORITHM_NAME}.decl.h \
-     && perl -pi -e 's/impl_noname_0, options/impl_noname_0, std::move(options)/g' Algorithm${ALGORITHM_NAME}.def.h \
+     && perl -pi -e 's/impl_noname_0, initialization_items/impl_noname_0, std::move(initialization_items)/g' Algorithm${ALGORITHM_NAME}.decl.h \
+     && perl -pi -e 's/impl_noname_0, initialization_items/impl_noname_0, std::move(initialization_items)/g' Algorithm${ALGORITHM_NAME}.def.h \
      \
      \
      && perl -pi -e 's/\(\\s*impl_obj->template\\s+simple_action<\\s*Action\)\\s*>\\\(args/\\1>\(std::move\(args\)/g' Algorithm${ALGORITHM_NAME}.def.h \

--- a/src/Domain/Creators/DomainCreator.hpp
+++ b/src/Domain/Creators/DomainCreator.hpp
@@ -106,7 +106,7 @@ class DomainCreator {
 
   virtual Domain<VolumeDim, TargetFrame> create_domain() const = 0;
 
-  /// Obtain the initial grid extents of the block with the given index.
+  /// Obtain the initial grid extents of the Element%s in each block.
   virtual std::vector<std::array<size_t, VolumeDim>> initial_extents() const
       noexcept = 0;
 

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -6,11 +6,13 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Index.hpp"
@@ -30,6 +32,7 @@
 #include "Utilities/NoSuchType.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 /// \cond
@@ -55,16 +58,49 @@ template <size_t VolumeDim, typename Frame>
 struct Domain : db::SimpleTag {
   static std::string name() noexcept { return "Domain"; }
   using type = ::Domain<VolumeDim, Frame>;
+  using option_tags = tmpl::list<::OptionTags::DomainCreator<VolumeDim, Frame>>;
+
+  static ::Domain<VolumeDim, Frame> create_from_options(
+      const std::unique_ptr<::DomainCreator<VolumeDim, Frame>>&
+          domain_creator) noexcept {
+    return domain_creator->create_domain();
+  }
 };
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
-/// The number of grid points per dimension for all elements in the initial
-/// computational domain
+/// The number of grid points per dimension for all elements in each block of
+/// the initial computational domain
 template <size_t Dim>
 struct InitialExtents : db::SimpleTag {
   static std::string name() noexcept { return "InitialExtents"; }
   using type = std::vector<std::array<size_t, Dim>>;
+  using option_tags =
+      tmpl::list<::OptionTags::DomainCreator<Dim, Frame::Inertial>>;
+
+  static std::vector<std::array<size_t, Dim>> create_from_options(
+      const std::unique_ptr<::DomainCreator<Dim, Frame::Inertial>>&
+          domain_creator) noexcept {
+    return domain_creator->initial_extents();
+  }
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// The initial refinement level per dimension for all elements in each block of
+/// the initial computational domain
+template <size_t Dim>
+struct InitialRefinementLevels : db::SimpleTag {
+  static std::string name() noexcept { return "InitialRefinementLevels"; }
+  using type = std::vector<std::array<size_t, Dim>>;
+  using option_tags =
+      tmpl::list<::OptionTags::DomainCreator<Dim, Frame::Inertial>>;
+
+  static std::vector<std::array<size_t, Dim>> create_from_options(
+      const std::unique_ptr<::DomainCreator<Dim, Frame::Inertial>>&
+          domain_creator) noexcept {
+    return domain_creator->initial_refinement_levels();
+  }
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -3,47 +3,38 @@
 
 #pragma once
 
+#include <cstddef>
+#include <vector>
+
 #include "AlgorithmArray.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementId.hpp"
 #include "Domain/ElementIndex.hpp"
 #include "Domain/InitialElementIds.hpp"
 #include "Domain/Tags.hpp"
-#include "IO/Observer/ObservationId.hpp"
-#include "IO/Observer/TypeOfObservation.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Info.hpp"
-#include "Parallel/Invoke.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 
 namespace elliptic {
 /*!
  * \brief The parallel component responsible for managing the DG elements that
  * compose the computational domain
  *
- * This parallel component will perform the following phases:
- *
- * - `Phase::Initialize`: Create the domain and execute
- * `elliptic::dg::Actions::InitializeElement` on all elements.
- * - `Phase::RegisterWithObservers` (optional)
- * - `Phase::Solve`: Execute the actions in `ActionList` on all elements. Repeat
- * until an action terminates the algorithm.
+ * This parallel component will perform the actions specified by the
+ * `PhaseDepActionList`.
  *
  * \note This parallel component is nearly identical to
  * `Evolution/DiscontinuousGalerkin/DgElementArray.hpp` right now, but will
  * likely diverge in the future, for instance to support a multigrid domain.
  *
- * Uses:
- * - Metavariables:
- *   - `domain_creator_tag`
- * - System:
- *   - `volume_dim`
- * - ConstGlobalCache:
- *   - All items required by the actions in `ActionList`
  */
-template <class Metavariables, class PhaseDepActionList,
-          class AddOptionsToDataBox>
+template <class Metavariables, class PhaseDepActionList>
 struct DgElementArray {
-  static constexpr size_t volume_dim = Metavariables::system::volume_dim;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
 
   using chare_type = Parallel::Algorithms::Array;
   using metavariables = Metavariables;
@@ -53,49 +44,48 @@ struct DgElementArray {
   using const_global_cache_tag_list =
       Parallel::get_const_global_cache_tags_from_pdal<PhaseDepActionList>;
 
-  using add_options_to_databox = AddOptionsToDataBox;
+  using array_allocation_tags =
+      tmpl::list<::Tags::Domain<volume_dim, Frame::Inertial>,
+                 ::Tags::InitialRefinementLevels<volume_dim>>;
 
-  using options = tmpl::list<typename Metavariables::domain_creator_tag>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>,
+      array_allocation_tags>;
 
-  static void initialize(
+  static void allocate_array(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
-      std::unique_ptr<DomainCreator<volume_dim, Frame::Inertial>>
-          domain_creator) noexcept;
+      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+          initialization_items) noexcept;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
     auto& local_cache = *(global_cache.ckLocalBranch());
     Parallel::get_parallel_component<DgElementArray>(local_cache)
         .start_phase(next_phase);
   }
 };
 
-template <class Metavariables, class PhaseDepActionList,
-          class AddOptionsToDataBox>
-void DgElementArray<Metavariables, PhaseDepActionList, AddOptionsToDataBox>::
-    initialize(Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
-               const std::unique_ptr<DomainCreator<volume_dim, Frame::Inertial>>
-                   domain_creator) noexcept {
+template <class Metavariables, class PhaseDepActionList>
+void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
+    Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+    const tuples::tagged_tuple_from_typelist<initialization_tags>&
+        initialization_items) noexcept {
   auto& dg_element_array = Parallel::get_parallel_component<DgElementArray>(
       *(global_cache.ckLocalBranch()));
-
-  auto domain = domain_creator->create_domain();
+  const auto& domain =
+      get<::Tags::Domain<volume_dim, Frame::Inertial>>(initialization_items);
+  const auto& initial_refinement_levels =
+      get<::Tags::InitialRefinementLevels<volume_dim>>(initialization_items);
   for (const auto& block : domain.blocks()) {
-    const auto initial_ref_levs =
-        domain_creator->initial_refinement_levels()[block.id()];
+    const auto initial_ref_levs = initial_refinement_levels[block.id()];
     const std::vector<ElementId<volume_dim>> element_ids =
         initial_element_ids(block.id(), initial_ref_levs);
     int which_proc = 0;
     const int number_of_procs = Parallel::number_of_procs();
     for (size_t i = 0; i < element_ids.size(); ++i) {
       dg_element_array(ElementIndex<volume_dim>(element_ids[i]))
-          .insert(global_cache,
-                  tuples::tagged_tuple_from_typelist<
-                      typename add_options_to_databox::simple_tags>(
-                      domain_creator->initial_extents(),
-                      domain_creator->create_domain()),
-                  which_proc);
+          .insert(global_cache, initialization_items, which_proc);
       which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
     }
   }

--- a/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
@@ -28,7 +28,6 @@
 #include "NumericalAlgorithms/LinearSolver/Tags.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
-#include "Parallel/AddOptionsToDataBox.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -45,6 +44,8 @@
 /// \cond
 template <size_t Dim>
 struct Metavariables {
+  static constexpr size_t volume_dim = Dim;
+
   static constexpr OptionString help{
       "Find the solution to a Poisson problem in Dim spatial dimensions.\n"
       "Analytic solution: ProductOfSinusoids\n"
@@ -70,9 +71,6 @@ struct Metavariables {
   // Parse numerical flux parameters from the input file to store in the cache.
   using normal_dot_numerical_flux = OptionTags::NumericalFlux<
       Poisson::FirstOrderInternalPenaltyFlux<Dim>>;
-
-  // Set up the domain creator from the input file.
-  using domain_creator_tag = OptionTags::DomainCreator<Dim, Frame::Inertial>;
 
   // Collect all items to store in the cache.
   using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
@@ -125,10 +123,7 @@ struct Metavariables {
                              dg::Actions::ReceiveDataForFluxes<Metavariables>,
                              dg::Actions::ApplyFluxes,
                              typename linear_solver::perform_step,
-                             typename linear_solver::prepare_step>>>,
-
-          Parallel::ForwardAllOptionsToDataBox<
-              Initialization::option_tags<initialization_actions>>>>,
+                             typename linear_solver::prepare_step>>>>>,
       typename linear_solver::component_list,
       tmpl::list<observers::Observer<Metavariables>,
                  observers::ObserverWriter<Metavariables>>>;

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -31,11 +31,6 @@ struct Inertial;
 }  // namespace Frame
 /// \endcond
 
-template <typename PhaseDepAction>
-struct get_action_list_from_phase_dep_action {
-  using type = typename PhaseDepAction::action_list;
-};
-
 template <class Metavariables, class PhaseDepActionList,
           class AddOptionsToDataBox>
 struct DgElementArray {

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -74,6 +74,7 @@ class CProxy_ConstGlobalCache;
 /// \endcond
 
 struct EvolutionMetavars {
+  static constexpr size_t volume_dim = 1;
   using system = Burgers::System;
   using temporal_id = Tags::TimeId;
   static constexpr bool local_time_stepping = false;
@@ -99,7 +100,6 @@ struct EvolutionMetavars {
                  OptionTags::TypedTimeStepper<tmpl::conditional_t<
                      local_time_stepping, LtsTimeStepper, TimeStepper>>,
                  OptionTags::EventsAndTriggers<events, triggers>>;
-  using domain_creator_tag = OptionTags::DomainCreator<1, Frame::Inertial>;
 
   struct ObservationType {};
   using element_observation_type = ObservationType;
@@ -144,7 +144,7 @@ struct EvolutionMetavars {
           dg::Initialization::slice_tags_to_face<
               typename system::variables_tag>,
           dg::Initialization::slice_tags_to_exterior<>>,
-      Initialization::Actions::Evolution<system>,
+      Initialization::Actions::Evolution<EvolutionMetavars>,
       dg::Actions::InitializeMortars<EvolutionMetavars>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::Minmod<1>,
@@ -178,9 +178,7 @@ struct EvolutionMetavars {
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      compute_rhs, update_variables, Actions::AdvanceTime>>>>,
-          Parallel::ForwardAllOptionsToDataBox<
-              Initialization::option_tags<initialization_actions>>>>;
+                      compute_rhs, update_variables, Actions::AdvanceTime>>>>>>;
 
   static constexpr OptionString help{
       "Evolve the Burgers equation.\n\n"

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -86,13 +86,13 @@ class CProxy_ConstGlobalCache;
 /// \endcond
 
 struct EvolutionMetavars {
+  static constexpr size_t volume_dim = 3;
   // To switch which analytic solution is evolved you only need to change the
   // line `using analytic_solution = ...;` and include the header file for the
   // solution.
   //  using analytic_solution = grmhd::Solutions::SmoothFlow;
   using analytic_solution = RelativisticEuler::Solutions::FishboneMoncriefDisk;
 
-  using domain_creator_tag = OptionTags::DomainCreator<3, Frame::Inertial>;
   using system = grmhd::ValenciaDivClean::System<
       typename analytic_solution::equation_of_state_type>;
   static constexpr size_t thermodynamic_dim = system::thermodynamic_dim;
@@ -181,7 +181,7 @@ struct EvolutionMetavars {
           dg::Initialization::slice_tags_to_exterior<
               typename system::spacetime_variables_tag,
               typename system::primitive_variables_tag>>,
-      Initialization::Actions::Evolution<system>,
+      Initialization::Actions::Evolution<EvolutionMetavars>,
       dg::Actions::InitializeMortars<EvolutionMetavars>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::Minmod<3>,
@@ -218,9 +218,7 @@ struct EvolutionMetavars {
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      compute_rhs, update_variables, Actions::AdvanceTime>>>>,
-          Parallel::ForwardAllOptionsToDataBox<
-              Initialization::option_tags<initialization_actions>>>>;
+                      compute_rhs, update_variables, Actions::AdvanceTime>>>>>>;
 
   using const_global_cache_tag_list =
       tmpl::list<analytic_solution_tag,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanAnalyticData.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanAnalyticData.hpp
@@ -83,6 +83,7 @@ class CProxy_ConstGlobalCache;
 /// \endcond
 
 struct EvolutionMetavars {
+  static constexpr size_t volume_dim = 3;
   using analytic_data = grmhd::AnalyticData::CylindricalBlastWave;
 
   using system = grmhd::ValenciaDivClean::System<
@@ -170,7 +171,7 @@ struct EvolutionMetavars {
           dg::Initialization::slice_tags_to_exterior<
               typename system::spacetime_variables_tag,
               typename system::primitive_variables_tag>>,
-      Initialization::Actions::Evolution<system>,
+      Initialization::Actions::Evolution<EvolutionMetavars>,
       dg::Actions::InitializeMortars<EvolutionMetavars>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::Minmod<3>,
@@ -207,9 +208,7 @@ struct EvolutionMetavars {
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      compute_rhs, update_variables, Actions::AdvanceTime>>>>,
-          Parallel::ForwardAllOptionsToDataBox<
-              Initialization::option_tags<initialization_actions>>>>;
+                      compute_rhs, update_variables, Actions::AdvanceTime>>>>>>;
 
   using const_global_cache_tag_list =
       tmpl::list<analytic_data_tag,
@@ -217,8 +216,6 @@ struct EvolutionMetavars {
                      local_time_stepping, LtsTimeStepper, TimeStepper>>,
                  grmhd::ValenciaDivClean::OptionTags::DampingParameter,
                  OptionTags::EventsAndTriggers<events, triggers>>;
-
-  using domain_creator_tag = OptionTags::DomainCreator<3, Frame::Inertial>;
 
   static constexpr OptionString help{
       "Evolve analytic data using the Valencia formulation of the GRMHD system "

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -82,9 +82,9 @@ class CProxy_ConstGlobalCache;
 
 template <size_t Dim>
 struct EvolutionMetavars {
-  using analytic_solution = NewtonianEuler::Solutions::IsentropicVortex<Dim>;
+  static constexpr size_t volume_dim = Dim;
 
-  using domain_creator_tag = OptionTags::DomainCreator<Dim, Frame::Inertial>;
+  using analytic_solution = NewtonianEuler::Solutions::IsentropicVortex<Dim>;
 
   using system = NewtonianEuler::System<
       Dim, typename analytic_solution::equation_of_state_type>;
@@ -175,7 +175,7 @@ struct EvolutionMetavars {
           dg::Initialization::slice_tags_to_exterior<
               typename system::primitive_variables_tag,
               NewtonianEuler::Tags::SoundSpeed<DataVector>>>,
-      Initialization::Actions::Evolution<system>,
+      Initialization::Actions::Evolution<EvolutionMetavars>,
       dg::Actions::InitializeMortars<EvolutionMetavars>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::Minmod<Dim>,
@@ -210,9 +210,7 @@ struct EvolutionMetavars {
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      compute_rhs, update_variables, Actions::AdvanceTime>>>>,
-          Parallel::ForwardAllOptionsToDataBox<
-              Initialization::option_tags<initialization_actions>>>>;
+                      compute_rhs, update_variables, Actions::AdvanceTime>>>>>>;
 
   using const_global_cache_tag_list =
       tmpl::list<analytic_solution_tag,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -77,6 +77,7 @@ class CProxy_ConstGlobalCache;
 
 template <size_t Dim>
 struct EvolutionMetavars {
+  static constexpr size_t volume_dim = Dim;
   // Customization/"input options" to simulation
   using system = ScalarWave::System<Dim>;
   using temporal_id = Tags::TimeId;
@@ -103,7 +104,6 @@ struct EvolutionMetavars {
                  OptionTags::TypedTimeStepper<tmpl::conditional_t<
                      local_time_stepping, LtsTimeStepper, TimeStepper>>,
                  OptionTags::EventsAndTriggers<events, triggers>>;
-  using domain_creator_tag = OptionTags::DomainCreator<Dim, Frame::Inertial>;
 
   struct ObservationType {};
   using element_observation_type = ObservationType;
@@ -157,7 +157,7 @@ struct EvolutionMetavars {
           dg::Initialization::slice_tags_to_face<
               typename system::variables_tag>,
           dg::Initialization::slice_tags_to_exterior<>>,
-      Initialization::Actions::Evolution<system>,
+      Initialization::Actions::Evolution<EvolutionMetavars>,
       dg::Actions::InitializeMortars<EvolutionMetavars>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
@@ -190,9 +190,7 @@ struct EvolutionMetavars {
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      compute_rhs, update_variables, Actions::AdvanceTime>>>>,
-          Parallel::ForwardAllOptionsToDataBox<
-              Initialization::option_tags<initialization_actions>>>>;
+                      compute_rhs, update_variables, Actions::AdvanceTime>>>>>>;
 
   static constexpr OptionString help{
       "Evolve a Scalar Wave in Dim spatial dimension.\n\n"

--- a/src/Evolution/Initialization/ConservativeSystem.hpp
+++ b/src/Evolution/Initialization/ConservativeSystem.hpp
@@ -50,8 +50,7 @@ namespace Actions {
 /// - Removes: nothing
 /// - Modifies: nothing
 struct ConservativeSystem {
-  using initialization_option_tags =
-      tmpl::list<Initialization::Tags::InitialTime>;
+  using initialization_tags = tmpl::list<Initialization::Tags::InitialTime>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,

--- a/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
+++ b/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
@@ -178,6 +178,9 @@ struct DiscontinuousGalerkin {
     }
   };
 
+  using initialization_tags =
+      tmpl::list<::Tags::InitialExtents<Metavariables::volume_dim>>;
+
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent>
   static auto apply(db::DataBox<DbTagsList>& box,

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -32,6 +32,28 @@ struct Inertial;
 }  // namespace Frame
 /// \endcond
 
+namespace Evolution_detail {
+// Global time stepping
+template <typename Metavariables,
+          Requires<not Metavariables::local_time_stepping> = nullptr>
+TimeDelta get_initial_time_step(
+    const Time& initial_time, const double initial_dt_value,
+    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/) noexcept {
+  return (initial_dt_value > 0.0 ? 1 : -1) * initial_time.slab().duration();
+}
+
+// Local time stepping
+template <typename Metavariables,
+          Requires<Metavariables::local_time_stepping> = nullptr>
+TimeDelta get_initial_time_step(
+    const Time& initial_time, const double initial_dt_value,
+    const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
+  const auto& step_controller =
+      Parallel::get<OptionTags::StepController>(cache);
+  return step_controller.choose_step(initial_time, initial_dt_value);
+}
+}  // namespace Evolution_detail
+
 namespace Initialization {
 namespace Actions {
 /// \ingroup InitializationGroup
@@ -55,18 +77,18 @@ namespace Actions {
 /// - Modifies: nothing
 ///
 /// \note HistoryEvolvedVariables is allocated, but needs to be initialized
-template <typename System>
+template <typename Metavariables>
 struct Evolution {
-  using initialization_option_tags =
+  using initialization_tags =
       tmpl::list<Tags::InitialTime, Tags::InitialTimeDelta,
-                 Tags::InitialSlabSize>;
+                 Tags::InitialSlabSize<Metavariables::local_time_stepping>>;
 
-  static constexpr size_t dim = System::volume_dim;
-  using variables_tag = typename System::variables_tag;
+  static constexpr size_t dim = Metavariables::volume_dim;
+  using variables_tag = typename Metavariables::system::variables_tag;
   using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
 
-  template <typename LocalSystem, bool IsInFluxConservativeForm =
-                                      LocalSystem::is_in_flux_conservative_form>
+  template <typename System, bool IsInFluxConservativeForm =
+                                 System::is_in_flux_conservative_form>
   struct ComputeTags {
     using type = db::AddComputeTags<
         ::Tags::Time,
@@ -77,8 +99,8 @@ struct Evolution {
             typename System::gradients_tags>>;
   };
 
-  template <typename LocalSystem>
-  struct ComputeTags<LocalSystem, true> {
+  template <typename System>
+  struct ComputeTags<System, true> {
     using type = db::AddComputeTags<
         ::Tags::Time,
         ::Tags::DivCompute<
@@ -88,29 +110,8 @@ struct Evolution {
                                     ::Tags::Coordinates<dim, Frame::Logical>>>>;
   };
 
-  // Global time stepping
-  template <typename Metavariables,
-            Requires<not Metavariables::local_time_stepping> = nullptr>
-  static TimeDelta get_initial_time_step(
-      const Time& initial_time, const double initial_dt_value,
-      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/) noexcept {
-    return (initial_dt_value > 0.0 ? 1 : -1) * initial_time.slab().duration();
-  }
-
-  // Local time stepping
-  template <typename Metavariables,
-            Requires<Metavariables::local_time_stepping> = nullptr>
-  static TimeDelta get_initial_time_step(
-      const Time& initial_time, const double initial_dt_value,
-      const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
-    const auto& step_controller =
-        Parallel::get<OptionTags::StepController>(cache);
-    return step_controller.choose_step(initial_time, initial_dt_value);
-  }
-
-  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent,
+  template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent,
             Requires<tmpl::list_contains_v<
                 typename db::DataBox<DbTagsList>::simple_item_tags,
                 Initialization::Tags::InitialTime>> = nullptr>
@@ -123,7 +124,8 @@ struct Evolution {
 
     const double initial_time_value = db::get<Tags::InitialTime>(box);
     const double initial_dt_value = db::get<Tags::InitialTimeDelta>(box);
-    const double initial_slab_size = db::get<Tags::InitialSlabSize>(box);
+    const double initial_slab_size =
+        db::get<Tags::InitialSlabSize<Metavariables::local_time_stepping>>(box);
 
     const bool time_runs_forward = initial_dt_value > 0.0;
     const Slab initial_slab =
@@ -133,8 +135,8 @@ struct Evolution {
             : Slab::with_duration_to_end(initial_time_value, initial_slab_size);
     const Time initial_time =
         time_runs_forward ? initial_slab.start() : initial_slab.end();
-    const TimeDelta initial_dt =
-        get_initial_time_step(initial_time, initial_dt_value, cache);
+    const TimeDelta initial_dt = Evolution_detail::get_initial_time_step(
+        initial_time, initial_dt_value, cache);
 
     const size_t num_grid_points =
         db::get<::Tags::Mesh<dim>>(box).number_of_grid_points();
@@ -154,7 +156,8 @@ struct Evolution {
         -static_cast<int64_t>(time_stepper.number_of_past_steps()),
         initial_time);
 
-    using compute_tags = typename ComputeTags<System>::type;
+    using compute_tags =
+        typename ComputeTags<typename Metavariables::system>::type;
     return std::make_tuple(
         merge_into_databox<
             Evolution,
@@ -170,9 +173,8 @@ struct Evolution {
             std::move(history)));
   }
 
-  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent,
+  template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent,
             Requires<not tmpl::list_contains_v<
                 typename db::DataBox<DbTagsList>::simple_item_tags,
                 Initialization::Tags::InitialTime>> = nullptr>

--- a/src/Evolution/Initialization/NonconservativeSystem.hpp
+++ b/src/Evolution/Initialization/NonconservativeSystem.hpp
@@ -42,8 +42,7 @@ namespace Actions {
 /// - Removes: nothing
 /// - Modifies: nothing
 struct NonconservativeSystem {
-  using initialization_option_tags =
-      tmpl::list<Initialization::Tags::InitialTime>;
+  using initialization_tags = tmpl::list<Initialization::Tags::InitialTime>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,

--- a/src/Evolution/Initialization/Tags.hpp
+++ b/src/Evolution/Initialization/Tags.hpp
@@ -3,17 +3,13 @@
 
 #pragma once
 
-#include <array>
-#include <cstddef>
+#include <cmath>
 #include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "DataStructures/Tensor/IndexType.hpp"
-
-/// \cond
-template <size_t VolumeDim, typename TargetFrame>
-class Domain;
-/// \endcond
+#include "Time/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 
 namespace Initialization {
 /// \ingroup InitializationGroup
@@ -22,16 +18,43 @@ namespace Tags {
 struct InitialTime : db::SimpleTag {
   static std::string name() noexcept { return "InitialTime"; }
   using type = double;
+  using option_tags = tmpl::list<OptionTags::InitialTime>;
+
+  static double create_from_options(const double initial_time) noexcept {
+    return initial_time;
+  }
 };
 
 struct InitialTimeDelta : db::SimpleTag {
   static std::string name() noexcept { return "InitialTimeDelta"; }
   using type = double;
+  using option_tags = tmpl::list<OptionTags::InitialTimeStep>;
+
+  static double create_from_options(const double initial_time_step) noexcept {
+    return initial_time_step;
+  }
 };
 
+template <bool UsingLocalTimeStepping>
 struct InitialSlabSize : db::SimpleTag {
   static std::string name() noexcept { return "InitialSlabSize"; }
   using type = double;
+  using option_tags = tmpl::list<OptionTags::InitialSlabSize>;
+
+  static double create_from_options(const double initial_slab_size) noexcept {
+    return initial_slab_size;
+  }
+};
+
+template <>
+struct InitialSlabSize<false> : db::SimpleTag {
+  static std::string name() noexcept { return "InitialSlabSize"; }
+  using type = double;
+  using option_tags = tmpl::list<OptionTags::InitialTimeStep>;
+
+  static double create_from_options(const double initial_time_step) noexcept {
+    return std::abs(initial_time_step);
+  }
 };
 }  // namespace Tags
 }  // namespace Initialization

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Initialize.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Initialize.hpp
@@ -35,8 +35,7 @@ namespace ValenciaDivClean {
 namespace Actions {
 
 struct InitializeGrTags {
-  using initialization_option_tags =
-      tmpl::list<Initialization::Tags::InitialTime>;
+  using initialization_tags = tmpl::list<Initialization::Tags::InitialTime>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,

--- a/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
+++ b/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
@@ -9,12 +9,14 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Options/Options.hpp"
-#include "Parallel/AddOptionsToDataBox.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Info.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Invoke.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Printf.hpp"
+#include "Utilities/TMPL.hpp"
 /// [executable_example_includes]
 
 /// [executable_example_options]
@@ -48,11 +50,11 @@ struct HelloWorld {
   using const_global_cache_tag_list = tmpl::list<OptionTags::Name>;
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Execute, tmpl::list<>>>;
-  using options = tmpl::list<>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept;

--- a/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
+++ b/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
@@ -53,8 +53,6 @@ struct HelloWorld {
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Execute, tmpl::list<>>>;
   using options = tmpl::list<>;
-  static void initialize(Parallel::CProxy_ConstGlobalCache<
-                         Metavariables>& /* global_cache */) noexcept {}
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept;

--- a/src/IO/Observer/ObserverComponent.hpp
+++ b/src/IO/Observer/ObserverComponent.hpp
@@ -8,10 +8,10 @@
 #include "IO/Observer/ArrayComponentId.hpp"
 #include "IO/Observer/Initialize.hpp"
 #include "IO/Observer/Tags.hpp"
-#include "Parallel/AddOptionsToDataBox.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
-#include "Parallel/Invoke.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace observers {
 /*!
@@ -27,13 +27,12 @@ template <class Metavariables>
 struct Observer {
   using chare_type = Parallel::Algorithms::Group;
   using const_global_cache_tag_list = tmpl::list<>;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename metavariables::Phase, metavariables::Phase::Initialization,
       tmpl::list<Actions::Initialize<Metavariables>>>>;
-
-  using options = tmpl::list<>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase /*next_phase*/,
@@ -52,12 +51,11 @@ struct ObserverWriter {
   using const_global_cache_tag_list =
       tmpl::list<OptionTags::ReductionFileName, OptionTags::VolumeFileName>;
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename metavariables::Phase, metavariables::Phase::Initialization,
       tmpl::list<Actions::InitializeWriter<Metavariables>>>>;
-
-  using options = tmpl::list<>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase /*next_phase*/,

--- a/src/IO/Observer/ObserverComponent.hpp
+++ b/src/IO/Observer/ObserverComponent.hpp
@@ -35,9 +35,6 @@ struct Observer {
 
   using options = tmpl::list<>;
 
-  static void initialize(Parallel::CProxy_ConstGlobalCache<
-                         Metavariables>& /*global_cache*/) noexcept {}
-
   static void execute_next_phase(
       const typename Metavariables::Phase /*next_phase*/,
       Parallel::CProxy_ConstGlobalCache<
@@ -61,9 +58,6 @@ struct ObserverWriter {
       tmpl::list<Actions::InitializeWriter<Metavariables>>>>;
 
   using options = tmpl::list<>;
-
-  static void initialize(Parallel::CProxy_ConstGlobalCache<
-                         Metavariables>& /*global_cache*/) noexcept {}
 
   static void execute_next_phase(
       const typename Metavariables::Phase /*next_phase*/,

--- a/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
@@ -101,43 +101,39 @@ auto make_tuple_of_box(
 /// - Modifies: nothing
 ///
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
-template <typename InterpolationTargetTag>
+template <typename Metavariables, typename InterpolationTargetTag>
 struct InitializeInterpolationTarget {
-  /// For requirements on Metavariables, see InterpolationTarget
-  template <typename Metavariables>
   using return_tag_list_initial = tmpl::list<
       Tags::IndicesOfFilledInterpPoints, Tags::TemporalIds<Metavariables>,
       Tags::CompletedTemporalIds<Metavariables>,
       ::Tags::Variables<
           typename InterpolationTargetTag::vars_to_interpolate_to_target>>;
-  template <typename Metavariables>
   using return_tag_list =
-      tmpl::append<return_tag_list_initial<Metavariables>,
+      tmpl::append<return_tag_list_initial,
                    typename initialize_interpolation_target_detail::
                        initialization_tags<InterpolationTargetTag>::type>;
 
-  template <typename Metavariables>
   struct AddOptionsToDataBox {
     using simple_tags =
-        tmpl::list<::Tags::Domain<Metavariables::domain_dim,
-                                  typename Metavariables::domain_frame>>;
+        tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>;
     template <typename DbTagsList>
-    static auto apply(db::DataBox<DbTagsList>&& box,
-                      ::Domain<Metavariables::domain_dim,
-                               typename Metavariables::domain_frame>
-                          domain) noexcept {
+    static auto apply(
+        db::DataBox<DbTagsList>&& box,
+        ::Domain<Metavariables::volume_dim, Frame::Inertial> domain) noexcept {
       return db::create_from<db::RemoveTags<>, simple_tags>(std::move(box),
                                                             std::move(domain));
     }
   };
 
+  using initialization_tags =
+      tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>;
+
   template <
-      typename DbTagsList, typename... InboxTags, typename Metavariables,
-      typename ArrayIndex, typename ActionList, typename ParallelComponent,
-      Requires<tmpl::list_contains_v<
-                   DbTagsList,
-                   ::Tags::Domain<Metavariables::domain_dim,
-                                  typename Metavariables::domain_frame>> and
+      typename DbTagsList, typename... InboxTags, typename ArrayIndex,
+      typename ActionList, typename ParallelComponent,
+      Requires<tmpl::list_contains_v<DbTagsList,
+                                     ::Tags::Domain<Metavariables::volume_dim,
+                                                    Frame::Inertial>> and
                not tmpl::list_contains_v<
                    DbTagsList, Tags::IndicesOfFilledInterpPoints>> = nullptr>
   static auto apply(db::DataBox<DbTagsList>& box,
@@ -149,7 +145,7 @@ struct InitializeInterpolationTarget {
     return initialize_interpolation_target_detail::make_tuple_of_box<
         InterpolationTargetTag>(
         db::create_from<db::RemoveTags<>,
-                        db::get_items<return_tag_list_initial<Metavariables>>>(
+                        db::get_items<return_tag_list_initial>>(
             std::move(box), db::item_type<Tags::IndicesOfFilledInterpPoints>{},
             db::item_type<Tags::TemporalIds<Metavariables>>{},
             db::item_type<Tags::CompletedTemporalIds<Metavariables>>{},
@@ -159,9 +155,8 @@ struct InitializeInterpolationTarget {
         cache);
   }
 
-  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent,
+  template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent,
             Requires<tmpl::list_contains_v<
                 DbTagsList, Tags::IndicesOfFilledInterpPoints>> = nullptr>
   static std::tuple<db::DataBox<DbTagsList>&&> apply(

--- a/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
@@ -85,9 +85,8 @@ void operator|(PUP::er& p, Info<VolumeDim, TagList>& t) noexcept {  // NOLINT
 template <typename Metavariables,
           typename InterpolationTargetTag, typename TagList>
 struct Holder {
-  std::unordered_map<
-      typename Metavariables::temporal_id::type,
-      Info<Metavariables::domain_dim, TagList>>
+  std::unordered_map<typename Metavariables::temporal_id::type,
+                     Info<Metavariables::volume_dim, TagList>>
       infos;
   std::unordered_set<typename Metavariables::temporal_id::type>
       temporal_ids_when_data_has_been_interpolated;

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -148,11 +148,6 @@ struct InterpolationTarget {
           tmpl::list<::observers::Actions::RegisterSingletonWithObserverWriter<
                          RegistrationHelper>,
                      Parallel::Actions::TerminatePhase>>>;
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<metavariables>& /*global_cache*/,
-      std::unique_ptr<DomainCreator<Metavariables::domain_dim,
-                                    typename Metavariables::domain_frame>>
-      /*domain_creator*/) noexcept {};
   static void execute_next_phase(
       typename metavariables::Phase next_phase,
       Parallel::CProxy_ConstGlobalCache<metavariables>& global_cache) noexcept {

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -173,7 +173,7 @@ struct ApparentHorizon {
 
     // In the future, when we add support for multiple Frames,
     // the code that transforms coordinates from the Strahlkorper Frame
-    // to `Metavariables::domain_frame` will go here.  That transformation
+    // to Frame::Inertial will go here.  That transformation
     // may depend on `temporal_id`.
 
     send_points_to_interpolator<InterpolationTargetTag>(

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
@@ -156,12 +156,11 @@ struct KerrHorizon {
       const typename Metavariables::temporal_id::type& temporal_id) noexcept {
     // In the future, when we add support for multiple Frames,
     // the code that transforms coordinates from the Strahlkorper Frame
-    // to `Metavariables::domain_frame` will go here.  That transformation
+    // to Frame::Inertial will go here.  That transformation
     // may depend on `temporal_id`.
     send_points_to_interpolator<InterpolationTargetTag>(
         box, cache,
-        db::get<StrahlkorperTags::CartesianCoords<
-            typename Metavariables::domain_frame>>(box),
+        db::get<StrahlkorperTags::CartesianCoords<::Frame::Inertial>>(box),
         temporal_id);
   }
 };

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
@@ -38,8 +38,7 @@ namespace OptionHolders {
 /// A line segment extending from `Begin` to `End`,
 /// containing `NumberOfPoints` uniformly-spaced points including the endpoints.
 ///
-/// \note Input coordinates are interpreted in the frame given by
-/// `Metavariables::domain_frame`
+/// \note Input coordinates are interpreted in `Frame::Inertial`
 template <size_t VolumeDim>
 struct LineSegment {
   struct Begin {
@@ -125,8 +124,8 @@ struct LineSegment {
 
     // Fill points on a line segment
     const double fractional_distance = 1.0 / (options.number_of_points - 1);
-    tnsr::I<DataVector, VolumeDim, typename Metavariables::domain_frame>
-        target_points(options.number_of_points);
+    tnsr::I<DataVector, VolumeDim, Frame::Inertial> target_points(
+        options.number_of_points);
     for (size_t n = 0; n < options.number_of_points; ++n) {
       for (size_t d = 0; d < VolumeDim; ++d) {
         target_points.get(d)[n] =

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -56,8 +56,8 @@ namespace OptionHolders {
 /// The `target_points` form a 3D mesh ordered with \f$r\f$ varying fastest,
 /// then \f$\theta\f$, and finally \f$\phi\f$ varying slowest.
 ///
-/// \note Input coordinates (radii, angles) are interpreted in the frame given
-/// by `Metavariables::domain_frame`
+/// \note Input coordinates (radii, angles) are interpreted in the
+/// `Frame::Inertial`
 struct WedgeSectionTorus {
   struct MinRadius {
     using type = double;
@@ -264,8 +264,7 @@ struct WedgeSectionTorus {
 
     // Compute x/y/z coordinates
     // Note: theta measured from +z axis, phi measured from +x axis
-    tnsr::I<DataVector, 3, typename Metavariables::domain_frame> target_points(
-        num_total);
+    tnsr::I<DataVector, 3, Frame::Inertial> target_points(num_total);
     get<0>(target_points) = radii * sin(thetas) * cos(phis);
     get<1>(target_points) = radii * sin(thetas) * sin(phis);
     get<2>(target_points) = radii * cos(thetas);

--- a/src/NumericalAlgorithms/Interpolation/Interpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Interpolator.hpp
@@ -7,10 +7,10 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
-#include "Parallel/AddOptionsToDataBox.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
-#include "Parallel/Invoke.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace intrp {
 
@@ -22,13 +22,13 @@ template <class Metavariables>
 struct Interpolator {
   using chare_type = Parallel::Algorithms::Group;
   using const_global_cache_tag_list = tmpl::list<>;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename metavariables::Phase, metavariables::Phase::Initialization,
       tmpl::list<Actions::InitializeInterpolator,
                  Parallel::Actions::TerminatePhase>>>;
-  using options = tmpl::list<>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   static void execute_next_phase(
       typename Metavariables::Phase next_phase,
       const Parallel::CProxy_ConstGlobalCache<Metavariables>&

--- a/src/NumericalAlgorithms/Interpolation/Interpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Interpolator.hpp
@@ -29,8 +29,6 @@ struct Interpolator {
       tmpl::list<Actions::InitializeInterpolator,
                  Parallel::Actions::TerminatePhase>>>;
   using options = tmpl::list<>;
-  static void initialize(Parallel::CProxy_ConstGlobalCache<Metavariables>&
-                         /*global_cache*/) noexcept {};
   static void execute_next_phase(
       typename Metavariables::Phase next_phase,
       const Parallel::CProxy_ConstGlobalCache<Metavariables>&

--- a/src/NumericalAlgorithms/Interpolation/Tags.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Tags.hpp
@@ -53,7 +53,7 @@ struct CompletedTemporalIds : db::SimpleTag {
 template <typename Metavariables>
 struct VolumeVarsInfo : db::SimpleTag {
   struct Info {
-    Mesh<Metavariables::domain_dim> mesh;
+    Mesh<Metavariables::volume_dim> mesh;
     Variables<typename Metavariables::interpolator_source_vars> vars;
 
     void pup(PUP::er& p) noexcept {  // NOLINT
@@ -63,7 +63,7 @@ struct VolumeVarsInfo : db::SimpleTag {
   };
   using type = std::unordered_map<
       typename Metavariables::temporal_id::type,
-      std::unordered_map<ElementId<Metavariables::domain_dim>, Info>>;
+      std::unordered_map<ElementId<Metavariables::volume_dim>, Info>>;
   static std::string name() noexcept { return "VolumeVarsInfo"; }
 };
 

--- a/src/NumericalAlgorithms/Interpolation/TryToInterpolate.hpp
+++ b/src/NumericalAlgorithms/Interpolation/TryToInterpolate.hpp
@@ -58,9 +58,7 @@ void interpolate_data(
 
           // Get list of ElementIds that have the correct temporal_id and that
           // have not yet been interpolated.
-          std::vector<
-              ElementId<Metavariables::domain_dim>>
-              element_ids;
+          std::vector<ElementId<Metavariables::volume_dim>> element_ids;
 
           for (const auto& volume_info_inner : volume_info_outer.second) {
             // Have we interpolated this element before?
@@ -107,9 +105,8 @@ void interpolate_data(
                 });
 
             // Now interpolate.
-            intrp::Irregular<Metavariables::domain_dim>
-                interpolator(volume_info.mesh,
-                             element_coord_holder.element_logical_coords);
+            intrp::Irregular<Metavariables::volume_dim> interpolator(
+                volume_info.mesh, element_coord_holder.element_logical_coords);
             interp_info.vars.emplace_back(interpolator.interpolate(local_vars));
             interp_info.global_offsets.emplace_back(
                 element_coord_holder.offsets);

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
@@ -57,9 +57,6 @@ struct ResidualMonitor {
           tmpl::list<observers::Actions::RegisterSingletonWithObserverWriter<
               LinearSolver::observe_detail::Registration>>>>;
 
-  static void initialize(Parallel::CProxy_ConstGlobalCache<
-                         Metavariables>& /*global_cache*/) noexcept {}
-
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
@@ -11,11 +11,9 @@
 #include "Informer/Verbosity.hpp"
 #include "NumericalAlgorithms/LinearSolver/Observe.hpp"
 #include "NumericalAlgorithms/LinearSolver/Tags.hpp"
-#include "Options/Options.hpp"
-#include "Parallel/AddOptionsToDataBox.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
-#include "Parallel/Info.hpp"
-#include "Parallel/Invoke.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -43,8 +41,6 @@ struct ResidualMonitor {
   using const_global_cache_tag_list =
       tmpl::list<LinearSolver::OptionTags::Verbosity,
                  LinearSolver::OptionTags::ConvergenceCriteria>;
-  using options = tmpl::list<>;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -56,6 +52,8 @@ struct ResidualMonitor {
           Metavariables::Phase::RegisterWithObserver,
           tmpl::list<observers::Actions::RegisterSingletonWithObserverWriter<
               LinearSolver::observe_detail::Registration>>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -57,8 +57,6 @@ struct ResidualMonitor {
           tmpl::list<observers::Actions::RegisterSingletonWithObserverWriter<
               LinearSolver::observe_detail::Registration>>>>;
 
-  static void initialize(Parallel::CProxy_ConstGlobalCache<
-                         Metavariables>& /*global_cache*/) noexcept {}
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -11,11 +11,9 @@
 #include "Informer/Tags.hpp"
 #include "NumericalAlgorithms/LinearSolver/Observe.hpp"
 #include "NumericalAlgorithms/LinearSolver/Tags.hpp"
-#include "Options/Options.hpp"
-#include "Parallel/AddOptionsToDataBox.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
-#include "Parallel/Info.hpp"
-#include "Parallel/Invoke.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -43,8 +41,6 @@ struct ResidualMonitor {
   using const_global_cache_tag_list =
       tmpl::list<LinearSolver::OptionTags::Verbosity,
                  LinearSolver::OptionTags::ConvergenceCriteria>;
-  using options = tmpl::list<>;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -56,7 +52,8 @@ struct ResidualMonitor {
           Metavariables::Phase::RegisterWithObserver,
           tmpl::list<observers::Actions::RegisterSingletonWithObserverWriter<
               LinearSolver::observe_detail::Registration>>>>;
-
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -478,7 +478,7 @@ template <typename... Tags>
 struct apply_helper<tmpl::list<Tags...>> {
   template <typename Metavariables, typename Options, typename F>
   static decltype(auto) apply(const Options& opts, F&& func) {
-    return func(opts.template get<Tags>()...);
+    return func(opts.template get<Tags, Metavariables>()...);
   }
 };
 }  // namespace Options_detail

--- a/src/Parallel/Main.ci
+++ b/src/Parallel/Main.ci
@@ -8,7 +8,7 @@ module Main {
   template <typename Metavariables>
   mainchare [migratable] Main {
     entry Main(CkArgMsg* msg);
-    entry void initialize();
+    entry void allocate_array_components_and_execute_initialization_phase();
     entry void execute_next_phase();
   }
 

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -62,15 +62,17 @@ class Main : public CBase_Main<Metavariables> {
   explicit Main(CkMigrateMessage* /*msg*/)
       : options_("Uninitialized after migration") {}
 
-  /// Initialize the parallel_components.
-  void initialize() noexcept;
+  /// Allocate the initial elements of array components, and then execute the
+  /// initialization phase on each component
+  void allocate_array_components_and_execute_initialization_phase() noexcept;
 
   /// Determine the next phase of the simulation and execute it.
   void execute_next_phase() noexcept;
 
  private:
   template <typename ParallelComponent>
-  using parallel_component_options = typename ParallelComponent::options;
+  using parallel_component_options = Parallel::get_option_tags<
+      typename ParallelComponent::initialization_tags>;
   using option_list = tmpl::remove_duplicates<tmpl::flatten<tmpl::list<
       const_global_cache_tags,
       tmpl::transform<component_list,
@@ -236,6 +238,13 @@ Main<Metavariables>::Main(CkArgMsg* msg) noexcept
     ERROR(e.what());
   }
 
+  const auto items_from_options =
+      options_.template apply<option_list, Metavariables>(
+          [](auto... args) noexcept {
+            return tuples::tagged_tuple_from_typelist<option_list>(
+                std::move(args)...);
+          });
+
   const_global_cache_proxy_ =
       options_.template apply<const_global_cache_tags, Metavariables>(
           [](auto... args) {
@@ -259,23 +268,18 @@ Main<Metavariables>::Main(CkArgMsg* msg) noexcept
       const_global_cache_proxy_.ckGetGroupID());
 
   tmpl::for_each<group_component_list>([
-    this, &the_parallel_components, &const_global_cache_dependency
+    this, &the_parallel_components, &items_from_options, &
+    const_global_cache_dependency
   ](auto parallel_component_v) noexcept {
     using parallel_component = tmpl::type_from<decltype(parallel_component_v)>;
     using ParallelComponentProxy =
         Parallel::proxy_from_parallel_component<parallel_component>;
-    using add_options_to_databox =
-        typename parallel_component::add_options_to_databox;
     tuples::get<tmpl::type_<ParallelComponentProxy>>(the_parallel_components) =
         ParallelComponentProxy::ckNew(
             const_global_cache_proxy_,
-            options_.template apply<
-                typename add_options_to_databox::simple_tags, Metavariables>(
-                [](auto... args) noexcept {
-                  return tuples::tagged_tuple_from_typelist<
-                      typename add_options_to_databox::simple_tags>(
-                      std::move(args)...);
-                }),
+            Parallel::create_from_options(
+                items_from_options,
+                typename parallel_component::initialization_tags{}),
             &const_global_cache_dependency);
   });
 
@@ -284,27 +288,23 @@ Main<Metavariables>::Main(CkArgMsg* msg) noexcept
       tmpl::filter<component_list,
                    Parallel::is_chare_proxy<tmpl::bind<
                        Parallel::proxy_from_parallel_component, tmpl::_1>>>;
-  tmpl::for_each<singleton_component_list>([ this, &the_parallel_components ](
-      auto parallel_component_v) noexcept {
+  tmpl::for_each<singleton_component_list>([
+    this, &the_parallel_components, &items_from_options
+  ](auto parallel_component_v) noexcept {
     using parallel_component = tmpl::type_from<decltype(parallel_component_v)>;
     using ParallelComponentProxy =
         Parallel::proxy_from_parallel_component<parallel_component>;
-    using add_options_to_databox =
-        typename parallel_component::add_options_to_databox;
     tuples::get<tmpl::type_<ParallelComponentProxy>>(the_parallel_components) =
         ParallelComponentProxy::ckNew(
             const_global_cache_proxy_,
-            options_
-                .template apply<typename add_options_to_databox::simple_tags,
-                                Metavariables>([](auto... args) noexcept {
-                  return tuples::tagged_tuple_from_typelist<
-                      typename add_options_to_databox::simple_tags>(
-                      std::move(args)...);
-                }));
+            Parallel::create_from_options(
+                items_from_options,
+                typename parallel_component::initialization_tags{}));
   });
 
-  // Create proxies for empty array chares (which are created by the
-  // initialize functions of the parallel_components)
+  // Create proxies for empty array chares (whose elements will be created by
+  // the allocate functions of the array components during
+  // execute_initialization_phase)
   using array_component_list = tmpl::filter<
       component_list,
       tmpl::and_<Parallel::is_array_proxy<tmpl::bind<
@@ -340,31 +340,43 @@ Main<Metavariables>::Main(CkArgMsg* msg) noexcept
   // Send the complete list of parallel_components to the ConstGlobalCache on
   // each Charm++ node.  After all nodes have finished, the callback is
   // executed.
-  CkCallback callback(CkIndex_Main<Metavariables>::initialize(),
-                      this->thisProxy);
+  CkCallback callback(
+      CkIndex_Main<Metavariables>::
+          allocate_array_components_and_execute_initialization_phase(),
+      this->thisProxy);
   const_global_cache_proxy_.set_parallel_components(the_parallel_components,
                                                     callback);
 }
 
 template <typename Metavariables>
-void Main<Metavariables>::initialize() noexcept {
+void Main<Metavariables>::
+    allocate_array_components_and_execute_initialization_phase() noexcept {
   ASSERT(current_phase_ == Metavariables::Phase::Initialization,
-         "Must be in the Initialization phase during initialization.");
+         "Must be in the Initialization phase.");
+  // This is created again to avoid sending it through Charm++ callbacks, and
+  // so it goes cleanly out of scope after initialization
+  const auto items_from_options =
+      options_.template apply<option_list, Metavariables>(
+          [](auto... args) noexcept {
+            return tuples::tagged_tuple_from_typelist<option_list>(
+                std::move(args)...);
+          });
   using array_component_list =
       tmpl::filter<component_list,
                    Parallel::is_array_proxy<tmpl::bind<
                        Parallel::proxy_from_parallel_component, tmpl::_1>>>;
-  tmpl::for_each<array_component_list>([this](auto array_component) noexcept {
-    using ParallelComponent = tmpl::type_from<decltype(array_component)>;
-    options_.template apply<typename ParallelComponent::options, Metavariables>(
-        [this](auto... opts) {
-          ParallelComponent::initialize(const_global_cache_proxy_,
-                                        std::move(opts)...);
-        });
+  tmpl::for_each<array_component_list>([ this, &items_from_options ](
+      auto parallel_component_v) noexcept {
+    using parallel_component = tmpl::type_from<decltype(parallel_component_v)>;
+    parallel_component::allocate_array(
+        const_global_cache_proxy_,
+        Parallel::create_from_options(
+            items_from_options,
+            typename parallel_component::initialization_tags{}));
   });
-  tmpl::for_each<component_list>([this](auto parallel_component) noexcept {
-    using ParallelComponent = tmpl::type_from<decltype(parallel_component)>;
-    Parallel::get_parallel_component<ParallelComponent>(
+  tmpl::for_each<component_list>([this](auto parallel_component_v) noexcept {
+    using parallel_component = tmpl::type_from<decltype(parallel_component_v)>;
+    Parallel::get_parallel_component<parallel_component>(
         *(const_global_cache_proxy_.ckLocalBranch()))
         .start_phase(current_phase_);
   });

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -5,6 +5,7 @@
 
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 namespace Parallel {
@@ -140,6 +141,27 @@ template <typename InitializationTagsList>
 using get_option_tags = tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
     InitializationTagsList,
     detail::get_option_tags_from_initialization_tag<tmpl::_1>>>>;
+
+namespace detail {
+template <typename Tag, typename... OptionTags, typename... OptionTagsForTag>
+typename Tag::type create_initialization_item_from_options(
+    const tuples::TaggedTuple<OptionTags...>& options,
+    tmpl::list<OptionTagsForTag...> /*meta*/) noexcept {
+  return Tag::create_from_options(tuples::get<OptionTagsForTag>(options)...);
+}
+}  // namespace detail
+
+/// \ingroup ParallelGroup
+/// \brief Given a list of tags and a tagged tuple containing items
+/// created from input options, return a tagged tuple of items constructed
+/// by calls to create_from_options for each tag in the list.
+template <typename... Tags, typename... OptionTags>
+tuples::TaggedTuple<Tags...> create_from_options(
+    const tuples::TaggedTuple<OptionTags...>& options,
+    tmpl::list<Tags...> /*meta*/) noexcept {
+  return {detail::create_initialization_item_from_options<Tags>(
+      options, typename Tags::option_tags{})...};
+}
 
 /// \cond
 namespace Algorithms {

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -101,6 +101,31 @@ template <typename PhaseDepActionList>
 using get_initialization_actions_list = tmpl::flatten<tmpl::transform<
     PhaseDepActionList, detail::get_initialization_actions_list<tmpl::_1>>>;
 
+namespace detail {
+template <typename Action, typename = cpp17::void_t<>>
+struct get_initialization_tags_from_action {
+  using type = tmpl::list<>;
+};
+
+template <typename Action>
+struct get_initialization_tags_from_action<
+    Action, cpp17::void_t<typename Action::initialization_tags>> {
+  using type = typename Action::initialization_tags;
+};
+}  // namespace detail
+
+/// \ingroup ParallelGroup
+/// \brief Given a list of initialization actions, and possibly a list of tags
+/// needed for allocation of an array component, returns a list of the
+/// unique initialization_tags for all the actions (and the allocate function).
+template <typename InitializationActionsList,
+          typename AllocationTagsList = tmpl::list<>>
+using get_initialization_tags = tmpl::remove_duplicates<tmpl::flatten<
+    tmpl::list<AllocationTagsList,
+               tmpl::transform<
+                   InitializationActionsList,
+                   detail::get_initialization_tags_from_action<tmpl::_1>>>>>;
+
 /// \cond
 namespace Algorithms {
 struct Singleton;

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -80,6 +80,27 @@ using get_const_global_cache_tags_from_pdal =
             get_action_list_from_phase_dep_action_list<tmpl::_1>>>,
         Parallel_detail::get_const_global_cache_tags_from_action<tmpl::_1>>>>;
 
+namespace detail {
+template <typename PhaseAction>
+struct get_initialization_actions_list {
+  using type = tmpl::list<>;
+};
+
+template <typename PhaseType, typename InitializationActionsList>
+struct get_initialization_actions_list<Parallel::PhaseActions<
+    PhaseType, PhaseType::Initialization, InitializationActionsList>> {
+  using type = InitializationActionsList;
+};
+}  // namespace detail
+
+/// \ingroup ParallelGroup
+/// \brief Given the phase dependent action list, return the list of
+/// actions in the Initialization phase (or an empty list if the Initialization
+/// phase is absent from the phase dependent action list)
+template <typename PhaseDepActionList>
+using get_initialization_actions_list = tmpl::flatten<tmpl::transform<
+    PhaseDepActionList, detail::get_initialization_actions_list<tmpl::_1>>>;
+
 /// \cond
 namespace Algorithms {
 struct Singleton;

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -126,6 +126,21 @@ using get_initialization_tags = tmpl::remove_duplicates<tmpl::flatten<
                    InitializationActionsList,
                    detail::get_initialization_tags_from_action<tmpl::_1>>>>>;
 
+namespace detail {
+template <typename InitializationTag>
+struct get_option_tags_from_initialization_tag {
+  using type = typename InitializationTag::option_tags;
+};
+}  // namespace detail
+
+/// \ingroup ParallelGroup
+/// \brief Given a list of initialization tags, returns a list of the
+/// unique option tags required to construct them.
+template <typename InitializationTagsList>
+using get_option_tags = tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+    InitializationTagsList,
+    detail::get_option_tags_from_initialization_tag<tmpl::_1>>>>;
+
 /// \cond
 namespace Algorithms {
 struct Singleton;

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
@@ -62,9 +62,8 @@ namespace Actions {
  */
 template <size_t Dim>
 struct InitializeDomain {
-  using initialization_option_tags =
-      tmpl::list<::Tags::InitialExtents<Dim>,
-                 ::Tags::Domain<Dim, Frame::Inertial>>;
+  using initialization_tags = tmpl::list<::Tags::InitialExtents<Dim>,
+                                         ::Tags::Domain<Dim, Frame::Inertial>>;
 
   template <
       typename DataBox, typename... InboxTags, typename Metavariables,

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp
@@ -88,7 +88,7 @@ struct InitializeMortars {
       typename flux_comm_types::simple_mortar_data_tag>;
 
  public:
-  using initialization_option_tags = tmpl::list<::Tags::InitialExtents<dim>>;
+  using initialization_tags = tmpl::list<::Tags::InitialExtents<dim>>;
 
   template <typename DataBox, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent,

--- a/src/Utilities/TaggedTuple.hpp
+++ b/src/Utilities/TaggedTuple.hpp
@@ -721,6 +721,7 @@ std::ostream& operator<<(std::ostream& os,
   auto helper = make_overloader(
       [&current_value, &os](const auto& element,
                             const std::integral_constant<bool, true> /*meta*/) {
+        using ::operator<<;
         os << element;
         current_value++;
         if (current_value < sizeof...(Tags)) {

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -168,10 +168,10 @@ struct mock_interpolation_target {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>>>>;
+          Metavariables, InterpolationTargetTag>>>>;
   using add_options_to_databox =
       typename intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template AddOptionsToDataBox<Metavariables>;
+          Metavariables, InterpolationTargetTag>::AddOptionsToDataBox;
 
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
@@ -217,8 +217,7 @@ struct MockMetavariables {
                  GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>;
   using interpolation_target_tags = tmpl::list<AhA>;
   using temporal_id  = ::Tags::TimeId;
-  using domain_frame = Frame::Inertial;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
   using component_list =
       tmpl::list<mock_interpolation_target<MockMetavariables, AhA>,
                  mock_interpolator<MockMetavariables>>;

--- a/tests/Unit/DataStructures/VectorImplTestHelper.hpp
+++ b/tests/Unit/DataStructures/VectorImplTestHelper.hpp
@@ -515,12 +515,13 @@ void test_function_on_vector_operands(
   const size_t size = size_distribution(generator);
   // using each distribution, generate a value for the appropriate operand type
   // and put it in a tuple.
-  std::tuple<Operands...> operand_values{make_with_random_values<Operands>(
-      make_not_null(&generator),
-      UniformCustomDistribution<
-          tt::get_fundamental_type_t<get_vector_element_type_t<Operands>>>{
-          std::get<Is>(bounds)},
-      size)...};
+  std::tuple<std::decay_t<Operands>...> operand_values{
+      make_with_random_values<Operands>(
+          make_not_null(&generator),
+          UniformCustomDistribution<
+              tt::get_fundamental_type_t<get_vector_element_type_t<Operands>>>{
+              std::get<Is>(bounds)},
+          size)...};
   // wrap the tuple of random values according to the passed in `Wraps`
   auto wrapped_operands = wrap_tuple<Wraps...>(
       operand_values, std::make_index_sequence<sizeof...(Bounds)>{});

--- a/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -72,12 +72,12 @@ struct mock_interpolation_target {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<intrp::Actions::InitializeInterpolationTarget<
-              InterpolationTargetTag>>>,
+              Metavariables, InterpolationTargetTag>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
   using add_options_to_databox =
       typename intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template AddOptionsToDataBox<Metavariables>;
+          Metavariables, InterpolationTargetTag>::AddOptionsToDataBox;
 };
 
 template <typename InterpolationTargetTag>

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -56,12 +56,12 @@ struct mock_interpolation_target {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<intrp::Actions::InitializeInterpolationTarget<
-              InterpolationTargetTag>>>,
+              Metavariables, InterpolationTargetTag>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
   using add_options_to_databox =
       typename intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template AddOptionsToDataBox<Metavariables>;
+          Metavariables, InterpolationTargetTag>::AddOptionsToDataBox;
 };
 
 struct MockComputeTargetPoints {
@@ -94,8 +94,7 @@ struct MockMetavariables {
     using compute_target_points = MockComputeTargetPoints;
   };
   using temporal_id = ::Tags::TimeId;
-  using domain_frame = Frame::Inertial;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
 
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
@@ -71,7 +71,7 @@ struct MockMetavariables {
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
   using temporal_id = ::Tags::TimeId;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags =
       tmpl::list<InterpolationTagA, InterpolationTagB, InterpolationTagC>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -42,10 +42,10 @@ struct mock_interpolation_target {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>>>>;
+          Metavariables, InterpolationTargetTag>>>>;
   using add_options_to_databox =
       typename intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template AddOptionsToDataBox<Metavariables>;
+          Metavariables, InterpolationTargetTag>::AddOptionsToDataBox;
 };
 
 struct Metavariables {
@@ -54,8 +54,7 @@ struct Metavariables {
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
   using temporal_id = ::Tags::TimeId;
-  using domain_frame = Frame::Inertial;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
 
   using component_list = tmpl::list<
       mock_interpolation_target<Metavariables, InterpolationTargetA>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
@@ -45,7 +45,7 @@ struct Metavariables {
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
   using temporal_id = ::Tags::TimeId;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolatorTargetA>;
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -117,7 +117,7 @@ template <typename Metavariables>
 struct mock_element {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
-  using array_index = ElementIndex<Metavariables::domain_dim>;
+  using array_index = ElementIndex<Metavariables::volume_dim>;
   using const_global_cache_tag_list = tmpl::list<>;
   using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list =
@@ -132,7 +132,7 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target = tmpl::list<Tags::Lapse>;
   };
   using temporal_id = ::Tags::TimeId;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<Tags::Lapse>;
   using interpolation_target_tags = tmpl::list<InterpolatorTargetA>;
 
@@ -145,8 +145,8 @@ struct MockMetavariables {
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
                   "[Unit]") {
   using metavars = MockMetavariables;
-  const ElementId<metavars::domain_dim> element_id(2);
-  const ElementIndex<metavars::domain_dim> array_index(element_id);
+  const ElementId<metavars::volume_dim> element_id(2);
+  const ElementIndex<metavars::volume_dim> array_index(element_id);
 
   using interp_component = mock_interpolator<metavars>;
   using elem_component = mock_element<metavars>;
@@ -159,7 +159,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
                                              array_index);
   runner.set_phase(metavars::Phase::Testing);
 
-  const Mesh<metavars::domain_dim> mesh(5, Spectral::Basis::Legendre,
+  const Mesh<metavars::volume_dim> mesh(5, Spectral::Basis::Legendre,
                                         Spectral::Quadrature::GaussLobatto);
   const double observation_time = 2.0;
   Variables<metavars::interpolator_source_vars> vars(
@@ -168,11 +168,11 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
   std::iota(vars.data(), vars.data() + vars.size(), 1.0);
 
   const auto box = db::create<db::AddSimpleTags<
-      metavars::temporal_id, ::Tags::Mesh<metavars::domain_dim>,
+      metavars::temporal_id, ::Tags::Mesh<metavars::volume_dim>,
       ::Tags::Variables<typename decltype(vars)::tags_list>>>(
       TimeId(true, 0, Slab(0., observation_time).end()), mesh, vars);
 
-  intrp::Events::Interpolate<metavars::domain_dim,
+  intrp::Events::Interpolate<metavars::volume_dim,
                              metavars::interpolator_source_vars> event{};
 
   event.run(box, runner.cache(), array_index,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -38,8 +38,7 @@ struct MockMetavariables {
     using type = compute_target_points::options_type;
   };
   using temporal_id = ::Tags::TimeId;
-  using domain_frame = Frame::Inertial;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -34,8 +34,7 @@ struct MockMetavariables {
     using type = compute_target_points::options_type;
   };
   using temporal_id = ::Tags::TimeId;
-  using domain_frame = Frame::Inertial;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -30,8 +30,7 @@ struct MockMetavariables {
     using type = compute_target_points::options_type;
   };
   using temporal_id = ::Tags::TimeId;
-  using domain_frame = Frame::Inertial;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -79,7 +79,7 @@ struct mock_interpolation_target {
   using const_global_cache_tag_list = tmpl::list<>;
   using simple_tags =
       db::get_items<typename intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template return_tag_list<Metavariables>>;
+          Metavariables, InterpolationTargetTag>::return_tag_list>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -88,7 +88,7 @@ struct mock_interpolation_target {
                              Metavariables::Phase::Testing, tmpl::list<>>>;
   using add_options_to_databox =
       typename intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template AddOptionsToDataBox<Metavariables>;
+          Metavariables, InterpolationTargetTag>::AddOptionsToDataBox;
 };
 
 template <typename InterpolationTargetTag>
@@ -226,8 +226,7 @@ struct MockMetavariables {
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
   using temporal_id = ::Tags::TimeId;
-  using domain_frame = Frame::Inertial;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
 
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -32,8 +32,7 @@ struct MockMetavariables {
     using type = compute_target_points::options_type;
   };
   using temporal_id = ::Tags::TimeId;
-  using domain_frame = Frame::Inertial;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -114,12 +114,12 @@ struct mock_interpolation_target {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<intrp::Actions::InitializeInterpolationTarget<
-              InterpolationTargetTag>>>,
+              Metavariables, InterpolationTargetTag>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
   using add_options_to_databox =
       typename intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template AddOptionsToDataBox<Metavariables>;
+          Metavariables, InterpolationTargetTag>::AddOptionsToDataBox;
 
   using replace_these_simple_actions =
       tmpl::list<intrp::Actions::InterpolationTargetReceiveVars<
@@ -155,8 +155,7 @@ struct Metavariables {
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
   using temporal_id = ::Tags::TimeId;
-  using domain_frame = Frame::Inertial;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
   using component_list =
       tmpl::list<mock_interpolation_target<Metavariables, InterpolationTargetA>,
                  mock_interpolator<Metavariables>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -126,7 +126,7 @@ struct MockInterpolationTargetReceiveVars {
       for (size_t s = 0; s < global_offsets[i].size(); ++s) {
         // Coords at this point. They are the same as the input coordinates,
         // but in strange order because of global_offsets.
-        std::array<double, Metavariables::domain_dim> coords{
+        std::array<double, Metavariables::volume_dim> coords{
             {1.0 + 0.1 * global_offsets[i][s],
              1.0 + 0.12 * global_offsets[i][s],
              1.0 + 0.14 * global_offsets[i][s]}};
@@ -188,7 +188,7 @@ struct mock_interpolation_target {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<intrp::Actions::InitializeInterpolationTarget<
-              InterpolationTargetTag>>>,
+              Metavariables, InterpolationTargetTag>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Registration, tmpl::list<>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -196,7 +196,7 @@ struct mock_interpolation_target {
 
   using add_options_to_databox =
       typename intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template AddOptionsToDataBox<Metavariables>;
+          Metavariables, InterpolationTargetTag>::AddOptionsToDataBox;
 
   using replace_these_simple_actions =
       tmpl::list<intrp::Actions::InterpolationTargetReceiveVars<
@@ -238,8 +238,7 @@ struct MockMetavariables {
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
   using temporal_id = ::Tags::TimeId;
-  using domain_frame = Frame::Inertial;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
       mock_interpolator<MockMetavariables>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -71,7 +71,7 @@ struct MockMetavariables {
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
   using temporal_id = ::Tags::TimeId;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolatorTargetA>;
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -169,7 +169,7 @@ struct MockInterpolationTarget {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<intrp::Actions::InitializeInterpolationTarget<
-              InterpolationTargetTag>>>,
+              Metavariables, InterpolationTargetTag>>>,
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Registration,
           tmpl::list<::observers::Actions::RegisterSingletonWithObserverWriter<
@@ -178,7 +178,7 @@ struct MockInterpolationTarget {
                              Metavariables::Phase::Testing, tmpl::list<>>>;
   using add_options_to_databox =
       typename intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template AddOptionsToDataBox<Metavariables>;
+          Metavariables, InterpolationTargetTag>::AddOptionsToDataBox;
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
 };
@@ -273,8 +273,7 @@ struct MockMetavariables {
                  gr::Tags::SpatialMetric<3, Frame::Inertial>>;
   using interpolation_target_tags = tmpl::list<SurfaceA, SurfaceB, SurfaceC>;
   using temporal_id = ::Tags::TimeId;
-  using domain_frame = Frame::Inertial;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
   using component_list =
       tmpl::list<MockObserverWriter<MockMetavariables>,
                  MockInterpolationTarget<MockMetavariables, SurfaceA>,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -183,14 +183,14 @@ struct mock_interpolation_target {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<intrp::Actions::InitializeInterpolationTarget<
-              InterpolationTargetTag>>>,
+              Metavariables, InterpolationTargetTag>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Registration, tmpl::list<>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
   using add_options_to_databox =
       typename intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template AddOptionsToDataBox<Metavariables>;
+          Metavariables, InterpolationTargetTag>::AddOptionsToDataBox;
 
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
@@ -252,8 +252,7 @@ struct MockMetavariables {
       tmpl::list<InterpolationTargetA, InterpolationTargetB,
                  InterpolationTargetC>;
   using temporal_id = ::Tags::TimeId;
-  using domain_frame = Frame::Inertial;
-  static constexpr size_t domain_dim = 3;
+  static constexpr size_t volume_dim = 3;
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
       mock_interpolation_target<MockMetavariables, InterpolationTargetB>,

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -241,9 +241,6 @@ struct OutputCleaner {
   using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using const_global_cache_tag_list = tmpl::list<>;
 
-  static void initialize(Parallel::CProxy_ConstGlobalCache<
-                         Metavariables>& /*global_cache*/) noexcept {}
-
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {

--- a/tests/Unit/Options/Test_Factory.cpp
+++ b/tests/Unit/Options/Test_Factory.cpp
@@ -160,6 +160,12 @@ void test_factory_with_metavars() {
   // `creatable_classes`
   CHECK(opts.get<OptionType, Metavars<false>>()->name() ==
         "TestWithArg(stuff)no");
+  auto result_true = opts.apply<tmpl::list<OptionType>, Metavars<true>>(
+      [&](auto arg) { return arg; });
+  CHECK(result_true->name() == "TestWithArg(stuff)yes");
+  auto result_false = opts.apply<tmpl::list<OptionType>, Metavars<false>>(
+      [&](auto arg) { return arg; });
+  CHECK(result_false->name() == "TestWithArg(stuff)no");
 }
 
 void test_factory_object_vector() {

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -121,12 +121,24 @@ add_algorithm_test("AlgorithmNodelock" "")
 
 # Tests that do not require their own Chare setup and can work with the
 # unit tests
-set(PARALLEL_TESTS
-  Parallel/Test_ConstGlobalCacheDataBox.cpp
-  Parallel/Test_Parallel.cpp
-  Parallel/Test_ParallelComponentHelpers.cpp
-  Parallel/Test_PupStlCpp11.cpp
-  Parallel/Test_TypeTraits.cpp
+set(LIBRARY "Test_Parallel")
+
+set(LIBRARY_SOURCES
+  Test_ConstGlobalCacheDataBox.cpp
+  Test_Parallel.cpp
+  Test_ParallelComponentHelpers.cpp
+  Test_PupStlCpp11.cpp
+  Test_TypeTraits.cpp
   )
 
-set(SPECTRE_TESTS "${SPECTRE_TESTS};${PARALLEL_TESTS}" PARENT_SCOPE)
+add_test_library(
+  ${LIBRARY}
+  "Parallel"
+  "${LIBRARY_SOURCES}"
+  ""
+  )
+
+add_dependencies(
+  ${LIBRARY}
+  module_ConstGlobalCache
+  )

--- a/tests/Unit/Parallel/Test_AlgorithmBadBoxApply.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmBadBoxApply.cpp
@@ -47,9 +47,6 @@ struct Component {
   using const_global_cache_tag_list = tmpl::list<>;
   using options = tmpl::list<>;
 
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
-
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
       const Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -212,8 +212,6 @@ struct NoOpsComponent {
   using const_global_cache_tag_list = tmpl::list<>;
   using options = tmpl::list<>;
 
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
@@ -376,8 +374,6 @@ struct MutateComponent {
   using const_global_cache_tag_list = tmpl::list<>;
   using options = tmpl::list<>;
 
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
@@ -545,9 +541,6 @@ struct ReceiveComponent {
   using const_global_cache_tag_list = tmpl::list<>;
   using options = tmpl::list<>;
 
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
-
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
       const Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
@@ -658,9 +651,6 @@ struct AnyOrderComponent {
                                         receive_data_test::update_instance>>>;
   using const_global_cache_tag_list = tmpl::list<>;
   using options = tmpl::list<>;
-
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -26,6 +26,7 @@
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Main.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
@@ -200,7 +201,6 @@ template <class Metavariables>
 struct NoOpsComponent {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Initialization,
@@ -209,9 +209,9 @@ struct NoOpsComponent {
           typename Metavariables::Phase, Metavariables::Phase::NoOpsStart,
           tmpl::list<no_op_test::increment_count_actions_called,
                      no_op_test::no_op>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   using const_global_cache_tag_list = tmpl::list<>;
-  using options = tmpl::list<>;
-
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
@@ -361,7 +361,6 @@ struct MutateComponent {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
   using array_index = ElementId;  // Just to test nothing breaks
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Initialization,
@@ -371,8 +370,9 @@ struct MutateComponent {
                              tmpl::list<add_remove_test::add_int_value_10,
                                         add_remove_test::increment_int0,
                                         add_remove_test::remove_int0>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   using const_global_cache_tag_list = tmpl::list<>;
-  using options = tmpl::list<>;
 
 
   static void execute_next_phase(
@@ -527,7 +527,6 @@ struct ReceiveComponent {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
   using array_index = ElementId;  // Just to test nothing breaks
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Initialization,
@@ -538,8 +537,9 @@ struct ReceiveComponent {
                      add_remove_test::increment_int0,
                      add_remove_test::remove_int0,
                      receive_data_test::update_instance>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   using const_global_cache_tag_list = tmpl::list<>;
-  using options = tmpl::list<>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
@@ -636,7 +636,6 @@ struct AnyOrderComponent {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
   using array_index = ElementId;  // Just to test nothing breaks
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -649,8 +648,9 @@ struct AnyOrderComponent {
                                         any_order::iterate_increment_int0,
                                         add_remove_test::remove_int0,
                                         receive_data_test::update_instance>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   using const_global_cache_tag_list = tmpl::list<>;
-  using options = tmpl::list<>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
@@ -7,11 +7,11 @@
 #include "DataStructures/DataBox/DataBox.hpp"  // IWYU pragma: keep
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Options/Options.hpp"
-#include "Parallel/AddOptionsToDataBox.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Main.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 
@@ -39,18 +39,18 @@ template <class Metavariables>
 struct Component {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
                                         Metavariables::Phase::Initialization,
                                         tmpl::list<>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   using const_global_cache_tag_list = tmpl::list<>;
-  using options = tmpl::list<>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
-      const Parallel::CProxy_ConstGlobalCache<
-          Metavariables>& global_cache) {
+      const Parallel::CProxy_ConstGlobalCache<Metavariables>&
+          global_cache) noexcept {
     if (next_phase == Metavariables::Phase::Execute) {
       auto& local_cache = *(global_cache.ckLocalBranch());
       Parallel::simple_action<error_call_single_action_from_action>(*(

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
@@ -47,9 +47,6 @@ struct Component {
   using const_global_cache_tag_list = tmpl::list<>;
   using options = tmpl::list<>;
 
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
-
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
       const Parallel::CProxy_ConstGlobalCache<

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
@@ -48,29 +48,34 @@ struct Component {
   using options = tmpl::list<>;
 
   static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
-    auto& local_cache = *(global_cache.ckLocalBranch());
-    Parallel::simple_action<error_call_single_action_from_action>(
-        *(Parallel::get_parallel_component<Component>(local_cache).ckLocal()));
-  }
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
 
   static void execute_next_phase(
-      const typename Metavariables::Phase /*next_phase*/,
+      const typename Metavariables::Phase next_phase,
       const Parallel::CProxy_ConstGlobalCache<
-          Metavariables>& /*global_cache*/) {}
+          Metavariables>& global_cache) {
+    if (next_phase == Metavariables::Phase::Execute) {
+      auto& local_cache = *(global_cache.ckLocalBranch());
+      Parallel::simple_action<error_call_single_action_from_action>(*(
+          Parallel::get_parallel_component<Component>(local_cache).ckLocal()));
+    }
+  }
 };
 
 struct TestMetavariables {
   using component_list = tmpl::list<Component<TestMetavariables>>;
   using const_global_cache_tag_list = tmpl::list<>;
 
-  enum class Phase { Initialization, Exit };
+  enum class Phase { Initialization, Execute, Exit };
 
   static constexpr OptionString help = "Executable for testing";
 
-  static Phase determine_next_phase(const Phase& /*current_phase*/,
+  static Phase determine_next_phase(const Phase& current_phase,
                                     const Parallel::CProxy_ConstGlobalCache<
                                         TestMetavariables>& /*cache_proxy*/) {
+    if (current_phase == Phase::Initialization) {
+      return Phase::Execute;
+    }
     return Phase::Exit;
   }
 };

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
@@ -7,11 +7,11 @@
 #include "DataStructures/DataBox/DataBox.hpp"  // IWYU pragma: keep
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Options/Options.hpp"
-#include "Parallel/AddOptionsToDataBox.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Main.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 
@@ -43,17 +43,18 @@ template <class Metavariables>
 struct Component {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
                                         Metavariables::Phase::Initialization,
                                         tmpl::list<>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   using const_global_cache_tag_list = tmpl::list<>;
-  using options = tmpl::list<>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
-      const Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
+      const Parallel::CProxy_ConstGlobalCache<Metavariables>&
+          global_cache) noexcept {
     if (next_phase == Metavariables::Phase::Execute) {
       auto& local_cache = *(global_cache.ckLocalBranch());
       Parallel::simple_action<error_call_single_action_from_action>(*(

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
@@ -51,9 +51,6 @@ struct Component {
   using const_global_cache_tag_list = tmpl::list<>;
   using options = tmpl::list<>;
 
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
-
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
       const Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
@@ -52,29 +52,33 @@ struct Component {
   using options = tmpl::list<>;
 
   static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
-    auto& local_cache = *(global_cache.ckLocalBranch());
-    Parallel::simple_action<error_call_single_action_from_action>(
-        *(Parallel::get_parallel_component<Component>(local_cache).ckLocal()));
-  }
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
 
   static void execute_next_phase(
-      const typename Metavariables::Phase /*next_phase*/,
-      const Parallel::CProxy_ConstGlobalCache<
-          Metavariables>& /*global_cache*/) {}
+      const typename Metavariables::Phase next_phase,
+      const Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
+    if (next_phase == Metavariables::Phase::Execute) {
+      auto& local_cache = *(global_cache.ckLocalBranch());
+      Parallel::simple_action<error_call_single_action_from_action>(*(
+          Parallel::get_parallel_component<Component>(local_cache).ckLocal()));
+    }
+  }
 };
 
 struct TestMetavariables {
   using component_list = tmpl::list<Component<TestMetavariables>>;
   using const_global_cache_tag_list = tmpl::list<>;
 
-  enum class Phase { Initialization, Exit };
+  enum class Phase { Initialization, Execute, Exit };
 
   static constexpr OptionString help = "Executable for testing";
 
-  static Phase determine_next_phase(const Phase& /*current_phase*/,
+  static Phase determine_next_phase(const Phase& current_phase,
                                     const Parallel::CProxy_ConstGlobalCache<
                                         TestMetavariables>& /*cache_proxy*/) {
+    if (current_phase == Phase::Initialization) {
+      return Phase::Execute;
+    }
     return Phase::Exit;
   }
 };

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -323,9 +323,6 @@ struct NodegroupParallelComponent {
                      typename Metavariables::Phase,
                      Metavariables::Phase::CheckThreadedResult, tmpl::list<>>>;
 
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
-
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -18,12 +18,12 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
-#include "Parallel/AddOptionsToDataBox.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Info.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Main.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Parallel/Printf.hpp"
 #include "Utilities/Gsl.hpp"
@@ -433,16 +433,17 @@ struct SingletonParallelComponent {
   using chare_type = Parallel::Algorithms::Singleton;
   using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::PerformSingletonAlgorithm,
                              tmpl::list<SingletonActions::CountReceives>>>;
-  using options = tmpl::list<>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
-      const Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
+      const Parallel::CProxy_ConstGlobalCache<Metavariables>&
+          global_cache) noexcept {
     if (next_phase == Metavariables::Phase::PerformSingletonAlgorithm) {
       auto& local_cache = *(global_cache.ckLocalBranch());
       /// [perform_algorithm]
@@ -461,7 +462,6 @@ struct ArrayParallelComponent {
   using chare_type = Parallel::Algorithms::Array;
   using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Initialization,
@@ -471,11 +471,14 @@ struct ArrayParallelComponent {
           Metavariables::Phase::PerformArrayAlgorithm,
           tmpl::list<ArrayActions::AddIntValue10, ArrayActions::IncrementInt0,
                      ArrayActions::RemoveInt0, ArrayActions::SendToSingleton>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   using array_index = int;
-  using options = tmpl::list<>;
 
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
+  static void allocate_array(
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      /*initialization_items*/) noexcept {
     auto& local_cache = *(global_cache.ckLocalBranch());
     auto& array_proxy =
         Parallel::get_parallel_component<ArrayParallelComponent>(local_cache);
@@ -491,7 +494,7 @@ struct ArrayParallelComponent {
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
     auto& local_cache = *(global_cache.ckLocalBranch());
     if (next_phase == Metavariables::Phase::PerformArrayAlgorithm) {
       Parallel::get_parallel_component<ArrayParallelComponent>(local_cache)
@@ -506,15 +509,16 @@ struct GroupParallelComponent {
   using chare_type = Parallel::Algorithms::Group;
   using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<GroupActions::Initialize, GroupActions::CheckComponentType>>>;
-  using options = tmpl::list<>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase /*next_phase*/,
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
+      Parallel::CProxy_ConstGlobalCache<
+          Metavariables>& /*global_cache*/) noexcept {}
 };
 
 template <class Metavariables>
@@ -522,16 +526,17 @@ struct NodegroupParallelComponent {
   using chare_type = Parallel::Algorithms::Nodegroup;
   using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<NodegroupActions::Initialize,
                  GroupActions::CheckComponentType>>>;
-  using options = tmpl::list<>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase /*next_phase*/,
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
+      Parallel::CProxy_ConstGlobalCache<
+          Metavariables>& /*global_cache*/) noexcept {}
 };
 
 struct TestMetavariables {

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -440,9 +440,6 @@ struct SingletonParallelComponent {
                              tmpl::list<SingletonActions::CountReceives>>>;
   using options = tmpl::list<>;
 
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
-
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
       const Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
@@ -515,9 +512,6 @@ struct GroupParallelComponent {
       tmpl::list<GroupActions::Initialize, GroupActions::CheckComponentType>>>;
   using options = tmpl::list<>;
 
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
-
   static void execute_next_phase(
       const typename Metavariables::Phase /*next_phase*/,
       Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
@@ -534,9 +528,6 @@ struct NodegroupParallelComponent {
       tmpl::list<NodegroupActions::Initialize,
                  GroupActions::CheckComponentType>>>;
   using options = tmpl::list<>;
-
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
 
   static void execute_next_phase(
       const typename Metavariables::Phase /*next_phase*/,

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -19,12 +19,12 @@
 #include "DataStructures/DataBox/DataBox.hpp"  // IWYU pragma: keep
 #include "ErrorHandling/Error.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
-#include "Parallel/AddOptionsToDataBox.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Info.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Main.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Parallel/Reduction.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -105,13 +105,13 @@ template <class Metavariables>
 struct SingletonParallelComponent {
   using chare_type = Parallel::Algorithms::Singleton;
   using const_global_cache_tag_list = tmpl::list<>;
-  using options = tmpl::list<>;
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
                                         Metavariables::Phase::Initialization,
                                         tmpl::list<>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase /*next_phase*/,
@@ -230,17 +230,19 @@ template <class Metavariables>
 struct ArrayParallelComponent {
   using chare_type = Parallel::Algorithms::Array;
   using const_global_cache_tag_list = tmpl::list<>;
-  using options = tmpl::list<>;
   using metavariables = Metavariables;
   using array_index = int;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
                                         Metavariables::Phase::Initialization,
                                         tmpl::list<>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
+  static void allocate_array(
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      /*initialization_items*/) noexcept {
     auto& local_cache = *(global_cache.ckLocalBranch());
     auto& array_proxy =
         Parallel::get_parallel_component<ArrayParallelComponent>(local_cache);
@@ -256,7 +258,7 @@ struct ArrayParallelComponent {
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
     auto& local_cache = *(global_cache.ckLocalBranch());
     if (next_phase == Metavariables::Phase::CallArrayReduce) {
       Parallel::simple_action<ArrayReduce>(

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -113,9 +113,6 @@ struct SingletonParallelComponent {
                                         Metavariables::Phase::Initialization,
                                         tmpl::list<>>>;
 
-  static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
-
   static void execute_next_phase(
       const typename Metavariables::Phase /*next_phase*/,
       const Parallel::CProxy_ConstGlobalCache<

--- a/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
@@ -23,10 +23,10 @@ void register_pupables();
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Informer/InfoFromBuild.hpp"
 #include "Parallel/Abort.hpp"
-#include "Parallel/AddOptionsToDataBox.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Exit.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Parallel/Printf.hpp"
 #include "Utilities/TMPL.hpp"
@@ -96,12 +96,12 @@ template <class Metavariables>
 struct SingletonParallelComponent {
   using chare_type = Parallel::Algorithms::Singleton;
   using const_global_cache_tag_list = tmpl::list<name, age, height>;
-  using options = tmpl::list<>;
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
 
 template <class Metavariables>
@@ -109,36 +109,36 @@ struct ArrayParallelComponent {
   using chare_type = Parallel::Algorithms::Array;
   using const_global_cache_tag_list = tmpl::list<height, shape_of_nametag>;
   using array_index = int;
-  using options = tmpl::list<>;
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
 
 template <class Metavariables>
 struct GroupParallelComponent {
   using chare_type = Parallel::Algorithms::Group;
   using const_global_cache_tag_list = tmpl::list<name>;
-  using options = tmpl::list<>;
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
 
 template <class Metavariables>
 struct NodegroupParallelComponent {
   using chare_type = Parallel::Algorithms::Nodegroup;
   using const_global_cache_tag_list = tmpl::list<height>;
-  using options = tmpl::list<>;
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
 
 struct TestMetavariables {

--- a/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
+++ b/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
@@ -19,6 +19,33 @@ struct Action2 {
   using inbox_tags = tmpl::list<Tag1, Tag2, Tag3>;
 };
 
+struct InitAction0 {};
+struct InitAction1 {};
+struct InitAction2 {};
+struct InitAction3 {};
+
+enum class Phase { Initialization, Execute, Exit };
+
+struct ComponentInit {
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Phase, Phase::Initialization,
+      tmpl::list<InitAction0, InitAction1, InitAction2>>>;
+};
+
+struct ComponentExecute {
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Phase, Phase::Execute,
+                                        tmpl::list<Action0, Action1>>>;
+};
+
+struct ComponentInitAndExecute {
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Phase, Phase::Initialization,
+                             tmpl::list<InitAction3>>,
+      Parallel::PhaseActions<Phase, Phase::Execute,
+                             tmpl::list<InitAction2, Action0, Action2>>>;
+};
+
 static_assert(cpp17::is_same_v<Parallel::get_inbox_tags_from_action<Action2>,
                                tmpl::list<Tag1, Tag2, Tag3>>,
               "Failed testing get_inbox_tags_from_action");
@@ -28,4 +55,23 @@ static_assert(
         Parallel::get_inbox_tags<tmpl::list<Action0, Action1, Action2>>,
         tmpl::list<Tag0, Tag1, Tag2, Tag3>>,
     "Failed testing get_inbox_tags");
+
+static_assert(
+    cpp17::is_same_v<Parallel::get_initialization_actions_list<
+                         ComponentInit::phase_dependent_action_list>,
+                     tmpl::list<InitAction0, InitAction1, InitAction2>>,
+    "Failed testing get_intialization_actions_list");
+
+static_assert(
+    cpp17::is_same_v<Parallel::get_initialization_actions_list<
+                         ComponentExecute::phase_dependent_action_list>,
+                     tmpl::list<>>,
+    "Failed testing get_intialization_actions_list");
+
+static_assert(
+    cpp17::is_same_v<Parallel::get_initialization_actions_list<
+                         ComponentInitAndExecute::phase_dependent_action_list>,
+                     tmpl::list<InitAction3>>,
+    "Failed testing get_intialization_actions_list");
+
 }  // namespace

--- a/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
+++ b/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
@@ -77,20 +77,20 @@ struct ComponentInitWithAllocate {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Phase, Phase::Initialization,
       tmpl::list<InitAction0, InitAction1, InitAction2>>>;
-  using allocation_tags = tmpl::list<InitTag4, InitTag5>;
+  using array_allocation_tags = tmpl::list<InitTag4, InitTag5>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>,
-      allocation_tags>;
+      array_allocation_tags>;
 };
 
 struct ComponentExecuteWithAllocate {
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<Phase, Phase::Execute,
                                         tmpl::list<Action0, Action1>>>;
-  using allocation_tags = tmpl::list<InitTag6, InitTag7>;
+  using array_allocation_tags = tmpl::list<InitTag6, InitTag7>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>,
-      allocation_tags>;
+      array_allocation_tags>;
 };
 
 struct ComponentInitAndExecuteWithAllocate {
@@ -99,10 +99,10 @@ struct ComponentInitAndExecuteWithAllocate {
                              tmpl::list<InitAction3>>,
       Parallel::PhaseActions<Phase, Phase::Execute,
                              tmpl::list<InitAction2, Action0, Action2>>>;
-  using allocation_tags = tmpl::list<InitTag3, InitTag4>;
+  using array_allocation_tags = tmpl::list<InitTag3, InitTag4>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>,
-      allocation_tags>;
+      array_allocation_tags>;
 };
 
 static_assert(cpp17::is_same_v<Parallel::get_inbox_tags_from_action<Action2>,

--- a/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
+++ b/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
@@ -1,8 +1,12 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include <vector>
+
+#include "Options/ParseOptions.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 namespace {
@@ -153,5 +157,53 @@ static_assert(
     cpp17::is_same_v<ComponentInitAndExecuteWithAllocate::initialization_tags,
                      tmpl::list<InitTag3, InitTag4, InitTag0, InitTag1>>,
     "Failed testing get_initialization_tags");
+
+namespace OptionTags {
+struct Yards {};
+struct Dim {};
+struct Greeting {};
+struct Name {};
+}  // namespace OptionTags
+
+namespace Initialization {
+namespace Tags {
+struct Yards {
+  using option_tags = tmpl::list<OptionTags::Yards>;
+};
+struct Feet {
+  using option_tags = tmpl::list<OptionTags::Yards>;
+};
+struct Sides {
+  using option_tags = tmpl::list<OptionTags::Yards, OptionTags::Dim>;
+};
+struct FullGreeting {
+  using option_tags = tmpl::list<OptionTags::Greeting, OptionTags::Name>;
+};
+}  // namespace Tags
+}  // namespace Initialization
+
+using initialization_tags_0 = tmpl::list<>;
+
+using initialization_tags_1 =
+    tmpl::list<Initialization::Tags::Yards, Initialization::Tags::Feet,
+               Initialization::Tags::Sides>;
+
+using initialization_tags_2 =
+    tmpl::list<Initialization::Tags::Yards, Initialization::Tags::Feet,
+               Initialization::Tags::FullGreeting>;
+
+static_assert(cpp17::is_same_v<Parallel::get_option_tags<initialization_tags_0>,
+                               tmpl::list<>>,
+              "Failed testing get_option_tags");
+
+static_assert(cpp17::is_same_v<Parallel::get_option_tags<initialization_tags_1>,
+                               tmpl::list<OptionTags::Yards, OptionTags::Dim>>,
+              "Failed testing get_option_tags");
+
+static_assert(
+    cpp17::is_same_v<
+        Parallel::get_option_tags<initialization_tags_2>,
+        tmpl::list<OptionTags::Yards, OptionTags::Greeting, OptionTags::Name>>,
+    "Failed testing get_option_tags");
 
 }  // namespace

--- a/tests/Unit/Parallel/Test_TypeTraits.cpp
+++ b/tests/Unit/Parallel/Test_TypeTraits.cpp
@@ -7,7 +7,6 @@
 #include "AlgorithmGroup.hpp"
 #include "AlgorithmNodegroup.hpp"
 #include "AlgorithmSingleton.hpp"
-#include "Parallel/AddOptionsToDataBox.hpp"
 #include "Parallel/TypeTraits.hpp"
 
 namespace PUP {
@@ -28,19 +27,19 @@ struct Metavariables {
 
 struct SingletonParallelComponent {
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
+  using initialization_tags = tmpl::list<>;
 };
 struct ArrayParallelComponent {
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
+  using initialization_tags = tmpl::list<>;
 };
 struct GroupParallelComponent {
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
+  using initialization_tags = tmpl::list<>;
 };
 struct NodegroupParallelComponent {
   using metavariables = Metavariables;
-  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
+  using initialization_tags = tmpl::list<>;
 };
 
 using singleton_proxy =

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
@@ -12,6 +12,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/AddOptionsToDataBox.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
@@ -41,7 +42,7 @@ struct TagMultiplyByTwo : db::ComputeTag {
 };
 
 struct Action0 {
-  using initialization_option_tags = tmpl::list<InitialTime>;
+  using initialization_tags = tmpl::list<InitialTime>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -102,15 +103,14 @@ struct Component {
                  Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   /// [actions]
 
-  /// [options_to_databox]
-  using add_options_to_databox = Parallel::ForwardAllOptionsToDataBox<
-      Initialization::option_tags<initialization_actions>>;
-  /// [options_to_databox]
-
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
                                         Metavariables::Phase::Initialization,
                                         initialization_actions>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using add_options_to_databox =
+      Parallel::ForwardAllOptionsToDataBox<initialization_tags>;
 };
 
 struct Metavariables {

--- a/tests/Unit/Utilities/Test_TaggedTuple.cpp
+++ b/tests/Unit/Utilities/Test_TaggedTuple.cpp
@@ -15,7 +15,7 @@
 
 namespace PUP {
 class er;
-}
+}  // namespace PUP
 
 namespace {
 struct name {
@@ -27,6 +27,9 @@ struct age {
 };
 struct email {
   using type = std::string;
+};
+struct parents {
+  using type = std::vector<std::string>;
 };
 
 struct not_streamable {
@@ -48,17 +51,17 @@ struct not_streamable_tag {
 
 SPECTRE_TEST_CASE("Unit.Utilities.TaggedTuple", "[Utilities][Unit]") {
   /// [construction_example]
-  tuples::TaggedTuple<name, age, email, not_streamable_tag> test(
-      "bla", 17, "bla@bla.bla", 0);
+  tuples::TaggedTuple<name, age, email, parents, not_streamable_tag> test(
+      "bla", 17, "bla@bla.bla", std::vector<std::string>{"Mom", "Dad"}, 0);
   /// [construction_example]
   static_assert(tuples::TaggedTuple<name, age, email>::size() == 3,
                 "Failed to test size of TaggedTuple");
   {
     std::stringstream ss;
     ss << test;
-    CHECK(ss.str() == "(bla, 17, bla@bla.bla, NOT STREAMABLE)");
+    CHECK(ss.str() == "(bla, 17, bla@bla.bla, (Mom,Dad), NOT STREAMABLE)");
   }
-  CHECK(test.size() == 4);
+  CHECK(test.size() == 5);
   /// [get_example]
   CHECK("bla" == tuples::get<name>(test));
   CHECK(17 == tuples::get<age>(test));


### PR DESCRIPTION
## Proposed changes

This PR improves the handling of options for initialization of the DataBoxes of components.
It fixes a potential bug as there was no guarantee that the options passed into the components
corresponded to the specified tags (types were checked by the compiler, but options of the same
type potentially could be mixed up).
This PR will allow the initialization items to have different types from the options constructed from the input file.

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

I will add a commit to update the parallel infrastructure documentation.
In a forthcoming PR, I will update the ConstGlobalCache to use this infrastructure so the Domain
can be placed in the ConstGlobalCache.
