### PR TITLE
Factor out InitializeGrTags in relativistic hydro systems

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -21,9 +21,9 @@
 #include "Evolution/Initialization/ConservativeSystem.hpp"
 #include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
 #include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Initialization/GrTagsForHydro.hpp"
 #include "Evolution/Initialization/Limiter.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp"
-#include "Evolution/Systems/GrMhd/ValenciaDivClean/Initialize.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
@@ -190,8 +190,7 @@ struct EvolutionMetavars {
   };
 
   using initialization_actions = tmpl::list<
-      dg::Actions::InitializeDomain<3>,
-      grmhd::ValenciaDivClean::Actions::InitializeGrTags,
+      dg::Actions::InitializeDomain<3>, Initialization::Actions::GrTagsForHydro,
       Initialization::Actions::ConservativeSystem,
       VariableFixing::Actions::FixVariables<
           VariableFixing::FixToAtmosphere<thermodynamic_dim>>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
@@ -19,6 +19,7 @@
 #include "Evolution/Initialization/ConservativeSystem.hpp"
 #include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
 #include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Initialization/GrTagsForHydro.hpp"
 #include "Evolution/Initialization/Limiter.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/Initialize.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/System.hpp"
@@ -164,8 +165,7 @@ struct EvolutionMetavars {
   };
 
   using initialization_actions = tmpl::list<
-      dg::Actions::InitializeDomain<3>,
-      RadiationTransport::M1Grey::Actions::InitializeGrTags,
+      dg::Actions::InitializeDomain<3>, Initialization::Actions::GrTagsForHydro,
       Initialization::Actions::ConservativeSystem,
       RadiationTransport::M1Grey::Actions::InitializeM1Tags,
       Actions::UpdateM1Closure,

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Initialize.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Initialize.hpp
@@ -34,60 +34,6 @@ namespace RadiationTransport {
 namespace M1Grey {
 namespace Actions {
 
-struct InitializeGrTags {
-  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent>
-  static auto apply(db::DataBox<DbTagsList>& box,
-                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    const Parallel::ConstGlobalCache<Metavariables>& cache,
-                    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/) noexcept {
-    using system = typename Metavariables::system;
-    static constexpr size_t dim = system::volume_dim;
-    using gr_tag = typename system::spacetime_variables_tag;
-    using simple_tags = db::AddSimpleTags<gr_tag>;
-    using compute_tags = db::AddComputeTags<>;
-
-    const double initial_time = db::get<Initialization::Tags::InitialTime>(box);
-    using GrVars = typename gr_tag::type;
-
-    const size_t num_grid_points =
-        db::get<::Tags::Mesh<dim>>(box).number_of_grid_points();
-    const auto& inertial_coords =
-        db::get<::Tags::Coordinates<dim, Frame::Inertial>>(box);
-
-    // Set initial data from analytic solution
-    GrVars gr_vars{num_grid_points};
-    make_overloader(
-        [ initial_time, &inertial_coords ](
-            std::true_type /*is_analytic_solution*/,
-            const gsl::not_null<GrVars*> local_gr_vars,
-            const auto& local_cache) noexcept {
-          using solution_tag = ::Tags::AnalyticSolutionBase;
-          local_gr_vars->assign_subset(
-              Parallel::get<solution_tag>(local_cache)
-                  .variables(inertial_coords, initial_time,
-                             typename GrVars::tags_list{}));
-        },
-        [&inertial_coords](std::false_type /*is_analytic_solution*/,
-                           const gsl::not_null<GrVars*> local_gr_vars,
-                           const auto& local_cache) noexcept {
-          using analytic_data_tag = ::Tags::AnalyticDataBase;
-          local_gr_vars->assign_subset(
-              Parallel::get<analytic_data_tag>(local_cache)
-                  .variables(inertial_coords, typename GrVars::tags_list{}));
-        })(
-        evolution::is_analytic_solution<typename Metavariables::initial_data>{},
-        make_not_null(&gr_vars), cache);
-
-    return std::make_tuple(
-        Initialization::merge_into_databox<InitializeGrTags, simple_tags,
-                                           compute_tags>(std::move(box),
-                                                         std::move(gr_vars)));
-  }
-};
-
 struct InitializeM1Tags {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,


### PR DESCRIPTION
## Proposed changes

Factor out GR tags initialization in hydro systems.

Currently used by
  - ValenciaDivClean
  - M1

To be used at least by
  - Valencia

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
