### PR TITLE
Add non-Euclidean Poisson fluxes

### DIFF
--- a/src/Elliptic/Systems/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Systems/Poisson/CMakeLists.txt
@@ -13,4 +13,5 @@ target_link_libraries(
   ${LIBRARY}
   INTERFACE DataStructures
   INTERFACE ErrorHandling
+  INTERFACE GeneralRelativity
   )

--- a/src/Elliptic/Systems/Poisson/Equations.hpp
+++ b/src/Elliptic/Systems/Poisson/Equations.hpp
@@ -52,11 +52,22 @@ namespace Poisson {
 
 /*!
  * \brief Compute the fluxes \f$F^i=\partial_i u(x)\f$ for the Poisson
- * equation on a flat metric in Cartesian coordinates.
+ * equation on a flat spatial metric in Cartesian coordinates.
  */
 template <size_t Dim>
 void euclidean_fluxes(
     gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> flux_for_field,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& field_gradient) noexcept;
+
+/*!
+ * \brief Compute the fluxes \f$F^i=\sqrt{\gamma}\gamma^{ij}\partial_j u(x)\f$
+ * for the curved-space Poisson equation on a spatial metric \f$\gamma_{ij}\f$.
+ */
+template <size_t Dim>
+void noneuclidean_fluxes(
+    gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> flux_for_field,
+    const tnsr::II<DataVector, Dim, Frame::Inertial>& inv_spatial_metric,
+    const Scalar<DataVector>& det_spatial_metric,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& field_gradient) noexcept;
 
 /*!

--- a/tests/Unit/Elliptic/Systems/Poisson/Equations.py
+++ b/tests/Unit/Elliptic/Systems/Poisson/Equations.py
@@ -8,6 +8,11 @@ def euclidean_fluxes(field_gradient):
     return field_gradient
 
 
+def noneuclidean_fluxes(inv_spatial_metric, det_spatial_metric, field_gradient):
+    return np.sqrt(det_spatial_metric) * np.einsum(
+        'ij,j', inv_spatial_metric, field_gradient)
+
+
 def auxiliary_fluxes(field, dim):
     return np.diag(np.repeat(field, dim))
 

--- a/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
@@ -55,6 +55,9 @@ void test_equations(const DataVector& used_for_size) {
   pypp::check_with_random_values<1>(&Poisson::euclidean_fluxes<Dim>,
                                     "Equations", {"euclidean_fluxes"},
                                     {{{0., 1.}}}, used_for_size);
+  pypp::check_with_random_values<1>(&Poisson::noneuclidean_fluxes<Dim>,
+                                    "Equations", {"noneuclidean_fluxes"},
+                                    {{{0., 1.}}}, used_for_size);
   pypp::check_with_random_values<1>(
       &Poisson::auxiliary_fluxes<Dim>, "Equations",
       {MakeString{} << "auxiliary_fluxes_" << Dim << "d"}, {{{0., 1.}}},


### PR DESCRIPTION
## Proposed changes

These can be used to solve the Poisson equation on a curved
background metric. We'll need to do that for XCTS solves where
we don't assume conformal flatness.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
