### PR TITLE
Improvements to ConstGlobalCache tag lists

### DIFF
--- a/docs/DevGuide/CreatingExecutables.md
+++ b/docs/DevGuide/CreatingExecutables.md
@@ -83,13 +83,14 @@ the `PrintMessage` action is called during the `Execute` phase.
 The `PrintMessage` action is executed on whatever process the singleton
 component is created upon, and prints a message.
 
-Executables can read in an input file (specified by the `--input-file` argument)
-that will be parsed when the executable begins.  %Options specified in the input
-file can be used to either place items in a constant global cache (by specifying
-options in the `const_global_cache_tag_list` of the metavariables or component
-structs) or be passed to the `initialize` function of a component (by specifying
-options in the `options` type alias of the component).  `SingletonHelloWorld`
-specifies a single option
+Executables can read in an input file (specified by the `--input-file`
+argument) that will be parsed when the executable begins.  %Options
+specified in the input file can be used to either place items in a
+constant global cache (by specifying tags in the
+`const_global_cache_tags` type alias of the metavariables or component
+structs) or be passed to the `allocate_array` function of an array
+component (by specifying tags in the `allocation_tags` type alias of
+the component).  `SingletonHelloWorld` specifies a single option
 
 \snippet SingletonHelloWorld.hpp executable_example_options
 

--- a/docs/DevGuide/CreatingExecutables.md
+++ b/docs/DevGuide/CreatingExecutables.md
@@ -85,12 +85,15 @@ component is created upon, and prints a message.
 
 Executables can read in an input file (specified by the `--input-file`
 argument) that will be parsed when the executable begins.  %Options
-specified in the input file can be used to either place items in a
-constant global cache (by specifying tags in the
-`const_global_cache_tags` type alias of the metavariables or component
-structs) or be passed to the `allocate_array` function of an array
-component (by specifying tags in the `allocation_tags` type alias of
-the component).  `SingletonHelloWorld` specifies a single option
+specified in the input file can be used to either place items in the
+Parallel::ConstGlobalCache (by specifying tags in the
+`const_global_cache_tags` type alias of the metavariables, component
+and action structs), to construct items in the db::DataBox of
+components during initialization (by specifying tags in the
+`initialization_tags` type alias of action struct), or be passed to
+the `allocate_array` function of an array component (by specifying
+tags in the `allocation_tags` type alias of the component).
+`SingletonHelloWorld` specifies a single option
 
 \snippet SingletonHelloWorld.hpp executable_example_options
 

--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -55,8 +55,9 @@ specify the following:
   `DgElementArray` parallel component listed. An example of a `component_list`
   for one of the test executables is:
   \snippet Test_AlgorithmCore.cpp component_list_example
-- `using const_global_cache_tag_list`: a (possibly empty) `tmpl::list` of
-  OptionTags that are needed by the metavariables.
+- `using const_global_cache_tags`: a `tmpl::list` of tags that are
+  used to place items in the ConstGlobalCache.  The alias may be
+  omitted if the list is empty.
 - `Phase`: an `enum class` that must contain at least `Initialization` and
   `Exit`. Phases are described in the next section.
 - `determine_next_phase`: a static function with the signature
@@ -194,12 +195,12 @@ Each %Parallel Component struct must have the following type aliases:
    `tmpl::list` of tags that will be fetched from the DataBox by the
    action.  All `initialization_tags` are removed from the DataBox of
    the component at the end of the `Initialization` phase.
-5. `using const_global_cache_tag_list` is set to a `tmpl::list` of
-   tags that are required by the parallel component. This is usually
-   obtained from the `phase_dependent_action_list` using the
-   `Parallel::get_const_global_cache_tags` metafunction. These tags
-   correspond to items that are stored in the ConstGlobalCaches (of
-   which there is one copy per Charm++ node).
+5. `using const_global_cache_tags` is set to a `tmpl::list` of tags
+   that are required by the `allocate_array` function of a parallel
+   component, or simple actions called on the parallel component.
+   These tags correspond to items that are stored in the
+   ConstGlobalCaches (of which there is one copy per Charm++ node).
+   The alias can be omitted if the list is empty.
 
 \note Array parallel components must also specify the type alias `using
 array_index`, which is set to the type that indexes the %Parallel Component

--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -106,7 +106,7 @@ In contrast, an evolution executable might have phases
 similar `switch` or `if-else` logic in the `determine_next_phase`
 function. The first phase that is entered is always
 `Initialization`. During the `Initialization` phase the
-`ConstGlobalCache` is created, all non-array components are created,
+`Parallel::ConstGlobalCache` is created, all non-array components are created,
 and empty array components are created.  Next, the function
 `allocate_array_components_and_execute_initialization_phase` is called
 which allocates the elements of each array component, and then starts
@@ -172,18 +172,19 @@ Each %Parallel Component struct must have the following type aliases:
    Component struct have a template parameter `Metavariables` that is the
    global metavariables struct. Examples of this technique are given below.
 3. `using phase_dependent_action_list` is set to a `tmpl::list` of
-   `Parallel::PhaseActions<PhaseType, Phase, tmpl::list<Actions...>>` where each
-   `PhaseAction` represents a PDAL that will be executed on the parallel
-   component during the specified phase. The  %Actions are executed in the order
-   that they are given in the `tmpl::list`s of the PDALs, but the phases need
-   not be run in linear order. However, `DataBox` types are constructed assuming
-   the phases are performed from first in the `phase_dependent_action_list` to
-   the last. Simple actions (described below) can be executed in any phase. If
-   there are no iterable actions in a phase then a `PhaseAction` need not be
-   specified for that phase. However, at least one `PhaseAction`, even it if is
-   empty, must be specified.
+   `Parallel::PhaseActions<PhaseType, Phase, tmpl::list<Actions...>>`
+   where each `PhaseAction` represents a PDAL that will be executed on
+   the parallel component during the specified phase. The %Actions are
+   executed in the order that they are given in the `tmpl::list`s of
+   the PDALs, but the phases need not be run in linear order. However,
+   `db::DataBox` types are constructed assuming the phases are
+   performed from first in the `phase_dependent_action_list` to the
+   last. Simple actions (described below) can be executed in any
+   phase. If there are no iterable actions in a phase then a
+   `PhaseAction` need not be specified for that phase. However, at
+   least one `PhaseAction`, even if it is empty, must be specified.
 4. `using initialization_tags` which is a `tmpl::list` of all the tags
-   that will be inserted into the initial `DataBox` of each component.
+   that will be inserted into the initial `db::DataBox` of each component.
    These tags are db::SimpleTag%s that have have a `using option_tags`
    type alias and a static function `create_from_options` (see the
    example below).  This list can usually be constructed from the
@@ -192,15 +193,18 @@ Each %Parallel Component struct must have the following type aliases:
    helper function `Parallel::get_initialization_tags` (see the
    examples of components below).  Each initialization action may
    specify a type alias `using initialization_tags` which are a
-   `tmpl::list` of tags that will be fetched from the DataBox by the
-   action.  All `initialization_tags` are removed from the DataBox of
+   `tmpl::list` of tags that will be fetched from the db::DataBox by the
+   action.  All `initialization_tags` are removed from the db::DataBox of
    the component at the end of the `Initialization` phase.
 5. `using const_global_cache_tags` is set to a `tmpl::list` of tags
-   that are required by the `allocate_array` function of a parallel
+   that are required by the `allocate_array` function of an array
    component, or simple actions called on the parallel component.
    These tags correspond to items that are stored in the
-   ConstGlobalCaches (of which there is one copy per Charm++ node).
-   The alias can be omitted if the list is empty.
+   Parallel::ConstGlobalCache (of which there is one copy per Charm++
+   node).  The alias can be omitted if the list is empty.  (See
+   `array_allocation_tags` below for specifying tags needed for the
+   `allocate_array` function, but will not be added to the
+   Parallel::ConstGlobalCache.)
 
 \note Array parallel components must also specify the type alias `using
 array_index`, which is set to the type that indexes the %Parallel Component
