### PR TITLE
Refactor Minmod limiter test

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
@@ -61,8 +61,8 @@ bool minmod_limited_slopes(
         effective_neighbor_sizes, dim, side);
   };
 
-  // The LambdaPiN limiter allows high-order solutions to escape limiting if
-  // the boundary values are not too different from the mean value:
+  // The LambdaPiN limiter calls a simple troubled-cell indicator to avoid
+  // limiting solutions that appear smooth:
   if (minmod_type == Limiters::MinmodType::LambdaPiN) {
     const bool u_needs_limiting = troubled_cell_indicator(
         boundary_buffer, tvbm_constant, u, element, mesh, element_size,

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
@@ -23,7 +23,7 @@ namespace Limiters {
 namespace Minmod_detail {
 
 template <size_t VolumeDim>
-bool minmod_tci_wrapper(
+bool minmod_limited_slopes(
     const gsl::not_null<double*> u_mean,
     const gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
     const gsl::not_null<DataVector*> u_lin_buffer,
@@ -64,7 +64,7 @@ bool minmod_tci_wrapper(
   // The LambdaPiN limiter allows high-order solutions to escape limiting if
   // the boundary values are not too different from the mean value:
   if (minmod_type == Limiters::MinmodType::LambdaPiN) {
-    bool u_needs_limiting = troubled_cell_indicator(
+    const bool u_needs_limiting = troubled_cell_indicator(
         boundary_buffer, tvbm_constant, u, element, mesh, element_size,
         effective_neighbor_means, effective_neighbor_sizes,
         volume_and_slice_indices);
@@ -106,7 +106,7 @@ bool minmod_tci_wrapper(
     const double upper_slope = 0.5 * difference_to_neighbor(d, Side::Upper);
     const double lower_slope = 0.5 * difference_to_neighbor(d, Side::Lower);
 
-    const MinmodResult& result =
+    const MinmodResult result =
         minmod_tvbm(local_slope, max_slope_factor * upper_slope,
                     max_slope_factor * lower_slope, tvbm_scale);
     gsl::at(*u_limited_slopes, d) = result.value;
@@ -133,7 +133,7 @@ bool minmod_tci_wrapper(
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                            \
-  template bool minmod_tci_wrapper<DIM(data)>(                          \
+  template bool minmod_limited_slopes<DIM(data)>(                       \
       const gsl::not_null<double*>,                                     \
       const gsl::not_null<std::array<double, DIM(data)>*>,              \
       const gsl::not_null<DataVector*>,                                 \

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
@@ -74,7 +74,7 @@ namespace Minmod_detail {
 // Note: This function is only made available in this header file to facilitate
 // testing.
 template <size_t VolumeDim>
-bool minmod_tci_wrapper(
+bool minmod_limited_slopes(
     gsl::not_null<double*> u_mean,
     gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
     gsl::not_null<DataVector*> u_lin_buffer,

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
@@ -64,12 +64,10 @@ struct SizeOfElement;
 namespace Limiters {
 
 namespace Minmod_detail {
-// Implements the troubled-cell indicator for the Minmod limiter.
-//
-// Because the Minmod limiter uses the same algorithm to detect troubled cells
-// and to correct the data on these cells, we optimize by having the TCI return
-// (by reference) some additional data that are used by the limiter in the case
-// where the TCI returns true (i.e., the case where limiting is needed).
+// This function combines the evaluation of the troubled-cell indicator with the
+// computation of the post-limiter reduced slopes. The returned bool indicates
+// whether the slopes are to be reduced. The slopes themselves are returned by
+// pointer.
 //
 // Note: This function is only made available in this header file to facilitate
 // testing.

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
@@ -83,13 +83,13 @@ bool limit_one_tensor(
     DataVector& u = (*tensor)[i];
     double u_mean;
     std::array<double, VolumeDim> u_limited_slopes{};
-    const bool reduce_slope = minmod_tci_wrapper(
+    const bool reduce_slopes = minmod_limited_slopes(
         make_not_null(&u_mean), make_not_null(&u_limited_slopes), u_lin_buffer,
         boundary_buffer, minmod_type, tvbm_constant, u, element, mesh,
         element_size, effective_neighbor_means, effective_neighbor_sizes,
         volume_and_slice_indices);
 
-    if (reduce_slope or using_linear_limiter_on_non_linear_mesh) {
+    if (reduce_slopes or using_linear_limiter_on_non_linear_mesh) {
       u = u_mean;
       for (size_t d = 0; d < VolumeDim; ++d) {
         u += logical_coords.get(d) * gsl::at(u_limited_slopes, d);

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
@@ -162,7 +162,7 @@ bool Minmod<VolumeDim, tmpl::list<Tags...>>::operator()(
     return false;
   }
 
-  // Optimization: allocate temporary buffer to be used in `limit_one_tensor`
+  // Optimization: allocate a single buffer to avoid multiple allocations
   std::unique_ptr<double[], decltype(&free)> contiguous_buffer(nullptr, &free);
   DataVector u_lin_buffer{};
   std::array<DataVector, VolumeDim> boundary_buffer{};

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
@@ -104,12 +104,12 @@ bool troubled_cell_indicator(
               element, tensor_storage_index, neighbor_data);
 
       const DataVector& u = tensor[tensor_storage_index];
-      const bool tci_triggered = troubled_cell_indicator(
+      const bool component_needs_limiting = troubled_cell_indicator(
           make_not_null(&boundary_buffer), tvbm_constant, u, element, mesh,
           element_size, effective_neighbor_means, effective_neighbor_sizes,
           volume_and_slice_indices);
 
-      if (tci_triggered) {
+      if (component_needs_limiting) {
         some_component_needs_limiting = true;
         // Skip remaining components of this tensor
         return '0';

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
@@ -64,6 +64,7 @@ struct VectorTag : db::SimpleTag {
 };
 
 void test_minmod_option_parsing() noexcept {
+  INFO("Test Minmod option parsing");
   const auto lambda_pi1_default =
       test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
           "  Type: LambdaPi1");
@@ -94,6 +95,7 @@ void test_minmod_option_parsing() noexcept {
 }
 
 void test_minmod_serialization() noexcept {
+  INFO("Test Minmod serialization");
   const Limiters::Minmod<1, tmpl::list<ScalarTag>> minmod(
       Limiters::MinmodType::LambdaPi1);
   test_serialization(minmod);
@@ -1058,6 +1060,7 @@ void test_work(
 }
 
 void test_minmod_limiter_1d() noexcept {
+  INFO("Test Minmod limiter in 1D");
   // The goals of this test are,
   // 1. check that Minmod::op() limits different tensors independently
   // See comments in the 3D test for full details.
@@ -1110,6 +1113,7 @@ void test_minmod_limiter_1d() noexcept {
 }
 
 void test_minmod_limiter_2d() noexcept {
+  INFO("Test Minmod limiter in 2D");
   // The goals of this test are,
   // 1. check that Minmod::op() limits different tensors independently
   // 2. check that Minmod::op() limits different dimensions independently
@@ -1198,6 +1202,7 @@ void test_minmod_limiter_2d() noexcept {
 }
 
 void test_minmod_limiter_3d() noexcept {
+  INFO("Test Minmod limiter in 3D");
   // The goals of this test are,
   // 1. check that Minmod::op() limits different tensors independently
   // 2. check that Minmod::op() limits different dimensions independently
@@ -1325,40 +1330,26 @@ void test_minmod_limiter_3d() noexcept {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.Minmod", "[Limiters][Unit]") {
-  {
-    INFO("Test Minmod option-parsing and serialization");
-    test_minmod_option_parsing();
-    test_minmod_serialization();
-  }
+  test_minmod_option_parsing();
+  test_minmod_serialization();
 
-  {
-    INFO("Test Minmod package_data");
-    test_package_data_1d();
-    test_package_data_2d();
-    test_package_data_3d();
-  }
+  test_package_data_1d();
+  test_package_data_2d();
+  test_package_data_3d();
 
-  {
-    INFO("Test Minmod TCI wrapper");
-    test_minmod_tci_wrapper_1d();
-    test_minmod_tci_wrapper_2d();
-    test_minmod_tci_wrapper_3d();
-  }
+  // These functions test
+  // - the TCI for the limiter, i.e., when the limiter activates
+  // - the reduced slopes requested in the event of an activation
+  test_minmod_tci_wrapper_1d();
+  test_minmod_tci_wrapper_2d();
+  test_minmod_tci_wrapper_3d();
 
-  {
-    INFO("Test Minmod limiter in 1d");
-    test_minmod_limiter_1d();
-  }
+  // These functions test the correctness of the limited solution
+  test_minmod_limiter_1d();
+  test_minmod_limiter_2d();
+  test_minmod_limiter_3d();
 
-  {
-    INFO("Test Minmod limiter in 2d");
-    test_minmod_limiter_2d();
-    test_minmod_limiter_two_lower_xi_neighbors();
-  }
-
-  {
-    INFO("Test Minmod limiter in 3d");
-    test_minmod_limiter_3d();
-    test_minmod_limiter_four_upper_xi_neighbors();
-  }
+  // These functions test the limiter with h-refinement
+  test_minmod_limiter_two_lower_xi_neighbors();
+  test_minmod_limiter_four_upper_xi_neighbors();
 }


### PR DESCRIPTION
## Proposed changes

- refactor the `Minmod::package_data()` test, with a new design that splits the testing of `package_data()` from the testing of the limiting.
- reorder some code blocks in the Minmod test so that they match the order in which they are called
- improve a few variable names and comments through the Minmod limiter and its test

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

