### PR TITLE
Automatically dereference unique_ptrs in the DataBox

### DIFF
--- a/src/ApparentHorizons/FastFlow.cpp
+++ b/src/ApparentHorizons/FastFlow.cpp
@@ -63,8 +63,8 @@ namespace {
 template <typename Frame>
 DataVector fast_flow_weight(
     const Scalar<DataVector>& one_form_magnitude,
-    const db::item_type<StrahlkorperTags::Rhat<Frame>>& r_hat,
-    const db::item_type<StrahlkorperTags::Radius<Frame>>& radius,
+    const db::const_item_type<StrahlkorperTags::Rhat<Frame>>& r_hat,
+    const db::const_item_type<StrahlkorperTags::Radius<Frame>>& radius,
     const tnsr::II<DataVector, 3, Frame>& inverse_surface_metric) noexcept {
   // Form Euclidean surface metric
   auto flat_metric =

--- a/src/ApparentHorizons/Tags.cpp
+++ b/src/ApparentHorizons/Tags.cpp
@@ -26,7 +26,7 @@ aliases::ThetaPhi<Frame> ThetaPhi<Frame>::function(
 
 template <typename Frame>
 aliases::OneForm<Frame> Rhat<Frame>::function(
-    const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
+    const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
   const auto& theta = get<0>(theta_phi);
   const auto& phi = get<1>(theta_phi);
 
@@ -41,7 +41,7 @@ aliases::OneForm<Frame> Rhat<Frame>::function(
 
 template <typename Frame>
 aliases::Jacobian<Frame> Jacobian<Frame>::function(
-    const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
+    const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
   const auto& theta = get<0>(theta_phi);
   const auto& phi = get<1>(theta_phi);
   const DataVector sin_phi = sin(phi);
@@ -60,7 +60,7 @@ aliases::Jacobian<Frame> Jacobian<Frame>::function(
 
 template <typename Frame>
 aliases::InvJacobian<Frame> InvJacobian<Frame>::function(
-    const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
+    const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
   const auto& theta = get<0>(theta_phi);
   const auto& phi = get<1>(theta_phi);
   const DataVector sin_phi = sin(phi);
@@ -79,7 +79,7 @@ aliases::InvJacobian<Frame> InvJacobian<Frame>::function(
 
 template <typename Frame>
 aliases::InvHessian<Frame> InvHessian<Frame>::function(
-    const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
+    const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
   const auto& theta = get<0>(theta_phi);
   const auto& phi = get<1>(theta_phi);
   const DataVector sin_phi = sin(phi);
@@ -135,7 +135,7 @@ aliases::InvHessian<Frame> InvHessian<Frame>::function(
 template <typename Frame>
 aliases::Vector<Frame> CartesianCoords<Frame>::function(
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-    const db::item_type<Rhat<Frame>>& r_hat) noexcept {
+    const db::const_item_type<Rhat<Frame>>& r_hat) noexcept {
   auto coords = make_with_value<aliases::Vector<Frame>>(radius, 0.0);
   for (size_t d = 0; d < 3; ++d) {
     coords.get(d) = gsl::at(strahlkorper.center(), d) + r_hat.get(d) * radius;
@@ -146,7 +146,7 @@ aliases::Vector<Frame> CartesianCoords<Frame>::function(
 template <typename Frame>
 aliases::OneForm<Frame> DxRadius<Frame>::function(
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-    const db::item_type<InvJacobian<Frame>>& inv_jac) noexcept {
+    const db::const_item_type<InvJacobian<Frame>>& inv_jac) noexcept {
   auto dx_radius = make_with_value<aliases::OneForm<Frame>>(radius, 0.0);
   const DataVector one_over_r = 1.0 / radius;
   const auto dr = strahlkorper.ylm_spherepack().gradient(radius);
@@ -163,8 +163,8 @@ aliases::OneForm<Frame> DxRadius<Frame>::function(
 template <typename Frame>
 aliases::SecondDeriv<Frame> D2xRadius<Frame>::function(
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-    const db::item_type<InvJacobian<Frame>>& inv_jac,
-    const db::item_type<InvHessian<Frame>>& inv_hess) noexcept {
+    const db::const_item_type<InvJacobian<Frame>>& inv_jac,
+    const db::const_item_type<InvHessian<Frame>>& inv_hess) noexcept {
   auto d2x_radius = make_with_value<aliases::SecondDeriv<Frame>>(radius, 0.0);
   const DataVector one_over_r_squared = 1.0 / square(radius);
   const auto derivs =
@@ -201,7 +201,7 @@ aliases::SecondDeriv<Frame> D2xRadius<Frame>::function(
 template <typename Frame>
 DataVector LaplacianRadius<Frame>::function(
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-    const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
+    const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
   const auto derivs =
       strahlkorper.ylm_spherepack().first_and_second_derivative(radius);
   return get<0, 0>(derivs.second) + get<1, 1>(derivs.second) +
@@ -210,8 +210,8 @@ DataVector LaplacianRadius<Frame>::function(
 
 template <typename Frame>
 aliases::OneForm<Frame> NormalOneForm<Frame>::function(
-    const db::item_type<DxRadius<Frame>>& dx_radius,
-    const db::item_type<Rhat<Frame>>& r_hat) noexcept {
+    const db::const_item_type<DxRadius<Frame>>& dx_radius,
+    const db::const_item_type<Rhat<Frame>>& r_hat) noexcept {
   auto one_form = make_with_value<aliases::OneForm<Frame>>(r_hat, 0.0);
   for (size_t d = 0; d < 3; ++d) {
     one_form.get(d) = r_hat.get(d) - dx_radius.get(d);
@@ -222,8 +222,8 @@ aliases::OneForm<Frame> NormalOneForm<Frame>::function(
 template <typename Frame>
 aliases::Jacobian<Frame> Tangents<Frame>::function(
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-    const db::item_type<Rhat<Frame>>& r_hat,
-    const db::item_type<Jacobian<Frame>>& jac) noexcept {
+    const db::const_item_type<Rhat<Frame>>& r_hat,
+    const db::const_item_type<Jacobian<Frame>>& jac) noexcept {
   const auto dr = strahlkorper.ylm_spherepack().gradient(radius);
   auto tangents = make_with_value<aliases::Jacobian<Frame>>(radius, 0.0);
   for (size_t i = 0; i < 2; ++i) {

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -57,7 +57,7 @@ template <typename Frame>
 struct Rhat : db::ComputeTag {
   static std::string name() noexcept { return "Rhat"; }
   static aliases::OneForm<Frame> function(
-      const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
+      const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
 
@@ -70,7 +70,7 @@ template <typename Frame>
 struct Jacobian : db::ComputeTag {
   static std::string name() noexcept { return "Jacobian"; }
   static aliases::Jacobian<Frame> function(
-      const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
+      const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
 
@@ -82,7 +82,7 @@ template <typename Frame>
 struct InvJacobian : db::ComputeTag {
   static std::string name() noexcept { return "InvJacobian"; }
   static aliases::InvJacobian<Frame> function(
-      const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
+      const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
 
@@ -94,7 +94,7 @@ template <typename Frame>
 struct InvHessian : db::ComputeTag {
   static std::string name() noexcept { return "InvHessian"; }
   static aliases::InvHessian<Frame> function(
-      const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
+      const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
 
@@ -119,7 +119,7 @@ struct CartesianCoords : db::ComputeTag {
   static std::string name() noexcept { return "CartesianCoords"; }
   static aliases::Vector<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-      const db::item_type<Rhat<Frame>>& r_hat) noexcept;
+      const db::const_item_type<Rhat<Frame>>& r_hat) noexcept;
   using argument_tags =
       tmpl::list<Strahlkorper<Frame>, Radius<Frame>, Rhat<Frame>>;
 };
@@ -135,7 +135,7 @@ struct DxRadius : db::ComputeTag {
   static std::string name() noexcept { return "DxRadius"; }
   static aliases::OneForm<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-      const db::item_type<InvJacobian<Frame>>& inv_jac) noexcept;
+      const db::const_item_type<InvJacobian<Frame>>& inv_jac) noexcept;
   using argument_tags =
       tmpl::list<Strahlkorper<Frame>, Radius<Frame>, InvJacobian<Frame>>;
 };
@@ -152,8 +152,8 @@ struct D2xRadius : db::ComputeTag {
   static std::string name() noexcept { return "D2xRadius"; }
   static aliases::SecondDeriv<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-      const db::item_type<InvJacobian<Frame>>& inv_jac,
-      const db::item_type<InvHessian<Frame>>& inv_hess) noexcept;
+      const db::const_item_type<InvJacobian<Frame>>& inv_jac,
+      const db::const_item_type<InvHessian<Frame>>& inv_hess) noexcept;
   using argument_tags = tmpl::list<Strahlkorper<Frame>, Radius<Frame>,
                                    InvJacobian<Frame>, InvHessian<Frame>>;
 };
@@ -166,7 +166,7 @@ struct LaplacianRadius : db::ComputeTag {
   static std::string name() noexcept { return "LaplacianRadius"; }
   static DataVector function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-      const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
+      const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
   using argument_tags =
       tmpl::list<Strahlkorper<Frame>, Radius<Frame>, ThetaPhi<Frame>>;
 };
@@ -184,8 +184,8 @@ template <typename Frame>
 struct NormalOneForm : db::ComputeTag {
   static std::string name() noexcept { return "NormalOneForm"; }
   static aliases::OneForm<Frame> function(
-      const db::item_type<DxRadius<Frame>>& dx_radius,
-      const db::item_type<Rhat<Frame>>& r_hat) noexcept;
+      const db::const_item_type<DxRadius<Frame>>& dx_radius,
+      const db::const_item_type<Rhat<Frame>>& r_hat) noexcept;
   using argument_tags = tmpl::list<DxRadius<Frame>, Rhat<Frame>>;
 };
 
@@ -209,8 +209,8 @@ struct Tangents : db::ComputeTag {
   static std::string name() noexcept { return "Tangents"; }
   static aliases::Jacobian<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-      const db::item_type<Rhat<Frame>>& r_hat,
-      const db::item_type<Jacobian<Frame>>& jac) noexcept;
+      const db::const_item_type<Rhat<Frame>>& r_hat,
+      const db::const_item_type<Jacobian<Frame>>& jac) noexcept;
   using argument_tags = tmpl::list<Strahlkorper<Frame>, Radius<Frame>,
                                    Rhat<Frame>, Jacobian<Frame>>;
 };

--- a/src/DataStructures/DataBox/DataBoxHelpers.hpp
+++ b/src/DataStructures/DataBox/DataBoxHelpers.hpp
@@ -73,9 +73,10 @@ using is_a_tensor = tt::is_a<Tensor, T>;
 template <typename TagsList>
 auto get_tensor_from_box(const db::DataBox<TagsList>& box,
                          const std::string& tag_name) {
-  using tags =
-      tmpl::filter<TagsList, tmpl::bind<DataBoxHelpers_detail::is_a_tensor,
-                                        tmpl::bind<db::item_type, tmpl::_1>>>;
+  using tags = tmpl::filter<TagsList,
+                            tmpl::bind<DataBoxHelpers_detail::is_a_tensor,
+                                       tmpl::bind<db::const_item_type, tmpl::_1,
+                                                  tmpl::pin<TagsList>>>>;
   return DataBoxHelpers_detail::get_tensor_from_box<tags>(box, tag_name);
 }
 

--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -31,7 +31,7 @@ struct dt : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
     return "dt(" + db::tag_name<Tag>() + ")";
   }
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
   using tag = Tag;
 };
 
@@ -41,7 +41,7 @@ struct dt : db::PrefixTag, db::SimpleTag {
 /// \snippet Test_DataBoxPrefixes.cpp analytic_name
 template <typename Tag>
 struct Analytic : db::PrefixTag, db::SimpleTag {
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
   using tag = Tag;
 };
 
@@ -56,10 +56,10 @@ struct Flux;
 /// \cond
 template <typename Tag, typename VolumeDim, typename Fr>
 struct Flux<Tag, VolumeDim, Fr,
-            Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>> : db::PrefixTag,
-                                                                db::SimpleTag {
+            Requires<tt::is_a_v<Tensor, db::const_item_type<Tag>>>>
+    : db::PrefixTag, db::SimpleTag {
   using type = TensorMetafunctions::prepend_spatial_index<
-      db::item_type<Tag>, VolumeDim::value, UpLo::Up, Fr>;
+      db::const_item_type<Tag>, VolumeDim::value, UpLo::Up, Fr>;
   using tag = Tag;
   static std::string name() noexcept {
     return "Flux(" + db::tag_name<Tag>() + ")";
@@ -68,9 +68,9 @@ struct Flux<Tag, VolumeDim, Fr,
 
 template <typename Tag, typename VolumeDim, typename Fr>
 struct Flux<Tag, VolumeDim, Fr,
-            Requires<tt::is_a_v<::Variables, db::item_type<Tag>>>>
+            Requires<tt::is_a_v<::Variables, db::const_item_type<Tag>>>>
     : db::PrefixTag, db::SimpleTag {
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
   using tag = Tag;
   static std::string name() noexcept {
     return "Flux(" + db::tag_name<Tag>() + ")";
@@ -84,7 +84,7 @@ struct Flux<Tag, VolumeDim, Fr,
 /// \snippet Test_DataBoxPrefixes.cpp source_name
 template <typename Tag>
 struct Source : db::PrefixTag, db::SimpleTag {
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
   using tag = Tag;
   static std::string name() noexcept {
     return "Source(" + db::tag_name<Tag>() + ")";
@@ -96,7 +96,7 @@ struct Source : db::PrefixTag, db::SimpleTag {
 /// variables
 template <typename Tag>
 struct FixedSource : db::PrefixTag, db::SimpleTag {
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
   using tag = Tag;
 };
 
@@ -106,7 +106,7 @@ struct FixedSource : db::PrefixTag, db::SimpleTag {
 /// \snippet Test_DataBoxPrefixes.cpp initial_name
 template <typename Tag>
 struct Initial : db::PrefixTag, db::SimpleTag {
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
   using tag = Tag;
   static std::string name() noexcept {
     return "Initial(" + db::tag_name<Tag>() + ")";
@@ -120,7 +120,7 @@ struct Initial : db::PrefixTag, db::SimpleTag {
 /// \snippet Test_DataBoxPrefixes.cpp normal_dot_flux_name
 template <typename Tag>
 struct NormalDotFlux : db::PrefixTag, db::SimpleTag {
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
   using tag = Tag;
   static std::string name() noexcept {
     return "NormalDotFlux(" + db::tag_name<Tag>() + ")";
@@ -134,7 +134,7 @@ struct NormalDotFlux : db::PrefixTag, db::SimpleTag {
 /// \snippet Test_DataBoxPrefixes.cpp normal_dot_numerical_flux_name
 template <typename Tag>
 struct NormalDotNumericalFlux : db::PrefixTag, db::SimpleTag {
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
   using tag = Tag;
   static std::string name() noexcept {
     return "NormalDotNumericalFlux(" + db::tag_name<Tag>() + ")";
@@ -148,7 +148,7 @@ struct NormalDotNumericalFlux : db::PrefixTag, db::SimpleTag {
 /// \snippet Test_DataBoxPrefixes.cpp next_name
 template <typename Tag>
 struct Next : db::PrefixTag, db::SimpleTag {
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
   using tag = Tag;
   static std::string name() noexcept {
     return "Next(" + db::tag_name<Tag>() + ")";

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -76,8 +76,8 @@ struct Magnitude : db::PrefixTag, db::SimpleTag {
 template <typename Tag>
 struct EuclideanMagnitude : Magnitude<Tag>, db::ComputeTag {
   using base = Magnitude<Tag>;
-  static constexpr Scalar<DataVector> (*function)(const db::item_type<Tag>&) =
-      magnitude;
+  static constexpr Scalar<DataVector> (*function)(
+      const db::const_item_type<Tag>&) = magnitude;
   using argument_tags = tmpl::list<Tag>;
 };
 
@@ -90,7 +90,8 @@ template <typename Tag, typename MetricTag>
 struct NonEuclideanMagnitude : Magnitude<Tag>, db::ComputeTag {
   using base = Magnitude<Tag>;
   static constexpr Scalar<DataVector> (*function)(
-      const db::item_type<Tag>&, const db::item_type<MetricTag>&) = magnitude;
+      const db::const_item_type<Tag>&,
+      const db::const_item_type<MetricTag>&) = magnitude;
   using argument_tags = tmpl::list<Tag, MetricTag>;
 };
 
@@ -105,7 +106,7 @@ struct Normalized : db::PrefixTag, db::SimpleTag {
     return "Normalized(" + Tag::name() + ")";
   }
   using tag = Tag;
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -117,9 +118,9 @@ template <typename Tag>
 struct NormalizedCompute : Normalized<Tag>, db::ComputeTag {
   using base = Normalized<Tag>;
   static constexpr auto function(
-      const db::item_type<Tag>&
+      const db::const_item_type<Tag>&
           vector_in,  // Compute items need to take const references
-      const db::item_type<Magnitude<Tag>>& magnitude) noexcept {
+      const db::const_item_type<Magnitude<Tag>>& magnitude) noexcept {
     auto vector = vector_in;
     for (size_t d = 0; d < vector.index_dim(0); ++d) {
       vector.get(d) /= get(magnitude);
@@ -137,8 +138,8 @@ struct NormalizedCompute : Normalized<Tag>, db::ComputeTag {
 template <typename Tag>
 struct Sqrt : db::ComputeTag {
   static std::string name() noexcept { return "Sqrt(" + Tag::name() + ")"; }
-  static constexpr Scalar<DataVector> (*function)(const db::item_type<Tag>&) =
-      sqrt_magnitude;
+  static constexpr Scalar<DataVector> (*function)(
+      const db::const_item_type<Tag>&) = sqrt_magnitude;
   using argument_tags = tmpl::list<Tag>;
 };
 }  // namespace Tags

--- a/src/DataStructures/Tensor/EagerMath/Norms.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Norms.hpp
@@ -113,8 +113,8 @@ struct PointwiseL2Norm : db::SimpleTag {
 template <typename Tag>
 struct PointwiseL2NormCompute : PointwiseL2Norm<Tag>, db::ComputeTag {
   using base = PointwiseL2Norm<Tag>;
-  static constexpr db::item_type<PointwiseL2Norm<Tag>> (*function)(
-      const db::item_type<Tag>&) = pointwise_l2_norm;
+  static constexpr db::const_item_type<PointwiseL2Norm<Tag>> (*function)(
+      const db::const_item_type<Tag>&) = pointwise_l2_norm;
   using argument_tags = tmpl::list<Tag>;
 };
 
@@ -144,8 +144,8 @@ struct L2Norm : db::SimpleTag {
 template <typename Tag>
 struct L2NormCompute : L2Norm<Tag>, db::ComputeTag {
   using base = L2Norm<Tag>;
-  static constexpr db::item_type<L2Norm<Tag>> (*function)(
-      const db::item_type<Tag>&) = l2_norm;
+  static constexpr db::const_item_type<L2Norm<Tag>> (*function)(
+      const db::const_item_type<Tag>&) = l2_norm;
   using argument_tags = tmpl::list<Tag>;
 };
 }  // namespace Tags

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -877,13 +877,14 @@ struct MakeWithValueImpl<Variables<TagListOut>, Variables<TagListIn>> {
 
 namespace db {
 template <typename TagList, typename Tag>
-struct Subitems<TagList, Tag,
-                Requires<tt::is_a_v<Variables, item_type<Tag, TagList>>>> {
-  using type = typename item_type<Tag>::tags_list;
+struct Subitems<
+    TagList, Tag,
+    Requires<tt::is_a_v<Variables, const_item_type<Tag, TagList>>>> {
+  using type = typename const_item_type<Tag>::tags_list;
 
-  template <typename Subtag>
+  template <typename Subtag, typename LocalTag = Tag>
   static void create_item(
-      const gsl::not_null<item_type<Tag>*> parent_value,
+      const gsl::not_null<item_type<LocalTag>*> parent_value,
       const gsl::not_null<item_type<Subtag>*> sub_value) noexcept {
     auto& vars = get<Subtag>(*parent_value);
     // Only update the Tensor if the Variables has changed its allocation
@@ -896,8 +897,8 @@ struct Subitems<TagList, Tag,
   }
 
   template <typename Subtag>
-  static const item_type<Subtag>& create_compute_item(
-      const item_type<Tag>& parent_value) noexcept {
+  static const const_item_type<Subtag>& create_compute_item(
+      const const_item_type<Tag>& parent_value) noexcept {
     return get<Subtag>(parent_value);
   }
 };

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -104,8 +104,10 @@ struct InterfaceCompute<Tags::BoundaryDirectionsExterior<VolumeDim>,
   }
 
   static auto function(
-      const db::item_type<Tags::Interface<dirs, Mesh<VolumeDim - 1>>>& meshes,
-      const db::item_type<Tags::ElementMap<VolumeDim, Frame>>& map) noexcept {
+      const db::const_item_type<Tags::Interface<dirs, Mesh<VolumeDim - 1>>>&
+          meshes,
+      const db::const_item_type<Tags::ElementMap<VolumeDim, Frame>>&
+          map) noexcept {
     std::unordered_map<::Direction<VolumeDim>,
                        tnsr::i<DataVector, VolumeDim, Frame>>
         normals{};

--- a/src/Domain/InterfaceHelpers.hpp
+++ b/src/Domain/InterfaceHelpers.hpp
@@ -82,7 +82,7 @@ SPECTRE_ALWAYS_INLINE constexpr auto interface_apply_impl(
     const db::DataBox<DbTagsList>& box, tmpl::list<ArgumentTags...> /*meta*/,
     ExtraArgs&&... extra_args) noexcept {
   using interface_return_type = std::decay_t<decltype(interface_invokable(
-      std::declval<db::item_type<ArgumentTags, DbTagsList>>()...,
+      std::declval<db::const_item_type<ArgumentTags, DbTagsList>>()...,
       std::declval<ExtraArgs&&>()...))>;
   constexpr size_t volume_dim = DirectionsTag::volume_dim;
   DirectionMap<volume_dim, interface_return_type> result{};

--- a/src/Elliptic/DiscontinuousGalerkin/ImposeBoundaryConditions.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/ImposeBoundaryConditions.hpp
@@ -106,7 +106,7 @@ struct ImposeHomogeneousDirichletBoundaryConditions {
                ::Tags::BoundaryDirectionsExterior<system::volume_dim>,
                typename system::variables_tag>>*>
                exterior_boundary_vars,
-           const db::item_type<::Tags::Interface<
+           const db::const_item_type<::Tags::Interface<
                ::Tags::BoundaryDirectionsInterior<system::volume_dim>,
                typename system::variables_tag>>& interior_vars) noexcept {
           for (auto& exterior_direction_and_vars : *exterior_boundary_vars) {

--- a/src/Elliptic/DiscontinuousGalerkin/ImposeInhomogeneousBoundaryConditionsOnSource.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/ImposeInhomogeneousBoundaryConditionsOnSource.hpp
@@ -107,17 +107,17 @@ struct ImposeInhomogeneousBoundaryConditionsOnSource {
           &analytic_solution, &normal_dot_numerical_flux_computer
         ](const gsl::not_null<db::item_type<fixed_sources_tag>*> fixed_sources,
           const Mesh<volume_dim>& mesh,
-          const db::item_type<::Tags::BoundaryDirectionsInterior<volume_dim>>&
-              boundary_directions,
-          const db::item_type<::Tags::Interface<
+          const db::const_item_type<::Tags::BoundaryDirectionsInterior<
+              volume_dim>>& boundary_directions,
+          const db::const_item_type<::Tags::Interface<
               ::Tags::BoundaryDirectionsExterior<volume_dim>,
               ::Tags::Coordinates<volume_dim, Frame::Inertial>>>&
               boundary_coordinates,
-          const db::item_type<::Tags::Interface<
+          const db::const_item_type<::Tags::Interface<
               ::Tags::BoundaryDirectionsInterior<volume_dim>,
               ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<volume_dim>>>>&
               normalized_face_normals,
-          const db::item_type<::Tags::Interface<
+          const db::const_item_type<::Tags::Interface<
               ::Tags::BoundaryDirectionsInterior<volume_dim>,
               ::Tags::Magnitude<::Tags::UnnormalizedFaceNormal<volume_dim>>>>&
               magnitude_of_face_normals) noexcept {

--- a/src/Elliptic/FirstOrderComputeTags.hpp
+++ b/src/Elliptic/FirstOrderComputeTags.hpp
@@ -41,8 +41,9 @@ struct FirstOrderFluxesCompute<
   using argument_tags = tmpl::list<VarsTag, fluxes_computer_tag, FluxesArgs...>;
   using volume_tags = tmpl::list<fluxes_computer_tag>;
   static constexpr auto function(
-      const db::item_type<VarsTag>& vars, const FluxesComputer& fluxes_computer,
-      const db::item_type<FluxesArgs>&... fluxes_args) noexcept {
+      const db::const_item_type<VarsTag>& vars,
+      const FluxesComputer& fluxes_computer,
+      const db::const_item_type<FluxesArgs>&... fluxes_args) noexcept {
     auto fluxes = make_with_value<db::item_type<base>>(vars, 0.);
     // Compute fluxes for primal fields
     fluxes_computer.apply(
@@ -76,8 +77,8 @@ struct FirstOrderSourcesCompute<
   using base = db::add_tag_prefix<::Tags::Source, VarsTag>;
   using argument_tags = tmpl::list<VarsTag, SourcesArgs...>;
   static constexpr auto function(
-      const db::item_type<VarsTag>& vars,
-      const db::item_type<SourcesArgs>&... sources_args) noexcept {
+      const db::const_item_type<VarsTag>& vars,
+      const db::const_item_type<SourcesArgs>&... sources_args) noexcept {
     auto sources = make_with_value<db::item_type<base>>(vars, 0.);
     // Compute sources for primal fields
     SourcesComputer::apply(

--- a/src/Elliptic/FirstOrderOperator.hpp
+++ b/src/Elliptic/FirstOrderOperator.hpp
@@ -65,8 +65,8 @@ struct FirstOrderOperator {
   using argument_tags = tmpl::list<div_fluxes_tag, sources_tag>;
   static void apply(const gsl::not_null<db::item_type<operator_tag>*>
                         operator_applied_to_vars,
-                    const db::item_type<div_fluxes_tag>& div_fluxes,
-                    const db::item_type<sources_tag>& sources) noexcept {
+                    const db::const_item_type<div_fluxes_tag>& div_fluxes,
+                    const db::const_item_type<sources_tag>& sources) noexcept {
     *operator_applied_to_vars = sources - div_fluxes;
   }
 };

--- a/src/Evolution/ComputeTags.hpp
+++ b/src/Evolution/ComputeTags.hpp
@@ -27,11 +27,12 @@ struct AnalyticCompute
   using argument_tags =
       tmpl::list<AnalyticSolutionTag, ::Tags::Coordinates<Dim, Frame::Inertial>,
                  ::Tags::Time>;
-  static db::item_type<base> function(
-      const db::item_type<AnalyticSolutionTag>& analytic_solution_computer,
+  static db::const_item_type<base> function(
+      const db::const_item_type<AnalyticSolutionTag>&
+          analytic_solution_computer,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
       const double& time) noexcept {
-    return db::item_type<base>(
+    return db::const_item_type<base>(
         variables_from_tagged_tuple(analytic_solution_computer.variables(
             inertial_coords, time, AnalyticFieldsTagList{})));
   }

--- a/src/Evolution/Conservative/ConservativeDuDt.hpp
+++ b/src/Evolution/Conservative/ConservativeDuDt.hpp
@@ -32,8 +32,8 @@ struct ConservativeDuDt {
   struct apply_helper<tmpl::list<TensorTags...>, tmpl::list<SourcedTags...>> {
     static void function(
         const gsl::not_null<db::item_type<TensorTags>*>... dt_u,
-        const db::item_type<TensorTags>&... div_flux,
-        const db::item_type<SourcedTags>&... sources) noexcept {
+        const db::const_item_type<TensorTags>&... div_flux,
+        const db::const_item_type<SourcedTags>&... sources) noexcept {
       const auto negate = [](const auto a, const auto& b) noexcept {
         for (size_t i = 0; i < a->size(); ++i) {
           (*a)[i] = -b[i];

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoModifiedSolution.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoModifiedSolution.hpp
@@ -524,8 +524,8 @@ using LimiterNeighborData = std::unordered_map<
 template <typename Tag, size_t VolumeDim, typename Package>
 void hweno_modified_neighbor_solution(
     const gsl::not_null<db::item_type<Tag>*> modified_tensor,
-    const db::item_type<Tag>& local_tensor, const Element<VolumeDim>& element,
-    const Mesh<VolumeDim>& mesh,
+    const db::const_item_type<Tag>& local_tensor,
+    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
     const LimiterNeighborData<VolumeDim, Package>& neighbor_data,
     const std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>&
         primary_neighbor) noexcept {

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
@@ -503,7 +503,7 @@ class Krivodonova<VolumeDim, tmpl::list<Tags...>> {
 
   /// \brief Package data for sending to neighbor elements.
   void package_data(gsl::not_null<PackagedData*> packaged_data,
-                    const db::item_type<Tags>&... tensors,
+                    const db::const_item_type<Tags>&... tensors,
                     const Mesh<VolumeDim>& mesh,
                     const OrientationMap<VolumeDim>& orientation_map) const
       noexcept;
@@ -550,7 +550,7 @@ class Krivodonova<VolumeDim, tmpl::list<Tags...>> {
   char fill_variables_tag_with_spectral_coeffs(
       gsl::not_null<Variables<tmpl::list<::Tags::Modal<Tags>...>>*>
           modal_coeffs,
-      const db::item_type<Tag>& nodal_tensor, const Mesh<Dim>& mesh) const
+      const db::const_item_type<Tag>& nodal_tensor, const Mesh<Dim>& mesh) const
       noexcept;
 
   std::array<double,
@@ -581,7 +581,7 @@ Krivodonova<VolumeDim, tmpl::list<Tags...>>::Krivodonova(
 template <size_t VolumeDim, typename... Tags>
 void Krivodonova<VolumeDim, tmpl::list<Tags...>>::package_data(
     const gsl::not_null<PackagedData*> packaged_data,
-    const db::item_type<Tags>&... tensors, const Mesh<VolumeDim>& mesh,
+    const db::const_item_type<Tags>&... tensors, const Mesh<VolumeDim>& mesh,
     const OrientationMap<VolumeDim>& orientation_map) const noexcept {
   if (UNLIKELY(disable_for_debugging_)) {
     // Do not initialize packaged_data
@@ -964,8 +964,8 @@ char Krivodonova<VolumeDim, tmpl::list<Tags...>>::
     fill_variables_tag_with_spectral_coeffs(
         const gsl::not_null<Variables<tmpl::list<::Tags::Modal<Tags>...>>*>
             modal_coeffs,
-        const db::item_type<Tag>& nodal_tensor, const Mesh<Dim>& mesh) const
-    noexcept {
+        const db::const_item_type<Tag>& nodal_tensor,
+        const Mesh<Dim>& mesh) const noexcept {
   auto& coeffs_tensor = get<::Tags::Modal<Tag>>(*modal_coeffs);
   auto tensor_it = nodal_tensor.begin();
   for (auto coeffs_it = coeffs_tensor.begin(); coeffs_it != coeffs_tensor.end();

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp
@@ -28,7 +28,7 @@ template <typename Metavariables>
 struct LimiterCommunicationTag {
   static constexpr size_t volume_dim = Metavariables::system::volume_dim;
   using packaged_data_t = typename Metavariables::limiter::type::PackagedData;
-  using temporal_id = db::item_type<typename Metavariables::temporal_id>;
+  using temporal_id = db::const_item_type<typename Metavariables::temporal_id>;
   using type =
       std::map<temporal_id,
                std::unordered_map<

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
@@ -221,7 +221,7 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
   ///        each dimension of logical coordinates.
   /// \param orientation_map The orientation of the neighbor
   void package_data(gsl::not_null<PackagedData*> packaged_data,
-                    const db::item_type<Tags>&... tensors,
+                    const db::const_item_type<Tags>&... tensors,
                     const Mesh<VolumeDim>& mesh,
                     const std::array<double, VolumeDim>& element_size,
                     const OrientationMap<VolumeDim>& orientation_map) const

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
@@ -123,7 +123,7 @@ void Minmod<VolumeDim, tmpl::list<Tags...>>::pup(PUP::er& p) noexcept {
 template <size_t VolumeDim, typename... Tags>
 void Minmod<VolumeDim, tmpl::list<Tags...>>::package_data(
     const gsl::not_null<PackagedData*> packaged_data,
-    const db::item_type<Tags>&... tensors, const Mesh<VolumeDim>& mesh,
+    const db::const_item_type<Tags>&... tensors, const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
     const OrientationMap<VolumeDim>& orientation_map) const noexcept {
   if (UNLIKELY(disable_for_debugging_)) {

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
@@ -72,7 +72,7 @@ bool troubled_cell_indicator(
 // - a variable `element_size` that is a `std::array<double, VolumeDim>`
 template <size_t VolumeDim, typename PackagedData, typename... Tags>
 bool troubled_cell_indicator(
-    const db::item_type<Tags>&... tensors,
+    const db::const_item_type<Tags>&... tensors,
     const std::unordered_map<
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -162,7 +162,7 @@ class Weno<VolumeDim, tmpl::list<Tags...>> {
 
   /// \brief Package data for sending to neighbor elements
   void package_data(gsl::not_null<PackagedData*> packaged_data,
-                    const db::item_type<Tags>&... tensors,
+                    const db::const_item_type<Tags>&... tensors,
                     const Mesh<VolumeDim>& mesh,
                     const std::array<double, VolumeDim>& element_size,
                     const OrientationMap<VolumeDim>& orientation_map) const
@@ -213,7 +213,7 @@ void Weno<VolumeDim, tmpl::list<Tags...>>::pup(PUP::er& p) noexcept {
 template <size_t VolumeDim, typename... Tags>
 void Weno<VolumeDim, tmpl::list<Tags...>>::package_data(
     const gsl::not_null<PackagedData*> packaged_data,
-    const db::item_type<Tags>&... tensors, const Mesh<VolumeDim>& mesh,
+    const db::const_item_type<Tags>&... tensors, const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
     const OrientationMap<VolumeDim>& orientation_map) const noexcept {
   if (UNLIKELY(disable_for_debugging_)) {

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
@@ -24,13 +24,13 @@ class Variables;
 namespace GeneralizedHarmonic {
 namespace GeneralizedHarmonic_detail {
 template <typename FieldTag>
-db::item_type<FieldTag> weight_char_field(
-    const db::item_type<FieldTag>& char_field_int,
+db::const_item_type<FieldTag> weight_char_field(
+    const db::const_item_type<FieldTag>& char_field_int,
     const DataVector& char_speed_int,
-    const db::item_type<FieldTag>& char_field_ext,
+    const db::const_item_type<FieldTag>& char_field_ext,
     const DataVector& char_speed_ext) noexcept {
   const DataVector& char_speed_avg{0.5 * (char_speed_int + char_speed_ext)};
-  db::item_type<FieldTag> weighted_char_field = char_field_int;
+  db::const_item_type<FieldTag> weighted_char_field = char_field_int;
   auto weighted_char_field_it = weighted_char_field.begin();
   for (auto int_it = char_field_int.begin(), ext_it = char_field_ext.begin();
        int_it != char_field_int.end();
@@ -49,15 +49,15 @@ db::item_type<FieldTag> weight_char_field(
 // (if the char speed is outgoing) or the product of the exterior char field
 // and its char speed (if the char speed is incoming).
 template <size_t Dim>
-db::item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>
+db::const_item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>
 weight_char_fields(
-    const db::item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>&
+    const db::const_item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>&
         char_fields_int,
-    const db::item_type<Tags::CharacteristicSpeeds<Dim, Frame::Inertial>>&
+    const db::const_item_type<Tags::CharacteristicSpeeds<Dim, Frame::Inertial>>&
         char_speeds_int,
-    const db::item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>&
+    const db::const_item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>&
         char_fields_ext,
-    const db::item_type<Tags::CharacteristicSpeeds<Dim, Frame::Inertial>>&
+    const db::const_item_type<Tags::CharacteristicSpeeds<Dim, Frame::Inertial>>&
         char_speeds_ext) noexcept {
   const auto& u_psi_int =
       get<Tags::UPsi<Dim, Frame::Inertial>>(char_fields_int);
@@ -88,7 +88,7 @@ weight_char_fields(
   const DataVector& char_speed_u_minus_ext{char_speeds_ext[3]};
 
   auto weighted_char_fields = make_with_value<
-      db::item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>>(
+      db::const_item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>>(
       char_speed_u_psi_int, 0.0);
 
   get<Tags::UPsi<Dim, Frame::Inertial>>(weighted_char_fields) =

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -323,7 +323,8 @@ template <size_t SpatialDim, typename Frame>
 void damped_harmonic_h(
     const gsl::not_null<db::item_type<Tags::GaugeH<SpatialDim, Frame>>*>
         gauge_h,
-    const db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>& gauge_h_init,
+    const db::const_item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+        gauge_h_init,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, SpatialDim, Frame>& shift,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
@@ -419,9 +420,10 @@ void spacetime_deriv_damped_harmonic_h(
     const gsl::not_null<
         db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>*>
         d4_gauge_h,
-    const db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>& gauge_h_init,
-    const db::item_type<Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>&
-        dgauge_h_init,
+    const db::const_item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+        gauge_h_init,
+    const db::const_item_type<
+        Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>& dgauge_h_init,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, SpatialDim, Frame>& shift,
     const tnsr::a<DataVector, SpatialDim, Frame>&

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -99,7 +99,8 @@ namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame>
 void damped_harmonic_h(
     gsl::not_null<db::item_type<Tags::GaugeH<SpatialDim, Frame>>*> gauge_h,
-    const db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>& gauge_h_init,
+    const db::const_item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+        gauge_h_init,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, SpatialDim, Frame>& shift,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
@@ -133,8 +134,10 @@ struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
       ::Tags::Coordinates<SpatialDim, Frame>,
       Tags::GaugeHSpatialWeightDecayWidth<Frame>>;
 
-  static constexpr db::item_type<Tags::GaugeH<SpatialDim, Frame>> function(
-      const db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>& gauge_h_init,
+  static constexpr db::const_item_type<Tags::GaugeH<SpatialDim, Frame>>
+  function(
+      const db::const_item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+          gauge_h_init,
       const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, SpatialDim, Frame>& shift,
       const Scalar<DataVector>& sqrt_det_spatial_metric,
@@ -230,9 +233,10 @@ template <size_t SpatialDim, typename Frame>
 void spacetime_deriv_damped_harmonic_h(
     gsl::not_null<db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>*>
         d4_gauge_h,
-    const db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>& gauge_h_init,
-    const db::item_type<Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>&
-        dgauge_h_init,
+    const db::const_item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+        gauge_h_init,
+    const db::const_item_type<
+        Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>& dgauge_h_init,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, SpatialDim, Frame>& shift,
     const tnsr::a<DataVector, SpatialDim, Frame>&

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Fluxes.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Fluxes.hpp
@@ -79,11 +79,11 @@ struct ComputeFluxes {
       const gsl::not_null<db::item_type<
           ::Tags::Flux<Tags::TildeS<Frame::Inertial, NeutrinoSpecies>,
                        tmpl::size_t<3>, Frame::Inertial>>*>... tilde_s_flux,
-      const db::item_type<
+      const db::const_item_type<
           Tags::TildeE<Frame::Inertial, NeutrinoSpecies>>&... tilde_e,
-      const db::item_type<
+      const db::const_item_type<
           Tags::TildeS<Frame::Inertial, NeutrinoSpecies>>&... tilde_s,
-      const db::item_type<
+      const db::const_item_type<
           Tags::TildeP<Frame::Inertial, NeutrinoSpecies>>&... tilde_p,
       const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, 3, Frame::Inertial>& shift,

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/M1Closure.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/M1Closure.hpp
@@ -140,17 +140,17 @@ struct ComputeM1Closure<tmpl::list<NeutrinoSpecies...>> {
           db::item_type<Tags::TildeHNormal<NeutrinoSpecies>>*>... tilde_hn,
       const gsl::not_null<db::item_type<
           Tags::TildeHSpatial<Frame::Inertial, NeutrinoSpecies>>*>... tilde_hi,
-      const db::item_type<
+      const db::const_item_type<
           Tags::TildeE<Frame::Inertial, NeutrinoSpecies>>&... tilde_e,
-      const db::item_type<
+      const db::const_item_type<
           Tags::TildeS<Frame::Inertial, NeutrinoSpecies>>&... tilde_s,
-      const db::item_type<
+      const db::const_item_type<
           hydro::Tags::SpatialVelocity<DataVector, 3, Frame::Inertial>>&
           spatial_velocity,
-      const db::item_type<hydro::Tags::LorentzFactor<DataVector>>&
+      const db::const_item_type<hydro::Tags::LorentzFactor<DataVector>>&
           lorentz_factor,
-      const db::item_type<gr::Tags::SpatialMetric<3>>& spatial_metric,
-      const db::item_type<gr::Tags::InverseSpatialMetric<3>>&
+      const db::const_item_type<gr::Tags::SpatialMetric<3>>& spatial_metric,
+      const db::const_item_type<gr::Tags::InverseSpatialMetric<3>>&
           inv_spatial_metric) noexcept {
     EXPAND_PACK_LEFT_TO_RIGHT(detail::compute_closure_impl(
         closure_factor, tilde_p, tilde_j, tilde_hn, tilde_hi, tilde_e, tilde_s,

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Sources.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Sources.hpp
@@ -95,11 +95,11 @@ struct ComputeSources {
           Tags::TildeE<Frame::Inertial, NeutrinoSpecies>>*>... sources_tilde_e,
       const gsl::not_null<db::item_type<
           Tags::TildeS<Frame::Inertial, NeutrinoSpecies>>*>... sources_tilde_s,
-      const db::item_type<
+      const db::const_item_type<
           Tags::TildeE<Frame::Inertial, NeutrinoSpecies>>&... tilde_e,
-      const db::item_type<
+      const db::const_item_type<
           Tags::TildeS<Frame::Inertial, NeutrinoSpecies>>&... tilde_s,
-      const db::item_type<
+      const db::const_item_type<
           Tags::TildeP<Frame::Inertial, NeutrinoSpecies>>&... tilde_p,
       const Scalar<DataVector>& lapse,
       const tnsr::i<DataVector, 3, Frame::Inertial>& d_lapse,

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp
@@ -80,12 +80,12 @@ struct ApplyBoundaryFluxesLocalTimeStepping {
         [&cache](
             const gsl::not_null<db::item_type<variables_tag>*> vars,
             const gsl::not_null<db::item_type<mortar_data_tag>*> mortar_data,
-            const db::item_type<Tags::Mesh<volume_dim>>& mesh,
-            const db::item_type<Tags::Mortars<Tags::Mesh<volume_dim - 1>,
-                                              volume_dim>>& mortar_meshes,
-            const db::item_type<Tags::Mortars<Tags::MortarSize<volume_dim - 1>,
-                                              volume_dim>>& mortar_sizes,
-            const db::item_type<Tags::TimeStep>& time_step) noexcept {
+            const db::const_item_type<Tags::Mesh<volume_dim>>& mesh,
+            const db::const_item_type<Tags::Mortars<Tags::Mesh<volume_dim - 1>,
+                                                    volume_dim>>& mortar_meshes,
+            const db::const_item_type<Tags::Mortars<
+                Tags::MortarSize<volume_dim - 1>, volume_dim>>& mortar_sizes,
+            const db::const_item_type<Tags::TimeStep>& time_step) noexcept {
           // Having the lambda just wrap another lambda works around a
           // gcc 6.4.0 segfault.
           [

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp
@@ -88,10 +88,10 @@ struct ApplyFluxes {
         [&cache](
             const gsl::not_null<db::item_type<dt_variables_tag>*> dt_vars,
             const gsl::not_null<db::item_type<mortar_data_tag>*> mortar_data,
-            const db::item_type<Tags::Mesh<volume_dim>>& mesh,
-            const db::item_type<Tags::Mortars<Tags::Mesh<volume_dim - 1>,
-                                              volume_dim>>& mortar_meshes,
-            const db::item_type<
+            const db::const_item_type<Tags::Mesh<volume_dim>>& mesh,
+            const db::const_item_type<Tags::Mortars<Tags::Mesh<volume_dim - 1>,
+                                                    volume_dim>>& mortar_meshes,
+            const db::const_item_type<
                 Tags::Mortars<Tags::MortarSize<volume_dim - 1>, volume_dim>>&
                 mortar_sizes) noexcept {
           const auto& normal_dot_numerical_flux_computer =

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp
@@ -79,7 +79,7 @@ struct ComputeNonconservativeBoundaryFluxes {
                          DirectionsTag>>(
         [](const gsl::not_null<db::item_type<interface_normal_dot_fluxes_tag>*>
                boundary_fluxes,
-           const db::item_type<DirectionsTag>& internal_directions,
+           const db::const_item_type<DirectionsTag>& internal_directions,
            const auto&... tensors) noexcept {
           for (const auto& direction : internal_directions) {
             // Prepending the type name works around an issue with gcc-6

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
@@ -84,7 +84,7 @@ struct ReceiveDataForFluxes {
                        mortar_data,
                    const gsl::not_null<db::item_type<neighbor_temporal_id_tag>*>
                        neighbor_next_temporal_ids,
-                   const db::item_type<Tags::Next<temporal_id_tag>>&
+                   const db::const_item_type<Tags::Next<temporal_id_tag>>&
                        local_next_temporal_id) noexcept {
           auto& inbox =
               tuples::get<typename flux_comm_types::FluxesTag>(inboxes);

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
@@ -50,7 +50,7 @@ struct FluxCommunicationTypes {
   /// The type of the local data stored on the mortar.  Contains the
   /// packaged data and the local flux.
   using LocalMortarData = Variables<tmpl::remove_duplicates<tmpl::append<
-      typename db::item_type<normal_dot_fluxes_tag>::tags_list,
+      typename db::const_item_type<normal_dot_fluxes_tag>::tags_list,
       typename PackagedData::tags_list>>>;
 
   /// The type of the data needed for the local part of the flux
@@ -79,21 +79,23 @@ struct FluxCommunicationTypes {
   using simple_mortar_data_tag =
       BasedMortars<Tags::VariablesBoundaryData,
                    Tags::SimpleBoundaryData<
-                       db::item_type<typename Metavariables::temporal_id>,
+                       db::const_item_type<typename Metavariables::temporal_id>,
                        LocalData, PackagedData>,
                    volume_dim>;
 
   /// The DataBox tag for the data stored on the mortars for local
   /// stepping.
-  using local_time_stepping_mortar_data_tag = BasedMortars<
-      Tags::VariablesBoundaryData,
-      Tags::BoundaryHistory<LocalData, PackagedData,
-                            db::item_type<typename system::variables_tag>>,
-      volume_dim>;
+  using local_time_stepping_mortar_data_tag =
+      BasedMortars<Tags::VariablesBoundaryData,
+                   Tags::BoundaryHistory<
+                       LocalData, PackagedData,
+                       db::const_item_type<typename system::variables_tag>>,
+                   volume_dim>;
 
   /// The inbox tag for flux communication.
   struct FluxesTag {
-    using temporal_id = db::item_type<typename Metavariables::temporal_id>;
+    using temporal_id =
+        db::const_item_type<typename Metavariables::temporal_id>;
     using type = std::map<
         temporal_id,
         FixedHashMap<maximum_number_of_neighbors(volume_dim),

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
@@ -151,14 +151,15 @@ auto compute_boundary_flux_contribution(
     const Mesh<Dim>& face_mesh, const Mesh<Dim>& mortar_mesh,
     const size_t extent_perpendicular_to_boundary,
     const std::array<Spectral::MortarSize, Dim>& mortar_size) noexcept
-    -> db::item_type<
+    -> db::const_item_type<
         db::remove_tag_prefix<typename FluxCommTypes::normal_dot_fluxes_tag>> {
   static_assert(cpp17::is_same_v<std::decay_t<LocalData>,
                                  typename FluxCommTypes::LocalData>,
                 "Second argument must be a FluxCommTypes::LocalData");
   using variables_tag =
       db::remove_tag_prefix<typename FluxCommTypes::normal_dot_fluxes_tag>;
-  db::item_type<db::add_tag_prefix<Tags::NormalDotNumericalFlux, variables_tag>>
+  db::const_item_type<db::add_tag_prefix<Tags::NormalDotNumericalFlux,
+                                         variables_tag>>
       normal_dot_numerical_fluxes(mortar_mesh.number_of_grid_points(), 0.0);
   MortarHelpers_detail::apply_normal_dot_numerical_flux(
       make_not_null(&normal_dot_numerical_fluxes),

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp
@@ -64,9 +64,9 @@ struct NormalDotFluxCompute : db::add_tag_prefix<NormalDotFlux, Tag>,
       Tags::Normalized<Tags::UnnormalizedFaceNormal<VolumeDim, Fr>>;
 
  public:
-  static auto function(const db::item_type<flux_tag>& flux,
-                       const db::item_type<normal_tag>& normal) noexcept {
-    using tags_list = typename db::item_type<Tag>::tags_list;
+  static auto function(const db::const_item_type<flux_tag>& flux,
+                       const db::const_item_type<normal_tag>& normal) noexcept {
+    using tags_list = typename db::const_item_type<Tag>::tags_list;
     auto result = make_with_value<
         ::Variables<db::wrap_tags_in<NormalDotFlux, tags_list>>>(flux, 0.);
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Hll.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Hll.hpp
@@ -104,9 +104,10 @@ struct Hll {
                              tmpl::list<NormalDotFluxTags...>> {
     static void function(
         const gsl::not_null<Variables<package_tags>*> packaged_data,
-        const db::item_type<NormalDotFluxTags>&... n_dot_f_to_package,
-        const db::item_type<VariablesTags>&... u_to_package,
-        const db::item_type<char_speeds_tag>& characteristic_speeds) noexcept {
+        const db::const_item_type<NormalDotFluxTags>&... n_dot_f_to_package,
+        const db::const_item_type<VariablesTags>&... u_to_package,
+        const db::const_item_type<char_speeds_tag>&
+            characteristic_speeds) noexcept {
       expand_pack((get<VariablesTags>(*packaged_data) = u_to_package)...);
       expand_pack(
           (get<NormalDotFluxTags>(*packaged_data) = n_dot_f_to_package)...);
@@ -149,21 +150,23 @@ struct Hll {
     static void function(
         const gsl::not_null<
             db::item_type<NormalDotNumericalFluxTags>*>... n_dot_numerical_f,
-        const db::item_type<NormalDotFluxTags>&... n_dot_f_interior,
-        const db::item_type<VariablesTags>&... u_interior,
-        const db::item_type<MinSignalSpeed>& min_signal_speed_interior,
-        const db::item_type<MaxSignalSpeed>& max_signal_speed_interior,
-        const db::item_type<NormalDotFluxTags>&... minus_n_dot_f_exterior,
-        const db::item_type<VariablesTags>&... u_exterior,
-        const db::item_type<MinSignalSpeed>& min_signal_speed_exterior,
-        const db::item_type<MaxSignalSpeed>&
+        const db::const_item_type<NormalDotFluxTags>&... n_dot_f_interior,
+        const db::const_item_type<VariablesTags>&... u_interior,
+        const db::const_item_type<MinSignalSpeed>& min_signal_speed_interior,
+        const db::const_item_type<MaxSignalSpeed>& max_signal_speed_interior,
+        const db::const_item_type<NormalDotFluxTags>&... minus_n_dot_f_exterior,
+        const db::const_item_type<VariablesTags>&... u_exterior,
+        const db::const_item_type<MinSignalSpeed>& min_signal_speed_exterior,
+        const db::const_item_type<MaxSignalSpeed>&
             max_signal_speed_exterior) noexcept {
-      auto min_signal_speed = make_with_value<db::item_type<MinSignalSpeed>>(
-          min_signal_speed_interior,
-          std::numeric_limits<double>::signaling_NaN());
-      auto max_signal_speed = make_with_value<db::item_type<MaxSignalSpeed>>(
-          max_signal_speed_interior,
-          std::numeric_limits<double>::signaling_NaN());
+      auto min_signal_speed =
+          make_with_value<db::const_item_type<MinSignalSpeed>>(
+              min_signal_speed_interior,
+              std::numeric_limits<double>::signaling_NaN());
+      auto max_signal_speed =
+          make_with_value<db::const_item_type<MaxSignalSpeed>>(
+              max_signal_speed_interior,
+              std::numeric_limits<double>::signaling_NaN());
       for (size_t s = 0; s < min_signal_speed.begin()->size(); ++s) {
         get(min_signal_speed)[s] = std::min(get(min_signal_speed_interior)[s],
                                             -get(max_signal_speed_exterior)[s]);

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp
@@ -73,9 +73,10 @@ struct LocalLaxFriedrichs {
                              tmpl::list<NormalDotFluxTags...>> {
     static void apply(
         const gsl::not_null<Variables<package_tags>*> packaged_data,
-        const db::item_type<NormalDotFluxTags>&... n_dot_f_to_package,
-        const db::item_type<VariablesTags>&... u_to_package,
-        const db::item_type<char_speeds_tag>& characteristic_speeds) noexcept {
+        const db::const_item_type<NormalDotFluxTags>&... n_dot_f_to_package,
+        const db::const_item_type<VariablesTags>&... u_to_package,
+        const db::const_item_type<char_speeds_tag>&
+            characteristic_speeds) noexcept {
       ASSERT(packaged_data->number_of_grid_points() ==
              characteristic_speeds[0].size(),
              "Size of packaged data (" << packaged_data->number_of_grid_points()
@@ -109,12 +110,13 @@ struct LocalLaxFriedrichs {
     static void apply(
         const gsl::not_null<
             db::item_type<NormalDotNumericalFluxTags>*>... n_dot_numerical_f,
-        const db::item_type<NormalDotFluxTags>&... n_dot_f_interior,
-        const db::item_type<VariablesTags>&... u_interior,
-        const db::item_type<MaxAbsCharSpeed>& max_abs_speed_interior,
-        const db::item_type<NormalDotFluxTags>&... minus_n_dot_f_exterior,
-        const db::item_type<VariablesTags>&... u_exterior,
-        const db::item_type<MaxAbsCharSpeed>& max_abs_speed_exterior) noexcept {
+        const db::const_item_type<NormalDotFluxTags>&... n_dot_f_interior,
+        const db::const_item_type<VariablesTags>&... u_interior,
+        const db::const_item_type<MaxAbsCharSpeed>& max_abs_speed_interior,
+        const db::const_item_type<NormalDotFluxTags>&... minus_n_dot_f_exterior,
+        const db::const_item_type<VariablesTags>&... u_exterior,
+        const db::const_item_type<MaxAbsCharSpeed>&
+            max_abs_speed_exterior) noexcept {
       const Scalar<DataVector> max_abs_speed(DataVector(
           max(get(max_abs_speed_interior), get(max_abs_speed_exterior))));
       const auto assemble_numerical_flux = [&max_abs_speed](

--- a/src/NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp
@@ -47,12 +47,11 @@ struct AddTemporalIdsToInterpolationTarget {
 
     db::mutate_apply<tmpl::list<Tags::TemporalIds<Metavariables>>,
                      tmpl::list<Tags::CompletedTemporalIds<Metavariables>>>(
-        [&temporal_ids](
-            const gsl::not_null<
-                db::item_type<Tags::TemporalIds<Metavariables>>*>
-                ids,
-            const db::item_type<Tags::CompletedTemporalIds<Metavariables>>&
-                completed_ids) noexcept {
+        [&temporal_ids](const gsl::not_null<
+                            db::item_type<Tags::TemporalIds<Metavariables>>*>
+                            ids,
+                        const db::const_item_type<Tags::CompletedTemporalIds<
+                            Metavariables>>& completed_ids) noexcept {
           // We allow this Action to be called multiple times with the
           // same temporal_ids (e.g. from each node of a NodeGroup
           // ParallelComponent such as Interpolator). If multiple calls

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
@@ -199,11 +199,12 @@ struct FindApparentHorizon {
     db::mutate_apply<tmpl::list<::Tags::Variables<vars_tags>>,
                      tmpl::list<StrahlkorperTags::Strahlkorper<Frame::Inertial>,
                                 ::ah::Tags::FastFlow>>(
-        [](const gsl::not_null<db::item_type<::Tags::Variables<vars_tags>>*>
-               vars,
-           const db::item_type<StrahlkorperTags::Strahlkorper<Frame::Inertial>>&
-               strahlkorper,
-           const db::item_type<::ah::Tags::FastFlow>& fast_flow) noexcept {
+        [
+        ](const gsl::not_null<db::item_type<::Tags::Variables<vars_tags>>*>
+              vars,
+          const db::const_item_type<
+              StrahlkorperTags::Strahlkorper<Frame::Inertial>>& strahlkorper,
+          const db::const_item_type<::ah::Tags::FastFlow>& fast_flow) noexcept {
           const size_t L_mesh = fast_flow.current_l_mesh(strahlkorper);
           const auto prolonged_strahlkorper =
               Strahlkorper<Frame::Inertial>(L_mesh, L_mesh, strahlkorper);

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
@@ -52,7 +52,7 @@ struct reduction_data_type<tmpl::list<Ts...>> {
   // the list of things being observed.
   using type = Parallel::ReductionData<
       Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
-      Parallel::ReductionDatum<typename db::item_type<Ts>,
+      Parallel::ReductionDatum<db::const_item_type<Ts>,
                                funcl::AssertEqual<>>...>;
 };
 

--- a/src/NumericalAlgorithms/Interpolation/Interpolate.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Interpolate.hpp
@@ -75,7 +75,7 @@ class Interpolate<VolumeDim, tmpl::list<Tensors...>, EventRegistrars>
 
   template <typename Metavariables, typename ParallelComponent>
   void operator()(const TimeStepId& time_id, const Mesh<VolumeDim>& mesh,
-                  const db::item_type<Tensors>&... tensors,
+                  const db::const_item_type<Tensors>&... tensors,
                   Parallel::ConstGlobalCache<Metavariables>& cache,
                   const ElementIndex<VolumeDim>& array_index,
                   const ParallelComponent* const /*meta*/) const noexcept {

--- a/src/NumericalAlgorithms/Interpolation/TryToInterpolate.hpp
+++ b/src/NumericalAlgorithms/Interpolation/TryToInterpolate.hpp
@@ -43,7 +43,7 @@ void interpolate_data(
           const gsl::not_null<
               db::item_type<Tags::InterpolatedVarsHolders<Metavariables>>*>
               holders,
-          const db::item_type<Tags::VolumeVarsInfo<Metavariables>>&
+          const db::const_item_type<Tags::VolumeVarsInfo<Metavariables>>&
               volume_vars_info) noexcept {
         auto& interp_info =
             get<Vars::HolderTag<InterpolationTargetTag, Metavariables>>(

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -41,19 +41,20 @@ struct div;
 
 /// \cond
 template <typename Tag>
-struct div<Tag, Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
+struct div<Tag, Requires<tt::is_a_v<Tensor, db::const_item_type<Tag>>>>
     : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept { return "div(" + Tag::name() + ")"; }
   using tag = Tag;
-  using type = TensorMetafunctions::remove_first_index<db::item_type<Tag>>;
+  using type =
+      TensorMetafunctions::remove_first_index<db::const_item_type<Tag>>;
 };
 
 template <typename Tag>
-struct div<Tag, Requires<tt::is_a_v<::Variables, db::item_type<Tag>>>>
+struct div<Tag, Requires<tt::is_a_v<::Variables, db::const_item_type<Tag>>>>
     : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept { return "div(" + Tag::name() + ")"; }
   using tag = Tag;
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
 };
 /// \endcond
 }  // namespace Tags
@@ -80,7 +81,7 @@ template <typename Tag, typename InverseJacobianTag>
 struct DivCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
  private:
   using inv_jac_indices =
-      typename db::item_type<InverseJacobianTag>::index_list;
+      typename db::const_item_type<InverseJacobianTag>::index_list;
   static constexpr auto dim = tmpl::back<inv_jac_indices>::dim;
   static_assert(cpp17::is_same_v<typename tmpl::front<inv_jac_indices>::Frame,
                                  Frame::Logical>,
@@ -88,7 +89,7 @@ struct DivCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
 
  public:
   static constexpr auto function =
-      divergence<typename db::item_type<Tag>::tags_list, dim,
+      divergence<typename db::const_item_type<Tag>::tags_list, dim,
                  typename tmpl::back<inv_jac_indices>::Frame>;
   using argument_tags = tmpl::list<Tag, Tags::Mesh<dim>, InverseJacobianTag>;
 };

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
@@ -29,7 +29,7 @@ Variables<db::wrap_tags_in<Tags::div, FluxTags>> divergence(
     using DivFluxTag = Tags::div<FluxTag>;
 
     using first_index =
-        tmpl::front<typename db::item_type<FluxTag>::index_list>;
+        tmpl::front<typename db::const_item_type<FluxTag>::index_list>;
     static_assert(
         cpp17::is_same_v<typename first_index::Frame, DerivativeFrame> and
             first_index::ul == UpLo::Up,

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp
@@ -48,8 +48,8 @@ struct PrepareStep {
         make_not_null(&box),
         [](const gsl::not_null<db::item_type<LinearSolver::Tags::IterationId>*>
                iteration_id,
-           const db::item_type<::Tags::Next<LinearSolver::Tags::IterationId>>&
-               next_iteration_id) noexcept {
+           const db::const_item_type<::Tags::Next<
+               LinearSolver::Tags::IterationId>>& next_iteration_id) noexcept {
           *iteration_id = next_iteration_id;
         },
         get<::Tags::Next<LinearSolver::Tags::IterationId>>(box));
@@ -132,8 +132,8 @@ struct UpdateFieldValues {
         make_not_null(&box),
         [alpha](const gsl::not_null<db::item_type<residual_tag>*> r,
                 const gsl::not_null<db::item_type<fields_tag>*> x,
-                const db::item_type<operand_tag>& p,
-                const db::item_type<operator_tag>& Ap) noexcept {
+                const db::const_item_type<operand_tag>& p,
+                const db::const_item_type<operator_tag>& Ap) noexcept {
           *x += alpha * p;
           *r -= alpha * Ap;
         },
@@ -174,7 +174,7 @@ struct UpdateOperand {
   static auto apply(db::DataBox<DbTagsList>& box,
                     Parallel::ConstGlobalCache<Metavariables>& cache,
                     const ArrayIndex& array_index, const double res_ratio,
-                    const db::item_type<LinearSolver::Tags::HasConverged>&
+                    const db::const_item_type<LinearSolver::Tags::HasConverged>&
                         has_converged) noexcept {
     db::mutate<operand_tag, LinearSolver::Tags::HasConverged>(
         make_not_null(&box),
@@ -183,7 +183,7 @@ struct UpdateOperand {
         ](const gsl::not_null<db::item_type<operand_tag>*> p,
           const gsl::not_null<db::item_type<LinearSolver::Tags::HasConverged>*>
               local_has_converged,
-          const db::item_type<residual_tag>& r) noexcept {
+          const db::const_item_type<residual_tag>& r) noexcept {
           *p = r + res_ratio * *p;
           *local_has_converged = has_converged;
         },

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
@@ -60,8 +60,8 @@ struct InitializeElement {
     db::mutate<operand_tag>(
         make_not_null(&box),
         [](const gsl::not_null<db::item_type<operand_tag>*> operand,
-           const db::item_type<source_tag>& source,
-           const db::item_type<operator_applied_to_fields_tag>&
+           const db::const_item_type<source_tag>& source,
+           const db::const_item_type<operator_applied_to_fields_tag>&
                operator_applied_to_fields) noexcept {
           *operand = source - operator_applied_to_fields;
         },
@@ -109,7 +109,7 @@ struct InitializeHasConverged {
   static void apply(db::DataBox<DbTagsList>& box,
                     Parallel::ConstGlobalCache<Metavariables>& cache,
                     const ArrayIndex& array_index,
-                    const db::item_type<LinearSolver::Tags::HasConverged>&
+                    const db::const_item_type<LinearSolver::Tags::HasConverged>&
                         has_converged) noexcept {
     db::mutate<LinearSolver::Tags::HasConverged>(
         make_not_null(&box), [&has_converged](

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/ElementActions.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/ElementActions.hpp
@@ -57,8 +57,8 @@ struct PrepareStep {
            const gsl::not_null<
                db::item_type<orthogonalization_iteration_id_tag>*>
                orthogonalization_iteration_id,
-           const db::item_type<::Tags::Next<LinearSolver::Tags::IterationId>>&
-               next_iteration_id) noexcept {
+           const db::const_item_type<::Tags::Next<
+               LinearSolver::Tags::IterationId>>& next_iteration_id) noexcept {
           *iteration_id = next_iteration_id;
           *orthogonalization_iteration_id = 0;
         },
@@ -97,7 +97,7 @@ struct PerformStep {
     db::mutate<operand_tag>(
         make_not_null(&box),
         [](const gsl::not_null<db::item_type<operand_tag>*> operand,
-           const db::item_type<operator_tag>& operator_action) noexcept {
+           const db::const_item_type<operator_tag>& operator_action) noexcept {
           *operand = db::item_type<operand_tag>(operator_action);
         },
         get<operator_tag>(box));
@@ -151,7 +151,8 @@ struct OrthogonalizeOperand {
             const gsl::not_null<
                 db::item_type<orthogonalization_iteration_id_tag>*>
                 orthogonalization_iteration_id,
-            const db::item_type<basis_history_tag>& basis_history) noexcept {
+            const db::const_item_type<basis_history_tag>&
+                basis_history) noexcept {
           *operand -= orthogonalization *
                       gsl::at(basis_history, *orthogonalization_iteration_id);
           (*orthogonalization_iteration_id)++;
@@ -212,7 +213,7 @@ struct NormalizeOperandAndUpdateField {
                     Parallel::ConstGlobalCache<Metavariables>& cache,
                     const ArrayIndex& array_index, const double normalization,
                     const DenseVector<double>& minres,
-                    const db::item_type<LinearSolver::Tags::HasConverged>&
+                    const db::const_item_type<LinearSolver::Tags::HasConverged>&
                         has_converged) noexcept {
     db::mutate<operand_tag, basis_history_tag, fields_tag,
                LinearSolver::Tags::HasConverged>(
@@ -224,7 +225,8 @@ struct NormalizeOperandAndUpdateField {
           const gsl::not_null<db::item_type<fields_tag>*> field,
           const gsl::not_null<db::item_type<LinearSolver::Tags::HasConverged>*>
               local_has_converged,
-          const db::item_type<initial_fields_tag>& initial_field) noexcept {
+          const db::const_item_type<initial_fields_tag>&
+              initial_field) noexcept {
           *operand /= normalization;
           basis_history->push_back(*operand);
           *field = initial_field;

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/InitializeElement.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/InitializeElement.hpp
@@ -63,8 +63,8 @@ struct InitializeElement {
     db::mutate<operand_tag>(
         make_not_null(&box),
         [](const gsl::not_null<db::item_type<operand_tag>*> operand,
-           const db::item_type<source_tag>& source,
-           const db::item_type<operator_applied_to_fields_tag>&
+           const db::const_item_type<source_tag>& source,
+           const db::const_item_type<operator_applied_to_fields_tag>&
                operator_applied_to_fields) noexcept {
           *operand = source - operator_applied_to_fields;
         },
@@ -127,7 +127,7 @@ struct NormalizeInitialOperand {
                     Parallel::ConstGlobalCache<Metavariables>& cache,
                     const ArrayIndex& array_index,
                     const double residual_magnitude,
-                    const db::item_type<LinearSolver::Tags::HasConverged>&
+                    const db::const_item_type<LinearSolver::Tags::HasConverged>&
                         has_converged) noexcept {
     db::mutate<operand_tag, basis_history_tag,
                LinearSolver::Tags::HasConverged>(

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
@@ -140,7 +140,7 @@ struct StoreOrthogonalization {
             const gsl::not_null<
                 db::item_type<orthogonalization_iteration_id_tag>*>
                 orthogonalization_iteration_id,
-            const db::item_type<LinearSolver::Tags::IterationId>&
+            const db::const_item_type<LinearSolver::Tags::IterationId>&
                 iteration_id) noexcept {
           (*orthogonalization_history)(*orthogonalization_iteration_id,
                                        iteration_id) = orthogonalization;
@@ -185,8 +185,9 @@ struct StoreFinalOrthogonalization {
         [orthogonalization](
             const gsl::not_null<db::item_type<orthogonalization_history_tag>*>
                 orthogonalization_history,
-            const db::item_type<LinearSolver::Tags::IterationId>& iteration_id,
-            const db::item_type<orthogonalization_iteration_id_tag>&
+            const db::const_item_type<LinearSolver::Tags::IterationId>&
+                iteration_id,
+            const db::const_item_type<orthogonalization_iteration_id_tag>&
                 orthogonalization_iteration_id) noexcept {
           (*orthogonalization_history)(orthogonalization_iteration_id,
                                        iteration_id) = sqrt(orthogonalization);

--- a/src/NumericalAlgorithms/LinearSolver/Tags.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Tags.hpp
@@ -182,7 +182,7 @@ struct OrthogonalizationHistory : db::PrefixTag, db::SimpleTag {
  * `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
  * db::add_tag_prefix<LinearSolver::Tags::Operand, Tag>>` and
  * `db::add_tag_prefix<::Tags::FixedSource, Tag>`, respectively. Therefore, each
- * basis vector is of the type `db::item_type<db::add_tag_prefix<Operand,
+ * basis vector is of the type `db::const_item_type<db::add_tag_prefix<Operand,
  * Tag>>`.
  */
 template <typename Tag>
@@ -192,7 +192,8 @@ struct KrylovSubspaceBasis : db::PrefixTag, db::SimpleTag {
     // operator
     return "KrylovSubspaceBasis(" + Tag::name() + ")";
   }
-  using type = std::vector<db::item_type<db::add_tag_prefix<Operand, Tag>>>;
+  using type =
+      std::vector<db::const_item_type<db::add_tag_prefix<Operand, Tag>>>;
   using tag = Tag;
 };
 
@@ -223,7 +224,7 @@ struct HasConvergedCompute : LinearSolver::Tags::HasConverged, db::ComputeTag {
       tmpl::list<LinearSolver::Tags::ConvergenceCriteria,
                  LinearSolver::Tags::IterationId, residual_magnitude_tag,
                  initial_residual_magnitude_tag>;
-  static db::item_type<LinearSolver::Tags::HasConverged> function(
+  static db::const_item_type<LinearSolver::Tags::HasConverged> function(
       const Convergence::Criteria& convergence_criteria,
       const size_t& iteration_id, const double& residual_magnitude,
       const double& initial_residual_magnitude) noexcept {

--- a/src/NumericalAlgorithms/Spectral/SwshDerivatives.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshDerivatives.hpp
@@ -197,7 +197,8 @@ struct AngularDerivativesImpl<tmpl::list<DerivativeTags...>,
           DerivativeTags>>*>... transform_of_derivative_scalars,
       const gsl::not_null<db::item_type<Tags::SwshTransform<
           DeDuplicatedDifferentiatedFromTags>>*>... transform_of_input_scalars,
-      const db::item_type<DeDuplicatedDifferentiatedFromTags>&... input_scalars,
+      const db::const_item_type<DeDuplicatedDifferentiatedFromTags>&...
+          input_scalars,
       const size_t l_max, const size_t number_of_radial_points) noexcept {
     apply_to_vectors(make_not_null(&get(*transform_of_derivative_scalars))...,
                      make_not_null(&get(*transform_of_input_scalars))...,
@@ -224,8 +225,8 @@ struct AngularDerivativesImpl<tmpl::list<DerivativeTags...>,
       const gsl::not_null<typename db::item_type<Tags::SwshTransform<
           DeDuplicatedDifferentiatedFromTags>>::type*>... transform_of_inputs,
       const gsl::not_null<
-          typename db::item_type<DerivativeTags>::type*>... derivatives,
-      const typename db::item_type<
+          typename db::const_item_type<DerivativeTags>::type*>... derivatives,
+      const typename db::const_item_type<
           DeDuplicatedDifferentiatedFromTags>::type&... inputs,
       const size_t l_max, const size_t number_of_radial_points) noexcept {
     // perform the forward transform on the minimal set of input nodal

--- a/src/NumericalAlgorithms/Spectral/SwshTransform.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTransform.hpp
@@ -421,13 +421,13 @@ struct SwshTransform;
 /// \cond
 template <typename... TransformTags, ComplexRepresentation Representation>
 struct SwshTransform<tmpl::list<TransformTags...>, Representation> {
-  static constexpr int spin =
-      db::item_type<tmpl::front<tmpl::list<TransformTags...>>>::type::spin;
+  static constexpr int spin = db::const_item_type<
+      tmpl::front<tmpl::list<TransformTags...>>>::type::spin;
 
-  static_assert(
-      tmpl2::flat_all_v<db::item_type<TransformTags>::type::spin == spin...>,
-      "All Tags in TagList submitted to SwshTransform must have the "
-      "same spin weight.");
+  static_assert(tmpl2::flat_all_v<
+                    db::const_item_type<TransformTags>::type::spin == spin...>,
+                "All Tags in TagList submitted to SwshTransform must have the "
+                "same spin weight.");
 
   using return_tags = tmpl::list<Tags::SwshTransform<TransformTags>...>;
   using argument_tags =
@@ -436,8 +436,8 @@ struct SwshTransform<tmpl::list<TransformTags...>, Representation> {
   static void apply(
       const gsl::not_null<
           db::item_type<Tags::SwshTransform<TransformTags>>*>... coefficients,
-      const db::item_type<TransformTags>&... collocations, const size_t l_max,
-      const size_t number_of_radial_points) noexcept {
+      const db::const_item_type<TransformTags>&... collocations,
+      const size_t l_max, const size_t number_of_radial_points) noexcept {
     // forward to the version which takes parameter packs of vectors
     apply_to_vectors(make_not_null(&get(*coefficients))...,
                      get(collocations)..., l_max, number_of_radial_points);
@@ -463,7 +463,7 @@ struct SwshTransform<tmpl::list<TransformTags...>, Representation> {
   static void apply_to_vectors(
       const gsl::not_null<typename db::item_type<
           Tags::SwshTransform<TransformTags>>::type*>... coefficients,
-      const typename db::item_type<TransformTags>::type&... collocations,
+      const typename db::const_item_type<TransformTags>::type&... collocations,
       size_t l_max, size_t number_of_radial_points) noexcept;
 };
 /// \endcond
@@ -505,11 +505,12 @@ struct InverseSwshTransform;
 /// \cond
 template <typename... TransformTags, ComplexRepresentation Representation>
 struct InverseSwshTransform<tmpl::list<TransformTags...>, Representation> {
-  static constexpr int spin =
-      db::item_type<tmpl::front<tmpl::list<TransformTags...>>>::type::spin;
+  static constexpr int spin = db::const_item_type<
+      tmpl::front<tmpl::list<TransformTags...>>>::type::spin;
 
   static_assert(
-      tmpl2::flat_all_v<db::item_type<TransformTags>::type::spin == spin...>,
+      tmpl2::flat_all_v<db::const_item_type<TransformTags>::type::spin ==
+                        spin...>,
       "All Tags in TagList submitted to InverseSwshTransform must have the "
       "same spin weight.");
 
@@ -519,7 +520,8 @@ struct InverseSwshTransform<tmpl::list<TransformTags...>, Representation> {
 
   static void apply(
       const gsl::not_null<db::item_type<TransformTags>*>... collocations,
-      const db::item_type<Tags::SwshTransform<TransformTags>>&... coefficients,
+      const db::const_item_type<
+          Tags::SwshTransform<TransformTags>>&... coefficients,
       const size_t l_max, const size_t number_of_radial_points) noexcept {
     // forward to the version which takes parameter packs of vectors
     apply_to_vectors(make_not_null(&get(*collocations))...,
@@ -546,7 +548,7 @@ struct InverseSwshTransform<tmpl::list<TransformTags...>, Representation> {
   static void apply_to_vectors(
       const gsl::not_null<
           typename db::item_type<TransformTags>::type*>... collocations,
-      const typename db::item_type<
+      const typename db::const_item_type<
           Tags::SwshTransform<TransformTags>>::type&... coefficients,
       size_t l_max, size_t number_of_radial_points) noexcept;
 };
@@ -556,7 +558,8 @@ void SwshTransform<tmpl::list<TransformTags...>, Representation>::
     apply_to_vectors(
         const gsl::not_null<typename db::item_type<
             Tags::SwshTransform<TransformTags>>::type*>... coefficients,
-        const typename db::item_type<TransformTags>::type&... collocations,
+        const typename db::const_item_type<
+            TransformTags>::type&... collocations,
         const size_t l_max, const size_t number_of_radial_points) noexcept {
   EXPAND_PACK_LEFT_TO_RIGHT(coefficients->destructive_resize(
       size_of_libsharp_coefficient_vector(l_max) * number_of_radial_points));
@@ -609,7 +612,7 @@ void InverseSwshTransform<tmpl::list<TransformTags...>, Representation>::
     apply_to_vectors(
         const gsl::not_null<
             typename db::item_type<TransformTags>::type*>... collocations,
-        const typename db::item_type<
+        const typename db::const_item_type<
             Tags::SwshTransform<TransformTags>>::type&... coefficients,
         const size_t l_max, const size_t number_of_radial_points) noexcept {
   EXPAND_PACK_LEFT_TO_RIGHT(collocations->destructive_resize(

--- a/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
@@ -123,12 +123,13 @@ class ObserveErrorNorms<VolumeDim, tmpl::list<Tensors...>, EventRegistrars>
 
   template <typename Metavariables, typename ArrayIndex,
             typename ParallelComponent>
-  void operator()(const double time,
-                  const db::item_type<coordinates_tag>& inertial_coordinates,
-                  const db::item_type<Tensors>&... tensors,
-                  Parallel::ConstGlobalCache<Metavariables>& cache,
-                  const ArrayIndex& /*array_index*/,
-                  const ParallelComponent* const /*meta*/) const noexcept {
+  void operator()(
+      const double time,
+      const db::const_item_type<coordinates_tag>& inertial_coordinates,
+      const db::const_item_type<Tensors>&... tensors,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/,
+      const ParallelComponent* const /*meta*/) const noexcept {
     const auto analytic_solution =
         Parallel::get<Tags::AnalyticSolutionBase>(cache).variables(
             inertial_coordinates, time, tmpl::list<Tensors...>{});

--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -165,10 +165,10 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
   template <typename Metavariables, typename ParallelComponent>
   void operator()(
       const double time, const Mesh<VolumeDim>& mesh,
-      const db::item_type<coordinates_tag>& inertial_coordinates,
-      const db::item_type<
+      const db::const_item_type<coordinates_tag>& inertial_coordinates,
+      const db::const_item_type<
           AnalyticSolutionTensors>&... analytic_solution_tensors,
-      const db::item_type<NonSolutionTensors>&... non_solution_tensors,
+      const db::const_item_type<NonSolutionTensors>&... non_solution_tensors,
       Parallel::ConstGlobalCache<Metavariables>& cache,
       const ElementIndex<VolumeDim>& array_index,
       const ParallelComponent* const /*meta*/) const noexcept {
@@ -183,8 +183,8 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
     components.reserve(alg::accumulate(
         std::initializer_list<size_t>{
             inertial_coordinates.size(),
-            db::item_type<AnalyticSolutionTensors>::size()...,
-            db::item_type<NonSolutionTensors>::size()...},
+            db::const_item_type<AnalyticSolutionTensors>::size()...,
+            db::const_item_type<NonSolutionTensors>::size()...},
         0_st));
 
     const auto record_tensor_components = [this, &components, &element_name](

--- a/src/Time/Actions/RecordTimeStepperData.hpp
+++ b/src/Time/Actions/RecordTimeStepperData.hpp
@@ -64,8 +64,8 @@ struct RecordTimeStepperData {
         make_not_null(&box),
         [](const gsl::not_null<db::item_type<dt_variables_tag>*> dt_vars,
            const gsl::not_null<db::item_type<history_tag>*> history,
-           const db::item_type<variables_tag>& vars,
-           const db::item_type<Tags::SubstepTime>& time) noexcept {
+           const db::const_item_type<variables_tag>& vars,
+           const db::const_item_type<Tags::SubstepTime>& time) noexcept {
           history->insert(time, vars, std::move(*dt_vars));
         },
         db::get<variables_tag>(box), db::get<Tags::SubstepTime>(box));

--- a/src/Time/Actions/SelfStartActions.hpp
+++ b/src/Time/Actions/SelfStartActions.hpp
@@ -103,7 +103,7 @@ struct InitialValue : db::PrefixTag, db::SimpleTag {
     return "InitialValue(" + Tag::name() + ")";
   }
   using tag = Tag;
-  using type = std::tuple<db::item_type<Tag>>;
+  using type = std::tuple<db::const_item_type<Tag>>;
 };
 }  // namespace Tags
 
@@ -292,9 +292,9 @@ struct CheckForOrderIncrease {
           make_not_null(&box),
           [
           ](const gsl::not_null<
-                db::item_type<::Tags::Next<::Tags::TimeStepId>>*>
-                next_time_id,
-            const db::item_type<::Tags::TimeStepId>& current_time_id) noexcept {
+                db::item_type<::Tags::Next<::Tags::TimeStepId>>*> next_time_id,
+            const db::const_item_type<::Tags::TimeStepId>&
+                current_time_id) noexcept {
             const Slab slab = current_time_id.step_time().slab();
             *next_time_id =
                 TimeStepId(current_time_id.time_runs_forward(),
@@ -357,7 +357,7 @@ struct StartNextOrderIfReady {
         db::mutate<Tag>(
             make_not_null(&box),
             [](const gsl::not_null<db::item_type<Tag>*> value,
-               const db::item_type<Tags::InitialValue<Tag>>&
+               const db::const_item_type<Tags::InitialValue<Tag>>&
                    initial_value) noexcept {
               *value = get<0>(initial_value);
             },
@@ -408,7 +408,7 @@ struct Cleanup {
     db::mutate<::Tags::TimeStep>(
         make_not_null(&box),
         [](const gsl::not_null<db::item_type<::Tags::TimeStep>*> time_step,
-           const db::item_type<initial_step_tag>& initial_step) noexcept {
+           const db::const_item_type<initial_step_tag>& initial_step) noexcept {
           *time_step = get<0>(initial_step);
         },
         db::get<initial_step_tag>(box));

--- a/src/Time/Actions/UpdateU.hpp
+++ b/src/Time/Actions/UpdateU.hpp
@@ -60,9 +60,10 @@ struct UpdateU {
 
     db::mutate<variables_tag, history_tag>(
         make_not_null(&box),
-        [&cache](const gsl::not_null<db::item_type<variables_tag>*> vars,
-                 const gsl::not_null<db::item_type<history_tag>*> history,
-                 const db::item_type<Tags::TimeStep>& time_step) noexcept {
+        [&cache](
+            const gsl::not_null<db::item_type<variables_tag>*> vars,
+            const gsl::not_null<db::item_type<history_tag>*> history,
+            const db::const_item_type<Tags::TimeStep>& time_step) noexcept {
           const auto& time_stepper =
               Parallel::get<Tags::TimeStepperBase>(cache);
           time_stepper.update_u(vars, history, time_step);

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -91,7 +91,8 @@ struct HistoryEvolvedVariables<> : db::BaseTag {};
 
 template <typename Tag, typename DtTag>
 struct HistoryEvolvedVariables : HistoryEvolvedVariables<>, db::SimpleTag {
-  using type = TimeSteppers::History<db::item_type<Tag>, db::item_type<DtTag>>;
+  using type = TimeSteppers::History<db::const_item_type<Tag>,
+                                     db::const_item_type<DtTag>>;
 };
 /// \endcond
 

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -80,8 +80,8 @@ void test_radius_and_derivs() {
   CHECK_ITERABLE_APPROX(strahlkorper_radius, expected_radius);
 
   // Test derivative of radius
-  db::item_type<StrahlkorperTags::DxRadius<Frame::Inertial>> expected_dx_radius(
-      n_pts);
+  db::const_item_type<StrahlkorperTags::DxRadius<Frame::Inertial>>
+      expected_dx_radius(n_pts);
   for (size_t s = 0; s < n_pts; ++s) {
     // Analytic solution Mark Scheel computed in Mathematica
     const double theta = theta_phi[0][s];
@@ -107,7 +107,7 @@ void test_radius_and_derivs() {
   CHECK_ITERABLE_APPROX(strahlkorper_dx_radius, expected_dx_radius);
 
   // Test second derivatives.
-  db::item_type<StrahlkorperTags::D2xRadius<Frame::Inertial>>
+  db::const_item_type<StrahlkorperTags::D2xRadius<Frame::Inertial>>
       expected_d2x_radius(n_pts);
   for (size_t s = 0; s < n_pts; ++s) {
     // Messy analytic solution Mark Scheel computed in Mathematica
@@ -173,7 +173,7 @@ void test_normals() {
 
   // Test surface_tangents
 
-  db::item_type<StrahlkorperTags::Tangents<Frame::Inertial>>
+  db::const_item_type<StrahlkorperTags::Tangents<Frame::Inertial>>
       expected_surface_tangents(n_pts);
   const double amp = -sqrt(3.0 / 8.0 / M_PI) * y11_amplitude;
 
@@ -208,7 +208,7 @@ void test_normals() {
   CHECK_ITERABLE_APPROX(surface_tangents, expected_surface_tangents);
 
   // Test surface_cartesian_coordinates
-  db::item_type<StrahlkorperTags::CartesianCoords<Frame::Inertial>>
+  db::const_item_type<StrahlkorperTags::CartesianCoords<Frame::Inertial>>
       expected_cart_coords(n_pts);
 
   {
@@ -222,7 +222,7 @@ void test_normals() {
   CHECK_ITERABLE_APPROX(expected_cart_coords, cart_coords);
 
   // Test surface_normal_one_form
-  db::item_type<StrahlkorperTags::NormalOneForm<Frame::Inertial>>
+  db::const_item_type<StrahlkorperTags::NormalOneForm<Frame::Inertial>>
       expected_normal_one_form(n_pts);
   {
     const auto& r = db::get<StrahlkorperTags::Radius<Frame::Inertial>>(box);

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxTag.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxTag.cpp
@@ -25,13 +25,13 @@ struct Var2 : db::SimpleTag {
 template <typename Tag>
 struct Prefix : db::PrefixTag, db::SimpleTag {
   using tag = Tag;
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
 };
 
 template <typename Tag, typename Arg1, typename Arg2>
 struct PrefixWithArgs : db::PrefixTag, db::SimpleTag {
   using tag = Tag;
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
 };
 }  // namespace
 

--- a/tests/Unit/DataStructures/Test_Tags.cpp
+++ b/tests/Unit/DataStructures/Test_Tags.cpp
@@ -86,7 +86,7 @@ void test_multiplies_tag() noexcept {
       Tags::SpinWeighted<ComplexScalarTag, std::integral_constant<int, 1>>,
       Tags::SpinWeighted<ComplexScalarTag, std::integral_constant<int, -2>>>;
   static_assert(
-      cpp17::is_same_v<db::item_type<test_multiplies_tag>,
+      cpp17::is_same_v<db::const_item_type<test_multiplies_tag>,
                        Scalar<SpinWeighted<ComplexDataVector, -1>>>,
       "Failed testing Tags::Multiplies for Tags::SpinWeighted operands");
   CHECK(test_multiplies_tag::name() ==

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -57,7 +57,7 @@ struct scalar2 : db::SimpleTag {
 /// [prefix_variables_tag]
 template <class Tag>
 struct Prefix0 : db::PrefixTag, db::SimpleTag {
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
   using tag = Tag;
   static std::string name() noexcept { return "Prefix0"; }
 };
@@ -65,21 +65,21 @@ struct Prefix0 : db::PrefixTag, db::SimpleTag {
 
 template <class Tag>
 struct Prefix1 : db::PrefixTag, db::SimpleTag {
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
   using tag = Tag;
   static std::string name() noexcept { return "Prefix1"; }
 };
 
 template <class Tag>
 struct Prefix2 : db::PrefixTag, db::SimpleTag {
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
   using tag = Tag;
   static std::string name() noexcept { return "Prefix2"; }
 };
 
 template <class Tag>
 struct Prefix3 : db::PrefixTag, db::SimpleTag {
-  using type = db::item_type<Tag>;
+  using type = db::const_item_type<Tag>;
   using tag = Tag;
   static std::string name() noexcept { return "Prefix3"; }
 };

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -71,7 +71,7 @@ template <typename Tag>
 struct Negate : db::PrefixTag, db::ComputeTag {
   static std::string name() noexcept { return "Negate"; }
   using tag = Tag;
-  static constexpr auto function(const db::item_type<Tag>& x) noexcept {
+  static constexpr auto function(const db::const_item_type<Tag>& x) noexcept {
     return -x;
   }
   using argument_tags = tmpl::list<Tag>;

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -251,9 +251,9 @@ void test_detail_functions(const DataType& used_for_size) noexcept {
 // Wrap `DampedHarmonicHCompute::function` here to make its time
 // argument a double, allowing for `pypp::check_with_random_values` to work.
 template <size_t SpatialDim, typename Frame>
-db::item_type<GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame>>
+db::const_item_type<GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame>>
 wrap_DampedHarmonicHCompute(
-    const db::item_type<GeneralizedHarmonic::Tags::InitialGaugeH<
+    const db::const_item_type<GeneralizedHarmonic::Tags::InitialGaugeH<
         SpatialDim, Frame>>& gauge_h_init,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, SpatialDim, Frame>& shift,
@@ -273,9 +273,9 @@ template <size_t SpatialDim, typename Frame>
 void test_damped_harmonic_h_function(const DataVector& used_for_size) noexcept {
   // H_a
   pypp::check_with_random_values<1>(
-      static_cast<db::item_type<
+      static_cast<db::const_item_type<
           GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame>> (*)(
-          const db::item_type<
+          const db::const_item_type<
               GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame>>&,
           const Scalar<DataVector>&,
           const tnsr::I<DataVector, SpatialDim, Frame>&,
@@ -1056,13 +1056,15 @@ void test_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
 // Wrap `SpacetimeDerivDampedHarmonicHCompute::function` here to make its time
 // argument a double, allowing for `pypp::check_with_random_values` to work.
 template <size_t SpatialDim, typename Frame>
-db::item_type<
+db::const_item_type<
     GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>
 wrap_SpacetimeDerivDampedHarmonicHCompute(
-    const db::item_type<GeneralizedHarmonic::Tags::InitialGaugeH<
+    const db::const_item_type<GeneralizedHarmonic::Tags::InitialGaugeH<
+
         SpatialDim, Frame>>& gauge_h_init,
-    const db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<
-        SpatialDim, Frame>>& dgauge_h_init,
+    const db::const_item_type<
+        GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<
+            SpatialDim, Frame>>& dgauge_h_init,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, SpatialDim, Frame>& shift,
     const tnsr::a<DataVector, SpatialDim, Frame>&
@@ -1087,23 +1089,24 @@ template <size_t SpatialDim, typename Frame>
 void test_deriv_damped_harmonic_h_function(
     const DataVector& used_for_size) noexcept {
   pypp::check_with_random_values<1>(
-      static_cast<db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
-          SpatialDim, Frame>> (*)(
-          const db::item_type<
-              GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame>>&,
-          const db::item_type<
-              GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<SpatialDim,
-                                                                     Frame>>&,
-          const Scalar<DataVector>&,
-          const tnsr::I<DataVector, SpatialDim, Frame>&,
-          const tnsr::a<DataVector, SpatialDim, Frame>&,
-          const Scalar<DataVector>&,
-          const tnsr::II<DataVector, SpatialDim, Frame>&,
-          const tnsr::aa<DataVector, SpatialDim, Frame>&,
-          const tnsr::aa<DataVector, SpatialDim, Frame>&,
-          const tnsr::iaa<DataVector, SpatialDim, Frame>&, const double,
-          const double, const double,
-          const tnsr::I<DataVector, SpatialDim, Frame>&, const double)>(
+      static_cast<
+          db::const_item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
+              SpatialDim, Frame>> (*)(
+              const db::const_item_type<
+                  GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame>>&,
+              const db::const_item_type<
+                  GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<
+                      SpatialDim, Frame>>&,
+              const Scalar<DataVector>&,
+              const tnsr::I<DataVector, SpatialDim, Frame>&,
+              const tnsr::a<DataVector, SpatialDim, Frame>&,
+              const Scalar<DataVector>&,
+              const tnsr::II<DataVector, SpatialDim, Frame>&,
+              const tnsr::aa<DataVector, SpatialDim, Frame>&,
+              const tnsr::aa<DataVector, SpatialDim, Frame>&,
+              const tnsr::iaa<DataVector, SpatialDim, Frame>&, const double,
+              const double, const double,
+              const tnsr::I<DataVector, SpatialDim, Frame>&, const double)>(
           &wrap_SpacetimeDerivDampedHarmonicHCompute<SpatialDim, Frame>),
       "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
       "DampedHarmonic",

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_UpwindFlux.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_UpwindFlux.cpp
@@ -43,15 +43,15 @@
 namespace GeneralizedHarmonic {
 namespace GeneralizedHarmonic_detail {
 template <size_t Dim>
-db::item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>
+db::const_item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>
 weight_char_fields(
-    const db::item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>&
+    const db::const_item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>&
         char_fields_int,
-    const db::item_type<Tags::CharacteristicSpeeds<Dim, Frame::Inertial>>&
+    const db::const_item_type<Tags::CharacteristicSpeeds<Dim, Frame::Inertial>>&
         char_speeds_int,
-    const db::item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>&
+    const db::const_item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>&
         char_fields_ext,
-    const db::item_type<Tags::CharacteristicSpeeds<Dim, Frame::Inertial>>&
+    const db::const_item_type<Tags::CharacteristicSpeeds<Dim, Frame::Inertial>>&
         char_speeds_ext) noexcept;
 }  // namespace GeneralizedHarmonic_detail
 }  // namespace GeneralizedHarmonic

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -77,7 +77,8 @@ struct MockInterpolatorReceiveVolumeData {
       db::DataBox<DbTags>& /*box*/,
       Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/,
-      const db::item_type<typename Metavariables::temporal_id>& temporal_id,
+      const db::const_item_type<typename Metavariables::temporal_id>&
+          temporal_id,
       const ElementId<VolumeDim>& element_id, const ::Mesh<VolumeDim>& mesh,
       Variables<typename Metavariables::interpolator_source_vars>&&
           vars) noexcept {

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
@@ -102,7 +102,7 @@ struct MockInitializeHasConverged {
   static void apply(db::DataBox<DbTagsList>& box,  // NOLINT
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
-                    const db::item_type<LinearSolver::Tags::HasConverged>&
+                    const db::const_item_type<LinearSolver::Tags::HasConverged>&
                         has_converged) noexcept {
     db::mutate<CheckConvergedTag>(
         make_not_null(&box), [&has_converged](const gsl::not_null<
@@ -138,7 +138,7 @@ struct MockUpdateOperand {
   static void apply(db::DataBox<DbTagsList>& box,  // NOLINT
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/, const double res_ratio,
-                    const db::item_type<LinearSolver::Tags::HasConverged>&
+                    const db::const_item_type<LinearSolver::Tags::HasConverged>&
                         has_converged) noexcept {
     db::mutate<CheckValueTag, CheckConvergedTag>(
         make_not_null(&box),

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
@@ -112,7 +112,7 @@ struct MockNormalizeInitialOperand {
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     const double residual_magnitude,
-                    const db::item_type<LinearSolver::Tags::HasConverged>&
+                    const db::const_item_type<LinearSolver::Tags::HasConverged>&
                         has_converged) noexcept {
     db::mutate<CheckValueTag, CheckConvergedTag>(
         make_not_null(&box),
@@ -153,7 +153,7 @@ struct MockNormalizeOperandAndUpdateField {
                     const ArrayIndex& /*array_index*/,
                     const double normalization,
                     const DenseVector<double>& minres,
-                    const db::item_type<LinearSolver::Tags::HasConverged>&
+                    const db::const_item_type<LinearSolver::Tags::HasConverged>&
                         has_converged) noexcept {
     db::mutate<CheckValueTag, CheckVectorTag, CheckConvergedTag>(
         make_not_null(&box),

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
@@ -41,7 +41,7 @@ struct OtherDataTag : db::SimpleTag {
 template <typename VarsTag>
 struct SomeComputeTag : db::ComputeTag {
   static std::string name() noexcept { return "SomeComputeTag"; }
-  static size_t function(const db::item_type<VarsTag>& vars) {
+  static size_t function(const db::const_item_type<VarsTag>& vars) {
     return vars.number_of_grid_points();
   }
   using argument_tags = tmpl::list<VarsTag>;


### PR DESCRIPTION
The interesting stuff is in the first commit.  The fixup is changing calls to item_type and has been separated out for ease of reviewing.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
