### PR TITLE
Add constraints for the scalar-wave system in curved spacetime

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY CurvedScalarWave)
 
 set(LIBRARY_SOURCES
   Characteristics.cpp
+  Constraints.cpp
   Equations.cpp
   )
 

--- a/src/Evolution/Systems/CurvedScalarWave/Constraints.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Constraints.cpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/Constraints.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace CurvedScalarWave {
+template <size_t SpatialDim>
+tnsr::i<DataVector, SpatialDim, Frame::Inertial> one_index_constraint(
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& d_psi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept {
+  tnsr::i<DataVector, SpatialDim, Frame::Inertial> constraint(
+      get_size(get<0>(phi)));
+  one_index_constraint<SpatialDim>(make_not_null(&constraint), d_psi, phi);
+  return constraint;
+}
+
+template <size_t SpatialDim>
+void one_index_constraint(
+    const gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*>
+        constraint,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& d_psi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept {
+  if (get_size(get<0>(*constraint)) != get_size(get<0>(phi))) {
+    *constraint =
+        tnsr::i<DataVector, SpatialDim, Frame::Inertial>(get_size(get<0>(phi)));
+  }
+  // Declare iterators for d_psi and phi outside the for loop,
+  // because they are const but constraint is not
+  auto d_psi_it = d_psi.cbegin(), phi_it = phi.cbegin();
+
+  for (auto constraint_it = (*constraint).begin();
+       constraint_it != (*constraint).end();
+       ++constraint_it, (void)++d_psi_it, (void)++phi_it) {
+    *constraint_it = *d_psi_it - *phi_it;
+  }
+}
+
+template <size_t SpatialDim>
+tnsr::ij<DataVector, SpatialDim, Frame::Inertial> two_index_constraint(
+    const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>& d_phi) noexcept {
+  auto constraint =
+      make_with_value<tnsr::ij<DataVector, SpatialDim, Frame::Inertial>>(d_phi,
+                                                                         0.);
+  two_index_constraint<SpatialDim>(make_not_null(&constraint), d_phi);
+  return constraint;
+}
+
+template <size_t SpatialDim>
+void two_index_constraint(
+    const gsl::not_null<tnsr::ij<DataVector, SpatialDim, Frame::Inertial>*>
+        constraint,
+    const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>& d_phi) noexcept {
+  if (get_size(get<0, 0>(*constraint)) != get_size(get<0, 0>(d_phi))) {
+    *constraint =
+        make_with_value<tnsr::ij<DataVector, SpatialDim, Frame::Inertial>>(
+            d_phi, 0.);
+  }
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      constraint->get(i, j) = d_phi.get(i, j) - d_phi.get(j, i);
+    }
+  }
+}
+}  // namespace CurvedScalarWave
+
+// Explicit Instantiations
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template tnsr::i<DataVector, DIM(data), Frame::Inertial>                    \
+  CurvedScalarWave::one_index_constraint(                                     \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&,                 \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&) noexcept;       \
+  template void CurvedScalarWave::one_index_constraint(                       \
+      const gsl::not_null<tnsr::i<DataVector, DIM(data), Frame::Inertial>*>,  \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&,                 \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&) noexcept;       \
+  template tnsr::ij<DataVector, DIM(data), Frame::Inertial>                   \
+  CurvedScalarWave::two_index_constraint(                                     \
+      const tnsr::ij<DataVector, DIM(data), Frame::Inertial>&) noexcept;      \
+  template void CurvedScalarWave::two_index_constraint(                       \
+      const gsl::not_null<tnsr::ij<DataVector, DIM(data), Frame::Inertial>*>, \
+      const tnsr::ij<DataVector, DIM(data), Frame::Inertial>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+/// \endcond

--- a/src/Evolution/Systems/CurvedScalarWave/Constraints.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Constraints.hpp
@@ -1,10 +1,19 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+///\file
+/// Defines functions to calculate the scalar wave constraints in
+/// curved spacetime
+
 #pragma once
+
+#include <cstddef>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace CurvedScalarWave {
@@ -36,6 +45,95 @@ struct ConstraintGamma2Compute : ConstraintGamma2, db::ComputeTag {
     return make_with_value<type>(used_for_size, 1.);
   }
   using base = ConstraintGamma2;
+};
+}  // namespace Tags
+
+// @{
+/*!
+ * \brief Computes the scalar-wave one-index constraint.
+ *
+ * \details Computes the scalar-wave one-index constraint,
+ * \f$C_{i} = \partial_i\psi - \Phi_{i},\f$ which is
+ * given by Eq. (19) of \cite Holst2004wt
+ */
+template <size_t SpatialDim>
+tnsr::i<DataVector, SpatialDim, Frame::Inertial> one_index_constraint(
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& d_psi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept;
+
+template <size_t SpatialDim>
+void one_index_constraint(
+    gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*> constraint,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& d_psi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept;
+// @}
+
+// @{
+/*!
+ * \brief Computes the scalar-wave 2-index constraint.
+ *
+ * \details Computes the scalar-wave 2-index FOSH constraint
+ * [Eq. (20) of \cite Holst2004wt],
+ *
+ * \f{eqnarray}{
+ * C_{ij} &\equiv& \partial_i \Phi_j - \partial_j \Phi_i
+ * \f}
+ *
+ * where \f$\Phi_{i} = \partial_i\psi\f$; and \f$\psi\f$ is the scalar field.
+ */
+template <size_t SpatialDim>
+tnsr::ij<DataVector, SpatialDim, Frame::Inertial> two_index_constraint(
+    const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>& d_phi) noexcept;
+
+template <size_t SpatialDim>
+void two_index_constraint(
+    gsl::not_null<tnsr::ij<DataVector, SpatialDim, Frame::Inertial>*>
+        constraint,
+    const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>& d_phi) noexcept;
+// @}
+
+namespace Tags {
+/*!
+ * \brief Compute item to get the one-index constraint for the scalar-wave
+ * evolution system.
+ *
+ * \details See `one_index_constraint()`. Can be retrieved using
+ * `CurvedScalarWave::Tags::OneIndexConstraint`.
+ */
+template <size_t SpatialDim>
+struct OneIndexConstraintCompute : OneIndexConstraint<SpatialDim>,
+                                   db::ComputeTag {
+  using argument_tags =
+      tmpl::list<::Tags::deriv<Psi, tmpl::size_t<SpatialDim>, Frame::Inertial>,
+                 Phi<SpatialDim>>;
+  using return_type = tnsr::i<DataVector, SpatialDim, Frame::Inertial>;
+  static constexpr void (*function)(
+      const gsl::not_null<return_type*> result,
+      const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&,
+      const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&) =
+      &one_index_constraint<SpatialDim>;
+  using base = OneIndexConstraint<SpatialDim>;
+};
+
+/*!
+ * \brief Compute item to get the two-index constraint for the scalar-wave
+ * evolution system.
+ *
+ * \details See `two_index_constraint()`. Can be retrieved using
+ * `CurvedScalarWave::Tags::TwoIndexConstraint`.
+ */
+template <size_t SpatialDim>
+struct TwoIndexConstraintCompute : TwoIndexConstraint<SpatialDim>,
+                                   db::ComputeTag {
+  using argument_tags =
+      tmpl::list<::Tags::deriv<Phi<SpatialDim>, tmpl::size_t<SpatialDim>,
+                               Frame::Inertial>>;
+  using return_type = tnsr::ij<DataVector, SpatialDim, Frame::Inertial>;
+  static constexpr void (*function)(
+      const gsl::not_null<return_type*> result,
+      const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>&) =
+      &two_index_constraint<SpatialDim>;
+  using base = TwoIndexConstraint<SpatialDim>;
 };
 }  // namespace Tags
 }  // namespace CurvedScalarWave

--- a/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
@@ -37,25 +37,26 @@ namespace CurvedScalarWave {
  * \cite Holst2004wt :
  *
  * \f{align}
- * \partial_t\Psi = & (1 + \gamma_1) N^k \partial_k \Psi - N \Pi - \gamma_1 N^k
- * \Phi_k \\
+ * \partial_t\Psi = & (1 + \gamma_1) \beta^k \partial_k \Psi - \alpha \Pi -
+ * \gamma_1 \beta^k \Phi_k \\
  *
- * \partial_t\Pi = & - N g^{ij}\partial_i\Phi_j + N^k \partial_k \Pi + \gamma_1
- * \gamma_2 N^k \partial_k \Psi  + N \Gamma^i - g^{ij} \Phi_i \partial_j N
- *  + N K \Pi - \gamma_1  \gamma_2 N^k \Phi_k\\
+ * \partial_t\Pi = & - \alpha \gamma^{ij}\partial_i\Phi_j + \beta^k \partial_k
+ * \Pi + \gamma_1 \gamma_2 \beta^k \partial_k \Psi  + \alpha \Gamma^i -
+ * \gamma^{ij} \Phi_i \partial_j \alpha
+ *  + \alpha K \Pi - \gamma_1  \gamma_2 \beta^k \Phi_k\\
  *
- * \partial_t\Phi_i = & - N \partial_i \Pi  + N^k \partial_k \Phi + \gamma_2
- * N \partial_i \Psi - \Pi
- * \partial_i N + \Phi_k \partial_i N^j - \gamma_2 N \Phi_i\\
+ * \partial_t\Phi_i = & - \alpha \partial_i \Pi  + \beta^k \partial_k \Phi +
+ * \gamma_2 \alpha \partial_i \Psi - \Pi
+ * \partial_i \alpha + \Phi_k \partial_i \beta^j - \gamma_2 \alpha \Phi_i\\
  * \f}
  *
  * where \f$\Psi\f$ is the scalar field, \f$\Pi\f$ is the
  * conjugate momentum to \f$\Psi\f$, \f$\Phi_i=\partial_i\Psi\f$ is an
- * auxiliary variable, \f$N\f$ is the lapse, \f$N^k\f$ is the shift, \f$ g_{ij}
- * \f$ is the spatial metric, \f$ K \f$ is the trace of the extrinsic curvature,
- * and \f$ \Gamma^i \f$ is the trace of the Christoffel symbol of the second
- * kind.
- * \f$\gamma_1, \gamma_2\f$ are constraint damping parameters.
+ * auxiliary variable, \f$\alpha\f$ is the lapse, \f$\beta^k\f$ is the shift,
+ * \f$ \gamma_{ij} \f$ is the spatial metric, \f$ K \f$ is the trace of the
+ * extrinsic curvature, and \f$ \Gamma^i \f$ is the trace of the Christoffel
+ * symbol of the second kind. \f$\gamma_1, \gamma_2\f$ are constraint damping
+ * parameters.
  */
 template <size_t Dim>
 struct ComputeDuDt {

--- a/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
@@ -13,7 +13,11 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/CurvedScalarWave/TagsDeclarations.hpp"
 
+/// \cond
 class DataVector;
+template <class>
+class Variables;
+/// \endcond
 
 namespace CurvedScalarWave {
 struct Psi : db::SimpleTag {
@@ -26,21 +30,42 @@ struct Pi : db::SimpleTag {
   static std::string name() noexcept { return "Pi"; }
 };
 
-template <size_t Dim>
+template <size_t SpatialDim>
 struct Phi : db::SimpleTag {
-  using type = tnsr::i<DataVector, Dim>;
+  using type = tnsr::i<DataVector, SpatialDim>;
   static std::string name() noexcept { return "Phi"; }
 };
 
 namespace Tags {
 struct ConstraintGamma1 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "ConstraintGamma1"; }
 };
 
 struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "ConstraintGamma2"; }
+};
+
+/*!
+ * \brief Tag for the one-index constraint of the scalar wave
+ * system in curved spacetime.
+ *
+ * For details on how this is defined and computed, see
+ * `OneIndexConstraintCompute`.
+ */
+template <size_t SpatialDim>
+struct OneIndexConstraint : db::SimpleTag {
+  using type = tnsr::i<DataVector, SpatialDim, Frame::Inertial>;
+};
+/*!
+ * \brief Tag for the two-index constraint of the scalar wave
+ * system in curved spacetime.
+ *
+ * For details on how this is defined and computed, see
+ * `TwoIndexConstraintCompute`.
+ */
+template <size_t SpatialDim>
+struct TwoIndexConstraint : db::SimpleTag {
+  using type = tnsr::ij<DataVector, SpatialDim, Frame::Inertial>;
 };
 
 // @{

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_CurvedScalarWave")
 
 set(LIBRARY_SOURCES
+  Test_Constraints.cpp
   TestHelpers.cpp
   Test_Characteristics.cpp
   Test_DuDt.cpp

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Constraints.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Constraints.py
@@ -1,0 +1,18 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+# Test functions for one-index constraint
+
+def one_index_constraint(d_psi, phi):
+    return d_psi - phi
+
+# End test functions for one-index constraint
+
+# Test functions for two-index constraint
+
+def two_index_constraint(d_phi):
+    return d_phi - np.transpose(d_phi)
+
+# End test functions for two-index constraint

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Constraints.cpp
@@ -1,0 +1,104 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Constraints.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace {
+// Test the return-by-value one-index constraint function using random values
+template <size_t SpatialDim>
+void test_one_index_constraint_random(
+    const DataVector& used_for_size) noexcept {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::i<DataVector, SpatialDim, Frame::Inertial> (*)(
+          const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&,
+          const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&)>(
+          &CurvedScalarWave::one_index_constraint<SpatialDim>),
+      "Constraints", "one_index_constraint", {{{-10.0, 10.0}}}, used_for_size);
+}
+
+// Test the return-by-value two-index constraint function using random values
+template <size_t SpatialDim>
+void test_two_index_constraint_random(
+    const DataVector& used_for_size) noexcept {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::ij<DataVector, SpatialDim, Frame::Inertial> (*)(
+          const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>&)>(
+          &CurvedScalarWave::two_index_constraint<SpatialDim>),
+      "Constraints", "two_index_constraint", {{{-10.0, 10.0}}}, used_for_size,
+      1.0e-12);
+}
+
+// Test compute items for various constraints via insertion and retrieval
+// in a databox
+template <size_t SpatialDim>
+void test_constraint_compute_items(const DataVector& used_for_size) noexcept {
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(0.0, 1.0);
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+
+  // Randomized tensors
+  const auto phi = make_with_random_values<tnsr::i<DataVector, SpatialDim>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto d_phi = make_with_random_values<tnsr::ij<DataVector, SpatialDim>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto d_psi = make_with_random_values<tnsr::i<DataVector, SpatialDim>>(
+      nn_generator, nn_distribution, used_for_size);
+  // Insert into databox
+  const auto box = db::create<
+      db::AddSimpleTags<
+          CurvedScalarWave::Phi<SpatialDim>,
+          ::Tags::deriv<CurvedScalarWave::Phi<SpatialDim>,
+                        tmpl::size_t<SpatialDim>, Frame::Inertial>,
+          ::Tags::deriv<CurvedScalarWave::Psi, tmpl::size_t<SpatialDim>,
+                        Frame::Inertial>>,
+      db::AddComputeTags<
+          CurvedScalarWave::Tags::OneIndexConstraintCompute<SpatialDim>,
+          CurvedScalarWave::Tags::TwoIndexConstraintCompute<SpatialDim>>>(
+      phi, d_phi, d_psi);
+
+  // Check compute tag against locally computed quantities
+  CHECK(db::get<CurvedScalarWave::Tags::OneIndexConstraint<SpatialDim>>(box) ==
+        CurvedScalarWave::one_index_constraint(d_psi, phi));
+  CHECK(db::get<CurvedScalarWave::Tags::TwoIndexConstraint<SpatialDim>>(box) ==
+        CurvedScalarWave::two_index_constraint(d_phi));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Constraints",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/CurvedScalarWave/"};
+  const auto used_for_size =
+      DataVector(5, std::numeric_limits<double>::signaling_NaN());
+  // Test the one-index constraint with random numbers
+  test_one_index_constraint_random<1>(used_for_size);
+  test_one_index_constraint_random<2>(used_for_size);
+  test_one_index_constraint_random<3>(used_for_size);
+
+  // Test the two-index constraint with random numbers
+  test_two_index_constraint_random<1>(used_for_size);
+  test_two_index_constraint_random<2>(used_for_size);
+  test_two_index_constraint_random<3>(used_for_size);
+
+  // Compute items
+  test_constraint_compute_items<1>(used_for_size);
+  test_constraint_compute_items<2>(used_for_size);
+  test_constraint_compute_items<3>(used_for_size);
+}


### PR DESCRIPTION
## Proposed changes

For the scalar wave system in curved background spacetime this PR adds:
 * simple tags for constraints,
 * functions to compute constraints,
 * corresponding compute tags, and

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
