### PR TITLE
Add RepeatUntil action

### DIFF
--- a/tests/Unit/Parallel/Actions/Test_Goto.cpp
+++ b/tests/Unit/Parallel/Actions/Test_Goto.cpp
@@ -3,7 +3,10 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <string>
+
 #include "Parallel/Actions/Goto.hpp"  // IWYU pragma: keep
+#include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -13,21 +16,63 @@ namespace {
 struct Label1;
 struct Label2;
 
+struct Counter : db::SimpleTag {
+  using type = size_t;
+};
+
+struct HasConverged : db::ComputeTag {
+  using argument_tags = tmpl::list<Counter>;
+  static bool function(const size_t& counter) noexcept { return counter >= 2; }
+  static std::string name() noexcept { return "HasConverged"; }
+};
+
+struct Increment {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<Counter>(
+        make_not_null(&box), [](const gsl::not_null<size_t*> counter) noexcept {
+          (*counter)++;
+        });
+    return {std::move(box)};
+  }
+};
+
 template <typename Metavariables>
 struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Testing,
-      tmpl::list<Actions::Goto<Label1>, Actions::Label<Label2>,
-                 Actions::Label<Label1>, Actions::Goto<Label2>>>>;
+
+  using repeat_until_phase_action_list = tmpl::flatten<
+      tmpl::list<Actions::RepeatUntil<HasConverged, tmpl::list<Increment>>,
+                 Parallel::Actions::TerminatePhase>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<
+              tmpl::list<Counter>, tmpl::list<HasConverged>>>>,
+
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::TestGoto,
+          tmpl::list<Actions::Goto<Label1>, Actions::Label<Label2>,
+                     Actions::Label<Label1>, Actions::Goto<Label2>>>,
+
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::TestRepeatUntil,
+                             repeat_until_phase_action_list>>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
 
-  enum class Phase { Testing, Exit };
+  enum class Phase { Initialization, TestGoto, TestRepeatUntil, Exit };
 };
 }  // namespace
 
@@ -35,9 +80,10 @@ SPECTRE_TEST_CASE("Unit.Parallel.GotoAction", "[Unit][Parallel][Actions]") {
   using component = Component<Metavariables>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   MockRuntimeSystem runner{{}};
-  ActionTesting::emplace_component<component>(&runner, 0);
+  ActionTesting::emplace_component_and_initialize<component>(&runner, 0,
+                                                             {size_t{0}});
 
-  runner.set_phase(Metavariables::Phase::Testing);
+  runner.set_phase(Metavariables::Phase::TestGoto);
   runner.force_next_action_to_be<component, Actions::Label<Label1>>(0);
   runner.next_action<component>(0);
   CHECK(runner.get_next_action_index<component>(0) == 3);
@@ -49,4 +95,21 @@ SPECTRE_TEST_CASE("Unit.Parallel.GotoAction", "[Unit][Parallel][Actions]") {
   runner.force_next_action_to_be<component, Actions::Goto<Label2>>(0);
   runner.next_action<component>(0);
   CHECK(runner.get_next_action_index<component>(0) == 1);
+
+  runner.set_phase(Metavariables::Phase::TestRepeatUntil);
+  while (not ActionTesting::get_terminate<component>(runner, 0)) {
+    runner.next_action<component>(0);
+  }
+  CHECK(ActionTesting::get_databox_tag<component, HasConverged>(runner, 0));
+  CHECK(ActionTesting::get_databox_tag<component, Counter>(runner, 0) == 2);
+
+  // Test zero iterations of the `RepeatUntil` loop
+  runner.set_phase(Metavariables::Phase::TestRepeatUntil);
+  runner.next_action<component>(0);
+  CHECK(runner.get_next_action_index<component>(0) ==
+        tmpl::index_of<typename component::repeat_until_phase_action_list,
+                       Parallel::Actions::TerminatePhase>::value);
+  // Make sure `Increment` was not called for this situation where the
+  // condition is already fulfilled at the start.
+  CHECK(ActionTesting::get_databox_tag<component, Counter>(runner, 0) == 2);
 }


### PR DESCRIPTION
## Proposed changes

This repeats an action list until a condition is met. For example, it can repeat iterating a linear solve until it has converged, then proceed to the next action.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
