### PR TITLE
Add Python bindings for EOS and TOV solution

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -20,3 +20,5 @@ target_link_libraries(
   INTERFACE GeneralRelativity
   INTERFACE Interpolation
   )
+
+add_subdirectory(Python)

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Bindings.cpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <boost/python.hpp>
+
+namespace gr {
+namespace Solutions {
+namespace py_bindings {
+void bind_tov();
+}  // namespace py_bindings
+}  // namespace Solutions
+}  // namespace gr
+
+BOOST_PYTHON_MODULE(_PyGeneralRelativitySolutions) {
+  Py_Initialize();
+  gr::Solutions::py_bindings::bind_tov();
+}

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PyGeneralRelativitySolutions")
+
+spectre_python_add_module(
+  GeneralRelativity
+  LIBRARY_NAME ${LIBRARY}
+  MODULE_PATH "PointwiseFunctions/AnalyticSolutions"
+  SOURCES
+  Bindings.cpp
+  Tov.cpp
+  )
+
+spectre_python_link_libraries(
+  ${LIBRARY}
+  PUBLIC GeneralRelativitySolutions
+  )
+
+spectre_python_add_dependencies(
+  ${LIBRARY}
+  PyEquationsOfState
+  )

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Tov.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Tov.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <boost/python.hpp>
+#include <string>
+
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+
+namespace bp = boost::python;
+
+namespace gr {
+namespace Solutions {
+namespace py_bindings {
+
+void bind_tov() {
+  bp::class_<TovSolution, boost::noncopyable>(
+      "Tov",
+      // boost::python receives no compile-time information on default
+      // arguments, so we don't expose them to Python for now. We could write
+      // thin wrappers for them if we needed to:
+      // https://www.boost.org/doc/libs/1_66_0/libs/python/doc/html/tutorial/tutorial/functions.html#tutorial.functions.default_arguments
+      bp::init<const EquationsOfState::EquationOfState<true, 1>&, double>(
+          (bp::arg("equation_of_state"), bp::arg("central_mass_density"))))
+      .def("outer_radius", &TovSolution::outer_radius)
+      .def("mass_over_radius", &TovSolution::mass_over_radius)
+      .def("mass", &TovSolution::mass)
+      .def("log_specific_enthalpy", &TovSolution::log_specific_enthalpy);
+}
+
+}  // namespace py_bindings
+}  // namespace Solutions
+}  // namespace gr

--- a/src/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -19,3 +19,7 @@ target_link_libraries(
   INTERFACE DataStructures
   INTERFACE ErrorHandling
   )
+
+if(BUILD_PYTHON_BINDINGS)
+  add_subdirectory(EquationsOfState/Python)
+endif()

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Bindings.cpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <boost/python.hpp>
+
+namespace EquationsOfState {
+namespace py_bindings {
+void bind_equation_of_state();
+void bind_polytropic_fluid();
+}  // namespace py_bindings
+}  // namespace EquationsOfState
+
+BOOST_PYTHON_MODULE(_PyEquationsOfState) {
+  Py_Initialize();
+  EquationsOfState::py_bindings::bind_equation_of_state();
+  EquationsOfState::py_bindings::bind_polytropic_fluid();
+}

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PyEquationsOfState")
+
+spectre_python_add_module(
+  EquationsOfState
+  LIBRARY_NAME ${LIBRARY}
+  MODULE_PATH "PointwiseFunctions/Hydro"
+  SOURCES
+  Bindings.cpp
+  EquationOfState.cpp
+  PolytropicFluid.cpp
+  )
+
+spectre_python_link_libraries(
+  ${LIBRARY}
+  PUBLIC DataStructures
+  PUBLIC Hydro
+  )

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/EquationOfState.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/EquationOfState.cpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <boost/python.hpp>
+#include <string>
+
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+
+namespace bp = boost::python;
+
+namespace EquationsOfState {
+namespace py_bindings {
+
+void bind_equation_of_state() {
+  // This is a virtual base class, so we expose it only to use it in Python
+  // wrappers of derived classes.
+  bp::class_<EquationOfState<true, 1>, boost::noncopyable>(
+      "RelativisticEquationOfState1D", bp::no_init);
+}
+
+}  // namespace py_bindings
+}  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/PolytropicFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/PolytropicFluid.cpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <boost/python.hpp>
+#include <string>
+
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+
+namespace bp = boost::python;
+
+namespace EquationsOfState {
+namespace py_bindings {
+
+void bind_polytropic_fluid() {
+  // We can't expose any member functions without wrapping tensors in Python,
+  // so we only expose the initializer for now.
+  bp::class_<PolytropicFluid<true>, bp::bases<EquationOfState<true, 1>>>(
+      "RelativisticPolytropicFluid",
+      bp::init<double, double>(
+          (bp::arg("polytropic_constant"), bp::arg("polytropic_exponent"))));
+}
+
+}  // namespace py_bindings
+}  // namespace EquationsOfState

