### PR TITLE
Cce precomputation step

### DIFF
--- a/src/DataStructures/SpinWeighted.hpp
+++ b/src/DataStructures/SpinWeighted.hpp
@@ -441,7 +441,7 @@ operator/(const get_vector_element_type_t<T>& lhs,
 
 template <typename T, int Spin>
 SPECTRE_ALWAYS_INLINE SpinWeighted<decltype(conj(std::declval<T>())), -Spin>
-conj(const SpinWeighted<T, Spin> value) noexcept {
+conj(const SpinWeighted<T, Spin>& value) noexcept {
   return {conj(value.data())};
 }
 

--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   InitializeCce.cpp
   LinearOperators.cpp
   LinearSolve.cpp
+  PrecomputeCceDependencies.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Cce)
 
 set(LIBRARY_SOURCES
   Equations.cpp
+  LinearOperators.cpp
   LinearSolve.cpp
   )
 

--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Cce)
 
 set(LIBRARY_SOURCES
   Equations.cpp
+  InitializeCce.cpp
   LinearOperators.cpp
   LinearSolve.cpp
   )

--- a/src/Evolution/Systems/Cce/InitializeCce.cpp
+++ b/src/Evolution/Systems/Cce/InitializeCce.cpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/InitializeCce.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Cce {
+
+void InitializeJ::apply(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& r) noexcept {
+  const size_t number_of_radial_points =
+      get(*j).size() / get(boundary_j).size();
+  const DataVector one_minus_y_collocation =
+      1.0 - Spectral::collocation_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto>(
+                number_of_radial_points);
+  for (size_t i = 0; i < number_of_radial_points; i++) {
+    ComplexDataVector angular_view_j{
+        get(*j).data().data() + get(boundary_j).size() * i,
+        get(boundary_j).size()};
+    // auto is acceptable here as these two values are only used once in the
+    // below computation. `auto` causes an expression template to be
+    // generated, rather than allocating.
+    const auto one_minus_y_coefficient =
+        0.25 * (3.0 * get(boundary_j).data() +
+                get(r).data() * get(boundary_dr_j).data());
+    const auto one_minus_y_cubed_coefficient =
+        -0.0625 *
+        (get(boundary_j).data() + get(r).data() * get(boundary_dr_j).data());
+    angular_view_j =
+        one_minus_y_collocation[i] * one_minus_y_coefficient +
+        pow<3>(one_minus_y_collocation[i]) * one_minus_y_cubed_coefficient;
+  }
+}
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/InitializeCce.hpp
+++ b/src/Evolution/Systems/Cce/InitializeCce.hpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class ComplexDataVector;
+/// \endcond
+
+namespace Cce {
+
+/*!
+ * \brief Initialize \f$J\f$ on the first hypersurface from provided boundary
+ * values of \f$J\f$, \f$R\f$, and \f$\partial_r J\f$.
+ *
+ * \details This initial data is chosen to take the function:
+ *
+ *\f[ J = \frac{A}{r} + \frac{B}{r^3},
+ *\f]
+ *
+ * where
+ *
+ * \f{align*}{
+ * A &= R \left( \frac{3}{2} J|_{r = R} + \frac{1}{2} R \partial_r J|_{r =
+ * R}\right) \notag\\
+ * B &= - \frac{1}{2} R^3 (J|_{r = R} + R \partial_r J|_{r = R})
+ * \f}
+ */
+struct InitializeJ {
+  using boundary_tags = tmpl::list<Tags::BoundaryValue<Tags::BondiJ>,
+                                   Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
+                                   Tags::BoundaryValue<Tags::BondiR>>;
+
+  using return_tags = tmpl::list<Tags::BondiJ>;
+  using argument_tags = tmpl::append<boundary_tags>;
+
+  static void apply(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& r) noexcept;
+};
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/IntegrandInputSteps.hpp
+++ b/src/Evolution/Systems/Cce/IntegrandInputSteps.hpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/Cce/Equations.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce {
+
+/*!
+ * The set of Bondi quantities computed by hypersurface step, in the required
+ * order of computation
+ */
+using bondi_hypersurface_step_tags =
+    tmpl::list<Tags::BondiBeta, Tags::BondiQ, Tags::BondiU, Tags::BondiW,
+               Tags::BondiH>;
+
+/*!
+ * Metafunction that is a `tmpl::list` of the temporary tags taken by the
+ * `ComputeBondiIntegrand` computational struct.
+ */
+template <typename Tag>
+using integrand_temporary_tags =
+    typename ComputeBondiIntegrand<Tag>::temporary_tags;
+
+/*!
+ * \brief A type list for the set of `BoundaryValue` tags needed as an input to
+ * any of the template specializations of
+ *
+ * `PrecomputeCceDependencies`.
+ * \details This is provided for easy and maintainable
+ * construction of a `Variables` or \ref DataBoxGroup with all of the quantities
+ * necessary for a Cce computation or portion thereof.
+ * A container of these tags should have size
+ * `Spectral::Swsh::number_of_swsh_collocation_points(l_max)`.
+ */
+template <template <typename> class BoundaryPrefix>
+using pre_computation_boundary_tags =
+    tmpl::list<BoundaryPrefix<Tags::BondiR>,
+               BoundaryPrefix<Tags::DuRDividedByR>>;
+
+/*!
+ * \brief A type list for the set of tags computed by the set of
+ * template specializations of `PrecomputeCceDepedencies`.
+ *
+ * \details This is provided for
+ * easy and maintainable construction of a `Variables` or `DataBox` with all of
+ * the quantities needed for a Cce computation or component. The data structures
+ * represented by these tags should each have size `number_of_radial_points *
+ * number_of_swsh_collocation_points(l_max)`. All of these tags may be computed
+ * at once if using a \ref DataBoxGroup using the template
+ * `mutate_all_precompute_cce_dependencies` or individually using
+ * the template specializations `PrecomputeCceDependencies`.
+ */
+using pre_computation_tags =
+    tmpl::list<Tags::DuRDividedByR, Tags::EthRDividedByR,
+               Tags::EthEthRDividedByR, Tags::EthEthbarRDividedByR,
+               Tags::BondiK, Tags::OneMinusY, Tags::BondiR>;
+
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/LinearOperators.cpp
+++ b/src/Evolution/Systems/Cce/LinearOperators.cpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/LinearOperators.hpp"
+
+#include <array>
+#include <cstddef>
+#include <functional>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Domain/Mesh.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/ApplyMatrices.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace Cce {
+void logical_partial_directional_derivative_of_complex(
+    const gsl::not_null<ComplexDataVector*> d_u, const ComplexDataVector& u,
+    const Mesh<3>& mesh, const size_t dimension_to_differentiate) noexcept {
+  const auto empty_matrix = Matrix{};
+  std::array<std::reference_wrapper<const Matrix>, 3> matrix_array{
+    {std::ref(empty_matrix), std::ref(empty_matrix), std::ref(empty_matrix)}};
+  gsl::at(matrix_array, dimension_to_differentiate) =
+      std::ref(Spectral::differentiation_matrix(
+          mesh.slice_through(dimension_to_differentiate)));
+  apply_matrices(d_u, matrix_array, u, mesh.extents());
+}
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/LinearOperators.hpp
+++ b/src/Evolution/Systems/Cce/LinearOperators.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+template <size_t Dim>
+class Mesh;
+class ComplexDataVector;
+/// \endcond
+
+namespace Cce {
+/*!
+ * \brief Computes the partial derivative along a particular direction
+ * determined by the `dimension_to_differentiate`.
+ * The input `u` is differentiated with the spectral matrix and the solution is
+ * placed in `d_u`.
+ *
+ * \note This is placed in Cce Utilities for its currently narrow use-case. If
+ * more general uses desire a single partial derivative of complex values, this
+ * should be moved to `NumericalAlgorithms`. This utility currently assumes the
+ * spatial dimensionality is 3, which would also need to be generalized, likely
+ * by creating a wrapping struct with partial template specializations.
+ */
+void logical_partial_directional_derivative_of_complex(
+    gsl::not_null<ComplexDataVector*> d_u, const ComplexDataVector& u,
+    const Mesh<3>& mesh, size_t dimension_to_differentiate) noexcept;
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/PrecomputeCceDependencies.cpp
+++ b/src/Evolution/Systems/Cce/PrecomputeCceDependencies.cpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/PrecomputeCceDependencies.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/VectorAlgebra.hpp"
+
+namespace Cce {
+
+namespace detail {
+template <typename DerivKind>
+void angular_derivative_of_r_divided_by_r_impl(
+    const gsl::not_null<
+        SpinWeighted<ComplexDataVector,
+                     Spectral::Swsh::Tags::derivative_spin_weight<DerivKind>>*>
+        d_r_divided_by_r,
+    const SpinWeighted<ComplexDataVector, 0>& boundary_r, const size_t l_max,
+    const size_t number_of_radial_points) noexcept {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  // first set the first angular view
+  SpinWeighted<ComplexDataVector,
+               Spectral::Swsh::Tags::derivative_spin_weight<DerivKind>>
+      d_r_divided_by_r_boundary;
+  d_r_divided_by_r_boundary.data() = ComplexDataVector{
+      d_r_divided_by_r->data().data(), number_of_angular_points};
+  Spectral::Swsh::angular_derivatives<tmpl::list<DerivKind>>(
+      l_max, 1, make_not_null(&d_r_divided_by_r_boundary), boundary_r);
+  d_r_divided_by_r_boundary.data() /= boundary_r.data();
+  // all of the angular shells after the innermost one
+  ComplexDataVector d_r_divided_by_r_tail_shells{
+      d_r_divided_by_r->data().data() + number_of_angular_points,
+      (number_of_radial_points - 1) * number_of_angular_points};
+  repeat(make_not_null(&d_r_divided_by_r_tail_shells),
+         d_r_divided_by_r_boundary.data(), number_of_radial_points - 1);
+}
+}  // namespace detail
+
+namespace detail {
+// explicit  template instantiations
+template void
+angular_derivative_of_r_divided_by_r_impl<Spectral::Swsh::Tags::Eth>(
+    const gsl::not_null<SpinWeighted<
+        ComplexDataVector, Spectral::Swsh::Tags::derivative_spin_weight<
+                               Spectral::Swsh::Tags::Eth>>*>
+        d_r_divided_by_r,
+    const SpinWeighted<ComplexDataVector, 0>& boundary_r, const size_t l_max,
+    const size_t number_of_radial_points) noexcept;
+
+template void
+angular_derivative_of_r_divided_by_r_impl<Spectral::Swsh::Tags::EthEth>(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, 2>*> d_r_divided_by_r,
+    const SpinWeighted<ComplexDataVector, 0>& boundary_r, const size_t l_max,
+    const size_t number_of_radial_points) noexcept;
+
+template void
+angular_derivative_of_r_divided_by_r_impl<Spectral::Swsh::Tags::EthEthbar>(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, 0>*> d_r_divided_by_r,
+    const SpinWeighted<ComplexDataVector, 0>& boundary_r, const size_t l_max,
+    const size_t number_of_radial_points) noexcept;
+}  // namespace detail
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/PrecomputeCceDependencies.hpp
+++ b/src/Evolution/Systems/Cce/PrecomputeCceDependencies.hpp
@@ -1,0 +1,262 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/VectorAlgebra.hpp"
+
+namespace Cce {
+
+namespace detail {
+// A convenience function for computing the spin-weighted derivatives of \f$R\f$
+// divided by \f$R\f$, which appears often in Jacobians to transform between
+// Bondi coordinates and the numerical coordinates used in CCE.
+template <typename DerivKind>
+void angular_derivative_of_r_divided_by_r_impl(
+    gsl::not_null<
+        SpinWeighted<ComplexDataVector,
+                     Spectral::Swsh::Tags::derivative_spin_weight<DerivKind>>*>
+        d_r_divided_by_r,
+    const SpinWeighted<ComplexDataVector, 0>& boundary_r, size_t l_max,
+    size_t number_of_radial_points) noexcept;
+
+}  // namespace detail
+
+/*!
+ * \brief A set of procedures for computing the set of inputs to the CCE
+ * integrand computations that can be computed before any of the intermediate
+ * integrands are evaluated.
+ *
+ * \details The template specializations of this template are
+ * compatible with acting as a the mutator in a \ref DataBoxGroup
+ * `db::mutate_apply` operation. For flexibility in defining the \ref
+ * DataBoxGroup structure, the tags for `Tensor`s used in these functions are
+ * also organized into type lists:
+ * -  type alias `integration_independent_tags`: with a subset of
+ * `Cce::pre_computation_tags`, used for both input and output.
+ * -  type alias `boundary_values`: with a subset of
+ *   `Cce::pre_computation_boundary_tags`, used only for input.
+ * - type alias `pre_swsh_derivatives` containing hypersurface quantities. For
+ * this struct, it will only ever contain `Cce::Tags::BondiJ`, and is used as
+ * input.
+ *
+ * The `BoundaryPrefix` tag allows easy switching between the
+ * regularity-preserving version and standard CCE
+ *
+ */
+template <template <typename> class BoundaryPrefix, typename Tag>
+struct PrecomputeCceDependencies;
+
+/// Computes \f$1 - y\f$ for the CCE system.
+template <template <typename> class BoundaryPrefix>
+struct PrecomputeCceDependencies<BoundaryPrefix, Tags::OneMinusY> {
+  using boundary_tags = tmpl::list<>;
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using integration_independent_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<Tags::OneMinusY>;
+  using argument_tags = tmpl::list<Spectral::Swsh::Tags::LMax,
+                                   Spectral::Swsh::Tags::NumberOfRadialPoints>;
+
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+          one_minus_y,
+      const size_t l_max, const size_t number_of_radial_points) noexcept {
+    const size_t number_of_angular_points =
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+    const DataVector one_minus_y_collocation =
+        1.0 - Spectral::collocation_points<Spectral::Basis::Legendre,
+                                           Spectral::Quadrature::GaussLobatto>(
+                  number_of_radial_points);
+    // iterate through the angular 'chunks' and set them to their 1-y value
+    for (size_t i = 0; i < number_of_radial_points; ++i) {
+      ComplexDataVector angular_view{
+          get(*one_minus_y).data().data() + number_of_angular_points * i,
+          number_of_angular_points};
+      angular_view = one_minus_y_collocation[i];
+    }
+  }
+};
+
+/// Computes a volume version of Bondi radius of the worldtube \f$R\f$ from its
+/// boundary value (by repeating it over the radial dimension)
+template <template <typename> class BoundaryPrefix>
+struct PrecomputeCceDependencies<BoundaryPrefix, Tags::BondiR> {
+  using boundary_tags = tmpl::list<BoundaryPrefix<Tags::BondiR>>;
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using integration_independent_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<Tags::BondiR>;
+  using argument_tags =
+      tmpl::append<boundary_tags,
+                   tmpl::list<Spectral::Swsh::Tags::NumberOfRadialPoints>>;
+
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> r,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+      const size_t number_of_radial_points) noexcept {
+    repeat(make_not_null(&get(*r).data()), get(boundary_r).data(),
+           number_of_radial_points);
+  }
+};
+
+/// Computes \f$\partial_u R / R\f$ from its boundary value (by repeating it
+/// over the radial dimension).
+template <template <typename> class BoundaryPrefix>
+struct PrecomputeCceDependencies<BoundaryPrefix, Tags::DuRDividedByR> {
+  using boundary_tags = tmpl::list<BoundaryPrefix<Tags::DuRDividedByR>>;
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using integration_independent_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<Tags::DuRDividedByR>;
+  using argument_tags =
+      tmpl::append<boundary_tags,
+                   tmpl::list<Spectral::Swsh::Tags::NumberOfRadialPoints>>;
+
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+          du_r_divided_by_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>&
+          boundary_du_r_divided_by_r,
+      const size_t number_of_radial_points) noexcept {
+    repeat(make_not_null(&get(*du_r_divided_by_r).data()),
+           get(boundary_du_r_divided_by_r).data(), number_of_radial_points);
+  }
+};
+
+/// Computes \f$\eth R / R\f$ by differentiating and repeating the boundary
+/// value of \f$R\f$.
+template <template <typename> class BoundaryPrefix>
+struct PrecomputeCceDependencies<BoundaryPrefix, Tags::EthRDividedByR> {
+  using boundary_tags = tmpl::list<BoundaryPrefix<Tags::BondiR>>;
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using integration_independent_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<Tags::EthRDividedByR>;
+  using argument_tags =
+      tmpl::append<boundary_tags,
+                   tmpl::list<Spectral::Swsh::Tags::LMax,
+                              Spectral::Swsh::Tags::NumberOfRadialPoints>>;
+
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*>
+          eth_r_divided_by_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+      const size_t l_max, const size_t number_of_radial_points) noexcept {
+    detail::angular_derivative_of_r_divided_by_r_impl<
+        Spectral::Swsh::Tags::Eth>(make_not_null(&get(*eth_r_divided_by_r)),
+                                   get(boundary_r), l_max,
+                                   number_of_radial_points);
+  }
+};
+
+/// Computes \f$\eth \eth R / R\f$ by differentiating and repeating the boundary
+/// value of \f$R\f$.
+template <template <typename> class BoundaryPrefix>
+struct PrecomputeCceDependencies<BoundaryPrefix, Tags::EthEthRDividedByR> {
+  using boundary_tags = tmpl::list<BoundaryPrefix<Tags::BondiR>>;
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using integration_independent_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<Tags::EthEthRDividedByR>;
+  using argument_tags =
+      tmpl::append<boundary_tags,
+                   tmpl::list<Spectral::Swsh::Tags::LMax,
+                              Spectral::Swsh::Tags::NumberOfRadialPoints>>;
+
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
+          eth_eth_r_divided_by_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+      const size_t l_max, const size_t number_of_radial_points) noexcept {
+    detail::angular_derivative_of_r_divided_by_r_impl<
+        Spectral::Swsh::Tags::EthEth>(
+        make_not_null(&get(*eth_eth_r_divided_by_r)), get(boundary_r), l_max,
+        number_of_radial_points);
+  }
+};
+
+/// Computes \f$\eth \bar{\eth} R / R\f$ by differentiating and repeating the
+/// boundary value of \f$R\f$.
+template <template <typename> class BoundaryPrefix>
+struct PrecomputeCceDependencies<BoundaryPrefix, Tags::EthEthbarRDividedByR> {
+  using boundary_tags = tmpl::list<BoundaryPrefix<Tags::BondiR>>;
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using integration_independent_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<Tags::EthEthbarRDividedByR>;
+  using argument_tags =
+      tmpl::append<boundary_tags,
+                   tmpl::list<Spectral::Swsh::Tags::LMax,
+                              Spectral::Swsh::Tags::NumberOfRadialPoints>>;
+
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+          eth_ethbar_r_divided_by_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+      const size_t l_max, const size_t number_of_radial_points) noexcept {
+    detail::angular_derivative_of_r_divided_by_r_impl<
+        Spectral::Swsh::Tags::EthEthbar>(
+        make_not_null(&get(*eth_ethbar_r_divided_by_r)), get(boundary_r), l_max,
+        number_of_radial_points);
+  }
+};
+
+/// Computes \f$K = \sqrt{1 + J \bar{J}}\f$.
+template <template <typename> class BoundaryPrefix>
+struct PrecomputeCceDependencies<BoundaryPrefix, Tags::BondiK> {
+  using boundary_tags = tmpl::list<>;
+  using pre_swsh_derivative_tags = tmpl::list<Tags::BondiJ>;
+  using integration_independent_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<Tags::BondiK>;
+  using argument_tags = tmpl::append<tmpl::list<Spectral::Swsh::Tags::LMax>,
+                                     pre_swsh_derivative_tags>;
+
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> k,
+      const size_t /*l_max*/,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& j) noexcept {
+    get(*k).data() = sqrt(1.0 + get(j).data() * conj(get(j)).data());
+  }
+};
+
+/*!
+ * \brief Convenience routine for computing all of the CCE inputs to integrand
+ * computation that do not depend on intermediate integrand results. It should
+ * be executed before moving through the hierarchy of integrands.
+ *
+ * \details Provided a \ref DataBoxGroup with the appropriate tags (including
+ * `Cce::pre_computation_boundary_tags`, `Cce::pre_computation_tags`,
+ * `Cce::Tags::BondiJ` and `Spectral::Swsh::Tags::LMax`), this function will
+ * apply all of the necessary mutations to update the
+ * `Cce::pre_computation_tags` to their correct values for the current values
+ * for the remaining (input) tags.
+ *
+ * The `BoundaryPrefix` template template parameter is to be passed a prefix
+ * tag associated with the boundary value prefix used in the computation (e.g.
+ * `Cce::Tags::BoundaryValue`), and allows easy switching between the
+ * regularity-preserving version and standard CCE.
+ */
+template <template <typename> class BoundaryPrefix, typename DataBoxType>
+void mutate_all_precompute_cce_dependencies(
+    const gsl::not_null<DataBoxType*> box) noexcept {
+  tmpl::for_each<pre_computation_tags>([&box](auto x) {
+    using integration_independent_tag = typename decltype(x)::type;
+    using mutation =
+        PrecomputeCceDependencies<BoundaryPrefix, integration_independent_tag>;
+    db::mutate_apply<mutation>(box);
+  });
+}
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -7,6 +7,7 @@
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 
 namespace Cce {
 
@@ -88,8 +89,15 @@ struct Dy : db::PrefixTag, db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>;
   using tag = Tag;
   static const size_t dimension_to_differentiate = 2;
-  static const size_t dim = 3;
   static std::string name() noexcept { return "Dy(" + Tag::name() + ")"; }
+};
+
+/// The derivative with respect to Bondi \f$r\f$
+template <typename Tag>
+struct Dr : db::PrefixTag, db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>;
+  using tag = Tag;
+  static std::string name() noexcept { return "Dr(" + Tag::name() + ")"; }
 };
 
 // prefix tags associated with the integrands which are used as input to solvers
