### PR TITLE
Refactor MinmodTci

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Limiters)
 
 set(LIBRARY_SOURCES
   HwenoModifiedSolution.cpp
+  Minmod.cpp
   MinmodHelpers.cpp
   MinmodTci.cpp
   MinmodType.cpp

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
@@ -1,0 +1,175 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <utility>
+
+#include "Domain/Element.hpp"  // IWYU pragma: keep
+#include "Domain/Side.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/Linearize.hpp"
+#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace Limiters {
+namespace Minmod_detail {
+
+template <size_t VolumeDim>
+bool minmod_tci_wrapper(
+    const gsl::not_null<double*> u_mean,
+    const gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
+    const gsl::not_null<DataVector*> u_lin_buffer,
+    const gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
+    const Limiters::MinmodType minmod_type, const double tvbm_constant,
+    const DataVector& u, const Element<VolumeDim>& element,
+    const Mesh<VolumeDim>& mesh,
+    const std::array<double, VolumeDim>& element_size,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_means,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
+    const std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,
+                               gsl::span<std::pair<size_t, size_t>>>,
+                     VolumeDim>& volume_and_slice_indices) noexcept {
+  const double tvbm_scale = [&tvbm_constant, &element_size ]() noexcept {
+    const double max_h =
+        *std::max_element(element_size.begin(), element_size.end());
+    return tvbm_constant * square(max_h);
+  }
+  ();
+
+  // Results from SpECTRE paper (https://arxiv.org/abs/1609.00098) used a
+  // max_slope_factor a factor of 2.0 too small, so that LambdaPi1 behaved
+  // like MUSCL, and MUSCL was even more dissipative.
+  const double max_slope_factor =
+      (minmod_type == Limiters::MinmodType::Muscl) ? 1.0 : 2.0;
+
+  *u_mean = mean_value(u, mesh);
+
+  const auto difference_to_neighbor = [
+    &u_mean, &element, &element_size, &effective_neighbor_means, &
+    effective_neighbor_sizes
+  ](const size_t dim, const Side& side) noexcept {
+    return effective_difference_to_neighbor(
+        *u_mean, element, element_size, effective_neighbor_means,
+        effective_neighbor_sizes, dim, side);
+  };
+
+  // The LambdaPiN limiter allows high-order solutions to escape limiting if
+  // the boundary values are not too different from the mean value:
+  if (minmod_type == Limiters::MinmodType::LambdaPiN) {
+    bool u_needs_limiting = false;
+    for (size_t d = 0; d < VolumeDim; ++d) {
+      const double u_lower = mean_value_on_boundary(
+          &(gsl::at(*boundary_buffer, d)),
+          gsl::at(volume_and_slice_indices, d).first, u, mesh, d, Side::Lower);
+      const double u_upper = mean_value_on_boundary(
+          &(gsl::at(*boundary_buffer, d)),
+          gsl::at(volume_and_slice_indices, d).second, u, mesh, d, Side::Upper);
+      const double diff_lower = difference_to_neighbor(d, Side::Lower);
+      const double diff_upper = difference_to_neighbor(d, Side::Upper);
+
+      // Results from SpECTRE paper (https://arxiv.org/abs/1609.00098) used
+      // minmod_tvbm(..., 0.0), rather than minmod_tvbm(..., tvbm_scale)
+      const bool activated_lower =
+          minmod_tvbm(*u_mean - u_lower, diff_lower, diff_upper, tvbm_scale)
+              .activated;
+      const bool activated_upper =
+          minmod_tvbm(u_upper - *u_mean, diff_lower, diff_upper, tvbm_scale)
+              .activated;
+      if (activated_lower or activated_upper) {
+        u_needs_limiting = true;
+        break;
+      }
+    }
+
+    if (not u_needs_limiting) {
+      // Skip the limiting step for this tensor component
+#ifdef SPECTRE_DEBUG
+      *u_mean = std::numeric_limits<double>::signaling_NaN();
+      *u_limited_slopes =
+          make_array<VolumeDim>(std::numeric_limits<double>::signaling_NaN());
+#endif  // ifdef SPECTRE_DEBUG
+      return false;
+    }
+  }  // end if LambdaPiN
+
+  // If the LambdaPiN check did not skip the limiting, then proceed as normal
+  // to determine whether the slopes need to be reduced.
+  //
+  // Note that we expect the Muscl and LambdaPi1 limiters to linearize the
+  // solution whether or not the slope needed reduction. To permit this
+  // linearization, we always return (by reference) the slopes when these
+  // limiters are in use. In contrast, for LambdaPiN, we only return the slopes
+  // when they do in fact need to be reduced.
+  bool slopes_need_reducing = false;
+
+  linearize(u_lin_buffer, u, mesh);
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    const double u_lower =
+        mean_value_on_boundary(&(gsl::at(*boundary_buffer, d)),
+                               gsl::at(volume_and_slice_indices, d).first,
+                               *u_lin_buffer, mesh, d, Side::Lower);
+    const double u_upper =
+        mean_value_on_boundary(&(gsl::at(*boundary_buffer, d)),
+                               gsl::at(volume_and_slice_indices, d).second,
+                               *u_lin_buffer, mesh, d, Side::Upper);
+
+    // Divide by element's width (2.0 in logical coordinates) to get a slope
+    const double local_slope = 0.5 * (u_upper - u_lower);
+    const double upper_slope = 0.5 * difference_to_neighbor(d, Side::Upper);
+    const double lower_slope = 0.5 * difference_to_neighbor(d, Side::Lower);
+
+    const MinmodResult& result =
+        minmod_tvbm(local_slope, max_slope_factor * upper_slope,
+                    max_slope_factor * lower_slope, tvbm_scale);
+    gsl::at(*u_limited_slopes, d) = result.value;
+    if (result.activated) {
+      slopes_need_reducing = true;
+    }
+  }
+
+#ifdef SPECTRE_DEBUG
+  // Guard against incorrect use of returned (by reference) slopes in a
+  // LambdaPiN limiter, by setting these to NaN when they should not be used.
+  if (minmod_type == Limiters::MinmodType::LambdaPiN and
+      not slopes_need_reducing) {
+    *u_mean = std::numeric_limits<double>::signaling_NaN();
+    *u_limited_slopes =
+        make_array<VolumeDim>(std::numeric_limits<double>::signaling_NaN());
+  }
+#endif  // ifdef SPECTRE_DEBUG
+
+  return slopes_need_reducing;
+}
+
+// Explicit instantiations
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                            \
+  template bool minmod_tci_wrapper<DIM(data)>(                          \
+      const gsl::not_null<double*>,                                     \
+      const gsl::not_null<std::array<double, DIM(data)>*>,              \
+      const gsl::not_null<DataVector*>,                                 \
+      const gsl::not_null<std::array<DataVector, DIM(data)>*>,          \
+      const Limiters::MinmodType, const double, const DataVector&,      \
+      const Element<DIM(data)>&, const Mesh<DIM(data)>&,                \
+      const std::array<double, DIM(data)>&,                             \
+      const DirectionMap<DIM(data), double>&,                           \
+      const DirectionMap<DIM(data), double>&,                           \
+      const std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,  \
+                                 gsl::span<std::pair<size_t, size_t>>>, \
+                       DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+
+}  // namespace Minmod_detail
+}  // namespace Limiters

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
@@ -83,7 +83,7 @@ bool limit_one_tensor(
     DataVector& u = (*tensor)[i];
     double u_mean;
     std::array<double, VolumeDim> u_limited_slopes{};
-    const bool reduce_slope = troubled_cell_indicator(
+    const bool reduce_slope = minmod_tci_wrapper(
         make_not_null(&u_mean), make_not_null(&u_limited_slopes), u_lin_buffer,
         boundary_buffer, minmod_type, tvbm_constant, u, element, mesh,
         element_size, effective_neighbor_means, effective_neighbor_sizes,

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
@@ -3,10 +3,14 @@
 
 #include "Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp"
 
+#include <algorithm>
 #include <array>
+#include <cmath>
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "Domain/Element.hpp"             // IWYU pragma: keep
 #include "Domain/Mesh.hpp"                // IWYU pragma: keep
+#include "Domain/Side.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
@@ -14,6 +18,27 @@
 
 namespace Limiters {
 namespace Minmod_detail {
+
+MinmodResult minmod_tvbm(const double a, const double b, const double c,
+                         const double tvbm_scale) noexcept {
+  if (fabs(a) <= tvbm_scale) {
+    return {a, false};
+  }
+  if ((std::signbit(a) == std::signbit(b)) and
+      (std::signbit(a) == std::signbit(c))) {
+    // The if/else group below could be more simply written as
+    //   std::copysign(std::min({fabs(a), fabs(b), fabs(c)}), a);
+    // however, by separating different cases, we gain the ability to
+    // distinguish whether or not the limiter activated.
+    if (fabs(a) <= fabs(b) and fabs(a) <= fabs(c)) {
+      return {a, false};
+    } else {
+      return {std::copysign(std::min(fabs(b), fabs(c)), a), true};
+    }
+  } else {
+    return {0.0, true};
+  }
+}
 
 template <size_t VolumeDim>
 void allocate_buffers(
@@ -42,15 +67,41 @@ void allocate_buffers(
   }
 }
 
+template <size_t VolumeDim>
+double effective_difference_to_neighbor(
+    const double u_mean, const Element<VolumeDim>& element,
+    const std::array<double, VolumeDim>& element_size,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_means,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
+    const size_t dim, const Side& side) noexcept {
+  const auto& externals = element.external_boundaries();
+  const auto dir = Direction<VolumeDim>(dim, side);
+  const bool has_neighbors = (externals.find(dir) == externals.end());
+  if (has_neighbors) {
+    const double neighbor_mean = effective_neighbor_means.at(dir);
+    const double neighbor_size = effective_neighbor_sizes.at(dir);
+    const double distance_factor =
+        0.5 * (1.0 + neighbor_size / gsl::at(element_size, dim));
+    return (side == Side::Lower ? -1.0 : 1.0) * (neighbor_mean - u_mean) /
+           distance_factor;
+  } else {
+    return 0.0;
+  }
+}
+
 // Explicit instantiations
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                            \
-  template void allocate_buffers<DIM(data)>(                            \
-      const gsl::not_null<std::unique_ptr<double[], decltype(&free)>*>, \
-      const gsl::not_null<DataVector*>,                                 \
-      const gsl::not_null<std::array<DataVector, DIM(data)>*>,          \
-      const Mesh<DIM(data)>&) noexcept;
+#define INSTANTIATE(_, data)                                                   \
+  template void allocate_buffers<DIM(data)>(                                   \
+      const gsl::not_null<std::unique_ptr<double[], decltype(&free)>*>,        \
+      const gsl::not_null<DataVector*>,                                        \
+      const gsl::not_null<std::array<DataVector, DIM(data)>*>,                 \
+      const Mesh<DIM(data)>&) noexcept;                                        \
+  template double effective_difference_to_neighbor<DIM(data)>(                 \
+      double, const Element<DIM(data)>&, const std::array<double, DIM(data)>&, \
+      const DirectionMap<DIM(data), double>&,                                  \
+      const DirectionMap<DIM(data), double>&, size_t, const Side&) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
@@ -44,8 +44,17 @@ struct MinmodResult {
 MinmodResult minmod_tvbm(double a, double b, double c,
                          double tvbm_scale) noexcept;
 
+// Allocate the buffer `boundary_buffer` to the correct sizes expected by
+// `troubled_cell_indicator` for its arguments
+template <size_t VolumeDim>
+void allocate_buffers(
+    gsl::not_null<std::unique_ptr<double[], decltype(&free)>*>
+        contiguous_buffer,
+    gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
+    const Mesh<VolumeDim>& mesh) noexcept;
+
 // Allocate the buffers `u_lin_buffer` and `boundary_buffer` to the correct
-// sizes expected by `troubled_cell_indicator` for its arguments
+// sizes expected by the Minmod limiter.
 template <size_t VolumeDim>
 void allocate_buffers(
     gsl::not_null<std::unique_ptr<double[], decltype(&free)>*>

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
@@ -23,6 +23,7 @@ template <size_t VolumeDim>
 class ElementId;
 template <size_t VolumeDim>
 class Mesh;
+enum class Side;
 
 namespace boost {
 template <class T>
@@ -32,6 +33,16 @@ struct hash;
 
 namespace Limiters {
 namespace Minmod_detail {
+
+// Encodes the return status of the minmod_tvbm function.
+struct MinmodResult {
+  const double value;
+  const bool activated;
+};
+
+// The TVBM-corrected minmod function, see e.g. Cockburn reference Eq. 2.26.
+MinmodResult minmod_tvbm(double a, double b, double c,
+                         double tvbm_scale) noexcept;
 
 // Allocate the buffers `u_lin_buffer` and `boundary_buffer` to the correct
 // sizes expected by `troubled_cell_indicator` for its arguments
@@ -115,6 +126,25 @@ DirectionMap<VolumeDim, double> compute_effective_neighbor_means(
   }
   return result;
 }
+
+// Compute an effective element-center-to-neighbor-center distance that accounts
+// for the possibility of different refinement levels or discontinuous maps
+// (e.g., at Block boundaries). Treated naively, these domain features can make
+// a smooth solution appear to be non-smooth in the logical coordinates, which
+// could potentially lead to the limiter triggering erroneously. This effective
+// distance is used to scale the difference in the means, so that a linear
+// function at a refinement or Block boundary will still appear smooth to the
+// limiter. The factor is normalized to be 1.0 on a uniform grid.
+//
+// Note that this is not "by the book" Minmod, but an attempt to
+// generalize Minmod to work on non-uniform grids.
+template <size_t VolumeDim>
+double effective_difference_to_neighbor(
+    double u_mean, const Element<VolumeDim>& element,
+    const std::array<double, VolumeDim>& element_size,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_means,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes, size_t dim,
+    const Side& side) noexcept;
 
 }  // namespace Minmod_detail
 }  // namespace Limiters

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
@@ -5,31 +5,24 @@
 
 #include <algorithm>
 #include <array>
-#include <limits>
 #include <utility>
 
 #include "Domain/Element.hpp"  // IWYU pragma: keep
 #include "Domain/Side.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp"
-#include "NumericalAlgorithms/LinearOperators/Linearize.hpp"
 #include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/MakeArray.hpp"
 
 namespace Limiters {
 namespace Minmod_detail {
 
 template <size_t VolumeDim>
 bool troubled_cell_indicator(
-    const gsl::not_null<double*> u_mean,
-    const gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
-    const gsl::not_null<DataVector*> u_lin_buffer,
     const gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
-    const Limiters::MinmodType minmod_type, const double tvbm_constant,
-    const DataVector& u, const Element<VolumeDim>& element,
-    const Mesh<VolumeDim>& mesh,
+    const double tvbm_constant, const DataVector& u,
+    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
     const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
@@ -42,128 +35,54 @@ bool troubled_cell_indicator(
     return tvbm_constant * square(max_h);
   }
   ();
-
-  // Results from SpECTRE paper (https://arxiv.org/abs/1609.00098) used a
-  // max_slope_factor a factor of 2.0 too small, so that LambdaPi1 behaved
-  // like MUSCL, and MUSCL was even more dissipative.
-  const double max_slope_factor =
-      (minmod_type == Limiters::MinmodType::Muscl) ? 1.0 : 2.0;
-
-  *u_mean = mean_value(u, mesh);
+  const double u_mean = mean_value(u, mesh);
 
   const auto difference_to_neighbor = [
     &u_mean, &element, &element_size, &effective_neighbor_means, &
     effective_neighbor_sizes
   ](const size_t dim, const Side& side) noexcept {
     return effective_difference_to_neighbor(
-        *u_mean, element, element_size, effective_neighbor_means,
+        u_mean, element, element_size, effective_neighbor_means,
         effective_neighbor_sizes, dim, side);
   };
 
-  // The LambdaPiN limiter allows high-order solutions to escape limiting if
-  // the boundary values are not too different from the mean value:
-  if (minmod_type == Limiters::MinmodType::LambdaPiN) {
-    bool u_needs_limiting = false;
-    for (size_t d = 0; d < VolumeDim; ++d) {
-      const double u_lower = mean_value_on_boundary(
-          &(gsl::at(*boundary_buffer, d)),
-          gsl::at(volume_and_slice_indices, d).first, u, mesh, d, Side::Lower);
-      const double u_upper = mean_value_on_boundary(
-          &(gsl::at(*boundary_buffer, d)),
-          gsl::at(volume_and_slice_indices, d).second, u, mesh, d, Side::Upper);
-      const double diff_lower = difference_to_neighbor(d, Side::Lower);
-      const double diff_upper = difference_to_neighbor(d, Side::Upper);
-
-      // Results from SpECTRE paper (https://arxiv.org/abs/1609.00098) used
-      // minmod_tvbm(..., 0.0), rather than minmod_tvbm(..., tvbm_scale)
-      const bool activated_lower =
-          minmod_tvbm(*u_mean - u_lower, diff_lower, diff_upper, tvbm_scale)
-              .activated;
-      const bool activated_upper =
-          minmod_tvbm(u_upper - *u_mean, diff_lower, diff_upper, tvbm_scale)
-              .activated;
-      if (activated_lower or activated_upper) {
-        u_needs_limiting = true;
-        break;
-      }
-    }
-
-    if (not u_needs_limiting) {
-      // Skip the limiting step for this tensor component
-#ifdef SPECTRE_DEBUG
-      *u_mean = std::numeric_limits<double>::signaling_NaN();
-      *u_limited_slopes =
-          make_array<VolumeDim>(std::numeric_limits<double>::signaling_NaN());
-#endif  // ifdef SPECTRE_DEBUG
-      return false;
-    }
-  }  // end if LambdaPiN
-
-  // If the LambdaPiN check did not skip the limiting, then proceed as normal
-  // to determine whether the slopes need to be reduced.
-  //
-  // Note that we expect the Muscl and LambdaPi1 limiters to linearize the
-  // solution whether or not the slope needed reduction. To permit this
-  // linearization, we always return (by reference) the slopes when these
-  // limiters are in use. In contrast, for LambdaPiN, we only return the slopes
-  // when they do in fact need to be reduced.
-  bool slopes_need_reducing = false;
-
-  linearize(u_lin_buffer, u, mesh);
   for (size_t d = 0; d < VolumeDim; ++d) {
-    const double u_lower =
-        mean_value_on_boundary(&(gsl::at(*boundary_buffer, d)),
-                               gsl::at(volume_and_slice_indices, d).first,
-                               *u_lin_buffer, mesh, d, Side::Lower);
-    const double u_upper =
-        mean_value_on_boundary(&(gsl::at(*boundary_buffer, d)),
-                               gsl::at(volume_and_slice_indices, d).second,
-                               *u_lin_buffer, mesh, d, Side::Upper);
+    const double u_lower = mean_value_on_boundary(
+        &(gsl::at(*boundary_buffer, d)),
+        gsl::at(volume_and_slice_indices, d).first, u, mesh, d, Side::Lower);
+    const double u_upper = mean_value_on_boundary(
+        &(gsl::at(*boundary_buffer, d)),
+        gsl::at(volume_and_slice_indices, d).second, u, mesh, d, Side::Upper);
+    const double diff_lower = difference_to_neighbor(d, Side::Lower);
+    const double diff_upper = difference_to_neighbor(d, Side::Upper);
 
-    // Divide by element's width (2.0 in logical coordinates) to get a slope
-    const double local_slope = 0.5 * (u_upper - u_lower);
-    const double upper_slope = 0.5 * difference_to_neighbor(d, Side::Upper);
-    const double lower_slope = 0.5 * difference_to_neighbor(d, Side::Lower);
-
-    const MinmodResult& result =
-        minmod_tvbm(local_slope, max_slope_factor * upper_slope,
-                    max_slope_factor * lower_slope, tvbm_scale);
-    gsl::at(*u_limited_slopes, d) = result.value;
-    if (result.activated) {
-      slopes_need_reducing = true;
+    // Results from SpECTRE paper (https://arxiv.org/abs/1609.00098) used
+    // minmod_tvbm(..., 0.0), rather than minmod_tvbm(..., tvbm_scale)
+    const bool activated_lower =
+        minmod_tvbm(u_mean - u_lower, diff_lower, diff_upper, tvbm_scale)
+            .activated;
+    const bool activated_upper =
+        minmod_tvbm(u_upper - u_mean, diff_lower, diff_upper, tvbm_scale)
+            .activated;
+    if (activated_lower or activated_upper) {
+      return true;
     }
   }
-
-#ifdef SPECTRE_DEBUG
-  // Guard against incorrect use of returned (by reference) slopes in a
-  // LambdaPiN limiter, by setting these to NaN when they should not be used.
-  if (minmod_type == Limiters::MinmodType::LambdaPiN and
-      not slopes_need_reducing) {
-    *u_mean = std::numeric_limits<double>::signaling_NaN();
-    *u_limited_slopes =
-        make_array<VolumeDim>(std::numeric_limits<double>::signaling_NaN());
-  }
-#endif  // ifdef SPECTRE_DEBUG
-
-  return slopes_need_reducing;
+  return false;
 }
 
 // Explicit instantiations
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                            \
-  template bool troubled_cell_indicator<DIM(data)>(                     \
-      const gsl::not_null<double*>,                                     \
-      const gsl::not_null<std::array<double, DIM(data)>*>,              \
-      const gsl::not_null<DataVector*>,                                 \
-      const gsl::not_null<std::array<DataVector, DIM(data)>*>,          \
-      const Limiters::MinmodType, const double, const DataVector&,      \
-      const Element<DIM(data)>&, const Mesh<DIM(data)>&,                \
-      const std::array<double, DIM(data)>&,                             \
-      const DirectionMap<DIM(data), double>&,                           \
-      const DirectionMap<DIM(data), double>&,                           \
-      const std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,  \
-                                 gsl::span<std::pair<size_t, size_t>>>, \
+#define INSTANTIATE(_, data)                                                 \
+  template bool troubled_cell_indicator<DIM(data)>(                          \
+      const gsl::not_null<std::array<DataVector, DIM(data)>*>, const double, \
+      const DataVector&, const Element<DIM(data)>&, const Mesh<DIM(data)>&,  \
+      const std::array<double, DIM(data)>&,                                  \
+      const DirectionMap<DIM(data), double>&,                                \
+      const DirectionMap<DIM(data), double>&,                                \
+      const std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,       \
+                                 gsl::span<std::pair<size_t, size_t>>>,      \
                        DIM(data)>&) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
@@ -109,12 +109,12 @@ bool troubled_cell_indicator(
               element, tensor_storage_index, neighbor_data);
 
       const DataVector& u = tensor[tensor_storage_index];
-      const bool reduce_slope = troubled_cell_indicator(
+      const bool tci_triggered = troubled_cell_indicator(
           make_not_null(&boundary_buffer), tvbm_constant, u, element, mesh,
           element_size, effective_neighbor_means, effective_neighbor_sizes,
           volume_and_slice_indices);
 
-      if (reduce_slope) {
+      if (tci_triggered) {
         some_component_needs_limiting = true;
         // Skip remaining components of this tensor
         return '0';

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
@@ -10,13 +10,13 @@
 #include <utility>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "DataStructures/DataVector.hpp"
 #include "DataStructures/SliceIterator.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+class DataVector;
 template <size_t VolumeDim>
 class Direction;
 template <size_t Dim, typename T>
@@ -74,14 +74,10 @@ bool troubled_cell_indicator(
     const double tvbm_constant, const Element<VolumeDim>& element,
     const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size) noexcept {
-  // Optimization: allocate temporary buffer to be used in TCI
-  // TODO(FH): consider a more specialized helper function that doesn't allocate
-  //           u_lin_buffer, because we don't need that buffer here.
+  // Optimization: allocate temporary buffer for multiple DataVectors
   std::unique_ptr<double[], decltype(&free)> contiguous_buffer(nullptr, &free);
-  DataVector u_lin_buffer{};
   std::array<DataVector, VolumeDim> boundary_buffer{};
   Minmod_detail::allocate_buffers(make_not_null(&contiguous_buffer),
-                                  make_not_null(&u_lin_buffer),
                                   make_not_null(&boundary_buffer), mesh);
 
   // Optimization: precompute the slice indices since this is (surprisingly)

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -283,12 +283,11 @@ bool Weno<VolumeDim, tmpl::list<Tags...>>::operator()(
 
   // Troubled-cell detection for WENO flags the element for limiting if any
   // component of any tensor needs limiting.
-  const auto minmod_tci_type = MinmodType::LambdaPiN;
   const double minmod_tci_tvbm_constant = 0.0;
   const bool cell_is_troubled =
       Minmod_detail::troubled_cell_indicator<VolumeDim, PackagedData, Tags...>(
-          (*tensors)..., neighbor_data, minmod_tci_type,
-          minmod_tci_tvbm_constant, element, mesh, element_size);
+          (*tensors)..., neighbor_data, minmod_tci_tvbm_constant, element, mesh,
+          element_size);
 
   if (not cell_is_troubled) {
     // No limiting is needed

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
@@ -7,7 +7,9 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -15,9 +17,11 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
+#include "DataStructures/SliceIterator.hpp"
 #include "DataStructures/Tags.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Element.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/LogicalCoordinates.hpp"
@@ -29,9 +33,11 @@
 #include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/TestHelpers.hpp"
@@ -89,6 +95,649 @@ void test_minmod_serialization() noexcept {
   const Limiters::Minmod<1, tmpl::list<ScalarTag>> minmod(
       Limiters::MinmodType::LambdaPi1);
   test_serialization(minmod);
+}
+
+// Helper function to wrap the allocation of the optimization buffers for the
+// troubled cell indicator function.
+template <size_t VolumeDim>
+bool wrap_allocations_and_tci(
+    const gsl::not_null<double*> u_mean,
+    const gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
+    const Limiters::MinmodType& minmod_type, const double tvbm_constant,
+    const DataVector& u, const Element<VolumeDim>& element,
+    const Mesh<VolumeDim>& mesh,
+    const std::array<double, VolumeDim>& element_size,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_means,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept {
+  // Allocate the various temporary buffers.
+  DataVector u_lin_buffer(mesh.number_of_grid_points());
+  std::array<DataVector, VolumeDim> boundary_buffer{};
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    const size_t num_points = mesh.slice_away(d).number_of_grid_points();
+    gsl::at(boundary_buffer, d) = DataVector(num_points);
+  }
+
+  const auto volume_and_slice_buffer_and_indices =
+      volume_and_slice_indices(mesh.extents());
+  const auto& volume_and_slice_indices =
+      volume_and_slice_buffer_and_indices.second;
+
+  return Limiters::Minmod_detail::minmod_tci_wrapper(
+      u_mean, u_limited_slopes, make_not_null(&u_lin_buffer),
+      make_not_null(&boundary_buffer), minmod_type, tvbm_constant, u, element,
+      mesh, element_size, effective_neighbor_means, effective_neighbor_sizes,
+      volume_and_slice_indices);
+}
+
+auto make_two_neighbors(const double left, const double right) noexcept {
+  DirectionMap<1, double> result;
+  result[Direction<1>::lower_xi()] = left;
+  result[Direction<1>::upper_xi()] = right;
+  return result;
+}
+
+auto make_four_neighbors(const std::array<double, 4>& values) noexcept {
+  DirectionMap<2, double> result;
+  result[Direction<2>::lower_xi()] = values[0];
+  result[Direction<2>::upper_xi()] = values[1];
+  result[Direction<2>::lower_eta()] = values[2];
+  result[Direction<2>::upper_eta()] = values[3];
+  return result;
+}
+
+auto make_six_neighbors(const std::array<double, 6>& values) noexcept {
+  DirectionMap<3, double> result;
+  result[Direction<3>::lower_xi()] = values[0];
+  result[Direction<3>::upper_xi()] = values[1];
+  result[Direction<3>::lower_eta()] = values[2];
+  result[Direction<3>::upper_eta()] = values[3];
+  result[Direction<3>::lower_zeta()] = values[4];
+  result[Direction<3>::upper_zeta()] = values[5];
+  return result;
+}
+
+// Test that TCI detects a troubled cell when expected, and returns the correct
+// mean and reduced slopes.
+template <size_t VolumeDim>
+void test_minmod_tci_activates(
+    const Limiters::MinmodType& minmod_type, const double tvbm_constant,
+    const DataVector& input, const Element<VolumeDim>& element,
+    const Mesh<VolumeDim>& mesh,
+    const std::array<double, VolumeDim>& element_size,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_means,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
+    const std::array<double, VolumeDim>& expected_slopes) noexcept {
+  double u_mean{};
+  std::array<double, VolumeDim> u_limited_slopes{};
+  const bool tci_activated = wrap_allocations_and_tci(
+      make_not_null(&u_mean), make_not_null(&u_limited_slopes), minmod_type,
+      tvbm_constant, input, element, mesh, element_size,
+      effective_neighbor_means, effective_neighbor_sizes);
+  CHECK(tci_activated);
+  CHECK(u_mean == approx(mean_value(input, mesh)));
+  CHECK_ITERABLE_APPROX(u_limited_slopes, expected_slopes);
+}
+
+// Test that TCI does not detect a troubled cell.
+template <size_t VolumeDim>
+void test_minmod_tci_does_not_activate(
+    const Limiters::MinmodType& minmod_type, const double tvbm_constant,
+    const DataVector& input, const Element<VolumeDim>& element,
+    const Mesh<VolumeDim>& mesh,
+    const std::array<double, VolumeDim>& element_size,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_means,
+    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
+    const std::array<double, VolumeDim>& original_slopes) noexcept {
+  double u_mean{};
+  std::array<double, VolumeDim> u_limited_slopes{};
+  const bool tci_activated = wrap_allocations_and_tci(
+      make_not_null(&u_mean), make_not_null(&u_limited_slopes), minmod_type,
+      tvbm_constant, input, element, mesh, element_size,
+      effective_neighbor_means, effective_neighbor_sizes);
+  CHECK_FALSE(tci_activated);
+  if (minmod_type != Limiters::MinmodType::LambdaPiN) {
+    CHECK(u_mean == approx(mean_value(input, mesh)));
+    CHECK_ITERABLE_APPROX(u_limited_slopes, original_slopes);
+  }
+}
+
+void test_tci_on_linear_function(
+    const size_t number_of_grid_points,
+    const Limiters::MinmodType& minmod_type) noexcept {
+  INFO("Testing linear function...");
+  CAPTURE(number_of_grid_points);
+  CAPTURE(get_output(minmod_type));
+  const double tvbm_constant = 0.0;
+  const auto element = TestHelpers::Limiters::make_element<1>();
+  const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const auto element_size = make_array<1>(2.0);
+
+  const auto test_activates =
+      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
+          const DataVector& local_input, const double left, const double right,
+          const double expected_slope) noexcept {
+    const auto expected_slopes = make_array<1>(expected_slope);
+    test_minmod_tci_activates(minmod_type, tvbm_constant, local_input, element,
+                              mesh, element_size,
+                              make_two_neighbors(left, right),
+                              make_two_neighbors(2.0, 2.0), expected_slopes);
+  };
+  const auto test_does_not_activate =
+      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
+          const DataVector& local_input, const double left, const double right,
+          const double original_slope) noexcept {
+    const auto original_slopes = make_array<1>(original_slope);
+    test_minmod_tci_does_not_activate(
+        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
+        original_slopes);
+  };
+
+  // With a MUSCL limiter, the largest allowed slope is half as big as for a
+  // LambdaPi1 or LambdaPiN limiter. We can re-use the same test cases by
+  // correspondingly scaling the slope:
+  const double muscl_slope_factor =
+      (minmod_type == Limiters::MinmodType::Muscl) ? 0.5 : 1.0;
+  const double eps = 100.0 * std::numeric_limits<double>::epsilon();
+
+  // Test a positive-slope function
+  {
+    const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
+      const auto coords = logical_coordinates(mesh);
+      return DataVector{3.6 + 1.2 * muscl_slope_factor * get<0>(coords)};
+    }
+    ();
+
+    // Steepness test
+    // Limiter does not reduce slope if (difference of means) > (local slope),
+    // but reduces slope if (difference of means) < (local slope)
+    test_does_not_activate(input, 2.0, 6.0, 1.2 * muscl_slope_factor);
+    test_does_not_activate(input, 2.4 - eps, 4.8 + eps,
+                           1.2 * muscl_slope_factor);
+    test_activates(input, 2.6, 6.0, 1.0 * muscl_slope_factor);
+    test_activates(input, 2.0, 4.0, 0.4 * muscl_slope_factor);
+    test_activates(input, 2.6, 4.0, 0.4 * muscl_slope_factor);
+
+    // Local extremum test
+    // Limiter flattens slope if both neighbors are above (below) the mean
+    test_activates(input, 1.0, 2.0, 0.0);
+    test_activates(input, 6.0, 9.0, 0.0);
+
+    // Oscillation test
+    // Limiter flattens slope if sign(difference of means) != sign(local slope)
+    test_activates(input, 3.9, 2.7, 0.0);
+  }
+
+  // Test a negative-slope function
+  {
+    const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
+      const auto coords = logical_coordinates(mesh);
+      return DataVector{-0.4 - 0.8 * muscl_slope_factor * get<0>(coords)};
+    }
+    ();
+
+    // Steepness test
+    test_does_not_activate(input, 0.9, -2.3, -0.8 * muscl_slope_factor);
+    test_does_not_activate(input, 0.4 + eps, -1.2 - eps,
+                           -0.8 * muscl_slope_factor);
+    test_activates(input, 0.2, -1.2, -0.6 * muscl_slope_factor);
+    test_activates(input, 0.4, -0.5, -0.1 * muscl_slope_factor);
+    test_activates(input, 0.2, -0.5, -0.1 * muscl_slope_factor);
+
+    // Local extremum test
+    test_activates(input, 1.3, -0.1, 0.0);
+    test_activates(input, -3.2, -0.8, 0.0);
+
+    // Oscillation test
+    test_activates(input, -2.3, 0.2, 0.0);
+  }
+}
+
+void test_tci_on_quadratic_function(
+    const size_t number_of_grid_points,
+    const Limiters::MinmodType& minmod_type) noexcept {
+  INFO("Testing quadratic function...");
+  CAPTURE(number_of_grid_points);
+  CAPTURE(get_output(minmod_type));
+  const double tvbm_constant = 0.0;
+  const auto element = TestHelpers::Limiters::make_element<1>();
+  const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const auto element_size = make_array<1>(2.0);
+
+  const auto test_activates =
+      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
+          const DataVector& local_input, const double left, const double right,
+          const double expected_slope) noexcept {
+    const auto expected_slopes = make_array<1>(expected_slope);
+    test_minmod_tci_activates(minmod_type, tvbm_constant, local_input, element,
+                              mesh, element_size,
+                              make_two_neighbors(left, right),
+                              make_two_neighbors(2.0, 2.0), expected_slopes);
+  };
+  const auto test_does_not_activate =
+      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
+          const DataVector& local_input, const double left, const double right,
+          const double original_slope) noexcept {
+    const auto original_slopes = make_array<1>(original_slope);
+    test_minmod_tci_does_not_activate(
+        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
+        original_slopes);
+  };
+
+  const double muscl_slope_factor =
+      (minmod_type == Limiters::MinmodType::Muscl) ? 0.5 : 1.0;
+
+  const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
+    const auto coords = logical_coordinates(mesh);
+    const auto& x = get<0>(coords);
+    // For easier testing, center the quadratic term on the grid: otherwise this
+    // term will affect the average slope on the element.
+    return DataVector{13.0 + 4.0 * muscl_slope_factor * x + 2.5 * square(x)};
+  }
+  ();
+  const double mean = mean_value(input, mesh);
+
+  // Steepness test
+  // Cases where slope is not steep enough to need limiting
+  test_does_not_activate(input, mean - 5.0, mean + 5.0,
+                         4.0 * muscl_slope_factor);
+  test_does_not_activate(input, mean - 4.01, mean + 4.01,
+                         4.0 * muscl_slope_factor);
+  // Cases where slope is too steep and needs to be reduced
+  test_activates(input, mean - 3.99, mean + 3.99, 3.99 * muscl_slope_factor);
+  test_activates(input, mean - 1.3, mean + 1.9, 1.3 * muscl_slope_factor);
+
+  // Local extremum test
+  test_activates(input, 9.4, 2.3, 0.0);
+  test_activates(input, 14.0, 18.2, 0.0);
+
+  // Oscillation test
+  test_activates(input, 14.0, 2.3, 0.0);
+}
+
+void test_tci_with_tvbm_correction(
+    const size_t number_of_grid_points,
+    const Limiters::MinmodType& minmod_type) noexcept {
+  INFO("Testing TVBM correction...");
+  CAPTURE(number_of_grid_points);
+  CAPTURE(get_output(minmod_type));
+  const auto element = TestHelpers::Limiters::make_element<1>();
+  const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const auto element_size = make_array<1>(2.0);
+
+  const auto test_activates = [&minmod_type, &element, &mesh, &element_size ](
+      const double tvbm_constant, const DataVector& local_input,
+      const double left, const double right,
+      const double expected_slope) noexcept {
+    const auto expected_slopes = make_array<1>(expected_slope);
+    test_minmod_tci_activates(minmod_type, tvbm_constant, local_input, element,
+                              mesh, element_size,
+                              make_two_neighbors(left, right),
+                              make_two_neighbors(2.0, 2.0), expected_slopes);
+  };
+  const auto test_does_not_activate =
+      [&minmod_type, &element, &mesh, &
+       element_size ](const double tvbm_constant, const DataVector& local_input,
+                      const double left, const double right,
+                      const double original_slope) noexcept {
+    const auto original_slopes = make_array<1>(original_slope);
+    test_minmod_tci_does_not_activate(
+        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
+        original_slopes);
+  };
+
+  // Slopes will be compared to m * h^2, where here h = 2
+  const double tvbm_m0 = 0.0;
+  const double tvbm_m1 = 1.0;
+  const double tvbm_m2 = 2.0;
+
+  const auto input = [&mesh]() noexcept {
+    const auto coords = logical_coordinates(mesh);
+    return DataVector{21.6 + 7.2 * get<0>(coords)};
+  }
+  ();
+
+  // The TVBM constant sets a threshold slope, below which the solution will not
+  // be limited. We test this by increasing the TVBM constant until the limiter
+  // stops activating / stops changing the solution.
+  const double left = (minmod_type == Limiters::MinmodType::Muscl) ? 8.4 : 15.0;
+  const double right =
+      (minmod_type == Limiters::MinmodType::Muscl) ? 34.8 : 30.0;
+  test_activates(tvbm_m0, input, left, right, 6.6);
+  test_activates(tvbm_m1, input, left, right, 6.6);
+  test_does_not_activate(tvbm_m2, input, left, right, 7.2);
+}
+
+// Here we test the coupling of the LambdaPiN troubled cell detector with the
+// TVBM constant value.
+void test_lambda_pin_troubled_cell_tvbm_correction(
+    const size_t number_of_grid_points) noexcept {
+  INFO("Testing LambdaPiN-TVBM correction...");
+  CAPTURE(number_of_grid_points);
+  const auto element = TestHelpers::Limiters::make_element<1>();
+  const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const auto logical_coords = logical_coordinates(mesh);
+  const auto element_size = make_array<1>(2.0);
+
+  const auto test_activates = [&element, &mesh, &element_size ](
+      const double tvbm_constant, const DataVector& local_input,
+      const double left, const double right,
+      const double expected_slope) noexcept {
+    const auto expected_slopes = make_array<1>(expected_slope);
+    test_minmod_tci_activates(Limiters::MinmodType::LambdaPiN, tvbm_constant,
+                              local_input, element, mesh, element_size,
+                              make_two_neighbors(left, right),
+                              make_two_neighbors(2.0, 2.0), expected_slopes);
+  };
+  const auto test_does_not_activate = [&element, &mesh, &element_size ](
+      const double tvbm_constant, const DataVector& local_input,
+      const double left, const double right) noexcept {
+    // Because in this test the TCI is LambdaPiN, no slopes are returned, and
+    // no comparison is made. So set these to NaN
+    const auto original_slopes =
+        make_array<1>(std::numeric_limits<double>::signaling_NaN());
+    test_minmod_tci_does_not_activate(
+        Limiters::MinmodType::LambdaPiN, tvbm_constant, local_input, element,
+        mesh, element_size, make_two_neighbors(left, right),
+        make_two_neighbors(2.0, 2.0), original_slopes);
+  };
+
+  const double m0 = 0.0;
+  const double m1 = 1.0;
+  const double m2 = 2.0;
+
+  const auto input = [&mesh]() noexcept {
+    const auto coords = logical_coordinates(mesh);
+    return DataVector{10.0 * step_function(get<0>(coords))};
+  }
+  ();
+
+  // Establish baseline m = 0 case; LambdaPiN normally avoids limiting when
+  // max(edge - mean) <= min(neighbor - mean)
+  test_does_not_activate(m0, input, 0.0, 10.0);
+  test_does_not_activate(m0, input, -0.3, 10.2);
+  // but does limit if max(edge - mean) > min(neighbor - mean)
+  test_activates(m0, input, 0.02, 10.0, 4.98);
+  test_activates(m0, input, 0.0, 9.99, 4.99);
+
+  // However, with a non-zero TVBM constant, LambdaPiN should additionally avoid
+  // limiting when max(edge - mean) < TVBM correction.
+  // We test first a case where the TVBM correction is too small to affect
+  // the limiter action,
+  test_does_not_activate(m1, input, 0.0, 10.0);
+  test_does_not_activate(m1, input, -0.3, 10.2);
+  test_activates(m1, input, 0.02, 10.0, 4.98);
+  test_activates(m1, input, 0.0, 9.99, 4.99);
+
+  // And a case where the TVBM correction enables LambdaPiN to avoid limiting
+  // (Note that the slope here is still too large to avoid limiting through
+  // the normal TVBM tolerance.)
+  test_does_not_activate(m2, input, 0.0, 10.0);
+  test_does_not_activate(m2, input, -0.3, 10.2);
+  test_does_not_activate(m2, input, 0.02, 10.0);
+  test_does_not_activate(m2, input, 0.0, 9.99);
+}
+
+void test_tci_at_boundary(const size_t number_of_grid_points,
+                          const Limiters::MinmodType& minmod_type) noexcept {
+  INFO("Testing limiter at boundary...");
+  CAPTURE(number_of_grid_points);
+  CAPTURE(get_output(minmod_type));
+  const double tvbm_constant = 0.0;
+  const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const auto element_size = make_array<1>(2.0);
+
+  const double muscl_slope_factor =
+      (minmod_type == Limiters::MinmodType::Muscl) ? 0.5 : 1.0;
+  const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
+    const auto coords = logical_coordinates(mesh);
+    return DataVector{1.2 * muscl_slope_factor * get<0>(coords)};
+  }
+  ();
+
+  // Test with element that has external lower-xi boundary
+  const auto element_at_lower_xi_boundary =
+      TestHelpers::Limiters::make_element<1>({{Direction<1>::lower_xi()}});
+  for (const double neighbor : {-1.3, 3.6, 4.8, 13.2}) {
+    test_minmod_tci_activates(
+        minmod_type, tvbm_constant, input, element_at_lower_xi_boundary, mesh,
+        element_size, {{std::make_pair(Direction<1>::upper_xi(), neighbor)}},
+        {{std::make_pair(Direction<1>::upper_xi(), element_size[0])}},
+        make_array<1>(0.0));
+  }
+
+  // Test with element that has external upper-xi boundary
+  const auto element_at_upper_xi_boundary =
+      TestHelpers::Limiters::make_element<1>({{Direction<1>::upper_xi()}});
+  for (const double neighbor : {-1.3, 3.6, 4.8, 13.2}) {
+    test_minmod_tci_activates(
+        minmod_type, tvbm_constant, input, element_at_upper_xi_boundary, mesh,
+        element_size, {{std::make_pair(Direction<1>::lower_xi(), neighbor)}},
+        {{std::make_pair(Direction<1>::lower_xi(), element_size[0])}},
+        make_array<1>(0.0));
+  }
+}
+
+void test_tci_with_different_size_neighbor(
+    const size_t number_of_grid_points,
+    const Limiters::MinmodType& minmod_type) noexcept {
+  INFO("Testing limiter with neighboring elements of different size...");
+  CAPTURE(number_of_grid_points);
+  CAPTURE(get_output(minmod_type));
+  const double tvbm_constant = 0.0;
+  const auto element = TestHelpers::Limiters::make_element<1>();
+  const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const double dx = 1.0;
+  const auto element_size = make_array<1>(dx);
+
+  const auto test_activates =
+      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
+          const DataVector& local_input, const double left, const double right,
+          const double left_size, const double right_size,
+          const double expected_slope) noexcept {
+    const auto expected_slopes = make_array<1>(expected_slope);
+    test_minmod_tci_activates(
+        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        make_two_neighbors(left, right),
+        make_two_neighbors(left_size, right_size), expected_slopes);
+  };
+  const auto test_does_not_activate =
+      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
+          const DataVector& local_input, const double left, const double right,
+          const double left_size, const double right_size,
+          const double original_slope) noexcept {
+    const auto original_slopes = make_array<1>(original_slope);
+    test_minmod_tci_does_not_activate(
+        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        make_two_neighbors(left, right),
+        make_two_neighbors(left_size, right_size), original_slopes);
+  };
+
+  const double muscl_slope_factor =
+      (minmod_type == Limiters::MinmodType::Muscl) ? 0.5 : 1.0;
+  const double eps = 100.0 * std::numeric_limits<double>::epsilon();
+
+  const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
+    const auto coords = logical_coordinates(mesh);
+    return DataVector{2.0 + 1.2 * muscl_slope_factor * get<0>(coords)};
+  }
+  ();
+
+  // Establish baseline using evenly-sized elements
+  test_does_not_activate(input, 0.8 - eps, 3.2 + eps, dx, dx,
+                         1.2 * muscl_slope_factor);
+
+  const double larger = 2.0 * dx;
+  const double smaller = 0.5 * dx;
+
+  // Larger neighbor with same mean => true reduction in slope => trigger
+  test_activates(input, 0.8 - eps, 3.2, dx, larger, 0.8 * muscl_slope_factor);
+  // Larger neighbor with larger mean => same slope => no trigger
+  test_does_not_activate(input, 0.8 - eps, 3.8 + eps, dx, larger,
+                         1.2 * muscl_slope_factor);
+
+  // Smaller neighbor with same mean => increased slope => no trigger
+  test_does_not_activate(input, 0.8 - eps, 3.2 + eps, dx, smaller,
+                         1.2 * muscl_slope_factor);
+  // Smaller neighbor with lower mean => same slope => no trigger
+  test_does_not_activate(input, 0.8 - eps, 2.9 + eps, dx, smaller,
+                         1.2 * muscl_slope_factor);
+
+  test_activates(input, 0.8, 3.2 + eps, larger, dx, 0.8 * muscl_slope_factor);
+  test_does_not_activate(input, 0.2 - eps, 3.2 + eps, larger, dx,
+                         1.2 * muscl_slope_factor);
+
+  test_does_not_activate(input, 0.8 - eps, 3.2 + eps, smaller, dx,
+                         1.2 * muscl_slope_factor);
+  test_does_not_activate(input, 1.1 - eps, 3.2 + eps, smaller, dx,
+                         1.2 * muscl_slope_factor);
+}
+
+// In 1D, test combinations of MinmodType, TVBM constant, polynomial order, etc.
+// Check that each combination has the expected TCI behavior.
+void test_minmod_tci_wrapper_1d() noexcept {
+  INFO("Testing Minmod minmod_tci_wrapper in 1D");
+  for (const auto& minmod_type :
+       {Limiters::MinmodType::LambdaPi1, Limiters::MinmodType::LambdaPiN,
+        Limiters::MinmodType::Muscl}) {
+    for (const auto num_grid_points : std::array<size_t, 2>{{2, 4}}) {
+      test_tci_on_linear_function(num_grid_points, minmod_type);
+      test_tci_with_tvbm_correction(num_grid_points, minmod_type);
+      test_tci_at_boundary(num_grid_points, minmod_type);
+      test_tci_with_different_size_neighbor(num_grid_points, minmod_type);
+    }
+    // This test only makes sense with more than 2 grid points
+    test_tci_on_quadratic_function(4, minmod_type);
+  }
+  // This test only makes sense with LambdaPiN and more than 2 grid points
+  test_lambda_pin_troubled_cell_tvbm_correction(4);
+}
+
+// In 2D, test that the dimension-by-dimension application of the TCI works as
+// expected.
+void test_minmod_tci_wrapper_2d() noexcept {
+  INFO("Testing Minmod minmod_tci_wrapper in 2D");
+  const auto minmod_type = Limiters::MinmodType::LambdaPi1;
+  const double tvbm_constant = 0.0;
+  const auto element = TestHelpers::Limiters::make_element<2>();
+  const Mesh<2> mesh(3, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const auto element_size = make_array<2>(2.0);
+
+  const auto test_activates =
+      [&minmod_type, &tvbm_constant, &element, &mesh, &
+       element_size ](const DataVector& local_input,
+                      const std::array<double, 4>& neighbor_means,
+                      const std::array<double, 2>& expected_slopes) noexcept {
+    test_minmod_tci_activates(
+        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        make_four_neighbors(neighbor_means),
+        make_four_neighbors(make_array<4>(2.0)), expected_slopes);
+  };
+  const auto test_does_not_activate =
+      [&minmod_type, &tvbm_constant, &element, &mesh, &
+       element_size ](const DataVector& local_input,
+                      const std::array<double, 4>& neighbor_means,
+                      const std::array<double, 2>& original_slopes) noexcept {
+    test_minmod_tci_does_not_activate(
+        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        make_four_neighbors(neighbor_means),
+        make_four_neighbors(make_array<4>(2.0)), original_slopes);
+  };
+
+  const auto input = [&mesh]() noexcept {
+    const auto coords = logical_coordinates(mesh);
+    const auto& x = get<0>(coords);
+    const auto& y = get<1>(coords);
+    return DataVector{3.0 + x + 2.0 * y + 0.1 * x * y};
+  }
+  ();
+
+  // Case with no activation
+  test_does_not_activate(input, {{1.9, 4.2, -0.5, 5.6}}, {{1.0, 2.0}});
+
+  // Limit because of xi-direction neighbors
+  test_activates(input, {{2.2, 4.2, -0.5, 5.6}}, {{0.8, 2.0}});
+  test_activates(input, {{1.9, 3.2, -0.5, 5.6}}, {{0.2, 2.0}});
+
+  // Limit because of eta-direction neighbors
+  test_activates(input, {{1.9, 4.2, 1.5, 5.6}}, {{1.0, 1.5}});
+  test_activates(input, {{1.9, 4.2, -0.5, 2.9}}, {{1.0, 0.0}});
+
+  // Limit for xi and eta directions
+  test_activates(input, {{2.2, 4.2, 1.5, 5.6}}, {{0.8, 1.5}});
+  test_activates(input, {{3.9, 4.2, -0.5, 2.9}}, {{0.0, 0.0}});
+}
+
+// In 3D, test that the dimension-by-dimension application of the TCI works as
+// expected.
+void test_minmod_tci_wrapper_3d() noexcept {
+  INFO("Testing Minmod minmod_tci_wrapper in 3D");
+  const auto minmod_type = Limiters::MinmodType::LambdaPi1;
+  const double tvbm_constant = 0.0;
+  const auto element = TestHelpers::Limiters::make_element<3>();
+  const Mesh<3> mesh(3, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const auto element_size = make_array<3>(2.0);
+
+  const auto test_activates =
+      [&minmod_type, &tvbm_constant, &element, &mesh, &
+       element_size ](const DataVector& local_input,
+                      const std::array<double, 6>& neighbor_means,
+                      const std::array<double, 3>& expected_slopes) noexcept {
+    test_minmod_tci_activates(
+        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        make_six_neighbors(neighbor_means),
+        make_six_neighbors(make_array<6>(2.0)), expected_slopes);
+  };
+  const auto test_does_not_activate =
+      [&minmod_type, &tvbm_constant, &element, &mesh, &
+       element_size ](const DataVector& local_input,
+                      const std::array<double, 6>& neighbor_means,
+                      const std::array<double, 3>& original_slopes) noexcept {
+    test_minmod_tci_does_not_activate(
+        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        make_six_neighbors(neighbor_means),
+        make_six_neighbors(make_array<6>(2.0)), original_slopes);
+  };
+
+  const auto input = [&mesh]() noexcept {
+    const auto coords = logical_coordinates(mesh);
+    const auto& x = get<0>(coords);
+    const auto& y = get<1>(coords);
+    const auto& z = get<2>(coords);
+    return DataVector{2.0 - 1.6 * x + 0.4 * y + 0.4 * z + 0.1 * x * y -
+                      0.1 * x * z - 0.2 * y * z};
+  }
+  ();
+
+  // Case with no activation
+  test_does_not_activate(input, {{3.8, -0.1, 1.5, 2.7, 1.2, 2.5}},
+                         {{-1.6, 0.4, 0.4}});
+
+  // Limit because of xi-direction neighbors
+  test_activates(input, {{3.4, -0.1, 1.5, 2.7, 1.2, 2.5}}, {{-1.4, 0.4, 0.4}});
+  test_activates(input, {{3.8, 2.1, 1.5, 2.7, 1.2, 2.5}}, {{0.0, 0.4, 0.4}});
+
+  // Limit because of eta-direction neighbors
+  test_activates(input, {{3.8, -0.1, 1.9, 2.7, 1.2, 2.5}}, {{-1.6, 0.1, 0.4}});
+  test_activates(input, {{3.8, -0.1, 1.5, 2.3, 1.2, 2.5}}, {{-1.6, 0.3, 0.4}});
+
+  // Limit because of zeta-direction neighbors
+  test_activates(input, {{3.8, -0.1, 1.5, 2.7, 2.2, 2.5}}, {{-1.6, 0.4, 0.0}});
+  test_activates(input, {{3.8, -0.1, 1.5, 2.7, 1.2, 2.1}}, {{-1.6, 0.4, 0.1}});
+
+  // Limit for xi, eta, and zeta directions
+  test_activates(input, {{3.4, -0.1, 1.5, 2.3, 1.2, 2.1}}, {{-1.4, 0.3, 0.1}});
+  test_activates(input, {{3.8, 2.1, 2.1, 2.7, 2.2, 2.5}}, {{0.0, 0.0, 0.0}});
 }
 
 // Test that the limiter activates in the x-direction only. Domain quantities
@@ -670,6 +1319,13 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.Minmod", "[Limiters][Unit]") {
     INFO("Test Minmod option-parsing and serialization");
     test_minmod_option_parsing();
     test_minmod_serialization();
+  }
+
+  {
+    INFO("Test Minmod TCI wrapper");
+    test_minmod_tci_wrapper_1d();
+    test_minmod_tci_wrapper_2d();
+    test_minmod_tci_wrapper_3d();
   }
 
   {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodTci.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodTci.cpp
@@ -25,14 +25,10 @@
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp"
-#include "Evolution/DiscontinuousGalerkin/Limiters/MinmodType.hpp"
-#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
-#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/TestHelpers.hpp"
 
@@ -42,16 +38,12 @@ namespace {
 // troubled cell indicator function.
 template <size_t VolumeDim>
 bool wrap_allocations_and_tci(
-    const gsl::not_null<double*> u_mean,
-    const gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
-    const Limiters::MinmodType& minmod_type, const double tvbm_constant,
-    const DataVector& u, const Element<VolumeDim>& element,
-    const Mesh<VolumeDim>& mesh,
+    const double tvbm_constant, const DataVector& u,
+    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
     const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept {
   // Allocate the various temporary buffers.
-  DataVector u_lin_buffer(mesh.number_of_grid_points());
   std::array<DataVector, VolumeDim> boundary_buffer{};
   for (size_t d = 0; d < VolumeDim; ++d) {
     const size_t num_points = mesh.slice_away(d).number_of_grid_points();
@@ -64,9 +56,8 @@ bool wrap_allocations_and_tci(
       volume_and_slice_buffer_and_indices.second;
 
   return Limiters::Minmod_detail::troubled_cell_indicator(
-      u_mean, u_limited_slopes, make_not_null(&u_lin_buffer),
-      make_not_null(&boundary_buffer), minmod_type, tvbm_constant, u, element,
-      mesh, element_size, effective_neighbor_means, effective_neighbor_sizes,
+      make_not_null(&boundary_buffer), tvbm_constant, u, element, mesh,
+      element_size, effective_neighbor_means, effective_neighbor_sizes,
       volume_and_slice_indices);
 }
 
@@ -97,349 +88,151 @@ auto make_six_neighbors(const std::array<double, 6>& values) noexcept {
   return result;
 }
 
-// Test that TCI detects a troubled cell when expected, and returns the correct
-// mean and reduced slopes.
+// Test that TCI detects a troubled cell when expected
 template <size_t VolumeDim>
-void test_minmod_tci_activates(
-    const Limiters::MinmodType& minmod_type, const double tvbm_constant,
+void test_minmod_tci_activation(
+    const bool expected_activation, const double tvbm_constant,
     const DataVector& input, const Element<VolumeDim>& element,
     const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
-    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
-    const std::array<double, VolumeDim>& expected_slopes) noexcept {
-  double u_mean{};
-  std::array<double, VolumeDim> u_limited_slopes{};
+    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept {
   const bool tci_activated = wrap_allocations_and_tci(
-      make_not_null(&u_mean), make_not_null(&u_limited_slopes), minmod_type,
       tvbm_constant, input, element, mesh, element_size,
       effective_neighbor_means, effective_neighbor_sizes);
-  CHECK(tci_activated);
-  CHECK(u_mean == approx(mean_value(input, mesh)));
-  CHECK_ITERABLE_APPROX(u_limited_slopes, expected_slopes);
+  CHECK(tci_activated == expected_activation);
 }
 
-// Test that TCI does not detect a troubled cell.
-template <size_t VolumeDim>
-void test_minmod_tci_does_not_activate(
-    const Limiters::MinmodType& minmod_type, const double tvbm_constant,
-    const DataVector& input, const Element<VolumeDim>& element,
-    const Mesh<VolumeDim>& mesh,
-    const std::array<double, VolumeDim>& element_size,
-    const DirectionMap<VolumeDim, double>& effective_neighbor_means,
-    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
-    const std::array<double, VolumeDim>& original_slopes) noexcept {
-  double u_mean{};
-  std::array<double, VolumeDim> u_limited_slopes{};
-  const bool tci_activated = wrap_allocations_and_tci(
-      make_not_null(&u_mean), make_not_null(&u_limited_slopes), minmod_type,
-      tvbm_constant, input, element, mesh, element_size,
-      effective_neighbor_means, effective_neighbor_sizes);
-  CHECK_FALSE(tci_activated);
-  if (minmod_type != Limiters::MinmodType::LambdaPiN) {
-    CHECK(u_mean == approx(mean_value(input, mesh)));
-    CHECK_ITERABLE_APPROX(u_limited_slopes, original_slopes);
-  }
-}
-
-void test_tci_on_linear_function(
-    const size_t number_of_grid_points,
-    const Limiters::MinmodType& minmod_type) noexcept {
+void test_tci_on_linear_function(const size_t number_of_grid_points) noexcept {
   INFO("Testing linear function...");
   CAPTURE(number_of_grid_points);
-  CAPTURE(get_output(minmod_type));
-  const double tvbm_constant = 0.0;
   const auto element = TestHelpers::Limiters::make_element<1>();
   const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
-  const auto element_size = make_array<1>(2.0);
 
-  const auto test_activates =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
-          const DataVector& local_input, const double left, const double right,
-          const double expected_slope) noexcept {
-    const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_tci_activates(minmod_type, tvbm_constant, local_input, element,
-                              mesh, element_size,
-                              make_two_neighbors(left, right),
-                              make_two_neighbors(2.0, 2.0), expected_slopes);
-  };
-  const auto test_does_not_activate =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
-          const DataVector& local_input, const double left, const double right,
-          const double original_slope) noexcept {
-    const auto original_slopes = make_array<1>(original_slope);
-    test_minmod_tci_does_not_activate(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
-        make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
-        original_slopes);
+  // Lambda takes tvbm_scale = tvbm_constant * h^2, to facilitate specifying
+  // critical threshold values for testing
+  const auto test_activation = [&mesh, &element ](
+      const bool expected, const DataVector& input, const double left_mean,
+      const double right_mean, const double tvbm_scale) noexcept {
+    const double h = 1.2;
+    const double tvbm_constant = tvbm_scale / square(h);
+    const auto element_size = make_array<1>(h);
+    test_minmod_tci_activation(
+        expected, tvbm_constant, input, element, mesh, element_size,
+        make_two_neighbors(left_mean, right_mean), make_two_neighbors(h, h));
   };
 
-  // With a MUSCL limiter, the largest allowed slope is half as big as for a
-  // LambdaPi1 or LambdaPiN limiter. We can re-use the same test cases by
-  // correspondingly scaling the slope:
-  const double muscl_slope_factor =
-      (minmod_type == Limiters::MinmodType::Muscl) ? 0.5 : 1.0;
-  const double eps = 100.0 * std::numeric_limits<double>::epsilon();
-
-  // Test a positive-slope function
-  {
-    const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
-      const auto coords = logical_coordinates(mesh);
-      return DataVector{3.6 + 1.2 * muscl_slope_factor * get<0>(coords)};
-    }
-    ();
-
-    // Steepness test
-    // Limiter does not reduce slope if (difference of means) > (local slope),
-    // but reduces slope if (difference of means) < (local slope)
-    test_does_not_activate(input, 2.0, 6.0, 1.2 * muscl_slope_factor);
-    test_does_not_activate(input, 2.4 - eps, 4.8 + eps,
-                           1.2 * muscl_slope_factor);
-    test_activates(input, 2.6, 6.0, 1.0 * muscl_slope_factor);
-    test_activates(input, 2.0, 4.0, 0.4 * muscl_slope_factor);
-    test_activates(input, 2.6, 4.0, 0.4 * muscl_slope_factor);
-
-    // Local extremum test
-    // Limiter flattens slope if both neighbors are above (below) the mean
-    test_activates(input, 1.0, 2.0, 0.0);
-    test_activates(input, 6.0, 9.0, 0.0);
-
-    // Oscillation test
-    // Limiter flattens slope if sign(difference of means) != sign(local slope)
-    test_activates(input, 3.9, 2.7, 0.0);
+  // mean = 1.6
+  // delta_left = delta_right = 0.2
+  const DataVector input = [&mesh]() noexcept {
+    const auto x = get<0>(logical_coordinates(mesh));
+    return DataVector{1.6 + 0.2 * x};
   }
+  ();
 
-  // Test a negative-slope function
-  {
-    const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
-      const auto coords = logical_coordinates(mesh);
-      return DataVector{-0.4 - 0.8 * muscl_slope_factor * get<0>(coords)};
-    }
-    ();
+  // Test trigger due to left, right neighbors
+  test_activation(false, input, 1.35, 1.85, 0.0);
+  test_activation(true, input, 1.45, 1.85, 0.0);
+  test_activation(true, input, 1.35, 1.75, 0.0);
+  test_activation(true, input, 1.45, 1.75, 0.0);
 
-    // Steepness test
-    test_does_not_activate(input, 0.9, -2.3, -0.8 * muscl_slope_factor);
-    test_does_not_activate(input, 0.4 + eps, -1.2 - eps,
-                           -0.8 * muscl_slope_factor);
-    test_activates(input, 0.2, -1.2, -0.6 * muscl_slope_factor);
-    test_activates(input, 0.4, -0.5, -0.1 * muscl_slope_factor);
-    test_activates(input, 0.2, -0.5, -0.1 * muscl_slope_factor);
+  // Test trigger due to slope changing sign
+  test_activation(true, input, 1.7, 1.85, 0.0);
+  test_activation(true, input, 1.45, 1.5, 0.0);
 
-    // Local extremum test
-    test_activates(input, 1.3, -0.1, 0.0);
-    test_activates(input, -3.2, -0.8, 0.0);
-
-    // Oscillation test
-    test_activates(input, -2.3, 0.2, 0.0);
-  }
+  // Test TVBM can avoid the triggers
+  test_activation(true, input, 1.45, 1.75, 0.19);
+  test_activation(true, input, 1.7, 1.85, 0.19);
+  test_activation(true, input, 1.45, 1.5, 0.19);
+  test_activation(false, input, 1.45, 1.75, 0.21);
+  test_activation(false, input, 1.7, 1.85, 0.21);
+  test_activation(false, input, 1.45, 1.5, 0.21);
 }
 
 void test_tci_on_quadratic_function(
-    const size_t number_of_grid_points,
-    const Limiters::MinmodType& minmod_type) noexcept {
+    const size_t number_of_grid_points) noexcept {
   INFO("Testing quadratic function...");
   CAPTURE(number_of_grid_points);
-  CAPTURE(get_output(minmod_type));
-  const double tvbm_constant = 0.0;
   const auto element = TestHelpers::Limiters::make_element<1>();
   const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
-  const auto element_size = make_array<1>(2.0);
 
-  const auto test_activates =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
-          const DataVector& local_input, const double left, const double right,
-          const double expected_slope) noexcept {
-    const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_tci_activates(minmod_type, tvbm_constant, local_input, element,
-                              mesh, element_size,
-                              make_two_neighbors(left, right),
-                              make_two_neighbors(2.0, 2.0), expected_slopes);
-  };
-  const auto test_does_not_activate =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
-          const DataVector& local_input, const double left, const double right,
-          const double original_slope) noexcept {
-    const auto original_slopes = make_array<1>(original_slope);
-    test_minmod_tci_does_not_activate(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
-        make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
-        original_slopes);
+  // Lambda takes tvbm_scale = tvbm_constant * h^2, to facilitate specifying
+  // critical threshold values for testing
+  const auto test_activation = [&mesh, &element ](
+      const bool expected, const DataVector& input, const double left_mean,
+      const double right_mean, const double tvbm_scale) noexcept {
+    const double h = 1.2;
+    const double tvbm_constant = tvbm_scale / square(h);
+    const auto element_size = make_array<1>(h);
+    test_minmod_tci_activation(
+        expected, tvbm_constant, input, element, mesh, element_size,
+        make_two_neighbors(left_mean, right_mean), make_two_neighbors(h, h));
   };
 
-  const double muscl_slope_factor =
-      (minmod_type == Limiters::MinmodType::Muscl) ? 0.5 : 1.0;
-
-  const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
-    const auto coords = logical_coordinates(mesh);
-    const auto& x = get<0>(coords);
-    // For easier testing, center the quadratic term on the grid: otherwise this
-    // term will affect the average slope on the element.
-    return DataVector{13.0 + 4.0 * muscl_slope_factor * x + 2.5 * square(x)};
-  }
-  ();
-  const double mean = mean_value(input, mesh);
-
-  // Steepness test
-  // Cases where slope is not steep enough to need limiting
-  test_does_not_activate(input, mean - 5.0, mean + 5.0,
-                         4.0 * muscl_slope_factor);
-  test_does_not_activate(input, mean - 4.01, mean + 4.01,
-                         4.0 * muscl_slope_factor);
-  // Cases where slope is too steep and needs to be reduced
-  test_activates(input, mean - 3.99, mean + 3.99, 3.99 * muscl_slope_factor);
-  test_activates(input, mean - 1.3, mean + 1.9, 1.3 * muscl_slope_factor);
-
-  // Local extremum test
-  test_activates(input, 9.4, 2.3, 0.0);
-  test_activates(input, 14.0, 18.2, 0.0);
-
-  // Oscillation test
-  test_activates(input, 14.0, 2.3, 0.0);
-}
-
-void test_tci_with_tvbm_correction(
-    const size_t number_of_grid_points,
-    const Limiters::MinmodType& minmod_type) noexcept {
-  INFO("Testing TVBM correction...");
-  CAPTURE(number_of_grid_points);
-  CAPTURE(get_output(minmod_type));
-  const auto element = TestHelpers::Limiters::make_element<1>();
-  const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
-                     Spectral::Quadrature::GaussLobatto);
-  const auto element_size = make_array<1>(2.0);
-
-  const auto test_activates = [&minmod_type, &element, &mesh, &element_size ](
-      const double tvbm_constant, const DataVector& local_input,
-      const double left, const double right,
-      const double expected_slope) noexcept {
-    const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_tci_activates(minmod_type, tvbm_constant, local_input, element,
-                              mesh, element_size,
-                              make_two_neighbors(left, right),
-                              make_two_neighbors(2.0, 2.0), expected_slopes);
-  };
-  const auto test_does_not_activate =
-      [&minmod_type, &element, &mesh, &
-       element_size ](const double tvbm_constant, const DataVector& local_input,
-                      const double left, const double right,
-                      const double original_slope) noexcept {
-    const auto original_slopes = make_array<1>(original_slope);
-    test_minmod_tci_does_not_activate(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
-        make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
-        original_slopes);
-  };
-
-  // Slopes will be compared to m * h^2, where here h = 2
-  const double tvbm_m0 = 0.0;
-  const double tvbm_m1 = 1.0;
-  const double tvbm_m2 = 2.0;
-
-  const auto input = [&mesh]() noexcept {
-    const auto coords = logical_coordinates(mesh);
-    return DataVector{21.6 + 7.2 * get<0>(coords)};
+  // mean = 1.5
+  // delta_left = 0.1
+  // delta_right = 0.3
+  const DataVector input = [&mesh]() noexcept {
+    const auto x = get<0>(logical_coordinates(mesh));
+    return DataVector{1.45 + 0.2 * x + 0.15 * square(x)};
   }
   ();
 
-  // The TVBM constant sets a threshold slope, below which the solution will not
-  // be limited. We test this by increasing the TVBM constant until the limiter
-  // stops activating / stops changing the solution.
-  const double left = (minmod_type == Limiters::MinmodType::Muscl) ? 8.4 : 15.0;
-  const double right =
-      (minmod_type == Limiters::MinmodType::Muscl) ? 34.8 : 30.0;
-  test_activates(tvbm_m0, input, left, right, 6.6);
-  test_activates(tvbm_m1, input, left, right, 6.6);
-  test_does_not_activate(tvbm_m2, input, left, right, 7.2);
-}
+  // Test trigger due to left, right neighbors
+  test_activation(false, input, 1.15, 1.85, 0.0);
+  test_activation(true, input, 1.25, 1.85, 0.0);
+  test_activation(true, input, 1.15, 1.75, 0.0);
+  test_activation(true, input, 1.25, 1.75, 0.0);
 
-// Here we test the coupling of the LambdaPiN troubled cell detector with the
-// TVBM constant value.
-void test_lambda_pin_troubled_cell_tvbm_correction(
-    const size_t number_of_grid_points) noexcept {
-  INFO("Testing LambdaPiN-TVBM correction...");
-  CAPTURE(number_of_grid_points);
-  const auto element = TestHelpers::Limiters::make_element<1>();
-  const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
-                     Spectral::Quadrature::GaussLobatto);
-  const auto logical_coords = logical_coordinates(mesh);
-  const auto element_size = make_array<1>(2.0);
+  // Test TVBM can avoid the trigger
+  test_activation(true, input, 1.25, 1.85, 0.11);
+  test_activation(true, input, 1.25, 1.85, 0.29);
+  test_activation(false, input, 1.25, 1.85, 0.31);
 
-  const auto test_activates = [&element, &mesh, &element_size ](
-      const double tvbm_constant, const DataVector& local_input,
-      const double left, const double right,
-      const double expected_slope) noexcept {
-    const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_tci_activates(Limiters::MinmodType::LambdaPiN, tvbm_constant,
-                              local_input, element, mesh, element_size,
-                              make_two_neighbors(left, right),
-                              make_two_neighbors(2.0, 2.0), expected_slopes);
-  };
-  const auto test_does_not_activate = [&element, &mesh, &element_size ](
-      const double tvbm_constant, const DataVector& local_input,
-      const double left, const double right) noexcept {
-    // Because in this test the TCI is LambdaPiN, no slopes are returned, and
-    // no comparison is made. So set these to NaN
-    const auto original_slopes =
-        make_array<1>(std::numeric_limits<double>::signaling_NaN());
-    test_minmod_tci_does_not_activate(
-        Limiters::MinmodType::LambdaPiN, tvbm_constant, local_input, element,
-        mesh, element_size, make_two_neighbors(left, right),
-        make_two_neighbors(2.0, 2.0), original_slopes);
-  };
-
-  const double m0 = 0.0;
-  const double m1 = 1.0;
-  const double m2 = 2.0;
-
-  const auto input = [&mesh]() noexcept {
-    const auto coords = logical_coordinates(mesh);
-    return DataVector{10.0 * step_function(get<0>(coords))};
+  // mean = 1.5
+  // delta_left = -0.1
+  // delta_right = 0.3
+  const DataVector input2 = [&mesh]() noexcept {
+    const auto x = get<0>(logical_coordinates(mesh));
+    return DataVector{1.4 + 0.1 * x + 0.3 * square(x)};
   }
   ();
 
-  // Establish baseline m = 0 case; LambdaPiN normally avoids limiting when
-  // max(edge - mean) <= min(neighbor - mean)
-  test_does_not_activate(m0, input, 0.0, 10.0);
-  test_does_not_activate(m0, input, -0.3, 10.2);
-  // but does limit if max(edge - mean) > min(neighbor - mean)
-  test_activates(m0, input, 0.02, 10.0, 4.98);
-  test_activates(m0, input, 0.0, 9.99, 4.99);
+  // Because left-to-mean and mean-to-right slopes have different signs,
+  // any TCI call with TVBM=0 should trigger
+  test_activation(true, input2, 1.7, 1.9, 0.0);
+  test_activation(true, input2, 1.7, 1.3, 0.0);
+  test_activation(true, input2, 1.3, 1.7, 0.0);
+  test_activation(true, input2, 1.1, 1.9, 0.0);
 
-  // However, with a non-zero TVBM constant, LambdaPiN should additionally avoid
-  // limiting when max(edge - mean) < TVBM correction.
-  // We test first a case where the TVBM correction is too small to affect
-  // the limiter action,
-  test_does_not_activate(m1, input, 0.0, 10.0);
-  test_does_not_activate(m1, input, -0.3, 10.2);
-  test_activates(m1, input, 0.02, 10.0, 4.98);
-  test_activates(m1, input, 0.0, 9.99, 4.99);
+  // Conversely, because left-to-mean and mean-to-right slopes have different
+  // signs, calls with TVBM>0 give results that depend on neighbor means
+  test_activation(true, input2, 1.7, 1.3, 0.11);
+  test_activation(true, input2, 1.7, 1.3, 0.29);
+  test_activation(false, input2, 1.7, 1.3, 0.31);
 
-  // And a case where the TVBM correction enables LambdaPiN to avoid limiting
-  // (Note that the slope here is still too large to avoid limiting through
-  // the normal TVBM tolerance.)
-  test_does_not_activate(m2, input, 0.0, 10.0);
-  test_does_not_activate(m2, input, -0.3, 10.2);
-  test_does_not_activate(m2, input, 0.02, 10.0);
-  test_does_not_activate(m2, input, 0.0, 9.99);
+  test_activation(true, input2, 1.3, 1.7, 0.11);
+  test_activation(true, input2, 1.3, 1.7, 0.29);
+  test_activation(false, input2, 1.3, 1.7, 0.31);
+
+  test_activation(false, input2, 1.1, 1.9, 0.11);
+  test_activation(false, input2, 1.1, 1.9, 0.29);
+  test_activation(false, input2, 1.1, 1.9, 0.31);
 }
 
-void test_tci_at_boundary(const size_t number_of_grid_points,
-                          const Limiters::MinmodType& minmod_type) noexcept {
+void test_tci_at_boundary(const size_t number_of_grid_points) noexcept {
   INFO("Testing limiter at boundary...");
   CAPTURE(number_of_grid_points);
-  CAPTURE(get_output(minmod_type));
   const double tvbm_constant = 0.0;
   const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   const auto element_size = make_array<1>(2.0);
 
-  const double muscl_slope_factor =
-      (minmod_type == Limiters::MinmodType::Muscl) ? 0.5 : 1.0;
-  const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
+  const auto input = [&mesh]() noexcept {
     const auto coords = logical_coordinates(mesh);
-    return DataVector{1.2 * muscl_slope_factor * get<0>(coords)};
+    return DataVector{1.2 * get<0>(coords)};
   }
   ();
 
@@ -447,31 +240,27 @@ void test_tci_at_boundary(const size_t number_of_grid_points,
   const auto element_at_lower_xi_boundary =
       TestHelpers::Limiters::make_element<1>({{Direction<1>::lower_xi()}});
   for (const double neighbor : {-1.3, 3.6, 4.8, 13.2}) {
-    test_minmod_tci_activates(
-        minmod_type, tvbm_constant, input, element_at_lower_xi_boundary, mesh,
+    test_minmod_tci_activation(
+        true, tvbm_constant, input, element_at_lower_xi_boundary, mesh,
         element_size, {{std::make_pair(Direction<1>::upper_xi(), neighbor)}},
-        {{std::make_pair(Direction<1>::upper_xi(), element_size[0])}},
-        make_array<1>(0.0));
+        {{std::make_pair(Direction<1>::upper_xi(), element_size[0])}});
   }
 
   // Test with element that has external upper-xi boundary
   const auto element_at_upper_xi_boundary =
       TestHelpers::Limiters::make_element<1>({{Direction<1>::upper_xi()}});
   for (const double neighbor : {-1.3, 3.6, 4.8, 13.2}) {
-    test_minmod_tci_activates(
-        minmod_type, tvbm_constant, input, element_at_upper_xi_boundary, mesh,
+    test_minmod_tci_activation(
+        true, tvbm_constant, input, element_at_upper_xi_boundary, mesh,
         element_size, {{std::make_pair(Direction<1>::lower_xi(), neighbor)}},
-        {{std::make_pair(Direction<1>::lower_xi(), element_size[0])}},
-        make_array<1>(0.0));
+        {{std::make_pair(Direction<1>::lower_xi(), element_size[0])}});
   }
 }
 
 void test_tci_with_different_size_neighbor(
-    const size_t number_of_grid_points,
-    const Limiters::MinmodType& minmod_type) noexcept {
+    const size_t number_of_grid_points) noexcept {
   INFO("Testing limiter with neighboring elements of different size...");
   CAPTURE(number_of_grid_points);
-  CAPTURE(get_output(minmod_type));
   const double tvbm_constant = 0.0;
   const auto element = TestHelpers::Limiters::make_element<1>();
   const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
@@ -479,119 +268,80 @@ void test_tci_with_different_size_neighbor(
   const double dx = 1.0;
   const auto element_size = make_array<1>(dx);
 
-  const auto test_activates =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
-          const DataVector& local_input, const double left, const double right,
-          const double left_size, const double right_size,
-          const double expected_slope) noexcept {
-    const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_tci_activates(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
-        make_two_neighbors(left, right),
-        make_two_neighbors(left_size, right_size), expected_slopes);
-  };
-  const auto test_does_not_activate =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
-          const DataVector& local_input, const double left, const double right,
-          const double left_size, const double right_size,
-          const double original_slope) noexcept {
-    const auto original_slopes = make_array<1>(original_slope);
-    test_minmod_tci_does_not_activate(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
-        make_two_neighbors(left, right),
-        make_two_neighbors(left_size, right_size), original_slopes);
+  const auto test_activation =
+      [&tvbm_constant, &element, &mesh, &element_size ](
+          const bool expected_activation, const DataVector& local_input,
+          const double left, const double right, const double left_size,
+          const double right_size) noexcept {
+    test_minmod_tci_activation(expected_activation, tvbm_constant, local_input,
+                               element, mesh, element_size,
+                               make_two_neighbors(left, right),
+                               make_two_neighbors(left_size, right_size));
   };
 
-  const double muscl_slope_factor =
-      (minmod_type == Limiters::MinmodType::Muscl) ? 0.5 : 1.0;
   const double eps = 100.0 * std::numeric_limits<double>::epsilon();
 
-  const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
+  const auto input = [&mesh]() noexcept {
     const auto coords = logical_coordinates(mesh);
-    return DataVector{2.0 + 1.2 * muscl_slope_factor * get<0>(coords)};
+    return DataVector{2.0 + 1.2 * get<0>(coords)};
   }
   ();
 
   // Establish baseline using evenly-sized elements
-  test_does_not_activate(input, 0.8 - eps, 3.2 + eps, dx, dx,
-                         1.2 * muscl_slope_factor);
+  test_activation(false, input, 0.8 - eps, 3.2 + eps, dx, dx);
 
   const double larger = 2.0 * dx;
   const double smaller = 0.5 * dx;
 
   // Larger neighbor with same mean => true reduction in slope => trigger
-  test_activates(input, 0.8 - eps, 3.2, dx, larger, 0.8 * muscl_slope_factor);
+  test_activation(true, input, 0.8 - eps, 3.2, dx, larger);
   // Larger neighbor with larger mean => same slope => no trigger
-  test_does_not_activate(input, 0.8 - eps, 3.8 + eps, dx, larger,
-                         1.2 * muscl_slope_factor);
+  test_activation(false, input, 0.8 - eps, 3.8 + eps, dx, larger);
 
   // Smaller neighbor with same mean => increased slope => no trigger
-  test_does_not_activate(input, 0.8 - eps, 3.2 + eps, dx, smaller,
-                         1.2 * muscl_slope_factor);
+  test_activation(false, input, 0.8 - eps, 3.2 + eps, dx, smaller);
   // Smaller neighbor with lower mean => same slope => no trigger
-  test_does_not_activate(input, 0.8 - eps, 2.9 + eps, dx, smaller,
-                         1.2 * muscl_slope_factor);
+  test_activation(false, input, 0.8 - eps, 2.9 + eps, dx, smaller);
 
-  test_activates(input, 0.8, 3.2 + eps, larger, dx, 0.8 * muscl_slope_factor);
-  test_does_not_activate(input, 0.2 - eps, 3.2 + eps, larger, dx,
-                         1.2 * muscl_slope_factor);
+  test_activation(true, input, 0.8, 3.2 + eps, larger, dx);
+  test_activation(false, input, 0.2 - eps, 3.2 + eps, larger, dx);
 
-  test_does_not_activate(input, 0.8 - eps, 3.2 + eps, smaller, dx,
-                         1.2 * muscl_slope_factor);
-  test_does_not_activate(input, 1.1 - eps, 3.2 + eps, smaller, dx,
-                         1.2 * muscl_slope_factor);
+  test_activation(false, input, 0.8 - eps, 3.2 + eps, smaller, dx);
+  test_activation(false, input, 1.1 - eps, 3.2 + eps, smaller, dx);
 }
 
-// In 1D, test combinations of MinmodType, TVBM constant, polynomial order, etc.
+// In 1D, test combinations of TVBM constant, polynomial order, etc.
 // Check that each combination has the expected TCI behavior.
 void test_minmod_tci_1d() noexcept {
   INFO("Testing MinmodTci in 1D");
-  for (const auto& minmod_type :
-       {Limiters::MinmodType::LambdaPi1, Limiters::MinmodType::LambdaPiN,
-        Limiters::MinmodType::Muscl}) {
-    for (const auto num_grid_points : std::array<size_t, 2>{{2, 4}}) {
-      test_tci_on_linear_function(num_grid_points, minmod_type);
-      test_tci_with_tvbm_correction(num_grid_points, minmod_type);
-      test_tci_at_boundary(num_grid_points, minmod_type);
-      test_tci_with_different_size_neighbor(num_grid_points, minmod_type);
-    }
-    // This test only makes sense with more than 2 grid points
-    test_tci_on_quadratic_function(4, minmod_type);
+  for (const auto num_grid_points : std::array<size_t, 2>{{2, 4}}) {
+    test_tci_on_linear_function(num_grid_points);
+    test_tci_at_boundary(num_grid_points);
+    test_tci_with_different_size_neighbor(num_grid_points);
   }
-  // This test only makes sense with LambdaPiN and more than 2 grid points
-  test_lambda_pin_troubled_cell_tvbm_correction(4);
+  // This test only makes sense with more than 2 grid points
+  test_tci_on_quadratic_function(3);
+  test_tci_on_quadratic_function(4);
 }
 
 // In 2D, test that the dimension-by-dimension application of the TCI works as
 // expected.
 void test_minmod_tci_2d() noexcept {
   INFO("Testing MinmodTci in 2D");
-  const auto minmod_type = Limiters::MinmodType::LambdaPi1;
   const double tvbm_constant = 0.0;
   const auto element = TestHelpers::Limiters::make_element<2>();
   const Mesh<2> mesh(3, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   const auto element_size = make_array<2>(2.0);
 
-  const auto test_activates =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &
-       element_size ](const DataVector& local_input,
-                      const std::array<double, 4>& neighbor_means,
-                      const std::array<double, 2>& expected_slopes) noexcept {
-    test_minmod_tci_activates(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
-        make_four_neighbors(neighbor_means),
-        make_four_neighbors(make_array<4>(2.0)), expected_slopes);
-  };
-  const auto test_does_not_activate =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &
-       element_size ](const DataVector& local_input,
-                      const std::array<double, 4>& neighbor_means,
-                      const std::array<double, 2>& original_slopes) noexcept {
-    test_minmod_tci_does_not_activate(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
-        make_four_neighbors(neighbor_means),
-        make_four_neighbors(make_array<4>(2.0)), original_slopes);
+  const auto test_activation =
+      [&tvbm_constant, &element, &mesh, &element_size ](
+          const bool expected_activation, const DataVector& local_input,
+          const std::array<double, 4>& neighbor_means) noexcept {
+    test_minmod_tci_activation(expected_activation, tvbm_constant, local_input,
+                               element, mesh, element_size,
+                               make_four_neighbors(neighbor_means),
+                               make_four_neighbors(make_array<4>(2.0)));
   };
 
   const auto input = [&mesh]() noexcept {
@@ -603,51 +353,39 @@ void test_minmod_tci_2d() noexcept {
   ();
 
   // Case with no activation
-  test_does_not_activate(input, {{1.9, 4.2, -0.5, 5.6}}, {{1.0, 2.0}});
+  test_activation(false, input, {{1.9, 4.2, -0.5, 5.6}});
 
   // Limit because of xi-direction neighbors
-  test_activates(input, {{2.2, 4.2, -0.5, 5.6}}, {{0.8, 2.0}});
-  test_activates(input, {{1.9, 3.2, -0.5, 5.6}}, {{0.2, 2.0}});
+  test_activation(true, input, {{2.2, 4.2, -0.5, 5.6}});
+  test_activation(true, input, {{1.9, 3.2, -0.5, 5.6}});
 
   // Limit because of eta-direction neighbors
-  test_activates(input, {{1.9, 4.2, 1.5, 5.6}}, {{1.0, 1.5}});
-  test_activates(input, {{1.9, 4.2, -0.5, 2.9}}, {{1.0, 0.0}});
+  test_activation(true, input, {{1.9, 4.2, 1.5, 5.6}});
+  test_activation(true, input, {{1.9, 4.2, -0.5, 2.9}});
 
   // Limit for xi and eta directions
-  test_activates(input, {{2.2, 4.2, 1.5, 5.6}}, {{0.8, 1.5}});
-  test_activates(input, {{3.9, 4.2, -0.5, 2.9}}, {{0.0, 0.0}});
+  test_activation(true, input, {{2.2, 4.2, 1.5, 5.6}});
+  test_activation(true, input, {{3.9, 4.2, -0.5, 2.9}});
 }
 
-// In 2D, test that the dimension-by-dimension application of the TCI works as
+// In 3D, test that the dimension-by-dimension application of the TCI works as
 // expected.
 void test_minmod_tci_3d() noexcept {
   INFO("Testing MinmodTci in 3D");
-  const auto minmod_type = Limiters::MinmodType::LambdaPi1;
   const double tvbm_constant = 0.0;
   const auto element = TestHelpers::Limiters::make_element<3>();
   const Mesh<3> mesh(3, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   const auto element_size = make_array<3>(2.0);
 
-  const auto test_activates =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &
-       element_size ](const DataVector& local_input,
-                      const std::array<double, 6>& neighbor_means,
-                      const std::array<double, 3>& expected_slopes) noexcept {
-    test_minmod_tci_activates(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
-        make_six_neighbors(neighbor_means),
-        make_six_neighbors(make_array<6>(2.0)), expected_slopes);
-  };
-  const auto test_does_not_activate =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &
-       element_size ](const DataVector& local_input,
-                      const std::array<double, 6>& neighbor_means,
-                      const std::array<double, 3>& original_slopes) noexcept {
-    test_minmod_tci_does_not_activate(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
-        make_six_neighbors(neighbor_means),
-        make_six_neighbors(make_array<6>(2.0)), original_slopes);
+  const auto test_activation =
+      [&tvbm_constant, &element, &mesh, &element_size ](
+          const bool expected_activation, const DataVector& local_input,
+          const std::array<double, 6>& neighbor_means) noexcept {
+    test_minmod_tci_activation(expected_activation, tvbm_constant, local_input,
+                               element, mesh, element_size,
+                               make_six_neighbors(neighbor_means),
+                               make_six_neighbors(make_array<6>(2.0)));
   };
 
   const auto input = [&mesh]() noexcept {
@@ -661,24 +399,23 @@ void test_minmod_tci_3d() noexcept {
   ();
 
   // Case with no activation
-  test_does_not_activate(input, {{3.8, -0.1, 1.5, 2.7, 1.2, 2.5}},
-                         {{-1.6, 0.4, 0.4}});
+  test_activation(false, input, {{3.8, -0.1, 1.5, 2.7, 1.2, 2.5}});
 
   // Limit because of xi-direction neighbors
-  test_activates(input, {{3.4, -0.1, 1.5, 2.7, 1.2, 2.5}}, {{-1.4, 0.4, 0.4}});
-  test_activates(input, {{3.8, 2.1, 1.5, 2.7, 1.2, 2.5}}, {{0.0, 0.4, 0.4}});
+  test_activation(true, input, {{3.4, -0.1, 1.5, 2.7, 1.2, 2.5}});
+  test_activation(true, input, {{3.8, 2.1, 1.5, 2.7, 1.2, 2.5}});
 
   // Limit because of eta-direction neighbors
-  test_activates(input, {{3.8, -0.1, 1.9, 2.7, 1.2, 2.5}}, {{-1.6, 0.1, 0.4}});
-  test_activates(input, {{3.8, -0.1, 1.5, 2.3, 1.2, 2.5}}, {{-1.6, 0.3, 0.4}});
+  test_activation(true, input, {{3.8, -0.1, 1.9, 2.7, 1.2, 2.5}});
+  test_activation(true, input, {{3.8, -0.1, 1.5, 2.3, 1.2, 2.5}});
 
   // Limit because of zeta-direction neighbors
-  test_activates(input, {{3.8, -0.1, 1.5, 2.7, 2.2, 2.5}}, {{-1.6, 0.4, 0.0}});
-  test_activates(input, {{3.8, -0.1, 1.5, 2.7, 1.2, 2.1}}, {{-1.6, 0.4, 0.1}});
+  test_activation(true, input, {{3.8, -0.1, 1.5, 2.7, 2.2, 2.5}});
+  test_activation(true, input, {{3.8, -0.1, 1.5, 2.7, 1.2, 2.1}});
 
   // Limit for xi, eta, and zeta directions
-  test_activates(input, {{3.4, -0.1, 1.5, 2.3, 1.2, 2.1}}, {{-1.4, 0.3, 0.1}});
-  test_activates(input, {{3.8, 2.1, 2.1, 2.7, 2.2, 2.5}}, {{0.0, 0.0, 0.0}});
+  test_activation(true, input, {{3.4, -0.1, 1.5, 2.3, 1.2, 2.1}});
+  test_activation(true, input, {{3.8, 2.1, 2.1, 2.7, 2.2, 2.5}});
 }
 
 struct ScalarTag : db::SimpleTag {
@@ -696,7 +433,6 @@ void test_minmod_tci_several_tensors() noexcept {
   INFO("Testing MinmodTci action on several tensors");
   // Test that TCI returns true if just one component needs limiting, which
   // we do by limiting a scalar and vector in 3D
-  const auto minmod_type = Limiters::MinmodType::LambdaPi1;
   const double tvbm_constant = 0.0;
   const auto element = TestHelpers::Limiters::make_element<3>();
   const size_t number_of_grid_points = 2;
@@ -775,8 +511,8 @@ void test_minmod_tci_several_tensors() noexcept {
   bool activation =
       Limiters::Minmod_detail::troubled_cell_indicator<3, TestPackagedData,
                                                        ScalarTag, VectorTag<3>>(
-          local_scalar, local_vector, neighbor_data, minmod_type, tvbm_constant,
-          element, mesh, element_size);
+          local_scalar, local_vector, neighbor_data, tvbm_constant, element,
+          mesh, element_size);
   CHECK_FALSE(activation);
 
   // Case where the scalar triggers limiting
@@ -784,8 +520,8 @@ void test_minmod_tci_several_tensors() noexcept {
   activation =
       Limiters::Minmod_detail::troubled_cell_indicator<3, TestPackagedData,
                                                        ScalarTag, VectorTag<3>>(
-          local_scalar, local_vector, neighbor_data, minmod_type, tvbm_constant,
-          element, mesh, element_size);
+          local_scalar, local_vector, neighbor_data, tvbm_constant, element,
+          mesh, element_size);
   CHECK(activation);
 
   // Case where the vector x-component triggers limiting
@@ -794,8 +530,8 @@ void test_minmod_tci_several_tensors() noexcept {
   activation =
       Limiters::Minmod_detail::troubled_cell_indicator<3, TestPackagedData,
                                                        ScalarTag, VectorTag<3>>(
-          local_scalar, local_vector, neighbor_data, minmod_type, tvbm_constant,
-          element, mesh, element_size);
+          local_scalar, local_vector, neighbor_data, tvbm_constant, element,
+          mesh, element_size);
   CHECK(activation);
 
   // Case where the vector y-component triggers limiting
@@ -804,8 +540,8 @@ void test_minmod_tci_several_tensors() noexcept {
   activation =
       Limiters::Minmod_detail::troubled_cell_indicator<3, TestPackagedData,
                                                        ScalarTag, VectorTag<3>>(
-          local_scalar, local_vector, neighbor_data, minmod_type, tvbm_constant,
-          element, mesh, element_size);
+          local_scalar, local_vector, neighbor_data, tvbm_constant, element,
+          mesh, element_size);
   CHECK(activation);
 
   // Case where the vector z-component triggers limiting
@@ -814,8 +550,8 @@ void test_minmod_tci_several_tensors() noexcept {
   activation =
       Limiters::Minmod_detail::troubled_cell_indicator<3, TestPackagedData,
                                                        ScalarTag, VectorTag<3>>(
-          local_scalar, local_vector, neighbor_data, minmod_type, tvbm_constant,
-          element, mesh, element_size);
+          local_scalar, local_vector, neighbor_data, tvbm_constant, element,
+          mesh, element_size);
   CHECK(activation);
 }
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
@@ -275,11 +275,11 @@ void test_weno_tci_1d() noexcept {
   }
   ();
 
-  // These means lead to slopes (as estimated from the difference of means
-  // between neighboring elements) that are larger than or less than the mean
-  // local slope. This should lead the MinmodTci to not activate, or activate.
-  const std::array<double, 2> means_no_activation = {{5., -0.7}};
-  const std::array<double, 2> means_activation = {{5., -0.6}};
+  // Here we specify two sets of neighbor means: one such that the TCI does not
+  // trigger, another such that the TCI does trigger.
+  // Local mean: 4/3; largest mean-to-edge slope: 8/3
+  const std::array<double, 2> means_no_activation = {{4., -1.4}};
+  const std::array<double, 2> means_activation = {{4., -1.3}};
 
   test_weno_tci_work(mesh, scalar, means_no_activation, means_activation);
 }
@@ -297,8 +297,9 @@ void test_weno_tci_2d() noexcept {
   }
   ();
 
-  const std::array<double, 4> means_no_activation = {{-1.1, 1.1, -1.1, 1.1}};
-  const std::array<double, 4> means_activation = {{-1.1, 1.1, -1.1, 0.9}};
+  // Local mean: 0; largest mean-to-edge slope in x and y: 4/3
+  const std::array<double, 4> means_no_activation = {{-1.4, 1.4, -1.4, 1.4}};
+  const std::array<double, 4> means_activation = {{-1.4, 1.4, -1.4, 1.3}};
 
   test_weno_tci_work(mesh, scalar, means_no_activation, means_activation);
 }
@@ -317,10 +318,11 @@ void test_weno_tci_3d() noexcept {
   }
   ();
 
+  // Local mean: 0; largest mean-to-edge slope in x and y: 1, in z: -0.2
   const std::array<double, 6> means_no_activation = {
       {-1.1, 1.1, -1.1, 1.1, 0.25, -0.25}};
   const std::array<double, 6> means_activation = {
-      {-1.1, 1.1, -1.1, 1.1, 0.1, -0.25}};
+      {-1.1, 1.1, -1.1, 1.1, 0.15, -0.25}};
 
   test_weno_tci_work(mesh, scalar, means_no_activation, means_activation);
 }


### PR DESCRIPTION
## Proposed changes

The current design of `MinmodTci` bundles some logic that, in hindsight, did not belong in the TCI and should have remained in the minmod limiter itself. This PR moves this logic out of the TCI and into the limiter.

This change has no effect on the minmod limiter, but can affect the triggering of other limiters that used the minmod TCI, because the removed logic could change the detection of troubled cells. Tests are adjusted accordingly.

I've tried to make the refactor a little easier to review by splitting it into multiple commits. The strategy for the refactor is as follows:
1. First, copy the entire TCI code into the limiter,
2. Then, simplify the TCI by removing the unnecessary logic,
3. Then, call the (new, trimmed-down) TCI from the limiter.

Commits should be viewed in this order:
1. Move some functions from MinmodTci to MinmodHelpers
2. Copy MinmodTci code into Minmod
3. Cut down MinmodTci to only the TCI part
4. Add new allocation helper for MinmodTci
5. Improve variable names in MinmodTci
6. Improve comments in MinmodTci
7. Use new TCI in Minmod limiter


### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

