### PR TITLE
Allow testing option tags with test_creation

### DIFF
--- a/src/Parallel/Serialize.hpp
+++ b/src/Parallel/Serialize.hpp
@@ -22,7 +22,7 @@
  * \tparam T type to serialize
  */
 template <typename T, typename U>
-std::vector<char> serialize(const U& obj) {
+std::vector<char> serialize(const U& obj) noexcept {
   static_assert(std::is_same<T, U>::value,
                 "Explicit type for serialization differs from deduced type");
   const T& typed_obj = obj;
@@ -47,7 +47,8 @@ std::vector<char> serialize(const U& obj) {
  * \tparam T the type to deserialize to
  */
 template <typename T>
-T deserialize(const void* const data) {
+T deserialize(const void* const data) noexcept {  // NOLINT
+  // clang-tidy: no const in forward decl (this is a definition)
   PUP::fromMem reader(data);
   T result{};
   reader | result;

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -4,9 +4,10 @@
 set(executable RunTests)
 
 set(SPECTRE_TESTS
-  "Test_ActionTesting.cpp"
-  "Test_TestHelpers.cpp"
-  "Test_TestingFramework.cpp"
+  Test_ActionTesting.cpp
+  Test_TestCreation.cpp
+  Test_TestHelpers.cpp
+  Test_TestingFramework.cpp
   )
 
 set(SPECTRE_COMPILATION_TESTS "TestCompilationFramework.cpp")

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -31,46 +31,46 @@ void test_aligned_blocks(
 SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
   const auto domain_creator_1d =
       TestHelpers::test_factory_creation<DomainCreator<1>>(
-          "  AlignedLattice:\n"
-          "    BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n"
-          "    IsPeriodicIn: [false]\n"
-          "    InitialGridPoints: [3]\n"
-          "    InitialRefinement: [2]\n");
+          "AlignedLattice:\n"
+          "  BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n"
+          "  IsPeriodicIn: [false]\n"
+          "  InitialGridPoints: [3]\n"
+          "  InitialRefinement: [2]\n");
   const auto* aligned_blocks_creator_1d =
       dynamic_cast<const creators::AlignedLattice<1>*>(domain_creator_1d.get());
   test_aligned_blocks(*aligned_blocks_creator_1d);
 
   const auto domain_creator_2d =
       TestHelpers::test_factory_creation<DomainCreator<2>>(
-          "  AlignedLattice:\n"
-          "    BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2, 8.9]]\n"
-          "    IsPeriodicIn: [false, true]\n"
-          "    InitialGridPoints: [3, 4]\n"
-          "    InitialRefinement: [2, 1]\n");
+          "AlignedLattice:\n"
+          "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2, 8.9]]\n"
+          "  IsPeriodicIn: [false, true]\n"
+          "  InitialGridPoints: [3, 4]\n"
+          "  InitialRefinement: [2, 1]\n");
   const auto* aligned_blocks_creator_2d =
       dynamic_cast<const creators::AlignedLattice<2>*>(domain_creator_2d.get());
   test_aligned_blocks(*aligned_blocks_creator_2d);
 
   const auto domain_creator_3d =
       TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  AlignedLattice:\n"
-          "    BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n"
-          "    IsPeriodicIn: [false, true, false]\n"
-          "    InitialGridPoints: [3, 4, 5]\n"
-          "    InitialRefinement: [2, 1, 0]\n");
+          "AlignedLattice:\n"
+          "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n"
+          "  IsPeriodicIn: [false, true, false]\n"
+          "  InitialGridPoints: [3, 4, 5]\n"
+          "  InitialRefinement: [2, 1, 0]\n");
   const auto* aligned_blocks_creator_3d =
       dynamic_cast<const creators::AlignedLattice<3>*>(domain_creator_3d.get());
   test_aligned_blocks(*aligned_blocks_creator_3d);
 
   const auto cubical_shell_domain =
       TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  AlignedLattice:\n"
-          "    BlockBounds: [[0.1, 2.6, 5.1, 6.0], [-0.4, 3.2, 6.2, 7.0], "
+          "AlignedLattice:\n"
+          "  BlockBounds: [[0.1, 2.6, 5.1, 6.0], [-0.4, 3.2, 6.2, 7.0], "
           "[-0.2, 3.2, 4.0, 5.2]]\n"
-          "    IsPeriodicIn: [false, false, false]\n"
-          "    InitialGridPoints: [3, 4, 5]\n"
-          "    InitialRefinement: [2, 1, 0]\n"
-          "    BlocksToExclude: [[1, 1, 1]]");
+          "  IsPeriodicIn: [false, false, false]\n"
+          "  InitialGridPoints: [3, 4, 5]\n"
+          "  InitialRefinement: [2, 1, 0]\n"
+          "  BlocksToExclude: [[1, 1, 1]]");
   const auto* cubical_shell_creator_3d =
       dynamic_cast<const creators::AlignedLattice<3>*>(
           cubical_shell_domain.get());
@@ -78,13 +78,13 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
 
   const auto unit_cubical_shell_domain =
       TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  AlignedLattice:\n"
-          "    BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
+          "AlignedLattice:\n"
+          "  BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
           "[-1.5, -0.5, 0.5, 1.5]]\n"
-          "    IsPeriodicIn: [false, false, false]\n"
-          "    InitialGridPoints: [5, 5, 5]\n"
-          "    InitialRefinement: [1, 1, 1]\n"
-          "    BlocksToExclude: [[1, 1, 1]]");
+          "  IsPeriodicIn: [false, false, false]\n"
+          "  InitialGridPoints: [5, 5, 5]\n"
+          "  InitialRefinement: [1, 1, 1]\n"
+          "  BlocksToExclude: [[1, 1, 1]]");
   const auto* unit_cubical_shell_creator_3d =
       dynamic_cast<const creators::AlignedLattice<3>*>(
           unit_cubical_shell_domain.get());
@@ -98,12 +98,12 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice.Error",
   ERROR_TEST();
   const auto failed_cubical_shell_domain =
       TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  AlignedLattice:\n"
-          "    BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
+          "AlignedLattice:\n"
+          "  BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
           "[-1.5, -0.5, 0.5, 1.5]]\n"
