### PR TITLE
Add compute item for evolution analytic solutions

### DIFF
--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -36,6 +36,16 @@ struct dt : db::PrefixTag, db::SimpleTag {
 };
 
 /// \ingroup DataBoxTagsGroup
+/// \brief Prefix indicating the analytic solution value for a quantity
+///
+/// \snippet Test_DataBoxPrefixes.cpp analytic_name
+template <typename Tag>
+struct Analytic : db::PrefixTag, db::SimpleTag {
+  using type = db::item_type<Tag>;
+  using tag = Tag;
+};
+
+/// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating a flux
 ///
 /// \snippet Test_DataBoxPrefixes.cpp flux_name

--- a/src/Evolution/ComputeTags.hpp
+++ b/src/Evolution/ComputeTags.hpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace evolution {
+namespace Tags {
+/*!
+ * \brief Use the `AnalyticSolutionTag` to compute the analytic solution of the
+ * tags in `AnalyticFieldsTagList`.
+ */
+template <size_t Dim, typename AnalyticSolutionTag,
+          typename AnalyticFieldsTagList>
+struct AnalyticCompute
+    : db::add_tag_prefix<::Tags::Analytic,
+                         ::Tags::Variables<AnalyticFieldsTagList>>,
+      db::ComputeTag {
+  using base = db::add_tag_prefix<::Tags::Analytic,
+                                  ::Tags::Variables<AnalyticFieldsTagList>>;
+  using argument_tags =
+      tmpl::list<AnalyticSolutionTag, ::Tags::Coordinates<Dim, Frame::Inertial>,
+                 ::Tags::Time>;
+  static db::item_type<base> function(
+      const db::item_type<AnalyticSolutionTag>& analytic_solution_computer,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
+      const double& time) noexcept {
+    return db::item_type<base>(
+        variables_from_tagged_tuple(analytic_solution_computer.variables(
+            inertial_coords, time, AnalyticFieldsTagList{})));
+  }
+};
+}  // namespace Tags
+}  // namespace evolution

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
@@ -68,7 +68,7 @@ namespace OptionTags {
 struct ValenciaDivCleanGroup {
   static std::string name() noexcept { return "ValenciaDivClean"; }
   static constexpr OptionString help{"Options for the evolution system"};
-  using group = ::OptionTags::EvolutionSystemGroup;
+  using group = evolution::OptionTags::SystemGroup;
 };
 
 /// \brief The constraint damping parameter

--- a/src/Evolution/Tags.hpp
+++ b/src/Evolution/Tags.hpp
@@ -7,6 +7,7 @@
 
 #include "Options/Options.hpp"
 
+namespace evolution {
 namespace OptionTags {
 
 /*!
@@ -14,7 +15,7 @@ namespace OptionTags {
  * \brief Groups option tags related to the time evolution, e.g. time step and
  * time stepper.
  */
-struct EvolutionGroup {
+struct Group {
   static std::string name() noexcept { return "Evolution"; }
   static constexpr OptionString help{"Options for the time evolution"};
 };
@@ -26,9 +27,10 @@ struct EvolutionGroup {
  * The option tags for the evolution system should be placed in a subgroup that
  * carries the system name. See e.g. `OptionTags::ValenciaDivCleanGroup`.
  */
-struct EvolutionSystemGroup {
+struct SystemGroup {
   static std::string name() noexcept { return "EvolutionSystem"; }
   static constexpr OptionString help{"The system of hyperbolic PDEs"};
 };
 
 }  // namespace OptionTags
+}  // namespace evolution

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -98,7 +98,7 @@ struct TimeStepper {
   static std::string name() noexcept { return "TimeStepper"; }
   static constexpr OptionString help{"The time stepper"};
   using type = std::unique_ptr<StepperType>;
-  using group = EvolutionGroup;
+  using group = evolution::OptionTags::Group;
 };
 
 /// \ingroup OptionTagsGroup
@@ -108,7 +108,7 @@ struct StepChoosers {
   static constexpr OptionString help{"Limits on LTS step size"};
   using type = std::vector<std::unique_ptr<::StepChooser<Registrars>>>;
   static size_t lower_bound_on_size() noexcept { return 1; }
-  using group = EvolutionGroup;
+  using group = evolution::OptionTags::Group;
 };
 
 /// \ingroup OptionTagsGroup
@@ -116,7 +116,7 @@ struct StepChoosers {
 struct StepController {
   static constexpr OptionString help{"The LTS step controller"};
   using type = std::unique_ptr<::StepController>;
-  using group = EvolutionGroup;
+  using group = evolution::OptionTags::Group;
 };
 
 /// \ingroup OptionTagsGroup
@@ -127,7 +127,7 @@ struct InitialTime {
   static constexpr OptionString help = {
       "The time at which the evolution is started."};
   static type default_value() noexcept { return 0.0; }
-  using group = EvolutionGroup;
+  using group = evolution::OptionTags::Group;
 };
 
 /// \ingroup OptionTagsGroup
@@ -138,7 +138,7 @@ struct InitialTimeStep {
   using type = double;
   static constexpr OptionString help =
       "The initial time step, before local stepping adjustment";
-  using group = EvolutionGroup;
+  using group = evolution::OptionTags::Group;
 };
 
 /// \ingroup OptionTagsGroup
@@ -148,7 +148,7 @@ struct InitialSlabSize {
   using type = double;
   static constexpr OptionString help = "The initial slab size";
   static type lower_bound() noexcept { return 0.; }
-  using group = EvolutionGroup;
+  using group = evolution::OptionTags::Group;
 };
 }  // namespace OptionTags
 

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
@@ -29,6 +29,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Prefixes",
   /// [dt_name]
   CHECK(db::tag_name<Tags::dt<Tag>>() == "dt(" + db::tag_name<Tag>() + ")");
   /// [dt_name]
+  /// [analytic_name]
+  CHECK(db::tag_name<Tags::Analytic<Tag>>() ==
+        "Analytic(" + db::tag_name<Tag>() + ")");
+  /// [analytic_name]
   using Dim = tmpl::size_t<2>;
   using Frame = Frame::Inertial;
   using VariablesTag = Tags::Variables<tmpl::list<TensorTag>>;

--- a/tests/Unit/Evolution/CMakeLists.txt
+++ b/tests/Unit/Evolution/CMakeLists.txt
@@ -11,6 +11,7 @@ add_subdirectory(VariableFixing)
 set(LIBRARY "Test_Evolution")
 
 set(LIBRARY_SOURCES
+  Test_ComputeTags.cpp
   Test_TypeTraits.cpp
   )
 

--- a/tests/Unit/Evolution/Test_ComputeTags.cpp
+++ b/tests/Unit/Evolution/Test_ComputeTags.cpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/ComputeTags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+struct FieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct AnalyticSolution {
+  tuples::TaggedTuple<FieldTag> variables(
+      const tnsr::I<DataVector, 1>& x, const double t,
+      const tmpl::list<FieldTag> /*meta*/) const noexcept {
+    return {Scalar<DataVector>{t * get<0>(x)}};
+  }
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+struct AnalyticSolutionTag : db::SimpleTag {
+  using type = AnalyticSolution;
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.ComputeTags", "[Unit][Evolution]") {
+  tnsr::I<DataVector, 1, Frame::Inertial> inertial_coords{{{{1., 2., 3., 4.}}}};
+  const double current_time = 2.;
+  const auto box =
+      db::create<db::AddSimpleTags<::Tags::Coordinates<1, Frame::Inertial>,
+                                   AnalyticSolutionTag, Tags::Time>,
+                 db::AddComputeTags<evolution::Tags::AnalyticCompute<
+                     1, AnalyticSolutionTag, tmpl::list<FieldTag>>>>(
+          std::move(inertial_coords), AnalyticSolution{}, current_time);
+  const DataVector expected{2., 4., 6., 8.};
+  CHECK_ITERABLE_APPROX(get(get<::Tags::Analytic<FieldTag>>(box)), expected);
+
+  CHECK(
+      db::tag_name<evolution::Tags::AnalyticCompute<1, AnalyticSolutionTag,
+                                                    tmpl::list<FieldTag>>>() ==
+      "Analytic(Variables(Analytic(FieldTag)))");
+}


### PR DESCRIPTION
## Proposed changes

This is allows actions to retrieve the analytic solution from the DataBox without having to
(re-)compute it. It also allows to share actions between the evolution and elliptic code that work with the analytic solution, e.g. the generic observers.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->