### PR TITLE
Swap for Variables, l1norm & l2norm for vectors, RunSingleTest works with parallel tests

### DIFF
--- a/src/DataStructures/ComplexDataVector.hpp
+++ b/src/DataStructures/ComplexDataVector.hpp
@@ -185,6 +185,16 @@ DEFINE_STD_ARRAY_INPLACE_BINOP(ComplexDataVector, double, operator+=,
                                std::plus<>())
 DEFINE_STD_ARRAY_INPLACE_BINOP(ComplexDataVector, double, operator-=,
                                std::minus<>())
+
+namespace blaze {
+// Partial specialization to disable being able to take the l?Norm of a
+// ComplexDataVector. This does *not* prevent taking the norm of the square (or
+// some other math expression) of a ComplexDataVector.
+template <typename Abs, typename Power>
+struct DVecNormHelper<
+    PointerVector<std::complex<double>, false, false, false, ComplexDataVector>,
+    Abs, Power> {};
+}  // namespace blaze
 /// \endcond
 
 MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(ComplexDataVector)

--- a/src/DataStructures/ComplexModalVector.hpp
+++ b/src/DataStructures/ComplexModalVector.hpp
@@ -194,5 +194,15 @@ DEFINE_STD_ARRAY_INPLACE_BINOP(ComplexModalVector,
                                ComplexModalVector, operator+=, std::plus<>())
 DEFINE_STD_ARRAY_INPLACE_BINOP(ComplexModalVector,
                                ComplexModalVector, operator-=, std::minus<>())
+
+namespace blaze {
+// Partial specialization to disable being able to take the l?Norm of a
+// ComplexModalVector. This does *not* prevent taking the norm of the square (or
+// some other math expression) of a ComplexModalVector.
+template <typename Abs, typename Power>
+struct DVecNormHelper<PointerVector<std::complex<double>, false, false, false,
+                                    ComplexModalVector>,
+                      Abs, Power> {};
+}  // namespace blaze
 /// \endcond
 MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(ComplexModalVector)

--- a/src/DataStructures/StripeIterator.cpp
+++ b/src/DataStructures/StripeIterator.cpp
@@ -12,23 +12,13 @@
 
 template <size_t Dim>
 StripeIterator::StripeIterator(const Index<Dim>& extents,
-                               const size_t stripe_dim)
+                               const size_t stripe_dim) noexcept
     : offset_(0),
       size_(extents.product()),
       stride_(std::accumulate(extents.begin(), extents.begin() + stripe_dim,
                               1_st, std::multiplies<size_t>())),
       stride_count_(0),
       jump_((extents[stripe_dim] - 1) * stride_) {}
-
-StripeIterator& StripeIterator::operator++() {
-  ++offset_;
-  ++stride_count_;
-  if (UNLIKELY(stride_count_ == stride_)) {
-    offset_ += jump_;
-    stride_count_ = 0;
-  }
-  return *this;
-}
 
 /// \cond HIDDEN_SYMBOLS
 template StripeIterator::StripeIterator(const Index<1>&, const size_t);

--- a/src/DataStructures/StripeIterator.hpp
+++ b/src/DataStructures/StripeIterator.hpp
@@ -6,6 +6,8 @@
 #include <cstddef>
 #include <limits>
 
+#include "Utilities/Gsl.hpp"
+
 template <size_t>
 class Index;
 
