### PR TITLE
Make libsharp not be architecture dependent on Docker

### DIFF
--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -90,6 +90,7 @@ RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.2.tar.gz -O bla
     && tar -xzf libsharp.tar.gz \
     && mv libsharp-* libsharp_build \
     && cd libsharp_build \
+    && sed -i 's/march=native/march=x86-64/' configure.ac \
     && autoconf \
     && ./configure --prefix=/usr/local --disable-openmp \
     && make -j4 \
@@ -148,7 +149,7 @@ RUN ln -s $(which clang++-5.0) /usr/local/bin/clang++ \
     && ln -s $(which clang-5.0) /usr/local/bin/clang \
     && ln -s $(which clang-format-5.0) /usr/local/bin/clang-format \
     && ln -s $(which clang-tidy-5.0) /usr/local/bin/clang-tidy
-RUN git clone https://charm.cs.illinois.edu/gerrit/charm \
+RUN git clone https://github.com/UIUC-PPL/charm \
     && cd /work/charm \
     && git checkout ${CHARM_GIT_TAG} \
     && ./build charm++ multicore-linux64 gcc ${PARALLEL_MAKE_ARG} -g -O0  \


### PR DESCRIPTION
## Proposed changes

- `libsharp` by default builds with `-march=native` which can cause problems on older machines. This PR changes `libsharp` to being built with `-march=x86-64` for Docker. (Thanks to @markscheel for catching this!)
- Update git repo to GitHub for Charm++.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
