### PR TITLE
Add Smooth Initial Data for RelativisticEuler

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.cpp
@@ -29,80 +29,12 @@ SmoothFlow::SmoothFlow(MeanVelocity::type mean_velocity,
                        const Pressure::type pressure,
                        const AdiabaticIndex::type adiabatic_index,
                        const PerturbationSize::type perturbation_size) noexcept
-    :  // clang-tidy: do not std::move trivial types.
-      mean_velocity_(std::move(mean_velocity)),  // NOLINT
-      // clang-tidy: do not std::move trivial types.
-      wavevector_(std::move(wavevector)),  // NOLINT
-      pressure_(pressure),
-      adiabatic_index_(adiabatic_index),
-      perturbation_size_(perturbation_size),
-      k_dot_v_(std::inner_product(mean_velocity_.begin(), mean_velocity_.end(),
-                                  wavevector_.begin(), 0.0)),
-      equation_of_state_{adiabatic_index_} {}
+    : RelativisticEuler::Solutions::SmoothFlow<3>(mean_velocity, wavevector,
+                                                  pressure, adiabatic_index,
+                                                  perturbation_size) {}
 
 void SmoothFlow::pup(PUP::er& p) noexcept {
-  p | mean_velocity_;
-  p | wavevector_;
-  p | pressure_;
-  p | adiabatic_index_;
-  p | perturbation_size_;
-  p | k_dot_v_;
-  p | equation_of_state_;
-  p | background_spacetime_;
-}
-
-template <typename DataType>
-DataType SmoothFlow::k_dot_x_minus_vt(const tnsr::I<DataType, 3>& x,
-                                      const double t) const noexcept {
-  auto result = make_with_value<DataType>(x, -k_dot_v_ * t);
-  for (size_t i = 0; i < 3; i++) {
-    result += gsl::at(wavevector_, i) * x.get(i);
-  }
-  return result;
-}
-
-// Primitive variables.
-template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>
-SmoothFlow::variables(
-    const tnsr::I<DataType, 3>& x, double t,
-    tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const
-    noexcept {
-  const DataType phase = k_dot_x_minus_vt(x, t);
-  return {Scalar<DataType>{DataType{1.0 + perturbation_size_ * sin(phase)}}};
-}
-
-template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>
-SmoothFlow::variables(
-    const tnsr::I<DataType, 3>& x, double t,
-    tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
-    noexcept {
-  const DataType phase = k_dot_x_minus_vt(x, t);
-  return {
-      Scalar<DataType>{pressure_ / ((adiabatic_index_ - 1.0) *
-                                    (1.0 + perturbation_size_ * sin(phase)))}};
-}
-
-template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::Pressure<DataType>> SmoothFlow::variables(
-    const tnsr::I<DataType, 3>& x, double /*t*/,
-    tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const noexcept {
-  return {make_with_value<Scalar<DataType>>(x, pressure_)};
-}
-
-template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>
-SmoothFlow::variables(const tnsr::I<DataType, 3>& x, double /*t*/,
-                      tmpl::list<hydro::Tags::SpatialVelocity<
-                          DataType, 3, Frame::Inertial>> /*meta*/) const
-    noexcept {
-  auto result = make_with_value<db::item_type<
-      hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>>(
-      x, mean_velocity_[0]);
-  get<1>(result) = mean_velocity_[1];
-  get<2>(result) = mean_velocity_[2];
-  return {std::move(result)};
+  RelativisticEuler::Solutions::SmoothFlow<3>::pup(p);
 }
 
 template <typename DataType>
@@ -126,41 +58,10 @@ SmoothFlow::variables(
       db::item_type<hydro::Tags::DivergenceCleaningField<DataType>>>(x, 0.0)};
 }
 
-template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>> SmoothFlow::variables(
-    const tnsr::I<DataType, 3>& x, double /*t*/,
-    tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const noexcept {
-  return {make_with_value<db::item_type<hydro::Tags::LorentzFactor<DataType>>>(
-      x,
-      1.0 / sqrt(1.0 - alg::accumulate(
-                           mean_velocity_, 0.0,
-                           funcl::Plus<funcl::Identity, funcl::Square<>>{})))};
-}
-
-template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>
-SmoothFlow::variables(
-    const tnsr::I<DataType, 3>& x, double t,
-    tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
-    noexcept {
-  Scalar<DataType> specific_internal_energy = std::move(
-      get<hydro::Tags::SpecificInternalEnergy<DataType>>(variables<DataType>(
-          x, t, tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>>{})));
-  get(specific_internal_energy) *= adiabatic_index_;
-  get(specific_internal_energy) += 1.0;
-  return {std::move(specific_internal_energy)};
-}
-
 bool operator==(const SmoothFlow& lhs, const SmoothFlow& rhs) noexcept {
-  // there is no comparison operator for the EoS, but should be okay as
-  // the adiabatic_indexs are compared
-  return lhs.mean_velocity_ == rhs.mean_velocity_ and
-         lhs.wavevector_ == rhs.wavevector_ and
-         lhs.pressure_ == rhs.pressure_ and
-         lhs.adiabatic_index_ == rhs.adiabatic_index_ and
-         lhs.perturbation_size_ == rhs.perturbation_size_ and
-         lhs.k_dot_v_ == rhs.k_dot_v_ and
-         lhs.background_spacetime_ == rhs.background_spacetime_;
+  using smooth_flow = RelativisticEuler::Solutions::SmoothFlow<3>;
+  return *static_cast<const smooth_flow*>(&lhs) ==
+         *static_cast<const smooth_flow*>(&rhs);
 }
 
 bool operator!=(const SmoothFlow& lhs, const SmoothFlow& rhs) noexcept {
@@ -176,11 +77,8 @@ bool operator!=(const SmoothFlow& lhs, const SmoothFlow& rhs) noexcept {
                             tmpl::list<TAG(data) < DTYPE(data)>> /*meta*/) \
           const noexcept;
 
-GENERATE_INSTANTIATIONS(
-    INSTANTIATE_SCALARS, (double, DataVector),
-    (hydro::Tags::RestMassDensity, hydro::Tags::SpecificInternalEnergy,
-     hydro::Tags::Pressure, hydro::Tags::DivergenceCleaningField,
-     hydro::Tags::LorentzFactor, hydro::Tags::SpecificEnthalpy))
+GENERATE_INSTANTIATIONS(INSTANTIATE_SCALARS, (double, DataVector),
+                        (hydro::Tags::DivergenceCleaningField))
 
 #define INSTANTIATE_VECTORS(_, data)                                         \
   template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3, Frame::Inertial>> \
@@ -190,8 +88,7 @@ GENERATE_INSTANTIATIONS(
           const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
-                        (hydro::Tags::SpatialVelocity,
-                         hydro::Tags::MagneticField))
+                        (hydro::Tags::MagneticField))
 
 #undef DTYPE
 #undef TAG

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY RelativisticEulerSolutions)
 
 set(LIBRARY_SOURCES
   FishboneMoncriefDisk.cpp
+  SmoothFlow.cpp
   TovStar.cpp
   )
 

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.cpp
@@ -1,0 +1,205 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <numeric>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Numeric.hpp"
+
+/// \cond
+namespace RelativisticEuler {
+namespace Solutions {
+
+template <size_t Dim>
+SmoothFlow<Dim>::SmoothFlow(const std::array<double, Dim> mean_velocity,
+                            const std::array<double, Dim> wavevector,
+                            const double pressure, const double adiabatic_index,
+                            const double perturbation_size) noexcept
+    :  // clang-tidy: do not std::move trivial types.
+      mean_velocity_(std::move(mean_velocity)),  // NOLINT
+      // clang-tidy: do not std::move trivial types.
+      wavevector_(std::move(wavevector)),  // NOLINT
+      pressure_(pressure),
+      adiabatic_index_(adiabatic_index),
+      perturbation_size_(perturbation_size),
+      k_dot_v_(std::inner_product(mean_velocity_.begin(), mean_velocity_.end(),
+                                  wavevector_.begin(), 0.0)),
+      equation_of_state_{adiabatic_index_} {}
+
+template <size_t Dim>
+void SmoothFlow<Dim>::pup(PUP::er& p) noexcept {
+  p | mean_velocity_;
+  p | wavevector_;
+  p | pressure_;
+  p | adiabatic_index_;
+  p | perturbation_size_;
+  p | k_dot_v_;
+  p | equation_of_state_;
+  p | background_spacetime_;
+}
+
+template <size_t Dim>
+template <typename DataType>
+DataType SmoothFlow<Dim>::k_dot_x_minus_vt(const tnsr::I<DataType, Dim>& x,
+                                           const double t) const noexcept {
+  auto result = make_with_value<DataType>(x, -k_dot_v_ * t);
+  for (size_t i = 0; i < Dim; i++) {
+    result += gsl::at(wavevector_, i) * x.get(i);
+  }
+  return result;
+}
+
+// Primitive variables.
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>
+SmoothFlow<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double t,
+    tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const
+    noexcept {
+  const DataType phase = k_dot_x_minus_vt(x, t);
+  return {Scalar<DataType>{DataType{1.0 + perturbation_size_ * sin(phase)}}};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>
+SmoothFlow<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double t,
+    tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
+    noexcept {
+  const DataType phase = k_dot_x_minus_vt(x, t);
+  return {
+      Scalar<DataType>{pressure_ / ((adiabatic_index_ - 1.0) *
+                                    (1.0 + perturbation_size_ * sin(phase)))}};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::Pressure<DataType>> SmoothFlow<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double /*t*/,
+    tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const noexcept {
+  return {make_with_value<Scalar<DataType>>(x, pressure_)};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<
+    hydro::Tags::SpatialVelocity<DataType, Dim, Frame::Inertial>>
+SmoothFlow<Dim>::variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+                           tmpl::list<hydro::Tags::SpatialVelocity<
+                               DataType, Dim, Frame::Inertial>> /*meta*/) const
+    noexcept {
+  auto result = make_with_value<db::item_type<
+      hydro::Tags::SpatialVelocity<DataType, Dim, Frame::Inertial>>>(x, 0.0);
+  for (size_t i = 0; i < Dim; ++i) {
+    result.get(i) = gsl::at(mean_velocity_, i);
+  }
+  return {std::move(result)};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>
+SmoothFlow<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double /*t*/,
+    tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const noexcept {
+  return {make_with_value<db::item_type<hydro::Tags::LorentzFactor<DataType>>>(
+      x,
+      1.0 / sqrt(1.0 - alg::accumulate(
+                           mean_velocity_, 0.0,
+                           funcl::Plus<funcl::Identity, funcl::Square<>>{})))};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>
+SmoothFlow<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double t,
+    tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
+    noexcept {
+  Scalar<DataType> specific_internal_energy = std::move(
+      get<hydro::Tags::SpecificInternalEnergy<DataType>>(variables<DataType>(
+          x, t, tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>>{})));
+  get(specific_internal_energy) *= adiabatic_index_;
+  get(specific_internal_energy) += 1.0;
+  return {std::move(specific_internal_energy)};
+}
+
+template <size_t Dim>
+bool operator==(const SmoothFlow<Dim>& lhs,
+                const SmoothFlow<Dim>& rhs) noexcept {
+  // there is no comparison operator for the EoS, but should be okay as
+  // the adiabatic_indexs are compared
+  return lhs.mean_velocity_ == rhs.mean_velocity_ and
+         lhs.wavevector_ == rhs.wavevector_ and
+         lhs.pressure_ == rhs.pressure_ and
+         lhs.adiabatic_index_ == rhs.adiabatic_index_ and
+         lhs.perturbation_size_ == rhs.perturbation_size_ and
+         lhs.k_dot_v_ == rhs.k_dot_v_ and
+         lhs.background_spacetime_ == rhs.background_spacetime_;
+}
+
+template <size_t Dim>
+bool operator!=(const SmoothFlow<Dim>& lhs,
+                const SmoothFlow<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define TAG(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE_CLASS(_, data)                                 \
+  template class SmoothFlow<DIM(data)>;                            \
+  template bool operator==(const SmoothFlow<DIM(data)>&,           \
+                           const SmoothFlow<DIM(data)>&) noexcept; \
+  template bool operator!=(const SmoothFlow<DIM(data)>&,           \
+                           const SmoothFlow<DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_CLASS, (1, 2, 3))
+
+#define INSTANTIATE_SCALARS(_, data)                          \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>>      \
+      SmoothFlow<DIM(data)>::variables(                       \
+          const tnsr::I<DTYPE(data), DIM(data)>& x, double t, \
+          tmpl::list<TAG(data) < DTYPE(data)>> /*meta*/) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_SCALARS, (1, 2, 3), (double, DataVector),
+                        (hydro::Tags::RestMassDensity,
+                         hydro::Tags::SpecificInternalEnergy,
+                         hydro::Tags::Pressure, hydro::Tags::LorentzFactor,
+                         hydro::Tags::SpecificEnthalpy))
+
+#define INSTANTIATE_VECTORS(_, data)                                       \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data), DIM(data),         \
+                               Frame::Inertial>>                           \
+      SmoothFlow<DIM(data)>::variables(                                    \
+          const tnsr::I<DTYPE(data), DIM(data)>& x, double t,              \
+          tmpl::list<TAG(data) < DTYPE(data), DIM(data), Frame::Inertial>> \
+          /*meta*/) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (1, 2, 3), (double, DataVector),
+                        (hydro::Tags::SpatialVelocity))
+
+#undef DIM
+#undef DTYPE
+#undef TAG
+#undef INSTANTIATE_CLASS
+#undef INSTANTIATE_SCALARS
+#undef INSTANTIATE_VECTORS
+}  // namespace Solutions
+}  // namespace RelativisticEuler
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp
@@ -51,7 +51,7 @@ namespace Solutions {
  * where the pressure is held constant.
  */
 template <size_t Dim>
-class SmoothFlow : public MarkAsAnalyticSolution {
+class SmoothFlow : virtual public MarkAsAnalyticSolution {
  public:
   using equation_of_state_type = EquationsOfState::IdealFluid<true>;
 

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp
@@ -1,0 +1,207 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <limits>
+#include <pup.h>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace RelativisticEuler {
+namespace Solutions {
+
+/*!
+ * \brief Smooth wave propagating in Minkowski spacetime.
+ *
+ * The relativistic Euler equations in Minkowski spacetime accept a
+ * solution with constant pressure and uniform spatial velocity provided
+ * that the rest mass density satisfies the advection equation
+ *
+ * \f{align*}
+ * \partial_t\rho + v^i\partial_i\rho = 0,
+ * f}
+ *
+ * and the specific internal energy is a function of the rest mass density only,
+ * \f$\epsilon = \epsilon(\rho)\f$. For testing purposes, this class implements
+ * this solution for the case where \f$\rho\f$ is a sine wave. The user
+ * specifies the mean flow velocity of the fluid, the wavevector of the density
+ * profile, and the amplitude \f$A\f$ of the density profile. In Cartesian
+ * coordinates \f$(x, y, z)\f$, and using dimensionless units, the primitive
+ * variables at a given time \f$t\f$ are then
+ *
+ * \f{align*}
+ * \rho(\vec{x},t) &= 1 + A \sin(\vec{k}\cdot(\vec{x} - \vec{v}t)) \\
+ * \vec{v}(\vec{x},t) &= [v_x, v_y, v_z]^{T},\\
+ * P(\vec{x},t) &= P, \\
+ * \epsilon(\vec{x}, t) &= \frac{P}{(\gamma - 1)\rho}\\
+ * \f}
+ *
+ * where we have assumed \f$\epsilon\f$ and \f$\rho\f$ to be related through an
+ * equation mathematically equivalent to the equation of state of an ideal gas,
+ * where the pressure is held constant.
+ */
+template <size_t Dim>
+class SmoothFlow : public MarkAsAnalyticSolution {
+ public:
+  using equation_of_state_type = EquationsOfState::IdealFluid<true>;
+
+  /// The mean flow velocity.
+  struct MeanVelocity {
+    using type = std::array<double, Dim>;
+    static constexpr OptionString help = {"The mean flow velocity."};
+  };
+
+  /// The wave vector of the profile.
+  struct WaveVector {
+    using type = std::array<double, Dim>;
+    static constexpr OptionString help = {"The wave vector of the profile."};
+  };
+
+  /// The constant pressure throughout the fluid.
+  struct Pressure {
+    using type = double;
+    static constexpr OptionString help = {
+        "The constant pressure throughout the fluid."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  /// The adiabatic index for the ideal fluid.
+  struct AdiabaticIndex {
+    using type = double;
+    static constexpr OptionString help = {
+        "The adiabatic index for the ideal fluid."};
+    static type lower_bound() noexcept { return 1.0; }
+  };
+
+  /// The perturbation amplitude of the rest mass density of the fluid.
+  struct PerturbationSize {
+    using type = double;
+    static constexpr OptionString help = {
+        "The perturbation size of the rest mass density."};
+    static type lower_bound() noexcept { return -1.0; }
+    static type upper_bound() noexcept { return 1.0; }
+  };
+
+  using options = tmpl::list<MeanVelocity, WaveVector, Pressure, AdiabaticIndex,
+                             PerturbationSize>;
+  static constexpr OptionString help = {"Smooth flow in Minkowski spacetime."};
+
+  SmoothFlow() = default;
+  SmoothFlow(const SmoothFlow& /*rhs*/) = delete;
+  SmoothFlow& operator=(const SmoothFlow& /*rhs*/) = delete;
+  SmoothFlow(SmoothFlow&& /*rhs*/) noexcept = default;
+  SmoothFlow& operator=(SmoothFlow&& /*rhs*/) noexcept = default;
+  ~SmoothFlow() = default;
+
+  SmoothFlow(std::array<double, Dim> mean_velocity,
+             std::array<double, Dim> wavevector, double pressure,
+             double adiabatic_index, double perturbation_size) noexcept;
+
+  explicit SmoothFlow(CkMigrateMessage* /*unused*/) noexcept {}
+
+  // @{
+  /// Retrieve hydro variable at `(x, t)`
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, Dim>& x, double t,
+      tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, Dim>& x, double t,
+      tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
+      noexcept
+      -> tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+                 tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+                 tmpl::list<hydro::Tags::SpatialVelocity<
+                     DataType, Dim, Frame::Inertial>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<
+          hydro::Tags::SpatialVelocity<DataType, Dim, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, Dim>& x, double /*t*/,
+      tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, Dim>& x, double t,
+      tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
+  // @}
+
+  /// Retrieve a collection of hydro variables at `(x, t)`
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, Dim>& x,
+                                         double t,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
+    static_assert(sizeof...(Tags) > 1,
+                  "The generic template will recurse infinitely if only one "
+                  "tag is being retrieved.");
+    return {get<Tags>(variables(x, t, tmpl::list<Tags>{}))...};
+  }
+
+  /// Retrieve the metric variables
+  template <typename DataType, typename Tag>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, Dim>& x, double t,
+                                     tmpl::list<Tag> /*meta*/) const noexcept {
+    return background_spacetime_.variables(x, t, tmpl::list<Tag>{});
+  }
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
+
+  const EquationsOfState::IdealFluid<true>& equation_of_state() const noexcept {
+    return equation_of_state_;
+  }
+
+ private:
+  template <size_t SpatialDim>
+  friend bool
+  operator==(  // NOLINT (clang-tidy: readability-redundant-declaration)
+      const SmoothFlow<SpatialDim>& lhs,
+      const SmoothFlow<SpatialDim>& rhs) noexcept;
+
+  // Computes the phase.
+  template <typename DataType>
+  DataType k_dot_x_minus_vt(const tnsr::I<DataType, Dim>& x, double t) const
+      noexcept;
+
+  std::array<double, Dim> mean_velocity_ =
+      make_array<Dim>(std::numeric_limits<double>::signaling_NaN());
+  std::array<double, Dim> wavevector_ =
+      make_array<Dim>(std::numeric_limits<double>::signaling_NaN());
+  double pressure_ = std::numeric_limits<double>::signaling_NaN();
+  double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();
+  double perturbation_size_ = std::numeric_limits<double>::signaling_NaN();
+  // The angular frequency.
+  double k_dot_v_ = std::numeric_limits<double>::signaling_NaN();
+  EquationsOfState::IdealFluid<true> equation_of_state_{};
+  gr::Solutions::Minkowski<Dim> background_spacetime_{};
+};
+
+template <size_t Dim>
+bool operator!=(const SmoothFlow<Dim>& lhs,
+                const SmoothFlow<Dim>& rhs) noexcept;
+}  // namespace Solutions
+}  // namespace RelativisticEuler

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_RelativisticEulerSolutions")
 
 set(LIBRARY_SOURCES
   Test_FishboneMoncriefDisk.cpp
+  Test_SmoothFlow.cpp
   Test_TovStar.cpp
   )
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.py
@@ -1,0 +1,43 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def rest_mass_density(x, t, mean_velocity, wave_vector, pressure,
+                      adiabatic_index, density_amplitude):
+    return (1.0 + (density_amplitude * np.sin(
+        np.dot(
+            np.asarray(wave_vector),
+            np.asarray(x) - np.asarray(mean_velocity) * t))))
+
+
+def spatial_velocity(x, t, mean_velocity, wave_vector, pressure,
+                     adiabatic_index, density_amplitude):
+    return np.asarray(mean_velocity)
+
+
+def specific_internal_energy(x, t, mean_velocity, wave_vector, pressure,
+                             adiabatic_index, density_amplitude):
+    return (
+        pressure / ((adiabatic_index - 1.0) * rest_mass_density(
+            x, t, mean_velocity, wave_vector, pressure, adiabatic_index,
+            density_amplitude)))
+
+
+def pressure(x, t, mean_velocity, wave_vector, pressure, adiabatic_index,
+             density_amplitude):
+    return pressure
+
+
+def specific_enthalpy(x, t, mean_velocity, wave_vector, pressure,
+                      adiabatic_index, density_amplitude):
+    return 1.0 + adiabatic_index * specific_internal_energy(
+        x, t, mean_velocity, wave_vector, pressure, adiabatic_index,
+        density_amplitude)
+
+
+def lorentz_factor(x, t, mean_velocity, wave_vector, pressure,
+                   adiabatic_index, density_amplitude):
+    return 1.0 / np.sqrt(1.0 - np.linalg.norm(np.asarray(mean_velocity))**2)
+

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_SmoothFlow.cpp
@@ -1,0 +1,143 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/ParseOptions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+
+template <size_t Dim>
+struct SmoothFlowProxy : RelativisticEuler::Solutions::SmoothFlow<Dim> {
+  using RelativisticEuler::Solutions::SmoothFlow<Dim>::SmoothFlow;
+
+  template <typename DataType>
+  using variables_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataType>,
+                 hydro::Tags::SpatialVelocity<DataType, Dim, Frame::Inertial>,
+                 hydro::Tags::SpecificInternalEnergy<DataType>,
+                 hydro::Tags::Pressure<DataType>,
+                 hydro::Tags::LorentzFactor<DataType>,
+                 hydro::Tags::SpecificEnthalpy<DataType>>;
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<variables_tags<DataType>>
+  primitive_variables(const tnsr::I<DataType, Dim>& x, double t) const
+      noexcept {
+    return this->variables(x, t, variables_tags<DataType>{});
+  }
+};
+
+template <size_t Dim, typename DataType>
+void test_solution(const DataType& used_for_size,
+                   const std::array<double, Dim>& mean_velocity,
+                   const std::string& mean_velocity_opt,
+                   const std::array<double, Dim>& wave_vector,
+                   const std::string& wave_vector_opt) {
+  const double pressure = 1.23;
+  const double adiabatic_index = 1.3334;
+  const double perturbation_size = 0.78;
+
+  SmoothFlowProxy<Dim> solution(mean_velocity, wave_vector, pressure,
+                                adiabatic_index, perturbation_size);
+  pypp::check_with_random_values<
+      1, typename SmoothFlowProxy<Dim>::template variables_tags<DataType>>(
+      &SmoothFlowProxy<Dim>::template primitive_variables<DataType>, solution,
+      "SmoothFlow",
+      {"rest_mass_density", "spatial_velocity", "specific_internal_energy",
+       "pressure", "lorentz_factor", "specific_enthalpy"},
+      {{{-15., 15.}}},
+      std::make_tuple(mean_velocity, wave_vector, pressure, adiabatic_index,
+                      perturbation_size),
+      used_for_size);
+
+  // Test a few of the GR components to make sure that the implementation
+  // correctly forwards to the background solution. Not meant to be extensive.
+  const auto coords =
+      make_with_value<tnsr::I<DataType, Dim>>(used_for_size, 1.0);
+  const double dummy_time = 1.1;
+  const gr::Solutions::Minkowski<Dim> minkowski{};
+  CHECK_ITERABLE_APPROX(
+      get<gr::Tags::Lapse<DataType>>(minkowski.variables(
+          coords, dummy_time, tmpl::list<gr::Tags::Lapse<DataType>>{})),
+      get<gr::Tags::Lapse<DataType>>(solution.variables(
+          coords, dummy_time, tmpl::list<gr::Tags::Lapse<DataType>>{})));
+  CHECK_ITERABLE_APPROX(
+      (get<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>(minkowski.variables(
+          coords, dummy_time,
+          tmpl::list<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>{}))),
+      (get<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>(solution.variables(
+          coords, dummy_time,
+          tmpl::list<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>{}))));
+  CHECK_ITERABLE_APPROX(
+      (get<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>(
+          minkowski.variables(
+              coords, dummy_time,
+              tmpl::list<
+                  gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>{}))),
+      (get<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>(
+          solution.variables(coords, dummy_time,
+                             tmpl::list<gr::Tags::SpatialMetric<
+                                 Dim, Frame::Inertial, DataType>>{}))));
+
+  const auto solution_from_options =
+      test_creation<RelativisticEuler::Solutions::SmoothFlow<Dim>>(
+          "  MeanVelocity: " + mean_velocity_opt +
+          "\n"
+          "  WaveVector: " +
+          wave_vector_opt +
+          "\n"
+          "  Pressure: 1.23\n"
+          "  AdiabaticIndex: 1.3334\n"
+          "  PerturbationSize: 0.78");
+  CHECK(solution == solution_from_options);
+
+  RelativisticEuler::Solutions::SmoothFlow<Dim> solution_to_move(
+      mean_velocity, wave_vector, pressure, adiabatic_index, perturbation_size);
+
+  test_move_semantics(std::move(solution_to_move),
+                      solution_from_options);  //  NOLINT
+  test_serialization(solution);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.SmoothFlow",
+    "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/RelativisticEuler"};
+  test_solution<1>(std::numeric_limits<double>::signaling_NaN(), {{-0.3}},
+                   "[-0.3]", {{0.4}}, "[0.4]");
+  test_solution<1>(DataVector(5), {{-0.3}}, "[-0.3]", {{0.4}}, "[0.4]");
+  test_solution<2>(std::numeric_limits<double>::signaling_NaN(), {{-0.3, 0.1}},
+                   "[-0.3, 0.1]", {{0.4, -0.24}}, "[0.4, -0.24]");
+  test_solution<2>(DataVector(5), {{-0.3, 0.1}}, "[-0.3, 0.1]", {{0.4, -0.24}},
+                   "[0.4, -0.24]");
+  test_solution<3>(std::numeric_limits<double>::signaling_NaN(),
+                   {{-0.3, 0.1, -0.002}}, "[-0.3, 0.1, -0.002]",
+                   {{0.4, -0.24, 0.054}}, "[0.4, -0.24, 0.054]");
+  test_solution<3>(DataVector(5), {{-0.3, 0.1, -0.002}}, "[-0.3, 0.1, -0.002]",
+                   {{0.4, -0.24, 0.054}}, "[0.4, -0.24, 0.054]");
+}


### PR DESCRIPTION
## Proposed changes

- Move SmoothFlow hydro variables functions to RelativisticEuler class templated in spatial dimension
- Have GrMhd SmoothFlow inherit from 3-d RelativisticEuler class

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
