### PR TITLE
Dual frames part1: Enable serialization of functions of time

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,6 +7,7 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 PointerAlignment: Left
 DerivePointerAlignment: false
+IncludeBlocks: Preserve
 IncludeCategories:
   - Regex:           '^<.*'
     Priority:        1

--- a/src/ControlSystem/FunctionOfTime.hpp
+++ b/src/ControlSystem/FunctionOfTime.hpp
@@ -4,20 +4,22 @@
 #pragma once
 
 #include <array>
+#include <pup.h>
 #include <vector>
 
 #include "DataStructures/DataVector.hpp"
+#include "Parallel/CharmPupable.hpp"
 
 /// \ingroup ControlSystemGroup
 /// Base class for FunctionsOfTime
-class FunctionOfTime {
+class FunctionOfTime : public PUP::able {
  public:
   FunctionOfTime() = default;
   FunctionOfTime(FunctionOfTime&&) noexcept = default;
   FunctionOfTime& operator=(FunctionOfTime&&) noexcept = default;
   FunctionOfTime(const FunctionOfTime&) = delete;
   FunctionOfTime& operator=(const FunctionOfTime&) = delete;
-  virtual ~FunctionOfTime() = default;
+  ~FunctionOfTime() override = default;
 
   virtual std::array<double, 2> time_bounds() const noexcept = 0;
 
@@ -25,4 +27,6 @@ class FunctionOfTime {
   virtual std::array<DataVector, 2> func_and_deriv(double t) const noexcept = 0;
   virtual std::array<DataVector, 3> func_and_2_derivs(double t) const
       noexcept = 0;
+
+  WRAPPED_PUPable_abstract(FunctionOfTime);  // NOLINT
 };

--- a/tests/Unit/ControlSystem/Test_PiecewisePolynomial.cpp
+++ b/tests/Unit/ControlSystem/Test_PiecewisePolynomial.cpp
@@ -5,28 +5,23 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
 
 #include "ControlSystem/FunctionOfTime.hpp"
 #include "ControlSystem/PiecewisePolynomial.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 
-SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial",
-                  "[ControlSystem][Unit]") {
-  double t = 0.0;
-  const double dt = 0.6;
-  const double final_time = 4.0;
-  constexpr size_t deriv_order = 3;
-
-  // test two component system (x**3 and x**2)
-  const std::array<DataVector, deriv_order + 1> init_func{
-      {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(t,
-                                                                   init_func);
-  FunctionOfTime& f_of_t = f_of_t_derived;
-
+namespace {
+template <size_t DerivOrder>
+void test(const gsl::not_null<FunctionOfTime*> f_of_t,
+          const gsl::not_null<FunctionsOfTime::PiecewisePolynomial<DerivOrder>*>
+              f_of_t_derived,
+          double t, const double dt, const double final_time) noexcept {
   while (t < final_time) {
-    const auto lambdas0 = f_of_t.func_and_2_derivs(t);
+    const auto lambdas0 = f_of_t->func_and_2_derivs(t);
     CHECK(approx(lambdas0[0][0]) == cube(t));
     CHECK(approx(lambdas0[0][1]) == square(t));
     CHECK(approx(lambdas0[1][0]) == 3.0 * square(t));
@@ -34,52 +29,43 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial",
     CHECK(approx(lambdas0[2][0]) == 6.0 * t);
     CHECK(approx(lambdas0[2][1]) == 2.0);
 
-    const auto lambdas1 = f_of_t.func_and_deriv(t);
+    const auto lambdas1 = f_of_t->func_and_deriv(t);
     CHECK(approx(lambdas1[0][0]) == cube(t));
     CHECK(approx(lambdas1[0][1]) == square(t));
     CHECK(approx(lambdas1[1][0]) == 3.0 * square(t));
     CHECK(approx(lambdas1[1][1]) == 2.0 * t);
 
-    const auto lambdas2 = f_of_t.func(t);
+    const auto lambdas2 = f_of_t->func(t);
     CHECK(approx(lambdas2[0][0]) == cube(t));
     CHECK(approx(lambdas2[0][1]) == square(t));
 
     t += dt;
-    f_of_t_derived.update(t, {6.0, 0.0});
+    f_of_t_derived->update(t, {6.0, 0.0});
   }
   // test time_bounds function
-  const auto t_bounds = f_of_t.time_bounds();
+  const auto t_bounds = f_of_t->time_bounds();
   CHECK(t_bounds[0] == 0.0);
   CHECK(t_bounds[1] == 4.2);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial.NonConstDeriv",
-    "[ControlSystem][Unit]") {
-  double t = 0.0;
-  const double dt = 0.6;
-  const double final_time = 4.0;
-  constexpr size_t deriv_order = 2;
-
-  // initally x**2, but update with non-constant 2nd deriv
-  const std::array<DataVector, deriv_order + 1> init_func{
-      {{0.0}, {0.0}, {2.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(t,
-                                                                   init_func);
-  FunctionOfTime& f_of_t = f_of_t_derived;
-
+template <size_t DerivOrder>
+void test_non_const_deriv(
+    const gsl::not_null<FunctionOfTime*> f_of_t,
+    const gsl::not_null<FunctionsOfTime::PiecewisePolynomial<DerivOrder>*>
+        f_of_t_derived,
+    double t, const double dt, const double final_time) noexcept {
   while (t < final_time) {
     t += dt;
-    f_of_t_derived.update(t, {3.0 + t});
+    f_of_t_derived->update(t, {3.0 + t});
   }
-  const auto lambdas0 = f_of_t.func_and_2_derivs(t);
+  const auto lambdas0 = f_of_t->func_and_2_derivs(t);
   CHECK(approx(lambdas0[0][0]) == 33.948);
   CHECK(approx(lambdas0[1][0]) == 19.56);
   CHECK(approx(lambdas0[2][0]) == 7.2);
-  const auto lambdas1 = f_of_t.func_and_deriv(t);
+  const auto lambdas1 = f_of_t->func_and_deriv(t);
   CHECK(approx(lambdas1[0][0]) == 33.948);
   CHECK(approx(lambdas1[1][0]) == 19.56);
-  const auto lambdas2 = f_of_t.func(t);
+  const auto lambdas2 = f_of_t->func(t);
   CHECK(approx(lambdas2[0][0]) == 33.948);
 
   CHECK(lambdas0.size() == 3);
@@ -87,15 +73,8 @@ SPECTRE_TEST_CASE(
   CHECK(lambdas2.size() == 1);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial.WithinRoundoff",
-    "[ControlSystem][Unit]") {
-  constexpr size_t deriv_order = 3;
-  const std::array<DataVector, deriv_order + 1> init_func{
-      {{1.0, 1.0}, {3.0, 2.0}, {6.0, 2.0}, {6.0, 0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(1.0, init_func);
-  f_of_t.update(2.0, {6.0, 0.0});
-
+template <size_t DerivOrder>
+void test_within_roundoff(const FunctionOfTime& f_of_t) noexcept {
   const auto lambdas0 = f_of_t.func_and_2_derivs(1.0 - 5.0e-16);
   CHECK(approx(lambdas0[0][0]) == 1.0);
   CHECK(approx(lambdas0[1][0]) == 3.0);
@@ -111,6 +90,112 @@ SPECTRE_TEST_CASE(
   const auto lambdas2 = f_of_t.func(1.0 - 5.0e-16);
   CHECK(approx(lambdas2[0][0]) == 1.0);
   CHECK(approx(lambdas2[0][1]) == 1.0);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial",
+                  "[ControlSystem][Unit]") {
+  PUPable_reg(FunctionsOfTime::PiecewisePolynomial<2>);
+  PUPable_reg(FunctionsOfTime::PiecewisePolynomial<3>);
+
+  {
+    INFO("Core test");
+    double t = 0.0;
+    const double dt = 0.6;
+    const double final_time = 4.0;
+    constexpr size_t deriv_order = 3;
+
+    // test two component system (x**3 and x**2)
+    const std::array<DataVector, deriv_order + 1> init_func{
+        {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
+    {
+      INFO("Test with simple construction.");
+      FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(t, init_func);
+      FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t2 =
+          serialize_and_deserialize(f_of_t);
+
+      test(make_not_null(&f_of_t), make_not_null(&f_of_t), t, dt, final_time);
+      test(make_not_null(&f_of_t2), make_not_null(&f_of_t2), t, dt, final_time);
+    }
+    {
+      INFO("Test with base class construction.");
+      std::unique_ptr<FunctionOfTime> f_of_t =
+          std::make_unique<FunctionsOfTime::PiecewisePolynomial<deriv_order>>(
+              t, init_func);
+      std::unique_ptr<FunctionOfTime> f_of_t2 =
+          serialize_and_deserialize(f_of_t);
+
+      test(make_not_null(f_of_t.get()),
+           make_not_null(
+               dynamic_cast<FunctionsOfTime::PiecewisePolynomial<deriv_order>*>(
+                   f_of_t.get())),
+           t, dt, final_time);
+      test(make_not_null(f_of_t2.get()),
+           make_not_null(
+               dynamic_cast<FunctionsOfTime::PiecewisePolynomial<deriv_order>*>(
+                   f_of_t2.get())),
+           t, dt, final_time);
+    }
+  }
+
+  {
+    INFO("Non-constant derivative test.");
+    double t = 0.0;
+    const double dt = 0.6;
+    const double final_time = 4.0;
+    constexpr size_t deriv_order = 2;
+
+    // initally x**2, but update with non-constant 2nd deriv
+    const std::array<DataVector, deriv_order + 1> init_func{
+        {{0.0}, {0.0}, {2.0}}};
+    {
+      INFO("Test with simple construction.");
+      FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(t, init_func);
+      FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t2 =
+          serialize_and_deserialize(f_of_t);
+      test_non_const_deriv(make_not_null(&f_of_t), make_not_null(&f_of_t), t,
+                           dt, final_time);
+      test_non_const_deriv(make_not_null(&f_of_t2), make_not_null(&f_of_t2), t,
+                           dt, final_time);
+    }
+    {
+      INFO("Test with base class construction.");
+      std::unique_ptr<FunctionOfTime> f_of_t =
+          std::make_unique<FunctionsOfTime::PiecewisePolynomial<deriv_order>>(
+              t, init_func);
+      std::unique_ptr<FunctionOfTime> f_of_t2 =
+          serialize_and_deserialize(f_of_t);
+
+      test_non_const_deriv(
+          make_not_null(f_of_t.get()),
+          make_not_null(
+              dynamic_cast<FunctionsOfTime::PiecewisePolynomial<deriv_order>*>(
+                  f_of_t.get())),
+          t, dt, final_time);
+      test_non_const_deriv(
+          make_not_null(f_of_t2.get()),
+          make_not_null(
+              dynamic_cast<FunctionsOfTime::PiecewisePolynomial<deriv_order>*>(
+                  f_of_t2.get())),
+          t, dt, final_time);
+    }
+  }
+  {
+    INFO("Test within roundoff.");
+    constexpr size_t deriv_order = 3;
+    const std::array<DataVector, deriv_order + 1> init_func{
+        {{1.0, 1.0}, {3.0, 2.0}, {6.0, 2.0}, {6.0, 0.0}}};
+
+    FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(1.0, init_func);
+    FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t2 =
+        serialize_and_deserialize(f_of_t);
+
+    f_of_t.update(2.0, {6.0, 0.0});
+    f_of_t2.update(2.0, {6.0, 0.0});
+
+    test_within_roundoff<deriv_order>(f_of_t);
+    test_within_roundoff<deriv_order>(f_of_t2);
+  }
 }
 
 // [[OutputRegex, t must be increasing from call to call. Attempted to update at

--- a/tests/Unit/ControlSystem/Test_SettleToConstant.cpp
+++ b/tests/Unit/ControlSystem/Test_SettleToConstant.cpp
@@ -4,29 +4,18 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
+#include <memory>
 
 #include "ControlSystem/FunctionOfTime.hpp"
 #include "ControlSystem/SettleToConstant.hpp"
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "Utilities/ConstantExpressions.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 
-SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.SettleToConstant",
-                  "[ControlSystem][Unit]") {
-  const double match_time = 10.0;
-  const double decay_time = 5.0;
-  // set init_func to f(t) = 5 + 2t + 3t^2
-  const double f_t0 = 5.0 + 2.0 * match_time + 3.0 * square(match_time);
-  const double dtf_t0 = 2.0 + 6.0 * match_time;
-  const double d2tf_t0 = 6.0;
-  // compute coefficients for check
-  const double C = -(decay_time * d2tf_t0 + dtf_t0);
-  const double B = decay_time * (C - dtf_t0);
-  const double A = f_t0 - B;
-  const std::array<DataVector, 3> init_func{{{f_t0}, {dtf_t0}, {d2tf_t0}}};
-  const FunctionsOfTime::SettleToConstant f_of_t_derived(init_func, match_time,
-                                                         decay_time);
-  const FunctionOfTime& f_of_t = f_of_t_derived;
-
+namespace {
+void test(const FunctionOfTime& f_of_t, const double match_time,
+          const double f_t0, const double dtf_t0, const double d2tf_t0,
+          const double A) noexcept {
   // check that values agree at the matching time
   const auto lambdas0 = f_of_t.func_and_2_derivs(match_time);
   CHECK(approx(lambdas0[0][0]) == f_t0);
@@ -56,4 +45,45 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.SettleToConstant",
   // test time_bounds function
   const auto t_bounds = f_of_t.time_bounds();
   CHECK(t_bounds[0] == 10.0);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.SettleToConstant",
+                  "[ControlSystem][Unit]") {
+  PUPable_reg(FunctionsOfTime::SettleToConstant);
+
+  const double match_time = 10.0;
+  const double decay_time = 5.0;
+  // set init_func to f(t) = 5 + 2t + 3t^2
+  const double f_t0 = 5.0 + 2.0 * match_time + 3.0 * square(match_time);
+  const double dtf_t0 = 2.0 + 6.0 * match_time;
+  const double d2tf_t0 = 6.0;
+  // compute coefficients for check
+  const double C = -(decay_time * d2tf_t0 + dtf_t0);
+  const double B = decay_time * (C - dtf_t0);
+  const double A = f_t0 - B;
+  const std::array<DataVector, 3> init_func{{{f_t0}, {dtf_t0}, {d2tf_t0}}};
+
+  {
+    INFO("Test with simple construction.");
+    const FunctionsOfTime::SettleToConstant f_of_t_derived(
+        init_func, match_time, decay_time);
+    test(f_of_t_derived, match_time, f_t0, dtf_t0, d2tf_t0, A);
+
+    const FunctionsOfTime::SettleToConstant f_of_t_derived2 =
+        serialize_and_deserialize(f_of_t_derived);
+    test(f_of_t_derived2, match_time, f_t0, dtf_t0, d2tf_t0, A);
+  }
+
+  {
+    INFO("Test with base class construction.");
+    const std::unique_ptr<FunctionOfTime> f_of_t =
+        std::make_unique<FunctionsOfTime::SettleToConstant>(
+            init_func, match_time, decay_time);
+    test(*f_of_t, match_time, f_t0, dtf_t0, d2tf_t0, A);
+
+    const std::unique_ptr<FunctionOfTime> f_of_t2 =
+        serialize_and_deserialize(f_of_t);
+    test(*f_of_t2, match_time, f_t0, dtf_t0, d2tf_t0, A);
+  }
 }


### PR DESCRIPTION
## Proposed changes

Functions of time need to be serializable for dual frames (because everything needs to be serializable...). This PR makes the already implemented serializable.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
