### PR TITLE
Add characteristic transform matrices for NewtonianEuler

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -443,6 +443,17 @@
   author   = "Krivodonova, Lilia"
 }
 
+@book{Kulikovskii2000,
+  title      = "Mathematical Aspects of Numerical Solution of Hyperbolic
+                Systems",
+  author     = "Kulikovskii, A. G. and Pogorelov, N. V. and Semenov, A. Y.",
+  isbn       = "9780367397739",
+  series     = "Monographs and Surveys in Pure and Applied Mathematics",
+  url        = "https://www.crcpress.com/Mathematical-Aspects-of-Numerical-Solution-of-Hyperbolic-Systems/Kulikovskii-Pogorelov-Semenov/p/book/9780367397739",
+  year       = "2000",
+  publisher  = "CRC Press"
+}
+
 @article{Lindblom1998dp,
   author         = "Lindblom, Lee",
   title          = "Phase transitions and the mass radius curves of

--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.cpp
@@ -3,10 +3,17 @@
 
 #include "Evolution/Systems/NewtonianEuler/Characteristics.hpp"
 
+#include <cmath>
+#include <iterator>
+
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "ErrorHandling/Assert.hpp"
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"  // IWYU pragma: keep
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -39,6 +46,345 @@ std::array<DataVector, Dim + 2> characteristic_speeds(
   characteristic_speeds(make_not_null(&char_speeds), velocity, sound_speed,
                         normal);
   return char_speeds;
+}
+
+template <>
+Matrix right_eigenvectors<1>(const tnsr::I<double, 1>& velocity,
+                             const Scalar<double>& sound_speed_squared,
+                             const Scalar<double>& specific_enthalpy,
+                             const Scalar<double>& kappa_over_density,
+                             const tnsr::i<double, 1>& unit_normal) noexcept {
+  ASSERT(equal_within_roundoff(get(magnitude(unit_normal)), 1.),
+         "Expected unit normal, but got normal with magnitude "
+             << get(magnitude(unit_normal)));
+
+  const double u = get<0>(velocity);
+  const double n_x = get<0>(unit_normal);
+  const double c = sqrt(get(sound_speed_squared));
+  const double v_n = get(dot_product(velocity, unit_normal));
+
+  Matrix result(3, 3);
+  result(0, 0) = 1.;
+  result(0, 1) = 1.;
+  result(0, 2) = 1.;
+  result(1, 0) = u - n_x * c;
+  result(1, 1) = u;
+  result(1, 2) = u + n_x * c;
+  result(2, 0) = get(specific_enthalpy) - c * v_n;
+  result(2, 1) = get(specific_enthalpy) -
+                 get(sound_speed_squared) / get(kappa_over_density);
+  result(2, 2) = get(specific_enthalpy) + c * v_n;
+  return result;
+}
+
+template <>
+Matrix right_eigenvectors<2>(const tnsr::I<double, 2>& velocity,
+                             const Scalar<double>& sound_speed_squared,
+                             const Scalar<double>& specific_enthalpy,
+                             const Scalar<double>& kappa_over_density,
+                             const tnsr::i<double, 2>& unit_normal) noexcept {
+  ASSERT(equal_within_roundoff(get(magnitude(unit_normal)), 1.),
+         "Expected unit normal, but got normal with magnitude "
+             << get(magnitude(unit_normal)));
+
+  const double u = get<0>(velocity);
+  const double v = get<1>(velocity);
+  const double n_x = get<0>(unit_normal);
+  const double n_y = get<1>(unit_normal);
+  const double c = sqrt(get(sound_speed_squared));
+  const double v_n = get(dot_product(velocity, unit_normal));
+
+  Matrix result(4, 4);
+  result(0, 0) = 1.;
+  result(0, 1) = 1.;
+  result(0, 2) = 0.;
+  result(0, 3) = 1.;
+  result(1, 0) = u - n_x * c;
+  result(1, 1) = u;
+  result(1, 2) = -n_y;
+  result(1, 3) = u + n_x * c;
+  result(2, 0) = v - n_y * c;
+  result(2, 1) = v;
+  result(2, 2) = n_x;
+  result(2, 3) = v + n_y * c;
+  result(3, 0) = get(specific_enthalpy) - c * v_n;
+  result(3, 1) = get(specific_enthalpy) -
+                 get(sound_speed_squared) / get(kappa_over_density);
+  result(3, 2) = -n_y * u + n_x * v;
+  result(3, 3) = get(specific_enthalpy) + c * v_n;
+  return result;
+}
+
+template <>
+Matrix right_eigenvectors<3>(const tnsr::I<double, 3>& velocity,
+                             const Scalar<double>& sound_speed_squared,
+                             const Scalar<double>& specific_enthalpy,
+                             const Scalar<double>& kappa_over_density,
+                             const tnsr::i<double, 3>& unit_normal) noexcept {
+  ASSERT(equal_within_roundoff(get(magnitude(unit_normal)), 1.),
+         "Expected unit normal, but got normal with magnitude "
+             << get(magnitude(unit_normal)));
+
+  const double u = get<0>(velocity);
+  const double v = get<1>(velocity);
+  const double w = get<2>(velocity);
+  const double n_x = get<0>(unit_normal);
+  const double n_y = get<1>(unit_normal);
+  const double n_z = get<2>(unit_normal);
+  const double c = sqrt(get(sound_speed_squared));
+  const double v_n = get(dot_product(velocity, unit_normal));
+
+  Matrix result(5, 5);
+  result(0, 0) = 1.;
+  result(1, 0) = u - n_x * c;
+  result(2, 0) = v - n_y * c;
+  result(3, 0) = w - n_z * c;
+  result(4, 0) = get(specific_enthalpy) - v_n * c;
+  result(0, 1) = 1.;
+  result(1, 1) = u;
+  result(2, 1) = v;
+  result(3, 1) = w;
+  result(4, 1) = get(specific_enthalpy) -
+                 get(sound_speed_squared) / get(kappa_over_density);
+  result(0, 4) = 1.;
+  result(1, 4) = u + n_x * c;
+  result(2, 4) = v + n_y * c;
+  result(3, 4) = w + n_z * c;
+  result(4, 4) = get(specific_enthalpy) + v_n * c;
+
+  // There is some degeneracy in the choice of the column eigenvectors. The row
+  // eigenvectors are chosen so that the largest of (n_x, n_y, n_z) appears in
+  // the denominator, because this avoids division by zero. Here we make the
+  // consistent choice of right eigenvectors.
+  const auto index_of_largest =
+      std::distance(unit_normal.begin(), alg::max_element(unit_normal, [
+                    ](const double n1, const double n2) noexcept {
+                      return fabs(n1) < fabs(n2);
+                    }));
+  if (index_of_largest == 0) {
+    // right eigenvectors corresponding to left eigenvectors with 1/n_x terms
+    result(0, 2) = 0.;
+    result(1, 2) = -n_y;
+    result(2, 2) = n_x;
+    result(3, 2) = 0.;
+    result(4, 2) = -n_y * u + n_x * v;
+    result(0, 3) = 0.;
+    result(1, 3) = -n_z;
+    result(2, 3) = 0.;
+    result(3, 3) = n_x;
+    result(4, 3) = -n_z * u + n_x * w;
+  } else if (index_of_largest == 1) {
+    // right eigenvectors corresponding to left eigenvectors with 1/n_y terms
+    result(0, 2) = 0.;
+    result(1, 2) = -n_y;
+    result(2, 2) = n_x;
+    result(3, 2) = 0.;
+    result(4, 2) = -n_y * u + n_x * v;
+    result(0, 3) = 0.;
+    result(1, 3) = 0.;
+    result(2, 3) = -n_z;
+    result(3, 3) = n_y;
+    result(4, 3) = -n_z * v + n_y * w;
+  } else {
+    // right eigenvectors corresponding to left eigenvectors with 1/n_z terms
+    result(0, 2) = 0.;
+    result(1, 2) = -n_z;
+    result(2, 2) = 0.;
+    result(3, 2) = n_x;
+    result(4, 2) = -n_z * u + n_x * w;
+    result(0, 3) = 0.;
+    result(1, 3) = 0.;
+    result(2, 3) = -n_z;
+    result(3, 3) = n_y;
+    result(4, 3) = -n_z * v + n_y * w;
+  }
+  return result;
+}
+
+template <>
+Matrix left_eigenvectors<1>(const tnsr::I<double, 1>& velocity,
+                            const Scalar<double>& sound_speed_squared,
+                            const Scalar<double>& specific_enthalpy,
+                            const Scalar<double>& kappa_over_density,
+                            const tnsr::i<double, 1>& unit_normal) noexcept {
+  ASSERT(equal_within_roundoff(get(magnitude(unit_normal)), 1.),
+         "Expected unit normal, but got normal with magnitude "
+             << get(magnitude(unit_normal)));
+
+  // Temporary with a useful combination, as per Kulikovskii Ch3
+  const double theta = get(dot_product(velocity, velocity)) -
+                       get(specific_enthalpy) +
+                       get(sound_speed_squared) / get(kappa_over_density);
+
+  const double u = get<0>(velocity);
+  const double n_x = get<0>(unit_normal);
+  const double c = sqrt(get(sound_speed_squared));
+  const double v_n = get(dot_product(velocity, unit_normal));
+
+  Matrix result(3, 3);
+  result(0, 0) = 0.5 * (get(kappa_over_density) * theta + c * v_n) /
+                 get(sound_speed_squared);
+  result(0, 1) =
+      -0.5 * (get(kappa_over_density) * u + n_x * c) / get(sound_speed_squared);
+  result(0, 2) = 0.5 * get(kappa_over_density) / get(sound_speed_squared);
+  result(1, 0) =
+      1. - get(kappa_over_density) * theta / get(sound_speed_squared);
+  result(1, 1) = get(kappa_over_density) * u / get(sound_speed_squared);
+  result(1, 2) = -get(kappa_over_density) / get(sound_speed_squared);
+  result(2, 0) = 0.5 * (get(kappa_over_density) * theta - c * v_n) /
+                 get(sound_speed_squared);
+  result(2, 1) =
+      -0.5 * (get(kappa_over_density) * u - n_x * c) / get(sound_speed_squared);
+  result(2, 2) = 0.5 * get(kappa_over_density) / get(sound_speed_squared);
+  return result;
+}
+
+template <>
+Matrix left_eigenvectors<2>(const tnsr::I<double, 2>& velocity,
+                            const Scalar<double>& sound_speed_squared,
+                            const Scalar<double>& specific_enthalpy,
+                            const Scalar<double>& kappa_over_density,
+                            const tnsr::i<double, 2>& unit_normal) noexcept {
+  ASSERT(equal_within_roundoff(get(magnitude(unit_normal)), 1.),
+         "Expected unit normal, but got normal with magnitude "
+             << get(magnitude(unit_normal)));
+
+  // Temporary with a useful combination, as per Kulikovskii Ch3
+  const double theta = get(dot_product(velocity, velocity)) -
+                       get(specific_enthalpy) +
+                       get(sound_speed_squared) / get(kappa_over_density);
+
+  const double u = get<0>(velocity);
+  const double v = get<1>(velocity);
+  const double n_x = get<0>(unit_normal);
+  const double n_y = get<1>(unit_normal);
+  const double c = sqrt(get(sound_speed_squared));
+  const double v_n = get(dot_product(velocity, unit_normal));
+
+  Matrix result(4, 4);
+  result(0, 0) = 0.5 * (get(kappa_over_density) * theta + c * v_n) /
+                 get(sound_speed_squared);
+  result(0, 1) =
+      -0.5 * (get(kappa_over_density) * u + n_x * c) / get(sound_speed_squared);
+  result(0, 2) =
+      -0.5 * (get(kappa_over_density) * v + n_y * c) / get(sound_speed_squared);
+  result(0, 3) = 0.5 * get(kappa_over_density) / get(sound_speed_squared);
+  result(1, 0) =
+      1. - get(kappa_over_density) * theta / get(sound_speed_squared);
+  result(1, 1) = get(kappa_over_density) * u / get(sound_speed_squared);
+  result(1, 2) = get(kappa_over_density) * v / get(sound_speed_squared);
+  result(1, 3) = -get(kappa_over_density) / get(sound_speed_squared);
+  result(2, 0) = n_y * u - n_x * v;
+  result(2, 1) = -n_y;
+  result(2, 2) = n_x;
+  result(2, 3) = 0.;
+  result(3, 0) = 0.5 * (get(kappa_over_density) * theta - c * v_n) /
+                 get(sound_speed_squared);
+  result(3, 1) =
+      -0.5 * (get(kappa_over_density) * u - n_x * c) / get(sound_speed_squared);
+  result(3, 2) =
+      -0.5 * (get(kappa_over_density) * v - n_y * c) / get(sound_speed_squared);
+  result(3, 3) = 0.5 * get(kappa_over_density) / get(sound_speed_squared);
+  return result;
+}
+
+template <>
+Matrix left_eigenvectors<3>(const tnsr::I<double, 3>& velocity,
+                            const Scalar<double>& sound_speed_squared,
+                            const Scalar<double>& specific_enthalpy,
+                            const Scalar<double>& kappa_over_density,
+                            const tnsr::i<double, 3>& unit_normal) noexcept {
+  ASSERT(equal_within_roundoff(get(magnitude(unit_normal)), 1.),
+         "Expected unit normal, but got normal with magnitude "
+             << get(magnitude(unit_normal)));
+
+  // Temporary with a useful combination, as per Kulikovskii Ch3
+  const double theta = get(dot_product(velocity, velocity)) -
+                       get(specific_enthalpy) +
+                       get(sound_speed_squared) / get(kappa_over_density);
+
+  const double u = get<0>(velocity);
+  const double v = get<1>(velocity);
+  const double w = get<2>(velocity);
+  const double n_x = get<0>(unit_normal);
+  const double n_y = get<1>(unit_normal);
+  const double n_z = get<2>(unit_normal);
+  const double c = sqrt(get(sound_speed_squared));
+  const double v_n = get(dot_product(velocity, unit_normal));
+
+  Matrix result(5, 5);
+  result(0, 0) = 0.5 * (get(kappa_over_density) * theta + c * v_n) /
+                 get(sound_speed_squared);
+  result(0, 1) =
+      -0.5 * (get(kappa_over_density) * u + n_x * c) / get(sound_speed_squared);
+  result(0, 2) =
+      -0.5 * (get(kappa_over_density) * v + n_y * c) / get(sound_speed_squared);
+  result(0, 3) =
+      -0.5 * (get(kappa_over_density) * w + n_z * c) / get(sound_speed_squared);
+  result(0, 4) = 0.5 * get(kappa_over_density) / get(sound_speed_squared);
+  result(1, 0) =
+      1. - get(kappa_over_density) * theta / get(sound_speed_squared);
+  result(1, 1) = get(kappa_over_density) * u / get(sound_speed_squared);
+  result(1, 2) = get(kappa_over_density) * v / get(sound_speed_squared);
+  result(1, 3) = get(kappa_over_density) * w / get(sound_speed_squared);
+  result(1, 4) = -get(kappa_over_density) / get(sound_speed_squared);
+  result(4, 0) = 0.5 * (get(kappa_over_density) * theta - c * v_n) /
+                 get(sound_speed_squared);
+  result(4, 1) =
+      -0.5 * (get(kappa_over_density) * u - n_x * c) / get(sound_speed_squared);
+  result(4, 2) =
+      -0.5 * (get(kappa_over_density) * v - n_y * c) / get(sound_speed_squared);
+  result(4, 3) =
+      -0.5 * (get(kappa_over_density) * w - n_z * c) / get(sound_speed_squared);
+  result(4, 4) = 0.5 * get(kappa_over_density) / get(sound_speed_squared);
+
+  // There is some degeneracy in the choice of the row eigenvectors. Here, we
+  // use rows where the largest of (n_x, n_y, n_z) appears in the denominator,
+  // because this avoids division by zero. A consistent choice of right
+  // eigenvectors must be made.
+  const auto index_of_largest =
+      std::distance(unit_normal.begin(), alg::max_element(unit_normal, [
+                    ](const double n1, const double n2) noexcept {
+                      return fabs(n1) < fabs(n2);
+                    }));
+  if (index_of_largest == 0) {
+    // left eigenvectors with 1/n_x terms
+    result(2, 0) = (n_y * v_n - v) / n_x;
+    result(2, 1) = -n_y;
+    result(2, 2) = (1. - square(n_y)) / n_x;
+    result(2, 3) = -n_y * n_z / n_x;
+    result(2, 4) = 0.;
+    result(3, 0) = (n_z * v_n - w) / n_x;
+    result(3, 1) = -n_z;
+    result(3, 2) = -n_y * n_z / n_x;
+    result(3, 3) = n_x + square(n_y) / n_x;
+    result(3, 4) = 0.;
+  } else if (index_of_largest == 1) {
+    // left eigenvectors with 1/n_y terms
+    result(2, 0) = (u - n_x * v_n) / n_y;
+    result(2, 1) = (-1. + square(n_x)) / n_y;
+    result(2, 2) = n_x;
+    result(2, 3) = n_x * n_z / n_y;
+    result(2, 4) = 0.;
+    result(3, 0) = (n_z * v_n - w) / n_y;
+    result(3, 1) = -n_x * n_z / n_y;
+    result(3, 2) = -n_z;
+    result(3, 3) = n_y + square(n_x) / n_y;
+    result(3, 4) = 0.;
+  } else {
+    // left eigenvectors with 1/n_z terms
+    result(2, 0) = (u - n_x * v_n) / n_z;
+    result(2, 1) = (-1. + square(n_x)) / n_z;
+    result(2, 2) = n_x * n_y / n_z;
+    result(2, 3) = n_x;
+    result(2, 4) = 0.;
+    result(3, 0) = (v - n_y * v_n) / n_z;
+    result(3, 1) = n_x * n_y / n_z;
+    result(3, 2) = (-1. + square(n_y)) / n_z;
+    result(3, 3) = n_y;
+    result(3, 4) = 0.;
+  }
+  return result;
 }
 
 }  // namespace NewtonianEuler

