### PR TITLE
Add characteristics for curved-scalar-wave system

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -4,8 +4,9 @@
 set(LIBRARY CurvedScalarWave)
 
 set(LIBRARY_SOURCES
-    Equations.cpp
-    )
+  Characteristics.cpp
+  Equations.cpp
+  )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 

--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.cpp
@@ -1,0 +1,229 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace CurvedScalarWave {
+template <size_t SpatialDim>
+void characteristic_speeds(
+    const gsl::not_null<std::array<DataVector, 4>*> char_speeds,
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+        unit_normal_one_form) noexcept {
+  if (UNLIKELY(get_size((*char_speeds)[0]) != get_size(get(gamma_1)))) {
+    *char_speeds = make_with_value<std::array<DataVector, 4>>(
+        get(gamma_1), std::numeric_limits<double>::signaling_NaN());
+  }
+  const auto shift_dot_normal = get(dot_product(shift, unit_normal_one_form));
+  (*char_speeds)[0] = -(1. + get(gamma_1)) * shift_dot_normal;  // v(VPsi)
+  (*char_speeds)[1] = -shift_dot_normal;                        // v(VZero)
+  (*char_speeds)[2] = -shift_dot_normal + get(lapse);           // v(VPlus)
+  (*char_speeds)[3] = -shift_dot_normal - get(lapse);           // v(VMinus)
+}
+
+template <size_t SpatialDim>
+std::array<DataVector, 4> characteristic_speeds(
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+        unit_normal_one_form) noexcept {
+  auto char_speeds = make_with_value<std::array<DataVector, 4>>(
+      get<0>(unit_normal_one_form),
+      std::numeric_limits<double>::signaling_NaN());
+  characteristic_speeds(make_not_null(&char_speeds), gamma_1, lapse, shift,
+                        unit_normal_one_form);
+  return char_speeds;
+}
+
+template <size_t SpatialDim>
+void characteristic_fields(
+    const gsl::not_null<Variables<tmpl::list<
+        Tags::VPsi, Tags::VZero<SpatialDim>, Tags::VPlus, Tags::VMinus>>*>
+        char_fields,
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::II<DataVector, SpatialDim, Frame::Inertial>&
+        inverse_spatial_metric,
+    const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+        unit_normal_one_form) noexcept {
+  if (UNLIKELY(get_size(get(get<Tags::VPsi>(*char_fields))) !=
+               get_size(get(gamma_2)))) {
+    *char_fields =
+        Variables<tmpl::list<Tags::VPsi, Tags::VZero<SpatialDim>, Tags::VPlus,
+                             Tags::VMinus>>(get_size(get(gamma_2)));
+  }
+  const auto phi_dot_normal = dot_product(
+      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric), phi);
+
+  // Eq.(34) of Holst+ (2004) for VZero
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    get<Tags::VZero<SpatialDim>>(*char_fields).get(i) =
+        phi.get(i) - unit_normal_one_form.get(i) * get(phi_dot_normal);
+  }
+
+  // Eq.(33) of Holst+ (2004) for VPsi
+  get<Tags::VPsi>(*char_fields) = psi;
+
+  // Eq.(35) of Holst+ (2004) for VPlus and VMinus
+  get(get<Tags::VPlus>(*char_fields)) =
+      get(pi) + get(phi_dot_normal) - get(gamma_2) * get(psi);
+  get(get<Tags::VMinus>(*char_fields)) =
+      get(pi) - get(phi_dot_normal) - get(gamma_2) * get(psi);
+}
+
+template <size_t SpatialDim>
+Variables<
+    tmpl::list<Tags::VPsi, Tags::VZero<SpatialDim>, Tags::VPlus, Tags::VMinus>>
+characteristic_fields(
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::II<DataVector, SpatialDim, Frame::Inertial>&
+        inverse_spatial_metric,
+    const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+        unit_normal_one_form) noexcept {
+  auto char_fields =
+      make_with_value<Variables<tmpl::list<Tags::VPsi, Tags::VZero<SpatialDim>,
+                                           Tags::VPlus, Tags::VMinus>>>(
+          get(gamma_2), std::numeric_limits<double>::signaling_NaN());
+  characteristic_fields(make_not_null(&char_fields), gamma_2,
+                        inverse_spatial_metric, psi, pi, phi,
+                        unit_normal_one_form);
+  return char_fields;
+}
+
+template <size_t SpatialDim>
+void evolved_fields_from_characteristic_fields(
+    const gsl::not_null<Variables<tmpl::list<Psi, Pi, Phi<SpatialDim>>>*>
+        evolved_fields,
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+        unit_normal_one_form) noexcept {
+  if (UNLIKELY(get_size(get(get<Psi>(*evolved_fields))) !=
+               get_size(get(gamma_2)))) {
+    *evolved_fields =
+        Variables<tmpl::list<Psi, Pi, Phi<SpatialDim>>>(get_size(get(gamma_2)));
+  }
+  // Eq.(36) of Holst+ (2005) for Psi
+  get<Psi>(*evolved_fields) = v_psi;
+
+  // Eq.(37) - (38) of Holst+ (2004) for Pi and Phi
+  get<Pi>(*evolved_fields).get() =
+      0.5 * (get(v_plus) + get(v_minus)) + get(gamma_2) * get(v_psi);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    get<Phi<SpatialDim>>(*evolved_fields).get(i) =
+        0.5 * (get(v_plus) - get(v_minus)) * unit_normal_one_form.get(i) +
+        v_zero.get(i);
+  }
+}
+
+template <size_t SpatialDim>
+Variables<tmpl::list<Psi, Pi, Phi<SpatialDim>>>
+evolved_fields_from_characteristic_fields(
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+        unit_normal_one_form) noexcept {
+  auto evolved_fields =
+      make_with_value<Variables<tmpl::list<Psi, Pi, Phi<SpatialDim>>>>(
+          get(gamma_2), std::numeric_limits<double>::signaling_NaN());
+  evolved_fields_from_characteristic_fields(make_not_null(&evolved_fields),
+                                            gamma_2, v_psi, v_zero, v_plus,
+                                            v_minus, unit_normal_one_form);
+  return evolved_fields;
+}
+
+template <size_t SpatialDim>
+double ComputeLargestCharacteristicSpeed<SpatialDim>::apply(
+    const std::array<DataVector, 4>& char_speeds) noexcept {
+  std::array<double, 4> max_speeds{
+      {max(abs(char_speeds[0])), max(abs(char_speeds[1])),
+       max(abs(char_speeds[2])), max(abs(char_speeds[3]))}};
+  return *std::max_element(max_speeds.begin(), max_speeds.end());
+}
+}  // namespace CurvedScalarWave
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template void CurvedScalarWave::characteristic_speeds(                      \
+      const gsl::not_null<std::array<DataVector, 4>*> char_speeds,            \
+      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,     \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& shift,           \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                  \
+          unit_normal_one_form) noexcept;                                     \
+  template std::array<DataVector, 4> CurvedScalarWave::characteristic_speeds( \
+      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,     \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& shift,           \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                  \
+          unit_normal_one_form) noexcept;                                     \
+  template struct CurvedScalarWave::CharacteristicSpeedsCompute<DIM(data)>;   \
+  template void CurvedScalarWave::characteristic_fields(                      \
+      const gsl::not_null<Variables<tmpl::list<                               \
+          CurvedScalarWave::Tags::VPsi,                                       \
+          CurvedScalarWave::Tags::VZero<DIM(data)>,                           \
+          CurvedScalarWave::Tags::VPlus, CurvedScalarWave::Tags::VMinus>>*>   \
+          char_fields,                                                        \
+      const Scalar<DataVector>& gamma_2,                                      \
+      const tnsr::II<DataVector, DIM(data), Frame::Inertial>&                 \
+          inverse_spatial_metric,                                             \
+      const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,            \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi,             \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                  \
+          unit_normal_one_form) noexcept;                                     \
+  template Variables<tmpl::list<                                              \
+      CurvedScalarWave::Tags::VPsi, CurvedScalarWave::Tags::VZero<DIM(data)>, \
+      CurvedScalarWave::Tags::VPlus, CurvedScalarWave::Tags::VMinus>>         \
+  CurvedScalarWave::characteristic_fields(                                    \
+      const Scalar<DataVector>& gamma_2,                                      \
+      const tnsr::II<DataVector, DIM(data), Frame::Inertial>&                 \
+          inverse_spatial_metric,                                             \
+      const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,            \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi,             \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                  \
+          unit_normal_one_form) noexcept;                                     \
+  template struct CurvedScalarWave::CharacteristicFieldsCompute<DIM(data)>;   \
+  template void CurvedScalarWave::evolved_fields_from_characteristic_fields(  \
+      const gsl::not_null<                                                    \
+          Variables<tmpl::list<CurvedScalarWave::Psi, CurvedScalarWave::Pi,   \
+                               CurvedScalarWave::Phi<DIM(data)>>>*>           \
+          evolved_fields,                                                     \
+      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,     \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& v_zero,          \
+      const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,    \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                  \
+          unit_normal_one_form) noexcept;                                     \
+  template Variables<tmpl::list<CurvedScalarWave::Psi, CurvedScalarWave::Pi,  \
+                                CurvedScalarWave::Phi<DIM(data)>>>            \
+  CurvedScalarWave::evolved_fields_from_characteristic_fields(                \
+      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,     \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& v_zero,          \
+      const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,    \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                  \
+          unit_normal_one_form) noexcept;                                     \
+  template struct CurvedScalarWave::                                          \
+      EvolvedFieldsFromCharacteristicFieldsCompute<DIM(data)>;                \
+  template struct CurvedScalarWave::ComputeLargestCharacteristicSpeed<DIM(    \
+      data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM

--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
@@ -1,0 +1,241 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Constraints.hpp"
+#include "Evolution/Systems/CurvedScalarWave/TagsDeclarations.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace CurvedScalarWave {
+// @{
+/*!
+ * \ingroup CurvedScalarWave
+ * \brief Compute the characteristic speeds for the scalar wave system in curved
+ * spacetime.
+ *
+ * Computes the speeds as described in "Optimal constraint projection for
+ * hyperbolic evolution systems" by Holst et. al \cite Holst2004wt
+ * [see text following Eq. (32)]. The characteristic fields' names used here
+ * are similar to the paper:
+ *
+ * \f{align*}
+ * \mathrm{SpECTRE} && \mathrm{Holst} \\
+ * v^{\hat \psi} && Z^1 \\
+ * v^{\hat 0}_{i} && Z^{2}_{i} \\
+ * v^{\hat \pm} && u^{1\pm}
+ * \f}
+ *
+ * The corresponding characteristic speeds \f$\lambda\f$ are given in the text
+ * following Eq. (38) of \cite Holst2004wt :
+ *
+ * \f{align*}
+ * \lambda_{\hat \psi} =& -(1 + \gamma_1) n_k N^k \\
+ * \lambda_{\hat 0} =& -n_k N^k \\
+ * \lambda_{\hat \pm} =& -n_k N^k \pm N
+ * \f}
+ *
+ * where \f$n_k\f$ is the unit normal to the surface.
+ */
+template <size_t SpatialDim>
+std::array<DataVector, 4> characteristic_speeds(
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+        unit_normal_one_form) noexcept;
+
+template <size_t SpatialDim>
+void characteristic_speeds(
+    gsl::not_null<std::array<DataVector, 4>*> char_speeds,
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+        unit_normal_one_form) noexcept;
+
+template <size_t SpatialDim>
+struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<SpatialDim>,
+                                     db::ComputeTag {
+  using base = Tags::CharacteristicSpeeds<SpatialDim>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<
+      Tags::ConstraintGamma1, gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<SpatialDim, Frame::Inertial, DataVector>,
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<SpatialDim>>>;
+
+  static constexpr void function(
+      gsl::not_null<return_type*> result, const Scalar<DataVector>& gamma_1,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
+      const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+          unit_normal_one_form) noexcept {
+    characteristic_speeds<SpatialDim>(result, gamma_1, lapse, shift,
+                                      unit_normal_one_form);
+  }
+};
+// @}
+
+// @{
+/*!
+ * \ingroup CurvedScalarWave
+ * \brief Computes characteristic fields from evolved fields
+ *
+ * \ref CharacteristicFieldsCompute and
+ * \ref EvolvedFieldsFromCharacteristicFieldsCompute convert between
+ * characteristic and evolved fields for the scalar-wave system in curved
+ * spacetime.
+ *
+ * \ref CharacteristicFieldsCompute computes
+ * characteristic fields as described in "Optimal constraint projection for
+ * hyperbolic evolution systems" by Holst et. al \cite Holst2004wt .
+ * Their names used here differ from this paper:
+ *
+ * \f{align*}
+ * \mathrm{SpECTRE} && \mathrm{Holst} \\
+ * v^{\hat \psi} && Z^1 \\
+ * v^{\hat 0}_{i} && Z^{2}_{i} \\
+ * v^{\hat \pm} && u^{1\pm}
+ * \f}
+ *
+ * The characteristic fields \f$u\f$ are given in terms of the evolved fields by
+ * Eq. (33) - (35) of \cite Holst2004wt, respectively:
+ *
+ * \f{align*}
+ * v^{\hat \psi} =& \psi \\
+ * v^{\hat 0}_{i} =& (\delta^k_i - n_i n^k) \Phi_{k} := P^k_i \Phi_{k} \\
+ * v^{\hat \pm} =& \Pi \pm n^i \Phi_{i} - \gamma_2\psi
+ * \f}
+ *
+ * where \f$\psi\f$ is the scalar field, \f$\Pi\f$ and \f$\Phi_{i}\f$ are
+ * evolved fields introduced by first derivatives of \f$\psi\f$, \f$\gamma_2\f$
+ * is a constraint damping parameter, and \f$n_k\f$ is the unit normal to the
+ * surface.
+ *
+ * \ref EvolvedFieldsFromCharacteristicFieldsCompute computes evolved fields
+ * \f$w\f$ in terms of the characteristic fields. This uses the inverse of
+ * above relations (c.f. Eq. (36) - (38) of \cite Holst2004wt ):
+ *
+ * \f{align*}
+ * \psi =& v^{\hat \psi}, \\
+ * \Pi =& \frac{1}{2}(v^{\hat +} + v^{\hat -}) + \gamma_2 v^{\hat \psi}, \\
+ * \Phi_{i} =& \frac{1}{2}(v^{\hat +} - v^{\hat -}) n_i + v^{\hat 0}_{i}.
+ * \f}
+ *
+ * The corresponding characteristic speeds \f$\lambda\f$ are computed by
+ * \ref CharacteristicSpeedsCompute .
+ */
+template <size_t SpatialDim>
+Variables<
+    tmpl::list<Tags::VPsi, Tags::VZero<SpatialDim>, Tags::VPlus, Tags::VMinus>>
+characteristic_fields(
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::II<DataVector, SpatialDim, Frame::Inertial>&
+        inverse_spatial_metric,
+    const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+        unit_normal_one_form) noexcept;
+
+template <size_t SpatialDim>
+void characteristic_fields(
+    gsl::not_null<Variables<tmpl::list<Tags::VPsi, Tags::VZero<SpatialDim>,
+                                       Tags::VPlus, Tags::VMinus>>*>
+        char_fields,
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::II<DataVector, SpatialDim, Frame::Inertial>&
+        inverse_spatial_metric,
+    const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+        unit_normal_one_form) noexcept;
+
+template <size_t SpatialDim>
+struct CharacteristicFieldsCompute : Tags::CharacteristicFields<SpatialDim>,
+                                     db::ComputeTag {
+  using base = Tags::CharacteristicFields<SpatialDim>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<
+      Tags::ConstraintGamma2,
+      gr::Tags::InverseSpatialMetric<SpatialDim, Frame::Inertial, DataVector>,
+      Psi, Pi, Phi<SpatialDim>,
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<SpatialDim>>>;
+
+  static constexpr void function(
+      gsl::not_null<return_type*> result, const Scalar<DataVector>& gamma_2,
+      const tnsr::II<DataVector, SpatialDim, Frame::Inertial>&
+          inverse_spatial_metric,
+      const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
+      const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi,
+      const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+          unit_normal_one_form) noexcept {
+    characteristic_fields<SpatialDim>(result, gamma_2, inverse_spatial_metric,
+                                      psi, pi, phi, unit_normal_one_form);
+  }
+};
+// @}
+
+// @{
+/*!
+ * \ingroup CurvedScalarWave
+ * \brief For expressions used here to compute evolved fields from
+ * characteristic ones, see \ref CharacteristicFieldsCompute.
+ */
+template <size_t SpatialDim>
+Variables<tmpl::list<Psi, Pi, Phi<SpatialDim>>>
+evolved_fields_from_characteristic_fields(
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+        unit_normal_one_form) noexcept;
+
+template <size_t SpatialDim>
+void evolved_fields_from_characteristic_fields(
+    gsl::not_null<Variables<tmpl::list<Psi, Pi, Phi<SpatialDim>>>*>
+        evolved_fields,
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+        unit_normal_one_form) noexcept;
+
+template <size_t SpatialDim>
+struct EvolvedFieldsFromCharacteristicFieldsCompute
+    : Tags::EvolvedFieldsFromCharacteristicFields<SpatialDim>,
+      db::ComputeTag {
+  using base = Tags::EvolvedFieldsFromCharacteristicFields<SpatialDim>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<
+      Tags::ConstraintGamma2, Tags::VPsi, Tags::VZero<SpatialDim>, Tags::VPlus,
+      Tags::VMinus,
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<SpatialDim>>>;
+
+  static constexpr void function(
+      gsl::not_null<return_type*> result, const Scalar<DataVector>& gamma_2,
+      const Scalar<DataVector>& v_psi,
+      const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& v_zero,
+      const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+      const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+          unit_normal_one_form) noexcept {
+    evolved_fields_from_characteristic_fields<SpatialDim>(
+        result, gamma_2, v_psi, v_zero, v_plus, v_minus, unit_normal_one_form);
+  }
+};
+// @}
+
+/*!
+ * \ingroup CurvedScalarWave
+ * \brief Computes the largest magnitude of the characteristic speeds.
+ */
+template <size_t SpatialDim>
+struct ComputeLargestCharacteristicSpeed {
+  using argument_tags = tmpl::list<Tags::CharacteristicSpeeds<SpatialDim>>;
+  static double apply(const std::array<DataVector, 4>& char_speeds) noexcept;
+};
+}  // namespace CurvedScalarWave