@@ -270,7 +274,7 @@ For those familiar with Charm++, actions should be thought of as effectively
 being entry methods. They are functions that can be invoked on a remote object
 (chare/parallel component) using a `CProxy` (see the [Charm++
 manual](http://charm.cs.illinois.edu/help)), which is retrieved from the
-ConstGlobalCache using the parallel component struct and the
+Parallel::ConstGlobalCache using the parallel component struct and the
 `Parallel::get_parallel_component()` function. %Actions are structs with a
 static `apply` method and come in three variants: simple actions, iterable
 actions, and reduction actions. One important thing to note
@@ -293,27 +297,30 @@ and methods using template parameters and invocation of actions. This approach
 allows us to eliminate the need for users to work with Charm++'s interface
 files, which can be error prone and difficult to use.
 
-The ConstGlobalCache is passed to each action so that the action has access
-to global data and is able to invoke actions on other parallel components. The
-`ParallelComponent` template parameter is the tag of the parallel component that
-invoked the action. A proxy to the calling parallel component can then be
-retrieved from the ConstGlobalCache. The remote entry method invocations are
-slightly different for different types of actions, so they will be discussed
-below. However, one thing that is disallowed for all actions is calling an
-action locally from within an action on the same parallel component.
-Specifically,
+The Parallel::ConstGlobalCache is passed to each action so that the
+action has access to global data and is able to invoke actions on
+other parallel components. The `ParallelComponent` template parameter
+is the tag of the parallel component that invoked the action. A proxy
+to the calling parallel component can then be retrieved from the
+Parallel::ConstGlobalCache. The remote entry method invocations are
+slightly different for different types of actions, so they will be
+discussed below. However, one thing that is disallowed for all actions
+is calling an action locally from within an action on the same
+parallel component.  Specifically,
 
 \snippet Test_AlgorithmNestedApply1.cpp bad_recursive_call
 
-Here `ckLocal()`  is a Charm++ provided method that returns a pointer to the
-local (currently executing) parallel component. See the [Charm++
-manual](http://charm.cs.illinois.edu/help) for more information.
-However, you are able to queue a new action to be executed later on the same
-parallel component by getting your own parallel component from the
-ConstGlobalCache (`Parallel::get_parallel_component<ParallelComponent>(cache)`).
-The difference between the two calls is that by calling an action through the
-parallel component you will first finish the series of actions you are in, then
-when they are complete Charm++ will call the next queued action.
+Here `ckLocal()` is a Charm++ provided method that returns a pointer
+to the local (currently executing) parallel component. See the
+[Charm++ manual](http://charm.cs.illinois.edu/help) for more
+information.  However, you are able to queue a new action to be
+executed later on the same parallel component by getting your own
+parallel component from the Parallel::ConstGlobalCache
+(`Parallel::get_parallel_component<ParallelComponent>(cache)`).  The
+difference between the two calls is that by calling an action through
+the parallel component you will first finish the series of actions you
+are in, then when they are complete Charm++ will call the next queued
+action.
 
 Array, group, and nodegroup parallel components can have actions invoked in two
 ways. First is a broadcast where the action is called on all elements of the
@@ -339,21 +346,22 @@ That is, it is equal to the `action_list` type alias in the current PDAL.
 
 ## 1. Simple Actions {#dev_guide_parallelization_simple_actions}
 
-Simple actions are designed to be called in a similar fashion to member
-functions of classes. They are the direct analog of entry methods in Charm++
-except that the member data is stored in the `db::DataBox` that is passed in as
-the first argument. A simple action must return void but can use `db::mutate` to
-change values of items in the `DataBox` if the `DataBox` is taken as a non-const
-reference. In some cases you will need specific items to be in the `DataBox`
-otherwise the action won't compile. To restrict which `DataBox`es can be passed
-you should use `Requires` in the action's `apply` function template parameter
-list. For example,
+Simple actions are designed to be called in a similar fashion to
+member functions of classes. They are the direct analog of entry
+methods in Charm++ except that the member data is stored in the
+`db::DataBox` that is passed in as the first argument. A simple action
+must return void but can use `db::mutate` to change values of items in
+the `db::DataBox` if the `db::DataBox` is taken as a non-const
+reference. In some cases you will need specific items to be in the
+`db::DataBox` otherwise the action won't compile. To restrict which
+`db::DataBox`es can be passed you should use `Requires` in the
+action's `apply` function template parameter list. For example,
 \snippet Test_AlgorithmCore.cpp requires_action
 where the conditional checks if any element in the parameter pack `DbTags` is
 `CountActionsCalled`.
 
 A simple action that does not take any arguments can be called using a `CProxy`
-from the ConstGlobalCache as follows:
+from the Parallel::ConstGlobalCache as follows:
 
 \snippet Test_AlgorithmCore.cpp simple_action_call
 
@@ -404,33 +412,36 @@ It is the responsibility of the iterable action to remove data from the inboxes
 that will no longer be needed. The removal of unneeded data should be done in
 the `apply` function.
 
-Iterable actions can change the type of the DataBox by adding or removing
-elements/tags from the DataBox. The only requirement is that the last action in
-each PDAL returns a DataBox that is the same type for each
-iteration. Iterable actions can also request that the algorithm no
-longer be executed, and control which action in the current PDAL will be
-executed next. This is all done via the return value from the `apply` function.
-The `apply` function for iterable actions must return a `std::tuple` of one,
-two, or three elements. The first element of the tuple is the new DataBox,
-which can be the same as the type passed in or a DataBox with different tags.
-Most iterable actions will simply return:
+Iterable actions can change the type of the db::DataBox by adding or
+removing elements/tags from the db::DataBox. The only requirement is
+that the last action in each PDAL returns a db::DataBox that is the
+same type for each iteration. Iterable actions can also request that
+the algorithm no longer be executed, and control which action in the
+current PDAL will be executed next. This is all done via the return
+value from the `apply` function.  The `apply` function for iterable
+actions must return a `std::tuple` of one, two, or three elements. The
+first element of the tuple is the new db::DataBox, which can be the
+same as the type passed in or a db::DataBox with different tags.  Most
+iterable actions will simply return:
 
 \snippet Test_AlgorithmParallel.cpp return_forward_as_tuple
 
-By returning the DataBox as a reference in a `std::tuple` we avoid any
-unnecessary copying of the DataBox. The second argument is an optional bool, and
-controls whether or not the algorithm is terminated. If the bool is `true` then
-the algorithm is terminated, by default it is `false`. Here is an example of how
-to return a DataBox with the same type that is passed in and also terminate
+By returning the db::DataBox as a reference in a `std::tuple` we avoid
+any unnecessary copying of the db::DataBox. The second argument is an
+optional bool, and controls whether or not the algorithm is
+terminated. If the bool is `true` then the algorithm is terminated, by
+default it is `false`. Here is an example of how to return a
+db::DataBox with the same type that is passed in and also terminate
 the algorithm:
 
 \snippet Test_AlgorithmParallel.cpp return_with_termination
 
-Notice that we again return a reference to the DataBox, which is done to avoid
-any copying. After an algorithm has been terminated it can be restarted by
-passing `false` to the `set_terminate` method or by calling `receive_data(...,
-true)`. Since the order in which messages are received is undefined in most
-cases the `receive_data(..., true)` call should be used to restart the
+Notice that we again return a reference to the db::DataBox, which is
+done to avoid any copying. After an algorithm has been terminated it
+can be restarted by passing `false` to the `set_terminate` method or
+by calling `receive_data(..., true)`. Since the order in which
+messages are received is undefined in most cases the
+`receive_data(..., true)` call should be used to restart the
 algorithm.
 
 The third optional element in the returned `std::tuple` is a `size_t` whose
@@ -441,11 +452,12 @@ get an `tmpl::integral_constant` with the value of the index of the element
 
 \snippet Test_AlgorithmCore.cpp out_of_order_action
 
-Again a reference to the DataBox is returned, while the termination `bool` and
-next action `size_t` are returned by value. The metafunction call
-`tmpl::index_of<ActionList, iterate_increment_int0>::%value` returns a `size_t`
-whose value is that of the action `iterate_increment_int0` in the PDAL.
-The indexing of actions in the PDAL starts at `0`.
+Again a reference to the db::DataBox is returned, while the
+termination `bool` and next action `size_t` are returned by value. The
+metafunction call `tmpl::index_of<ActionList,
+iterate_increment_int0>::%value` returns a `size_t` whose value is
+that of the action `iterate_increment_int0` in the PDAL.  The indexing
+of actions in the PDAL starts at `0`.
 
 Iterable actions are invoked as part of the algorithm and so the only way
 to request they be invoked is by having the algorithm run on the parallel

--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -41,9 +41,8 @@ struct DgElementArray {
   using phase_dependent_action_list = PhaseDepActionList;
   using array_index = ElementIndex<volume_dim>;
 
-  using const_global_cache_tag_list = tmpl::flatten<tmpl::append<
-      Parallel::get_const_global_cache_tags_from_pdal<PhaseDepActionList>,
-      tmpl::list<::Tags::Domain<volume_dim, Frame::Inertial>>>>;
+  using const_global_cache_tags =
+      tmpl::list<::Tags::Domain<volume_dim, Frame::Inertial>>;
 
   using array_allocation_tags =
       tmpl::list<::Tags::InitialRefinementLevels<volume_dim>>;

--- a/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
@@ -75,7 +75,7 @@ struct Metavariables {
       Tags::NumericalFlux<Poisson::FirstOrderInternalPenaltyFlux<Dim>>;
 
   // Collect all items to store in the cache.
-  using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
+  using const_global_cache_tags = tmpl::list<analytic_solution_tag>;
 
   // Collect all reduction tags for observers
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -36,9 +36,8 @@ struct DgElementArray {
   using phase_dependent_action_list = PhaseDepActionList;
   using array_index = ElementIndex<volume_dim>;
 
-  using const_global_cache_tag_list = tmpl::flatten<tmpl::append<
-      Parallel::get_const_global_cache_tags_from_pdal<PhaseDepActionList>,
-      tmpl::list<::Tags::Domain<volume_dim, Frame::Inertial>>>>;
+  using const_global_cache_tags =
+      tmpl::list<::Tags::Domain<volume_dim, Frame::Inertial>>;
 
   using array_allocation_tags =
       tmpl::list<::Tags::InitialRefinementLevels<volume_dim>>;

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -95,7 +95,7 @@ struct EvolutionMetavars {
                      1, db::get_variables_tags_list<system::variables_tag>>>;
   using triggers = Triggers::time_triggers;
 
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<initial_data_tag,
                  Tags::TimeStepper<tmpl::conditional_t<
                      local_time_stepping, LtsTimeStepper, TimeStepper>>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -244,7 +244,7 @@ struct EvolutionMetavars {
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
                       compute_rhs, update_variables, Actions::AdvanceTime>>>>>>;
 
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<initial_data_tag,
                  Tags::TimeStepper<tmpl::conditional_t<
                      local_time_stepping, LtsTimeStepper, TimeStepper>>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -212,7 +212,7 @@ struct EvolutionMetavars {
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
                       compute_rhs, update_variables, Actions::AdvanceTime>>>>>>;
 
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<initial_data_tag,
                  Tags::TimeStepper<tmpl::conditional_t<
                      local_time_stepping, LtsTimeStepper, TimeStepper>>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -99,7 +99,7 @@ struct EvolutionMetavars {
 
   // A tmpl::list of tags to be added to the ConstGlobalCache by the
   // metavariables
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<initial_data_tag,
                  Tags::TimeStepper<tmpl::conditional_t<
                      local_time_stepping, LtsTimeStepper, TimeStepper>>,

--- a/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
+++ b/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
@@ -58,7 +58,7 @@ struct PrintMessage {
 /// [executable_example_singleton]
 template <class Metavariables>
 struct HelloWorld {
-  using const_global_cache_tag_list = tmpl::list<Tags::Name>;
+  using const_global_cache_tags = tmpl::list<Tags::Name>;
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
@@ -83,8 +83,6 @@ void HelloWorld<Metavariables>::execute_next_phase(
 
 /// [executable_example_metavariables]
 struct Metavars {
-  using const_global_cache_tag_list = tmpl::list<>;
-
   using component_list = tmpl::list<HelloWorld<Metavars>>;
 
   static constexpr OptionString help{

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -100,7 +100,6 @@ struct Metavariables {
 
   enum class Phase { Initialization, RegisterWithObserver, Export, Exit };
 
-  using const_global_cache_tag_list = tmpl::list<>;
   using component_list = tmpl::list<
       DgElementArray<
           Metavariables,

--- a/src/IO/Observer/ObserverComponent.hpp
+++ b/src/IO/Observer/ObserverComponent.hpp
@@ -26,7 +26,6 @@ namespace observers {
 template <class Metavariables>
 struct Observer {
   using chare_type = Parallel::Algorithms::Group;
-  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename metavariables::Phase, metavariables::Phase::Initialization,
@@ -48,7 +47,7 @@ struct Observer {
 template <class Metavariables>
 struct ObserverWriter {
   using chare_type = Parallel::Algorithms::Nodegroup;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<Tags::ReductionFileName, Tags::VolumeFileName>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -122,9 +122,10 @@ struct InterpolationTarget {
     }
   };
   using chare_type = ::Parallel::Algorithms::Singleton;
-  using const_global_cache_tag_list = Parallel::get_const_global_cache_tags<
-      tmpl::list<typename InterpolationTargetTag::compute_target_points,
-                 typename InterpolationTargetTag::post_interpolation_callback>>;
+  using const_global_cache_tags =
+      Parallel::get_const_global_cache_tags_from_actions<tmpl::list<
+          typename InterpolationTargetTag::compute_target_points,
+          typename InterpolationTargetTag::post_interpolation_callback>>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<

--- a/src/NumericalAlgorithms/Interpolation/Interpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Interpolator.hpp
@@ -21,7 +21,6 @@ namespace intrp {
 template <class Metavariables>
 struct Interpolator {
   using chare_type = Parallel::Algorithms::Group;
-  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename metavariables::Phase, metavariables::Phase::Initialization,

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
@@ -39,7 +39,7 @@ namespace cg_detail {
 template <typename Metavariables, typename FieldsTag>
 struct ResidualMonitor {
   using chare_type = Parallel::Algorithms::Singleton;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<LinearSolver::Tags::Verbosity,
                  LinearSolver::Tags::ConvergenceCriteria>;
   using metavariables = Metavariables;

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -39,7 +39,7 @@ namespace gmres_detail {
 template <typename Metavariables, typename FieldsTag>
 struct ResidualMonitor {
   using chare_type = Parallel::Algorithms::Singleton;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<LinearSolver::Tags::Verbosity,
                  LinearSolver::Tags::ConvergenceCriteria>;
   using metavariables = Metavariables;

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -370,7 +370,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>> {
 
   bool terminate_{true};
 
-  using all_cache_tags = ConstGlobalCache_detail::make_tag_list<metavariables>;
+  using all_cache_tags = get_const_global_cache_tags<metavariables>;
   using initial_databox = db::compute_databox_type<tmpl::flatten<tmpl::list<
       Tags::ConstGlobalCacheImpl<metavariables>,
       typename ParallelComponent::initialization_tags,

--- a/src/Parallel/ConstGlobalCache.ci
+++ b/src/Parallel/ConstGlobalCache.ci
@@ -2,7 +2,6 @@
 // See LICENSE.txt for details.
 
 module ConstGlobalCache {
-  include "Parallel/ConstGlobalCacheHelper.hpp";
   include "Parallel/ParallelComponentHelpers.hpp";
   include "Utilities/TaggedTuple.hpp";
   namespace Parallel {
@@ -11,7 +10,7 @@ module ConstGlobalCache {
   nodegroup[migratable] ConstGlobalCache {
     entry ConstGlobalCache(
         tuples::tagged_tuple_from_typelist<
-            typename ConstGlobalCache_detail::make_tag_list<Metavariables>>&);
+            get_const_global_cache_tags<Metavariables>>&);
     entry void set_parallel_components(
         tuples::tagged_tuple_from_typelist<tmpl::transform<
             typename Metavariables::component_list,

--- a/src/Parallel/ConstGlobalCache.hpp
+++ b/src/Parallel/ConstGlobalCache.hpp
@@ -69,9 +69,33 @@ using get_component_if_mocked = tmpl::front<tmpl::type_from<tmpl::conditional_t<
 /// \ingroup ParallelGroup
 /// A Charm++ chare that caches constant data once per Charm++ node.
 ///
-/// Metavariables must define the following metavariables:
-///   - const_global_cache_tag_list   typelist of tags of constant data
-///   - component_list   typelist of ParallelComponents
+///` Metavariables` must define the following metavariables:
+///   - `component_list`   typelist of ParallelComponents
+///   - `const_global_cache_tags`   (possibly empty) typelist of tags of
+///     constant data
+///
+/// The tag list for the items added to the ConstGlobalCache is created by
+/// combining the following tag lists:
+/// - `Metavariables::const_global_cache_tags` which should contain only those
+///    tags that cannot be added from the following tag lists:
+/// - `Component::const_global_cache_tags` for each `Component` in
+///   `Metavariables::component_list` which should contain the tags needed by
+///   any simple actions called on the Component, as well as tags need by the
+///   `allocate_array` function of an array component.  The type alias may be
+///   omitted for an empty list.
+/// - `Action::const_global_cache_tags` for each `Action` in the
+///    `phase_dependent_action_list` of each `Component` of
+///    `Metavariables::component_list` which should contain the tags needed by
+///    that  Action.  The type alias may be omitted for an empty list.
+///
+/// The tags in the `const_global_cache_tags` type lists are db::SimpleTag%s
+/// that have a `using option_tags` type alias and a static function
+/// `create_from_options` that are used to create the constant data from input
+/// file options.
+///
+/// References to items in the ConstGlobalCache are also added to the
+/// db::DataBox of each `Component` in the `Metavariables::component_list` with
+/// the same tag with which they were inserted into the ConstGlobalCache.
 template <typename Metavariables>
 class ConstGlobalCache : public CBase_ConstGlobalCache<Metavariables> {
   using parallel_component_tag_list = tmpl::transform<

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -39,8 +39,7 @@ template <typename Metavariables>
 class Main : public CBase_Main<Metavariables> {
  public:
   using component_list = typename Metavariables::component_list;
-  using const_global_cache_tags =
-      ConstGlobalCache_detail::make_tag_list<Metavariables>;
+  using const_global_cache_tags = get_const_global_cache_tags<Metavariables>;
 
   /// \cond HIDDEN_SYMBOLS
   /// The constructor used to register the class

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -385,8 +385,7 @@ class MockDistributedObject {
   using PhaseType =
       typename tmpl::front<phase_dependent_action_lists>::phase_type;
 
-  using all_cache_tags =
-      Parallel::ConstGlobalCache_detail::make_tag_list<metavariables>;
+  using all_cache_tags = Parallel::get_const_global_cache_tags<metavariables>;
   using initialization_tags =
       typename detail::get_initialization_tags_from_component<Component>::type;
   using initial_tags = tmpl::flatten<tmpl::list<
@@ -1315,7 +1314,7 @@ class MockRuntimeSystem {
 
   using GlobalCache = Parallel::ConstGlobalCache<Metavariables>;
   using CacheTuple = tuples::tagged_tuple_from_typelist<
-      Parallel::ConstGlobalCache_detail::make_tag_list<Metavariables>>;
+      Parallel::get_const_global_cache_tags<Metavariables>>;
 
   using mock_objects_tags =
       tmpl::transform<typename Metavariables::component_list,

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -163,9 +163,10 @@ struct mock_interpolation_target {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = Parallel::get_const_global_cache_tags<
-      tmpl::list<typename InterpolationTargetTag::compute_target_points,
-                 typename InterpolationTargetTag::post_interpolation_callback>>;
+  using const_global_cache_tags =
+      Parallel::get_const_global_cache_tags_from_actions<tmpl::list<
+          typename InterpolationTargetTag::compute_target_points,
+          typename InterpolationTargetTag::post_interpolation_callback>>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<intrp::Actions::InitializeInterpolationTarget<
@@ -180,7 +181,6 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<intrp::Actions::InitializeInterpolator>>>;
@@ -218,7 +218,7 @@ struct MockMetavariables {
   using component_list =
       tmpl::list<mock_interpolation_target<MockMetavariables, AhA>,
                  mock_interpolator<MockMetavariables>>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<::Tags::Domain<3, Frame::Inertial>>;
 
   enum class Phase { Initialization, Registration, Testing, Exit };

--- a/tests/Unit/Elliptic/Actions/Test_ComputeOperatorAction.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_ComputeOperatorAction.cpp
@@ -50,7 +50,6 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndexType;
-  using const_global_cache_tag_list = tmpl::list<>;
   using simple_tags =
       db::AddSimpleTags<var_tag,
                         LinearSolver::Tags::OperatorAppliedTo<var_tag>>;
@@ -66,7 +65,6 @@ struct Component {
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
   using system = System;
-  using const_global_cache_tag_list = tmpl::list<>;
   using temporal_id = TemporalId;
   enum class Phase { Initialization, Testing, Exit };
 };

--- a/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
@@ -62,7 +62,7 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<::Tags::Domain<Dim, Frame::Inertial>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -81,7 +81,7 @@ struct Metavariables {
   using system = System<Dim>;
   using component_list = tmpl::list<ElementArray<Dim, Metavariables>>;
   using analytic_solution_tag = Tags::AnalyticSolution<AnalyticSolution<Dim>>;
-  using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
+  using const_global_cache_tags = tmpl::list<analytic_solution_tag>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
@@ -182,7 +182,7 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tag_list = tmpl::list<NumericalFluxTag>;
+  using const_global_cache_tags = tmpl::list<NumericalFluxTag>;
 
   using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
   using simple_tags = db::AddSimpleTags<
@@ -230,7 +230,6 @@ struct Metavariables {
   using system = System;
   using component_list = tmpl::list<ElementArray<Metavariables>>;
   using temporal_id = TemporalId;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using normal_dot_numerical_flux = NumericalFluxTag;
   enum class Phase { Initialization, Testing, Exit };

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
@@ -96,7 +96,6 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -127,7 +126,7 @@ struct Metavariables {
   using analytic_solution_tag = Tags::AnalyticSolution<AnalyticSolution<Dim>>;
   using normal_dot_numerical_flux = Tags::NumericalFlux<NumericalFlux<Dim>>;
   using component_list = tmpl::list<ElementArray<Dim, Metavariables>>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<analytic_solution_tag, normal_dot_numerical_flux>;
   enum class Phase { Initialization, Testing, Exit };
 };

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
@@ -124,10 +124,8 @@ struct ElementArray {
 template <size_t Dim>
 struct Metavariables {
   using system = System<Dim>;
-  using analytic_solution_tag =
-      OptionTags::AnalyticSolution<AnalyticSolution<Dim>>;
-  using normal_dot_numerical_flux =
-      OptionTags::NumericalFlux<NumericalFlux<Dim>>;
+  using analytic_solution_tag = Tags::AnalyticSolution<AnalyticSolution<Dim>>;
+  using normal_dot_numerical_flux = Tags::NumericalFlux<NumericalFlux<Dim>>;
   using component_list = tmpl::list<ElementArray<Dim, Metavariables>>;
   using const_global_cache_tag_list =
       tmpl::list<analytic_solution_tag, normal_dot_numerical_flux>;

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
@@ -45,7 +45,7 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<::Tags::Domain<Dim, Frame::Inertial>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -83,7 +83,6 @@ template <size_t Dim>
 struct Metavariables {
   using system = System<Dim>;
   using component_list = tmpl::list<ElementArray<Dim, Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
@@ -53,7 +53,6 @@ struct MockElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<2>;
-  using const_global_cache_tag_list = tmpl::list<>;
   using simple_tags =
       db::AddSimpleTags<LinearSolver::Tags::IterationId, Tags::Mesh<2>,
                         Poisson::Field, Tags::Coordinates<2, Frame::Inertial>>;
@@ -79,7 +78,6 @@ struct MockObserverComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
   using component_being_mocked = observers::Observer<Metavariables>;
   using simple_tags =
       typename observers::Actions::Initialize<Metavariables>::simple_tags;
@@ -95,9 +93,8 @@ struct MockObserverWriterComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list =
-      tmpl::list<observers::Tags::ReductionFileName,
-                 observers::Tags::VolumeFileName>;
+  using const_global_cache_tags = tmpl::list<observers::Tags::ReductionFileName,
+                                             observers::Tags::VolumeFileName>;
   using component_being_mocked = observers::ObserverWriter<Metavariables>;
   using simple_tags =
       typename observers::Actions::InitializeWriter<Metavariables>::simple_tags;
@@ -127,7 +124,7 @@ struct Metavariables {
                                     MockObserverComponent<Metavariables>,
                                     MockObserverWriterComponent<Metavariables>>;
   using analytic_solution_tag = AnalyticSolutionTag;
-  using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
+  using const_global_cache_tags = tmpl::list<analytic_solution_tag>;
 
   struct ObservationType {};
   using element_observation_type = ObservationType;

--- a/tests/Unit/Evolution/Actions/Test_ComputeTimeDerivative.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeTimeDerivative.cpp
@@ -51,7 +51,6 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndexType;
-  using const_global_cache_tag_list = tmpl::list<>;
   using simple_tags = tmpl::list<var_tag, Tags::dt<var_tag>>;
 
   using phase_dependent_action_list = tmpl::list<
@@ -66,7 +65,6 @@ struct component {
 struct Metavariables {
   using component_list = tmpl::list<component<Metavariables>>;
   using system = System;
-  using const_global_cache_tag_list = tmpl::list<>;
   using temporal_id = TemporalId;
 
   enum class Phase { Initialization, Testing, Exit };

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
@@ -63,7 +63,6 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndexType;
-  using const_global_cache_tag_list = tmpl::list<>;
   using simple_tags = tmpl::list<Var1, Var2, flux_tag>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -77,7 +76,6 @@ struct component {
 struct Metavariables {
   using component_list = tmpl::list<component<Metavariables>>;
   using system = System;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 }  // namespace

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
@@ -74,7 +74,6 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndexType;
-  using const_global_cache_tag_list = tmpl::list<>;
   using simple_tags = tmpl::list<System::variables_tag, Var3, source_tag>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -88,7 +87,6 @@ struct component {
 struct Metavariables {
   using component_list = tmpl::list<component<Metavariables>>;
   using system = System;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 }  // namespace

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
@@ -104,7 +104,7 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tag_list = tmpl::list<LimiterTag>;
+  using const_global_cache_tags = tmpl::list<LimiterTag>;
   using simple_tags =
       db::AddSimpleTags<TemporalId, Tags::Mesh<Dim>, Tags::Element<Dim>,
                         Tags::ElementMap<Dim>, Var>;
@@ -121,7 +121,6 @@ struct component {
 template <size_t Dim>
 struct Metavariables {
   using component_list = tmpl::list<component<Dim, Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   using limiter = LimiterTag;
   using system = System<Dim>;
   using temporal_id = TemporalId;

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
@@ -65,7 +65,7 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tag_list = tmpl::list<LimiterTag>;
+  using const_global_cache_tags = tmpl::list<LimiterTag>;
   using simple_tags =
       db::AddSimpleTags<TemporalId, Tags::Mesh<Dim>, Tags::Element<Dim>,
                         Tags::ElementMap<Dim>,
@@ -86,7 +86,6 @@ struct component {
 template <size_t Dim>
 struct Metavariables {
   using component_list = tmpl::list<component<Dim, Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   using limiter = LimiterTag;
   using system = System<Dim>;
   using temporal_id = TemporalId;

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_Filtering.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_Filtering.cpp
@@ -80,8 +80,6 @@ struct Component {
               tmpl::list<dg::Actions::ExponentialFilter<
                   0, tmpl::list<Tags::VectorVar<dim>, Tags::ScalarVar>>>>>>;
   /// [action_list_example]
-  using const_global_cache_tag_list = Parallel::get_const_global_cache_tags<
-      typename tmpl::at_c<phase_dependent_action_list, 1>::action_list>;
 };
 
 template <size_t Dim, bool FilterIndividually>
@@ -91,7 +89,6 @@ struct Metavariables {
   using system = System<Dim>;
   static constexpr bool local_time_stepping = true;
   using component_list = tmpl::list<Component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ObserveErrorNorms.cpp
@@ -102,7 +102,6 @@ struct ElementComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
                                         Metavariables::Phase::Initialization,
@@ -119,7 +118,6 @@ struct MockObserverComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
                                         Metavariables::Phase::Initialization,
@@ -131,7 +129,7 @@ struct Metavariables {
   using system = System;
   using component_list = tmpl::list<ElementComponent<Metavariables>,
                                     MockObserverComponent<Metavariables>>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<Tags::AnalyticSolution<typename System::solution_for_test>>;
   enum class Phase { Initialization, Testing, Exit };
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ObserveFields.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ObserveFields.cpp
@@ -105,7 +105,6 @@ struct ElementComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Metavariables::system::volume_dim>;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
                                         Metavariables::Phase::Initialization,
@@ -122,7 +121,6 @@ struct MockObserverComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
                                         Metavariables::Phase::Initialization,
@@ -134,7 +132,7 @@ struct Metavariables {
   using system = System;
   using component_list = tmpl::list<ElementComponent<Metavariables>,
                                     MockObserverComponent<Metavariables>>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<Tags::AnalyticSolution<typename System::solution_for_test>>;
   enum class Phase { Initialization, Testing, Exit };
 

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -40,7 +40,7 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<events_and_triggers_tag>;
+  using const_global_cache_tags = tmpl::list<events_and_triggers_tag>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Testing,
       tmpl::list<Actions::RunEventsAndTriggers>>>;
@@ -48,7 +48,6 @@ struct Component {
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Actions.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Actions.cpp
@@ -33,8 +33,6 @@ struct mock_component {
   using array_index = size_t;
   using Closure = typename RadiationTransport::M1Grey::ComputeM1Closure<
       typename Metavariables::neutrino_species>;
-  using const_global_cache_tag_list = Parallel::get_const_global_cache_tags<
-      tmpl::list<Actions::UpdateM1Closure>>;
   using simple_tags = db::AddSimpleTags<tmpl::flatten<
       tmpl::list<typename Closure::return_tags, typename Closure::argument_tags,
                  Tags::Coordinates<3, Frame::Inertial>>>>;
@@ -49,7 +47,6 @@ struct mock_component {
 
 struct Metavariables {
   using component_list = tmpl::list<mock_component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   using neutrino_species = tmpl::list<neutrinos::ElectronNeutrinos<1>,
                                       neutrinos::HeavyLeptonNeutrinos<0>>;
   enum class Phase { Initialization, Testing, Exit };

--- a/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
@@ -42,14 +42,10 @@ struct mock_component {
                              Metavariables::Phase::Testing,
                              tmpl::list<VariableFixing::Actions::FixVariables<
                                  VariableFixing::RadiallyFallingFloor<3>>>>>;
-  using const_global_cache_tag_list =
-      Parallel::get_const_global_cache_tags_from_pdal<
-          phase_dependent_action_list>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<mock_component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 }  // namespace

--- a/tests/Unit/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/IO/Observers/ObserverHelpers.hpp
@@ -46,7 +46,6 @@ struct element_component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndexType;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase,
@@ -61,7 +60,6 @@ struct observer_component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using component_being_mocked = observers::Observer<Metavariables>;
   using simple_tags =
@@ -79,9 +77,8 @@ struct observer_writer_component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list =
-      tmpl::list<observers::Tags::ReductionFileName,
-                 observers::Tags::VolumeFileName>;
+  using const_global_cache_tags = tmpl::list<observers::Tags::ReductionFileName,
+                                             observers::Tags::VolumeFileName>;
 
   using component_being_mocked = observers::ObserverWriter<Metavariables>;
   using simple_tags =
@@ -108,7 +105,6 @@ struct Metavariables {
       tmpl::list<element_component<Metavariables, TypeOfObservation>,
                  observer_component<Metavariables>,
                  observer_writer_component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   /// [make_reduction_data_tags]
   using observed_reduction_data_tags =

--- a/tests/Unit/IO/Observers/Test_Initialize.cpp
+++ b/tests/Unit/IO/Observers/Test_Initialize.cpp
@@ -23,7 +23,6 @@ struct observer_component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using simple_tags =
       typename observers::Actions::Initialize<Metavariables>::simple_tags;
@@ -37,7 +36,6 @@ struct observer_component {
 
 struct Metavariables {
   using component_list = tmpl::list<observer_component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   using observed_reduction_data_tags = tmpl::list<>;
 
   enum class Phase { Initialization, Testing, Exit };

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
@@ -84,7 +84,7 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<2>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<Tags::TimeStepper<LtsTimeStepper>, NumericalFluxTag>;
   using simple_tags =
       db::AddSimpleTags<Tags::Mesh<2>, Tags::Mortars<Tags::Mesh<1>, 2>,
@@ -106,7 +106,6 @@ struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
   using temporal_id = TimeStepId;
   static constexpr bool local_time_stepping = true;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using normal_dot_numerical_flux = NumericalFluxTag;
   enum class Phase { Initialization, Testing, Exit };

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyFluxes.cpp
@@ -103,7 +103,7 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tag_list = tmpl::list<NumericalFluxTag<Flux>>;
+  using const_global_cache_tags = tmpl::list<NumericalFluxTag<Flux>>;
   using simple_tags =
       db::AddSimpleTags<Tags::Mesh<Dim>, Tags::Coordinates<Dim, Frame::Logical>,
                         Tags::Mortars<Tags::Mesh<Dim - 1>, Dim>,
@@ -126,7 +126,6 @@ struct Metavariables {
   using component_list = tmpl::list<component<Dim, Flux, Metavariables>>;
   using temporal_id = TemporalId;
   static constexpr bool local_time_stepping = false;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using normal_dot_numerical_flux = NumericalFluxTag<Flux>;
   enum class Phase { Initialization, Testing, Exit };

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -106,7 +106,6 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<2>;
-  using const_global_cache_tag_list = tmpl::list<>;
   using simple_tags =
       db::AddSimpleTags<Tags::Element<2>, Tags::Mesh<2>, Tags::ElementMap<2>,
                         interface_tag<Tags::Variables<tmpl::list<Var, Var2>>>,
@@ -134,7 +133,6 @@ struct component {
 struct Metavariables {
   using system = System;
   using component_list = tmpl::list<component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -160,7 +160,7 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tag_list = tmpl::list<NumericalFluxTag<Dim>>;
+  using const_global_cache_tags = tmpl::list<NumericalFluxTag<Dim>>;
   using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
 
   using simple_tags =
@@ -197,7 +197,6 @@ struct Metavariables {
   using system = System<Dim>;
   using component_list = tmpl::list<component<Dim, Metavariables>>;
   using temporal_id = TemporalId;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using normal_dot_numerical_flux = NumericalFluxTag<Dim>;
   enum class Phase { Initialization, Testing, Exit };

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -158,7 +158,7 @@ struct lts_component {
   using metavariables = MV;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tag_list = tmpl::list<NumericalFluxTag<Dim>>;
+  using const_global_cache_tags = tmpl::list<NumericalFluxTag<Dim>>;
   using flux_comm_types = dg::FluxCommunicationTypes<MV>;
 
   using simple_tags = db::AddSimpleTags<
@@ -192,7 +192,6 @@ struct LtsMetavariables {
   using system = System<Dim>;
   using component_list = tmpl::list<lts_component<Dim, LtsMetavariables>>;
   using temporal_id = TemporalId;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using normal_dot_numerical_flux = NumericalFluxTag<Dim>;
   enum class Phase { Initialization, Testing, Exit };

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -194,7 +194,7 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<NumericalFluxTag, BoundaryConditionTag>;
   using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
 
@@ -240,7 +240,6 @@ struct Metavariables {
   using system = System<HasPrimitiveAndConservativeVars>;
   using component_list = tmpl::list<component<Metavariables>>;
   using temporal_id = TemporalId;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using normal_dot_numerical_flux = NumericalFluxTag;
   using boundary_condition_tag = BoundaryConditionTag;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -65,8 +65,8 @@ struct mock_interpolation_target {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
   using component_being_mocked = void;  // not needed.
-  using const_global_cache_tag_list = tmpl::flatten<tmpl::append<
-      Parallel::get_const_global_cache_tags<tmpl::list<
+  using const_global_cache_tags = tmpl::flatten<tmpl::append<
+      Parallel::get_const_global_cache_tags_from_actions<tmpl::list<
           typename Metavariables::InterpolationTargetA::compute_target_points>>,
       tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>>>;
   using phase_dependent_action_list = tmpl::list<
@@ -120,7 +120,6 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -52,7 +52,7 @@ struct mock_interpolation_target {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<::Tags::Domain<3, Frame::Inertial>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -97,7 +97,6 @@ struct MockMetavariables {
 
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
@@ -44,7 +44,6 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
   using simple_tags = db::get_items<
       intrp::Actions::InitializeInterpolator::return_tag_list<Metavariables>>;
   using phase_dependent_action_list = tmpl::list<
@@ -75,7 +74,6 @@ struct MockMetavariables {
       tmpl::list<InterpolationTagA, InterpolationTagB, InterpolationTagC>;
 
   using component_list = tmpl::list<mock_interpolator<MockMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -39,7 +39,7 @@ struct mock_interpolation_target {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<::Tags::Domain<3, Frame::Inertial>>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -57,7 +57,6 @@ struct Metavariables {
 
   using component_list = tmpl::list<
       mock_interpolation_target<Metavariables, InterpolationTargetA>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
@@ -31,7 +31,6 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<intrp::Actions::InitializeInterpolator>>>;
@@ -48,7 +47,6 @@ struct Metavariables {
   using interpolation_target_tags = tmpl::list<InterpolatorTargetA>;
 
   using component_list = tmpl::list<mock_interpolator<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -102,7 +102,6 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<intrp::Actions::InitializeInterpolator>>>;
@@ -116,7 +115,6 @@ struct mock_element {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Metavariables::volume_dim>;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
                                         Metavariables::Phase::Initialization,
@@ -135,7 +133,6 @@ struct MockMetavariables {
 
   using component_list = tmpl::list<mock_interpolator<MockMetavariables>,
                                     mock_element<MockMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -47,7 +47,6 @@ struct MockMetavariables {
       tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
                      MockMetavariables, InterpolationTargetA>,
                  InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -43,7 +43,6 @@ struct MockMetavariables {
       InterpTargetTestHelpers::mock_interpolation_target<MockMetavariables,
                                                          InterpolationTargetA>,
       InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -39,7 +39,6 @@ struct MockMetavariables {
       tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
                      MockMetavariables, InterpolationTargetA>,
                  InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -76,7 +76,7 @@ struct mock_interpolation_target {
   using array_index = size_t;
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>;
   using simple_tags =
       db::get_items<typename intrp::Actions::InitializeInterpolationTarget<
@@ -197,7 +197,6 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -230,7 +229,6 @@ struct MockMetavariables {
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
       mock_interpolator<MockMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -41,7 +41,6 @@ struct MockMetavariables {
       tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
                      MockMetavariables, InterpolationTargetA>,
                  InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -108,7 +108,7 @@ struct mock_interpolation_target {
   using array_index = size_t;
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>;
 
   using phase_dependent_action_list = tmpl::list<
@@ -132,7 +132,6 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -157,7 +156,6 @@ struct Metavariables {
   using component_list =
       tmpl::list<mock_interpolation_target<Metavariables, InterpolationTargetA>,
                  mock_interpolator<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -182,7 +182,7 @@ struct mock_interpolation_target {
   using array_index = size_t;
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>;
 
   using phase_dependent_action_list = tmpl::list<
@@ -212,7 +212,6 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
   using simple_tags = db::get_items<
       intrp::Actions::InitializeInterpolator::return_tag_list<Metavariables>>;
   using phase_dependent_action_list = tmpl::list<
@@ -239,7 +238,6 @@ struct MockMetavariables {
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
       mock_interpolator<MockMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Registration, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -33,7 +33,6 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -51,7 +50,6 @@ struct mock_element {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Initialization,
@@ -75,7 +73,6 @@ struct MockMetavariables {
 
   using component_list = tmpl::list<mock_interpolator<MockMetavariables>,
                                     mock_element<MockMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Registration, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -120,7 +120,7 @@ struct MockObserverWriter {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<observers::Tags::ReductionFileName>;
   using simple_tags =
       typename observers::Actions::InitializeWriter<Metavariables>::simple_tags;
@@ -161,8 +161,8 @@ struct MockInterpolationTarget {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::flatten<tmpl::append<
-      Parallel::get_const_global_cache_tags<tmpl::list<
+  using const_global_cache_tags = tmpl::flatten<tmpl::append<
+      Parallel::get_const_global_cache_tags_from_actions<tmpl::list<
           typename InterpolationTargetTag::compute_target_points,
           typename InterpolationTargetTag::post_interpolation_callback>>,
       tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>>>;
@@ -186,7 +186,6 @@ struct MockInterpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -277,7 +276,6 @@ struct MockMetavariables {
                  MockInterpolationTarget<MockMetavariables, SurfaceB>,
                  MockInterpolationTarget<MockMetavariables, SurfaceC>,
                  MockInterpolator<MockMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Registration, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -177,8 +177,8 @@ struct mock_interpolation_target {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::flatten<tmpl::append<
-      Parallel::get_const_global_cache_tags<
+  using const_global_cache_tags = tmpl::flatten<tmpl::append<
+      Parallel::get_const_global_cache_tags_from_actions<
           tmpl::list<intrp::Actions::LineSegment<InterpolationTargetTag, 3>>>,
       tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>>>;
   using phase_dependent_action_list = tmpl::list<
@@ -200,7 +200,6 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -256,7 +255,6 @@ struct MockMetavariables {
       mock_interpolation_target<MockMetavariables, InterpolationTargetB>,
       mock_interpolation_target<MockMetavariables, InterpolationTargetC>,
       mock_interpolator<MockMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Registration, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Actions/Test_TerminateIfConverged.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Actions/Test_TerminateIfConverged.cpp
@@ -25,7 +25,6 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -37,7 +36,6 @@ struct ElementArray {
 
 struct Metavariables {
   using component_list = tmpl::list<ElementArray<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
@@ -28,7 +28,6 @@ struct Metavariables {
                               observers::ObserverWriter<Metavariables>,
                               helpers::OutputCleaner<Metavariables>>,
                    typename linear_solver::component_list>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
@@ -31,7 +31,6 @@ struct Metavariables {
                               observers::ObserverWriter<Metavariables>,
                               helpers::OutputCleaner<Metavariables>>,
                    typename linear_solver::component_list>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ElementActions.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ElementActions.cpp
@@ -39,7 +39,6 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -57,7 +56,6 @@ struct ElementArray {
 
 struct Metavariables {
   using component_list = tmpl::list<ElementArray<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
@@ -85,9 +85,9 @@ struct MockResidualMonitor {
   // testing framework
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       typename LinearSolver::cg_detail::ResidualMonitor<
-          Metavariables, fields_tag>::const_global_cache_tag_list;
+          Metavariables, fields_tag>::const_global_cache_tags;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<
@@ -159,7 +159,6 @@ struct MockElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<check_tags>>>>;
@@ -177,7 +176,6 @@ struct Metavariables {
   using component_list = tmpl::list<MockResidualMonitor<Metavariables>,
                                     MockElementArray<Metavariables>,
                                     helpers::MockObserverWriter<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, RegisterWithObserver, Testing, Exit };
 };
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -299,7 +299,7 @@ struct ElementArray {
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>,
       array_allocation_tags>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<LinearOperator, Source, ExpectedResult>;
   using array_index = int;
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
@@ -30,7 +30,6 @@ struct Metavariables {
                               observers::ObserverWriter<Metavariables>,
                               helpers::OutputCleaner<Metavariables>>,
                    typename linear_solver::component_list>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
@@ -45,7 +45,6 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -64,7 +63,6 @@ struct ElementArray {
 
 struct Metavariables {
   using component_list = tmpl::list<ElementArray<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
@@ -27,7 +27,6 @@ struct Metavariables {
                               observers::ObserverWriter<Metavariables>,
                               helpers::OutputCleaner<Metavariables>>,
                    typename linear_solver::component_list>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
@@ -94,9 +94,9 @@ struct MockResidualMonitor {
   // testing framework
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       typename LinearSolver::gmres_detail::ResidualMonitor<
-          Metavariables, fields_tag>::const_global_cache_tag_list;
+          Metavariables, fields_tag>::const_global_cache_tags;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<
@@ -176,7 +176,6 @@ struct MockElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<check_tags>>>>;
@@ -194,7 +193,6 @@ struct Metavariables {
   using component_list = tmpl::list<MockResidualMonitor<Metavariables>,
                                     MockElementArray<Metavariables>,
                                     helpers::MockObserverWriter<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, RegisterWithObserver, Testing, Exit };
 };
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -222,7 +222,7 @@ struct ElementArray {
   /// [action_list]
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<LinearOperator, Source, InitialGuess, ExpectedResult>;
 
   static void allocate_array(
@@ -283,7 +283,6 @@ struct OutputCleaner {
                                         tmpl::list<CleanOutput<true>>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ResidualMonitorActionsTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ResidualMonitorActionsTestHelpers.hpp
@@ -87,7 +87,6 @@ struct MockObserverWriter {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<observer_writer_tags>>>>;

--- a/tests/Unit/Parallel/Actions/Test_Goto.cpp
+++ b/tests/Unit/Parallel/Actions/Test_Goto.cpp
@@ -18,7 +18,6 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Testing,
       tmpl::list<Actions::Goto<Label1>, Actions::Label<Label2>,
@@ -27,7 +26,6 @@ struct Component {
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   enum class Phase { Testing, Exit };
 };

--- a/tests/Unit/Parallel/Actions/Test_TerminatePhase.cpp
+++ b/tests/Unit/Parallel/Actions/Test_TerminatePhase.cpp
@@ -14,7 +14,6 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Testing,
       tmpl::list<Parallel::Actions::TerminatePhase>>>;
@@ -22,7 +21,6 @@ struct Component {
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/Parallel/Test_AlgorithmBadBoxApply.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmBadBoxApply.cpp
@@ -45,7 +45,6 @@ struct Component {
                                         tmpl::list<>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
@@ -61,7 +60,6 @@ struct Component {
 
 struct TestMetavariables {
   using component_list = tmpl::list<Component<TestMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   enum class Phase { Initialization, Execute, Exit };
 

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -210,7 +210,6 @@ struct NoOpsComponent {
                      no_op_test::no_op>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
@@ -371,7 +370,6 @@ struct MutateComponent {
                                         add_remove_test::remove_int0>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
 
   static void execute_next_phase(
@@ -538,7 +536,6 @@ struct ReceiveComponent {
                      receive_data_test::update_instance>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
@@ -649,7 +646,6 @@ struct AnyOrderComponent {
                                         receive_data_test::update_instance>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
@@ -671,7 +667,6 @@ struct TestMetavariables {
                                     ReceiveComponent<TestMetavariables>,
                                     AnyOrderComponent<TestMetavariables>>;
   /// [component_list_example]
-  using const_global_cache_tag_list = tmpl::list<>;
 
   /// [help_string_example]
   static constexpr OptionString help =

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
@@ -45,7 +45,6 @@ struct Component {
                                         tmpl::list<>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
@@ -61,7 +60,6 @@ struct Component {
 
 struct TestMetavariables {
   using component_list = tmpl::list<Component<TestMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   enum class Phase { Initialization, Execute, Exit };
 

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
@@ -49,7 +49,6 @@ struct Component {
                                         tmpl::list<>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
@@ -65,7 +64,6 @@ struct Component {
 
 struct TestMetavariables {
   using component_list = tmpl::list<Component<TestMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   enum class Phase { Initialization, Execute, Exit };
 

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -251,7 +251,6 @@ struct reduce_threaded_method {
 template <class Metavariables>
 struct ArrayParallelComponent {
   using chare_type = Parallel::Algorithms::Array;
-  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
   using array_index = int;
   using phase_dependent_action_list =
@@ -304,7 +303,6 @@ struct ArrayParallelComponent {
 template <class Metavariables>
 struct NodegroupParallelComponent {
   using chare_type = Parallel::Algorithms::Nodegroup;
-  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
@@ -345,7 +343,6 @@ struct TestMetavariables {
   using component_list =
       tmpl::list<ArrayParallelComponent<TestMetavariables>,
                  NodegroupParallelComponent<TestMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   static constexpr const char* const help{"Test nodelocks in Algorithm"};
   static constexpr bool ignore_unrecognized_command_line_options = false;

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -431,7 +431,6 @@ struct Initialize {
 template <class Metavariables>
 struct SingletonParallelComponent {
   using chare_type = Parallel::Algorithms::Singleton;
-  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -460,7 +459,6 @@ struct SingletonParallelComponent {
 template <class Metavariables>
 struct ArrayParallelComponent {
   using chare_type = Parallel::Algorithms::Array;
-  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -507,7 +505,6 @@ struct ArrayParallelComponent {
 template <class Metavariables>
 struct GroupParallelComponent {
   using chare_type = Parallel::Algorithms::Group;
-  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -524,7 +521,6 @@ struct GroupParallelComponent {
 template <class Metavariables>
 struct NodegroupParallelComponent {
   using chare_type = Parallel::Algorithms::Nodegroup;
-  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -545,7 +541,6 @@ struct TestMetavariables {
                  ArrayParallelComponent<TestMetavariables>,
                  GroupParallelComponent<TestMetavariables>,
                  NodegroupParallelComponent<TestMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   static constexpr const char* const help{"Test Algorithm in parallel"};
   static constexpr bool ignore_unrecognized_command_line_options = false;

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -104,7 +104,6 @@ struct ProcessCustomReductionAction {
 template <class Metavariables>
 struct SingletonParallelComponent {
   using chare_type = Parallel::Algorithms::Singleton;
-  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
@@ -229,7 +228,6 @@ struct ArrayReduce {
 template <class Metavariables>
 struct ArrayParallelComponent {
   using chare_type = Parallel::Algorithms::Array;
-  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
   using array_index = int;
   using phase_dependent_action_list =
@@ -272,7 +270,6 @@ struct TestMetavariables {
   using component_list =
       tmpl::list<SingletonParallelComponent<TestMetavariables>,
                  ArrayParallelComponent<TestMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   static constexpr const char* const help{"Test reductions using Algorithm"};
   static constexpr bool ignore_unrecognized_command_line_options = false;

--- a/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
@@ -95,7 +95,7 @@ struct shape_of_nametag : shape_of_nametag_base {
 template <class Metavariables>
 struct SingletonParallelComponent {
   using chare_type = Parallel::Algorithms::Singleton;
-  using const_global_cache_tag_list = tmpl::list<name, age, height>;
+  using const_global_cache_tags = tmpl::list<name, age, height>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -107,7 +107,7 @@ struct SingletonParallelComponent {
 template <class Metavariables>
 struct ArrayParallelComponent {
   using chare_type = Parallel::Algorithms::Array;
-  using const_global_cache_tag_list = tmpl::list<height, shape_of_nametag>;
+  using const_global_cache_tags = tmpl::list<height, shape_of_nametag>;
   using array_index = int;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
@@ -120,7 +120,7 @@ struct ArrayParallelComponent {
 template <class Metavariables>
 struct GroupParallelComponent {
   using chare_type = Parallel::Algorithms::Group;
-  using const_global_cache_tag_list = tmpl::list<name>;
+  using const_global_cache_tags = tmpl::list<name>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -132,7 +132,7 @@ struct GroupParallelComponent {
 template <class Metavariables>
 struct NodegroupParallelComponent {
   using chare_type = Parallel::Algorithms::Nodegroup;
-  using const_global_cache_tag_list = tmpl::list<height>;
+  using const_global_cache_tags = tmpl::list<height>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -147,7 +147,6 @@ struct TestMetavariables {
                  ArrayParallelComponent<TestMetavariables>,
                  GroupParallelComponent<TestMetavariables>,
                  NodegroupParallelComponent<TestMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Testing, Exit };
 };
 
@@ -155,8 +154,8 @@ struct TestMetavariables {
 
 SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCache", "[Unit][Parallel]") {
   {
-    using tag_list = typename Parallel::ConstGlobalCache_detail::make_tag_list<
-        TestMetavariables>;
+    using tag_list =
+        typename Parallel::get_const_global_cache_tags<TestMetavariables>;
     static_assert(
         cpp17::is_same_v<tag_list,
                          tmpl::list<name, age, height, shape_of_nametag>>,
@@ -174,8 +173,8 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCache", "[Unit][Parallel]") {
   }
 
   {
-    using tag_list = typename Parallel::ConstGlobalCache_detail::make_tag_list<
-        TestMetavariables>;
+    using tag_list =
+        typename Parallel::get_const_global_cache_tags<TestMetavariables>;
     static_assert(
         cpp17::is_same_v<tag_list,
                          tmpl::list<name, age, height, shape_of_nametag>>,

--- a/tests/Unit/Parallel/Test_ConstGlobalCacheDataBox.cpp
+++ b/tests/Unit/Parallel/Test_ConstGlobalCacheDataBox.cpp
@@ -18,54 +18,48 @@
 #include "Utilities/TaggedTuple.hpp"
 
 namespace Parallel {
-namespace OptionTags {
-struct IntegerList : db::BaseTag {
+namespace Tags {
+struct IntegerList : db::SimpleTag {
   using type = std::array<int, 3>;
-  static constexpr OptionString help = {"Help"};
 };
 
 struct UniquePtrIntegerList : db::BaseTag {
   using type = std::unique_ptr<std::array<int, 3>>;
-  static constexpr OptionString help = {"Help"};
 };
-}  // namespace OptionTags
+}  // namespace Tags
 
 namespace {
 struct Metavars {
-  using const_global_cache_tag_list =
-      tmpl::list<OptionTags::IntegerList, OptionTags::UniquePtrIntegerList>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::IntegerList, Tags::UniquePtrIntegerList>;
   using component_list = tmpl::list<>;
 };
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCacheDataBox", "[Unit][Parallel]") {
-  tuples::TaggedTuple<OptionTags::IntegerList, OptionTags::UniquePtrIntegerList>
-      tuple{};
-  tuples::get<OptionTags::IntegerList>(tuple) = std::array<int, 3>{{-1, 3, 7}};
-  tuples::get<OptionTags::UniquePtrIntegerList>(tuple) =
+  tuples::TaggedTuple<Tags::IntegerList, Tags::UniquePtrIntegerList> tuple{};
+  tuples::get<Tags::IntegerList>(tuple) = std::array<int, 3>{{-1, 3, 7}};
+  tuples::get<Tags::UniquePtrIntegerList>(tuple) =
       std::make_unique<std::array<int, 3>>(std::array<int, 3>{{1, 5, -8}});
   ConstGlobalCache<Metavars> cache{std::move(tuple)};
-  auto box = db::create<
-      db::AddSimpleTags<Tags::ConstGlobalCacheImpl<Metavars>>,
-      db::AddComputeTags<
-          Tags::FromConstGlobalCache<OptionTags::IntegerList>,
-          Tags::FromConstGlobalCache<OptionTags::UniquePtrIntegerList>>>(
-      &cpp17::as_const(cache));
+  auto box =
+      db::create<db::AddSimpleTags<Tags::ConstGlobalCacheImpl<Metavars>>,
+                 db::AddComputeTags<
+                     Tags::FromConstGlobalCache<Tags::IntegerList>,
+                     Tags::FromConstGlobalCache<Tags::UniquePtrIntegerList>>>(
+          &cpp17::as_const(cache));
   CHECK(db::get<Tags::ConstGlobalCache>(box) == &cache);
-  CHECK(std::array<int, 3>{{-1, 3, 7}} ==
-        db::get<OptionTags::IntegerList>(box));
+  CHECK(std::array<int, 3>{{-1, 3, 7}} == db::get<Tags::IntegerList>(box));
   CHECK(std::array<int, 3>{{1, 5, -8}} ==
-        db::get<OptionTags::UniquePtrIntegerList>(box));
-  CHECK(&Parallel::get<OptionTags::IntegerList>(cache) ==
-        &db::get<OptionTags::IntegerList>(box));
-  CHECK(&Parallel::get<OptionTags::UniquePtrIntegerList>(cache) ==
-        &db::get<OptionTags::UniquePtrIntegerList>(box));
+        db::get<Tags::UniquePtrIntegerList>(box));
+  CHECK(&Parallel::get<Tags::IntegerList>(cache) ==
+        &db::get<Tags::IntegerList>(box));
+  CHECK(&Parallel::get<Tags::UniquePtrIntegerList>(cache) ==
+        &db::get<Tags::UniquePtrIntegerList>(box));
 
-  tuples::TaggedTuple<OptionTags::IntegerList, OptionTags::UniquePtrIntegerList>
-      tuple2{};
-  tuples::get<OptionTags::IntegerList>(tuple2) =
-      std::array<int, 3>{{10, -3, 700}};
-  tuples::get<OptionTags::UniquePtrIntegerList>(tuple2) =
+  tuples::TaggedTuple<Tags::IntegerList, Tags::UniquePtrIntegerList> tuple2{};
+  tuples::get<Tags::IntegerList>(tuple2) = std::array<int, 3>{{10, -3, 700}};
+  tuples::get<Tags::UniquePtrIntegerList>(tuple2) =
       std::make_unique<std::array<int, 3>>(std::array<int, 3>{{100, -7, -300}});
   ConstGlobalCache<Metavars> cache2{std::move(tuple2)};
   db::mutate<Tags::ConstGlobalCache>(
@@ -76,18 +70,17 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCacheDataBox", "[Unit][Parallel]") {
       });
 
   CHECK(db::get<Tags::ConstGlobalCache>(box) == &cache2);
-  CHECK(std::array<int, 3>{{10, -3, 700}} ==
-        db::get<OptionTags::IntegerList>(box));
+  CHECK(std::array<int, 3>{{10, -3, 700}} == db::get<Tags::IntegerList>(box));
   CHECK(std::array<int, 3>{{100, -7, -300}} ==
-        db::get<OptionTags::UniquePtrIntegerList>(box));
-  CHECK(&Parallel::get<OptionTags::IntegerList>(cache2) ==
-        &db::get<OptionTags::IntegerList>(box));
-  CHECK(&Parallel::get<OptionTags::UniquePtrIntegerList>(cache2) ==
-        &db::get<OptionTags::UniquePtrIntegerList>(box));
+        db::get<Tags::UniquePtrIntegerList>(box));
+  CHECK(&Parallel::get<Tags::IntegerList>(cache2) ==
+        &db::get<Tags::IntegerList>(box));
+  CHECK(&Parallel::get<Tags::UniquePtrIntegerList>(cache2) ==
+        &db::get<Tags::UniquePtrIntegerList>(box));
 
-  CHECK(Tags::FromConstGlobalCache<OptionTags::IntegerList>::name() ==
+  CHECK(Tags::FromConstGlobalCache<Tags::IntegerList>::name() ==
         "FromConstGlobalCache(IntegerList)");
-  CHECK(Tags::FromConstGlobalCache<OptionTags::UniquePtrIntegerList>::name() ==
+  CHECK(Tags::FromConstGlobalCache<Tags::UniquePtrIntegerList>::name() ==
         "FromConstGlobalCache(UniquePtrIntegerList)");
 }
 }  // namespace Parallel

--- a/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
+++ b/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
@@ -16,6 +16,10 @@ struct Tag0 {};
 struct Tag1 {};
 struct Tag2 {};
 struct Tag3 {};
+struct Tag4 {};
+struct Tag5 {};
+struct Tag6 {};
+struct Tag7 {};
 
 struct Action0 {
   using inbox_tags = tmpl::list<Tag0, Tag1>;
@@ -23,6 +27,7 @@ struct Action0 {
 struct Action1 {};
 struct Action2 {
   using inbox_tags = tmpl::list<Tag1, Tag2, Tag3>;
+  using const_global_cache_tags = tmpl::list<Tag6>;
 };
 
 struct InitTag0 {};
@@ -61,6 +66,7 @@ struct ComponentExecute {
                                         tmpl::list<Action0, Action1>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using const_global_cache_tags = tmpl::list<Tag2, Tag4>;
 };
 
 struct ComponentInitAndExecute {
@@ -81,6 +87,7 @@ struct ComponentInitWithAllocate {
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>,
       array_allocation_tags>;
+  using const_global_cache_tags = tmpl::list<Tag1, Tag5, Tag7>;
 };
 
 struct ComponentExecuteWithAllocate {
@@ -103,17 +110,90 @@ struct ComponentInitAndExecuteWithAllocate {
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>,
       array_allocation_tags>;
+  using const_global_cache_tags = tmpl::list<Tag2, Tag4>;
 };
 
-static_assert(cpp17::is_same_v<Parallel::get_inbox_tags_from_action<Action2>,
-                               tmpl::list<Tag1, Tag2, Tag3>>,
-              "Failed testing get_inbox_tags_from_action");
+struct Metavariables0 {
+  using component_list = tmpl::list<ComponentInit>;
+};
+
+struct Metavariables1 {
+  using const_global_cache_tags = tmpl::list<Tag0, Tag4>;
+  using component_list = tmpl::list<>;
+};
+
+struct Metavariables2 {
+  using component_list = tmpl::list<ComponentInitWithAllocate>;
+};
+
+struct Metavariables3 {
+  using const_global_cache_tags = tmpl::list<Tag0, Tag4>;
+  using component_list = tmpl::list<ComponentInitWithAllocate>;
+};
+
+struct Metavariables4 {
+  using component_list = tmpl::list<ComponentInitAndExecute>;
+};
+
+struct Metavariables5 {
+  using const_global_cache_tags = tmpl::list<Tag0, Tag4>;
+  using component_list = tmpl::list<ComponentInitAndExecute>;
+};
+
+struct Metavariables6 {
+  using component_list = tmpl::list<ComponentInitAndExecuteWithAllocate>;
+};
+
+struct Metavariables7 {
+  using const_global_cache_tags = tmpl::list<Tag0, Tag4>;
+  using component_list = tmpl::list<ComponentInitAndExecuteWithAllocate>;
+};
 
 static_assert(
     cpp17::is_same_v<
         Parallel::get_inbox_tags<tmpl::list<Action0, Action1, Action2>>,
         tmpl::list<Tag0, Tag1, Tag2, Tag3>>,
     "Failed testing get_inbox_tags");
+
+static_assert(
+    cpp17::is_same_v<Parallel::get_const_global_cache_tags<Metavariables0>,
+                     tmpl::list<>>,
+    "Failed testing get_const_global_cache_tags");
+
+static_assert(
+    cpp17::is_same_v<Parallel::get_const_global_cache_tags<Metavariables1>,
+                     tmpl::list<Tag0, Tag4>>,
+    "Failed testing get_const_global_cache_tags");
+
+static_assert(
+    cpp17::is_same_v<Parallel::get_const_global_cache_tags<Metavariables2>,
+                     tmpl::list<Tag1, Tag5, Tag7>>,
+    "Failed testing get_const_global_cache_tags");
+
+static_assert(
+    cpp17::is_same_v<Parallel::get_const_global_cache_tags<Metavariables3>,
+                     tmpl::list<Tag0, Tag4, Tag1, Tag5, Tag7>>,
+    "Failed testing get_const_global_cache_tags");
+
+static_assert(
+    cpp17::is_same_v<Parallel::get_const_global_cache_tags<Metavariables4>,
+                     tmpl::list<Tag6>>,
+    "Failed testing get_const_global_cache_tags");
+
+static_assert(
+    cpp17::is_same_v<Parallel::get_const_global_cache_tags<Metavariables5>,
+                     tmpl::list<Tag0, Tag4, Tag6>>,
+    "Failed testing get_const_global_cache_tags");
+
+static_assert(
+    cpp17::is_same_v<Parallel::get_const_global_cache_tags<Metavariables6>,
+                     tmpl::list<Tag2, Tag4, Tag6>>,
+    "Failed testing get_const_global_cache_tags");
+
+static_assert(
+    cpp17::is_same_v<Parallel::get_const_global_cache_tags<Metavariables7>,
+                     tmpl::list<Tag0, Tag4, Tag2, Tag6>>,
+    "Failed testing get_const_global_cache_tags");
 
 static_assert(
     cpp17::is_same_v<Parallel::get_initialization_actions_list<

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_MutateApply.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_MutateApply.cpp
@@ -38,7 +38,6 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Initialization,
@@ -52,7 +51,6 @@ struct Component {
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
@@ -37,7 +37,7 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<::Tags::Domain<Dim, Frame::Inertial>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -59,7 +59,6 @@ struct ElementArray {
 template <size_t Dim>
 struct Metavariables {
   using component_list = tmpl::list<ElementArray<Dim, Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
@@ -63,7 +63,7 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<::Tags::Domain<Dim, Frame::Inertial>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -87,7 +87,6 @@ template <size_t Dim>
 struct Metavariables {
   using system = System<Dim>;
   using component_list = tmpl::list<ElementArray<Dim, Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
@@ -52,7 +52,7 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<::Tags::Domain<Dim, Frame::Inertial>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -107,7 +107,6 @@ struct Metavariables {
   using temporal_id = TemporalId;
   static constexpr bool local_time_stepping = false;
   using normal_dot_numerical_flux = NormalDotNumericalFluxTag;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddComputeTags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddComputeTags.cpp
@@ -38,7 +38,6 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -53,7 +52,6 @@ struct Component {
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   enum class Phase { Initialization, Testing, Exit };
 };

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
@@ -94,7 +94,6 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   /// [actions]
   using initialization_actions =
@@ -112,8 +111,6 @@ struct Component {
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
-  using temporal_id = TemporalId;
 
   enum class Phase { Initialization, Exit };
 };

--- a/tests/Unit/Test_ActionTesting.cpp
+++ b/tests/Unit/Test_ActionTesting.cpp
@@ -48,7 +48,6 @@ struct component_for_simple_action_mock {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Initialization,
@@ -174,7 +173,6 @@ struct threaded_action_b_mock {
 struct SimpleActionMockMetavariables {
   using component_list = tmpl::list<
       component_for_simple_action_mock<SimpleActionMockMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   enum class Phase { Initialization, Testing, Exit };
 };
@@ -182,7 +180,7 @@ struct SimpleActionMockMetavariables {
 struct MockMetavariablesWithGlobalCacheTags {
   using component_list = tmpl::list<
       component_for_simple_action_mock<SimpleActionMockMetavariables>>;
-  using const_global_cache_tag_list = tmpl::list<ValueTag,PassedToB>;
+  using const_global_cache_tags = tmpl::list<ValueTag, PassedToB>;
 
   enum class Phase { Initialization, Testing, Exit };
 };
@@ -307,7 +305,6 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
@@ -317,7 +314,6 @@ struct Component {
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   enum class Phase { Testing, Exit };
 };

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -34,8 +34,7 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list =
-      tmpl::list<Tags::TimeStepper<TimeStepper>>;
+  using const_global_cache_tags = tmpl::list<Tags::TimeStepper<TimeStepper>>;
 
   using simple_tags =
       db::AddSimpleTags<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>,
@@ -52,7 +51,6 @@ struct Component {
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   enum class Phase { Initialization, Testing, Exit };
 };

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -52,8 +52,7 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list =
-      tmpl::list<Tags::TimeStepper<LtsTimeStepper>>;
+  using const_global_cache_tags = tmpl::list<Tags::TimeStepper<LtsTimeStepper>>;
   using simple_tags = tmpl::list<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>,
                                  Tags::TimeStep, history_tag>;
   using phase_dependent_action_list = tmpl::list<
@@ -68,7 +67,7 @@ struct Component {
 struct Metavariables {
   using system = System;
   static constexpr bool local_time_stepping = true;
-  using const_global_cache_tag_list = change_step_size::const_global_cache_tags;
+  using const_global_cache_tags = change_step_size::const_global_cache_tags;
   using component_list = tmpl::list<Component<Metavariables>>;
   enum class Phase { Initialization, Testing, Exit };
 };

--- a/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
+++ b/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
@@ -45,7 +45,6 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
   using simple_tags = db::AddSimpleTags<Tags::TimeStepId, variables_tag,
                                         dt_variables_tag, history_tag>;
   using compute_tags = db::AddComputeTags<Tags::SubstepTime>;
@@ -62,7 +61,6 @@ struct Component {
 struct Metavariables {
   using system = System;
   using component_list = tmpl::list<Component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialization, Testing, Exit };
 };
 }  // namespace

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -108,7 +108,6 @@ struct Metavariables {
   static constexpr bool has_primitives = HasPrimitives;
   using system = System<HasPrimitives>;
   using component_list = tmpl::list<Component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   using ordered_list_of_primitive_recovery_schemes = tmpl::list<>;
   using temporal_id = TemporalId;
 
@@ -120,8 +119,7 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list =
-      tmpl::list<Tags::TimeStepper<TimeStepper>>;
+  using const_global_cache_tags = tmpl::list<Tags::TimeStepper<TimeStepper>>;
   using simple_tags = tmpl::flatten<db::AddSimpleTags<
       typename metavariables::system::variables_tag,
       typename metavariables::system::test_primitive_variables_tags,

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -49,8 +49,7 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list =
-      tmpl::list<Tags::TimeStepper<TimeStepper>>;
+  using const_global_cache_tags = tmpl::list<Tags::TimeStepper<TimeStepper>>;
   using simple_tags =
       db::AddSimpleTags<Tags::TimeStep, variables_tag, history_tag>;
 
@@ -66,7 +65,6 @@ struct Component {
 struct Metavariables {
   using system = System;
   using component_list = tmpl::list<Component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
 
   enum class Phase { Initialization, Testing, Exit };
 };

--- a/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
@@ -25,7 +25,6 @@
 namespace {
 struct Metavariables {
   using component_list = tmpl::list<>;
-  using const_global_cache_tag_list = tmpl::list<>;
 };
 }  // namespace
 

--- a/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
@@ -45,8 +45,7 @@ struct CharacteristicSpeed : db::SimpleTag {
 
 struct Metavariables {
   using component_list = tmpl::list<>;
-  using const_global_cache_tag_list =
-      tmpl::list<Tags::TimeStepper<TimeStepper>>;
+  using const_global_cache_tags = tmpl::list<Tags::TimeStepper<TimeStepper>>;
   struct system {
     struct compute_largest_characteristic_speed {
       using argument_tags = tmpl::list<CharacteristicSpeed>;

--- a/tests/Unit/Time/StepChoosers/Test_Constant.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Constant.cpp
@@ -21,7 +21,6 @@
 namespace {
 struct Metavariables {
   using component_list = tmpl::list<>;
-  using const_global_cache_tag_list = tmpl::list<>;
 };
 
 using StepChooserType =

--- a/tests/Unit/Time/StepChoosers/Test_Increase.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Increase.cpp
@@ -25,7 +25,6 @@
 namespace {
 struct Metavariables {
   using component_list = tmpl::list<>;
-  using const_global_cache_tag_list = tmpl::list<>;
 };
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

- Unify name used for tag lists
- Eliminate empty lists
- Tags from actions in phase-dependent action lists of components are collected in the metafunction that collects all ConstGlobalCache tags instead of in each component.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
