### PR TITLE
Add cubic spline interpolator

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Interpolation)
 
 set(LIBRARY_SOURCES
   BarycentricRational.cpp
+  CubicSpline.cpp
   InterpolationTargetApparentHorizon.cpp
   InterpolationTargetKerrHorizon.cpp
   InterpolationTargetLineSegment.cpp

--- a/src/NumericalAlgorithms/Interpolation/CubicSpline.cpp
+++ b/src/NumericalAlgorithms/Interpolation/CubicSpline.cpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/CubicSpline.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <gsl/gsl_spline.h>
+#include <memory>
+#include <pup.h>
+
+#include "ErrorHandling/Assert.hpp"
+
+namespace intrp {
+CubicSpline::CubicSpline(std::vector<double> x_values,
+                         std::vector<double> y_values) noexcept
+    : x_values_(std::move(x_values)), y_values_(std::move(y_values)) {
+  ASSERT(x_values_.size() == y_values_.size(),
+         "The x-value and y-value vectors must be of the same length, but "
+         "received x-value of size: "
+             << x_values_.size()
+             << " and y-value of size: " << y_values_.size());
+  ASSERT(std::is_sorted(x_values_.begin(), x_values_.end()),
+         "The x-values must be sorted.");
+  initialize_interpolant();
+}
+
+void CubicSpline::gsl_interp_accel_deleter::operator()(
+    gsl_interp_accel* const acc) const noexcept {
+  gsl_interp_accel_free(acc);
+}
+
+void CubicSpline::gsl_spline_deleter::operator()(gsl_spline* const spline) const
+    noexcept {
+  gsl_spline_free(spline);
+}
+
+void CubicSpline::initialize_interpolant() noexcept {
+  const size_t num_points = x_values_.size();
+  acc_ = std::unique_ptr<gsl_interp_accel, gsl_interp_accel_deleter>{
+      gsl_interp_accel_alloc()};
+  spline_ = std::unique_ptr<gsl_spline, gsl_spline_deleter>{
+      gsl_spline_alloc(gsl_interp_cspline, num_points)};
+  gsl_spline_init(spline_.get(), x_values_.data(), y_values_.data(),
+                  num_points);
+}
+
+double CubicSpline::operator()(const double x_to_interp_to) const noexcept {
+  ASSERT(
+      x_to_interp_to >= x_values_.front() and
+          x_to_interp_to <= x_values_.back(),
+      "The point "
+          << x_to_interp_to
+          << " to interpolate to is outside the domain of the interpolation ["
+          << x_values_.front() << ", " << x_values_.back() << "].");
+  return gsl_spline_eval(spline_.get(), x_to_interp_to, acc_.get());
+}
+
+void CubicSpline::pup(PUP::er& p) noexcept {
+  p | x_values_;
+  p | y_values_;
+  if (p.isUnpacking()) {
+    initialize_interpolant();
+  }
+}
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/CubicSpline.hpp
+++ b/src/NumericalAlgorithms/Interpolation/CubicSpline.hpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <gsl/gsl_spline.h>
+#include <memory>
+#include <vector>
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace intrp {
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief A natural cubic spline interpolation class
+ *
+ * The class builds a cubic spline interpolant with natural boundary conditions
+ * using the `x_values` and `y_values` passed into the constructor. For details
+ * on the algorithm see the GSL documentation on `gsl_interp_cspline`.
+ *
+ * Here is an example how to use this class:
+ *
+ * \snippet Test_CubicSpline.cpp interpolate_example
+ */
+class CubicSpline {
+ public:
+  CubicSpline(std::vector<double> x_values,
+              std::vector<double> y_values) noexcept;
+
+  CubicSpline() noexcept = default;
+  CubicSpline(const CubicSpline& /*rhs*/) = delete;
+  CubicSpline& operator=(const CubicSpline& /*rhs*/) = delete;
+  CubicSpline(CubicSpline&& /*rhs*/) noexcept = default;
+  CubicSpline& operator=(CubicSpline&& rhs) noexcept = default;
+  ~CubicSpline() noexcept = default;
+
+  double operator()(double x_to_interp_to) const noexcept;
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  struct gsl_interp_accel_deleter {
+    void operator()(gsl_interp_accel* acc) const noexcept;
+  };
+  struct gsl_spline_deleter {
+    void operator()(gsl_spline* spline) const noexcept;
+  };
+
+  void initialize_interpolant() noexcept;
+
+  std::vector<double> x_values_;
+  std::vector<double> y_values_;
+  std::unique_ptr<gsl_interp_accel, gsl_interp_accel_deleter> acc_;
+  std::unique_ptr<gsl_spline, gsl_spline_deleter> spline_;
+};
+}  // namespace intrp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_AddTemporalIdsToInterpolationTarget.cpp
   Test_BarycentricRational.cpp
   Test_CleanUpInterpolator.cpp
+  Test_CubicSpline.cpp
   Test_InitializeInterpolationTarget.cpp
   Test_InitializeInterpolator.cpp
   Test_InterpolateEvent.cpp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
@@ -1,0 +1,142 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <random>
+#include <vector>
+
+#include "NumericalAlgorithms/Interpolation/CubicSpline.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+template <class F>
+void test_cubic_spline(const F& function, const double lower_bound,
+                       const double upper_bound, const size_t size,
+                       const double tolerance,
+                       const double tolerance_interior) noexcept {
+  // Construct random points between lower and upper bound to interpolate
+  // through. Always include the bounds in the x-values.
+  std::vector<double> x_values(size), y_values(size);
+  const double delta_x = (upper_bound - lower_bound) / size;
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(0., delta_x);
+  x_values.front() = lower_bound;
+  for (size_t i = 1; i < size - 1; ++i) {
+    x_values[i] = lower_bound + i * delta_x + dist(gen);
+  }
+  x_values.back() = upper_bound;
+  for (size_t i = 0; i < size; ++i) {
+    y_values[i] = function(x_values[i]);
+  }
+
+  Approx custom_approx = Approx::custom().epsilon(tolerance).scale(1.);
+  Approx custom_approx_interior =
+      Approx::custom().epsilon(tolerance_interior).scale(1.);
+
+  // Construct the interpolant and give an example
+  /// [interpolate_example]
+  intrp::CubicSpline interpolant{x_values, y_values};
+  const double x_to_interpolate_to =
+      lower_bound + (upper_bound - lower_bound) / 2.;
+  CHECK(interpolant(x_to_interpolate_to) ==
+        custom_approx_interior(function(x_to_interpolate_to)));
+  /// [interpolate_example]
+
+  // Check that the interpolation is exact at the datapoints
+  for (const auto& x_value : x_values) {
+    CHECK(interpolant(x_value) == approx(function(x_value)));
+  }
+
+  // Check that the interpolation matches the function within the given
+  // tolerance. Also check that the serialized-and-deserialized interpolant does
+  // the same.
+  const auto deserialized_interpolant = serialize_and_deserialize(interpolant);
+  double max_error = 0.;
+  double max_error_x_value = std::numeric_limits<double>::signaling_NaN();
+  double max_error_interior = 0.;
+  double max_error_interior_x_value =
+      std::numeric_limits<double>::signaling_NaN();
+  for (size_t i = 0; i < 10 * size; ++i) {
+    const double x_value = lower_bound + i * delta_x * 0.1 + 0.1 * dist(gen);
+    CAPTURE(x_value);
+    const double y_value = function(x_value);
+    const double interpolated_y_value = interpolant(x_value);
+    CHECK(interpolated_y_value == custom_approx(y_value));
+    CHECK(deserialized_interpolant(x_value) == interpolated_y_value);
+    // Record max error for better test failure reports
+    const double error = abs(interpolated_y_value - y_value);
+    if (error > max_error) {
+      max_error = error;
+      max_error_x_value = x_value;
+    }
+    // Test the interpolation away from the boundaries with a lower tolerance.
+    // Since this is a cubic spline interpolation, boundary effects should be
+    // confined to the outer three interpolation points.
+    const double boundary_fraction = 0.3;
+    if (i > 10 * size * boundary_fraction and
+        i < 10 * size * (1. - boundary_fraction)) {
+      CHECK(interpolated_y_value == custom_approx_interior(y_value));
+      if (error > max_error_interior) {
+        max_error_interior = error;
+        max_error_interior_x_value = x_value;
+      }
+    }
+  }
+  // Output information on the precision the interpolation achieved when it
+  // failed to stay within the given tolerances
+  CAPTURE_PRECISE(max_error);
+  CAPTURE_PRECISE(max_error_interior);
+  // These checks are needed to trigger the max_error captures above
+  CHECK(interpolant(max_error_x_value) ==
+        custom_approx(function(max_error_x_value)));
+  CHECK(interpolant(max_error_interior_x_value) ==
+        custom_approx_interior(function(max_error_interior_x_value)));
+
+  // Make sure moving the interpolant doesn't break anything
+  const auto moved_interpolant = std::move(interpolant);
+  const double x_value = lower_bound + dist(gen) * size;
+  const double y_value = function(x_value);
+  CHECK(moved_interpolant(x_value) == custom_approx(y_value));
+}
+
+void test_with_polynomial(const size_t number_of_points,
+                          const size_t polynomial_degree,
+                          const double tolerance,
+                          const double tolerance_interior) {
+  CAPTURE(polynomial_degree);
+  CAPTURE(number_of_points);
+  std::vector<double> coeffs(polynomial_degree + 1, 1.);
+  test_cubic_spline(
+      [&coeffs](const auto& x) noexcept {
+        return evaluate_polynomial(coeffs, x);
+      },
+      -1., 2.3, number_of_points, tolerance, tolerance_interior);
+}
+
+void test_with_natural_boundary(const size_t number_of_points,
+                                const double tolerance) {
+  CAPTURE(number_of_points);
+  // Precision at the boundaries should be the same as in the interior since
+  // the natural boundary conditions are correct for this function
+  test_cubic_spline(
+      [](const auto& x) noexcept { return cube(sin(x)); }, 0., M_PI,
+      number_of_points, tolerance, tolerance);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.CubicSpline",
+                  "[Unit][NumericalAlgorithms]") {
+  test_with_polynomial(10, 1, 1.e-14, 1.e-14);
+  test_with_polynomial(10, 2, 1.e-1, 1.e-2);
+  test_with_polynomial(100, 2, 1.e-3, 1.e-12);
+  test_with_polynomial(100, 3, 1.e-2, 1.e-12);
+  test_with_polynomial(1000, 3, 1.e-4, 1.e-12);
+  test_with_polynomial(1000, 4, 1.e-3, 1.e-9);
+  test_with_polynomial(1000, 5, 1.e-3, 1.e-8);
+  test_with_natural_boundary(10, 1.e-1);
+  test_with_natural_boundary(100, 1.e-5);
+  test_with_natural_boundary(1000, 1.e-9);
+}


### PR DESCRIPTION
## Proposed changes

This interpolator is more robust than the existing BarycentricRational interpolator when dealing with a lot of data points that may not be nicely spaced. This is the case e.g. for the result of a numerical integration as is done in the TOV solver.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
