### PR TITLE
Improve Python module configuration with CMake

### DIFF
--- a/cmake/SpectreSetupPython.cmake
+++ b/cmake/SpectreSetupPython.cmake
@@ -55,11 +55,14 @@ configure_file(
 # - SOURCES       The C++ source files for bindings. Omit if no bindings
 #                 are being generated.
 #
+# - LIBRARY_NAME  The name of the C++ libray, e.g. PyDataStructures.
+#                 Required if SOURCES are specified. Must begin with "Py".
+#
 # - PYTHON_FILES  List of the python files (relative to
 #                 ${CMAKE_SOURCE_DIR}/src) to add to the module. Omit if
 #                 no python files are to be provided.
 function(SPECTRE_PYTHON_ADD_MODULE MODULE_NAME)
-  set(SINGLE_VALUE_ARGS MODULE_PATH)
+  set(SINGLE_VALUE_ARGS MODULE_PATH LIBRARY_NAME)
   set(MULTI_VALUE_ARGS SOURCES PYTHON_FILES)
   cmake_parse_arguments(
     ARG ""
@@ -81,19 +84,27 @@ function(SPECTRE_PYTHON_ADD_MODULE MODULE_NAME)
 
   # Add our python library, if it has sources
   set(SPECTRE_PYTHON_MODULE_IMPORT "")
-  if(NOT "${ARG_SOURCES}" STREQUAL "")
-    add_library("Py${MODULE_NAME}" MODULE ${ARG_SOURCES})
+  if(BUILD_PYTHON_BINDINGS AND NOT "${ARG_SOURCES}" STREQUAL "")
+    if("${ARG_LIBRARY_NAME}" STREQUAL "")
+      message(FATAL_ERROR "Set a LIBRARY_NAME for Python module "
+          "'${MODULE_NAME}' that has sources.")
+    endif()
+    if(NOT "${ARG_LIBRARY_NAME}" MATCHES "^Py")
+      message(FATAL_ERROR "The LIBRARY_NAME for Python module "
+          "'${MODULE_NAME}' must begin with 'Py' but is '${ARG_LIBRARY_NAME}'.")
+    endif()
+    add_library(${ARG_LIBRARY_NAME} MODULE ${ARG_SOURCES})
     # We don't want the 'lib' prefix for python modules, so we set the output name
     SET_TARGET_PROPERTIES(
-      "Py${MODULE_NAME}"
+      ${ARG_LIBRARY_NAME}
       PROPERTIES
       PREFIX ""
-      LIBRARY_OUTPUT_NAME "_${MODULE_NAME}"
+      LIBRARY_OUTPUT_NAME "_${ARG_LIBRARY_NAME}"
       LIBRARY_OUTPUT_DIRECTORY ${MODULE_LOCATION}
       )
-    set(SPECTRE_PYTHON_MODULE_IMPORT "from ._${MODULE_NAME} import *")
-    add_dependencies(test-executables "Py${MODULE_NAME}")
-  endif(NOT "${ARG_SOURCES}" STREQUAL "")
+    set(SPECTRE_PYTHON_MODULE_IMPORT "from ._${ARG_LIBRARY_NAME} import *")
+    add_dependencies(test-executables ${ARG_LIBRARY_NAME})
+  endif(BUILD_PYTHON_BINDINGS AND NOT "${ARG_SOURCES}" STREQUAL "")
 
   # Read the __init__.py file if it exists
   set(INIT_FILE_LOCATION "${MODULE_LOCATION}/__init__.py")
@@ -204,6 +215,31 @@ function(SPECTRE_PYTHON_ADD_MODULE MODULE_NAME)
   endwhile(NOT ${CURRENT_MODULE} STREQUAL ${SPECTRE_PYTHON_PREFIX})
 endfunction()
 
+# Link with the LIBRARIES if Python bindings are being built
+function (spectre_python_link_libraries LIBRARY_NAME)
+  if(NOT BUILD_PYTHON_BINDINGS)
+    return()
+  endif()
+  target_link_libraries(
+    ${LIBRARY_NAME}
+    # Forward all remaining arguments
+    ${ARGN}
+    ${SPECTRE_LINK_PYBINDINGS}
+    )
+endfunction()
+
+# Add the DEPENDENCIES if Python bindings are being built
+function (spectre_python_add_dependencies LIBRARY_NAME)
+  if(NOT BUILD_PYTHON_BINDINGS)
+    return()
+  endif()
+  add_dependencies(
+    ${LIBRARY_NAME}
+    # Forward all remaining arguments
+    ${ARGN}
+    )
+endfunction()
+
 # Register a python test file with ctest.
 # - TEST_NAME    The name of the test,
 #                e.g. "Unit.DataStructures.Python.DataVector"
@@ -211,11 +247,8 @@ endfunction()
 # - FILE         The file to add, e.g. Test_DataVector.py
 #
 # - TAGS         A semicolon separated list of labels for the test,
-#                e.g. "unit;DataStructures;python"
+#                e.g. "Unit;DataStructures;Python"
 function(SPECTRE_ADD_PYTHON_TEST TEST_NAME FILE TAGS)
-  if(NOT BUILD_PYTHON_BINDINGS)
-    return()
-  endif()
   get_filename_component(FILE "${FILE}" ABSOLUTE)
   string(TOLOWER "${TAGS}" TAGS)
 
@@ -236,4 +269,19 @@ function(SPECTRE_ADD_PYTHON_TEST TEST_NAME FILE TAGS)
     LABELS "${TAGS}"
     ENVIRONMENT "PYTHONPATH=${SPECTRE_PYTHON_PREFIX_PARENT}:\$PYTHONPATH"
     )
+endfunction()
+
+# Register a python test file that uses bindings with ctest.
+# - TEST_NAME    The name of the test,
+#                e.g. "Unit.DataStructures.Python.DataVector"
+#
+# - FILE         The file to add, e.g. Test_DataVector.py
+#
+# - TAGS         A semicolon separated list of labels for the test,
+#                e.g. "Unit;DataStructures;Python"
+function(SPECTRE_ADD_PYTHON_BINDINGS_TEST TEST_NAME FILE TAGS)
+  if(NOT BUILD_PYTHON_BINDINGS)
+    return()
+  endif()
+  spectre_add_python_test(${TEST_NAME} ${FILE} ${TAGS})
 endfunction()

--- a/cmake/SpectreSetupPython.cmake
+++ b/cmake/SpectreSetupPython.cmake
@@ -240,6 +240,24 @@ function (spectre_python_add_dependencies LIBRARY_NAME)
     )
 endfunction()
 
