### PR TITLE
Add Ah finder to GH exec

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 set(LIBS_TO_LINK
+    ApparentHorizons
     CoordinateMaps
     DiscontinuousGalerkin
     Domain
@@ -12,6 +13,7 @@ set(LIBS_TO_LINK
     GeneralizedHarmonicGaugeSourceFunctions
     IO
     Informer
+    Interpolation
     LinearOperators
     MathFunctions
     Time

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -6,6 +6,9 @@
 #include <cstddef>
 #include <vector>
 
+#include "AlgorithmSingleton.hpp"
+#include "ApparentHorizons/ComputeItems.hpp"
+#include "ApparentHorizons/Tags.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Tags.hpp"
 #include "ErrorHandling/Error.hpp"
@@ -25,12 +28,28 @@
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/RegisterObservers.hpp"
 #include "IO/Observer/Tags.hpp"
+#include "Informer/Tags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp"
+#include "NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
+#include "NumericalAlgorithms/Interpolation/CleanUpInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/Interpolate.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp"
+#include "NumericalAlgorithms/Interpolation/Interpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
@@ -106,12 +125,61 @@ struct EvolutionMetavars {
                                       ThreeIndexConstraint<volume_dim, frame>>,
           ::Tags::PointwiseL2Norm<GeneralizedHarmonic::Tags::
                                       FourIndexConstraint<volume_dim, frame>>>>;
-  using events = tmpl::list<
+
+  // HACK until we merge in a compute tag StrahlkorperGr::AreaCompute.
+  // For now, simply do a surface integral of unity on the horizon to get the
+  // horizon area.
+  struct Unity : db::ComputeTag {
+    static std::string name() noexcept { return "Unity"; }
+    static Scalar<DataVector> function(
+        const Scalar<DataVector>& used_for_size) noexcept {
+      return make_with_value<Scalar<DataVector>>(used_for_size, 1.0);
+    }
+    using argument_tags =
+        tmpl::list<StrahlkorperGr::Tags::AreaElement<Frame::Inertial>>;
+  };
+
+  struct Horizon {
+    using tags_to_observe =
+        tmpl::list<StrahlkorperGr::Tags::SurfaceIntegral<Unity, frame>>;
+    using compute_items_on_source = tmpl::list<
+        gr::Tags::SpatialMetricCompute<volume_dim, frame, DataVector>,
+        ah::Tags::InverseSpatialMetricCompute<volume_dim, frame>,
+        ah::Tags::ExtrinsicCurvatureCompute<volume_dim, frame>,
+        ah::Tags::SpatialChristoffelSecondKindCompute<volume_dim, frame>>;
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::SpatialMetric<volume_dim, frame, DataVector>,
+                   gr::Tags::InverseSpatialMetric<volume_dim, frame>,
+                   gr::Tags::ExtrinsicCurvature<volume_dim, frame>,
+                   gr::Tags::SpatialChristoffelSecondKind<volume_dim, frame>>;
+    using compute_items_on_target = tmpl::append<
+        tmpl::list<StrahlkorperGr::Tags::AreaElement<frame>, Unity>,
+        tags_to_observe>;
+    using compute_target_points =
+        intrp::Actions::ApparentHorizon<Horizon, ::Frame::Inertial>;
+    using post_interpolation_callback =
+        intrp::callbacks::FindApparentHorizon<Horizon>;
+    using post_horizon_find_callback =
+        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, Horizon,
+                                                     Horizon>;
+  };
+  using interpolation_target_tags = tmpl::list<Horizon>;
+  using interpolator_source_vars =
+      tmpl::list<gr::Tags::SpacetimeMetric<volume_dim, frame>,
+                 GeneralizedHarmonic::Tags::Pi<volume_dim, frame>,
+                 GeneralizedHarmonic::Tags::Phi<volume_dim, frame>>;
+
+  using observation_events = tmpl::list<
       dg::Events::Registrars::ObserveErrorNorms<Tags::Time,
                                                 analytic_solution_fields>,
       dg::Events::Registrars::ObserveFields<
           volume_dim, Tags::Time, observe_fields, analytic_solution_fields>>;
   using triggers = Triggers::time_triggers;
+
+  // Events include the observation events and finding the horizon
+  using events = tmpl::push_back<
+      observation_events,
+      intrp::Events::Registrars::Interpolate<3, interpolator_source_vars>>;
 
   // A tmpl::list of tags to be added to the ConstGlobalCache by the
   // metavariables
@@ -130,8 +198,9 @@ struct EvolutionMetavars {
   struct ObservationType {};
   using element_observation_type = ObservationType;
 
-  using observed_reduction_data_tags =
-      observers::collect_reduction_data_tags<Event<events>::creatable_classes>;
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::push_back<Event<observation_events>::creatable_classes,
+                      typename Horizon::post_horizon_find_callback>>;
 
   using step_actions = tmpl::flatten<tmpl::list<
       dg::Actions::ComputeNonconservativeBoundaryFluxes<
@@ -148,7 +217,7 @@ struct EvolutionMetavars {
   enum class Phase {
     Initialization,
     InitializeTimeStepperHistory,
-    RegisterWithObserver,
+    Register,
     Evolve,
     Exit
   };
@@ -208,6 +277,8 @@ struct EvolutionMetavars {
   using component_list = tmpl::list<
       observers::Observer<EvolutionMetavars>,
       observers::ObserverWriter<EvolutionMetavars>,
+      intrp::Interpolator<EvolutionMetavars>,
+      intrp::InterpolationTarget<EvolutionMetavars, Horizon>,
       DgElementArray<
           EvolutionMetavars,
           tmpl::list<
@@ -219,12 +290,13 @@ struct EvolutionMetavars {
                   SelfStart::self_start_procedure<step_actions>>,
 
               Parallel::PhaseActions<
-                  Phase, Phase::RegisterWithObserver,
-                  tmpl::list<observers::Actions::RegisterWithObservers<
+                  Phase, Phase::Register,
+                  tmpl::flatten<tmpl::list<
+                             intrp::Actions::RegisterElementWithInterpolator,
+                             observers::Actions::RegisterWithObservers<
                                  observers::RegisterObservers<
                                      Tags::Time, element_observation_type>>,
-                             Parallel::Actions::TerminatePhase>>,
-
+                             Parallel::Actions::TerminatePhase>>>,
               Parallel::PhaseActions<
                   Phase, Phase::Evolve,
                   tmpl::list<Actions::RunEventsAndTriggers, step_actions,
@@ -243,8 +315,8 @@ struct EvolutionMetavars {
       case Phase::Initialization:
         return Phase::InitializeTimeStepperHistory;
       case Phase::InitializeTimeStepperHistory:
-        return Phase::RegisterWithObserver;
-      case Phase::RegisterWithObserver:
+        return Phase::Register;
+      case Phase::Register:
         return Phase::Evolve;
       case Phase::Evolve:
         return Phase::Exit;

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -11,20 +11,25 @@
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.01
-  TimeStepper: RungeKutta3
+  TimeStepper:
+    AdamsBashforthN:
+      Order: 1
 
 DomainCreator:
-    Brick:
-      LowerBound: [4.0, -0.5, -0.5]
-      UpperBound: [5.0, 0.5, 0.5]
-      InitialRefinement: [1, 1, 1]
-      InitialGridPoints: [5, 5, 5]
-      IsPeriodicIn: [false, false, false]
+    Shell:
+      InnerRadius: 1.9
+      OuterRadius: 2.3
+      InitialRefinement: 0
+      InitialGridPoints: [5, 5]
+      UseEquiangularMap: true
+      AspectRatio: 1.0
+      UseLogarithmicMap: true
+      RadialBlockLayers: 1
 
 AnalyticSolution:
   KerrSchild:
     Mass: 1.0
-    Spin: [0.0, 0.0, 0.4]
+    Spin: [0.0, 0.0, 0.0]
     Center: [0.0, 0.0, 0.0]
 
 EvolutionSystem:
@@ -46,9 +51,24 @@ EventsAndTriggers:
       N: 5
       Offset: 0
   : - ObserveFields
-  ? PastTime: 0.03
+  ? EveryNSlabs:
+      N: 5
+      Offset: 2
+  : - Interpolate
+  ? SpecifiedSlabs:
+      Slabs: [3]
   : - Completion
 
 Observers:
   VolumeFileName: "GhKerrSchildVolumeData"
   ReductionFileName: "GhKerrSchildReductionData"
+
+ApparentHorizons:
+  Horizon:
+    InitialGuess:
+      Lmax: 4
+      Radius: 2.2
+      Center: [0.0, 0.0, 0.0]
+    FastFlow:
+      Flow: Fast
+    Verbosity: Verbose


### PR DESCRIPTION
Adds an apparent horizon finder to the GH executable.

To do this, you have to evolve a shell instead of a block, which takes much longer than one brick. Suggestions for speeding up the test are welcome. (The AH finder itself takes less than 10% of the total time; most is just evolving the full shell.)

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
