### PR TITLE
Fix building with clang9

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -23,6 +23,7 @@ add_dependencies(
 
 target_link_libraries(
   ${LIBRARY}
+  INTERFACE ApparentHorizons
   INTERFACE Domain
   INTERFACE ErrorHandling
   INTERFACE Spectral

--- a/src/NumericalAlgorithms/Spectral/SwshTags.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTags.hpp
@@ -47,19 +47,27 @@ struct EthbarEthbar {};
 /// no derivative is taken.
 struct NoDerivative {};
 
+namespace detail {
+template <typename DerivativeKind>
+inline constexpr int derivative_spin_weight_impl() noexcept {
+  if (cpp17::is_same_v<DerivativeKind, Eth>) {
+    return 1;
+  } else if (cpp17::is_same_v<DerivativeKind, Ethbar>) {
+    return -1;
+  } else if (cpp17::is_same_v<DerivativeKind, EthEth>) {
+    return 2;
+  } else if (cpp17::is_same_v<DerivativeKind, EthbarEthbar>) {
+    return -2;
+  }
+  return 0;
+}
+}  // namespace detail
+
 // utility function for determining the change of spin after a spin-weighted
 // derivative has been applied.
 template <typename DerivativeKind>
-constexpr int derivative_spin_weight = 0;
-
-template <>
-constexpr int derivative_spin_weight<Eth> = 1;
-template <>
-constexpr int derivative_spin_weight<Ethbar> = -1;
-template <>
-constexpr int derivative_spin_weight<EthEth> = 2;
-template <>
-constexpr int derivative_spin_weight<EthbarEthbar> = -2;
+constexpr int derivative_spin_weight =
+    detail::derivative_spin_weight_impl<DerivativeKind>();
 
 namespace detail {
 // The below tags are used to find the new type represented by the spin-weighted


### PR DESCRIPTION
## Proposed changes

Some changes in clang 9 and ld.lld broke the build. Apparently Interpolation depends on ApparentHorizons (not so great...) and template specializations of variables in headers leads to (I think incorrect) strong references during linking.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
