### PR TITLE
Add utility function to VolumeData

### DIFF
--- a/src/IO/H5/VolumeData.cpp
+++ b/src/IO/H5/VolumeData.cpp
@@ -20,7 +20,10 @@
 #include "IO/H5/Header.hpp"
 #include "IO/H5/Helpers.hpp"
 #include "IO/H5/Version.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Literals.hpp"
 #include "Utilities/Numeric.hpp"
+
 /// \cond HIDDEN_SYMBOLS
 namespace h5 {
 namespace {
@@ -304,6 +307,27 @@ std::vector<std::vector<size_t>> VolumeData::get_extents(
     individual_extents.emplace_back(iter, iter + extents_per_element);
   }
   return individual_extents;
+}
+
+std::pair<size_t, size_t> offset_and_length_for_grid(
+    const std::string& grid_name,
+    const std::vector<std::string>& all_grid_names,
+    const std::vector<std::vector<size_t>>& all_extents) noexcept {
+  auto found_grid_name = alg::find(all_grid_names, grid_name);
+  if (found_grid_name == all_grid_names.end()) {
+    ERROR("Found no grid named '" + grid_name + "'.");
+  } else {
+    const auto element_index =
+        std::distance(all_grid_names.begin(), found_grid_name);
+    const size_t element_data_offset = std::accumulate(
+        all_extents.begin(), all_extents.begin() + element_index,
+        0_st, [](size_t offset, std::vector<size_t> extents) noexcept {
+          return offset + alg::accumulate(extents, 1_st, std::multiplies<>{});
+        });
+    const size_t element_data_length = alg::accumulate(
+        gsl::at(all_extents, element_index), 1_st, std::multiplies<>{});
+    return {element_data_offset, element_data_length};
+  }
 }
 
 size_t VolumeData::get_dimension() const noexcept {

--- a/src/IO/H5/VolumeData.hpp
+++ b/src/IO/H5/VolumeData.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <hdf5.h>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -52,7 +53,9 @@ namespace h5 {
  * and their extents in the order which they and the data were written.
  * For example, if the first grid has name `GRID_NAME` with extents
  * `{2, 2, 2}`, it was responsible for contributing the first 2*2*2 = 8 grid
- * points worth of data in each tensor dataset.
+ * points worth of data in each tensor dataset. Use the
+ * `h5::offset_and_length_for_grid` function to compute the offset into the
+ * contiguous dataset that corresponds to a particular grid.
  *
  * \warning Currently the topology of the grids is assumed to be tensor products
  * of lines, i.e. lines, quadrilaterals, and hexahedrons. However, this can be
@@ -133,4 +136,31 @@ class VolumeData : public h5::Object {
   detail::OpenGroup volume_data_group_{};
   std::string header_{};
 };
+
+/*!
+ * \brief Find the interval within the contiguous dataset stored in
+ * `h5::VolumeData` that holds data for a particular `grid_name`.
+ *
+ * `h5::VolumeData` stores data for all grids that compose the volume
+ * contiguously. This function helps with reconstructing which part of that
+ * contiguous dataset belongs to a particular grid. See the `h5::VolumeData`
+ * documentation for more information on how it stores data.
+ *
+ * To use this function, call `h5::VolumeData::get_grid_names` and
+ * `h5::VolumeData::get_extents` and pass the results for the `all_grid_names`
+ * and `all_extents` arguments, respectively. This means you can retrieve this
+ * information from an `h5::VolumeData` once and use it to call
+ * `offset_and_length_for_grid` multiple times with different `grid_name`s.
+ *
+ * Here is an example for using this function:
+ *
+ * \snippet Test_VolumeData.cpp find_offset
+ *
+ * \see `h5::VolumeData`
+ */
+std::pair<size_t, size_t> offset_and_length_for_grid(
+    const std::string& grid_name,
+    const std::vector<std::string>& all_grid_names,
+    const std::vector<std::vector<size_t>>& all_extents) noexcept;
+
 }  // namespace h5

--- a/tests/Unit/IO/Test_VolumeData.cpp
+++ b/tests/Unit/IO/Test_VolumeData.cpp
@@ -207,6 +207,24 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
   for (size_t i = 0; i < observation_ids.size(); ++i) {
     check_time(observation_ids[i], observation_values[i]);
   }
+
+  {
+    INFO("offset_and_length_for_grid");
+    const size_t observation_id = observation_ids.front();
+    /// [find_offset]
+    const auto all_grid_names = volume_file.get_grid_names(observation_id);
+    const auto all_extents = volume_file.get_extents(observation_id);
+    const auto first_grid_offset_and_length = h5::offset_and_length_for_grid(
+        grid_names.front(), all_grid_names, all_extents);
+    /// [find_offset]
+    CHECK(first_grid_offset_and_length.first == 0);
+    CHECK(first_grid_offset_and_length.second == 8);
+    const auto last_grid_offset_and_length = h5::offset_and_length_for_grid(
+        grid_names.back(), all_grid_names, all_extents);
+    CHECK(last_grid_offset_and_length.first == 8);
+    CHECK(last_grid_offset_and_length.second == 8);
+  }
+
   if (file_system::check_if_file_exists(h5_file_name)) {
     file_system::rm(h5_file_name, true);
   }


### PR DESCRIPTION
## Proposed changes

Adds a utility function to find the offset into the contiguous dataset stored in `h5::VolumeData`
for a particular `grid_name`.


### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
