### PR TITLE
Make EvolveNewtonianEuler handle analytic data

### DIFF
--- a/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
@@ -18,26 +18,35 @@ set(LIBS_TO_LINK
   Utilities
   )
 
-add_spectre_parallel_executable(
-  EvolveNewtonianEuler1D
-  EvolveNewtonianEuler
-  Evolution/Executables/NewtonianEuler
-  EvolutionMetavars<1>
-  "${LIBS_TO_LINK}"
-  )
+function(add_newtonian_euler_executable EXECUTABLE_NAME DIM INITIAL_DATA)
+  add_spectre_parallel_executable(
+    "Evolve${EXECUTABLE_NAME}${DIM}D"
+    EvolveNewtonianEuler
+    Evolution/Executables/NewtonianEuler
+    "EvolutionMetavars<${DIM},${INITIAL_DATA}>"
+    "${LIBS_TO_LINK}"
+    )
+endfunction(add_newtonian_euler_executable)
 
-add_spectre_parallel_executable(
-  EvolveNewtonianEuler2D
-  EvolveNewtonianEuler
-  Evolution/Executables/NewtonianEuler
-  EvolutionMetavars<2>
-  "${LIBS_TO_LINK}"
-  )
+function(add_riemann_problem_executable DIM)
+  add_newtonian_euler_executable(
+    RiemannProblem
+    ${DIM}
+    NewtonianEuler::Solutions::RiemannProblem<${DIM}>
+    )
+endfunction(add_riemann_problem_executable)
 
-add_spectre_parallel_executable(
-  EvolveNewtonianEuler3D
-  EvolveNewtonianEuler
-  Evolution/Executables/NewtonianEuler
-  EvolutionMetavars<3>
-  "${LIBS_TO_LINK}"
-  )
+add_riemann_problem_executable(1)
+add_riemann_problem_executable(2)
+add_riemann_problem_executable(3)
+
+function(add_isentropic_vortex_executable DIM)
+  add_newtonian_euler_executable(
+    IsentropicVortex
+    ${DIM}
+    NewtonianEuler::Solutions::IsentropicVortex<${DIM}>
+    )
+endfunction(add_isentropic_vortex_executable)
+
+add_isentropic_vortex_executable(2)
+add_isentropic_vortex_executable(3)

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEulerFwd.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEulerFwd.hpp
@@ -5,5 +5,14 @@
 
 #include <cstddef>
 
+namespace NewtonianEuler {
+namespace Solutions {
 template <size_t Dim>
+class RiemannProblem;
+template <size_t Dim>
+class IsentropicVortex;
+}  // namespace Solutions
+}  // namespace NewtonianEuler
+
+template <size_t Dim, typename InitialData>
 struct EvolutionMetavars;

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Executable: EvolveNewtonianEuler3D
+# Executable: EvolveRiemannProblem1D
 # Check: execute
 
 Evolution:
@@ -11,22 +11,22 @@ Evolution:
     RungeKutta3
 
 DomainCreator:
-  Brick:
-    LowerBound: [-0.25, 0.0, 0.0]
-    UpperBound: [0.75, 0.1, 0.1]
-    IsPeriodicIn: [false, false, false]
-    InitialRefinement: [4, 0, 0]
-    InitialGridPoints: [2, 2, 2]
+  Interval:
+    LowerBound: [-0.25]
+    UpperBound: [0.75]
+    IsPeriodicIn: [false]
+    InitialRefinement: [1]
+    InitialGridPoints: [2]
 
 AnalyticSolution:
   RiemannProblem:
     AdiabaticIndex: 1.4
     InitialPosition: 0.25
     LeftMassDensity: 1.0
-    LeftVelocity: [0.0, 0.5, -0.3]
+    LeftVelocity: [0.0]
     LeftPressure: 1.0
     RightMassDensity: 0.125
-    RightVelocity: [0.0, 0.2, 0.1]
+    RightVelocity: [0.0]
     RightPressure: 0.1
 
 NumericalFlux:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Executable: EvolveNewtonianEuler1D
+# Executable: EvolveRiemannProblem2D
 # Check: execute
 
 Evolution:
@@ -11,22 +11,22 @@ Evolution:
     RungeKutta3
 
 DomainCreator:
-  Interval:
-    LowerBound: [-0.25]
-    UpperBound: [0.75]
-    IsPeriodicIn: [false]
-    InitialRefinement: [1]
-    InitialGridPoints: [2]
+  Rectangle:
+    LowerBound: [-0.25, 0.0]
+    UpperBound: [0.75, 0.1]
+    IsPeriodicIn: [false, false]
+    InitialRefinement: [4, 0]
+    InitialGridPoints: [2, 2]
 
 AnalyticSolution:
   RiemannProblem:
     AdiabaticIndex: 1.4
     InitialPosition: 0.25
     LeftMassDensity: 1.0
-    LeftVelocity: [0.0]
+    LeftVelocity: [0.0, 0.5]
     LeftPressure: 1.0
     RightMassDensity: 0.125
-    RightVelocity: [0.0]
+    RightVelocity: [0.0, 0.2]
     RightPressure: 0.1
 
 NumericalFlux:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Executable: EvolveNewtonianEuler2D
+# Executable: EvolveRiemannProblem3D
 # Check: execute
 
 Evolution:
@@ -11,22 +11,22 @@ Evolution:
     RungeKutta3
 
 DomainCreator:
-  Rectangle:
-    LowerBound: [-0.25, 0.0]
-    UpperBound: [0.75, 0.1]
-    IsPeriodicIn: [false, false]
-    InitialRefinement: [4, 0]
-    InitialGridPoints: [2, 2]
+  Brick:
+    LowerBound: [-0.25, 0.0, 0.0]
+    UpperBound: [0.75, 0.1, 0.1]
+    IsPeriodicIn: [false, false, false]
+    InitialRefinement: [4, 0, 0]
+    InitialGridPoints: [2, 2, 2]
 
 AnalyticSolution:
   RiemannProblem:
     AdiabaticIndex: 1.4
     InitialPosition: 0.25
     LeftMassDensity: 1.0
-    LeftVelocity: [0.0, 0.5]
+    LeftVelocity: [0.0, 0.5, -0.3]
     LeftPressure: 1.0
     RightMassDensity: 0.125
-    RightVelocity: [0.0, 0.2]
+    RightVelocity: [0.0, 0.2, 0.1]
     RightPressure: 0.1
 
 NumericalFlux:


### PR DESCRIPTION
- Template Metavariables in initial data type
- Allow evolution of analytic data by making analytic BCs and ObserveErrorNorms optional
- Executable is now compiled by `make`ing Evolve + name of the initial data class

These changes will make evolving analytic data straightforward, in the same way `ValenciaDivClean` does.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
