### PR TITLE
Add "protocols" to define metaprogramming interfaces

### DIFF
--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -2,6 +2,10 @@
 # See LICENSE.txt for details.
 
 option(DEBUG_SYMBOLS "Add -g to CMAKE_CXX_FLAGS if ON, -g0 if OFF." ON)
+option(SPECTRE_ALWAYS_CHECK_PROTOCOL_CONFORMANCE
+  "Rigorously check protocol conformance instead of deferring to unit tests. \
+May significantly increase compile time."
+  OFF)
 
 option(OVERRIDE_ARCH "The architecture to use. Default is native." OFF)
 
@@ -40,3 +44,15 @@ add_definitions(-DBOOST_SP_DISABLE_THREADS)
 # Note: This header guard hasn't changed since 2002 so it seems not too insane
 # to rely on.
 add_definitions(-DBOOST_MULTI_ARRAY_TYPES_RG071801_HPP)
+
+# Also enable rigorous protocol conformance checks in debug builds. If we find
+# that debug builds increase in compile time significantly we can disable this.
+if (${SPECTRE_ALWAYS_CHECK_PROTOCOL_CONFORMANCE}
+    OR "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+  if (${SPECTRE_ALWAYS_CHECK_PROTOCOL_CONFORMANCE})
+    message(STATUS "Enable rigorous protocol conformance checks")
+  else()
+    message(STATUS "Enable rigorous protocol conformance checks in Debug build")
+  endif()
+  add_definitions(-DSPECTRE_ALWAYS_CHECK_PROTOCOL_CONFORMANCE)
+endif()

--- a/docs/DevGuide/DevGuide.md
+++ b/docs/DevGuide/DevGuide.md
@@ -40,6 +40,7 @@ can be found here.
 Designed to give the reader an introduction to SpECTRE's most recurring
 concepts and patterns.
 - \ref databox_foundations "Towards SpECTRE's DataBox"
+- \ref protocols "Protocols: metaprogramming interfaces"
 
 ### Technical Documentation for Fluent Developers
 Assumes a thorough familiarity and fluency in SpECTRE's usage of TMP.

--- a/docs/DevGuide/Protocols.md
+++ b/docs/DevGuide/Protocols.md
@@ -1,0 +1,153 @@
+\cond NEVER
+Distributed under the MIT License.
+See LICENSE.txt for details.
+\endcond
+# Protocols {#protocols}
+
+\tableofcontents
+
+# Overview of protocols {#protocols_overview}
+
+Protocols are a concept we use in SpECTRE to define metaprogramming interfaces.
+A variation of this concept is built into many languages, so this is a quote
+from the [Swift documentation](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html):
+
+> A protocol defines a blueprint of methods, properties, and other requirements
+> that suit a particular task or piece of functionality. The protocol can then
+> be adopted by a class, structure, or enumeration to provide an actual
+> implementation of those requirements. Any type that satisfies the requirements
+> of a protocol is said to conform to that protocol.
+
+You should define a protocol when you need a template parameter to conform to an
+interface. Protocols are implemented as unary type traits. Here is an example of
+a protocol that is adapted from the
+[Swift documentation](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html):
+
+\snippet Utilities/Test_ProtocolHelpers.cpp named_protocol
+
+The protocol defines an interface that any type that adopts it must implement.
+For example, the following class conforms to the protocol we just defined:
+
+\snippet Utilities/Test_ProtocolHelpers.cpp named_conformance
+
+The class indicates it conforms to the protocol by (publicly) inheriting from
+`tt::ConformsTo<TheProtocol>`.
+
+Once you have defined a protocol, you can check if a class conforms to it using
+the `tt::conforms_to` metafunction:
+
+\snippet Utilities/Test_ProtocolHelpers.cpp conforms_to
+
+Note that checking for protocol conformance is cheap, because the
+`tt::conforms_to` metafunction only checks if the class _indicates_ it conforms
+to the protocol via the above inheritance. The rigorous test whether the class
+actually fullfills all of the protocol's requirements is deferred to its unit
+tests (see \ref protocols_testing_conformance). Therefore you may freely use
+protocol conformance checks in your code.
+
+This is how you can write code that relies on the interface defined by the
+protocol:
+
+\snippet Utilities/Test_ProtocolHelpers.cpp using_named_protocol
+
+Checking for protocol conformance here makes it clear that we are expecting
+a template parameter that exposes the particular interface we have defined in
+the protocol. Therefore, the author of the protocol and of the code that uses it
+has explicitly defined (and documented!) the interface they expect. And the
+developer who consumes the protocol by writing classes that conform to it knows
+exactly what needs to be implemented.
+
+Note that the `tt::conforms_to` metafunction is SFINAE-friendly, so you can also
+use it like this:
+
+\snippet Utilities/Test_ProtocolHelpers.cpp protocol_sfinae
+
+We typically define protocols in a file named `Protocols.hpp` and within a
+`protocols` namespace, similar to how we write \ref DataBoxTagsGroup "tags" in a
+`Tags.hpp` file and within a `Tags` namespace. The file should be placed in the
+directory associated with the code that depends on classes conforming to the
+protocols. For example, the protocol `Named` in the example above would be
+placed in directory that also has the `greet` function.
+
+# Protocol users: Testing protocol conformance {#protocols_testing_conformance}
+
+Any class that indicates it conforms to the protocol must test that it actually
+does using the `test_protocol_conformance` metafunction from
+`tests/Unit/ProtocolTestHelpers.hpp`:
+
+\snippet Utilities/Test_ProtocolHelpers.cpp test_protocol_conformance
+
+# Protocol authors: Protocols must be unary type traits {#protocols_author}
+
+When you author a new protocol, keep in mind that protocols must be unary type
+traits. This means they take a single template parameter (typically named
+`ConformingType`) and inherit from `std::true_type` or `std::false_type`
+depending on whether the `ConformingType` fullfills the protocol's requirements.
+Make sure to implement the protocol in a SFINAE-friendly way. You may find the
+macros in `Utilities/TypeTraits.hpp` useful. For example, we use
+`CREATE_IS_CALLABLE` in the protocols above for testing the existence and return
+type of a member function.
+
+Occasionally, you might be tempted to add additional template parameters to the
+protocol. In those situations, make the additional parameters part of your
+protocol instead. The reason for this guideline is that protocols
+will always be used as unary type traits when inheriting from
+`tt::ConformsTo<Protocol>`. Therefore, any template parameters of the protocol
+must also be template parameters of their conforming classes, which means the
+protocol can just check them.
+
+For example, we could be tempted to follow this antipattern:
+
+\snippet Utilities/Test_ProtocolHelpers.cpp named_antipattern
+
+However, instead of making the protocol a non-unary template we should add a
+requirement to it:
+
+\snippet Utilities/Test_ProtocolHelpers.cpp named_with_type
+
+Classes would need to specify the additional template parameters for any
+protocols they conform to anyway, if the protocols had any. So they might as
+well expose them:
+
+\snippet Utilities/Test_ProtocolHelpers.cpp person_with_name_type
+
+This pattern also allows us to check for protocol conformance first and then add
+further checks about the types if we wanted to:
+
+\snippet Utilities/Test_ProtocolHelpers.cpp example_check_name_type
+
+# Protocol authors: Testing a protocol {#protocols_testing}
+
+We are currently testing protocol conformance as part of our unit tests, so
+that the global `tt::conforms_to` convenience metafunction only needs to check
+if a type inherits off the protocol, but doesn't need to check the protocol's
+(possibly fairly expensive) implementation. This is primarily to keep compile
+times low, and may be reconsidered when transitioning to C++ "concepts". Full
+protocol conformance is tested in the `test_protocol_conformance` metafunction
+mentioned above.
+
+To make sure their protocol functions correctly, protocol authors must test
+its implementation in a unit test (e.g. in a `Test_Protocols.hpp`):
+
+\snippet Utilities/Test_ProtocolHelpers.cpp testing_a_protocol
+
+They should make sure to test the implementation with classes that conform to
+the protocol, and others that don't. This means the test will always include an
+example implementation of a class that conforms to the protocol, and the
+protocol author should add it to the documentation of the protocol through a
+Doxygen snippet. This gives users a convenient way to see how the author intends
+their interface to be implemented.
+
+# Protocols and C++20 "Constraints and concepts" {#protocols_and_constraints}
+
+A feature related to protocols is in C++20 and goes under the name of
+[constraints and concepts](https://en.cppreference.com/w/cpp/language/constraints).
+Every protocol defines a _concept_, but it defers checking its requirements to
+the unit tests to save compile time. In other words, protocols provide a way to
+_indicate_ that a class fulfills a set of requirements, whereas C++20
+constraints provide a way to _check_ that a class fulfills a set of
+requirements. Therefore, the two features complement each other. Once C++20
+becomes available in SpECTRE we can either gradually convert our protocols to
+concepts and use them as constraints directly if we find the impact on compile
+time negligible, or we can add a concept that checks protocol conformance the
+same way that `tt::conforms_to_v` currently does (i.e. by checking inheritance).

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -92,6 +92,7 @@ INPUT += @PROJECT_SOURCE_DIR@/tests/Unit/ActionTesting.hpp \
          @PROJECT_SOURCE_DIR@/tests/Unit/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp \
          @PROJECT_SOURCE_DIR@/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/VerifyGrMhdSolution.hpp \
          @PROJECT_SOURCE_DIR@/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp \
+         @PROJECT_SOURCE_DIR@/tests/Unit/ProtocolTestHelpers.hpp \
          @PROJECT_SOURCE_DIR@/tests/Unit/Pypp/CheckWithRandomValues.hpp  \
          @PROJECT_SOURCE_DIR@/tests/Unit/Pypp/Pypp.hpp  \
          @PROJECT_SOURCE_DIR@/tests/Unit/Pypp/PyppFundamentals.hpp  \

--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -620,6 +620,13 @@
  */
 
 /*!
+ * \defgroup ProtocolsGroup Protocols
+ * \brief Classes that define metaprogramming interfaces
+ *
+ * See the \ref protocols section of the dev guide for details.
+ */
+
+/*!
  * \defgroup PythonBindingsGroup Python Bindings
  * \brief Classes and functions useful when writing python bindings.
  *

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1529,6 +1529,7 @@ constexpr const Type& get_item_from_box(const DataBox<TagList>& box,
 
 namespace DataBox_detail {
 CREATE_IS_CALLABLE(apply)
+CREATE_IS_CALLABLE_V(apply)
 
 template <typename TagsList>
 struct Apply;

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -476,6 +476,7 @@ using item_type = typename DataBox_detail::item_type_impl<TagList, Tag>::type;
 
 namespace DataBox_detail {
 CREATE_IS_CALLABLE(function)
+CREATE_IS_CALLABLE_V(function)
 
 template <typename Tag, typename TagList, typename TagTypesList>
 struct check_compute_item_is_invokable;

--- a/src/NumericalAlgorithms/RootFinding/GslMultiRoot.hpp
+++ b/src/NumericalAlgorithms/RootFinding/GslMultiRoot.hpp
@@ -124,6 +124,7 @@ int gsl_multirootfunctionfdf_wrapper_fdf(const gsl_vector* const x,
 }
 
 CREATE_IS_CALLABLE(jacobian)
+CREATE_IS_CALLABLE_V(jacobian)
 }  // namespace gsl_multiroot_detail
 
 /*!

--- a/src/Utilities/ProtocolHelpers.hpp
+++ b/src/Utilities/ProtocolHelpers.hpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "Utilities/TypeTraits.hpp"
+
+namespace tt {
+
+/*!
+ * \ingroup ProtocolsGroup
+ * \brief Indicate a class conforms to the `Protocol`.
+ *
+ * (Publicly) inherit classes from this class to indicate they conform to the
+ * `Protocol`.
+ *
+ * \see Documentation on \ref protocols
+ */
+template <template <class> class Protocol>
+struct ConformsTo {};
+
+// Note that std::is_convertible is used in the following type aliases as it
+// will not match private base classes (unlike std::is_base_of)
+
+// @{
+/*!
+ * \ingroup ProtocolsGroup
+ * \brief Checks if the `ConformingType` conforms to the `Protocol`.
+ *
+ * By default, only checks if the class derives off the protocol to reduce
+ * compile time. Protocol conformance is tested rigorously in the unit tests
+ * instead. Set the `SPECTRE_ALWAYS_CHECK_PROTOCOL_CONFORMANCE` CMake option to
+ * always enable rigorous protocol conformance checks.
+ *
+ * \see Documentation on \ref protocols
+ */
+#ifdef SPECTRE_ALWAYS_CHECK_PROTOCOL_CONFORMANCE
+template <typename ConformingType, template <class> class Protocol>
+constexpr bool conforms_to_v =
+    cpp17::is_convertible_v<ConformingType*, ConformsTo<Protocol>*>and
+        Protocol<ConformingType>::value;
+template <typename ConformingType, template <class> class Protocol>
+using conforms_to =
+    cpp17::bool_constant<conforms_to_v<ConformingType, Protocol>>;
+#else   // SPECTRE_ALWAYS_CHECK_PROTOCOL_CONFORMANCE
+template <typename ConformingType, template <class> class Protocol>
+using conforms_to =
+    typename std::is_convertible<ConformingType*, ConformsTo<Protocol>*>;
+template <typename ConformingType, template <class> class Protocol>
+constexpr bool conforms_to_v =
+    cpp17::is_convertible_v<ConformingType*, ConformsTo<Protocol>*>;
+#endif  // SPECTRE_ALWAYS_CHECK_PROTOCOL_CONFORMANCE
+// @}
+
+}  // namespace tt

--- a/src/Utilities/TypeTraits.hpp
+++ b/src/Utilities/TypeTraits.hpp
@@ -858,9 +858,12 @@ using is_callable_t = typename is_callable<T, Args...>::type;
  * `is_METHOD_NAME_callable` and is not placed in
  * the `tt` namespace. To avoid collisions it is highly recommended that type
  * traits generated with this macro are generated into `_detail` namespaces.
- * This will reduce redefinition compilation errors. Note that a variable
- * template `is_METHOD_NAME_callable_v`, and a `is_METHOD_NAME_callable_t` that
- * is either `std::true_type` or `std::false_type` is also generated.
+ * This will reduce redefinition compilation errors.
+ *
+ * Note that variable templates with `_r` and `_t` suffixes that follow the
+ * standard library's naming convention are also generated. To generate
+ * corresponding `_v` metafunctions, call `CREATE_IS_CALLABLE` first and then
+ * `CREATE_IS_CALLABLE_V` and/or `CREATE_IS_CALLABLE_R_V`.
  *
  * \example
  * \snippet Utilities/Test_TypeTraits.cpp CREATE_IS_CALLABLE_EXAMPLE
@@ -889,27 +892,36 @@ using is_callable_t = typename is_callable<T, Args...>::type;
                          ReturnType>;                                          \
     using type = std::integral_constant<bool, value>;                          \
   };                                                                           \