--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Matrix.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"               // for get
 #include "DataStructures/Tensor/TypeAliases.hpp"          // IWYU pragma: keep
@@ -60,6 +61,57 @@ std::array<DataVector, Dim + 2> characteristic_speeds(
     const tnsr::I<DataVector, Dim>& velocity,
     const Scalar<DataVector>& sound_speed,
     const tnsr::i<DataVector, Dim>& normal) noexcept;
+// @}
+
+// @{
+/*!
+ * \brief Compute the transform matrices between the conserved variables and
+ * the characteristic variables of the NewtonianEuler system.
+ *
+ * Let \f$u\f$ be the conserved (i.e., evolved) variables of the Newtonian Euler
+ * system, and \f$w\f$ the characteristic variables of this system with respect
+ * to a unit normal one form \f$n_i\f$.  The function `left_eigenvectors`
+ * computes the matrix \f$\Omega_{L}\f$ corresponding to the transform
+ * \f$w = \Omega_{L} u\f$. The function `right_eigenvectors` computes the matrix
+ * \f$\Omega_{R}\f$ corresponding to the inverse transform
+ * \f$u = \Omega_{R} w\f$. Here the components of \f$u\f$ are ordered as
+ * \f$u = \{\rho, \rho v_x, \rho v_y, \rho v_z, e\}\f$ in 3D, and the components
+ * of \f$w\f$ are ordered by their corresponding eigenvalues
+ * (i.e., characteristic speeds)
+ * \f$\lambda = \{v_n - c_s, v_n, v_n, v_n, v_n + c_s\}\f$. In these
+ * expressions, \f$\rho\f$ is the fluid mass density, \f$v_{x,y,z}\f$ are the
+ * components of the fluid velocity, \f$e\f$ is the total energy density,
+ * \f$v_n\f$ is the component of the velocity along the unit normal \f$n_i\f$,
+ * and \f$c_s\f$ is the sound speed.
+ *
+ * For a short discussion of the characteristic transformation and the matrices
+ * \f$\Omega_{L}\f$ and \f$\Omega_{R}\f$, see \cite Kulikovskii2000 Chapter 3.
+ *
+ * Here we briefly summarize the procedure. With \f$F^x(u)\f$ the Newtonian
+ * Euler flux in direction \f$x\f$, then the flux Jacobian along \f$x\f$ is the
+ * matrix \f$A_x = \partial F^x_{\beta}(u) / \partial u_{\alpha}\f$. The indices
+ * \f$\alpha, \beta\f$ range over the different evolved fields. In higher
+ * dimensions, the flux Jacobian along the unit normal \f$n_i\f$ is
+ * \f$A = n_x A_x + n_y A_y + n_z A_z\f$.
+ * This matrix can be diagonalized as \f$A = \Omega_{R} \Lambda \Omega_{L}\f$.
+ * Here \f$\Lambda = \mathrm{diag}(v_n - c_s, v_n, v_n, v_n, v_n + c_s)\f$
+ * is a diagonal matrix containing the characteristic speeds; \f$\Omega_{R}\f$
+ * is a matrix whose columns are the right eigenvectors of \f$A\f$;
+ * \f$\Omega_{L}\f$ is the inverse of \f$R\f$.
+ */
+template <size_t Dim>
+Matrix right_eigenvectors(const tnsr::I<double, Dim>& velocity,
+                          const Scalar<double>& sound_speed_squared,
+                          const Scalar<double>& specific_enthalpy,
+                          const Scalar<double>& kappa_over_density,
+                          const tnsr::i<double, Dim>& unit_normal) noexcept;
+
+template <size_t Dim>
+Matrix left_eigenvectors(const tnsr::I<double, Dim>& velocity,
+                         const Scalar<double>& sound_speed_squared,
+                         const Scalar<double>& specific_enthalpy,
+                         const Scalar<double>& kappa_over_density,
+                         const tnsr::i<double, Dim>& unit_normal) noexcept;
 // @}
 
 namespace Tags {

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Characteristics.cpp
@@ -4,14 +4,20 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <random>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Direction.hpp"
 #include "Evolution/Systems/NewtonianEuler/Characteristics.hpp"
+#include "Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/StdHelpers.hpp"
@@ -80,6 +86,212 @@ void test_largest_characteristic_speed(
         max(get(sound_speed) + get(magnitude(velocity))));
 }
 