-          "    IsPeriodicIn: [true, false, false]\n"
-          "    InitialGridPoints: [5, 5, 5]\n"
-          "    InitialRefinement: [1, 1, 1]\n"
-          "    BlocksToExclude: [[1, 1, 1]]");
+          "  IsPeriodicIn: [true, false, false]\n"
+          "  InitialGridPoints: [5, 5, 5]\n"
+          "  InitialRefinement: [1, 1, 1]\n"
+          "  BlocksToExclude: [[1, 1, 1]]");
 }
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -29,51 +29,55 @@ void test_aligned_blocks(
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
-  const auto domain_creator_1d = test_factory_creation<DomainCreator<1>>(
-      "  AlignedLattice:\n"
-      "    BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n"
-      "    IsPeriodicIn: [false]\n"
-      "    InitialGridPoints: [3]\n"
-      "    InitialRefinement: [2]\n");
+  const auto domain_creator_1d =
+      TestHelpers::test_factory_creation<DomainCreator<1>>(
+          "  AlignedLattice:\n"
+          "    BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n"
+          "    IsPeriodicIn: [false]\n"
+          "    InitialGridPoints: [3]\n"
+          "    InitialRefinement: [2]\n");
   const auto* aligned_blocks_creator_1d =
       dynamic_cast<const creators::AlignedLattice<1>*>(domain_creator_1d.get());
   test_aligned_blocks(*aligned_blocks_creator_1d);
 
-  const auto domain_creator_2d = test_factory_creation<DomainCreator<2>>(
-      "  AlignedLattice:\n"
-      "    BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2, 8.9]]\n"
-      "    IsPeriodicIn: [false, true]\n"
-      "    InitialGridPoints: [3, 4]\n"
-      "    InitialRefinement: [2, 1]\n");
+  const auto domain_creator_2d =
+      TestHelpers::test_factory_creation<DomainCreator<2>>(
+          "  AlignedLattice:\n"
+          "    BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2, 8.9]]\n"
+          "    IsPeriodicIn: [false, true]\n"
+          "    InitialGridPoints: [3, 4]\n"
+          "    InitialRefinement: [2, 1]\n");
   const auto* aligned_blocks_creator_2d =
       dynamic_cast<const creators::AlignedLattice<2>*>(domain_creator_2d.get());
   test_aligned_blocks(*aligned_blocks_creator_2d);
 
-  const auto domain_creator_3d = test_factory_creation<DomainCreator<3>>(
-      "  AlignedLattice:\n"
-      "    BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n"
-      "    IsPeriodicIn: [false, true, false]\n"
-      "    InitialGridPoints: [3, 4, 5]\n"
-      "    InitialRefinement: [2, 1, 0]\n");
+  const auto domain_creator_3d =
+      TestHelpers::test_factory_creation<DomainCreator<3>>(
+          "  AlignedLattice:\n"
+          "    BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n"
+          "    IsPeriodicIn: [false, true, false]\n"
+          "    InitialGridPoints: [3, 4, 5]\n"
+          "    InitialRefinement: [2, 1, 0]\n");
   const auto* aligned_blocks_creator_3d =
       dynamic_cast<const creators::AlignedLattice<3>*>(domain_creator_3d.get());
   test_aligned_blocks(*aligned_blocks_creator_3d);
 
-  const auto cubical_shell_domain = test_factory_creation<DomainCreator<3>>(
-      "  AlignedLattice:\n"
-      "    BlockBounds: [[0.1, 2.6, 5.1, 6.0], [-0.4, 3.2, 6.2, 7.0], "
-      "[-0.2, 3.2, 4.0, 5.2]]\n"
-      "    IsPeriodicIn: [false, false, false]\n"
-      "    InitialGridPoints: [3, 4, 5]\n"
-      "    InitialRefinement: [2, 1, 0]\n"
-      "    BlocksToExclude: [[1, 1, 1]]");
+  const auto cubical_shell_domain =
+      TestHelpers::test_factory_creation<DomainCreator<3>>(
+          "  AlignedLattice:\n"
+          "    BlockBounds: [[0.1, 2.6, 5.1, 6.0], [-0.4, 3.2, 6.2, 7.0], "
+          "[-0.2, 3.2, 4.0, 5.2]]\n"
+          "    IsPeriodicIn: [false, false, false]\n"
+          "    InitialGridPoints: [3, 4, 5]\n"
+          "    InitialRefinement: [2, 1, 0]\n"
+          "    BlocksToExclude: [[1, 1, 1]]");
   const auto* cubical_shell_creator_3d =
       dynamic_cast<const creators::AlignedLattice<3>*>(
           cubical_shell_domain.get());
   test_aligned_blocks(*cubical_shell_creator_3d);
 
   const auto unit_cubical_shell_domain =
-      test_factory_creation<DomainCreator<3>>(
+      TestHelpers::test_factory_creation<DomainCreator<3>>(
           "  AlignedLattice:\n"
           "    BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
           "[-1.5, -0.5, 0.5, 1.5]]\n"
@@ -93,7 +97,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice.Error",
                   "[Unit][ErrorHandling]") {
   ERROR_TEST();
   const auto failed_cubical_shell_domain =
-      test_factory_creation<DomainCreator<3>>(
+      TestHelpers::test_factory_creation<DomainCreator<3>>(
           "  AlignedLattice:\n"
           "    BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
           "[-1.5, -0.5, 0.5, 1.5]]\n"

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -199,13 +199,14 @@ void test_brick() {
 
 void test_brick_factory() {
   INFO("Brick factory");
-  const auto domain_creator = test_factory_creation<DomainCreator<3>>(
-      "  Brick:\n"
-      "    LowerBound: [0,0,0]\n"
-      "    UpperBound: [1,2,3]\n"
-      "    IsPeriodicIn: [True,False,True]\n"
-      "    InitialGridPoints: [3,4,3]\n"
-      "    InitialRefinement: [2,3,2]\n");
+  const auto domain_creator =
+      TestHelpers::test_factory_creation<DomainCreator<3>>(
+          "  Brick:\n"
+          "    LowerBound: [0,0,0]\n"
+          "    UpperBound: [1,2,3]\n"
+          "    IsPeriodicIn: [True,False,True]\n"
+          "    InitialGridPoints: [3,4,3]\n"
+          "    InitialRefinement: [2,3,2]\n");
   const auto* brick_creator =
       dynamic_cast<const creators::Brick*>(domain_creator.get());
   test_brick_construction(

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -201,12 +201,12 @@ void test_brick_factory() {
   INFO("Brick factory");
   const auto domain_creator =
       TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  Brick:\n"
-          "    LowerBound: [0,0,0]\n"
-          "    UpperBound: [1,2,3]\n"
-          "    IsPeriodicIn: [True,False,True]\n"
-          "    InitialGridPoints: [3,4,3]\n"
-          "    InitialRefinement: [2,3,2]\n");
+          "Brick:\n"
+          "  LowerBound: [0,0,0]\n"
+          "  UpperBound: [1,2,3]\n"
+          "  IsPeriodicIn: [True,False,True]\n"
+          "  InitialGridPoints: [3,4,3]\n"
+          "  InitialRefinement: [2,3,2]\n");
   const auto* brick_creator =
       dynamic_cast<const creators::Brick*>(domain_creator.get());
   test_brick_construction(

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -206,7 +206,7 @@ void test_cylinder_boundaries_equiangular() {
 
 void test_cylinder_factory_equiangular() {
   INFO("Cylinder factory equiangular");
-  const auto cylinder = test_factory_creation<DomainCreator<3>>(
+  const auto cylinder = TestHelpers::test_factory_creation<DomainCreator<3>>(
       "  Cylinder:\n"
       "    InnerRadius: 1.0\n"
       "    OuterRadius: 3.0\n"
@@ -244,7 +244,7 @@ void test_cylinder_boundaries_equidistant() {
 
 void test_cylinder_factory_equidistant() {
   INFO("Cylinder factory equidistant");
-  const auto cylinder = test_factory_creation<DomainCreator<3>>(
+  const auto cylinder = TestHelpers::test_factory_creation<DomainCreator<3>>(
       "  Cylinder:\n"
       "    InnerRadius: 1.0\n"
       "    OuterRadius: 3.0\n"
@@ -282,7 +282,7 @@ void test_cylinder_boundaries_equiangular_not_periodic_in_z() {
 
 void test_cylinder_factory_equiangular_not_periodic_in_z() {
   INFO("Cylinder factory equiangular not periodic in z");
-  const auto cylinder = test_factory_creation<DomainCreator<3>>(
+  const auto cylinder = TestHelpers::test_factory_creation<DomainCreator<3>>(
       "  Cylinder:\n"
       "    InnerRadius: 1.0\n"
       "    OuterRadius: 3.0\n"
@@ -321,7 +321,7 @@ void test_cylinder_boundaries_equidistant_not_periodic_in_z() {
 
 void test_cylinder_factory_equidistant_not_periodic_in_z() {
   INFO("Cylinder factory equidistant not periodic in z");
-  const auto cylinder = test_factory_creation<DomainCreator<3>>(
+  const auto cylinder = TestHelpers::test_factory_creation<DomainCreator<3>>(
       "  Cylinder:\n"
       "    InnerRadius: 1.0\n"
       "    OuterRadius: 3.0\n"

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -207,14 +207,14 @@ void test_cylinder_boundaries_equiangular() {
 void test_cylinder_factory_equiangular() {
   INFO("Cylinder factory equiangular");
   const auto cylinder = TestHelpers::test_factory_creation<DomainCreator<3>>(
-      "  Cylinder:\n"
-      "    InnerRadius: 1.0\n"
-      "    OuterRadius: 3.0\n"
-      "    LowerBound: -1.2\n"
-      "    UpperBound: 3.7\n"
-      "    InitialRefinement: 2\n"
-      "    InitialGridPoints: [2,3,4]\n"
-      "    UseEquiangularMap: true\n");
+          "Cylinder:\n"
+          "  InnerRadius: 1.0\n"
+          "  OuterRadius: 3.0\n"
+          "  LowerBound: -1.2\n"
+          "  UpperBound: 3.7\n"
+          "  InitialRefinement: 2\n"
+          "  InitialGridPoints: [2,3,4]\n"
+          "  UseEquiangularMap: true\n");
 
   const double inner_radius = 1.0, outer_radius = 3.0;
   const double lower_bound = -1.2, upper_bound = 3.7;
@@ -245,14 +245,14 @@ void test_cylinder_boundaries_equidistant() {
 void test_cylinder_factory_equidistant() {
   INFO("Cylinder factory equidistant");
   const auto cylinder = TestHelpers::test_factory_creation<DomainCreator<3>>(
-      "  Cylinder:\n"
-      "    InnerRadius: 1.0\n"
-      "    OuterRadius: 3.0\n"
-      "    LowerBound: -1.2\n"
-      "    UpperBound: 3.7\n"
-      "    InitialRefinement: 2\n"
-      "    InitialGridPoints: [2,3,4]\n"
-      "    UseEquiangularMap: false\n");
+          "Cylinder:\n"
+          "  InnerRadius: 1.0\n"
+          "  OuterRadius: 3.0\n"
+          "  LowerBound: -1.2\n"
+          "  UpperBound: 3.7\n"
+          "  InitialRefinement: 2\n"
+          "  InitialGridPoints: [2,3,4]\n"
+          "  UseEquiangularMap: false\n");
 
   const double inner_radius = 1.0, outer_radius = 3.0;
   const double lower_bound = -1.2, upper_bound = 3.7;
@@ -283,15 +283,15 @@ void test_cylinder_boundaries_equiangular_not_periodic_in_z() {
 void test_cylinder_factory_equiangular_not_periodic_in_z() {
   INFO("Cylinder factory equiangular not periodic in z");
   const auto cylinder = TestHelpers::test_factory_creation<DomainCreator<3>>(
-      "  Cylinder:\n"
-      "    InnerRadius: 1.0\n"
-      "    OuterRadius: 3.0\n"
-      "    LowerBound: -1.2\n"
-      "    UpperBound: 3.7\n"
-      "    IsPeriodicInZ: false\n"
-      "    InitialRefinement: 2\n"
-      "    InitialGridPoints: [2,3,4]\n"
-      "    UseEquiangularMap: true\n");
+          "Cylinder:\n"
+          "  InnerRadius: 1.0\n"
+          "  OuterRadius: 3.0\n"
+          "  LowerBound: -1.2\n"
+          "  UpperBound: 3.7\n"
+          "  IsPeriodicInZ: false\n"
+          "  InitialRefinement: 2\n"
+          "  InitialGridPoints: [2,3,4]\n"
+          "  UseEquiangularMap: true\n");
 
   const double inner_radius = 1.0, outer_radius = 3.0;
   const double lower_bound = -1.2, upper_bound = 3.7;
@@ -322,15 +322,15 @@ void test_cylinder_boundaries_equidistant_not_periodic_in_z() {
 void test_cylinder_factory_equidistant_not_periodic_in_z() {
   INFO("Cylinder factory equidistant not periodic in z");
   const auto cylinder = TestHelpers::test_factory_creation<DomainCreator<3>>(
-      "  Cylinder:\n"
-      "    InnerRadius: 1.0\n"
-      "    OuterRadius: 3.0\n"
-      "    LowerBound: -1.2\n"
-      "    UpperBound: 3.7\n"
-      "    IsPeriodicInZ: false\n"
-      "    InitialRefinement: 2\n"
-      "    InitialGridPoints: [2,3,4]\n"
-      "    UseEquiangularMap: false\n");
+          "Cylinder:\n"
+          "  InnerRadius: 1.0\n"
+          "  OuterRadius: 3.0\n"
+          "  LowerBound: -1.2\n"
+          "  UpperBound: 3.7\n"
+          "  IsPeriodicInZ: false\n"
+          "  InitialRefinement: 2\n"
+          "  InitialGridPoints: [2,3,4]\n"
+          "  UseEquiangularMap: false\n");
 
   const double inner_radius = 1.0, outer_radius = 3.0;
   const double lower_bound = -1.2, upper_bound = 3.7;

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -142,12 +142,12 @@ void test_disk_boundaries_equiangular() {
 void test_disk_factory_equiangular() {
   INFO("Disk factory equiangular");
   const auto disk = TestHelpers::test_factory_creation<DomainCreator<2>>(
-      "  Disk:\n"
-      "    InnerRadius: 1\n"
-      "    OuterRadius: 3\n"
-      "    InitialRefinement: 2\n"
-      "    InitialGridPoints: [2,3]\n"
-      "    UseEquiangularMap: true\n");
+          "Disk:\n"
+          "  InnerRadius: 1\n"
+          "  OuterRadius: 3\n"
+          "  InitialRefinement: 2\n"
+          "  InitialGridPoints: [2,3]\n"
+          "  UseEquiangularMap: true\n");
 
   const double inner_radius = 1.0, outer_radius = 3.0;
   const size_t refinement_level = 2;
@@ -173,12 +173,12 @@ void test_disk_boundaries_equidistant() {
 void test_disk_factory_equidistant() {
   INFO("Disk factory equidistant");
   const auto disk = TestHelpers::test_factory_creation<DomainCreator<2>>(
-      "  Disk:\n"
-      "    InnerRadius: 1\n"
-      "    OuterRadius: 3\n"
-      "    InitialRefinement: 2\n"
-      "    InitialGridPoints: [2,3]\n"
-      "    UseEquiangularMap: false\n");
+          "Disk:\n"
+          "  InnerRadius: 1\n"
+          "  OuterRadius: 3\n"
+          "  InitialRefinement: 2\n"
+          "  InitialGridPoints: [2,3]\n"
+          "  UseEquiangularMap: false\n");
 
   const double inner_radius = 1.0, outer_radius = 3.0;
   const size_t refinement_level = 2;

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -141,7 +141,7 @@ void test_disk_boundaries_equiangular() {
 
 void test_disk_factory_equiangular() {
   INFO("Disk factory equiangular");
-  const auto disk = test_factory_creation<DomainCreator<2>>(
+  const auto disk = TestHelpers::test_factory_creation<DomainCreator<2>>(
       "  Disk:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -172,7 +172,7 @@ void test_disk_boundaries_equidistant() {
 
 void test_disk_factory_equidistant() {
   INFO("Disk factory equidistant");
-  const auto disk = test_factory_creation<DomainCreator<2>>(
+  const auto disk = TestHelpers::test_factory_creation<DomainCreator<2>>(
       "  Disk:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"

--- a/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
+++ b/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
@@ -49,14 +49,14 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.FrustalCloak.Factory",
                   "[Domain][Unit]") {
   const auto frustal_cloak =
       TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  FrustalCloak:\n"
-          "    InitialRefinement: 3\n"
-          "    InitialGridPoints: [2,3]\n"
-          "    UseEquiangularMap: true\n"
-          "    ProjectionFactor: 0.3\n"
-          "    LengthInnerCube: 15.5\n"
-          "    LengthOuterCube: 42.4\n"
-          "    OriginPreimage: [0.2,0.3,-0.1]");
+          "FrustalCloak:\n"
+          "  InitialRefinement: 3\n"
+          "  InitialGridPoints: [2,3]\n"
+          "  UseEquiangularMap: true\n"
+          "  ProjectionFactor: 0.3\n"
+          "  LengthInnerCube: 15.5\n"
+          "  LengthOuterCube: 42.4\n"
+          "  OriginPreimage: [0.2,0.3,-0.1]");
   test_frustal_cloak_construction(
       dynamic_cast<const domain::creators::FrustalCloak&>(*frustal_cloak));
 }

--- a/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
+++ b/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
@@ -47,15 +47,16 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.FrustalCloak.Connectivity",
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.FrustalCloak.Factory",
                   "[Domain][Unit]") {
-  const auto frustal_cloak = test_factory_creation<DomainCreator<3>>(
-      "  FrustalCloak:\n"
-      "    InitialRefinement: 3\n"
-      "    InitialGridPoints: [2,3]\n"
-      "    UseEquiangularMap: true\n"
-      "    ProjectionFactor: 0.3\n"
-      "    LengthInnerCube: 15.5\n"
-      "    LengthOuterCube: 42.4\n"
-      "    OriginPreimage: [0.2,0.3,-0.1]");
+  const auto frustal_cloak =
+      TestHelpers::test_factory_creation<DomainCreator<3>>(
+          "  FrustalCloak:\n"
+          "    InitialRefinement: 3\n"
+          "    InitialGridPoints: [2,3]\n"
+          "    UseEquiangularMap: true\n"
+          "    ProjectionFactor: 0.3\n"
+          "    LengthInnerCube: 15.5\n"
+          "    LengthOuterCube: 42.4\n"
+          "    OriginPreimage: [0.2,0.3,-0.1]");
   test_frustal_cloak_construction(
       dynamic_cast<const domain::creators::FrustalCloak&>(*frustal_cloak));
 }

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -97,13 +97,14 @@ void test_interval() {
 
 void test_interval_factory() {
   INFO("Interval factory");
-  const auto domain_creator = test_factory_creation<DomainCreator<1>>(
-      "  Interval:\n"
-      "    LowerBound: [0]\n"
-      "    UpperBound: [1]\n"
-      "    IsPeriodicIn: [True]\n"
-      "    InitialGridPoints: [3]\n"
-      "    InitialRefinement: [2]\n");
+  const auto domain_creator =
+      TestHelpers::test_factory_creation<DomainCreator<1>>(
+          "  Interval:\n"
+          "    LowerBound: [0]\n"
+          "    UpperBound: [1]\n"
+          "    IsPeriodicIn: [True]\n"
+          "    InitialGridPoints: [3]\n"
+          "    InitialRefinement: [2]\n");
   const auto* interval_creator =
       dynamic_cast<const creators::Interval*>(domain_creator.get());
   test_interval_construction(*interval_creator, {{0.}}, {{1.}}, {{{3}}},

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -99,12 +99,12 @@ void test_interval_factory() {
   INFO("Interval factory");
   const auto domain_creator =
       TestHelpers::test_factory_creation<DomainCreator<1>>(
-          "  Interval:\n"
-          "    LowerBound: [0]\n"
-          "    UpperBound: [1]\n"
-          "    IsPeriodicIn: [True]\n"
-          "    InitialGridPoints: [3]\n"
-          "    InitialRefinement: [2]\n");
+          "Interval:\n"
+          "  LowerBound: [0]\n"
+          "  UpperBound: [1]\n"
+          "  IsPeriodicIn: [True]\n"
+          "  InitialGridPoints: [3]\n"
+          "  InitialRefinement: [2]\n");
   const auto* interval_creator =
       dynamic_cast<const creators::Interval*>(domain_creator.get());
   test_interval_construction(*interval_creator, {{0.}}, {{1.}}, {{{3}}},

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -132,13 +132,14 @@ void test_rectangle() {
 
 void test_rectangle_factory() {
   INFO("Rectangle factory");
-  const auto domain_creator = test_factory_creation<DomainCreator<2>>(
-      "  Rectangle:\n"
-      "    LowerBound: [0,0]\n"
-      "    UpperBound: [1,2]\n"
-      "    IsPeriodicIn: [True,False]\n"
-      "    InitialGridPoints: [3,4]\n"
-      "    InitialRefinement: [2,3]\n");
+  const auto domain_creator =
+      TestHelpers::test_factory_creation<DomainCreator<2>>(
+          "  Rectangle:\n"
+          "    LowerBound: [0,0]\n"
+          "    UpperBound: [1,2]\n"
+          "    IsPeriodicIn: [True,False]\n"
+          "    InitialGridPoints: [3,4]\n"
+          "    InitialRefinement: [2,3]\n");
   const auto* rectangle_creator =
       dynamic_cast<const creators::Rectangle*>(domain_creator.get());
   test_rectangle_construction(

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -134,12 +134,12 @@ void test_rectangle_factory() {
   INFO("Rectangle factory");
   const auto domain_creator =
       TestHelpers::test_factory_creation<DomainCreator<2>>(
-          "  Rectangle:\n"
-          "    LowerBound: [0,0]\n"
-          "    UpperBound: [1,2]\n"
-          "    IsPeriodicIn: [True,False]\n"
-          "    InitialGridPoints: [3,4]\n"
-          "    InitialRefinement: [2,3]\n");
+          "Rectangle:\n"
+          "  LowerBound: [0,0]\n"
+          "  UpperBound: [1,2]\n"
+          "  IsPeriodicIn: [True,False]\n"
+          "  InitialGridPoints: [3,4]\n"
+          "  InitialRefinement: [2,3]\n");
   const auto* rectangle_creator =
       dynamic_cast<const creators::Rectangle*>(domain_creator.get());
   test_rectangle_construction(

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -274,14 +274,15 @@ void test_rotated_bricks_factory() {
   const OrientationMap<3> rotation_F_then_U{std::array<Direction<3>, 3>{
       {Direction<3>::lower_zeta(), Direction<3>::upper_xi(),
        Direction<3>::lower_eta()}}};
-  const auto domain_creator = test_factory_creation<DomainCreator<3>>(
-      "  RotatedBricks:\n"
-      "    LowerBound: [0.1, -0.4, -0.2]\n"
-      "    Midpoint:   [2.6, 3.2, 1.7]\n"
-      "    UpperBound: [5.1, 6.2, 3.2]\n"
-      "    IsPeriodicIn: [false, false, false]\n"
-      "    InitialGridPoints: [[3,2],[1,4],[5,6]]\n"
-      "    InitialRefinement: [2,1,0]\n");
+  const auto domain_creator =
+      TestHelpers::test_factory_creation<DomainCreator<3>>(
+          "  RotatedBricks:\n"
+          "    LowerBound: [0.1, -0.4, -0.2]\n"
+          "    Midpoint:   [2.6, 3.2, 1.7]\n"
+          "    UpperBound: [5.1, 6.2, 3.2]\n"
+          "    IsPeriodicIn: [false, false, false]\n"
+          "    InitialGridPoints: [[3,2],[1,4],[5,6]]\n"
+          "    InitialRefinement: [2,1,0]\n");
   const auto* rotated_bricks_creator =
       dynamic_cast<const creators::RotatedBricks*>(domain_creator.get());
   test_rotated_bricks_construction(

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -276,13 +276,13 @@ void test_rotated_bricks_factory() {
        Direction<3>::lower_eta()}}};
   const auto domain_creator =
       TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  RotatedBricks:\n"
-          "    LowerBound: [0.1, -0.4, -0.2]\n"
-          "    Midpoint:   [2.6, 3.2, 1.7]\n"
-          "    UpperBound: [5.1, 6.2, 3.2]\n"
-          "    IsPeriodicIn: [false, false, false]\n"
-          "    InitialGridPoints: [[3,2],[1,4],[5,6]]\n"
-          "    InitialRefinement: [2,1,0]\n");
+          "RotatedBricks:\n"
+          "  LowerBound: [0.1, -0.4, -0.2]\n"
+          "  Midpoint:   [2.6, 3.2, 1.7]\n"
+          "  UpperBound: [5.1, 6.2, 3.2]\n"
+          "  IsPeriodicIn: [false, false, false]\n"
+          "  InitialGridPoints: [[3,2],[1,4],[5,6]]\n"
+          "  InitialRefinement: [2,1,0]\n");
   const auto* rotated_bricks_creator =
       dynamic_cast<const creators::RotatedBricks*>(domain_creator.get());
   test_rotated_bricks_construction(

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -101,14 +101,15 @@ void test_rotated_intervals_factory() {
   INFO("Rotated intervals factory");
   const OrientationMap<1> flipped{
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}};
-  const auto domain_creator = test_factory_creation<DomainCreator<1>>(
-      "  RotatedIntervals:\n"
-      "    LowerBound: [0.0]\n"
-      "    Midpoint:   [0.5]\n"
-      "    UpperBound: [1.0]\n"
-      "    IsPeriodicIn: [True]\n"
-      "    InitialGridPoints: [[3,2]]\n"
-      "    InitialRefinement: [2]\n");
+  const auto domain_creator =
+      TestHelpers::test_factory_creation<DomainCreator<1>>(
+          "  RotatedIntervals:\n"
+          "    LowerBound: [0.0]\n"
+          "    Midpoint:   [0.5]\n"
+          "    UpperBound: [1.0]\n"
+          "    IsPeriodicIn: [True]\n"
+          "    InitialGridPoints: [[3,2]]\n"
+          "    InitialRefinement: [2]\n");
   const auto* rotated_intervals_creator =
       dynamic_cast<const creators::RotatedIntervals*>(domain_creator.get());
   test_rotated_intervals_construction(

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -103,13 +103,13 @@ void test_rotated_intervals_factory() {
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}};
   const auto domain_creator =
       TestHelpers::test_factory_creation<DomainCreator<1>>(
-          "  RotatedIntervals:\n"
-          "    LowerBound: [0.0]\n"
-          "    Midpoint:   [0.5]\n"
-          "    UpperBound: [1.0]\n"
-          "    IsPeriodicIn: [True]\n"
-          "    InitialGridPoints: [[3,2]]\n"
-          "    InitialRefinement: [2]\n");
+          "RotatedIntervals:\n"
+          "  LowerBound: [0.0]\n"
+          "  Midpoint:   [0.5]\n"
+          "  UpperBound: [1.0]\n"
+          "  IsPeriodicIn: [True]\n"
+          "  InitialGridPoints: [[3,2]]\n"
+          "  InitialRefinement: [2]\n");
   const auto* rotated_intervals_creator =
       dynamic_cast<const creators::RotatedIntervals*>(domain_creator.get());
   test_rotated_intervals_construction(

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -161,14 +161,15 @@ void test_rotated_rectangles_factory() {
   const OrientationMap<2> quarter_turn_ccw{std::array<Direction<2>, 2>{
       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}};
 
-  const auto domain_creator = test_factory_creation<DomainCreator<2>>(
-      "  RotatedRectangles:\n"
-      "    LowerBound: [0.1, -0.4]\n"
-      "    Midpoint:   [2.6, 3.2]\n"
-      "    UpperBound: [5.1, 6.2]\n"
-      "    IsPeriodicIn: [false, false]\n"
-      "    InitialGridPoints: [[3,2],[1,4]]\n"
-      "    InitialRefinement: [2,1]\n");
+  const auto domain_creator =
+      TestHelpers::test_factory_creation<DomainCreator<2>>(
+          "  RotatedRectangles:\n"
+          "    LowerBound: [0.1, -0.4]\n"
+          "    Midpoint:   [2.6, 3.2]\n"
+          "    UpperBound: [5.1, 6.2]\n"
+          "    IsPeriodicIn: [false, false]\n"
+          "    InitialGridPoints: [[3,2],[1,4]]\n"
+          "    InitialRefinement: [2,1]\n");
   const auto* rotated_rectangles_creator =
       dynamic_cast<const creators::RotatedRectangles*>(domain_creator.get());
   test_rotated_rectangles_construction(

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -163,13 +163,13 @@ void test_rotated_rectangles_factory() {
 
   const auto domain_creator =
       TestHelpers::test_factory_creation<DomainCreator<2>>(
-          "  RotatedRectangles:\n"
-          "    LowerBound: [0.1, -0.4]\n"
-          "    Midpoint:   [2.6, 3.2]\n"
-          "    UpperBound: [5.1, 6.2]\n"
-          "    IsPeriodicIn: [false, false]\n"
-          "    InitialGridPoints: [[3,2],[1,4]]\n"
-          "    InitialRefinement: [2,1]\n");
+          "RotatedRectangles:\n"
+          "  LowerBound: [0.1, -0.4]\n"
+          "  Midpoint:   [2.6, 3.2]\n"
+          "  UpperBound: [5.1, 6.2]\n"
+          "  IsPeriodicIn: [false, false]\n"
+          "  InitialGridPoints: [[3,2],[1,4]]\n"
+          "  InitialRefinement: [2,1]\n");
   const auto* rotated_rectangles_creator =
       dynamic_cast<const creators::RotatedRectangles*>(domain_creator.get());
   test_rotated_rectangles_construction(

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -273,11 +273,11 @@ void test_shell_boundaries() {
 void test_shell_factory_equiangular() {
   INFO("Shell factory equiangular");
   const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
-      "  Shell:\n"
-      "    InnerRadius: 1\n"
-      "    OuterRadius: 3\n"
-      "    InitialRefinement: 2\n"
-      "    InitialGridPoints: [2,3]\n");
+          "Shell:\n"
+          "  InnerRadius: 1\n"
+          "  OuterRadius: 3\n"
+          "  InitialRefinement: 2\n"
+          "  InitialGridPoints: [2,3]\n");
   const double inner_radius = 1.0, outer_radius = 3.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
@@ -289,12 +289,12 @@ void test_shell_factory_equiangular() {
 void test_shell_factory_equidistant() {
   INFO("Shell factory equidistant");
   const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
-      "  Shell:\n"
-      "    InnerRadius: 1\n"
-      "    OuterRadius: 3\n"
-      "    InitialRefinement: 2\n"
-      "    InitialGridPoints: [2,3]\n"
-      "    UseEquiangularMap: false\n");
+      "Shell:\n"
+      "  InnerRadius: 1\n"
+      "  OuterRadius: 3\n"
+      "  InitialRefinement: 2\n"
+      "  InitialGridPoints: [2,3]\n"
+      "  UseEquiangularMap: false\n");
   const double inner_radius = 1.0, outer_radius = 3.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
@@ -322,13 +322,13 @@ void test_shell_boundaries_aspect_ratio() {
 void test_shell_factory_aspect_ratio() {
   INFO("Shell factory aspect ratio");
   const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
-      "  Shell:\n"
-      "    InnerRadius: 1\n"
-      "    OuterRadius: 3\n"
-      "    InitialRefinement: 2\n"
-      "    InitialGridPoints: [2,3]\n"
-      "    UseEquiangularMap: false\n"
-      "    AspectRatio: 2.0        \n");
+      "Shell:\n"
+      "  InnerRadius: 1\n"
+      "  OuterRadius: 3\n"
+      "  InitialRefinement: 2\n"
+      "  InitialGridPoints: [2,3]\n"
+      "  UseEquiangularMap: false\n"
+      "  AspectRatio: 2.0        \n");
   const double inner_radius = 1.0, outer_radius = 3.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
@@ -359,14 +359,14 @@ void test_shell_boundaries_logarithmic_map() {
 void test_shell_factory_logarithmic_map() {
   INFO("Shell factory logarithmic map");
   const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
-      "  Shell:\n"
-      "    InnerRadius: 1\n"
-      "    OuterRadius: 3\n"
-      "    InitialRefinement: 2\n"
-      "    InitialGridPoints: [2,3]\n"
-      "    UseEquiangularMap: false\n"
-      "    AspectRatio: 2.0        \n"
-      "    UseLogarithmicMap: true\n");
+      "Shell:\n"
+      "  InnerRadius: 1\n"
+      "  OuterRadius: 3\n"
+      "  InitialRefinement: 2\n"
+      "  InitialGridPoints: [2,3]\n"
+      "  UseEquiangularMap: false\n"
+      "  AspectRatio: 2.0        \n"
+      "  UseLogarithmicMap: true\n");
   const double inner_radius = 1.0, outer_radius = 3.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
@@ -381,15 +381,15 @@ void test_shell_factory_logarithmic_map() {
 void test_shell_factory_wedges_four_on_equator() {
   INFO("Shell factory wedges four on equator");
   const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
-      "  Shell:\n"
-      "    InnerRadius: 1\n"
-      "    OuterRadius: 3\n"
-      "    InitialRefinement: 2\n"
-      "    InitialGridPoints: [2,3]\n"
-      "    UseEquiangularMap: false\n"
-      "    AspectRatio: 2.0        \n"
-      "    UseLogarithmicMap: true\n"
-      "    WhichWedges: FourOnEquator\n");
+      "Shell:\n"
+      "  InnerRadius: 1\n"
+      "  OuterRadius: 3\n"
+      "  InitialRefinement: 2\n"
+      "  InitialGridPoints: [2,3]\n"
+      "  UseEquiangularMap: false\n"
+      "  AspectRatio: 2.0        \n"
+      "  UseLogarithmicMap: true\n"
+      "  WhichWedges: FourOnEquator\n");
   const double inner_radius = 1.0, outer_radius = 3.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
@@ -405,15 +405,15 @@ void test_shell_factory_wedges_four_on_equator() {
 void test_shell_factory_wedges_one_along_minus_x() {
   INFO("Shell factory wedges one along minus x");
   const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
-      "  Shell:\n"
-      "    InnerRadius: 2\n"
-      "    OuterRadius: 3\n"
-      "    InitialRefinement: 2\n"
-      "    InitialGridPoints: [2,3]\n"
-      "    UseEquiangularMap: true\n"
-      "    AspectRatio: 2.7        \n"
-      "    UseLogarithmicMap: false\n"
-      "    WhichWedges: OneAlongMinusX \n");
+      "Shell:\n"
+      "  InnerRadius: 2\n"
+      "  OuterRadius: 3\n"
+      "  InitialRefinement: 2\n"
+      "  InitialGridPoints: [2,3]\n"
+      "  UseEquiangularMap: true\n"
+      "  AspectRatio: 2.7        \n"
+      "  UseLogarithmicMap: false\n"
+      "  WhichWedges: OneAlongMinusX \n");
   const double inner_radius = 2.0, outer_radius = 3.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
@@ -524,15 +524,15 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell", "[Domain][Unit]") {
   {
     INFO("shell factory logarithmic block layers");
     const auto log_shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
-        "  Shell:\n"
-        "    InnerRadius: 1\n"
-        "    OuterRadius: 3\n"
-        "    InitialRefinement: 2\n"
-        "    InitialGridPoints: [2,3]\n"
-        "    UseEquiangularMap: false\n"
-        "    AspectRatio: 2.0        \n"
-        "    UseLogarithmicMap: true\n"
-        "    RadialBlockLayers: 6\n");
+        "Shell:\n"
+        "  InnerRadius: 1\n"
+        "  OuterRadius: 3\n"
+        "  InitialRefinement: 2\n"
+        "  InitialGridPoints: [2,3]\n"
+        "  UseEquiangularMap: false\n"
+        "  AspectRatio: 2.0        \n"
+        "  UseLogarithmicMap: true\n"
+        "  RadialBlockLayers: 6\n");
   }
   {
     INFO("Radial block layers 1");

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -272,7 +272,7 @@ void test_shell_boundaries() {
 
 void test_shell_factory_equiangular() {
   INFO("Shell factory equiangular");
-  const auto shell = test_factory_creation<DomainCreator<3>>(
+  const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
       "  Shell:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -288,7 +288,7 @@ void test_shell_factory_equiangular() {
 
 void test_shell_factory_equidistant() {
   INFO("Shell factory equidistant");
-  const auto shell = test_factory_creation<DomainCreator<3>>(
+  const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
       "  Shell:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -321,7 +321,7 @@ void test_shell_boundaries_aspect_ratio() {
 
 void test_shell_factory_aspect_ratio() {
   INFO("Shell factory aspect ratio");
-  const auto shell = test_factory_creation<DomainCreator<3>>(
+  const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
       "  Shell:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -358,7 +358,7 @@ void test_shell_boundaries_logarithmic_map() {
 
 void test_shell_factory_logarithmic_map() {
   INFO("Shell factory logarithmic map");
-  const auto shell = test_factory_creation<DomainCreator<3>>(
+  const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
       "  Shell:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -380,7 +380,7 @@ void test_shell_factory_logarithmic_map() {
 
 void test_shell_factory_wedges_four_on_equator() {
   INFO("Shell factory wedges four on equator");
-  const auto shell = test_factory_creation<DomainCreator<3>>(
+  const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
       "  Shell:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -404,7 +404,7 @@ void test_shell_factory_wedges_four_on_equator() {
 
 void test_shell_factory_wedges_one_along_minus_x() {
   INFO("Shell factory wedges one along minus x");
-  const auto shell = test_factory_creation<DomainCreator<3>>(
+  const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
       "  Shell:\n"
       "    InnerRadius: 2\n"
       "    OuterRadius: 3\n"
@@ -523,7 +523,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell", "[Domain][Unit]") {
 
   {
     INFO("shell factory logarithmic block layers");
-    const auto log_shell = test_factory_creation<DomainCreator<3>>(
+    const auto log_shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
         "  Shell:\n"
         "    InnerRadius: 1\n"
         "    OuterRadius: 3\n"

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -206,7 +206,7 @@ void test_sphere_boundaries_equiangular() {
 
 void test_sphere_factory_equiangular() {
   INFO("Sphere factory equiangular");
-  const auto sphere = test_factory_creation<DomainCreator<3>>(
+  const auto sphere = TestHelpers::test_factory_creation<DomainCreator<3>>(
       "  Sphere:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -239,7 +239,7 @@ void test_sphere_boundaries_equidistant() {
 
 void test_sphere_factory_equidistant() {
   INFO("Sphere factory equidistant");
-  const auto sphere = test_factory_creation<DomainCreator<3>>(
+  const auto sphere = TestHelpers::test_factory_creation<DomainCreator<3>>(
       "  Sphere:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"

--- a/tests/Unit/Elliptic/Triggers/Test_EveryNIterations.cpp
+++ b/tests/Unit/Elliptic/Triggers/Test_EveryNIterations.cpp
@@ -32,7 +32,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Triggers.EveryNIterations",
       elliptic::Triggers::Registrars::EveryNIterations<IterationIdTag>>>;
   Parallel::register_derived_classes_with_charm<TriggerType>();
 
-  const auto trigger = test_factory_creation<TriggerType>(
+  const auto trigger = TestHelpers::test_factory_creation<TriggerType>(
       "  EveryNIterations:\n"
       "    N: 3\n"
       "    Offset: 5");

--- a/tests/Unit/Elliptic/Triggers/Test_EveryNIterations.cpp
+++ b/tests/Unit/Elliptic/Triggers/Test_EveryNIterations.cpp
@@ -33,9 +33,9 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Triggers.EveryNIterations",
   Parallel::register_derived_classes_with_charm<TriggerType>();
 
   const auto trigger = TestHelpers::test_factory_creation<TriggerType>(
-      "  EveryNIterations:\n"
-      "    N: 3\n"
-      "    Offset: 5");
+      "EveryNIterations:\n"
+      "  N: 3\n"
+      "  Offset: 5");
 
   const auto sent_trigger = serialize_and_deserialize(trigger);
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
@@ -66,16 +66,16 @@ struct VectorTag : db::SimpleTag {
 void test_minmod_option_parsing() noexcept {
   INFO("Test Minmod option parsing");
   const auto lambda_pi1_default =
-      test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
+      TestHelpers::test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
           "  Type: LambdaPi1");
   const auto lambda_pi1_m0 =
-      test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
+      TestHelpers::test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
           "  Type: LambdaPi1\n  TvbmConstant: 0.0");
   const auto lambda_pi1_m1 =
-      test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
+      TestHelpers::test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
           "  Type: LambdaPi1\n  TvbmConstant: 1.0");
   const auto muscl_default =
-      test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
+      TestHelpers::test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
           "  Type: Muscl");
 
   // Test default TVBM value, operator==, and operator!=
@@ -83,14 +83,15 @@ void test_minmod_option_parsing() noexcept {
   CHECK(lambda_pi1_default != lambda_pi1_m1);
   CHECK(lambda_pi1_default != muscl_default);
 
-  test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
+  TestHelpers::test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
       "  Type: LambdaPiN");
-  test_creation<Limiters::Minmod<2, tmpl::list<ScalarTag>>>(
+  TestHelpers::test_creation<Limiters::Minmod<2, tmpl::list<ScalarTag>>>(
       "  Type: LambdaPiN");
-  test_creation<Limiters::Minmod<3, tmpl::list<ScalarTag, VectorTag<3>>>>(
+  TestHelpers::test_creation<
+      Limiters::Minmod<3, tmpl::list<ScalarTag, VectorTag<3>>>>(
       "  Type: LambdaPiN");
 
-  test_creation<Limiters::Minmod<3, tmpl::list<ScalarTag>>>(
+  TestHelpers::test_creation<Limiters::Minmod<3, tmpl::list<ScalarTag>>>(
       "  Type: LambdaPiN\n  DisableForDebugging: True");
 }
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
@@ -67,16 +67,18 @@ void test_minmod_option_parsing() noexcept {
   INFO("Test Minmod option parsing");
   const auto lambda_pi1_default =
       TestHelpers::test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
-          "  Type: LambdaPi1");
+          "Type: LambdaPi1");
   const auto lambda_pi1_m0 =
       TestHelpers::test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
-          "  Type: LambdaPi1\n  TvbmConstant: 0.0");
+          "Type: LambdaPi1\n"
+          "TvbmConstant: 0.0");
   const auto lambda_pi1_m1 =
       TestHelpers::test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
-          "  Type: LambdaPi1\n  TvbmConstant: 1.0");
+          "Type: LambdaPi1\n"
+          "TvbmConstant: 1.0");
   const auto muscl_default =
       TestHelpers::test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
-          "  Type: Muscl");
+          "Type: Muscl");
 
   // Test default TVBM value, operator==, and operator!=
   CHECK(lambda_pi1_default == lambda_pi1_m0);
@@ -84,15 +86,16 @@ void test_minmod_option_parsing() noexcept {
   CHECK(lambda_pi1_default != muscl_default);
 
   TestHelpers::test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
-      "  Type: LambdaPiN");
+      "Type: LambdaPiN");
   TestHelpers::test_creation<Limiters::Minmod<2, tmpl::list<ScalarTag>>>(
-      "  Type: LambdaPiN");
+      "Type: LambdaPiN");
   TestHelpers::test_creation<
       Limiters::Minmod<3, tmpl::list<ScalarTag, VectorTag<3>>>>(
-      "  Type: LambdaPiN");
+      "Type: LambdaPiN");
 
   TestHelpers::test_creation<Limiters::Minmod<3, tmpl::list<ScalarTag>>>(
-      "  Type: LambdaPiN\n  DisableForDebugging: True");
+      "Type: LambdaPiN\n"
+      "DisableForDebugging: True");
 }
 
 void test_minmod_serialization() noexcept {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodType.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodType.cpp
@@ -11,11 +11,11 @@
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.MinmodType", "[Limiters][Unit]") {
   CHECK(Limiters::MinmodType::LambdaPi1 ==
-        TestHelpers::test_enum_creation<Limiters::MinmodType>("LambdaPi1"));
+        TestHelpers::test_creation<Limiters::MinmodType>("LambdaPi1"));
   CHECK(Limiters::MinmodType::LambdaPiN ==
-        TestHelpers::test_enum_creation<Limiters::MinmodType>("LambdaPiN"));
+        TestHelpers::test_creation<Limiters::MinmodType>("LambdaPiN"));
   CHECK(Limiters::MinmodType::Muscl ==
-        TestHelpers::test_enum_creation<Limiters::MinmodType>("Muscl"));
+        TestHelpers::test_creation<Limiters::MinmodType>("Muscl"));
 
   CHECK(get_output(Limiters::MinmodType::LambdaPi1) == "LambdaPi1");
   CHECK(get_output(Limiters::MinmodType::LambdaPiN) == "LambdaPiN");
@@ -26,5 +26,5 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.MinmodType", "[Limiters][Unit]") {
 SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.MinmodType.OptionParseError",
                   "[Limiters][Unit]") {
   ERROR_TEST();
-  TestHelpers::test_enum_creation<Limiters::MinmodType>("BadType");
+  TestHelpers::test_creation<Limiters::MinmodType>("BadType");
 }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodType.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodType.cpp
@@ -11,11 +11,11 @@
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.MinmodType", "[Limiters][Unit]") {
   CHECK(Limiters::MinmodType::LambdaPi1 ==
-        test_enum_creation<Limiters::MinmodType>("LambdaPi1"));
+        TestHelpers::test_enum_creation<Limiters::MinmodType>("LambdaPi1"));
   CHECK(Limiters::MinmodType::LambdaPiN ==
-        test_enum_creation<Limiters::MinmodType>("LambdaPiN"));
+        TestHelpers::test_enum_creation<Limiters::MinmodType>("LambdaPiN"));
   CHECK(Limiters::MinmodType::Muscl ==
-        test_enum_creation<Limiters::MinmodType>("Muscl"));
+        TestHelpers::test_enum_creation<Limiters::MinmodType>("Muscl"));
 
   CHECK(get_output(Limiters::MinmodType::LambdaPi1) == "LambdaPi1");
   CHECK(get_output(Limiters::MinmodType::LambdaPiN) == "LambdaPiN");
@@ -26,5 +26,5 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.MinmodType", "[Limiters][Unit]") {
 SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.MinmodType.OptionParseError",
                   "[Limiters][Unit]") {
   ERROR_TEST();
-  test_enum_creation<Limiters::MinmodType>("BadType");
+  TestHelpers::test_enum_creation<Limiters::MinmodType>("BadType");
 }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
@@ -68,18 +68,19 @@ void test_weno_option_parsing() noexcept {
   INFO("Test WENO option parsing");
 
   const auto hweno_1d =
-      test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>("  Type: Hweno");
+      TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
+          "  Type: Hweno");
   const auto hweno_1d_default_weight =
-      test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
+      TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
           "  Type: Hweno\n  NeighborWeight: 0.001");
   const auto hweno_1d_larger_weight =
-      test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
+      TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
           "  Type: Hweno\n  NeighborWeight: 0.01");
   const auto hweno_1d_disabled =
-      test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
+      TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
           "  Type: Hweno\n  DisableForDebugging: True");
   const auto simple_weno_1d =
-      test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
+      TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
           "  Type: SimpleWeno");
 
   // Check neighbor_weight default from options, op==, op!=
@@ -89,10 +90,11 @@ void test_weno_option_parsing() noexcept {
   CHECK(hweno_1d != simple_weno_1d);
 
   const auto hweno_2d =
-      test_creation<Limiters::Weno<2, tmpl::list<ScalarTag>>>("  Type: Hweno");
-  const auto hweno_3d_larger_weight =
-      test_creation<Limiters::Weno<3, tmpl::list<ScalarTag, VectorTag<3>>>>(
-          "  Type: Hweno\n  NeighborWeight: 0.01\n  DisableForDebugging: True");
+      TestHelpers::test_creation<Limiters::Weno<2, tmpl::list<ScalarTag>>>(
+          "  Type: Hweno");
+  const auto hweno_3d_larger_weight = TestHelpers::test_creation<
+      Limiters::Weno<3, tmpl::list<ScalarTag, VectorTag<3>>>>(
+      "  Type: Hweno\n  NeighborWeight: 0.01\n  DisableForDebugging: True");
 
   // Check that creation from options gives correct object
   const Limiters::Weno<1, tmpl::list<ScalarTag>> expected_hweno_1d(

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
@@ -69,19 +69,22 @@ void test_weno_option_parsing() noexcept {
 
   const auto hweno_1d =
       TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
-          "  Type: Hweno");
+          "Type: Hweno");
   const auto hweno_1d_default_weight =
       TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
-          "  Type: Hweno\n  NeighborWeight: 0.001");
+          "Type: Hweno\n"
+          "NeighborWeight: 0.001");
   const auto hweno_1d_larger_weight =
       TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
-          "  Type: Hweno\n  NeighborWeight: 0.01");
+          "Type: Hweno\n"
+          "NeighborWeight: 0.01");
   const auto hweno_1d_disabled =
       TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
-          "  Type: Hweno\n  DisableForDebugging: True");
+          "Type: Hweno\n"
+          "DisableForDebugging: True");
   const auto simple_weno_1d =
       TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
-          "  Type: SimpleWeno");
+          "Type: SimpleWeno");
 
   // Check neighbor_weight default from options, op==, op!=
   CHECK(hweno_1d == hweno_1d_default_weight);
@@ -91,10 +94,12 @@ void test_weno_option_parsing() noexcept {
 
   const auto hweno_2d =
       TestHelpers::test_creation<Limiters::Weno<2, tmpl::list<ScalarTag>>>(
-          "  Type: Hweno");
+          "Type: Hweno");
   const auto hweno_3d_larger_weight = TestHelpers::test_creation<
       Limiters::Weno<3, tmpl::list<ScalarTag, VectorTag<3>>>>(
-      "  Type: Hweno\n  NeighborWeight: 0.01\n  DisableForDebugging: True");
+      "Type: Hweno\n"
+      "NeighborWeight: 0.01\n"
+      "DisableForDebugging: True");
 
   // Check that creation from options gives correct object
   const Limiters::Weno<1, tmpl::list<ScalarTag>> expected_hweno_1d(

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoType.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoType.cpp
@@ -11,9 +11,9 @@
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.WenoType", "[Limiters][Unit]") {
   CHECK(Limiters::WenoType::Hweno ==
-        test_enum_creation<Limiters::WenoType>("Hweno"));
+        TestHelpers::test_enum_creation<Limiters::WenoType>("Hweno"));
   CHECK(Limiters::WenoType::SimpleWeno ==
-        test_enum_creation<Limiters::WenoType>("SimpleWeno"));
+        TestHelpers::test_enum_creation<Limiters::WenoType>("SimpleWeno"));
 
   CHECK(get_output(Limiters::WenoType::Hweno) == "Hweno");
   CHECK(get_output(Limiters::WenoType::SimpleWeno) == "SimpleWeno");
@@ -23,5 +23,5 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.WenoType", "[Limiters][Unit]") {
 SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.WenoType.OptionParseError",
                   "[Limiters][Unit]") {
   ERROR_TEST();
-  test_enum_creation<Limiters::WenoType>("BadType");
+  TestHelpers::test_enum_creation<Limiters::WenoType>("BadType");
 }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoType.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoType.cpp
@@ -11,9 +11,9 @@
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.WenoType", "[Limiters][Unit]") {
   CHECK(Limiters::WenoType::Hweno ==
-        TestHelpers::test_enum_creation<Limiters::WenoType>("Hweno"));
+        TestHelpers::test_creation<Limiters::WenoType>("Hweno"));
   CHECK(Limiters::WenoType::SimpleWeno ==
-        TestHelpers::test_enum_creation<Limiters::WenoType>("SimpleWeno"));
+        TestHelpers::test_creation<Limiters::WenoType>("SimpleWeno"));
 
   CHECK(get_output(Limiters::WenoType::Hweno) == "Hweno");
   CHECK(get_output(Limiters::WenoType::SimpleWeno) == "SimpleWeno");
@@ -23,5 +23,5 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.WenoType", "[Limiters][Unit]") {
 SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.WenoType.OptionParseError",
                   "[Limiters][Unit]") {
   ERROR_TEST();
-  TestHelpers::test_enum_creation<Limiters::WenoType>("BadType");
+  TestHelpers::test_creation<Limiters::WenoType>("BadType");
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_FixConservatives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_FixConservatives.cpp
@@ -75,7 +75,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.GrMhd.ValenciaDivClean.FixConservatives",
   test_serialization(variable_fixer);
 
   const auto fixer_from_options =
-      test_creation<VariableFixing::FixConservatives>(
+      TestHelpers::test_creation<VariableFixing::FixConservatives>(
           "  MinimumValueOfD: 1.0e-12\n"
           "  CutoffD: 1.0e-11\n"
           "  SafetyFactorForB: 0.0\n"

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_FixConservatives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_FixConservatives.cpp
@@ -76,9 +76,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.GrMhd.ValenciaDivClean.FixConservatives",
 
   const auto fixer_from_options =
       TestHelpers::test_creation<VariableFixing::FixConservatives>(
-          "  MinimumValueOfD: 1.0e-12\n"
-          "  CutoffD: 1.0e-11\n"
-          "  SafetyFactorForB: 0.0\n"
-          "  SafetyFactorForS: 0.0\n");
+          "MinimumValueOfD: 1.0e-12\n"
+          "CutoffD: 1.0e-11\n"
+          "SafetyFactorForB: 0.0\n"
+          "SafetyFactorForS: 0.0\n");
   test_variable_fixer(fixer_from_options);
 }

--- a/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
@@ -107,9 +107,9 @@ void test_variable_fixer() noexcept {
 
   const auto fixer_from_options_1d =
       TestHelpers::test_creation<VariableFixing::FixToAtmosphere<Dim, 1>>(
-          "  DensityOfAtmosphere: 1.0e-12\n"
-          "  DensityCutoff: 1.0e-11\n");
-  test_variable_fixer<Dim>(fixer_from_options_1d);
+          "DensityOfAtmosphere: 1.0e-12\n"
+          "DensityCutoff: 1.0e-11\n");
+  test_variable_fixer(fixer_from_options_1d);
 
   // Test for representative 2-d equation of state
   VariableFixing::FixToAtmosphere<Dim, 2> variable_fixer_2d{1.e-12, 1.e-11};
@@ -118,8 +118,8 @@ void test_variable_fixer() noexcept {
 
   const auto fixer_from_options_2d =
       TestHelpers::test_creation<VariableFixing::FixToAtmosphere<Dim, 2>>(
-          "  DensityOfAtmosphere: 1.0e-12\n"
-          "  DensityCutoff: 1.0e-11\n");
+          "DensityOfAtmosphere: 1.0e-12\n"
+          "DensityCutoff: 1.0e-11\n");
   test_variable_fixer<Dim>(fixer_from_options_2d);
 }
 }  // namespace

--- a/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
@@ -106,7 +106,7 @@ void test_variable_fixer() noexcept {
   test_serialization(variable_fixer_1d);
 
   const auto fixer_from_options_1d =
-      test_creation<VariableFixing::FixToAtmosphere<Dim, 1>>(
+      TestHelpers::test_creation<VariableFixing::FixToAtmosphere<Dim, 1>>(
           "  DensityOfAtmosphere: 1.0e-12\n"
           "  DensityCutoff: 1.0e-11\n");
   test_variable_fixer<Dim>(fixer_from_options_1d);
@@ -117,7 +117,7 @@ void test_variable_fixer() noexcept {
   test_serialization(variable_fixer_2d);
 
   const auto fixer_from_options_2d =
-      test_creation<VariableFixing::FixToAtmosphere<Dim, 2>>(
+      TestHelpers::test_creation<VariableFixing::FixToAtmosphere<Dim, 2>>(
           "  DensityOfAtmosphere: 1.0e-12\n"
           "  DensityCutoff: 1.0e-11\n");
   test_variable_fixer<Dim>(fixer_from_options_2d);

--- a/tests/Unit/Evolution/VariableFixing/Test_LimitLorentzFactor.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_LimitLorentzFactor.cpp
@@ -82,8 +82,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.LimitLorentzFactor",
 
     const auto fixer_from_options =
         TestHelpers::test_creation<LimitLorentzFactor>(
-            "  MaxDensityCutoff: 1.0e-4\n"
-            "  LorentzFactorCap: 50.0\n");
+            "MaxDensityCutoff: 1.0e-4\n"
+            "LorentzFactorCap: 50.0\n");
     test_variable_fixer(fixer_from_options);
   }
 }

--- a/tests/Unit/Evolution/VariableFixing/Test_LimitLorentzFactor.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_LimitLorentzFactor.cpp
@@ -80,9 +80,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.LimitLorentzFactor",
     test_serialization(variable_fixer);
     test_variable_fixer(serialize_and_deserialize(variable_fixer));
 
-    const auto fixer_from_options = test_creation<LimitLorentzFactor>(
-        "  MaxDensityCutoff: 1.0e-4\n"
-        "  LorentzFactorCap: 50.0\n");
+    const auto fixer_from_options =
+        TestHelpers::test_creation<LimitLorentzFactor>(
+            "  MaxDensityCutoff: 1.0e-4\n"
+            "  LorentzFactorCap: 50.0\n");
     test_variable_fixer(fixer_from_options);
   }
 }

--- a/tests/Unit/Evolution/VariableFixing/Test_RadiallyFallingFloor.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_RadiallyFallingFloor.cpp
@@ -46,7 +46,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.RadiallyFallingFloor",
   test_serialization(variable_fixer);
 
   const auto fixer_from_options =
-      test_creation<VariableFixing::RadiallyFallingFloor<3>>(
+      TestHelpers::test_creation<VariableFixing::RadiallyFallingFloor<3>>(
           "  MinimumRadius: 1.e-4\n"
           "  ScaleDensityFloor: 1.e-5\n"
           "  PowerDensityFloor: -1.5\n"

--- a/tests/Unit/Evolution/VariableFixing/Test_RadiallyFallingFloor.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_RadiallyFallingFloor.cpp
@@ -47,10 +47,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.RadiallyFallingFloor",
 
   const auto fixer_from_options =
       TestHelpers::test_creation<VariableFixing::RadiallyFallingFloor<3>>(
-          "  MinimumRadius: 1.e-4\n"
-          "  ScaleDensityFloor: 1.e-5\n"
-          "  PowerDensityFloor: -1.5\n"
-          "  ScalePressureFloor: 0.33333333333333333e-7\n"
-          "  PowerPressureFloor: -2.5\n");
+          "MinimumRadius: 1.e-4\n"
+          "ScaleDensityFloor: 1.e-5\n"
+          "PowerDensityFloor: -1.5\n"
+          "ScalePressureFloor: 0.33333333333333333e-7\n"
+          "PowerPressureFloor: -2.5\n");
   test_variable_fixer(fixer_from_options);
 }

--- a/tests/Unit/NumericalAlgorithms/Convergence/Test_Criteria.cpp
+++ b/tests/Unit/NumericalAlgorithms/Convergence/Test_Criteria.cpp
@@ -18,8 +18,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.Convergence.Criteria",
   test_copy_semantics(criteria);
   const auto created_criteria =
       TestHelpers::test_creation<Convergence::Criteria>(
-          "  MaxIterations: 2\n"
-          "  AbsoluteResidual: 0.1\n"
-          "  RelativeResidual: 0.5\n");
+          "MaxIterations: 2\n"
+          "AbsoluteResidual: 0.1\n"
+          "RelativeResidual: 0.5\n");
   CHECK(created_criteria == criteria);
 }

--- a/tests/Unit/NumericalAlgorithms/Convergence/Test_Criteria.cpp
+++ b/tests/Unit/NumericalAlgorithms/Convergence/Test_Criteria.cpp
@@ -16,9 +16,10 @@ SPECTRE_TEST_CASE("Unit.Numerical.Convergence.Criteria",
   CHECK(criteria != Convergence::Criteria{2, 0.1, 0.6});
   test_serialization(criteria);
   test_copy_semantics(criteria);
-  const auto created_criteria = test_creation<Convergence::Criteria>(
-      "  MaxIterations: 2\n"
-      "  AbsoluteResidual: 0.1\n"
-      "  RelativeResidual: 0.5\n");
+  const auto created_criteria =
+      TestHelpers::test_creation<Convergence::Criteria>(
+          "  MaxIterations: 2\n"
+          "  AbsoluteResidual: 0.1\n"
+          "  RelativeResidual: 0.5\n");
   CHECK(created_criteria == criteria);
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -69,12 +69,12 @@ SPECTRE_TEST_CASE(
   // Test creation of options
   const auto created_opts = TestHelpers::test_creation<
       intrp::OptionHolders::ApparentHorizon<Frame::Inertial>>(
-      "  FastFlow:\n"
-      "  Verbosity: Verbose\n"
-      "  InitialGuess:\n"
-      "    Center: [0.05, 0.06, 0.07]\n"
-      "    Radius: 2.0\n"
-      "    Lmax: 12");
+      "FastFlow:\n"
+      "Verbosity: Verbose\n"
+      "InitialGuess:\n"
+      "  Center: [0.05, 0.06, 0.07]\n"
+      "  Radius: 2.0\n"
+      "  Lmax: 12");
   CHECK(created_opts == apparent_horizon_opts);
 
   const auto domain_creator =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -67,14 +67,14 @@ SPECTRE_TEST_CASE(
       Verbosity::Verbose);
 
   // Test creation of options
-  const auto created_opts =
-      test_creation<intrp::OptionHolders::ApparentHorizon<Frame::Inertial>>(
-          "  FastFlow:\n"
-          "  Verbosity: Verbose\n"
-          "  InitialGuess:\n"
-          "    Center: [0.05, 0.06, 0.07]\n"
-          "    Radius: 2.0\n"
-          "    Lmax: 12");
+  const auto created_opts = TestHelpers::test_creation<
+      intrp::OptionHolders::ApparentHorizon<Frame::Inertial>>(
+      "  FastFlow:\n"
+      "  Verbosity: Verbose\n"
+      "  InitialGuess:\n"
+      "    Center: [0.05, 0.06, 0.07]\n"
+      "    Radius: 2.0\n"
+      "    Lmax: 12");
   CHECK(created_opts == apparent_horizon_opts);
 
   const auto domain_creator =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -65,10 +65,10 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.KerrHorizon",
   // Test creation of options
   const auto created_opts =
       TestHelpers::test_creation<intrp::OptionHolders::KerrHorizon>(
-          "  Center: [0.05, 0.06, 0.07]\n"
-          "  DimensionlessSpin: [0.2, 0.3, 0.4]\n"
-          "  Lmax: 18\n"
-          "  Mass: 1.8");
+          "Center: [0.05, 0.06, 0.07]\n"
+          "DimensionlessSpin: [0.2, 0.3, 0.4]\n"
+          "Lmax: 18\n"
+          "Mass: 1.8");
   CHECK(created_opts == kerr_horizon_opts);
 
   const auto domain_creator =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -63,11 +63,12 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.KerrHorizon",
                                                       dimless_spin);
 
   // Test creation of options
-  const auto created_opts = test_creation<intrp::OptionHolders::KerrHorizon>(
-      "  Center: [0.05, 0.06, 0.07]\n"
-      "  DimensionlessSpin: [0.2, 0.3, 0.4]\n"
-      "  Lmax: 18\n"
-      "  Mass: 1.8");
+  const auto created_opts =
+      TestHelpers::test_creation<intrp::OptionHolders::KerrHorizon>(
+          "  Center: [0.05, 0.06, 0.07]\n"
+          "  DimensionlessSpin: [0.2, 0.3, 0.4]\n"
+          "  Lmax: 18\n"
+          "  Mass: 1.8");
   CHECK(created_opts == kerr_horizon_opts);
 
   const auto domain_creator =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -49,10 +49,11 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.LineSegment",
                                                          {{2.4, 2.4, 2.4}}, 15);
 
   // Test creation of options
-  const auto created_opts = test_creation<intrp::OptionHolders::LineSegment<3>>(
-      "  Begin: [1.0, 1.0, 1.0]\n"
-      "  End: [2.4, 2.4, 2.4]\n"
-      "  NumberOfPoints: 15");
+  const auto created_opts =
+      TestHelpers::test_creation<intrp::OptionHolders::LineSegment<3>>(
+          "  Begin: [1.0, 1.0, 1.0]\n"
+          "  End: [2.4, 2.4, 2.4]\n"
+          "  NumberOfPoints: 15");
   CHECK(created_opts == line_segment_opts);
 
   const auto domain_creator =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -51,9 +51,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.LineSegment",
   // Test creation of options
   const auto created_opts =
       TestHelpers::test_creation<intrp::OptionHolders::LineSegment<3>>(
-          "  Begin: [1.0, 1.0, 1.0]\n"
-          "  End: [2.4, 2.4, 2.4]\n"
-          "  NumberOfPoints: 15");
+          "Begin: [1.0, 1.0, 1.0]\n"
+          "End: [2.4, 2.4, 2.4]\n"
+          "NumberOfPoints: 15");
   CHECK(created_opts == line_segment_opts);
 
   const auto domain_creator =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -137,14 +137,14 @@ SPECTRE_TEST_CASE(
   // Check creating the options
   const auto created_torus =
       TestHelpers::test_creation<intrp::OptionHolders::WedgeSectionTorus>(
-          "  MinRadius: 1.8\n"
-          "  MaxRadius: 20.\n"
-          "  MinTheta: 0.785\n"
-          "  MaxTheta: 2.356\n"
-          "  NumberRadialPoints: 20\n"
-          "  NumberThetaPoints: 10\n"
-          "  NumberPhiPoints: 20\n"
-          "  UniformThetaGrid: true\n");
+          "MinRadius: 1.8\n"
+          "MaxRadius: 20.\n"
+          "MinTheta: 0.785\n"
+          "MaxTheta: 2.356\n"
+          "NumberRadialPoints: 20\n"
+          "NumberThetaPoints: 10\n"
+          "NumberPhiPoints: 20\n"
+          "UniformThetaGrid: true\n");
   CHECK(created_torus == intrp::OptionHolders::WedgeSectionTorus(
                              1.8, 20., 0.785, 2.356, 20, 10, 20, false, true));
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -136,7 +136,7 @@ SPECTRE_TEST_CASE(
     "[Unit]") {
   // Check creating the options
   const auto created_torus =
-      test_creation<intrp::OptionHolders::WedgeSectionTorus>(
+      TestHelpers::test_creation<intrp::OptionHolders::WedgeSectionTorus>(
           "  MinRadius: 1.8\n"
           "  MaxRadius: 20.\n"
           "  MinTheta: 0.785\n"

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
@@ -219,8 +219,8 @@ void test_exponential_filter_creation() noexcept {
   using Filter = Filters::Exponential<0>;
 
   const Filter filter = TestHelpers::test_creation<Filter>(
-      "  Alpha: 36\n"
-      "  HalfPower: 32\n");
+      "Alpha: 36\n"
+      "HalfPower: 32\n");
 
   CHECK(filter == Filter{36.0, 32, false});
   CHECK_FALSE(filter == Filter{35.0, 32, false});

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
@@ -218,7 +218,7 @@ template <size_t Dim>
 void test_exponential_filter_creation() noexcept {
   using Filter = Filters::Exponential<0>;
 
-  const Filter filter = test_creation<Filter>(
+  const Filter filter = TestHelpers::test_creation<Filter>(
       "  Alpha: 36\n"
       "  HalfPower: 32\n");
 

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
@@ -319,7 +319,7 @@ void test_system() noexcept {
       ObservationTimeTag, typename System::vars_for_test>>>;
   Parallel::register_derived_classes_with_charm<EventType>();
   const auto factory_event =
-      test_factory_creation<EventType>("  ObserveErrorNorms");
+      TestHelpers::test_factory_creation<EventType>("  ObserveErrorNorms");
   auto serialized_event = serialize_and_deserialize(factory_event);
   test_observe<System>(std::move(serialized_event));
 }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
@@ -319,7 +319,7 @@ void test_system() noexcept {
       ObservationTimeTag, typename System::vars_for_test>>>;
   Parallel::register_derived_classes_with_charm<EventType>();
   const auto factory_event =
-      TestHelpers::test_factory_creation<EventType>("  ObserveErrorNorms");
+      TestHelpers::test_factory_creation<EventType>("ObserveErrorNorms");
   auto serialized_event = serialize_and_deserialize(factory_event);
   test_observe<System>(std::move(serialized_event));
 }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -395,8 +395,8 @@ void test_system() noexcept {
       typename System::all_vars_for_test,
       typename System::solution_for_test::vars_for_test>>>;
   Parallel::register_derived_classes_with_charm<EventType>();
-  const auto factory_event =
-      test_factory_creation<EventType>(System::creation_string_for_test);
+  const auto factory_event = TestHelpers::test_factory_creation<EventType>(
+      System::creation_string_for_test);
   auto serialized_event = serialize_and_deserialize(factory_event);
   test_observe<System>(std::move(serialized_event));
 }
@@ -411,13 +411,14 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields", "[Unit][Evolution]") {
 SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields.bad_field",
                   "[Unit][Evolution]") {
   ERROR_TEST();
-  test_creation<ScalarSystem::ObserveEvent>("  VariablesToObserve: [NotAVar]");
+  TestHelpers::test_creation<ScalarSystem::ObserveEvent>(
+      "  VariablesToObserve: [NotAVar]");
 }
 
 // [[OutputRegex, Scalar specified multiple times]]
 SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields.repeated_field",
                   "[Unit][Evolution]") {
   ERROR_TEST();
-  test_creation<ScalarSystem::ObserveEvent>(
+  TestHelpers::test_creation<ScalarSystem::ObserveEvent>(
       "  VariablesToObserve: [Scalar, Scalar]");
 }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -182,7 +182,7 @@ struct ScalarSystem {
       dg::Events::ObserveFields<volume_dim, ObservationTimeTag,
                                 all_vars_for_test,
                                 solution_for_test::vars_for_test>;
-  static constexpr auto creation_string_for_test = "  ObserveFields";
+  static constexpr auto creation_string_for_test = "ObserveFields";
   static ObserveEvent make_test_object() noexcept { return ObserveEvent{}; }
 };
 
@@ -274,8 +274,8 @@ struct ComplicatedSystem {
                                 all_vars_for_test,
                                 solution_for_test::vars_for_test>;
   static constexpr auto creation_string_for_test =
-      "  ObserveFields:\n"
-      "    VariablesToObserve: [Scalar, Vector, Tensor, Tensor2]";
+      "ObserveFields:\n"
+      "  VariablesToObserve: [Scalar, Vector, Tensor, Tensor2]";
   static ObserveEvent make_test_object() noexcept {
     return ObserveEvent({"Scalar", "Vector", "Tensor", "Tensor2"});
   }
@@ -412,7 +412,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields.bad_field",
                   "[Unit][Evolution]") {
   ERROR_TEST();
   TestHelpers::test_creation<ScalarSystem::ObserveEvent>(
-      "  VariablesToObserve: [NotAVar]");
+      "VariablesToObserve: [NotAVar]");
 }
 
 // [[OutputRegex, Scalar specified multiple times]]
@@ -420,5 +420,5 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields.repeated_field",
                   "[Unit][Evolution]") {
   ERROR_TEST();
   TestHelpers::test_creation<ScalarSystem::ObserveEvent>(
-      "  VariablesToObserve: [Scalar, Scalar]");
+      "VariablesToObserve: [Scalar, Scalar]");
 }

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -88,72 +88,72 @@ void check_trigger(const bool expected, const std::string& trigger_string) {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.EventsAndTriggers", "[Unit][Evolution]") {
-  TestHelpers::test_factory_creation<Event<tmpl::list<>>>("  Completion");
+  TestHelpers::test_factory_creation<Event<tmpl::list<>>>("Completion");
 
-  check_trigger(true, "  Always");
-  check_trigger(false, "  Not: Always");
+  check_trigger(true, "Always");
+  check_trigger(false, "Not: Always");
   check_trigger(true,
-                "  Not:\n"
-                "    Not: Always");
-
-  check_trigger(true,
-                "  And:\n"
-                "    - Always\n"
-                "    - Always");
-  check_trigger(false,
-                "  And:\n"
-                "    - Always\n"
-                "    - Not: Always");
-  check_trigger(false,
-                "  And:\n"
-                "    - Not: Always\n"
-                "    - Always");
-  check_trigger(false,
-                "  And:\n"
-                "    - Not: Always\n"
-                "    - Not: Always");
-  check_trigger(false,
-                "  And:\n"
-                "    - Always\n"
-                "    - Always\n"
-                "    - Not: Always");
+                "Not:\n"
+                "  Not: Always");
 
   check_trigger(true,
-                "  Or:\n"
-                "    - Always\n"
-                "    - Always");
-  check_trigger(true,
-                "  Or:\n"
-                "    - Always\n"
-                "    - Not: Always");
-  check_trigger(true,
-                "  Or:\n"
-                "    - Not: Always\n"
-                "    - Always");
+                "And:\n"
+                "  - Always\n"
+                "  - Always");
   check_trigger(false,
-                "  Or:\n"
-                "    - Not: Always\n"
-                "    - Not: Always");
+                "And:\n"
+                "  - Always\n"
+                "  - Not: Always");
+  check_trigger(false,
+                "And:\n"
+                "  - Not: Always\n"
+                "  - Always");
+  check_trigger(false,
+                "And:\n"
+                "  - Not: Always\n"
+                "  - Not: Always");
+  check_trigger(false,
+                "And:\n"
+                "  - Always\n"
+                "  - Always\n"
+                "  - Not: Always");
+
   check_trigger(true,
-                "  Or:\n"
-                "    - Not: Always\n"
-                "    - Not: Always\n"
-                "    - Always");
+                "Or:\n"
+                "  - Always\n"
+                "  - Always");
+  check_trigger(true,
+                "Or:\n"
+                "  - Always\n"
+                "  - Not: Always");
+  check_trigger(true,
+                "Or:\n"
+                "  - Not: Always\n"
+                "  - Always");
+  check_trigger(false,
+                "Or:\n"
+                "  - Not: Always\n"
+                "  - Not: Always");
+  check_trigger(true,
+                "Or:\n"
+                "  - Not: Always\n"
+                "  - Not: Always\n"
+                "  - Always");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.EventsAndTriggers.creation",
                   "[Unit][Evolution]") {
   const auto events_and_triggers =
       TestHelpers::test_creation<EventsAndTriggersType>(
-          "  ? Not: Always\n"
-          "  : - Completion\n"
-          "  ? Or:\n"
-          "    - Not: Always\n"
-          "    - Always\n"
-          "  : - Completion\n"
-          "    - Completion\n"
-          "  ? Not: Always\n"
-          "  : - Completion\n");
+          "? Not: Always\n"
+          ": - Completion\n"
+          "? Or:\n"
+          "  - Not: Always\n"
+          "  - Always\n"
+          ": - Completion\n"
+          "  - Completion\n"
+          "? Not: Always\n"
+          ": - Completion\n");
 
   run_events_and_triggers(events_and_triggers, true);
 }

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -73,7 +73,7 @@ void run_events_and_triggers(const EventsAndTriggersType& events_and_triggers,
 void check_trigger(const bool expected, const std::string& trigger_string) {
   // Test factory
   std::unique_ptr<Trigger<tmpl::list<>>> trigger =
-      test_factory_creation<Trigger<tmpl::list<>>>(trigger_string);
+      TestHelpers::test_factory_creation<Trigger<tmpl::list<>>>(trigger_string);
 
   EventsAndTriggersType::Storage events_and_triggers_map;
   events_and_triggers_map.emplace(
@@ -88,7 +88,7 @@ void check_trigger(const bool expected, const std::string& trigger_string) {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.EventsAndTriggers", "[Unit][Evolution]") {
-  test_factory_creation<Event<tmpl::list<>>>("  Completion");
+  TestHelpers::test_factory_creation<Event<tmpl::list<>>>("  Completion");
 
   check_trigger(true, "  Always");
   check_trigger(false, "  Not: Always");
@@ -143,16 +143,17 @@ SPECTRE_TEST_CASE("Unit.Evolution.EventsAndTriggers", "[Unit][Evolution]") {
 
 SPECTRE_TEST_CASE("Unit.Evolution.EventsAndTriggers.creation",
                   "[Unit][Evolution]") {
-  const auto events_and_triggers = test_creation<EventsAndTriggersType>(
-      "  ? Not: Always\n"
-      "  : - Completion\n"
-      "  ? Or:\n"
-      "    - Not: Always\n"
-      "    - Always\n"
-      "  : - Completion\n"
-      "    - Completion\n"
-      "  ? Not: Always\n"
-      "  : - Completion\n");
+  const auto events_and_triggers =
+      TestHelpers::test_creation<EventsAndTriggersType>(
+          "  ? Not: Always\n"
+          "  : - Completion\n"
+          "  ? Or:\n"
+          "    - Not: Always\n"
+          "    - Always\n"
+          "  : - Completion\n"
+          "    - Completion\n"
+          "  ? Not: Always\n"
+          "  : - Completion\n");
 
   run_events_and_triggers(events_and_triggers, true);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_BondiHoyleAccretion.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_BondiHoyleAccretion.cpp
@@ -60,13 +60,13 @@ struct BondiHoyleAccretionProxy : grmhd::AnalyticData::BondiHoyleAccretion {
 void test_create_from_options() noexcept {
   const auto accretion =
       TestHelpers::test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
-          "  BhMass: 1.0\n"
-          "  BhDimlessSpin: 0.23\n"
-          "  RestMassDensity: 2.7\n"
-          "  FlowSpeed: 0.34\n"
-          "  MagFieldStrength: 5.76\n"
-          "  PolytropicConstant: 30.0\n"
-          "  PolytropicExponent: 1.5");
+          "BhMass: 1.0\n"
+          "BhDimlessSpin: 0.23\n"
+          "RestMassDensity: 2.7\n"
+          "FlowSpeed: 0.34\n"
+          "MagFieldStrength: 5.76\n"
+          "PolytropicConstant: 30.0\n"
+          "PolytropicExponent: 1.5");
   CHECK(accretion == grmhd::AnalyticData::BondiHoyleAccretion(
                          1.0, 0.23, 2.7, 0.34, 5.76, 30.0, 1.5));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_BondiHoyleAccretion.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_BondiHoyleAccretion.cpp
@@ -59,7 +59,7 @@ struct BondiHoyleAccretionProxy : grmhd::AnalyticData::BondiHoyleAccretion {
 
 void test_create_from_options() noexcept {
   const auto accretion =
-      test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
+      TestHelpers::test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
           "  BhMass: 1.0\n"
           "  BhDimlessSpin: 0.23\n"
           "  RestMassDensity: 2.7\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_CylindricalBlastWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_CylindricalBlastWave.cpp
@@ -63,7 +63,7 @@ struct CylindricalBlastWaveProxy : grmhd::AnalyticData::CylindricalBlastWave {
 
 void test_create_from_options() noexcept {
   const auto cylindrical_blast_wave =
-      test_creation<grmhd::AnalyticData::CylindricalBlastWave>(
+      TestHelpers::test_creation<grmhd::AnalyticData::CylindricalBlastWave>(
           "  InnerRadius: 0.8\n"
           "  OuterRadius: 1.0\n"
           "  InnerDensity: 1.0e-2\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_CylindricalBlastWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_CylindricalBlastWave.cpp
@@ -64,14 +64,14 @@ struct CylindricalBlastWaveProxy : grmhd::AnalyticData::CylindricalBlastWave {
 void test_create_from_options() noexcept {
   const auto cylindrical_blast_wave =
       TestHelpers::test_creation<grmhd::AnalyticData::CylindricalBlastWave>(
-          "  InnerRadius: 0.8\n"
-          "  OuterRadius: 1.0\n"
-          "  InnerDensity: 1.0e-2\n"
-          "  OuterDensity: 1.0e-4\n"
-          "  InnerPressure: 1.0\n"
-          "  OuterPressure: 5.0e-4\n"
-          "  MagneticField: [0.1, 0.0, 0.0]\n"
-          "  AdiabaticIndex: 1.3333333333333333333");
+          "InnerRadius: 0.8\n"
+          "OuterRadius: 1.0\n"
+          "InnerDensity: 1.0e-2\n"
+          "OuterDensity: 1.0e-4\n"
+          "InnerPressure: 1.0\n"
+          "OuterPressure: 5.0e-4\n"
+          "MagneticField: [0.1, 0.0, 0.0]\n"
+          "AdiabaticIndex: 1.3333333333333333333");
   CHECK(cylindrical_blast_wave == grmhd::AnalyticData::CylindricalBlastWave(
                                       0.8, 1.0, 1.0e-2, 1.0e-4, 1.0, 5.0e-4,
                                       std::array<double, 3>{{0.1, 0.0, 0.0}},

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticFieldLoop.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticFieldLoop.cpp
@@ -60,7 +60,7 @@ struct MagneticFieldLoopProxy : grmhd::AnalyticData::MagneticFieldLoop {
 
 void test_create_from_options() noexcept {
   const auto magnetic_field_loop =
-      test_creation<grmhd::AnalyticData::MagneticFieldLoop>(
+      TestHelpers::test_creation<grmhd::AnalyticData::MagneticFieldLoop>(
           "  Pressure: 3.0\n"
           "  RestMassDensity: 1.0\n"
           "  AdiabaticIndex: 1.66666666666666667\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticFieldLoop.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticFieldLoop.cpp
@@ -61,13 +61,13 @@ struct MagneticFieldLoopProxy : grmhd::AnalyticData::MagneticFieldLoop {
 void test_create_from_options() noexcept {
   const auto magnetic_field_loop =
       TestHelpers::test_creation<grmhd::AnalyticData::MagneticFieldLoop>(
-          "  Pressure: 3.0\n"
-          "  RestMassDensity: 1.0\n"
-          "  AdiabaticIndex: 1.66666666666666667\n"
-          "  AdvectionVelocity: [0.5, 0.04166666666666667, 0.0]\n"
-          "  MagFieldStrength: 0.001\n"
-          "  InnerRadius: 0.06\n"
-          "  OuterRadius: 0.3\n");
+          "Pressure: 3.0\n"
+          "RestMassDensity: 1.0\n"
+          "AdiabaticIndex: 1.66666666666666667\n"
+          "AdvectionVelocity: [0.5, 0.04166666666666667, 0.0]\n"
+          "MagFieldStrength: 0.001\n"
+          "InnerRadius: 0.06\n"
+          "OuterRadius: 0.3\n");
   CHECK(magnetic_field_loop ==
         grmhd::AnalyticData::MagneticFieldLoop(
             3.0, 1.0, 1.66666666666666667,

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticRotor.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticRotor.cpp
@@ -59,14 +59,15 @@ struct MagneticRotorProxy : grmhd::AnalyticData::MagneticRotor {
 };
 
 void test_create_from_options() noexcept {
-  const auto magnetic_rotor = test_creation<grmhd::AnalyticData::MagneticRotor>(
-      "  RotorRadius: 0.1\n"
-      "  RotorDensity: 10.0\n"
-      "  BackgroundDensity: 1.0\n"
-      "  Pressure: 1.0\n"
-      "  AngularVelocity: 9.95\n"
-      "  MagneticField: [3.5449077018, 0.0, 0.0]\n"
-      "  AdiabaticIndex: 1.6666666666666666");
+  const auto magnetic_rotor =
+      TestHelpers::test_creation<grmhd::AnalyticData::MagneticRotor>(
+          "  RotorRadius: 0.1\n"
+          "  RotorDensity: 10.0\n"
+          "  BackgroundDensity: 1.0\n"
+          "  Pressure: 1.0\n"
+          "  AngularVelocity: 9.95\n"
+          "  MagneticField: [3.5449077018, 0.0, 0.0]\n"
+          "  AdiabaticIndex: 1.6666666666666666");
   CHECK(magnetic_rotor == grmhd::AnalyticData::MagneticRotor(
                               0.1, 10.0, 1.0, 1.0, 9.95,
                               std::array<double, 3>{{3.5449077018, 0.0, 0.0}},

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticRotor.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticRotor.cpp
@@ -61,13 +61,13 @@ struct MagneticRotorProxy : grmhd::AnalyticData::MagneticRotor {
 void test_create_from_options() noexcept {
   const auto magnetic_rotor =
       TestHelpers::test_creation<grmhd::AnalyticData::MagneticRotor>(
-          "  RotorRadius: 0.1\n"
-          "  RotorDensity: 10.0\n"
-          "  BackgroundDensity: 1.0\n"
-          "  Pressure: 1.0\n"
-          "  AngularVelocity: 9.95\n"
-          "  MagneticField: [3.5449077018, 0.0, 0.0]\n"
-          "  AdiabaticIndex: 1.6666666666666666");
+          "RotorRadius: 0.1\n"
+          "RotorDensity: 10.0\n"
+          "BackgroundDensity: 1.0\n"
+          "Pressure: 1.0\n"
+          "AngularVelocity: 9.95\n"
+          "MagneticField: [3.5449077018, 0.0, 0.0]\n"
+          "AdiabaticIndex: 1.6666666666666666");
   CHECK(magnetic_rotor == grmhd::AnalyticData::MagneticRotor(
                               0.1, 10.0, 1.0, 1.0, 9.95,
                               std::array<double, 3>{{3.5449077018, 0.0, 0.0}},
@@ -152,4 +152,3 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.GrMhd.MagneticRotor",
       std::array<double, 3>{{3.5449077018, 0.0, 0.0}}, 1.6666666666666666);
   ERROR("Failed to trigger PARSE_ERROR in a parse error test");
 }
-

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedFmDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedFmDisk.cpp
@@ -68,16 +68,17 @@ struct MagnetizedFmDiskProxy : grmhd::AnalyticData::MagnetizedFmDisk {
 };
 
 void test_create_from_options() noexcept {
-  const auto disk = test_creation<grmhd::AnalyticData::MagnetizedFmDisk>(
-      "  BhMass: 1.3\n"
-      "  BhDimlessSpin: 0.345\n"
-      "  InnerEdgeRadius: 6.123\n"
-      "  MaxPressureRadius: 14.2\n"
-      "  PolytropicConstant: 0.065\n"
-      "  PolytropicExponent: 1.654\n"
-      "  ThresholdDensity: 0.42\n"
-      "  InversePlasmaBeta: 85.0\n"
-      "  BFieldNormGridRes: 6");
+  const auto disk =
+      TestHelpers::test_creation<grmhd::AnalyticData::MagnetizedFmDisk>(
+          "  BhMass: 1.3\n"
+          "  BhDimlessSpin: 0.345\n"
+          "  InnerEdgeRadius: 6.123\n"
+          "  MaxPressureRadius: 14.2\n"
+          "  PolytropicConstant: 0.065\n"
+          "  PolytropicExponent: 1.654\n"
+          "  ThresholdDensity: 0.42\n"
+          "  InversePlasmaBeta: 85.0\n"
+          "  BFieldNormGridRes: 6");
   CHECK(disk == grmhd::AnalyticData::MagnetizedFmDisk(
                     1.3, 0.345, 6.123, 14.2, 0.065, 1.654, 0.42, 85.0, 6));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedFmDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedFmDisk.cpp
@@ -70,15 +70,15 @@ struct MagnetizedFmDiskProxy : grmhd::AnalyticData::MagnetizedFmDisk {
 void test_create_from_options() noexcept {
   const auto disk =
       TestHelpers::test_creation<grmhd::AnalyticData::MagnetizedFmDisk>(
-          "  BhMass: 1.3\n"
-          "  BhDimlessSpin: 0.345\n"
-          "  InnerEdgeRadius: 6.123\n"
-          "  MaxPressureRadius: 14.2\n"
-          "  PolytropicConstant: 0.065\n"
-          "  PolytropicExponent: 1.654\n"
-          "  ThresholdDensity: 0.42\n"
-          "  InversePlasmaBeta: 85.0\n"
-          "  BFieldNormGridRes: 6");
+          "BhMass: 1.3\n"
+          "BhDimlessSpin: 0.345\n"
+          "InnerEdgeRadius: 6.123\n"
+          "MaxPressureRadius: 14.2\n"
+          "PolytropicConstant: 0.065\n"
+          "PolytropicExponent: 1.654\n"
+          "ThresholdDensity: 0.42\n"
+          "InversePlasmaBeta: 85.0\n"
+          "BFieldNormGridRes: 6");
   CHECK(disk == grmhd::AnalyticData::MagnetizedFmDisk(
                     1.3, 0.345, 6.123, 14.2, 0.065, 1.654, 0.42, 85.0, 6));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_OrszagTangVortex.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_OrszagTangVortex.cpp
@@ -72,5 +72,5 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.GrMhd.OrszagTangVortex",
   test_variables(DataVector(5));
 
   test_serialization(OrszagTangVortex{});
-  test_creation<OrszagTangVortex>("");
+  TestHelpers::test_creation<OrszagTangVortex>("");
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Bump.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Bump.cpp
@@ -38,9 +38,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Bump",
 
   const auto created_solution =
       TestHelpers::test_creation<Burgers::Solutions::Bump>(
-          "  HalfWidth: 5.\n"
-          "  Height: 3.\n"
-          "  Center: -8.\n");
+          "HalfWidth: 5.\n"
+          "Height: 3.\n"
+          "Center: -8.\n");
   const auto x = tnsr::I<DataVector, 1>{{{positions}}};
   const double t = 0.0;
   CHECK(created_solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}) ==

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Bump.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Bump.cpp
@@ -36,10 +36,11 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Bump",
           tnsr::I<DataVector, 1>{{{positions}}}, 0.)),
       height * (1. - square((positions - center) / half_width)));
 
-  const auto created_solution = test_creation<Burgers::Solutions::Bump>(
-      "  HalfWidth: 5.\n"
-      "  Height: 3.\n"
-      "  Center: -8.\n");
+  const auto created_solution =
+      TestHelpers::test_creation<Burgers::Solutions::Bump>(
+          "  HalfWidth: 5.\n"
+          "  Height: 3.\n"
+          "  Center: -8.\n");
   const auto x = tnsr::I<DataVector, 1>{{{positions}}};
   const double t = 0.0;
   CHECK(created_solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}) ==

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Linear.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Linear.cpp
@@ -33,7 +33,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Linear",
                         positions / -shock_time);
 
   const auto created_solution =
-      test_creation<Burgers::Solutions::Linear>("  ShockTime: 1.5");
+      TestHelpers::test_creation<Burgers::Solutions::Linear>(
+          "  ShockTime: 1.5");
   const auto x = tnsr::I<DataVector, 1>{{{positions}}};
   const double t = 0.0;
   CHECK(created_solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}) ==

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Linear.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Linear.cpp
@@ -33,8 +33,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Linear",
                         positions / -shock_time);
 
   const auto created_solution =
-      TestHelpers::test_creation<Burgers::Solutions::Linear>(
-          "  ShockTime: 1.5");
+      TestHelpers::test_creation<Burgers::Solutions::Linear>("ShockTime: 1.5");
   const auto x = tnsr::I<DataVector, 1>{{{positions}}};
   const double t = 0.0;
   CHECK(created_solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}) ==

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Step.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Step.cpp
@@ -46,10 +46,11 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Step",
   // solution breaks the tests of check_burgers_solution
   check_burgers_solution(solution, positions, {0., 0.7, 1.2, 10.0});
 
-  const auto created_solution = test_creation<Burgers::Solutions::Step>(
-      "  LeftValue: 2.3\n"
-      "  RightValue: 1.2\n"
-      "  InitialPosition: -0.5");
+  const auto created_solution =
+      TestHelpers::test_creation<Burgers::Solutions::Step>(
+          "  LeftValue: 2.3\n"
+          "  RightValue: 1.2\n"
+          "  InitialPosition: -0.5");
   const auto x = tnsr::I<DataVector, 1>{{{positions}}};
   const double t = 0.0;
   CHECK(created_solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}) ==

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Step.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Step.cpp
@@ -48,9 +48,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Step",
 
   const auto created_solution =
       TestHelpers::test_creation<Burgers::Solutions::Step>(
-          "  LeftValue: 2.3\n"
-          "  RightValue: 1.2\n"
-          "  InitialPosition: -0.5");
+          "LeftValue: 2.3\n"
+          "RightValue: 1.2\n"
+          "InitialPosition: -0.5");
   const auto x = tnsr::I<DataVector, 1>{{{positions}}};
   const double t = 0.0;
   CHECK(created_solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}) ==

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
@@ -55,7 +55,7 @@ SPECTRE_TEST_CASE(
       Elasticity::ConstitutiveRelations::IsotropicHomogeneous<2>{
           79.36507936507935, 38.75968992248062}};
   const Elasticity::Solutions::BentBeam created_solution =
-      test_creation<Elasticity::Solutions::BentBeam>(
+      TestHelpers::test_creation<Elasticity::Solutions::BentBeam>(
           "  Length: 5.\n"
           "  Height: 1.\n"
           "  BendingMoment: 0.5\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
@@ -56,12 +56,12 @@ SPECTRE_TEST_CASE(
           79.36507936507935, 38.75968992248062}};
   const Elasticity::Solutions::BentBeam created_solution =
       TestHelpers::test_creation<Elasticity::Solutions::BentBeam>(
-          "  Length: 5.\n"
-          "  Height: 1.\n"
-          "  BendingMoment: 0.5\n"
-          "  Material:\n"
-          "    BulkModulus: 79.36507936507935\n"
-          "    ShearModulus: 38.75968992248062\n");
+          "Length: 5.\n"
+          "Height: 1.\n"
+          "BendingMoment: 0.5\n"
+          "Material:\n"
+          "  BulkModulus: 79.36507936507935\n"
+          "  ShearModulus: 38.75968992248062\n");
   CHECK(created_solution == check_solution);
   test_serialization(check_solution);
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_Minkowski.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_Minkowski.cpp
@@ -116,7 +116,7 @@ void test_minkowski(const T& value) {
 
 template <size_t Dim>
 void test_option_creation() {
-  test_creation<gr::Solutions::Minkowski<Dim>>("");
+  TestHelpers::test_creation<gr::Solutions::Minkowski<Dim>>("");
 }
 }  // namespace
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
@@ -70,12 +70,12 @@ struct AlfvenWaveProxy : grmhd::Solutions::AlfvenWave {
 
 void test_create_from_options() noexcept {
   const auto wave = TestHelpers::test_creation<grmhd::Solutions::AlfvenWave>(
-      "  WaveNumber: 2.2\n"
-      "  Pressure: 1.23\n"
-      "  RestMassDensity: 0.2\n"
-      "  AdiabaticIndex: 1.4\n"
-      "  BkgdMagneticField: [0.0, 0.0, 2.0]\n"
-      "  WaveMagneticField: [0.75, 0.0, 0.0]");
+      "WaveNumber: 2.2\n"
+      "Pressure: 1.23\n"
+      "RestMassDensity: 0.2\n"
+      "AdiabaticIndex: 1.4\n"
+      "BkgdMagneticField: [0.0, 0.0, 2.0]\n"
+      "WaveMagneticField: [0.75, 0.0, 0.0]");
   CHECK(wave == grmhd::Solutions::AlfvenWave(2.2, 1.23, 0.2, 1.4,
                                              {{0.0, 0.0, 2.0}},
                                              {{0.75, 0.0, 0.0}}));

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
@@ -69,7 +69,7 @@ struct AlfvenWaveProxy : grmhd::Solutions::AlfvenWave {
 };
 
 void test_create_from_options() noexcept {
-  const auto wave = test_creation<grmhd::Solutions::AlfvenWave>(
+  const auto wave = TestHelpers::test_creation<grmhd::Solutions::AlfvenWave>(
       "  WaveNumber: 2.2\n"
       "  Pressure: 1.23\n"
       "  RestMassDensity: 0.2\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
@@ -64,7 +64,7 @@ struct BondiMichelProxy : grmhd::Solutions::BondiMichel {
 };
 
 void test_create_from_options() noexcept {
-  const auto flow = test_creation<grmhd::Solutions::BondiMichel>(
+  const auto flow = TestHelpers::test_creation<grmhd::Solutions::BondiMichel>(
       "  Mass: 1.2\n"
       "  SonicRadius: 5.0\n"
       "  SonicDensity: 0.05\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
@@ -65,11 +65,11 @@ struct BondiMichelProxy : grmhd::Solutions::BondiMichel {
 
 void test_create_from_options() noexcept {
   const auto flow = TestHelpers::test_creation<grmhd::Solutions::BondiMichel>(
-      "  Mass: 1.2\n"
-      "  SonicRadius: 5.0\n"
-      "  SonicDensity: 0.05\n"
-      "  PolytropicExponent: 1.4\n"
-      "  MagFieldStrength: 2.0");
+      "Mass: 1.2\n"
+      "SonicRadius: 5.0\n"
+      "SonicDensity: 0.05\n"
+      "PolytropicExponent: 1.4\n"
+      "MagFieldStrength: 2.0");
   CHECK(flow == grmhd::Solutions::BondiMichel(1.2, 5.0, 0.05, 1.4, 2.0));
 }
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_KomissarovShock.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_KomissarovShock.cpp
@@ -69,16 +69,16 @@ struct KomissarovShockProxy : grmhd::Solutions::KomissarovShock {
 void test_create_from_options() noexcept {
   const auto komissarov_shock =
       TestHelpers::test_creation<grmhd::Solutions::KomissarovShock>(
-          "  AdiabaticIndex: 1.33\n"
-          "  LeftDensity: 1.\n"
-          "  RightDensity: 3.323\n"
-          "  LeftPressure: 10.\n"
-          "  RightPressure: 55.36\n"
-          "  LeftVelocity: [0.83, 0., 0.]\n"
-          "  RightVelocity: [0.62, -0.44, 0.]\n"
-          "  LeftMagneticField: [10., 18.28, 0.]\n"
-          "  RightMagneticField: [10., 14.49, 0.]\n"
-          "  ShockSpeed: 0.5\n");
+          "AdiabaticIndex: 1.33\n"
+          "LeftDensity: 1.\n"
+          "RightDensity: 3.323\n"
+          "LeftPressure: 10.\n"
+          "RightPressure: 55.36\n"
+          "LeftVelocity: [0.83, 0., 0.]\n"
+          "RightVelocity: [0.62, -0.44, 0.]\n"
+          "LeftMagneticField: [10., 18.28, 0.]\n"
+          "RightMagneticField: [10., 14.49, 0.]\n"
+          "ShockSpeed: 0.5\n");
   CHECK(komissarov_shock == grmhd::Solutions::KomissarovShock(
                                 1.33, 1., 3.323, 10., 55.36,
                                 std::array<double, 3>{{0.83, 0., 0.}},

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_KomissarovShock.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_KomissarovShock.cpp
@@ -68,7 +68,7 @@ struct KomissarovShockProxy : grmhd::Solutions::KomissarovShock {
 
 void test_create_from_options() noexcept {
   const auto komissarov_shock =
-      test_creation<grmhd::Solutions::KomissarovShock>(
+      TestHelpers::test_creation<grmhd::Solutions::KomissarovShock>(
           "  AdiabaticIndex: 1.33\n"
           "  LeftDensity: 1.\n"
           "  RightDensity: 3.323\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
@@ -69,11 +69,11 @@ struct SmoothFlowProxy : grmhd::Solutions::SmoothFlow {
 
 void test_create_from_options() noexcept {
   const auto flow = TestHelpers::test_creation<grmhd::Solutions::SmoothFlow>(
-      "  MeanVelocity: [0.1, -0.2, 0.3]\n"
-      "  WaveVector: [-0.13, -0.54, 0.04]\n"
-      "  Pressure: 1.23\n"
-      "  AdiabaticIndex: 1.4\n"
-      "  PerturbationSize: 0.75");
+      "MeanVelocity: [0.1, -0.2, 0.3]\n"
+      "WaveVector: [-0.13, -0.54, 0.04]\n"
+      "Pressure: 1.23\n"
+      "AdiabaticIndex: 1.4\n"
+      "PerturbationSize: 0.75");
   CHECK(flow == grmhd::Solutions::SmoothFlow({{0.1, -0.2, 0.3}},
                                              {{-0.13, -0.54, 0.04}}, 1.23, 1.4,
                                              0.75));

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
@@ -68,7 +68,7 @@ struct SmoothFlowProxy : grmhd::Solutions::SmoothFlow {
 };
 
 void test_create_from_options() noexcept {
-  const auto flow = test_creation<grmhd::Solutions::SmoothFlow>(
+  const auto flow = TestHelpers::test_creation<grmhd::Solutions::SmoothFlow>(
       "  MeanVelocity: [0.1, -0.2, 0.3]\n"
       "  WaveVector: [-0.13, -0.54, 0.04]\n"
       "  Pressure: 1.23\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
@@ -78,8 +78,9 @@ void test_solution(
     input += "\n  PerturbAmplitude: " + perturbation_amplitude_option;
   }
 
-  const auto vortex_from_options =
-      test_creation<NewtonianEuler::Solutions::IsentropicVortex<Dim>>(input);
+  const auto vortex_from_options = TestHelpers::test_creation<
+      NewtonianEuler::Solutions::IsentropicVortex<Dim>>(input);
+
   CHECK(vortex_from_options == vortex);
 
   IsentropicVortexProxy<Dim> vortex_to_move(1.43, center, mean_velocity, 3.76,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
@@ -80,7 +80,6 @@ void test_solution(
 
   const auto vortex_from_options = TestHelpers::test_creation<
       NewtonianEuler::Solutions::IsentropicVortex<Dim>>(input);
-
   CHECK(vortex_from_options == vortex);
 
   IsentropicVortexProxy<Dim> vortex_to_move(1.43, center, mean_velocity, 3.76,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_RiemannProblem.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_RiemannProblem.cpp
@@ -67,19 +67,19 @@ void test_solution(const std::array<double, Dim> left_velocity,
 
   const auto solution_from_options = TestHelpers::test_creation<
       NewtonianEuler::Solutions::RiemannProblem<Dim>>(
-      "  AdiabaticIndex: 1.4\n"
-      "  InitialPosition: 0.5\n"
-      "  LeftMassDensity: 1.0\n"
-      "  LeftVelocity: " +
+      "AdiabaticIndex: 1.4\n"
+      "InitialPosition: 0.5\n"
+      "LeftMassDensity: 1.0\n"
+      "LeftVelocity: " +
       left_velocity_opt +
       "\n"
-      "  LeftPressure: 1.0\n"
-      "  RightMassDensity: 0.125\n"
-      "  RightVelocity: " +
+      "LeftPressure: 1.0\n"
+      "RightMassDensity: 0.125\n"
+      "RightVelocity: " +
       right_velocity_opt +
       "\n"
-      "  RightPressure: 0.1\n"
-      "  PressureStarTol: 1.e-6");
+      "RightPressure: 0.1\n"
+      "PressureStarTol: 1.e-6");
   CHECK(solution_from_options == solution);
 
   RiemannProblemProxy<Dim> solution_to_move(1.4, 0.5, 1.0, left_velocity, 1.0,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_RiemannProblem.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_RiemannProblem.cpp
@@ -65,21 +65,21 @@ void test_solution(const std::array<double, Dim> left_velocity,
                       0.1),
       used_for_size, 1.e-9);
 
-  const auto solution_from_options =
-      test_creation<NewtonianEuler::Solutions::RiemannProblem<Dim>>(
-          "  AdiabaticIndex: 1.4\n"
-          "  InitialPosition: 0.5\n"
-          "  LeftMassDensity: 1.0\n"
-          "  LeftVelocity: " +
-          left_velocity_opt +
-          "\n"
-          "  LeftPressure: 1.0\n"
-          "  RightMassDensity: 0.125\n"
-          "  RightVelocity: " +
-          right_velocity_opt +
-          "\n"
-          "  RightPressure: 0.1\n"
-          "  PressureStarTol: 1.e-6");
+  const auto solution_from_options = TestHelpers::test_creation<
+      NewtonianEuler::Solutions::RiemannProblem<Dim>>(
+      "  AdiabaticIndex: 1.4\n"
+      "  InitialPosition: 0.5\n"
+      "  LeftMassDensity: 1.0\n"
+      "  LeftVelocity: " +
+      left_velocity_opt +
+      "\n"
+      "  LeftPressure: 1.0\n"
+      "  RightMassDensity: 0.125\n"
+      "  RightVelocity: " +
+      right_velocity_opt +
+      "\n"
+      "  RightPressure: 0.1\n"
+      "  PressureStarTol: 1.e-6");
   CHECK(solution_from_options == solution);
 
   RiemannProblemProxy<Dim> solution_to_move(1.4, 0.5, 1.0, left_velocity, 1.0,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
@@ -51,7 +51,7 @@ void test_solution() {
 
   const Poisson::Solutions::Lorentzian<Dim> check_solution{};
   const Poisson::Solutions::Lorentzian<Dim> created_solution =
-      TestHelpers::test_creation<Poisson::Solutions::Lorentzian<Dim>>("  ");
+      TestHelpers::test_creation<Poisson::Solutions::Lorentzian<Dim>>("");
   CHECK(created_solution == check_solution);
   test_serialization(check_solution);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
@@ -51,7 +51,7 @@ void test_solution() {
 
   const Poisson::Solutions::Lorentzian<Dim> check_solution{};
   const Poisson::Solutions::Lorentzian<Dim> created_solution =
-      test_creation<Poisson::Solutions::Lorentzian<Dim>>("  ");
+      TestHelpers::test_creation<Poisson::Solutions::Lorentzian<Dim>>("  ");
   CHECK(created_solution == check_solution);
   test_serialization(check_solution);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
@@ -58,7 +58,7 @@ void test_solution() {
       {{{0., 1.}}}, std::make_tuple(), DataVector(5));
 
   Poisson::Solutions::Moustache<Dim> created_solution =
-      test_creation<Poisson::Solutions::Moustache<Dim>>("  ");
+      TestHelpers::test_creation<Poisson::Solutions::Moustache<Dim>>("  ");
   CHECK(created_solution == solution);
   test_serialization(solution);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
@@ -58,7 +58,7 @@ void test_solution() {
       {{{0., 1.}}}, std::make_tuple(), DataVector(5));
 
   Poisson::Solutions::Moustache<Dim> created_solution =
-      TestHelpers::test_creation<Poisson::Solutions::Moustache<Dim>>("  ");
+      TestHelpers::test_creation<Poisson::Solutions::Moustache<Dim>>("");
   CHECK(created_solution == solution);
   test_serialization(solution);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
@@ -66,7 +66,7 @@ void test_solution(const std::array<double, Dim>& wave_numbers,
 
   Poisson::Solutions::ProductOfSinusoids<Dim> created_solution =
       TestHelpers::test_creation<Poisson::Solutions::ProductOfSinusoids<Dim>>(
-          "  WaveNumbers: " + options);
+          "WaveNumbers: " + options);
   CHECK(created_solution == solution);
   test_serialization(solution);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
@@ -65,7 +65,7 @@ void test_solution(const std::array<double, Dim>& wave_numbers,
       std::make_tuple(wave_numbers), DataVector(5));
 
   Poisson::Solutions::ProductOfSinusoids<Dim> created_solution =
-      test_creation<Poisson::Solutions::ProductOfSinusoids<Dim>>(
+      TestHelpers::test_creation<Poisson::Solutions::ProductOfSinusoids<Dim>>(
           "  WaveNumbers: " + options);
   CHECK(created_solution == solution);
   test_serialization(solution);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/Test_ConstantM1.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/Test_ConstantM1.cpp
@@ -60,8 +60,8 @@ struct ConstantM1Proxy : RadiationTransport::M1Grey::Solutions::ConstantM1 {
 void test_create_from_options() noexcept {
   const auto flow = TestHelpers::test_creation<
       RadiationTransport::M1Grey::Solutions::ConstantM1>(
-      "  MeanVelocity: [0.0, 0.2, 0.1]\n"
-      "  ComovingEnergyDensity: 1.3");
+      "MeanVelocity: [0.0, 0.2, 0.1]\n"
+      "ComovingEnergyDensity: 1.3");
   CHECK(flow == RadiationTransport::M1Grey::Solutions::ConstantM1(
                     {{0.0, 0.2, 0.1}}, 1.3));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/Test_ConstantM1.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/Test_ConstantM1.cpp
@@ -58,10 +58,10 @@ struct ConstantM1Proxy : RadiationTransport::M1Grey::Solutions::ConstantM1 {
 };
 
 void test_create_from_options() noexcept {
-  const auto flow =
-      test_creation<RadiationTransport::M1Grey::Solutions::ConstantM1>(
-          "  MeanVelocity: [0.0, 0.2, 0.1]\n"
-          "  ComovingEnergyDensity: 1.3");
+  const auto flow = TestHelpers::test_creation<
+      RadiationTransport::M1Grey::Solutions::ConstantM1>(
+      "  MeanVelocity: [0.0, 0.2, 0.1]\n"
+      "  ComovingEnergyDensity: 1.3");
   CHECK(flow == RadiationTransport::M1Grey::Solutions::ConstantM1(
                     {{0.0, 0.2, 0.1}}, 1.3));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
@@ -72,12 +72,12 @@ struct FishboneMoncriefDiskProxy
 void test_create_from_options() noexcept {
   const auto disk = TestHelpers::test_creation<
       RelativisticEuler::Solutions::FishboneMoncriefDisk>(
-      "  BhMass: 1.0\n"
-      "  BhDimlessSpin: 0.23\n"
-      "  InnerEdgeRadius: 6.0\n"
-      "  MaxPressureRadius: 12.0\n"
-      "  PolytropicConstant: 0.001\n"
-      "  PolytropicExponent: 1.4");
+      "BhMass: 1.0\n"
+      "BhDimlessSpin: 0.23\n"
+      "InnerEdgeRadius: 6.0\n"
+      "MaxPressureRadius: 12.0\n"
+      "PolytropicConstant: 0.001\n"
+      "PolytropicExponent: 1.4");
   CHECK(disk == RelativisticEuler::Solutions::FishboneMoncriefDisk(
                     1.0, 0.23, 6.0, 12.0, 0.001, 1.4));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
@@ -70,14 +70,14 @@ struct FishboneMoncriefDiskProxy
 };
 
 void test_create_from_options() noexcept {
-  const auto disk =
-      test_creation<RelativisticEuler::Solutions::FishboneMoncriefDisk>(
-          "  BhMass: 1.0\n"
-          "  BhDimlessSpin: 0.23\n"
-          "  InnerEdgeRadius: 6.0\n"
-          "  MaxPressureRadius: 12.0\n"
-          "  PolytropicConstant: 0.001\n"
-          "  PolytropicExponent: 1.4");
+  const auto disk = TestHelpers::test_creation<
+      RelativisticEuler::Solutions::FishboneMoncriefDisk>(
+      "  BhMass: 1.0\n"
+      "  BhDimlessSpin: 0.23\n"
+      "  InnerEdgeRadius: 6.0\n"
+      "  MaxPressureRadius: 12.0\n"
+      "  PolytropicConstant: 0.001\n"
+      "  PolytropicExponent: 1.4");
   CHECK(disk == RelativisticEuler::Solutions::FishboneMoncriefDisk(
                     1.0, 0.23, 6.0, 12.0, 0.001, 1.4));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_SmoothFlow.cpp
@@ -104,14 +104,14 @@ void test_solution(const DataType& used_for_size,
 
   const auto solution_from_options =
       TestHelpers::test_creation<RelativisticEuler::Solutions::SmoothFlow<Dim>>(
-          "  MeanVelocity: " + mean_velocity_opt +
+          "MeanVelocity: " + mean_velocity_opt +
           "\n"
-          "  WaveVector: " +
+          "WaveVector: " +
           wave_vector_opt +
           "\n"
-          "  Pressure: 1.23\n"
-          "  AdiabaticIndex: 1.3334\n"
-          "  PerturbationSize: 0.78");
+          "Pressure: 1.23\n"
+          "AdiabaticIndex: 1.3334\n"
+          "PerturbationSize: 0.78");
   CHECK(solution == solution_from_options);
 
   RelativisticEuler::Solutions::SmoothFlow<Dim> solution_to_move(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_SmoothFlow.cpp
@@ -103,7 +103,7 @@ void test_solution(const DataType& used_for_size,
                                  Dim, Frame::Inertial, DataType>>{}))));
 
   const auto solution_from_options =
-      test_creation<RelativisticEuler::Solutions::SmoothFlow<Dim>>(
+      TestHelpers::test_creation<RelativisticEuler::Solutions::SmoothFlow<Dim>>(
           "  MeanVelocity: " + mean_velocity_opt +
           "\n"
           "  WaveVector: " +

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
@@ -29,9 +29,9 @@ namespace {
 void test_create_from_options() noexcept {
   const auto star = TestHelpers::test_creation<
       RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>>(
-      "  CentralDensity: 1.0e-5\n"
-      "  PolytropicConstant: 0.001\n"
-      "  PolytropicExponent: 1.4");
+      "CentralDensity: 1.0e-5\n"
+      "PolytropicConstant: 0.001\n"
+      "PolytropicExponent: 1.4");
   CHECK(star ==
         RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>(
             0.00001, 0.001, 1.4));

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
@@ -27,7 +27,7 @@
 namespace {
 
 void test_create_from_options() noexcept {
-  const auto star = test_creation<
+  const auto star = TestHelpers::test_creation<
       RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>>(
       "  CentralDensity: 1.0e-5\n"
       "  PolytropicConstant: 0.001\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
@@ -159,11 +159,11 @@ void test_1d() {
 
   const auto created_solution =
       TestHelpers::test_creation<ScalarWave::Solutions::PlaneWave<1>>(
-          "  WaveVector: [-1.5]\n"
-          "  Center: [2.4]\n"
-          "  Profile:\n"
-          "    PowX:\n"
-          "      Power: 3");
+          "WaveVector: [-1.5]\n"
+          "Center: [2.4]\n"
+          "Profile:\n"
+          "  PowX:\n"
+          "    Power: 3");
   CHECK(
       created_solution.variables(
           x, t,
@@ -219,11 +219,11 @@ void test_2d() {
 
   const auto created_solution =
       TestHelpers::test_creation<ScalarWave::Solutions::PlaneWave<2>>(
-          "  WaveVector: [1.5, -7.2]\n"
-          "  Center: [2.4, -4.8]\n"
-          "  Profile:\n"
-          "    PowX:\n"
-          "      Power: 3");
+          "WaveVector: [1.5, -7.2]\n"
+          "Center: [2.4, -4.8]\n"
+          "Profile:\n"
+          "  PowX:\n"
+          "    Power: 3");
   CHECK(
       created_solution.variables(
           x, t,
@@ -297,11 +297,11 @@ void test_3d() {
 
   const auto created_solution =
       TestHelpers::test_creation<ScalarWave::Solutions::PlaneWave<3>>(
-          "  WaveVector: [1.5, -7.2, 2.7]\n"
-          "  Center: [2.4, -4.8, 8.4]\n"
-          "  Profile:\n"
-          "    PowX:\n"
-          "      Power: 3");
+          "WaveVector: [1.5, -7.2, 2.7]\n"
+          "Center: [2.4, -4.8, 8.4]\n"
+          "Profile:\n"
+          "  PowX:\n"
+          "    Power: 3");
   CHECK(
       created_solution.variables(
           x, t,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
@@ -158,7 +158,7 @@ void test_1d() {
       deserialized_pw, x, t);
 
   const auto created_solution =
-      test_creation<ScalarWave::Solutions::PlaneWave<1>>(
+      TestHelpers::test_creation<ScalarWave::Solutions::PlaneWave<1>>(
           "  WaveVector: [-1.5]\n"
           "  Center: [2.4]\n"
           "  Profile:\n"
@@ -218,7 +218,7 @@ void test_2d() {
       deserialized_pw, x, t);
 
   const auto created_solution =
-      test_creation<ScalarWave::Solutions::PlaneWave<2>>(
+      TestHelpers::test_creation<ScalarWave::Solutions::PlaneWave<2>>(
           "  WaveVector: [1.5, -7.2]\n"
           "  Center: [2.4, -4.8]\n"
           "  Profile:\n"
@@ -296,7 +296,7 @@ void test_3d() {
       deserialized_pw, x, t);
 
   const auto created_solution =
-      test_creation<ScalarWave::Solutions::PlaneWave<3>>(
+      TestHelpers::test_creation<ScalarWave::Solutions::PlaneWave<3>>(
           "  WaveVector: [1.5, -7.2, 2.7]\n"
           "  Center: [2.4, -4.8, 8.4]\n"
           "  Profile:\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
@@ -65,11 +65,11 @@ SPECTRE_TEST_CASE("Unit.AnalyticSolutions.WaveEquation.RegularSphericalWave",
 
   const auto created_solution =
       TestHelpers::test_creation<ScalarWave::Solutions::RegularSphericalWave>(
-          "  Profile:\n"
-          "    Gaussian:\n"
-          "      Amplitude: 1.\n"
-          "      Width: 1.\n"
-          "      Center: 0.\n");
+          "Profile:\n"
+          "  Gaussian:\n"
+          "    Amplitude: 1.\n"
+          "    Width: 1.\n"
+          "    Center: 0.\n");
   CHECK(
       created_solution.variables(
           x, 1.,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
@@ -64,7 +64,7 @@ SPECTRE_TEST_CASE("Unit.AnalyticSolutions.WaveEquation.RegularSphericalWave",
                         DataVector({{0., 0., 0., 0.}}));
 
   const auto created_solution =
-      test_creation<ScalarWave::Solutions::RegularSphericalWave>(
+      TestHelpers::test_creation<ScalarWave::Solutions::RegularSphericalWave>(
           "  Profile:\n"
           "    Gaussian:\n"
           "      Amplitude: 1.\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_ConstantDensityStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_ConstantDensityStar.cpp
@@ -91,6 +91,6 @@ SPECTRE_TEST_CASE(
   pypp::SetupLocalPythonEnvironment local_python_env{
       "PointwiseFunctions/AnalyticSolutions/Xcts"};
   test_solution(0.01, 1.,
-                "  Density: 0.01\n"
-                "  Radius: 1.\n");
+                "Density: 0.01\n"
+                "Radius: 1.\n");
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_ConstantDensityStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_ConstantDensityStar.cpp
@@ -78,7 +78,7 @@ void test_solution(const double density, const double radius,
       make_with_value<Scalar<DataVector>>(far_away_coords, 1.));
 
   Xcts::Solutions::ConstantDensityStar created_solution =
-      test_creation<Xcts::Solutions::ConstantDensityStar>(options);
+      TestHelpers::test_creation<Xcts::Solutions::ConstantDensityStar>(options);
   CHECK(created_solution == solution);
   test_serialization(solution);
 }

--- a/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/Test_IsotropicHomogeneous.cpp
+++ b/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/Test_IsotropicHomogeneous.cpp
@@ -34,7 +34,7 @@ void test_type_traits() {
   CHECK(relation !=
         Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>{2., 2.});
   test_serialization(relation);
-  const auto created_relation = test_creation<
+  const auto created_relation = TestHelpers::test_creation<
       Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>>(
       "  BulkModulus: 1.\n"
       "  ShearModulus: 2.\n");

--- a/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/Test_IsotropicHomogeneous.cpp
+++ b/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/Test_IsotropicHomogeneous.cpp
@@ -36,8 +36,8 @@ void test_type_traits() {
   test_serialization(relation);
   const auto created_relation = TestHelpers::test_creation<
       Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>>(
-      "  BulkModulus: 1.\n"
-      "  ShearModulus: 2.\n");
+      "BulkModulus: 1.\n"
+      "ShearModulus: 2.\n");
   CHECK(created_relation == relation);
   Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim> moved_relation{
       1., 2.};

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
@@ -38,23 +38,23 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.DarkEnergyFluid",
                                        1.0 / 3.0);
 
   TestHelpers::EquationsOfState::check(
-      test_factory_creation<EoS::EquationOfState<true, 2>>(
+      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
           {"  DarkEnergyFluid:\n"
            "    ParameterW: 1.0\n"}),
       "dark_energy_fluid", d_for_size, 1.0);
   TestHelpers::EquationsOfState::check(
-      test_factory_creation<EoS::EquationOfState<true, 2>>(
+      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
           {"  DarkEnergyFluid:\n"
            "    ParameterW: 0.3333333333333333\n"}),
       "dark_energy_fluid", d_for_size, 1.0 / 3.0);
 
   TestHelpers::EquationsOfState::check(
-      test_factory_creation<EoS::EquationOfState<true, 2>>(
+      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
           {"  DarkEnergyFluid:\n"
            "    ParameterW: 1.0\n"}),
       "dark_energy_fluid", dv_for_size, 1.0);
   TestHelpers::EquationsOfState::check(
-      test_factory_creation<EoS::EquationOfState<true, 2>>(
+      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
           {"  DarkEnergyFluid:\n"
            "    ParameterW: 0.3333333333333333\n"}),
       "dark_energy_fluid", dv_for_size, 1.0 / 3.0);

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
@@ -39,23 +39,23 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.DarkEnergyFluid",
 
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
-          {"  DarkEnergyFluid:\n"
-           "    ParameterW: 1.0\n"}),
+          {"DarkEnergyFluid:\n"
+           "  ParameterW: 1.0\n"}),
       "dark_energy_fluid", d_for_size, 1.0);
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
-          {"  DarkEnergyFluid:\n"
-           "    ParameterW: 0.3333333333333333\n"}),
+          {"DarkEnergyFluid:\n"
+           "  ParameterW: 0.3333333333333333\n"}),
       "dark_energy_fluid", d_for_size, 1.0 / 3.0);
 
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
-          {"  DarkEnergyFluid:\n"
-           "    ParameterW: 1.0\n"}),
+          {"DarkEnergyFluid:\n"
+           "  ParameterW: 1.0\n"}),
       "dark_energy_fluid", dv_for_size, 1.0);
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
-          {"  DarkEnergyFluid:\n"
-           "    ParameterW: 0.3333333333333333\n"}),
+          {"DarkEnergyFluid:\n"
+           "  ParameterW: 0.3333333333333333\n"}),
       "dark_energy_fluid", dv_for_size, 1.0 / 3.0);
 }

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
@@ -37,23 +37,23 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.IdealFluid",
                                        "ideal_fluid", dv_for_size, 4.0 / 3.0);
 
   TestHelpers::EquationsOfState::check(
-      test_factory_creation<EoS::EquationOfState<true, 2>>(
+      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
           {"  IdealFluid:\n"
            "    AdiabaticIndex: 1.6666666666666667\n"}),
       "ideal_fluid", d_for_size, 5.0 / 3.0);
   TestHelpers::EquationsOfState::check(
-      test_factory_creation<EoS::EquationOfState<true, 2>>(
+      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
           {"  IdealFluid:\n"
            "    AdiabaticIndex: 1.3333333333333333\n"}),
       "ideal_fluid", dv_for_size, 4.0 / 3.0);
 
   TestHelpers::EquationsOfState::check(
-      test_factory_creation<EoS::EquationOfState<false, 2>>(
+      TestHelpers::test_factory_creation<EoS::EquationOfState<false, 2>>(
           {"  IdealFluid:\n"
            "    AdiabaticIndex: 1.6666666666666667\n"}),
       "ideal_fluid", d_for_size, 5.0 / 3.0);
   TestHelpers::EquationsOfState::check(
-      test_factory_creation<EoS::EquationOfState<false, 2>>(
+      TestHelpers::test_factory_creation<EoS::EquationOfState<false, 2>>(
           {"  IdealFluid:\n"
            "    AdiabaticIndex: 1.3333333333333333\n"}),
       "ideal_fluid", dv_for_size, 4.0 / 3.0);

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
@@ -38,23 +38,23 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.IdealFluid",
 
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
-          {"  IdealFluid:\n"
-           "    AdiabaticIndex: 1.6666666666666667\n"}),
+          {"IdealFluid:\n"
+           "  AdiabaticIndex: 1.6666666666666667\n"}),
       "ideal_fluid", d_for_size, 5.0 / 3.0);
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
-          {"  IdealFluid:\n"
-           "    AdiabaticIndex: 1.3333333333333333\n"}),
+          {"IdealFluid:\n"
+           "  AdiabaticIndex: 1.3333333333333333\n"}),
       "ideal_fluid", dv_for_size, 4.0 / 3.0);
 
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_factory_creation<EoS::EquationOfState<false, 2>>(
-          {"  IdealFluid:\n"
-           "    AdiabaticIndex: 1.6666666666666667\n"}),
+          {"IdealFluid:\n"
+           "  AdiabaticIndex: 1.6666666666666667\n"}),
       "ideal_fluid", d_for_size, 5.0 / 3.0);
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_factory_creation<EoS::EquationOfState<false, 2>>(
-          {"  IdealFluid:\n"
-           "    AdiabaticIndex: 1.3333333333333333\n"}),
+          {"IdealFluid:\n"
+           "  AdiabaticIndex: 1.3333333333333333\n"}),
       "ideal_fluid", dv_for_size, 4.0 / 3.0);
 }

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
@@ -38,27 +38,27 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.PolytropicFluid",
 
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_factory_creation<EoS::EquationOfState<true, 1>>(
-          {"  PolytropicFluid:\n"
-           "    PolytropicConstant: 100.0\n"
-           "    PolytropicExponent: 2.0\n"}),
+          {"PolytropicFluid:\n"
+           "  PolytropicConstant: 100.0\n"
+           "  PolytropicExponent: 2.0\n"}),
       "polytropic", d_for_size, 100.0, 2.0);
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_factory_creation<EoS::EquationOfState<true, 1>>(
-          {"  PolytropicFluid:\n"
-           "    PolytropicConstant: 134.0\n"
-           "    PolytropicExponent: 1.5\n"}),
+          {"PolytropicFluid:\n"
+           "  PolytropicConstant: 134.0\n"
+           "  PolytropicExponent: 1.5\n"}),
       "polytropic", dv_for_size, 134.0, 1.5);
 
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_factory_creation<EoS::EquationOfState<false, 1>>(
-          {"  PolytropicFluid:\n"
-           "    PolytropicConstant: 121.0\n"
-           "    PolytropicExponent: 1.2\n"}),
+          {"PolytropicFluid:\n"
+           "  PolytropicConstant: 121.0\n"
+           "  PolytropicExponent: 1.2\n"}),
       "polytropic", d_for_size, 121.0, 1.2);
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_factory_creation<EoS::EquationOfState<false, 1>>(
-          {"  PolytropicFluid:\n"
-           "    PolytropicConstant: 117.0\n"
-           "    PolytropicExponent: 1.12\n"}),
+          {"PolytropicFluid:\n"
+           "  PolytropicConstant: 117.0\n"
+           "  PolytropicExponent: 1.12\n"}),
       "polytropic", dv_for_size, 117.0, 1.12);
 }

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
@@ -37,26 +37,26 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.PolytropicFluid",
                                        "polytropic", dv_for_size, 117.0, 1.12);
 
   TestHelpers::EquationsOfState::check(
-      test_factory_creation<EoS::EquationOfState<true, 1>>(
+      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 1>>(
           {"  PolytropicFluid:\n"
            "    PolytropicConstant: 100.0\n"
            "    PolytropicExponent: 2.0\n"}),
       "polytropic", d_for_size, 100.0, 2.0);
   TestHelpers::EquationsOfState::check(
-      test_factory_creation<EoS::EquationOfState<true, 1>>(
+      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 1>>(
           {"  PolytropicFluid:\n"
            "    PolytropicConstant: 134.0\n"
            "    PolytropicExponent: 1.5\n"}),
       "polytropic", dv_for_size, 134.0, 1.5);
 
   TestHelpers::EquationsOfState::check(
-      test_factory_creation<EoS::EquationOfState<false, 1>>(
+      TestHelpers::test_factory_creation<EoS::EquationOfState<false, 1>>(
           {"  PolytropicFluid:\n"
            "    PolytropicConstant: 121.0\n"
            "    PolytropicExponent: 1.2\n"}),
       "polytropic", d_for_size, 121.0, 1.2);
   TestHelpers::EquationsOfState::check(
-      test_factory_creation<EoS::EquationOfState<false, 1>>(
+      TestHelpers::test_factory_creation<EoS::EquationOfState<false, 1>>(
           {"  PolytropicFluid:\n"
            "    PolytropicConstant: 117.0\n"
            "    PolytropicExponent: 1.12\n"}),

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
@@ -77,10 +77,10 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Gaussian",
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Gaussian.Factory",
                   "[PointwiseFunctions][Unit]") {
   TestHelpers::test_factory_creation<MathFunction<1>>(
-      "  Gaussian:\n"
-      "    Amplitude: 3\n"
-      "    Width: 2\n"
-      "    Center: -9");
+      "Gaussian:\n"
+      "  Amplitude: 3\n"
+      "  Width: 2\n"
+      "  Center: -9");
   // Catch requires us to have at least one CHECK in each test
   // The Unit.PointwiseFunctions.MathFunctions.Gaussian.Factory does not need to
   // check anything

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
@@ -76,7 +76,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Gaussian",
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Gaussian.Factory",
                   "[PointwiseFunctions][Unit]") {
-  test_factory_creation<MathFunction<1>>(
+  TestHelpers::test_factory_creation<MathFunction<1>>(
       "  Gaussian:\n"
       "    Amplitude: 3\n"
       "    Width: 2\n"

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
@@ -100,7 +100,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX",
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX.Factory",
                   "[PointwiseFunctions][Unit]") {
-  test_factory_creation<MathFunction<1>>("  PowX:\n    Power: 3");
+  TestHelpers::test_factory_creation<MathFunction<1>>("  PowX:\n    Power: 3");
   // Catch requires us to have at least one CHECK in each test
   // The Unit.PointwiseFunctions.MathFunctions.PowX.Factory does not need to
   // check anything

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
@@ -100,7 +100,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX",
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX.Factory",
                   "[PointwiseFunctions][Unit]") {
-  TestHelpers::test_factory_creation<MathFunction<1>>("  PowX:\n    Power: 3");
+  TestHelpers::test_factory_creation<MathFunction<1>>("PowX:\n    Power: 3");
   // Catch requires us to have at least one CHECK in each test
   // The Unit.PointwiseFunctions.MathFunctions.PowX.Factory does not need to
   // check anything

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
@@ -67,10 +67,10 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sinusoid",
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sinusoid.Factory",
                   "[PointwiseFunctions][Unit]") {
   TestHelpers::test_factory_creation<MathFunction<1>>(
-      "  Sinusoid:\n"
-      "    Amplitude: 3\n"
-      "    Wavenumber: 2\n"
-      "    Phase: -9");
+      "Sinusoid:\n"
+      "  Amplitude: 3\n"
+      "  Wavenumber: 2\n"
+      "  Phase: -9");
   // Catch requires us to have at least one CHECK in each test
   // The Unit.PointwiseFunctions.MathFunctions.Sinusoid.Factory does not need to
   // check anything

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
@@ -66,7 +66,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sinusoid",
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sinusoid.Factory",
                   "[PointwiseFunctions][Unit]") {
-  test_factory_creation<MathFunction<1>>(
+  TestHelpers::test_factory_creation<MathFunction<1>>(
       "  Sinusoid:\n"
       "    Amplitude: 3\n"
       "    Wavenumber: 2\n"

--- a/tests/Unit/TestCreation.hpp
+++ b/tests/Unit/TestCreation.hpp
@@ -10,6 +10,7 @@
 #include "Options/ParseOptions.hpp"
 #include "Utilities/NoSuchType.hpp"
 
+namespace TestHelpers {
 namespace TestCreation_detail {
 template <typename T>
 struct Opt {
@@ -34,7 +35,7 @@ T test_creation(const std::string& construction_string) noexcept {
 template <typename BaseClass, typename Metavariables = NoSuchType>
 std::unique_ptr<BaseClass> test_factory_creation(
     const std::string& construction_string) noexcept {
-  return test_creation<std::unique_ptr<BaseClass>, Metavariables>(
+  return TestHelpers::test_creation<std::unique_ptr<BaseClass>, Metavariables>(
       construction_string);
 }
 
@@ -50,3 +51,4 @@ T test_enum_creation(const std::string& enum_string) noexcept {
   options.parse("Opt: " + enum_string);
   return options.template get<TestCreation_detail::Opt<T>, Metavariables>();
 }
+}  // namespace TestHelpers

--- a/tests/Unit/TestCreation.hpp
+++ b/tests/Unit/TestCreation.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <boost/algorithm/string.hpp>
 #include <memory>
 #include <string>
 
@@ -12,43 +13,89 @@
 
 namespace TestHelpers {
 namespace TestCreation_detail {
-template <typename T>
-struct Opt {
-  using type = T;
-  static constexpr OptionString help = {"halp"};
+template <typename Tag, typename = void>
+struct AddGroups {
+  template <typename OptionTag = Tag>
+  static std::string apply(std::string construction_string) noexcept {
+    construction_string.insert(0, 2, ' ');
+    construction_string =
+        boost::algorithm::replace_all_copy(construction_string, "\n", "\n  ");
+    construction_string.insert(
+        0, Options_detail::name_helper<OptionTag>::name() + ":\n");
+    return construction_string;
+  }
+};
+
+template <typename Tag>
+struct AddGroups<Tag, cpp17::void_t<typename Tag::group>> {
+  static std::string apply(const std::string& construction_string) noexcept {
+    return AddGroups<typename Tag::group>::apply(
+        AddGroups<void>::template apply<Tag>(construction_string));
+  }
 };
 }  // namespace TestCreation_detail
 
 /// \ingroup TestingFrameworkGroup
-/// Construct an object from a given string.  Each line in the string
-/// must be indented.
-template <typename T, typename Metavariables = NoSuchType>
+/// The default option tag for `TestHelpers::test_creation()`, and
+/// `TestHelpers::test_factory_creation()`.
+template <typename T>
+struct TestCreationOpt {
+  using type = T;
+  static constexpr OptionString help = {"halp"};
+};
+
+/// \ingroup TestingFrameworkGroup
+/// Construct an object or enum from a given string.
+///
+/// When creating a non-enum option the string must not contain the name of the
+/// option (specifically, the struct being created from options, which is the
+/// name of the struct by default if no `name()` function is present). For
+/// example, to create a struct named `ClassWithoutMetavariables` with an option
+/// tag named `SizeT` the following would be used:
+///
+/// \snippet Test_TestCreation.cpp size_t_argument
+///
+/// When creating an enum option the string must not contain the name of the
+/// enum being constructed. The following is an example of an enum named `Color`
+/// with a member `Purple` being created from options.
+///
+/// \snippet Test_TestCreation.cpp enum_purple
+///
+/// Option tags can be tested by passing them as the second template parameter.
+/// If the metavariables are required to create the class then the metavariables
+/// must be passed as the third template parameter. The default option tag is
+/// `TestCreationOpt<T>`.
+template <typename T, typename OptionTag = TestCreationOpt<T>,
+          typename Metavariables = NoSuchType>
 T test_creation(const std::string& construction_string) noexcept {
-  Options<tmpl::list<TestCreation_detail::Opt<T>>> options("");
-  options.parse("Opt:\n" + construction_string);
-  return options.template get<TestCreation_detail::Opt<T>, Metavariables>();
+  Options<tmpl::list<OptionTag>> options("");
+  options.parse(
+      TestCreation_detail::AddGroups<OptionTag>::apply(construction_string));
+  return options.template get<OptionTag, Metavariables>();
 }
 
 /// \ingroup TestingFrameworkGroup
-/// Construct a factory object from a given string.  Each line in the
-/// string must be indented.
-template <typename BaseClass, typename Metavariables = NoSuchType>
+/// Construct a factory object from a given string.
+///
+/// The string must contain the name of the option (specifically, the struct
+/// being created from options, which is the name of the struct). Note that it
+/// is not the name of the base class, but the name of the derived class that
+/// must be given. For example, to create a `BaseClass*` pointing to a derived
+/// class of type `size_t_argument_base` with an option tag name `SizeT` the
+/// following would be used:
+///
+/// \snippet Test_TestCreation.cpp size_t_argument_base
+///
+/// Option tags can be tested by passing them as the second template parameter.
+/// If the metavariables are required to create the class then the metavariables
+/// must be passed as the third template parameter. The default option tag is
+/// `TestCreationOpt<std::unique_ptr<BaseClass>>`.
+template <typename BaseClass,
+          typename OptionTag = TestCreationOpt<std::unique_ptr<BaseClass>>,
+          typename Metavariables = NoSuchType>
 std::unique_ptr<BaseClass> test_factory_creation(
     const std::string& construction_string) noexcept {
-  return TestHelpers::test_creation<std::unique_ptr<BaseClass>, Metavariables>(
-      construction_string);
-}
-
-/// \ingroup TestingFrameworkGroup
-/// Construct an enum from a given string.
-///
-/// Whereas `test_creation` creates a class with options, this creates an enum.
-/// The enum is created from a simple string with no newlines or indents.
-template <typename T, typename Metavariables = NoSuchType,
-          Requires<std::is_enum<T>::value> = nullptr>
-T test_enum_creation(const std::string& enum_string) noexcept {
-  Options<tmpl::list<TestCreation_detail::Opt<T>>> options("");
-  options.parse("Opt: " + enum_string);
-  return options.template get<TestCreation_detail::Opt<T>, Metavariables>();
+  return TestHelpers::test_creation<std::unique_ptr<BaseClass>, OptionTag,
+                                    Metavariables>(construction_string);
 }
 }  // namespace TestHelpers

--- a/tests/Unit/Test_TestCreation.cpp
+++ b/tests/Unit/Test_TestCreation.cpp
@@ -1,0 +1,416 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <ostream>
+#include <string>
+
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/NoSuchType.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/TestCreation.hpp"
+
+namespace {
+enum class Color { Red, Green, Purple };
+}  // namespace
+
+template <>
+struct create_from_yaml<Color> {
+  template <typename Metavariables>
+  static Color create(const Option& options) {
+    return create<void>(options);
+  }
+};
+template <>
+Color create_from_yaml<Color>::create<void>(const Option& options) {
+  const std::string color_read = options.parse_as<std::string>();
+  if (color_read == "Red") {
+    return Color::Red;
+  } else if (color_read == "Green") {
+    return Color::Green;
+  } else if (color_read == "Purple") {
+    return Color::Purple;
+  }
+  PARSE_ERROR(options.context(), "Failed to convert \""
+                                     << color_read
+                                     << "\" to Color. Expected one of: "
+                                        "{Red, Green, Purple}.");
+}
+
+namespace {
+struct ClassWithoutMetavariables {
+  struct SizeT {
+    using type = size_t;
+    static constexpr OptionString help = {"SizeT help"};
+  };
+
+  using options = tmpl::list<SizeT>;
+  static constexpr OptionString help = {"Help"};
+
+  explicit ClassWithoutMetavariables(const size_t in_value) : value(in_value) {}
+
+  ClassWithoutMetavariables() = default;
+
+  size_t value{0};
+};
+
+struct ClassWithMetavariables {
+  struct SizeT {
+    using type = size_t;
+    static constexpr OptionString help = {"SizeT help"};
+  };
+
+  using options = tmpl::list<SizeT>;
+  static constexpr OptionString help = {"Help"};
+
+  template <typename Metavariables>
+  // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
+  ClassWithMetavariables(const size_t in_value,
+                         const OptionContext& /*context*/,
+                         Metavariables /*meta*/) {
+    value = in_value * Metavariables::value_multiplier;
+  }
+
+  ClassWithMetavariables(const size_t /*in_value*/,
+                         const OptionContext& /*context*/, NoSuchType /*meta*/)
+      : value{std::numeric_limits<size_t>::max()} {}
+
+  ClassWithMetavariables() = default;
+
+  size_t value{0};
+};
+
+struct OptionGroup1 {
+  static constexpr OptionString help = {"OptionGroup1 help"};
+};
+
+struct OptionGroup2 {
+  static constexpr OptionString help = {"OptionGroup2 help"};
+  using group = OptionGroup1;
+};
+
+template <typename T>
+struct NoGroup {
+  using type = T;
+  static constexpr OptionString help = {"halp"};
+};
+
+template <typename T>
+struct OneGroup {
+  using type = T;
+  static constexpr OptionString help = {"halp"};
+  using group = OptionGroup1;
+};
+
+template <typename T>
+struct TwoGroup {
+  using type = T;
+  static constexpr OptionString help = {"halp"};
+  using group = OptionGroup2;
+};
+
+template <size_t ValueMultiplier>
+struct Metavars {
+  static constexpr size_t value_multiplier = ValueMultiplier;
+};
+
+struct DerivedClassWithoutMetavariables;
+struct DerivedClassWithMetavariables;
+
+struct BaseClass {
+  using creatable_classes = tmpl::list<DerivedClassWithoutMetavariables,
+                                       DerivedClassWithMetavariables>;
+  BaseClass() = default;
+  BaseClass(const BaseClass&) = delete;
+  BaseClass& operator=(const BaseClass&) = delete;
+  BaseClass(BaseClass&&) = default;
+  BaseClass& operator=(BaseClass&&) = default;
+  virtual ~BaseClass() = default;
+
+  virtual size_t get_value() const = 0;
+};
+
+struct DerivedClassWithoutMetavariables : BaseClass {
+  struct SizeT {
+    using type = size_t;
+    static constexpr OptionString help = {"SizeT help"};
+  };
+
+  using options = tmpl::list<SizeT>;
+  static constexpr OptionString help = {"Help"};
+
+  explicit DerivedClassWithoutMetavariables(const size_t in_value)
+      : value(in_value) {}
+
+  DerivedClassWithoutMetavariables() = default;
+  DerivedClassWithoutMetavariables(const DerivedClassWithoutMetavariables&) =
+      delete;
+  DerivedClassWithoutMetavariables& operator=(
+      const DerivedClassWithoutMetavariables&) = delete;
+  DerivedClassWithoutMetavariables(DerivedClassWithoutMetavariables&&) =
+      default;
+  DerivedClassWithoutMetavariables& operator=(
+      DerivedClassWithoutMetavariables&&) = default;
+  ~DerivedClassWithoutMetavariables() override = default;
+
+  size_t get_value() const override { return value; }
+
+  size_t value{0};
+};
+
+struct DerivedClassWithMetavariables : BaseClass {
+  struct SizeT {
+    using type = size_t;
+    static constexpr OptionString help = {"SizeT help"};
+  };
+
+  using options = tmpl::list<SizeT>;
+  static constexpr OptionString help = {"Help"};
+
+  template <typename Metavariables>
+  // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
+  DerivedClassWithMetavariables(const size_t in_value,
+                                const OptionContext& /*context*/,
+                                Metavariables /*meta*/) {
+    value = in_value * Metavariables::value_multiplier;
+  }
+
+  DerivedClassWithMetavariables(const size_t /*in_value*/,
+                                const OptionContext& /*context*/,
+                                NoSuchType /*meta*/)
+      : value{std::numeric_limits<size_t>::max()} {}
+
+  DerivedClassWithMetavariables() = default;
+  DerivedClassWithMetavariables(const DerivedClassWithMetavariables&) = delete;
+  DerivedClassWithMetavariables& operator=(
+      const DerivedClassWithMetavariables&) = delete;
+  DerivedClassWithMetavariables(DerivedClassWithMetavariables&&) = default;
+  DerivedClassWithMetavariables& operator=(DerivedClassWithMetavariables&&) =
+      default;
+  ~DerivedClassWithMetavariables() override = default;
+
+  size_t get_value() const override { return value; }
+
+  size_t value{0};
+};
+
+void test_test_creation() {
+  // Test creation of fundamentals
+  CHECK(TestHelpers::test_creation<double>("1.846") == 1.846);
+  CHECK(
+      TestHelpers::test_creation<double, TestHelpers::TestCreationOpt<double>>(
+          "1.846") == 1.846);
+  CHECK(TestHelpers::test_creation<double, NoGroup<double>>("1.846") == 1.846);
+  CHECK(TestHelpers::test_creation<double, OneGroup<double>>("1.846") == 1.846);
+  CHECK(TestHelpers::test_creation<double, TwoGroup<double>>("1.846") == 1.846);
+
+  // Test class that doesn't need metavariables when not passing metavariables
+  /// [size_t_argument]
+  CHECK(
+      TestHelpers::test_creation<ClassWithoutMetavariables>("SizeT: 7").value ==
+      7);
+  /// [size_t_argument]
+
+  CHECK(
+      TestHelpers::test_creation<ClassWithoutMetavariables,
+                                 NoGroup<ClassWithoutMetavariables>>("SizeT: 4")
+          .value == 4);
+  CHECK(TestHelpers::test_creation<ClassWithoutMetavariables,
+                                   OneGroup<ClassWithoutMetavariables>>(
+            "SizeT: 5")
+            .value == 5);
+  CHECK(TestHelpers::test_creation<ClassWithoutMetavariables,
+                                   TwoGroup<ClassWithoutMetavariables>>(
+            "SizeT: 6")
+            .value == 6);
+
+  // Test class that doesn't need metavariables but passing metavariables
+  CHECK(
+      TestHelpers::test_creation<
+          ClassWithoutMetavariables,
+          TestHelpers::TestCreationOpt<ClassWithoutMetavariables>, Metavars<3>>(
+          "SizeT: 8")
+          .value == 8);
+  CHECK(TestHelpers::test_creation<ClassWithoutMetavariables,
+                                   NoGroup<ClassWithoutMetavariables>,
+                                   Metavars<4>>("SizeT: 9")
+            .value == 9);
+  CHECK(TestHelpers::test_creation<ClassWithoutMetavariables,
+                                   OneGroup<ClassWithoutMetavariables>,
+                                   Metavars<5>>("SizeT: 10")
+            .value == 10);
+  CHECK(TestHelpers::test_creation<ClassWithoutMetavariables,
+                                   TwoGroup<ClassWithoutMetavariables>,
+                                   Metavars<6>>("SizeT: 11")
+            .value == 11);
+
+  // Test class that uses metavariables but not passing metavariables
+  CHECK(TestHelpers::test_creation<
+            ClassWithMetavariables,
+            TestHelpers::TestCreationOpt<ClassWithMetavariables>>("SizeT: 4")
+            .value == std::numeric_limits<size_t>::max());
+  CHECK(TestHelpers::test_creation<ClassWithMetavariables,
+                                   NoGroup<ClassWithMetavariables>>("SizeT: 4")
+            .value == std::numeric_limits<size_t>::max());
+  CHECK(TestHelpers::test_creation<ClassWithMetavariables,
+                                   OneGroup<ClassWithMetavariables>>("SizeT: 4")
+            .value == std::numeric_limits<size_t>::max());
+  CHECK(TestHelpers::test_creation<ClassWithMetavariables,
+                                   TwoGroup<ClassWithMetavariables>>("SizeT: 4")
+            .value == std::numeric_limits<size_t>::max());
+
+  // Test class that uses metavariables but passing metavariables
+  CHECK(TestHelpers::test_creation<
+            ClassWithMetavariables,
+            TestHelpers::TestCreationOpt<ClassWithMetavariables>, Metavars<3>>(
+            "SizeT: 4")
+            .value == 12);
+  CHECK(
+      TestHelpers::test_creation<ClassWithMetavariables,
+                                 NoGroup<ClassWithMetavariables>, Metavars<4>>(
+          "SizeT: 4")
+          .value == 16);
+  CHECK(
+      TestHelpers::test_creation<ClassWithMetavariables,
+                                 OneGroup<ClassWithMetavariables>, Metavars<5>>(
+          "SizeT: 4")
+          .value == 20);
+  CHECK(
+      TestHelpers::test_creation<ClassWithMetavariables,
+                                 TwoGroup<ClassWithMetavariables>, Metavars<6>>(
+          "SizeT: 4")
+          .value == 24);
+}
+
+void test_test_factory_creation() {
+  // Test derived class that doesn't need metavariables when not passing
+  // metavariables
+  /// [size_t_argument_base]
+  CHECK(TestHelpers::test_factory_creation<BaseClass>(
+            "DerivedClassWithoutMetavariables:\n"
+            "  SizeT: 5")
+            ->get_value() == 5);
+  /// [size_t_argument_base]
+  CHECK(TestHelpers::test_factory_creation<BaseClass,
+                                           NoGroup<std::unique_ptr<BaseClass>>>(
+            "DerivedClassWithoutMetavariables:\n"
+            "  SizeT: 6")
+            ->get_value() == 6);
+  CHECK(
+      TestHelpers::test_factory_creation<BaseClass,
+                                         OneGroup<std::unique_ptr<BaseClass>>>(
+          "DerivedClassWithoutMetavariables:\n"
+          "  SizeT: 7")
+          ->get_value() == 7);
+  CHECK(
+      TestHelpers::test_factory_creation<BaseClass,
+                                         TwoGroup<std::unique_ptr<BaseClass>>>(
+          "DerivedClassWithoutMetavariables:\n"
+          "  SizeT: 8")
+          ->get_value() == 8);
+
+  // Test derived class that doesn't need metavariables when passing
+  // metavariables
+  CHECK(TestHelpers::test_factory_creation<
+            BaseClass, TestHelpers::TestCreationOpt<std::unique_ptr<BaseClass>>,
+            Metavars<4>>("DerivedClassWithoutMetavariables:\n"
+                         "  SizeT: 15")
+            ->get_value() == 15);
+  CHECK(TestHelpers::test_factory_creation<
+            BaseClass, NoGroup<std::unique_ptr<BaseClass>>, Metavars<4>>(
+            "DerivedClassWithoutMetavariables:\n"
+            "  SizeT: 16")
+            ->get_value() == 16);
+  CHECK(TestHelpers::test_factory_creation<
+            BaseClass, OneGroup<std::unique_ptr<BaseClass>>, Metavars<4>>(
+            "DerivedClassWithoutMetavariables:\n"
+            "  SizeT: 17")
+            ->get_value() == 17);
+  CHECK(TestHelpers::test_factory_creation<
+            BaseClass, TwoGroup<std::unique_ptr<BaseClass>>, Metavars<4>>(
+            "DerivedClassWithoutMetavariables:\n"
+            "  SizeT: 18")
+            ->get_value() == 18);
+
+  // Test creating derived class that requires Metavariables but with no
+  // Metavariables passed.
+  CHECK(
+      TestHelpers::test_factory_creation<
+          BaseClass, TestHelpers::TestCreationOpt<std::unique_ptr<BaseClass>>>(
+          "DerivedClassWithMetavariables:\n"
+          "  SizeT: 4")
+          ->get_value() == std::numeric_limits<size_t>::max());
+  CHECK(TestHelpers::test_factory_creation<BaseClass,
+                                           NoGroup<std::unique_ptr<BaseClass>>>(
+            "DerivedClassWithMetavariables:\n"
+            "  SizeT: 4")
+            ->get_value() == std::numeric_limits<size_t>::max());
+  CHECK(
+      TestHelpers::test_factory_creation<BaseClass,
+                                         OneGroup<std::unique_ptr<BaseClass>>>(
+          "DerivedClassWithMetavariables:\n"
+          "  SizeT: 4")
+          ->get_value() == std::numeric_limits<size_t>::max());
+  CHECK(
+      TestHelpers::test_factory_creation<BaseClass,
+                                         TwoGroup<std::unique_ptr<BaseClass>>>(
+          "DerivedClassWithMetavariables:\n"
+          "  SizeT: 4")
+          ->get_value() == std::numeric_limits<size_t>::max());
+
+  // Test creating derived class passing Metavariables
+  CHECK(TestHelpers::test_factory_creation<
+            BaseClass, TestHelpers::TestCreationOpt<std::unique_ptr<BaseClass>>,
+            Metavars<3>>("DerivedClassWithMetavariables:\n"
+                         "  SizeT: 4")
+            ->get_value() == 12);
+  CHECK(TestHelpers::test_factory_creation<
+            BaseClass, NoGroup<std::unique_ptr<BaseClass>>, Metavars<4>>(
+            "DerivedClassWithMetavariables:\n"
+            "  SizeT: 4")
+            ->get_value() == 16);
+  CHECK(TestHelpers::test_factory_creation<
+            BaseClass, OneGroup<std::unique_ptr<BaseClass>>, Metavars<5>>(
+            "DerivedClassWithMetavariables:\n"
+            "  SizeT: 4")
+            ->get_value() == 20);
+  CHECK(TestHelpers::test_factory_creation<
+            BaseClass, TwoGroup<std::unique_ptr<BaseClass>>, Metavars<6>>(
+            "DerivedClassWithMetavariables:\n"
+            "  SizeT: 4")
+            ->get_value() == 24);
+}
+
+void test_test_enum_creation() {
+  /// [enum_purple]
+  CHECK(TestHelpers::test_creation<Color>("Purple") == Color::Purple);
+  /// [enum_purple]
+  CHECK(TestHelpers::test_creation<Color, TestHelpers::TestCreationOpt<Color>>(
+            "Purple") == Color::Purple);
+  CHECK(TestHelpers::test_creation<Color, NoGroup<Color>>("Purple") ==
+        Color::Purple);
+  CHECK(TestHelpers::test_creation<Color, OneGroup<Color>>("Purple") ==
+        Color::Purple);
+  CHECK(TestHelpers::test_creation<Color, TwoGroup<Color>>("Purple") ==
+        Color::Purple);
+  CHECK(TestHelpers::test_creation<Color, TestHelpers::TestCreationOpt<Color>,
+                                   Metavars<3>>("Purple") == Color::Purple);
+  CHECK(TestHelpers::test_creation<Color, NoGroup<Color>, Metavars<3>>(
+            "Purple") == Color::Purple);
+  CHECK(TestHelpers::test_creation<Color, OneGroup<Color>, Metavars<3>>(
+            "Purple") == Color::Purple);
+  CHECK(TestHelpers::test_creation<Color, TwoGroup<Color>, Metavars<3>>(
+            "Purple") == Color::Purple);
+}
+
+SPECTRE_TEST_CASE("Unit.TestCreation", "[Unit]") {
+  test_test_creation();
+  test_test_factory_creation();
+  test_test_enum_creation();
+}
+}  // namespace

--- a/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
@@ -55,7 +55,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ByBlock", "[Unit][Time]") {
           expected);
   }
 
-  test_factory_creation<StepChooserType>(
+  TestHelpers::test_factory_creation<StepChooserType>(
       "  ByBlock:\n"
       "    Sizes: [1.0, 2.0]");
 }

--- a/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
@@ -56,6 +56,6 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ByBlock", "[Unit][Time]") {
   }
 
   TestHelpers::test_factory_creation<StepChooserType>(
-      "  ByBlock:\n"
-      "    Sizes: [1.0, 2.0]");
+      "ByBlock:\n"
+      "  Sizes: [1.0, 2.0]");
 }

--- a/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
@@ -90,7 +90,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Cfl", "[Unit][Time]") {
   CHECK(get_suggestion(1, 1., 2., {0., 2., 3., 5.}) == approx(0.5));
   CHECK(get_suggestion(1, 1., 1., {0., 2., 2.5, 5.}) == approx(0.5));
 
-  test_factory_creation<StepChooserType>(
+  TestHelpers::test_factory_creation<StepChooserType>(
       "  Cfl:\n"
       "    SafetyFactor: 5.0");
 }

--- a/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
@@ -91,6 +91,6 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Cfl", "[Unit][Time]") {
   CHECK(get_suggestion(1, 1., 1., {0., 2., 2.5, 5.}) == approx(0.5));
 
   TestHelpers::test_factory_creation<StepChooserType>(
-      "  Cfl:\n"
-      "    SafetyFactor: 5.0");
+      "Cfl:\n"
+      "  SafetyFactor: 5.0");
 }

--- a/tests/Unit/Time/StepChoosers/Test_Constant.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Constant.cpp
@@ -44,12 +44,12 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Constant", "[Unit][Time]") {
   CHECK(serialize_and_deserialize(constant_base)->desired_step(box, cache) ==
         5.4);
 
-  TestHelpers::test_factory_creation<StepChooserType>("  Constant: 5.4");
+  TestHelpers::test_factory_creation<StepChooserType>("Constant: 5.4");
 }
 
 // [[OutputRegex, Requested step magnitude should be positive]]
 SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Constant.bad_create",
                   "[Unit][Time]") {
   ERROR_TEST();
-  TestHelpers::test_factory_creation<StepChooserType>("  Constant: -5.4");
+  TestHelpers::test_factory_creation<StepChooserType>("Constant: -5.4");
 }

--- a/tests/Unit/Time/StepChoosers/Test_Constant.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Constant.cpp
@@ -44,12 +44,12 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Constant", "[Unit][Time]") {
   CHECK(serialize_and_deserialize(constant_base)->desired_step(box, cache) ==
         5.4);
 
-  test_factory_creation<StepChooserType>("  Constant: 5.4");
+  TestHelpers::test_factory_creation<StepChooserType>("  Constant: 5.4");
 }
 
 // [[OutputRegex, Requested step magnitude should be positive]]
 SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Constant.bad_create",
                   "[Unit][Time]") {
   ERROR_TEST();
-  test_factory_creation<StepChooserType>("  Constant: -5.4");
+  TestHelpers::test_factory_creation<StepChooserType>("  Constant: -5.4");
 }

--- a/tests/Unit/Time/StepChoosers/Test_Increase.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Increase.cpp
@@ -51,7 +51,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Increase", "[Unit][Time]") {
           1.25);
   }
 
-  test_factory_creation<StepChooserType>(
+  TestHelpers::test_factory_creation<StepChooserType>(
       "  Increase:\n"
       "    Factor: 5.0");
 }

--- a/tests/Unit/Time/StepChoosers/Test_Increase.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Increase.cpp
@@ -52,6 +52,6 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Increase", "[Unit][Time]") {
   }
 
   TestHelpers::test_factory_creation<StepChooserType>(
-      "  Increase:\n"
-      "    Factor: 5.0");
+      "Increase:\n"
+      "  Factor: 5.0");
 }

--- a/tests/Unit/Time/StepChoosers/Test_PreventRapidIncrease.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_PreventRapidIncrease.cpp
@@ -113,5 +113,5 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.PreventRapidIncrease",
   check_case({2, 5}, {{0, 5}, {2, 5}, {3, 5}, {4, 5}});
   check_case({1, 20}, {{1, 5}, {1, 4}, {3, 5}, {4, 5}});
 
-  test_factory_creation<StepChooserType>("  PreventRapidIncrease");
+  TestHelpers::test_factory_creation<StepChooserType>("  PreventRapidIncrease");
 }

--- a/tests/Unit/Time/StepChoosers/Test_PreventRapidIncrease.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_PreventRapidIncrease.cpp
@@ -113,5 +113,5 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.PreventRapidIncrease",
   check_case({2, 5}, {{0, 5}, {2, 5}, {3, 5}, {4, 5}});
   check_case({1, 20}, {{1, 5}, {1, 4}, {3, 5}, {4, 5}});
 
-  TestHelpers::test_factory_creation<StepChooserType>("  PreventRapidIncrease");
+  TestHelpers::test_factory_creation<StepChooserType>("PreventRapidIncrease");
 }

--- a/tests/Unit/Time/StepControllers/Test_BinaryFraction.cpp
+++ b/tests/Unit/Time/StepControllers/Test_BinaryFraction.cpp
@@ -36,7 +36,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.BinaryFraction", "[Unit][Time]") {
   };
   check(StepControllers::BinaryFraction{});
   check(*serialize_and_deserialize(
-      test_factory_creation<StepController>("  BinaryFraction")));
+      TestHelpers::test_factory_creation<StepController>("  BinaryFraction")));
 }
 
 // [[OutputRegex, Not at a binary-fraction time within slab]]

--- a/tests/Unit/Time/StepControllers/Test_BinaryFraction.cpp
+++ b/tests/Unit/Time/StepControllers/Test_BinaryFraction.cpp
@@ -36,7 +36,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.BinaryFraction", "[Unit][Time]") {
   };
   check(StepControllers::BinaryFraction{});
   check(*serialize_and_deserialize(
-      TestHelpers::test_factory_creation<StepController>("  BinaryFraction")));
+      TestHelpers::test_factory_creation<StepController>("BinaryFraction")));
 }
 
 // [[OutputRegex, Not at a binary-fraction time within slab]]

--- a/tests/Unit/Time/StepControllers/Test_FullSlab.cpp
+++ b/tests/Unit/Time/StepControllers/Test_FullSlab.cpp
@@ -33,5 +33,5 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.FullSlab", "[Unit][Time]") {
   };
   check(StepControllers::FullSlab{});
   check(*serialize_and_deserialize(
-      test_factory_creation<StepController>("  FullSlab")));
+      TestHelpers::test_factory_creation<StepController>("  FullSlab")));
 }

--- a/tests/Unit/Time/StepControllers/Test_FullSlab.cpp
+++ b/tests/Unit/Time/StepControllers/Test_FullSlab.cpp
@@ -33,5 +33,5 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.FullSlab", "[Unit][Time]") {
   };
   check(StepControllers::FullSlab{});
   check(*serialize_and_deserialize(
-      TestHelpers::test_factory_creation<StepController>("  FullSlab")));
+      TestHelpers::test_factory_creation<StepController>("FullSlab")));
 }

--- a/tests/Unit/Time/StepControllers/Test_SimpleTimes.cpp
+++ b/tests/Unit/Time/StepControllers/Test_SimpleTimes.cpp
@@ -42,5 +42,5 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.SimpleTimes", "[Unit][Time]") {
   };
   check(StepControllers::SimpleTimes{});
   check(*serialize_and_deserialize(
-      TestHelpers::test_factory_creation<StepController>("  SimpleTimes")));
+      TestHelpers::test_factory_creation<StepController>("SimpleTimes")));
 }

--- a/tests/Unit/Time/StepControllers/Test_SimpleTimes.cpp
+++ b/tests/Unit/Time/StepControllers/Test_SimpleTimes.cpp
@@ -42,5 +42,5 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.SimpleTimes", "[Unit][Time]") {
   };
   check(StepControllers::SimpleTimes{});
   check(*serialize_and_deserialize(
-      test_factory_creation<StepController>("  SimpleTimes")));
+      TestHelpers::test_factory_creation<StepController>("  SimpleTimes")));
 }

--- a/tests/Unit/Time/StepControllers/Test_SplitRemaining.cpp
+++ b/tests/Unit/Time/StepControllers/Test_SplitRemaining.cpp
@@ -37,5 +37,5 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.SplitRemaining", "[Unit][Time]") {
   };
   check(StepControllers::SplitRemaining{});
   check(*serialize_and_deserialize(
-      TestHelpers::test_factory_creation<StepController>("  SplitRemaining")));
+      TestHelpers::test_factory_creation<StepController>("SplitRemaining")));
 }

--- a/tests/Unit/Time/StepControllers/Test_SplitRemaining.cpp
+++ b/tests/Unit/Time/StepControllers/Test_SplitRemaining.cpp
@@ -37,5 +37,5 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.SplitRemaining", "[Unit][Time]") {
   };
   check(StepControllers::SplitRemaining{});
   check(*serialize_and_deserialize(
-      test_factory_creation<StepController>("  SplitRemaining")));
+      TestHelpers::test_factory_creation<StepController>("  SplitRemaining")));
 }

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -60,10 +60,12 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN", "[Unit][Time]") {
   CHECK_FALSE(can_change(end, start, mid));
   CHECK_FALSE(can_change(end, mid, start));
 
-  test_factory_creation<TimeStepper>("  AdamsBashforthN:\n"
-                                     "    Order: 3");
-  test_factory_creation<LtsTimeStepper>("  AdamsBashforthN:\n"
-                                        "    Order: 3");
+  TestHelpers::test_factory_creation<TimeStepper>(
+      "  AdamsBashforthN:\n"
+      "    Order: 3");
+  TestHelpers::test_factory_creation<LtsTimeStepper>(
+      "  AdamsBashforthN:\n"
+      "    Order: 3");
 
   TimeSteppers::AdamsBashforthN ab4(4);
   test_serialization(ab4);

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -61,11 +61,11 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN", "[Unit][Time]") {
   CHECK_FALSE(can_change(end, mid, start));
 
   TestHelpers::test_factory_creation<TimeStepper>(
-      "  AdamsBashforthN:\n"
-      "    Order: 3");
+      "AdamsBashforthN:\n"
+      "  Order: 3");
   TestHelpers::test_factory_creation<LtsTimeStepper>(
-      "  AdamsBashforthN:\n"
-      "    Order: 3");
+      "AdamsBashforthN:\n"
+      "  Order: 3");
 
   TimeSteppers::AdamsBashforthN ab4(4);
   test_serialization(ab4);

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
@@ -20,7 +20,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3", "[Unit][Time]") {
   TimeStepperTestUtils::check_convergence_order(stepper, 3);
   TimeStepperTestUtils::check_dense_output(stepper, 3);
 
-  TestHelpers::test_factory_creation<TimeStepper>("  RungeKutta3");
+  TestHelpers::test_factory_creation<TimeStepper>("RungeKutta3");
   test_serialization(stepper);
   test_serialization_via_base<TimeStepper, TimeSteppers::RungeKutta3>();
   // test operator !=

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
@@ -20,7 +20,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3", "[Unit][Time]") {
   TimeStepperTestUtils::check_convergence_order(stepper, 3);
   TimeStepperTestUtils::check_dense_output(stepper, 3);
 
-  test_factory_creation<TimeStepper>("  RungeKutta3");
+  TestHelpers::test_factory_creation<TimeStepper>("  RungeKutta3");
   test_serialization(stepper);
   test_serialization_via_base<TimeStepper, TimeSteppers::RungeKutta3>();
   // test operator !=

--- a/tests/Unit/Time/Triggers/Test_EveryNSlabs.cpp
+++ b/tests/Unit/Time/Triggers/Test_EveryNSlabs.cpp
@@ -27,7 +27,7 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.EveryNSlabs", "[Unit][Time]") {
   using TriggerType = Trigger<tmpl::list<Triggers::Registrars::EveryNSlabs>>;
   Parallel::register_derived_classes_with_charm<TriggerType>();
 
-  const auto trigger = test_factory_creation<TriggerType>(
+  const auto trigger = TestHelpers::test_factory_creation<TriggerType>(
       "  EveryNSlabs:\n"
       "    N: 3\n"
       "    Offset: 5");

--- a/tests/Unit/Time/Triggers/Test_EveryNSlabs.cpp
+++ b/tests/Unit/Time/Triggers/Test_EveryNSlabs.cpp
@@ -28,9 +28,9 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.EveryNSlabs", "[Unit][Time]") {
   Parallel::register_derived_classes_with_charm<TriggerType>();
 
   const auto trigger = TestHelpers::test_factory_creation<TriggerType>(
-      "  EveryNSlabs:\n"
-      "    N: 3\n"
-      "    Offset: 5");
+      "EveryNSlabs:\n"
+      "  N: 3\n"
+      "  Offset: 5");
 
   const auto sent_trigger = serialize_and_deserialize(trigger);
 

--- a/tests/Unit/Time/Triggers/Test_PastTime.cpp
+++ b/tests/Unit/Time/Triggers/Test_PastTime.cpp
@@ -26,7 +26,8 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.PastTime", "[Unit][Time]") {
   using TriggerType = Trigger<tmpl::list<Triggers::Registrars::PastTime>>;
   Parallel::register_derived_classes_with_charm<TriggerType>();
 
-  const auto trigger = test_factory_creation<TriggerType>("  PastTime: -7.");
+  const auto trigger =
+      TestHelpers::test_factory_creation<TriggerType>("  PastTime: -7.");
 
   const auto sent_trigger = serialize_and_deserialize(trigger);
 

--- a/tests/Unit/Time/Triggers/Test_PastTime.cpp
+++ b/tests/Unit/Time/Triggers/Test_PastTime.cpp
@@ -27,7 +27,7 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.PastTime", "[Unit][Time]") {
   Parallel::register_derived_classes_with_charm<TriggerType>();
 
   const auto trigger =
-      TestHelpers::test_factory_creation<TriggerType>("  PastTime: -7.");
+      TestHelpers::test_factory_creation<TriggerType>("PastTime: -7.");
 
   const auto sent_trigger = serialize_and_deserialize(trigger);
 

--- a/tests/Unit/Time/Triggers/Test_SpecifiedSlabs.cpp
+++ b/tests/Unit/Time/Triggers/Test_SpecifiedSlabs.cpp
@@ -28,8 +28,8 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.SpecifiedSlabs", "[Unit][Time]") {
   Parallel::register_derived_classes_with_charm<TriggerType>();
 
   const auto trigger = TestHelpers::test_factory_creation<TriggerType>(
-      "  SpecifiedSlabs:\n"
-      "    Slabs: [3, 6, 8]");
+      "SpecifiedSlabs:\n"
+      "  Slabs: [3, 6, 8]");
 
   const auto sent_trigger = serialize_and_deserialize(trigger);
 

--- a/tests/Unit/Time/Triggers/Test_SpecifiedSlabs.cpp
+++ b/tests/Unit/Time/Triggers/Test_SpecifiedSlabs.cpp
@@ -27,7 +27,7 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.SpecifiedSlabs", "[Unit][Time]") {
   using TriggerType = Trigger<tmpl::list<Triggers::Registrars::SpecifiedSlabs>>;
   Parallel::register_derived_classes_with_charm<TriggerType>();
 
-  const auto trigger = test_factory_creation<TriggerType>(
+  const auto trigger = TestHelpers::test_factory_creation<TriggerType>(
       "  SpecifiedSlabs:\n"
       "    Slabs: [3, 6, 8]");
 

--- a/tests/Unit/Utilities/Test_Registration.cpp
+++ b/tests/Unit/Utilities/Test_Registration.cpp
@@ -89,9 +89,15 @@ SPECTRE_TEST_CASE("Unit.Utilities.Registration", "[Unit][Utilities]") {
       Base<tmpl::list<Registrars::Derived1, Registrars::Derived2<double>,
                       Registrars::Derived3<4>>>;
   /// [registrar_use]
-  CHECK(test_factory_creation<ConcreteBase>("  Derived1")->func() == 1);
-  CHECK(test_factory_creation<ConcreteBase>("  Derived2")->func() == 2);
-  CHECK(test_factory_creation<ConcreteBase>("  Derived3")->func() == 4);
+  CHECK(
+      TestHelpers::test_factory_creation<ConcreteBase>("  Derived1")->func() ==
+      1);
+  CHECK(
+      TestHelpers::test_factory_creation<ConcreteBase>("  Derived2")->func() ==
+      2);
+  CHECK(
+      TestHelpers::test_factory_creation<ConcreteBase>("  Derived3")->func() ==
+      4);
 
   // Test standalone derived classes
   CHECK(Derived1<>{}.func() == 1);

--- a/tests/Unit/Utilities/Test_Registration.cpp
+++ b/tests/Unit/Utilities/Test_Registration.cpp
@@ -89,15 +89,12 @@ SPECTRE_TEST_CASE("Unit.Utilities.Registration", "[Unit][Utilities]") {
       Base<tmpl::list<Registrars::Derived1, Registrars::Derived2<double>,
                       Registrars::Derived3<4>>>;
   /// [registrar_use]
-  CHECK(
-      TestHelpers::test_factory_creation<ConcreteBase>("  Derived1")->func() ==
-      1);
-  CHECK(
-      TestHelpers::test_factory_creation<ConcreteBase>("  Derived2")->func() ==
-      2);
-  CHECK(
-      TestHelpers::test_factory_creation<ConcreteBase>("  Derived3")->func() ==
-      4);
+  CHECK(TestHelpers::test_factory_creation<ConcreteBase>("Derived1")->func() ==
+        1);
+  CHECK(TestHelpers::test_factory_creation<ConcreteBase>("Derived2")->func() ==
+        2);
+  CHECK(TestHelpers::test_factory_creation<ConcreteBase>("Derived3")->func() ==
+        4);
 
   // Test standalone derived classes
   CHECK(Derived1<>{}.func() == 1);


### PR DESCRIPTION
## Proposed changes

- Move `test_*_creation` into the `TesHelpers` namespace
- Extend `test_*_creation` to allow testing  the option tags.
- Remove the two extra spaces at the beginning of the option strings passed to the `test_*_creation` functions.

I'm not sure what we are currently supposed to do for testing option tags, so I decided to see what people think about this. One question I have: @wthrowe what do you think is the best way to test this code? Maybe adding a `Test_TestCreation.cpp`?

Commit order:
1. Move test_*_creation into TestHelpers namespace
2. Add tests for test_creation and option tag as template param
3. Remove extra spaces in test_*_creation calls

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