@@ -19,13 +21,21 @@ class StripeIterator {
   /// Construct from the grid points in each direction and which dimension the
   /// stripes are in.
   template <size_t Dim>
-  StripeIterator(const Index<Dim>& extents, size_t stripe_dim);
+  StripeIterator(const Index<Dim>& extents, size_t stripe_dim) noexcept;
 
   /// Returns `true` if the iterator is valid
   explicit operator bool() const noexcept { return offset_ < size_; }
 
   /// Increment to the next stripe.
-  StripeIterator& operator++();
+  StripeIterator& operator++() noexcept {
+    ++offset_;
+    ++stride_count_;
+    if (UNLIKELY(stride_count_ == stride_)) {
+      offset_ += jump_;
+      stride_count_ = 0;
+    }
+    return *this;
+  }
 
   /// Offset into DataVector for first element of stripe.
   size_t offset() const noexcept { return offset_; }

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -829,6 +829,16 @@ bool operator!=(const Variables<TagsList>& lhs,
   return not(lhs == rhs);
 }
 
+template <typename... TagsLhs, typename... TagsRhs,
+          Requires<not std::is_same<tmpl::list<TagsLhs...>,
+                                    tmpl::list<TagsRhs...>>::value> = nullptr>
+void swap(Variables<tmpl::list<TagsLhs...>>& lhs,
+          Variables<tmpl::list<TagsRhs...>>& rhs) noexcept {
+  Variables<tmpl::list<TagsLhs...>> temp{std::move(lhs)};
+  lhs = std::move(rhs);
+  rhs = std::move(temp);
+}
+
 /// \ingroup DataStructuresGroup
 /// Construct a variables from the `Tensor`s in a `TaggedTuple`.
 template <typename... Tags>

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp
@@ -42,6 +42,15 @@ auto lift_flux(Variables<tmpl::list<FluxTags...>> flux,
                Scalar<DataVector> magnitude_of_face_normal) noexcept
     -> Variables<tmpl::list<db::remove_tag_prefix<FluxTags>...>> {
   auto lift_factor = std::move(get(magnitude_of_face_normal));
+  // The LGL weights are:
+  //   w_i = 2 / ((N + 1) * N * (P_{N}(xi_i))^2)
+  // and so at the end points (xi = +/- 1) we get:
+  //   w_0 = 2 / ((N + 1) * N)
+  //   w_N = 2 / ((N + 1) * N)
+  // The negative sign comes from bringing the boundary correction over to the
+  // RHS of the equal sign (e.g. `du/dt=Source - div Flux - boundary corr`),
+  // while the magnitude of the normal vector above accounts for the ratios of
+  // spatial metrics and Jacobians.
   lift_factor *= -0.5 * (extent_perpendicular_to_boundary *
                          (extent_perpendicular_to_boundary - 1));
 

--- a/src/Utilities/Gsl.hpp
+++ b/src/Utilities/Gsl.hpp
@@ -847,6 +847,22 @@ constexpr ElementType& at(span<ElementType, Extent> s,
 #if __GNUC__ > 6
 #pragma GCC diagnostic pop
 #endif  // __GNUC__ > 6
+
+template <class ElementType, std::ptrdiff_t Extent>
+std::ostream& operator<<(std::ostream& os,
+                         const span<ElementType, Extent> t) noexcept {
+  os << "(";
+  auto it = t.cbegin();
+  if (it != t.cend()) {
+    os << *it;
+    ++it;
+    for (; it != t.cend(); ++it) {
+      os << ",";
+      os << *it;
+    }
+  }
+  return os << ")";
+}
 }  // namespace gsl
 
 // The remainder of this file is

--- a/src/Utilities/PointerVector.hpp
+++ b/src/Utilities/PointerVector.hpp
@@ -85,6 +85,196 @@ template <typename T>
 const bool blaze_is_numeric_v = blaze_is_numeric<T>;
 #endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
 
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 2))
+// The code to the corresponding endif has the following license applied to it
+// since it is a modification of the Blaze v3.3 code.
+//
+//  Copyright (C) 2012-2018 Klaus Iglberger - All Rights Reserved
+//
+//  This file is part of the Blaze library. You can redistribute it and/or
+//  modify it under the terms of the New (Revised) BSD License. Redistribution
+//  and use in source and binary forms, with or without modification, are
+//  permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  3. Neither the names of the Blaze development group nor the names of its
+//     contributors may be used to endorse or promote products derived from this
+//     software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+namespace blaze {
+template <typename T>
+BLAZE_ALWAYS_INLINE constexpr EnableIf_<Or<IsBuiltin<T>, IsComplex<T>>, T>
+evaluate(const T& a) noexcept {
+  return a;
+}
+
+template <typename T>
+BLAZE_ALWAYS_INLINE constexpr decltype(auto) pow2(const T& a) noexcept(
+    noexcept(a * a)) {
+  return (a * a);
+}
+
+struct Pow2 {
+  explicit inline Pow2() noexcept = default;
+  template <typename T>
+  BLAZE_ALWAYS_INLINE constexpr decltype(auto) operator()(const T& a) const
+      noexcept {
+    return pow2(a);
+  }
+
+  template <typename T>
+  static constexpr bool simdEnabled() {
+    return HasSIMDMult<T, T>::value;
+  }
+
+  template <typename T>
+  BLAZE_ALWAYS_INLINE decltype(auto) load(const T& a) const {
+    BLAZE_CONSTRAINT_MUST_BE_SIMD_PACK(T);
+    return pow2(a);
+  }
+};
+
+template <typename VT, typename Abs, typename Power>
+struct DVecNormHelper {
+  using CT = RemoveReference_<CompositeType_<VT>>;
+
+  // NOLINTNEXTLINE
+  BLAZE_CREATE_HAS_DATA_OR_FUNCTION_MEMBER_TYPE_TRAIT(HasSIMDEnabled,
+                                                      simdEnabled);
+  // NOLINTNEXTLINE
+  BLAZE_CREATE_HAS_DATA_OR_FUNCTION_MEMBER_TYPE_TRAIT(HasLoad, load);
+
+  struct UseSIMDEnabledFlag {
+    enum : bool {
+      value = Power::BLAZE_TEMPLATE simdEnabled<ElementType_<VT>>()
+    };
+  };
+
+  enum : bool {
+    value = useOptimizedKernels && CT::simdEnabled &&
+            If_<And<HasSIMDEnabled<Abs>, HasSIMDEnabled<Power>>,
+                UseSIMDEnabledFlag, And<HasLoad<Abs>, HasLoad<Power>>>::value &&
+            HasSIMDAdd<ElementType_<CT>, ElementType_<CT>>::value
+  };
+};
+
+template <typename VT, bool TF, typename Abs, typename Power, typename Root>
+inline decltype(auto) norm_backend(const DenseVector<VT, TF>& dv, Abs abs,
+                                   Power power, Root root,
+                                   FalseType /*meta*/) noexcept {
+  using CT = CompositeType_<VT>;
+  using ET = ElementType_<VT>;
+  using RT = decltype(evaluate(root(std::declval<ET>())));
+
+  if ((~dv).size() == 0UL) {
+    return RT();
+  }
+
+  CT tmp(~dv);
+
+  const size_t N(tmp.size());
+
+  ET norm(power(abs(tmp[0UL])));
+  size_t i(1UL);
+
+  for (; (i + 4UL) <= N; i += 4UL) {
+    norm += power(abs(tmp[i])) + power(abs(tmp[i + 1UL])) +
+            power(abs(tmp[i + 2UL])) + power(abs(tmp[i + 3UL]));
+  }
+  for (; (i + 2UL) <= N; i += 2UL) {
+    norm += power(abs(tmp[i])) + power(abs(tmp[i + 1UL]));
+  }
+  for (; i < N; ++i) {
+    norm += power(abs(tmp[i]));
+  }
+
+  return evaluate(root(norm));
+}
+
+template <typename VT, bool TF, typename Abs, typename Power, typename Root>
+inline decltype(auto) norm_backend(const DenseVector<VT, TF>& dv, Abs abs,
+                                   Power power, Root root,
+                                   TrueType /*meta*/) noexcept {
+  using CT = CompositeType_<VT>;
+  using ET = ElementType_<VT>;
+  using RT = decltype(evaluate(root(std::declval<ET>())));
+
+  enum : size_t { SIMDSIZE = SIMDTrait<ET>::size };
+
+  if ((~dv).size() == 0UL) {
+    return RT();
+  }
+
+  CT tmp(~dv);
+
+  const size_t N(tmp.size());
+
+  constexpr bool remainder(!usePadding || !IsPadded<VT>::value);
+
+  const size_t ipos((remainder) ? (N & size_t(-SIMDSIZE)) : (N));
+  BLAZE_INTERNAL_ASSERT(!remainder || (N - (N % SIMDSIZE)) == ipos,
+                        "Invalid end calculation");
+
+  SIMDTrait_<ET> xmm1, xmm2, xmm3, xmm4;
+  size_t i(0UL);
+
+  for (; (i + SIMDSIZE * 3UL) < ipos; i += SIMDSIZE * 4UL) {
+    xmm1 += power(abs(tmp.load(i)));
+    xmm2 += power(abs(tmp.load(i + SIMDSIZE)));
+    xmm3 += power(abs(tmp.load(i + SIMDSIZE * 2UL)));
+    xmm4 += power(abs(tmp.load(i + SIMDSIZE * 3UL)));
+  }
+  for (; (i + SIMDSIZE) < ipos; i += SIMDSIZE * 2UL) {
+    xmm1 += power(abs(tmp.load(i)));
+    xmm2 += power(abs(tmp.load(i + SIMDSIZE)));
+  }
+  for (; i < ipos; i += SIMDSIZE) {
+    xmm1 += power(abs(tmp.load(i)));
+  }
+
+  ET norm(sum(xmm1 + xmm2 + xmm3 + xmm4));
+
+  for (; remainder && i < N; ++i) {
+    norm += power(abs(tmp[i]));
+  }
+
+  return evaluate(root(norm));
+}
+
+template <typename VT, bool TF, typename Abs, typename Power, typename Root>
+decltype(auto) norm_backend(const DenseVector<VT, TF>& dv, Abs abs, Power power,
+                            Root root) {
+  return norm_backend(~dv, abs, power, root,
+                      Bool<DVecNormHelper<VT, Abs, Power>::value>());
+}
+
+template <typename VT, bool TF>
+decltype(auto) l1Norm(const DenseVector<VT, TF>& dv) noexcept {
+  return norm_backend(~dv, Abs(), Noop(), Noop());
+}
+
+template <typename VT, bool TF>
+inline decltype(auto) l2Norm(const DenseVector<VT, TF>& dv) noexcept {
+  return norm_backend(~dv, Noop(), Pow2(), Sqrt());
+}
+}  // namespace blaze
+#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 2))
+
 namespace blaze {
 template <typename T>
 BLAZE_ALWAYS_INLINE SIMDdouble step_function(const SIMDf64<T>& v) noexcept

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -462,6 +462,25 @@ void test_variables_prefix_semantics() noexcept {
   vars_to = std::move(prefix_vars_move_assign_from);
   CHECK_VARIABLES_APPROX(
       vars_to, VariablesType(number_of_grid_points, variables_vals[3]));
+
+  // Test swap with prefix
+  PrefixVariablesType prefix_vars_swap{number_of_grid_points};
+  VariablesType vars_swap{2 * number_of_grid_points};
+  fill_with_random_values(make_not_null(&prefix_vars_swap), make_not_null(&gen),
+                          make_not_null(&dist));
+  fill_with_random_values(make_not_null(&vars_swap), make_not_null(&gen),
+                          make_not_null(&dist));
+  const PrefixVariablesType expected_vars_swap(prefix_vars_swap);
+  const VariablesType expected_prefix_vars_swap(vars_swap);
+  swap(vars_swap, prefix_vars_swap);
+  CHECK(
+      gsl::span<const value_type>(expected_vars_swap.data(),
+                                  2 * number_of_grid_points) ==
+      gsl::span<const value_type>(vars_swap.data(), 2 * number_of_grid_points));
+  CHECK(gsl::span<const value_type>(expected_prefix_vars_swap.data(),
+                                    number_of_grid_points) ==
+        gsl::span<const value_type>(prefix_vars_swap.data(),
+                                    number_of_grid_points));
 }
 
 template <typename VectorType>

--- a/tests/Unit/Pypp/CMakeLists.txt
+++ b/tests/Unit/Pypp/CMakeLists.txt
@@ -10,5 +10,5 @@ add_test_library(
   "Test_Pypp"
   "Pypp"
   "${LIBRARY_SOURCES}"
-  "ErrorHandling"
+  "DataStructures;ErrorHandling"
   )

--- a/tests/Unit/RunSingleTest/CMakeLists.txt
+++ b/tests/Unit/RunSingleTest/CMakeLists.txt
@@ -3,22 +3,55 @@
 
 set(EXECUTABLE "RunSingleTest")
 
+# RunSingleTest can be used to compile only a subset of the code base
+# for testing purposes. It uses the RunTests infrastructure with a slightly
+# different implementation in the cpp file in order to not depend on all
+# the test libraries. Note that while typically the `RunSingleTest`
+# executable will be used for quick write/build/run cycles of a single test,
+# more than one test and source file can be compiled. The main use of
+# `RunSingleTest` is to decrease turnaround time when changing very low-level
+# code such as DataVector or certain parts of Utilities that cause most or
+# all of the source tree to be rebuilt. Rather than having to wait for the
+# source tree rebuild before running the tests via `RunTests` the individual
+# test source files containing the test(s) of interest can be rebuilt.
+#
+# In order to run the tests in one or more test source files without
+# compiling the whole source tree:
+# 1. Update the cpp files built by replacing `Test_DataVector.cpp`
+#    in `add_spectre_executable` below.
+# 2. Update the first `target_link_libraries` below to link the required
+#    SpECTRE libraries.
+# 3. Run `./bin/RunSingleTest` passing as arguments the test(s) to run.
+#    If no test names are given then all tests in the built source files
+#    are run. If any of them are error tests the executable will terminate
+#    when reaching the error.
 add_spectre_executable(
   ${EXECUTABLE}
   EXCLUDE_FROM_ALL
   ${EXECUTABLE}.cpp
+
   # The following lines list the source files with tests in them to be
   # compiled into the executable.
   ../DataStructures/Test_DataVector.cpp
   )
 
+# Modify which libraries to link for your test case.
 target_link_libraries(
   ${EXECUTABLE}
   DataStructures
   )
 
-set_target_properties(
+# Core required libraries
+target_link_libraries(
   ${EXECUTABLE}
-  PROPERTIES
-  LINK_FLAGS "-nomain -nomain-module"
+  Informer
+  Test_Pypp
+  ${SPECTRE_LIBRARIES}
+  )
+
+add_dependencies(
+  ${EXECUTABLE}
+  module_ConstGlobalCache
+  module_Main
+  module_RunTests
   )

--- a/tests/Unit/RunSingleTest/RunSingleTest.cpp
+++ b/tests/Unit/RunSingleTest/RunSingleTest.cpp
@@ -3,11 +3,53 @@
 
 #define CATCH_CONFIG_RUNNER
 
+#include "tests/Unit/RunTests.hpp"
+
 #include "tests/Unit/TestingFramework.hpp"
 
-void CkRegisterMainModule() {}
+#include <charm++.h>
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <string>
 
-int main(int argc, char* argv[]) {
-  // clang-tidy: internal warning in Catch
-  return Catch::Session{}.run(argc, argv);  // NOLINT
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "Informer/InfoFromBuild.hpp"
+#include "Parallel/Abort.hpp"
+#include "Parallel/Exit.hpp"
+#include "Parallel/Printf.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+RunTests::RunTests(CkArgMsg* msg) {
+  std::set_terminate(
+      []() { Parallel::abort("Called terminate. Aborting..."); });
+  Parallel::printf("%s", info_from_build().c_str());
+  enable_floating_point_exceptions();
+  const int result = Catch::Session().run(msg->argc, msg->argv);
+  // In the case where we run all the non-failure tests at once we must ensure
+  // that we only initialize and finalize the python env once. Initialization is
+  // done in the constructor of SetupLocalPythonEnvironment, while finalization
+  // is done in the constructor of RunTests.
+  pypp::SetupLocalPythonEnvironment::finalize_env();
+  if (0 == result) {
+    Parallel::exit();
+  }
+  Parallel::abort("A catch test has failed.");
 }
+
+#include "tests/Unit/RunTests.def.h"  /// IWYU pragma: keep
+
+// Needed for tests that use the ConstGlobalCache since it registers itself with
+// Charm++. However, since Parallel/CharmMain.tpp isn't included in the RunTests
+// executable, no actual registration is done, the ConstGlobalCache is only
+// queued for registration.
+namespace Parallel {
+namespace charmxx {
+class RegistrationHelper;
+/// \cond
+std::unique_ptr<RegistrationHelper>* charm_register_list = nullptr;
+size_t charm_register_list_capacity = 0;
+size_t charm_register_list_size = 0;
+/// \endcond
+}  // namespace charmxx
+}  // namespace Parallel

--- a/tests/Unit/Utilities/Test_Gsl.cpp
+++ b/tests/Unit/Utilities/Test_Gsl.cpp
@@ -3,15 +3,31 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <numeric>
+#include <vector>
+
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace {
 template <typename T>
 void func(const gsl::not_null<T*> t) { *t += 2; }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Utilities.Gsl.make_not_null", "[Unit][Utilities]") {
+void test_make_not_null() noexcept {
   int x = 5;
   func(make_not_null(&x));
   CHECK(x == 7);
+}
+
+void test_span_stream() noexcept {
+  std::vector<double> a(4);
+  std::iota(a.begin(), a.end(), 1.3);
+  gsl::span<const double> span_a(a.data(), a.size());
+  CHECK(get_output(span_a) == "(1.3,2.3,3.3,4.3)");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Utilities.Gsl", "[Unit][Utilities]") {
+  test_make_not_null();
+  test_span_stream();
 }


### PR DESCRIPTION
## Proposed changes

A few changes and additions I encountered while working on subcell.

- I'm back porting the Blaze l1Norm and l2Norm functions since they're useful and getting newer versions of Blaze to compile with AVX-512 was a nightmare.
- While back porting I wanted `RunSingleTest` to work with an ActionTesting test. I figured out how to get that to work and am adding it here.
- I wanted to swap two Variables where one had wrapped tags of the other, so that is being added.
- I needed to use `StripeIterator` (or at least explored it a bit) and so that gets some minor cleanup.
- I was confused by what our flux lifting was doing and so added a clarifying comment.
- I wanted to stream out a `gsl::span`, so I'm adding a stream operator for that.
- I found the same issue with wrapped tags not being printed correctly in `Variables` that @wthrowe  had found, but also cleaned up the code there a bit so I'm just submitting the cleanup.

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
