### PR TITLE
Evolve GH initial data imported from spec

### DIFF
--- a/cmake/AddInputFileTests.cmake
+++ b/cmake/AddInputFileTests.cmake
@@ -98,12 +98,24 @@ function(add_input_file_tests INPUT_FILE_DIR)
     set(INPUT_FILE_CHECKS "parse;${INPUT_FILE_CHECKS}")
     list(REMOVE_DUPLICATES "INPUT_FILE_CHECKS")
 
+    # Read the timeout duration specified in input file, empty is accepted.
+    # The default duration is 2 seconds.
+    string(REGEX MATCH "#[ ]*Timeout:[^\n]+"
+      INPUT_FILE_TIMEOUT "${INPUT_FILE_CONTENTS}")
+    if("${INPUT_FILE_TIMEOUT}" STREQUAL "")
+      set(INPUT_FILE_TIMEOUT "${TIMEOUT}")
+    else()
+      string(REGEX REPLACE "#[ ]*Timeout:[ ]*" ""
+        INPUT_FILE_TIMEOUT "${INPUT_FILE_TIMEOUT}")
+      string(STRIP "${INPUT_FILE_TIMEOUT}" INPUT_FILE_TIMEOUT)
+    endif()
+
     foreach(CHECK_TYPE ${INPUT_FILE_CHECKS})
       add_single_input_file_test(
         ${INPUT_FILE}
         ${INPUT_FILE_EXECUTABLE}
         ${CHECK_TYPE}
-        ${TIMEOUT}
+        ${INPUT_FILE_TIMEOUT}
         )
     endforeach()
     add_dependencies(test-executables ${INPUT_FILE_EXECUTABLE})

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -57,13 +57,18 @@ struct is_databox<DataBox<tmpl::list<Tags...>>> : std::true_type {};
 /// \endcond
 // @}
 
+// @{
 /// \ingroup DataBoxGroup
 /// Equal to `true` if `Tag` can be retrieved from a `DataBox` of type
 /// `DataBoxType`.
 template <typename Tag, typename DataBoxType>
+using tag_is_retrievable = tmpl::any<typename DataBoxType::tags_list,
+                                     std::is_base_of<tmpl::pin<Tag>, tmpl::_1>>;
+
+template <typename Tag, typename DataBoxType>
 constexpr bool tag_is_retrievable_v =
-    tmpl::any<typename DataBoxType::tags_list,
-              std::is_base_of<tmpl::pin<Tag>, tmpl::_1>>::value;
+    tag_is_retrievable<Tag, DataBoxType>::value;
+// @}
 
 namespace DataBox_detail {
 template <class Tag, class Type>

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -988,5 +988,10 @@ using Tempiaa = TempTensor<N, tnsr::iaa<DataType, SpatialDim, Fr>>;
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
           typename DataType = DataVector>
 using Tempabb = TempTensor<N, tnsr::abb<DataType, SpatialDim, Fr>>;
+
+// Rank 4
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+          typename DataType = DataVector>
+using Tempijaa = TempTensor<N, tnsr::ijaa<DataType, SpatialDim, Fr>>;
 // @}
 }  // namespace Tags