+add_custom_target(python-executables)
+
+# Register a Python file as an executable. It will be symlinked to bin/.
+# - EXECUTABLE_NAME   The name of the executable in bin/
+#
+# - EXECUTABLE_PATH   Path to the Python file within the Python package,
+#                     e.g. "Visualization/GenerateXdmf.py"
+#                     Note this is the path within the Python package that was
+#                     configured by calling `spectre_python_add_module`, _not_
+#                     the path to the Python file in `src/`.
+function (spectre_python_add_executable EXECUTABLE_NAME EXECUTABLE_PATH)
+  add_custom_target(${EXECUTABLE_NAME} ALL
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+    "${SPECTRE_PYTHON_PREFIX}/${EXECUTABLE_PATH}"
+    "${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME}")
+  add_dependencies(python-executables ${EXECUTABLE_NAME})
+endfunction()
+
 # Register a python test file with ctest.
 # - TEST_NAME    The name of the test,
 #                e.g. "Unit.DataStructures.Python.DataVector"

--- a/docs/DevGuide/PythonBindings.md
+++ b/docs/DevGuide/PythonBindings.md
@@ -19,11 +19,12 @@ python module, be it with or without bindings, easy.  The python bindings are
 built only if `-D BUILD_PYTHON_BINDINGS=ON` is passed when invoking cmake.
 
 The function `spectre_python_add_module` takes as its first argument the module,
-in our case
-`DataStructures`. The bindings library will be prefixed with `Py`, and therefore
-be called `PyDataStructures`. Optionally, a list of `SOURCES` can be passed to
-the CMake function. If the python module will only consist of python files, then
-the `SOURCES` option should not be specified. Python files that should be part
+in our case `DataStructures`. Optionally, a list of `SOURCES` can be passed to
+the CMake function. If you specify `SOURCES`, you must also specify a
+`LIBRARY_NAME`. A good `LIBRARY_NAME` is the name of the C++ library for which
+bindings are being built prefixed with `Py`, e.g. `PyDataStructures`. If the
+Python module will only consist of Python files, then the `SOURCES` option
+should not be specified. Python files that should be part
 of the module can be passed with the keyword `PYTHON_FILES`, e.g.
 `PYTHON_FILES Hello.py HelloWorld.py`. Finally, the `MODULE_PATH` named argument
 can be passed with a string that is the path to where the module should be. For
@@ -35,27 +36,37 @@ function:
 
 \code
 spectre_python_add_module(
-  ExtraDataStructures
+  Extra
+  LIBRARY_NAME "PyExtraDataStructures"
   MODULE_PATH "DataStructures/"
   SOURCES Bindings.cpp MyCoolDataStructure.cpp
   PYTHON_FILES CoolPythonDataStructure.py
   )
 \endcode
 
-The library that is added has the name `PyExtraDataStructures` and requires that
-at least the `${SPECTRE_LINK_PYBINDINGS}` be set as the last entry to the
-`target_link_libraries` call. For example,
+The library that is added has the name `PyExtraDataStructures`. Make sure to
+call `spectre_python_link_libraries` for every Python module that compiles
+`SOURCES`. For example,
 
 \code
