### PR TITLE
Upwind flux for the CurvedScalarWave system

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.cpp
@@ -11,12 +11,79 @@
 #include "DataStructures/Variables.hpp"      // IWYU pragma: keep
 #include "Evolution/Systems/CurvedScalarWave/System.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Math.hpp"
 #include "Utilities/TMPL.hpp"  // IWYU pragma: keep
 
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
 
 namespace CurvedScalarWave {
+namespace CurvedScalarWave_detail {
+template <typename FieldTag>
+db::const_item_type<FieldTag> weight_char_field(
+    const db::const_item_type<FieldTag>& char_field_int,
+    const DataVector& char_speed_int,
+    const db::const_item_type<FieldTag>& char_field_ext,
+    const DataVector& char_speed_ext) noexcept {
+  const DataVector& char_speed_avg{0.5 * (char_speed_int + char_speed_ext)};
+  db::const_item_type<FieldTag> weighted_char_field = char_field_int;
+  auto weighted_char_field_it = weighted_char_field.begin();
+  for (auto int_it = char_field_int.begin(), ext_it = char_field_ext.begin();
+       int_it != char_field_int.end();
+       ++int_it, ++ext_it, ++weighted_char_field_it) {
+    *weighted_char_field_it *= step_function(char_speed_avg) * char_speed_avg;
+    *weighted_char_field_it +=
+        step_function(-char_speed_avg) * char_speed_avg * *ext_it;
+  }
+
+  return weighted_char_field;
+}
+
+template <size_t Dim>
+db::const_item_type<Tags::CharacteristicFields<Dim>> weight_char_fields(
+    const db::const_item_type<Tags::CharacteristicFields<Dim>>& char_fields_int,
+    const db::const_item_type<Tags::CharacteristicSpeeds<Dim>>& char_speeds_int,
+    const db::const_item_type<Tags::CharacteristicFields<Dim>>& char_fields_ext,
+    const db::const_item_type<Tags::CharacteristicSpeeds<Dim>>&
+        char_speeds_ext) noexcept {
+  const auto& v_psi_int = get<Tags::VPsi>(char_fields_int);
+  const auto& v_zero_int = get<Tags::VZero<Dim>>(char_fields_int);
+  const auto& v_plus_int = get<Tags::VPlus>(char_fields_int);
+  const auto& v_minus_int = get<Tags::VMinus>(char_fields_int);
+
+  const DataVector& char_speed_v_psi_int{char_speeds_int[0]};
+  const DataVector& char_speed_v_zero_int{char_speeds_int[1]};
+  const DataVector& char_speed_v_plus_int{char_speeds_int[2]};
+  const DataVector& char_speed_v_minus_int{char_speeds_int[3]};
+
+  const auto& v_psi_ext = get<Tags::VPsi>(char_fields_ext);
+  const auto& v_zero_ext = get<Tags::VZero<Dim>>(char_fields_ext);
+  const auto& v_plus_ext = get<Tags::VPlus>(char_fields_ext);
+  const auto& v_minus_ext = get<Tags::VMinus>(char_fields_ext);
+
+  const DataVector& char_speed_v_psi_ext{char_speeds_ext[0]};
+  const DataVector& char_speed_v_zero_ext{char_speeds_ext[1]};
+  const DataVector& char_speed_v_plus_ext{char_speeds_ext[2]};
+  const DataVector& char_speed_v_minus_ext{char_speeds_ext[3]};
+
+  auto weighted_char_fields =
+      make_with_value<db::const_item_type<Tags::CharacteristicFields<Dim>>>(
+          char_speed_v_psi_int, 0.);
+
+  get<Tags::VPsi>(weighted_char_fields) = weight_char_field<Tags::VPsi>(
+      v_psi_int, char_speed_v_psi_int, v_psi_ext, char_speed_v_psi_ext);
+  get<Tags::VZero<Dim>>(weighted_char_fields) =
+      weight_char_field<Tags::VZero<Dim>>(v_zero_int, char_speed_v_zero_int,
+                                          v_zero_ext, char_speed_v_zero_ext);
+  get<Tags::VPlus>(weighted_char_fields) = weight_char_field<Tags::VPlus>(
+      v_plus_int, char_speed_v_plus_int, v_plus_ext, char_speed_v_plus_ext);
+  get<Tags::VMinus>(weighted_char_fields) = weight_char_field<Tags::VMinus>(
+      v_minus_int, char_speed_v_minus_int, v_minus_ext, char_speed_v_minus_ext);
+
+  return weighted_char_fields;
+}
+}  // namespace CurvedScalarWave_detail
+
 /// \cond
 template <size_t Dim>
 void ComputeDuDt<Dim>::apply(
@@ -67,6 +134,126 @@ void ComputeDuDt<Dim>::apply(
     }
   }
 }
