### PR TITLE
Allow PointerVector to work with ICC

### DIFF
--- a/src/Utilities/PointerVector.hpp
+++ b/src/Utilities/PointerVector.hpp
@@ -1210,10 +1210,8 @@ PointerVector<Type, AF, PF, TF, ExprResultType>::stream(
 
 template <typename Type, bool AF, bool PF, bool TF, typename ExprResultType>
 template <typename VT>
-inline std::enable_if_t<
-    not(PointerVector<Type, AF, PF, TF, ExprResultType>::template PointerVector<
-        Type, AF, PF, TF, ExprResultType>::BLAZE_TEMPLATE
-            VectorizedAssign<VT>::value)>
+inline std::enable_if_t<not(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                                BLAZE_TEMPLATE VectorizedAssign<VT>::value)>
 PointerVector<Type, AF, PF, TF, ExprResultType>::assign(
     const blaze::DenseVector<VT, TF>& rhs) {
   BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
@@ -1290,10 +1288,8 @@ PointerVector<Type, AF, PF, TF, ExprResultType>::assign(
 
 template <typename Type, bool AF, bool PF, bool TF, typename ExprResultType>
 template <typename VT>
-inline std::enable_if_t<
-    not(PointerVector<Type, AF, PF, TF, ExprResultType>::template PointerVector<
-        Type, AF, PF, TF, ExprResultType>::BLAZE_TEMPLATE
-            VectorizedAddAssign<VT>::value)>
+inline std::enable_if_t<not(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                                BLAZE_TEMPLATE VectorizedAddAssign<VT>::value)>
 PointerVector<Type, AF, PF, TF, ExprResultType>::addAssign(
     const blaze::DenseVector<VT, TF>& rhs) {
   BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
@@ -1368,10 +1364,8 @@ inline void PointerVector<Type, AF, PF, TF, ExprResultType>::addAssign(
 
 template <typename Type, bool AF, bool PF, bool TF, typename ExprResultType>
 template <typename VT>
-inline std::enable_if_t<
-    not(PointerVector<Type, AF, PF, TF, ExprResultType>::template PointerVector<
-        Type, AF, PF, TF, ExprResultType>::BLAZE_TEMPLATE
-            VectorizedSubAssign<VT>::value)>
+inline std::enable_if_t<not(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                                BLAZE_TEMPLATE VectorizedSubAssign<VT>::value)>
 PointerVector<Type, AF, PF, TF, ExprResultType>::subAssign(
     const blaze::DenseVector<VT, TF>& rhs) {
   BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
@@ -1446,10 +1440,8 @@ inline void PointerVector<Type, AF, PF, TF, ExprResultType>::subAssign(
 
 template <typename Type, bool AF, bool PF, bool TF, typename ExprResultType>
 template <typename VT>
-inline std::enable_if_t<
-    not(PointerVector<Type, AF, PF, TF, ExprResultType>::template PointerVector<
-        Type, AF, PF, TF, ExprResultType>::BLAZE_TEMPLATE
-            VectorizedMultAssign<VT>::value)>
+inline std::enable_if_t<not(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                                BLAZE_TEMPLATE VectorizedMultAssign<VT>::value)>
 PointerVector<Type, AF, PF, TF, ExprResultType>::multAssign(
     const blaze::DenseVector<VT, TF>& rhs) {
   BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
@@ -1526,10 +1518,8 @@ inline void PointerVector<Type, AF, PF, TF, ExprResultType>::multAssign(
 
 template <typename Type, bool AF, bool PF, bool TF, typename ExprResultType>
 template <typename VT>
-inline std::enable_if_t<
-    not(PointerVector<Type, AF, PF, TF, ExprResultType>::template PointerVector<
-        Type, AF, PF, TF, ExprResultType>::BLAZE_TEMPLATE
-            VectorizedDivAssign<VT>::value)>
+inline std::enable_if_t<not(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                                BLAZE_TEMPLATE VectorizedDivAssign<VT>::value)>
 PointerVector<Type, AF, PF, TF, ExprResultType>::divAssign(
     const blaze::DenseVector<VT, TF>& rhs) {
   BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");


### PR DESCRIPTION
## Proposed changes

Make PointerVector work with Intel 2019 compiler. There are still other things that don't work with Intel, but this was an easy first step.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