@@ -195,6 +203,8 @@ struct DuRDividedByR : db::SimpleTag {
 /// radius of the worldtube.
 struct EthRDividedByR : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 1>>;
+  using derivative_kind = Spectral::Swsh::Tags::Eth;
+  static constexpr int spin = 1;
   static std::string name() noexcept { return "EthRDividedByR"; }
 };
 
@@ -202,6 +212,8 @@ struct EthRDividedByR : db::SimpleTag {
 /// radius of the worldtube.
 struct EthEthRDividedByR : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 2>>;
+  using derivative_kind = Spectral::Swsh::Tags::EthEth;
+  static constexpr int spin = 2;
   static std::string name() noexcept { return "EthEthRDividedByR"; }
 };
 
@@ -209,6 +221,8 @@ struct EthEthRDividedByR : db::SimpleTag {
 /// Bondi radius of the worldtube.
 struct EthEthbarRDividedByR : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
+  using derivative_kind = Spectral::Swsh::Tags::EthEthbar;
+  static constexpr int spin = 0;
   static std::string name() noexcept { return "EthEthbarRDividedByR"; }
 };
 

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -46,6 +46,7 @@ struct tensor : db::SimpleTag {
 /// [simple_variables_tag]
 template <typename VectorType>
 struct scalar : db::SimpleTag {
+  static std::string name() noexcept { return "scalar name"; }
   using type = Scalar<VectorType>;
 };
 template <typename VectorType>
@@ -229,7 +230,7 @@ void test_variables_construction_and_access() noexcept {
       "T(2)=(" +
       expected_output_tensor +
       ")\n\n"
-      "scalar:\n"
+      "scalar name:\n"
       "T()=(" +
       expected_output_initial +
       ")\n\n"
@@ -254,7 +255,7 @@ void test_variables_construction_and_access() noexcept {
           tmpl::list<VariablesTestTags_detail::tensor<VectorType>,
                      VariablesTestTags_detail::scalar<VectorType>,
                      VariablesTestTags_detail::scalar2<VectorType>>>::name() ==
-      "Variables(tensor name,scalar,scalar2 name)");
+      "Variables(tensor name,scalar name,scalar2 name)");
 }
 
 template <typename VectorType>

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_InitializeCce.cpp
   Test_LinearOperators.cpp
   Test_LinearSolve.cpp