+template <size_t Dim>
+Matrix analytic_flux_jacobian(const tnsr::I<double, Dim>& velocity,
+                              double kappa_over_density, double theta,
+                              double specific_enthalpy,
+                              const tnsr::i<double, Dim>& unit_normal) noexcept;
+
+template <>
+Matrix analytic_flux_jacobian<1>(
+    const tnsr::I<double, 1>& velocity, const double kappa_over_density,
+    const double theta, const double specific_enthalpy,
+    const tnsr::i<double, 1>& unit_normal) noexcept {
+  const double n_x = get<0>(unit_normal);
+  const double u = get<0>(velocity);
+  const Matrix a_x{{0., 1., 0.},
+                   {kappa_over_density * theta - square(u),
+                    u * (2. - kappa_over_density), kappa_over_density},
+                   {u * (kappa_over_density * theta - specific_enthalpy),
+                    specific_enthalpy - kappa_over_density * square(u),
+                    u * (kappa_over_density + 1.)}};
+  return n_x * a_x;
+}
+
+template <>
+Matrix analytic_flux_jacobian<2>(
+    const tnsr::I<double, 2>& velocity, const double kappa_over_density,
+    const double theta, const double specific_enthalpy,
+    const tnsr::i<double, 2>& unit_normal) noexcept {
+  const double n_x = get<0>(unit_normal);
+  const double n_y = get<1>(unit_normal);
+  const double u = get<0>(velocity);
+  const double v = get<1>(velocity);
+  const Matrix a_x{
+      {0., 1., 0., 0.},
+      {kappa_over_density * theta - square(u), u * (2. - kappa_over_density),
+       -v * kappa_over_density, kappa_over_density},
+      {-u * v, v, u, 0.},
+      {u * (kappa_over_density * theta - specific_enthalpy),
+       specific_enthalpy - kappa_over_density * square(u),
+       -u * v * kappa_over_density, u * (kappa_over_density + 1.)}};
+  const Matrix a_y{
+      {0., 0., 1., 0.},
+      {-u * v, v, u, 0.},
+      {kappa_over_density * theta - square(v), -u * kappa_over_density,
+       v * (2. - kappa_over_density), kappa_over_density},
+      {v * (kappa_over_density * theta - specific_enthalpy),
+       -u * v * kappa_over_density,
+       specific_enthalpy - kappa_over_density * square(v),
+       v * (kappa_over_density + 1.)}};
+  return n_x * a_x + n_y * a_y;
+}
+
+template <>
+Matrix analytic_flux_jacobian<3>(
+    const tnsr::I<double, 3>& velocity, const double kappa_over_density,
+    const double theta, const double specific_enthalpy,
+    const tnsr::i<double, 3>& unit_normal) noexcept {
+  const double n_x = get<0>(unit_normal);
+  const double n_y = get<1>(unit_normal);
+  const double n_z = get<2>(unit_normal);
+  const double u = get<0>(velocity);
+  const double v = get<1>(velocity);
+  const double w = get<2>(velocity);
+  const Matrix a_x{
+      {0., 1., 0., 0., 0.},
+      {kappa_over_density * theta - square(u), u * (2. - kappa_over_density),
+       -v * kappa_over_density, -w * kappa_over_density, kappa_over_density},
+      {-u * v, v, u, 0., 0.},
+      {-u * w, w, 0., u, 0.},
+      {u * (kappa_over_density * theta - specific_enthalpy),
+       specific_enthalpy - kappa_over_density * square(u),
+       -u * v * kappa_over_density, -u * w * kappa_over_density,
+       u * (kappa_over_density + 1.)}};
+  const Matrix a_y{
+      {0., 0., 1., 0., 0.},
+      {-u * v, v, u, 0., 0.},
+      {kappa_over_density * theta - square(v), -u * kappa_over_density,
+       v * (2. - kappa_over_density), -w * kappa_over_density,
+       kappa_over_density},
+      {-v * w, 0., w, v, 0.},
+      {v * (kappa_over_density * theta - specific_enthalpy),
+       -u * v * kappa_over_density,
+       specific_enthalpy - kappa_over_density * square(v),
+       -v * w * kappa_over_density, v * (kappa_over_density + 1.)}};
+  const Matrix a_z{{0., 0., 0., 1., 0.},
+                   {-u * w, w, 0., u, 0.},
+                   {-v * w, 0., w, v, 0.},
+                   {kappa_over_density * theta - square(w),
+                    -u * kappa_over_density, -v * kappa_over_density,
+                    w * (2. - kappa_over_density), kappa_over_density},
+                   {w * (kappa_over_density * theta - specific_enthalpy),
+                    -u * w * kappa_over_density, -v * w * kappa_over_density,
+                    specific_enthalpy - kappa_over_density * square(w),
+                    w * (kappa_over_density + 1.)}};
+  return n_x * a_x + n_y * a_y + n_z * a_z;
+}
+
+template <size_t Dim>
+void test_right_and_left_eigenvectors() noexcept {
+  // This test verifies that the eigenvectors satisfy the conditions by which
+  // they are defined:
+  // - the right and left eigenvectors are matrix inverses of each other, i.e.,
+  //   left * right == right * left == identity
+  // - the right and left eigenvectors diagonalize the flux Jacobian, i.e.,
+  //   right * eigenvalues * left == flux
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(-1., 1.);
+  std::uniform_real_distribution<> distribution_positive(1e-3, 1.);
+
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+  const auto nn_distribution_positive = make_not_null(&distribution_positive);
+
+  const double used_for_size = 0.;
+  // This computes a unit normal. It is NOT uniformly distributed in angle,
+  // but for this test the angular distribution is not important.
+  const auto unit_normal = [&]() noexcept {
+    auto result = make_with_random_values<tnsr::i<double, Dim>>(
+        nn_generator, nn_distribution, used_for_size);
+    double normal_magnitude = get(magnitude(result));
+    // Though highly unlikely, the normal could have length nearly 0. If this
+    // happens, we edit the normal to make it non-zero.
+    if (normal_magnitude < 1e-3) {
+      get<0>(result) += 0.9;
+      normal_magnitude = get(magnitude(result));
+    }
+    for (auto& n_i : result) {
+      n_i /= normal_magnitude;
+    }
+    return result;
+  }
+  ();
+
+  // To check the diagonalization of the Jacobian, we need a self consistent set
+  // of primitive and derived-from-primitive variables -- so generate everything
+  // from the primitives
+  const auto density = make_with_random_values<Scalar<double>>(
+      nn_generator, nn_distribution_positive, used_for_size);
+  const auto velocity = make_with_random_values<tnsr::I<double, Dim>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto specific_internal_energy = make_with_random_values<Scalar<double>>(
+      nn_generator, nn_distribution_positive, used_for_size);
+
+  const Scalar<double> v_squared{{{get(dot_product(velocity, velocity))}}};
+  const Scalar<double> energy_density{
+      {{get(density) * get(specific_internal_energy) +
+        0.5 * get(density) * get(v_squared)}}};
+
+  const EquationsOfState::IdealFluid<false> equation_of_state{5. / 3.};
+  const auto pressure = equation_of_state.pressure_from_density_and_energy(
+      density, specific_internal_energy);
+  const Scalar<double> specific_enthalpy{
+      {{(get(energy_density) + get(pressure)) / get(density)}}};
+  const auto sound_speed_squared = NewtonianEuler::sound_speed_squared(
+      density, specific_internal_energy, equation_of_state);
+  const auto kappa_over_density = Scalar<double>{
+      {{get(equation_of_state
+                .kappa_times_p_over_rho_squared_from_density_and_energy(
+                    density, specific_internal_energy)) *
+        get(density) / get(pressure)}}};
+
+  const Matrix right = NewtonianEuler::right_eigenvectors(
+      velocity, sound_speed_squared, specific_enthalpy, kappa_over_density,
+      unit_normal);
+  const Matrix left = NewtonianEuler::left_eigenvectors(
+      velocity, sound_speed_squared, specific_enthalpy, kappa_over_density,
+      unit_normal);
+
+  // Check that eigenvectors are inverses of each other
+  const auto id1 = left * right;
+  const auto id2 = right * left;
+
+  // For small values of specific_internal_energy, the relative error can
+  // increase from the default level
+  Approx local_approx = Approx::custom().epsilon(1e-12).scale(1.0);
+  for (size_t i = 0; i < Dim + 2; ++i) {
+    for (size_t j = 0; j < Dim + 2; ++j) {
+      const double delta_ij = (i == j) ? 1. : 0.;
+      CHECK(id1(i, j) == local_approx(delta_ij));
+      CHECK(id2(i, j) == local_approx(delta_ij));
+    }
+  }
+
+  // Check that eigenvectors give correct fluxes
+  const double v_n = get(dot_product(unit_normal, velocity));
+  Matrix eigenvalues(Dim + 2, Dim + 2, 0.);
+  for (size_t i = 0; i < Dim + 2; ++i) {
+    eigenvalues(i, i) = v_n;
+  }
+  eigenvalues(0, 0) -= sqrt(get(sound_speed_squared));
+  eigenvalues(Dim + 1, Dim + 1) += sqrt(get(sound_speed_squared));
+  const auto flux_jacobian = right * eigenvalues * left;
+
+  const Scalar<double> theta{
+      {{get(v_squared) - get(specific_enthalpy) +
+        get(sound_speed_squared) / get(kappa_over_density)}}};
+  const auto expected_flux_jacobian =
+      analytic_flux_jacobian(velocity, get(kappa_over_density), get(theta),
+                             get(specific_enthalpy), unit_normal);
+
+  for (size_t i = 0; i < Dim + 2; ++i) {
+    for (size_t j = 0; j < Dim + 2; ++j) {
+      CHECK(flux_jacobian(i, j) == local_approx(expected_flux_jacobian(i, j)));
+    }
+  }
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Characteristics",
@@ -91,4 +303,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Characteristics",
   CHECK_FOR_DATAVECTORS(test_characteristic_speeds, (1, 2, 3))
   CHECK_FOR_DATAVECTORS(test_with_normal_along_coordinate_axes, (1, 2, 3))
   CHECK_FOR_DATAVECTORS(test_largest_characteristic_speed, (1, 2, 3))
+
+  test_right_and_left_eigenvectors<1>();
+  test_right_and_left_eigenvectors<2>();
+  test_right_and_left_eigenvectors<3>();
 }


### PR DESCRIPTION
## Proposed changes

Adds the matrices that transform a set of NewtonianEuler evolved/conserved fields to (or from) a set of characteristic fields.

This is a prerequisite for limiting the characteristic fields of the NewtonianEuler system.


### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
