### PR TITLE
Fix 1663: loosen area element test tol

### DIFF
--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -286,7 +286,8 @@ void test_euclidean_surface_integral_of_vector(
   const auto integral_2 = StrahlkorperGr::euclidean_surface_integral_of_vector(
       euclidean_area_element, test_vector, normal_one_form, strahlkorper);
 
-  CHECK(integral_1 == approx(integral_2));
+  Approx custom_approx = Approx::custom().epsilon(1.e-13).scale(1.0);
+  CHECK(integral_1 == custom_approx(integral_2));
 }
 
 template <typename Solution, typename Frame>
@@ -500,8 +501,8 @@ void test_integral_correspondence(
       euclidean_area_element, scalar_1, strahlkorper);
   const double integral_2 = StrahlkorperGr::surface_integral_of_scalar(
       area_element, scalar_2, strahlkorper);
-
-  CHECK(integral_1 == approx(integral_2));
+  Approx custom_approx = Approx::custom().epsilon(1.e-13).scale(1.0);
+  CHECK(integral_1 == custom_approx(integral_2));
 }
 
 template <typename Solution, typename Fr>


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
