### PR TITLE
Add generic elliptic internal penalty flux

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/ImposeBoundaryConditions.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/ImposeBoundaryConditions.hpp
@@ -122,17 +122,18 @@ struct ImposeHomogeneousDirichletBoundaryConditions {
             // handled as contributions to the source in InitializeElement.
             // Imposing them here would not work because we are working with the
             // linear solver operand.
-            tmpl::for_each<dirichlet_tags>([
-              &interior_vars, &exterior_vars, &direction
-            ](auto dirichlet_tag_val) noexcept {
+            tmpl::for_each<dirichlet_tags>([&exterior_vars](
+                auto dirichlet_tag_val) noexcept {
               using dirichlet_tag =
                   tmpl::type_from<decltype(dirichlet_tag_val)>;
               using dirichlet_operand_tag =
                   LinearSolver::Tags::Operand<dirichlet_tag>;
-              // Use mirror principle. This only works for scalars right now.
-              get(get<dirichlet_operand_tag>(exterior_vars)) =
-                  -1. *
-                  get<dirichlet_operand_tag>(interior_vars.at(direction)).get();
+              // Use mirror principle
+              auto& exterior_dirichlet_field =
+                  get<dirichlet_operand_tag>(exterior_vars);
+              for (size_t i = 0; i < exterior_dirichlet_field.size(); i++) {
+                exterior_dirichlet_field[i] *= -1.;
+              }
             });
           }
         },

--- a/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp
@@ -1,0 +1,410 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Metafunctions.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace Tags {
+template <typename>
+struct Normalized;
+}  // namespace Tags
+/// \endcond
+
+namespace elliptic {
+namespace dg {
+namespace NumericalFluxes {
+
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \ingroup NumericalFluxesGroup
+ * \brief The internal penalty flux for first-order elliptic equations.
+ *
+ * \details Computes the internal penalty numerical flux (see e.g.
+ * \cite HesthavenWarburton, section 7.2) dotted with the interface unit normal.
+ *
+ * We implement here a suggested generalization of the internal penalty flux
+ * for any set of elliptic PDEs up to second order in derivatives. It is
+ * designed for fluxes (i.e. principal parts of the PDEs) that may depend on the
+ * dynamic fields, but do so at most linearly. This is the case for the velocity
+ * potential equation of binary neutron stars, for example. The linearity is
+ * only necessary to impose inhomogeneous boundary conditions as contributions
+ * to the fixed source (see
+ * `elliptic::dg::Actions::ImposeInhomogeneousBoundaryConditionsOnSource`).
+ *
+ * We reduce the second-order elliptic PDEs to first-order form by introducing
+ * an _auxiliary_ variable \f$v\f$ for each _primal_ variable \f$u\f$ (i.e. for
+ * each variable whose second derivative appears in the equations). Then, the
+ * equations take the _flux-form_
+ *
+ * \f{align}
+ * -\partial_i F^i_A + S_A = f_A
+ * \f}
+ *
+ * where the fluxes \f$F^i_A(u,v)\f$ and sources \f$S_A(u,v)\f$ are indexed
+ * (with capital letters) by the variables and we have defined \f$f_A(x)\f$ as
+ * those sources that are independent of the variables. Note that the fluxes are
+ * functions of the primal and auxiliary variables; e.g. for a Poisson system
+ * \f$\{u,v_i\}\f$ on a spatial metric \f$\gamma_{ij}\f$ they are simply
+ * \f$F^i_u(v)=\sqrt{\gamma}\gamma^{ij} v_j\f$ and
+ * \f$F^i_{v_j}(u)=u\delta^i_j\f$ (see `Poisson::FirstOrderSystem`) or for an
+ * Elasticity system \f$\{\xi^i,S_{ij}\}\f$ with Young's tensor
+ * \f$Y^{ijkl}\f$ they are \f$F^i_{\xi^j}(S)=Y^{ijkl}S_{kl}\f$ and
+ * \f$F^i_{S_{jk}}(\xi)=\delta^i_{(j}\xi_{k)}\f$. Since each primal flux is
+ * commonly only a function of the corresponding auxiliary variable and
+ * vice-versa, we omit the other function arguments here to lighten the
+ * notational load.
+ *
+ * We now choose the internal penalty numerical fluxes \f$(n_i F^i_A)^*\f$ as
+ * follows for each primal variable \f$u\f$ and their corresponding auxiliary
+ * variable \f$v\f$:
+ *
+ * \f{align}
+ * (n_i F^i_u)^* &= \frac{1}{2} n_i \left( F^i_u(\partial_j
+ * F^j_v(u^\mathrm{int})) + F^i_u(\partial_j F^j_v(u^\mathrm{ext}))
+ * \right) - \sigma n_i \left(F^i_u(n_j F^j_v(u^\mathrm{int})) - F^i_u(
+ * n_j F^j_v(u^\mathrm{ext}))\right) \\
+ * (n_i F^i_v)^* &= \frac{1}{2} n_i \left(F^i_v(u^\mathrm{int}) +
+ * F^i_v(u^\mathrm{ext})\right)
+ * \f}
+ *
+ * Note that we have assumed \f$n^\mathrm{ext}_i=-n_i\f$ here, i.e. face normals
+ * don't depend on the dynamic variables (which may be discontinuous on element
+ * faces). This is the case for the problems we are expecting to solve, because
+ * those will be on fixed background metrics (e.g. a conformal metric for the
+ * XCTS system).
+ *
+ * Also note that the numerical fluxes intentionally don't depend on the
+ * auxiliary field values \f$v\f$. This property allows us to use the numerical
+ * fluxes also for the second-order (or _primal_) DG formulation, where we
+ * remove the need for an auxiliary variable. For the first-order system we
+ * could replace the divergence in \f$(n_i F^i_u)^*\f$ with \f$v\f$, which would
+ * result in a generalized "stabilized central flux" that is slightly less
+ * sparse than the internal penalty flux (see e.g. \cite HesthavenWarburton,
+ * section 7.2). We could also choose to ignore the fluxes in the penalty term,
+ * but preliminary tests suggest that this may hurt convergence.
+ *
+ * For a Poisson system (see above) this numeric flux reduces to the standard
+ * internal penalty flux (see e.g. \cite HesthavenWarburton, section 7.2, or
+ * \cite Arnold2002)
+ *
+ * \f{align}
+ * (n_i F^i_u)^* &= n_i v_i^* = \frac{1}{2} n_i \left(\partial_i u^\mathrm{int}
+ * + \partial_i u^\mathrm{ext}\right) - \sigma \left(u^\mathrm{int} -
+ * u^\mathrm{ext}\right) \\
+ * (n_i F^i_{v_j})^* &= n_j u^* = \frac{1}{2} n_j \left(u^\mathrm{int} +
+ * u^\mathrm{ext}\right)
+ * \f}
+ *
+ * where a sum over repeated indices is assumed, since the equation is
+ * formulated on a Euclidean geometry.
+ *
+ * This generalization of the internal penalty flux is based on unpublished work
+ * by Nils L. Fischer (nils.fischer@aei.mpg.de).
+ *
+ * The penalty factor \f$\sigma\f$ is responsible for removing zero eigenmodes
+ * and impacts the conditioning of the linear operator to be solved. It can be
+ * chosen as \f$\sigma=C\frac{N_\mathrm{points}^2}{h}\f$ where
+ * \f$N_\mathrm{points}\f$ is the number of collocation points (i.e. the
+ * polynomial degree plus 1), \f$h\f$ is a measure of the element size in
+ * inertial coordinates (both measured perpendicular to the interface under
+ * consideration) and \f$C\geq 1\f$ is a free parameter (see e.g.
+ * \cite HesthavenWarburton, section 7.2).
+ */
+template <size_t Dim, typename FluxesComputerTag, typename FieldTagsList,
+          typename AuxiliaryFieldTagsList,
+          typename FluxesComputer = db::item_type<FluxesComputerTag>,
+          typename FluxesArgs = typename FluxesComputer::argument_tags>
+struct FirstOrderInternalPenalty;
+
+template <size_t Dim, typename FluxesComputerTag, typename... FieldTags,
+          typename... AuxiliaryFieldTags, typename FluxesComputer,
+          typename... FluxesArgs>
+struct FirstOrderInternalPenalty<Dim, FluxesComputerTag,
+                                 tmpl::list<FieldTags...>,
+                                 tmpl::list<AuxiliaryFieldTags...>,
+                                 FluxesComputer, tmpl::list<FluxesArgs...>> {
+ private:
+  using fluxes_computer_tag = FluxesComputerTag;
+
+  template <typename Tag>
+  struct NormalDotDivFlux : db::PrefixTag, db::SimpleTag {
+    using tag = Tag;
+    using type = TensorMetafunctions::remove_first_index<db::item_type<Tag>>;
+  };
+
+  template <typename Tag>
+  struct NormalDotNormalDotFlux : db::PrefixTag, db::SimpleTag {
+    using tag = Tag;
+    using type = TensorMetafunctions::remove_first_index<db::item_type<Tag>>;
+  };
+
+ public:
+  struct PenaltyParameter {
+    using type = double;
+    // Currently this is used as the full prefactor `sigma` to the penalty term.
+    // This means it needs to be chosen large enough so that the scheme is
+    // stable everywhere. A good estimate is the the largest
+    // `sigma > N_points^2 / h` (see class documentation) over all elements in
+    // the domain. Choosing `sigma` the same everywhere means it is an
+    // overestimate on non-uniform meshes where elements are large or polynomial
+    // degrees are small, but this only affects the conditioning of the scheme,
+    // i.e. it will converge slower but to the same solution. When it becomes
+    // possible to communicate non-tensors (the element size and the number of
+    // collocation points on either side of the mortar), this option will be
+    // changed to be just the free parameter `C` multiplying `N_points^2 / h`.
+    // This will improve conditioning on non-uniform meshes. Currently, the
+    // `packaged_data` is a `Variables` which can only hold tensors.
+    static constexpr OptionString help = {
+        "The prefactor to the penalty term of the flux."};
+  };
+  using options = tmpl::list<PenaltyParameter>;
+  static constexpr OptionString help = {
+      "The internal penalty flux for elliptic systems."};
+  static std::string name() noexcept { return "InternalPenalty"; }
+
+  FirstOrderInternalPenalty() = default;
+  explicit FirstOrderInternalPenalty(const double penalty_parameter) noexcept
+      : penalty_parameter_(penalty_parameter) {}
+
+  // clang-tidy: non-const reference
+  void pup(PUP::er& p) noexcept { p | penalty_parameter_; }  // NOLINT
+
+  // These tags are sliced to the interface of the element and passed to
+  // `package_data` to provide the data needed to compute the numerical fluxes.
+  using argument_tags =
+      tmpl::list<::Tags::NormalDotFlux<AuxiliaryFieldTags>...,
+                 ::Tags::div<::Tags::Flux<AuxiliaryFieldTags, tmpl::size_t<Dim>,
+                                          Frame::Inertial>>...,
+                 fluxes_computer_tag, FluxesArgs...,
+                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
+  using volume_tags = tmpl::list<fluxes_computer_tag>;
+
+  // This is the data needed to compute the numerical flux.
+  // `SendBoundaryFluxes` calls `package_data` to store these tags in a
+  // Variables. Local and remote values of this data are then combined in the
+  // `()` operator.
+  using package_tags =
+      tmpl::list<::Tags::NormalDotFlux<AuxiliaryFieldTags>...,
+                 NormalDotDivFlux<AuxiliaryFieldTags>...,
+                 NormalDotNormalDotFlux<AuxiliaryFieldTags>...>;
+
+  // Following the packaged_data pointer, this function expects as arguments the
+  // types in `argument_tags`.
+  void package_data(
+      const gsl::not_null<Variables<package_tags>*> packaged_data,
+      const db::item_type<::Tags::NormalDotFlux<
+          AuxiliaryFieldTags>>&... normal_dot_auxiliary_field_fluxes,
+      const db::item_type<::Tags::div<
+          ::Tags::Flux<AuxiliaryFieldTags, tmpl::size_t<Dim>,
+                       Frame::Inertial>>>&... div_auxiliary_field_fluxes,
+      const FluxesComputer& fluxes_computer,
+      const db::item_type<FluxesArgs>&... fluxes_args,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
+      const noexcept {
+    auto principal_div_aux_field_fluxes = make_with_value<Variables<tmpl::list<
+        ::Tags::Flux<FieldTags, tmpl::size_t<Dim>, Frame::Inertial>...>>>(
+        interface_unit_normal, std::numeric_limits<double>::signaling_NaN());
+    auto principal_ndot_aux_field_fluxes = make_with_value<Variables<tmpl::list<
+        ::Tags::Flux<FieldTags, tmpl::size_t<Dim>, Frame::Inertial>...>>>(
+        interface_unit_normal, std::numeric_limits<double>::signaling_NaN());
+    fluxes_computer.apply(
+        make_not_null(
+            &get<::Tags::Flux<FieldTags, tmpl::size_t<Dim>, Frame::Inertial>>(
+                principal_div_aux_field_fluxes))...,
+        fluxes_args..., div_auxiliary_field_fluxes...);
+    fluxes_computer.apply(
+        make_not_null(
+            &get<::Tags::Flux<FieldTags, tmpl::size_t<Dim>, Frame::Inertial>>(
+                principal_ndot_aux_field_fluxes))...,
+        fluxes_args..., normal_dot_auxiliary_field_fluxes...);
+    const auto apply_normal_dot =
+        [
+          &packaged_data, &principal_div_aux_field_fluxes,
+          &principal_ndot_aux_field_fluxes, &interface_unit_normal
+        ](auto field_tag_v, auto auxiliary_field_tag_v,
+          const auto& normal_dot_auxiliary_field_flux) noexcept {
+      using field_tag = decltype(field_tag_v);
+      using auxiliary_field_tag = decltype(auxiliary_field_tag_v);
+      // Compute n.F_v(u)
+      get<::Tags::NormalDotFlux<auxiliary_field_tag>>(*packaged_data) =
+          normal_dot_auxiliary_field_flux;
+      // Compute n.F_u(div(F_v(u))) and n.F_u(n.F_v(u))
+      normal_dot_flux(
+          make_not_null(
+              &get<NormalDotDivFlux<auxiliary_field_tag>>(*packaged_data)),
+          interface_unit_normal,
+          get<::Tags::Flux<field_tag, tmpl::size_t<Dim>, Frame::Inertial>>(
+              principal_div_aux_field_fluxes));
+      normal_dot_flux(
+          make_not_null(&get<NormalDotNormalDotFlux<auxiliary_field_tag>>(
+              *packaged_data)),
+          interface_unit_normal,
+          get<::Tags::Flux<field_tag, tmpl::size_t<Dim>, Frame::Inertial>>(
+              principal_ndot_aux_field_fluxes));
+    };
+    EXPAND_PACK_LEFT_TO_RIGHT(apply_normal_dot(
+        FieldTags{}, AuxiliaryFieldTags{}, normal_dot_auxiliary_field_fluxes));
+  }
+
+  // This function combines local and remote data to the numerical fluxes.
+  // The numerical fluxes as not-null pointers are the first arguments. The
+  // other arguments are the packaged types for the interior side followed by
+  // the packaged types for the exterior side.
+  void operator()(
+      const gsl::not_null<db::item_type<::Tags::NormalDotNumericalFlux<
+          FieldTags>>*>... numerical_flux_for_fields,
+      const gsl::not_null<db::item_type<::Tags::NormalDotNumericalFlux<
+          AuxiliaryFieldTags>>*>... numerical_flux_for_auxiliary_fields,
+      const db::item_type<::Tags::NormalDotFlux<
+          AuxiliaryFieldTags>>&... normal_dot_auxiliary_flux_interiors,
+      const db::item_type<NormalDotDivFlux<
+          AuxiliaryFieldTags>>&... normal_dot_div_auxiliary_flux_interiors,
+      const db::item_type<NormalDotNormalDotFlux<
+          AuxiliaryFieldTags>>&... ndot_ndot_aux_flux_interiors,
+      const db::item_type<::Tags::NormalDotFlux<
+          AuxiliaryFieldTags>>&... minus_normal_dot_auxiliary_flux_exteriors,
+      const db::item_type<NormalDotDivFlux<
+          AuxiliaryFieldTags>>&... minus_normal_dot_div_aux_flux_exteriors,
+      const db::item_type<NormalDotDivFlux<
+          AuxiliaryFieldTags>>&... ndot_ndot_aux_flux_exteriors) const
+      noexcept {
+    // Need polynomial degrees and element size to compute this dynamically
+    const double penalty = penalty_parameter_;
+
+    const auto assemble_numerical_fluxes = [&penalty](
+        const auto numerical_flux_for_field,
+        const auto numerical_flux_for_auxiliary_field,
+        const auto& normal_dot_auxiliary_flux_interior,
+        const auto& normal_dot_div_auxiliary_flux_interior,
+        const auto& ndot_ndot_aux_flux_interior,
+        const auto& minus_normal_dot_auxiliary_flux_exterior,
+        const auto& minus_normal_dot_div_aux_flux_exterior,
+        const auto& ndot_ndot_aux_flux_exterior) noexcept {
+      for (auto it = numerical_flux_for_auxiliary_field->begin();
+           it != numerical_flux_for_auxiliary_field->end(); it++) {
+        const auto index =
+            numerical_flux_for_auxiliary_field->get_tensor_index(it);
+        // We are working with the n.F_v(u) computed on either side of the
+        // interface, so (assuming the normal is independent of the dynamic
+        // variables) the data we get from the other element contains _minus_
+        // the normal from this element. So we cancel the minus sign when
+        // computing the average here.
+        *it = 0.5 * (normal_dot_auxiliary_flux_interior.get(index) -
+                     minus_normal_dot_auxiliary_flux_exterior.get(index));
+      }
+      for (auto it = numerical_flux_for_field->begin();
+           it != numerical_flux_for_field->end(); it++) {
+        const auto index = numerical_flux_for_field->get_tensor_index(it);
+        *it = 0.5 * (normal_dot_div_auxiliary_flux_interior.get(index) -
+                     minus_normal_dot_div_aux_flux_exterior.get(index)) -
+              penalty * (ndot_ndot_aux_flux_interior.get(index) -
+                         ndot_ndot_aux_flux_exterior.get(index));
+      }
+    };
+    EXPAND_PACK_LEFT_TO_RIGHT(assemble_numerical_fluxes(
+        numerical_flux_for_fields, numerical_flux_for_auxiliary_fields,
+        normal_dot_auxiliary_flux_interiors,
+        normal_dot_div_auxiliary_flux_interiors, ndot_ndot_aux_flux_interiors,
+        minus_normal_dot_auxiliary_flux_exteriors,
+        minus_normal_dot_div_aux_flux_exteriors, ndot_ndot_aux_flux_exteriors));
+  }
+
+  // This function computes the boundary contributions from Dirichlet boundary
+  // conditions. This data is what remains to be added to the boundaries when
+  // homogeneous (i.e. zero) boundary conditions are assumed in the calculation
+  // of the numerical fluxes, but we wish to impose inhomogeneous (i.e. nonzero)
+  // boundary conditions. Since this contribution does not depend on the
+  // numerical field values, but only on the Dirichlet boundary data, it may be
+  // added as contribution to the source of the elliptic systems. Then, it
+  // remains to solve the homogeneous problem with the modified source.
+  void compute_dirichlet_boundary(
+      const gsl::not_null<db::item_type<::Tags::NormalDotNumericalFlux<
+          FieldTags>>*>... numerical_flux_for_fields,
+      const gsl::not_null<db::item_type<::Tags::NormalDotNumericalFlux<
+          AuxiliaryFieldTags>>*>... numerical_flux_for_auxiliary_fields,
+      const db::item_type<FieldTags>&... dirichlet_fields,
+      const FluxesComputer& fluxes_computer,
+      const db::item_type<FluxesArgs>&... fluxes_args,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
+      const noexcept {
+    // Need polynomial degrees and element size to compute this dynamically
+    const double penalty = penalty_parameter_;
+
+    // Compute n.F_v(u)
+    auto dirichlet_auxiliary_field_fluxes =
+        make_with_value<Variables<tmpl::list<::Tags::Flux<
+            AuxiliaryFieldTags, tmpl::size_t<Dim>, Frame::Inertial>...>>>(
+            interface_unit_normal,
+            std::numeric_limits<double>::signaling_NaN());
+    fluxes_computer.apply(
+        make_not_null(&get<::Tags::Flux<AuxiliaryFieldTags, tmpl::size_t<Dim>,
+                                        Frame::Inertial>>(
+            dirichlet_auxiliary_field_fluxes))...,
+        fluxes_args..., dirichlet_fields...);
+    const auto apply_normal_dot_aux =
+        [&interface_unit_normal, &dirichlet_auxiliary_field_fluxes ](
+            auto auxiliary_field_tag_v,
+            const auto numerical_flux_for_auxiliary_field) noexcept {
+      using auxiliary_field_tag = decltype(auxiliary_field_tag_v);
+      normal_dot_flux(
+          numerical_flux_for_auxiliary_field, interface_unit_normal,
+          get<::Tags::Flux<auxiliary_field_tag, tmpl::size_t<Dim>,
+                           Frame::Inertial>>(dirichlet_auxiliary_field_fluxes));
+    };
+    EXPAND_PACK_LEFT_TO_RIGHT(apply_normal_dot_aux(
+        AuxiliaryFieldTags{}, numerical_flux_for_auxiliary_fields));
+
+    // Compute 2 * sigma * n.F_u(n.F_v(u))
+    auto principal_dirichlet_auxiliary_field_fluxes =
+        make_with_value<Variables<tmpl::list<
+            ::Tags::Flux<FieldTags, tmpl::size_t<Dim>, Frame::Inertial>...>>>(
+            interface_unit_normal,
+            std::numeric_limits<double>::signaling_NaN());
+    fluxes_computer.apply(
+        make_not_null(
+            &get<::Tags::Flux<FieldTags, tmpl::size_t<Dim>, Frame::Inertial>>(
+                principal_dirichlet_auxiliary_field_fluxes))...,
+        fluxes_args..., *numerical_flux_for_auxiliary_fields...);
+    const auto assemble_dirichlet_penalty = [
+      &interface_unit_normal, &penalty,
+      &principal_dirichlet_auxiliary_field_fluxes
+    ](auto field_tag_v, const auto numerical_flux_for_field) noexcept {
+      using field_tag = decltype(field_tag_v);
+      normal_dot_flux(
+          numerical_flux_for_field, interface_unit_normal,
+          get<::Tags::Flux<field_tag, tmpl::size_t<Dim>, Frame::Inertial>>(
+              principal_dirichlet_auxiliary_field_fluxes));
+      for (auto it = numerical_flux_for_field->begin();
+           it != numerical_flux_for_field->end(); it++) {
+        *it *= 2 * penalty;
+      }
+    };
+    EXPAND_PACK_LEFT_TO_RIGHT(
+        assemble_dirichlet_penalty(FieldTags{}, numerical_flux_for_fields));
+  }
+
+ private:
+  double penalty_parameter_ = std::numeric_limits<double>::signaling_NaN();
+};
+
+}  // namespace NumericalFluxes
+}  // namespace dg
+}  // namespace elliptic

