### PR TITLE
Generalize WENO oscillation indicators

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
@@ -9,7 +9,7 @@ set(LIBRARY_SOURCES
   MinmodTci.cpp
   MinmodType.cpp
   WenoGridHelpers.cpp
-  WenoHelpers.cpp
+  WenoOscillationIndicator.cpp
   WenoType.cpp
   )
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -367,7 +367,8 @@ bool Weno<VolumeDim, tmpl::list<Tags...>>::operator()(
       [ this, &mesh, &
         modified_neighbor_solutions ](auto tag, const auto tensor) noexcept {
     Weno_detail::reconstruct_from_weighted_sum<decltype(tag)>(
-        tensor, mesh, neighbor_linear_weight_, modified_neighbor_solutions);
+        tensor, mesh, neighbor_linear_weight_, modified_neighbor_solutions,
+        Weno_detail::DerivativeWeight::Unity);
     return '0';
   };
   expand_pack(wrap_reconstruct_one_tensor(Tags{}, tensors)...);

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Variables.hpp"  // IWYU pragma: keep
 #include "Domain/Direction.hpp"          // IWYU pragma: keep
 #include "Domain/ElementId.hpp"          // IWYU pragma: keep
+#include "Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp"
 #include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
@@ -31,21 +32,6 @@ struct hash;
 
 namespace Limiters {
 namespace Weno_detail {
-
-// Compute the WENO oscillation indicator (also called the smoothness indicator)
-//
-// The oscillation indicator measures the amount of variation in the input data,
-// with larger indicator values corresponding to a larger amount of variation
-// (either from large monotonic slopes or from oscillations).
-//
-// Implements an indicator similar to that of Eq. 23 of Dumbser2007, but with
-// the necessary adaptations for use on square/cube grids. We favor this
-// indicator because it is formulated in the reference coordinates, which we
-// use for the WENO reconstruction, and because it lends itself to an efficient
-// implementation.
-template <size_t VolumeDim>
-double oscillation_indicator(const DataVector& data,
-                             const Mesh<VolumeDim>& mesh) noexcept;
 
 // Compute the unnormalized nonlinear WENO weights. This is a fairly standard
 // choice of weights; see e.g., Eq. 3.9 of Zhong2013 or Eq. 3.6 of Zhu2016.

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp
@@ -55,7 +55,8 @@ void reconstruct_from_weighted_sum(
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
         Variables<TagsList>,
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
-        neighbor_vars) noexcept {
+        neighbor_vars,
+    const DerivativeWeight derivative_weight) noexcept {
   for (size_t tensor_storage_index = 0;
        tensor_storage_index < local_tensor->size(); ++tensor_storage_index) {
     auto& local_polynomial = (*local_tensor)[tensor_storage_index];
@@ -90,14 +91,16 @@ void reconstruct_from_weighted_sum(
     // Update `local_weights` and `neighbor_weights` to hold the unnormalized
     // nonlinear weights.
     local_weight = unnormalized_nonlinear_weight(
-        local_weight, oscillation_indicator(local_polynomial, mesh));
+        local_weight,
+        oscillation_indicator(local_polynomial, mesh, derivative_weight));
     for (const auto& kv : neighbor_vars) {
       const auto& key = kv.first;
       const auto& neighbor_tensor_component =
           get<Tag>(kv.second)[tensor_storage_index];
       neighbor_weights[key] = unnormalized_nonlinear_weight(
           neighbor_weights[key],
-          oscillation_indicator(neighbor_tensor_component, mesh));
+          oscillation_indicator(neighbor_tensor_component, mesh,
+                                derivative_weight));
     }
 
     // Update `local_weights` and `neighbor_weights` to hold the normalized

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.cpp
@@ -1,7 +1,9 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp"
+
+#include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/IndexIterator.hpp"  // IWYU pragma: keep

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.cpp
@@ -3,6 +3,8 @@
 
 #include "Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp"
 
+#include <array>
+#include <cmath>
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
@@ -11,10 +13,14 @@
 #include "DataStructures/ModalVector.hpp"
 #include "Domain/Mesh.hpp"  // IWYU pragma: keep
 #include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
 #include "NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/StaticCache.hpp"
 
 namespace {
 // Given the modal expansion corresponding to some function f(x), compute the
@@ -36,15 +42,17 @@ ModalVector modal_derivative(const ModalVector& coeffs) noexcept {
 
 // For a given pair of Legendre polynomial basis functions (P_m, P_n), compute
 // the sum of the integrals of all their derivatives:
-// \sum_{l=0}^{N} f(l) \int d^(l)/dx^(l) P_m(x) * d^(l)/dx^(l) P_n(x) * dx
-// where f(l) is some weight given to each term in the sum. In the current
-// implementation we keep f(l) = 1, but this could be generalized in the future.
+// \sum_{l=0}^{N} w(l) \int d^(l)/dx^(l) P_m(x) * d^(l)/dx^(l) P_n(x) * dx
+// where w(l) is some weight given to each term in the sum.
 //
 // The implemented algorithm computes the l'th derivative of P_m (and P_n) as a
 // modal expansion in lower-order Legendre polynomials. The integrals can be
 // carried out using the orthogonality relations between these basis functions.
-double compute_sum_of_legendre_derivs(const size_t number_of_modes,
-                                      const size_t m, const size_t n) noexcept {
+double compute_sum_of_legendre_derivs(
+    const size_t number_of_modes, const size_t m, const size_t n,
+    const std::array<
+        double, Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>&
+        weights_for_derivatives) noexcept {
   ModalVector coeffs_m(number_of_modes, 0.);
   coeffs_m[m] = 1.;
   ModalVector coeffs_n(number_of_modes, 0.);
@@ -52,16 +60,17 @@ double compute_sum_of_legendre_derivs(const size_t number_of_modes,
   double result = 0.;
   // This is the l == 0 term of the sum
   if (m == n) {
-    result += Spectral::compute_basis_function_normalization_square<
-        Spectral::Basis::Legendre>(m);
+    result += weights_for_derivatives[0] *
+              Spectral::compute_basis_function_normalization_square<
+                  Spectral::Basis::Legendre>(m);
   }
   // This is the main l > 0 part of the sum
   for (size_t l = 1; l < number_of_modes; ++l) {
-    const double factor_of_l = 1.;
+    const double weight = gsl::at(weights_for_derivatives, l);
     coeffs_m = modal_derivative(coeffs_m);
     coeffs_n = modal_derivative(coeffs_n);
     for (size_t i = 0; i < number_of_modes; ++i) {
-      result += factor_of_l * coeffs_m[i] * coeffs_n[i] *
+      result += weight * coeffs_m[i] * coeffs_n[i] *
                 Spectral::compute_basis_function_normalization_square<
                     Spectral::Basis::Legendre>(i);
     }
@@ -88,11 +97,34 @@ double compute_sum_of_legendre_derivs(const size_t number_of_modes,
 // m == 0 or n == 0 vanishes. We thus slightly reduce the necessary storage by
 // computing only the (N-1)^2 matrix where we start at m, n >= 1.
 template <size_t VolumeDim>
-Matrix compute_indicator_matrix(const Mesh<VolumeDim>& mesh) noexcept {
+Matrix compute_indicator_matrix(
+    const Mesh<VolumeDim>& mesh,
+    const Limiters::Weno_detail::DerivativeWeight derivative_weight) noexcept {
   ASSERT(mesh.basis() == make_array<VolumeDim>(Spectral::Basis::Legendre),
          "No implementation for mesh: " << mesh);
   Matrix result(mesh.number_of_grid_points() - 1,
                 mesh.number_of_grid_points() - 1);
+
+  const std::array<
+      double, Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>
+      weights_for_derivatives = [&derivative_weight]() noexcept {
+    auto weights = make_array<
+        Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(1.);
+    if (derivative_weight ==
+        Limiters::Weno_detail::DerivativeWeight::PowTwoEll) {
+      for (size_t l = 0; l < weights.size(); ++l) {
+        gsl::at(weights, l) = pow(2., 2. * l - 1.);
+      }
+    } else if (derivative_weight == Limiters::Weno_detail::DerivativeWeight::
+                                        PowTwoEllOverEllFactorial) {
+      for (size_t l = 0; l < weights.size(); ++l) {
+        gsl::at(weights, l) = 0.5 * square(pow(2., l) / factorial(l));
+      }
+    }
+    return weights;
+  }
+  ();
+
   for (IndexIterator<VolumeDim> m(mesh.extents()); m; ++m) {
     if (m.collapsed_index() == 0) {
       // Skip the terms associated with the cell average of the data
@@ -107,19 +139,21 @@ Matrix compute_indicator_matrix(const Mesh<VolumeDim>& mesh) noexcept {
       // polynomial math
       auto& result_mn =
           result(m.collapsed_index() - 1, n.collapsed_index() - 1);
-      result_mn =
-          compute_sum_of_legendre_derivs(mesh.extents(0), m()[0], n()[0]);
+      result_mn = compute_sum_of_legendre_derivs(
+          mesh.extents(0), m()[0], n()[0], weights_for_derivatives);
       for (size_t dim = 1; dim < VolumeDim; ++dim) {
-        result_mn *= compute_sum_of_legendre_derivs(mesh.extents(dim), m()[dim],
-                                                    n()[dim]);
+        result_mn *= compute_sum_of_legendre_derivs(
+            mesh.extents(dim), m()[dim], n()[dim], weights_for_derivatives);
       }
     }
     // Subtract the tensor-product term that has no derivatives
     double term_with_no_derivs =
+        weights_for_derivatives[0] *
         Spectral::compute_basis_function_normalization_square<
             Spectral::Basis::Legendre>(m()[0]);
     for (size_t dim = 1; dim < VolumeDim; ++dim) {
       term_with_no_derivs *=
+          weights_for_derivatives[0] *
           Spectral::compute_basis_function_normalization_square<
               Spectral::Basis::Legendre>(m()[dim]);
     }
@@ -134,16 +168,39 @@ Matrix compute_indicator_matrix(const Mesh<VolumeDim>& mesh) noexcept {
 namespace Limiters {
 namespace Weno_detail {
 
+std::ostream& operator<<(std::ostream& os,
+                         DerivativeWeight derivative_weight) noexcept {
+  switch (derivative_weight) {
+    case DerivativeWeight::Unity:
+      return os << "Unity";
+    case DerivativeWeight::PowTwoEll:
+      return os << "PowTwoEll";
+    case DerivativeWeight::PowTwoEllOverEllFactorial:
+      return os << "PowTwoEllOverEllFactorial";
+    default:
+      ERROR("Unknown DerivativeWeight");
+  }
+}
+
 template <size_t VolumeDim>
-double oscillation_indicator(const DataVector& data,
-                             const Mesh<VolumeDim>& mesh) noexcept {
+double oscillation_indicator(
+    const DataVector& data, const Mesh<VolumeDim>& mesh,
+    const DerivativeWeight derivative_weight) noexcept {
   ASSERT(mesh.basis() == make_array<VolumeDim>(Spectral::Basis::Legendre),
          "No implementation for mesh: " << mesh);
 
-  // Optimization: store the indicator matrix in a static so it is only computed
-  // once at the beginning of the simulation. This caching will have to be
-  // generalized to handle simulations with more than one mesh.
-  static const Matrix indicator_matrix = compute_indicator_matrix(mesh);
+  // Optimization: cache the indicator matrix, because it does not depend on the
+  // data. This caching will have to be generalized to handle simulations with
+  // more than one mesh.
+  const auto cache = make_static_cache<CacheEnumeration<
+      DerivativeWeight, DerivativeWeight::Unity, DerivativeWeight::PowTwoEll,
+      DerivativeWeight::PowTwoEllOverEllFactorial>>(
+      [&mesh](const DerivativeWeight dw) noexcept->Matrix {
+        return compute_indicator_matrix(mesh, dw);
+      });
+  const Matrix indicator_matrix = cache(derivative_weight);
+
+  // Check there is only one mesh, i.e., that we satisfy the cache assumptions.
   static const Mesh<VolumeDim> mesh_for_cached_matrix = mesh;
   ASSERT(
       mesh_for_cached_matrix == mesh,
@@ -177,7 +234,7 @@ double oscillation_indicator(const DataVector& data,
 
 #define INSTANTIATE(_, data)                        \
   template double oscillation_indicator<DIM(data)>( \
-      const DataVector&, const Mesh<DIM(data)>&) noexcept;
+      const DataVector&, const Mesh<DIM(data)>&, DerivativeWeight) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <ostream>
 
 /// \cond
 class DataVector;
@@ -13,6 +14,19 @@ class Mesh;
 
 namespace Limiters {
 namespace Weno_detail {
+
+// Denote different schemes for computing related oscillation indicators by
+// changing the relative weight given to each derivative of the input data.
+// - Unity: l'th derivative has weight 1
+// - PowTwoEll: l'th derivative has weight 2^(2 l - 1)
+//   This penalizes higher derivatives more strongly: w(l=4) = 128
+// - PowTwoEllOverEllFactorial: l'th derivative has weight 2^(2 l - 1) / (l!)^2
+//   This penalizes the 1st and 2nd derivatives most strongly, but then higher
+//   derivatives have decreasing weights so are weakly penalized: w(l=4) = 0.222
+enum class DerivativeWeight { Unity, PowTwoEll, PowTwoEllOverEllFactorial };
+
+std::ostream& operator<<(std::ostream& os,
+                         DerivativeWeight derivative_weight) noexcept;
 
 // Compute the WENO oscillation indicator (also called the smoothness indicator)
 //
@@ -27,7 +41,8 @@ namespace Weno_detail {
 // implementation.
 template <size_t VolumeDim>
 double oscillation_indicator(const DataVector& data,
-                             const Mesh<VolumeDim>& mesh) noexcept;
+                             const Mesh<VolumeDim>& mesh,
+                             DerivativeWeight derivative_weight) noexcept;
 
 }  // namespace Weno_detail
 }  // namespace Limiters

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \cond
+class DataVector;
+template <size_t>
+class Mesh;
+/// \endcond
+
+namespace Limiters {
+namespace Weno_detail {
+
+// Compute the WENO oscillation indicator (also called the smoothness indicator)
+//
+// The oscillation indicator measures the amount of variation in the input data,
+// with larger indicator values corresponding to a larger amount of variation
+// (either from large monotonic slopes or from oscillations).
+//
+// Implements an indicator similar to that of Eq. 23 of Dumbser2007, but with
+// the necessary adaptations for use on square/cube grids. We favor this
+// indicator because it is formulated in the reference coordinates, which we
+// use for the WENO reconstruction, and because it lends itself to an efficient
+// implementation.
+template <size_t VolumeDim>
+double oscillation_indicator(const DataVector& data,
+                             const Mesh<VolumeDim>& mesh) noexcept;
+
+}  // namespace Weno_detail
+}  // namespace Limiters

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_MinmodType.cpp
   Test_Weno.cpp
   Test_WenoGridHelpers.cpp
+  Test_WenoOscillationIndicator.cpp
   Test_WenoHelpers.cpp
   Test_WenoType.cpp
   )

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
@@ -30,6 +30,7 @@
 #include "Evolution/DiscontinuousGalerkin/Limiters/HwenoModifiedSolution.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/WenoType.hpp"
 #include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -448,13 +449,15 @@ void test_weno_work(
   auto expected_scalar = get<ScalarTag>(local_vars);
   Limiters::Weno_detail::reconstruct_from_weighted_sum<ScalarTag>(
       make_not_null(&expected_scalar), mesh, neighbor_linear_weight,
-      expected_neighbor_modified_vars);
+      expected_neighbor_modified_vars,
+      Limiters::Weno_detail::DerivativeWeight::Unity);
   CHECK_ITERABLE_CUSTOM_APPROX(expected_scalar, scalar, local_approx);
 
   auto expected_vector = get<VectorTag<VolumeDim>>(local_vars);
   Limiters::Weno_detail::reconstruct_from_weighted_sum<VectorTag<VolumeDim>>(
       make_not_null(&expected_vector), mesh, neighbor_linear_weight,
-      expected_neighbor_modified_vars);
+      expected_neighbor_modified_vars,
+      Limiters::Weno_detail::DerivativeWeight::Unity);
   CHECK_ITERABLE_CUSTOM_APPROX(expected_vector, vector, local_approx);
 }
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoGridHelpers.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoGridHelpers.cpp
@@ -161,7 +161,7 @@ void test_grid_helpers_3d() {
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.WenoGridHelpers",
+SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.Weno.GridHelpers",
                   "[Limiters][Unit]") {
   test_check_element_no_href();
   test_grid_helpers_1d();

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoHelpers.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoHelpers.cpp
@@ -29,75 +29,6 @@
 
 namespace {
 
-void test_oscillation_indicator_1d() noexcept {
-  const Mesh<1> mesh(5, Spectral::Basis::Legendre,
-                     Spectral::Quadrature::GaussLobatto);
-  const auto logical_coords = logical_coordinates(mesh);
-  const DataVector& x = get<0>(logical_coords);
-
-  const auto data = DataVector{1. + x - pow<4>(x)};
-  const auto indicator =
-      Limiters::Weno_detail::oscillation_indicator(data, mesh);
-
-  // Expected result computed in Mathematica:
-  // f[x_] := 1 + x - x^4
-  // Integrate[Sum[Evaluate[D[f[x], {x, i}]^2], {i, 1, 4}], {x, -1, 1}]
-  const double expected = 56006. / 35.;
-  CHECK(indicator == approx(expected));
-}
-
-void test_oscillation_indicator_2d() noexcept {
-  const Mesh<2> mesh({{4, 5}}, Spectral::Basis::Legendre,
-                     Spectral::Quadrature::GaussLobatto);
-  const auto logical_coords = logical_coordinates(mesh);
-  const DataVector& x = get<0>(logical_coords);
-  const DataVector& y = get<1>(logical_coords);
-
-  const auto data =
-      DataVector{square(x) + cube(y) - 2.5 * x * y + square(x) * y};
-  const auto indicator =
-      Limiters::Weno_detail::oscillation_indicator(data, mesh);
-
-  // Expected result computed in Mathematica:
-  // g[x_, y_] := x^2 + y^3 - (5/2) x y + x^2 y
-  // Integrate[
-  //  Sum[Evaluate[D[g[x, y], {x, i}, {y, j}]^2], {i, 1, 3}, {j, 1, 4}]
-  //   + Sum[Evaluate[D[g[x, y], {x, i}]^2], {i, 1, 3}]
-  //   + Sum[Evaluate[D[g[x, y], {y, j}]^2], {j, 1, 4}],
-  //  {x, -1, 1}, {y, -1, 1}]
-  const double expected = 2647. / 9.;
-  CHECK(indicator == approx(expected));
-}
-
-void test_oscillation_indicator_3d() noexcept {
-  const Mesh<3> mesh({{4, 3, 5}}, Spectral::Basis::Legendre,
-                     Spectral::Quadrature::GaussLobatto);
-  const auto logical_coords = logical_coordinates(mesh);
-  const DataVector& x = get<0>(logical_coords);
-  const DataVector& y = get<1>(logical_coords);
-  const DataVector& z = get<2>(logical_coords);
-
-  const auto data = DataVector{square(x) + 2. * y + z - 6. * cube(z) -
-                               3. * x * square(y) * cube(z) - x * y + y * z};
-  const auto indicator =
-      Limiters::Weno_detail::oscillation_indicator(data, mesh);
-
-  // Expected result computed in Mathematica:
-  // h[x_, y_, z_] := x^2 + 2 y + z - 6 z^3 - 3 x y^2 z^3 - x y + y z
-  // Integrate[
-  //  Sum[Evaluate[D[h[x, y, z], {x, i}, {y, j}, {z, k}]^2],
-  //      {i, 1, 3}, {j, 1, 2}, {k, 1, 4}]
-  //   + Sum[Evaluate[ D[h[x, y, z], {x, i}, {y, j}]^2], {i, 1, 3}, {j, 1, 2}]
-  //   + Sum[Evaluate[ D[h[x, y, z], {x, i}, {z, k}]^2], {i, 1, 3}, {k, 1, 4}]
-  //   + Sum[Evaluate[ D[h[x, y, z], {y, j}, {z, k}]^2], {j, 1, 2}, {k, 1, 4}]
-  //   + Sum[Evaluate[ D[h[x, y, z], {x, i}]^2], {i, 1, 3}]
-  //   + Sum[Evaluate[ D[h[x, y, z], {y, j}]^2], {j, 1, 2}]
-  //   + Sum[Evaluate[ D[h[x, y, z], {z, k}]^2], {k, 1, 4}],
-  //  {x, -1, 1}, {y, -1, 1}, {z, -1, 1}]
-  const double expected = 3066352. / 75.;
-  CHECK(indicator == approx(expected));
-}
-
 struct ScalarTag : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() noexcept { return "Scalar"; }
@@ -324,28 +255,7 @@ void test_reconstruction_3d() noexcept {
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.WenoHelpers.OscillationIndicator",
-                  "[Limiters][Unit]") {
-  test_oscillation_indicator_1d();
-  test_oscillation_indicator_2d();
-  test_oscillation_indicator_3d();
-}
-
-// At the moment, this TEST_CASE cannot be merged with the OscillationIndicator
-// TEST_CASE.
-//
-// This is because the function `oscillation_indicator` uses a static variable
-// to cache the expensive computation of an intermediate result, which depends
-// on the mesh. This caching is simplistic, and assumes a single mesh is used.
-// This assumption is okay for our simple grids right now, but the caching will
-// need to become more sophisticated when we want to handle more general
-// domains.
-//
-// Until the caching is improved, the tests must choose between:
-// - all tests (with a particular VolumeDim) use the same mesh, OR
-// - tests use different meshes but are in different TEST_CASEs.
-// We opt for the latter, as this provides a more rigorous test of the code.
-SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.WenoHelpers.Reconstruction",
+SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.Weno.Helpers",
                   "[Limiters][Unit]") {
   test_reconstruction_1d();
   test_reconstruction_2d();

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoHelpers.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoHelpers.cpp
@@ -19,6 +19,7 @@
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp"
 #include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -81,7 +82,8 @@ void test_reconstruction_1d() noexcept {
       ScalarTag::type{{{evaluate_polynomial({{0., 0., 1., 1., 2.}})}}});
 
   Limiters::Weno_detail::reconstruct_from_weighted_sum<ScalarTag>(
-      make_not_null(&scalar), mesh, neighbor_linear_weight, neighbor_vars);
+      make_not_null(&scalar), mesh, neighbor_linear_weight, neighbor_vars,
+      Limiters::Weno_detail::DerivativeWeight::Unity);
 
   CHECK(mean_value(get(scalar), mesh) == approx(expected_scalar_mean));
 
@@ -158,7 +160,8 @@ void test_reconstruction_2d() noexcept {
             evaluate_polynomial({{0., 0., 0., 1., 0., 0., 1., 1., 1.}})}}});
 
   Limiters::Weno_detail::reconstruct_from_weighted_sum<VectorTag<2>>(
-      make_not_null(&vector), mesh, neighbor_linear_weight, neighbor_vars);
+      make_not_null(&vector), mesh, neighbor_linear_weight, neighbor_vars,
+      Limiters::Weno_detail::DerivativeWeight::Unity);
 
   CHECK(mean_value(get<0>(vector), mesh) == approx(expected_vector_means[0]));
   CHECK(mean_value(get<1>(vector), mesh) == approx(expected_vector_means[1]));
@@ -241,7 +244,8 @@ void test_reconstruction_3d() noexcept {
       {{evaluate_polynomial({{0.1, 0., 0.5, 0.2, 0.2, 0.2}})}}});
 
   Limiters::Weno_detail::reconstruct_from_weighted_sum<ScalarTag>(
-      make_not_null(&scalar), mesh, neighbor_linear_weight, neighbor_vars);
+      make_not_null(&scalar), mesh, neighbor_linear_weight, neighbor_vars,
+      Limiters::Weno_detail::DerivativeWeight::Unity);
 
   CHECK(mean_value(get(scalar), mesh) == approx(expected_scalar_mean));
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoOscillationIndicator.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoOscillationIndicator.cpp
@@ -3,6 +3,8 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <string>
+
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/LogicalCoordinates.hpp"
@@ -10,27 +12,58 @@
 #include "Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GetOutput.hpp"
 
 namespace {
 
+void test_derivative_weight() noexcept {
+  INFO("Test DerivativeWeight");
+
+  CHECK(get_output(Limiters::Weno_detail::DerivativeWeight::Unity) == "Unity");
+  CHECK(get_output(Limiters::Weno_detail::DerivativeWeight::PowTwoEll) ==
+        "PowTwoEll");
+  CHECK(
+      get_output(
+          Limiters::Weno_detail::DerivativeWeight::PowTwoEllOverEllFactorial) ==
+      "PowTwoEllOverEllFactorial");
+}
+
 void test_oscillation_indicator_1d() noexcept {
+  INFO("Test oscillation_indicator in 1D");
   const Mesh<1> mesh(5, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
   const DataVector& x = get<0>(logical_coords);
 
   const auto data = DataVector{1. + x - pow<4>(x)};
-  const auto indicator =
-      Limiters::Weno_detail::oscillation_indicator(data, mesh);
+  const auto indicator = Limiters::Weno_detail::oscillation_indicator(
+      data, mesh, Limiters::Weno_detail::DerivativeWeight::Unity);
 
   // Expected result computed in Mathematica:
   // f[x_] := 1 + x - x^4
-  // Integrate[Sum[Evaluate[D[f[x], {x, i}]^2], {i, 1, 4}], {x, -1, 1}]
+  // w[i_] := 1
+  // Integrate[Sum[w[i] Evaluate[D[f[x], {x, i}]^2], {i, 1, 4}], {x, -1, 1}]
   const double expected = 56006. / 35.;
   CHECK(indicator == approx(expected));
+
+  // As above, but with derivative weights given by
+  // w[i_] := 2^(2 i - 1)
+  const auto indicator2 = Limiters::Weno_detail::oscillation_indicator(
+      data, mesh, Limiters::Weno_detail::DerivativeWeight::PowTwoEll);
+  const double expected2 = 5607628. / 35.;
+  CHECK(indicator2 == approx(expected2));
+
+  // Again as above, but with derivative weights given by
+  // w[i_] := 2^(2 i - 1) / (i!)^2
+  const auto indicator3 = Limiters::Weno_detail::oscillation_indicator(
+      data, mesh,
+      Limiters::Weno_detail::DerivativeWeight::PowTwoEllOverEllFactorial);
+  const double expected3 = 76196. / 105.;
+  CHECK(indicator3 == approx(expected3));
 }
 
 void test_oscillation_indicator_2d() noexcept {
+  INFO("Test oscillation_indicator in 2D");
   const Mesh<2> mesh({{4, 5}}, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
@@ -39,21 +72,37 @@ void test_oscillation_indicator_2d() noexcept {
 
   const auto data =
       DataVector{square(x) + cube(y) - 2.5 * x * y + square(x) * y};
-  const auto indicator =
-      Limiters::Weno_detail::oscillation_indicator(data, mesh);
+  const auto indicator = Limiters::Weno_detail::oscillation_indicator(
+      data, mesh, Limiters::Weno_detail::DerivativeWeight::Unity);
 
   // Expected result computed in Mathematica:
   // g[x_, y_] := x^2 + y^3 - (5/2) x y + x^2 y
+  // w[i_] := 1
   // Integrate[
-  //  Sum[Evaluate[D[g[x, y], {x, i}, {y, j}]^2], {i, 1, 3}, {j, 1, 4}]
-  //   + Sum[Evaluate[D[g[x, y], {x, i}]^2], {i, 1, 3}]
-  //   + Sum[Evaluate[D[g[x, y], {y, j}]^2], {j, 1, 4}],
+  //  Sum[w[i] w[j] Evaluate[D[g[x, y], {x, i}, {y, j}]^2],
+  //      {i, 1, 3}, {j, 1, 4}]
+  //   + Sum[w[i] w[0] Evaluate[D[g[x, y], {x, i}]^2], {i, 1, 3}]
+  //   + Sum[w[0] w[j] Evaluate[D[g[x, y], {y, j}]^2], {j, 1, 4}],
   //  {x, -1, 1}, {y, -1, 1}]
   const double expected = 2647. / 9.;
   CHECK(indicator == approx(expected));
+
+  // w[i_] := 2^(2 i - 1)
+  const auto indicator2 = Limiters::Weno_detail::oscillation_indicator(
+      data, mesh, Limiters::Weno_detail::DerivativeWeight::PowTwoEll);
+  const double expected2 = 26938. / 9.;
+  CHECK(indicator2 == approx(expected2));
+
+  // w[i_] := 2^(2 i - 1) / (i!)^2
+  const auto indicator3 = Limiters::Weno_detail::oscillation_indicator(
+      data, mesh,
+      Limiters::Weno_detail::DerivativeWeight::PowTwoEllOverEllFactorial);
+  const double expected3 = 3178. / 9.;
+  CHECK(indicator3 == approx(expected3));
 }
 
 void test_oscillation_indicator_3d() noexcept {
+  INFO("Test oscillation_indicator in 3D");
   const Mesh<3> mesh({{4, 3, 5}}, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
@@ -63,29 +112,48 @@ void test_oscillation_indicator_3d() noexcept {
 
   const auto data = DataVector{square(x) + 2. * y + z - 6. * cube(z) -
                                3. * x * square(y) * cube(z) - x * y + y * z};
-  const auto indicator =
-      Limiters::Weno_detail::oscillation_indicator(data, mesh);
+  const auto indicator = Limiters::Weno_detail::oscillation_indicator(
+      data, mesh, Limiters::Weno_detail::DerivativeWeight::Unity);
 
   // Expected result computed in Mathematica:
   // h[x_, y_, z_] := x^2 + 2 y + z - 6 z^3 - 3 x y^2 z^3 - x y + y z
+  // w[i_] := 1
   // Integrate[
-  //  Sum[Evaluate[D[h[x, y, z], {x, i}, {y, j}, {z, k}]^2],
+  //  Sum[w[i] w[j] w[k] Evaluate[D[h[x, y, z], {x, i}, {y, j}, {z, k}]^2],
   //      {i, 1, 3}, {j, 1, 2}, {k, 1, 4}]
-  //   + Sum[Evaluate[ D[h[x, y, z], {x, i}, {y, j}]^2], {i, 1, 3}, {j, 1, 2}]
-  //   + Sum[Evaluate[ D[h[x, y, z], {x, i}, {z, k}]^2], {i, 1, 3}, {k, 1, 4}]
-  //   + Sum[Evaluate[ D[h[x, y, z], {y, j}, {z, k}]^2], {j, 1, 2}, {k, 1, 4}]
-  //   + Sum[Evaluate[ D[h[x, y, z], {x, i}]^2], {i, 1, 3}]
-  //   + Sum[Evaluate[ D[h[x, y, z], {y, j}]^2], {j, 1, 2}]
-  //   + Sum[Evaluate[ D[h[x, y, z], {z, k}]^2], {k, 1, 4}],
+  //   + Sum[w[i] w[j] w[0] Evaluate[ D[h[x, y, z], {x, i}, {y, j}]^2],
+  //         {i, 1, 3}, {j, 1, 2}]
+  //   + Sum[w[i] w[0] w[k] Evaluate[ D[h[x, y, z], {x, i}, {z, k}]^2],
+  //         {i, 1, 3}, {k, 1, 4}]
+  //   + Sum[w[0] w[j] w[k] Evaluate[ D[h[x, y, z], {y, j}, {z, k}]^2],
+  //         {j, 1, 2}, {k, 1, 4}]
+  //   + Sum[w[i] w[0] w[0] Evaluate[ D[h[x, y, z], {x, i}]^2], {i, 1, 3}]
+  //   + Sum[w[0] w[j] w[0] Evaluate[ D[h[x, y, z], {y, j}]^2], {j, 1, 2}]
+  //   + Sum[w[0] w[0] w[k] Evaluate[ D[h[x, y, z], {z, k}]^2], {k, 1, 4}],
   //  {x, -1, 1}, {y, -1, 1}, {z, -1, 1}]
   const double expected = 3066352. / 75.;
   CHECK(indicator == approx(expected));
+
+  // w[i_] := 2^(2 i - 1)
+  const auto indicator2 = Limiters::Weno_detail::oscillation_indicator(
+      data, mesh, Limiters::Weno_detail::DerivativeWeight::PowTwoEll);
+  const double expected2 = 3611348444. / 525.;
+  CHECK(indicator2 == approx(expected2));
+
+  // w[i_] := 2^(2 i - 1) / (i!)^2
+  const auto indicator3 = Limiters::Weno_detail::oscillation_indicator(
+      data, mesh,
+      Limiters::Weno_detail::DerivativeWeight::PowTwoEllOverEllFactorial);
+  const double expected3 = 54886604. / 525.;
+  CHECK(indicator3 == approx(expected3));
 }
 
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.Weno.OscillationIndicator",
                   "[Limiters][Unit]") {
+  test_derivative_weight();
+
   test_oscillation_indicator_1d();
   test_oscillation_indicator_2d();
   test_oscillation_indicator_3d();

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoOscillationIndicator.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoOscillationIndicator.cpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace {
+
+void test_oscillation_indicator_1d() noexcept {
+  const Mesh<1> mesh(5, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const auto logical_coords = logical_coordinates(mesh);
+  const DataVector& x = get<0>(logical_coords);
+
+  const auto data = DataVector{1. + x - pow<4>(x)};
+  const auto indicator =
+      Limiters::Weno_detail::oscillation_indicator(data, mesh);
+
+  // Expected result computed in Mathematica:
+  // f[x_] := 1 + x - x^4
+  // Integrate[Sum[Evaluate[D[f[x], {x, i}]^2], {i, 1, 4}], {x, -1, 1}]
+  const double expected = 56006. / 35.;
+  CHECK(indicator == approx(expected));
+}
+
+void test_oscillation_indicator_2d() noexcept {
+  const Mesh<2> mesh({{4, 5}}, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const auto logical_coords = logical_coordinates(mesh);
+  const DataVector& x = get<0>(logical_coords);
+  const DataVector& y = get<1>(logical_coords);
+
+  const auto data =
+      DataVector{square(x) + cube(y) - 2.5 * x * y + square(x) * y};
+  const auto indicator =
+      Limiters::Weno_detail::oscillation_indicator(data, mesh);
+
+  // Expected result computed in Mathematica:
+  // g[x_, y_] := x^2 + y^3 - (5/2) x y + x^2 y
+  // Integrate[
+  //  Sum[Evaluate[D[g[x, y], {x, i}, {y, j}]^2], {i, 1, 3}, {j, 1, 4}]
+  //   + Sum[Evaluate[D[g[x, y], {x, i}]^2], {i, 1, 3}]
+  //   + Sum[Evaluate[D[g[x, y], {y, j}]^2], {j, 1, 4}],
+  //  {x, -1, 1}, {y, -1, 1}]
+  const double expected = 2647. / 9.;
+  CHECK(indicator == approx(expected));
+}
+
+void test_oscillation_indicator_3d() noexcept {
+  const Mesh<3> mesh({{4, 3, 5}}, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const auto logical_coords = logical_coordinates(mesh);
+  const DataVector& x = get<0>(logical_coords);
+  const DataVector& y = get<1>(logical_coords);
+  const DataVector& z = get<2>(logical_coords);
+
+  const auto data = DataVector{square(x) + 2. * y + z - 6. * cube(z) -
+                               3. * x * square(y) * cube(z) - x * y + y * z};
+  const auto indicator =
+      Limiters::Weno_detail::oscillation_indicator(data, mesh);
+
+  // Expected result computed in Mathematica:
+  // h[x_, y_, z_] := x^2 + 2 y + z - 6 z^3 - 3 x y^2 z^3 - x y + y z
+  // Integrate[
+  //  Sum[Evaluate[D[h[x, y, z], {x, i}, {y, j}, {z, k}]^2],
+  //      {i, 1, 3}, {j, 1, 2}, {k, 1, 4}]
+  //   + Sum[Evaluate[ D[h[x, y, z], {x, i}, {y, j}]^2], {i, 1, 3}, {j, 1, 2}]
+  //   + Sum[Evaluate[ D[h[x, y, z], {x, i}, {z, k}]^2], {i, 1, 3}, {k, 1, 4}]
+  //   + Sum[Evaluate[ D[h[x, y, z], {y, j}, {z, k}]^2], {j, 1, 2}, {k, 1, 4}]
+  //   + Sum[Evaluate[ D[h[x, y, z], {x, i}]^2], {i, 1, 3}]
+  //   + Sum[Evaluate[ D[h[x, y, z], {y, j}]^2], {j, 1, 2}]
+  //   + Sum[Evaluate[ D[h[x, y, z], {z, k}]^2], {k, 1, 4}],
+  //  {x, -1, 1}, {y, -1, 1}, {z, -1, 1}]
+  const double expected = 3066352. / 75.;
+  CHECK(indicator == approx(expected));
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.Weno.OscillationIndicator",
+                  "[Limiters][Unit]") {
+  test_oscillation_indicator_1d();
+  test_oscillation_indicator_2d();
+  test_oscillation_indicator_3d();
+}


### PR DESCRIPTION
## Proposed changes

Not a full generalization — but allows for a family of related oscillation indicators obtained by giving different weights to different derivatives of the data.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).