### PR TITLE
Remove dependence on Time from observe events

### DIFF
--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
@@ -11,6 +11,7 @@
 #include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep
 #include "Evolution/Actions/ComputeVolumeFluxes.hpp"
 #include "Evolution/Actions/ComputeVolumeSources.hpp"
+#include "Evolution/ComputeTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp"
@@ -49,6 +50,7 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.hpp"
@@ -110,12 +112,12 @@ struct EvolutionMetavars {
 
   // public for use by the Charm++ registration code
   using events = tmpl::flatten<tmpl::list<
-      tmpl::conditional_t<
-          evolution::is_analytic_solution_v<initial_data>,
-          dg::Events::Registrars::ObserveErrorNorms<3, analytic_variables_tags>,
-          tmpl::list<>>,
+      tmpl::conditional_t<evolution::is_analytic_solution_v<initial_data>,
+                          dg::Events::Registrars::ObserveErrorNorms<
+                              Tags::Time, analytic_variables_tags>,
+                          tmpl::list<>>,
       dg::Events::Registrars::ObserveFields<
-          3,
+          3, Tags::Time,
           tmpl::append<
               db::get_variables_tags_list<typename system::variables_tag>,
               db::get_variables_tags_list<
@@ -177,6 +179,12 @@ struct EvolutionMetavars {
               typename system::spacetime_variables_tag,
               typename system::primitive_variables_tag>>,
       Initialization::Actions::Evolution<EvolutionMetavars>,
+      tmpl::conditional_t<
+          evolution::is_analytic_solution_v<initial_data>,
+          Initialization::Actions::AddComputeTags<
+              tmpl::list<evolution::Tags::AnalyticCompute<
+                  3, initial_data_tag, analytic_variables_tags>>>,
+          tmpl::list<>>,
       dg::Actions::InitializeMortars<EvolutionMetavars>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::Minmod<3>,
@@ -199,7 +207,7 @@ struct EvolutionMetavars {
                   Phase, Phase::RegisterWithObserver,
                   tmpl::list<observers::Actions::RegisterWithObservers<
                                  observers::RegisterObservers<
-                                     element_observation_type>>,
+                                     Tags::Time, element_observation_type>>,
                              Parallel::Actions::TerminatePhase>>,
 
               Parallel::PhaseActions<

--- a/src/IO/Observer/RegisterObservers.hpp
+++ b/src/IO/Observer/RegisterObservers.hpp
@@ -8,19 +8,20 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "IO/Observer/ObservationId.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"
-#include "Time/Tags.hpp"
 
 namespace observers {
 /// Passed to `RegisterWithObservers` action to register observer event.
-template <typename ObsType>
+template <typename ObservationValueTag, typename ObsType>
 struct RegisterObservers {
   template <typename ParallelComponent, typename DbTagsList,
             typename ArrayIndex>
   static std::pair<observers::TypeOfObservation, observers::ObservationId>
   register_info(const db::DataBox<DbTagsList>& box,
                 const ArrayIndex& /*array_index*/) noexcept {
-    return {observers::TypeOfObservation::ReductionAndVolume,
-            observers::ObservationId{db::get<::Tags::Time>(box), ObsType{}}};
+    return {
+        observers::TypeOfObservation::ReductionAndVolume,
+        observers::ObservationId{
+            static_cast<double>(db::get<ObservationValueTag>(box)), ObsType{}}};
   }
 };
 }  // namespace observers


### PR DESCRIPTION
## Proposed changes

With the analytic solutions available through the DataBox (#1690) the generic observers don't need to re-compute the anymore. This means they don't need to depend on `Time` anymore and can be used by the elliptic code.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