--- a/src/Evolution/Systems/CurvedScalarWave/Constraints.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Constraints.hpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace CurvedScalarWave {
+namespace Tags {
+/*!
+ * \brief Compute items to compute constraint damping parameters.
+ *
+ * \details For the evolution system with constraint damping parameters
+ * to be symmetric-hyperbolic, we need \f$\gamma_1 \gamma_2 = 0\f$. When
+ * \f$\gamma_1 = 0\f$, Ref. \cite Holst2004wt shows that the one-index
+ * constraint decays exponentially on a time-scale \f$ 1/\gamma_2\f$.
+ * Conversely, they also show that using \f$\gamma_2 > 0\f$ leads to
+ * exponential suppression of constraint violations.
+ *
+ * Can be retrieved using `CurvedScalarWave::Tags::ConstraintGamma1`
+ * and `CurvedScalarWave::Tags::ConstraintGamma2`.
+ */
+struct ConstraintGamma1Compute : ConstraintGamma1, db::ComputeTag {
+  using argument_tags = tmpl::list<Psi>;
+  static auto function(const Scalar<DataVector>& used_for_size) noexcept {
+    return make_with_value<type>(used_for_size, 0.);
+  }
+  using base = ConstraintGamma1;
+};
+/// \copydoc ConstraintGamma1Compute
+struct ConstraintGamma2Compute : ConstraintGamma2, db::ComputeTag {
+  using argument_tags = tmpl::list<Psi>;
+  static auto function(const Scalar<DataVector>& used_for_size) noexcept {
+    return make_with_value<type>(used_for_size, 1.);
+  }
+  using base = ConstraintGamma2;
+};
+}  // namespace Tags
+}  // namespace CurvedScalarWave

