### PR TITLE
Use db::tag_name in DataBox

### DIFF
--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -66,7 +66,6 @@ struct Tag2 : db::SimpleTag, Tag2Base {
 };
 struct Tag3 : db::SimpleTag {
   using type = std::string;
-  static std::string name() noexcept { return "Tag3"; }
 };
 
 /// [databox_compute_item_tag_example]

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxTag.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxTag.cpp
@@ -195,20 +195,52 @@ static_assert(
 namespace {
 struct PureBaseTag : db::BaseTag {};
 
-struct SimpleTag : PureBaseTag, db::SimpleTag {
+struct UnnamedSimpleTag : PureBaseTag, db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "SimpleTag"; }
 };
 
-struct ComputeTag : SimpleTag, db::ComputeTag {
+struct NamedSimpleTag : PureBaseTag, db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "NamedSimpleTag::name"; }
+};
+
+struct NamedComputeTag : UnnamedSimpleTag, db::ComputeTag {
   using argument_list = tmpl::list<>;
-  static std::string name() noexcept { return "ComputeTag"; }
+  static std::string name() noexcept { return "NamedComputeTag::name"; }
+};
+
+struct BasedComputeTag : UnnamedSimpleTag, db::ComputeTag {
+  using base = UnnamedSimpleTag;
+  using argument_list = tmpl::list<>;
+};
+
+struct NamedBasedComputeTag : UnnamedSimpleTag, db::ComputeTag {
+  using base = UnnamedSimpleTag;
+  using argument_list = tmpl::list<>;
+  static std::string name() noexcept { return "NamedBasedComputeTag::name"; }
+};
+
+struct InheritedComputeTag : NamedSimpleTag, db::ComputeTag {
+  using argument_list = tmpl::list<>;
+};
+
+template <typename Tag>
+struct UnnamedPrefix : db::PrefixTag, db::SimpleTag {
+  using tag = Tag;
 };
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataBoxTag",
                   "[Unit][DataStructures]") {
   CHECK(db::tag_name<PureBaseTag>() == "PureBaseTag");
-  CHECK(db::tag_name<SimpleTag>() == "SimpleTag");
-  CHECK(db::tag_name<ComputeTag>() == "ComputeTag");
+  CHECK(db::tag_name<UnnamedSimpleTag>() == "UnnamedSimpleTag");
+  CHECK(db::tag_name<NamedSimpleTag>() == "NamedSimpleTag::name");
+  CHECK(db::tag_name<NamedComputeTag>() == "NamedComputeTag::name");
+  CHECK(db::tag_name<BasedComputeTag>() == "UnnamedSimpleTag");
+  CHECK(db::tag_name<NamedBasedComputeTag>() == "NamedBasedComputeTag::name");
+  CHECK(db::tag_name<InheritedComputeTag>() == "NamedSimpleTag::name");
+  CHECK(db::tag_name<UnnamedPrefix<UnnamedSimpleTag>>() ==
+        "UnnamedPrefix(UnnamedSimpleTag)");
+  CHECK(db::tag_name<UnnamedPrefix<NamedSimpleTag>>() ==
+        "UnnamedPrefix(NamedSimpleTag::name)");
 }


### PR DESCRIPTION
A number of people have hit errors related to this recently (probably because of my comments about tag_name), so I've split this off from #1681 (and expanded it) so it can be merged more quickly.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