-                                                                               \
-  template <typename ReturnType, typename T, typename... Args>                 \
-  static constexpr const bool is_##METHOD_NAME##_callable_r_v =                \
-      is_##METHOD_NAME##_callable_r<ReturnType, T, Args...>::value;            \
-                                                                               \
   template <typename ReturnType, typename T, typename... Args>                 \
   using is_##METHOD_NAME##_callable_r_t =                                      \
       typename is_##METHOD_NAME##_callable_r<ReturnType, T, Args...>::type;    \
-                                                                               \
-  template <typename T, typename... Args>                                      \
-  static constexpr const bool is_##METHOD_NAME##_callable_v =                  \
-      is_##METHOD_NAME##_callable_r_v<AnyReturnType##METHOD_NAME, T, Args...>; \
-                                                                               \
-  template <typename T, typename... Args>                                      \
+  template <typename TT, typename... TArgs>                                    \
+  using is_##METHOD_NAME##_callable =                                          \
+      is_##METHOD_NAME##_callable_r<AnyReturnType##METHOD_NAME, TT, TArgs...>; \
+  template <typename TT, typename... TArgs>                                    \
   using is_##METHOD_NAME##_callable_t =                                        \
-      is_##METHOD_NAME##_callable_r_t<AnyReturnType##METHOD_NAME, T, Args...>;
+      is_##METHOD_NAME##_callable_r_t<AnyReturnType##METHOD_NAME, TT,          \
+                                      TArgs...>;
+// Separate macros to avoid compiler warnings about unused variables
+#define CREATE_IS_CALLABLE_R_V(METHOD_NAME)                     \
+  template <typename ReturnType, typename T, typename... Args>  \
+  static constexpr const bool is_##METHOD_NAME##_callable_r_v = \
+      is_##METHOD_NAME##_callable_r<ReturnType, T, Args...>::value;
+#define CREATE_IS_CALLABLE_V(METHOD_NAME)                     \
+  template <typename T, typename... Args>                     \
+  static constexpr const bool is_##METHOD_NAME##_callable_v = \
+      is_##METHOD_NAME##_callable<T, Args...>::value;
+// @}
 