+  Test_PrecomputeCceDependencies.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Cce")
 set(LIBRARY_SOURCES
   CceComputationTestHelpers.cpp
   Test_Equations.cpp
+  Test_InitializeCce.cpp
   Test_LinearOperators.cpp
   Test_LinearSolve.cpp
   )

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Cce")
 set(LIBRARY_SOURCES
   CceComputationTestHelpers.cpp
   Test_Equations.cpp
+  Test_LinearOperators.cpp
   Test_LinearSolve.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/Cce/CceComputationTestHelpers.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/CceComputationTestHelpers.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -42,6 +43,31 @@ void volume_one_minus_y(
         get(*one_minus_y).data().data() + number_of_angular_points * i,
         number_of_angular_points};
     angular_view = one_minus_y_collocation[i];
+  }
+}
+
+void generate_volume_data_from_separated_values(
+    const gsl::not_null<ComplexDataVector*> volume_data,
+    const gsl::not_null<ComplexDataVector*> one_divided_by_r,
+    const ComplexDataVector& angular_collocation,
+    const ComplexModalVector& radial_coefficients, const size_t l_max,
+    const size_t number_of_radial_grid_points) noexcept {
+  for (size_t i = 0; i < number_of_radial_grid_points; ++i) {
+    ComplexDataVector volume_angular_view{
+        volume_data->data() +
+            i * Spectral::Swsh::number_of_swsh_collocation_points(l_max),
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+    ComplexDataVector one_divided_by_r_angular_view{
+        one_divided_by_r->data() +
+            i * Spectral::Swsh::number_of_swsh_collocation_points(l_max),
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+    volume_angular_view = angular_collocation * radial_coefficients[0];
+    for (size_t radial_power = 1; radial_power < radial_coefficients.size();
+         ++radial_power) {
+      volume_angular_view += angular_collocation *
+                             radial_coefficients[radial_power] *
+                             power(one_divided_by_r_angular_view, radial_power);
+    }
   }
 }
 }  // namespace TestHelpers

--- a/tests/Unit/Evolution/Systems/Cce/CceComputationTestHelpers.hpp
+++ b/tests/Unit/Evolution/Systems/Cce/CceComputationTestHelpers.hpp
@@ -3,9 +3,13 @@
 
 #pragma once
 
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "DataStructures/SpinWeighted.hpp"
-#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 /// \cond
 class ComplexDataVector;
@@ -41,5 +45,26 @@ void volume_one_minus_y(
 ComplexDataVector power(const ComplexDataVector& value,
                         size_t exponent) noexcept;
 
+// A utility for copying a set of tags from one DataBox to another. Useful in
+// the Cce tests, where often an expected input needs to be copied to the box
+// which is to be tested.
+template <typename... Tags>
+struct CopyDataBoxTags {
+  template <typename FromDataBox, typename ToDataBox>
+  static void apply(const gsl::not_null<ToDataBox*> to_data_box,
+                    const FromDataBox& from_data_box) noexcept {
+    db::mutate<Tags...>(
+        to_data_box,
+        [](const gsl::not_null<db::item_type<Tags>*>... to_value,
+           const typename Tags::type&... from_value) {
+          auto assign = [](auto to, auto from) {
+            *to = from;
+            return 0;
+          };
+          expand_pack(assign(to_value, from_value)...);
+        },
+        db::get<Tags>(from_data_box)...);
+  }
+};
 }  // namespace TestHelpers
 }  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Test_InitializeCce.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_InitializeCce.cpp