--- a/src/Evolution/Systems/CurvedScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.cpp
@@ -87,7 +87,7 @@ using derivative_frame = Frame::Inertial;
 #define INSTANTIATION(_, data)                                               \
   template class CurvedScalarWave::ComputeDuDt<DIM(data)>;                   \
   template Variables<                                                        \
-      db::wrap_tags_in<Tags::deriv, derivative_tags<DIM(data)>,              \
+      db::wrap_tags_in<::Tags::deriv, derivative_tags<DIM(data)>,            \
                        tmpl::size_t<DIM(data)>, derivative_frame>>           \
   partial_derivatives<derivative_tags<DIM(data)>, variables_tags<DIM(data)>, \
                       DIM(data), derivative_frame>(                          \

--- a/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
@@ -21,8 +21,10 @@ struct Psi;
 struct Pi;
 template <size_t Dim>
 struct Phi;
+namespace Tags {
 struct ConstraintGamma1;
 struct ConstraintGamma2;
+}  // namespace Tags
 }  // namespace CurvedScalarWave
 /// \endcond
 
@@ -58,20 +60,20 @@ namespace CurvedScalarWave {
 template <size_t Dim>
 struct ComputeDuDt {
   using argument_tags = tmpl::list<
-      Pi, Phi<Dim>, Tags::deriv<Psi, tmpl::size_t<Dim>, Frame::Inertial>,
-      Tags::deriv<Pi, tmpl::size_t<Dim>, Frame::Inertial>,
-      Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
+      Pi, Phi<Dim>, ::Tags::deriv<Psi, tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::deriv<Pi, tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
       gr::Tags::Lapse<DataVector>,
       gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
-      Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
-                  Frame::Inertial>,
-      Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
-                  tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
+                    Frame::Inertial>,
+      ::Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
+                    tmpl::size_t<Dim>, Frame::Inertial>,
       gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
       gr::Tags::TraceSpatialChristoffelSecondKind<Dim, Frame::Inertial,
                                                   DataVector>,
-      gr::Tags::TraceExtrinsicCurvature<DataVector>, ConstraintGamma1,
-      ConstraintGamma2>;
+      gr::Tags::TraceExtrinsicCurvature<DataVector>, Tags::ConstraintGamma1,
+      Tags::ConstraintGamma2>;
 
   static void apply(
       gsl::not_null<Scalar<DataVector>*> dt_pi,

--- a/src/Evolution/Systems/CurvedScalarWave/System.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/System.hpp
@@ -12,7 +12,7 @@
 namespace Tags {
 template <class>
 class Variables;
-} // Namespace Tags
+}  // Namespace Tags
 
 /*!
  * \ingroup EvolutionSystemsGroup
@@ -26,7 +26,7 @@ struct System {
   static constexpr bool has_primitive_and_conservative_vars = false;
   static constexpr size_t volume_dim = Dim;
 
-  using variables_tag = Tags::Variables<tmpl::list<Pi, Phi<Dim>, Psi>>;
+  using variables_tag = ::Tags::Variables<tmpl::list<Pi, Phi<Dim>, Psi>>;
   using gradients_tags = tmpl::list<Pi, Phi<Dim>, Psi>;
 
   using compute_time_derivative = ComputeDuDt<Dim>;

--- a/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
@@ -11,6 +11,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/CurvedScalarWave/TagsDeclarations.hpp"
 
 class DataVector;
 
@@ -31,6 +32,7 @@ struct Phi : db::SimpleTag {
   static std::string name() noexcept { return "Phi"; }
 };
 
+namespace Tags {
 struct ConstraintGamma1 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() noexcept { return "ConstraintGamma1"; }
@@ -40,4 +42,41 @@ struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() noexcept { return "ConstraintGamma2"; }
 };
+
+// @{
+/// \brief Tags corresponding to the characteristic fields of the
+/// scalar-wave system in curved spacetime.
+///
+/// \details For details on how these are defined and computed, \see
+/// CharacteristicSpeedsCompute
+struct VPsi : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+template <size_t Dim>
+struct VZero : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+};
+struct VPlus : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+struct VMinus : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+// @}
+
+template <size_t Dim>
+struct CharacteristicSpeeds : db::SimpleTag {
+  using type = std::array<DataVector, 4>;
+};
+
+template <size_t Dim>
+struct CharacteristicFields : db::SimpleTag {
+  using type = Variables<tmpl::list<VPsi, VZero<Dim>, VPlus, VMinus>>;
+};
+
+template <size_t Dim>
+struct EvolvedFieldsFromCharacteristicFields : db::SimpleTag {
+  using type = Variables<tmpl::list<Psi, Pi, Phi<Dim>>>;
+};
+}  // namespace Tags
 }  // namespace CurvedScalarWave

--- a/src/Evolution/Systems/CurvedScalarWave/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/TagsDeclarations.hpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+namespace CurvedScalarWave {
+struct Psi;
+struct Pi;
+template <size_t Dim>
+struct Phi;
+
+/// \brief Tags for the curved scalar wave system
+namespace Tags {
+struct ConstraintGamma1;
+struct ConstraintGamma2;
+
+struct VPsi;
+template <size_t Dim>
+struct VZero;
+struct VPlus;
+struct VMinus;
+
+template <size_t Dim>
+struct CharacteristicSpeeds;
+template <size_t Dim>
+struct CharacteristicFields;
+template <size_t Dim>
+struct EvolvedFieldsFromCharacteristicFields;
+}  // namespace Tags
+}  // namespace CurvedScalarWave

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_CurvedScalarWave")
 
 set(LIBRARY_SOURCES
   TestHelpers.cpp
+  Test_Characteristics.cpp
   Test_DuDt.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Characteristics.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Characteristics.py
@@ -1,0 +1,69 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+# Test functions for characteristic speeds
+
+
+def char_speed_vpsi(gamma1, lapse, shift, unit_normal):
+    return - (1. + gamma1) * np.dot(shift, unit_normal)
+
+
+def char_speed_vzero(gamma1, lapse, shift, unit_normal):
+    return - np.dot(shift, unit_normal)
+
+
+def char_speed_vplus(gamma1, lapse, shift, unit_normal):
+    return - np.dot(shift, unit_normal) + lapse
+
+
+def char_speed_vminus(gamma1, lapse, shift, unit_normal):
+    return - np.dot(shift, unit_normal) - lapse
+
+# End test functions for characteristic speeds
+
+
+# Test functions for characteristic fields
+
+def char_field_vpsi(gamma2, inverse_spatial_metric, psi,
+                    pi, phi, normal_one_form):
+    return psi
+
+
+def char_field_vzero(gamma2, inverse_spatial_metric, psi,
+                     pi, phi, normal_one_form):
+    normal_vector =\
+        np.einsum('ij,j', inverse_spatial_metric, normal_one_form)
+    projection_tensor = np.identity(len(normal_vector)) -\
+        np.einsum('i,j', normal_one_form, normal_vector)
+    return np.einsum('ij,j->i', projection_tensor, phi)
+
+
+def char_field_vplus(gamma2, inverse_spatial_metric, psi,
+                     pi, phi, normal_one_form):
+    phi_dot_normal = np.einsum(
+        'ij,i,j', inverse_spatial_metric, normal_one_form, phi)
+    return pi + phi_dot_normal - (gamma2 * psi)
+
+
+def char_field_vminus(gamma2, inverse_spatial_metric, psi,
+                      pi, phi, normal_one_form):
+    phi_dot_normal = np.einsum(
+        'ij,i,j', inverse_spatial_metric, normal_one_form, phi)
+    return pi - phi_dot_normal - (gamma2 * psi)
+
+
+def evol_field_psi(gamma2, vpsi, vzero, vplus, vminus, normal_one_form):
+    return vpsi
+
+
+def evol_field_pi(gamma2, vpsi, vzero, vplus, vminus, normal_one_form):
+    return 0.5 * (vplus + vminus) + gamma2 * vpsi
+
+
+def evol_field_phi(gamma2, vpsi, vzero, vplus, vminus, normal_one_form):
+    udiff = 0.5 * (vplus - vminus)
+    return (normal_one_form * udiff) + vzero
+
+# End test functions for characteristic fields

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Characteristics.cpp
@@ -1,0 +1,251 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+namespace {
+template <size_t Index, size_t SpatialDim>
+Scalar<DataVector> speed_with_index(
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& normal) {
+  return Scalar<DataVector>{CurvedScalarWave::characteristic_speeds(
+      gamma_1, lapse, shift, normal)[Index]};
+}
+
+template <size_t SpatialDim>
+void test_characteristic_speeds() noexcept {
+  const DataVector used_for_size(5);
+  pypp::check_with_random_values<1>(speed_with_index<0, SpatialDim>,
+                                    "Characteristics", "char_speed_vpsi",
+                                    {{{-10.0, 10.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(speed_with_index<1, SpatialDim>,
+                                    "Characteristics", "char_speed_vzero",
+                                    {{{-10.0, 10.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(speed_with_index<3, SpatialDim>,
+                                    "Characteristics", "char_speed_vminus",
+                                    {{{-10.0, 10.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(speed_with_index<2, SpatialDim>,
+                                    "Characteristics", "char_speed_vplus",
+                                    {{{-10.0, 10.0}}}, used_for_size);
+}
+}  // namespace
+
+namespace {
+template <typename Tag, size_t SpatialDim>
+typename Tag::type field_with_tag(
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::II<DataVector, SpatialDim, Frame::Inertial>&
+        inverse_spatial_metric,
+    const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& normal_one_form) {
+  return get<Tag>(CurvedScalarWave::characteristic_fields(
+      gamma_2, inverse_spatial_metric, psi, pi, phi, normal_one_form));
+}
+
+template <size_t SpatialDim>
+void test_characteristic_fields() noexcept {
+  const DataVector used_for_size(5);
+  // VPsi
+  pypp::check_with_random_values<1>(
+      field_with_tag<CurvedScalarWave::Tags::VPsi, SpatialDim>,
+      "Characteristics", "char_field_vpsi", {{{-10., 10.}}}, used_for_size);
+  // VZero
+  pypp::check_with_random_values<1>(
+      field_with_tag<CurvedScalarWave::Tags::VZero<SpatialDim>, SpatialDim>,
+      "Characteristics", "char_field_vzero", {{{-10., 10.}}}, used_for_size);
+  // VPlus
+  pypp::check_with_random_values<1>(
+      field_with_tag<CurvedScalarWave::Tags::VPlus, SpatialDim>,
+      "Characteristics", "char_field_vplus", {{{-10., 10.}}}, used_for_size);
+  // VMinus
+  pypp::check_with_random_values<1>(
+      field_with_tag<CurvedScalarWave::Tags::VMinus, SpatialDim>,
+      "Characteristics", "char_field_vminus", {{{-10., 10.}}}, used_for_size);
+}
+}  // namespace
+
+namespace {
+template <typename Tag, size_t SpatialDim>
+typename Tag::type evolved_field_with_tag(
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& u_psi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& u_zero,
+    const Scalar<DataVector>& u_plus, const Scalar<DataVector>& u_minus,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& normal_one_form) {
+  return get<Tag>(CurvedScalarWave::evolved_fields_from_characteristic_fields(
+      gamma_2, u_psi, u_zero, u_plus, u_minus, normal_one_form));
+}
+
+template <size_t SpatialDim>
+void test_evolved_from_characteristic_fields() noexcept {
+  const DataVector used_for_size(5);
+  // Psi
+  pypp::check_with_random_values<1>(
+      evolved_field_with_tag<CurvedScalarWave::Psi, SpatialDim>,
+      "Characteristics", "evol_field_psi", {{{-10., 10.}}}, used_for_size);
+  // Pi
+  pypp::check_with_random_values<1>(
+      evolved_field_with_tag<CurvedScalarWave::Pi, SpatialDim>,
+      "Characteristics", "evol_field_pi", {{{-10., 10.}}}, used_for_size);
+  // Phi
+  pypp::check_with_random_values<1>(
+      evolved_field_with_tag<CurvedScalarWave::Phi<SpatialDim>, SpatialDim>,
+      "Characteristics", "evol_field_phi", {{{-10., 10.}}}, used_for_size);
+}
+
+template <size_t SpatialDim>
+void test_characteristics_compute_tags() noexcept {
+  const DataVector used_for_size(5);
+
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(0.0, 1.0);
+
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+
+  // Randomized tensors
+  const auto gamma_1 = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto gamma_2 = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto lapse = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          nn_generator, nn_distribution, used_for_size);
+  const auto inverse_spatial_metric = make_with_random_values<
+      tnsr::II<DataVector, SpatialDim, Frame::Inertial>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto psi = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto pi = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto phi =
+      make_with_random_values<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
+          nn_generator, nn_distribution, used_for_size);
+  const auto normal =
+      make_with_random_values<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
+          nn_generator, nn_distribution, used_for_size);
+
+  // Insert into databox
+  const auto box = db::create<
+      db::AddSimpleTags<
+          CurvedScalarWave::Tags::ConstraintGamma1,
+          CurvedScalarWave::Tags::ConstraintGamma2, gr::Tags::Lapse<DataVector>,
+          gr::Tags::Shift<SpatialDim, Frame::Inertial, DataVector>,
+          gr::Tags::InverseSpatialMetric<SpatialDim, Frame::Inertial,
+                                         DataVector>,
+          CurvedScalarWave::Psi, CurvedScalarWave::Pi,
+          CurvedScalarWave::Phi<SpatialDim>,
+          ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<SpatialDim>>>,
+      db::AddComputeTags<
+          CurvedScalarWave::CharacteristicSpeedsCompute<SpatialDim>,
+          CurvedScalarWave::CharacteristicFieldsCompute<SpatialDim>>>(
+      gamma_1, gamma_2, lapse, shift, inverse_spatial_metric, psi, pi, phi,
+      normal);
+  // Test compute tag for char speeds
+  CHECK(
+      db::get<CurvedScalarWave::Tags::CharacteristicSpeeds<SpatialDim>>(box) ==
+      CurvedScalarWave::characteristic_speeds(gamma_1, lapse, shift, normal));
+  // Test compute tag for char fields
+  CHECK(
+      db::get<CurvedScalarWave::Tags::CharacteristicFields<SpatialDim>>(box) ==
+      CurvedScalarWave::characteristic_fields(gamma_2, inverse_spatial_metric,
+                                              psi, pi, phi, normal));
+
+  // more randomized tensors
+  const auto u_psi = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto u_zero =
+      make_with_random_values<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
+          nn_generator, nn_distribution, used_for_size);
+  const auto u_plus = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto u_minus = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution, used_for_size);
+  // Insert into databox
+  const auto box2 = db::create<
+      db::AddSimpleTags<
+          CurvedScalarWave::Tags::ConstraintGamma2,
+          CurvedScalarWave::Tags::VPsi,
+          CurvedScalarWave::Tags::VZero<SpatialDim>,
+          CurvedScalarWave::Tags::VPlus, CurvedScalarWave::Tags::VMinus,
+          ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<SpatialDim>>>,
+      db::AddComputeTags<
+          CurvedScalarWave::EvolvedFieldsFromCharacteristicFieldsCompute<
+              SpatialDim>>>(gamma_2, u_psi, u_zero, u_plus, u_minus, normal);
+  // Test compute tag for evolved fields computed from char fields
+  CHECK(db::get<CurvedScalarWave::Tags::EvolvedFieldsFromCharacteristicFields<
+            SpatialDim>>(box2) ==
+        CurvedScalarWave::evolved_fields_from_characteristic_fields(
+            gamma_2, u_psi, u_zero, u_plus, u_minus, normal));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Characteristics",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/CurvedScalarWave/"};
+
+  test_characteristic_speeds<1>();
+  test_characteristic_speeds<2>();
+  test_characteristic_speeds<3>();
+
+  test_characteristic_fields<1>();
+  test_characteristic_fields<2>();
+  test_characteristic_fields<3>();
+
+  test_evolved_from_characteristic_fields<1>();
+  test_evolved_from_characteristic_fields<2>();
+  test_evolved_from_characteristic_fields<3>();
+
+  test_characteristics_compute_tags<1>();
+  test_characteristics_compute_tags<2>();
+  test_characteristics_compute_tags<3>();
+
+  CHECK(CurvedScalarWave::ComputeLargestCharacteristicSpeed<1>::apply(
+            {{DataVector{1., -4., 3.4, 2., 5.},
+              DataVector{22., -8., 190., 6., 4.},
+              DataVector{1., -7., 31., 2., 5.},
+              DataVector{7., 8.9, 4., 2., 1.}}}) == 190.);
+  CHECK(CurvedScalarWave::ComputeLargestCharacteristicSpeed<1>::apply(
+            {{DataVector{1., 4., 3., 2., 5.}, DataVector{2., 8., -10., 6., 4.},
+              DataVector{1., 7., 3., -11., 5.},
+              DataVector{7., 3., 4., 2., 1.}}}) == 11.);
+
+  CHECK(CurvedScalarWave::ComputeLargestCharacteristicSpeed<2>::apply(
+            {{DataVector{1., -4., 3.4, 2., 5.},
+              DataVector{22., -8., 190., 6., 4.},
+              DataVector{1., -7., 31., 2., 5.},
+              DataVector{7., 8.9, 4., 2., 1.}}}) == 190.);
+  CHECK(CurvedScalarWave::ComputeLargestCharacteristicSpeed<2>::apply(
+            {{DataVector{1., 4., 3., 2., 5.}, DataVector{2., 8., -10., 6., 4.},
+              DataVector{1., 7., 3., -11., 5.},
+              DataVector{7., 3., 4., 2., 1.}}}) == 11.);
+
+  CHECK(CurvedScalarWave::ComputeLargestCharacteristicSpeed<3>::apply(
+            {{DataVector{1., -4., 3.4, 2., 5.},
+              DataVector{22., -8., 190., 6., 4.},
+              DataVector{1., -7., 31., 2., 5.},
+              DataVector{7., 8.9, 4., 2., 1.}}}) == 190.);
+  CHECK(CurvedScalarWave::ComputeLargestCharacteristicSpeed<3>::apply(
+            {{DataVector{1., 4., 3., 2., 5.}, DataVector{2., 8., -10., 6., 4.},
+              DataVector{1., 7., 3., -11., 5.},
+              DataVector{7., 3., 4., 2., 1.}}}) == 11.);
+}


### PR DESCRIPTION
## Proposed changes

For the scalar wave system in curved background spacetime, this PR adds:
 * simple tags for characteristics,
 * functions to convert between fundamental and characteristic fields, 
 * corresponding compute tags,
 * their unit tests.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).