--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -45,7 +45,7 @@ struct import_numeric_data_cache_tags {
 template <typename Metavariables, typename DgElementArray>
 struct import_numeric_data_cache_tags<Metavariables, DgElementArray, true> {
   using type = typename read_element_data_action<
-      Metavariables, DgElementArray>::const_global_cache_tag_list;
+      Metavariables, DgElementArray>::const_global_cache_tags;
 };
 
 template <typename Metavariables, typename DgElementArray,

--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -13,13 +13,67 @@
 #include "Domain/ElementIndex.hpp"
 #include "Domain/InitialElementIds.hpp"
 #include "Domain/Tags.hpp"
+#include "Elliptic/NumericInitialGuess.hpp"
+#include "Elliptic/Tags.hpp"
+#include "IO/DataImporter/DataFileReader.hpp"
+#include "IO/DataImporter/DataFileReaderActions.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Info.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "ParallelAlgorithms/Actions/SetData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
 namespace elliptic {
+
+namespace DgElementArray_detail {
+
+template <typename Metavariables, typename DgElementArray>
+using read_element_data_action = importer::ThreadedActions::ReadElementData<
+    elliptic::OptionTags::NumericInitialGuess,
+    typename Metavariables::initial_guess::import_fields,
+    ::Actions::SetData<typename Metavariables::initial_guess::import_fields>,
+    DgElementArray>;
+
+template <typename Metavariables, typename DgElementArray,
+          bool Enable = elliptic::is_numeric_initial_guess_v<
+              typename Metavariables::initial_guess>>
+struct import_numeric_data_cache_tags {
+  using type = tmpl::list<>;
+};
+
+template <typename Metavariables, typename DgElementArray>
+struct import_numeric_data_cache_tags<Metavariables, DgElementArray, true> {
+  using type = typename read_element_data_action<
+      Metavariables, DgElementArray>::const_global_cache_tag_list;
+};
+
+template <typename Metavariables, typename DgElementArray,
+          bool Enable = elliptic::is_numeric_initial_guess_v<
+              typename Metavariables::initial_guess>>
+struct try_import_data {
+  static void apply(
+      const typename Metavariables::Phase /*next_phase*/,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
+};
+
+template <typename Metavariables, typename DgElementArray>
+struct try_import_data<Metavariables, DgElementArray, true> {
+  static void apply(
+      const typename Metavariables::Phase next_phase,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
+    if (next_phase == Metavariables::Phase::ImportData) {
+      auto& local_cache = *(global_cache.ckLocalBranch());
+      Parallel::threaded_action<
+          read_element_data_action<Metavariables, DgElementArray>>(
+          Parallel::get_parallel_component<
+              importer::DataFileReader<Metavariables>>(local_cache));
+    }
+  }
+};
+
+}  // namespace DgElementArray_detail
+
 /*!
  * \brief The parallel component responsible for managing the DG elements that
  * compose the computational domain
@@ -41,8 +95,10 @@ struct DgElementArray {
   using phase_dependent_action_list = PhaseDepActionList;
   using array_index = ElementIndex<volume_dim>;
 
-  using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<volume_dim, Frame::Inertial>>;
+  using const_global_cache_tags = tmpl::flatten<tmpl::list<
+      tmpl::type_from<DgElementArray_detail::import_numeric_data_cache_tags<
+          Metavariables, DgElementArray>>,
+      ::Tags::Domain<volume_dim, Frame::Inertial>>>;
 
   using array_allocation_tags =
       tmpl::list<::Tags::InitialRefinementLevels<volume_dim>>;
@@ -62,6 +118,10 @@ struct DgElementArray {
     auto& local_cache = *(global_cache.ckLocalBranch());
     Parallel::get_parallel_component<DgElementArray>(local_cache)
         .start_phase(next_phase);
+
+    DgElementArray_detail::try_import_data<Metavariables,
+                                           DgElementArray>::apply(next_phase,
+                                                                  global_cache);
   }
 };
 

--- a/src/Elliptic/NumericInitialGuess.hpp
+++ b/src/Elliptic/NumericInitialGuess.hpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "Utilities/TypeTraits.hpp"
+
+namespace elliptic {
+
+/// Empty base class for marking a class as a numeric initial guess.
+///
+/// \see `elliptic::is_numeric_initial_guess`
+struct MarkAsNumericInitialGuess {};
+
+// @{
+/// Checks if the class `T` is marked as a numeric initial guess.
+template <typename T>
+using is_numeric_initial_guess =
+    typename std::is_convertible<T*, MarkAsNumericInitialGuess*>;
+
+template <typename T>
+constexpr bool is_numeric_initial_guess_v =
+    cpp17::is_convertible_v<T*, MarkAsNumericInitialGuess*>;
+// @}
+
+/// Provides compile-time information for importing a numeric initial guess for
+/// the `System` from a data file.
+template <typename System>
+struct NumericInitialGuess : MarkAsNumericInitialGuess {
+  using import_fields =
+      db::get_variables_tags_list<typename System::fields_tag>;
+};
+
+}  // namespace elliptic

--- a/src/Elliptic/Tags.hpp
+++ b/src/Elliptic/Tags.hpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "IO/DataImporter/Tags.hpp"
+#include "Options/Options.hpp"
+
+namespace elliptic {
+namespace OptionTags {
+/*!
+ * \brief Holds option tags for importing numeric data as initial guess for an
+ * elliptic solve.
+ */
+struct NumericInitialGuess {
+  using group = importer::OptionTags::Group;
+  static constexpr OptionString help = "Initial guess";
+};
+}  // namespace OptionTags
+}  // namespace elliptic

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -43,7 +43,7 @@ struct import_numeric_data_cache_tags {
 template <typename Metavariables, typename DgElementArray>
 struct import_numeric_data_cache_tags<Metavariables, DgElementArray, true> {
   using type = typename read_element_data_action<
-      Metavariables, DgElementArray>::const_global_cache_tag_list;
+      Metavariables, DgElementArray>::const_global_cache_tags;
 };
 
 template <typename Metavariables, typename DgElementArray,

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -13,11 +13,64 @@
 #include "Domain/ElementIndex.hpp"
 #include "Domain/InitialElementIds.hpp"
 #include "Domain/Tags.hpp"
+#include "Evolution/NumericalInitialData.hpp"
+#include "Evolution/Tags.hpp"
+#include "IO/DataImporter/DataFileReader.hpp"
+#include "IO/DataImporter/DataFileReaderActions.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Info.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "ParallelAlgorithms/Actions/SetData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+
+namespace DgElementArray_detail {
+
+template <typename Metavariables, typename DgElementArray>
+using read_element_data_action = importer::ThreadedActions::ReadElementData<
+    ::OptionTags::NumericalInitialData,
+    typename Metavariables::initial_data::import_fields,
+    ::Actions::SetData<typename Metavariables::initial_data::import_fields>,
+    DgElementArray>;
+
+template <typename Metavariables, typename DgElementArray,
+          bool Enable =
+              is_numerical_initial_data_v<typename Metavariables::initial_data>>
+struct import_numeric_data_cache_tags {
+  using type = tmpl::list<>;
+};
+
+template <typename Metavariables, typename DgElementArray>
+struct import_numeric_data_cache_tags<Metavariables, DgElementArray, true> {
+  using type = typename read_element_data_action<
+      Metavariables, DgElementArray>::const_global_cache_tag_list;
+};
+
+template <typename Metavariables, typename DgElementArray,
+          bool Enable =
+              is_numerical_initial_data_v<typename Metavariables::initial_data>>
+struct try_import_data {
+  static void apply(
+      const typename Metavariables::Phase /*next_phase*/,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
+};
+
+template <typename Metavariables, typename DgElementArray>
+struct try_import_data<Metavariables, DgElementArray, true> {
+  static void apply(
+      const typename Metavariables::Phase next_phase,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
+    if (next_phase == Metavariables::Phase::ImportData) {
+      auto& local_cache = *(global_cache.ckLocalBranch());
+      Parallel::threaded_action<
+          read_element_data_action<Metavariables, DgElementArray>>(
+          Parallel::get_parallel_component<
+              importer::DataFileReader<Metavariables>>(local_cache));
+    }
+  }
+};
+
+}  // namespace DgElementArray_detail
 
 /*!
  * \brief The parallel component responsible for managing the DG elements that
@@ -36,8 +89,11 @@ struct DgElementArray {
   using phase_dependent_action_list = PhaseDepActionList;
   using array_index = ElementIndex<volume_dim>;
 
-  using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<volume_dim, Frame::Inertial>>;
+
+  using const_global_cache_tags = tmpl::flatten<tmpl::list<
+      tmpl::type_from<DgElementArray_detail::import_numeric_data_cache_tags<
+          Metavariables, DgElementArray>>,
+      tmpl::list<::Tags::Domain<volume_dim, Frame::Inertial>>>>;
 
   using array_allocation_tags =
       tmpl::list<::Tags::InitialRefinementLevels<volume_dim>>;
@@ -57,6 +113,10 @@ struct DgElementArray {
     auto& local_cache = *(global_cache.ckLocalBranch());
     Parallel::get_parallel_component<DgElementArray>(local_cache)
         .start_phase(next_phase);
+
+    DgElementArray_detail::try_import_data<Metavariables,
+                                           DgElementArray>::apply(next_phase,
+                                                                  global_cache);
   }
 };
 

--- a/src/Evolution/DiscontinuousGalerkin/Filtering.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Filtering.hpp
@@ -161,7 +161,12 @@ class ExponentialFilter<FilterIndex, tmpl::list<TagsToFilter...>> {
   }
   using group = ::OptionTags::FilteringGroup;
 
-  using options = tmpl::list<Alpha, HalfPower, DisableForDebugging>;
+  using option_tags = tmpl::list<Alpha, HalfPower, DisableForDebugging>;
+  static ExponentialFilter create_from_options(const double& alpha,
+                                               const double& half_power,
+                                               bool disable_for_debugging) {
+    return ExponentialFilter(alpha, half_power, disable_for_debugging);
+  }
   static constexpr OptionString help = {"An exponential filter."};
 
   ExponentialFilter() = default;

--- a/src/Evolution/DiscontinuousGalerkin/ObserveNorms.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/ObserveNorms.hpp
@@ -120,12 +120,13 @@ class ObserveNorms<VolumeDim, tmpl::list<Tensors...>, EventRegistrars>
 
   template <typename Metavariables, typename ArrayIndex,
             typename ParallelComponent>
-  void operator()(const double time,
-                  const db::item_type<coordinates_tag>& inertial_coordinates,
-                  const db::item_type<Tensors>&... tensors,
-                  Parallel::ConstGlobalCache<Metavariables>& cache,
-                  const ArrayIndex& /*array_index*/,
-                  const ParallelComponent* const /*meta*/) const noexcept {
+  void operator()(
+      const double time,
+      const db::item_type<coordinates_tag>& /*inertial_coordinates*/,
+      const db::item_type<Tensors>&... tensors,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/,
+      const ParallelComponent* const /*meta*/) const noexcept {
     tuples::TaggedTuple<LocalSquareError<Tensors>...> local_square_errors;
     const auto record_errors = [&local_square_errors](
         const auto tensor_tag_v, const auto& tensor) noexcept {

--- a/src/Evolution/DiscontinuousGalerkin/ObserveNorms.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/ObserveNorms.hpp
@@ -1,0 +1,169 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/EventsAndTriggers/Event.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
+#include "IO/Observer/ReductionActions.hpp"   // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+namespace Tags {
+struct Time;
+}  // namespace Tags
+/// \endcond
+
+namespace dg {
+namespace Events {
+template <size_t VolumeDim, typename Tensors, typename EventRegistrars>
+class ObserveNorms;
+
+namespace Registrars {
+template <size_t VolumeDim, typename Tensors>
+struct ObserveNorms {
+  template <typename RegistrarList>
+  using f = Events::ObserveNorms<VolumeDim, Tensors, RegistrarList>;
+};
+}  // namespace Registrars
+
+template <size_t VolumeDim, typename Tensors,
+          typename EventRegistrars =
+              tmpl::list<Registrars::ObserveNorms<VolumeDim, Tensors>>>
+class ObserveNorms;  // IWYU pragma: keep
+
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief %Observe the RMS norms in tensors.
+ *
+ * Writes reduction quantities:
+ * - `Time`
+ * - `NumberOfPoints` = total number of points in the domain
+ * - `Norm(*)` = RMS Norm in `Tensors` =
+ *   \f$\operatorname{RMS}\left(\sqrt{\sum_{\text{independent components}}\left[
+ *   \text{value}\right]^2}\right)\f$
+ *   over all points
+ *
+ * \warning Currently, only one reduction observation event can be
+ * triggered at a given time.  Causing multiple events to run at once
+ * will produce unpredictable results.
+ */
+template <size_t VolumeDim, typename... Tensors, typename EventRegistrars>
+class ObserveNorms<VolumeDim, tmpl::list<Tensors...>, EventRegistrars>
+    : public Event<EventRegistrars> {
+ private:
+  using coordinates_tag = ::Tags::Coordinates<VolumeDim, Frame::Inertial>;
+
+  template <typename Tag>
+  struct LocalSquareError {
+    using type = double;
+  };
+
+  using L2ErrorDatum = Parallel::ReductionDatum<double, funcl::Plus<>,
+                                                funcl::Sqrt<funcl::Divides<>>,
+                                                std::index_sequence<1>>;
+  using ReductionData = tmpl::wrap<
+      tmpl::append<
+          tmpl::list<Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+                     Parallel::ReductionDatum<size_t, funcl::Plus<>>>,
+          tmpl::filled_list<L2ErrorDatum, sizeof...(Tensors)>>,
+      Parallel::ReductionData>;
+
+ public:
+  /// \cond
+  explicit ObserveNorms(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ObserveNorms);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::list<>;
+  static constexpr OptionString help =
+      "Observe the RMS norms of tensors\n"
+      "\n"
+      "Writes reduction quantities:\n"
+      " * Time\n"
+      " * NumberOfPoints = total number of points in the domain\n"
+      " * Error(*) = RMS norms of Tensors (see online help details)\n"
+      "\n"
+      "Warning: Currently, only one reduction observation event can be\n"
+      "triggered at a given time.  Causing multiple events to run at once\n"
+      "will produce unpredictable results.";
+
+  ObserveNorms() = default;
+
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
+
+  using argument_tags = tmpl::list<::Tags::Time, coordinates_tag, Tensors...>;
+
+  template <typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
+  void operator()(const double time,
+                  const db::item_type<coordinates_tag>& inertial_coordinates,
+                  const db::item_type<Tensors>&... tensors,
+                  Parallel::ConstGlobalCache<Metavariables>& cache,
+                  const ArrayIndex& /*array_index*/,
+                  const ParallelComponent* const /*meta*/) const noexcept {
+    tuples::TaggedTuple<LocalSquareError<Tensors>...> local_square_errors;
+    const auto record_errors = [&local_square_errors](
+        const auto tensor_tag_v, const auto& tensor) noexcept {
+      using tensor_tag = tmpl::type_from<decltype(tensor_tag_v)>;
+      double local_square_error = 0.0;
+      for (size_t i = 0; i < tensor.size(); ++i) {
+        const auto error = tensor[i];
+        local_square_error += alg::accumulate(square(error), 0.0);
+      }
+      get<LocalSquareError<tensor_tag>>(local_square_errors) =
+          local_square_error;
+      return 0;
+    };
+    expand_pack(record_errors(tmpl::type_<Tensors>{}, tensors)...);
+    const size_t num_points = get_first_argument(tensors...).begin()->size();
+
+    // Send data to reduction observer
+    auto& local_observer =
+        *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+             cache)
+             .ckLocalBranch();
+    Parallel::simple_action<observers::Actions::ContributeReductionData>(
+        local_observer,
+        observers::ObservationId(
+            time, typename Metavariables::element_observation_type{}),
+        std::string{"/element_data"},
+        std::vector<std::string>{"Time", "NumberOfPoints",
+                                 ("Error(" + Tensors::name() + ")")...},
+        ReductionData{
+            time, num_points,
+            std::move(get<LocalSquareError<Tensors>>(local_square_errors))...});
+  }
+};
+
+/// \cond
+template <size_t VolumeDim, typename... Tensors, typename EventRegistrars>
+PUP::able::PUP_ID ObserveNorms<VolumeDim, tmpl::list<Tensors...>,
+                               EventRegistrars>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace Events
+}  // namespace dg

--- a/src/Evolution/Executables/CMakeLists.txt
+++ b/src/Evolution/Executables/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Burgers)
+add_subdirectory(GeneralizedHarmonic)
 add_subdirectory(GrMhd)
 add_subdirectory(NewtonianEuler)
 add_subdirectory(ScalarWave)

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBS_TO_LINK
+    CoordinateMaps
+    DiscontinuousGalerkin
+    Domain
+    DomainCreators
+    GeneralRelativity
+    GeneralRelativitySolutions
+    GeneralizedHarmonic
+    GeneralizedHarmonicGaugeSourceFunctions
+    IO
+    Informer
+    LinearOperators
+    MathFunctions
+    Time
+    Utilities
+    ${SPECTRE_LIBRARIES}
+  )
+
+add_spectre_parallel_executable(
+  EvolveGeneralizedHarmonic
+  EvolveGeneralizedHarmonic
+  Evolution/Executables/GeneralizedHarmonic
+  EvolutionMetavars
+  "${LIBS_TO_LINK}"
+)

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 set(LIBS_TO_LINK
+    ApparentHorizons
     CoordinateMaps
     DiscontinuousGalerkin
     Domain
@@ -12,6 +13,7 @@ set(LIBS_TO_LINK
     GeneralizedHarmonicGaugeSourceFunctions
     IO
     Informer
+    Interpolation
     LinearOperators
     MathFunctions
     Time

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -1,0 +1,289 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep
+#include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"  // IWYU pragma: keep
+#include "Evolution/DiscontinuousGalerkin/ObserveErrorNorms.hpp"
+#include "Evolution/DiscontinuousGalerkin/ObserveFields.hpp"
+#include "Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"  // IWYU pragma: keep
+#include "Evolution/EventsAndTriggers/Event.hpp"
+#include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"  // IWYU pragma: keep
+#include "Evolution/EventsAndTriggers/Tags.hpp"
+#include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Initialization/Limiter.hpp"
+#include "Evolution/Initialization/NonconservativeSystem.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"  // IWYU pragma: keep // for UpwindFlux
+#include "Evolution/Systems/GeneralizedHarmonic/Initialize.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "IO/Observer/Actions.hpp"  // IWYU pragma: keep
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
+#include "IO/Observer/RegisterObservers.hpp"
+#include "IO/Observer/Tags.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Time/Actions/AdvanceTime.hpp"            // IWYU pragma: keep
+#include "Time/Actions/ChangeStepSize.hpp"         // IWYU pragma: keep
+#include "Time/Actions/RecordTimeStepperData.hpp"  // IWYU pragma: keep
+#include "Time/Actions/SelfStartActions.hpp"       // IWYU pragma: keep
+#include "Time/Actions/UpdateU.hpp"                // IWYU pragma: keep
+#include "Time/StepChoosers/Cfl.hpp"               // IWYU pragma: keep
+#include "Time/StepChoosers/Constant.hpp"          // IWYU pragma: keep
+#include "Time/StepChoosers/Increase.hpp"          // IWYU pragma: keep
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/StepControllers/StepController.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Time/Triggers/TimeTriggers.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Frame {
+// IWYU pragma: no_forward_declare MathFunction
+struct Inertial;
+}  // namespace Frame
+namespace Parallel {
+template <typename Metavariables>
+class CProxy_ConstGlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+struct EvolutionMetavars {
+  // Customization/"input options" to simulation
+  static constexpr int volume_dim = 3;
+  using frame = Frame::Inertial;
+  using system = GeneralizedHarmonic::System<volume_dim>;
+  using temporal_id = Tags::TimeStepId;
+  static constexpr bool local_time_stepping = false;
+  using initial_data_tag = Tags::AnalyticSolution<
+      GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>>;
+  using boundary_condition_tag = initial_data_tag;
+  using normal_dot_numerical_flux =
+      Tags::NumericalFlux<GeneralizedHarmonic::UpwindFlux<volume_dim>>;
+  using events = tmpl::list<
+      dg::Events::Registrars::ObserveErrorNorms<
+          volume_dim, typename system::variables_tag::tags_list>,
+      dg::Events::Registrars::ObserveFields<
+          volume_dim,
+          tmpl::append<
+              typename system::variables_tag::tags_list,
+              tmpl::list<::Tags::PointwiseL2Norm<
+                             GeneralizedHarmonic::Tags::GaugeConstraint<
+                                 volume_dim, frame>>,
+                         ::Tags::PointwiseL2Norm<
+                             GeneralizedHarmonic::Tags::ThreeIndexConstraint<
+                                 volume_dim, frame>>,
+                         ::Tags::PointwiseL2Norm<
+                             GeneralizedHarmonic::Tags::FourIndexConstraint<
+                                 volume_dim, frame>>>>,
+          typename system::variables_tag::tags_list>>;
+  using triggers = Triggers::time_triggers;
+
+  // A tmpl::list of tags to be added to the ConstGlobalCache by the
+  // metavariables
+  using const_global_cache_tag_list = tmpl::list<
+      initial_data_tag,
+      Tags::TimeStepper<tmpl::conditional_t<local_time_stepping, LtsTimeStepper,
+                                            TimeStepper>>,
+      GeneralizedHarmonic::Tags::GaugeHRollOnStartTime,
+      GeneralizedHarmonic::Tags::GaugeHRollOnTimeWindow,
+      GeneralizedHarmonic::Tags::GaugeHSpatialWeightDecayWidth<frame>,
+      Tags::EventsAndTriggers<events, triggers>>;
+
+  using step_choosers =
+      tmpl::list<StepChoosers::Registrars::Cfl<volume_dim, frame>,
+                 StepChoosers::Registrars::Constant,
+                 StepChoosers::Registrars::Increase>;
+
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
+  using observed_reduction_data_tags =
+      observers::collect_reduction_data_tags<Event<events>::creatable_classes>;
+
+  using compute_rhs = tmpl::flatten<tmpl::list<
+      dg::Actions::ComputeNonconservativeBoundaryFluxes<
+          Tags::InternalDirections<volume_dim>>,
+      dg::Actions::SendDataForFluxes<EvolutionMetavars>,
+      Actions::ComputeTimeDerivative,
+      dg::Actions::ComputeNonconservativeBoundaryFluxes<
+          Tags::BoundaryDirectionsInterior<volume_dim>>,
+      dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
+      dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
+      tmpl::conditional_t<local_time_stepping, tmpl::list<>,
+                          dg::Actions::ApplyFluxes>,
+      Actions::RecordTimeStepperData>>;
+  using update_variables = tmpl::flatten<tmpl::list<
+      tmpl::conditional_t<local_time_stepping,
+                          dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
+                          tmpl::list<>>,
+      Actions::UpdateU>>;
+
+  enum class Phase {
+    Initialization,
+    InitializeTimeStepperHistory,
+    RegisterWithObserver,
+    Evolve,
+    Exit
+  };
+
+  using initialization_actions = tmpl::list<
+      dg::Actions::InitializeDomain<volume_dim>,
+      Initialization::Actions::NonconservativeSystem,
+      GeneralizedHarmonic::Actions::InitializeGHAnd3Plus1VariablesTags<
+          volume_dim>,
+      dg::Actions::InitializeInterfaces<
+          system,
+          dg::Initialization::slice_tags_to_face<
+              typename system::variables_tag,
+              gr::Tags::SpatialMetricCompute<volume_dim, frame, DataVector>,
+              gr::Tags::DetAndInverseSpatialMetricCompute<volume_dim, frame,
+                                                          DataVector>,
+              gr::Tags::ShiftCompute<volume_dim, frame, DataVector>,
+              gr::Tags::LapseCompute<volume_dim, frame, DataVector>>,
+          dg::Initialization::slice_tags_to_exterior<
+              gr::Tags::SpatialMetricCompute<volume_dim, frame, DataVector>,
+              gr::Tags::DetAndInverseSpatialMetricCompute<volume_dim, frame,
+                                                          DataVector>,
+              gr::Tags::ShiftCompute<volume_dim, frame, DataVector>,
+              gr::Tags::LapseCompute<volume_dim, frame, DataVector>>,
+          dg::Initialization::face_compute_tags<
+              ::Tags::BoundaryCoordinates<volume_dim, frame>,
+              GeneralizedHarmonic::Tags::ConstraintGamma0Compute<volume_dim,
+                                                                 frame>,
+              GeneralizedHarmonic::Tags::ConstraintGamma1Compute<volume_dim,
+                                                                 frame>,
+              GeneralizedHarmonic::Tags::ConstraintGamma2Compute<volume_dim,
+                                                                 frame>,
+              GeneralizedHarmonic::CharacteristicFieldsCompute<volume_dim,
+                                                               frame>,
+              GeneralizedHarmonic::CharacteristicSpeedsCompute<volume_dim,
+                                                               frame>>,
+          dg::Initialization::exterior_compute_tags<
+              GeneralizedHarmonic::Tags::ConstraintGamma0Compute<volume_dim,
+                                                                 frame>,
+              GeneralizedHarmonic::Tags::ConstraintGamma1Compute<volume_dim,
+                                                                 frame>,
+              GeneralizedHarmonic::Tags::ConstraintGamma2Compute<volume_dim,
+                                                                 frame>,
+              GeneralizedHarmonic::CharacteristicFieldsCompute<volume_dim,
+                                                               frame>,
+              GeneralizedHarmonic::CharacteristicSpeedsCompute<volume_dim,
+                                                               frame>>>,
+      Initialization::Actions::Evolution<EvolutionMetavars>,
+      GeneralizedHarmonic::Actions::InitializeGaugeTags<volume_dim>,
+      GeneralizedHarmonic::Actions::InitializeConstraintsTags<volume_dim>,
+      dg::Actions::InitializeMortars<EvolutionMetavars, true>,
+      Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
+      Initialization::Actions::Minmod<volume_dim>,
+      Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+
+  using component_list = tmpl::list<
+      observers::Observer<EvolutionMetavars>,
+      observers::ObserverWriter<EvolutionMetavars>,
+      DgElementArray<
+          EvolutionMetavars,
+          tmpl::list<
+              Parallel::PhaseActions<Phase, Phase::Initialization,
+                                     initialization_actions>,
+              Parallel::PhaseActions<
+                  Phase, Phase::InitializeTimeStepperHistory,
+                  tmpl::flatten<tmpl::list<SelfStart::self_start_procedure<
+                      compute_rhs, update_variables>>>>,
+              Parallel::PhaseActions<
+                  Phase, Phase::RegisterWithObserver,
+                  tmpl::list<observers::Actions::RegisterWithObservers<
+                                 observers::RegisterObservers<
+                                     element_observation_type>>,
+                             Parallel::Actions::TerminatePhase>>,
+              Parallel::PhaseActions<
+                  Phase, Phase::Evolve,
+                  tmpl::flatten<tmpl::list<
+                      Actions::RunEventsAndTriggers,
+                      tmpl::conditional_t<
+                          local_time_stepping,
+                          Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
+                      compute_rhs, update_variables, Actions::AdvanceTime>>>>>>;
+
+  static constexpr OptionString help{
+      "Evolve a generalized harmonic analytic solution.\n\n"
+      "The analytic solution is: KerrSchild\n"
+      "The numerical flux is:    UpwindFlux\n"};
+
+  static Phase determine_next_phase(
+      const Phase& current_phase,
+      const Parallel::CProxy_ConstGlobalCache<
+          EvolutionMetavars>& /*cache_proxy*/) noexcept {
+    switch (current_phase) {
+      case Phase::Initialization:
+        return Phase::InitializeTimeStepperHistory;
+      case Phase::InitializeTimeStepperHistory:
+        return Phase::RegisterWithObserver;
+      case Phase::RegisterWithObserver:
+        return Phase::Evolve;
+      case Phase::Evolve:
+        return Phase::Exit;
+      case Phase::Exit:
+        ERROR(
+            "Should never call determine_next_phase with the current phase "
+            "being 'Exit'");
+      default:
+        ERROR(
+            "Unknown type of phase. Did you static_cast<Phase> an integral "
+            "value?");
+    }
+  }
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling,
+    &domain::creators::register_derived_with_charm,
+    &Parallel::register_derived_classes_with_charm<MathFunction<1>>,
+    &Parallel::register_derived_classes_with_charm<
+        Event<metavariables::events>>,
+    &Parallel::register_derived_classes_with_charm<
+        StepChooser<metavariables::step_choosers>>,
+    &Parallel::register_derived_classes_with_charm<StepController>,
+    &Parallel::register_derived_classes_with_charm<TimeStepper>,
+    &Parallel::register_derived_classes_with_charm<
+        Trigger<metavariables::triggers>>};
+
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -232,26 +232,27 @@ struct EvolutionMetavars {
       tmpl::push_back<Event<observation_events>::creatable_classes,
                       typename Horizon::post_horizon_find_callback>>;
 
-  using compute_rhs = tmpl::flatten<
-      tmpl::list<dg::Actions::ComputeNonconservativeBoundaryFluxes<
-                     Tags::InternalDirections<volume_dim>>,
-                 dg::Actions::SendDataForFluxes<EvolutionMetavars>,
-                 Actions::ComputeTimeDerivative,
-                 dg::Actions::ComputeNonconservativeBoundaryFluxes<
-                     Tags::BoundaryDirectionsInterior<volume_dim>>,
-                 dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
-                 tmpl::conditional_t<local_time_stepping, tmpl::list<>,
-                                     dg::Actions::ApplyFluxes>,
-                 Actions::RecordTimeStepperData>>;
+  using compute_rhs = tmpl::flatten<tmpl::list<
+      dg::Actions::ComputeNonconservativeBoundaryFluxes<
+          Tags::InternalDirections<volume_dim>>,
+      dg::Actions::SendDataForFluxes<EvolutionMetavars>,
+      Actions::ComputeTimeDerivative,
+      dg::Actions::ComputeNonconservativeBoundaryFluxes<
+          Tags::BoundaryDirectionsInterior<volume_dim>>,
+      dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
+      tmpl::conditional_t<local_time_stepping, tmpl::list<>,
+                          dg::Actions::ApplyFluxes>,
+      GeneralizedHarmonic::Actions::
+          ImposeConstraintPreservingBoundaryConditions<EvolutionMetavars>,
+      Actions::RecordTimeStepperData>>;
   using update_variables = tmpl::flatten<tmpl::list<
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,
-      GeneralizedHarmonic::Actions::
-          ImposeConstraintPreservingBoundaryConditions<EvolutionMetavars>,
-      Actions::UpdateU,
-      dg::Actions::ExponentialFilter<
-          0, typename system::variables_tag::type::tags_list>>>;
+      Actions::UpdateU  //,
+                        // dg::Actions::ExponentialFilter<
+      // 0, typename system::variables_tag::type::tags_list>
+      >>;
 
   enum class Phase {
     Initialization,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -13,8 +13,8 @@
 #include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/Filtering.hpp"
-#include "Evolution/DiscontinuousGalerkin/ObserveErrorNorms.hpp"
 #include "Evolution/DiscontinuousGalerkin/ObserveFields.hpp"
+#include "Evolution/DiscontinuousGalerkin/ObserveNorms.hpp"
 #include "Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"  // IWYU pragma: keep
 #include "Evolution/EventsAndTriggers/Event.hpp"
 #include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"  // IWYU pragma: keep
@@ -111,9 +111,17 @@ struct EvolutionMetavars {
 
   using normal_dot_numerical_flux =
       Tags::NumericalFlux<GeneralizedHarmonic::UpwindFlux<volume_dim>>;
+
+  using constraint_tags = tmpl::list<
+      GeneralizedHarmonic::Tags::GaugeConstraint<volume_dim, frame>,
+      GeneralizedHarmonic::Tags::TwoIndexConstraint<volume_dim, frame>,
+      GeneralizedHarmonic::Tags::FConstraint<volume_dim, frame>,
+      GeneralizedHarmonic::Tags::ThreeIndexConstraint<volume_dim, frame>,
+      GeneralizedHarmonic::Tags::FourIndexConstraint<volume_dim, frame>,
+      GeneralizedHarmonic::Tags::ConstraintEnergy<volume_dim, frame>>;
+
   using events = tmpl::list<
-      dg::Events::Registrars::ObserveErrorNorms<
-          volume_dim, typename system::variables_tag::tags_list>,
+      dg::Events::Registrars::ObserveNorms<volume_dim, constraint_tags>,
       dg::Events::Registrars::ObserveFields<
           volume_dim,
           tmpl::append<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -183,10 +183,9 @@ struct EvolutionMetavars {
                           tmpl::list<>>,
       GeneralizedHarmonic::Actions::
           ImposeConstraintPreservingBoundaryConditions<EvolutionMetavars>,
-      Actions::UpdateU  //,
-                        // dg::Actions::ExponentialFilter<
-      // 0, typename system::variables_tag::type::tags_list>
-      >>;
+      Actions::UpdateU,
+      dg::Actions::ExponentialFilter<
+          0, typename system::variables_tag::type::tags_list>>>;
 
   enum class Phase {
     Initialization,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -23,11 +23,14 @@
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/Limiter.hpp"
 #include "Evolution/Initialization/NonconservativeSystem.hpp"
+#include "Evolution/NumericalInitialData.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"  // IWYU pragma: keep // for UpwindFlux
 #include "Evolution/Systems/GeneralizedHarmonic/Initialize.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "IO/DataImporter/DataFileReader.hpp"
+#include "IO/DataImporter/ElementActions.hpp"
 #include "IO/Observer/Actions.hpp"  // IWYU pragma: keep
 #include "IO/Observer/Helpers.hpp"
 #include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
@@ -94,9 +97,18 @@ struct EvolutionMetavars {
   using system = GeneralizedHarmonic::System<volume_dim>;
   using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = false;
-  using initial_data_tag = Tags::AnalyticSolution<
-      GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>>;
+
+  using analytic_solution =
+      GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>;
+  using analytic_solution_tag = Tags::AnalyticSolution<analytic_solution>;
+  using initial_data_tag = Tags::AnalyticSolution<analytic_solution>;
   using boundary_condition_tag = initial_data_tag;
+
+  // The type of initial data for the evolution. Set to `analytic_solution` for
+  // starting from an analytic solution, or `NumericalInitialData` to read
+  // data from the disk.
+  using initial_data = NumericalInitialData<system>;
+
   using normal_dot_numerical_flux =
       Tags::NumericalFlux<GeneralizedHarmonic::UpwindFlux<volume_dim>>;
   using events = tmpl::list<
@@ -172,6 +184,7 @@ struct EvolutionMetavars {
     Initialization,
     InitializeTimeStepperHistory,
     RegisterWithObserver,
+    ImportData,
     Evolve,
     Exit
   };
@@ -229,9 +242,12 @@ struct EvolutionMetavars {
       Initialization::Actions::Minmod<volume_dim>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
-  using component_list = tmpl::list<
+  using component_list = tmpl::flatten<tmpl::list<
       observers::Observer<EvolutionMetavars>,
       observers::ObserverWriter<EvolutionMetavars>,
+      tmpl::conditional_t<is_numerical_initial_data_v<initial_data>,
+                          importer::DataFileReader<EvolutionMetavars>,
+                          tmpl::list<>>,
       DgElementArray<
           EvolutionMetavars,
           tmpl::list<
@@ -243,10 +259,15 @@ struct EvolutionMetavars {
                       compute_rhs, update_variables>>>>,
               Parallel::PhaseActions<
                   Phase, Phase::RegisterWithObserver,
-                  tmpl::list<observers::Actions::RegisterWithObservers<
-                                 observers::RegisterObservers<
-                                     element_observation_type>>,
-                             Parallel::Actions::TerminatePhase>>,
+                  tmpl::flatten<
+                      tmpl::list<observers::Actions::RegisterWithObservers<
+                                     observers::RegisterObservers<
+                                         element_observation_type>>,
+                                 tmpl::conditional_t<
+                                     is_numerical_initial_data_v<initial_data>,
+                                     importer::Actions::RegisterWithImporter,
+                                     tmpl::list<>>,
+                                 Parallel::Actions::TerminatePhase>>>,
               Parallel::PhaseActions<
                   Phase, Phase::Evolve,
                   tmpl::flatten<tmpl::list<
@@ -254,7 +275,8 @@ struct EvolutionMetavars {
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      compute_rhs, update_variables, Actions::AdvanceTime>>>>>>;
+                      compute_rhs, update_variables,
+                      Actions::AdvanceTime>>>>>>>;
 
   static constexpr OptionString help{
       "Evolve a generalized harmonic analytic solution.\n\n"
@@ -271,6 +293,9 @@ struct EvolutionMetavars {
       case Phase::InitializeTimeStepperHistory:
         return Phase::RegisterWithObserver;
       case Phase::RegisterWithObserver:
+        return is_numerical_initial_data_v<initial_data> ? Phase::ImportData
+                                                         : Phase::Evolve;
+      case Phase::ImportData:
         return Phase::Evolve;
       case Phase::Evolve:
         return Phase::Exit;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicFwd.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicFwd.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+struct EvolutionMetavars;

--- a/src/Evolution/NumericalInitialData.hpp
+++ b/src/Evolution/NumericalInitialData.hpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "Utilities/TypeTraits.hpp"
+
+/// Empty base class for marking a class as numerical initial data.
+///
+/// \see `is_numeric_initial_data`
+struct MarkAsNumericalInitialData {};
+
+// @{
+/// Checks if the class `T` is marked as numerical initial data.
+template <typename T>
+using is_numerical_initial_data =
+  typename std::is_convertible<T*, MarkAsNumericalInitialData*>;
+
+template <typename T>
+constexpr bool is_numerical_initial_data_v =
+  cpp17::is_convertible_v<T*, MarkAsNumericalInitialData*>;
+// @}
+
+/// Provides compile-time information for importing numerical initial data for
+/// the `System` from a data file.
+template <typename System>
+struct NumericalInitialData : MarkAsNumericalInitialData {
+    using import_fields = typename System::initial_data_fields_tag;
+};

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions.hpp
@@ -1,0 +1,490 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/DataOnSlice.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesHelpers.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/IndexToSliceAt.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditionsImpl.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/InterfaceActionHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Parallel/Abort.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Printf.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+namespace Tags {
+template <typename Tag>
+struct Magnitude;
+}  // namespace Tags
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace GeneralizedHarmonic {
+namespace Actions {
+
+namespace BoundaryConditions_detail {}  // namespace BoundaryConditions_detail
+
+/// \ingroup ActionsGroup
+/// \brief Packages data on external boundaries for calculating numerical flux.
+/// Computes contributions on the interior side from the volume, and imposes
+/// constraint preserving boundary conditions on the exterior side.
+///
+/// With:
+/// - Boundary<Tag> =
+///   Tags::Interface<Tags::BoundaryDirections<volume_dim>, Tag>
+/// - External<Tag> =
+///   Tags::Interface<Tags::ExternalBoundaryDirections<volume_dim>, Tag>
+///
+/// Uses:
+/// - ConstGlobalCache:
+///   - Metavariables::normal_dot_numerical_flux
+///   - Metavariables::boundary_condition
+/// - DataBox:
+///   - Tags::Element<volume_dim>
+///   - Boundary<Tags listed in
+///               Metavariables::normal_dot_numerical_flux::type::argument_tags>
+///   - External<Tags listed in
+///               Metavariables::normal_dot_numerical_flux::type::argument_tags>
+///   - Boundary<Tags::Mesh<volume_dim - 1>>
+///   - External<Tags::Mesh<volume_dim - 1>>
+///   - Boundary<Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>,
+///   - External<Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>,
+///   - Boundary<Tags::BoundaryCoordinates<volume_dim>>,
+///   - Metavariables::temporal_id
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///      - Tags::VariablesBoundaryData
+///      - External<Tags::dt<typename system::variables_tag>>
+///
+/// \see ReceiveDataForFluxes
+template <typename Metavariables>
+struct ImposeConstraintPreservingBoundaryConditions {
+ private:
+  // {UPsi,UZero,UPlus,UMinus}BcMethod are used to select exactly
+  // how to apply the requested boundary condition based on user input. A
+  // specialized `apply_impl` struct is used that implements the boundary
+  // condition calculation for the different types.
+  using UPsiBcMethod = BoundaryConditions_detail::UPsiBcMethod;
+  using UZeroBcMethod = BoundaryConditions_detail::UZeroBcMethod;
+  using UPlusBcMethod = BoundaryConditions_detail::UPlusBcMethod;
+  using UMinusBcMethod = BoundaryConditions_detail::UMinusBcMethod;
+
+ public:
+  using const_global_cache_tags =
+      tmpl::list<typename Metavariables::normal_dot_numerical_flux,
+                 typename Metavariables::boundary_condition_tag>;
+
+ private:
+  /* ------------------------------------------------------------------------
+   * ------------------------------------------------------------------------
+   * ---------------- APPLY BJORHUS BOUNDARY CONDITIONS  --------------------
+   * ------------------------------------------------------------------------
+   * ------------------------------------------------------------------------
+   */
+  template <size_t VolumeDim, UPsiBcMethod UPsiMethod,
+            UZeroBcMethod UZeroMethod, UPlusBcMethod UPlusMethod,
+            UMinusBcMethod UMinusMethod, typename DbTags>
+  struct apply_impl {
+    static std::tuple<db::DataBox<DbTags>&&> function_impl(
+        db::DataBox<DbTags>& box,
+        const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
+      // ------------------------------- (1)
+      // Get information about system:
+      // tags for evolved variables and their time derivatives
+      using system = typename Metavariables::system;
+      using variables_tag = typename system::variables_tag;
+      using dt_variables_tag =
+          db::add_tag_prefix<Metavariables::temporal_id::template step_prefix,
+                             variables_tag>;
+      constexpr const size_t number_of_independent_components =
+          dt_variables_tag::type::number_of_independent_components;
+
+      const db::item_type<::Tags::Mesh<VolumeDim>>& mesh =
+          db::get<::Tags::Mesh<VolumeDim>>(box);
+      const size_t volume_grid_points = mesh.extents().product();
+      const auto& unit_normal_one_forms = db::get<
+          ::Tags::Interface<::Tags::BoundaryDirectionsInterior<VolumeDim>,
+                            ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<
+                                VolumeDim, Frame::Inertial>>>>(box);
+      // const auto& external_bdry_vars = db::get<::Tags::Interface<
+      //::Tags::BoundaryDirectionsInterior<VolumeDim>, variables_tag>>(box);
+      const auto& volume_all_vars = db::get<variables_tag>(box);
+      const auto& volume_all_dt_vars = db::get<dt_variables_tag>(box);
+      const auto& external_bdry_char_speeds = db::get<::Tags::Interface<
+          ::Tags::BoundaryDirectionsInterior<VolumeDim>,
+          Tags::CharacteristicSpeeds<VolumeDim, Frame::Inertial>>>(box);
+      const auto& external_bdry_inertial_coords = db::get<
+          ::Tags::Interface<::Tags::BoundaryDirectionsInterior<VolumeDim>,
+                            ::Tags::Coordinates<VolumeDim, Frame::Inertial>>>(
+          box);
+
+      // ------------------------------- (2)
+      // Apply the boundary condition
+      // Loop over external boundaries and set dt_volume_vars on them
+      for (auto& external_direction_and_normals : unit_normal_one_forms) {
+        const auto& direction = external_direction_and_normals.first;
+        const size_t dimension = direction.dimension();
+        const auto& unit_normal_one_form =
+            external_direction_and_normals.second;
+        const size_t slice_grid_points =
+            mesh.extents().slice_away(dimension).product();
+        // Get U on this slice
+        const auto vars =
+            data_on_slice(volume_all_vars, mesh.extents(), dimension,
+                          index_to_slice_at(mesh.extents(), direction));
+        ASSERT(vars.number_of_grid_points() == slice_grid_points,
+               "vars_on_slice has wrong number of grid points.  "
+               "Expected "
+                   << slice_grid_points << ", got "
+                   << vars.number_of_grid_points());
+        // Get dt<U> on this slice
+        const auto dt_vars =
+            data_on_slice(volume_all_dt_vars, mesh.extents(), dimension,
+                          index_to_slice_at(mesh.extents(), direction));
+        // Get characteristic speeds
+        const auto& char_speeds = external_bdry_char_speeds.at(direction);
+        // For external boundaries that are within a horizon,
+        // all characteristic fields are outgoing (toward the singularity)
+        if (BoundaryConditions_detail::min_characteristic_speed<VolumeDim>(
+                char_speeds) >= 0.) {
+          continue;
+        }
+        // Get boundary coordinates
+        const auto& inertial_coords =
+            external_bdry_inertial_coords.at(direction);
+        // ------------------------------- (2)
+        // Create a TempTensor that stores all temporaries computed
+        // here and elsewhere
+        TempBuffer<BoundaryConditions_detail::all_local_vars<VolumeDim>> buffer(
+            slice_grid_points);
+        // ------------------------------- (2.2)
+        // Compute local variables, including:
+        // (A) unit normal form to interface
+        // (B) 4metric, inv4metric, lapse, shift on this slice
+        // (C) dampign parameter ConstraintGamma2 on this slice
+        // (D) Compute projection operator on this slice
+        // (E) dt<U> on this slice from `volume_all_dt_vars`
+        BoundaryConditions_detail::local_variables(
+            make_not_null(&buffer), box, direction, dimension, mesh, vars,
+            dt_vars, unit_normal_one_form, char_speeds);
+
+        // FIXME: Are there incoming char speeds on the inner boundary?
+        if (true) {  // {{{
+          const auto& x =
+              get<::Tags::TempI<37, VolumeDim, Frame::Inertial, DataVector>>(
+                  buffer);
+          // If radius of surface is less than 10, then assume we are on an
+          // inner boundary. FIXME
+          const auto& min_r_squared =
+              min(square(get<0>(x)) + square(get<1>(x)) + square(get<2>(x)));
+          const auto min_inertial_r_squared =
+              min(square(get<0>(inertial_coords)) +
+                  square(get<1>(inertial_coords)) +
+                  square(get<2>(inertial_coords)));
+          if (min_r_squared < 3.5 * 3.5 or min_inertial_r_squared < 3.5 * 3.5) {
+            const auto& min_speed =
+                BoundaryConditions_detail::min_characteristic_speed<VolumeDim>(
+                    char_speeds);
+            if (min_speed <= 0.0) {
+              Parallel::printf(
+                  "\nWARNING: Incoming char speeds on INNER boundary at t=%f\n",
+                  db::get<::Tags::Time>(box));
+              Parallel::printf(
+                  "  Min speed %f at min (inertial) radius %f (%f)\n\n",
+                  min_speed, sqrt(min_r_squared), sqrt(min_inertial_r_squared));
+              // Is the face normal outward facing, really?
+              for (size_t i = 0; i < 5; ++i) {
+                Parallel::printf(
+                    " >> (random pt (%f, %f, %f)) unnormalized_normal_{x,y,z}: "
+                    "(%f, %f, "
+                    "%f)\n",
+                    get<0>(x)[i], get<1>(x)[i], get<2>(x)[i],
+                    get<0>(unit_normal_one_form)[i],
+                    get<1>(unit_normal_one_form)[i],
+                    get<2>(unit_normal_one_form)[i]);
+                Parallel::printf(
+                    "     (same random pt) r dot normal (should be NEGative): "
+                    "%f\n",
+                    get<0>(x)[i] * get<0>(unit_normal_one_form)[i] +
+                        get<1>(x)[i] * get<1>(unit_normal_one_form)[i] +
+                        get<2>(x)[i] * get<2>(unit_normal_one_form)[i]);
+                Parallel::printf(
+                    "     (same random pt) char speeds (psi, 0, +, -): %f, %f, "
+                    "%f, %f\n",
+                    char_speeds.at(0)[i], char_speeds.at(1)[i],
+                    char_speeds.at(2)[i], char_speeds.at(3)[i]);
+              }
+              Parallel::abort("Aborting for above reason...");
+            }
+          }
+        }  // }}}
+
+        db::mutate<dt_variables_tag>(
+            make_not_null(&box),
+            // Function that applies bdry conditions to dt<variables>
+            [
+              &volume_grid_points, &slice_grid_points, &mesh, &dimension,
+              &direction, &buffer, &vars, &dt_vars, &unit_normal_one_form,
+              &inertial_coords, &char_speeds
+            ](const gsl::not_null<db::item_type<dt_variables_tag>*>
+                  volume_dt_vars,
+              const double /* time */, const auto& /* boundary_condition */
+              ) noexcept {
+              // ------------------------------- (1)
+              // Preliminaries
+              ASSERT(
+                  volume_dt_vars->number_of_grid_points() == volume_grid_points,
+                  "volume_dt_vars has wrong number of grid points.  Expected "
+                      << volume_grid_points << ", got "
+                      << volume_dt_vars->number_of_grid_points());
+              // ------------------------------- (2)
+              // Compute desired values of dt_volume_vars
+              //
+              // ------------------------------- (2.1)
+              // Get desired values of CharProjection<dt<U>>
+              //
+              // At all points on the interface where the char speed of any
+              // (given) characteristic field is +ve, we "do nothing", and
+              // when its -ve, we apply Bjorhus BCs. This is achieved through
+              // `set_bc_when_char_speed_is_negative`.
+              const auto bc_dt_u_psi =
+                  BoundaryConditions_detail::set_bc_when_char_speed_is_negative(
+                      get<::Tags::Tempaa<22, VolumeDim, Frame::Inertial,
+                                         DataVector>>(buffer),
+                      BoundaryConditions_detail::set_dt_u_psi<
+                          typename Tags::UPsi<VolumeDim, Frame::Inertial>::type,
+                          VolumeDim>::apply(UPsiMethod, buffer, vars, dt_vars,
+                                            unit_normal_one_form),
+                      char_speeds.at(0));
+              const auto bc_dt_u_zero =
+                  BoundaryConditions_detail::set_bc_when_char_speed_is_negative(
+                      get<::Tags::Tempiaa<23, VolumeDim, Frame::Inertial,
+                                          DataVector>>(buffer),
+                      BoundaryConditions_detail::set_dt_u_zero<
+                          typename Tags::UZero<VolumeDim,
+                                               Frame::Inertial>::type,
+                          VolumeDim>::apply(UZeroMethod, buffer, vars, dt_vars,
+                                            unit_normal_one_form),
+                      char_speeds.at(1));
+              const auto bc_dt_u_plus =
+                  BoundaryConditions_detail::set_bc_when_char_speed_is_negative(
+                      get<::Tags::Tempaa<24, VolumeDim, Frame::Inertial,
+                                         DataVector>>(buffer),
+                      BoundaryConditions_detail::set_dt_u_plus<
+                          typename Tags::UPlus<VolumeDim,
+                                               Frame::Inertial>::type,
+                          VolumeDim>::apply(UPlusMethod, buffer, vars, dt_vars,
+                                            unit_normal_one_form),
+                      char_speeds.at(2));
+              const auto bc_dt_u_minus =
+                  BoundaryConditions_detail::set_bc_when_char_speed_is_negative(
+                      get<::Tags::Tempaa<25, VolumeDim, Frame::Inertial,
+                                         DataVector>>(buffer),
+                      BoundaryConditions_detail::set_dt_u_minus<
+                          typename Tags::UMinus<VolumeDim,
+                                                Frame::Inertial>::type,
+                          VolumeDim>::apply(UMinusMethod, buffer, vars, dt_vars,
+                                            inertial_coords,
+                                            unit_normal_one_form),
+                      char_speeds.at(3));
+              // Convert them to desired values on dt<U>
+              const auto bc_dt_all_u =
+                  evolved_fields_from_characteristic_fields(
+                      get<::Tags::TempScalar<26, DataVector>>(
+                          buffer),  // Gamma2
+                      bc_dt_u_psi, bc_dt_u_zero, bc_dt_u_plus, bc_dt_u_minus,
+                      unit_normal_one_form);
+              // Now store final values of dt<U> in suitable data structure
+              // FIXME: How can I extract this list of dt<U> tags directly
+              // from `dt_variables_tag`?
+              const tuples::TaggedTuple<
+                  db::add_tag_prefix<
+                      Metavariables::temporal_id::template step_prefix,
+                      gr::Tags::SpacetimeMetric<VolumeDim, Frame::Inertial,
+                                                DataVector>>,
+                  db::add_tag_prefix<
+                      Metavariables::temporal_id::template step_prefix,
+                      Tags::Phi<VolumeDim, Frame::Inertial>>,
+                  db::add_tag_prefix<
+                      Metavariables::temporal_id::template step_prefix,
+                      Tags::Pi<VolumeDim, Frame::Inertial>>>
+                  bc_dt_tuple(
+                      std::move(get<gr::Tags::SpacetimeMetric<
+                                    VolumeDim, Frame::Inertial, DataVector>>(
+                          bc_dt_all_u)),
+                      std::move(get<Tags::Phi<VolumeDim, Frame::Inertial>>(
+                          bc_dt_all_u)),
+                      std::move(get<Tags::Pi<VolumeDim, Frame::Inertial>>(
+                          bc_dt_all_u)));
+              const auto slice_data_ = variables_from_tagged_tuple(bc_dt_tuple);
+              const auto* slice_data = slice_data_.data();
+
+              // ------------------------------- (2.4)
+              // Assign BC values of dt_volume_vars on external boundary
+              // slices of volume variables
+              auto* const volume_dt_data = volume_dt_vars->data();
+              for (SliceIterator si(
+                       mesh.extents(), dimension,
+                       index_to_slice_at(mesh.extents(), direction));
+                   si; ++si) {
+                for (size_t i = 0; i < number_of_independent_components; ++i) {
+                  // clang-tidy: do not use pointer arithmetic
+                  volume_dt_data[si.volume_offset() +       // NOLINT
+                                 i * volume_grid_points] =  // NOLINT
+                      slice_data[si.slice_offset() +        // NOLINT
+                                 i * slice_grid_points];    // NOLINT
+                }
+              }
+            },
+            db::get<::Tags::Time>(box),
+            get<typename Metavariables::boundary_condition_tag>(cache));
+      }
+
+      return std::forward_as_tuple(std::move(box));
+    }
+  };
+
+  template <size_t VolumeDim, typename DbTags>
+  struct apply_impl<VolumeDim, UPsiBcMethod::AnalyticBc,
+                    UZeroBcMethod::AnalyticBc, UPlusBcMethod::AnalyticBc,
+                    UMinusBcMethod::AnalyticBc, DbTags> {
+    static std::tuple<db::DataBox<DbTags>&&> function_impl(
+        db::DataBox<DbTags>& box,
+        const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
+      using system = typename Metavariables::system;
+
+      // Apply the boundary condition
+      db::mutate_apply<tmpl::list<::Tags::Interface<
+                           ::Tags::BoundaryDirectionsExterior<VolumeDim>,
+                           typename system::variables_tag>>,
+                       tmpl::list<>>(
+          [](const gsl::not_null<db::item_type<::Tags::Interface<
+                 ::Tags::BoundaryDirectionsExterior<VolumeDim>,
+                 typename system::variables_tag>>*>
+                 external_bdry_vars,
+             const double time, const auto& boundary_condition,
+             const auto& boundary_coords) noexcept {
+            // Loop over external boundaries
+            for (auto& external_direction_and_vars : *external_bdry_vars) {
+              auto& direction = external_direction_and_vars.first;
+              auto& vars = external_direction_and_vars.second;
+              // Get evolved variables on current boundary from AnalyticSolution
+              // and assign them to `vars`
+              vars.assign_subset(boundary_condition.variables(
+                  boundary_coords.at(direction), time,
+                  typename system::variables_tag::type::tags_list{}));
+            }
+          },
+          make_not_null(&box), db::get<::Tags::Time>(box),
+          get<typename Metavariables::boundary_condition_tag>(cache),
+          db::get<::Tags::Interface<
+              ::Tags::BoundaryDirectionsExterior<VolumeDim>,
+              ::Tags::Coordinates<VolumeDim, Frame::Inertial>>>(box));
+
+      contribute_data_to_mortar(make_not_null(&box), cache);
+      return std::forward_as_tuple(std::move(box));
+    }
+  };
+
+  /* ------------------------------------------------------------------------
+   * ------------------------------------------------------------------------
+   * ---------------- SEND DATA TO MORTAR FOR ANALYTIC BCs ------------------
+   * ------------------------------------------------------------------------
+   * ------------------------------------------------------------------------
+   */
+  template <typename DbTags>
+  static void contribute_data_to_mortar(
+      const gsl::not_null<db::DataBox<DbTags>*> box,
+      const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
+    using system = typename Metavariables::system;
+    constexpr size_t volume_dim = system::volume_dim;
+
+    const auto& element = db::get<::Tags::Element<volume_dim>>(*box);
+    const auto& temporal_id =
+        db::get<typename Metavariables::temporal_id>(*box);
+    const auto& normal_dot_numerical_flux_computer =
+        get<typename Metavariables::normal_dot_numerical_flux>(cache);
+
+    for (const auto& direction : element.external_boundaries()) {
+      const auto mortar_id = std::make_pair(
+          direction, ElementId<volume_dim>::external_boundary_id());
+
+      auto interior_data = DgActions_detail::compute_local_mortar_data(
+          *box, direction, normal_dot_numerical_flux_computer,
+          ::Tags::BoundaryDirectionsInterior<volume_dim>{}, Metavariables{});
+
+      auto exterior_data = DgActions_detail::compute_packaged_data(
+          *box, direction, normal_dot_numerical_flux_computer,
+          ::Tags::BoundaryDirectionsExterior<volume_dim>{}, Metavariables{});
+
+      db::mutate<::Tags::VariablesBoundaryData>(
+          box, [&mortar_id, &temporal_id, &interior_data, &exterior_data ](
+                   const gsl::not_null<
+                       db::item_type<::Tags::VariablesBoundaryData, DbTags>*>
+                       mortar_data) noexcept {
+            mortar_data->at(mortar_id).local_insert(temporal_id,
+                                                    std::move(interior_data));
+            mortar_data->at(mortar_id).remote_insert(temporal_id,
+                                                     std::move(exterior_data));
+          });
+    }
+  }
+
+ public:
+  template <typename DbTags, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTags>&&> apply(
+      db::DataBox<DbTags>& box, tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    // Here be user logic that determines / selects from various options for
+    // setting BCs on individual characteristic variables
+    return apply_impl<Metavariables::system::volume_dim,
+                      // BC choice for U_\Psi
+                      UPsiBcMethod::ConstraintPreservingBjorhus,
+                      // BC choice for U_0
+                      UZeroBcMethod::ConstraintPreservingBjorhus,
+                      // BC choice for U_+
+                      UPlusBcMethod::Freezing,
+                      // BC choice for U_-
+                      UMinusBcMethod::ConstraintPreservingPhysicalBjorhus,
+                      DbTags>::function_impl(box, cache);
+  }
+};
+
+}  // namespace Actions
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditionsHelpers.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditionsHelpers.hpp
@@ -1,0 +1,312 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/DataOnSlice.hpp"
+#include "DataStructures/LeviCivitaIterator.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesHelpers.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/IndexToSliceAt.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/InterfaceActionHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+namespace Tags {
+template <typename Tag>
+struct Magnitude;
+}  // namespace Tags
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace GeneralizedHarmonic {
+namespace Actions {
+namespace BoundaryConditions_detail {
+template <size_t VolumeDim>
+double min_characteristic_speed(
+    const typename GeneralizedHarmonic::Tags::CharacteristicSpeeds<
+        VolumeDim, Frame::Inertial>::type& char_speeds) noexcept {
+  std::array<double, 4> min_speeds{
+      {min(char_speeds.at(0)), min(char_speeds.at(1)), min(char_speeds.at(2)),
+       min(char_speeds.at(3))}};
+  return *std::min_element(min_speeds.begin(), min_speeds.end());
+}
+
+template <typename T, typename DataType>
+T set_bc_when_char_speed_is_negative(const T& rhs_char_dt_u,
+                                     const T& desired_bc_dt_u,
+                                     const DataType& char_speed_u) noexcept {
+  auto bc_dt_u = rhs_char_dt_u;
+  auto it1 = bc_dt_u.begin();
+  auto it2 = desired_bc_dt_u.begin();
+  for (; it2 != desired_bc_dt_u.end(); ++it1, ++it2) {
+    for (size_t i = 0; i < it1->size(); ++i) {
+      if (char_speed_u[i] < 0.) {
+        (*it1)[i] = (*it2)[i];
+      }
+    }
+  }
+  return bc_dt_u;
+}
+}  // namespace BoundaryConditions_detail
+}  // namespace Actions
+
+// Eq. (2.20) of Kidder, Scheel & Teukolsky (KST) [gr-qc/0105031v1]
+// Compute R_{ij} from D_(k,i,j) = (1/2) \partial_k g_(ij)
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::ii<DataType, VolumeDim, Frame> spatial_ricci_tensor_from_KST_vars(
+    const tnsr::ijj<DataType, VolumeDim, Frame>& kst_var_D,
+    const tnsr::ijkk<DataType, VolumeDim, Frame>& d_kst_var_D,
+    const tnsr::II<DataType, VolumeDim, Frame>&
+        inverse_spatial_metric) noexcept {
+  auto ricci = make_with_value<tnsr::ii<DataType, VolumeDim, Frame>>(
+      inverse_spatial_metric, 0.);
+
+  // New variable to avoid recomputing stuff in nested loops
+  tnsr::ijj<DataType, VolumeDim, Frame> Dudd(
+      get_size(get<0, 0>(inverse_spatial_metric)));
+
+  for (size_t k = 0; k < VolumeDim; ++k) {
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = i; j < VolumeDim; ++j) {  // Symmetry
+        Dudd.get(k, i, j) = 0.;
+        for (size_t l = 0; l < VolumeDim; ++l)
+          Dudd.get(k, i, j) +=
+              inverse_spatial_metric.get(k, l) * kst_var_D.get(l, i, j);
+      }
+    }
+  }
+
+  // New variable to avoid recomputing stuff in nested loops
+  tnsr::ijk<DataType, VolumeDim, Frame> Dddu(
+      get_size(get<0, 0>(inverse_spatial_metric)));
+  for (size_t k = 0; k < VolumeDim; ++k) {
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        Dddu.get(i, j, k) = 0.;
+        for (size_t l = 0; l < VolumeDim; ++l)
+          Dddu.get(i, j, k) +=
+              inverse_spatial_metric.get(k, l) * kst_var_D.get(i, j, l);
+      }
+    }
+  }
+
+  // New variable to avoid recomputing stuff in nested loops
+  tnsr::i<DataType, VolumeDim, Frame> Dtr1(
+      get_size(get<0, 0>(inverse_spatial_metric)));
+  //  kst_var_D.get(i,m,n)*inverse_spatial_metric.get(m,n)
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    Dtr1.get(i) = 0.;
+    for (size_t j = 0; j < VolumeDim; ++j)
+      Dtr1.get(i) += Dddu.get(i, j, j);
+  }
+  //   kst_var_D.get(m,n,i)*inverse_spatial_metric.get(m,n)
+  tnsr::i<DataType, VolumeDim, Frame> Dtr2(
+      get_size(get<0, 0>(inverse_spatial_metric)));
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    Dtr2.get(i) = 0.;
+    for (size_t j = 0; j < VolumeDim; ++j)
+      Dtr2.get(i) += Dudd.get(j, j, i);
+  }
+
+  const auto Dtr1up = raise_or_lower_index(Dtr1, inverse_spatial_metric);
+  const auto Dtr2up = raise_or_lower_index(Dtr2, inverse_spatial_metric);
+
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {  // Symmetry
+      ricci.get(i, j) = 0.;
+      for (size_t p = 0; p < VolumeDim; ++p) {
+        ricci.get(i, j) += (kst_var_D.get(p, i, j) - kst_var_D.get(i, j, p) -
+                            kst_var_D.get(j, i, p)) *
+                           (2.0 * Dtr2up.get(p) - Dtr1up.get(p));
+        for (size_t q = 0; q < VolumeDim; ++q) {
+          ricci.get(i, j) +=
+              0.5 * inverse_spatial_metric.get(p, q) *
+                  (d_kst_var_D.get(j, q, p, i) + d_kst_var_D.get(i, q, p, j) -
+                   d_kst_var_D.get(j, i, p, q) - d_kst_var_D.get(i, j, p, q) +
+                   d_kst_var_D.get(p, i, q, j) + d_kst_var_D.get(p, j, q, i) -
+                   2.0 * d_kst_var_D.get(q, p, i, j)) +
+              Dddu.get(i, p, q) * Dddu.get(j, q, p) +
+              2.0 * Dudd.get(p, i, q) * Dddu.get(p, j, q) -
+              2.0 * Dudd.get(p, q, i) * Dudd.get(q, p, j);
+        }
+      }
+    }
+  }
+
+  return ricci;
+}
+
+// Eq. (2.19) of Kidder, Scheel & Teukolsky (KST) [gr-qc/0105031v1]
+// Compute \Gamma^k_{ij} from D_(k,i,j) = (1/2) \partial_k g_(ij)
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::Ijj<DataType, VolumeDim, Frame>
+spatial_christoffel_second_kind_from_KST_vars(
+    const tnsr::ijj<DataType, VolumeDim, Frame>& kst_var_D,
+    const tnsr::II<DataType, VolumeDim, Frame>&
+        inverse_spatial_metric) noexcept {
+  tnsr::ijj<DataType, VolumeDim, Frame> christoffel_first_kind{
+      get_size(get<0, 0>(inverse_spatial_metric))};
+  for (size_t k = 0; k < VolumeDim; ++k) {
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = i; j < VolumeDim; ++j) {  // Symmetry
+        christoffel_first_kind.get(k, i, j) = kst_var_D.get(i, j, k) +
+                                              kst_var_D.get(j, i, k) -
+                                              kst_var_D.get(k, i, j);
+      }
+    }
+  }
+  auto christoffel_second_kind =
+      make_with_value<tnsr::Ijj<DataType, VolumeDim, Frame>>(
+          inverse_spatial_metric, 0.);
+  // raise first index
+  for (size_t k = 0; k < VolumeDim; ++k) {
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        for (size_t l = 0; l < VolumeDim; ++l) {
+          christoffel_second_kind.get(k, i, j) +=
+              inverse_spatial_metric.get(k, l) *
+              christoffel_first_kind.get(l, i, j);
+        }
+      }
+    }
+  }
+  return christoffel_second_kind;
+}
+
+// Spatial projection tensors
+template <size_t VolumeDim, typename Frame, typename DataType, typename RetType>
+void spatial_projection_tensor(
+    const gsl::not_null<RetType*> projection_tensor,
+    const tnsr::II<DataType, VolumeDim, Frame>& inverse_spatial_metric,
+    const tnsr::A<DataType, VolumeDim, Frame>& normal_vector) noexcept {
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {
+      projection_tensor->get(i, j) =
+          inverse_spatial_metric.get(i, j) -
+          normal_vector.get(i + 1) * normal_vector.get(j + 1);
+    }
+  }
+}
+template <size_t VolumeDim, typename Frame, typename DataType, typename RetType>
+void spatial_projection_tensor(
+    const gsl::not_null<RetType*> projection_tensor,
+    const tnsr::ii<DataType, VolumeDim, Frame>& spatial_metric,
+    const tnsr::a<DataType, VolumeDim, Frame>& normal_one_form) noexcept {
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {
+      projection_tensor->get(i, j) =
+          spatial_metric.get(i, j) -
+          normal_one_form.get(i + 1) * normal_one_form.get(j + 1);
+    }
+  }
+}
+template <size_t VolumeDim, typename Frame, typename DataType, typename RetType>
+void spatial_projection_tensor(
+    const gsl::not_null<RetType*> projection_tensor,
+    const tnsr::A<DataType, VolumeDim, Frame>& normal_vector,
+    const tnsr::a<DataType, VolumeDim, Frame>& normal_one_form) noexcept {
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    projection_tensor->get(i, i) = 0.;
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      projection_tensor->get(i, j) =
+          -normal_vector.get(i + 1) * normal_one_form.get(j + 1);
+    }
+  }
+}
+
+// This computes U8(+/-)_{ij} = [P^(a_i P^b)_j - (1/2) P_{ij} P^{ab}] *
+//                              [E_{ab} -/+ \epsilon_{a}{}^{cd} n_d B_{cb}]
+//
+// Note that U8+_{ij} is proportional to the Newman-Penrose Psi4
+//       and U8-_{ij} is proportional to the Newman-Penrose Psi0
+//
+// Here
+// U8(a,b)     = U8_{ab}
+// ni(a)       = n_a      (unit normal)
+// nI(a)       = n^a
+// PIJ(a,b)    = P^{ab}   (projection operator = g^{ab} - n^a n^b)
+// Pij(a,b)    = P_{ab}   (projection operator = g_{ab} - n_a n_b)
+// PIj(a,b)    = P^a_b    (projection operator = g^a_b  - n^a n_b)
+// K(a,b)      = K_{ab}
+// Ricci(a,b)  = Ricci_{ab}
+// Invg(a,b)   = g^{ab}
+// CdK(a,b)(c) = \nabla_c K_{ab}
+template <size_t VolumeDim, typename Frame, typename DataType, typename RetType>
+void weyl_propagating(
+    const gsl::not_null<RetType*> U8,
+    const tnsr::ii<DataType, VolumeDim, Frame>& ricci,
+    const tnsr::ii<DataType, VolumeDim, Frame>& extrinsic_curvature,
+    const tnsr::II<DataType, VolumeDim, Frame>& inverse_spatial_metric,
+    const tnsr::ijj<DataType, VolumeDim, Frame>& CdK,
+    const tnsr::a<DataType, VolumeDim, Frame>& /* unit_normal */,
+    const tnsr::A<DataType, VolumeDim, Frame>& unit_interface_normal_vector,
+    const tnsr::II<DataType, VolumeDim, Frame>& projection_IJ,
+    const tnsr::ii<DataType, VolumeDim, Frame>& projection_ij,
+    const tnsr::Ij<DataType, VolumeDim, Frame>& projection_Ij,
+    const int sign) noexcept {
+  // Fill temp with unprojected quantity
+  tnsr::ii<DataType, VolumeDim, Frame> temp(
+      get_size(get<0>(unit_interface_normal_vector)));
+  for (size_t a = 0; a < VolumeDim; ++a) {
+    for (size_t b = a; b < VolumeDim; ++b) {  // Symmetry
+      temp.get(a, b) = ricci.get(a, b);
+      for (size_t c = 0; c < VolumeDim; ++c) {
+        temp.get(a, b) -=
+            sign * unit_interface_normal_vector.get(c) *
+            (CdK.get(c, a, b) - 0.5 * (CdK.get(b, a, c) + CdK.get(a, b, c)));
+        for (size_t d = 0; d < VolumeDim; ++d) {
+          temp.get(a, b) +=
+              inverse_spatial_metric.get(c, d) *
+              (extrinsic_curvature.get(a, b) * extrinsic_curvature.get(c, d) -
+               extrinsic_curvature.get(a, c) * extrinsic_curvature.get(d, b));
+        }
+      }
+    }
+  }
+
+  // Now project
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {  // Symmetry
+      U8->get(i, j) = 0.;
+      for (size_t a = 0; a < VolumeDim; ++a) {
+        for (size_t b = 0; b < VolumeDim; ++b) {
+          U8->get(i, j) +=
+              (projection_Ij.get(a, i) * projection_Ij.get(b, j) -
+               0.5 * projection_IJ.get(a, b) * projection_ij.get(i, j)) *
+              temp.get(a, b);
+        }
+      }
+    }
+  }
+}
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditionsImpl.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditionsImpl.hpp
@@ -1,0 +1,1425 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/DataOnSlice.hpp"
+#include "DataStructures/LeviCivitaIterator.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesHelpers.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/IndexToSliceAt.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditionsHelpers.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/InterfaceActionHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+namespace Tags {
+template <typename Tag>
+struct Magnitude;
+}  // namespace Tags
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace GeneralizedHarmonic {
+namespace Actions {
+
+namespace BoundaryConditions_detail {}  // namespace BoundaryConditions_detail
+
+namespace BoundaryConditions_detail {
+enum class UPsiBcMethod {
+  AnalyticBc,
+  Freezing,
+  ConstraintPreservingBjorhus,
+  ConstraintPreservingDirichlet,
+  Unknown
+};
+enum class UZeroBcMethod {
+  AnalyticBc,
+  Freezing,
+  ConstraintPreservingBjorhus,
+  ConstraintPreservingDirichlet,
+  ConstraintPreservingRealDirichlet,
+  Unknown
+};
+enum class UPlusBcMethod { AnalyticBc, Freezing, Unknown };
+enum class UMinusBcMethod {
+  AnalyticBc,
+  Freezing,
+  ConstraintPreservingBjorhus,
+  ConstraintPreservingPhysicalBjorhus,
+  Unknown
+};
+
+template <size_t VolumeDim>
+using all_local_vars = tmpl::list<
+    // timelike and spacelike SPACETIME oneforms, l_a and k_a
+    ::Tags::Tempa<0, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::Tempa<1, VolumeDim, Frame::Inertial, DataVector>,
+    // timelike and spacelike SPACETIME vectors, l^a and k^a
+    ::Tags::TempA<2, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::TempA<3, VolumeDim, Frame::Inertial, DataVector>,
+    // SPACETIME form of interface normal (vector and oneform)
+    ::Tags::Tempa<4, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::TempA<5, VolumeDim, Frame::Inertial, DataVector>,
+    // spacetime null form t_a and vector t^a
+    ::Tags::Tempa<6, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::TempA<7, VolumeDim, Frame::Inertial, DataVector>,
+    // interface normal dot shift: n_k N^k
+    ::Tags::TempScalar<8, DataVector>,
+    // spacetime projection operator P_ab, P^ab, and P^a_b
+    ::Tags::TempAA<9, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::Tempaa<10, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::TempAb<11, VolumeDim, Frame::Inertial, DataVector>,
+    // Char speeds
+    ::Tags::TempScalar<12, DataVector>, ::Tags::TempScalar<13, DataVector>,
+    ::Tags::TempScalar<14, DataVector>, ::Tags::TempScalar<15, DataVector>,
+    // Characteristics of Constraints
+    ::Tags::Tempa<16, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::Tempa<34, VolumeDim, Frame::Inertial, DataVector>,
+    // ::Tags::Tempia<35, VolumeDim, Frame::Inertial, DataVector>,   // C_{ja}
+    // ::Tags::Tempa<36, VolumeDim, Frame::Inertial, DataVector>,    // F_a
+    ::Tags::Tempiaa<17, VolumeDim, Frame::Inertial, DataVector>,  // C_{jab}
+    // e^{ijk} C_{jkab}
+    ::Tags::Tempiaa<18, VolumeDim, Frame::Inertial, DataVector>,
+    // 3+1 geometric quantities: lapse, shift, inverse
+    // 3-metric, extrinsic curvature K_ij
+    ::Tags::TempScalar<19, DataVector>,
+    ::Tags::TempI<20, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::TempII<21, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::Tempii<35, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::TempAA<36, VolumeDim, Frame::Inertial, DataVector>,
+    // Characteristic projected time derivatives of evolved
+    // fields
+    ::Tags::Tempaa<22, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::Tempiaa<23, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::Tempaa<24, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::Tempaa<25, VolumeDim, Frame::Inertial, DataVector>,
+    // Constraint damping parameter gamma2
+    ::Tags::TempScalar<26, DataVector>,
+    // Preallocated memory to store boundary conditions
+    ::Tags::Tempaa<27, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::Tempiaa<28, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::Tempaa<29, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::Tempaa<30, VolumeDim, Frame::Inertial, DataVector>,
+    // derivatives of psi, pi, phi
+    ::Tags::Tempiaa<31, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::Tempiaa<32, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::Tempijaa<33, VolumeDim, Frame::Inertial, DataVector>,
+    // <34>, <35>, <36> defined above
+    // mapped coordinates
+    ::Tags::TempI<37, VolumeDim, Frame::Inertial, DataVector>>;
+
+// \brief This function computes intermediate variables needed for
+// Bjorhus-type constraint preserving boundary conditions for the
+// GeneralizedHarmonic system
+template <size_t VolumeDim, typename TagsList, typename DbTags,
+          typename VarsTagsList, typename DtVarsTagsList>
+void local_variables(
+    gsl::not_null<TempBuffer<TagsList>*> buffer, const db::DataBox<DbTags>& box,
+    const Direction<VolumeDim>& direction, const size_t& dimension,
+    const typename ::Tags::Mesh<VolumeDim>::type& mesh,
+    const Variables<VarsTagsList>& /* vars */,
+    const Variables<DtVarsTagsList>& dt_vars,
+    const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_one_form,
+    const typename Tags::CharacteristicSpeeds<VolumeDim, Frame::Inertial>::type&
+        char_speeds) noexcept {
+  //
+  // NOTE: variable names below closely follow \cite Lindblom2005qh
+  //
+  // 1) Extract quantities from databox that are needed to compute
+  // intermediate variables
+  using tags_needed_on_slice = tmpl::list<
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>,
+      gr::Tags::SpatialMetric<VolumeDim, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<VolumeDim, Frame::Inertial, DataVector>,
+      gr::Tags::SpacetimeNormalOneForm<VolumeDim, Frame::Inertial, DataVector>,
+      gr::Tags::SpacetimeNormalVector<VolumeDim, Frame::Inertial, DataVector>,
+      gr::Tags::SpacetimeMetric<VolumeDim, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpacetimeMetric<VolumeDim, Frame::Inertial, DataVector>,
+      gr::Tags::ExtrinsicCurvature<VolumeDim, Frame::Inertial, DataVector>,
+      // ---- derivs of Psi, Pi, and Phi.
+      gr::Tags::DerivSpacetimeMetric<VolumeDim, Frame::Inertial, DataVector>,
+      ::Tags::deriv<Tags::Pi<VolumeDim, Frame::Inertial>,
+                    tmpl::size_t<VolumeDim>, Frame::Inertial>,
+      ::Tags::deriv<Tags::Phi<VolumeDim, Frame::Inertial>,
+                    tmpl::size_t<VolumeDim>, Frame::Inertial>,
+      // ---- constraint damping parameters
+      // Tags::ConstraintGamma0,
+      // Tags::ConstraintGamma1,
+      Tags::ConstraintGamma2,
+      // Characteristics
+      // Constraints
+      Tags::TwoIndexConstraint<VolumeDim, Frame::Inertial>,
+      Tags::ThreeIndexConstraint<VolumeDim, Frame::Inertial>,
+      Tags::FourIndexConstraint<VolumeDim, Frame::Inertial>,
+      Tags::FConstraint<VolumeDim, Frame::Inertial>,
+      ::Tags::MappedCoordinates<::Tags::ElementMap<3, Frame::Inertial>,
+                                ::Tags::Coordinates<3, Frame::Logical>>
+      //
+      >;
+  const auto vars_on_this_slice = db::data_on_slice(
+      box, mesh.extents(), dimension,
+      index_to_slice_at(mesh.extents(), direction), tags_needed_on_slice{});
+
+  // 2) name quantities as its just easier
+  const auto& shift =
+      get<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>>(
+          vars_on_this_slice);
+  // const auto& spatial_metric =
+  //     get<gr::Tags::SpatialMetric<VolumeDim, Frame::Inertial, DataVector>>(
+  //         vars_on_this_slice);
+  const auto& inverse_spatial_metric = get<
+      gr::Tags::InverseSpatialMetric<VolumeDim, Frame::Inertial, DataVector>>(
+      vars_on_this_slice);
+  const auto& spacetime_normal_one_form = get<
+      gr::Tags::SpacetimeNormalOneForm<VolumeDim, Frame::Inertial, DataVector>>(
+      vars_on_this_slice);
+  const auto& spacetime_normal_vector = get<
+      gr::Tags::SpacetimeNormalVector<VolumeDim, Frame::Inertial, DataVector>>(
+      vars_on_this_slice);
+  const auto& spacetime_metric =
+      get<gr::Tags::SpacetimeMetric<VolumeDim, Frame::Inertial, DataVector>>(
+          vars_on_this_slice);
+  const auto& inverse_spacetime_metric = get<
+      gr::Tags::InverseSpacetimeMetric<VolumeDim, Frame::Inertial, DataVector>>(
+      vars_on_this_slice);
+  /*const auto& gamma0 =
+      get<Tags::ConstraintGamma0>(vars_on_this_slice);
+  const auto& gamma1 =
+      get<Tags::ConstraintGamma1>(vars_on_this_slice);*/
+  const auto& gamma2 = get<Tags::ConstraintGamma2>(vars_on_this_slice);
+  const auto& two_index_constraint =
+      get<Tags::TwoIndexConstraint<VolumeDim, Frame::Inertial>>(
+          vars_on_this_slice);
+  const auto& f_constraint =
+      get<Tags::FConstraint<VolumeDim, Frame::Inertial>>(vars_on_this_slice);
+  // storage for DT<UChar> = CharProjection(dt<U>)
+  const auto& rhs_dt_psi = get<::Tags::dt<
+      gr::Tags::SpacetimeMetric<VolumeDim, Frame::Inertial, DataVector>>>(
+      dt_vars);
+  const auto& rhs_dt_pi =
+      get<::Tags::dt<Tags::Pi<VolumeDim, Frame::Inertial>>>(dt_vars);
+  const auto& rhs_dt_phi =
+      get<::Tags::dt<Tags::Phi<VolumeDim, Frame::Inertial>>>(dt_vars);
+  const auto char_projected_dt_u = characteristic_fields(
+      gamma2, inverse_spatial_metric, rhs_dt_psi, rhs_dt_pi, rhs_dt_phi,
+      unit_interface_normal_one_form);
+
+  // 3) Extract variable storage out of the buffer now
+  // timelike and spacelike SPACETIME vectors, l^a and k^a
+  auto& local_outgoing_null_one_form =
+      get<::Tags::Tempa<0, VolumeDim, Frame::Inertial, DataVector>>(*buffer);
+  auto& local_incoming_null_one_form =
+      get<::Tags::Tempa<1, VolumeDim, Frame::Inertial, DataVector>>(*buffer);
+  // timelike and spacelike SPACETIME oneforms, l_a and k_a
+  auto& local_outgoing_null_vector =
+      get<::Tags::TempA<2, VolumeDim, Frame::Inertial, DataVector>>(*buffer);
+  auto& local_incoming_null_vector =
+      get<::Tags::TempA<3, VolumeDim, Frame::Inertial, DataVector>>(*buffer);
+  // SPACETIME form of interface normal (vector and oneform)
+  auto& local_interface_normal_one_form =
+      get<::Tags::Tempa<4, VolumeDim, Frame::Inertial, DataVector>>(*buffer);
+  auto& local_interface_normal_vector =
+      get<::Tags::TempA<5, VolumeDim, Frame::Inertial, DataVector>>(*buffer);
+  // spacetime null form t_a and vector t^a
+  get<::Tags::Tempa<6, VolumeDim, Frame::Inertial, DataVector>>(*buffer) = get<
+      gr::Tags::SpacetimeNormalOneForm<VolumeDim, Frame::Inertial, DataVector>>(
+      vars_on_this_slice);
+  get<::Tags::TempA<7, VolumeDim, Frame::Inertial, DataVector>>(*buffer) = get<
+      gr::Tags::SpacetimeNormalVector<VolumeDim, Frame::Inertial, DataVector>>(
+      vars_on_this_slice);
+  // interface normal dot shift: n_k N^k
+  auto& interface_normal_dot_shift =
+      get<::Tags::TempScalar<8, DataVector>>(*buffer);
+  // spacetime projection operator P_ab, P^ab, and P^a_b
+  auto& local_projection_AB =
+      get<::Tags::TempAA<9, VolumeDim, Frame::Inertial, DataVector>>(*buffer);
+  auto& local_projection_ab =
+      get<::Tags::Tempaa<10, VolumeDim, Frame::Inertial, DataVector>>(*buffer);
+  auto& local_projection_Ab =
+      get<::Tags::TempAb<11, VolumeDim, Frame::Inertial, DataVector>>(*buffer);
+  // 4.4) Characteristic speeds
+  get(get<::Tags::TempScalar<12, DataVector>>(*buffer)) = char_speeds.at(0);
+  get(get<::Tags::TempScalar<13, DataVector>>(*buffer)) = char_speeds.at(1);
+  get(get<::Tags::TempScalar<14, DataVector>>(*buffer)) = char_speeds.at(2);
+  get(get<::Tags::TempScalar<15, DataVector>>(*buffer)) = char_speeds.at(3);
+  // constraint characteristics
+  auto& local_constraint_char_zero_minus =
+      get<::Tags::Tempa<16, VolumeDim, Frame::Inertial, DataVector>>(*buffer);
+  auto& local_constraint_char_zero_plus =
+      get<::Tags::Tempa<34, VolumeDim, Frame::Inertial, DataVector>>(*buffer);
+  // 4.6) c^\hat{3}_{jab} = C_{jab} = \partial_j\psi_{ab} - \Phi_{jab}
+  get<::Tags::Tempiaa<17, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<Tags::ThreeIndexConstraint<VolumeDim, Frame::Inertial>>(
+          vars_on_this_slice);
+  // 4.7) c^\hat{4}_{ijab} = C_{ijab}
+  get<::Tags::Tempiaa<18, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<Tags::FourIndexConstraint<VolumeDim, Frame::Inertial>>(
+          vars_on_this_slice);
+  // lapse, shift and inverse spatial_metric
+  get<::Tags::TempScalar<19, DataVector>>(*buffer) =
+      get<gr::Tags::Lapse<DataVector>>(vars_on_this_slice);
+  get<::Tags::TempI<20, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>>(
+          vars_on_this_slice);
+  get<::Tags::TempII<21, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<gr::Tags::InverseSpatialMetric<VolumeDim, Frame::Inertial,
+                                         DataVector>>(vars_on_this_slice);
+  get<::Tags::Tempii<35, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<gr::Tags::ExtrinsicCurvature<VolumeDim, Frame::Inertial, DataVector>>(
+          vars_on_this_slice);
+  get<::Tags::TempAA<36, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<gr::Tags::InverseSpacetimeMetric<VolumeDim, Frame::Inertial,
+                                           DataVector>>(vars_on_this_slice);
+  // Characteristic projected time derivatives of evolved fields
+  get<::Tags::Tempaa<22, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<Tags::UPsi<VolumeDim, Frame::Inertial>>(char_projected_dt_u);
+  get<::Tags::Tempiaa<23, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<Tags::UZero<VolumeDim, Frame::Inertial>>(char_projected_dt_u);
+  get<::Tags::Tempaa<24, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<Tags::UPlus<VolumeDim, Frame::Inertial>>(char_projected_dt_u);
+  get<::Tags::Tempaa<25, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<Tags::UMinus<VolumeDim, Frame::Inertial>>(char_projected_dt_u);
+  // Spatial derivatives of evolved variables: Psi, Pi and Phi
+  get<::Tags::Tempiaa<31, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<gr::Tags::DerivSpacetimeMetric<VolumeDim, Frame::Inertial,
+                                         DataVector>>(vars_on_this_slice);
+  get<::Tags::Tempiaa<32, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<::Tags::deriv<Tags::Pi<VolumeDim, Frame::Inertial>,
+                        tmpl::size_t<VolumeDim>, Frame::Inertial>>(
+          vars_on_this_slice);
+  get<::Tags::Tempijaa<33, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<::Tags::deriv<Tags::Phi<VolumeDim, Frame::Inertial>,
+                        tmpl::size_t<VolumeDim>, Frame::Inertial>>(
+          vars_on_this_slice);
+  // Constraint damping parameters
+  get<::Tags::TempScalar<26, DataVector>>(*buffer) =
+      get<Tags::ConstraintGamma2>(vars_on_this_slice);
+
+  // Coordinates
+  get<::Tags::TempI<37, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<::Tags::MappedCoordinates<
+          ::Tags::ElementMap<VolumeDim, Frame::Inertial>,
+          ::Tags::Coordinates<VolumeDim, Frame::Logical>>>(vars_on_this_slice);
+
+  // 4) Compute intermediate variables now
+  // 4.1) Spacetime form of interface normal (vector and oneform)
+  const auto unit_interface_normal_vector = raise_or_lower_index(
+      unit_interface_normal_one_form, inverse_spatial_metric);
+  get<0>(local_interface_normal_one_form) = 0.;
+  get<0>(local_interface_normal_vector) = 0.;
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    local_interface_normal_one_form.get(1 + i) =
+        unit_interface_normal_one_form.get(i);
+    local_interface_normal_vector.get(1 + i) =
+        unit_interface_normal_vector.get(i);
+  }
+  // 4.2) timelike and spacelike SPACETIME vectors, l^a and k^a,
+  //      without (1/sqrt(2))
+  for (size_t a = 0; a < VolumeDim + 1; ++a) {
+    local_outgoing_null_one_form.get(a) =
+        spacetime_normal_one_form.get(a) +
+        local_interface_normal_one_form.get(a);
+    local_incoming_null_one_form.get(a) =
+        spacetime_normal_one_form.get(a) -
+        local_interface_normal_one_form.get(a);
+    local_outgoing_null_vector.get(a) =
+        spacetime_normal_vector.get(a) + local_interface_normal_vector.get(a);
+    local_incoming_null_vector.get(a) =
+        spacetime_normal_vector.get(a) - local_interface_normal_vector.get(a);
+  }
+  //       interface_normal_dot_shift = n_i N^i
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    get(interface_normal_dot_shift) =
+        shift.get(i) * local_interface_normal_one_form.get(i + 1);
+  }
+  // 4.3) Spacetime projection operators P_ab, P^ab and P^a_b
+  for (size_t a = 0; a < VolumeDim + 1; ++a) {
+    for (size_t b = 0; b < VolumeDim + 1; ++b) {
+      local_projection_ab.get(a, b) =
+          spacetime_metric.get(a, b) +
+          spacetime_normal_one_form.get(a) * spacetime_normal_one_form.get(b) -
+          local_interface_normal_one_form.get(a) *
+              local_interface_normal_one_form.get(b);
+      local_projection_Ab.get(a, b) =
+          spacetime_normal_one_form.get(a) * spacetime_normal_vector.get(b) -
+          local_interface_normal_one_form.get(a) *
+              local_interface_normal_vector.get(b);
+      if (UNLIKELY(a == b)) {
+        local_projection_Ab.get(a, b) += 1.;
+      }
+      local_projection_AB.get(a, b) =
+          inverse_spacetime_metric.get(a, b) +
+          spacetime_normal_vector.get(a) * spacetime_normal_vector.get(b) -
+          local_interface_normal_vector.get(a) *
+              local_interface_normal_vector.get(b);
+    }
+  }
+  // 4.5) c^{\hat{0}-}_a = F_a + n^k C_{ka}
+  for (size_t a = 0; a < VolumeDim + 1; ++a) {
+    local_constraint_char_zero_minus.get(a) = f_constraint.get(a);
+    local_constraint_char_zero_plus.get(a) = f_constraint.get(a);
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      local_constraint_char_zero_minus.get(a) +=
+          unit_interface_normal_vector.get(i) * two_index_constraint.get(i, a);
+      local_constraint_char_zero_plus.get(a) -=
+          unit_interface_normal_vector.get(i) * two_index_constraint.get(i, a);
+    }
+  }
+}
+
+// \brief This struct sets boundary condition on dt<UPsi>
+template <typename ReturnType, size_t VolumeDim>
+struct set_dt_u_psi {
+  template <typename TagsList, typename VarsTagsList, typename DtVarsTagsList>
+  static ReturnType apply(const UPsiBcMethod Method,
+                          TempBuffer<TagsList>& buffer,
+                          const Variables<VarsTagsList>& vars,
+                          const Variables<DtVarsTagsList>& /* dt_vars */,
+                          const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+                          /* unit_normal_one_form */) noexcept {
+    // Not using auto below to enforce a loose test on the quantity being
+    // fetched from the buffer
+    const typename Tags::ThreeIndexConstraint<VolumeDim, Frame::Inertial>::type&
+        three_index_constraint =
+            get<::Tags::Tempiaa<17, VolumeDim, Frame::Inertial, DataVector>>(
+                buffer);
+    const tnsr::A<DataVector, VolumeDim,
+                  Frame::Inertial>& unit_interface_normal_vector =
+        get<::Tags::TempA<5, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const typename gr::Tags::Lapse<DataVector>::type& lapse =
+        get<::Tags::TempScalar<19, DataVector>>(buffer);
+    const typename gr::Tags::Shift<VolumeDim, Frame::Inertial,
+                                   DataVector>::type& shift =
+        get<::Tags::TempI<20, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const typename Tags::Pi<VolumeDim, Frame::Inertial>::type& pi =
+        get<Tags::Pi<VolumeDim, Frame::Inertial>>(vars);
+    const typename Tags::Phi<VolumeDim, Frame::Inertial>::type& phi =
+        get<Tags::Phi<VolumeDim, Frame::Inertial>>(vars);
+    const typename Tags::UPsi<VolumeDim, Frame::Inertial>::type&
+        char_projected_rhs_dt_u_psi =
+            get<::Tags::Tempaa<22, VolumeDim, Frame::Inertial, DataVector>>(
+                buffer);
+    const typename Tags::CharacteristicSpeeds<VolumeDim, Frame::Inertial>::type
+        char_speeds{{get(get<::Tags::TempScalar<12, DataVector>>(buffer)),
+                     get(get<::Tags::TempScalar<13, DataVector>>(buffer)),
+                     get(get<::Tags::TempScalar<14, DataVector>>(buffer)),
+                     get(get<::Tags::TempScalar<15, DataVector>>(buffer))}};
+    // Memory allocated for return type
+    ReturnType& bc_dt_u_psi =
+        get<::Tags::Tempaa<27, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    std::fill(bc_dt_u_psi.begin(), bc_dt_u_psi.end(), 0.);
+    // Switch on prescribed boundary condition method
+    switch (Method) {
+      case UPsiBcMethod::Freezing:
+        return bc_dt_u_psi;
+      case UPsiBcMethod::ConstraintPreservingBjorhus:
+        return apply_bjorhus_constraint_preserving(
+            make_not_null(&bc_dt_u_psi), unit_interface_normal_vector,
+            three_index_constraint, char_projected_rhs_dt_u_psi, char_speeds);
+      case UPsiBcMethod::ConstraintPreservingDirichlet:
+        return apply_dirichlet_constraint_preserving(
+            make_not_null(&bc_dt_u_psi), lapse, shift, pi, phi);
+      case UPsiBcMethod::Unknown:
+      default:
+        ASSERT(false, "Requested BC method fo UPsi not implemented!");
+    }
+    // dummy return to suppress compiler warning
+    return ReturnType{};
+  }
+
+ private:
+  static ReturnType apply_bjorhus_constraint_preserving(
+      const gsl::not_null<ReturnType*> bc_dt_u_psi,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_vector,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+          three_index_constraint,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+          char_projected_rhs_dt_u_psi,
+      const std::array<DataVector, 4>& char_speeds) noexcept;
+  static ReturnType apply_dirichlet_constraint_preserving(
+      const gsl::not_null<ReturnType*> bc_dt_u_psi,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, VolumeDim, Frame::Inertial>& shift,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& pi,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& phi) noexcept;
+};
+
+template <typename ReturnType, size_t VolumeDim>
+ReturnType
+set_dt_u_psi<ReturnType, VolumeDim>::apply_bjorhus_constraint_preserving(
+    const gsl::not_null<ReturnType*> bc_dt_u_psi,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_vector,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+        three_index_constraint,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_u_psi,
+    const std::array<DataVector, 4>& char_speeds) noexcept {
+  ASSERT(get_size(get<0, 0>(*bc_dt_u_psi)) ==
+             get_size(get<0>(unit_interface_normal_vector)),
+         "Size of input variables and temporary memory do not match.");
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      bc_dt_u_psi->get(a, b) += char_projected_rhs_dt_u_psi.get(a, b);
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        bc_dt_u_psi->get(a, b) += char_speeds.at(0) *
+                                  unit_interface_normal_vector.get(i + 1) *
+                                  three_index_constraint.get(i, a, b);
+      }
+    }
+  }
+  return *bc_dt_u_psi;
+}
+
+template <typename ReturnType, size_t VolumeDim>
+ReturnType
+set_dt_u_psi<ReturnType, VolumeDim>::apply_dirichlet_constraint_preserving(
+    const gsl::not_null<ReturnType*> bc_dt_u_psi,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, VolumeDim, Frame::Inertial>& shift,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& pi,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& phi) noexcept {
+  ASSERT(get_size(get<0, 0>(*bc_dt_u_psi)) == get_size(get(lapse)),
+         "Size of input variables and temporary memory do not match.");
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      bc_dt_u_psi->get(a, b) -= get(lapse) * pi.get(a, b);
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        bc_dt_u_psi->get(a, b) += shift.get(i) * phi.get(i, a, b);
+      }
+    }
+  }
+  return *bc_dt_u_psi;
+}
+
+// \brief This struct sets boundary condition on dt<UZero>
+template <typename ReturnType, size_t VolumeDim>
+struct set_dt_u_zero {
+  template <typename TagsList, typename VarsTagsList, typename DtVarsTagsList>
+  static ReturnType apply(const UZeroBcMethod Method,
+                          TempBuffer<TagsList>& buffer,
+                          const Variables<VarsTagsList>& vars,
+                          const Variables<DtVarsTagsList>& /* dt_vars */,
+                          const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+                              unit_normal_one_form) noexcept {
+    // Not using auto below to enforce a loose test on the quantity being
+    // fetched from the buffer
+    const tnsr::A<DataVector, VolumeDim,
+                  Frame::Inertial>& unit_interface_normal_vector =
+        get<::Tags::TempA<5, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const typename Tags::FourIndexConstraint<VolumeDim, Frame::Inertial>::type&
+        four_index_constraint =
+            get<::Tags::Tempiaa<18, VolumeDim, Frame::Inertial, DataVector>>(
+                buffer);
+    const typename Tags::UZero<VolumeDim, Frame::Inertial>::type&
+        char_projected_rhs_dt_u_zero =
+            get<::Tags::Tempiaa<23, VolumeDim, Frame::Inertial, DataVector>>(
+                buffer);
+    const typename Tags::CharacteristicSpeeds<VolumeDim, Frame::Inertial>::type
+        char_speeds{{get(get<::Tags::TempScalar<12, DataVector>>(buffer)),
+                     get(get<::Tags::TempScalar<13, DataVector>>(buffer)),
+                     get(get<::Tags::TempScalar<14, DataVector>>(buffer)),
+                     get(get<::Tags::TempScalar<15, DataVector>>(buffer))}};
+
+    // spacetime unit vector t^a
+    const auto& spacetime_unit_normal_vector =
+        get<::Tags::TempA<7, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const typename gr::Tags::Lapse<DataVector>::type& lapse =
+        get<::Tags::TempScalar<19, DataVector>>(buffer);
+    const typename gr::Tags::Shift<VolumeDim, Frame::Inertial,
+                                   DataVector>::type& shift =
+        get<::Tags::TempI<20, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const auto& inverse_spatial_metric =
+        get<::Tags::TempII<21, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+
+    const typename Tags::Pi<VolumeDim, Frame::Inertial>::type& pi =
+        get<Tags::Pi<VolumeDim, Frame::Inertial>>(vars);
+    const typename Tags::Phi<VolumeDim, Frame::Inertial>::type& phi =
+        get<Tags::Phi<VolumeDim, Frame::Inertial>>(vars);
+    const auto& d_spacetime_metric =
+        get<::Tags::Tempiaa<31, VolumeDim, Frame::Inertial, DataVector>>(
+            buffer);
+    const auto& d_pi =
+        get<::Tags::Tempiaa<32, VolumeDim, Frame::Inertial, DataVector>>(
+            buffer);
+    const auto& d_phi =
+        get<::Tags::Tempijaa<33, VolumeDim, Frame::Inertial, DataVector>>(
+            buffer);
+
+    // Memory allocated for return type
+    ReturnType& bc_dt_u_zero =
+        get<::Tags::Tempiaa<28, VolumeDim, Frame::Inertial, DataVector>>(
+            buffer);
+    std::fill(bc_dt_u_zero.begin(), bc_dt_u_zero.end(), 0.);
+    // Switch on prescribed boundary condition method
+    switch (Method) {
+      case UZeroBcMethod::Freezing:
+        return bc_dt_u_zero;
+      case UZeroBcMethod::ConstraintPreservingBjorhus:
+        return apply_bjorhus_constraint_preserving(
+            make_not_null(&bc_dt_u_zero), unit_interface_normal_vector,
+            four_index_constraint, char_projected_rhs_dt_u_zero, char_speeds);
+      case UZeroBcMethod::ConstraintPreservingDirichlet:
+        return apply_dirichlet_constraint_preserving(
+            make_not_null(&bc_dt_u_zero), unit_interface_normal_vector,
+            unit_normal_one_form, spacetime_unit_normal_vector, lapse, shift,
+            inverse_spatial_metric, pi, phi, d_spacetime_metric, d_pi, d_phi);
+      case UZeroBcMethod::ConstraintPreservingRealDirichlet:
+        return apply_real_dirichlet_constraint_preserving(
+            make_not_null(&bc_dt_u_zero), unit_interface_normal_vector,
+            unit_normal_one_form, spacetime_unit_normal_vector, lapse, shift,
+            inverse_spatial_metric, pi, phi, d_pi, d_phi);
+      case UZeroBcMethod::Unknown:
+      default:
+        ASSERT(false, "Requested BC method fo UZero not implemented!");
+    }
+    // dummy return to suppress compiler warning
+    return ReturnType{};
+  }
+
+ private:
+  static ReturnType apply_bjorhus_constraint_preserving(
+      const gsl::not_null<ReturnType*> bc_dt_u_zero,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_vector,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+          four_index_constraint,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+          char_projected_rhs_dt_u_zero,
+      const std::array<DataVector, 4>& char_speeds) noexcept;
+  static ReturnType apply_dirichlet_constraint_preserving(
+      const gsl::not_null<ReturnType*> bc_dt_u_zero,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_vector,
+      const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_one_form,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          spacetime_unit_normal_vector,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, VolumeDim, Frame::Inertial>& shift,
+      const tnsr::II<DataVector, VolumeDim, Frame::Inertial>&
+          inverse_spatial_metric,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& pi,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& phi,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& d_psi,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& d_pi,
+      const tnsr::ijaa<DataVector, VolumeDim, Frame::Inertial>& d_phi) noexcept;
+  static ReturnType apply_real_dirichlet_constraint_preserving(
+      const gsl::not_null<ReturnType*> bc_dt_u_zero,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_vector,
+      const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_one_form,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          spacetime_unit_normal_vector,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, VolumeDim, Frame::Inertial>& shift,
+      const tnsr::II<DataVector, VolumeDim, Frame::Inertial>&
+          inverse_spatial_metric,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& pi,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& phi,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& d_pi,
+      const tnsr::ijaa<DataVector, VolumeDim, Frame::Inertial>& d_phi) noexcept;
+};
+
+template <typename ReturnType, size_t VolumeDim>
+ReturnType
+set_dt_u_zero<ReturnType, VolumeDim>::apply_bjorhus_constraint_preserving(
+    const gsl::not_null<ReturnType*> bc_dt_u_zero,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_vector,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+        four_index_constraint,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_u_zero,
+    const std::array<DataVector, 4>& char_speeds) noexcept {
+  ASSERT(get_size(get<0, 0, 0>(*bc_dt_u_zero)) ==
+             get_size(get<0>(unit_interface_normal_vector)),
+         "Size of input variables and temporary memory do not match.");
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        bc_dt_u_zero->get(i, a, b) += char_projected_rhs_dt_u_zero.get(i, a, b);
+      }
+      // Lets say this term is T2_{kab} := - n_l N^l n^j C_{jkab}.
+      // But we store C4_{iab} = LeviCivita^{ijk} dphi_{jkab},
+      // which means  C_{jkab} = LeviCivita^{ijk} C4_{iab}
+      // where C4 is `four_index_constraint`.
+      // therefore, T2_{kab} =  char_speed<UZero> n^j C_{jkab}
+      // (since char_speed<UZero> = - n_l N^l), and therefore:
+      // T2_{kab} = char_speed<UZero> n^j LeviCivita^{ijk} C4_{iab}.
+      // Let LeviCivitaIterator be indexed by
+      // it[0] <--> i,
+      // it[1] <--> j,
+      // it[2] <--> k, then
+      // T2_{it[2], ab} += char_speed<UZero> n^it[1] it.sign() C4_{it[0], ab};
+      for (LeviCivitaIterator<VolumeDim> it; it; ++it) {
+        bc_dt_u_zero->get(it[2], a, b) +=
+            it.sign() * char_speeds.at(1) *
+            unit_interface_normal_vector.get(it[1] + 1) *
+            four_index_constraint.get(it[0], a, b);
+      }
+    }
+  }
+  return *bc_dt_u_zero;
+}
+
+template <typename ReturnType, size_t VolumeDim>
+ReturnType
+set_dt_u_zero<ReturnType, VolumeDim>::apply_dirichlet_constraint_preserving(
+    const gsl::not_null<ReturnType*> bc_dt_u_zero,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_vector,
+    const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_one_form,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+        spacetime_unit_normal_vector,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, VolumeDim, Frame::Inertial>& shift,
+    const tnsr::II<DataVector, VolumeDim, Frame::Inertial>&
+        inverse_spatial_metric,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& pi,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& phi,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& d_psi,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& d_pi,
+    const tnsr::ijaa<DataVector, VolumeDim, Frame::Inertial>& d_phi) noexcept {
+  ASSERT(get_size(get<0, 0, 0>(*bc_dt_u_zero)) == get_size(get(lapse)),
+         "Size of input variables and temporary memory do not match.");
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = 0; b <= VolumeDim; ++b) {
+      // For a chosen (a, b):
+      //  tmp_i = -N \partial_i \Pi_{ab} (T1)
+      //        + 0.5 N * t^c t^d \partial_i \psi_{cd} Pi_{ab} (T2)
+      //        + N^j \partial_i \Phi_{jab} (T3)
+      //        + N t^e g^{mj} \partial_i \psi_{ej} \Phi_{mab} (T4)
+      // and,
+      //  bc_dt_u_zero_{iab} = tmp_i - n_i n^k tmp_k (for a chosen (a, b))
+      tnsr::i<DataVector, VolumeDim, Frame::Inertial> tmp(get_size(get(lapse)));
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        tmp.get(i) = -get(lapse) * d_pi.get(i, a, b);  // T1
+        // (subtract dLapse*Pi)
+        for (size_t c = 0; c <= VolumeDim; ++c) {
+          for (size_t d = 0; d <= VolumeDim; ++d) {
+            tmp.get(i) += 0.5 * get(lapse) *  // T2
+                          spacetime_unit_normal_vector.get(c) *
+                          spacetime_unit_normal_vector.get(d) *
+                          d_psi.get(i, c, d) * pi.get(a, b);
+          }
+        }
+        for (size_t j = 0; j < VolumeDim; ++j) {
+          tmp.get(i) += shift.get(j) * d_phi.get(i, j, a, b);  // T3
+          // (add d_k Shift^j \Phi_{jab})
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            for (size_t e = 0; e <= VolumeDim; ++e) {
+              tmp.get(i) += get(lapse) * spacetime_unit_normal_vector.get(e) *
+                            inverse_spatial_metric.get(j, k) *
+                            d_psi.get(i, e, k + 1) * phi.get(j, a, b);  // T4
+            }
+          }
+        }
+      }
+      DataVector normal_dot_tmp(get_size(get(lapse)), 0.);
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        normal_dot_tmp += unit_interface_normal_vector.get(i + 1) * tmp.get(i);
+      }
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        bc_dt_u_zero->get(i, a, b) +=
+            tmp.get(i) - unit_interface_normal_one_form.get(i) * normal_dot_tmp;
+      }
+    }
+  }
+  return *bc_dt_u_zero;
+}
+
+template <typename ReturnType, size_t VolumeDim>
+ReturnType set_dt_u_zero<ReturnType, VolumeDim>::
+    apply_real_dirichlet_constraint_preserving(
+        const gsl::not_null<ReturnType*> bc_dt_u_zero,
+        const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+            unit_interface_normal_vector,
+        const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+            unit_interface_normal_one_form,
+        const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+            spacetime_unit_normal_vector,
+        const Scalar<DataVector>& lapse,
+        const tnsr::I<DataVector, VolumeDim, Frame::Inertial>& shift,
+        const tnsr::II<DataVector, VolumeDim, Frame::Inertial>&
+            inverse_spatial_metric,
+        const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& pi,
+        const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& phi,
+        const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& d_pi,
+        const tnsr::ijaa<DataVector, VolumeDim, Frame::Inertial>&
+            d_phi) noexcept {
+  ASSERT(get_size(get<0, 0, 0>(*bc_dt_u_zero)) == get_size(get(lapse)),
+         "Size of input variables and temporary memory do not match.");
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = 0; b <= VolumeDim; ++b) {
+      // For a chosen (a, b):
+      //  tmp_i = -N \partial_i \Pi_{ab} (T1)
+      //        + 0.5 N * t^c t^d \phi_{icd} Pi_{ab} (T2)
+      //        + N^j \partial_i \Phi_{jab} (T3)
+      //        + N t^e g^{jk} \psi_{iek} \Phi_{jab} (T4)
+      // and,
+      //  bc_dt_u_zero_{iab} = tmp_i - n_i n^k tmp_k (for a chosen (a, b))
+      tnsr::i<DataVector, VolumeDim, Frame::Inertial> tmp(get_size(get(lapse)));
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        tmp.get(i) = -get(lapse) * d_pi.get(i, a, b);  // T1
+        // (subtract dLapse*Pi)
+        for (size_t c = 0; c <= VolumeDim; ++c) {
+          for (size_t d = 0; d <= VolumeDim; ++d) {
+            tmp.get(i) += 0.5 * get(lapse) *  // T2
+                          spacetime_unit_normal_vector.get(c) *
+                          spacetime_unit_normal_vector.get(d) *
+                          phi.get(i, c, d) * pi.get(a, b);
+          }
+        }
+        for (size_t j = 0; j < VolumeDim; ++j) {
+          tmp.get(i) += shift.get(j) * d_phi.get(i, j, a, b);  // T3
+          // (add d_k Shift^j \Phi_{jab})
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            for (size_t e = 0; e <= VolumeDim; ++e) {
+              tmp.get(i) += get(lapse) * spacetime_unit_normal_vector.get(e) *
+                            inverse_spatial_metric.get(j, k) *
+                            phi.get(i, e, k + 1) * phi.get(j, a, b);  // T4
+            }
+          }
+        }
+      }
+      DataVector normal_dot_tmp(get_size(get(lapse)), 0.);
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        normal_dot_tmp += unit_interface_normal_vector.get(i + 1) * tmp.get(i);
+      }
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        bc_dt_u_zero->get(i, a, b) +=
+            tmp.get(i) - unit_interface_normal_one_form.get(i) * normal_dot_tmp;
+      }
+    }
+  }
+  return *bc_dt_u_zero;
+}
+
+// \brief This struct sets boundary condition on dt<UPlus>
+template <typename ReturnType, size_t VolumeDim>
+struct set_dt_u_plus {
+  template <typename TagsList, typename VarsTagsList, typename DtVarsTagsList>
+  static ReturnType apply(const UPlusBcMethod Method,
+                          TempBuffer<TagsList>& buffer,
+                          const Variables<VarsTagsList>& /* vars */,
+                          const Variables<DtVarsTagsList>& /* dt_vars */,
+                          const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+                          /* unit_normal_one_form */) noexcept {
+    // Memory allocated for return type
+    ReturnType& bc_dt_u_plus =
+        get<::Tags::Tempaa<29, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    std::fill(bc_dt_u_plus.begin(), bc_dt_u_plus.end(), 0.);
+    // Switch on prescribed boundary condition method
+    switch (Method) {
+      case UPlusBcMethod::Freezing:
+        return bc_dt_u_plus;
+      case UPlusBcMethod::Unknown:
+      default:
+        ASSERT(false, "Requested BC method fo UPlus not implemented!");
+    }
+    // dummy return to suppress compiler warning
+    return ReturnType{};
+  }
+
+ private:
+};
+
+// \brief This struct sets boundary condition on dt<UMinus>
+template <typename ReturnType, size_t VolumeDim>
+struct set_dt_u_minus {
+  template <typename TagsList, typename VarsTagsList, typename DtVarsTagsList>
+  static ReturnType apply(
+      const UMinusBcMethod Method, TempBuffer<TagsList>& buffer,
+      const Variables<VarsTagsList>& vars,
+      const Variables<DtVarsTagsList>& /* dt_vars */,
+      const typename ::Tags::Coordinates<VolumeDim, Frame::Inertial>::type&
+          inertial_coords,
+      const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+      /* unit_normal_one_form */) noexcept {
+    // Not using auto below to enforce a loose test on the quantity being
+    // fetched from the buffer
+    const typename Tags::ConstraintGamma2::type& constraint_gamma2 =
+        get<::Tags::TempScalar<26, DataVector>>(buffer);
+    const typename Tags::ThreeIndexConstraint<VolumeDim, Frame::Inertial>::type&
+        three_index_constraint =
+            get<::Tags::Tempiaa<17, VolumeDim, Frame::Inertial, DataVector>>(
+                buffer);
+    const tnsr::a<DataVector, VolumeDim,
+                  Frame::Inertial>& unit_interface_normal_one_form =
+        get<::Tags::Tempa<4, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const tnsr::A<DataVector, VolumeDim,
+                  Frame::Inertial>& unit_interface_normal_vector =
+        get<::Tags::TempA<5, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const tnsr::A<DataVector, VolumeDim,
+                  Frame::Inertial>& spacetime_unit_normal_vector =
+        get<::Tags::TempA<7, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+
+    const typename Tags::UPsi<VolumeDim, Frame::Inertial>::type&
+        char_projected_rhs_dt_u_psi =
+            get<::Tags::Tempaa<22, VolumeDim, Frame::Inertial, DataVector>>(
+                buffer);
+    const typename Tags::UMinus<VolumeDim, Frame::Inertial>::type&
+        char_projected_rhs_dt_u_minus =
+            get<::Tags::Tempaa<25, VolumeDim, Frame::Inertial, DataVector>>(
+                buffer);
+    const typename Tags::CharacteristicSpeeds<VolumeDim, Frame::Inertial>::type
+        char_speeds{{get(get<::Tags::TempScalar<12, DataVector>>(buffer)),
+                     get(get<::Tags::TempScalar<13, DataVector>>(buffer)),
+                     get(get<::Tags::TempScalar<14, DataVector>>(buffer)),
+                     get(get<::Tags::TempScalar<15, DataVector>>(buffer))}};
+
+    // timelike and spacelike SPACETIME vectors, l^a and k^a
+    const auto& outgoing_null_one_form =
+        get<::Tags::Tempa<0, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const auto& incoming_null_one_form =
+        get<::Tags::Tempa<1, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    // timelike and spacelike SPACETIME oneforms, l_a and k_a
+    const auto& outgoing_null_vector =
+        get<::Tags::TempA<2, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const auto& incoming_null_vector =
+        get<::Tags::TempA<3, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    // spacetime projection operator P_ab, P^ab, and P^a_b
+    const auto& projection_AB =
+        get<::Tags::TempAA<9, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const auto& projection_ab =
+        get<::Tags::Tempaa<10, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const auto& projection_Ab =
+        get<::Tags::TempAb<11, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    // constraint characteristics
+    const auto& constraint_char_zero_minus =
+        get<::Tags::Tempa<16, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const auto& constraint_char_zero_plus =
+        get<::Tags::Tempa<34, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+
+    const auto& inverse_spatial_metric =
+        get<::Tags::TempII<21, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const auto& extrinsic_curvature =
+        get<::Tags::Tempii<35, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const auto& inverse_spacetime_metric =
+        get<::Tags::TempAA<36, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+
+    const typename Tags::Phi<VolumeDim, Frame::Inertial>::type& phi =
+        get<Tags::Phi<VolumeDim, Frame::Inertial>>(vars);
+    // const auto& d_pi =
+    //     get<::Tags::Tempiaa<32, VolumeDim, Frame::Inertial, DataVector>>(
+    //         buffer);
+    const auto& d_phi =
+        get<::Tags::Tempijaa<33, VolumeDim, Frame::Inertial, DataVector>>(
+            buffer);
+    // Memory allocated for return type
+    ReturnType& bc_dt_u_minus =
+        get<::Tags::Tempaa<30, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    std::fill(bc_dt_u_minus.begin(), bc_dt_u_minus.end(), 0.);
+    // Switch on prescribed boundary condition method
+    switch (Method) {
+      case UMinusBcMethod::Freezing:
+        return apply_gauge_sommerfeld(
+            make_not_null(&bc_dt_u_minus), constraint_gamma2, inertial_coords,
+            incoming_null_one_form, outgoing_null_one_form,
+            incoming_null_vector, outgoing_null_vector, projection_Ab,
+            char_projected_rhs_dt_u_psi);
+      case UMinusBcMethod::ConstraintPreservingBjorhus:
+        apply_bjorhus_constraint_preserving(
+            make_not_null(&bc_dt_u_minus), incoming_null_one_form,
+            outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
+            projection_ab, projection_Ab, projection_AB,
+            constraint_char_zero_plus, constraint_char_zero_minus,
+            char_projected_rhs_dt_u_minus, char_speeds);
+        return apply_gauge_sommerfeld(
+            make_not_null(&bc_dt_u_minus), constraint_gamma2, inertial_coords,
+            incoming_null_one_form, outgoing_null_one_form,
+            incoming_null_vector, outgoing_null_vector, projection_Ab,
+            char_projected_rhs_dt_u_psi);
+      case UMinusBcMethod::ConstraintPreservingPhysicalBjorhus:
+        apply_bjorhus_constraint_preserving(
+            make_not_null(&bc_dt_u_minus), incoming_null_one_form,
+            outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
+            projection_ab, projection_Ab, projection_AB,
+            constraint_char_zero_plus, constraint_char_zero_minus,
+            char_projected_rhs_dt_u_minus, char_speeds);
+        apply_bjorhus_constraint_preserving_physical(
+            make_not_null(&bc_dt_u_minus), constraint_gamma2,
+            unit_interface_normal_one_form, unit_interface_normal_vector,
+            spacetime_unit_normal_vector, projection_ab, projection_Ab,
+            projection_AB, inverse_spatial_metric, extrinsic_curvature,
+            inverse_spacetime_metric, three_index_constraint,
+            char_projected_rhs_dt_u_minus, phi, d_phi, char_speeds);
+        return apply_gauge_sommerfeld(
+            make_not_null(&bc_dt_u_minus), constraint_gamma2, inertial_coords,
+            incoming_null_one_form, outgoing_null_one_form,
+            incoming_null_vector, outgoing_null_vector, projection_Ab,
+            char_projected_rhs_dt_u_psi);
+      case UMinusBcMethod::Unknown:
+      default:
+        ASSERT(false, "Requested BC method fo UMinus not implemented!");
+    }
+    // dummy return to suppress compiler warning
+    return ReturnType{};
+  }
+
+ private:
+  static ReturnType apply_bjorhus_constraint_preserving(
+      const gsl::not_null<ReturnType*> bc_dt_u_minus,
+      const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+          incoming_null_one_form,
+      const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+          outgoing_null_one_form,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          incoming_null_vector,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          outgoing_null_vector,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& projection_ab,
+      const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+      const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>& projection_AB,
+      const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+          constraint_char_zero_plus,
+      const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+          constraint_char_zero_minus,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+          char_projected_rhs_dt_u_minus,
+      const std::array<DataVector, 4>& char_speeds) noexcept;
+  static ReturnType apply_bjorhus_constraint_preserving_physical(
+      const gsl::not_null<ReturnType*> bc_dt_u_minus,
+      const Scalar<DataVector>& gamma2,
+      const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_one_form,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_vector,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          spacetime_unit_normal_vector,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& projection_ab,
+      const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+      const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>& projection_AB,
+      const tnsr::II<DataVector, VolumeDim, Frame::Inertial>&
+          inverse_spatial_metric,
+      const tnsr::ii<DataVector, VolumeDim, Frame::Inertial>&
+          extrinsic_curvature,
+      const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>&
+          inverse_spacetime_metric,
+      const typename Tags::ThreeIndexConstraint<
+          VolumeDim, Frame::Inertial>::type& three_index_constraint,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+          char_projected_rhs_dt_u_minus,
+      const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& phi,
+      const tnsr::ijaa<DataVector, VolumeDim, Frame::Inertial>& d_phi,
+      const std::array<DataVector, 4>& char_speeds) noexcept;
+  static ReturnType apply_gauge_sommerfeld(
+      const gsl::not_null<ReturnType*> bc_dt_u_minus,
+      const Scalar<DataVector>& gamma2,
+      const typename ::Tags::Coordinates<VolumeDim, Frame::Inertial>::type&
+          inertial_coords,
+      const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+          incoming_null_one_form,
+      const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+          outgoing_null_one_form,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          incoming_null_vector,
+      const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+          outgoing_null_vector,
+      const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+      const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+          char_projected_rhs_dt_u_psi) noexcept;
+};
+
+template <typename ReturnType, size_t VolumeDim>
+ReturnType
+set_dt_u_minus<ReturnType, VolumeDim>::apply_bjorhus_constraint_preserving(
+    const gsl::not_null<ReturnType*> bc_dt_u_minus,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        incoming_null_one_form,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        outgoing_null_one_form,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_plus,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_minus,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_u_minus,
+    const std::array<DataVector, 4>& char_speeds) noexcept {
+  ASSERT(get_size(get<0, 0>(*bc_dt_u_minus)) ==
+             get_size(get<0>(incoming_null_one_form)),
+         "Size of input variables and temporary memory do not match.");
+  const double mMu = 0.;  // hard-coded value from SpEC Bbh input file Mu = 0
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      for (size_t c = 0; c <= VolumeDim; ++c) {
+        for (size_t d = 0; d <= VolumeDim; ++d) {
+          bc_dt_u_minus->get(a, b) +=
+              0.25 *
+              (incoming_null_vector.get(c) * incoming_null_vector.get(d) *
+                   outgoing_null_one_form.get(a) *
+                   outgoing_null_one_form.get(b) -
+               incoming_null_vector.get(c) * projection_Ab.get(d, a) *
+                   outgoing_null_one_form.get(b) -
+               incoming_null_vector.get(c) * projection_Ab.get(d, b) *
+                   outgoing_null_one_form.get(a) -
+               incoming_null_vector.get(d) * projection_Ab.get(c, a) *
+                   outgoing_null_one_form.get(b) -
+               incoming_null_vector.get(d) * projection_Ab.get(c, b) *
+                   outgoing_null_one_form.get(a) +
+               2.0 * projection_AB.get(c, d) * projection_ab.get(a, b)) *
+              char_projected_rhs_dt_u_minus.get(c, d);
+        }
+      }
+      for (size_t c = 0; c <= VolumeDim; ++c) {
+        bc_dt_u_minus->get(a, b) +=
+            0.5 * char_speeds.at(3) *
+            (constraint_char_zero_minus.get(c) -
+             mMu * constraint_char_zero_plus.get(c)) *
+            (0.5 * outgoing_null_one_form.get(a) *
+                 outgoing_null_one_form.get(b) * incoming_null_vector.get(c) +
+             projection_ab.get(a, b) * outgoing_null_vector.get(c) -
+             projection_Ab.get(c, b) * outgoing_null_one_form.get(a) -
+             projection_Ab.get(c, a) * outgoing_null_one_form.get(b));
+      }
+    }
+  }
+  return *bc_dt_u_minus;
+}
+
+template <typename ReturnType, size_t VolumeDim>
+ReturnType set_dt_u_minus<ReturnType, VolumeDim>::
+    apply_bjorhus_constraint_preserving_physical(
+        const gsl::not_null<ReturnType*> bc_dt_u_minus,
+        const Scalar<DataVector>& gamma2,
+        const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+            unit_interface_normal_one_form,
+        const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+            unit_interface_normal_vector,
+        const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+            spacetime_unit_normal_vector,
+        const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& projection_ab,
+        const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+        const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>& projection_AB,
+        const tnsr::II<DataVector, VolumeDim, Frame::Inertial>&
+            inverse_spatial_metric,
+        const tnsr::ii<DataVector, VolumeDim, Frame::Inertial>&
+            extrinsic_curvature,
+        const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>&
+            inverse_spacetime_metric,
+        const typename Tags::ThreeIndexConstraint<
+            VolumeDim, Frame::Inertial>::type& three_index_constraint,
+        const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+            char_projected_rhs_dt_u_minus,
+        const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& phi,
+        const tnsr::ijaa<DataVector, VolumeDim, Frame::Inertial>& d_phi,
+        const std::array<DataVector, 4>& char_speeds) noexcept {
+  //-------------------------------------------------------------------
+  // Add in physical boundary condition
+  //-------------------------------------------------------------------
+  ASSERT(get_size(get<0, 0>(*bc_dt_u_minus)) == get_size(get(gamma2)),
+         "Size of input variables and temporary memory do not match.");
+  // hard-coded value from SpEC Bbh input file Mu = MuPhys = 0
+  const double mMuPhys = 0.;
+  const bool mAdjustPhysUsingC4 = true;
+  const bool mGamma2InPhysBc = true;
+
+  // In what follows, we use the notation of Kidder, Scheel & Teukolsky
+  // (2001) https://arxiv.org/pdf/gr-qc/0105031.pdf. We will refer to this
+  // article as KST henceforth, and use the abbreviation in variable names
+  // to disambiguate their origin.
+  auto U8p = make_with_value<tnsr::ii<DataVector, VolumeDim, Frame::Inertial>>(
+      unit_interface_normal_vector, 0.);
+  auto U8m = make_with_value<tnsr::ii<DataVector, VolumeDim, Frame::Inertial>>(
+      unit_interface_normal_vector, 0.);
+  {
+    // D_(k,i,j) = (1/2) \partial_k g_(ij) and its derivative
+    tnsr::ijj<DataVector, VolumeDim, Frame::Inertial> kst_D(
+        get_size(get(gamma2)));
+    tnsr::ijkk<DataVector, VolumeDim, Frame::Inertial> d_kst_D(
+        get_size(get(gamma2)));
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = i; j < VolumeDim; ++j) {
+        for (size_t k = 0; k < VolumeDim; ++k) {
+          kst_D.get(k, i, j) = 0.5 * phi.get(k, i + 1, j + 1);
+          for (size_t l = 0; l < VolumeDim; ++l) {
+            d_kst_D.get(l, k, i, j) = 0.5 * d_phi.get(l, k, i + 1, j + 1);
+          }
+        }
+      }
+    }
+
+    // ComputeRicciFromD(kst_D, d_kst_D, Invg, Ricci3);
+    auto ricci_3 = GeneralizedHarmonic::spatial_ricci_tensor_from_KST_vars(
+        kst_D, d_kst_D, inverse_spatial_metric);
+
+    tnsr::ijj<DataVector, VolumeDim, Frame::Inertial> CdK(
+        get_size(get(gamma2)));
+    {
+      const auto christoffel_second_kind =
+          GeneralizedHarmonic::spatial_christoffel_second_kind_from_KST_vars(
+              kst_D, inverse_spatial_metric);
+      // Ordinary derivative first
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        for (size_t j = i; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            CdK.get(k, i, j) = 0.5 * d_phi.get(k, 0, i + 1, j + 1);
+            for (size_t mu = 0; mu <= VolumeDim; ++mu) {
+              CdK.get(k, i, j) +=
+                  0.5 *
+                  (d_phi.get(k, i, j + 1, mu) + d_phi.get(k, j, i + 1, mu)) *
+                  spacetime_unit_normal_vector.get(mu);
+              for (size_t nu = 0; nu <= VolumeDim; ++nu) {
+                for (size_t a = 0; a <= VolumeDim; ++a) {
+                  CdK.get(k, i, j) -=
+                      0.5 * (phi.get(i, j + 1, mu) + phi.get(j, i + 1, mu)) *
+                      spacetime_unit_normal_vector.get(nu) *
+                      (inverse_spacetime_metric.get(a, mu) +
+                       0.5 * spacetime_unit_normal_vector.get(a) *
+                           spacetime_unit_normal_vector.get(mu)) *
+                      phi.get(k, a, nu);
+                }
+              }
+            }
+          }
+        }
+      }
+      // Now add gamma terms
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        for (size_t j = i; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            for (size_t l = 0; l < VolumeDim; ++l) {
+              CdK.get(k, i, j) -= christoffel_second_kind.get(l, i, k) *
+                                      extrinsic_curvature.get(l, j) +
+                                  christoffel_second_kind.get(l, j, k) *
+                                      extrinsic_curvature.get(l, i);
+            }
+          }
+        }
+      }
+    }
+
+    if (mAdjustPhysUsingC4) {
+      // This adds 4-index constraint terms to 3Ricci so as to cancel
+      // out normal derivatives from the final expression for U8.
+      // It is much easier to add them here than to recalculate U8
+      // from scratch.
+
+      // Add some 4-index constraint terms to 3Ricci.
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        for (size_t j = i; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            for (size_t l = 0; l < VolumeDim; ++l) {
+              ricci_3.get(i, j) +=
+                  0.5 * inverse_spatial_metric.get(k, l) *
+                  (d_kst_D.get(i, k, l, j) - d_kst_D.get(k, i, l, j) +
+                   d_kst_D.get(j, k, l, i) - d_kst_D.get(k, j, l, i));
+            }
+          }
+        }
+      }
+
+      // Add more 4-index constraint terms to 3Ricci
+      // These compensate for some of the CdK terms.
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        for (size_t j = i; j < VolumeDim; ++j) {
+          for (size_t a = 0; a <= VolumeDim; ++a) {
+            for (size_t k = 0; k < VolumeDim; ++k) {
+              ricci_3.get(i, j) +=
+                  0.5 * unit_interface_normal_vector.get(k + 1) *
+                  spacetime_unit_normal_vector.get(a) *
+                  (d_phi.get(i, k, j + 1, a) - d_phi.get(k, i, j + 1, a) +
+                   d_phi.get(j, k, i + 1, a) - d_phi.get(k, j, i + 1, a));
+            }
+          }
+        }
+      }
+    }
+
+    TempBuffer<tmpl::list<
+        // spatial projection operators P_ij, P^ij, and P^i_j
+        ::Tags::TempII<0, VolumeDim, Frame::Inertial, DataVector>,
+        ::Tags::Tempii<1, VolumeDim, Frame::Inertial, DataVector>,
+        ::Tags::TempIj<2, VolumeDim, Frame::Inertial, DataVector>>>
+        local_buffer(get_size(get<0>(unit_interface_normal_vector)));
+    auto& spatial_projection_IJ =
+        get<::Tags::TempII<0, VolumeDim, Frame::Inertial, DataVector>>(
+            local_buffer);
+    auto& spatial_projection_ij =
+        get<::Tags::Tempii<1, VolumeDim, Frame::Inertial, DataVector>>(
+            local_buffer);
+    auto& spatial_projection_Ij =
+        get<::Tags::TempIj<2, VolumeDim, Frame::Inertial, DataVector>>(
+            local_buffer);
+
+    // Make spatial projection operators
+    GeneralizedHarmonic::spatial_projection_tensor(
+        make_not_null(&spatial_projection_IJ), inverse_spatial_metric,
+        unit_interface_normal_vector);
+    GeneralizedHarmonic::spatial_projection_tensor(
+        make_not_null(&spatial_projection_ij),
+        determinant_and_inverse(inverse_spatial_metric).second,
+        unit_interface_normal_one_form);
+    GeneralizedHarmonic::spatial_projection_tensor(
+        make_not_null(&spatial_projection_Ij), unit_interface_normal_vector,
+        unit_interface_normal_one_form);
+
+    GeneralizedHarmonic::weyl_propagating(
+        make_not_null(&U8p), ricci_3, extrinsic_curvature,
+        inverse_spatial_metric, CdK, unit_interface_normal_one_form,
+        unit_interface_normal_vector, spatial_projection_IJ,
+        spatial_projection_ij, spatial_projection_Ij, 1);
+    GeneralizedHarmonic::weyl_propagating(
+        make_not_null(&U8m), ricci_3, extrinsic_curvature,
+        inverse_spatial_metric, CdK, unit_interface_normal_one_form,
+        unit_interface_normal_vector, spatial_projection_IJ,
+        spatial_projection_ij, spatial_projection_Ij, -1);
+  }
+
+  auto U3p = make_with_value<tnsr::aa<DataVector, VolumeDim, Frame::Inertial>>(
+      unit_interface_normal_vector, 0.);
+  auto U3m = make_with_value<tnsr::aa<DataVector, VolumeDim, Frame::Inertial>>(
+      unit_interface_normal_vector, 0.);
+  for (size_t mu = 0; mu <= VolumeDim; ++mu) {
+    for (size_t nu = mu; nu <= VolumeDim; ++nu) {
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        for (size_t j = 0; j < VolumeDim; ++j) {
+          U3p.get(mu, nu) += 2.0 * projection_Ab.get(i + 1, mu) *
+                             projection_Ab.get(j + 1, nu) * U8p.get(i, j);
+          U3m.get(mu, nu) += 2.0 * projection_Ab.get(i + 1, mu) *
+                             projection_Ab.get(j + 1, nu) * U8m.get(i, j);
+        }
+      }
+    }
+  }
+  // Impose physical boundary condition
+  if (mGamma2InPhysBc) {
+    DataVector tmp(get_size(get<0>(unit_interface_normal_vector)));
+    for (size_t mu = 0; mu <= VolumeDim; ++mu) {
+      for (size_t nu = mu; nu <= VolumeDim; ++nu) {
+        for (size_t a = 0; a <= VolumeDim; ++a) {
+          for (size_t b = 0; b <= VolumeDim; ++b) {
+            tmp = 0.;
+            for (size_t i = 0; i < VolumeDim; ++i) {
+              tmp += unit_interface_normal_vector.get(i + 1) *
+                     three_index_constraint.get(i, a, b);
+            }
+            tmp *= get(gamma2);
+            bc_dt_u_minus->get(mu, nu) +=
+                (projection_Ab.get(a, mu) * projection_Ab.get(b, nu) -
+                 0.5 * projection_ab.get(mu, nu) * projection_AB.get(a, b)) *
+                (char_projected_rhs_dt_u_minus.get(a, b) +
+                 char_speeds.at(3) *
+                     (U3m.get(a, b) - tmp - mMuPhys * U3p.get(a, b)));
+          }
+        }
+      }
+    }
+  } else {
+    for (size_t mu = 0; mu <= VolumeDim; ++mu) {
+      for (size_t nu = mu; nu <= VolumeDim; ++nu) {
+        for (size_t a = 0; a <= VolumeDim; ++a) {
+          for (size_t b = 0; b <= VolumeDim; ++b) {
+            bc_dt_u_minus->get(mu, nu) +=
+                (projection_Ab.get(a, mu) * projection_Ab.get(b, nu) -
+                 0.5 * projection_ab.get(mu, nu) * projection_AB.get(a, b)) *
+                (char_projected_rhs_dt_u_minus.get(a, b) +
+                 char_speeds.at(3) * (U3m.get(a, b) - mMuPhys * U3p.get(a, b)));
+          }
+        }
+      }
+    }
+  }
+  return *bc_dt_u_minus;
+}
+
+template <typename ReturnType, size_t VolumeDim>
+ReturnType set_dt_u_minus<ReturnType, VolumeDim>::apply_gauge_sommerfeld(
+    const gsl::not_null<ReturnType*> bc_dt_u_minus,
+    const Scalar<DataVector>& gamma2,
+    const typename ::Tags::Coordinates<VolumeDim, Frame::Inertial>::type&
+        inertial_coords,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        incoming_null_one_form,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        outgoing_null_one_form,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_u_psi) noexcept {
+  ASSERT(get_size(get<0, 0>(*bc_dt_u_minus)) ==
+             get_size(get<0>(incoming_null_one_form)),
+         "Size of input variables and temporary memory do not match.");
+  // gauge_bc_coeff below is hard-coded here to its default value in SpEC
+  const double gauge_bc_coeff = 1.;
+
+  DataVector inertial_radius(get_size(get<0>(inertial_coords)), 0.);
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    inertial_radius += square(inertial_coords.get(i));
+  }
+  inertial_radius = sqrt(inertial_radius);
+
+  // add in gauge BC
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      for (size_t c = 0; c <= VolumeDim; ++c) {
+        for (size_t d = 0; d <= VolumeDim; ++d) {
+          bc_dt_u_minus->get(a, b) +=
+              0.5 *
+              (incoming_null_one_form.get(a) * projection_Ab.get(c, b) *
+                   outgoing_null_vector.get(d) +
+               incoming_null_one_form.get(b) * projection_Ab.get(c, a) *
+                   outgoing_null_vector.get(d) -
+               0.5 * incoming_null_one_form.get(a) *
+                   outgoing_null_one_form.get(b) * incoming_null_vector.get(c) *
+                   outgoing_null_vector.get(d) -
+               0.5 * incoming_null_one_form.get(b) *
+                   outgoing_null_one_form.get(a) * incoming_null_vector.get(c) *
+                   outgoing_null_vector.get(d) -
+               0.5 * incoming_null_one_form.get(a) *
+                   incoming_null_one_form.get(b) * outgoing_null_vector.get(c) *
+                   outgoing_null_vector.get(d)) *
+              (get(gamma2) - gauge_bc_coeff * (1. / inertial_radius)) *
+              char_projected_rhs_dt_u_psi.get(c, d);
+        }
+      }
+    }
+  }
+
+  return *bc_dt_u_minus;
+}
+
+}  // namespace BoundaryConditions_detail
+}  // namespace Actions
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -401,33 +401,6 @@ void damped_harmonic_h(
   }
 }
 
