### PR TITLE
Disable FPEs in ASSERT and ERROR

### DIFF
--- a/src/ErrorHandling/Assert.hpp
+++ b/src/ErrorHandling/Assert.hpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "ErrorHandling/AbortWithErrorMessage.hpp"
+#include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Parallel/Abort.hpp"
 #include "Utilities/Literals.hpp"
 
@@ -37,6 +38,7 @@
 #define ASSERT(a, m)                                                          \
   do {                                                                        \
     if (!(a)) {                                                               \
+      disable_floating_point_exceptions();                                    \
       std::ostringstream avoid_name_collisions_ASSERT;                        \
       /* clang-tidy: macro arg in parentheses */                              \
       avoid_name_collisions_ASSERT << m; /* NOLINT */                         \
@@ -50,10 +52,12 @@
   do {                                                 \
     if (false) {                                       \
       static_cast<void>(a);                            \
+      disable_floating_point_exceptions();             \
       std::ostringstream avoid_name_collisions_ASSERT; \
       /* clang-tidy: macro arg in parentheses */       \
-      avoid_name_collisions_ASSERT << m;  /* NOLINT */ \
+      avoid_name_collisions_ASSERT << m; /* NOLINT */  \
       static_cast<void>(avoid_name_collisions_ASSERT); \
+      enable_floating_point_exceptions();              \
     }                                                  \
   } while (false)
 #endif

--- a/src/ErrorHandling/Error.hpp
+++ b/src/ErrorHandling/Error.hpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "ErrorHandling/AbortWithErrorMessage.hpp"
+#include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Parallel/Abort.hpp"
 #include "Utilities/Literals.hpp"
 
@@ -34,6 +35,7 @@
 // code generation).
 #define ERROR(m)                                                            \
   do {                                                                      \
+    disable_floating_point_exceptions();                                    \
     std::ostringstream avoid_name_collisions_ERROR;                         \
     /* clang-tidy: macro arg in parentheses */                              \
     avoid_name_collisions_ERROR << m; /* NOLINT */                          \


### PR DESCRIPTION
## Proposed changes

Previously an ASSERT or ERROR could fail to print out info because an FPE was
triggered during the streaming process.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