--- a/src/Elliptic/Systems/Poisson/Equations.cpp
+++ b/src/Elliptic/Systems/Poisson/Equations.cpp
@@ -3,23 +3,13 @@
 
 #include "Elliptic/Systems/Poisson/Equations.hpp"
 
-#include <array>
+#include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "DataStructures/Variables.hpp"  // IWYU pragma: keep
-#include "Elliptic/Systems/Poisson/FirstOrderSystem.hpp"
-#include "Elliptic/Systems/Poisson/Tags.hpp"  // IWYU pragma: keep
-#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"  // IWYU pragma: keep
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
-#include "Utilities/TMPL.hpp"
-// IWYU pragma: no_forward_declare Tags::deriv
-// IWYU pragma: no_forward_declare Tags::div
-// IWYU pragma: no_forward_declare Variables
-// IWYU pragma: no_forward_declare Tensor
 
 namespace Poisson {
 
@@ -56,86 +46,11 @@ void auxiliary_fluxes(gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*>
   }
 }
 
-template <size_t Dim>
-void FirstOrderInternalPenaltyFlux<Dim>::package_data(
-    const gsl::not_null<Variables<package_tags>*> packaged_data,
-    const Scalar<DataVector>& field,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>& grad_field,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
-    const noexcept {
-  get<LinearSolver::Tags::Operand<Tags::Field>>(*packaged_data) = field;
-
-  for (size_t d = 0; d < Dim; d++) {
-    get<NormalTimesFieldFlux>(*packaged_data).get(d) =
-        interface_unit_normal.get(d) * get(field);
-  }
-
-  get<NormalDotGradFieldFlux>(*packaged_data).get() =
-      get<0>(interface_unit_normal) * get<0>(grad_field);
-  for (size_t d = 1; d < Dim; d++) {
-    get<NormalDotGradFieldFlux>(*packaged_data).get() +=
-        interface_unit_normal.get(d) * grad_field.get(d);
-  }
-}
-
-template <size_t Dim>
-void FirstOrderInternalPenaltyFlux<Dim>::operator()(
-    const gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
-    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
-        numerical_flux_for_auxiliary_field,
-    const Scalar<DataVector>& field_interior,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>&
-        normal_times_field_interior,
-    const Scalar<DataVector>& normal_dot_grad_field_interior,
-    const Scalar<DataVector>& field_exterior,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>&
-        minus_normal_times_field_exterior,
-    const Scalar<DataVector>& minus_normal_dot_grad_field_exterior) const
-    noexcept {
-  // Need polynomial degress and element size to compute this dynamically
-  const double penalty = penalty_parameter_;
-
-  // The minus sign in the equation is canceled by the one in `lift_flux`
-  for (size_t d = 0; d < Dim; d++) {
-    numerical_flux_for_auxiliary_field->get(d) =
-        0.5 * (normal_times_field_interior.get(d) -
-               minus_normal_times_field_exterior.get(d));
-  }
-
-  // The minus sign in the equation is canceled by the one in `lift_flux`
-  numerical_flux_for_field->get() =
-      0.5 * (get(normal_dot_grad_field_interior) -
-             get(minus_normal_dot_grad_field_exterior)) -
-      penalty * (get(field_interior) - get(field_exterior));
-}
-
-template <size_t Dim>
-void FirstOrderInternalPenaltyFlux<Dim>::compute_dirichlet_boundary(
-    const gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
-    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
-        numerical_flux_for_auxiliary_field,
-    const Scalar<DataVector>& dirichlet_field,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
-    const noexcept {
-  // Need polynomial degress and element size to compute this dynamically
-  const double penalty = penalty_parameter_;
-
-  // The minus sign in the equation is canceled by the one in `lift_flux`
-  for (size_t d = 0; d < Dim; d++) {
-    numerical_flux_for_auxiliary_field->get(d) =
-        interface_unit_normal.get(d) * get(dirichlet_field);
-  }
-
-  // The minus sign in the equation is canceled by the one in `lift_flux`
-  numerical_flux_for_field->get() = 2. * penalty * get(dirichlet_field);
-}
-
 }  // namespace Poisson
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                 \
-  template class Poisson::FirstOrderInternalPenaltyFlux<DIM(data)>;          \
   template void Poisson::euclidean_fluxes<DIM(data)>(                        \
       const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>, \
       const tnsr::i<DataVector, DIM(data), Frame::Inertial>&) noexcept;      \

--- a/src/Elliptic/Systems/Poisson/Equations.hpp
+++ b/src/Elliptic/Systems/Poisson/Equations.hpp
@@ -4,45 +4,14 @@
 #pragma once
 
 #include <cstddef>
-#include <string>
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"
-#include "DataStructures/Tensor/TypeAliases.hpp"
-#include "DataStructures/Variables.hpp"  // IWYU pragma: keep
-#include "Domain/FaceNormal.hpp"
-#include "Domain/Tags.hpp"
-#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"  // IWYU pragma: keep
-#include "Options/Options.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
-
-// IWYU pragma: no_forward_declare Tags::deriv
-// IWYU pragma: no_forward_declare Tensor
-// IWYU pragma: no_forward_declare Variables
 
 /// \cond
 class DataVector;
-template <size_t>
-class Mesh;
-namespace Tags {
-template <typename>
-struct Normalized;
-}  // namespace Tags
-namespace LinearSolver {
-namespace Tags {
-template <typename>
-struct Operand;
-}  // namespace Tags
-}  // namespace LinearSolver
-namespace Poisson {
-namespace Tags {
-struct Field;
-template <size_t>
-struct AuxiliaryField;
-}  // namespace Tags
-}  // namespace Poisson
 namespace PUP {
 class er;
 }  // namespace PUP
@@ -118,123 +87,6 @@ struct Sources {
                     const Scalar<DataVector>& /*field*/) noexcept {
     get(*source_for_field) = 0.;
   }
-};
-
-/*!
- * \brief The internal penalty flux for the first oder formulation of the
- * Poisson equation.
- *
- * \details For the sourced equation this is \f$-\frac{\nabla u_\mathrm{int} +
- * \nabla u_\mathrm{ext}}{2} + \sigma \left(u_\mathrm{int} -
- * u_\mathrm{ext}\right)\f$ and for the auxiliary equation it is \f$\frac{
- * u_\mathrm{int} + u_\mathrm{ext}}{2}\f$. The penalty factor \f$\sigma\f$ is
- * responsible for removing zero eigenmodes and impacts the conditioning of the
- * linear operator to be solved. It can be chosen as
- * \f$\sigma=C\frac{N_\mathrm{points}^2}{h}\f$ where \f$N_\mathrm{points}\f$ is
- * the number of collocation points (i.e. the polynomial degree plus 1),
- * \f$h\f$ is a measure of the element size in inertial coordinates and \f$C\leq
- * 1\f$ is a free parameter (see e.g. \cite HesthavenWarburton, section 7.2).
- */
-template <size_t Dim>
-struct FirstOrderInternalPenaltyFlux {
- public:
-  struct PenaltyParameter {
-    using type = double;
-    // Currently this is used as the full prefactor to the penalty term. When it
-    // becomes possible to compute a measure of the size $h$ of an element and
-    // the number of collocation points $p$ on both sides of the mortar, this
-    // should be changed to be just the parameter multiplying $\frac{p^2}{h}$.
-    static constexpr OptionString help = {
-        "The prefactor to the penalty term of the flux."};
-  };
-  using options = tmpl::list<PenaltyParameter>;
-  static constexpr OptionString help = {
-      "Computes the internal penalty flux for a Poisson system."};
-  static std::string name() noexcept { return "InternalPenalty"; }
-
-  FirstOrderInternalPenaltyFlux() = default;
-  explicit FirstOrderInternalPenaltyFlux(double penalty_parameter)
-      : penalty_parameter_(penalty_parameter) {}
-
-  // clang-tidy: non-const reference
-  void pup(PUP::er& p) noexcept { p | penalty_parameter_; }  // NOLINT
-
-  struct NormalTimesFieldFlux : db::SimpleTag {
-    using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
-    static std::string name() noexcept { return "NormalTimesFieldFlux"; }
-  };
-
-  struct NormalDotGradFieldFlux : db::SimpleTag {
-    using type = Scalar<DataVector>;
-    static std::string name() noexcept { return "NormalDotGradFieldFlux"; }
-  };
-
-  // These tags are sliced to the interface of the element and passed to
-  // `package_data` to provide the data needed to compute the numerical fluxes.
-  using argument_tags =
-      tmpl::list<LinearSolver::Tags::Operand<Tags::Field>,
-                 ::Tags::div<::Tags::Flux<
-                     LinearSolver::Tags::Operand<::Tags::deriv<
-                         Tags::Field, tmpl::size_t<Dim>, Frame::Inertial>>,
-                     tmpl::size_t<Dim>, Frame::Inertial>>,
-                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
-
-  // This is the data needed to compute the numerical flux.
-  // `SendBoundaryFluxes` calls `package_data` to store these tags in a
-  // Variables. Local and remote values of this data are then combined in the
-  // `()` operator.
-  using package_tags = tmpl::list<LinearSolver::Tags::Operand<Tags::Field>,
-                                  NormalTimesFieldFlux, NormalDotGradFieldFlux>;
-
-  // Following the packaged_data pointer, this function expects as arguments the
-  // types in `argument_tags`.
-  void package_data(gsl::not_null<Variables<package_tags>*> packaged_data,
-                    const Scalar<DataVector>& field,
-                    const tnsr::i<DataVector, Dim, Frame::Inertial>& grad_field,
-                    const tnsr::i<DataVector, Dim, Frame::Inertial>&
-                        interface_unit_normal) const noexcept;
-
-  // This function combines local and remote data to the numerical fluxes.
-  // The numerical fluxes as not-null pointers are the first arguments. The
-  // other arguments are the packaged types for the interior side followed by
-  // the packaged types for the exterior side.
-  void operator()(
-      gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
-      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
-          numerical_flux_for_auxiliary_field,
-      const Scalar<DataVector>& field_interior,
-      const tnsr::i<DataVector, Dim, Frame::Inertial>&
-          normal_times_field_interior,
-      const Scalar<DataVector>& normal_dot_grad_field_interior,
-      const Scalar<DataVector>& field_exterior,
-      const tnsr::i<DataVector, Dim, Frame::Inertial>&
-          minus_normal_times_field_exterior,
-      const Scalar<DataVector>& minus_normal_dot_grad_field_exterior) const
-      noexcept;
-
-  // This function computes the boundary contributions from Dirichlet boundary
-  // conditions. This data is what remains to be added to the boundaries when
-  // homogeneous (i.e. zero) boundary conditions are assumed in the calculation
-  // of the numerical fluxes, but we wish to impose inhomogeneous (i.e. nonzero)
-  // boundary conditions. Since this contribution does not depend on the
-  // numerical field values, but only on the Dirichlet boundary data, it may be
-  // added as contribution to the source of the elliptic systems. Then, it
-  // remains to solve the homogeneous problem with the modified source.
-  // The first arguments to this function are the boundary contributions to
-  // compute as not-null pointers, in the order they appear in the
-  // `system::fields_tag`. They are followed by the field values of the tags in
-  // `system::primal_fields`. The last argument is the
-  // normalized unit covector to the element face.
-  void compute_dirichlet_boundary(
-      gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
-      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
-          numerical_flux_for_auxiliary_field,
-      const Scalar<DataVector>& dirichlet_field,
-      const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
-      const noexcept;
-
- private:
-  double penalty_parameter_{};
 };
 
 }  // namespace Poisson

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
@@ -1,19 +1,15 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-add_subdirectory(NumericalFluxes)
-
-set(LIBRARY "Test_EllipticDG")
+set(LIBRARY "Test_EllipticNumericalFluxes")
 
 set(LIBRARY_SOURCES
-  Test_ImposeBoundaryConditions.cpp
-  Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
-  Test_InitializeFluxes.cpp
+  Test_FirstOrderInternalPenalty.cpp
   )
 
 add_test_library(
   ${LIBRARY}
-  "Elliptic/DiscontinuousGalerkin/"
+  "Elliptic/DiscontinuousGalerkin/NumericalFluxes"
   "${LIBRARY_SOURCES}"
   "DataStructures;Domain;ErrorHandling"
   )

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.py
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.py
@@ -1,0 +1,92 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def average(int, ext):
+    return 0.5 * (int + ext)
+
+
+def jump(int, ext):
+    return int - ext
+
+
+def flux_for_field(grad_field, fluxes_argument):
+    return fluxes_argument * np.asarray(grad_field)
+
+
+def flux_for_auxiliary_field(field, fluxes_argument, dim):
+    return np.diag(np.repeat(fluxes_argument * field, dim))
+
+
+def normal_dot_numerical_flux_for_field(
+        n_dot_aux_flux_int, n_dot_aux_flux_ext,
+        div_aux_flux_int, div_aux_flux_ext,
+        fluxes_argument, penalty_parameter,
+        face_normal_int):
+    sigma = penalty_parameter
+    return np.dot(face_normal_int,
+                  average(
+                      flux_for_field(div_aux_flux_int, fluxes_argument),
+                      flux_for_field(div_aux_flux_ext, fluxes_argument)
+                  ) - sigma * jump(
+                      flux_for_field(n_dot_aux_flux_int, fluxes_argument),
+                      flux_for_field(-n_dot_aux_flux_ext, fluxes_argument)
+                  ))
+
+
+def normal_dot_numerical_flux_for_auxiliary_field(
+        n_dot_aux_flux_int, minus_n_dot_aux_flux_ext,
+        div_aux_flux_int, div_aux_flux_ext,
+        fluxes_argument, penalty_parameter,
+        face_normal_int):
+    # `minus_n_dot_aux_flux_ext` is from the element on the other side of the
+    # interface, so it is _minus_ the same quantity if it was computed with the
+    # normal from this element (assuming normals don't depend on the dynamic
+    # variables). See the `()` operator in
+    # `elliptic::dg::NumericalFluxes::FirstOrderInternalPenalty` for details.
+    return average(n_dot_aux_flux_int, -minus_n_dot_aux_flux_ext)
+
+
+def normal_dot_dirichlet_flux_for_field(
+        dirichlet_field, fluxes_argument, penalty_parameter, face_normal, dim):
+    sigma = penalty_parameter
+    return 2. * sigma * np.dot(
+        face_normal,
+        flux_for_field(
+            np.dot(
+                face_normal,
+                flux_for_auxiliary_field(dirichlet_field, fluxes_argument, dim)
+            ), fluxes_argument))
+
+
+def normal_dot_dirichlet_flux_for_field_1d(*args, **kwargs):
+    return normal_dot_dirichlet_flux_for_field(*args, dim=1, **kwargs)
+
+
+def normal_dot_dirichlet_flux_for_field_2d(*args, **kwargs):
+    return normal_dot_dirichlet_flux_for_field(*args, dim=2, **kwargs)
+
+
+def normal_dot_dirichlet_flux_for_field_3d(*args, **kwargs):
+    return normal_dot_dirichlet_flux_for_field(*args, dim=3, **kwargs)
+
+
+def normal_dot_dirichlet_flux_for_auxiliary_field(
+        dirichlet_field, fluxes_argument, penalty_parameter, face_normal, dim):
+    return np.dot(
+        face_normal,
+        flux_for_auxiliary_field(dirichlet_field, fluxes_argument, dim))
+
+
+def normal_dot_dirichlet_flux_for_auxiliary_field_1d(*args, **kwargs):
+    return normal_dot_dirichlet_flux_for_auxiliary_field(*args, dim=1, **kwargs)
+
+
+def normal_dot_dirichlet_flux_for_auxiliary_field_2d(*args, **kwargs):
+    return normal_dot_dirichlet_flux_for_auxiliary_field(*args, dim=2, **kwargs)
+
+
+def normal_dot_dirichlet_flux_for_auxiliary_field_3d(*args, **kwargs):
+    return normal_dot_dirichlet_flux_for_auxiliary_field(*args, dim=3, **kwargs)

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp
@@ -1,0 +1,81 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace EllipticNumericalFluxesTestHelpers {
+
+template <class... PackageDataTags, class FluxType,
+          class... NormalDotNumericalFluxTypes>
+void apply_numerical_flux(
+    const FluxType& flux,
+    const Variables<tmpl::list<PackageDataTags...>>& packaged_data_int,
+    const Variables<tmpl::list<PackageDataTags...>>& packaged_data_ext,
+    NormalDotNumericalFluxTypes&&... normal_dot_numerical_flux) noexcept {
+  flux(std::forward<NormalDotNumericalFluxTypes>(normal_dot_numerical_flux)...,
+       get<PackageDataTags>(packaged_data_int)...,
+       get<PackageDataTags>(packaged_data_ext)...);
+}
+
+namespace detail {
+
+/// Test that the flux is single-valued on the interface, i.e. that the elements
+/// on either side of the interface are working with the same numerical flux
+/// data
+template <size_t Dim, typename FluxType, typename... VariablesTags>
+void test_conservation_impl(const FluxType& flux_computer,
+                            const DataVector& used_for_size,
+                            const tmpl::list<VariablesTags...> /*meta*/) {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(0.0, 1.0);
+
+  using PackagedData = Variables<typename FluxType::package_tags>;
+  const auto packaged_data_interior = make_with_random_values<PackagedData>(
+      make_not_null(&gen), make_not_null(&dist), used_for_size);
+  const auto packaged_data_exterior = make_with_random_values<PackagedData>(
+      make_not_null(&gen), make_not_null(&dist), used_for_size);
+
+  Variables<tmpl::list<VariablesTags...>> n_dot_num_flux_interior(
+      used_for_size.size(), std::numeric_limits<double>::signaling_NaN());
+  apply_numerical_flux(flux_computer, packaged_data_interior,
+                       packaged_data_exterior,
+                       &get<VariablesTags>(n_dot_num_flux_interior)...);
+
+  Variables<tmpl::list<VariablesTags...>> n_dot_num_flux_exterior(
+      used_for_size.size(), std::numeric_limits<double>::signaling_NaN());
+  apply_numerical_flux(flux_computer, packaged_data_exterior,
+                       packaged_data_interior,
+                       &get<VariablesTags>(n_dot_num_flux_exterior)...);
+
+  const auto check = [](const auto& int_flux, const auto& ext_flux) noexcept {
+    for (size_t i = 0; i < int_flux.size(); ++i) {
+      CHECK_ITERABLE_APPROX(int_flux[i], -ext_flux[i]);
+    }
+    return nullptr;
+  };
+
+  EXPAND_PACK_LEFT_TO_RIGHT(check(get<VariablesTags>(n_dot_num_flux_interior),
+                                  get<VariablesTags>(n_dot_num_flux_exterior)));
+}
+
+}  // namespace detail
+
+template <size_t Dim, typename VariablesTags, typename FluxType>
+void test_conservation(const FluxType& flux_computer,
+                       const DataVector& used_for_size) {
+  detail::test_conservation_impl<Dim>(flux_computer, used_for_size,
+                                      VariablesTags{});
+}
+
+}  // namespace EllipticNumericalFluxesTestHelpers

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/Test_FirstOrderInternalPenalty.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/Test_FirstOrderInternalPenalty.cpp
@@ -1,0 +1,154 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp"
+#include "Utilities/MakeString.hpp"
+#include "tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+namespace {
+
+struct ScalarFieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct AuxiliaryFieldTag : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim>;
+};
+
+struct AnArgument : db::SimpleTag {
+  using type = double;
+};
+
+template <size_t Dim>
+struct Fluxes {
+  using argument_tags = tmpl::list<AnArgument>;
+  static void apply(
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> flux_for_field,
+      const double an_argument,
+      const tnsr::i<DataVector, Dim>& auxiliary_field) {
+    for (size_t d = 0; d < Dim; d++) {
+      flux_for_field->get(d) = auxiliary_field.get(d) * an_argument;
+    }
+  }
+  static void apply(
+      const gsl::not_null<tnsr::Ij<DataVector, Dim>*> flux_for_aux_field,
+      const double an_argument, const Scalar<DataVector>& field) {
+    std::fill(flux_for_aux_field->begin(), flux_for_aux_field->end(), 0.);
+    for (size_t d = 0; d < Dim; d++) {
+      flux_for_aux_field->get(d, d) = get(field) * an_argument;
+    }
+  }
+};
+
+template <size_t Dim>
+struct FluxesComputerTag : db::SimpleTag {
+  using type = Fluxes<Dim>;
+  static std::string name() noexcept { return "FluxesComputerTag"; }
+};
+
+template <size_t Dim>
+void apply_ip_flux(
+    const gsl::not_null<Scalar<DataVector>*> n_dot_num_f_field,
+    const gsl::not_null<tnsr::i<DataVector, Dim>*> n_dot_num_f_aux,
+    const tnsr::i<DataVector, Dim>& n_dot_aux_flux_int,
+    const tnsr::i<DataVector, Dim>& n_dot_aux_flux_ext,
+    const tnsr::i<DataVector, Dim>& div_aux_flux_int,
+    const tnsr::i<DataVector, Dim>& div_aux_flux_ext,
+    const double fluxes_argument, const double penalty_parameter,
+    const tnsr::i<DataVector, Dim>& face_normal_int) noexcept {
+  using NumericalFlux =
+      elliptic::dg::NumericalFluxes::FirstOrderInternalPenalty<
+          Dim, FluxesComputerTag<Dim>, tmpl::list<ScalarFieldTag>,
+          tmpl::list<AuxiliaryFieldTag<Dim>>>;
+
+  NumericalFlux numerical_flux{penalty_parameter};
+  Fluxes<Dim> fluxes_computer{};
+  using PackagedData = Variables<typename NumericalFlux::package_tags>;
+
+  auto packaged_data_interior = make_with_value<PackagedData>(
+      face_normal_int, std::numeric_limits<double>::signaling_NaN());
+  numerical_flux.package_data(
+      make_not_null(&packaged_data_interior), n_dot_aux_flux_int,
+      div_aux_flux_int, fluxes_computer, fluxes_argument, face_normal_int);
+  auto packaged_data_exterior = make_with_value<PackagedData>(
+      face_normal_int, std::numeric_limits<double>::signaling_NaN());
+  tnsr::i<DataVector, Dim> face_normal_ext{face_normal_int};
+  for (size_t d = 0; d < Dim; d++) {
+    face_normal_ext.get(d) *= -1.;
+  }
+  numerical_flux.package_data(
+      make_not_null(&packaged_data_exterior), n_dot_aux_flux_ext,
+      div_aux_flux_ext, fluxes_computer, fluxes_argument, face_normal_ext);
+
+  EllipticNumericalFluxesTestHelpers::apply_numerical_flux(
+      numerical_flux, packaged_data_interior, packaged_data_exterior,
+      n_dot_num_f_field, n_dot_num_f_aux);
+}
+
+template <size_t Dim>
+void apply_ip_dirichlet_flux(
+    const gsl::not_null<Scalar<DataVector>*> n_dot_num_f_field,
+    const gsl::not_null<tnsr::i<DataVector, Dim>*> n_dot_num_f_aux,
+    const Scalar<DataVector>& dirichlet_field, const double fluxes_argument,
+    const double penalty_parameter,
+    const tnsr::i<DataVector, Dim>& face_normal) noexcept {
+  using NumericalFlux =
+      elliptic::dg::NumericalFluxes::FirstOrderInternalPenalty<
+          Dim, FluxesComputerTag<Dim>, tmpl::list<ScalarFieldTag>,
+          tmpl::list<AuxiliaryFieldTag<Dim>>>;
+
+  NumericalFlux numerical_flux{penalty_parameter};
+  Fluxes<Dim> fluxes_computer{};
+
+  numerical_flux.compute_dirichlet_boundary(n_dot_num_f_field, n_dot_num_f_aux,
+                                            dirichlet_field, fluxes_computer,
+                                            fluxes_argument, face_normal);
+}
+
+template <size_t Dim>
+void test_equations(const DataVector& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &apply_ip_flux<Dim>, "FirstOrderInternalPenalty",
+      {"normal_dot_numerical_flux_for_field",
+       "normal_dot_numerical_flux_for_auxiliary_field"},
+      {{{-1.0, 1.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      &apply_ip_dirichlet_flux<Dim>, "FirstOrderInternalPenalty",
+      {MakeString{} << "normal_dot_dirichlet_flux_for_field_" << Dim << "d",
+       MakeString{} << "normal_dot_dirichlet_flux_for_auxiliary_field_" << Dim
+                    << "d"},
+      {{{-1.0, 1.0}}}, used_for_size);
+}
+
+template <size_t Dim>
+void test_conservation(const DataVector& used_for_size) {
+  elliptic::dg::NumericalFluxes::FirstOrderInternalPenalty<
+      Dim, FluxesComputerTag<Dim>, tmpl::list<ScalarFieldTag>,
+      tmpl::list<AuxiliaryFieldTag<Dim>>>
+      numerical_flux{1.5};
+  EllipticNumericalFluxesTestHelpers::test_conservation<
+      Dim, tmpl::list<ScalarFieldTag, AuxiliaryFieldTag<Dim>>>(numerical_flux,
+                                                               used_for_size);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.DG.NumericalFluxes.FirstOrderInternalPenalty",
+                  "[Unit][Elliptic][Fluxes]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Elliptic/DiscontinuousGalerkin/NumericalFluxes"};
+
+  GENERATE_UNINITIALIZED_DATAVECTOR;
+  CHECK_FOR_DATAVECTORS(test_equations, (1, 2, 3))
+  CHECK_FOR_DATAVECTORS(test_conservation, (1, 2, 3))
+}

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
@@ -30,6 +30,7 @@
 #include "Domain/SegmentId.hpp"
 #include "Domain/Tags.hpp"
 #include "Elliptic/DiscontinuousGalerkin/ImposeInhomogeneousBoundaryConditionsOnSource.hpp"
+#include "Elliptic/Tags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
@@ -53,10 +54,18 @@ struct ScalarFieldTag : db::SimpleTag {
 };
 
 template <size_t Dim>
+struct Fluxes {
+  using argument_tags = tmpl::list<>;
+  // clang-tidy: no runtime references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+template <size_t Dim>
 struct System {
   static constexpr size_t volume_dim = Dim;
   using fields_tag = Tags::Variables<tmpl::list<ScalarFieldTag>>;
   using primal_fields = tmpl::list<ScalarFieldTag>;
+  using fluxes = Fluxes<Dim>;
   template <typename Tag>
   using magnitude_tag = Tags::EuclideanMagnitude<Tag>;
 };
@@ -80,7 +89,7 @@ template <size_t Dim>
 struct NumericalFlux {
   void compute_dirichlet_boundary(
       const gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
-      const Scalar<DataVector>& field,
+      const Scalar<DataVector>& field, const Fluxes<Dim>& /*flux_computer*/,
       const tnsr::i<DataVector, Dim,
                     Frame::Inertial>& /*interface_unit_normal*/) const
       noexcept {
@@ -127,7 +136,8 @@ struct Metavariables {
   using normal_dot_numerical_flux = Tags::NumericalFlux<NumericalFlux<Dim>>;
   using component_list = tmpl::list<ElementArray<Dim, Metavariables>>;
   using const_global_cache_tags =
-      tmpl::list<analytic_solution_tag, normal_dot_numerical_flux>;
+      tmpl::list<elliptic::Tags::FluxesComputer<Fluxes<Dim>>,
+                 analytic_solution_tag, normal_dot_numerical_flux>;
   enum class Phase { Initialization, Testing, Exit };
 };
 
@@ -144,7 +154,7 @@ void test_impose_inhomogeneous_boundary_conditions_on_source(
       source_vars{source_expected.size(), 0.};
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{
-      {AnalyticSolution<Dim>{}, NumericalFlux<Dim>{}}};
+      {Fluxes<Dim>{}, AnalyticSolution<Dim>{}, NumericalFlux<Dim>{}}};
   ActionTesting::emplace_component_and_initialize<element_array>(
       &runner, element_id,
       {domain_creator.create_domain(), domain_creator.initial_extents(),

--- a/tests/Unit/Elliptic/Systems/Poisson/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Poisson/CMakeLists.txt
@@ -12,5 +12,5 @@ add_test_library(
   ${LIBRARY}
   "Elliptic/Systems/Poisson/"
   "${LIBRARY_SOURCES}"
-  "CoordinateMaps;DataStructures;Domain;Poisson;PoissonSolutions;Utilities"
+  "DataStructures;Poisson;Utilities"
   )

--- a/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
@@ -4,49 +4,23 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
-#include <cmath>
 #include <cstddef>
-#include <memory>
 #include <string>
-#include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/CoordinateMaps/Affine.hpp"
-#include "Domain/CoordinateMaps/CoordinateMap.hpp"
-#include "Domain/CoordinateMaps/ProductMaps.hpp"
-#include "Domain/ElementId.hpp"
-#include "Domain/ElementMap.hpp"
-#include "Domain/LogicalCoordinates.hpp"  // IWYU pragma: keep
-#include "Domain/Mesh.hpp"
-#include "Domain/SegmentId.hpp"
-#include "Domain/Tags.hpp"
 #include "Elliptic/Systems/Poisson/Equations.hpp"
-#include "Elliptic/Systems/Poisson/Tags.hpp"  // IWYU pragma: keep
-#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"  // IWYU pragma: keep
-#include "NumericalAlgorithms/Spectral/Spectral.hpp"
-#include "ParallelAlgorithms/LinearSolver/Tags.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp"
+#include "Elliptic/Systems/Poisson/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/MakeArray.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
-
-// IWYU pragma: no_include <pup.h>
-
-// IWYU pragma: no_forward_declare db::DataBox
-// IWYU pragma: no_forward_declare Tags::deriv
-// IWYU pragma: no_forward_declare Tags::div
-// IWYU pragma: no_forward_declare Tensor
-// IWYU pragma: no_forward_declare Variables
 
 namespace {
 
@@ -127,212 +101,4 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Poisson", "[Unit][Elliptic]") {
   GENERATE_UNINITIALIZED_DATAVECTOR;
   CHECK_FOR_DATAVECTORS(test_equations, (1, 2, 3));
   CHECK_FOR_DATAVECTORS(test_computers, (1, 2, 3));
-}
-
-// The following will move to a separate test for the internal penalty flux
-
-namespace {
-
-template <class... Tags, class FluxType, class... NormalDotNumericalFluxTypes>
-void apply_numerical_flux(
-    const FluxType& flux,
-    const Variables<tmpl::list<Tags...>>& packaged_data_int,
-    const Variables<tmpl::list<Tags...>>& packaged_data_ext,
-    NormalDotNumericalFluxTypes&&... normal_dot_numerical_flux) {
-  flux(std::forward<NormalDotNumericalFluxTypes>(normal_dot_numerical_flux)...,
-       get<Tags>(packaged_data_int)..., get<Tags>(packaged_data_ext)...);
-}
-
-template <size_t Dim, typename DbTagsList>
-void test_first_order_internal_penalty_flux(
-    const db::DataBox<DbTagsList>& domain_box) {
-  using field_tag = Poisson::Tags::Field;
-  using auxiliary_field_tag =
-      ::Tags::deriv<field_tag, tmpl::size_t<Dim>, Frame::Inertial>;
-
-  const auto num_points =
-      get<Tags::Mesh<Dim>>(domain_box).number_of_grid_points();
-
-  const auto& inertial_coords =
-      get<Tags::Coordinates<Dim, Frame::Inertial>>(domain_box);
-
-  const Poisson::Solutions::ProductOfSinusoids<Dim> solution(
-      make_array<Dim>(1.));
-  const auto field_variables = solution.variables(
-      inertial_coords, tmpl::list<field_tag, auxiliary_field_tag>{});
-
-  // Any numbers are fine, doesn't have anything to do with unit normal
-  tnsr::i<DataVector, Dim, Frame::Inertial> unit_normal(num_points, 0.0);
-  tnsr::i<DataVector, Dim, Frame::Inertial> opposite_unit_normal(num_points,
-                                                                 0.0);
-  for (size_t d = 0; d < Dim; ++d) {
-    unit_normal.get(d) = inertial_coords.get(d);
-    opposite_unit_normal.get(d) = -inertial_coords.get(d);
-  }
-
-  Variables<typename Poisson::FirstOrderInternalPenaltyFlux<Dim>::package_tags>
-      packaged_data_int(num_points, 0.0);
-  Variables<typename Poisson::FirstOrderInternalPenaltyFlux<Dim>::package_tags>
-      packaged_data_ext(num_points, 0.0);
-
-  const auto& grad_field = get<auxiliary_field_tag>(field_variables);
-
-  Poisson::FirstOrderInternalPenaltyFlux<Dim> flux_computer(10.);
-  Scalar<DataVector> normal_dot_numerical_flux_for_field(num_points, 0.0);
-  tnsr::i<DataVector, Dim, Frame::Inertial>
-      normal_dot_numerical_flux_for_aux_field(num_points, 0.0);
-
-  tnsr::i<DataVector, Dim, Frame::Inertial> normal_times_field(num_points, 0.0);
-  Scalar<DataVector> normal_dot_aux_field(num_points, 0.0);
-  for (size_t d = 0; d < Dim; ++d) {
-    normal_times_field.get(d) =
-        unit_normal.get(d) * get(get<field_tag>(field_variables));
-    get(normal_dot_aux_field) +=
-        unit_normal.get(d) * get<auxiliary_field_tag>(field_variables).get(d);
-  }
-
-  // Consistency: u^*(u,u)=u
-  {
-    flux_computer.package_data(make_not_null(&packaged_data_int),
-                               get<field_tag>(field_variables), grad_field,
-                               unit_normal);
-    flux_computer.package_data(make_not_null(&packaged_data_ext),
-                               get<field_tag>(field_variables), grad_field,
-                               opposite_unit_normal);
-    apply_numerical_flux(
-        flux_computer, packaged_data_int, packaged_data_ext,
-        make_not_null(&normal_dot_numerical_flux_for_field),
-        make_not_null(&normal_dot_numerical_flux_for_aux_field));
-
-    CHECK_ITERABLE_APPROX(get(normal_dot_numerical_flux_for_field),
-                          get(normal_dot_aux_field));
-    for (size_t d = 0; d < Dim; ++d) {
-      CHECK_ITERABLE_APPROX(normal_dot_numerical_flux_for_aux_field.get(d),
-                            normal_times_field.get(d));
-    }
-  }
-
-  // Manufacture different data for the exterior
-  Scalar<DataVector> ext_field(num_points, 0.0);
-  get(ext_field) += get<0>(inertial_coords);
-  tnsr::i<DataVector, Dim, Frame::Inertial> ext_grad_field(num_points, 0.0);
-  for (size_t d = 0; d < Dim; ++d) {
-    ext_grad_field.get(d) = get<auxiliary_field_tag>(field_variables).get(d) +
-                            inertial_coords.get(d);
-  }
-
-  // Conservation: u^* is single-valued (same on both sides of the interface)
-  {
-    flux_computer.package_data(make_not_null(&packaged_data_int),
-                               get<field_tag>(field_variables), grad_field,
-                               unit_normal);
-    flux_computer.package_data(make_not_null(&packaged_data_ext), ext_field,
-                               ext_grad_field, opposite_unit_normal);
-    apply_numerical_flux(
-        flux_computer, packaged_data_int, packaged_data_ext,
-        make_not_null(&normal_dot_numerical_flux_for_field),
-        make_not_null(&normal_dot_numerical_flux_for_aux_field));
-
-    Scalar<DataVector> reversed_normal_dot_numerical_flux_for_field(num_points,
-                                                                    0.0);
-    tnsr::i<DataVector, Dim, Frame::Inertial>
-        reversed_normal_dot_numerical_flux_for_aux_field(num_points, 0.0);
-    apply_numerical_flux(
-        flux_computer, packaged_data_ext, packaged_data_int,
-        make_not_null(&reversed_normal_dot_numerical_flux_for_field),
-        make_not_null(&reversed_normal_dot_numerical_flux_for_aux_field));
-
-    CHECK_ITERABLE_APPROX(get(normal_dot_numerical_flux_for_field),
-                          -get(reversed_normal_dot_numerical_flux_for_field));
-    for (size_t d = 0; d < Dim; ++d) {
-      CHECK_ITERABLE_APPROX(
-          normal_dot_numerical_flux_for_aux_field.get(d),
-          -reversed_normal_dot_numerical_flux_for_aux_field.get(d));
-    }
-  }
-
-  // Explicit data
-  {
-    flux_computer.package_data(make_not_null(&packaged_data_int),
-                               get<field_tag>(field_variables), grad_field,
-                               unit_normal);
-    flux_computer.package_data(make_not_null(&packaged_data_ext), ext_field,
-                               ext_grad_field, opposite_unit_normal);
-    apply_numerical_flux(
-        flux_computer, packaged_data_int, packaged_data_ext,
-        make_not_null(&normal_dot_numerical_flux_for_field),
-        make_not_null(&normal_dot_numerical_flux_for_aux_field));
-
-    Scalar<DataVector> expected_normal_dot_numerical_flux_for_field(num_points,
-                                                                    0.0);
-    tnsr::i<DataVector, Dim, Frame::Inertial>
-        expected_normal_dot_numerical_flux_for_aux_field(num_points, 0.0);
-    get(expected_normal_dot_numerical_flux_for_field) =
-        -10. * (get(get<field_tag>(field_variables)) - get(ext_field));
-    for (size_t d = 0; d < Dim; d++) {
-      get(expected_normal_dot_numerical_flux_for_field) +=
-          0.5 * unit_normal.get(d) *
-          (grad_field.get(d) + ext_grad_field.get(d));
-      expected_normal_dot_numerical_flux_for_aux_field.get(d) =
-          0.5 * unit_normal.get(d) *
-          (get(get<field_tag>(field_variables)) + get(ext_field));
-    }
-
-    CHECK_ITERABLE_APPROX(get(normal_dot_numerical_flux_for_field),
-                          get(expected_normal_dot_numerical_flux_for_field));
-    for (size_t d = 0; d < Dim; ++d) {
-      CHECK_ITERABLE_APPROX(
-          normal_dot_numerical_flux_for_aux_field.get(d),
-          expected_normal_dot_numerical_flux_for_aux_field.get(d));
-    }
-  }
-}
-
-template <size_t Dim>
-using simple_tags = db::AddSimpleTags<Tags::Mesh<Dim>, Tags::ElementMap<Dim>>;
-template <size_t Dim>
-using compute_tags = db::AddComputeTags<
-    Tags::LogicalCoordinates<Dim>,
-    Tags::MappedCoordinates<Tags::ElementMap<Dim>,
-                            Tags::Coordinates<Dim, Frame::Logical>>,
-    Tags::InverseJacobian<Tags::ElementMap<Dim>,
-                          Tags::Coordinates<Dim, Frame::Logical>>>;
-}  // namespace
-
-SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Poisson.FirstOrderInternalPenalty",
-                  "[Unit][Elliptic]") {
-  using Affine = domain::CoordinateMaps::Affine;
-  Mesh<1> mesh_1d{5, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto};
-  ElementMap<1, Frame::Inertial> element_map_1d{
-      ElementId<1>{0, make_array<1>(SegmentId{0, 0})},
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          Affine{-1., 1., 0., M_PI})};
-  auto domain_box_1d = db::create<simple_tags<1>, compute_tags<1>>(
-      mesh_1d, std::move(element_map_1d));
-  Mesh<2> mesh_2d{5, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto};
-  ElementMap<2, Frame::Inertial> element_map_2d{
-      ElementId<2>{0, make_array<2>(SegmentId{0, 0})},
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>(
-              Affine{-1., 1., 0., M_PI}, Affine{-1., 1., 0., M_PI}))};
-  auto domain_box_2d = db::create<simple_tags<2>, compute_tags<2>>(
-      mesh_2d, std::move(element_map_2d));
-  Mesh<3> mesh_3d{5, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto};
-  ElementMap<3, Frame::Inertial> element_map_3d{
-      ElementId<3>{0, make_array<3>(SegmentId{0, 0})},
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>(
-              Affine{-1., 1., 0., M_PI}, Affine{-1., 1., 0., M_PI},
-              Affine{-1., 1., 0., M_PI}))};
-  auto domain_box_3d = db::create<simple_tags<3>, compute_tags<3>>(
-      mesh_3d, std::move(element_map_3d));
-
-  SECTION("InternalPenaltyFlux") {
-    test_first_order_internal_penalty_flux<1>(domain_box_1d);
-    test_first_order_internal_penalty_flux<2>(domain_box_2d);
-    test_first_order_internal_penalty_flux<3>(domain_box_3d);
-  }
 }


### PR DESCRIPTION
## Proposed changes

This PR complements #1670 in generalizing the elliptic solver for any set of elliptic PDEs in flux-formulation. It implements my suggestion for a generalized internal penalty flux. Once both PRs are merged, solving elliptic problems such as Elasticity, XCTS or Punctures with a first-order DG formulation only requires implementing the system equations.

-  [x] Depends on #1672

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