-template <size_t SpatialDim, typename Frame>
-typename db::item_type<Tags::GaugeH<SpatialDim, Frame>>
-DampedHarmonicHCompute<SpatialDim, Frame>::function(
-    const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
-        gauge_h_init,
-    const Scalar<DataVector>& lapse,
-    const tnsr::I<DataVector, SpatialDim, Frame>& shift,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
-    const double& time, const double& t_start, const double& sigma_t,
-    const tnsr::I<DataVector, SpatialDim, Frame>& coords,
-    const double& sigma_r) noexcept {
-  typename db::item_type<Tags::GaugeH<SpatialDim, Frame>> gauge_h{
-      get_size(get(lapse))};
-  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame>(
-      make_not_null(&gauge_h), gauge_h_init, lapse, shift,
-      sqrt_det_spatial_metric, spacetime_metric, time, coords, 1., 1.,
-      1.,                // amp_coef_{L1, L2, S}
-      4, 4, 4,           // exp_{L1, L2, S}
-      t_start, sigma_t,  // _h_init
-      t_start, sigma_t,  // _L1
-      t_start, sigma_t,  // _L2
-      t_start, sigma_t,  // _S
-      sigma_r);
-  return gauge_h;
-}
-
 // Spacetime derivatives of the damped harmonic gauge source function.
 //
 // The following functions and struct compute spacetime derivatives, i.e.