+// @{
 /*!
  * \ingroup TypeTraitsGroup
  * \brief Generate a type trait to check if a class has a `static constexpr`
  * variable, optionally also checking its type.
+ *
+ * To generate the corresponding `_v` metafunction, call
+ * `CREATE_HAS_STATIC_MEMBER_VARIABLE` first and then
+ * `CREATE_HAS_STATIC_MEMBER_VARIABLE_V`.
  *
  * \example
  * \snippet Utilities/Test_TypeTraits.cpp CREATE_HAS_EXAMPLE
@@ -932,11 +944,13 @@ using is_callable_t = typename is_callable<T, Args...>::type;
             cpp17::is_same_v<VariableType, NoSuchType*****> or               \
             cpp17::is_same_v<                                                \
                 std::remove_const_t<decltype(CheckingType::CONSTEXPR_NAME)>, \
-                VariableType>> {};                                           \
-                                                                             \
-  template <typename CheckingType, typename VariableType = NoSuchType*****>  \
-  static constexpr const bool has_##CONSTEXPR_NAME##_v =                     \
+                VariableType>> {};
+// Separate macros to avoid compiler warnings about unused variables
+#define CREATE_HAS_STATIC_MEMBER_VARIABLE_V(CONSTEXPR_NAME)                 \
+  template <typename CheckingType, typename VariableType = NoSuchType*****> \
+  static constexpr const bool has_##CONSTEXPR_NAME##_v =                    \
       has_##CONSTEXPR_NAME<CheckingType, VariableType>::value;
+// @}
 
 // @{
 /// \ingroup TypeTraitsGroup

--- a/tests/Unit/DataStructures/DataBox/TestHelpers.hpp
+++ b/tests/Unit/DataStructures/DataBox/TestHelpers.hpp
@@ -16,6 +16,7 @@ namespace db {
 
 namespace detail {
 CREATE_IS_CALLABLE(name)
+CREATE_IS_CALLABLE_V(name)
 
 template <typename Tag>
 void check_tag_name(const std::string& expected_name) {

--- a/tests/Unit/ProtocolTestHelpers.hpp
+++ b/tests/Unit/ProtocolTestHelpers.hpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Utilities/ProtocolHelpers.hpp"
+
+namespace ProtocolHelpers_detail {
+
+template <typename ConformingType, template <class> class Protocol>
+struct TestProtocolConformanceImpl : std::true_type {
+#ifdef SPECTRE_ALWAYS_CHECK_PROTOCOL_CONFORMANCE
+  static_assert(
+      tt::conforms_to_v<ConformingType, Protocol>,
+      "The type does not conform to the protocol or does not (publicly) "
+      "inherit from it. The type is listed as the first template parameter to "
+      "`test_protocol_conformance` and the protocol is listed as the second "
+      "template parameter.");
+#else   // SPECTRE_ALWAYS_CHECK_PROTOCOL_CONFORMANCE
+  static_assert(
+      tt::conforms_to_v<ConformingType, Protocol>,
+      "The type does not indicate it conforms to the protocol. The type is "
+      "listed as the first template parameter to `test_protocol_conformance` "
+      "and the protocol is listed as the second template parameter. "
+      "Have you forgotten to (publicly) inherit it from the protocol?");
+  static_assert(
+      Protocol<ConformingType>::value,
+      "The type does not conform to the protocol. The type is "
+      "listed as the first template parameter to `test_protocol_conformance` "
+      "and the protocol is listed as the second template parameter.");
+#endif  // SPECTRE_ALWAYS_CHECK_PROTOCOL_CONFORMANCE
+};
+
+}  // namespace ProtocolHelpers_detail
+
+/*!
+ * \ingroup ProtocolsGroup
+ * \brief Test that the `ConformingType` conforms to the `Protocol`
+ *
+ * Since the `tt::conforms_to_v` metafunction only checks if a class _indicates_
+ * it conforms to the protocol (unless the
+ * `SPECTRE_ALWAYS_CHECK_PROTOCOL_CONFORMANCE` flag is set), use the
+ * `test_protocol_conformance` metafunction in unit tests to check the class
+ * actually fulfills the requirements defined by the protocol's
+ * `is_conforming_v` metafunction.
+ */
+template <typename ConformingType, template <class> class Protocol>
+static constexpr bool test_protocol_conformance =
+    ProtocolHelpers_detail::TestProtocolConformanceImpl<ConformingType,
+                                                        Protocol>::value;

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LIBRARY_SOURCES
   Test_Numeric.cpp
   Test_Overloader.cpp
   Test_PrettyType.cpp
