### PR TITLE
Add characteristics for the scalar-wave system

### DIFF
--- a/src/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -4,9 +4,10 @@
 set(LIBRARY ScalarWave)
 
 set(LIBRARY_SOURCES
-    Constraints.cpp
-    Equations.cpp
-    )
+  Characteristics.cpp
+  Constraints.cpp
+  Equations.cpp
+  )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 

--- a/src/Evolution/Systems/ScalarWave/Characteristics.cpp
+++ b/src/Evolution/Systems/ScalarWave/Characteristics.cpp
@@ -1,0 +1,176 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarWave/Characteristics.hpp"
+
+#include <array>
+
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"  // IWYU pragma: keep
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarWave {
+template <size_t Dim>
+void characteristic_speeds(
+    const gsl::not_null<std::array<DataVector, 4>*> char_speeds,
+    const tnsr::i<DataVector, Dim,
+                  Frame::Inertial>& /*unit_normal_one_form*/) noexcept {
+  (*char_speeds)[0] = 0.;   // v(VPsi)
+  (*char_speeds)[1] = 0.;   // v(VZero)
+  (*char_speeds)[2] = 1.;   // v(VPlus)
+  (*char_speeds)[3] = -1.;  // v(VMinus)
+}
+
+template <size_t Dim>
+std::array<DataVector, 4> characteristic_speeds(
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        unit_normal_one_form) noexcept {
+  auto char_speeds = make_with_value<std::array<DataVector, 4>>(
+      get<0>(unit_normal_one_form), 0.);
+  characteristic_speeds(make_not_null(&char_speeds), unit_normal_one_form);
+  return char_speeds;
+}
+
+template <size_t Dim>
+void characteristic_fields(
+    const gsl::not_null<Variables<
+        tmpl::list<Tags::VPsi, Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus>>*>
+        char_fields,
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        unit_normal_one_form) noexcept {
+  // Compute phi_dot_normal = n^i \Phi_{i} = \sum_i n_i \Phi_{i}
+  // (we use normal_one_form and normal_vector interchangeably in flat space)
+  const auto phi_dot_normal = dot_product(unit_normal_one_form, phi);
+
+  // Eq.(34) of Holst+ (2004) for VZero
+  for (size_t i = 0; i < Dim; ++i) {
+    get<Tags::VZero<Dim>>(*char_fields).get(i) =
+        phi.get(i) - unit_normal_one_form.get(i) * get(phi_dot_normal);
+  }
+
+  // Eq.(33) of Holst+ (2004) for VPsi
+  get<Tags::VPsi>(*char_fields) = psi;
+
+  // Eq.(35) of Holst+ (2004) for VPlus and VMinus
+  get(get<Tags::VPlus>(*char_fields)) =
+      get(pi) + get(phi_dot_normal) - get(gamma_2) * get(psi);
+  get(get<Tags::VMinus>(*char_fields)) =
+      get(pi) - get(phi_dot_normal) - get(gamma_2) * get(psi);
+}
+
+template <size_t Dim>
+Variables<tmpl::list<Tags::VPsi, Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus>>
+characteristic_fields(const Scalar<DataVector>& gamma_2,
+                      const Scalar<DataVector>& psi,
+                      const Scalar<DataVector>& pi,
+                      const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+                      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+                          unit_normal_one_form) noexcept {
+  Variables<tmpl::list<Tags::VPsi, Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus>>
+      char_fields(get_size(get(gamma_2)));
+  characteristic_fields(make_not_null(&char_fields), gamma_2, psi, pi, phi,
+                        unit_normal_one_form);
+  return char_fields;
+}
+
+template <size_t Dim>
+void evolved_fields_from_characteristic_fields(
+    const gsl::not_null<Variables<tmpl::list<Psi, Pi, Phi<Dim>>>*>
+        evolved_fields,
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        unit_normal_one_form) noexcept {
+  // Eq.(36) of Holst+ (2004) for Psi
+  get<Psi>(*evolved_fields) = v_psi;
+
+  // Eq.(37) - (38) of Holst+ (2004) for Pi and Phi
+  get<Pi>(*evolved_fields).get() =
+      0.5 * (get(v_plus) + get(v_minus)) + get(gamma_2) * get(v_psi);
+  for (size_t i = 0; i < Dim; ++i) {
+    get<Phi<Dim>>(*evolved_fields).get(i) =
+        0.5 * (get(v_plus) - get(v_minus)) * unit_normal_one_form.get(i) +
+        v_zero.get(i);
+  }
+}
+
+template <size_t Dim>
+Variables<tmpl::list<Psi, Pi, Phi<Dim>>>
+evolved_fields_from_characteristic_fields(
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        unit_normal_one_form) noexcept {
+  Variables<tmpl::list<Psi, Pi, Phi<Dim>>> evolved_fields(
+      get_size(get(gamma_2)));
+  evolved_fields_from_characteristic_fields(make_not_null(&evolved_fields),
+                                            gamma_2, v_psi, v_zero, v_plus,
+                                            v_minus, unit_normal_one_form);
+  return evolved_fields;
+}
+}  // namespace ScalarWave
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template void ScalarWave::characteristic_speeds(                             \
+      const gsl::not_null<std::array<DataVector, 4>*> char_speeds,             \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
+          unit_normal_one_form) noexcept;                                      \
+  template std::array<DataVector, 4> ScalarWave::characteristic_speeds(        \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
+          unit_normal_one_form) noexcept;                                      \
+  template struct ScalarWave::CharacteristicSpeedsCompute<DIM(data)>;          \
+  template void ScalarWave::characteristic_fields(                             \
+      const gsl::not_null<Variables<tmpl::list<                                \
+          ScalarWave::Tags::VPsi, ScalarWave::Tags::VZero<DIM(data)>,          \
+          ScalarWave::Tags::VPlus, ScalarWave::Tags::VMinus>>*>                \
+          char_fields,                                                         \
+      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,        \
+      const Scalar<DataVector>& pi,                                            \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi,              \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
+          unit_normal_one_form) noexcept;                                      \
+  template Variables<                                                          \
+      tmpl::list<ScalarWave::Tags::VPsi, ScalarWave::Tags::VZero<DIM(data)>,   \
+                 ScalarWave::Tags::VPlus, ScalarWave::Tags::VMinus>>           \
+  ScalarWave::characteristic_fields(                                           \
+      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,        \
+      const Scalar<DataVector>& pi,                                            \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi,              \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
+          unit_normal_one_form) noexcept;                                      \
+  template struct ScalarWave::CharacteristicFieldsCompute<DIM(data)>;          \
+  template void ScalarWave::evolved_fields_from_characteristic_fields(         \
+      const gsl::not_null<Variables<tmpl::list<                                \
+          ScalarWave::Psi, ScalarWave::Pi, ScalarWave::Phi<DIM(data)>>>*>      \
+          evolved_fields,                                                      \
+      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,      \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& v_zero,           \
+      const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,     \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
+          unit_normal_one_form) noexcept;                                      \
+  template Variables<                                                          \
+      tmpl::list<ScalarWave::Psi, ScalarWave::Pi, ScalarWave::Phi<DIM(data)>>> \
+  ScalarWave::evolved_fields_from_characteristic_fields(                       \
+      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,      \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& v_zero,           \
+      const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,     \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
+          unit_normal_one_form) noexcept;                                      \
+  template struct ScalarWave::EvolvedFieldsFromCharacteristicFieldsCompute<    \
+      DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM

