### PR TITLE
Add Newtonian Riemann Problem

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -648,6 +648,14 @@
   publisher  = "Princeton University Press",
 }
 
+@book{Toro2009,
+  author     = "Toro, E. F.",
+  title      = "Riemann Solvers and Numerical Methods for Fluid Dynamics",
+  year       = "2009",
+  url        = "https://www.springer.com/us/book/9783540252023",
+  publisher  = "Springer-Verlag Berlin Heidelberg",
+}
+
 @article{White2015omx,
   author         = "White, Christopher J. and Stone, James M. and Gammie,
                     Charles F.",

--- a/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
@@ -18,6 +18,14 @@ set(LIBS_TO_LINK
   )
 
 add_spectre_parallel_executable(
+  EvolveNewtonianEuler1D
+  EvolveNewtonianEuler
+  Evolution/Executables/NewtonianEuler
+  EvolutionMetavars<1>
+  "${LIBS_TO_LINK}"
+  )
+
+add_spectre_parallel_executable(
   EvolveNewtonianEuler2D
   EvolveNewtonianEuler
   Evolution/Executables/NewtonianEuler

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -38,7 +38,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"
-#include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Hll.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
@@ -51,7 +51,7 @@
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
@@ -84,7 +84,7 @@ template <size_t Dim>
 struct EvolutionMetavars {
   static constexpr size_t volume_dim = Dim;
 
-  using analytic_solution = NewtonianEuler::Solutions::IsentropicVortex<Dim>;
+  using analytic_solution = NewtonianEuler::Solutions::RiemannProblem<Dim>;
 
   using system = NewtonianEuler::System<
       Dim, typename analytic_solution::equation_of_state_type>;
@@ -100,8 +100,8 @@ struct EvolutionMetavars {
   using equation_of_state_tag = hydro::Tags::EquationOfState<
       typename analytic_solution_tag::type::equation_of_state_type>;
 
-  using normal_dot_numerical_flux = OptionTags::NumericalFlux<
-      dg::NumericalFluxes::LocalLaxFriedrichs<system>>;
+  using normal_dot_numerical_flux =
+      OptionTags::NumericalFlux<dg::NumericalFluxes::Hll<system>>;
 
   using limiter = OptionTags::Limiter<Limiters::Minmod<
       Dim, tmpl::list<NewtonianEuler::Tags::MassDensityCons<DataVector>,

--- a/src/NumericalAlgorithms/RootFinding/NewtonRaphson.hpp
+++ b/src/NumericalAlgorithms/RootFinding/NewtonRaphson.hpp
@@ -12,6 +12,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "ErrorHandling/Exceptions.hpp"
+#include "Utilities/MakeString.hpp"
 
 namespace RootFinder {
 /*!
@@ -49,8 +50,11 @@ double newton_raphson(const Function& f, const double initial_guess,
       f, initial_guess, lower_bound, upper_bound,
       std::round(std::log2(std::pow(10, digits))), max_iters);
   if (max_iters >= max_iterations) {
-    throw convergence_error(
-        "newton_raphson reached max iterations without converging");
+    throw convergence_error(MakeString{}
+                            << "newton_raphson reached max iterations of "
+                            << max_iterations
+                            << " without converging. Best result is: " << result
+                            << " with residual " << f(result).first);
   }
   return result;
 }
@@ -98,8 +102,12 @@ DataVector newton_raphson(const Function& f, const DataVector& initial_guess,
         [&f, i ](double x) noexcept { return f(x, i); }, initial_guess[i],
         lower_bound[i], upper_bound[i], digits_binary, max_iters);
     if (max_iters >= max_iterations) {
-      throw convergence_error(
-          "newton_raphson reached max iterations without converging");
+      throw convergence_error(MakeString{}
+                              << "newton_raphson reached max iterations of "
+                              << max_iterations
+                              << " without converging. Best result is: "
+                              << result_vector[i] << " with residual "
+                              << f(result_vector[i], i).first);
     }
   }
   return result_vector;

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/CMakeLists.txt
@@ -4,8 +4,9 @@
 set(LIBRARY NewtonianEulerSolutions)
 
 set(LIBRARY_SOURCES
-    IsentropicVortex.cpp
-    )
+  IsentropicVortex.cpp
+  RiemannProblem.cpp
+  )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.cpp
@@ -1,0 +1,541 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/RootFinding/NewtonRaphson.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Math.hpp"
+
+namespace {
+
+// Any of the two functions of the pressure and the initial data
+// in Eqns. (4.6) and (4.7) of Toro.
+template <size_t Dim>
+struct FunctionOfPressureAndData {
+  FunctionOfPressureAndData(const typename NewtonianEuler::Solutions::
+                                RiemannProblem<Dim>::InitialData& data,
+                            const double adiabatic_index) noexcept
+      : state_pressure_(data.pressure_),
+        adiabatic_index_(adiabatic_index),
+        constant_a_(data.constant_a_),
+        constant_b_(data.constant_b_) {
+    prefactor_ = 2.0 * data.sound_speed_ / (adiabatic_index_ - 1.0);
+    prefactor_deriv_ = data.sound_speed_ / adiabatic_index_ / state_pressure_;
+    exponent_ = 0.5 * (adiabatic_index_ - 1.0) / adiabatic_index_;
+    exponent_deriv_ = -0.5 * (adiabatic_index_ + 1.0) / adiabatic_index_;
+  }
+
+  double operator()(const double pressure) const noexcept {
+    // Value depends on whether the initial state is a shock
+    // (pressure > pressure of initial state) or a rarefaction wave
+    // (pressure <= pressure of initial state)
+    return pressure > state_pressure_
+               ? (pressure - state_pressure_) *
+                     sqrt(constant_a_ / (pressure + constant_b_))
+               : prefactor_ *
+                     (pow(pressure / state_pressure_, exponent_) - 1.0);
+  }
+
+  // First derivative with respect to the pressure.
+  double deriv(const double pressure) const noexcept {
+    return pressure > state_pressure_
+               ? 0.5 * sqrt(constant_a_) *
+                     (pressure + state_pressure_ + 2.0 * constant_b_) /
+                     pow(pressure + constant_b_, 1.5)
+               : prefactor_deriv_ * pow(pressure / state_pressure_, exponent_);
+  }
+
+ private:
+  double state_pressure_ = std::numeric_limits<double>::signaling_NaN();
+  double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();
+  double constant_a_ = std::numeric_limits<double>::signaling_NaN();
+  double constant_b_ = std::numeric_limits<double>::signaling_NaN();
+
+  // Auxiliary variables for computing the rarefaction wave
+  double prefactor_ = std::numeric_limits<double>::signaling_NaN();
+  double prefactor_deriv_ = std::numeric_limits<double>::signaling_NaN();
+  double exponent_ = std::numeric_limits<double>::signaling_NaN();
+  double exponent_deriv_ = std::numeric_limits<double>::signaling_NaN();
+};
+
+}  // namespace
+
+/// \cond
+namespace NewtonianEuler {
+namespace Solutions {
+
+template <size_t Dim>
+RiemannProblem<Dim>::RiemannProblem(
+    const double adiabatic_index, const double initial_position,
+    const double left_mass_density, const std::array<double, Dim> left_velocity,
+    const double left_pressure, const double right_mass_density,
+    const std::array<double, Dim> right_velocity, const double right_pressure,
+    const double pressure_star_tol) noexcept
+    : adiabatic_index_(adiabatic_index),
+      initial_position_(initial_position),
+      left_initial_data_(left_mass_density, left_velocity, left_pressure,
+                         adiabatic_index, propagation_axis_),
+      right_initial_data_(right_mass_density, right_velocity, right_pressure,
+                          adiabatic_index, propagation_axis_),
+      pressure_star_tol_(pressure_star_tol),
+      equation_of_state_(adiabatic_index) {
+  const double delta_u = right_initial_data_.normal_velocity_ -
+                         left_initial_data_.normal_velocity_;
+
+  // The pressure positivity condition must be met (Eqn. 4.40 of Toro).
+  ASSERT(2.0 *
+                     (left_initial_data_.sound_speed_ +
+                      right_initial_data_.sound_speed_) /
+                     (adiabatic_index_ - 1.0) -
+                 delta_u >
+             0.0,
+         "The pressure positivity condition must be met. Initial data do not "
+         "satisfy this criterion.");
+
+  // Before evaluating the solution at any (x, t), the type of solution
+  // (shock or rarefaction) on each side of the contact discontinuity
+  // must be sorted out. To do so, the first step is to compute the
+  // state variables in the star region by solving a transcendental equation,
+  // which is what all the math in this constructor is about.
+
+  // The initial guess to obtain p_* is given by the
+  // Two-Shock approximation (Eqn. (4.47) in Toro), which gives best results
+  // overall. Other options are also possible (see Section 4.3.2 of Toro.)
+  const double guess_for_pressure_star = [&delta_u, this ](
+      const InitialData& left, const InitialData& right) noexcept {
+    // Eqn. (4.47) of Toro: guess derived from a linearized solution
+    // based on primitive variables.
+    double p_pv =
+        0.5 * (left.pressure_ + right.pressure_ -
+               0.25 * delta_u * (left.mass_density_ + right.mass_density_) *
+                   (left.sound_speed_ + right.sound_speed_));
+    p_pv = std::max(pressure_star_tol_, p_pv);
+
+    // Eqns. (4.48) of Toro: Two-Shock wave approximation.
+    const double g_left = sqrt(left.constant_a_ / (p_pv + left.constant_b_));
+    const double g_right = sqrt(right.constant_a_ / (p_pv + right.constant_b_));
+    return std::max(pressure_star_tol_, (g_left * left.pressure_ +
+                                         g_right * right.pressure_ - delta_u) /
+                                            (g_left + g_right));
+  }
+  (left_initial_data_, right_initial_data_);
+
+  // Compute bracket for root finder according to value of the function whose
+  // root we want (Eqn. 4.39 of Toro.)
+  FunctionOfPressureAndData<Dim> f_of_p_left(left_initial_data_,
+                                             adiabatic_index_);
+  FunctionOfPressureAndData<Dim> f_of_p_right(right_initial_data_,
+                                              adiabatic_index_);
+  const auto p_minmax =
+      std::minmax(left_initial_data_.pressure_, right_initial_data_.pressure_);
+  const double f_min =
+      f_of_p_left(p_minmax.first) + f_of_p_right(p_minmax.first) + delta_u;
+  const double f_max =
+      f_of_p_left(p_minmax.second) + f_of_p_right(p_minmax.second) + delta_u;
+
+  double pressure_lower;
+  double pressure_upper;
+  if (f_min > 0.0 and f_max > 0.0) {
+    pressure_lower = 0.0;
+    pressure_upper = p_minmax.first;
+  } else if (f_min < 0.0 and f_max > 0.0) {
+    pressure_lower = p_minmax.first;
+    pressure_upper = p_minmax.second;
+  } else {
+    pressure_lower = p_minmax.second;
+    pressure_upper = 10.0 * pressure_lower;  // Arbitrary upper bound < \infty
+  }
+
+  // Now get pressure by solving transcendental equation. Newton-Raphson is OK.
+  const auto f_of_p_and_deriv =
+      [&f_of_p_left, &f_of_p_right, &delta_u ](const double pressure) noexcept {
+    // Function of pressure in Eqn. (4.5) of Toro.
+    return std::make_pair(
+        f_of_p_left(pressure) + f_of_p_right(pressure) + delta_u,
+        f_of_p_left.deriv(pressure) + f_of_p_right.deriv(pressure));
+  };
+  try {
+    pressure_star_ = RootFinder::newton_raphson(
+        f_of_p_and_deriv, guess_for_pressure_star, pressure_lower,
+        pressure_upper, -log10(pressure_star_tol_));
+  } catch (std::exception& exception) {
+    ERROR(
+        "Failed to find p_* with Newton-Raphson root finder. Got "
+        "exception message:\n"
+        << exception.what()
+        << "\nIf the residual is small you can change the tolerance for the "
+           "root finder in the input file.");
+  }
+
+  // Calculated p_*, u_* is obtained from Eqn. (4.9) in Toro.
+  velocity_star_ =
+      0.5 * (left_initial_data_.normal_velocity_ +
+             right_initial_data_.normal_velocity_ -
+             f_of_p_left(pressure_star_) + f_of_p_right(pressure_star_));
+}
+
+template <size_t Dim>
+void RiemannProblem<Dim>::pup(PUP::er& p) noexcept {
+  p | adiabatic_index_;
+  p | initial_position_;
+  p | left_initial_data_;
+  p | right_initial_data_;
+  p | pressure_star_tol_;
+  p | pressure_star_;
+  p | velocity_star_;
+  p | equation_of_state_;
+}
+
+template <size_t Dim>
+RiemannProblem<Dim>::InitialData::InitialData(
+    const double mass_density, const std::array<double, Dim> velocity,
+    const double pressure, const double adiabatic_index,
+    const size_t propagation_axis) noexcept
+    : mass_density_(mass_density), velocity_(velocity), pressure_(pressure) {
+  ASSERT(mass_density_ > 0.0,
+         "The mass density must be positive. Value given: " << mass_density);
+  ASSERT(pressure_ > 0.0,
+         "The pressure must be positive. Value given: " << pressure);
+
+  sound_speed_ = sqrt(adiabatic_index * pressure / mass_density);
+  normal_velocity_ = gsl::at(velocity, propagation_axis);
+  constant_a_ = 2.0 / (adiabatic_index + 1.0) / mass_density;
+  constant_b_ = (adiabatic_index - 1.0) * pressure / (adiabatic_index + 1.0);
+}
+
+template <size_t Dim>
+void RiemannProblem<Dim>::InitialData::pup(PUP::er& p) noexcept {
+  p | mass_density_;
+  p | velocity_;
+  p | pressure_;
+  p | sound_speed_;
+  p | normal_velocity_;
+  p | constant_a_;
+  p | constant_b_;
+}
+
+template <size_t Dim>
+RiemannProblem<Dim>::Wave::Wave(const InitialData& data,
+                                const double pressure_star,
+                                const double velocity_star,
+                                const double adiabatic_index,
+                                const Side& side) noexcept
+    : pressure_ratio_(pressure_star / data.pressure_),
+      is_shock_(pressure_ratio_ > 1.0),
+      data_(data),
+      shock_(data, pressure_ratio_, adiabatic_index, side),
+      rarefaction_(data, pressure_ratio_, velocity_star, adiabatic_index,
+                   side) {}
+
+template <size_t Dim>
+double RiemannProblem<Dim>::Wave::mass_density(const double x_shifted,
+                                               const double t) const noexcept {
+  return (is_shock_ == true ? shock_.mass_density(x_shifted, t, data_)
+                            : rarefaction_.mass_density(x_shifted, t, data_));
+}
+
+template <size_t Dim>
+double RiemannProblem<Dim>::Wave::normal_velocity(
+    const double x_shifted, const double t, const double velocity_star) const
+    noexcept {
+  return (
+      is_shock_ == true
+          ? shock_.normal_velocity(x_shifted, t, data_, velocity_star)
+          : rarefaction_.normal_velocity(x_shifted, t, data_, velocity_star));
+}
+
+template <size_t Dim>
+double RiemannProblem<Dim>::Wave::pressure(const double x_shifted,
+                                           const double t,
+                                           const double pressure_star) const
+    noexcept {
+  return (is_shock_ == true
+              ? shock_.pressure(x_shifted, t, data_, pressure_star)
+              : rarefaction_.pressure(x_shifted, t, data_, pressure_star));
+}
+
+template <size_t Dim>
+RiemannProblem<Dim>::Shock::Shock(const InitialData& data,
+                                  const double pressure_ratio,
+                                  const double adiabatic_index,
+                                  const Side& side) noexcept
+    : direction_(side == Side::Left ? -1.0 : 1.0) {
+  const double gamma_mm = adiabatic_index - 1.0;
+  const double gamma_pp = adiabatic_index + 1.0;
+  const double gamma_mm_over_gamma_pp = gamma_mm / gamma_pp;
+
+  mass_density_star_ = data.mass_density_ *
+                       (pressure_ratio + gamma_mm_over_gamma_pp) /
+                       (pressure_ratio * gamma_mm_over_gamma_pp + 1.0);
+
+  shock_speed_ =
+      data.normal_velocity_ +
+      direction_ * data.sound_speed_ *
+          sqrt(0.5 * (gamma_pp * pressure_ratio + gamma_mm) / adiabatic_index);
+}
+
+template <size_t Dim>
+double RiemannProblem<Dim>::Shock::mass_density(const double x_shifted,
+                                                const double t,
+                                                const InitialData& data) const
+    noexcept {
+  return mass_density_star_ +
+         (data.mass_density_ - mass_density_star_) *
+             step_function(direction_ * (x_shifted - shock_speed_ * t));
+}
+
+template <size_t Dim>
+double RiemannProblem<Dim>::Shock::normal_velocity(
+    const double x_shifted, const double t, const InitialData& data,
+    const double velocity_star) const noexcept {
+  return velocity_star +
+         (data.normal_velocity_ - velocity_star) *
+             step_function(direction_ * (x_shifted - shock_speed_ * t));
+}
+
+template <size_t Dim>
+double RiemannProblem<Dim>::Shock::pressure(const double x_shifted,
+                                            const double t,
+                                            const InitialData& data,
+                                            const double pressure_star) const
+    noexcept {
+  return pressure_star +
+         (data.pressure_ - pressure_star) *
+             step_function(direction_ * (x_shifted - shock_speed_ * t));
+}
+
+template <size_t Dim>
+RiemannProblem<Dim>::Rarefaction::Rarefaction(const InitialData& data,
+                                              const double pressure_ratio,
+                                              const double velocity_star,
+                                              const double adiabatic_index,
+                                              const Side& side) noexcept
+    : direction_(side == Side::Left ? -1.0 : 1.0) {
+  gamma_mm_ = adiabatic_index - 1.0;
+  gamma_pp_ = adiabatic_index + 1.0;
+  mass_density_star_ =
+      data.mass_density_ * pow(pressure_ratio, 1.0 / adiabatic_index);
+  sound_speed_star_ =
+      data.sound_speed_ *
+      pow(pressure_ratio, 0.5 * (adiabatic_index - 1.0) / adiabatic_index);
+  head_speed_ = data.normal_velocity_ + direction_ * data.sound_speed_;
+  tail_speed_ = velocity_star + direction_ * sound_speed_star_;
+}
+
+template <size_t Dim>
+double RiemannProblem<Dim>::Rarefaction::mass_density(
+    const double x_shifted, const double t, const InitialData& data) const
+    noexcept {
+  const double s = (t > 0.0 ? (x_shifted / t) : 0.0);
+  return direction_ * (x_shifted - tail_speed_ * t) < 0.0
+             ? mass_density_star_
+             : (direction_ * (x_shifted - tail_speed_ * t) >= 0.0 and
+                        direction_ * (x_shifted - head_speed_ * t) < 0.0
+                    ? (data.mass_density_ *
+                       pow((2.0 - direction_ * gamma_mm_ *
+                                      (data.normal_velocity_ - s) /
+                                      data.sound_speed_) /
+                               gamma_pp_,
+                           2.0 / gamma_mm_))
+                    : data.mass_density_);
+}
+
+template <size_t Dim>
+double RiemannProblem<Dim>::Rarefaction::normal_velocity(
+    const double x_shifted, const double t, const InitialData& data,
+    const double velocity_star) const noexcept {
+  const double s = (t > 0.0 ? (x_shifted / t) : 0.0);
+  return direction_ * (x_shifted - tail_speed_ * t) < 0.0
+             ? velocity_star
+             : (direction_ * (x_shifted - tail_speed_ * t) >= 0.0 and
+                        direction_ * (x_shifted - head_speed_ * t) < 0.0
+                    ? (2.0 *
+                       (0.5 * gamma_mm_ * data.normal_velocity_ + s -
+                        direction_ * data.sound_speed_) /
+                       gamma_pp_)
+                    : data.normal_velocity_);
+}
+
+template <size_t Dim>
+double RiemannProblem<Dim>::Rarefaction::pressure(
+    const double x_shifted, const double t, const InitialData& data,
+    const double pressure_star) const noexcept {
+  const double s = (t > 0.0 ? (x_shifted / t) : 0.0);
+  return direction_ * (x_shifted - tail_speed_ * t) < 0.0
+             ? pressure_star
+             : (direction_ * (x_shifted - tail_speed_ * t) >= 0.0 and
+                        direction_ * (x_shifted - head_speed_ * t) < 0.0
+                    ? (data.pressure_ *
+                       pow((2.0 - direction_ * gamma_mm_ *
+                                      (data.normal_velocity_ - s) /
+                                      data.sound_speed_) /
+                               gamma_pp_,
+                           2.0 * (gamma_mm_ + 1.0) / gamma_mm_))
+                    : data.pressure_);
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<Tags::MassDensity<DataType>> RiemannProblem<Dim>::variables(
+    const tnsr::I<DataType, Dim, Frame::Inertial>& x_shifted, const double t,
+    tmpl::list<Tags::MassDensity<DataType>> /*meta*/, const Wave& left,
+    const Wave& right) const noexcept {
+  auto mass_density = make_with_value<Scalar<DataType>>(x_shifted, 0.0);
+  const double u_star_times_t = velocity_star_ * t;
+  for (size_t s = 0; s < get_size(get<0>(x_shifted)); ++s) {
+    const double x_shifted_s = get_element(x_shifted.get(propagation_axis_), s);
+    get_element(get(mass_density), s) =
+        (x_shifted_s < u_star_times_t ? left.mass_density(x_shifted_s, t)
+                                      : right.mass_density(x_shifted_s, t));
+  }
+  return mass_density;
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<Tags::Velocity<DataType, Dim, Frame::Inertial>>
+RiemannProblem<Dim>::variables(
+    const tnsr::I<DataType, Dim, Frame::Inertial>& x_shifted, const double t,
+    tmpl::list<Tags::Velocity<DataType, Dim, Frame::Inertial>> /*meta*/,
+    const Wave& left, const Wave& right) const noexcept {
+  auto velocity = make_with_value<tnsr::I<DataType, Dim, Frame::Inertial>>(
+      get<0>(x_shifted), 0.0);
+
+  const double u_star_times_t = velocity_star_ * t;
+  for (size_t s = 0; s < get_size(get<0>(x_shifted)); ++s) {
+    const double x_shifted_s = get_element(x_shifted.get(propagation_axis_), s);
+
+    size_t index = propagation_axis_ % Dim;
+    get_element(velocity.get(index), s) =
+        (x_shifted_s < u_star_times_t
+             ? left.normal_velocity(x_shifted_s, t, velocity_star_)
+             : right.normal_velocity(x_shifted_s, t, velocity_star_));
+
+    if (Dim > 1) {
+      index = (propagation_axis_ + 1) % Dim;
+      get_element(velocity.get(index), s) =
+          (x_shifted_s < u_star_times_t
+               ? gsl::at(left_initial_data_.velocity_, index)
+               : gsl::at(right_initial_data_.velocity_, index));
+    }
+
+    if (Dim > 2) {
+      index = (propagation_axis_ + 2) % Dim;
+      get_element(velocity.get(index), s) =
+          (x_shifted_s < u_star_times_t
+               ? gsl::at(left_initial_data_.velocity_, index)
+               : gsl::at(right_initial_data_.velocity_, index));
+    }
+  }
+  return velocity;
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<Tags::Pressure<DataType>> RiemannProblem<Dim>::variables(
+    const tnsr::I<DataType, Dim, Frame::Inertial>& x_shifted, const double t,
+    tmpl::list<Tags::Pressure<DataType>> /*meta*/, const Wave& left,
+    const Wave& right) const noexcept {
+  auto pressure = make_with_value<Scalar<DataType>>(x_shifted, 0.0);
+  const double u_star_times_t = velocity_star_ * t;
+  for (size_t s = 0; s < get_size(get<0>(x_shifted)); ++s) {
+    const double x_shifted_s = get_element(x_shifted.get(propagation_axis_), s);
+    get_element(get(pressure), s) =
+        (x_shifted_s < u_star_times_t
+             ? left.pressure(x_shifted_s, t, pressure_star_)
+             : right.pressure(x_shifted_s, t, pressure_star_));
+  }
+  return pressure;
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<Tags::SpecificInternalEnergy<DataType>>
+RiemannProblem<Dim>::variables(
+    const tnsr::I<DataType, Dim, Frame::Inertial>& x_shifted, const double t,
+    tmpl::list<Tags::SpecificInternalEnergy<DataType>> /*meta*/,
+    const Wave& left, const Wave& right) const noexcept {
+  return equation_of_state_.specific_internal_energy_from_density_and_pressure(
+      get<Tags::MassDensity<DataType>>(
+          variables(x_shifted, t, tmpl::list<Tags::MassDensity<DataType>>{},
+                    left, right)),
+      get<Tags::Pressure<DataType>>(variables(
+          x_shifted, t, tmpl::list<Tags::Pressure<DataType>>{}, left, right)));
+}
+
+template <size_t Dim>
+bool operator==(const RiemannProblem<Dim>& lhs,
+                const RiemannProblem<Dim>& rhs) noexcept {
+  return lhs.adiabatic_index_ == rhs.adiabatic_index_ and
+         lhs.initial_position_ == rhs.initial_position_ and
+         lhs.left_initial_data_ == rhs.left_initial_data_ and
+         lhs.right_initial_data_ == rhs.right_initial_data_ and
+         lhs.pressure_star_tol_ == rhs.pressure_star_tol_ and
+         lhs.pressure_star_ == rhs.pressure_star_ and
+         lhs.velocity_star_ == rhs.velocity_star_;
+}
+
+template <size_t Dim>
+bool operator!=(const RiemannProblem<Dim>& lhs,
+                const RiemannProblem<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define TAG(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE_CLASS(_, data)                                     \
+  template class RiemannProblem<DIM(data)>;                            \
+  template bool operator==(const RiemannProblem<DIM(data)>&,           \
+                           const RiemannProblem<DIM(data)>&) noexcept; \
+  template bool operator!=(const RiemannProblem<DIM(data)>&,           \
+                           const RiemannProblem<DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_CLASS, (1, 2, 3))
+
+#define INSTANTIATE_SCALARS(_, data)                                         \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>>                     \
+      RiemannProblem<DIM(data)>::variables(                                  \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>& x_shifted, \
+          const double t, tmpl::list<TAG(data) < DTYPE(data)>>,              \
+          const Wave& left, const Wave& right) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_SCALARS, (1, 2, 3), (double, DataVector),
+                        (Tags::MassDensity, Tags::Pressure,
+                         Tags::SpecificInternalEnergy))
+
+#define INSTANTIATE_VELOCITY(_, data)                                        \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data), DIM(data),           \
+                               Frame::Inertial>>                             \
+      RiemannProblem<DIM(data)>::variables(                                  \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>& x_shifted, \
+          const double t,                                                    \
+          tmpl::list<TAG(data) < DTYPE(data), DIM(data), Frame::Inertial>>,  \
+          const Wave& left, const Wave& right) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_VELOCITY, (1, 2, 3), (double, DataVector),
+                        (Tags::Velocity))
+
+#undef DIM
+#undef DTYPE
+#undef TAG
+#undef INSTANTIATE_CLASS
+#undef INSTANTIATE_SCALARS
+#undef INSTANTIATE_VELOCITY
+
+}  // namespace Solutions
+}  // namespace NewtonianEuler
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.hpp
@@ -1,0 +1,413 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PUP {
+class er;  // IWYU pragma: keep
+}  // namespace PUP
+/// \endcond
+
+namespace NewtonianEuler {
+namespace Solutions {
+
+/*!
+ * \brief Analytic solution to the Riemann Problem
+ *
+ * This class implements the exact Riemann solver described in detail in
+ * Chapter 4 of \cite Toro2009. We follow the notation there.
+ * The algorithm implemented here allows for 1, 2 and 3D wave propagation
+ * along any coordinate axis. Typical initial data for test cases
+ * (see \cite Toro2009) include:
+ *
+ * - Sod's Shock Tube (shock on the right, rarefaction on the left):
+ *   - \f$(\rho_L, u_L, p_L) = (1.0, 0.0, 1.0)\f$
+ *   - \f$(\rho_R, u_R, p_R) = (0.125, 0.0, 0.1)\f$
+ *   - Recommended setup for sample run:
+ *     - InitialTimeStep: 0.0001
+ *     - Final time: 0.2
+ *     - DomainCreator along wave propagation (no AMR):
+ *       - Interval of length 1
+ *       - InitialRefinement: 8
+ *       - InitialGridPoints: 2
+ *
+ * - "123" problem (two symmetric rarefaction waves):
+ *   - \f$(\rho_L, u_L, p_L) = (1.0, -2.0, 0.4)\f$
+ *   - \f$(\rho_R, u_R, p_R) = (1.0, 2.0, 0.4)\f$
+ *   - Recommended setup for sample run:
+ *     - InitialTimeStep: 0.0001
+ *     - Final time: 0.15
+ *     - DomainCreator along wave propagation (no AMR):
+ *       - Interval of length 1
+ *       - InitialRefinement: 8
+ *       - InitialGridPoints: 2
+ *
+ * - Collision of two blast waves (this test is challenging):
+ *   - \f$(\rho_L, u_L, p_L) = (5.99924, 19.5975, 460.894)\f$
+ *   - \f$(\rho_R, u_R, p_R) = (5.99242, -6.19633, 46.0950)\f$
+ *   - Recommended setup for sample run:
+ *     - InitialTimeStep: 0.00001
+ *     - Final time: 0.012
+ *     - DomainCreator along wave propagation (no AMR):
+ *       - Interval of length 1
+ *       - InitialRefinement: 8
+ *       - InitialGridPoints: 2
+ *
+ * - Lax problem:
+ *   - \f$(\rho_L, u_L, p_L) = (0.445, 0.698, 3.528)\f$
+ *   - \f$(\rho_R, u_R, p_R) = (0.5, 0.0, 0.571)\f$
+ *   - Recommended setup for sample run:
+ *     - InitialTimeStep: 0.00001
+ *     - Final time: 0.1
+ *     - DomainCreator along wave propagation (no AMR):
+ *       - Interval of length 1
+ *       - InitialRefinement: 8
+ *       - InitialGridPoints: 2
+ *
+ * where \f$\rho\f$ is the mass density, \f$p\f$ is the pressure, and
+ * \f$u\f$ denotes the normal velocity.
+ *
+ * \note Currently the propagation axis must be hard-coded as a `size_t`
+ * private member variable `propagation_axis_`, which can take one of
+ * the three values `PropagationAxis::X`, `PropagationAxis::Y`, and
+ * `PropagationAxis::Z`.
+ *
+ * \details The algorithm makes use of the following recipe:
+ *
+ * - Given the initial data on both sides of the initial interface of the
+ *   discontinuity (here called "left" and "right" sides, where a coordinate
+ *   axis points from left to right), we compute the pressure,
+ *   \f$p_*\f$, and the normal velocity,
+ *   \f$u_*\f$, in the so-called star region. This is done in the constructor.
+ *   Here "normal" refers to the normal direction to the initial interface.
+ *
+ * - Given the pressure and the normal velocity in the star region, two
+ *   `Wave` `struct`s are created, which represent the waves propagating
+ *   at later times on each side of the contact discontinuity. Each `Wave`
+ *   is equipped with two `struct`s named `Shock` and `Rarefaction` which
+ *   contain functions that compute the primitive variables depending on whether
+ *   the wave is a shock or a rarefaction.
+ *
+ * - If \f$p_* > p_K\f$, the wave is a shock, otherwise the wave is a
+ *   rarefaction. Here \f$K\f$ stands for \f$L\f$ or \f$R\f$: the left
+ *   and right initial pressure, respectively. Since this comparison can't be
+ *   performed at compile time, each `Wave` holds a `bool` member `is_shock_`
+ *   which is `true` if it is a shock, and `false` if it is a
+ *   rarefaction wave. This variable is used to evaluate the correct functions
+ *   at run time.
+ *
+ * - In order to obtain the primitives at a certain time and spatial location,
+ *   we evaluate whether the spatial location is on the left of the propagating
+ *   contact discontinuity \f$(x < u_* t)\f$ or on the right \f$(x > u_* t)\f$,
+ *   and we use the corresponding functions for left or right `Wave`s,
+ *   respectively.
+ *
+ * \note The characterization of each propagating wave will only
+ * depend on the normal velocity, while the initial jump in the components of
+ * the velocity transverse to the wave propagation will be advected at the
+ * speed of the contact discontinuity (\f$u_*\f$).
+ */
+template <size_t Dim>
+class RiemannProblem {
+  enum class Side { Left, Right };
+  enum PropagationAxis { X = 0, Y = 1, Z = 2 };
+
+  struct Wave;
+  struct Shock;
+  struct Rarefaction;
+
+ public:
+  using equation_of_state_type = EquationsOfState::IdealFluid<false>;
+
+  /// The adiabatic index of the fluid.
+  struct AdiabaticIndex {
+    using type = double;
+    static constexpr OptionString help = {"The adiabatic index of the fluid."};
+  };
+
+  /// Initial position of the discontinuity
+  struct InitialPosition {
+    using type = double;
+    static constexpr OptionString help = {
+        "The initial position of the discontinuity."};
+  };
+
+  /// The mass density on the left of the initial discontinuity
+  struct LeftMassDensity {
+    using type = double;
+    static constexpr OptionString help = {"The left mass density."};
+  };
+
+  /// The velocity on the left of the initial discontinuity
+  struct LeftVelocity {
+    using type = std::array<double, Dim>;
+    static constexpr OptionString help = {"The left velocity."};
+  };
+
+  /// The pressure on the left of the initial discontinuity
+  struct LeftPressure {
+    using type = double;
+    static constexpr OptionString help = {"The left pressure."};
+  };
+
+  /// The mass density on the right of the initial discontinuity
+  struct RightMassDensity {
+    using type = double;
+    static constexpr OptionString help = {"The right mass density."};
+  };
+
+  /// The velocity on the right of the initial discontinuity
+  struct RightVelocity {
+    using type = std::array<double, Dim>;
+    static constexpr OptionString help = {"The right velocity."};
+  };
+
+  /// The pressure on the right of the initial discontinuity
+  struct RightPressure {
+    using type = double;
+    static constexpr OptionString help = {"The right pressure."};
+  };
+
+  /// The tolerance for solving for \f$p_*\f$.
+  struct PressureStarTol {
+    using type = double;
+    static constexpr OptionString help = {
+        "The tolerance for the numerical solution for p star"};
+    static type default_value() noexcept { return 1.e-9; }
+  };
+
+  // Any of the two states that constitute the initial data, including
+  // some derived quantities that are used repeatedly at each evaluation of the
+  // different waves of the solution.
+  /// Holds initial data on a side of the discontinuity and related quantities
+  struct InitialData {
+    InitialData() = default;
+    InitialData(const InitialData& /*rhs*/) = default;
+    InitialData& operator=(const InitialData& /*rhs*/) = default;
+    InitialData(InitialData&& /*rhs*/) noexcept = default;
+    InitialData& operator=(InitialData&& /*rhs*/) noexcept = default;
+    ~InitialData() = default;
+
+    InitialData(double mass_density, std::array<double, Dim> velocity,
+                double pressure, double adiabatic_index,
+                size_t propagation_axis) noexcept;
+
+    // clang-tidy: no runtime references
+    void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
+
+    double mass_density_ = std::numeric_limits<double>::signaling_NaN();
+    std::array<double, Dim> velocity_ =
+        make_array<Dim>(std::numeric_limits<double>::signaling_NaN());
+    double pressure_ = std::numeric_limits<double>::signaling_NaN();
+    double sound_speed_ = std::numeric_limits<double>::signaling_NaN();
+    double normal_velocity_ = std::numeric_limits<double>::signaling_NaN();
+
+    // Data-dependent constants A and B in Eqns. (4.8) of Toro.
+    double constant_a_ = std::numeric_limits<double>::signaling_NaN();
+    double constant_b_ = std::numeric_limits<double>::signaling_NaN();
+
+    friend bool operator==(const InitialData& lhs,
+                           const InitialData& rhs) noexcept {
+      return lhs.mass_density_ == rhs.mass_density_ and
+             lhs.velocity_ == rhs.velocity_ and lhs.pressure_ == rhs.pressure_;
+    }
+  };
+
+  using options = tmpl::list<AdiabaticIndex, InitialPosition, LeftMassDensity,
+                             LeftVelocity, LeftPressure, RightMassDensity,
+                             RightVelocity, RightPressure, PressureStarTol>;
+
+  static constexpr OptionString help = {
+      "Riemann Problem in 1, 2 or 3D along any coordinate axis."};
+
+  RiemannProblem() = default;
+  RiemannProblem(const RiemannProblem& /*rhs*/) = delete;
+  RiemannProblem& operator=(const RiemannProblem& /*rhs*/) = delete;
+  RiemannProblem(RiemannProblem&& /*rhs*/) noexcept = default;
+  RiemannProblem& operator=(RiemannProblem&& /*rhs*/) noexcept = default;
+  ~RiemannProblem() = default;
+
+  RiemannProblem(
+      double adiabatic_index, double initial_position, double left_mass_density,
+      std::array<double, Dim> left_velocity, double left_pressure,
+      double right_mass_density, std::array<double, Dim> right_velocity,
+      double right_pressure,
+      double pressure_star_tol = PressureStarTol::default_value()) noexcept;
+
+  /// Retrieve a collection of hydrodynamic variables at position `x`
+  /// and time `t`
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataType, Dim, Frame::Inertial>& x, double t,
+      tmpl::list<Tags...> /*meta*/) const noexcept {
+    Wave left(left_initial_data_, pressure_star_, velocity_star_,
+              adiabatic_index_, Side::Left);
+    Wave right(right_initial_data_, pressure_star_, velocity_star_,
+               adiabatic_index_, Side::Right);
+
+    tnsr::I<DataType, Dim, Frame::Inertial> x_shifted(x);
+    x_shifted.get(propagation_axis_) -= initial_position_;
+
+    return {tuples::get<Tags>(
+        variables(x_shifted, t, tmpl::list<Tags>{}, left, right))...};
+  }
+
+  const EquationsOfState::IdealFluid<false>& equation_of_state() const
+      noexcept {
+    return equation_of_state_;
+  }
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
+
+  // Retrieve these member variables for testing purposes.
+  constexpr std::array<double, 2> diagnostic_star_region_values() const
+      noexcept {
+    return make_array(pressure_star_, velocity_star_);
+  }
+
+ private:
+  // @{
+  /// Retrieve hydro variable at `(x, t)`
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, Dim, Frame::Inertial>& x_shifted,
+                 double t, tmpl::list<Tags::MassDensity<DataType>> /*meta*/,
+                 const Wave& left, const Wave& right) const noexcept
+      -> tuples::TaggedTuple<Tags::MassDensity<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, Dim, Frame::Inertial>& x_shifted, double t,
+      tmpl::list<Tags::Velocity<DataType, Dim, Frame::Inertial>> /*meta*/,
+      const Wave& left, const Wave& right) const noexcept
+      -> tuples::TaggedTuple<Tags::Velocity<DataType, Dim, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, Dim, Frame::Inertial>& x_shifted,
+                 double t, tmpl::list<Tags::Pressure<DataType>> /*meta*/,
+                 const Wave& left, const Wave& right) const noexcept
+      -> tuples::TaggedTuple<Tags::Pressure<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, Dim, Frame::Inertial>& x_shifted,
+                 double t,
+                 tmpl::list<Tags::SpecificInternalEnergy<DataType>> /*meta*/,
+                 const Wave& left, const Wave& right) const noexcept
+      -> tuples::TaggedTuple<Tags::SpecificInternalEnergy<DataType>>;
+  // @}
+
+  // Any of the two waves propagating on each side of the contact discontinuity.
+  // Depending on whether p_* is larger or smaller
+  // than the initial pressure on the corresponding side, the wave is a
+  // shock (larger) or a rarefaction (smaller) wave. Since p_*
+  // is computed at run time, the characterization of the wave
+  // must also be done at run time. Shock and rarefaction waves will provide
+  // different functions to retrieve the primitive variables at a given (x, t).
+  // Here normal velocity means velocity along the wave propagation.
+  struct Wave {
+    Wave(const InitialData& data, double pressure_star, double velocity_star,
+         double adiabatic_index, const Side& side) noexcept;
+
+    double mass_density(double x_shifted, double t) const noexcept;
+
+    double normal_velocity(double x_shifted, double t,
+                           double velocity_star) const noexcept;
+
+    double pressure(double x_shifted, double t, double pressure_star) const
+        noexcept;
+
+   private:
+    // p_* over initial pressure on the corresponding side
+    double pressure_ratio_ = std::numeric_limits<double>::signaling_NaN();
+    // false if rarefaction wave
+    bool is_shock_ = true;
+
+    InitialData data_{};
+    Shock shock_{};
+    Rarefaction rarefaction_{};
+  };
+
+  struct Shock {
+    Shock(const InitialData& data, double pressure_ratio,
+          double adiabatic_index, const Side& side) noexcept;
+
+    double mass_density(double x_shifted, double t,
+                        const InitialData& data) const noexcept;
+    double normal_velocity(double x_shifted, double t, const InitialData& data,
+                           double velocity_star) const noexcept;
+
+    double pressure(double x_shifted, double t, const InitialData& data,
+                    double pressure_star) const noexcept;
+
+   private:
+    double direction_ = std::numeric_limits<double>::signaling_NaN();
+    double mass_density_star_ = std::numeric_limits<double>::signaling_NaN();
+    double shock_speed_ = std::numeric_limits<double>::signaling_NaN();
+  };
+
+  struct Rarefaction {
+    Rarefaction(const InitialData& data, double pressure_ratio,
+                double velocity_star, double adiabatic_index,
+                const Side& side) noexcept;
+
+    double mass_density(double x_shifted, double t,
+                        const InitialData& data) const noexcept;
+    double normal_velocity(double x_shifted, double t, const InitialData& data,
+                           double velocity_star) const noexcept;
+
+    double pressure(double x_shifted, double t, const InitialData& data,
+                    double pressure_star) const noexcept;
+
+   private:
+    double direction_ = std::numeric_limits<double>::signaling_NaN();
+    double gamma_mm_ = std::numeric_limits<double>::signaling_NaN();
+    double gamma_pp_ = std::numeric_limits<double>::signaling_NaN();
+    double mass_density_star_ = std::numeric_limits<double>::signaling_NaN();
+    double sound_speed_star_ = std::numeric_limits<double>::signaling_NaN();
+    double head_speed_ = std::numeric_limits<double>::signaling_NaN();
+    double tail_speed_ = std::numeric_limits<double>::signaling_NaN();
+  };
+
+  template <size_t SpatialDim>
+  friend bool
+  operator==(  // NOLINT (clang-tidy: readability-redundant-declaration)
+      const RiemannProblem<SpatialDim>& lhs,
+      const RiemannProblem<SpatialDim>& rhs) noexcept;
+
+  double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();
+  double initial_position_ = std::numeric_limits<double>::signaling_NaN();
+  size_t propagation_axis_ = PropagationAxis::X;
+  InitialData left_initial_data_{};
+  InitialData right_initial_data_{};
+
+  double pressure_star_tol_ = std::numeric_limits<double>::signaling_NaN();
+  // the pressure in the star region, p_*
+  double pressure_star_ = std::numeric_limits<double>::signaling_NaN();
+  // the velocity in the star region, u_*
+  double velocity_star_ = std::numeric_limits<double>::signaling_NaN();
+
+  EquationsOfState::IdealFluid<false> equation_of_state_{};
+};
+
+template <size_t Dim>
+bool operator!=(const RiemannProblem<Dim>& lhs,
+                const RiemannProblem<Dim>& rhs) noexcept;
+
+}  // namespace Solutions
+}  // namespace NewtonianEuler

