### PR TITLE
Allow initialization_tags_to_keep.

### DIFF
--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -195,7 +195,9 @@ Each %Parallel Component struct must have the following type aliases:
    specify a type alias `using initialization_tags` which are a
    `tmpl::list` of tags that will be fetched from the db::DataBox by the
    action.  All `initialization_tags` are removed from the db::DataBox of
-   the component at the end of the `Initialization` phase.
+   the component at the end of the `Initialization` phase, except for
+   tags listed in a type alias `using initialization_tags_to_keep` that
+   may appear in each initialization action.
 5. `using const_global_cache_tags` is set to a `tmpl::list` of tags
    that are required by the `allocate_array` function of an array
    component, or simple actions called on the parallel component.

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -114,6 +114,17 @@ struct get_initialization_tags_from_action<
     Action, cpp17::void_t<typename Action::initialization_tags>> {
   using type = typename Action::initialization_tags;
 };
+
+template <typename Action, typename = cpp17::void_t<>>
+struct get_initialization_tags_to_keep_from_action {
+  using type = tmpl::list<>;
+};
+
+template <typename Action>
+struct get_initialization_tags_to_keep_from_action<
+    Action, cpp17::void_t<typename Action::initialization_tags_to_keep>> {
+  using type = typename Action::initialization_tags_to_keep;
+};
 }  // namespace detail
 
 /// \ingroup ParallelGroup
@@ -127,6 +138,17 @@ using get_initialization_tags = tmpl::remove_duplicates<tmpl::flatten<
                tmpl::transform<
                    InitializationActionsList,
                    detail::get_initialization_tags_from_action<tmpl::_1>>>>>;
+
+/// \ingroup ParallelGroup
+/// \brief Given a list of initialization actions, returns a list of
+/// the unique initialization_tags_to_keep for all the actions.  These
+/// are the tags that are not removed from the DataBox after
+/// initialization.
+template <typename InitializationActionsList>
+using get_initialization_tags_to_keep =
+    tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+        InitializationActionsList,
+        detail::get_initialization_tags_to_keep_from_action<tmpl::_1>>>>;
 
 namespace detail {
 template <typename InitializationTag>

--- a/src/ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp
+++ b/src/ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp
@@ -33,7 +33,14 @@ struct RemoveOptionsAndTerminatePhase {
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/, ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using tags_to_remove = Parallel::get_initialization_tags<ActionList>;
+    using initialization_tags = Parallel::get_initialization_tags<ActionList>;
+    using initialization_tags_to_keep =
+        Parallel::get_initialization_tags_to_keep<ActionList>;
+    // Keep the tags that are in initialization_tags_to_keep.
+    using tags_to_remove = tmpl::remove_if<
+        initialization_tags,
+        tmpl::bind<tmpl::list_contains, tmpl::pin<initialization_tags_to_keep>,
+                   tmpl::_1>>;
     // Retrieve the `initialization_tags` that are still in the DataBox
     // and remove them.
     using tags_to_remove_this_time = tmpl::filter<


### PR DESCRIPTION
Normally initialization tags are removed from the DataBox after the
initialization phase.  Specifying initialization_tags_to_keep will
exempt the listed tags from removal.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