--- a/src/PythonBindings/CharmCompatibility.cpp
+++ b/src/PythonBindings/CharmCompatibility.cpp
@@ -4,6 +4,8 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <pup.h>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -11,6 +13,8 @@
 // provide resonable replacements for them. Getting the correct Charm++ library
 // linked is non-trivial since Charm++ generally wants you to use their `charmc`
 // script, but we want to avoid that.
+
+/// \cond
 
 __attribute__ ((format (printf, 1, 2)))
 // NOLINTNEXTLINE(cert-dcl50-cpp)
@@ -66,3 +70,48 @@ std::string get_library_versions() noexcept {
 
 std::string get_paths() noexcept { return "Not supported in python."; }
 }  // namespace formaline
+
+/*
+ * PUP::able support
+ *
+ * Here we provide dummy-implementations of functions in Charm++'s `pup.h` so
+ * that we can write Python wrappers for classes that derive from `PUP::able`.
+ * These functions are not intended to be called, so we throw exceptions that
+ * propagate to Python and provide an error message when one of the functions
+ * gets called accidentally.
+ */
+
+// Destructor will be called in Python, but doesn't need to do anything
+PUP::able::~able() = default;
+
+// gcc suggests to mark these functions `noreturn`, but they are declared in
+// pup.h
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=noreturn"
+#endif  // defined(__GNUC__) && !defined(__clang__)
+
+void PUP::able::pup(PUP::er& /*p*/) {
+  throw std::runtime_error{
+      "The function 'PUP::able::pup' is provided for compatibility with "
+      "Charm++ and is not intended to be called."};
+}
+
+PUP::able::PUP_ID PUP::able::register_constructor(const char* /*className*/,
+                                                  constructor_function /*fn*/) {
+  throw std::runtime_error{
+      "The function 'PUP::able::register_constructor' is provided for "
+      "compatibility with Charm++ and is not intended to be called."};
+}
+
+PUP::able* PUP::able::clone() const {
+  throw std::runtime_error{
+      "The function 'PUP::able::clone' is provided for compatibility with "
+      "Charm++ and is not intended to be called."};
+}
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif  // defined(__GNUC__) && !defined(__clang__)
+
+/// \endcond

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -17,3 +17,5 @@ add_test_library(
   "${LIBRARY_SOURCES}"
   "Test_Pypp;GeneralRelativitySolutions;GeneralizedHarmonic;GeneralRelativity;Utilities"
   )
+
+add_subdirectory(Python)

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_add_python_test(
+  "Unit.AnalyticSolutions.GeneralRelativity.Python.Tov"
+  "Test_Tov.py"
+  "Unit;PointwiseFunctions;Python")

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Test_Tov.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Test_Tov.py
@@ -1,0 +1,27 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import spectre.PointwiseFunctions.AnalyticSolutions.GeneralRelativity \
+    as spectre_gr_solutions
+import spectre.PointwiseFunctions.Hydro.EquationsOfState as spectre_eos
+
+import unittest
+
+
+class TestTov(unittest.TestCase):
+    def test_creation(self):
+        eos = spectre_eos.RelativisticPolytropicFluid(
+            polytropic_constant=8, polytropic_exponent=2)
+        tov = spectre_gr_solutions.Tov(
+            equation_of_state=eos, central_mass_density=1e-3)
+        # Just making sure we can call the member functions
+        outer_radius = tov.outer_radius()
+        self.assertAlmostEqual(outer_radius, 3.4685521362)
+        self.assertAlmostEqual(tov.mass(outer_radius), 0.0531036941)
+        self.assertAlmostEqual(
+            tov.mass_over_radius(outer_radius) * outer_radius, 0.0531036941)
+        self.assertAlmostEqual(tov.log_specific_enthalpy(outer_radius), 0.)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -15,3 +15,5 @@ add_test_library(
   "${LIBRARY_SOURCES}"
   "DataStructures;Hydro"
   )
+
+add_subdirectory(Python)

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_add_python_test(
+  "Unit.Hydro.EquationsOfState.Python.PolytropicFluid"
+  "Test_PolytropicFluid.py"
+  "Unit;EquationsOfState;Python")

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/Test_PolytropicFluid.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/Test_PolytropicFluid.py
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import spectre.PointwiseFunctions.Hydro.EquationsOfState as spectre_eos
+
+import unittest
+
+
+class TestPolytropicFluid(unittest.TestCase):
+    def test_creation(self):
+        # This class currently exposes no functionality, so we can't test
+        # anything but its base class and that it can be instantiated.
+        eos = spectre_eos.RelativisticPolytropicFluid(
+            polytropic_constant=100., polytropic_exponent=2.)
+        self.assertTrue(
+            isinstance(eos, spectre_eos.RelativisticEquationOfState1D))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Gets some of the technical difficulties out of the way for adding more Python bindings, and adds bindings for the polytropic EOS and the TOV solution.

- [x] The first commit is factored into #1763 

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
