### PR TITLE
Add limiter mean checks

### DIFF
--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
@@ -419,11 +419,28 @@ void test_weno_work(
   auto scalar = get<ScalarTag>(local_vars);
   auto vector = get<VectorTag<VolumeDim>>(local_vars);
 
+  // WENO should preserve the mean, so expected = initial
+  const double expected_scalar_mean = mean_value(get(scalar), mesh);
+  const auto expected_vector_means = [&vector, &mesh ]() noexcept {
+    std::array<double, VolumeDim> means{};
+    for (size_t d = 0; d < VolumeDim; ++d) {
+      gsl::at(means, d) = mean_value(vector.get(d), mesh);
+    }
+    return means;
+  }
+  ();
+
   const Weno weno(weno_type, neighbor_linear_weight);
   const bool activated = weno(make_not_null(&scalar), make_not_null(&vector),
                               element, mesh, element_size, neighbor_data);
 
   CHECK(activated);
+
+  CHECK(mean_value(get(scalar), mesh) == approx(expected_scalar_mean));
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    CHECK(mean_value(vector.get(d), mesh) ==
+          approx(gsl::at(expected_vector_means, d)));
+  }
 
   auto expected_scalar = get<ScalarTag>(local_vars);
   Limiters::Weno_detail::reconstruct_from_weighted_sum<ScalarTag>(


### PR DESCRIPTION
## Proposed changes

Improve the Minmod and WENO tests, by checking that the pre-limiter and post-limiter means are the same.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
