### PR TITLE
Make FixToAtmosphere also work in 1 and 2-d

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -194,7 +194,7 @@ struct EvolutionMetavars {
       grmhd::ValenciaDivClean::Actions::InitializeGrTags,
       Initialization::Actions::ConservativeSystem,
       VariableFixing::Actions::FixVariables<
-          VariableFixing::FixToAtmosphere<thermodynamic_dim>>,
+          VariableFixing::FixToAtmosphere<volume_dim, thermodynamic_dim>>,
       Actions::UpdateConservatives,
       dg::Actions::InitializeInterfaces<
           system,
@@ -241,7 +241,8 @@ struct EvolutionMetavars {
                   Phase, Phase::Evolve,
                   tmpl::list<
                       VariableFixing::Actions::FixVariables<
-                          VariableFixing::FixToAtmosphere<thermodynamic_dim>>,
+                          VariableFixing::FixToAtmosphere<volume_dim,
+                                                          thermodynamic_dim>>,
                       Actions::UpdateConservatives,
                       Actions::RunEventsAndTriggers,
                       tmpl::conditional_t<

--- a/src/Evolution/VariableFixing/FixToAtmosphere.cpp
+++ b/src/Evolution/VariableFixing/FixToAtmosphere.cpp
@@ -8,6 +8,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Overloader.hpp"
 
 // IWYU pragma: no_include <array>
 
@@ -16,8 +17,8 @@
 
 namespace VariableFixing {
 
-template <size_t ThermodynamicDim>
-FixToAtmosphere<ThermodynamicDim>::FixToAtmosphere(
+template <size_t Dim, size_t ThermodynamicDim>
+FixToAtmosphere<Dim, ThermodynamicDim>::FixToAtmosphere(
     const double density_of_atmosphere, const double density_cutoff,
     const OptionContext& context)
     : density_of_atmosphere_(density_of_atmosphere),
@@ -32,100 +33,96 @@ FixToAtmosphere<ThermodynamicDim>::FixToAtmosphere(
 }
 
 // clang-tidy: google-runtime-references
-template <size_t ThermodynamicDim>
-void FixToAtmosphere<ThermodynamicDim>::pup(PUP::er& p) noexcept {  // NOLINT
+template <size_t Dim, size_t ThermodynamicDim>
+void FixToAtmosphere<Dim, ThermodynamicDim>::pup(
+    PUP::er& p) noexcept {  // NOLINT
   p | density_of_atmosphere_;
   p | density_cutoff_;
 }
 
-template <>
-void FixToAtmosphere<1>::operator()(
+template <size_t Dim, size_t ThermodynamicDim>
+void FixToAtmosphere<Dim, ThermodynamicDim>::operator()(
     const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
     const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
-    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
         spatial_velocity,
     const gsl::not_null<Scalar<DataVector>*> lorentz_factor,
     const gsl::not_null<Scalar<DataVector>*> pressure,
     const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
-    const EquationsOfState::EquationOfState<true, 1>& equation_of_state) const
-    noexcept {
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) const noexcept {
   for (size_t i = 0; i < rest_mass_density->get().size(); i++) {
     if (UNLIKELY(rest_mass_density->get()[i] < density_cutoff_)) {
       rest_mass_density->get()[i] = density_of_atmosphere_;
-      for (size_t d = 0; d < 3; ++d) {
+      for (size_t d = 0; d < Dim; ++d) {
         spatial_velocity->get(d)[i] = 0.0;
       }
       lorentz_factor->get()[i] = 1.0;
       Scalar<double> atmosphere_density{density_of_atmosphere_};
-      pressure->get()[i] =
-          get(equation_of_state.pressure_from_density(atmosphere_density));
-      specific_internal_energy->get()[i] =
-          get(equation_of_state.specific_internal_energy_from_density(
-              atmosphere_density));
-      specific_enthalpy->get()[i] = get(
-          equation_of_state.specific_enthalpy_from_density(atmosphere_density));
+      make_overloader(
+          [
+            &atmosphere_density, &pressure, &specific_internal_energy,
+            &specific_enthalpy, &i
+          ](const EquationsOfState::EquationOfState<true, 1>&
+                the_equation_of_state) noexcept {
+            pressure->get()[i] =
+                get(the_equation_of_state.pressure_from_density(
+                    atmosphere_density));
+            specific_internal_energy->get()[i] =
+                get(the_equation_of_state.specific_internal_energy_from_density(
+                    atmosphere_density));
+            specific_enthalpy->get()[i] =
+                get(the_equation_of_state.specific_enthalpy_from_density(
+                    atmosphere_density));
+          },
+          [
+            &atmosphere_density, &pressure, &specific_internal_energy,
+            &specific_enthalpy, &i
+          ](const EquationsOfState::EquationOfState<true, 2>&
+                the_equation_of_state) noexcept {
+            Scalar<double> atmosphere_energy{0.0};
+            pressure->get()[i] =
+                get(the_equation_of_state.pressure_from_density_and_energy(
+                    atmosphere_density, atmosphere_energy));
+            specific_internal_energy->get()[i] = get(atmosphere_energy);
+            specific_enthalpy->get()[i] = get(
+                the_equation_of_state.specific_enthalpy_from_density_and_energy(
+                    atmosphere_density, atmosphere_energy));
+          })(equation_of_state);
     }
   }
 }
 
-template <>
-void FixToAtmosphere<2>::operator()(
-    const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
-    const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
-    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-        spatial_velocity,
-    const gsl::not_null<Scalar<DataVector>*> lorentz_factor,
-    const gsl::not_null<Scalar<DataVector>*> pressure,
-    const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
-    const EquationsOfState::EquationOfState<true, 2>& equation_of_state) const
-    noexcept {
-  for (size_t i = 0; i < rest_mass_density->get().size(); i++) {
-    if (UNLIKELY(rest_mass_density->get()[i] < density_cutoff_)) {
-      rest_mass_density->get()[i] = density_of_atmosphere_;
-      specific_internal_energy->get()[i] = 0.0;
-      for (size_t d = 0; d < 3; ++d) {
-        spatial_velocity->get(d)[i] = 0.0;
-      }
-      lorentz_factor->get()[i] = 1.0;
-      Scalar<double> atmosphere_density{density_of_atmosphere_};
-      Scalar<double> atmosphere_energy{0.0};
-      pressure->get()[i] =
-          get(equation_of_state.pressure_from_density_and_energy(
-              atmosphere_density, atmosphere_energy));
-      specific_enthalpy->get()[i] =
-          get(equation_of_state.specific_enthalpy_from_density_and_energy(
-              atmosphere_density, atmosphere_energy));
-    }
-  }
-}
-
-template <size_t LocalThermodynamicDim>
-bool operator==(const FixToAtmosphere<LocalThermodynamicDim>& lhs,
-                const FixToAtmosphere<LocalThermodynamicDim>& rhs) noexcept {
+template <size_t Dim, size_t LocalThermodynamicDim>
+bool operator==(
+    const FixToAtmosphere<Dim, LocalThermodynamicDim>& lhs,
+    const FixToAtmosphere<Dim, LocalThermodynamicDim>& rhs) noexcept {
   return lhs.density_of_atmosphere_ == rhs.density_of_atmosphere_ and
          lhs.density_cutoff_ == rhs.density_cutoff_;
 }
 
-template <size_t ThermodynamicDim>
-bool operator!=(const FixToAtmosphere<ThermodynamicDim>& lhs,
-                const FixToAtmosphere<ThermodynamicDim>& rhs) noexcept {
+template <size_t Dim, size_t ThermodynamicDim>
+bool operator!=(const FixToAtmosphere<Dim, ThermodynamicDim>& lhs,
+                const FixToAtmosphere<Dim, ThermodynamicDim>& rhs) noexcept {
   return not(lhs == rhs);
 }
 
-#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATION(r, data)                             \
-  template class FixToAtmosphere<GET_DIM(data)>;           \
-  template bool operator==(                                \
-      const FixToAtmosphere<GET_DIM(data)>& lhs,           \
-      const FixToAtmosphere<GET_DIM(data)>& rhs) noexcept; \
-  template bool operator!=(                                \
-      const FixToAtmosphere<GET_DIM(data)>& lhs,           \
-      const FixToAtmosphere<GET_DIM(data)>& rhs) noexcept;
+#define INSTANTIATION(r, data)                                           \
+  template class FixToAtmosphere<DIM(data), THERMO_DIM(data)>;           \
+  template bool operator==(                                              \
+      const FixToAtmosphere<DIM(data), THERMO_DIM(data)>& lhs,           \
+      const FixToAtmosphere<DIM(data), THERMO_DIM(data)>& rhs) noexcept; \
+  template bool operator!=(                                              \
+      const FixToAtmosphere<DIM(data), THERMO_DIM(data)>& lhs,           \
+      const FixToAtmosphere<DIM(data), THERMO_DIM(data)>& rhs) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
 
-#undef GET_DIM
+#undef DIM
+#undef THERMO_DIM
 #undef INSTANTIATION
 
 }  // namespace VariableFixing

--- a/src/Evolution/VariableFixing/FixToAtmosphere.hpp
+++ b/src/Evolution/VariableFixing/FixToAtmosphere.hpp
@@ -43,7 +43,7 @@ namespace VariableFixing {
 /// satisfy the equation of state.  For a two-dimensional equation of state, the
 /// specific internal energy is set to zero. In addition, the spatial velocity
 /// is set to zero, and the Lorentz factor is set to one.
-template <size_t ThermodynamicDim>
+template <size_t Dim, size_t ThermodynamicDim>
 class FixToAtmosphere {
  public:
   /// \brief Rest mass density of the atmosphere
@@ -87,7 +87,7 @@ class FixToAtmosphere {
   using return_tags =
       tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
                  hydro::Tags::SpecificInternalEnergy<DataVector>,
-                 hydro::Tags::SpatialVelocity<DataVector, 3>,
+                 hydro::Tags::SpatialVelocity<DataVector, Dim>,
                  hydro::Tags::LorentzFactor<DataVector>,
                  hydro::Tags::Pressure<DataVector>,
                  hydro::Tags::SpecificEnthalpy<DataVector>>;
@@ -96,7 +96,8 @@ class FixToAtmosphere {
   void operator()(
       gsl::not_null<Scalar<DataVector>*> rest_mass_density,
       gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
-      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> spatial_velocity,
+      gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          spatial_velocity,
       gsl::not_null<Scalar<DataVector>*> lorentz_factor,
       gsl::not_null<Scalar<DataVector>*> pressure,
       gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
@@ -104,18 +105,18 @@ class FixToAtmosphere {
           equation_of_state) const noexcept;
 
  private:
-  template <size_t LocalThermodynamicDim>
+  template <size_t SpatialDim, size_t LocalThermodynamicDim>
   // NOLINTNEXTLINE(readability-redundant-declaration)
   friend bool operator==(
-      const FixToAtmosphere<LocalThermodynamicDim>& lhs,
-      const FixToAtmosphere<LocalThermodynamicDim>& rhs) noexcept;
+      const FixToAtmosphere<SpatialDim, LocalThermodynamicDim>& lhs,
+      const FixToAtmosphere<SpatialDim, LocalThermodynamicDim>& rhs) noexcept;
 
   double density_of_atmosphere_{std::numeric_limits<double>::signaling_NaN()};
   double density_cutoff_{std::numeric_limits<double>::signaling_NaN()};
 };
 
-template <size_t ThermodynamicDim>
-bool operator!=(const FixToAtmosphere<ThermodynamicDim>& lhs,
-                const FixToAtmosphere<ThermodynamicDim>& rhs) noexcept;
+template <size_t Dim, size_t ThermodynamicDim>
+bool operator!=(const FixToAtmosphere<Dim, ThermodynamicDim>& lhs,
+                const FixToAtmosphere<Dim, ThermodynamicDim>& rhs) noexcept;
 
 }  // namespace VariableFixing

--- a/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
@@ -19,8 +19,9 @@
 
 namespace {
 
+template <size_t Dim>
 void test_variable_fixer(
-    const VariableFixing::FixToAtmosphere<1>& variable_fixer) {
+    const VariableFixing::FixToAtmosphere<Dim, 1>& variable_fixer) {
   EquationsOfState::PolytropicFluid<true> polytrope{1.0, 2.0};
 
   Scalar<DataVector> density{DataVector{2.e-12, 2.e-11}};
@@ -31,7 +32,7 @@ void test_variable_fixer(
 
   Scalar<DataVector> lorentz_factor{DataVector{5.0 / 3.0, 1.25}};
   auto spatial_velocity =
-      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(density, 0.0);
+      make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(density, 0.0);
   spatial_velocity.get(0) = DataVector{0.8, 0.6};
   variable_fixer(&density, &specific_internal_energy, &spatial_velocity,
                  &lorentz_factor, &pressure, &specific_enthalpy, polytrope);
@@ -44,7 +45,7 @@ void test_variable_fixer(
       polytrope.specific_internal_energy_from_density(expected_density);
   Scalar<DataVector> expected_lorentz_factor{DataVector{1.0, 1.25}};
   auto expected_spatial_velocity =
-      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(density, 0.0);
+      make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(density, 0.0);
   expected_spatial_velocity.get(0)[1] = 0.6;
 
   CHECK_ITERABLE_APPROX(density, expected_density);
@@ -56,8 +57,9 @@ void test_variable_fixer(
   CHECK_ITERABLE_APPROX(spatial_velocity, expected_spatial_velocity);
 }
 
+template <size_t Dim>
 void test_variable_fixer(
-    const VariableFixing::FixToAtmosphere<2>& variable_fixer) {
+    const VariableFixing::FixToAtmosphere<Dim, 2>& variable_fixer) {
   EquationsOfState::IdealFluid<true> ideal_fluid{5.0 / 3.0};
 
   Scalar<DataVector> density{DataVector{2.e-12, 2.e-11}};
@@ -70,7 +72,7 @@ void test_variable_fixer(
 
   Scalar<DataVector> lorentz_factor{DataVector{5.0 / 3.0, 1.25}};
   auto spatial_velocity =
-      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(density, 0.0);
+      make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(density, 0.0);
   spatial_velocity.get(0) = DataVector{0.8, 0.6};
   variable_fixer(&density, &specific_internal_energy, &spatial_velocity,
                  &lorentz_factor, &pressure, &specific_enthalpy, ideal_fluid);
@@ -84,7 +86,7 @@ void test_variable_fixer(
           expected_density, expected_specific_internal_energy);
   Scalar<DataVector> expected_lorentz_factor{DataVector{1.0, 1.25}};
   auto expected_spatial_velocity =
-      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(density, 0.0);
+      make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(density, 0.0);
   expected_spatial_velocity.get(0)[1] = 0.6;
 
   CHECK_ITERABLE_APPROX(density, expected_density);
@@ -95,27 +97,36 @@ void test_variable_fixer(
   CHECK_ITERABLE_APPROX(lorentz_factor, expected_lorentz_factor);
   CHECK_ITERABLE_APPROX(spatial_velocity, expected_spatial_velocity);
 }
+
+template <size_t Dim>
+void test_variable_fixer() noexcept {
+  // Test for representative 1-d equation of state
+  VariableFixing::FixToAtmosphere<Dim, 1> variable_fixer_1d{1.e-12, 1.e-11};
+  test_variable_fixer<Dim>(variable_fixer_1d);
+  test_serialization(variable_fixer_1d);
+
+  const auto fixer_from_options_1d =
+      test_creation<VariableFixing::FixToAtmosphere<Dim, 1>>(
+          "  DensityOfAtmosphere: 1.0e-12\n"
+          "  DensityCutoff: 1.0e-11\n");
+  test_variable_fixer<Dim>(fixer_from_options_1d);
+
+  // Test for representative 2-d equation of state
+  VariableFixing::FixToAtmosphere<Dim, 2> variable_fixer_2d{1.e-12, 1.e-11};
+  test_variable_fixer<Dim>(variable_fixer_2d);
+  test_serialization(variable_fixer_2d);
+
+  const auto fixer_from_options_2d =
+      test_creation<VariableFixing::FixToAtmosphere<Dim, 2>>(
+          "  DensityOfAtmosphere: 1.0e-12\n"
+          "  DensityCutoff: 1.0e-11\n");
+  test_variable_fixer<Dim>(fixer_from_options_2d);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.FixToAtmosphere",
                   "[VariableFixing][Unit]") {
-  VariableFixing::FixToAtmosphere<1> variable_fixer_1d{1.e-12, 1.e-11};
-  test_variable_fixer(variable_fixer_1d);
-  test_serialization(variable_fixer_1d);
-
-  const auto fixer_from_options_1d =
-      test_creation<VariableFixing::FixToAtmosphere<1>>(
-          "  DensityOfAtmosphere: 1.0e-12\n"
-          "  DensityCutoff: 1.0e-11\n");
-  test_variable_fixer(fixer_from_options_1d);
-
-  VariableFixing::FixToAtmosphere<2> variable_fixer_2d{1.e-12, 1.e-11};
-  test_variable_fixer(variable_fixer_2d);
-  test_serialization(variable_fixer_2d);
-
-  const auto fixer_from_options_2d =
-      test_creation<VariableFixing::FixToAtmosphere<2>>(
-          "  DensityOfAtmosphere: 1.0e-12\n"
-          "  DensityCutoff: 1.0e-11\n");
-  test_variable_fixer(fixer_from_options_2d);
+  test_variable_fixer<1>();
+  test_variable_fixer<2>();
+  test_variable_fixer<3>();
 }


### PR DESCRIPTION
## Proposed changes

FixToAtmosphere is a class that just applies floor values to hydro primitives, so nothing really prevents us from having it work in 1 and 2-d. This way it can be used by Valencia.

- Replace hard-coded spatial dimensionality equal to 3 with template parameter Dim
- Combine instantiations for 1 and 2-d Eos's into a single function

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
