### PR TITLE
Add initializer for elliptic analytic solution

### DIFF
--- a/src/Elliptic/Actions/InitializeAnalyticSolution.hpp
+++ b/src/Elliptic/Actions/InitializeAnalyticSolution.hpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace elliptic {
+namespace Actions {
+
+/*!
+ * \brief Place the analytic solution of the system fields in the DataBox.
+ *
+ * Uses:
+ * - DataBox:
+ *   - `AnalyticSolutionTag`
+ *   - `Tags::Coordinates<Dim, Frame::Inertial>`
+ *
+ * DataBox:
+ * - Adds:
+ *   - `db::wrap_tags_in<::Tags::Analytic, AnalyticSolutionFields>`
+ */
+template <typename AnalyticSolutionTag, typename AnalyticSolutionFields>
+struct InitializeAnalyticSolution {
+  using const_global_cache_tags = tmpl::list<AnalyticSolutionTag>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ElementIndex<Dim>& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using analytic_fields_tag =
+        db::add_tag_prefix<::Tags::Analytic,
+                           ::Tags::Variables<AnalyticSolutionFields>>;
+
+    const auto& inertial_coords =
+        get<::Tags::Coordinates<Dim, Frame::Inertial>>(box);
+    db::item_type<analytic_fields_tag> analytic_fields{
+        variables_from_tagged_tuple(get<AnalyticSolutionTag>(cache).variables(
+            inertial_coords, AnalyticSolutionFields{}))};
+
+    return std::make_tuple(
+        ::Initialization::merge_into_databox<
+            InitializeAnalyticSolution, db::AddSimpleTags<analytic_fields_tag>>(
+            std::move(box), std::move(analytic_fields)));
+  }
+};
+
+}  // namespace Actions
+}  // namespace elliptic

--- a/tests/Unit/Elliptic/Actions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Actions/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_EllipticActions")
 
 set(LIBRARY_SOURCES
+  Test_InitializeAnalyticSolution.cpp
   Test_InitializeSystem.cpp
   )
 

--- a/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
@@ -1,0 +1,105 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace {
+
+struct ScalarFieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct AnalyticSolution {
+  tuples::TaggedTuple<ScalarFieldTag> variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+      tmpl::list<ScalarFieldTag> /*meta*/) const noexcept {
+    Scalar<DataVector> solution{2. * get<0>(x)};
+    for (size_t d = 1; d < Dim; d++) {
+      get(solution) += 2. * x.get(d);
+    }
+    return {std::move(solution)};
+  }
+  // clang-tidy: do not use references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+template <size_t Dim>
+struct AnalyticSolutionTag : db::SimpleTag {
+  using type = AnalyticSolution<Dim>;
+};
+
+template <size_t Dim, typename Metavariables>
+struct ElementArray {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndex<Dim>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<
+              tmpl::list<::Tags::Coordinates<Dim, Frame::Inertial>>>>>,
+
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<elliptic::Actions::InitializeAnalyticSolution<
+              AnalyticSolutionTag<Dim>, tmpl::list<ScalarFieldTag>>>>>;
+};
+
+template <size_t Dim>
+struct Metavariables {
+  using element_array = ElementArray<Dim, Metavariables>;
+  using component_list = tmpl::list<element_array>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+template <size_t Dim>
+void test_initialize_analytic_solution(
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
+    const Scalar<DataVector>& expected_solution) {
+  using metavariables = Metavariables<Dim>;
+  using element_array = typename metavariables::element_array;
+  const ElementId<Dim> element_id{0};
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
+      {AnalyticSolution<Dim>{}}};
+  ActionTesting::emplace_component_and_initialize<element_array>(
+      &runner, element_id, {inertial_coords});
+  runner.set_phase(metavariables::Phase::Testing);
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  CHECK_ITERABLE_APPROX(
+      get(ActionTesting::get_databox_tag<element_array,
+                                         ::Tags::Analytic<ScalarFieldTag>>(
+          runner, element_id)),
+      get(expected_solution));
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeAnalyticSolution",
+                  "[Unit][Elliptic][Actions]") {
+  test_initialize_analytic_solution(
+      tnsr::I<DataVector, 1, Frame::Inertial>{{{{1., 2., 3., 4.}}}},
+      Scalar<DataVector>{{{{2., 4., 6., 8.}}}});
+  test_initialize_analytic_solution(
+      tnsr::I<DataVector, 2, Frame::Inertial>{{{{1., 2.}, {3., 4.}}}},
+      Scalar<DataVector>{{{{8., 12.}}}});
+  test_initialize_analytic_solution(
+      tnsr::I<DataVector, 3, Frame::Inertial>{{{{1., 2.}, {3., 4.}, {5., 6.}}}},
+      Scalar<DataVector>{{{{18., 24.}}}});
+}


### PR DESCRIPTION
## Proposed changes

This PR adds an initializer that places the analytic solution in the DataBox for elliptic systems so that actions don't have to (re-)compute it.

- The first commit is cherry-picked from #1690

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->