@@ -751,41 +724,6 @@ void spacetime_deriv_damped_harmonic_h(
     }
   }
 }
-
-template <size_t SpatialDim, typename Frame>
-typename db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>
-SpacetimeDerivDampedHarmonicHCompute<SpatialDim, Frame>::function(
-    const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
-        gauge_h_init,
-    const typename db::item_type<
-        Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>& dgauge_h_init,
-    const Scalar<DataVector>& lapse,
-    const tnsr::I<DataVector, SpatialDim, Frame>& shift,
-    const tnsr::a<DataVector, SpatialDim, Frame>&
-        spacetime_unit_normal_one_form,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
-    const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
-    const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
-    const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const double& time,
-    const double& t_start, const double& sigma_t,
-    const tnsr::I<DataVector, SpatialDim, Frame>& coords,
-    const double& sigma_r) noexcept {
-  typename db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>
-      d4_gauge_h{get_size(get(lapse))};
-  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h(
-      make_not_null(&d4_gauge_h), gauge_h_init, dgauge_h_init, lapse, shift,
-      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
-      inverse_spatial_metric, spacetime_metric, pi, phi, time, coords,
-      1., 1., 1.,        // amp_coef_{L1, L2, S}
-      4, 4, 4,           // exp_{L1, L2, S}
-      t_start, sigma_t,  // _h_init
-      t_start, sigma_t,  // _L1
-      t_start, sigma_t,  // _L2
-      t_start, sigma_t,  // _S
-      sigma_r);
-  return d4_gauge_h;
-}
 }  // namespace GeneralizedHarmonic
 
 // Explicit Instantiations