+  Test_ProtocolHelpers.cpp
   Test_Rational.cpp
   Test_Registration.cpp
   Test_Requires.cpp

--- a/tests/Unit/Utilities/Test_ProtocolHelpers.cpp
+++ b/tests/Unit/Utilities/Test_ProtocolHelpers.cpp
@@ -1,0 +1,164 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/ProtocolTestHelpers.hpp"
+
+namespace {
+
+/// [named_protocol]
+namespace protocols {
+namespace detail {
+CREATE_IS_CALLABLE(name)
+}  // namespace detail
+/*!
+ * \brief Has a name.
+ *
+ * Requires the class has these member functions:
+ * - `name`: Returns the name of the object as a `std::string`.
+ */
+template <typename ConformingType>
+using Named = detail::is_name_callable_r<std::string, ConformingType>;
+}  // namespace protocols
+/// [named_protocol]
+
+/// [named_conformance]
+class Person : public tt::ConformsTo<protocols::Named> {
+ public:
+  // Function required to conform to the protocol
+  std::string name() const { return first_name_ + " " + last_name_; }
+
+ private:
+  // Implementation details of the class that are irrelevant to the protocol
+  std::string first_name_;
+  std::string last_name_;
+
+ public:
+  Person(std::string first_name, std::string last_name)
+      : first_name_(std::move(first_name)), last_name_(std::move(last_name)) {}
+};
+/// [named_conformance]
+
+/// [using_named_protocol]
+template <typename NamedThing>
+std::string greet(const NamedThing& named_thing) {
+  // Make sure the template parameter conforms to the protocol
+  static_assert(tt::conforms_to_v<NamedThing, protocols::Named>,
+                "NamedThing must be Named.");
+  // Now we can rely on the interface that the protocol defines
+  return "Hello, " + named_thing.name() + "!";
+}
+/// [using_named_protocol]
+
+/// [protocol_sfinae]
+template <typename Thing,
+          Requires<not tt::conforms_to_v<Thing, protocols::Named>> = nullptr>
+std::string greet_anything(const Thing& /*anything*/) {
+  return "Hello!";
+}
+template <typename NamedThing,
+          Requires<tt::conforms_to_v<NamedThing, protocols::Named>> = nullptr>
+std::string greet_anything(const NamedThing& named_thing) {
+  return greet(named_thing);
+}
+/// [protocol_sfinae]
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Utilities.ProtocolHelpers", "[Utilities][Unit]") {
+  Person person{"Alice", "Bob"};
+  CHECK(greet(person) == "Hello, Alice Bob!");
+  CHECK(greet_anything<int>(0) == "Hello!");
+  CHECK(greet_anything(person) == "Hello, Alice Bob!");
+}
+
+// Test tt::conforms_to metafunction
+/// [conforms_to]
+static_assert(tt::conforms_to_v<Person, protocols::Named>,
+              "The class does not conform to the protocol.");
+/// [conforms_to]
+namespace {
+struct NotNamed {};
+class DerivedNonConformingClass : private Person {};
+class DerivedConformingClass : public Person {};
+}  // namespace
+static_assert(not tt::conforms_to_v<NotNamed, protocols::Named>,
+              "Failed testing tt::conforms_to_v");
+static_assert(
+    not tt::conforms_to_v<DerivedNonConformingClass, protocols::Named>,
+    "Failed testing tt::conforms_to_v");
+static_assert(tt::conforms_to_v<DerivedConformingClass, protocols::Named>,
+              "Failed testing tt::conforms_to_v");
+
+// Give examples about protocol antipatterns
+namespace {
+namespace protocols {
+/// [named_antipattern]
+// Don't do this. Protocols should be _unary_ type traits.
+template <typename ConformingType, typename NameType>
+using NamedAntipattern =
+    // Check that the `name` function exists _and_ its return type
+    detail::is_name_callable_r<NameType, ConformingType>;
+/// [named_antipattern]
+// Just making sure the protocol works correctly, even though this is an
+// antipattern
+static_assert(NamedAntipattern<Person, std::string>::value,
+              "Failed testing is_conforming_v");
+static_assert(not NamedAntipattern<Person, int>::value,
+              "Failed testing is_conforming_v");
+/// [named_with_type]
+// Instead, do this.
+namespace detail {
+CREATE_HAS_TYPE_ALIAS(NameType)
+CREATE_HAS_TYPE_ALIAS_V(NameType)
+// Lazily evaluated so we can use `ConformingType::NameType`
+template <typename ConformingType>
+struct IsNameCallableWithType
+    : is_name_callable_r_t<typename ConformingType::NameType, ConformingType> {
+};
+}  // namespace detail
+template <typename ConformingType>
+using NamedWithType =
+    // First check the class has a `NameType`, then use it to check the return
+    // type of the `name` function.
+    std::conditional_t<detail::has_NameType_v<ConformingType>,
+                       detail::IsNameCallableWithType<ConformingType>,
+                       std::false_type>;
+/// [named_with_type]
+}  // namespace protocols
+/// [person_with_name_type]
+struct PersonWithNameType : tt::ConformsTo<protocols::NamedWithType> {
+  using NameType = std::string;
+  std::string name() const;
+};
+/// [person_with_name_type]
+// Make sure the protocol is implemented correctly
+static_assert(not protocols::NamedWithType<Person>::value,
+              "Failed testing is_conforming_v");
+static_assert(protocols::NamedWithType<PersonWithNameType>::value,
+              "Failed testing is_conforming_v");
+/// [example_check_name_type]
+static_assert(tt::conforms_to_v<PersonWithNameType, protocols::NamedWithType>,
+              "The class does not conform to the protocol.");
+static_assert(
+    cpp17::is_same_v<typename PersonWithNameType::NameType, std::string>,
+    "The `NameType` isn't a `std::string`!");
+/// [example_check_name_type]
+}  // namespace
+
+// Give an example how a protocol author should test a new protocol
+/// [testing_a_protocol]
+static_assert(protocols::Named<Person>::value, "Failed testing the protocol");
+static_assert(not protocols::Named<NotNamed>::value,
+              "Failed testing the protocol");
+/// [testing_a_protocol]
+
+// Give an example how protocol consumers should test protocol conformance
+/// [test_protocol_conformance]
+static_assert(test_protocol_conformance<Person, protocols::Named>,
+              "Failed testing protocol conformance");
+/// [test_protocol_conformance]

