### PR TITLE
Flatten PDALs

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -220,10 +220,9 @@ struct EvolutionMetavars {
               Parallel::PhaseActions<Phase, Phase::Initialization,
                                      initialization_actions>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::InitializeTimeStepperHistory,
-                  tmpl::flatten<tmpl::list<SelfStart::self_start_procedure<
-                      compute_rhs, update_variables>>>>,
+              Parallel::PhaseActions<Phase, Phase::InitializeTimeStepperHistory,
+                                     SelfStart::self_start_procedure<
+                                         compute_rhs, update_variables>>,
 
               Parallel::PhaseActions<
                   Phase, Phase::RegisterWithObserver,
@@ -234,7 +233,7 @@ struct EvolutionMetavars {
 
               Parallel::PhaseActions<
                   Phase, Phase::Evolve,
-                  tmpl::flatten<tmpl::list<
+                  tmpl::list<
                       VariableFixing::Actions::FixVariables<
                           VariableFixing::FixToAtmosphere<thermodynamic_dim>>,
                       Actions::UpdateConservatives,
@@ -242,7 +241,7 @@ struct EvolutionMetavars {
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      compute_rhs, update_variables, Actions::AdvanceTime>>>>>>;
+                      compute_rhs, update_variables, Actions::AdvanceTime>>>>>;
 
   using const_global_cache_tags =
       tmpl::list<initial_data_tag,

--- a/src/Parallel/PhaseDependentActionList.hpp
+++ b/src/Parallel/PhaseDependentActionList.hpp
@@ -14,11 +14,11 @@ namespace Parallel {
  */
 template <typename PhaseType, PhaseType Phase, typename ActionsList>
 struct PhaseActions {
-  using action_list = ActionsList;
+  using action_list = tmpl::flatten<ActionsList>;
   using phase_type = PhaseType;
   static constexpr phase_type phase = Phase;
   using integral_constant_phase = std::integral_constant<PhaseType, Phase>;
-  static constexpr size_t number_of_actions = tmpl::size<ActionsList>::value;
+  static constexpr size_t number_of_actions = tmpl::size<action_list>::value;
 };
 
 /*!


### PR DESCRIPTION
## Proposed changes

Flattening the action list allows passing a nested list to `PhaseAction`. Then we don't have to `flatten` in the `Metavariables`, which makes the code slightly less verbose.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
