### PR TITLE
Rewrite WENO reconstruction to better match references

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
@@ -132,7 +132,7 @@ void Minmod<VolumeDim, tmpl::list<Tags...>>::package_data(
   }
 
   const auto wrap_compute_means =
-      [&mesh, &packaged_data ](auto tag, const auto& tensor) noexcept {
+      [&mesh, &packaged_data ](auto tag, const auto tensor) noexcept {
     for (size_t i = 0; i < tensor.size(); ++i) {
       // Compute the mean using the local orientation of the tensor and mesh:
       // this avoids the work of reorienting the tensor while giving the same
@@ -181,7 +181,7 @@ bool Minmod<VolumeDim, tmpl::list<Tags...>>::operator()(
   const auto wrap_limit_one_tensor = [
     this, &limiter_activated, &element, &mesh, &logical_coords, &element_size,
     &neighbor_data, &u_lin_buffer, &boundary_buffer, &volume_and_slice_indices
-  ](auto tag, const auto& tensor) noexcept {
+  ](auto tag, const auto tensor) noexcept {
     limiter_activated =
         Minmod_detail::limit_one_tensor<VolumeDim, decltype(tag)>(
             tensor, &u_lin_buffer, &boundary_buffer, minmod_type_,

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
@@ -103,7 +103,7 @@ bool troubled_cell_indicator(
   // track of whether a previous component needed limiting... and if so, then
   // we simply skip any work.
   bool some_component_needs_limiting = false;
-  const auto wrap_tci_one_tensor = [&](auto tag, const auto& tensor) noexcept {
+  const auto wrap_tci_one_tensor = [&](auto tag, const auto tensor) noexcept {
     if (some_component_needs_limiting) {
       // Skip this tensor completely
       return '0';

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -222,7 +222,7 @@ void Weno<VolumeDim, tmpl::list<Tags...>>::package_data(
   }
 
   const auto wrap_compute_means =
-      [&mesh, &packaged_data ](auto tag, const auto& tensor) noexcept {
+      [&mesh, &packaged_data ](auto tag, const auto tensor) noexcept {
     for (size_t i = 0; i < tensor.size(); ++i) {
       // Compute the mean using the local orientation of the tensor and mesh.
       get<::Tags::Mean<decltype(tag)>>(packaged_data->means)[i] =
@@ -237,7 +237,7 @@ void Weno<VolumeDim, tmpl::list<Tags...>>::package_data(
 
   (packaged_data->volume_data).initialize(mesh.number_of_grid_points());
   const auto wrap_copy_tensor = [&packaged_data](auto tag,
-                                                 const auto& tensor) noexcept {
+                                                 const auto tensor) noexcept {
     get<decltype(tag)>(packaged_data->volume_data) = tensor;
     return '0';
   };
@@ -311,7 +311,7 @@ bool Weno<VolumeDim, tmpl::list<Tags...>>::operator()(
     }
     const auto wrap_hweno_neighbor_solution_one_tensor =
         [&element, &mesh, &neighbor_data, &
-         modified_neighbor_solutions ](auto tag, const auto& tensor) noexcept {
+         modified_neighbor_solutions ](auto tag, const auto tensor) noexcept {
       for (const auto& neighbor_and_data : neighbor_data) {
         const auto& primary_neighbor = neighbor_and_data.first;
         auto& modified_tensor = get<decltype(tag)>(
@@ -347,7 +347,7 @@ bool Weno<VolumeDim, tmpl::list<Tags...>>::operator()(
   // solutions.
   const auto wrap_reconstruct_one_tensor =
       [ this, &mesh, &
-        modified_neighbor_solutions ](auto tag, const auto& tensor) noexcept {
+        modified_neighbor_solutions ](auto tag, const auto tensor) noexcept {
     Weno_detail::reconstruct_from_weighted_sum<decltype(tag)>(
         tensor, mesh, neighbor_linear_weight_, modified_neighbor_solutions);
     return '0';

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
@@ -501,18 +501,33 @@ void test_simple_weno_1d(const std::unordered_set<Direction<1>>&
   VariablesMap<1> neighbor_vars{};
   VariablesMap<1> neighbor_modified_vars{};
 
+  const auto shift_vars_to_local_means = [&mesh, &local_vars ](
+      const Variables<tmpl::list<ScalarTag, VectorTag<1>>>& input) noexcept {
+    const auto& local_s = get<ScalarTag>(local_vars);
+    const auto& local_v = get<VectorTag<1>>(local_vars);
+    auto result = input;
+    auto& s = get<ScalarTag>(result);
+    auto& v = get<VectorTag<1>>(result);
+    get(s) += mean_value(get(local_s), mesh) - mean_value(get(s), mesh);
+    get<0>(v) +=
+        mean_value(get<0>(local_v), mesh) - mean_value(get<0>(v), mesh);
+    return result;
+  };
+
   const auto lower_xi =
       std::make_pair(Direction<1>::lower_xi(), ElementId<1>(1));
   if (directions_of_external_boundaries.count(lower_xi.first) == 0) {
     neighbor_vars[lower_xi] = make_lower_xi_vars(logical_coords, -2.0);
-    neighbor_modified_vars[lower_xi] = make_lower_xi_vars(logical_coords);
+    neighbor_modified_vars[lower_xi] =
+        shift_vars_to_local_means(make_lower_xi_vars(logical_coords));
   }
 
   const auto upper_xi =
       std::make_pair(Direction<1>::upper_xi(), ElementId<1>(2));
   if (directions_of_external_boundaries.count(upper_xi.first) == 0) {
     neighbor_vars[upper_xi] = make_upper_xi_vars(logical_coords, 2.0);
-    neighbor_modified_vars[upper_xi] = make_upper_xi_vars(logical_coords);
+    neighbor_modified_vars[upper_xi] =
+        shift_vars_to_local_means(make_upper_xi_vars(logical_coords));
   }
 
   const auto neighbor_data = make_neighbor_data_from_neighbor_vars(
@@ -594,32 +609,51 @@ void test_simple_weno_2d(const std::unordered_set<Direction<2>>&
   VariablesMap<2> neighbor_vars{};
   VariablesMap<2> neighbor_modified_vars{};
 
+  const auto shift_vars_to_local_means = [&mesh, &local_vars ](
+      const Variables<tmpl::list<ScalarTag, VectorTag<2>>>& input) noexcept {
+    const auto& local_s = get<ScalarTag>(local_vars);
+    const auto& local_v = get<VectorTag<2>>(local_vars);
+    auto result = input;
+    auto& s = get<ScalarTag>(result);
+    auto& v = get<VectorTag<2>>(result);
+    get(s) += mean_value(get(local_s), mesh) - mean_value(get(s), mesh);
+    get<0>(v) +=
+        mean_value(get<0>(local_v), mesh) - mean_value(get<0>(v), mesh);
+    get<1>(v) +=
+        mean_value(get<1>(local_v), mesh) - mean_value(get<1>(v), mesh);
+    return result;
+  };
+
   const auto lower_xi =
       std::make_pair(Direction<2>::lower_xi(), ElementId<2>(1));
   if (directions_of_external_boundaries.count(lower_xi.first) == 0) {
     neighbor_vars[lower_xi] = make_lower_xi_vars(logical_coords, -2.0);
-    neighbor_modified_vars[lower_xi] = make_lower_xi_vars(logical_coords);
+    neighbor_modified_vars[lower_xi] =
+        shift_vars_to_local_means(make_lower_xi_vars(logical_coords));
   }
 
   const auto upper_xi =
       std::make_pair(Direction<2>::upper_xi(), ElementId<2>(2));
   if (directions_of_external_boundaries.count(upper_xi.first) == 0) {
     neighbor_vars[upper_xi] = make_upper_xi_vars(logical_coords, 2.0);
-    neighbor_modified_vars[upper_xi] = make_upper_xi_vars(logical_coords);
+    neighbor_modified_vars[upper_xi] =
+        shift_vars_to_local_means(make_upper_xi_vars(logical_coords));
   }
 
   const auto lower_eta =
       std::make_pair(Direction<2>::lower_eta(), ElementId<2>(3));
   if (directions_of_external_boundaries.count(lower_eta.first) == 0) {
     neighbor_vars[lower_eta] = make_lower_eta_vars(logical_coords, -2.0);
-    neighbor_modified_vars[lower_eta] = make_lower_eta_vars(logical_coords);
+    neighbor_modified_vars[lower_eta] =
+        shift_vars_to_local_means(make_lower_eta_vars(logical_coords));
   }
 
   const auto upper_eta =
       std::make_pair(Direction<2>::upper_eta(), ElementId<2>(4));
   if (directions_of_external_boundaries.count(upper_eta.first) == 0) {
     neighbor_vars[upper_eta] = make_upper_eta_vars(logical_coords, 2.0);
-    neighbor_modified_vars[upper_eta] = make_upper_eta_vars(logical_coords);
+    neighbor_modified_vars[upper_eta] =
+        shift_vars_to_local_means(make_upper_eta_vars(logical_coords));
   }
 
   const auto neighbor_data = make_neighbor_data_from_neighbor_vars(
@@ -735,46 +769,69 @@ void test_simple_weno_3d(const std::unordered_set<Direction<3>>&
   VariablesMap<3> neighbor_vars{};
   VariablesMap<3> neighbor_modified_vars{};
 
+  const auto shift_vars_to_local_means = [&mesh, &local_vars ](
+      const Variables<tmpl::list<ScalarTag, VectorTag<3>>>& input) noexcept {
+    const auto& local_s = get<ScalarTag>(local_vars);
+    const auto& local_v = get<VectorTag<3>>(local_vars);
+    auto result = input;
+    auto& s = get<ScalarTag>(result);
+    auto& v = get<VectorTag<3>>(result);
+    get(s) += mean_value(get(local_s), mesh) - mean_value(get(s), mesh);
+    get<0>(v) +=
+        mean_value(get<0>(local_v), mesh) - mean_value(get<0>(v), mesh);
+    get<1>(v) +=
+        mean_value(get<1>(local_v), mesh) - mean_value(get<1>(v), mesh);
+    get<2>(v) +=
+        mean_value(get<2>(local_v), mesh) - mean_value(get<2>(v), mesh);
+    return result;
+  };
+
   const auto lower_xi =
       std::make_pair(Direction<3>::lower_xi(), ElementId<3>(1));
   if (directions_of_external_boundaries.count(lower_xi.first) == 0) {
     neighbor_vars[lower_xi] = make_lower_xi_vars(logical_coords, -2.0);
-    neighbor_modified_vars[lower_xi] = make_lower_xi_vars(logical_coords);
+    neighbor_modified_vars[lower_xi] =
+        shift_vars_to_local_means(make_lower_xi_vars(logical_coords));
   }
 
   const auto upper_xi =
       std::make_pair(Direction<3>::upper_xi(), ElementId<3>(2));
   if (directions_of_external_boundaries.count(upper_xi.first) == 0) {
     neighbor_vars[upper_xi] = make_upper_xi_vars(logical_coords, 2.0);
-    neighbor_modified_vars[upper_xi] = make_upper_xi_vars(logical_coords);
+    neighbor_modified_vars[upper_xi] =
+        shift_vars_to_local_means(make_upper_xi_vars(logical_coords));
   }
 
   const auto lower_eta =
       std::make_pair(Direction<3>::lower_eta(), ElementId<3>(3));
   if (directions_of_external_boundaries.count(lower_eta.first) == 0) {
     neighbor_vars[lower_eta] = make_lower_eta_vars(logical_coords, -2.0);
-    neighbor_modified_vars[lower_eta] = make_lower_eta_vars(logical_coords);
+    neighbor_modified_vars[lower_eta] =
+        shift_vars_to_local_means(make_lower_eta_vars(logical_coords));
   }
 
   const auto upper_eta =
       std::make_pair(Direction<3>::upper_eta(), ElementId<3>(4));
   if (directions_of_external_boundaries.count(upper_eta.first) == 0) {
     neighbor_vars[upper_eta] = make_upper_eta_vars(logical_coords, 2.0);
-    neighbor_modified_vars[upper_eta] = make_upper_eta_vars(logical_coords);
+    neighbor_modified_vars[upper_eta] =
+        shift_vars_to_local_means(make_upper_eta_vars(logical_coords));
   }
 
   const auto lower_zeta =
       std::make_pair(Direction<3>::lower_zeta(), ElementId<3>(5));
   if (directions_of_external_boundaries.count(lower_zeta.first) == 0) {
     neighbor_vars[lower_zeta] = make_lower_zeta_vars(logical_coords, -2.0);
-    neighbor_modified_vars[lower_zeta] = make_lower_zeta_vars(logical_coords);
+    neighbor_modified_vars[lower_zeta] =
+        shift_vars_to_local_means(make_lower_zeta_vars(logical_coords));
   }
 
   const auto upper_zeta =
       std::make_pair(Direction<3>::upper_zeta(), ElementId<3>(6));
   if (directions_of_external_boundaries.count(upper_zeta.first) == 0) {
     neighbor_vars[upper_zeta] = make_upper_zeta_vars(logical_coords, 2.0);
-    neighbor_modified_vars[upper_zeta] = make_upper_zeta_vars(logical_coords);
+    neighbor_modified_vars[upper_zeta] =
+        shift_vars_to_local_means(make_upper_zeta_vars(logical_coords));
   }
 
   const auto neighbor_data = make_neighbor_data_from_neighbor_vars(


### PR DESCRIPTION
The old and new expressions are (should be) arithmetically equivalent, but the new
expression is a better match to many references.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