--- a/tests/Unit/Utilities/Test_TypeTraits.cpp
+++ b/tests/Unit/Utilities/Test_TypeTraits.cpp
@@ -439,6 +439,27 @@ static_assert(
     not has_foobar_v<testing_create_has_static_member_variable, size_t>,
     "Failed testing CREATE_HAS_STATIC_MEMBER_VARIABLE");
 /// [CREATE_HAS_EXAMPLE]
+
+/// [CREATE_HAS_TYPE_ALIAS]
+CREATE_HAS_TYPE_ALIAS(foo_alias)
+CREATE_HAS_TYPE_ALIAS_V(foo_alias)
+CREATE_HAS_TYPE_ALIAS(foobar_alias)
+CREATE_HAS_TYPE_ALIAS_V(foobar_alias)
+struct testing_create_has_type_alias {
+  using foo_alias = int;
+};
+
+static_assert(has_foo_alias_v<testing_create_has_type_alias>,
+              "Failed testing CREATE_HAS_TYPE_ALIAS");
+static_assert(has_foo_alias_v<testing_create_has_type_alias, int>,
+              "Failed testing CREATE_HAS_TYPE_ALIAS");
+static_assert(not has_foo_alias_v<testing_create_has_type_alias, double>,
+              "Failed testing CREATE_HAS_TYPE_ALIAS");
+static_assert(not has_foobar_alias_v<testing_create_has_type_alias>,
+              "Failed testing CREATE_HAS_TYPE_ALIAS");
+static_assert(not has_foobar_alias_v<testing_create_has_type_alias, int>,
+              "Failed testing CREATE_HAS_TYPE_ALIAS");
+/// [CREATE_HAS_TYPE_ALIAS]
 }  // namespace
 
 /// [is_hashable_example]