@@ -877,6 +815,97 @@ SpacetimeDerivDampedHarmonicHCompute<SpatialDim, Frame>::function(
           const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,          \
           const double g_exponent, const int exponent) noexcept;
 
+#define INSTANTIATE_DV_FUNC(_, data)                                           \
+  template void GeneralizedHarmonic::damped_harmonic_h(                        \
+      const gsl::not_null<typename db::item_type<                              \
+          GeneralizedHarmonic::Tags::GaugeH<DIM(data), FRAME(data)>>*>         \
+          gauge_h,                                                             \
+      const typename db::item_type<                                            \
+          GeneralizedHarmonic::Tags::InitialGaugeH<DIM(data), FRAME(data)>>&   \
+          gauge_h_init,                                                        \
+      const Scalar<DataVector>& lapse,                                         \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,                \
+      const Scalar<DataVector>& sqrt_det_spatial_metric,                       \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& spacetime_metric,    \
+      const double time,                                                       \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& coords,               \
+      const double amp_coef_L1, const double amp_coef_L2,                      \
+      const double amp_coef_S, const int exp_L1, const int exp_L2,             \
+      const int exp_S, const double t_start_h_init,                            \
+      const double sigma_t_h_init, const double t_start_L1,                    \
+      const double sigma_t_L1, const double t_start_L2,                        \
+      const double sigma_t_L2, const double t_start_S, const double sigma_t_S, \
+      const double sigma_r) noexcept;                                          \
+  template void GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h(        \
+      const gsl::not_null<typename db::item_type<                              \
+          GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<DIM(data),           \
+                                                          FRAME(data)>>*>      \
+          d4_gauge_h,                                                          \
+      const typename db::item_type<                                            \
+          GeneralizedHarmonic::Tags::InitialGaugeH<DIM(data), FRAME(data)>>&   \
+          gauge_h_init,                                                        \
+      const typename db::item_type<                                            \
+          GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<              \
+              DIM(data), FRAME(data)>>& dgauge_h_init,                         \
+      const Scalar<DataVector>& lapse,                                         \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,                \
+      const tnsr::a<DataVector, DIM(data), FRAME(data)>&                       \
+          spacetime_unit_normal_one_form,                                      \
+      const Scalar<DataVector>& sqrt_det_spatial_metric,                       \
+      const tnsr::II<DataVector, DIM(data), FRAME(data)>&                      \
+          inverse_spatial_metric,                                              \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& spacetime_metric,    \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& pi,                  \
+      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& phi,                \
+      const double time,                                                       \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& coords,               \
+      const double amp_coef_L1, const double amp_coef_L2,                      \
+      const double amp_coef_S, const int exp_L1, const int exp_L2,             \
+      const int exp_S, const double t_start_h_init,                            \
+      const double sigma_t_h_init, const double t_start_L1,                    \
+      const double sigma_t_L1, const double t_start_L2,                        \
+      const double sigma_t_L2, const double t_start_S, const double sigma_t_S, \
+      const double sigma_r) noexcept;                                          \
+  template typename db::item_type<                                             \
+      GeneralizedHarmonic::Tags::GaugeH<DIM(data), FRAME(data)>>               \
+  GeneralizedHarmonic::DampedHarmonicHCompute<DIM(data), FRAME(data)>::        \
+      function(const typename db::item_type<                                   \
+                   GeneralizedHarmonic::Tags::InitialGaugeH<                   \
+                       DIM(data), FRAME(data)>>& gauge_h_init,                 \
+               const Scalar<DataVector>& lapse,                                \
+               const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,       \
+               const Scalar<DataVector>& sqrt_det_spatial_metric,              \
+               const tnsr::aa<DataVector, DIM(data), FRAME(data)>&             \
+                   spacetime_metric,                                           \
+               const double& time, const double& t_start,                      \
+               const double& sigma_t,                                          \
+               const tnsr::I<DataVector, DIM(data), FRAME(data)>& coords,      \
+               const double& sigma_r) noexcept;                                \
+  template typename db::item_type<                                             \
+      GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<DIM(data), FRAME(data)>> \
+  GeneralizedHarmonic::                                                        \
+      SpacetimeDerivDampedHarmonicHCompute<DIM(data), FRAME(data)>::function(  \
+          const typename db::item_type<                                        \
+              GeneralizedHarmonic::Tags::InitialGaugeH<                        \
+                  DIM(data), FRAME(data)>>& gauge_h_init,                      \
+          const typename db::item_type<                                        \
+              GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<          \
+                  DIM(data), FRAME(data)>>& dgauge_h_init,                     \
+          const Scalar<DataVector>& lapse,                                     \
+          const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,            \
+          const tnsr::a<DataVector, DIM(data), FRAME(data)>&                   \
+              spacetime_unit_normal_one_form,                                  \
+          const Scalar<DataVector>& sqrt_det_spatial_metric,                   \
+          const tnsr::II<DataVector, DIM(data), FRAME(data)>&                  \
+              inverse_spatial_metric,                                          \
+          const tnsr::aa<DataVector, DIM(data), FRAME(data)>&                  \
+              spacetime_metric,                                                \
+          const tnsr::aa<DataVector, DIM(data), FRAME(data)>& pi,              \
+          const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& phi,            \
+          const double& time, const double& t_start, const double& sigma_t,    \
+          const tnsr::I<DataVector, DIM(data), FRAME(data)>& coords,           \
+          const double& sigma_r) noexcept;
+
 #define INSTANTIATE_SCALAR_FUNC(_, data)                                    \
   template void                                                             \
   GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse( \
@@ -890,25 +919,19 @@ SpacetimeDerivDampedHarmonicHCompute<SpatialDim, Frame>::function(
       const Scalar<DTYPE_SCAL(data)>& sqrt_det_spatial_metric,              \
       const double exponent) noexcept;
 
-#define INSTANTIATE_COMPUTE_ITEM(_, data)                                    \
-  template struct GeneralizedHarmonic::DampedHarmonicHCompute<DIM(data),     \
-                                                              FRAME(data)>;  \
-  template struct GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute< \
-      DIM(data), FRAME(data)>;
-
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
                         (Frame::Inertial))
 
-GENERATE_INSTANTIATIONS(INSTANTIATE_SCALAR_FUNC, (double, DataVector))
-
-GENERATE_INSTANTIATIONS(INSTANTIATE_COMPUTE_ITEM, (1, 2, 3), (DataVector),
+GENERATE_INSTANTIATIONS(INSTANTIATE_DV_FUNC, (1, 2, 3), (DataVector),
                         (Frame::Inertial))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_SCALAR_FUNC, (double, DataVector))
 
 #undef DIM
 #undef DTYPE
 #undef FRAME
 #undef DTYPE_SCAL
 #undef INSTANTIATE
+#undef INSTANTIATE_DV_FUNC
 #undef INSTANTIATE_SCALAR_FUNC
-#undef INSTANTIATE_COMPUTE_ITEM
 /// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -57,15 +57,21 @@ struct InitializeConstraintsTags {
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
     using compute_tags = db::AddComputeTags<
+        GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<Dim, frame>,
         GeneralizedHarmonic::Tags::GaugeConstraintCompute<Dim, frame>,
         GeneralizedHarmonic::Tags::FourIndexConstraintCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::FConstraintCompute<Dim, frame>,
         // following tags added to observe constraints
+        ::Tags::PointwiseL2NormCompute<
+            GeneralizedHarmonic::Tags::TwoIndexConstraint<Dim, frame>>,
         ::Tags::PointwiseL2NormCompute<
             GeneralizedHarmonic::Tags::GaugeConstraint<Dim, frame>>,
         ::Tags::PointwiseL2NormCompute<
             GeneralizedHarmonic::Tags::ThreeIndexConstraint<Dim, frame>>,
         ::Tags::PointwiseL2NormCompute<