--- a/src/Evolution/Systems/ScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/ScalarWave/Characteristics.hpp
@@ -1,0 +1,228 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <typename>
+class Variables;
+
+namespace Tags {
+template <typename Tag>
+struct Normalized;
+}  // namespace Tags
+/// \endcond
+
+namespace ScalarWave {
+namespace Tags {
+struct ConstraintGamma2Compute : ConstraintGamma2, db::ComputeTag {
+  using argument_tags = tmpl::list<Psi>;
+  static auto function(const Scalar<DataVector>& psi) noexcept {
+    return make_with_value<type>(psi, 0.);
+  }
+  using base = ConstraintGamma2;
+};
+}  // namespace Tags
+
+// @{
+/*!
+ * \ingroup ScalarWave
+ * \brief Compute the characteristic speeds for the scalar wave system.
+ *
+ * Computes the speeds as described in "Optimal constraint projection for
+ * hyperbolic evolution systems" by Holst et al. \cite Holst2004wt
+ * [see text following Eq.(32)]. The characteristic fields' names used here
+ * differ from this paper:
+ *
+ * \f{align*}
+ * \mathrm{SpECTRE} && \mathrm{Holst} \\
+ * v^{\hat \psi} && Z^1 \\
+ * v^{\hat 0}_{i} && Z^{2}_{i} \\
+ * v^{\hat \pm} && u^{1\pm}
+ * \f}
+ *
+ * The corresponding characteristic speeds \f$\lambda_{\hat \alpha}\f$ are given
+ * in the text following Eq.(38) of \cite Holst2004wt :
+ *
+ * \f{align*}
+ * \lambda_{\hat \psi} =& 0 \\
+ * \lambda_{\hat 0} =& 0 \\
+ * \lambda_{\hat \pm} =& \pm 1.
+ * \f}
+ */
+template <size_t Dim>
+std::array<DataVector, 4> characteristic_speeds(
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        unit_normal_one_form) noexcept;
+
+template <size_t Dim>
+void characteristic_speeds(
+    gsl::not_null<std::array<DataVector, 4>*> char_speeds,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        unit_normal_one_form) noexcept;
+
+template <size_t Dim>
+struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim>,
+                                     db::ComputeTag {
+  using base = Tags::CharacteristicSpeeds<Dim>;
+  using type = typename base::type;
+  using argument_tags =
+      tmpl::list<::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
+
+  static typename Tags::CharacteristicSpeeds<Dim>::type function(
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          unit_normal_one_form) noexcept {
+    return characteristic_speeds(unit_normal_one_form);
+  };
+};
+// @}
+
+// @{
+/*!
+ * \ingroup ScalarWave
+ * \brief Computes characteristic fields from evolved fields
+ *
+ * \ref CharacteristicFieldsCompute and
+ * \ref EvolvedFieldsFromCharacteristicFieldsCompute convert between
+ * characteristic and evolved fields for the scalar-wave system.
+ *
+ * \ref CharacteristicFieldsCompute computes
+ * characteristic fields as described in "Optimal constraint projection for
+ * hyperbolic evolution systems" by Holst et al. \cite Holst2004wt .
+ * Their names used here differ from this paper:
+ *
+ * \f{align*}
+ * \mathrm{SpECTRE} && \mathrm{Holst} \\
+ * v^{\hat \psi} && Z^1 \\
+ * v^{\hat 0}_{i} && Z^{2}_{i} \\
+ * v^{\hat \pm} && u^{1\pm}
+ * \f}
+ *
+ * The characteristic fields \f${v}^{\hat \alpha}\f$ are given in terms of
+ * the evolved fields by Eq.(33) - (35) of \cite Holst2004wt, respectively:
+ *
+ * \f{align*}
+ * v^{\hat \psi} =& \psi \\
+ * v^{\hat 0}_{i} =& (\delta^k_i - n_i n^k) \Phi_{k} := P^k_i \Phi_{k} \\
+ * v^{\hat \pm} =& \Pi \pm n^i \Phi_{i} - \gamma_2\psi
+ * \f}
+ *
+ * where \f$\psi\f$ is the scalar field, \f$\Phi_{i}=\partial_i \psi\f$ is an
+ * auxiliary variable, \f$\Pi\f$ is a conjugate momentum, \f$\gamma_2\f$
+ * is a constraint damping parameter, and \f$n_k\f$ is the unit normal to the
+ * surface along which the characteristic fields are defined.
+ *
+ * \ref EvolvedFieldsFromCharacteristicFieldsCompute computes evolved fields
+ * \f$u_\alpha\f$ in terms of the characteristic fields. This uses the inverse
+ * of above relations:
+ *
+ * \f{align*}
+ * \psi =& v^{\hat \psi}, \\
+ * \Pi =& \frac{1}{2}(v^{\hat +} + v^{\hat -}) + \gamma_2 v^{\hat \psi}, \\
+ * \Phi_{i} =& \frac{1}{2}(v^{\hat +} - v^{\hat -}) n_i + v^{\hat 0}_{i}.
+ * \f}
+ *
+ * The corresponding characteristic speeds \f$\lambda_{\hat \alpha}\f$
+ * are computed by \ref CharacteristicSpeedsCompute .
+ */
+template <size_t Dim>
+Variables<tmpl::list<Tags::VPsi, Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus>>
+characteristic_fields(const Scalar<DataVector>& gamma_2,
+                      const Scalar<DataVector>& psi,
+                      const Scalar<DataVector>& pi,
+                      const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+                      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+                          unit_normal_one_form) noexcept;
+
+template <size_t Dim>
+void characteristic_fields(
+    gsl::not_null<Variables<
+        tmpl::list<Tags::VPsi, Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus>>*>
+        char_fields,
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        unit_normal_one_form) noexcept;
+
+template <size_t Dim>
+struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim>,
+                                     db::ComputeTag {
+  using base = Tags::CharacteristicFields<Dim>;
+  using type = typename base::type;
+  using argument_tags =
+      tmpl::list<Tags::ConstraintGamma2, Psi, Pi, Phi<Dim>,
+                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
+
+  static typename Tags::CharacteristicFields<Dim>::type function(
+      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,
+      const Scalar<DataVector>& pi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          unit_normal_one_form) noexcept {
+    return characteristic_fields(gamma_2, psi, pi, phi, unit_normal_one_form);
+  };
+};
+// @}
+
+// @{
+/*!
+ * \ingroup ScalarWave
+ * \brief Compute evolved fields from characteristic fields.
+ *
+ * For expressions used here to compute evolved fields from characteristic ones,
+ * see \ref CharacteristicFieldsCompute.
+ */
+template <size_t Dim>
+Variables<tmpl::list<Psi, Pi, Phi<Dim>>>
+evolved_fields_from_characteristic_fields(
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        unit_normal_one_form) noexcept;
+
+template <size_t Dim>
+void evolved_fields_from_characteristic_fields(
+    gsl::not_null<Variables<tmpl::list<Psi, Pi, Phi<Dim>>>*> evolved_fields,
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        unit_normal_one_form) noexcept;
+
+template <size_t Dim>
+struct EvolvedFieldsFromCharacteristicFieldsCompute
+    : Tags::EvolvedFieldsFromCharacteristicFields<Dim>,
+      db::ComputeTag {
+  using base = Tags::EvolvedFieldsFromCharacteristicFields<Dim>;
+  using type = typename base::type;
+  using argument_tags =
+      tmpl::list<Tags::ConstraintGamma2, Tags::VPsi, Tags::VZero<Dim>,
+                 Tags::VPlus, Tags::VMinus,
+                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
+
+  static typename Tags::EvolvedFieldsFromCharacteristicFields<Dim>::type
+  function(const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
+           const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
+           const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+           const tnsr::i<DataVector, Dim, Frame::Inertial>&
+               unit_normal_one_form) noexcept {
+    return evolved_fields_from_characteristic_fields(
+        gamma_2, v_psi, v_zero, v_plus, v_minus, unit_normal_one_form);
+  };
+};
+// @}
+}  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.cpp
@@ -152,7 +152,7 @@ using derivative_frame = Frame::Inertial;
   template class ScalarWave::ComputeNormalDotFluxes<DIM(data)>;              \
   template class ScalarWave::UpwindFlux<DIM(data)>;                          \
   template Variables<                                                        \
