### PR TITLE
Improve mean and integral documentations

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp
@@ -16,15 +16,25 @@ class Mesh;
 
 /*!
  * \ingroup NumericalAlgorithmsGroup
- * \brief Compute the definite integral of a grid-function over a manifold.
+ * \brief Compute the definite integral of a function over a manifold.
  *
- * The integral is computed on the reference element by multiplying the
- * DataVector with the Spectral::quadrature_weights() in that
- * dimension.
- * \requires number of points in `integrand` and `mesh` are equal.
- * \param integrand the grid function to integrate.
- * \param mesh the Mesh of the manifold on which `integrand` is located.
- * \returns the definite integral of `integrand` on the manifold.
+ * Given a function \f$f\f$, compute its integral \f$I\f$ with respect to
+ * the logical coordinates \f$\boldsymbol{\xi} = (\xi, \eta, \zeta)\f$.
+ * E.g., in 1 dimension, \f$I = \int_{-1}^1 f d\xi\f$.
+ *
+ * The integral w.r.t. a different set of coordinates
+ * \f$\boldsymbol{x} = \boldsymbol{x}(\boldsymbol{\xi})\f$ can be computed
+ * by pre-multiplying \f$f\f$ by the Jacobian determinant
+ * \f$J = \det d\boldsymbol{x}/d\boldsymbol{\xi}\f$ of the mapping
+ * \f$\boldsymbol{x}(\boldsymbol{\xi})\f$. Note that, in the
+ * \f$\boldsymbol{x}\f$ coordinates, the domain of integration is the image of
+ * the logical cube (square in 2D, interval in 1D) under the mapping.
+ *
+ * The integral is computed by quadrature, using the quadrature rule for the
+ * basis associated with the collocation points.
+ *
+ * \param integrand the function to integrate.
+ * \param mesh the Mesh defining the grid points on the manifold.
  */
 template <size_t Dim>
 double definite_integral(const DataVector& integrand,

--- a/src/NumericalAlgorithms/LinearOperators/IndefiniteIntegral.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/IndefiniteIntegral.hpp
@@ -19,7 +19,17 @@ class not_null;
 /*!
  * \ingroup NumericalAlgorithmsGroup
  * \brief Compute the indefinite integral of a function in the
- * `dim_to_integrate`. Applying a zero boundary condition on each stripe.
+ * `dim_to_integrate`, applying a zero boundary condition on each stripe.
+ *
+ * Integrates with respect to one of the logical coordinates
+ * \f$\boldsymbol{\xi} = (\xi, \eta, \zeta)\f$.
+ *
+ * The integral w.r.t. a different set of coordinates
+ * \f$\boldsymbol{x} = \boldsymbol{x}(\boldsymbol{\xi})\f$ can be computed
+ * by pre-multiplying `integrand` by the Jacobian determinant
+ * \f$J = \det d\boldsymbol{x}/d\boldsymbol{\xi}\f$ of the mapping
+ * \f$\boldsymbol{x}(\boldsymbol{\xi})\f$. The integration is still performed
+ * along one logical-coordinate direction, indicated by `dim_to_integrate`.
  *
  * \requires number of points in `integrand` and `mesh` are equal.
  */

--- a/src/NumericalAlgorithms/LinearOperators/MeanValue.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/MeanValue.hpp
@@ -2,7 +2,7 @@
 // See LICENSE.txt for details.
 
 /// \file
-/// Defines function mean_value and mean_value_on_boundary.
+/// Defines functions mean_value and mean_value_on_boundary.
 
 #pragma once
 
@@ -22,17 +22,26 @@ class Mesh;
 
 /*!
  * \ingroup NumericalAlgorithmsGroup
- * \brief Compute the mean value of a grid-function over a manifold.
- * \f$mean value = \int f dV / \int dV\f$
+ * \brief Compute the mean value of a function over a manifold.
  *
- * \remarks The mean value is computed on the reference element(s).
- * \note The mean w.r.t. a different set of coordinates x can be computed
- * by pre-multiplying the argument f by the Jacobian J = dx/dxi of the mapping
- * from the reference coordinates xi to the coordinates x.
+ * Given a function \f$f\f$, compute its mean value \f$\bar{f}\f$ with respect
+ * to the logical coordinates \f$\boldsymbol{\xi} = (\xi, \eta, \zeta)\f$. E.g.,
+ * in 1 dimension, \f$\bar{f} = \int_{-1}^1 f d\xi \Big/ \int_{-1}^1 d\xi\f$.
  *
- * \returns the mean value of `f` on the manifold
- * \param f the grid function of which to find the mean.
- * \param mesh the Mesh of the manifold on which f is located.
+ * \note
+ * The mean w.r.t. a different set of coordinates
+ * \f$\boldsymbol{x} = \boldsymbol{x}(\boldsymbol{\xi})\f$ can't be directly
+ * computed using this function. Before calling `mean_value`, \f$f\f$ must be
+ * pre-multiplied by the Jacobian determinant
+ * \f$J = \det d\boldsymbol{x}/d\boldsymbol{\xi}\f$ of the mapping
+ * \f$\boldsymbol{x}(\boldsymbol{\xi})\f$. Additionally, the output of
+ * `mean_value` must be multiplied by a factor
+ * \f$2^{\text{d}} / \int J d^{\text{d}}\xi\f$ (in \f$d\f$ dimensions), to
+ * account for the different volume of the manifold in the \f$\boldsymbol{x}\f$
+ * coordinates.
+ *
+ * \param f the function to average.
+ * \param mesh the Mesh defining the grid points on the manifold.
  */
 template <size_t Dim>
 double mean_value(const DataVector& f, const Mesh<Dim>& mesh) noexcept {
@@ -42,15 +51,16 @@ double mean_value(const DataVector& f, const Mesh<Dim>& mesh) noexcept {
 // @{
 /*!
  * \ingroup NumericalAlgorithmsGroup
- * Compute the mean value of a grid-function on a boundary of a manifold.
- * \f$mean value = \int f dV / \int dV\f$
+ * \brief Compute the mean value of a function over a boundary of a manifold.
  *
- * \remarks The mean value is computed on the reference element(s).
+ * Given a function \f$f\f$, compute its mean value \f$\bar{f}\f$, over a
+ * boundary, with respect to the logical coordinates
+ * \f$\boldsymbol{\xi} = (\xi, \eta, \zeta)\f$.
  *
- * \returns the mean value of `f` on the boundary of the manifold
+ * \see `mean_value` for notes about means w.r.t. other coordinates.
  *
- * - `f` the grid function of which to find the mean.
- * - `mesh` the Mesh of the manifold on which f is located.
+ * - `f` the function to average.
+ * - `mesh` the Mesh defining the grid points on the manifold.
  * - `d` the dimension which is sliced away to get the boundary.
  * - `side` whether it is the lower or upper boundary in the d-th dimension.
  * - `boundary_buffer` is a pointer to a DataVector of size


### PR DESCRIPTION
## Proposed changes

- Improve clarity and fix rendering in `mean_value` documentation
- Improve clarity in `definite_integral` documentation

Fixes #1662.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