-            GeneralizedHarmonic::Tags::FourIndexConstraint<Dim, frame>>>;
+            GeneralizedHarmonic::Tags::FourIndexConstraint<Dim, frame>>,
+        ::Tags::PointwiseL2NormCompute<
+            GeneralizedHarmonic::Tags::FConstraint<Dim, frame>>>;
 
     return std::make_tuple(
         Initialization::merge_into_databox<InitializeConstraintsTags,
@@ -199,7 +205,9 @@ struct InitializeGaugeTags {
         GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<Dim, frame>>;
     using compute_tags = db::AddComputeTags<
         GeneralizedHarmonic::DampedHarmonicHCompute<Dim, frame>,
-        GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<Dim, frame>>;
+        GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::DerivGaugeHFromSpacetimeDerivGaugeHCompute<
+            Dim, frame>>;
 
     // Finally, insert gauge related quantities to the box
     return std::make_tuple(

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -1,0 +1,218 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <utility>  // IWYU pragma: keep
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Norms.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Initialization/Limiter.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace GeneralizedHarmonic {
+namespace Actions {
+template <size_t Dim>
+struct InitializeConstraintsTags {
+  using frame = Frame::Inertial;
+  using simple_tags = db::AddSimpleTags<>;
+  using compute_tags = db::AddComputeTags<
+      GeneralizedHarmonic::Tags::GaugeConstraintCompute<Dim, frame>,
+      GeneralizedHarmonic::Tags::FourIndexConstraintCompute<Dim, frame>,
+      // following tags added to observe constraints
+      ::Tags::PointwiseL2NormCompute<
+          GeneralizedHarmonic::Tags::GaugeConstraint<Dim, frame>>,
+      ::Tags::PointwiseL2NormCompute<
+          GeneralizedHarmonic::Tags::ThreeIndexConstraint<Dim, frame>>,
+      ::Tags::PointwiseL2NormCompute<
+          GeneralizedHarmonic::Tags::FourIndexConstraint<Dim, frame>>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    return std::make_tuple(
+        Initialization::merge_into_databox<InitializeConstraintsTags,
+                                           simple_tags, compute_tags>(
+            std::move(box)));
+  }
+};
+
+template <size_t Dim>
+struct InitializeGHAnd3Plus1VariablesTags {
+  using frame = Frame::Inertial;
+  using system = GeneralizedHarmonic::System<Dim>;
+  using variables_tag = typename system::variables_tag;
+
+  using simple_tags = db::AddSimpleTags<>;
+  using compute_tags = db::AddComputeTags<
+      gr::Tags::SpatialMetricCompute<Dim, frame, DataVector>,
+      gr::Tags::DetAndInverseSpatialMetricCompute<Dim, frame, DataVector>,
+      gr::Tags::ShiftCompute<Dim, frame, DataVector>,
+      gr::Tags::LapseCompute<Dim, frame, DataVector>,
+      gr::Tags::SqrtDetSpatialMetricCompute<Dim, frame, DataVector>,
+      gr::Tags::SpacetimeNormalOneFormCompute<Dim, frame, DataVector>,
+      gr::Tags::SpacetimeNormalVectorCompute<Dim, frame, DataVector>,
+      gr::Tags::InverseSpacetimeMetricCompute<Dim, frame, DataVector>,
+      GeneralizedHarmonic::Tags::DerivSpatialMetricCompute<Dim, frame>,
+      GeneralizedHarmonic::Tags::DerivLapseCompute<Dim, frame>,
+      GeneralizedHarmonic::Tags::DerivShiftCompute<Dim, frame>,
+      GeneralizedHarmonic::Tags::TimeDerivSpatialMetricCompute<Dim, frame>,
+      GeneralizedHarmonic::Tags::TimeDerivLapseCompute<Dim, frame>,
+      GeneralizedHarmonic::Tags::TimeDerivShiftCompute<Dim, frame>,
+      gr::Tags::DerivativesOfSpacetimeMetricCompute<Dim, frame>,
+      gr::Tags::DerivSpacetimeMetricCompute<Dim, frame>,
+      GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<Dim, frame>,
+      gr::Tags::SpacetimeChristoffelFirstKindCompute<Dim, frame, DataVector>,
+      gr::Tags::SpacetimeChristoffelSecondKindCompute<Dim, frame, DataVector>,
+      gr::Tags::TraceSpacetimeChristoffelFirstKindCompute<Dim, frame,
+                                                          DataVector>,
+      gr::Tags::SpatialChristoffelFirstKindCompute<Dim, frame, DataVector>,
+      gr::Tags::SpatialChristoffelSecondKindCompute<Dim, frame, DataVector>,
+      gr::Tags::TraceSpatialChristoffelFirstKindCompute<Dim, frame, DataVector>,
+      GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<Dim, frame>,
+      GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<Dim, frame>,
+      GeneralizedHarmonic::Tags::ConstraintGamma0Compute<Dim, frame>,
+      GeneralizedHarmonic::Tags::ConstraintGamma1Compute<Dim, frame>,
+      GeneralizedHarmonic::Tags::ConstraintGamma2Compute<Dim, frame>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    return std::make_tuple(
+        Initialization::merge_into_databox<InitializeGHAnd3Plus1VariablesTags,
+                                           simple_tags, compute_tags>(
+            std::move(box)));
+  }
+};
+
+template <size_t Dim>
+struct InitializeGaugeTags {
+  using frame = Frame::Inertial;
+  using system = GeneralizedHarmonic::System<Dim>;
+  using variables_tag = typename system::variables_tag;
+
+  using simple_tags = db::AddSimpleTags<
+      GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>,
+      GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<Dim, frame>>;
+  using compute_tags = db::AddComputeTags<
+      GeneralizedHarmonic::DampedHarmonicHCompute<Dim, frame>,
+      GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<Dim, frame>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    // compute initial-gauge related quantities
+    const auto mesh = db::get<::Tags::Mesh<Dim>>(box);
+    const size_t num_grid_points = mesh.number_of_grid_points();
+    const auto& lapse = get<gr::Tags::Lapse<DataVector>>(box);
+    const auto& dt_lapse = get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(box);
+    const auto& deriv_lapse = get<
+        ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>, frame>>(
+        box);
+    const auto& shift = get<gr::Tags::Shift<Dim, frame, DataVector>>(box);
+    const auto& dt_shift =
+        get<::Tags::dt<gr::Tags::Shift<Dim, frame, DataVector>>>(box);
+    const auto& deriv_shift =
+        get<::Tags::deriv<gr::Tags::Shift<Dim, frame, DataVector>,
+                          tmpl::size_t<Dim>, frame>>(box);
+    const auto& spatial_metric =
+        get<gr::Tags::SpatialMetric<Dim, frame, DataVector>>(box);
+    const auto& trace_extrinsic_curvature =
+        get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(box);
+    const auto& trace_christoffel_last_indices =
+        get<gr::Tags::TraceSpatialChristoffelFirstKind<Dim, frame, DataVector>>(
+            box);
+
+    // call compute item for the initial gauge source function
+    const auto initial_gauge_h = GeneralizedHarmonic::gauge_source<Dim, frame>(
+        lapse, dt_lapse, deriv_lapse, shift, dt_shift, deriv_shift,
+        spatial_metric, trace_extrinsic_curvature,
+        trace_christoffel_last_indices);
+    // set time derivatives of InitialGaugeH = 0
+    // NOTE: this will need to be generalized to handle numerical initial data
+    // and analytic initial data whose gauge is not initially stationary.
+    const auto dt_initial_gauge_source =
+        make_with_value<tnsr::a<DataVector, Dim, frame>>(lapse, 0.);
+
+    // compute spatial derivatives of InitialGaugeH
+    using InitialGaugeHVars = ::Variables<
+        tmpl::list<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>>>;
+    InitialGaugeHVars initial_gauge_h_vars{num_grid_points};
+
+    get<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>>(
+        initial_gauge_h_vars) = initial_gauge_h;
+    const auto inverse_jacobian = db::get<
+        ::Tags::InverseJacobian<::Tags::ElementMap<Dim, frame>,
+                                ::Tags::Coordinates<Dim, Frame::Logical>>>(box);
+    const auto d_initial_gauge_source =
+        get<::Tags::deriv<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>,
+                          tmpl::size_t<Dim>, frame>>(
+            partial_derivatives<typename InitialGaugeHVars::tags_list>(
+                initial_gauge_h_vars, mesh, inverse_jacobian));
+
+    // compute spacetime derivatives of InitialGaugeH
+    const auto initial_d4_gauge_h =
+        GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<
+            Dim, frame>::function(dt_initial_gauge_source,
+                                  d_initial_gauge_source);
+
+    // Finally, insert gauge related quantities to the box
+    return std::make_tuple(
+        Initialization::merge_into_databox<InitializeGaugeTags, simple_tags,
+                                           compute_tags>(
+            std::move(box), std::move(initial_gauge_h),
+            std::move(initial_d4_gauge_h)));
+  }
+};
+
+}  // namespace Actions
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -46,17 +46,6 @@ namespace Actions {
 template <size_t Dim>
 struct InitializeConstraintsTags {
   using frame = Frame::Inertial;
-  using simple_tags = db::AddSimpleTags<>;
-  using compute_tags = db::AddComputeTags<
-      GeneralizedHarmonic::Tags::GaugeConstraintCompute<Dim, frame>,
-      GeneralizedHarmonic::Tags::FourIndexConstraintCompute<Dim, frame>,
-      // following tags added to observe constraints
-      ::Tags::PointwiseL2NormCompute<
-          GeneralizedHarmonic::Tags::GaugeConstraint<Dim, frame>>,
-      ::Tags::PointwiseL2NormCompute<
-          GeneralizedHarmonic::Tags::ThreeIndexConstraint<Dim, frame>>,
-      ::Tags::PointwiseL2NormCompute<
-          GeneralizedHarmonic::Tags::FourIndexConstraint<Dim, frame>>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -67,9 +56,20 @@ struct InitializeConstraintsTags {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
+    using compute_tags = db::AddComputeTags<
+        GeneralizedHarmonic::Tags::GaugeConstraintCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::FourIndexConstraintCompute<Dim, frame>,
+        // following tags added to observe constraints
+        ::Tags::PointwiseL2NormCompute<
+            GeneralizedHarmonic::Tags::GaugeConstraint<Dim, frame>>,
+        ::Tags::PointwiseL2NormCompute<
+            GeneralizedHarmonic::Tags::ThreeIndexConstraint<Dim, frame>>,
+        ::Tags::PointwiseL2NormCompute<
+            GeneralizedHarmonic::Tags::FourIndexConstraint<Dim, frame>>>;
+
     return std::make_tuple(
         Initialization::merge_into_databox<InitializeConstraintsTags,
-                                           simple_tags, compute_tags>(
+                                           db::AddSimpleTags<>, compute_tags>(
             std::move(box)));
   }
 };
@@ -77,40 +77,6 @@ struct InitializeConstraintsTags {
 template <size_t Dim>
 struct InitializeGHAnd3Plus1VariablesTags {
   using frame = Frame::Inertial;
-  using system = GeneralizedHarmonic::System<Dim>;
-  using variables_tag = typename system::variables_tag;
-
-  using simple_tags = db::AddSimpleTags<>;
-  using compute_tags = db::AddComputeTags<
-      gr::Tags::SpatialMetricCompute<Dim, frame, DataVector>,
-      gr::Tags::DetAndInverseSpatialMetricCompute<Dim, frame, DataVector>,
-      gr::Tags::ShiftCompute<Dim, frame, DataVector>,
-      gr::Tags::LapseCompute<Dim, frame, DataVector>,
-      gr::Tags::SqrtDetSpatialMetricCompute<Dim, frame, DataVector>,
-      gr::Tags::SpacetimeNormalOneFormCompute<Dim, frame, DataVector>,
-      gr::Tags::SpacetimeNormalVectorCompute<Dim, frame, DataVector>,
-      gr::Tags::InverseSpacetimeMetricCompute<Dim, frame, DataVector>,
-      GeneralizedHarmonic::Tags::DerivSpatialMetricCompute<Dim, frame>,
-      GeneralizedHarmonic::Tags::DerivLapseCompute<Dim, frame>,
-      GeneralizedHarmonic::Tags::DerivShiftCompute<Dim, frame>,
-      GeneralizedHarmonic::Tags::TimeDerivSpatialMetricCompute<Dim, frame>,
-      GeneralizedHarmonic::Tags::TimeDerivLapseCompute<Dim, frame>,
-      GeneralizedHarmonic::Tags::TimeDerivShiftCompute<Dim, frame>,
-      gr::Tags::DerivativesOfSpacetimeMetricCompute<Dim, frame>,
-      gr::Tags::DerivSpacetimeMetricCompute<Dim, frame>,
-      GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<Dim, frame>,
-      gr::Tags::SpacetimeChristoffelFirstKindCompute<Dim, frame, DataVector>,
-      gr::Tags::SpacetimeChristoffelSecondKindCompute<Dim, frame, DataVector>,
-      gr::Tags::TraceSpacetimeChristoffelFirstKindCompute<Dim, frame,
-                                                          DataVector>,
-      gr::Tags::SpatialChristoffelFirstKindCompute<Dim, frame, DataVector>,
-      gr::Tags::SpatialChristoffelSecondKindCompute<Dim, frame, DataVector>,
-      gr::Tags::TraceSpatialChristoffelFirstKindCompute<Dim, frame, DataVector>,
-      GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<Dim, frame>,
-      GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<Dim, frame>,
-      GeneralizedHarmonic::Tags::ConstraintGamma0Compute<Dim, frame>,
-      GeneralizedHarmonic::Tags::ConstraintGamma1Compute<Dim, frame>,
-      GeneralizedHarmonic::Tags::ConstraintGamma2Compute<Dim, frame>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -121,9 +87,41 @@ struct InitializeGHAnd3Plus1VariablesTags {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
+    using compute_tags = db::AddComputeTags<
+        gr::Tags::SpatialMetricCompute<Dim, frame, DataVector>,
+        gr::Tags::DetAndInverseSpatialMetricCompute<Dim, frame, DataVector>,
+        gr::Tags::ShiftCompute<Dim, frame, DataVector>,
+        gr::Tags::LapseCompute<Dim, frame, DataVector>,
+        gr::Tags::SqrtDetSpatialMetricCompute<Dim, frame, DataVector>,
+        gr::Tags::SpacetimeNormalOneFormCompute<Dim, frame, DataVector>,
+        gr::Tags::SpacetimeNormalVectorCompute<Dim, frame, DataVector>,
+        gr::Tags::InverseSpacetimeMetricCompute<Dim, frame, DataVector>,
+        GeneralizedHarmonic::Tags::DerivSpatialMetricCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::DerivLapseCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::DerivShiftCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::TimeDerivSpatialMetricCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::TimeDerivLapseCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::TimeDerivShiftCompute<Dim, frame>,
+        gr::Tags::DerivativesOfSpacetimeMetricCompute<Dim, frame>,
+        gr::Tags::DerivSpacetimeMetricCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<Dim, frame>,
+        gr::Tags::SpacetimeChristoffelFirstKindCompute<Dim, frame, DataVector>,
+        gr::Tags::SpacetimeChristoffelSecondKindCompute<Dim, frame, DataVector>,
+        gr::Tags::TraceSpacetimeChristoffelFirstKindCompute<Dim, frame,
+                                                            DataVector>,
+        gr::Tags::SpatialChristoffelFirstKindCompute<Dim, frame, DataVector>,
+        gr::Tags::SpatialChristoffelSecondKindCompute<Dim, frame, DataVector>,
+        gr::Tags::TraceSpatialChristoffelFirstKindCompute<Dim, frame,
+                                                          DataVector>,
+        GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::ConstraintGamma0Compute<Dim, frame>,
+        GeneralizedHarmonic::Tags::ConstraintGamma1Compute<Dim, frame>,
+        GeneralizedHarmonic::Tags::ConstraintGamma2Compute<Dim, frame>>;
+
     return std::make_tuple(
         Initialization::merge_into_databox<InitializeGHAnd3Plus1VariablesTags,
-                                           simple_tags, compute_tags>(
+                                           db::AddSimpleTags<>, compute_tags>(
             std::move(box)));
   }
 };
@@ -131,15 +129,6 @@ struct InitializeGHAnd3Plus1VariablesTags {
 template <size_t Dim>
 struct InitializeGaugeTags {
   using frame = Frame::Inertial;
-  using system = GeneralizedHarmonic::System<Dim>;
-  using variables_tag = typename system::variables_tag;
-
-  using simple_tags = db::AddSimpleTags<
-      GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>,
-      GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<Dim, frame>>;
-  using compute_tags = db::AddComputeTags<
-      GeneralizedHarmonic::DampedHarmonicHCompute<Dim, frame>,
-      GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<Dim, frame>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -204,6 +193,13 @@ struct InitializeGaugeTags {
         GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<
             Dim, frame>::function(dt_initial_gauge_source,
                                   d_initial_gauge_source);
+    // Add all gauge tags
+    using simple_tags = db::AddSimpleTags<
+        GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>,
+        GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<Dim, frame>>;
+    using compute_tags = db::AddComputeTags<
+        GeneralizedHarmonic::DampedHarmonicHCompute<Dim, frame>,
+        GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<Dim, frame>>;
 
     // Finally, insert gauge related quantities to the box
     return std::make_tuple(

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -57,21 +57,26 @@ struct InitializeConstraintsTags {
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
     using compute_tags = db::AddComputeTags<
-        GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<Dim, frame>,
         GeneralizedHarmonic::Tags::GaugeConstraintCompute<Dim, frame>,
-        GeneralizedHarmonic::Tags::FourIndexConstraintCompute<Dim, frame>,
         GeneralizedHarmonic::Tags::FConstraintCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::FourIndexConstraintCompute<Dim, frame>,
+        GeneralizedHarmonic::Tags::ConstraintEnergyCompute<Dim, frame>,
+
         // following tags added to observe constraints
         ::Tags::PointwiseL2NormCompute<
-            GeneralizedHarmonic::Tags::TwoIndexConstraint<Dim, frame>>,
-        ::Tags::PointwiseL2NormCompute<
             GeneralizedHarmonic::Tags::GaugeConstraint<Dim, frame>>,
+        ::Tags::PointwiseL2NormCompute<
+            GeneralizedHarmonic::Tags::FConstraint<Dim, frame>>,
+        ::Tags::PointwiseL2NormCompute<
+            GeneralizedHarmonic::Tags::TwoIndexConstraint<Dim, frame>>,
         ::Tags::PointwiseL2NormCompute<
             GeneralizedHarmonic::Tags::ThreeIndexConstraint<Dim, frame>>,
         ::Tags::PointwiseL2NormCompute<
             GeneralizedHarmonic::Tags::FourIndexConstraint<Dim, frame>>,
         ::Tags::PointwiseL2NormCompute<
-            GeneralizedHarmonic::Tags::FConstraint<Dim, frame>>>;
+            GeneralizedHarmonic::Tags::ConstraintEnergy<Dim, frame>>>;
 
     return std::make_tuple(
         Initialization::merge_into_databox<InitializeConstraintsTags,

--- a/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
@@ -37,6 +37,9 @@ struct System {
                  Tags::Pi<Dim, Frame::Inertial>,
                  Tags::Phi<Dim, Frame::Inertial>>;
 
+  // List of fields necessary to import when specifying initial data
+  using initial_data_fields_tag = db::get_variables_tags_list<variables_tag>;
+
   using compute_time_derivative = ComputeDuDt<Dim>;
   using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;
   using char_speeds_tag = CharacteristicSpeedsCompute<Dim, Frame::Inertial>;

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -293,7 +293,6 @@ struct GeneralizedHarmonicGroup {
  */
 struct GaugeRollOnStart {
   using type = double;
-  static std::string name() noexcept { return "GaugeRollOnStart"; }
   static constexpr OptionString help{
       "Simulation time to start rolling-on evolution gauge"};
   using group = GeneralizedHarmonicGroup;
@@ -310,7 +309,6 @@ struct GaugeRollOnStart {
  */
 struct GaugeRollOnWindow {
   using type = double;
-  static std::string name() noexcept { return "GaugeRollOnWindow"; }
   static constexpr OptionString help{
       "Duration of gauge roll-on in simulation time"};
   using group = GeneralizedHarmonicGroup;

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
+#include "Evolution/Tags.hpp"
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 
@@ -53,6 +54,50 @@ struct ConstraintGamma1 : db::SimpleTag {
 struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() noexcept { return "ConstraintGamma2"; }
+};
+
+/*!
+ * \brief Gauge control parameter determining when to start rolling-on the
+ * evolution gauge.
+ *
+ * \details The evolution gauge is gradually transitioned to (or
+ * *rolled-on* to) at the beginning of an evolution. This parameter sets
+ * the coordinate time at which roll-on begins.
+ */
+struct GaugeHRollOnStartTime : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "GaugeHRollOnStartTime"; }
+};
+
+/*!
+ * \brief Gauge control parameter determining how long the transition to
+ * the evolution gauge should take at the start of an evolution.
+ *
+ * \details The evolution gauge is gradually transitioned to (or
+ * *rolled-on* to) at the beginning of an evolution. This parameter sets
+ * the width of the coordinate time window during which roll-on happens.
+ */
+struct GaugeHRollOnTimeWindow : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "GaugeHRollOnTimeWindow"; }
+};
+
+/*!
+ * \brief Gauge control parameter to specify the spatial weighting function
+ * that enters damped harmonic gauge source function.
+ *
+ * \details The evolution gauge source function is multiplied by a spatial
+ * weight function which controls where and how much it sources the damped
+ * harmonic gauge equation. The weight function is:
+ * \f$ W(x^i) = \exp[-(r/\sigma_r)^2] \f$.
+ * This weight function can be written with an extra factor inside the exponent
+ * in literature, e.g. \cite Deppe2018uye. We will absorb it here in
+ * \f$\sigma_r\f$. The parameter this tag tags is \f$ \sigma_r \f$.
+ */
+template <typename Frame>
+struct GaugeHSpatialWeightDecayWidth : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "GaugeHSpatialWeightDecayWidth"; }
 };
 
 /*!
@@ -214,6 +259,15 @@ struct ConstraintEnergy : db::SimpleTag {
 
 namespace OptionTags {
 /*!
+ * \ingroup OptionGroupsGroup
+ * Groups option tags related to the ValenciaDivClean evolution system.
+ */
+struct GeneralizedHarmonicGroup {
+  static std::string name() noexcept { return "GeneralizedHarmonic"; }
+  static constexpr OptionString help{"Options for the evolution system"};
+  using group = ::OptionTags::EvolutionSystemGroup;
+};
+/*!
  * \ingroup OptionTagsGroup
  * \brief Gauge control parameter determining when to start rolling-on the
  * evolution gauge.
@@ -222,11 +276,12 @@ namespace OptionTags {
  * *rolled-on* to) at the beginning of an evolution. This parameter sets
  * the coordinate time at which roll-on begins.
  */
-struct GaugeHRollOnStartTime : db::SimpleTag {
+struct GaugeRollOnStart : Tags::GaugeHRollOnStartTime {
   using type = double;
-  static std::string name() noexcept { return "GaugeHRollOnStartT"; }
+  static std::string name() noexcept { return "GaugeRollOnStart"; }
   static constexpr OptionString help{
       "Simulation time to start rolling-on evolution gauge"};
+  using group = GeneralizedHarmonicGroup;
 };
 
 /*!
@@ -238,11 +293,12 @@ struct GaugeHRollOnStartTime : db::SimpleTag {
  * *rolled-on* to) at the beginning of an evolution. This parameter sets
  * the width of the coordinate time window during which roll-on happens.
  */
-struct GaugeHRollOnTimeWindow : db::SimpleTag {
+struct GaugeRollOnWindow : Tags::GaugeHRollOnTimeWindow {
   using type = double;
-  static std::string name() noexcept { return "GaugeHRollOnTWindow"; }
+  static std::string name() noexcept { return "GaugeRollOnWindow"; }
   static constexpr OptionString help{
       "Duration of gauge roll-on in simulation time"};
+  using group = GeneralizedHarmonicGroup;
 };
 
 /*!
@@ -259,11 +315,12 @@ struct GaugeHRollOnTimeWindow : db::SimpleTag {
  * \f$\sigma_r\f$. The parameter this tag tags is \f$ \sigma_r \f$.
  */
 template <typename Frame>
-struct GaugeHSpatialWeightDecayWidth : db::SimpleTag {
+struct GaugeSpatialDecayWidth : Tags::GaugeHSpatialWeightDecayWidth<Frame> {
   using type = double;
-  static std::string name() noexcept { return "GaugeHDecayWidth"; }
+  static std::string name() noexcept { return "GaugeDecayWidth"; }
   static constexpr OptionString help{
       "Spatial width of weighting factor in evolution gauge"};
+  using group = GeneralizedHarmonicGroup;
 };
 }  // namespace OptionTags
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -67,6 +67,11 @@ struct ConstraintGamma2 : db::SimpleTag {
 struct GaugeHRollOnStartTime : db::SimpleTag {
   using type = double;
   static std::string name() noexcept { return "GaugeHRollOnStartTime"; }
+  using option_tags = tmpl::list<OptionTags::GaugeRollOnStart>;
+  static double create_from_options(
+      const double gauge_roll_on_start_time) noexcept {
+    return gauge_roll_on_start_time;
+  }
 };
 
 /*!
@@ -80,6 +85,11 @@ struct GaugeHRollOnStartTime : db::SimpleTag {
 struct GaugeHRollOnTimeWindow : db::SimpleTag {
   using type = double;
   static std::string name() noexcept { return "GaugeHRollOnTimeWindow"; }
+  using option_tags = tmpl::list<OptionTags::GaugeRollOnWindow>;
+  static double create_from_options(
+      const double gauge_roll_on_window) noexcept {
+    return gauge_roll_on_window;
+  }
 };
 
 /*!
@@ -98,6 +108,11 @@ template <typename Frame>
 struct GaugeHSpatialWeightDecayWidth : db::SimpleTag {
   using type = double;
   static std::string name() noexcept { return "GaugeHSpatialWeightDecayWidth"; }
+  using option_tags = tmpl::list<OptionTags::GaugeSpatialDecayWidth<Frame>>;
+  static double create_from_options(
+      const double gauge_spatial_decay_width) noexcept {
+    return gauge_spatial_decay_width;
+  }
 };
 
 /*!
@@ -276,7 +291,7 @@ struct GeneralizedHarmonicGroup {
  * *rolled-on* to) at the beginning of an evolution. This parameter sets
  * the coordinate time at which roll-on begins.
  */
-struct GaugeRollOnStart : Tags::GaugeHRollOnStartTime {
+struct GaugeRollOnStart {
   using type = double;
   static std::string name() noexcept { return "GaugeRollOnStart"; }
   static constexpr OptionString help{
@@ -293,7 +308,7 @@ struct GaugeRollOnStart : Tags::GaugeHRollOnStartTime {
  * *rolled-on* to) at the beginning of an evolution. This parameter sets
  * the width of the coordinate time window during which roll-on happens.
  */
-struct GaugeRollOnWindow : Tags::GaugeHRollOnTimeWindow {
+struct GaugeRollOnWindow {
   using type = double;
   static std::string name() noexcept { return "GaugeRollOnWindow"; }
   static constexpr OptionString help{
@@ -315,7 +330,7 @@ struct GaugeRollOnWindow : Tags::GaugeHRollOnTimeWindow {
  * \f$\sigma_r\f$. The parameter this tag tags is \f$ \sigma_r \f$.
  */
 template <typename Frame>
-struct GaugeSpatialDecayWidth : Tags::GaugeHSpatialWeightDecayWidth<Frame> {
+struct GaugeSpatialDecayWidth {
   using type = double;
   static std::string name() noexcept { return "GaugeDecayWidth"; }
   static constexpr OptionString help{

--- a/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
@@ -19,6 +19,10 @@ struct Phi;
 struct ConstraintGamma0;
 struct ConstraintGamma1;
 struct ConstraintGamma2;
+struct GaugeHRollOnStartTime;
+struct GaugeHRollOnTimeWindow;
+template <typename Frame>
+struct GaugeHSpatialWeightDecayWidth;
 template <size_t Dim, typename Frame = Frame::Inertial>
 struct InitialGaugeH;
 template <size_t Dim, typename Frame = Frame::Inertial>
@@ -60,9 +64,10 @@ struct ConstraintEnergy;
 
 /// \brief Input option tags for the generalized harmonic evolution system
 namespace OptionTags {
-struct GaugeHRollOnStartTime;
-struct GaugeHRollOnTimeWindow;
+struct GeneralizedHarmonicGroup;
+struct GaugeRollOnStart;
+struct GaugeRollOnWindow;
 template <typename Frame>
-struct GaugeHSpatialWeightDecayWidth;
+struct GaugeSpatialDecayWidth;
 }  // namespace OptionTags
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Tags.hpp
+++ b/src/Evolution/Tags.hpp
@@ -5,6 +5,7 @@
 
 #include <string>
 
+#include "IO/DataImporter/Tags.hpp"
 #include "Options/Options.hpp"
 
 namespace OptionTags {
@@ -31,4 +32,13 @@ struct EvolutionSystemGroup {
   static constexpr OptionString help{"The system of hyperbolic PDEs"};
 };
 
+/*!
+ * \brief Holds option tags for importing numerical initial data for an
+ * evolution.
+ *
+ */
+struct NumericalInitialData {
+  using group = importer::OptionTags::Group;
+  static constexpr OptionString help{"Initial data for evolution."};
+};
 }  // namespace OptionTags

--- a/src/IO/DataImporter/DataFileReader.hpp
+++ b/src/IO/DataImporter/DataFileReader.hpp
@@ -35,7 +35,6 @@ struct DataFileReader {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<detail::InitializeDataFileReader>>>;
-  using const_global_cache_tag_list = tmpl::list<>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 

--- a/src/IO/DataImporter/DataFileReader.hpp
+++ b/src/IO/DataImporter/DataFileReader.hpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "AlgorithmNodegroup.hpp"
+#include "IO/DataImporter/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+
+namespace importer {
+
+namespace detail {
+struct InitializeDataFileReader;
+}  // namespace detail
+
+/*!
+ * \brief A nodegroup parallel component that reads in a volume data file and
+ * distributes its data to elements of an array parallel component.
+ *
+ * Each element of the array parallel component must register itself before
+ * data can be sent to it. To do so, invoke
+ * `importer::Actions::RegisterWithImporter` on each the element. In a
+ * subsequent phase you can then invoke
+ * `importer::ThreadedActions::ReadElementData` on the `DataFileReader`
+ * component to read in the file and distribute its data to the registered
+ * elements.
+ */
+template <typename Metavariables>
+struct DataFileReader {
+  using chare_type = Parallel::Algorithms::Nodegroup;
+  using metavariables = Metavariables;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<detail::InitializeDataFileReader>>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void initialize(Parallel::CProxy_ConstGlobalCache<
+                         Metavariables>& /*global_cache*/) noexcept {}
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    Parallel::get_parallel_component<DataFileReader>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+
+namespace detail {
+struct InitializeDataFileReader {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using simple_tags = db::AddSimpleTags<Tags::RegisteredElements>;
+    using compute_tags = db::AddComputeTags<>;
+
+    return std::make_tuple(
+        ::Initialization::merge_into_databox<InitializeDataFileReader,
+                                             simple_tags, compute_tags>(
+            std::move(box), db::item_type<Tags::RegisteredElements>{}),
+        true);
+  }
+};
+}  // namespace detail
+
+}  // namespace importer

--- a/src/IO/DataImporter/DataFileReaderActions.hpp
+++ b/src/IO/DataImporter/DataFileReaderActions.hpp
@@ -113,7 +113,7 @@ struct ReadElementData {
   }
 
  public:
-  using const_global_cache_tag_list =
+  using const_global_cache_tags =
       tmpl::list<Tags::DataFileName<ImporterOptionsGroup>,
                  Tags::VolumeDataSubgroup<ImporterOptionsGroup>,
                  Tags::ObservationValue<ImporterOptionsGroup>>;

--- a/src/IO/DataImporter/DataFileReaderActions.hpp
+++ b/src/IO/DataImporter/DataFileReaderActions.hpp
@@ -1,0 +1,217 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "IO/DataImporter/Tags.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace importer {
+/// Actions related to the data importer
+namespace Actions {
+
+/*!
+ * \brief Invoked on the `importer::DataFileReader` component to store the
+ * registered data.
+ *
+ * The `importer::Actions::RegisterWithImporter` action, which is performed on
+ * each element of an array parallel component, invokes this action on the
+ * `importer::DataFileReader` component.
+ */
+struct RegisterElementWithSelf {
+  template <typename ParallelComponent, typename DataBox,
+            typename Metavariables, typename ArrayIndex,
+            Requires<db::tag_is_retrievable_v<Tags::RegisteredElements,
+                                              DataBox>> = nullptr>
+  static void apply(DataBox& box,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const observers::ArrayComponentId& array_component_id,
+                    const std::string& grid_name) noexcept {
+    db::mutate<Tags::RegisteredElements>(
+        make_not_null(&box),
+        [&array_component_id, &grid_name ](
+            const gsl::not_null<db::item_type<Tags::RegisteredElements>*>
+                registered_elements) noexcept {
+          (*registered_elements)[array_component_id] = grid_name;
+        });
+  }
+};
+
+}  // namespace Actions
+
+/// Threaded actions related to the data importer
+namespace ThreadedActions {
+
+/*!
+ * \brief Read a volume data file and distribute the data to the registered
+ * elements.
+ *
+ * This action can be invoked on the `importer::DataFileReader` component once
+ * all elements have been registered with it. It opens the data file, reads the
+ * data for each registered element and calls the `CallbackAction` on each
+ * element providing the data.
+ *
+ * - The `ImporterOptionsGroup` parameter specifies the \ref OptionGroupsGroup
+ * "options group" in the input file that provides the following run-time
+ * options:
+ *   - `importer::OptionTags::DataFileName`
+ *   - `importer::OptionTags::VolumeDataSubgroup`
+ *   - `importer::OptionTags::ObservationValue`
+ * - The `FieldTagsList` parameter specifies a typelist of tensor tags that
+ * are read from the file and provided to each element. It is assumed that the
+ * tensor data is stored in datasets named `db::tag_name<Tag>() + suffix`, where
+ * the `suffix` is empty for scalars or `"_"` followed by the
+ * `Tensor::component_name` for each independent tensor component.
+ * - The `CallbackAction` is invoked on each registered element of the
+ * `CallbackComponent` with a
+ * `tuples::tagged_tuple_from_typelist<FieldTagsList>` containing the
+ * tensor data for that element. The `CallbackComponent` must the the same that
+ * was encoded into the `observers::ArrayComponentId` used to register the
+ * elements.
+ */
+template <typename ImporterOptionsGroup, typename FieldTagsList,
+          typename CallbackAction, typename CallbackComponent>
+struct ReadElementData {
+ private:
+  template <typename T>
+  static std::string component_suffix(const T& tensor,
+                                      size_t component_index) noexcept {
+    return tensor.rank() == 0
+               ? ""
+               : "_" + tensor.component_name(
+                           tensor.get_tensor_index(component_index));
+  }
+  static size_t get_observation_id(const h5::VolumeData& volume_file,
+                                   const double observation_value) noexcept {
+    for (auto& observation_id : volume_file.list_observation_ids()) {
+      if (volume_file.get_observation_value(observation_id) ==
+          observation_value) {
+        return observation_id;
+      }
+    }
+    ERROR("No observation with value " << observation_value
+                                       << " found in volume file.");
+  }
+
+ public:
+  using const_global_cache_tag_list =
+      tmpl::list<Tags::DataFileName<ImporterOptionsGroup>,
+                 Tags::VolumeDataSubgroup<ImporterOptionsGroup>,
+                 Tags::ObservationValue<ImporterOptionsGroup>>;
+
+  template <typename ParallelComponent, typename DataBox,
+            typename Metavariables, typename ArrayIndex,
+            Requires<db::tag_is_retrievable_v<Tags::RegisteredElements,
+                                              DataBox>> = nullptr>
+  static void apply(DataBox& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const gsl::not_null<CmiNodeLock*> node_lock) noexcept {
+    Parallel::lock(node_lock);
+    {
+      // The scoping is to close the file before unlocking
+      h5::H5File<h5::AccessType::ReadOnly> h5file(
+          Parallel::get<Tags::DataFileName<ImporterOptionsGroup>>(cache));
+      constexpr size_t version_number = 0;
+      const auto& volume_file = h5file.get<h5::VolumeData>(
+          "/" + Parallel::get<Tags::VolumeDataSubgroup<ImporterOptionsGroup>>(
+                    cache),
+          version_number);
+      const auto observation_id = get_observation_id(
+          volume_file,
+          Parallel::get<Tags::ObservationValue<ImporterOptionsGroup>>(cache));
+      // Read the tensor data for all elements at once, since that's how it's
+      // stored in the file
+      tuples::tagged_tuple_from_typelist<FieldTagsList> all_tensor_data{};
+      tmpl::for_each<FieldTagsList>([
+        &all_tensor_data, &volume_file, &observation_id
+      ](auto field_tag_v) noexcept {
+        using field_tag = tmpl::type_from<decltype(field_tag_v)>;
+        auto& tensor_data = get<field_tag>(all_tensor_data);
+        for (size_t i = 0; i < tensor_data.size(); i++) {
+          tensor_data[i] = volume_file.get_tensor_component(
+              observation_id,
+              db::tag_name<field_tag>() + component_suffix(tensor_data, i));
+        }
+      });
+      // Retrieve the information needed to reconstruct which element the data
+      // belongs to
+      const auto all_grid_names = volume_file.get_grid_names(observation_id);
+      const auto all_extents = volume_file.get_extents(observation_id);
+      // Distribute the tensor data to the registered elements
+      for (auto& element_and_name : get<Tags::RegisteredElements>(box)) {
+        const CkArrayIndex& raw_element_index =
+            element_and_name.first.array_index();
+        // Check if the parallel component of the registered element matches the
+        // callback, because it's possible that elements from other components
+        // with the same index are also registered.
+        // Since the way the component is encoded in `ArrayComponentId` is
+        // private to that class, we construct one and compare.
+        if (element_and_name.first !=
+            observers::ArrayComponentId(
+                std::add_pointer_t<CallbackComponent>{nullptr},
+                raw_element_index)) {
+          continue;
+        }
+        // Find the data offset that corresponds to this element
+        const auto element_data_offset_and_length =
+            h5::offset_and_length_for_grid(element_and_name.second,
+                                           all_grid_names, all_extents);
+        // Extract this element's data from the read-in dataset
+        tuples::tagged_tuple_from_typelist<FieldTagsList> element_data{};
+        tmpl::for_each<FieldTagsList>([
+          &element_data, &element_data_offset_and_length, &all_tensor_data
+        ](auto field_tag_v) noexcept {
+          using field_tag = tmpl::type_from<decltype(field_tag_v)>;
+          auto& element_tensor_data = get<field_tag>(element_data);
+          // Iterate independent components of the tensor
+          for (size_t i = 0; i < element_tensor_data.size(); i++) {
+            const DataVector& data_tensor_component =
+                get<field_tag>(all_tensor_data)[i];
+            DataVector element_tensor_component{
+                element_data_offset_and_length.second};
+            // Retrieve data from slice of the contigious dataset
+            for (size_t j = 0; j < element_tensor_component.size(); j++) {
+              element_tensor_component[j] =
+                  data_tensor_component[element_data_offset_and_length.first +
+                                        j];
+            }
+            element_tensor_data[i] = element_tensor_component;
+          }
+        });
+        // Pass the data to the element in a simple action
+        const auto element_index =
+            Parallel::ArrayIndex<typename CallbackComponent::array_index>(
+                raw_element_index)
+                .get_index();
+        Parallel::simple_action<CallbackAction>(
+            Parallel::get_parallel_component<CallbackComponent>(
+                cache)[element_index],
+            std::move(element_data));
+      }
+    }
+    Parallel::unlock(node_lock);
+  }
+};
+
+}  // namespace ThreadedActions
+}  // namespace importer

--- a/src/IO/DataImporter/ElementActions.hpp
+++ b/src/IO/DataImporter/ElementActions.hpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/ElementId.hpp"
+#include "IO/DataImporter/DataFileReader.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/Requires.hpp"
+
+namespace importer {
+namespace Actions {
+
+struct RegisterElementWithSelf;
+
+/*!
+ * \brief Register an element with the data importer.
+ *
+ * Invoke this action on each element of an array parallel component to register
+ * them for receiving imported data.
+ */
+struct RegisterWithImporter {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ElementIndex<Dim>& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const std::string element_name = MakeString{}
+                                     << ElementId<Dim>(array_index);
+    auto& local_reader_component =
+        *Parallel::get_parallel_component<
+             importer::DataFileReader<Metavariables>>(cache)
+             .ckLocalBranch();
+    Parallel::simple_action<importer::Actions::RegisterElementWithSelf>(
+        local_reader_component,
+        observers::ArrayComponentId(
+            std::add_pointer_t<ParallelComponent>{nullptr},
+            Parallel::ArrayIndex<ElementIndex<Dim>>(array_index)),
+        element_name);
+    return {std::move(box)};
+  }
+};
+
+}  // namespace Actions
+}  // namespace importer

--- a/src/IO/DataImporter/Tags.hpp
+++ b/src/IO/DataImporter/Tags.hpp
@@ -1,0 +1,139 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "Options/Options.hpp"
+
+/// Items related to loading volume data from a file and distributing it to
+/// elements of an array component.
+namespace importer {
+
+/// The input file options associated with the data importer
+namespace OptionTags {
+
+/*!
+ * \ingroup OptionGroupsGroup
+ * \brief Groups the data importer configurations in the input file
+ */
+struct Group {
+  static std::string name() noexcept { return "DataImporters"; }
+  static constexpr OptionString help = "Options for loading volume data files";
+};
+
+/*!
+ * \brief The file to read volume data from.
+ */
+template <typename ImporterOptionsGroup>
+struct DataFileName {
+  static_assert(
+      cpp17::is_same_v<typename ImporterOptionsGroup::group, Group>,
+      "The importer options should be placed in the 'DataImporters' option "
+      "group. Add a type alias `using group = importers::OptionTags::Group`.");
+  using type = std::string;
+  static constexpr OptionString help = "Path to the data file";
+  using group = ImporterOptionsGroup;
+};
+
+/*!
+ * \brief The subgroup within the data file to read volume data from.
+ *
+ * This subgroup should conform to the `h5::VolumeData` format.
+ */
+template <typename ImporterOptionsGroup>
+struct VolumeDataSubgroup {
+  static_assert(
+      cpp17::is_same_v<typename ImporterOptionsGroup::group, Group>,
+      "The importer options should be placed in the 'DataImporters' option "
+      "group. Add a type alias `using group = importers::OptionTags::Group`.");
+  using type = std::string;
+  static constexpr OptionString help =
+      "Name of the subgroup within the file, excluding '.vol'";
+  using group = ImporterOptionsGroup;
+};
+
+/*!
+ * \brief The observation value at which to read volume data from the file.
+ */
+template <typename ImporterOptionsGroup>
+struct ObservationValue {
+  static_assert(
+      cpp17::is_same_v<typename ImporterOptionsGroup::group, Group>,
+      "The importer options should be placed in the 'DataImporters' option "
+      "group. Add a type alias `using group = importers::OptionTags::Group`.");
+  using type = double;
+  static constexpr OptionString help =
+      "The observation value at which to read volume data";
+  using group = ImporterOptionsGroup;
+};
+
+}  // namespace OptionTags
+
+/// The \ref DataBoxGroup tags associated with the data importer
+namespace Tags {
+
+/*!
+ * \brief The file to read volume data from.
+ */
+template <typename ImporterOptionsGroup>
+struct DataFileName : db::SimpleTag {
+  using type = std::string;
+  static std::string name() noexcept { return "DataFileName"; }
+  using option_tags =
+      tmpl::list<OptionTags::DataFileName<ImporterOptionsGroup>>;
+  static type create_from_options(const type& data_file_name) noexcept {
+    return data_file_name;
+  }
+};
+
+/*!
+ * \brief The subgroup within the data file to read volume data from.
+ *
+ * This subgroup should conform to the `h5::VolumeData` format.
+ */
+template <typename ImporterOptionsGroup>
+struct VolumeDataSubgroup : db::SimpleTag {
+  using type = std::string;
+  static std::string name() noexcept { return "VolumeDataSubgroup"; }
+  using option_tags =
+      tmpl::list<OptionTags::VolumeDataSubgroup<ImporterOptionsGroup>>;
+  static type create_from_options(const type& volume_data_subgroup) noexcept {
+    return volume_data_subgroup;
+  }
+};
+
+/*!
+ * \brief The observation value at which to read volume data from the file.
+ */
+template <typename ImporterOptionsGroup>
+struct ObservationValue : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "ObservationValue"; }
+  using option_tags =
+      tmpl::list<OptionTags::ObservationValue<ImporterOptionsGroup>>;
+  static type create_from_options(const type& observation_value) noexcept {
+    return observation_value;
+  }
+};
+
+/*!
+ * \brief The elements that will receive data from the importer.
+ *
+ * \details Identifiers for elements from multiple parallel components can be
+ * stored. Each element is identified by an `observers::ArrayComponentId` and
+ * also needs to provide the `std::string` that identifies it in the data file.
+ */
+struct RegisteredElements : db::SimpleTag {
+  static std::string name() noexcept { return "RegisteredElements"; }
+  using type = std::unordered_map<observers::ArrayComponentId, std::string>;
+};
+
+}  // namespace Tags
+
+}  // namespace importer

--- a/src/IO/H5/VolumeData.hpp
+++ b/src/IO/H5/VolumeData.hpp
@@ -52,7 +52,9 @@ namespace h5 {
  * and their extents in the order which they and the data were written.
  * For example, if the first grid has name `GRID_NAME` with extents
  * `{2, 2, 2}`, it was responsible for contributing the first 2*2*2 = 8 grid
- * points worth of data in each tensor dataset.
+ * points worth of data in each tensor dataset. Use the
+ * `h5::offset_and_length_for_grid` function to compute the offset into the
+ * contiguous dataset that corresponds to a particular grid.
  *
  * \warning Currently the topology of the grids is assumed to be tensor products
  * of lines, i.e. lines, quadrilaterals, and hexahedrons. However, this can be
@@ -133,4 +135,28 @@ class VolumeData : public h5::Object {
   detail::OpenGroup volume_data_group_{};
   std::string header_{};
 };
+
+/*!
+ * \brief Find the offset into the contiguous dataset stored in `h5::VolumeData`
+ * for a particular `grid_name`.
+ *
+ * `h5::VolumeData` stores data for all grids that compose the volume
+ * contiguously. This function helps with reconstructing which part of that
+ * contiguous dataset belongs to a particular grid. See the `h5::VolumeData`
+ * documentation for more information on how it stores data.
+ *
+ * To use this function, call `h5::VolumeData::get_grid_names` and
+ * `h5::VolumeData::get_extents` and pass the results for the `all_grid_names`
+ * and `all_extents` arguments, respectively. Here is an example for using this
+ * function:
+ *
+ * \snippet Test_VolumeData.cpp find_offset
+ *
+ * \see `h5::VolumeData`
+ */
+std::pair<size_t, size_t> offset_and_length_for_grid(
+    const std::string& grid_name,
+    const std::vector<std::string>& all_grid_names,
+    const std::vector<std::vector<size_t>>& all_extents) noexcept;
+
 }  // namespace h5

--- a/src/IO/Observer/ArrayComponentId.cpp
+++ b/src/IO/Observer/ArrayComponentId.cpp
@@ -21,4 +21,9 @@ bool operator!=(const ArrayComponentId& lhs,
                 const ArrayComponentId& rhs) noexcept {
   return not(lhs == rhs);
 }
+
+std::ostream& operator<<(std::ostream& os,
+                         const ArrayComponentId& array_component_id) noexcept {
+  return os << std::hash<ArrayComponentId>{}(array_component_id);
+}
 }  // namespace observers

--- a/src/IO/Observer/ArrayComponentId.hpp
+++ b/src/IO/Observer/ArrayComponentId.hpp
@@ -56,6 +56,9 @@ bool operator==(const ArrayComponentId& lhs,
 
 bool operator!=(const ArrayComponentId& lhs,
                 const ArrayComponentId& rhs) noexcept;
+
+std::ostream& operator<<(std::ostream& os,
+                         const ArrayComponentId& array_component_id) noexcept;
 }  // namespace observers
 
 namespace std {

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -65,7 +65,7 @@ struct ApparentHorizon {
                   Verbosity verbosity_in) noexcept;
 
   ApparentHorizon() = default;
-  ApparentHorizon(const ApparentHorizon& /*rhs*/) = delete;
+  ApparentHorizon(const ApparentHorizon& /*rhs*/) = default;
   ApparentHorizon& operator=(const ApparentHorizon& /*rhs*/) = delete;
   ApparentHorizon(ApparentHorizon&& /*rhs*/) noexcept = default;
   ApparentHorizon& operator=(ApparentHorizon&& /*rhs*/) noexcept = default;
@@ -87,6 +87,35 @@ bool operator!=(const ApparentHorizon<Frame>& lhs,
                 const ApparentHorizon<Frame>& rhs) noexcept;
 
 }  // namespace OptionHolders
+
+namespace OptionTags {
+struct ApparentHorizons {
+  static constexpr OptionString help{"Options for apparent horizon finders"};
+};
+
+template <typename InterpolationTargetTag, typename Frame>
+struct ApparentHorizon {
+  using type = OptionHolders::ApparentHorizon<Frame>;
+  static constexpr OptionString help{
+      "Options for interpolation onto apparent horizon."};
+  static std::string name() noexcept {
+    return option_name<InterpolationTargetTag>();
+  }
+  using group = ApparentHorizons;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+template <typename InterpolationTargetTag, typename Frame>
+struct ApparentHorizon : db::SimpleTag {
+  using type = OptionHolders::ApparentHorizon<Frame>;
+  using option_tags =
+      tmpl::list<OptionTags::ApparentHorizon<InterpolationTargetTag, Frame>>;
+  static type create_from_options(const type& option) noexcept {
+    return option;
+  }
+};
+}  // namespace Tags
 
 namespace Actions {
 /// \ingroup ActionsGroup
@@ -123,8 +152,8 @@ namespace Actions {
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
 template <typename InterpolationTargetTag, typename Frame>
 struct ApparentHorizon {
-  using options_type = OptionHolders::ApparentHorizon<Frame>;
-  using const_global_cache_tags = tmpl::list<InterpolationTargetTag>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::ApparentHorizon<InterpolationTargetTag, Frame>>;
   using initialization_tags =
       tmpl::append<StrahlkorperTags::items_tags<Frame>,
                    tmpl::list<::ah::Tags::FastFlow, ::Tags::Verbosity>,
@@ -133,7 +162,9 @@ struct ApparentHorizon {
   static auto initialize(
       db::DataBox<DbTags>&& box,
       const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
-    const auto& options = Parallel::get<InterpolationTargetTag>(cache);
+    const auto& options =
+        Parallel::get<Tags::ApparentHorizon<InterpolationTargetTag, Frame>>(
+            cache);
 
     // Put Strahlkorper and its ComputeItems, FastFlow,
     // and verbosity into a new DataBox.

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
@@ -67,7 +67,7 @@ struct KerrHorizon {
               const OptionContext& context = {});
 
   KerrHorizon() = default;
-  KerrHorizon(const KerrHorizon& /*rhs*/) = delete;
+  KerrHorizon(const KerrHorizon& /*rhs*/) = default;
   KerrHorizon& operator=(const KerrHorizon& /*rhs*/) = delete;
   KerrHorizon(KerrHorizon&& /*rhs*/) noexcept = default;
   KerrHorizon& operator=(KerrHorizon&& /*rhs*/) noexcept = default;
@@ -86,6 +86,31 @@ bool operator==(const KerrHorizon& lhs, const KerrHorizon& rhs) noexcept;
 bool operator!=(const KerrHorizon& lhs, const KerrHorizon& rhs) noexcept;
 
 }  // namespace OptionHolders
+
+namespace OptionTags {
+template <typename InterpolationTargetTag>
+struct KerrHorizon {
+  using type = OptionHolders::KerrHorizon;
+  static constexpr OptionString help{
+      "Options for interpolation onto Kerr horizon."};
+  static std::string name() noexcept {
+    return option_name<InterpolationTargetTag>();
+  }
+  using group = InterpolationTargets;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+template <typename InterpolationTargetTag>
+struct KerrHorizon : db::SimpleTag {
+  using type = OptionHolders::KerrHorizon;
+  using option_tags =
+      tmpl::list<OptionTags::KerrHorizon<InterpolationTargetTag>>;
+  static type create_from_options(const type& option) noexcept {
+    return option;
+  }
+};
+}  // namespace Tags
 
 namespace Actions {
 /// \ingroup ActionsGroup
@@ -119,8 +144,8 @@ namespace Actions {
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
 template <typename InterpolationTargetTag, typename Frame>
 struct KerrHorizon {
-  using options_type = OptionHolders::KerrHorizon;
-  using const_global_cache_tags = tmpl::list<InterpolationTargetTag>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::KerrHorizon<InterpolationTargetTag>>;
   using initialization_tags =
       tmpl::append<StrahlkorperTags::items_tags<Frame>,
                    StrahlkorperTags::compute_items_tags<Frame>>;
@@ -128,7 +153,8 @@ struct KerrHorizon {
   static auto initialize(
       db::DataBox<DbTags>&& box,
       const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
-    const auto& options = Parallel::get<InterpolationTargetTag>(cache);
+    const auto& options =
+        Parallel::get<Tags::KerrHorizon<InterpolationTargetTag>>(cache);
 
     // Make a Strahlkorper with the correct shape.
     ::Strahlkorper<Frame> strahlkorper(

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -129,7 +129,7 @@ struct WedgeSectionTorus {
                     const OptionContext& context = {});
 
   WedgeSectionTorus() = default;
-  WedgeSectionTorus(const WedgeSectionTorus& /*rhs*/) = delete;
+  WedgeSectionTorus(const WedgeSectionTorus& /*rhs*/) = default;
   WedgeSectionTorus& operator=(const WedgeSectionTorus& /*rhs*/) = delete;
   WedgeSectionTorus(WedgeSectionTorus&& /*rhs*/) noexcept = default;
   WedgeSectionTorus& operator=(WedgeSectionTorus&& /*rhs*/) noexcept = default;
@@ -156,6 +156,31 @@ bool operator!=(const WedgeSectionTorus& lhs,
 
 }  // namespace OptionHolders
 
+namespace OptionTags {
+template <typename InterpolationTargetTag>
+struct WedgeSectionTorus {
+  using type = OptionHolders::WedgeSectionTorus;
+  static constexpr OptionString help{
+      "Options for interpolation onto Kerr horizon."};
+  static std::string name() noexcept {
+    return option_name<InterpolationTargetTag>();
+  }
+  using group = InterpolationTargets;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+template <typename InterpolationTargetTag>
+struct WedgeSectionTorus : db::SimpleTag {
+  using type = OptionHolders::WedgeSectionTorus;
+  using option_tags =
+      tmpl::list<OptionTags::WedgeSectionTorus<InterpolationTargetTag>>;
+  static type create_from_options(const type& option) noexcept {
+    return option;
+  }
+};
+}  // namespace Tags
+
 namespace Actions {
 /// \ingroup ActionsGroup
 /// \brief Sends points in a wedge-sectioned torus to an `Interpolator`.
@@ -177,8 +202,8 @@ namespace Actions {
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
 template <typename InterpolationTargetTag>
 struct WedgeSectionTorus {
-  using options_type = OptionHolders::WedgeSectionTorus;
-  using const_global_cache_tags = tmpl::list<InterpolationTargetTag>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::WedgeSectionTorus<InterpolationTargetTag>>;
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
             typename ArrayIndex,
             Requires<tmpl::list_contains_v<
@@ -188,7 +213,8 @@ struct WedgeSectionTorus {
       Parallel::ConstGlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/,
       const typename Metavariables::temporal_id::type& temporal_id) noexcept {
-    const auto& options = Parallel::get<InterpolationTargetTag>(cache);
+    const auto& options =
+        Parallel::get<Tags::WedgeSectionTorus<InterpolationTargetTag>>(cache);
 
     // Compute locations of constant r/theta/phi surfaces
     const size_t num_radial = options.number_of_radial_points;

--- a/src/NumericalAlgorithms/Interpolation/Tags.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Tags.hpp
@@ -23,6 +23,17 @@ class ElementId;
 
 namespace intrp {
 
+
+namespace OptionTags {
+/*!
+ * \ingroup OptionGroupsGroup
+ * \brief Groups option tags for InterpolationTargets.
+ */
+struct InterpolationTargets {
+  static constexpr OptionString help{"Options for interpolation targets"};
+};
+}  // namespace OptionTags
+
 /// Tags for items held in the `DataBox` of `InterpolationTarget` or
 /// `Interpolator`.
 namespace Tags {

--- a/src/Parallel/ArrayIndex.hpp
+++ b/src/Parallel/ArrayIndex.hpp
@@ -44,12 +44,22 @@ struct ArrayIndex : public CkArrayIndex {
     nInts = sizeof(array_index) / sizeof(int);  // NOLINT
   }
 
+  ArrayIndex(const CkArrayIndex& array_index)
+      : CkArrayIndex(array_index),
+        array_index_(reinterpret_cast<Index*>(CkArrayIndex::data())) {
+    ASSERT(CkArrayIndex::nInts == sizeof(Index) / sizeof(int),
+           "The CkArrayIndex::nInts does not match the size of the custom "
+           "array index class.");
+  }
+
   ArrayIndex(const ArrayIndex& rhs) = delete;
   ArrayIndex& operator=(const ArrayIndex& rhs) = delete;
 
   ArrayIndex(ArrayIndex&& /*rhs*/) noexcept = delete;
   ArrayIndex& operator=(ArrayIndex&& /*rhs*/) noexcept = delete;
   ~ArrayIndex() = default;
+
+  const Index& get_index() const noexcept { return *array_index_; }
 
  private:
   Index* array_index_ = nullptr;

--- a/src/Parallel/ConstGlobalCache.hpp
+++ b/src/Parallel/ConstGlobalCache.hpp
@@ -43,10 +43,29 @@ using type_for_get = typename type_for_get_helper<
     typename tmpl::front<ConstGlobalCache_detail::get_list_of_matching_tags<
         ConstGlobalCacheTag, Metavariables>>::type>::type;
 
-template <typename ComponentFromList, typename ComponentToFind>
-struct get_component_if_mocked_helper
-    : std::is_same<typename ComponentFromList::component_being_mocked,
-                   ComponentToFind> {};
+template <class T, class = cpp17::void_t<>>
+struct has_component_being_mocked_alias : std::false_type {};
+
+template <class T>
+struct has_component_being_mocked_alias<
+    T, cpp17::void_t<typename T::component_being_mocked>> : std::true_type {};
+
+template <class T>
+constexpr bool has_component_being_mocked_alias_v =
+    has_component_being_mocked_alias<T>::value;
+
+template <typename ComponentToFind, typename ComponentFromList>
+struct get_component_if_mocked_helper {
+  static_assert(
+      has_component_being_mocked_alias_v<ComponentFromList>,
+      "The parallel component was not found, and it looks like it is not being "
+      "mocked. Did you forget to add it to the "
+      "'Metavariables::component_list'? See the first template parameter for "
+      "the component that we are looking for and the first template parameter "
+      "for the component that is being checked for mocking it.");
+  using type = std::is_same<typename ComponentFromList::component_being_mocked,
+                            ComponentToFind>;
+};
 
 /// In order to be able to use a mock action testing framework we need to be
 /// able to get the correct parallel component from the global cache even when
@@ -61,8 +80,8 @@ using get_component_if_mocked = tmpl::front<tmpl::type_from<tmpl::conditional_t<
     tmpl::list_contains_v<ComponentList, ParallelComponent>,
     tmpl::type_<tmpl::list<ParallelComponent>>,
     tmpl::lazy::find<ComponentList,
-                     get_component_if_mocked_helper<
-                         tmpl::_1, tmpl::pin<ParallelComponent>>>>>>;
+                     tmpl::type_<get_component_if_mocked_helper<
+                         tmpl::pin<ParallelComponent>, tmpl::_1>>>>>>;
 }  // namespace ConstGlobalCache_detail
 
 /// \ingroup ParallelGroup

--- a/src/Parallel/ConstGlobalCacheHelper.hpp
+++ b/src/Parallel/ConstGlobalCacheHelper.hpp
@@ -12,10 +12,10 @@ namespace Parallel {
 namespace ConstGlobalCache_detail {
 template <typename Component>
 using parallel_component_cache_tags =
-    typename Component::const_global_cache_tag_list;
+    typename Component::const_global_cache_tags;
 template <typename Metavariables>
 using make_tag_list = tmpl::remove_duplicates<
-    tmpl::append<typename Metavariables::const_global_cache_tag_list,
+    tmpl::append<typename Metavariables::const_global_cache_tags,
                  tmpl::join<tmpl::transform<
                      typename Metavariables::component_list,
                      tmpl::bind<parallel_component_cache_tags, tmpl::_1>>>>>;

--- a/src/ParallelAlgorithms/Actions/SetData.hpp
+++ b/src/ParallelAlgorithms/Actions/SetData.hpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+struct ConstGlobalCache;
+}
+/// \endcond
+
+namespace Actions {
+
+/*!
+ * \ingroup ActionsGroup
+ * \brief Mutate the DataBox tags in `TagsList` according to the `data`.
+ *
+ * DataBox changes:
+ * - Modifies:
+ *   - All tags in `TagsList`
+ */
+template <typename TagsList>
+struct SetData;
+
+template <typename... Tags>
+struct SetData<tmpl::list<Tags...>> {
+  template <
+      typename ParallelComponent, typename DataBox, typename Metavariables,
+      typename ArrayIndex,
+      Requires<cpp17::conjunction_v<db::tag_is_retrievable<Tags, DataBox>...>> =
+          nullptr>
+  static void apply(DataBox& box,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    tuples::TaggedTuple<Tags...> data) noexcept {
+    tmpl::for_each<tmpl::list<Tags...>>([&box, &data ](auto tag_v) noexcept {
+      using tag = tmpl::type_from<decltype(tag_v)>;
+      db::mutate<tag>(
+          make_not_null(&box), [&data](const gsl::not_null<db::item_type<tag>*>
+                                           value) noexcept {
+            *value = std::move(tuples::get<tag>(data));
+          });
+    });
+  }
+};
+
+}  // namespace Actions

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -796,6 +796,36 @@ struct GaugeHImplicitFrom3p1QuantitiesCompute : GaugeH<SpatialDim, Frame>,
 };
 
 /*!
+ * \brief  Compute item to get spatial derivatives of the gauge source function
+ * from its spacetime derivatives.
+ *
+ * \details Can be retrieved using
+ * `::Tags::deriv<GaugeH<SpatialDim, Frame>,tmpl::size_t<SpatialDim>, Frame>`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct DerivGaugeHFromSpacetimeDerivGaugeHCompute
+    : ::Tags::deriv<GaugeH<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<SpacetimeDerivGaugeH<SpatialDim, Frame>>;
+  static constexpr tnsr::ia<DataVector, SpatialDim, Frame> function(
+      const tnsr::ab<DataVector, SpatialDim, Frame>&
+          spacetime_deriv_gauge_source) {
+    auto deriv_gauge_source =
+        make_with_value<tnsr::ia<DataVector, SpatialDim, Frame>>(
+            spacetime_deriv_gauge_source, 0.0);
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      for (size_t a = 0; a < SpatialDim + 1; ++a) {
+        deriv_gauge_source.get(i, a) =
+            spacetime_deriv_gauge_source.get(1 + i, a);
+      }
+    }
+    return deriv_gauge_source;
+  }
+  using base =
+      ::Tags::deriv<GaugeH<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>;
+};
+
+/*!
  * \brief  Compute item to get spacetime derivative of the gauge source function
  * from its spatial and time derivatives.
  *

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -1,0 +1,53 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveGeneralizedHarmonic
+# Check: execute
+# Timeout: 4
+# ExpectedOutput:
+#   ReductionData.h5
+#   VolumeData0.h5
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.01
+  TimeStepper: RungeKutta3
+
+DomainCreator:
+    Brick:
+      LowerBound: [4.0, -0.5, -0.5]
+      UpperBound: [5.0, 0.5, 0.5]
+      InitialRefinement: [1, 1, 1]
+      InitialGridPoints: [5, 5, 5]
+      IsPeriodicIn: [false, false, false]
+
+AnalyticSolution:
+  KerrSchild:
+    Mass: 1.0
+    Spin: [0.0, 0.0, 0.4]
+    Center: [0.0, 0.0, 0.0]
+
+EvolutionSystem:
+  GeneralizedHarmonic:
+    GaugeRollOnStart: 100000.0
+    GaugeRollOnWindow: 100.0
+    GaugeDecayWidth: 50.0
+
+NumericalFlux:
+  UpwindFlux:
+
+EventsAndTriggers:
+  ? EveryNSlabs:
+      N: 2
+      Offset: 0
+  : - ObserveErrorNorms
+  ? EveryNSlabs:
+      N: 5
+      Offset: 0
+  : - ObserveFields
+  ? PastTime: 0.03
+  : - Completion
+
+Observers:
+  VolumeFileName: "VolumeData"
+  ReductionFileName: "ReductionData"

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -205,8 +205,6 @@ struct MockMetavariables {
     using post_interpolation_callback =
         intrp::callbacks::FindApparentHorizon<AhA>;
     using post_horizon_find_callback = PostHorizonFindCallback;
-    // This `type` is so this tag can be used to read options.
-    using type = typename compute_target_points::options_type;
   };
   using interpolator_source_vars =
       tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
@@ -256,7 +254,8 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
       false);
 
   tuples::TaggedTuple<::Tags::Domain<3, Frame::Inertial>,
-                      typename metavars::AhA>
+                      typename ::intrp::Tags::ApparentHorizon<
+                          typename metavars::AhA, Frame::Inertial>>
       tuple_of_opts{std::move(domain_creator.create_domain()),
                     std::move(apparent_horizon_opts)};
 

--- a/tests/Unit/Elliptic/CMakeLists.txt
+++ b/tests/Unit/Elliptic/CMakeLists.txt
@@ -4,3 +4,16 @@
 add_subdirectory(Actions)
 add_subdirectory(DiscontinuousGalerkin)
 add_subdirectory(Systems)
+
+set(LIBRARY "Test_Elliptic")
+
+set(LIBRARY_SOURCES
+  Test_NumericInitialGuess.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Elliptic"
+  "${LIBRARY_SOURCES}"
+  "DataStructures"
+  )

--- a/tests/Unit/Elliptic/Test_NumericInitialGuess.cpp
+++ b/tests/Unit/Elliptic/Test_NumericInitialGuess.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Elliptic/NumericInitialGuess.hpp"
+
+namespace {
+
+struct SomeNumericInitialGuess : elliptic::MarkAsNumericInitialGuess {};
+struct NoNumericInitialGuess {};
+
+static_assert(elliptic::is_numeric_initial_guess_v<SomeNumericInitialGuess>,
+              "Failed testing elliptic::is_numeric_initial_guess_v");
+static_assert(not elliptic::is_numeric_initial_guess_v<NoNumericInitialGuess>,
+              "Failed testing elliptic::is_numeric_initial_guess_v");
+
+struct FieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "FieldTag"; }
+};
+
+struct System {
+  using fields_tag = ::Tags::Variables<tmpl::list<FieldTag>>;
+};
+
+static_assert(cpp17::is_same_v<
+                  typename elliptic::NumericInitialGuess<System>::import_fields,
+                  tmpl::list<FieldTag>>,
+              "Failed testing elliptic::NumericInitialGuess");
+
+}  // namespace

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Tags.cpp
@@ -62,15 +62,14 @@ void test_simple_tags() {
   CHECK(
       db::tag_name<GeneralizedHarmonic::Tags::ConstraintEnergy<Dim, Frame>>() ==
       "ConstraintEnergy");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::GaugeHRollOnStartTime>() ==
+        "GaugeHRollOnStartTime");
+  CHECK(db::tag_name<GeneralizedHarmonic::Tags::GaugeHRollOnTimeWindow>() ==
+        "GaugeHRollOnTimeWindow");
   CHECK(
-      db::tag_name<GeneralizedHarmonic::OptionTags::GaugeHRollOnStartTime>() ==
-      "GaugeHRollOnStartT");
-  CHECK(
-      db::tag_name<GeneralizedHarmonic::OptionTags::GaugeHRollOnTimeWindow>() ==
-      "GaugeHRollOnTWindow");
-  CHECK(db::tag_name<GeneralizedHarmonic::OptionTags::
-                         GaugeHSpatialWeightDecayWidth<Frame>>() ==
-        "GaugeHDecayWidth");
+      db::tag_name<
+          GeneralizedHarmonic::Tags::GaugeHSpatialWeightDecayWidth<Frame>>() ==
+      "GaugeHSpatialWeightDecayWidth");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.Tags",

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -17,6 +17,8 @@ set(LIBRARY_SOURCES
   Test_VolumeData.cpp
   )
 
+add_subdirectory(DataImporter)
+
 add_test_library(
   ${LIBRARY}
   "IO"

--- a/tests/Unit/IO/DataImporter/CMakeLists.txt
+++ b/tests/Unit/IO/DataImporter/CMakeLists.txt
@@ -1,0 +1,53 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_DataImporter")
+
+set(LIBRARY_SOURCES
+  Test_Tags.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "IO/DataImporter"
+  "${LIBRARY_SOURCES}"
+  "IO"
+  )
+
+add_dependencies(
+  ${LIBRARY}
+  module_ConstGlobalCache
+  )
+
+function(add_algorithm_test TEST_NAME DIM)
+  set(HPP_NAME Test_${TEST_NAME})
+  set(EXECUTABLE_NAME ${HPP_NAME}${DIM}D)
+  set(TEST_IDENTIFIER Integration.DataImporter.${TEST_NAME}${DIM}D)
+
+  add_spectre_parallel_executable(
+    ${EXECUTABLE_NAME}
+    ${HPP_NAME}
+    tests/Unit/IO/DataImporter
+    Metavariables<${DIM}>
+    "DataStructures;Domain;ErrorHandling;Informer;IO"
+    )
+
+  add_dependencies(test-executables ${EXECUTABLE_NAME})
+
+  add_test(
+    NAME "\"${TEST_IDENTIFIER}\""
+    COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file
+    ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}.yaml
+    )
+
+  set_tests_properties(
+    "\"${TEST_IDENTIFIER}\""
+    PROPERTIES
+    TIMEOUT 5
+    LABELS "integration"
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+endfunction()
+
+add_algorithm_test("DataImporterAlgorithm" 1)
+add_algorithm_test("DataImporterAlgorithm" 2)
+add_algorithm_test("DataImporterAlgorithm" 3)

--- a/tests/Unit/IO/DataImporter/Test_DataFileReaderActions.cpp
+++ b/tests/Unit/IO/DataImporter/Test_DataFileReaderActions.cpp
@@ -1,0 +1,224 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "IO/DataImporter/DataFileReader.hpp"
+#include "IO/DataImporter/DataFileReaderActions.hpp"
+#include "IO/DataImporter/ElementActions.hpp"
+#include "IO/DataImporter/Tags.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+#include "Parallel/Printf.hpp"
+
+namespace {
+
+struct VectorTag : db::SimpleTag {
+  using type = tnsr::I<DataVector, 2>;
+  static std::string name() noexcept { return "V"; }
+};
+
+struct TensorTag : db::SimpleTag {
+  using type = tnsr::ij<DataVector, 2>;
+  static std::string name() noexcept { return "T"; }
+};
+
+using import_tags_list = tmpl::list<VectorTag, TensorTag>;
+
+struct TestImporter {
+  using group = importer::OptionTags::Group;
+  static constexpr OptionString help = "halp";
+};
+
+using ElementIndexType = ElementIndex<2>;
+
+template <typename Metavariables>
+struct MockElementArray {
+  using component_being_mocked = void;  // Not needed
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndexType;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox = db::DataBox<import_tags_list>;
+};
+
+template <typename Metavariables>
+struct MockDataFileReader {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using component_being_mocked = importer::DataFileReader<Metavariables>;
+  using initial_databox =
+      typename importer::DataFileReader<Metavariables>::initial_databox;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<MockElementArray<Metavariables>,
+                                    MockDataFileReader<Metavariables>>;
+  using const_global_cache_tag_list =
+      tmpl::list<importer::OptionTags::DataFileName<TestImporter>,
+                 importer::OptionTags::VolumeDataSubgroup<TestImporter>,
+                 importer::OptionTags::ObservationValue<TestImporter>>;
+  enum class Phase {};
+};
+
+struct TestCallback {
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ElementIndexType& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    tuples::tagged_tuple_from_typelist<import_tags_list>
+                        tensor_data) noexcept {
+    CHECK(get<VectorTag>(tensor_data) == get<VectorTag>(box));
+    CHECK(get<TensorTag>(tensor_data) == get<TensorTag>(box));
+  }
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.IO.DataImporter.DataFileReaderActions", "[Unit][IO]") {
+  using TupleOfMockDistributedObjects =
+      typename ActionTesting::MockRuntimeSystem<
+          Metavariables>::TupleOfMockDistributedObjects;
+  using reader_component = MockDataFileReader<Metavariables>;
+  using array_component = MockElementArray<Metavariables>;
+
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using ReaderMockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          reader_component>;
+  using ArrayMockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          array_component>;
+  TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<ReaderMockDistributedObjectsTag>(dist_objects)
+      .emplace(0, ActionTesting::MockDistributedObject<reader_component>{});
+
+  // Create a few elements with sample data
+  // Specific IDs have no significance, just need different IDs.
+  const std::vector<ElementId<2>> element_ids{{1, {{{1, 0}, {1, 0}}}},
+                                              {1, {{{1, 1}, {1, 0}}}},
+                                              {1, {{{1, 0}, {2, 3}}}},
+                                              {1, {{{1, 0}, {5, 4}}}},
+                                              {0, {{{1, 0}, {1, 0}}}}};
+  for (const auto& id : element_ids) {
+    const auto hashed_id = static_cast<double>(std::hash<ElementId<2>>{}(id));
+    const size_t num_points = 4;
+    db::item_type<VectorTag> vector{num_points};
+    get<0>(vector) = DataVector{0.5 * hashed_id, 1.0 * hashed_id,
+                                3.0 * hashed_id, -2.0 * hashed_id};
+    get<1>(vector) = DataVector{-0.5 * hashed_id, -1.0 * hashed_id,
+                                -3.0 * hashed_id, 2.0 * hashed_id};
+    db::item_type<TensorTag> tensor{num_points};
+    get<0, 0>(tensor) = DataVector{10.5 * hashed_id, 11.0 * hashed_id,
+                                   13.0 * hashed_id, -22.0 * hashed_id};
+    get<0, 1>(tensor) = DataVector{10.5 * hashed_id, -11.0 * hashed_id,
+                                   -13.0 * hashed_id, -22.0 * hashed_id};
+    get<1, 0>(tensor) = DataVector{-10.5 * hashed_id, 11.0 * hashed_id,
+                                   13.0 * hashed_id, 22.0 * hashed_id};
+    get<1, 1>(tensor) = DataVector{-10.5 * hashed_id, -11.0 * hashed_id,
+                                   -13.0 * hashed_id, 22.0 * hashed_id};
+    tuples::get<ArrayMockDistributedObjectsTag>(dist_objects)
+        .emplace(
+            ElementIndex<2>{id},
+            db::create<import_tags_list>(std::move(vector), std::move(tensor)));
+  }
+
+  // Setup the runner with its cache
+  tuples::TaggedTuple<importer::OptionTags::DataFileName<TestImporter>,
+                      importer::OptionTags::VolumeDataSubgroup<TestImporter>,
+                      importer::OptionTags::ObservationValue<TestImporter>>
+      cache_data{"TestImportVolumeFile.h5", "element_data", 0.};
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      cache_data, std::move(dist_objects)};
+
+  const auto get_element_box =
+      [&runner](const ElementId<2>& element_id) -> decltype(auto) {
+    return runner.algorithms<array_component>()
+        .at(element_id)
+        .get_databox<array_component::initial_databox>();
+  };
+
+  runner.simple_action<reader_component,
+                       importer::detail::InitializeDataFileReader>(0);
+
+  // Register elements
+  for (const auto& id : element_ids) {
+    runner.simple_action<array_component,
+                         importer::Actions::RegisterWithImporter>(id);
+    // Invoke the simple_action RegisterElementWithSelf that was called on the
+    // reader component by the RegisterWithImporter action.
+    runner.invoke_queued_simple_action<reader_component>(0);
+  }
+
+  // Write the sample data into an H5 file
+  const std::string h5_file_name = "TestImportVolumeFile.h5";
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+  h5::H5File<h5::AccessType::ReadWrite> h5_file{h5_file_name, false};
+  auto& volume_data = h5_file.insert<h5::VolumeData>("/element_data", 0);
+  for (const auto& id : element_ids) {
+    const auto& element_box = get_element_box(id);
+    const std::string element_name = MakeString{} << id << '/';
+    std::vector<TensorComponent> tensor_data(6);
+    const auto& vector = get<VectorTag>(element_box);
+    tensor_data[0] = TensorComponent(element_name + "V_x"s, get<0>(vector));
+    tensor_data[1] = TensorComponent(element_name + "V_y"s, get<1>(vector));
+    const auto& tensor = get<TensorTag>(element_box);
+    tensor_data[2] = TensorComponent(element_name + "T_xx"s, get<0, 0>(tensor));
+    tensor_data[3] = TensorComponent(element_name + "T_xy"s, get<0, 1>(tensor));
+    tensor_data[4] = TensorComponent(element_name + "T_yx"s, get<1, 0>(tensor));
+    tensor_data[5] = TensorComponent(element_name + "T_yy"s, get<1, 1>(tensor));
+    volume_data.insert_tensor_data(
+        0, 0., ExtentsAndTensorVolumeData{{2, 2}, tensor_data});
+  }
+
+  Parallel::printf("Queue read data action\n");
+  // Have the importer read the file and pass it to the callback
+  runner.algorithms<reader_component>()
+      .at(0)
+      .template threaded_action<importer::ThreadedActions::ReadElementData<
+          TestImporter, import_tags_list, TestCallback, array_component>>();
+  runner.invoke_queued_threaded_action<reader_component>(0);
+
+  // Invoke the queued callbacks on the elements that test if the data is
+  // correct
+  for (const auto& id : element_ids) {
+    runner.invoke_queued_simple_action<array_component>(id);
+  }
+
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+}

--- a/tests/Unit/IO/DataImporter/Test_DataImporterAlgorithm.hpp
+++ b/tests/Unit/IO/DataImporter/Test_DataImporterAlgorithm.hpp
@@ -1,0 +1,312 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#define CATCH_CONFIG_RUNNER
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "AlgorithmArray.hpp"
+#include "AlgorithmSingleton.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "IO/DataImporter/DataFileReader.hpp"
+#include "IO/DataImporter/DataFileReaderActions.hpp"
+#include "IO/DataImporter/ElementActions.hpp"
+#include "IO/DataImporter/Tags.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Main.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "ParallelAlgorithms/Actions/SetData.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+struct ScalarFieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "ScalarField"; }
+};
+
+template <size_t Dim>
+struct VectorFieldTag : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+  static std::string name() noexcept { return "VectorField"; }
+};
+
+struct NumericTestData {
+  using group = importer::OptionTags::Group;
+  static constexpr OptionString help = "Numeric data";
+};
+
+static constexpr size_t number_of_elements = 2;
+static constexpr std::array<std::array<size_t, 3>, number_of_elements> extents{
+    {// Grid extents on first element
+     {{2, 1, 1}},
+     // Grid extents on second element
+     {{3, 1, 1}}}};
+static const std::array<DataVector, number_of_elements> scalar_field_data{
+    {// Field on first element
+     {{1., 2.}},
+     // Field on second element
+     {{3., 4., 5.}}}};
+static const std::array<std::array<DataVector, 3>, number_of_elements>
+    vector_field_data{
+        {// Vector components on first element
+         {{{{1., 2.}}, {{3., 4.}}, {{5., 6.}}}},
+         // Vector components on second element
+         {{{{7., 8., 9.}}, {{10., 11., 12.}}, {{13., 14., 16.}}}}}};
+
+template <size_t Dim>
+struct WriteTestData {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    // Open file for test data
+    const auto& data_file_name =
+        get<importer::Tags::DataFileName<NumericTestData>>(cache);
+    if (file_system::check_if_file_exists(data_file_name)) {
+      file_system::rm(data_file_name, true);
+    }
+    h5::H5File<h5::AccessType::ReadWrite> data_file{data_file_name};
+    auto& test_data_file = data_file.insert<h5::VolumeData>("/test_data");
+
+    // Construct test data for all elements
+    std::vector<ExtentsAndTensorVolumeData> element_data{};
+    for (size_t i = 0; i < number_of_elements; i++) {
+      const std::string element_name = MakeString{} << ElementId<Dim>{i};
+      std::vector<TensorComponent> tensor_components{};
+      std::vector<size_t> element_extents{};
+      tensor_components.push_back(
+          {element_name + "/ScalarField", scalar_field_data[i]});
+      for (size_t d = 0; d < Dim; d++) {
+        static const std::array<std::string, 3> dim_suffix{{"x", "y", "z"}};
+        tensor_components.push_back(
+            {element_name + "/VectorField_" + dim_suffix[d],
+             vector_field_data[i][d]});
+        element_extents.push_back(extents[i][d]);
+      }
+      element_data.push_back(
+          {std::move(element_extents), std::move(tensor_components)});
+    }
+    test_data_file.write_volume_data(0, 3., std::move(element_data));
+
+    return {std::move(box), true};
+  }
+};
+
+struct CleanTestData {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const auto& data_file_name =
+        get<importer::Tags::DataFileName<NumericTestData>>(cache);
+    if (file_system::check_if_file_exists(data_file_name)) {
+      // file_system::rm(data_file_name, true);
+    } else {
+      ERROR("Expected test data file '" << data_file_name
+                                        << "' does not exist");
+    }
+    return {std::move(box), true};
+  }
+};
+
+template <size_t Dim, typename Metavariables>
+struct TestDataWriter {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using metavariables = Metavariables;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<WriteTestData<Dim>>>,
+
+                 Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::TestResult,
+                                        tmpl::list<CleanTestData>>>;
+  using initialization_tags = tmpl::list<>;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  static void initialize(Parallel::CProxy_ConstGlobalCache<
+                         Metavariables>& /*global_cache*/) noexcept {}
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
+    auto& local_component = Parallel::get_parallel_component<TestDataWriter>(
+        *(global_cache.ckLocalBranch()));
+    local_component.start_phase(next_phase);
+  }
+};
+
+template <size_t Dim>
+struct InitializeElement {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ElementIndex<Dim>& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    return std::make_tuple(
+        ::Initialization::merge_into_databox<
+            InitializeElement,
+            db::AddSimpleTags<ScalarFieldTag, VectorFieldTag<Dim>>>(
+            std::move(box), Scalar<DataVector>{}, tnsr::I<DataVector, Dim>{}),
+        true);
+  }
+};
+
+template <size_t Dim>
+struct TestResult {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ElementIndex<Dim>& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const size_t raw_element_index = ElementId<Dim>{array_index}.block_id();
+    Scalar<DataVector> expected_scalar_field{
+        scalar_field_data[raw_element_index]};
+    SPECTRE_PARALLEL_REQUIRE(get<ScalarFieldTag>(box) == expected_scalar_field);
+    tnsr::I<DataVector, Dim> expected_vector_field{};
+    for (size_t d = 0; d < Dim; d++) {
+      expected_vector_field[d] = vector_field_data[raw_element_index][d];
+    }
+    SPECTRE_PARALLEL_REQUIRE(get<VectorFieldTag<Dim>>(box) ==
+                             expected_vector_field);
+    return {std::move(box), true};
+  }
+};
+
+template <size_t Dim, typename Metavariables>
+struct ElementArray {
+  using chare_type = Parallel::Algorithms::Array;
+  using array_index = ElementIndex<Dim>;
+  using metavariables = Metavariables;
+  using initialization_tags = tmpl::list<>;
+  using array_allocation_tags = tmpl::list<>;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             tmpl::list<InitializeElement<Dim>>>,
+
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Register,
+                             tmpl::list<importer::Actions::RegisterWithImporter,
+                                        Parallel::Actions::TerminatePhase>>,
+
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::TestResult,
+                             tmpl::list<TestResult<Dim>>>>;
+
+  using import_fields = tmpl::list<ScalarFieldTag, VectorFieldTag<Dim>>;
+  using read_element_data_action = importer::ThreadedActions::ReadElementData<
+      NumericTestData, import_fields, ::Actions::SetData<import_fields>,
+      ElementArray>;
+
+  using const_global_cache_tag_list =
+      typename read_element_data_action::const_global_cache_tag_list;
+
+  static void allocate_array(
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+          initialization_items) noexcept {
+    auto& array_proxy = Parallel::get_parallel_component<ElementArray>(
+        *(global_cache.ckLocalBranch()));
+
+    for (size_t i = 0, which_proc = 0,
+                number_of_procs =
+                    static_cast<size_t>(Parallel::number_of_procs());
+         i < number_of_elements; i++) {
+      ElementIndex<Dim> element_index{ElementId<Dim>{i}};
+      array_proxy[element_index].insert(global_cache, initialization_items,
+                                        which_proc);
+      which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
+    }
+    array_proxy.doneInserting();
+  }
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    Parallel::get_parallel_component<ElementArray>(local_cache)
+        .start_phase(next_phase);
+
+    if (next_phase == Metavariables::Phase::ImportData) {
+      Parallel::threaded_action<read_element_data_action>(
+          Parallel::get_parallel_component<
+              importer::DataFileReader<Metavariables>>(local_cache));
+    }
+  }
+};
+
+}  // namespace
+
+template <size_t Dim>
+struct Metavariables {
+  using component_list = tmpl::list<ElementArray<Dim, Metavariables>,
+                                    TestDataWriter<Dim, Metavariables>,
+                                    importer::DataFileReader<Metavariables>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  static constexpr const char* const help{"Test the data importer"};
+  static constexpr bool ignore_unrecognized_command_line_options = false;
+
+  enum class Phase { Initialization, Register, ImportData, TestResult, Exit };
+
+  static Phase determine_next_phase(
+      const Phase& current_phase,
+      const Parallel::CProxy_ConstGlobalCache<
+          Metavariables>& /*cache_proxy*/) noexcept {
+    switch (current_phase) {
+      case Phase::Initialization:
+        return Phase::Register;
+      case Phase::Register:
+        return Phase::ImportData;
+      case Phase::ImportData:
+        return Phase::TestResult;
+      default:
+        return Phase::Exit;
+    }
+  }
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};

--- a/tests/Unit/IO/DataImporter/Test_DataImporterAlgorithm.yaml
+++ b/tests/Unit/IO/DataImporter/Test_DataImporterAlgorithm.yaml
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+DataImporters:
+  NumericTestData:
+    DataFileName: "Test_DataImporterAlgorithm.h5"
+    VolumeDataSubgroup: "test_data"
+    ObservationValue: 3.

--- a/tests/Unit/IO/DataImporter/Test_DataImporterAlgorithmFwd.hpp
+++ b/tests/Unit/IO/DataImporter/Test_DataImporterAlgorithmFwd.hpp
@@ -1,0 +1,9 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+template <size_t Dim>
+struct Metavariables;

--- a/tests/Unit/IO/DataImporter/Test_Tags.cpp
+++ b/tests/Unit/IO/DataImporter/Test_Tags.cpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "IO/DataImporter/Tags.hpp"
+
+SPECTRE_TEST_CASE("Unit.IO.DataImporter.Tags", "[Unit][IO]") {
+  CHECK(db::tag_name<importer::Tags::RegisteredElements>() ==
+        "RegisteredElements");
+}

--- a/tests/Unit/IO/Test_VolumeData.cpp
+++ b/tests/Unit/IO/Test_VolumeData.cpp
@@ -185,6 +185,24 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
   for (size_t i = 0; i < observation_ids.size(); ++i) {
     check_time(observation_ids[i], observation_values[i]);
   }
+
+  {
+    INFO("offset_and_length_for_grid");
+    const size_t observation_id = observation_ids.front();
+    /// [find_offset]
+    const auto all_grid_names = volume_file.get_grid_names(observation_id);
+    const auto all_extents = volume_file.get_extents(observation_id);
+    const auto first_grid_offset_and_length = h5::offset_and_length_for_grid(
+        grid_names.front(), all_grid_names, all_extents);
+    /// [find_offset]
+    CHECK(first_grid_offset_and_length.first = 0);
+    CHECK(first_grid_offset_and_length.second = 8);
+    const auto last_grid_offset_and_length = h5::offset_and_length_for_grid(
+        grid_names.back(), all_grid_names, all_extents);
+    CHECK(first_grid_offset_and_length.first = 8);
+    CHECK(first_grid_offset_and_length.second = 8);
+  }
+
   if (file_system::check_if_file_exists(h5_file_name)) {
     file_system::rm(h5_file_name, true);
   }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -134,10 +134,11 @@ struct mock_interpolator {
       MockReceivePoints<typename Metavariables::InterpolationTargetA>>;
 };
 
-template <typename MetaVariables, typename DomainCreator,
-          typename InterpolationTargetOption, typename BlockCoordHolder>
+template <typename MetaVariables, typename InterpolationTargetOptionTag,
+          typename DomainCreator, typename BlockCoordHolder>
 void test_interpolation_target(
-    const DomainCreator& domain_creator, InterpolationTargetOption options,
+    const DomainCreator& domain_creator,
+    typename InterpolationTargetOptionTag::type options,
     const BlockCoordHolder& expected_block_coord_holders) noexcept {
   using metavars = MetaVariables;
   using target_component =
@@ -146,7 +147,7 @@ void test_interpolation_target(
   using interp_component = mock_interpolator<metavars>;
 
   tuples::TaggedTuple<
-      typename metavars::InterpolationTargetA,
+      InterpolationTargetOptionTag,
       ::Tags::Domain<MetaVariables::volume_dim, Frame::Inertial>>
       tuple_of_opts{std::move(options),
                     std::move(domain_creator.create_domain())};

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -36,7 +36,6 @@ struct MockMetavariables {
     using compute_target_points =
         ::intrp::Actions::ApparentHorizon<InterpolationTargetA,
                                           ::Frame::Inertial>;
-    using type = compute_target_points::options_type;
   };
   using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
@@ -118,7 +117,10 @@ SPECTRE_TEST_CASE(
   }
   ();
 
-  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
+  InterpTargetTestHelpers::test_interpolation_target<
+      MockMetavariables,
+      intrp::Tags::ApparentHorizon<MockMetavariables::InterpolationTargetA,
+                                   Frame::Inertial>>(
       domain_creator, std::move(apparent_horizon_opts),
       expected_block_coord_holders);
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -32,7 +32,6 @@ struct MockMetavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::Actions::KerrHorizon<InterpolationTargetA, ::Frame::Inertial>;
-    using type = compute_target_points::options_type;
   };
   using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
@@ -129,7 +128,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.KerrHorizon",
   }
   ();
 
-  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
-      domain_creator, std::move(kerr_horizon_opts),
+  InterpTargetTestHelpers::test_interpolation_target<
+      MockMetavariables,
+      intrp::Tags::KerrHorizon<MockMetavariables::InterpolationTargetA>>(
+      domain_creator, kerr_horizon_opts,
       expected_block_coord_holders);
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -28,7 +28,6 @@ struct MockMetavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::Actions::LineSegment<InterpolationTargetA, 3>;
-    using type = compute_target_points::options_type;
   };
   using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
@@ -71,7 +70,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.LineSegment",
   }
   ();
 
-  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
+  InterpTargetTestHelpers::test_interpolation_target<
+      MockMetavariables,
+      intrp::Tags::LineSegment<MockMetavariables::InterpolationTargetA, 3>>(
       domain_creator, std::move(line_segment_opts),
       expected_block_coord_holders);
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -30,7 +30,6 @@ struct MockMetavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::Actions::WedgeSectionTorus<InterpolationTargetA>;
-    using type = compute_target_points::options_type;
   };
   using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
@@ -86,8 +85,10 @@ void test_r_theta_lgl() noexcept {
   }
   ();
 
-  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
-      domain_creator, std::move(wedge_section_torus_opts),
+  InterpTargetTestHelpers::test_interpolation_target<
+      MockMetavariables,
+      intrp::Tags::WedgeSectionTorus<MockMetavariables::InterpolationTargetA>>(
+      domain_creator, wedge_section_torus_opts,
       expected_block_coord_holders);
 }
 
@@ -124,8 +125,10 @@ void test_r_theta_uniform() noexcept {
   }
   ();
 
-  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
-      domain_creator, std::move(wedge_section_torus_opts),
+  InterpTargetTestHelpers::test_interpolation_target<
+      MockMetavariables,
+      intrp::Tags::WedgeSectionTorus<MockMetavariables::InterpolationTargetA>>(
+      domain_creator, wedge_section_torus_opts,
       expected_block_coord_holders);
 }
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -214,8 +214,6 @@ struct MockMetavariables {
             tmpl::list<StrahlkorperGr::Tags::SurfaceIntegral<
                 Tags::Square, ::Frame::Inertial>>,
             SurfaceA, SurfaceA>;
-    // This `type` is so this tag can be used to read options.
-    using type = typename compute_target_points::options_type;
   };
   struct SurfaceB {
     using compute_items_on_source = tmpl::list<>;
@@ -236,8 +234,6 @@ struct MockMetavariables {
                        StrahlkorperGr::Tags::SurfaceIntegral<
                            Tags::Negate, ::Frame::Inertial>>,
             SurfaceB, SurfaceB>;
-    // This `type` is so this tag can be used to read options.
-    using type = typename compute_target_points::options_type;
   };
   struct SurfaceC {
     using compute_items_on_source = tmpl::list<>;
@@ -255,8 +251,6 @@ struct MockMetavariables {
             tmpl::list<StrahlkorperGr::Tags::SurfaceIntegral<
                 Tags::Negate, ::Frame::Inertial>>,
             SurfaceC, SurfaceC>;
-    // This `type` is so this tag can be used to read options.
-    using type = typename compute_target_points::options_type;
   };
 
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
@@ -306,13 +300,15 @@ SPECTRE_TEST_CASE(
                                                         1.5, {{0.0, 0.0, 0.0}});
   const auto domain_creator =
       domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
-  tuples::TaggedTuple<observers::Tags::ReductionFileName, metavars::SurfaceA,
-                      ::Tags::Domain<3, Frame::Inertial>, metavars::SurfaceB,
-                      metavars::SurfaceC>
-      tuple_of_opts{h5_file_prefix, std::move(kerr_horizon_opts_A),
+  tuples::TaggedTuple<observers::Tags::ReductionFileName,
+                      ::intrp::Tags::KerrHorizon<metavars::SurfaceA>,
+                      ::Tags::Domain<3, Frame::Inertial>,
+                      ::intrp::Tags::KerrHorizon<metavars::SurfaceB>,
+                      ::intrp::Tags::KerrHorizon<metavars::SurfaceC>>
+      tuple_of_opts{h5_file_prefix, kerr_horizon_opts_A,
                     domain_creator.create_domain(),
-                    std::move(kerr_horizon_opts_B),
-                    std::move(kerr_horizon_opts_C)};
+                    kerr_horizon_opts_B,
+                    kerr_horizon_opts_C};
 
   ActionTesting::MockRuntimeSystem<metavars> runner{std::move(tuple_of_opts)};
   runner.set_phase(metavars::Phase::Initialization);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -177,9 +177,10 @@ struct mock_interpolation_target {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
+
   using const_global_cache_tags = tmpl::flatten<tmpl::append<
       Parallel::get_const_global_cache_tags_from_actions<
-          tmpl::list<intrp::Actions::LineSegment<InterpolationTargetTag, 3>>>,
+          tmpl::list<typename InterpolationTargetTag::compute_target_points>>,
       tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -221,7 +222,6 @@ struct MockMetavariables {
         intrp::Actions::LineSegment<InterpolationTargetA, 3>;
     using post_interpolation_callback =
         TestFunction<InterpolationTargetA, Tags::Square>;
-    using type = typename compute_target_points::options_type;
   };
   struct InterpolationTargetB {
     using compute_items_on_source = tmpl::list<Tags::SquareComputeItem>;
@@ -231,7 +231,6 @@ struct MockMetavariables {
         intrp::Actions::LineSegment<InterpolationTargetB, 3>;
     using post_interpolation_callback =
         TestFunction<InterpolationTargetB, Tags::Negate>;
-    using type = typename compute_target_points::options_type;
   };
   struct InterpolationTargetC {
     using compute_items_on_source = tmpl::list<>;
@@ -240,8 +239,6 @@ struct MockMetavariables {
     using compute_target_points =
         intrp::Actions::KerrHorizon<InterpolationTargetC, ::Frame::Inertial>;
     using post_interpolation_callback = TestKerrHorizonIntegral;
-    // This `type` is so this tag can be used to read options.
-    using type = typename compute_target_points::options_type;
   };
 
   using interpolator_source_vars = tmpl::list<Tags::TestSolution>;
@@ -281,11 +278,13 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
   const auto domain_creator =
       domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
   tuples::TaggedTuple<
-      metavars::InterpolationTargetA, ::Tags::Domain<3, Frame::Inertial>,
-      metavars::InterpolationTargetB, metavars::InterpolationTargetC>
+      intrp::Tags::LineSegment<metavars::InterpolationTargetA, 3>,
+      ::Tags::Domain<3, Frame::Inertial>,
+      intrp::Tags::LineSegment<metavars::InterpolationTargetB, 3>,
+      intrp::Tags::KerrHorizon<metavars::InterpolationTargetC>>
       tuple_of_opts(
           std::move(line_segment_opts_A), domain_creator.create_domain(),
-          std::move(line_segment_opts_B), std::move(kerr_horizon_opts_C));
+          std::move(line_segment_opts_B), kerr_horizon_opts_C);
 
   ActionTesting::MockRuntimeSystem<metavars> runner{std::move(tuple_of_opts)};
   runner.set_phase(metavars::Phase::Initialization);

--- a/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ParallelAlgorithmsActions")
 
 set(LIBRARY_SOURCES
   Test_MutateApply.cpp
+  Test_SetData.cpp
   )
 
 add_test_library(

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_SetData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_SetData.cpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Parallel/AddOptionsToDataBox.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Actions/SetData.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace {
+
+struct SomeNumber : db::SimpleTag {
+  using type = int;
+  static std::string name() noexcept { return "SomeNumber"; }
+};
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using add_options_to_databox = Parallel::AddNoOptionsToDataBox;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<SomeNumber>>>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<Component<Metavariables>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Actions.SetData", "[Unit][Actions]") {
+  using component = Component<Metavariables>;
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  ActionTesting::emplace_component_and_initialize<component>(&runner, 0, {0});
+
+  runner.set_phase(Metavariables::Phase::Testing);
+
+  ActionTesting::simple_action<component,
+                               Actions::SetData<tmpl::list<SomeNumber>>>(
+      make_not_null(&runner), 0, tuples::TaggedTuple<SomeNumber>{3});
+  CHECK(ActionTesting::get_databox_tag<component, SomeNumber>(runner, 0) == 3);
+}


### PR DESCRIPTION
This is a draft PR that attempts to evolve perturbed initial data (specifically, Kerr-Schild with an ingoing Teukolsky wave), where the initial data is imported from an H5 file (such as one assembled from spec output).

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