-      db::wrap_tags_in<Tags::deriv, derivative_tags<DIM(data)>,              \
+      db::wrap_tags_in<::Tags::deriv, derivative_tags<DIM(data)>,            \
                        tmpl::size_t<DIM(data)>, derivative_frame>>           \
   partial_derivatives<derivative_tags<DIM(data)>, variables_tags<DIM(data)>, \
                       DIM(data), derivative_frame>(                          \

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -63,8 +63,8 @@ namespace ScalarWave {
 template <size_t Dim>
 struct ComputeDuDt {
   using argument_tags =
-      tmpl::list<Pi, Tags::deriv<Pi, tmpl::size_t<Dim>, Frame::Inertial>,
-                 Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
+      tmpl::list<Pi, ::Tags::deriv<Pi, tmpl::size_t<Dim>, Frame::Inertial>,
+                 ::Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> dt_pi,
       gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
@@ -86,7 +86,7 @@ template <size_t Dim>
 struct ComputeNormalDotFluxes {
   using argument_tags =
       tmpl::list<Pi, Phi<Dim>,
-                 Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>;
+                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
   static void apply(gsl::not_null<Scalar<DataVector>*> pi_normal_dot_flux,
                     gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
                         phi_normal_dot_flux,
@@ -138,14 +138,14 @@ struct UpwindFlux {
   // Variables. Local and remote values of this data are then combined in the
   // `()` operator.
   using package_tags =
-      tmpl::list<Tags::NormalDotFlux<Pi>, Tags::NormalDotFlux<Phi<Dim>>, Pi,
+      tmpl::list<::Tags::NormalDotFlux<Pi>, ::Tags::NormalDotFlux<Phi<Dim>>, Pi,
                  NormalTimesFluxPi>;
 
   // These tags on the interface of the element are passed to
   // `package_data` to provide the data needed to compute the numerical fluxes.
   using argument_tags =
-      tmpl::list<Tags::NormalDotFlux<Pi>, Tags::NormalDotFlux<Phi<Dim>>, Pi,
-                 Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>;
+      tmpl::list<::Tags::NormalDotFlux<Pi>, ::Tags::NormalDotFlux<Phi<Dim>>, Pi,
+                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
 
   // pseudo-interface: used internally by Algorithm infrastructure, not
   // user-level code

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -20,7 +20,20 @@ class Variables;
 
 /*!
  * \ingroup EvolutionSystemsGroup
- * \brief Items related to evolving the scalar wave equation:
+ * \brief Items related to evolving the scalar wave equation.
+ *
+ * The equations of motion for the system augmented with constraint damping
+ * terms are given by Eq. (15), (23) and (24) of \cite Holst2004wt (setting
+ * background spacetime to Minkowskian):
+ *
+ * \f{align*}
+ * \partial_t \psi =& -\Pi \\
+ * \partial_t \Pi  =& -\partial^i \Phi_i \\
+ * \partial_t \Phi_i =& -\partial_i \Pi + \gamma_2 (\partial_i \psi - \Phi_i)
+ * \f}
+ *
+ * In our implementation here, to disable the constraint damping terms,
+ * set \f$\gamma_2 = 0\f$.
  */
 namespace ScalarWave {
 

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/ScalarWave/TagsDeclarations.hpp"
 
@@ -33,6 +34,11 @@ struct Phi : db::SimpleTag {
 };
 
 namespace Tags {
+struct ConstraintGamma2 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "ConstraintGamma2"; }
+};
+
 /*!
  * \brief Tag for the one-index constraint of the ScalarWave system
  *
@@ -52,6 +58,51 @@ struct OneIndexConstraint : db::SimpleTag {
 template <size_t Dim>
 struct TwoIndexConstraint : db::SimpleTag {
   using type = tnsr::ij<DataVector, Dim, Frame::Inertial>;
+};
+
+// @{
+/// \brief Tags corresponding to the characteristic fields of the flat-spacetime
+/// scalar-wave system.
+///
+/// \details For details on how these are defined and computed, \see
+/// CharacteristicSpeedsCompute
+struct VPsi : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "VPsi"; }
+};
+template <size_t Dim>
+struct VZero : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+  static std::string name() noexcept { return "VZero"; }
+};
+struct VPlus : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "VPlus"; }
+};
+struct VMinus : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "VMinus"; }
+};
+// @}
+
+template <size_t Dim>
+struct CharacteristicSpeeds : db::SimpleTag {
+  using type = std::array<DataVector, 4>;
+  static std::string name() noexcept { return "CharacteristicSpeeds"; }
+};
+
+template <size_t Dim>
+struct CharacteristicFields : db::SimpleTag {
+  using type = Variables<tmpl::list<VPsi, VZero<Dim>, VPlus, VMinus>>;
+  static std::string name() noexcept { return "CharacteristicFields"; }
+};
+
+template <size_t Dim>
+struct EvolvedFieldsFromCharacteristicFields : db::SimpleTag {
+  using type = Variables<tmpl::list<Psi, Pi, Phi<Dim>>>;
+  static std::string name() noexcept {
+    return "EvolvedFieldsFromCharacteristicFields";
+  }
 };
 }  // namespace Tags
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/ScalarWave/TagsDeclarations.hpp
@@ -13,9 +13,24 @@ struct Phi;
 
 /// \brief Tags for the ScalarWave evolution system
 namespace Tags {
+struct ConstraintGamma2;
+
 template <size_t Dim>
 struct OneIndexConstraint;
 template <size_t Dim>
 struct TwoIndexConstraint;
+
+struct VPsi;
+template <size_t Dim>
+struct VZero;
+struct VPlus;
+struct VMinus;
+
+template <size_t Dim>
+struct CharacteristicSpeeds;
+template <size_t Dim>
+struct CharacteristicFields;
+template <size_t Dim>
+struct EvolvedFieldsFromCharacteristicFields;
 }  // namespace Tags
 }  // namespace ScalarWave

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ScalarWave")
 
 set(LIBRARY_SOURCES
+  Test_Characteristics.cpp
   Test_Constraints.cpp
   Test_Equations.cpp
   )

--- a/tests/Unit/Evolution/Systems/ScalarWave/Characteristics.py
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Characteristics.py
@@ -1,0 +1,63 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+# Test functions for characteristic speeds
+def char_speed_vpsi(unit_normal):
+    return 0.
+
+
+def char_speed_vzero(unit_normal):
+    return 0.
+
+
+def char_speed_vplus(unit_normal):
+    return 1.
+
+
+def char_speed_vminus(unit_normal):
+    return -1.
+
+# End test functions for characteristic speeds
+
+
+# Test functions for characteristic fields
+def char_field_vpsi(gamma2, psi, pi, phi, normal_one_form):
+    return psi
+
+
+def char_field_vzero(gamma2, psi, pi, phi, normal_one_form):
+    normal_vector = normal_one_form
+    projection_tensor = np.identity(len(normal_vector)) -\
+        np.einsum('i,j', normal_one_form, normal_vector)
+    return np.einsum('ij,j->i', projection_tensor, phi)
+
+
+def char_field_vplus(gamma2, psi, pi, phi, normal_one_form):
+    normal_vector = normal_one_form
+    phi_dot_normal = np.einsum('i,i->', normal_vector, phi)
+    return pi + phi_dot_normal - (gamma2 * psi)
+
+
+def char_field_vminus(gamma2, psi, pi, phi, normal_one_form):
+    normal_vector = normal_one_form
+    phi_dot_normal = np.einsum('i,i->', normal_vector, phi)
+    return pi - phi_dot_normal - (gamma2 * psi)
+
+# End test functions for characteristic fields
+
+# Test functions for evolved fields
+def evol_field_psi(gamma2, vpsi, vzero, vplus, vminus, normal_one_form):
+    return vpsi
+
+
+def evol_field_pi(gamma2, vpsi, vzero, vplus, vminus, normal_one_form):
+    return 0.5 * (vplus + vminus) + gamma2 * vpsi
+
+
+def evol_field_phi(gamma2, vpsi, vzero, vplus, vminus, normal_one_form):
+    return 0.5 * (vplus - vminus) * normal_one_form + vzero
+
+# End test functions for evolved fields

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
@@ -1,0 +1,374 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"        // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Evolution/Systems/ScalarWave/Characteristics.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"
+#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+// IWYU pragma: no_forward_declare Tags::dt
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare Variables
+
+namespace {
+template <size_t Index, size_t Dim>
+Scalar<DataVector> speed_with_index(
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal) {
+  return Scalar<DataVector>{
+      ScalarWave::CharacteristicSpeedsCompute<Dim>::function(normal)[Index]};
+}
+
+template <size_t Dim>
+void test_characteristic_speeds() noexcept {
+  const DataVector used_for_size(5);
+  pypp::check_with_random_values<1>(speed_with_index<0, Dim>, "Characteristics",
+                                    "char_speed_vpsi", {{{-10.0, 10.0}}},
+                                    used_for_size);
+  pypp::check_with_random_values<1>(speed_with_index<1, Dim>, "Characteristics",
+                                    "char_speed_vzero", {{{-10.0, 10.0}}},
+                                    used_for_size);
+  pypp::check_with_random_values<1>(speed_with_index<3, Dim>, "Characteristics",
+                                    "char_speed_vminus", {{{-10.0, 10.0}}},
+                                    used_for_size);
+  pypp::check_with_random_values<1>(speed_with_index<2, Dim>, "Characteristics",
+                                    "char_speed_vplus", {{{-10.0, 10.0}}},
+                                    used_for_size);
+}
+
+// Test return-by-reference char speeds by comparing to analytic solution
+template <size_t Dim>
+void test_characteristic_speeds_analytic(
+    const size_t grid_size_each_dimension) noexcept {
+  // Setup mesh
+  Mesh<Dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+  // Get ingredients
+  const size_t n_pts = mesh.number_of_grid_points();
+  // Outward 3-normal to the surface on which characteristic fields are needed
+  const tnsr::i<DataVector, Dim, Frame::Inertial> unit_normal_one_form{
+      DataVector(n_pts, 1. / sqrt(Dim))};
+
+  // Get characteristic speeds locally
+  const auto vpsi_speed_expected =
+      make_with_value<Scalar<DataVector>>(unit_normal_one_form, 0.);
+  const auto vzero_speed_expected =
+      make_with_value<Scalar<DataVector>>(unit_normal_one_form, 0.);
+  const auto vplus_speed_expected =
+      make_with_value<Scalar<DataVector>>(unit_normal_one_form, 1.);
+  const auto vminus_speed_expected =
+      make_with_value<Scalar<DataVector>>(unit_normal_one_form, -1.);
+
+  // Check that locally computed fields match returned ones
+  const auto char_speeds =
+      ScalarWave::CharacteristicSpeedsCompute<Dim>::function(
+          unit_normal_one_form);
+  const auto& vpsi_speed = char_speeds[0];
+  const auto& vzero_speed = char_speeds[1];
+  const auto& vplus_speed = char_speeds[2];
+  const auto& vminus_speed = char_speeds[3];
+
+  CHECK_ITERABLE_APPROX(vpsi_speed_expected.get(), vpsi_speed);
+  CHECK_ITERABLE_APPROX(vzero_speed_expected.get(), vzero_speed);
+  CHECK_ITERABLE_APPROX(vplus_speed_expected.get(), vplus_speed);
+  CHECK_ITERABLE_APPROX(vminus_speed_expected.get(), vminus_speed);
+}
+}  // namespace
+
+namespace {
+template <typename Tag, size_t Dim>
+typename Tag::type field_with_tag(
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_one_form) {
+  return get<Tag>(ScalarWave::CharacteristicFieldsCompute<Dim>::function(
+      gamma_2, psi, pi, phi, normal_one_form));
+}
+
+template <size_t Dim>
+void test_characteristic_fields() noexcept {
+  const DataVector used_for_size(5);
+  // VPsi
+  pypp::check_with_random_values<1>(field_with_tag<ScalarWave::Tags::VPsi, Dim>,
+                                    "Characteristics", "char_field_vpsi",
+                                    {{{-100., 100.}}}, used_for_size);
+  // VZero
+  pypp::check_with_random_values<1>(
+      field_with_tag<ScalarWave::Tags::VZero<Dim>, Dim>, "Characteristics",
+      "char_field_vzero", {{{-100., 100.}}}, used_for_size);
+  // VPlus
+  pypp::check_with_random_values<1>(
+      field_with_tag<ScalarWave::Tags::VPlus, Dim>, "Characteristics",
+      "char_field_vplus", {{{-100., 100.}}}, used_for_size);
+  // VMinus
+  pypp::check_with_random_values<1>(
+      field_with_tag<ScalarWave::Tags::VMinus, Dim>, "Characteristics",
+      "char_field_vminus", {{{-100., 100.}}}, used_for_size);
+}
+
+// Test return-by-reference char fields by comparing to analytic solution
+template <size_t Dim, typename Solution>
+void test_characteristic_fields_analytic(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Set up grid
+  Mesh<Dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Set up coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-dependent solution.
+  const double t = 0.;
+
+  // Evaluate analytic solution
+  const auto vars = solution.variables(
+      x, t,
+      tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{});
+  // Get ingredients
+  const size_t n_pts = mesh.number_of_grid_points();
+  const auto gamma_2 = make_with_value<Scalar<DataVector>>(x, 0.1);
+  const auto& psi = get<ScalarWave::Psi>(vars);
+  const auto& phi = get<ScalarWave::Phi<Dim>>(vars);
+  const auto& pi = get<ScalarWave::Pi>(vars);
+  // Outward 3-normal to the surface on which characteristic fields are needed
+  const auto unit_normal_one_form =
+      make_with_value<tnsr::i<DataVector, Dim, Frame::Inertial>>(
+          x, 1. / sqrt(Dim));
+
+  // Compute characteristic fields locally
+  const auto phi_dot_normal = dot_product(unit_normal_one_form, phi);
+
+  tnsr::i<DataVector, Dim, Frame::Inertial> phi_dot_projection_tensor{
+      DataVector(n_pts)};
+  for (size_t i = 0; i < Dim; ++i) {
+    phi_dot_projection_tensor.get(i) =
+        phi.get(i) - unit_normal_one_form.get(i) * get(phi_dot_normal);
+  }
+
+  const auto& vpsi_expected = psi;
+  const auto& vzero_expected = phi_dot_projection_tensor;
+  const Scalar<DataVector> vplus_expected{get(pi) + get(phi_dot_normal) -
+                                          get(gamma_2) * get(psi)};
+  const Scalar<DataVector> vminus_expected{get(pi) - get(phi_dot_normal) -
+                                           get(gamma_2) * get(psi)};
+
+  // Check that locally computed fields match returned ones
+  const auto uvars = ScalarWave::CharacteristicFieldsCompute<Dim>::function(
+      gamma_2, psi, pi, phi, unit_normal_one_form);
+
+  const auto& vpsi = get<ScalarWave::Tags::VPsi>(uvars);
+  const auto& vzero = get<ScalarWave::Tags::VZero<Dim>>(uvars);
+  const auto& vplus = get<ScalarWave::Tags::VPlus>(uvars);
+  const auto& vminus = get<ScalarWave::Tags::VMinus>(uvars);
+
+  CHECK_ITERABLE_APPROX(vpsi_expected, vpsi);
+  CHECK_ITERABLE_APPROX(vzero_expected, vzero);
+  CHECK_ITERABLE_APPROX(vplus_expected, vplus);
+  CHECK_ITERABLE_APPROX(vminus_expected, vminus);
+}
+}  // namespace
+
+namespace {
+template <typename Tag, size_t Dim>
+typename Tag::type evol_field_with_tag(
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
+  return get<Tag>(
+      ScalarWave::EvolvedFieldsFromCharacteristicFieldsCompute<Dim>::function(
+          gamma_2, v_psi, v_zero, v_plus, v_minus, unit_normal_one_form));
+}
+
+template <size_t Dim>
+void test_evolved_from_characteristic_fields() noexcept {
+  const DataVector used_for_size(5);
+  // Psi
+  pypp::check_with_random_values<1>(evol_field_with_tag<ScalarWave::Psi, Dim>,
+                                    "Characteristics", "evol_field_psi",
+                                    {{{-100., 100.}}}, used_for_size);
+  // Pi
+  pypp::check_with_random_values<1>(evol_field_with_tag<ScalarWave::Pi, Dim>,
+                                    "Characteristics", "evol_field_pi",
+                                    {{{-100., 100.}}}, used_for_size);
+  // Phi
+  pypp::check_with_random_values<1>(
+      evol_field_with_tag<ScalarWave::Phi<Dim>, Dim>, "Characteristics",
+      "evol_field_phi", {{{-100., 100.}}}, used_for_size);
+}
+
+// Test return-by-reference evolved fields by comparing to analytic solution
+template <size_t Dim, typename Solution>
+void test_evolved_from_characteristic_fields_analytic(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Set up grid
+  Mesh<Dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Set up coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-dependent solution.
+  const double t = 0.;
+
+  // Evaluate analytic solution
+  const auto vars = solution.variables(
+      x, t,
+      tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{});
+  // Get ingredients
+  const size_t n_pts = mesh.number_of_grid_points();
+  const auto gamma_2 = make_with_value<Scalar<DataVector>>(x, 0.1);
+  const auto& psi_expected = get<ScalarWave::Psi>(vars);
+  const auto& phi_expected = get<ScalarWave::Phi<Dim>>(vars);
+  const auto& pi_expected = get<ScalarWave::Pi>(vars);
+  // Outward 3-normal to the surface on which characteristic fields are needed
+  const auto unit_normal_one_form =
+      make_with_value<tnsr::i<DataVector, Dim, Frame::Inertial>>(
+          x, 1. / sqrt(Dim));
+
+  // Fundamental fields (psi, pi, phi) have already been computed locally.
+  // Now, check that these locally computed fields match returned ones
+  // First, compute characteristic fields locally
+  const auto phi_dot_normal = dot_product(unit_normal_one_form, phi_expected);
+
+  tnsr::i<DataVector, Dim, Frame::Inertial> phi_dot_projection_tensor{
+      DataVector(n_pts)};
+  for (size_t i = 0; i < Dim; ++i) {
+    phi_dot_projection_tensor.get(i) =
+        phi_expected.get(i) - unit_normal_one_form.get(i) * get(phi_dot_normal);
+  }
+
+  const auto& vpsi = psi_expected;
+  const auto& vzero = phi_dot_projection_tensor;
+  const Scalar<DataVector> vplus{get(pi_expected) + get(phi_dot_normal) -
+                                 get(gamma_2) * get(psi_expected)};
+  const Scalar<DataVector> vminus{get(pi_expected) - get(phi_dot_normal) -
+                                  get(gamma_2) * get(psi_expected)};
+  // Second, obtain evolved fields using compute tag
+  {
+    const auto fields =
+        ScalarWave::EvolvedFieldsFromCharacteristicFieldsCompute<Dim>::function(
+            gamma_2, vpsi, vzero, vplus, vminus, unit_normal_one_form);
+    const auto& psi = get<ScalarWave::Psi>(fields);
+    const auto& pi = get<ScalarWave::Pi>(fields);
+    const auto& phi = get<ScalarWave::Phi<Dim>>(fields);
+
+    CHECK_ITERABLE_APPROX(psi_expected, psi);
+    CHECK_ITERABLE_APPROX(pi_expected, pi);
+    CHECK_ITERABLE_APPROX(phi_expected, phi);
+  }
+  // Third, obtain evolved fields using function
+  {
+    const auto fields = ScalarWave::evolved_fields_from_characteristic_fields(
+        gamma_2, vpsi, vzero, vplus, vminus, unit_normal_one_form);
+    const auto& psi = get<ScalarWave::Psi>(fields);
+    const auto& pi = get<ScalarWave::Pi>(fields);
+    const auto& phi = get<ScalarWave::Phi<Dim>>(fields);
+
+    CHECK_ITERABLE_APPROX(psi_expected, psi);
+    CHECK_ITERABLE_APPROX(pi_expected, pi);
+    CHECK_ITERABLE_APPROX(phi_expected, phi);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Characteristics",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/ScalarWave/"};
+
+  test_characteristic_speeds<1>();
+  test_characteristic_speeds<2>();
+  test_characteristic_speeds<3>();
+
+  test_characteristic_fields<1>();
+  test_characteristic_fields<2>();
+  test_characteristic_fields<3>();
+
+  test_evolved_from_characteristic_fields<1>();
+  test_evolved_from_characteristic_fields<2>();
+  test_evolved_from_characteristic_fields<3>();
+
+  // Test characteristics against 3D spherical wave
+  const size_t grid_size = 8;
+  const std::array<double, 3> lower_bound{{0.82, 1.22, 1.32}};
+  const std::array<double, 3> upper_bound{{0.78, 1.18, 1.28}};
+
+  const ScalarWave::Solutions::RegularSphericalWave spherical_wave_solution(
+      std::make_unique<MathFunctions::Gaussian>(1., 1., 0.));
+
+  test_characteristic_speeds_analytic<3>(grid_size);
+  test_characteristic_fields_analytic<3>(spherical_wave_solution, grid_size,
+                                         lower_bound, upper_bound);
+  test_evolved_from_characteristic_fields_analytic<3>(
+      spherical_wave_solution, grid_size, lower_bound, upper_bound);
+
+  // Test characteristics against 3D plane wave
+  const double kx = 1.5;
+  const double ky = -7.2;
+  const double kz = 2.7;
+  const double center_x = 2.4;
+  const double center_y = -4.8;
+  const double center_z = 8.4;
+  const ScalarWave::Solutions::PlaneWave<3> plane_wave_solution(
+      {{kx, ky, kz}}, {{center_x, center_y, center_z}},
+      std::make_unique<MathFunctions::PowX>(3));
+
+  test_characteristic_speeds_analytic<3>(grid_size);
+  test_characteristic_fields_analytic<3>(plane_wave_solution, grid_size,
+                                         lower_bound, upper_bound);
+  test_evolved_from_characteristic_fields_analytic<3>(
+      plane_wave_solution, grid_size, lower_bound, upper_bound);
+}


### PR DESCRIPTION
## Proposed changes

For the scalar wave system, this PR adds:
 * simple tags for characteristics,
 * functions to convert between fundamental and characteristic fields, 
 * corresponding compute tags, and
 * unit tests (both randomized and analytic).


### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).