### PR TITLE
Clean up OptionTags for InterpolationTargetTag::compute_target_points.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -65,7 +65,7 @@ struct ApparentHorizon {
                   Verbosity verbosity_in) noexcept;
 
   ApparentHorizon() = default;
-  ApparentHorizon(const ApparentHorizon& /*rhs*/) = delete;
+  ApparentHorizon(const ApparentHorizon& /*rhs*/) = default;
   ApparentHorizon& operator=(const ApparentHorizon& /*rhs*/) = delete;
   ApparentHorizon(ApparentHorizon&& /*rhs*/) noexcept = default;
   ApparentHorizon& operator=(ApparentHorizon&& /*rhs*/) noexcept = default;
@@ -87,6 +87,35 @@ bool operator!=(const ApparentHorizon<Frame>& lhs,
                 const ApparentHorizon<Frame>& rhs) noexcept;
 
 }  // namespace OptionHolders
+
+namespace OptionTags {
+struct ApparentHorizons {
+  static constexpr OptionString help{"Options for apparent horizon finders"};
+};
+
+template <typename InterpolationTargetTag, typename Frame>
+struct ApparentHorizon {
+  using type = OptionHolders::ApparentHorizon<Frame>;
+  static constexpr OptionString help{
+      "Options for interpolation onto apparent horizon."};
+  static std::string name() noexcept {
+    return option_name<InterpolationTargetTag>();
+  }
+  using group = ApparentHorizons;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+template <typename InterpolationTargetTag, typename Frame>
+struct ApparentHorizon : db::SimpleTag {
+  using type = OptionHolders::ApparentHorizon<Frame>;
+  using option_tags =
+      tmpl::list<OptionTags::ApparentHorizon<InterpolationTargetTag, Frame>>;
+  static type create_from_options(const type& option) noexcept {
+    return option;
+  }
+};
+}  // namespace Tags
 
 namespace Actions {
 /// \ingroup ActionsGroup
@@ -123,8 +152,8 @@ namespace Actions {
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
 template <typename InterpolationTargetTag, typename Frame>
 struct ApparentHorizon {
-  using options_type = OptionHolders::ApparentHorizon<Frame>;
-  using const_global_cache_tags = tmpl::list<InterpolationTargetTag>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::ApparentHorizon<InterpolationTargetTag, Frame>>;
   using initialization_tags =
       tmpl::append<StrahlkorperTags::items_tags<Frame>,
                    tmpl::list<::ah::Tags::FastFlow, ::Tags::Verbosity>,
@@ -133,7 +162,9 @@ struct ApparentHorizon {
   static auto initialize(
       db::DataBox<DbTags>&& box,
       const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
-    const auto& options = Parallel::get<InterpolationTargetTag>(cache);
+    const auto& options =
+        Parallel::get<Tags::ApparentHorizon<InterpolationTargetTag, Frame>>(
+            cache);
 
     // Put Strahlkorper and its ComputeItems, FastFlow,
     // and verbosity into a new DataBox.

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
@@ -67,7 +67,7 @@ struct KerrHorizon {
               const OptionContext& context = {});
 
   KerrHorizon() = default;
-  KerrHorizon(const KerrHorizon& /*rhs*/) = delete;
+  KerrHorizon(const KerrHorizon& /*rhs*/) = default;
   KerrHorizon& operator=(const KerrHorizon& /*rhs*/) = delete;
   KerrHorizon(KerrHorizon&& /*rhs*/) noexcept = default;
   KerrHorizon& operator=(KerrHorizon&& /*rhs*/) noexcept = default;
@@ -86,6 +86,31 @@ bool operator==(const KerrHorizon& lhs, const KerrHorizon& rhs) noexcept;
 bool operator!=(const KerrHorizon& lhs, const KerrHorizon& rhs) noexcept;
 
 }  // namespace OptionHolders
+
+namespace OptionTags {
+template <typename InterpolationTargetTag>
+struct KerrHorizon {
+  using type = OptionHolders::KerrHorizon;
+  static constexpr OptionString help{
+      "Options for interpolation onto Kerr horizon."};
+  static std::string name() noexcept {
+    return option_name<InterpolationTargetTag>();
+  }
+  using group = InterpolationTargets;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+template <typename InterpolationTargetTag>
+struct KerrHorizon : db::SimpleTag {
+  using type = OptionHolders::KerrHorizon;
+  using option_tags =
+      tmpl::list<OptionTags::KerrHorizon<InterpolationTargetTag>>;
+  static type create_from_options(const type& option) noexcept {
+    return option;
+  }
+};
+}  // namespace Tags
 
 namespace Actions {
 /// \ingroup ActionsGroup
@@ -119,8 +144,8 @@ namespace Actions {
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
 template <typename InterpolationTargetTag, typename Frame>
 struct KerrHorizon {
-  using options_type = OptionHolders::KerrHorizon;
-  using const_global_cache_tags = tmpl::list<InterpolationTargetTag>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::KerrHorizon<InterpolationTargetTag>>;
   using initialization_tags =
       tmpl::append<StrahlkorperTags::items_tags<Frame>,
                    StrahlkorperTags::compute_items_tags<Frame>>;
@@ -128,7 +153,8 @@ struct KerrHorizon {
   static auto initialize(
       db::DataBox<DbTags>&& box,
       const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
-    const auto& options = Parallel::get<InterpolationTargetTag>(cache);
+    const auto& options =
+        Parallel::get<Tags::KerrHorizon<InterpolationTargetTag>>(cache);
 
     // Make a Strahlkorper with the correct shape.
     ::Strahlkorper<Frame> strahlkorper(

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -129,7 +129,7 @@ struct WedgeSectionTorus {
                     const OptionContext& context = {});
 
   WedgeSectionTorus() = default;
-  WedgeSectionTorus(const WedgeSectionTorus& /*rhs*/) = delete;
+  WedgeSectionTorus(const WedgeSectionTorus& /*rhs*/) = default;
   WedgeSectionTorus& operator=(const WedgeSectionTorus& /*rhs*/) = delete;
   WedgeSectionTorus(WedgeSectionTorus&& /*rhs*/) noexcept = default;
   WedgeSectionTorus& operator=(WedgeSectionTorus&& /*rhs*/) noexcept = default;
@@ -156,6 +156,31 @@ bool operator!=(const WedgeSectionTorus& lhs,
 
 }  // namespace OptionHolders
 
+namespace OptionTags {
+template <typename InterpolationTargetTag>
+struct WedgeSectionTorus {
+  using type = OptionHolders::WedgeSectionTorus;
+  static constexpr OptionString help{
+      "Options for interpolation onto Kerr horizon."};
+  static std::string name() noexcept {
+    return option_name<InterpolationTargetTag>();
+  }
+  using group = InterpolationTargets;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+template <typename InterpolationTargetTag>
+struct WedgeSectionTorus : db::SimpleTag {
+  using type = OptionHolders::WedgeSectionTorus;
+  using option_tags =
+      tmpl::list<OptionTags::WedgeSectionTorus<InterpolationTargetTag>>;
+  static type create_from_options(const type& option) noexcept {
+    return option;
+  }
+};
+}  // namespace Tags
+
 namespace Actions {
 /// \ingroup ActionsGroup
 /// \brief Sends points in a wedge-sectioned torus to an `Interpolator`.
@@ -177,8 +202,8 @@ namespace Actions {
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
 template <typename InterpolationTargetTag>
 struct WedgeSectionTorus {
-  using options_type = OptionHolders::WedgeSectionTorus;
-  using const_global_cache_tags = tmpl::list<InterpolationTargetTag>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::WedgeSectionTorus<InterpolationTargetTag>>;
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
             typename ArrayIndex,
             Requires<tmpl::list_contains_v<
@@ -188,7 +213,8 @@ struct WedgeSectionTorus {
       Parallel::ConstGlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/,
       const typename Metavariables::temporal_id::type& temporal_id) noexcept {
-    const auto& options = Parallel::get<InterpolationTargetTag>(cache);
+    const auto& options =
+        Parallel::get<Tags::WedgeSectionTorus<InterpolationTargetTag>>(cache);
 
     // Compute locations of constant r/theta/phi surfaces
     const size_t num_radial = options.number_of_radial_points;

--- a/src/NumericalAlgorithms/Interpolation/Tags.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Tags.hpp
@@ -23,6 +23,17 @@ class ElementId;
 
 namespace intrp {
 
+
+namespace OptionTags {
+/*!
+ * \ingroup OptionGroupsGroup
+ * \brief Groups option tags for InterpolationTargets.
+ */
+struct InterpolationTargets {
+  static constexpr OptionString help{"Options for interpolation targets"};
+};
+}  // namespace OptionTags
+
 /// Tags for items held in the `DataBox` of `InterpolationTarget` or
 /// `Interpolator`.
 namespace Tags {

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -205,8 +205,6 @@ struct MockMetavariables {
     using post_interpolation_callback =
         intrp::callbacks::FindApparentHorizon<AhA>;
     using post_horizon_find_callback = PostHorizonFindCallback;
-    // This `type` is so this tag can be used to read options.
-    using type = typename compute_target_points::options_type;
   };
   using interpolator_source_vars =
       tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
@@ -256,7 +254,8 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
       false);
 
   tuples::TaggedTuple<::Tags::Domain<3, Frame::Inertial>,
-                      typename metavars::AhA>
+                      typename ::intrp::Tags::ApparentHorizon<
+                          typename metavars::AhA, Frame::Inertial>>
       tuple_of_opts{std::move(domain_creator.create_domain()),
                     std::move(apparent_horizon_opts)};
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -134,10 +134,11 @@ struct mock_interpolator {
       MockReceivePoints<typename Metavariables::InterpolationTargetA>>;
 };
 
-template <typename MetaVariables, typename DomainCreator,
-          typename InterpolationTargetOption, typename BlockCoordHolder>
+template <typename MetaVariables, typename InterpolationTargetOptionTag,
+          typename DomainCreator, typename BlockCoordHolder>
 void test_interpolation_target(
-    const DomainCreator& domain_creator, InterpolationTargetOption options,
+    const DomainCreator& domain_creator,
+    typename InterpolationTargetOptionTag::type options,
     const BlockCoordHolder& expected_block_coord_holders) noexcept {
   using metavars = MetaVariables;
   using target_component =
@@ -146,7 +147,7 @@ void test_interpolation_target(
   using interp_component = mock_interpolator<metavars>;
 
   tuples::TaggedTuple<
-      typename metavars::InterpolationTargetA,
+      InterpolationTargetOptionTag,
       ::Tags::Domain<MetaVariables::volume_dim, Frame::Inertial>>
       tuple_of_opts{std::move(options),
                     std::move(domain_creator.create_domain())};

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -36,7 +36,6 @@ struct MockMetavariables {
     using compute_target_points =
         ::intrp::Actions::ApparentHorizon<InterpolationTargetA,
                                           ::Frame::Inertial>;
-    using type = compute_target_points::options_type;
   };
   using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
@@ -118,7 +117,10 @@ SPECTRE_TEST_CASE(
   }
   ();
 
-  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
+  InterpTargetTestHelpers::test_interpolation_target<
+      MockMetavariables,
+      intrp::Tags::ApparentHorizon<MockMetavariables::InterpolationTargetA,
+                                   Frame::Inertial>>(
       domain_creator, std::move(apparent_horizon_opts),
       expected_block_coord_holders);
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -32,7 +32,6 @@ struct MockMetavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::Actions::KerrHorizon<InterpolationTargetA, ::Frame::Inertial>;
-    using type = compute_target_points::options_type;
   };
   using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
@@ -129,7 +128,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.KerrHorizon",
   }
   ();
 
-  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
-      domain_creator, std::move(kerr_horizon_opts),
+  InterpTargetTestHelpers::test_interpolation_target<
+      MockMetavariables,
+      intrp::Tags::KerrHorizon<MockMetavariables::InterpolationTargetA>>(
+      domain_creator, kerr_horizon_opts,
       expected_block_coord_holders);
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -28,7 +28,6 @@ struct MockMetavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::Actions::LineSegment<InterpolationTargetA, 3>;
-    using type = compute_target_points::options_type;
   };
   using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
@@ -71,7 +70,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.LineSegment",
   }
   ();
 
-  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
+  InterpTargetTestHelpers::test_interpolation_target<
+      MockMetavariables,
+      intrp::Tags::LineSegment<MockMetavariables::InterpolationTargetA, 3>>(
       domain_creator, std::move(line_segment_opts),
       expected_block_coord_holders);
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -30,7 +30,6 @@ struct MockMetavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::Actions::WedgeSectionTorus<InterpolationTargetA>;
-    using type = compute_target_points::options_type;
   };
   using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
@@ -86,8 +85,10 @@ void test_r_theta_lgl() noexcept {
   }
   ();
 
-  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
-      domain_creator, std::move(wedge_section_torus_opts),
+  InterpTargetTestHelpers::test_interpolation_target<
+      MockMetavariables,
+      intrp::Tags::WedgeSectionTorus<MockMetavariables::InterpolationTargetA>>(
+      domain_creator, wedge_section_torus_opts,
       expected_block_coord_holders);
 }
 
@@ -124,8 +125,10 @@ void test_r_theta_uniform() noexcept {
   }
   ();
 
-  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
-      domain_creator, std::move(wedge_section_torus_opts),
+  InterpTargetTestHelpers::test_interpolation_target<
+      MockMetavariables,
+      intrp::Tags::WedgeSectionTorus<MockMetavariables::InterpolationTargetA>>(
+      domain_creator, wedge_section_torus_opts,
       expected_block_coord_holders);
 }
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -214,8 +214,6 @@ struct MockMetavariables {
             tmpl::list<StrahlkorperGr::Tags::SurfaceIntegral<
                 Tags::Square, ::Frame::Inertial>>,
             SurfaceA, SurfaceA>;
-    // This `type` is so this tag can be used to read options.
-    using type = typename compute_target_points::options_type;
   };
   struct SurfaceB {
     using compute_items_on_source = tmpl::list<>;
@@ -236,8 +234,6 @@ struct MockMetavariables {
                        StrahlkorperGr::Tags::SurfaceIntegral<
                            Tags::Negate, ::Frame::Inertial>>,
             SurfaceB, SurfaceB>;
-    // This `type` is so this tag can be used to read options.
-    using type = typename compute_target_points::options_type;
   };
   struct SurfaceC {
     using compute_items_on_source = tmpl::list<>;
@@ -255,8 +251,6 @@ struct MockMetavariables {
             tmpl::list<StrahlkorperGr::Tags::SurfaceIntegral<
                 Tags::Negate, ::Frame::Inertial>>,
             SurfaceC, SurfaceC>;
-    // This `type` is so this tag can be used to read options.
-    using type = typename compute_target_points::options_type;
   };
 
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
@@ -306,13 +300,15 @@ SPECTRE_TEST_CASE(
                                                         1.5, {{0.0, 0.0, 0.0}});
   const auto domain_creator =
       domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
-  tuples::TaggedTuple<observers::Tags::ReductionFileName, metavars::SurfaceA,
-                      ::Tags::Domain<3, Frame::Inertial>, metavars::SurfaceB,
-                      metavars::SurfaceC>
-      tuple_of_opts{h5_file_prefix, std::move(kerr_horizon_opts_A),
+  tuples::TaggedTuple<observers::Tags::ReductionFileName,
+                      ::intrp::Tags::KerrHorizon<metavars::SurfaceA>,
+                      ::Tags::Domain<3, Frame::Inertial>,
+                      ::intrp::Tags::KerrHorizon<metavars::SurfaceB>,
+                      ::intrp::Tags::KerrHorizon<metavars::SurfaceC>>
+      tuple_of_opts{h5_file_prefix, kerr_horizon_opts_A,
                     domain_creator.create_domain(),
-                    std::move(kerr_horizon_opts_B),
-                    std::move(kerr_horizon_opts_C)};
+                    kerr_horizon_opts_B,
+                    kerr_horizon_opts_C};
 
   ActionTesting::MockRuntimeSystem<metavars> runner{std::move(tuple_of_opts)};
   runner.set_phase(metavars::Phase::Initialization);


### PR DESCRIPTION
Previously each InterpolationTargetTag was also the OptionsTag for
InterpolationTargetTag::compute_target_points (this was so you can have
many InterpolationTargetTags specified in the input file, with options
specified under the InterpolationTargetTag names, e.g. AhA or AhB).
This was moderately confusing because the InterpolationTargetTag struct
served two purposes. It became more confusing after the recent change
fdcb568 that made the ConstGlobalCache hold SimpleTags instead of
OptionTags; after that change, to get the Interpolator to work properly
with input files InterpolationTargetTag would need to be a
SimpleTag and an OptionTag, so one struct would serve 3 purposes.

This commit simplifies the above situation so that InterpolationTargetTag
no longer needs to tag options.

Now each InterpolationTargetTag::compute_target_points (LineSegment,
KerrHorizon, etc) has its own Tag and its own OptionsTag, separate
from InterpolationTargetTag.  To allow options for multiple InterpolationTargetTags
to be specified in the input file, these Tags and OptionTags are templated
on InterpolationTargetTag.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
