### PR TITLE
Fix #1730

### DIFF
--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
@@ -68,7 +68,7 @@ void test_cubic_spline(const F& function, const double lower_bound,
     CHECK(deserialized_interpolant(x_value) == interpolated_y_value);
     // Record max error for better test failure reports
     const double error = abs(interpolated_y_value - y_value);
-    if (error > max_error) {
+    if (error >= max_error) {
       max_error = error;
       max_error_x_value = x_value;
     }
@@ -79,7 +79,7 @@ void test_cubic_spline(const F& function, const double lower_bound,
     if (i > 10 * size * boundary_fraction and
         i < 10 * size * (1. - boundary_fraction)) {
       CHECK(interpolated_y_value == custom_approx_interior(y_value));
-      if (error > max_error_interior) {
+      if (error >= max_error_interior) {
         max_error_interior = error;
         max_error_interior_x_value = x_value;
       }


### PR DESCRIPTION
The max_error in this test was never updated from the initial NaN
in those cases where the error in the interior is
exactly zero everywhere.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
