### PR TITLE
Simplify self-start interface

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -132,7 +132,7 @@ struct EvolutionMetavars {
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<Event<events>::creatable_classes>;
 
-  using compute_rhs = tmpl::flatten<tmpl::list<
+  using step_actions = tmpl::flatten<tmpl::list<
       dg::Actions::ComputeNonconservativeBoundaryFluxes<
           Tags::InternalDirections<volume_dim>>,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
@@ -141,8 +141,8 @@ struct EvolutionMetavars {
           Tags::BoundaryDirectionsInterior<volume_dim>>,
       dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
-      dg::Actions::ApplyFluxes, Actions::RecordTimeStepperData>>;
-  using update_variables = tmpl::flatten<tmpl::list<Actions::UpdateU>>;
+      dg::Actions::ApplyFluxes, Actions::RecordTimeStepperData,
+      Actions::UpdateU>>;
 
   enum class Phase {
     Initialization,
@@ -212,7 +212,7 @@ struct EvolutionMetavars {
               Parallel::PhaseActions<
                   Phase, Phase::InitializeTimeStepperHistory,
                   tmpl::flatten<tmpl::list<SelfStart::self_start_procedure<
-                      compute_rhs, update_variables>>>>,
+                      step_actions>>>>,
               Parallel::PhaseActions<
                   Phase, Phase::RegisterWithObserver,
                   tmpl::list<observers::Actions::RegisterWithObservers<
@@ -222,8 +222,8 @@ struct EvolutionMetavars {
               Parallel::PhaseActions<
                   Phase, Phase::Evolve,
                   tmpl::flatten<
-                      tmpl::list<Actions::RunEventsAndTriggers, compute_rhs,
-                                 update_variables, Actions::AdvanceTime>>>>>>;
+                      tmpl::list<Actions::RunEventsAndTriggers, step_actions,
+                                 Actions::AdvanceTime>>>>>>;
 
   static constexpr OptionString help{
       "Evolve a generalized harmonic analytic solution.\n\n"

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -159,7 +159,7 @@ struct EvolutionMetavars {
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       typename Event<events>::creatable_classes>;
 
-  using compute_rhs = tmpl::flatten<tmpl::list<
+  using step_actions = tmpl::flatten<tmpl::list<
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       Actions::ComputeVolumeSources, Actions::ComputeTimeDerivative,
@@ -170,9 +170,7 @@ struct EvolutionMetavars {
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,
                           dg::Actions::ApplyFluxes>,
-      Actions::RecordTimeStepperData>>;
-
-  using update_variables = tmpl::flatten<tmpl::list<
+      Actions::RecordTimeStepperData,
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,
@@ -220,9 +218,9 @@ struct EvolutionMetavars {
               Parallel::PhaseActions<Phase, Phase::Initialization,
                                      initialization_actions>,
 
-              Parallel::PhaseActions<Phase, Phase::InitializeTimeStepperHistory,
-                                     SelfStart::self_start_procedure<
-                                         compute_rhs, update_variables>>,
+              Parallel::PhaseActions<
+                  Phase, Phase::InitializeTimeStepperHistory,
+                  SelfStart::self_start_procedure<step_actions>>,
 
               Parallel::PhaseActions<
                   Phase, Phase::RegisterWithObserver,
@@ -241,7 +239,7 @@ struct EvolutionMetavars {
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      compute_rhs, update_variables, Actions::AdvanceTime>>>>>;
+                      step_actions, Actions::AdvanceTime>>>>>;
 
   using const_global_cache_tags =
       tmpl::list<initial_data_tag,

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -131,16 +131,14 @@ struct Component {
 
   static constexpr bool has_primitives = Metavariables::has_primitives;
 
-  using update_actions = tmpl::conditional_t<
-      has_primitives, tmpl::list<Actions::UpdateU, Actions::UpdatePrimitives>,
-      Actions::UpdateU>;
+  using step_actions =
+      tmpl::list<Actions::ComputeTimeDerivative, Actions::RecordTimeStepperData,
+                 tmpl::conditional_t<
+                     has_primitives,
+                     tmpl::list<Actions::UpdateU, Actions::UpdatePrimitives>,
+                     Actions::UpdateU>>;
   using action_list = tmpl::flatten<
-      tmpl::list<SelfStart::self_start_procedure<
-                     tmpl::list<Actions::ComputeTimeDerivative,
-                                Actions::RecordTimeStepperData>,
-                     update_actions>,
-                 Actions::ComputeTimeDerivative,
-                 Actions::RecordTimeStepperData, update_actions>>;
+      tmpl::list<SelfStart::self_start_procedure<step_actions>, step_actions>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,


### PR DESCRIPTION
The steps to compute the RHS always end with recording the RHS, so
there is no need for the consumer to have to state that.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