--- a/tests/InputFiles/NewtonianEuler/NewtonianEuler1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/NewtonianEuler1D.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Executable: EvolveNewtonianEuler3D
+# Executable: EvolveNewtonianEuler1D
 # Check: execute
 
 Evolution:
@@ -11,22 +11,22 @@ Evolution:
     RungeKutta3
 
 DomainCreator:
-  Brick:
-    LowerBound: [-0.25, 0.0, 0.0]
-    UpperBound: [0.75, 0.1, 0.1]
-    IsPeriodicIn: [false, false, false]
-    InitialRefinement: [4, 0, 0]
-    InitialGridPoints: [2, 2, 2]
+  Interval:
+    LowerBound: [-0.25]
+    UpperBound: [0.75]
+    IsPeriodicIn: [false]
+    InitialRefinement: [1]
+    InitialGridPoints: [2]
 
 AnalyticSolution:
   RiemannProblem:
     AdiabaticIndex: 1.4
     InitialPosition: 0.25
     LeftMassDensity: 1.0
-    LeftVelocity: [0.0, 0.5, -0.3]
+    LeftVelocity: [0.0]
     LeftPressure: 1.0
     RightMassDensity: 0.125
-    RightVelocity: [0.0, 0.2, 0.1]
+    RightVelocity: [0.0]
     RightPressure: 0.1
 
 NumericalFlux:

