### PR TITLE
Rework swsh transform interface

### DIFF
--- a/src/NumericalAlgorithms/Spectral/SwshTags.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTags.hpp
@@ -165,6 +165,22 @@ struct SwshTransform : db::PrefixTag, db::SimpleTag {
     return "SwshTransform(" + Tag::name() + ")";
   }
 };
+
+/// \ingroup SwshGroup
+/// \brief Tag for the maximum spin-weighted spherical harmonic l; sets angular
+/// resolution.
+struct LMax : db::SimpleTag {
+  using type = size_t;
+  static std::string name() noexcept { return "LMax"; }
+};
+
+/// \ingroup SwshGroup
+/// \brief Tag for the number of radial grid points in the three-dimensional
+/// representation of radially concentric spherical shells
+struct NumberOfRadialPoints : db::SimpleTag {
+  using type = size_t;
+  static std::string name() noexcept { return "NumberOfRadialPoints"; }
+};
 }  // namespace Tags
 
 namespace detail {

--- a/src/NumericalAlgorithms/Spectral/SwshTransform.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTransform.cpp
@@ -104,165 +104,42 @@ void execute_libsharp_transform_set(
 }  // namespace detail
 
 template <ComplexRepresentation Representation, int Spin>
-void swsh_transform(const gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*>
-                        libsharp_coefficients,
-                    const SpinWeighted<ComplexDataVector, Spin>& collocation,
-                    const size_t l_max) noexcept {
-  size_t number_of_radial_points =
-      collocation.data().size() / number_of_swsh_collocation_points(l_max);
-
-  // append a list of pointers into the collocation point data. This is
-  // required because libsharp expects pointers to pointers.
-  std::vector<detail::ComplexDataView<Representation>> pre_transform_views;
-  pre_transform_views.reserve(number_of_radial_points);
-  std::vector<double*> pre_transform_collocation_data;
-  pre_transform_collocation_data.reserve(2 * number_of_radial_points);
-
-  const auto* collocation_metadata =
-      &cached_collocation_metadata<Representation>(l_max);
-  const auto* alm_info =
-      cached_coefficients_metadata(l_max).get_sharp_alm_info();
-
-  // libsharp considers two arrays per transform when spin is not zero.
-  const size_t num_transforms =
-      (Spin == 0 ? 2 * number_of_radial_points : number_of_radial_points);
-
-  detail::append_libsharp_collocation_pointers(
-      make_not_null(&pre_transform_collocation_data),
-      make_not_null(&pre_transform_views),
-      make_not_null(
-          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-          &const_cast<SpinWeighted<ComplexDataVector, Spin>&>(collocation)
-               .data()),
-      l_max, Spin >= 0);
-
-  if (libsharp_coefficients->data().size() !=
-      number_of_radial_points *
-          Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)) {
-    libsharp_coefficients->data() = ComplexModalVector{
-        number_of_radial_points *
-        Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
-  }
-
-  std::vector<std::complex<double>*> post_transform_coefficient_data;
-  post_transform_coefficient_data.reserve(2 * number_of_radial_points);
-
-  detail::append_libsharp_coefficient_pointers(
-      make_not_null(&post_transform_coefficient_data),
-      make_not_null(&libsharp_coefficients->data()), l_max);
-
-  detail::execute_libsharp_transform_set(
-      SHARP_MAP2ALM, Spin, make_not_null(&post_transform_coefficient_data),
-      make_not_null(&pre_transform_collocation_data),
-      make_not_null(collocation_metadata), alm_info, num_transforms);
-
-  detail::conjugate_views<Spin>(make_not_null(&pre_transform_views));
-}
-
-template <ComplexRepresentation Representation, int Spin>
 SpinWeighted<ComplexModalVector, Spin> swsh_transform(
-    const SpinWeighted<ComplexDataVector, Spin>& collocation,
-    const size_t l_max) noexcept {
+    const size_t l_max, const size_t number_of_radial_points,
+    const SpinWeighted<ComplexDataVector, Spin>& collocation) noexcept {
   SpinWeighted<ComplexModalVector, Spin> result_vector{};
-  swsh_transform<Representation, Spin>(make_not_null(&result_vector),
-                                       collocation, l_max);
+  swsh_transform<Representation, Spin>(l_max, number_of_radial_points,
+                                       make_not_null(&result_vector),
+                                       collocation);
   return result_vector;
 }
 
 template <ComplexRepresentation Representation, int Spin>
-void inverse_swsh_transform(
-    const gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> collocation,
-    const SpinWeighted<ComplexModalVector, Spin>& libsharp_coefficients,
-    const size_t l_max) noexcept {
-  const size_t number_of_radial_points =
-      libsharp_coefficients.data().size() /
-      (size_of_libsharp_coefficient_vector(l_max));
-
-  const auto* collocation_metadata =
-      &cached_collocation_metadata<Representation>(l_max);
-  const auto* alm_info =
-      cached_coefficients_metadata(l_max).get_sharp_alm_info();
-
-  std::vector<std::complex<double>*> pre_transform_coefficient_data;
-  pre_transform_coefficient_data.reserve(2 * number_of_radial_points);
-
-  detail::append_libsharp_coefficient_pointers(
-      make_not_null(&pre_transform_coefficient_data),
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-      make_not_null(&const_cast<SpinWeighted<ComplexModalVector, Spin>&>(
-                         libsharp_coefficients)
-                         .data()),
-      l_max);
-
-  std::vector<detail::ComplexDataView<Representation>> post_transform_views;
-  post_transform_views.reserve(number_of_radial_points);
-  std::vector<double*> post_transform_collocation_data;
-  post_transform_collocation_data.reserve(2 * number_of_radial_points);
-
-  if (collocation->data().size() !=
-      number_of_radial_points *
-          Spectral::Swsh::number_of_swsh_collocation_points(l_max)) {
-    collocation->data() = ComplexDataVector{
-        number_of_radial_points *
-        Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
-  }
-  // libsharp considers two arrays per transform when spin is not zero.
-  const size_t num_transforms = (Spin == 0 ? 2 : 1) * number_of_radial_points;
-
-  detail::append_libsharp_collocation_pointers(
-      make_not_null(&post_transform_collocation_data),
-      make_not_null(&post_transform_views), make_not_null(&collocation->data()),
-      l_max, true);
-  detail::execute_libsharp_transform_set(
-      SHARP_ALM2MAP, Spin, make_not_null(&pre_transform_coefficient_data),
-      make_not_null(&post_transform_collocation_data),
-      make_not_null(collocation_metadata), alm_info, num_transforms);
-
-  detail::conjugate_views<Spin>(make_not_null(&post_transform_views));
-
-  // The inverse transformed collocation data has just been placed in the
-  // memory blocks controlled by the `ComplexDataView`s. Finally, that data
-  // must be flushed back to the input vector.
-  for (auto& view : post_transform_views) {
-    view.copy_back_to_source();
-  }
-}
-
-template <ComplexRepresentation Representation, int Spin>
 SpinWeighted<ComplexDataVector, Spin> inverse_swsh_transform(
-    const SpinWeighted<ComplexModalVector, Spin>& libsharp_coefficients,
-    const size_t l_max) noexcept {
+    const size_t l_max, const size_t number_of_radial_points,
+    const SpinWeighted<ComplexModalVector, Spin>&
+        libsharp_coefficients) noexcept {
   SpinWeighted<ComplexDataVector, Spin> result_vector{};
-  inverse_swsh_transform<Representation, Spin>(make_not_null(&result_vector),
-                                               libsharp_coefficients, l_max);
+  inverse_swsh_transform<Representation, Spin>(l_max, number_of_radial_points,
+                                               make_not_null(&result_vector),
+                                               libsharp_coefficients);
   return result_vector;
 }
 
 #define GET_REPRESENTATION(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define GET_SPIN(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define SWSH_TRANSFORM_INSTANTIATION(r, data)                                \
-  template void swsh_transform<GET_REPRESENTATION(data), GET_SPIN(data)>(    \
-      const gsl::not_null<SpinWeighted<ComplexModalVector, GET_SPIN(data)>*> \
-          libsharp_coefficients,                                             \
-      const SpinWeighted<ComplexDataVector, GET_SPIN(data)>& collocation,    \
-      const size_t l_max) noexcept;                                          \
-  template SpinWeighted<ComplexModalVector, GET_SPIN(data)>                  \
-  swsh_transform<GET_REPRESENTATION(data), GET_SPIN(data)>(                  \
-      const SpinWeighted<ComplexDataVector, GET_SPIN(data)>& collocation,    \
-      const size_t l_max) noexcept;                                          \
-  template void                                                              \
-  inverse_swsh_transform<GET_REPRESENTATION(data), GET_SPIN(data)>(          \
-      const gsl::not_null<SpinWeighted<ComplexDataVector, GET_SPIN(data)>*>  \
-          collocation,                                                       \
-      const SpinWeighted<ComplexModalVector, GET_SPIN(data)>&                \
-          libsharp_coefficients,                                             \
-      const size_t l_max) noexcept;                                          \
-  template SpinWeighted<ComplexDataVector, GET_SPIN(data)>                   \
-  inverse_swsh_transform<GET_REPRESENTATION(data), GET_SPIN(data)>(          \
-      const SpinWeighted<ComplexModalVector, GET_SPIN(data)>&                \
-          libsharp_coefficients,                                             \
-      const size_t l_max) noexcept;
+#define SWSH_TRANSFORM_INSTANTIATION(r, data)                       \
+  template SpinWeighted<ComplexModalVector, GET_SPIN(data)>         \
+  swsh_transform<GET_REPRESENTATION(data), GET_SPIN(data)>(         \
+      const size_t l_max, const size_t number_of_radial_points,     \
+      const SpinWeighted<ComplexDataVector, GET_SPIN(data)>&        \
+          collocation) noexcept;                                    \
+  template SpinWeighted<ComplexDataVector, GET_SPIN(data)>          \
+  inverse_swsh_transform<GET_REPRESENTATION(data), GET_SPIN(data)>( \
+      const size_t l_max, const size_t number_of_radial_points,     \
+      const SpinWeighted<ComplexModalVector, GET_SPIN(data)>&       \
+          coefficients) noexcept;
 
 #define SWSH_TRANSFORM_UTILITIES_INSTANTIATION(r, data)                   \
   template void append_libsharp_collocation_pointers(                     \

--- a/tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp
@@ -123,14 +123,15 @@ template <int Spin, ComplexRepresentation Representation,
           typename BasisFunction>
 void swsh_collocation_from_coefficients_and_basis_func(
     const gsl::not_null<ComplexDataVector*> collocation_data,
-    const gsl::not_null<ComplexModalVector*> coefficient_data,
-    const size_t l_max, const size_t number_of_radial_points,
+    const ComplexModalVector& coefficient_data, const size_t l_max,
+    const size_t number_of_radial_points,
     const BasisFunction basis_function) noexcept {
   auto& spherical_harmonic_collocation =
       cached_collocation_metadata<Representation>(l_max);
   auto spherical_harmonic_lm =
       cached_coefficients_metadata(l_max).get_sharp_alm_info();
 
+  *collocation_data = 0.0;
   for (size_t i = 0; i < number_of_radial_points; ++i) {
     for (auto j : spherical_harmonic_collocation) {
       for (size_t m = 0; m < static_cast<size_t>(spherical_harmonic_lm->nm);
@@ -150,39 +151,37 @@ void swsh_collocation_from_coefficients_and_basis_func(
           (*collocation_data)[j.offset +
                               i * spherical_harmonic_collocation.size()] +=
               sharp_swsh_sign(Spin, m, true) *
-              (*coefficient_data)[m_start + l * l_stride +
-                                  i * size_of_libsharp_coefficient_vector(
-                                          l_max)] *
+              coefficient_data[m_start + l * l_stride +
+                               i * size_of_libsharp_coefficient_vector(l_max)] *
               basis_function(Spin, l, m, j.theta, j.phi);
 
           if (m != 0) {
             (*collocation_data)[j.offset +
                                 i * spherical_harmonic_collocation.size()] +=
                 sharp_swsh_sign(Spin, -m, true) *
-                conj(
-                    (*coefficient_data)[m_start + l * l_stride +
-                                        i * size_of_libsharp_coefficient_vector(
-                                                l_max)]) *
+                conj(coefficient_data[m_start + l * l_stride +
+                                      i * size_of_libsharp_coefficient_vector(
+                                              l_max)]) *
                 basis_function(Spin, l, -m, j.theta, j.phi);
           }
           (*collocation_data)[j.offset +
                               i * spherical_harmonic_collocation.size()] +=
               sharp_swsh_sign(Spin, m, false) * std::complex<double>(0.0, 1.0) *
-              (*coefficient_data)[m_start + l * l_stride +
-                                  (2 * i + 1) *
-                                      size_of_libsharp_coefficient_vector(
-                                          l_max) /
-                                      2] *
+              coefficient_data[m_start + l * l_stride +
+                               (2 * i + 1) *
+                                   size_of_libsharp_coefficient_vector(l_max) /
+                                   2] *
               basis_function(Spin, l, m, j.theta, j.phi);
           if (m != 0) {
             (*collocation_data)[j.offset +
                                 i * spherical_harmonic_collocation.size()] +=
                 sharp_swsh_sign(Spin, -m, false) *
                 std::complex<double>(0.0, 1.0) *
-                conj((*coefficient_data)
-                         [m_start + l * l_stride +
-                          (2 * i + 1) *
-                              size_of_libsharp_coefficient_vector(l_max) / 2]) *
+                conj(coefficient_data[m_start + l * l_stride +
+                                      (2 * i + 1) *
+                                          size_of_libsharp_coefficient_vector(
+                                              l_max) /
+                                          2]) *
                 basis_function(Spin, l, -m, j.theta, j.phi);
           }
         }

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCoefficients.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCoefficients.cpp
@@ -172,7 +172,8 @@ void check_goldberg_mode_conversion() {
   }
 
   SpinWeighted<ComplexModalVector, Spin> test_modes =
-      swsh_transform<Representation>(goldberg_collocation_points, l_max);
+      swsh_transform<Representation>(l_max, number_of_radial_points,
+                                     goldberg_collocation_points);
 
   Approx swsh_approx =
       Approx::custom()
@@ -242,7 +243,8 @@ void check_goldberg_mode_conversion() {
   }
 
   const auto inverse_transform_set_from_goldberg =
-      inverse_swsh_transform<Representation>(test_modes, l_max);
+      inverse_swsh_transform<Representation>(l_max, number_of_radial_points,
+                                             test_modes);
   CHECK_ITERABLE_CUSTOM_APPROX(inverse_transform_set_from_goldberg.data(),
                                goldberg_collocation_points.data(), swsh_approx);
 }

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransform.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransform.cpp
@@ -35,66 +35,48 @@ namespace Swsh {
 namespace {
 
 // for storing a computed spin-weighted value during the transform test
-template <int Spin>
+template <size_t index, int Spin>
 struct TestTag : db::SimpleTag {
   static std::string name() noexcept { return "TestTag"; }
   using type = Scalar<SpinWeighted<ComplexDataVector, Spin>>;
 };
 
-// for storing an expected spin-weighted value during the transform test
-template <int Spin>
-struct ExpectedTestTag : db::SimpleTag {
-  static std::string name() noexcept { return "ExpectedTestTag"; }
-  using type = Scalar<SpinWeighted<ComplexDataVector, Spin>>;
-};
-
 using TestDerivativeTagList =
-    tmpl::list<Tags::Derivative<TestTag<-1>, Tags::Eth>,
-               Tags::Derivative<TestTag<-1>, Tags::EthEthbar>,
-               Tags::Derivative<ExpectedTestTag<-1>, Tags::EthEthbar>,
-               Tags::Derivative<TestTag<2>, Tags::EthbarEthbar>>;
+    tmpl::list<Tags::Derivative<TestTag<0, -1>, Tags::Eth>,
+               Tags::Derivative<TestTag<0, -1>, Tags::EthEthbar>,
+               Tags::Derivative<TestTag<1, -1>, Tags::EthEthbar>,
+               Tags::Derivative<TestTag<0, 2>, Tags::EthbarEthbar>>;
 
-/// [make_transform_job_list]
-using ExpectedInverseJobs = tmpl::list<
-    TransformJob<
-        -1, ComplexRepresentation::RealsThenImags,
-        tmpl::list<Tags::Derivative<TestTag<-1>, Tags::EthEthbar>,
-                   Tags::Derivative<ExpectedTestTag<-1>, Tags::EthEthbar>>>,
-    TransformJob<0, ComplexRepresentation::RealsThenImags,
-                 tmpl::list<Tags::Derivative<TestTag<-1>, Tags::Eth>,
-                            Tags::Derivative<TestTag<2>, Tags::EthbarEthbar>>>>;
+/// [make_transform_list]
+using ExpectedInverseTransforms = tmpl::list<
+    SwshTransform<tmpl::list<Tags::Derivative<TestTag<0, -1>, Tags::EthEthbar>,
+                             Tags::Derivative<TestTag<1, -1>, Tags::EthEthbar>>,
+                  ComplexRepresentation::RealsThenImags>,
+    SwshTransform<
+        tmpl::list<Tags::Derivative<TestTag<0, -1>, Tags::Eth>,
+                   Tags::Derivative<TestTag<0, 2>, Tags::EthbarEthbar>>,
+        ComplexRepresentation::RealsThenImags>>;
 
-static_assert(
-    cpp17::is_same_v<
-        make_transform_job_list<ComplexRepresentation::RealsThenImags,
-                                     TestDerivativeTagList>,
-        ExpectedInverseJobs>,
-    "failed testing make_transform_job_list");
-/// [make_transform_job_list]
+static_assert(cpp17::is_same_v<
+                  make_transform_list<ComplexRepresentation::RealsThenImags,
+                                          TestDerivativeTagList>,
+                  ExpectedInverseTransforms>,
+              "failed testing make_transform_list");
+/// [make_transform_list]
 
 /// [make_transform_from_derivative_tags]
-using ExpectedJobs =
-    tmpl::list<TransformJob<-1, ComplexRepresentation::Interleaved,
-                            tmpl::list<TestTag<-1>, ExpectedTestTag<-1>>>,
-               TransformJob<2, ComplexRepresentation::Interleaved,
-                            tmpl::list<TestTag<2>>>>;
+using ExpectedTransforms =
+    tmpl::list<SwshTransform<tmpl::list<TestTag<0, -1>, TestTag<1, -1>>,
+                             ComplexRepresentation::Interleaved>,
+               SwshTransform<tmpl::list<TestTag<0, 2>>,
+                             ComplexRepresentation::Interleaved>>;
 
-static_assert(
-    cpp17::is_same_v<
-        make_transform_job_list_from_derivative_tags<
-            ComplexRepresentation::Interleaved, TestDerivativeTagList>,
-        ExpectedJobs>,
-    "failed testing make_transform_job_list_from_derivative_tags");
+static_assert(cpp17::is_same_v<make_transform_list_from_derivative_tags<
+                                   ComplexRepresentation::Interleaved,
+                                   TestDerivativeTagList>,
+                               ExpectedTransforms>,
+              "failed testing make_transform_list_from_derivative_tags");
 /// [make_transform_from_derivative_tags]
-
-static_assert(
-    cpp17::is_same_v<
-        typename tmpl::front<ExpectedInverseJobs>::CoefficientTagList,
-        tmpl::list<
-            Tags::SwshTransform<Tags::Derivative<TestTag<-1>, Tags::EthEthbar>>,
-            Tags::SwshTransform<
-                Tags::Derivative<ExpectedTestTag<-1>, Tags::EthEthbar>>>>,
-    "failed testing TransformJob");
 
 template <ComplexRepresentation Representation, int S>
 void test_transform_and_inverse_transform() noexcept {
@@ -105,51 +87,58 @@ void test_transform_and_inverse_transform() noexcept {
   const size_t number_of_radial_points = 2;
   UniformCustomDistribution<double> coefficient_distribution{-10.0, 10.0};
 
-  // create the variables for the transformations
-  // The four data structures will be used as:
-  // - `generated_modes`: randomly generated
-  // - `test_collocation`: computed from analytic expressions using the
-  //                       randomly generated coefficients in `generated_modes`
-  // - `transformed_modes`: computed from test_collocation points from forward
-  //                        transform
-  // next, we test the equivalence of the coefficients in test and expected
-  // for the inverse transform test, we use:
-  // - `expected_collocation`: copied from `test_collocation`
-  // - `test_collocation`: computed from an inverse transform of the
-  //                       `transformed_modes`, overwriting the previous data
-  // Finally, we test the equivalence of the `expected_collocation` and
-  // `test_collocation`
-  Variables<tmpl::list<ExpectedTestTag<S>, TestTag<S>>> collocation_data{
-      number_of_radial_points * number_of_swsh_collocation_points(l_max), 0.0};
-  Variables<tmpl::list<Tags::SwshTransform<ExpectedTestTag<S>>,
-                       Tags::SwshTransform<TestTag<S>>>>
-      coefficient_data{
-          size_of_libsharp_coefficient_vector(l_max) * number_of_radial_points,
-          0.0};
+  // A DataBox of two tags to transform and their spin-weighted transforms, to
+  // verify the DataBox-compatible mutate interface
+  using collocation_variables_tag =
+      ::Tags::Variables<tmpl::list<TestTag<0, S>, TestTag<1, S>>>;
+  using coefficients_variables_tag =
+      ::Tags::Variables<tmpl::list<Tags::SwshTransform<TestTag<0, S>>,
+                                   Tags::SwshTransform<TestTag<1, S>>>>;
+  auto box = db::create<
+      db::AddSimpleTags<collocation_variables_tag, coefficients_variables_tag,
+                        Tags::LMax, Tags::NumberOfRadialPoints>,
+      db::AddComputeTags<>>(
+      db::item_type<collocation_variables_tag>{
+          number_of_radial_points * number_of_swsh_collocation_points(l_max)},
+      db::item_type<coefficients_variables_tag>{
+          size_of_libsharp_coefficient_vector(l_max) * number_of_radial_points},
+      l_max, number_of_radial_points);
 
-  // randomly generate the mode coefficients
-  ComplexModalVector& generated_modes =
-      get(get<Tags::SwshTransform<ExpectedTestTag<S>>>(coefficient_data))
-          .data();
+  ComplexModalVector expected_modes{number_of_radial_points *
+                                    size_of_libsharp_coefficient_vector(l_max)};
   TestHelpers::generate_swsh_modes<S>(
-      make_not_null(&generated_modes), make_not_null(&gen),
+      make_not_null(&expected_modes), make_not_null(&gen),
       make_not_null(&coefficient_distribution), number_of_radial_points, l_max);
+  ComplexModalVector two_times_expected_modes = 2.0 * expected_modes;
 
   // fill the expected collocation point data by evaluating the analytic
   // functions. This is very slow and rough (due to factorial division), but
   // comparatively simple to formulate.
-  ComplexDataVector& test_collocation =
-      get(get<TestTag<S>>(collocation_data)).data();
-  TestHelpers::swsh_collocation_from_coefficients_and_basis_func<
-      S, Representation>(&test_collocation, &generated_modes, l_max,
-                         number_of_radial_points,
-                         TestHelpers::spin_weighted_spherical_harmonic);
-  // create the forward transformation job and execute
-  using JobTags = tmpl::list<TestTag<S>>;
-  const TransformJob<S, Representation, JobTags> job{l_max,
-                                                     number_of_radial_points};
-  const auto test_collocation_copy = test_collocation;
-  job.execute_transform(make_not_null(&coefficient_data), collocation_data);
+  const auto coefficients_to_analytic_collocation = [&l_max](
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, S>>*>
+          computed_collocation,
+      ComplexModalVector& modes) noexcept {
+    TestHelpers::swsh_collocation_from_coefficients_and_basis_func<
+        S, Representation>(make_not_null(&get(*computed_collocation).data()),
+                           modes, l_max, number_of_radial_points,
+                           TestHelpers::spin_weighted_spherical_harmonic);
+  };
+  db::mutate<TestTag<0, S>>(make_not_null(&box),
+                            coefficients_to_analytic_collocation,
+                            expected_modes);
+  db::mutate<TestTag<1, S>>(make_not_null(&box),
+                            coefficients_to_analytic_collocation,
+                            two_times_expected_modes);
+
+  const auto source_collocation_copy = get(db::get<TestTag<0, S>>(box));
+  // transform using the DataBox mutate interface
+  db::mutate_apply<
+      SwshTransform<tmpl::list<TestTag<0, S>, TestTag<1, S>>, Representation>>(
+      make_not_null(&box));
+
+  // verify that the collocation points haven't been altered by the
+  // transformation
+  CHECK(source_collocation_copy == get(db::get<TestTag<0, S>>(box)));
 
   // approximation needs to be a little loose to consistently accommodate
   // the ratios of factorials in the analytic form
@@ -158,36 +147,91 @@ void test_transform_and_inverse_transform() noexcept {
           .epsilon(std::numeric_limits<double>::epsilon() * 1.0e6)
           .scale(1.0);
 
-  // verify that the collocation points haven't been altered by the
-  // transformation
-  CHECK(test_collocation_copy == test_collocation_copy);
+  // check transformed modes against the generated ones
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(db::get<Tags::SwshTransform<TestTag<0, S>>>(box)).data(),
+      expected_modes, transform_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(db::get<Tags::SwshTransform<TestTag<1, S>>>(box)).data(),
+      2.0 * expected_modes, transform_approx);
 
-  ComplexDataVector& expected_collocation =
-      get(get<ExpectedTestTag<S>>(collocation_data)).data();
-  expected_collocation = test_collocation;
+  // check the function interface which transforms a single spin-weighted vector
+  // and returns the result
+  SpinWeighted<ComplexModalVector, S> transformed_modes_from_function_call =
+      swsh_transform<Representation>(l_max, number_of_radial_points,
+                                     get(db::get<TestTag<0, S>>(box)));
+  CHECK_ITERABLE_CUSTOM_APPROX(transformed_modes_from_function_call.data(),
+                               expected_modes, transform_approx);
 
-  const ComplexModalVector& transformed_modes =
-      get(get<Tags::SwshTransform<TestTag<S>>>(coefficient_data)).data();
-  CHECK_ITERABLE_CUSTOM_APPROX(transformed_modes, generated_modes,
-                               transform_approx);
+  // check the parameter-pack return by pointer function interface, which takes
+  // an arbitrary number of spin-weighted vectors to transform.
+  SpinWeighted<ComplexModalVector, S>
+      two_times_transformed_modes_from_function_call;
+  swsh_transform<Representation>(
+      l_max, number_of_radial_points,
+      make_not_null(&transformed_modes_from_function_call),
+      make_not_null(&two_times_transformed_modes_from_function_call),
+      get(db::get<TestTag<0, S>>(box)), get(db::get<TestTag<1, S>>(box)));
 
-  SpinWeighted<ComplexModalVector, S> modes_from_function_call =
-      swsh_transform<Representation>(get(get<TestTag<S>>(collocation_data)),
-                                     l_max);
-  CHECK_ITERABLE_CUSTOM_APPROX(modes_from_function_call.data(), generated_modes,
-                               transform_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      two_times_transformed_modes_from_function_call.data(),
+      2.0 * expected_modes, transform_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(transformed_modes_from_function_call.data(),
+                               expected_modes, transform_approx);
 
-  // create the inverse transformation job and execute
-  using InverseJobTags = tmpl::list<TestTag<S>>;
-  const TransformJob<S, Representation, InverseJobTags> inverse_job{
-      l_max, number_of_radial_points};
-  inverse_job.execute_inverse_transform(make_not_null(&collocation_data),
-                                        coefficient_data);
-  SpinWeighted<ComplexDataVector, S> collocation_values_from_function_call =
-      inverse_swsh_transform<Representation>(
-          get(get<Tags::SwshTransform<TestTag<S>>>(coefficient_data)), l_max);
-  CHECK_ITERABLE_CUSTOM_APPROX(test_collocation, expected_collocation,
-                               transform_approx);
+  ComplexDataVector expected_collocation =
+      get(db::get<TestTag<0, S>>(box)).data();
+
+  // clear out the existing collocation data so we know we get the
+  // correct inverse transform
+  db::mutate<TestTag<0, S>, TestTag<1, S>>(
+      make_not_null(&box),
+      [](const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, S>>*>
+             collocation,
+         const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, S>>*>
+             another_collocation) {
+        get(*collocation).data() = 0.0;
+        get(*another_collocation).data() = 0.0;
+      });
+
+  // transform using the DataBox mutate interface
+  db::mutate_apply<InverseSwshTransform<
+      tmpl::list<TestTag<0, S>, TestTag<1, S>>, Representation>>(
+      make_not_null(&box));
+
+  CHECK_ITERABLE_CUSTOM_APPROX(get(db::get<TestTag<0, S>>(box)).data(),
+                               expected_collocation, transform_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(get(db::get<TestTag<1, S>>(box)).data(),
+                               2.0 * expected_collocation, transform_approx);
+
+  // check the function interface which transforms a single spin-weighted vector
+  // and returns the result
+  SpinWeighted<ComplexDataVector, S>
+      transformed_collocation_from_function_call =
+          inverse_swsh_transform<Representation>(
+              l_max, number_of_radial_points,
+              get(db::get<Tags::SwshTransform<TestTag<0, S>>>(box)));
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      transformed_collocation_from_function_call.data(), expected_collocation,
+      transform_approx);
+
+  // check the parameter-pack return by pointer function interface, which takes
+  // an arbitrary number of spin-weighted vectors to transform.
+  SpinWeighted<ComplexDataVector, S>
+      two_times_transformed_collocation_from_function_call;
+  inverse_swsh_transform<Representation>(
+      l_max, number_of_radial_points,
+      make_not_null(&transformed_collocation_from_function_call),
+      make_not_null(&two_times_transformed_collocation_from_function_call),
+      get(db::get<Tags::SwshTransform<TestTag<0, S>>>(box)),
+      get(db::get<Tags::SwshTransform<TestTag<1, S>>>(box)));
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      two_times_transformed_collocation_from_function_call.data(),
+      2.0 * expected_collocation, transform_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      transformed_collocation_from_function_call.data(), expected_collocation,
+      transform_approx);
 }
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshTransform",


### PR DESCRIPTION
- no more variables
- databox mutate compatible
- simple tagless interface can now perform several transforms


### Types of changes:

- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
