### PR TITLE
Fix Test_EquationsOfState CMake configuration

### DIFF
--- a/cmake/SetupBuildStageTargets.cmake
+++ b/cmake/SetupBuildStageTargets.cmake
@@ -83,6 +83,7 @@ add_dependencies(test-libs-pointwise-functions
   Test_GrMhdAnalyticData
   Test_BurgersSolutions
   Test_ElasticitySolutions
+  Test_EquationsOfState
   Test_GeneralRelativitySolutions
   Test_GrMhdSolutions
   Test_NewtonianEulerSolutions

--- a/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -1,12 +1,11 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(EquationsOfState)
+
 set(LIBRARY "Test_Hydro")
 
 set(LIBRARY_SOURCES
-  EquationsOfState/Test_DarkEnergyFluid.cpp
-  EquationsOfState/Test_IdealFluid.cpp
-  EquationsOfState/Test_PolytropicFluid.cpp
   Test_LorentzFactor.cpp
   Test_MassFlux.cpp
   Test_SpecificEnthalpy.cpp

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -7,12 +7,11 @@ set(LIBRARY_SOURCES
   Test_DarkEnergyFluid.cpp
   Test_IdealFluid.cpp
   Test_PolytropicFluid.cpp
-  Test_SpecificEnthalpy.cpp
   )
 
 add_test_library(
   ${LIBRARY}
   "PointwiseFunctions/Hydro/EquationsOfState/"
   "${LIBRARY_SOURCES}"
-  "EquationsOfState;DataStructures;Utilities"
+  "DataStructures;Hydro"
   )


### PR DESCRIPTION
The Test_EquationsOfState library was not built before.
