### PR TITLE
Add constraints for the scalar-wave system

### DIFF
--- a/src/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY ScalarWave)
 
 set(LIBRARY_SOURCES
+    Constraints.cpp
     Equations.cpp
     )
 

--- a/src/Evolution/Systems/ScalarWave/Constraints.cpp
+++ b/src/Evolution/Systems/ScalarWave/Constraints.cpp
@@ -1,0 +1,91 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarWave/Constraints.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace ScalarWave {
+template <size_t SpatialDim>
+tnsr::i<DataVector, SpatialDim, Frame::Inertial> one_index_constraint(
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& d_psi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept {
+  tnsr::i<DataVector, SpatialDim, Frame::Inertial> constraint(
+      get_size(get<0>(phi)));
+  one_index_constraint(make_not_null(&constraint), d_psi, phi);
+  return constraint;
+}
+
+template <size_t SpatialDim>
+void one_index_constraint(
+    const gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*>
+        constraint,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& d_psi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept {
+  destructive_resize_components(constraint, get_size(get<0>(phi)));
+  // Declare iterators for d_psi and phi outside the for loop,
+  // because they are const but constraint is not
+  auto d_psi_it = d_psi.cbegin(), phi_it = phi.cbegin();
+
+  for (auto constraint_it = constraint->begin();
+       constraint_it != constraint->end();
+       ++constraint_it, (void)++d_psi_it, (void)++phi_it) {
+    *constraint_it = *d_psi_it - *phi_it;
+  }
+}
+
+template <size_t SpatialDim>
+tnsr::ij<DataVector, SpatialDim, Frame::Inertial> two_index_constraint(
+    const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>& d_phi) noexcept {
+  tnsr::ij<DataVector, SpatialDim, Frame::Inertial> constraint(
+      get_size(get<0, 0>(d_phi)));
+  two_index_constraint(make_not_null(&constraint), d_phi);
+  return constraint;
+}
+
+template <size_t SpatialDim>
+void two_index_constraint(
+    const gsl::not_null<tnsr::ij<DataVector, SpatialDim, Frame::Inertial>*>
+        constraint,
+    const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>& d_phi) noexcept {
+  destructive_resize_components(constraint, get_size(get<0, 0>(d_phi)));
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      constraint->get(i, j) = d_phi.get(i, j) - d_phi.get(j, i);
+    }
+  }
+}
+}  // namespace ScalarWave
+
+// Explicit Instantiations
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template tnsr::i<DataVector, DIM(data), Frame::Inertial>                    \
+  ScalarWave::one_index_constraint(                                           \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&,                 \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&) noexcept;       \
+  template void ScalarWave::one_index_constraint(                             \
+      const gsl::not_null<tnsr::i<DataVector, DIM(data), Frame::Inertial>*>,  \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&,                 \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&) noexcept;       \
+  template tnsr::ij<DataVector, DIM(data), Frame::Inertial>                   \
+  ScalarWave::two_index_constraint(                                           \
+      const tnsr::ij<DataVector, DIM(data), Frame::Inertial>&) noexcept;      \
+  template void ScalarWave::two_index_constraint(                             \
+      const gsl::not_null<tnsr::ij<DataVector, DIM(data), Frame::Inertial>*>, \
+      const tnsr::ij<DataVector, DIM(data), Frame::Inertial>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+/// \endcond

--- a/src/Evolution/Systems/ScalarWave/Constraints.hpp
+++ b/src/Evolution/Systems/ScalarWave/Constraints.hpp
@@ -1,0 +1,107 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace ScalarWave {
+// @{
+/*!
+ * \brief Compute the scalar-wave one-index constraint.
+ *
+ * \details Computes the scalar-wave one-index constraint,
+ * \f$C_{i} = \partial_i\psi - \Phi_{i},\f$ which is
+ * given by Eq. (19) of \cite Holst2004wt
+ */
+template <size_t SpatialDim>
+tnsr::i<DataVector, SpatialDim, Frame::Inertial> one_index_constraint(
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& d_psi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept;
+
+template <size_t SpatialDim>
+void one_index_constraint(
+    gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*> constraint,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& d_psi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept;
+// @}
+
+// @{
+/*!
+ * \brief Compute the scalar-wave 2-index constraint.
+ *
+ * \details Computes the scalar-wave 2-index constraint
+ * \f$C_{ij} = \partial_i\Phi_j - \partial_j\Phi_i,\f$
+ * where \f$\Phi_{i} = \partial_i\psi\f$, that is given by
+ * Eq. (20) of \cite Holst2004wt
+ *
+ * \note We do not support custom storage for antisymmetric tensors yet.
+ */
+template <size_t SpatialDim>
+tnsr::ij<DataVector, SpatialDim, Frame::Inertial> two_index_constraint(
+    const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>& d_phi) noexcept;
+
+template <size_t SpatialDim>
+void two_index_constraint(
+    gsl::not_null<tnsr::ij<DataVector, SpatialDim, Frame::Inertial>*>
+        constraint,
+    const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>& d_phi) noexcept;
+// @}
+
+namespace Tags {
+/*!
+ * \brief Compute item to get the one-index constraint for the scalar-wave
+ * evolution system.
+ *
+ * \details See `one_index_constraint()`. Can be retrieved using
+ * `ScalarWave::Tags::OneIndexConstraint`.
+ */
+template <size_t SpatialDim>
+struct OneIndexConstraintCompute : OneIndexConstraint<SpatialDim>,
+                                   db::ComputeTag {
+  using argument_tags =
+      tmpl::list<::Tags::deriv<Psi, tmpl::size_t<SpatialDim>, Frame::Inertial>,
+                 Phi<SpatialDim>>;
+  using return_type = tnsr::i<DataVector, SpatialDim, Frame::Inertial>;
+  static constexpr void (*function)(
+      const gsl::not_null<return_type*> result,
+      const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&,
+      const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&) =
+      &one_index_constraint<SpatialDim>;
+  using base = OneIndexConstraint<SpatialDim>;
+};
+
+/*!
+ * \brief Compute item to get the two-index constraint for the scalar-wave
+ * evolution system.
+ *
+ * \details See `two_index_constraint()`. Can be retrieved using
+ * `ScalarWave::Tags::TwoIndexConstraint`.
+ */
+template <size_t SpatialDim>
+struct TwoIndexConstraintCompute : TwoIndexConstraint<SpatialDim>,
+                                   db::ComputeTag {
+  using argument_tags =
+      tmpl::list<::Tags::deriv<Phi<SpatialDim>, tmpl::size_t<SpatialDim>,
+                               Frame::Inertial>>;
+  using return_type = tnsr::ij<DataVector, SpatialDim, Frame::Inertial>;
+  static constexpr void (*function)(
+      const gsl::not_null<return_type*> result,
+      const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>&) =
+      &two_index_constraint<SpatialDim>;
+  using base = TwoIndexConstraint<SpatialDim>;
+};
+
+}  // namespace Tags
+}  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.cpp
@@ -87,8 +87,8 @@ void UpwindFlux<Dim>::package_data(
   // to fill the exterior fields. This introduces a sign flip for each normal
   // used in computing the exterior fields.
   get<Pi>(*packaged_data) = pi;
-  get<Tags::NormalDotFlux<Pi>>(*packaged_data) = normal_dot_flux_pi;
-  get<Tags::NormalDotFlux<Phi<Dim>>>(*packaged_data) = normal_dot_flux_phi;
+  get<::Tags::NormalDotFlux<Pi>>(*packaged_data) = normal_dot_flux_pi;
+  get<::Tags::NormalDotFlux<Phi<Dim>>>(*packaged_data) = normal_dot_flux_phi;
   auto& normal_times_flux_pi = get<NormalTimesFluxPi>(*packaged_data);
   for (size_t d = 0; d < Dim; ++d) {
     normal_times_flux_pi.get(d) =

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -30,7 +30,7 @@ struct System {
   static constexpr bool has_primitive_and_conservative_vars = false;
   static constexpr size_t volume_dim = Dim;
 
-  using variables_tag = Tags::Variables<tmpl::list<Pi, Phi<Dim>, Psi>>;
+  using variables_tag = ::Tags::Variables<tmpl::list<Pi, Phi<Dim>, Psi>>;
   // Typelist of which subset of the variables to take the gradient of.
   using gradients_tags = tmpl::list<Pi, Phi<Dim>>;
 
@@ -40,6 +40,6 @@ struct System {
       ComputeLargestCharacteristicSpeed;
 
   template <typename Tag>
-  using magnitude_tag = Tags::EuclideanMagnitude<Tag>;
+  using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;
 };
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -11,6 +11,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ScalarWave/TagsDeclarations.hpp"
 
 class DataVector;
 
@@ -30,4 +31,27 @@ struct Phi : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
   static std::string name() noexcept { return "Phi"; }
 };
+
+namespace Tags {
+/*!
+ * \brief Tag for the one-index constraint of the ScalarWave system
+ *
+ * For details on how this is defined and computed, see
+ * `OneIndexConstraintCompute`.
+ */
+template <size_t Dim>
+struct OneIndexConstraint : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+};
+/*!
+ * \brief Tag for the two-index constraint of the ScalarWave system
+ *
+ * For details on how this is defined and computed, see
+ * `TwoIndexConstraintCompute`.
+ */
+template <size_t Dim>
+struct TwoIndexConstraint : db::SimpleTag {
+  using type = tnsr::ij<DataVector, Dim, Frame::Inertial>;
+};
+}  // namespace Tags
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/ScalarWave/TagsDeclarations.hpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+namespace ScalarWave {
+struct Psi;
+struct Pi;
+template <size_t Dim>
+struct Phi;
+
+/// \brief Tags for the ScalarWave evolution system
+namespace Tags {
+template <size_t Dim>
+struct OneIndexConstraint;
+template <size_t Dim>
+struct TwoIndexConstraint;
+}  // namespace Tags
+}  // namespace ScalarWave

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
@@ -100,16 +100,19 @@ PlaneWave<Dim>::variables(const tnsr::I<DataVector, Dim>& x, double t,
 }
 
 template <size_t Dim>
-tuples::TaggedTuple<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                    Tags::dt<ScalarWave::Psi>>
+tuples::TaggedTuple<::Tags::dt<ScalarWave::Pi>,
+                    ::Tags::dt<ScalarWave::Phi<Dim>>,
+                    ::Tags::dt<ScalarWave::Psi>>
 PlaneWave<Dim>::variables(
     const tnsr::I<DataVector, Dim>& x, double t,
-    const tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                     Tags::dt<ScalarWave::Psi>> /*meta*/) const noexcept {
-  tuples::TaggedTuple<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                      Tags::dt<ScalarWave::Psi>>
+    const tmpl::list<::Tags::dt<ScalarWave::Pi>,
+                     ::Tags::dt<ScalarWave::Phi<Dim>>,
+                     ::Tags::dt<ScalarWave::Psi>> /*meta*/) const noexcept {
+  tuples::TaggedTuple<::Tags::dt<ScalarWave::Pi>,
+                      ::Tags::dt<ScalarWave::Phi<Dim>>,
+                      ::Tags::dt<ScalarWave::Psi>>
       dt_variables{d2psi_dt2(x, t), d2psi_dtdx(x, t), dpsi_dt(x, t)};
-  get<Tags::dt<ScalarWave::Pi>>(dt_variables).get() *= -1.0;
+  get<::Tags::dt<ScalarWave::Pi>>(dt_variables).get() *= -1.0;
   return dt_variables;
 }
 

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -122,11 +122,13 @@ class PlaneWave : public MarkAsAnalyticSolution {
   ///
   /// \note This function's expected use case is setting the past time
   /// derivative values for Adams-Bashforth-like steppers.
-  tuples::TaggedTuple<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                      Tags::dt<ScalarWave::Psi>>
-  variables(const tnsr::I<DataVector, Dim>& x, double t,
-            tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                       Tags::dt<ScalarWave::Psi>> /*meta*/) const noexcept;
+  tuples::TaggedTuple<::Tags::dt<ScalarWave::Pi>,
+                      ::Tags::dt<ScalarWave::Phi<Dim>>,
+                      ::Tags::dt<ScalarWave::Psi>>
+  variables(
+      const tnsr::I<DataVector, Dim>& x, double t,
+      tmpl::list<::Tags::dt<ScalarWave::Pi>, ::Tags::dt<ScalarWave::Phi<Dim>>,
+                 ::Tags::dt<ScalarWave::Psi>> /*meta*/) const noexcept;
 
   // clang-tidy: no pass by reference
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
@@ -66,12 +66,12 @@ RegularSphericalWave::variables(
   return variables;
 }
 
-tuples::TaggedTuple<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
-                    Tags::dt<ScalarWave::Psi>>
+tuples::TaggedTuple<::Tags::dt<ScalarWave::Pi>, ::Tags::dt<ScalarWave::Phi<3>>,
+                    ::Tags::dt<ScalarWave::Psi>>
 RegularSphericalWave::variables(
     const tnsr::I<DataVector, 3>& x, double t,
-    const tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
-                     Tags::dt<ScalarWave::Psi>> /*meta*/) const noexcept {
+    const tmpl::list<::Tags::dt<ScalarWave::Pi>, ::Tags::dt<ScalarWave::Phi<3>>,
+                     ::Tags::dt<ScalarWave::Psi>> /*meta*/) const noexcept {
   const DataVector r = get(magnitude(x));
   // See class documentation for choice of cutoff
   const double r_cutoff = cbrt(std::numeric_limits<double>::epsilon());
@@ -100,17 +100,16 @@ RegularSphericalWave::variables(
       }
     }
   }
-  tuples::TaggedTuple<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
-                      Tags::dt<ScalarWave::Psi>>
+  tuples::TaggedTuple<::Tags::dt<ScalarWave::Pi>,
+                      ::Tags::dt<ScalarWave::Phi<3>>,
+                      ::Tags::dt<ScalarWave::Psi>>
       dt_variables{std::move(d2psi_dt2), std::move(d2psi_dtdx),
                    std::move(dpsi_dt)};
-  get<Tags::dt<ScalarWave::Pi>>(dt_variables).get() *= -1.0;
+  get<::Tags::dt<ScalarWave::Pi>>(dt_variables).get() *= -1.0;
   return dt_variables;
 }
 
-void RegularSphericalWave::pup(PUP::er& p) noexcept {
-  p | profile_;
-}
+void RegularSphericalWave::pup(PUP::er& p) noexcept { p | profile_; }
 
 }  // namespace Solutions
 }  // namespace ScalarWave

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
@@ -92,11 +92,13 @@ class RegularSphericalWave : public MarkAsAnalyticSolution {
             tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>,
                        ScalarWave::Psi> /*meta*/) const noexcept;
 
-  tuples::TaggedTuple<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
-                      Tags::dt<ScalarWave::Psi>>
-  variables(const tnsr::I<DataVector, 3>& x, double t,
-            tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
-                       Tags::dt<ScalarWave::Psi>> /*meta*/) const noexcept;
+  tuples::TaggedTuple<::Tags::dt<ScalarWave::Pi>,
+                      ::Tags::dt<ScalarWave::Phi<3>>,
+                      ::Tags::dt<ScalarWave::Psi>>
+  variables(
+      const tnsr::I<DataVector, 3>& x, double t,
+      tmpl::list<::Tags::dt<ScalarWave::Pi>, ::Tags::dt<ScalarWave::Phi<3>>,
+                 ::Tags::dt<ScalarWave::Psi>> /*meta*/) const noexcept;
 
   // clang-tidy: no pass by reference
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ScalarWave")
 
 set(LIBRARY_SOURCES
+  Test_Constraints.cpp
   Test_Equations.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/ScalarWave/Constraints.py
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Constraints.py
@@ -1,0 +1,12 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def one_index_constraint(dpsi, phi):
+    return dpsi - phi
+
+
+def two_index_constraint(dphi):
+    return dphi - np.transpose(dphi)

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Constraints.cpp
@@ -1,0 +1,197 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/ScalarWave/Constraints.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"
+#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+namespace {
+// Test the return-by-value one-index constraint function using random values
+template <size_t SpatialDim>
+void test_one_index_constraint_random(
+    const DataVector& used_for_size) noexcept {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::i<DataVector, SpatialDim, Frame::Inertial> (*)(
+          const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&,
+          const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&)>(
+          &ScalarWave::one_index_constraint<SpatialDim>),
+      "Constraints", "one_index_constraint", {{{-10.0, 10.0}}}, used_for_size);
+}
+
+// Test the return-by-value two-index constraint function using random values
+template <size_t SpatialDim>
+void test_two_index_constraint_random(
+    const DataVector& used_for_size) noexcept {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::ij<DataVector, SpatialDim, Frame::Inertial> (*)(
+          const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>&)>(
+          &ScalarWave::two_index_constraint<SpatialDim>),
+      "Constraints", "two_index_constraint", {{{-10.0, 10.0}}}, used_for_size,
+      1.0e-12);
+}
+
+template <typename Solution>
+void test_constraints_and_compute_tags_analytic(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound,
+    const double error_tolerance) noexcept {
+  constexpr size_t spatial_dim = 3;
+
+  // Check vs. time-independent analytic solution
+  // Set up grid
+  Mesh<3> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+               Spectral::Quadrature::GaussLobatto};
+  const size_t data_size = mesh.number_of_grid_points();
+
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1.0, 1.0, lower_bound[0], upper_bound[0]},
+          Affine{-1.0, 1.0, lower_bound[1], upper_bound[1]},
+          Affine{-1.0, 1.0, lower_bound[2], upper_bound[2]},
+      });
+
+  // Set up coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = 0.;
+
+  // Evaluate analytic solution
+  const auto vars = solution.variables(
+      x, t,
+      tmpl::list<ScalarWave::Pi, ScalarWave::Phi<spatial_dim>,
+                 ScalarWave::Psi>{});
+  const auto& psi = get<ScalarWave::Psi>(vars);
+  const auto& phi = get<ScalarWave::Phi<spatial_dim>>(vars);
+  const auto& pi = get<ScalarWave::Pi>(vars);
+  // Compute derivatives d_phi and d_psi numerically
+  // First, prepare
+  using variables_tags_to_differentiate =
+      tmpl::list<ScalarWave::Psi, ScalarWave::Phi<3>>;
+  Variables<variables_tags_to_differentiate> local_vars(data_size);
+  get<ScalarWave::Psi>(local_vars) = psi;
+  get<ScalarWave::Phi<spatial_dim>>(local_vars) = phi;
+  // Second, compute derivatives
+  const auto local_derivs =
+      partial_derivatives<variables_tags_to_differentiate>(
+          local_vars, mesh, coord_map.inv_jacobian(x_logical));
+  const auto& deriv_psi = get<
+      Tags::deriv<ScalarWave::Psi, tmpl::size_t<spatial_dim>, Frame::Inertial>>(
+      local_derivs);
+  const auto& deriv_phi =
+      get<Tags::deriv<ScalarWave::Phi<spatial_dim>, tmpl::size_t<spatial_dim>,
+                      Frame::Inertial>>(local_derivs);
+
+  // (1.) Get the constraints, and check that they vanish to error_tolerance
+  auto one_index_constraint =
+      make_with_value<tnsr::i<DataVector, spatial_dim, Frame::Inertial>>(
+          x, std::numeric_limits<double>::signaling_NaN());
+  ScalarWave::one_index_constraint(make_not_null(&one_index_constraint),
+                                   deriv_psi, phi);
+  auto two_index_constraint =
+      make_with_value<tnsr::ij<DataVector, spatial_dim, Frame::Inertial>>(
+          x, std::numeric_limits<double>::signaling_NaN());
+  ScalarWave::two_index_constraint(make_not_null(&two_index_constraint),
+                                   deriv_phi);
+
+  Approx numerical_approx = Approx::custom().epsilon(error_tolerance).scale(1.);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      one_index_constraint,
+      (make_with_value<tnsr::i<DataVector, spatial_dim, Frame::Inertial>>(x,
+                                                                          0.)),
+      numerical_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      two_index_constraint,
+      (make_with_value<tnsr::ij<DataVector, spatial_dim, Frame::Inertial>>(x,
+                                                                           0.)),
+      numerical_approx);
+
+  // (2.) Test that compute tags return expected values
+  const auto box = db::create<
+      db::AddSimpleTags<
+          ::Tags::Coordinates<spatial_dim, Frame::Inertial>, ScalarWave::Psi,
+          ScalarWave::Phi<spatial_dim>, ScalarWave::Pi,
+          ::Tags::deriv<ScalarWave::Psi, tmpl::size_t<spatial_dim>,
+                        Frame::Inertial>,
+          ::Tags::deriv<ScalarWave::Phi<spatial_dim>, tmpl::size_t<spatial_dim>,
+                        Frame::Inertial>>,
+      db::AddComputeTags<
+          ScalarWave::Tags::OneIndexConstraintCompute<spatial_dim>,
+          ScalarWave::Tags::TwoIndexConstraintCompute<spatial_dim>>>(
+      x, psi, phi, pi, deriv_psi, deriv_phi);
+
+  // Check that their compute items in databox furnish identical values
+  CHECK(db::get<ScalarWave::Tags::OneIndexConstraint<spatial_dim>>(box) ==
+        one_index_constraint);
+  CHECK(db::get<ScalarWave::Tags::TwoIndexConstraint<spatial_dim>>(box) ==
+        two_index_constraint);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Constraints",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/ScalarWave/"};
+  {
+    INFO("Testing constraints with randomized input");
+    // Test the one-index constraint with random numbers
+    GENERATE_UNINITIALIZED_DATAVECTOR;
+    CHECK_FOR_DATAVECTORS(test_one_index_constraint_random, (1, 2, 3));
+    CHECK_FOR_DATAVECTORS(test_two_index_constraint_random, (1, 2, 3));
+  }
+  {
+    INFO("Testing constraints for a spherical-wave analytic solution");
+    const size_t grid_size = 8;
+    const std::array<double, 3> upper_bound{{6., 6., 6.}};
+    const std::array<double, 3> lower_bound{{0., 0., 0.}};
+
+    const ScalarWave::Solutions::RegularSphericalWave solution(
+        std::make_unique<MathFunctions::Gaussian>(1., 1., 0.));
+
+    // Note: looser numerical tolerance because this check
+    // uses numerical derivatives
+    test_constraints_and_compute_tags_analytic(
+        solution, grid_size, lower_bound, upper_bound,
+        std::numeric_limits<double>::epsilon() * 1.e6);
+  }
+}


### PR DESCRIPTION
## Proposed changes

For the scalar wave system, this PR adds:

 * simple tags for constraints,
 * functions to compute constraints,
 * corresponding compute tags.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).