+
+template <size_t Dim>
+void ComputeNormalDotFluxes<Dim>::apply(
+    const gsl::not_null<Scalar<DataVector>*> pi_normal_dot_flux,
+    const gsl::not_null<tnsr::i<DataVector, Dim>*> phi_normal_dot_flux,
+    const gsl::not_null<Scalar<DataVector>*> psi_normal_dot_flux,
+    const Scalar<DataVector>& pi, const tnsr::i<DataVector, Dim>& phi,
+    const Scalar<DataVector>& psi, const Scalar<DataVector>& gamma1,
+    const Scalar<DataVector>& gamma2, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim>& shift,
+    const tnsr::II<DataVector, Dim>& inverse_spatial_metric,
+    const tnsr::i<DataVector, Dim>& interface_unit_normal) noexcept {
+  const auto shift_dot_normal = get(dot_product(shift, interface_unit_normal));
+  const auto normal_dot_phi = [&]() {
+    auto normal_dot_phi_ = make_with_value<Scalar<DataVector>>(psi, 0.);
+    for (size_t i = 0; i < Dim; ++i) {
+      for (size_t j = 0; j < Dim; ++j) {
+        get(normal_dot_phi_) += inverse_spatial_metric.get(i, j) *
+                                interface_unit_normal.get(j) * phi.get(i);
+      }
+    }
+    return normal_dot_phi_;
+  }();
+
+  psi_normal_dot_flux->get() =
+      -(1. + get(gamma1)) * shift_dot_normal * get(psi);
+
+  pi_normal_dot_flux->get() =
+      -shift_dot_normal * get(pi) + get(lapse) * get(normal_dot_phi) -
+      get(gamma1) * get(gamma2) * shift_dot_normal * get(psi);
+
+  for (size_t i = 0; i < Dim; ++i) {
+    phi_normal_dot_flux->get(i) =
+        get(lapse) * (interface_unit_normal.get(i) * get(pi) -
+                      get(gamma2) * interface_unit_normal.get(i) * get(psi)) -
+        shift_dot_normal * phi.get(i);
+  }
+}
+
+template <size_t Dim>
+void UpwindFlux<Dim>::package_data(
+    const gsl::not_null<Variables<package_tags>*> packaged_data,
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+    const Scalar<DataVector>& psi, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
+    const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
+    const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
+    const noexcept {
+  get<Psi>(*packaged_data) = psi;
+  get<Pi>(*packaged_data) = pi;
+  get<Phi<Dim>>(*packaged_data) = phi;
+  get<gr::Tags::Lapse<DataVector>>(*packaged_data) = lapse;
+  get<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>(*packaged_data) =
+      shift;
+  get<gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>(
+      *packaged_data) = inverse_spatial_metric;
+  get<Tags::ConstraintGamma1>(*packaged_data) = gamma1;
+  get<Tags::ConstraintGamma2>(*packaged_data) = gamma2;
+  get<::Tags::Normalized<
+      domain::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>(
+      *packaged_data) = interface_unit_normal;
+}
+
+template <size_t Dim>
+void UpwindFlux<Dim>::operator()(
+    const gsl::not_null<Scalar<DataVector>*> pi_normal_dot_numerical_flux,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        phi_normal_dot_numerical_flux,
+    const gsl::not_null<Scalar<DataVector>*> psi_normal_dot_numerical_flux,
+    const Scalar<DataVector>& pi_int,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi_int,
+    const Scalar<DataVector>& psi_int, const Scalar<DataVector>& lapse_int,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift_int,
+    const tnsr::II<DataVector, Dim, Frame::Inertial>&
+        inverse_spatial_metric_int,
+    const Scalar<DataVector>& gamma1_int, const Scalar<DataVector>& gamma2_int,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal_int,
+    const Scalar<DataVector>& pi_ext,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi_ext,
+    const Scalar<DataVector>& psi_ext, const Scalar<DataVector>& lapse_ext,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift_ext,
+    const tnsr::II<DataVector, Dim, Frame::Inertial>&
+        inverse_spatial_metric_ext,
+    const Scalar<DataVector>& gamma1_ext, const Scalar<DataVector>& gamma2_ext,
+    const tnsr::i<DataVector, Dim,
+                  Frame::Inertial>& /*interface_unit_normal_ext*/) const
+    noexcept {
+  const Scalar<DataVector> gamma1_avg{0.5 *
+                                      (get(gamma1_int) + get(gamma1_ext))};
+  const Scalar<DataVector> gamma2_avg{0.5 *
+                                      (get(gamma2_int) + get(gamma2_ext))};
+
+  const auto char_fields_int =
+      characteristic_fields(gamma2_avg, inverse_spatial_metric_int, psi_int,
+                            pi_int, phi_int, interface_unit_normal_int);
+  const auto char_speeds_int = characteristic_speeds(
+      gamma1_avg, lapse_int, shift_int, interface_unit_normal_int);
+  const auto char_fields_ext =
+      characteristic_fields(gamma2_avg, inverse_spatial_metric_ext, psi_ext,
+                            pi_ext, phi_ext, interface_unit_normal_int);
+  const auto char_speeds_ext = characteristic_speeds(
+      gamma1_avg, lapse_ext, shift_ext, interface_unit_normal_int);
+
+  const auto weighted_char_fields =
+      CurvedScalarWave_detail::weight_char_fields<Dim>(
+          char_fields_int, char_speeds_int, char_fields_ext, char_speeds_ext);
+
+  const auto weighted_evolved_fields =
+      evolved_fields_from_characteristic_fields(
+          gamma2_avg, get<Tags::VPsi>(weighted_char_fields),
+          get<Tags::VZero<Dim>>(weighted_char_fields),
+          get<Tags::VPlus>(weighted_char_fields),
+          get<Tags::VMinus>(weighted_char_fields), interface_unit_normal_int);
+
+  *psi_normal_dot_numerical_flux = get<Psi>(weighted_evolved_fields);
+  *pi_normal_dot_numerical_flux = get<Pi>(weighted_evolved_fields);
+  *phi_normal_dot_numerical_flux = get<Phi<Dim>>(weighted_evolved_fields);
+}
 /// \endcond
 }  // namespace CurvedScalarWave
 // Generate explicit instantiations of partial_derivatives function as well as