--- a/tests/Unit/Utilities/Test_TypeTraits.cpp
+++ b/tests/Unit/Utilities/Test_TypeTraits.cpp
@@ -393,7 +393,11 @@ static_assert(not tt::is_callable<BClassInTestTypeTraits>::value,
 namespace  {
 /// [CREATE_IS_CALLABLE_EXAMPLE]
 CREATE_IS_CALLABLE(foo)
+CREATE_IS_CALLABLE_V(foo)
+CREATE_IS_CALLABLE_R_V(foo)
 CREATE_IS_CALLABLE(foobar)
+CREATE_IS_CALLABLE_V(foobar)
+CREATE_IS_CALLABLE_R_V(foobar)
 struct bar {
   size_t foo(int /*unused*/, double /*unused*/) { return size_t{0}; }
 };
@@ -416,7 +420,9 @@ static_assert(not is_foobar_callable_v<bar, int, double>,
 
 /// [CREATE_HAS_EXAMPLE]
 CREATE_HAS_STATIC_MEMBER_VARIABLE(foo)
+CREATE_HAS_STATIC_MEMBER_VARIABLE_V(foo)
 CREATE_HAS_STATIC_MEMBER_VARIABLE(foobar)
+CREATE_HAS_STATIC_MEMBER_VARIABLE_V(foobar)
 struct testing_create_has_static_member_variable {
   static constexpr size_t foo = 1;
 };


### PR DESCRIPTION
## Proposed changes

This PR implements what I suggested in #1349. It adds a dev guide to the documentation that explains a lot of the reasoning and implementation, so I don't repeat it here in the description. This PR is a proposal to introduce this new concept, so I'm happy for any feedback!

<s>As an example, I add protocols for analytic solutions and analytic data in this PR. It replaces the current `MarkAsAnalyticSolution` struct (which is basically a protocol already) with a more structured approach.</s>

- [x] Depends on #1793

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
