### PR TITLE
Add an assert when a parallel component is missing

### DIFF
--- a/src/Parallel/ConstGlobalCache.hpp
+++ b/src/Parallel/ConstGlobalCache.hpp
@@ -60,10 +60,29 @@ using type_for_get = typename type_for_get_helper<
     typename tmpl::front<ConstGlobalCache_detail::get_list_of_matching_tags<
         ConstGlobalCacheTag, Metavariables>>::type>::type;
 
-template <typename ComponentFromList, typename ComponentToFind>
-struct get_component_if_mocked_helper
-    : std::is_same<typename ComponentFromList::component_being_mocked,
-                   ComponentToFind> {};
+template <class T, class = cpp17::void_t<>>
+struct has_component_being_mocked_alias : std::false_type {};
+
+template <class T>
+struct has_component_being_mocked_alias<
+    T, cpp17::void_t<typename T::component_being_mocked>> : std::true_type {};
+
+template <class T>
+constexpr bool has_component_being_mocked_alias_v =
+    has_component_being_mocked_alias<T>::value;
+
+template <typename ComponentToFind, typename ComponentFromList>
+struct get_component_if_mocked_helper {
+  static_assert(
+      has_component_being_mocked_alias_v<ComponentFromList>,
+      "The parallel component was not found, and it looks like it is not being "
+      "mocked. Did you forget to add it to the "
+      "'Metavariables::component_list'? See the first template parameter for "
+      "the component that we are looking for and the second template parameter "
+      "for the component that is being checked for mocking it.");
+  using type = std::is_same<typename ComponentFromList::component_being_mocked,
+                            ComponentToFind>;
+};
 
 /// In order to be able to use a mock action testing framework we need to be
 /// able to get the correct parallel component from the global cache even when
@@ -78,8 +97,8 @@ using get_component_if_mocked = tmpl::front<tmpl::type_from<tmpl::conditional_t<
     tmpl::list_contains_v<ComponentList, ParallelComponent>,
     tmpl::type_<tmpl::list<ParallelComponent>>,
     tmpl::lazy::find<ComponentList,
-                     get_component_if_mocked_helper<
-                         tmpl::_1, tmpl::pin<ParallelComponent>>>>>>;
+                     tmpl::type_<get_component_if_mocked_helper<
+                         tmpl::pin<ParallelComponent>, tmpl::_1>>>>>>;
 }  // namespace ConstGlobalCache_detail
 
 /// \ingroup ParallelGroup


### PR DESCRIPTION
## Proposed changes

When a parallel component was forgotten to be added to the
`Metavariables::component_list` the compiler (unhelpfully) complained
that a `component_being_mocked` alias was not found.
This commit adds an assert that gives a (hopefully more helpful) hint about
what's going on.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