-target_link_libraries(
+spectre_python_link_libraries(
   PyExtraDataStructures
   PUBLIC ExtraDataStructures
-  ${SPECTRE_LINK_PYBINDINGS}
   )
 \endcode
 
-\warning `${SPECTRE_LINK_PYBINDINGS}` must be the *last* argument to
-`target_link_libraries`.
+You may also call `spectre_python_add_dependencies` for Python modules that
+have `SOURCES`, e.g.
+
+\code
+spectre_python_add_dependencies(
+  PyExtraDataStructures
+  PyDataStructures
+  )
+\endcode
+
+Note that these functions will skip adding or configure any C++ libraries if
+the `BUILD_PYTHON_BINDINGS` flag is `OFF`.
 
 ## Writing Bindings
 
@@ -77,14 +88,16 @@ namespace py_bindings {
 void bind_datavector();
 }  // namespace py_bindings
 
-BOOST_PYTHON_MODULE(_DataStructures) {
+BOOST_PYTHON_MODULE(_PyDataStructures) {
   Py_Initialize();
   py_bindings::bind_datavector();
 }
 \endcode
 
 Note that the library name is passed to `BOOST_PYTHON_MODULE` and is prefixed
-with an underscore. The underscore is important!
+with an underscore. The underscore is important and the library name must be the
+same that is passed as `LIBRARY_NAME` to `spectre_python_add_module` (see
+above).
 
 The `DataVector` bindings serve as an example with code comments on how to write
 bindings for a class. There is also extensive documentation available directly
@@ -111,14 +124,13 @@ All the test cases should be in a single class so that the python unit testing
 framework will run all test functions on a single invocation to avoid startup
 cost.
 
-Below is an example of registering a python test file
+Below is an example of registering a python test file for bindings:
 
-\code
-spectre_add_python_test(
-  "Unit.DataStructures.Python.DataVector"
-  Test_DataVector.py
-  "unit;datastructures;python")
-\endcode
+\snippet tests/Unit/DataStructures/CMakeLists.txt example_add_pybindings_test
+
+Python code that does not use bindings must also be tested. You can register the
+test file using the `spectre_add_python_test` CMake function with the same
+signature as shown above.
 
 ## Using The Bindings
 

--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -19,6 +19,4 @@ target_link_libraries(
   INTERFACE ErrorHandling
   )
 
-if(BUILD_PYTHON_BINDINGS)
-  add_subdirectory(Python)
-endif()
+add_subdirectory(Python)

--- a/src/DataStructures/Python/Bindings.cpp
+++ b/src/DataStructures/Python/Bindings.cpp
@@ -27,7 +27,7 @@ void bind_datavector();
 void bind_matrix();
 }  // namespace py_bindings
 
-BOOST_PYTHON_MODULE(_DataStructures) {
+BOOST_PYTHON_MODULE(_PyDataStructures) {
   Py_Initialize();
   import_array();
   py_bindings::bind_datavector();

--- a/src/DataStructures/Python/CMakeLists.txt
+++ b/src/DataStructures/Python/CMakeLists.txt
@@ -5,14 +5,14 @@ set(LIBRARY "PyDataStructures")
 
 spectre_python_add_module(
   DataStructures
+  LIBRARY_NAME ${LIBRARY}
   SOURCES
   Bindings.cpp
   DataVector.cpp
   Matrix.cpp
   )
 
-target_link_libraries(
+spectre_python_link_libraries(
   ${LIBRARY}
   PUBLIC DataStructures
-  ${SPECTRE_LINK_PYBINDINGS}
   )

--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -29,6 +29,4 @@ target_link_libraries(
   INTERFACE Utilities
   )
 
-if(BUILD_PYTHON_BINDINGS)
-  add_subdirectory(H5/Python)
-endif()
+add_subdirectory(H5/Python)

--- a/src/IO/H5/Python/Bindings.cpp
+++ b/src/IO/H5/Python/Bindings.cpp
@@ -28,7 +28,7 @@ void bind_h5dat();
 void bind_h5vol();
 }  // namespace py_bindings
 
-BOOST_PYTHON_MODULE(_H5) {
+BOOST_PYTHON_MODULE(_PyH5) {
   Py_Initialize();
   import_array();
   py_bindings::bind_h5file();

--- a/src/IO/H5/Python/CMakeLists.txt
+++ b/src/IO/H5/Python/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "PyH5")
 
 spectre_python_add_module(
   H5
+  LIBRARY_NAME ${LIBRARY}
   SOURCES
   Bindings.cpp
   Dat.cpp
@@ -13,15 +14,14 @@ spectre_python_add_module(
   MODULE_PATH "IO/"
   )
 
-target_link_libraries(
+spectre_python_link_libraries(
   ${LIBRARY}
   PUBLIC IO
   PUBLIC DataStructures
   PUBLIC Informer
-  ${SPECTRE_LINK_PYBINDINGS}
   )
 
-add_dependencies(
+spectre_python_add_dependencies(
   ${LIBRARY}
   PyDataStructures
   )

--- a/src/Informer/CMakeLists.txt
+++ b/src/Informer/CMakeLists.txt
@@ -16,6 +16,4 @@ target_link_libraries(
   INTERFACE ErrorHandling
   )
 
-if(BUILD_PYTHON_BINDINGS)
-  add_subdirectory(Python)
-endif()
+add_subdirectory(Python)

--- a/src/Informer/Python/Bindings.cpp
+++ b/src/Informer/Python/Bindings.cpp
@@ -7,7 +7,7 @@ namespace py_bindings {
 void bind_info_at_compile();
 }  // namespace py_bindings
 
-BOOST_PYTHON_MODULE(_Informer) {
+BOOST_PYTHON_MODULE(_PyInformer) {
   Py_Initialize();
   py_bindings::bind_info_at_compile();
 }

--- a/src/Informer/Python/CMakeLists.txt
+++ b/src/Informer/Python/CMakeLists.txt
@@ -5,13 +5,13 @@ set(LIBRARY "PyInformer")
 
 spectre_python_add_module(
   Informer
+  LIBRARY_NAME ${LIBRARY}
   SOURCES
   Bindings.cpp
   InfoAtCompile.cpp
 )
 
-target_link_libraries(
+spectre_python_link_libraries(
   ${LIBRARY}
   PUBLIC Informer
-  ${SPECTRE_LINK_PYBINDINGS}
   )

--- a/src/Visualization/CMakeLists.txt
+++ b/src/Visualization/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-if(BUILD_PYTHON_BINDINGS)
-  add_subdirectory(Python)
-endif()
+add_subdirectory(Python)

--- a/src/Visualization/Python/CMakeLists.txt
+++ b/src/Visualization/Python/CMakeLists.txt
@@ -8,3 +8,8 @@ spectre_python_add_module(
   PYTHON_FILES
   Visualization/Python/GenerateXdmf.py
   )
+
+spectre_python_add_executable(
+  GenerateXdmf
+  Visualization/GenerateXdmf.py
+)

--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 # Distributed under the MIT License.
 # See LICENSE.txt for details.

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -44,11 +44,13 @@ add_test_library(
   "DataStructures;Utilities"
   )
 
-spectre_add_python_test(
+# [example_add_pybindings_test]
+spectre_add_python_bindings_test(
   "Unit.DataStructures.Python.DataVector"
   Test_DataVector.py
-  "unit;datastructures;python")
-spectre_add_python_test(
+  "Unit;DataStructures;Python")
+# [example_add_pybindings_test]
+spectre_add_python_bindings_test(
   "Unit.DataStructures.Python.Matrix"
   Test_Matrix.py
-  "unit;datastructures;python")
+  "Unit;DataStructures;Python")

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -29,12 +29,12 @@ add_dependencies(
   module_ConstGlobalCache
   )
 
-spectre_add_python_test(
+spectre_add_python_bindings_test(
   "Unit.IO.H5.Python"
   "Test_H5.py"
   "unit;IO;H5;python")
 
-spectre_add_python_test(
+spectre_add_python_bindings_test(
   "Unit.IO.H5.VolumeData.Python"
   "Test_VolumeData.py"
   "unit;IO;H5;Python"

--- a/tests/Unit/Informer/CMakeLists.txt
+++ b/tests/Unit/Informer/CMakeLists.txt
@@ -13,7 +13,7 @@ add_test_library(
   "${LIBRARY_SOURCES}"
   "Informer;Utilities"
   )
-spectre_add_python_test(
+spectre_add_python_bindings_test(
   "Unit.Informer.Python"
   "Test_InfoAtCompile.py"
   "Unit;Informer;Python")

--- a/tests/Unit/Visualization/CMakeLists.txt
+++ b/tests/Unit/Visualization/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-if(BUILD_PYTHON_BINDINGS)
-  add_subdirectory(Python)
-endif()
+add_subdirectory(Python)


### PR DESCRIPTION
## Proposed changes

- Remove the explicit `if(BUILD_PYTHON_BINDINGS)` checks in favor of checking this within the cmake helper functions.
- Build the Python modules that need no C++ bindings independently of the `BUILD_PYTHON_BINDINGS` flag.
- Allow Python module names that are different from their C++ library names. E.g. the C++ library `PyGeneralRelativitySolutions` should be exposed in Python as `AnalyticSolutions.GeneralRelativity`, _not_ `AnalyticSolutions.GeneralRelativitySolutions`.
- Allow exposing Python files as executables in `bin/`.

Closes #1758.