--- a/tests/InputFiles/NewtonianEuler/NewtonianEuler2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/NewtonianEuler2D.yaml
@@ -8,27 +8,29 @@ Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.0001
   TimeStepper:
-    AdamsBashforthN:
-      Order: 3
+    RungeKutta3
 
 DomainCreator:
   Rectangle:
-    LowerBound: [-1.0, -1.0]
-    UpperBound: [1.0, 1.0]
+    LowerBound: [-0.25, 0.0]
+    UpperBound: [0.75, 0.1]
     IsPeriodicIn: [false, false]
-    InitialRefinement: [1, 1]
-    InitialGridPoints: [5, 5]
+    InitialRefinement: [4, 0]
+    InitialGridPoints: [2, 2]
 
 AnalyticSolution:
-  IsentropicVortex:
+  RiemannProblem:
     AdiabaticIndex: 1.4
-    Center: [0.0, 0.0]
-    MeanVelocity: [1.0, 1.0]
-    PerturbAmplitude: 0.0
-    Strength: 5.0
+    InitialPosition: 0.25
+    LeftMassDensity: 1.0
+    LeftVelocity: [0.0, 0.5]
+    LeftPressure: 1.0
+    RightMassDensity: 0.125
+    RightVelocity: [0.0, 0.2]
+    RightPressure: 0.1
 
 NumericalFlux:
-  LocalLaxFriedrichs:
+  Hll:
 
 Limiter:
   Minmod:
@@ -42,10 +44,9 @@ EventsAndTriggers:
   # ? EveryNSlabs:
   #     N: 100
   #     Offset: 0
-  # : - ObserveErrorNorms
-  #   - ObserveFields:
+  # : - ObserveFields:
   #       VariablesToObserve: [MassDensity]
-  # ? PastTime: 1.0001
+  # ? PastTime: 0.7501
   ? SpecifiedSlabs:
       Slabs: [10]
   : - Completion

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_NewtonianEulerSolutions")
 
 set(LIBRARY_SOURCES
   Test_IsentropicVortex.cpp
+  Test_RiemannProblem.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.py
@@ -4,9 +4,6 @@
 import numpy as np
 
 
-# Functions for testing IsentropicVortex.cpp
-
-
 def mass_density(x, t, adiabatic_index, center, mean_velocity,
                  perturbation_amplitude, strength):
     x_tilde = x - center - t * np.array(mean_velocity)
@@ -43,4 +40,3 @@ def pressure(x, t, adiabatic_index, center, mean_velocity,
                     adiabatic_index)
 
 
-# End functions for testing IsentropicVortex.cpp

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.py
@@ -1,0 +1,150 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+# Note: Values for p_* and u_* correspond to those
+# values obtained for the initial data of the Sod tube test.
+
+
+def sound_speed(adiabatic_index, mass_density, pressure):
+    return np.sqrt(adiabatic_index * pressure / mass_density)
+
+
+def fan_density(x_shifted, t, adiabatic_index, mass_density, velocity,
+                pressure, direction):
+    s = (x_shifted / t) if t > 0.0 else 0.0
+    return (mass_density *
+            np.power((2.0 -
+                      direction * (adiabatic_index - 1.0) * (velocity - s) /
+                      sound_speed(adiabatic_index, mass_density, pressure))
+                     / (adiabatic_index + 1.0), 2.0 / (adiabatic_index - 1.0)))
+
+
+def fan_velocity(x_shifted, t, adiabatic_index, mass_density, velocity,
+                 pressure, direction):
+    s = (x_shifted / t) if t > 0.0 else 0.0
+    return (2.0 * (0.5 * (adiabatic_index - 1.0) * velocity + s - direction *
+                   sound_speed(adiabatic_index, mass_density, pressure)) /
+            (adiabatic_index + 1.0))
+
+
+def fan_pressure(x_shifted, t, adiabatic_index, mass_density, velocity,
+                 pressure, direction):
+    s = (x_shifted / t) if t > 0.0 else 0.0
+    return (pressure *
+            np.power((2.0 -
+                      direction * (adiabatic_index - 1.0) * (velocity - s) /
+                      sound_speed(adiabatic_index, mass_density, pressure))
+                     / (adiabatic_index + 1.0), 2.0 * adiabatic_index /
+                     (adiabatic_index - 1.0)))
+
+
+def rarefaction(x_shifted, t, quantity, quantity_star, adiabatic_index,
+                velocity_star, pressure_star, fan, mass_density,
+                velocity, pressure, direction):
+    pressure_ratio = pressure_star / pressure
+    sound_speed_ = sound_speed(adiabatic_index, mass_density, pressure)
+    sound_speed_star = sound_speed_ * np.power(pressure_ratio,
+                                              0.5 * (adiabatic_index - 1.0)
+                                              / adiabatic_index)
+    head_speed = velocity + direction * sound_speed_
+    tail_speed = velocity_star + direction * sound_speed_star
+    return (quantity_star if direction * (x_shifted - tail_speed * t) < 0.0 else
+            (fan(x_shifted, t, adiabatic_index, mass_density, velocity,
+                 pressure, direction)
+             if (direction * (x_shifted - tail_speed * t) >= 0.0 and
+                 direction * (x_shifted - head_speed * t) < 0.0)
+             else quantity))
+
+
+def shock(x_shifted, t, quantity, quantity_star, adiabatic_index,
+          pressure_star, mass_density, velocity, pressure, direction):
+    shock_speed = (velocity + direction *
+                   sound_speed(adiabatic_index, mass_density, pressure) *
+                   np.sqrt(0.5 * ((adiabatic_index + 1.0) *
+                                  (pressure_star / pressure) +
+                                  adiabatic_index - 1.0) /
+                           adiabatic_index))
+    return (quantity_star if direction * (x_shifted - shock_speed * t) < 0.0
+            else quantity)
+
+
+def mass_density(x, t, adiabatic_index, initial_pos, l_mass_density, l_velocity,
+                 l_pressure, r_mass_density, r_velocity, r_pressure):
+    velocity_star = 0.9274526526
+    pressure_star = 0.3031302631
+
+    # density in star region for shock
+    gamma_mm_over_gamma_pp = (adiabatic_index - 1.0) / (adiabatic_index + 1.0)
+    r_pressure_ratio = pressure_star / r_pressure
+    r_density_star = (r_mass_density *
+                      (r_pressure_ratio + gamma_mm_over_gamma_pp) /
+                      (r_pressure_ratio * gamma_mm_over_gamma_pp + 1.0))
+
+    # density in star region for rarefaction
+    l_density_star = l_mass_density * np.power(pressure_star / l_pressure,
+                                               1.0 / adiabatic_index)
+
+    x_shifted = x[0] - initial_pos
+    return (rarefaction(x_shifted, t, l_mass_density, l_density_star,
+                        adiabatic_index, velocity_star, pressure_star,
+                        fan_density, l_mass_density, l_velocity[0],
+                        l_pressure, -1.0)
+            if x_shifted < velocity_star * t else
+            shock(x_shifted, t, r_mass_density, r_density_star,
+                  adiabatic_index, pressure_star, r_mass_density, r_velocity[0],
+                  r_pressure, 1.0))
+
+
+def velocity(x, t, adiabatic_index, initial_pos, l_mass_density, l_velocity,
+             l_pressure, r_mass_density, r_velocity, r_pressure):
+    velocity_star = 0.9274526526
+    pressure_star = 0.3031302631
+
+    velocity = np.zeros(x.size)
+    x_shifted = x[0] - initial_pos
+    velocity[0] = (rarefaction(x_shifted, t, l_velocity[0], velocity_star,
+                               adiabatic_index, velocity_star, pressure_star,
+                               fan_velocity, l_mass_density, l_velocity[0],
+                               l_pressure, -1.0)
+                   if x_shifted < velocity_star * t else
+                   shock(x_shifted, t, r_velocity[0], velocity_star,
+                         adiabatic_index, pressure_star, r_mass_density,
+                         r_velocity[0], r_pressure, 1.0))
+    if (x.size > 1):
+        velocity[1] = (l_velocity[1] if x_shifted < velocity_star * t
+                       else r_velocity[1])
+    if (x.size > 2):
+        velocity[2] = (l_velocity[2] if x_shifted < velocity_star * t
+                       else r_velocity[2])
+    return velocity
+
+
+def pressure(x, t, adiabatic_index, initial_pos, l_mass_density, l_velocity,
+             l_pressure, r_mass_density, r_velocity, r_pressure):
+    velocity_star = 0.9274526526
+    pressure_star = 0.3031302631
+
+    x_shifted = x[0] - initial_pos
+    return (rarefaction(x_shifted, t, l_pressure, pressure_star,
+                        adiabatic_index, velocity_star, pressure_star,
+                        fan_pressure, l_mass_density, l_velocity[0],
+                        l_pressure, -1.0)
+            if x_shifted < velocity_star * t else
+            shock(x_shifted, t, r_pressure, pressure_star, adiabatic_index,
+                  pressure_star, r_mass_density, r_velocity[0], r_pressure,
+                  1.0))
+
+
+def specific_internal_energy(x, t, adiabatic_index, initial_pos, l_mass_density,
+                             l_velocity, l_pressure, r_mass_density, r_velocity,
+                             r_pressure):
+    return (pressure(x, t, adiabatic_index, initial_pos, l_mass_density,
+                     l_velocity, l_pressure, r_mass_density, r_velocity,
+                     r_pressure) /
+            mass_density(x, t, adiabatic_index, initial_pos, l_mass_density,
+                         l_velocity, l_pressure, r_mass_density, r_velocity,
+                         r_pressure) / (adiabatic_index - 1.0))
+

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
@@ -59,7 +59,7 @@ void test_solution(const DataType& used_for_size,
       1,
       typename IsentropicVortexProxy<Dim>::template variables_tags<DataType>>(
       &IsentropicVortexProxy<Dim>::template primitive_variables<DataType>,
-      vortex, "TestFunctions",
+      vortex, "IsentropicVortex",
       {"mass_density", "velocity", "specific_internal_energy", "pressure"},
       {{{-1., 1.}}}, std::make_tuple(1.43, center, mean_velocity, 0.5, 3.76),
       used_for_size);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_RiemannProblem.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_RiemannProblem.cpp
@@ -1,0 +1,234 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+
+template <size_t Dim>
+struct RiemannProblemProxy : NewtonianEuler::Solutions::RiemannProblem<Dim> {
+  using NewtonianEuler::Solutions::RiemannProblem<Dim>::RiemannProblem;
+
+  template <typename DataType>
+  using variables_tags =
+      tmpl::list<NewtonianEuler::Tags::MassDensity<DataType>,
+                 NewtonianEuler::Tags::Velocity<DataType, Dim, Frame::Inertial>,
+                 NewtonianEuler::Tags::Pressure<DataType>,
+                 NewtonianEuler::Tags::SpecificInternalEnergy<DataType>>;
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<variables_tags<DataType>>
+  primitive_variables(const tnsr::I<DataType, Dim, Frame::Inertial>& x,
+                      double t) const noexcept {
+    return this->variables(x, t, variables_tags<DataType>{});
+  }
+};
+
+template <size_t Dim, typename DataType>
+void test_solution(const std::array<double, Dim> left_velocity,
+                   const std::string& left_velocity_opt,
+                   const std::array<double, Dim> right_velocity,
+                   const std::string& right_velocity_opt,
+                   const DataType& used_for_size) noexcept {
+  // Member variables correspond to Sod tube test. For other test cases,
+  // new parameters in the star region must be given in the python modules.
+  RiemannProblemProxy<Dim> solution(1.4, 0.5, 1.0, left_velocity, 1.0, 0.125,
+                                    right_velocity, 0.1, 1.e-6);
+  pypp::check_with_random_values<
+      1, typename RiemannProblemProxy<Dim>::template variables_tags<DataType>>(
+      &RiemannProblemProxy<Dim>::template primitive_variables<DataType>,
+      solution, "RiemannProblem",
+      {"mass_density", "velocity", "pressure", "specific_internal_energy"},
+      {{{0.0, 1.0}}},
+      std::make_tuple(1.4, 0.5, 1.0, left_velocity, 1.0, 0.125, right_velocity,
+                      0.1),
+      used_for_size, 1.e-9);
+
+  const auto solution_from_options =
+      test_creation<NewtonianEuler::Solutions::RiemannProblem<Dim>>(
+          "  AdiabaticIndex: 1.4\n"
+          "  InitialPosition: 0.5\n"
+          "  LeftMassDensity: 1.0\n"
+          "  LeftVelocity: " +
+          left_velocity_opt +
+          "\n"
+          "  LeftPressure: 1.0\n"
+          "  RightMassDensity: 0.125\n"
+          "  RightVelocity: " +
+          right_velocity_opt +
+          "\n"
+          "  RightPressure: 0.1\n"
+          "  PressureStarTol: 1.e-6");
+  CHECK(solution_from_options == solution);
+
+  RiemannProblemProxy<Dim> solution_to_move(1.4, 0.5, 1.0, left_velocity, 1.0,
+                                            0.125, right_velocity, 0.1, 1.e-6);
+  test_move_semantics(std::move(solution_to_move), solution);  //  NOLINT
+  test_serialization(solution);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.RiemannProblem",
+    "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/NewtonianEuler"};
+
+  test_solution<1>({{0.0}}, "[0.0]", {{0.0}}, "[0.0]",
+                   std::numeric_limits<double>::signaling_NaN());
+  test_solution<1>({{0.0}}, "[0.0]", {{0.0}}, "[0.0]", DataVector(5));
+  test_solution<2>({{0.0, 0.4}}, "[0.0, 0.4]", {{0.0, -0.3}}, "[0.0, -0.3]",
+                   std::numeric_limits<double>::signaling_NaN());
+  test_solution<2>({{0.0, 0.4}}, "[0.0, 0.4]", {{0.0, -0.3}}, "[0.0, -0.3]",
+                   DataVector(5));
+  test_solution<3>({{0.0, 0.4, -0.12}}, "[0.0, 0.4, -0.12]",
+                   {{0.0, -0.3, 0.53}}, "[0.0, -0.3, 0.53]",
+                   std::numeric_limits<double>::signaling_NaN());
+  test_solution<3>({{0.0, 0.4, -0.12}}, "[0.0, 0.4, -0.12]",
+                   {{0.0, -0.3, 0.53}}, "[0.0, -0.3, 0.53]", DataVector(5));
+}
+
+// Test correct evaluation of the variables in the star region for the five
+// initial setups listed in Table 4.1 of \Toro2009. The numerical values to
+// compare with are listed in Table 4.2 of the same reference.
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.RiemannProblem.StarRg",
+    "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/NewtonianEuler"};
+  // The accuracy of the numbers provided by Toro isn't too high so
+  // we need to adjust the precision of the comparison accordingly.
+  Approx larger_approx = Approx::custom().epsilon(1.e-5);
+
+  const double adiabatic_index = 1.4;
+  // Initial position doesn't affect the numbers tested below.
+  const double initial_position = 0.7;
+
+  // Sod or Shock-Tube problem: one shock wave and one rarefaction wave.
+  NewtonianEuler::Solutions::RiemannProblem<1> sod(
+      adiabatic_index, initial_position, 1.0, {{0.0}}, 1.0, 0.125, {{0.0}},
+      0.1);
+  CHECK_ITERABLE_CUSTOM_APPROX(sod.diagnostic_star_region_values(),
+                               make_array(0.30313, 0.92745), larger_approx);
+
+  // "123" problem: two strong rarefaction waves. Contact is stationary.
+  NewtonianEuler::Solutions::RiemannProblem<2> one_two_three(
+      adiabatic_index, initial_position, 1.0, {{-2.0}}, 0.4, 1.0, {{2.0}}, 0.4);
+  CHECK_ITERABLE_CUSTOM_APPROX(one_two_three.diagnostic_star_region_values(),
+                               make_array(0.00189, 0.),
+                               Approx::custom().epsilon(1.e-2));
+
+  // Left half of the blast wave problem of Woodward&Corella.
+  NewtonianEuler::Solutions::RiemannProblem<3> left_blast_wave(
+      adiabatic_index, initial_position, 1.0, {{0.0}}, 1000.0, 1.0, {{0.0}},
+      0.01);
+  CHECK_ITERABLE_CUSTOM_APPROX(left_blast_wave.diagnostic_star_region_values(),
+                               make_array(460.894, 19.5975), larger_approx);
+
+  // Right half of the blast wave problem of Woodward&Corella.
+  NewtonianEuler::Solutions::RiemannProblem<3> right_blast_wave(
+      adiabatic_index, initial_position, 1.0, {{0.0}}, 0.01, 1.0, {{0.0}},
+      100.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(right_blast_wave.diagnostic_star_region_values(),
+                               make_array(46.0950, -6.19633), larger_approx);
+
+  // Collision of the two previous shocks.
+  NewtonianEuler::Solutions::RiemannProblem<3> shock_collision(
+      adiabatic_index, initial_position, 5.99924, {{19.5975}}, 460.894, 5.99242,
+      {{-6.19633}}, 46.0950);
+  CHECK_ITERABLE_CUSTOM_APPROX(shock_collision.diagnostic_star_region_values(),
+                               make_array(1691.64, 8.68975), larger_approx);
+}
+
+// [[OutputRegex, The pressure positivity condition must be met.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.RiemannProblem.PositP",
+    "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/NewtonianEuler"};
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  NewtonianEuler::Solutions::RiemannProblem<1> solution(
+      1.4, 0.7, 1.0, {{0.0}}, 1.0, 0.125, {{30.0}}, 1.1);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+    // clang-format off
+// [[OutputRegex, The mass density must be positive.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.RiemannProblem.Dens",
+    "[Unit][PointwiseFunctions]") {
+  // clang-format on
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/NewtonianEuler"};
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  NewtonianEuler::Solutions::RiemannProblem<2> solution(
+      1.4, 0.7, -1.0, {{0.0}}, 1.0, 0.125, {{30.0}}, 1.1);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The pressure must be positive.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.RiemannProblem.Pres",
+    "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/NewtonianEuler"};
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  NewtonianEuler::Solutions::RiemannProblem<3> solution(
+      1.4, 0.7, 1.0, {{0.0}}, -1.0, 0.125, {{30.0}}, 1.1);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+template <size_t Dim>
+struct Riemann {
+  using type = NewtonianEuler::Solutions::RiemannProblem<Dim>;
+  static constexpr OptionString help = {"Riemann problem."};
+};
+
+// [[OutputRegex, newton_raphson reached max iterations of 50 without
+// converging.]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.RiemannProblem.RootF",
+    "[Unit][PointwiseFunctions]") {
+  ERROR_TEST();
+  Options<tmpl::list<Riemann<1>>> test_options("");
+  test_options.parse(
+      "Riemann:\n"
+      "  AdiabaticIndex: 1.4\n"
+      "  InitialPosition: 0.25\n"
+      "  LeftMassDensity: 10.0\n"
+      "  LeftVelocity: [0.0]\n"
+      "  LeftPressure: 100.0\n"
+      "  RightMassDensity: 1.0\n"
+      "  RightVelocity: [0.0]\n"
+      "  RightPressure: 1.0\n"
+      "  PressureStarTol: 1.e-10");
+  test_options.get<Riemann<1>>();
+}


### PR DESCRIPTION
- Provides initial data for the Riemann Problem in 1, 2, and 3D along any coordinate axis.
- Provides the analytic solution at later times (that's why the class is `RiemannSolver`, and it's how is named in some literature [see refs], but it cant be renamed to `RiemannProblem` for clarity.)
- Axis of propagation is hard-coded for now because `pypp` won't allow testing classes with member variables of type other than `double`s and `std::array`s of `double`s.

I'm requesting reviews from people currently using this. 

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