@@ -87,6 +274,8 @@ using derivative_frame = Frame::Inertial;
 
 #define INSTANTIATION(_, data)                                               \
   template class CurvedScalarWave::ComputeDuDt<DIM(data)>;                   \
+  template struct CurvedScalarWave::ComputeNormalDotFluxes<DIM(data)>;       \
+  template struct CurvedScalarWave::UpwindFlux<DIM(data)>;                   \
   template Variables<                                                        \
       db::wrap_tags_in<::Tags::deriv, derivative_tags<DIM(data)>,            \
                        tmpl::size_t<DIM(data)>, derivative_frame>>           \

--- a/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
@@ -5,8 +5,13 @@
 
 #include <cstddef>
 
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Options/Options.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -15,17 +20,6 @@
 class DataVector;
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
-
-namespace CurvedScalarWave {
-struct Psi;
-struct Pi;
-template <size_t Dim>
-struct Phi;
-namespace Tags {
-struct ConstraintGamma1;
-struct ConstraintGamma2;
-}  // namespace Tags
-}  // namespace CurvedScalarWave
 /// \endcond
 
 namespace CurvedScalarWave {
@@ -60,6 +54,12 @@ namespace CurvedScalarWave {
  */
 template <size_t Dim>
 struct ComputeDuDt {
+ public:
+  template <template <class> class StepPrefix>
+  using return_tags = tmpl::list<db::add_tag_prefix<StepPrefix, Pi>,
+                                 db::add_tag_prefix<StepPrefix, Phi<Dim>>,
+                                 db::add_tag_prefix<StepPrefix, Psi>>;
+
   using argument_tags = tmpl::list<
       Pi, Phi<Dim>, ::Tags::deriv<Psi, tmpl::size_t<Dim>, Frame::Inertial>,
       ::Tags::deriv<Pi, tmpl::size_t<Dim>, Frame::Inertial>,
@@ -92,5 +92,208 @@ struct ComputeDuDt {
       const Scalar<DataVector>& trace_extrinsic_curvature,
       const Scalar<DataVector>& gamma1,
       const Scalar<DataVector>& gamma2) noexcept;
+};
+
+/*!
+ * \brief Compute fluxes for the scalar-wave system in curved spacetime.
+ *
+ * \details The expressions for fluxes is obtained from \cite Holst2004wt by
+ * taking the principal part of equations 15, 23, and 24, and replacing
+ * derivatives \f$ \partial_k \f$ with the unit normal \f$ n_k \f$ (c.f. Gauss'
+ * theorem). This gives:
+ *
+ * \f{align*}
+ * F(\psi) &= -(1 + \gamma_1) \beta^k n_k \psi \\
+ * F(\Pi) &= - \beta^k n_k \Pi + \alpha g^{ki}n_k \Phi_{i}
+ *           - \gamma_1 \gamma_2 \beta^k n_k \Psi  \\
+ * F(\Phi_{i}) &= - \beta^k n_k \Phi_{i} + \alpha n_i \Pi - \gamma_2 \alpha n_i
+ * \psi \f}
+ *
+ * where \f$\psi\f$ is the scalar field, \f$\Pi\f$ is its conjugate
+ * momentum, \f$ \Phi_{i} \f$ is an auxiliary field defined as the spatial
+ * derivative of \f$\psi\f$, \f$\alpha\f$ is the lapse, \f$ \beta^k \f$ is the
+ * shift, \f$ g^{ki} \f$ is the inverse spatial metric, and \f$ \gamma_1,
+ * \gamma_2\f$ are constraint damping parameters. Note that the last term in
+ * \f$F(\Pi)\f$ will be identically zero, as it is necessary to set
+ * \f$\gamma_1\gamma_2=0\f$ in order to make this first-order formulation of the
+ * curved scalar wave system symmetric hyperbolic.
+ */
+template <size_t Dim>
+struct ComputeNormalDotFluxes {
+ public:
+  using argument_tags =
+      tmpl::list<Pi, Phi<Dim>, Psi, Tags::ConstraintGamma1,
+                 Tags::ConstraintGamma2, gr::Tags::Lapse<>,
+                 gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>,
+                 ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<
+                     Dim, Frame::Inertial>>>;
+
+  static void apply(
+      gsl::not_null<Scalar<DataVector>*> pi_normal_dot_flux,
+      gsl::not_null<tnsr::i<DataVector, Dim>*> phi_normal_dot_flux,
+      gsl::not_null<Scalar<DataVector>*> psi_normal_dot_flux,
+      const Scalar<DataVector>& pi, const tnsr::i<DataVector, Dim>& phi,
+      const Scalar<DataVector>& psi, const Scalar<DataVector>& gamma1,
+      const Scalar<DataVector>& gamma2, const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, Dim>& shift,
+      const tnsr::II<DataVector, Dim>& inverse_spatial_metric,
+      const tnsr::i<DataVector, Dim>& interface_unit_normal) noexcept;
+};
+
+/*!
+ * \ingroup NumericalFluxesGroup
+ * \brief Computes the upwind flux for scalar-waves in curved spacetime.
+ *
+ * \details The upwind flux is given by \cite Teukolsky2015ega :
+ *
+ * \f[
+ * G = S\left(\Lambda^+ S^{-1} U^{\rm int}
+ *           + \Lambda^- S^{-1} U^{\rm ext}\right)
+ * = S \left(\Lambda^+ \hat{U}^{\rm int}
+ *           + \Lambda^- \hat{U}^{\rm ext}\right),
+ * \f]
+ *
+ * where
+ *
+ *  - \f$G\f$ is the numerical upwind flux dotted with the interface normal;
+ *  - \f$U\f$ is a vector of all evolved variables;
+ *  - \f$S\f$ is a matrix whose columns are the eigenvectors of the
+ *       characteristic matrix for the evolution system. It maps the
+ *       evolved variables to characteristic variables \f$\hat{U}\f$, s.t.
+ *       \f$\hat{U} := S^{-1}\cdot U\f$; and
+ *  - \f$\Lambda^\pm\f$ are diagonal matrices containing
+ *       positive / negative eigenvalues of the same matrix as its elements.
+ *
+ * The superscripts \f${\rm int}\f$ and \f${\rm ext}\f$ on \f$U\f$ indicate
+ * that the corresponding set of variables at the element interface have been
+ * taken from the _interior_ or _exterior_ of the element. Exterior of the
+ * element is naturally the interior of its neighboring element. Therefore,
+ * \f$\hat{U}^{\rm int}:= S^{-1}U^{\rm int}\f$ are the characteristic variables
+ * at the element interface computed using evolved variables from the interior
+ * of the element, and \f$\hat{U}^{\rm ext}= S^{-1}U^{\rm ext}\f$ are the
+ * same computed from evolved variables taken from the element exterior, i.e.
+ * the neighboring element.
+ * The sign of characteristic speeds indicates the direction of propagation of
+ * the corresponding characteristic field with respect to the interface normal
+ * that the field has been computed along (with negative speeds indicating
+ * incoming characteristics, and with positive speeds indicating outgoing
+ * characteristics). Therefore, \f$\Lambda^+\f$ contains characterstic speeds
+ * for variables that are outgoing from the element at the interface, and
+ * \f$\Lambda^-\f$ contains characteristic speeds for variables that are
+ * incoming to the element at the interface. An ambiguity naturally arises
+ * as to which set of evolved variables (''interior'' or ''exterior'') to use
+ * when computing these speeds. Following the treatment of generalized harmonic
+ * evolution system's characteristics in its upwind flux (\ref
+ * GeneralizedHarmonic::UpwindFlux ), here also we compute both and use their
+ * average, i.e. \f$\lambda^{\rm avg} = (\lambda^{\rm int} + \lambda^{\rm
+ * ext})/2\f$, to populate \f$\Lambda^\pm\f$.
+ *
+ *
+ * This function computes the upwind flux as follows:
+ *  -# Computes internal and external characteristic variables and speeds using
+ * evolved variables from
+ *     both the element interior and exterior.
+ *  -# Computes the average characteristic speeds and constructs
+ *      \f$\Lambda^{\pm}\f$.
+ *  -# Computes the upwind flux as a weigted sum of external and internal
+ *     characteristic variables
+ *
+ * \f[
+ * G = S\left(w_{\rm ext} \hat{U}^{\rm ext}
+ *       + w_{\rm int} \hat{U}^{\rm int}\right),
+ * \f]
+ *
+ * with weights \f$w_{\rm ext} = \Theta(-\Lambda)\cdot\Lambda\f$, and
+ * \f$w_{\rm int} = \Theta(\Lambda)\cdot\Lambda\f$, where \f$\Theta\f$ is the
+ * step function centered at zero, \f$\Lambda = \Lambda^+ + \Lambda^-\f$, and
+ * the dot operator \f$(\cdot)\f$ indicates an element-wise product.
+ *
+ * \warning With the averaging of characteristic speeds, this flux does not
+ * satisfy the generalized Rankine-Hugoniot conditions
+ * \f${G}^{\rm int}(\hat{U}^{\rm int}, \hat{U}^{\rm ext})
+ * = - {G}^{\rm ext}(\hat{U}^{\rm ext}, \hat{U}^{\rm int})\f$,
+ * which enforces that the flux leaving the element is equal to the flux
+ * entering the neighboring element, and vice versa. This condition is
+ * important for a well-balanced scheme, and so please use this flux with
+ * caution.
+ */
+template <size_t Dim>
+struct UpwindFlux {
+ public:
+  using options = tmpl::list<>;
+  static constexpr OptionString help = {
+      "Computes the curved scalar-wave upwind flux."};
+
+  // clang-tidy: non-const reference
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+
+  // This is the data needed to compute the numerical flux.
+  // `dg::SendBoundaryFluxes` calls `package_data` to store these tags in a
+  // Variables. Local and remote values of this data are then combined in the
+  // `()` operator.
+  using package_tags = tmpl::list<
+      Pi, Phi<Dim>, Psi, gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
+      Tags::ConstraintGamma1, Tags::ConstraintGamma2,
+      ::Tags::Normalized<
+          domain::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>;
+
+  // These tags on the interface of the element are passed to
+  // `package_data` to provide the data needed to compute the numerical fluxes.
+  using argument_tags = tmpl::list<
+      Pi, Phi<Dim>, Psi, gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
+      Tags::ConstraintGamma1, Tags::ConstraintGamma2,
+      ::Tags::Normalized<
+          domain::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>;
+
+  // pseudo-interface: used internally by Algorithm infrastructure, not
+  // user-level code
+  // Following the not-null pointer to packaged_data, this function expects as
+  // arguments the databox types of the `argument_tags`.
+  void package_data(
+      gsl::not_null<Variables<package_tags>*> packaged_data,
+      const Scalar<DataVector>& pi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+      const Scalar<DataVector>& psi, const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
+      const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
+      const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
+      const noexcept;
+
+  // pseudo-interface: used internally by Algorithm infrastructure, not
+  // user-level code
+  // The arguments are first the system::variables_tag::tags_list wrapped in
+  // Tags::NormalDotNumericalFlux as not-null pointers to write the results
+  // into, then the package_tags on the interior side of the mortar followed by
+  // the package_tags on the exterior side.
+  void operator()(
+      gsl::not_null<Scalar<DataVector>*> pi_normal_dot_numerical_flux,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          phi_normal_dot_numerical_flux,
+      gsl::not_null<Scalar<DataVector>*> psi_normal_dot_numerical_flux,
+      const Scalar<DataVector>& pi_int,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& phi_int,
+      const Scalar<DataVector>& psi_int, const Scalar<DataVector>& lapse_int,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& shift_int,
+      const tnsr::II<DataVector, Dim, Frame::Inertial>&
+          inverse_spatial_metric_int,
+      const Scalar<DataVector>& gamma1_int,
+      const Scalar<DataVector>& gamma2_int,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          interface_unit_normal_int,
+      const Scalar<DataVector>& pi_ext,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& phi_ext,
+      const Scalar<DataVector>& psi_ext, const Scalar<DataVector>& lapse_ext,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& shift_ext,
+      const tnsr::II<DataVector, Dim, Frame::Inertial>&
+          inverse_spatial_metric_ext,
+      const Scalar<DataVector>& gamma1_ext,
+      const Scalar<DataVector>& gamma2_ext,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          interface_unit_normal_ext) const noexcept;
 };
 }  // namespace CurvedScalarWave

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_Characteristics.cpp
   Test_DuDt.cpp
   Test_Tags.cpp
+  Test_UpwindFlux.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Fluxes.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Fluxes.py
@@ -1,0 +1,29 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+# Test functions for normal dot fluxes
+
+
+def psi_normal_dot_flux(psi, pi, phi, gamma1, gamma2, lapse, shift,
+                        inverse_spatial_metric, unit_normal):
+    return -(1. + gamma1) * np.dot(shift, unit_normal) * psi
+
+
+def pi_normal_dot_flux(psi, pi, phi, gamma1, gamma2, lapse, shift,
+                       inverse_spatial_metric, unit_normal):
+    return - np.dot(shift, unit_normal) * pi  \
+        + lapse * np.einsum("ki,k,iab->ab",
+                            inverse_spatial_metric, unit_normal, phi) \
+           - gamma1 * gamma2 * np.dot(shift, unit_normal) * psi
+
+
+def phi_dot_flux(psi, pi, phi, gamma1, gamma2, lapse, shift,
+                 inverse_spatial_metric, unit_normal):
+    return - np.dot(shift, unit_normal) * phi \
+        + lapse * np.einsum("i,ab->iab", unit_normal, pi) \
+           - gamma2 * lapse * np.einsum("i,ab->iab", unit_normal, psi)
+
+
+# End test functions for normal dot fluxes

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_UpwindFlux.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_UpwindFlux.cpp
@@ -1,0 +1,239 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <random>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Equations.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/DataStructures/RandomUnitNormal.hpp"
+#include "Helpers/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace CurvedScalarWave {
+namespace CurvedScalarWave_detail {
+template <size_t Dim>
+db::const_item_type<Tags::CharacteristicFields<Dim>> weight_char_fields(
+    const db::const_item_type<Tags::CharacteristicFields<Dim>>& char_fields_int,
+    const db::const_item_type<Tags::CharacteristicSpeeds<Dim>>& char_speeds_int,
+    const db::const_item_type<Tags::CharacteristicFields<Dim>>& char_fields_ext,
+    const db::const_item_type<Tags::CharacteristicSpeeds<Dim>>&
+        char_speeds_ext) noexcept;
+}  // namespace CurvedScalarWave_detail
+}  // namespace CurvedScalarWave
+
+namespace {
+// Test CSW upwind flux using random fields
+template <size_t Dim>
+void test_upwind_flux_random() noexcept {
+  const DataVector used_for_size{5,
+                                 std::numeric_limits<double>::signaling_NaN()};
+
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> dist(-1., 1.);
+  std::uniform_real_distribution<> dist_pert(-0.1, 0.1);
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_dist = make_not_null(&dist);
+  const auto nn_dist_pert = make_not_null(&dist_pert);
+
+  const auto one = make_with_value<Scalar<DataVector>>(used_for_size, 1.);
+  const auto minus_one =
+      make_with_value<Scalar<DataVector>>(used_for_size, -1.);
+  const auto five = make_with_value<Scalar<DataVector>>(used_for_size, 5.);
+  const auto minus_five =
+      make_with_value<Scalar<DataVector>>(used_for_size, -5.);
+
+  // Set psi, pi, phi to be random (phi, pi should not need to be consistent
+  // with psi for the flux consistency tests to pass)
+  const auto psi_int = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_dist_pert, used_for_size);
+  const auto psi_ext = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_dist_pert, used_for_size);
+  const auto phi_int =
+      make_with_random_values<tnsr::i<DataVector, Dim, Frame::Inertial>>(
+          nn_generator, nn_dist_pert, used_for_size);
+  const auto phi_ext =
+      make_with_random_values<tnsr::i<DataVector, Dim, Frame::Inertial>>(
+          nn_generator, nn_dist_pert, used_for_size);
+  const auto pi_int = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_dist_pert, used_for_size);
+  const auto pi_ext = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_dist_pert, used_for_size);
+
+  // Choose spacetime metric randomly, but make sure the result is
+  // still invertible. To do this, start with
+  // Minkowski, and then add a 10% random perturbation.
+  auto spacetime_metric_int =
+      make_with_random_values<tnsr::aa<DataVector, Dim, Frame::Inertial>>(
+          nn_generator, nn_dist_pert, used_for_size);
+  get<0, 0>(spacetime_metric_int) += get(minus_one);
+  for (size_t i = 1; i <= Dim; ++i) {
+    spacetime_metric_int.get(i, i) += get(one);
+  }
+
+  auto spacetime_metric_ext =
+      make_with_random_values<tnsr::aa<DataVector, Dim, Frame::Inertial>>(
+          nn_generator, nn_dist_pert, used_for_size);
+  get<0, 0>(spacetime_metric_ext) += get(minus_one);
+  for (size_t i = 1; i <= Dim; ++i) {
+    spacetime_metric_ext.get(i, i) += get(one);
+  }
+
+  const auto spatial_metric_int = gr::spatial_metric(spacetime_metric_int);
+  const auto inverse_spatial_metric_int =
+      determinant_and_inverse(spatial_metric_int).second;
+  const tnsr::i<DataVector, Dim, Frame::Inertial> unit_normal_one_form_int =
+      raise_or_lower_index(random_unit_normal(nn_generator, spatial_metric_int),
+                           spatial_metric_int);
+  tnsr::i<DataVector, Dim, Frame::Inertial> minus_unit_normal_one_form_int =
+      unit_normal_one_form_int;
+  for (size_t i = 0; i < Dim; ++i) {
+    minus_unit_normal_one_form_int.get(i) *= -1.;
+  }
+
+  const auto shift_int =
+      gr::shift(spacetime_metric_int, inverse_spatial_metric_int);
+  const auto lapse_int = gr::lapse(shift_int, spacetime_metric_int);
+
+  const auto spatial_metric_ext = gr::spatial_metric(spacetime_metric_ext);
+  const auto inverse_spatial_metric_ext =
+      determinant_and_inverse(spatial_metric_ext).second;
+  const DataVector one_form_magnitude_ext =
+      get(magnitude(unit_normal_one_form_int, inverse_spatial_metric_ext));
+
+  const auto shift_ext =
+      gr::shift(spacetime_metric_ext, inverse_spatial_metric_ext);
+  const auto lapse_ext = gr::lapse(shift_int, spacetime_metric_ext);
+
+  const auto gamma_1 = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_dist, used_for_size);
+  const auto gamma_2 = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_dist, used_for_size);
+
+  // Get the characteristic fields and speeds
+  const auto char_fields_int = CurvedScalarWave::characteristic_fields(
+      gamma_2, inverse_spatial_metric_int, psi_int, pi_int, phi_int,
+      unit_normal_one_form_int);
+  const auto char_fields_ext = CurvedScalarWave::characteristic_fields(
+      gamma_2, inverse_spatial_metric_ext, psi_ext, pi_ext, phi_ext,
+      unit_normal_one_form_int);
+
+  std::array<DataVector, 4> char_speeds_one{
+      {get(one), get(one), get(one), get(one)}};
+  std::array<DataVector, 4> char_speeds_minus_one{
+      {get(minus_one), get(minus_one), get(minus_one), get(minus_one)}};
+  std::array<DataVector, 4> char_speeds_five{
+      {get(five), get(five), get(five), get(five)}};
+  std::array<DataVector, 4> char_speeds_minus_five{
+      {get(minus_five), get(minus_five), get(minus_five), get(minus_five)}};
+
+  INFO("test curved-scalar-wave upwind weighting function")
+  // If all the char speeds are +1, the weighted fields should just
+  // be the interior fields
+  const auto weighted_char_fields_one =
+      CurvedScalarWave::CurvedScalarWave_detail::weight_char_fields<Dim>(
+          char_fields_int, char_speeds_one, char_fields_ext, char_speeds_one);
+  CHECK(weighted_char_fields_one == char_fields_int);
+
+  // If all the char speeds are -1, the weighted fields should just be
+  // the exterior fields up to a sign
+  const auto weighted_char_fields_minus_one =
+      CurvedScalarWave::CurvedScalarWave_detail::weight_char_fields<Dim>(
+          char_fields_int, char_speeds_minus_one, char_fields_ext,
+          char_speeds_minus_one);
+  CHECK(weighted_char_fields_minus_one == -1. * char_fields_ext);
+
+  // Check scaling by 5 instead of 1
+  const auto weighted_char_fields_minus_five =
+      CurvedScalarWave::CurvedScalarWave_detail::weight_char_fields<Dim>(
+          char_fields_int, char_speeds_minus_five, char_fields_ext,
+          char_speeds_minus_five);
+  const auto weighted_char_fields_five =
+      CurvedScalarWave::CurvedScalarWave_detail::weight_char_fields<Dim>(
+          char_fields_int, char_speeds_five, char_fields_ext, char_speeds_five);
+  CHECK(weighted_char_fields_minus_five == -5. * char_fields_ext);
+  CHECK(weighted_char_fields_five == 5. * char_fields_int);
+
+  // Check that if the same fields are given for the interior and exterior
+  // (except that the normal vector gets multiplied by -1.0) that the
+  // numerical flux reduces to the flux
+  INFO("test consistency of the curved-scalar-wave upwind flux")
+  CurvedScalarWave::UpwindFlux<Dim> flux_computer{};
+  auto packaged_data_int = make_with_value<
+      Variables<typename CurvedScalarWave::UpwindFlux<Dim>::package_tags>>(
+      used_for_size, std::numeric_limits<double>::signaling_NaN());
+  flux_computer.package_data(make_not_null(&packaged_data_int), pi_int, phi_int,
+                             psi_int, lapse_int, shift_int,
+                             inverse_spatial_metric_int, gamma_1, gamma_2,
+                             unit_normal_one_form_int);
+
+  auto packaged_data_int_opposite_normal = make_with_value<
+      Variables<typename CurvedScalarWave::UpwindFlux<Dim>::package_tags>>(
+      used_for_size, std::numeric_limits<double>::signaling_NaN());
+  flux_computer.package_data(make_not_null(&packaged_data_int_opposite_normal),
+                             pi_int, phi_int, psi_int, lapse_int, shift_int,
+                             inverse_spatial_metric_int, gamma_1, gamma_2,
+                             minus_unit_normal_one_form_int);
+
+  auto psi_normal_dot_numerical_flux = make_with_value<
+      db::item_type<::Tags::NormalDotNumericalFlux<CurvedScalarWave::Psi>>>(
+      used_for_size, std::numeric_limits<double>::signaling_NaN());
+  auto pi_normal_dot_numerical_flux = make_with_value<
+      db::item_type<::Tags::NormalDotNumericalFlux<CurvedScalarWave::Pi>>>(
+      used_for_size, std::numeric_limits<double>::signaling_NaN());
+  auto phi_normal_dot_numerical_flux = make_with_value<db::item_type<
+      ::Tags::NormalDotNumericalFlux<CurvedScalarWave::Phi<Dim>>>>(
+      used_for_size, std::numeric_limits<double>::signaling_NaN());
+  ::TestHelpers::NumericalFluxes::apply_numerical_flux(
+      flux_computer, packaged_data_int, packaged_data_int_opposite_normal,
+      make_not_null(&pi_normal_dot_numerical_flux),
+      make_not_null(&phi_normal_dot_numerical_flux),
+      make_not_null(&psi_normal_dot_numerical_flux));
+
+  CurvedScalarWave::ComputeNormalDotFluxes<Dim> normal_dot_flux_computer{};
+  auto psi_normal_dot_flux = make_with_value<
+      db::item_type<::Tags::NormalDotFlux<CurvedScalarWave::Psi>>>(
+      used_for_size, std::numeric_limits<double>::signaling_NaN());
+  auto pi_normal_dot_flux = make_with_value<
+      db::item_type<::Tags::NormalDotFlux<CurvedScalarWave::Pi>>>(
+      used_for_size, std::numeric_limits<double>::signaling_NaN());
+  auto phi_normal_dot_flux = make_with_value<
+      db::item_type<::Tags::NormalDotFlux<CurvedScalarWave::Phi<Dim>>>>(
+      used_for_size, std::numeric_limits<double>::signaling_NaN());
+  normal_dot_flux_computer.apply(
+      make_not_null(&pi_normal_dot_flux), make_not_null(&phi_normal_dot_flux),
+      make_not_null(&psi_normal_dot_flux), pi_int, phi_int, psi_int, gamma_1,
+      gamma_2, lapse_int, shift_int, inverse_spatial_metric_int,
+      unit_normal_one_form_int);
+
+  CHECK_ITERABLE_APPROX(psi_normal_dot_numerical_flux, psi_normal_dot_flux);
+  CHECK_ITERABLE_APPROX(pi_normal_dot_numerical_flux, pi_normal_dot_flux);
+  CHECK_ITERABLE_APPROX(phi_normal_dot_numerical_flux, phi_normal_dot_flux);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.UpwindFlux",
+                  "[Unit][Evolution]") {
+  test_upwind_flux_random<1>();
+  test_upwind_flux_random<2>();
+  test_upwind_flux_random<3>();
+}


### PR DESCRIPTION
## Proposed changes

Adding the upwind flux for the scalar-wave system in curved background spacetime. 


### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).