@@ -1,0 +1,141 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "Evolution/Systems/Cce/InitializeCce.hpp"
+#include "Evolution/Systems/Cce/LinearOperators.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Cce {
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.InitializeJ",
+                  "[Unit][Evolution]") {
+  MAKE_GENERATOR(generator);
+  UniformCustomDistribution<size_t> sdist{5, 8};
+  const size_t l_max = sdist(generator);
+  const size_t number_of_radial_points = sdist(generator);
+
+  using boundary_variables_tag = ::Tags::Variables<InitializeJ::boundary_tags>;
+  using pre_swsh_derivatives_variables_tag =
+      ::Tags::Variables<tmpl::list<Tags::BondiJ>>;
+
+  const size_t number_of_boundary_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  const size_t number_of_volume_points =
+      number_of_boundary_points * number_of_radial_points;
+  auto box_to_initialize =
+      db::create<db::AddSimpleTags<boundary_variables_tag,
+                                   pre_swsh_derivatives_variables_tag>>(
+          typename boundary_variables_tag::type{number_of_boundary_points},
+          typename pre_swsh_derivatives_variables_tag::type{
+              number_of_volume_points});
+
+  // generate some random values for the boundary data
+  UniformCustomDistribution<double> dist(0.1, 1.0);
+  db::mutate<Tags::BoundaryValue<Tags::BondiR>,
+             Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
+             Tags::BoundaryValue<Tags::BondiJ>>(
+      make_not_null(&box_to_initialize),
+      [&generator, &dist, &l_max](
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+              boundary_r,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
+              boundary_dr_j,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
+              boundary_j) {
+        get(*boundary_j).data() = make_with_random_values<ComplexDataVector>(
+            make_not_null(&generator), make_not_null(&dist),
+            Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+        get(*boundary_r).data() = make_with_random_values<ComplexDataVector>(
+            make_not_null(&generator), make_not_null(&dist),
+            Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+        get(*boundary_dr_j).data() = make_with_random_values<ComplexDataVector>(
+            make_not_null(&generator), make_not_null(&dist),
+            Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+      });
+
+  db::mutate_apply<InitializeJ>(make_not_null(&box_to_initialize));
+
+  SpinWeighted<ComplexDataVector, 2> dy_j{
+      number_of_radial_points *
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  SpinWeighted<ComplexDataVector, 2> dy_dy_j{
+      number_of_radial_points *
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  logical_partial_directional_derivative_of_complex(
+      make_not_null(&dy_j.data()),
+      get(db::get<Tags::BondiJ>(box_to_initialize)).data(),
+      Mesh<3>{{{Spectral::Swsh::number_of_swsh_theta_collocation_points(l_max),
+                Spectral::Swsh::number_of_swsh_phi_collocation_points(l_max),
+                number_of_radial_points}},
+              Spectral::Basis::Legendre,
+              Spectral::Quadrature::GaussLobatto},
+      2);
+  logical_partial_directional_derivative_of_complex(
+      make_not_null(&dy_dy_j.data()), dy_j.data(),
+      Mesh<3>{{{Spectral::Swsh::number_of_swsh_theta_collocation_points(l_max),
+                Spectral::Swsh::number_of_swsh_phi_collocation_points(l_max),
+                number_of_radial_points}},
+              Spectral::Basis::Legendre,
+              Spectral::Quadrature::GaussLobatto},
+      2);
+
+  // The goal for the initial data is that it should:
+  // - match the value of J and its first derivative on the boundary
+  // - have vanishing value and second derivative at scri+
+  ComplexDataVector mutable_j_copy =
+      get(db::get<Tags::BondiJ>(box_to_initialize)).data();
+  const auto boundary_slice_j = ComplexDataVector{
+      mutable_j_copy.data(),
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  const auto boundary_slice_dy_j = ComplexDataVector{
+      dy_j.data().data(),
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  const auto scri_slice_j = ComplexDataVector{
+      mutable_j_copy.data() +
+          (number_of_radial_points - 1) *
+              Spectral::Swsh::number_of_swsh_collocation_points(l_max),
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  const auto scri_slice_dy_dy_j = ComplexDataVector{
+      dy_dy_j.data().data() +
+          (number_of_radial_points - 1) *
+              Spectral::Swsh::number_of_swsh_collocation_points(l_max),
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+
+  Approx cce_approx =
+      Approx::custom()
+          .epsilon(std::numeric_limits<double>::epsilon() * 1.0e4)
+          .scale(1.0);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(db::get<Tags::BoundaryValue<Tags::BondiJ>>(box_to_initialize)).data(),
+      boundary_slice_j, cce_approx);
+  const auto boundary_slice_dr_j =
+      (2.0 / get(db::get<Tags::BoundaryValue<Tags::BondiR>>(box_to_initialize))
+                 .data()) *
+      boundary_slice_dy_j;
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      boundary_slice_dr_j,
+      get(db::get<Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>>(
+              box_to_initialize))
+          .data(),
+      cce_approx);
+  const ComplexDataVector scri_plus_zeroes{
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max), 0.0};
+  CHECK_ITERABLE_CUSTOM_APPROX(scri_slice_j, scri_plus_zeroes, cce_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(scri_slice_dy_dy_j, scri_plus_zeroes,
+                               cce_approx);
+}
+}  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Test_LinearOperators.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_LinearOperators.cpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Mesh.hpp"
+#include "Evolution/Systems/Cce/LinearOperators.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "Utilities/VectorAlgebra.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.LinearOperators",
+                  "[Unit][Evolution]") {
+  MAKE_GENERATOR(generator);
+  const size_t l_max = 6;
+  const size_t number_of_radial_points = 6;
+  UniformCustomDistribution<double> dist(0.1, 1.0);
+
+  const ComplexDataVector y = outer_product(
+      ComplexDataVector{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max), 1.0},
+      Spectral::collocation_points<Spectral::Basis::Legendre,
+                                   Spectral::Quadrature::GaussLobatto>(
+          number_of_radial_points));
+  const size_t polynomial_order = 3;
+  const DataVector y_polynomial_coefficients =
+      make_with_random_values<DataVector>(
+          make_not_null(&generator), make_not_null(&dist), polynomial_order);
+
+  ComplexDataVector to_differentiate{y.size(), 0.0};
+  ComplexDataVector expected_derivative{y.size(), 0.0};
+  for (size_t i = 0; i < polynomial_order; ++i) {
+    to_differentiate += pow(y, i) * y_polynomial_coefficients[i];
+    if (i != 0) {
+      expected_derivative +=
+          static_cast<double>(i) * pow(y, i - 1) * y_polynomial_coefficients[i];
+    }
+  }
+  ComplexDataVector derivative{y.size()};
+  Cce::logical_partial_directional_derivative_of_complex(
+      make_not_null(&derivative), to_differentiate,
+      Mesh<3>{{{Spectral::Swsh::number_of_swsh_theta_collocation_points(l_max),
+                Spectral::Swsh::number_of_swsh_phi_collocation_points(l_max),
+                number_of_radial_points}},
+              Spectral::Basis::Legendre,
+              Spectral::Quadrature::GaussLobatto},
+      2);
+  CHECK_ITERABLE_APPROX(expected_derivative, derivative);
+}

--- a/tests/Unit/Evolution/Systems/Cce/Test_PrecomputeCceDependencies.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_PrecomputeCceDependencies.cpp
@@ -1,0 +1,177 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
+#include "Evolution/Systems/Cce/PrecomputeCceDependencies.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/Evolution/Systems/Cce/CceComputationTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Cce {
+
+template <typename Generator, typename PrecomputationBox, typename ExpectedBox>
+void generate_boundary_values_and_expected(
+    const gsl::not_null<Generator*> generator,
+    const gsl::not_null<PrecomputationBox*> precomputation_box,
+    const gsl::not_null<ExpectedBox*> expected_box, const size_t l_max,
+    const size_t number_of_radial_grid_points) {
+  ComplexDataVector y = outer_product(
+      ComplexDataVector{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max), 1.0},
+      Spectral::collocation_points<Spectral::Basis::Legendre,
+                                   Spectral::Quadrature::GaussLobatto>(
+          number_of_radial_grid_points));
+
+  UniformCustomDistribution<double> dist(0.1, 1.0);
+  db::mutate<Tags::BoundaryValue<Tags::BondiR>,
+             Tags::BoundaryValue<Tags::DuRDividedByR>, Tags::BondiR,
+             Tags::DuRDividedByR, Tags::OneMinusY, Tags::BondiJ, Tags::BondiK>(
+      expected_box,
+      [&generator, &dist, &l_max, &number_of_radial_grid_points, &y](
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+              boundary_r,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+              boundary_du_r_divided_by_r,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> r,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+              du_r_divided_by_r,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+              one_minus_y,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> k) {
+        get(*boundary_r).data() =
+            (10.0 +
+             std::complex<double>(1.0, 0.0) *
+                 make_with_random_values<DataVector>(
+                     generator, make_not_null(&dist),
+                     Spectral::Swsh::number_of_swsh_collocation_points(l_max)));
+        get(*boundary_du_r_divided_by_r).data() =
+            std::complex<double>(1.0, 0.0) *
+            make_with_random_values<DataVector>(
+                generator, make_not_null(&dist),
+                Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+        // prevent aliasing; some terms are nonlinear in R
+        Spectral::Swsh::filter_swsh_boundary_quantity(
+            make_not_null(&get(*boundary_r)), l_max, l_max - 3);
+        repeat(make_not_null(&get(*r).data()), get(*boundary_r).data(),
+               number_of_radial_grid_points);
+        repeat(make_not_null(&get(*du_r_divided_by_r).data()),
+               get(*boundary_du_r_divided_by_r).data(),
+               number_of_radial_grid_points);
+        get(*one_minus_y).data() = 1.0 - y;
+        get(*j).data() = make_with_random_values<ComplexDataVector>(
+            generator, make_not_null(&dist),
+            number_of_radial_grid_points *
+                Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+        get(*k).data() = sqrt(1.0 + get(*j).data() * conj(get(*j).data()));
+      });
+
+  TestHelpers::CopyDataBoxTags<Tags::BoundaryValue<Tags::BondiR>,
+                               Tags::BoundaryValue<Tags::DuRDividedByR>,
+                               Tags::BondiJ>::apply(precomputation_box,
+                                                    *expected_box);
+
+  db::mutate<Tags::EthRDividedByR, Tags::EthEthbarRDividedByR,
+             Tags::EthEthRDividedByR>(
+      expected_box,
+      [&l_max, &number_of_radial_grid_points](
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*>
+              eth_r_divided_by_r,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+              eth_ethbar_r_divided_by_r,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
+              eth_eth_r_divided_by_r,
+          const Scalar<SpinWeighted<ComplexDataVector, 0>>& r) {
+        SpinWeighted<ComplexDataVector, 0> r_buffer;
+        r_buffer = get(r);
+        get(*eth_r_divided_by_r) =
+            Spectral::Swsh::angular_derivative<Spectral::Swsh::Tags::Eth>(
+                l_max, number_of_radial_grid_points, r_buffer) /
+            (get(r));
+        get(*eth_ethbar_r_divided_by_r) =
+            Spectral::Swsh::angular_derivative<Spectral::Swsh::Tags::EthEthbar>(
+                l_max, number_of_radial_grid_points, r_buffer) /
+            (get(r));
+        get(*eth_eth_r_divided_by_r) =
+            Spectral::Swsh::angular_derivative<Spectral::Swsh::Tags::EthEth>(
+                l_max, number_of_radial_grid_points, r_buffer) /
+            (get(r));
+      },
+      db::get<Tags::BondiR>(*expected_box));
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.PrecomputeCceDependencies",
+                  "[Unit][Evolution]") {
+  // Initialize the Variables that we need
+  MAKE_GENERATOR(generator);
+  UniformCustomDistribution<size_t> sdist{5, 8};
+  const size_t l_max = sdist(generator);
+  const size_t number_of_radial_grid_points = sdist(generator);
+
+  using boundary_variables_tag =
+      ::Tags::Variables<pre_computation_boundary_tags<Tags::BoundaryValue>>;
+  using independent_of_integration_variables_tag =
+      ::Tags::Variables<pre_computation_tags>;
+  using pre_swsh_derivatives_variables_tag =
+      ::Tags::Variables<tmpl::list<Tags::BondiJ>>;
+
+  const size_t number_of_boundary_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  const size_t number_of_volume_points =
+      number_of_boundary_points * number_of_radial_grid_points;
+  auto precomputation_box = db::create<db::AddSimpleTags<
+      boundary_variables_tag, independent_of_integration_variables_tag,
+      pre_swsh_derivatives_variables_tag, Spectral::Swsh::Tags::LMax,
+      Spectral::Swsh::Tags::NumberOfRadialPoints>>(
+      typename boundary_variables_tag::type{number_of_boundary_points},
+      typename independent_of_integration_variables_tag::type{
+          number_of_volume_points},
+      typename pre_swsh_derivatives_variables_tag::type{
+          number_of_volume_points},
+      l_max, number_of_radial_grid_points);
+
+  auto expected_box =
+      db::create<db::AddSimpleTags<boundary_variables_tag,
+                                   independent_of_integration_variables_tag,
+                                   pre_swsh_derivatives_variables_tag>>(
+          typename boundary_variables_tag::type{number_of_boundary_points},
+          typename independent_of_integration_variables_tag::type{
+              number_of_volume_points},
+          typename pre_swsh_derivatives_variables_tag::type{
+              number_of_volume_points});
+
+  generate_boundary_values_and_expected(
+      make_not_null(&generator), make_not_null(&precomputation_box),
+      make_not_null(&expected_box), l_max, number_of_radial_grid_points);
+
+  mutate_all_precompute_cce_dependencies<Tags::BoundaryValue>(
+      make_not_null(&precomputation_box));
+
+  CHECK_VARIABLES_APPROX(db::get<boundary_variables_tag>(precomputation_box),
+                         db::get<boundary_variables_tag>(expected_box));
+
+  CHECK_VARIABLES_APPROX(
+      db::get<pre_swsh_derivatives_variables_tag>(precomputation_box),
+      db::get<pre_swsh_derivatives_variables_tag>(expected_box));
+
+  CHECK_VARIABLES_APPROX(
+      db::get<independent_of_integration_variables_tag>(precomputation_box),
+      db::get<independent_of_integration_variables_tag>(expected_box));
+}
+}  // namespace Cce


### PR DESCRIPTION
## Proposed changes

Adds the first step in computing the inputs to the CCE integrand functions in `Equations.hpp`. Also adds supporting infrastructure of helpful typelists, derivative utilities, and first hypersurface initialization.

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code
