### PR TITLE
Allow any order of cache_tags in constructor of MockRuntimeSystem

### DIFF
--- a/src/Utilities/TaggedTuple.hpp
+++ b/src/Utilities/TaggedTuple.hpp
@@ -715,6 +715,35 @@ template <typename T>
 using tagged_tuple_from_typelist =
     typename TaggedTuple_detail::tagged_tuple_typelist_impl<T>::type;
 
+namespace TaggedTuple_detail {
+template <typename... InputTags, typename... OutputTags>
+TaggedTuple<OutputTags...> reorder_impl(
+    TaggedTuple<InputTags...>&& input,
+    tmpl::list<OutputTags...> /*meta*/) noexcept {
+  static_assert(
+      cpp17::is_same_v<tmpl::list_difference<tmpl::list<OutputTags...>,
+                                             tmpl::list<InputTags...>>,
+                       tmpl::list<>> and
+          cpp17::is_same_v<tmpl::list_difference<tmpl::list<InputTags...>,
+                                                 tmpl::list<OutputTags...>>,
+                           tmpl::list<>>,
+      "The input and output TaggedTuples must be the same except"
+      "for ordering.");
+  return TaggedTuple<OutputTags...>(std::move(get<OutputTags>(input))...);
+}
+}  // namespace TaggedTuple_detail
+
+/// Given an input TaggedTuple, produce an output TaggedTuple
+/// with the tags in a different order.  All tags must be the same
+/// except for ordering.
+/// \example
+/// \snippet Test_TaggedTuple.cpp reorder_example
+template <typename ReturnedTaggedTuple, typename... Tags>
+ReturnedTaggedTuple reorder(TaggedTuple<Tags...> input) noexcept {
+  return TaggedTuple_detail::reorder_impl(
+      std::move(input), typename ReturnedTaggedTuple::tags_list{});
+}
+
 /// Stream operator for TaggedTuple
 template <class... Tags>
 std::ostream& operator<<(std::ostream& os,

--- a/src/Utilities/TaggedTuple.hpp
+++ b/src/Utilities/TaggedTuple.hpp
@@ -347,6 +347,8 @@ class TaggedTuple : private tuples_detail::TaggedTupleLeaf<Tags>... {  // NOLINT
       TaggedTuple<LTags...>&& t) noexcept;
 
  public:
+  using tags_list = tmpl::list<Tags...>;
+
   static constexpr size_t size() noexcept { return sizeof...(Tags); }
 
   // clang-tidy: runtime-references
@@ -493,6 +495,7 @@ class TaggedTuple : private tuples_detail::TaggedTupleLeaf<Tags>... {  // NOLINT
 template <>
 class TaggedTuple<> {
  public:
+  using tags_list = tmpl::list<>;
   static constexpr size_t size() noexcept { return 0; }
   TaggedTuple() noexcept = default;
   void swap(TaggedTuple& /*unused*/) noexcept {}

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -1338,6 +1338,13 @@ class MockRuntimeSystem {
     });
   }
 
+  /// Construct from the tuple of ConstGlobalCache objects that might
+  /// be in a different order.
+  template <typename... Tags>
+  explicit MockRuntimeSystem(tuples::TaggedTuple<Tags...> cache_contents)
+      : MockRuntimeSystem(
+            tuples::reorder<CacheTuple>(std::move(cache_contents))) {}
+
   /// Emplace a component that does not need to be initialized.
   template <typename Component, typename... Options>
   void emplace_component(const typename Component::array_index& array_index,

--- a/tests/Unit/Utilities/Test_TaggedTuple.cpp
+++ b/tests/Unit/Utilities/Test_TaggedTuple.cpp
@@ -86,6 +86,29 @@ SPECTRE_TEST_CASE("Unit.Utilities.TaggedTuple", "[Utilities][Unit]") {
   }
 
   test_serialization(test2);
+
+  // Test reorder with non-const lvalue, and make sure
+  // that the non-const lvalue doesn't change.
+  const auto test3 = tuples::reorder<
+      tuples::TaggedTuple<email, not_streamable_tag, parents, age, name>>(test);
+  CHECK(test3 ==
+        tuples::TaggedTuple<email, not_streamable_tag, parents, age, name>{
+            "bla@bla.bla", 0, std::vector<std::string>{"Mom", "Dad"}, 17,
+            "Eamonn"});
+  CHECK(test ==
+        tuples::TaggedTuple<name, age, email, parents, not_streamable_tag>{
+            "Eamonn", 17, "bla@bla.bla", std::vector<std::string>{"Mom", "Dad"},
+            0});
+
+  /// [reorder_example]
+  const auto test4 = tuples::reorder<
+      tuples::TaggedTuple<email, not_streamable_tag, parents, age, name>>(
+      std::move(test));
+  /// [reorder_example]
+  CHECK(test4 ==
+        tuples::TaggedTuple<email, not_streamable_tag, parents, age, name>{
+            "bla@bla.bla", 0, std::vector<std::string>{"Mom", "Dad"}, 17,
+            "Eamonn"});
 }
 
 namespace {


### PR DESCRIPTION
## Proposed changes

Previously you needed to specify the cache_tags in the constructor of MockRuntimeSystem in a particular order.  There was no easy way to know what that order needed to be, other than trying an arbitrary order and looking at the compiler error.

Now you can supply tags in an arbitrary order (as long as all the tags are the same as the expected ones, other than the order).

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
