### PR TITLE
Add penalty flux for scalar waves

### DIFF
--- a/src/Evolution/Systems/ScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.cpp
@@ -10,7 +10,6 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/ScalarWave/System.hpp"
-#include "Evolution/Systems/ScalarWave/Tags.hpp"  // IWYU pragma: keep
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"   // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"  // IWYU pragma: keep
@@ -62,6 +61,76 @@ void ComputeNormalDotFluxes<Dim>::apply(
 
   for (size_t i = 0; i < Dim; ++i) {
     phi_normal_dot_flux->get(i) = interface_unit_normal.get(i) * get(pi);
+  }
+}
+
+template <size_t Dim>
+void PenaltyFlux<Dim>::package_data(
+    const gsl::not_null<Variables<package_tags>*> packaged_data,
+    const Scalar<DataVector>& normal_dot_flux_pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_dot_flux_phi,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
+    const noexcept {
+  // Computes the contribution to the numerical flux from one side of the
+  // interface.
+  //
+  // Note: when PenaltyFlux::operator() is called, an Element passes in its own
+  // packaged data to fill the interior fields, and its neighbor's packaged data
+  // to fill the exterior fields. This introduces a sign flip for each normal
+  // used in computing the exterior fields.
+  get<::Tags::NormalDotFlux<Pi>>(*packaged_data) = normal_dot_flux_pi;
+  get<::Tags::NormalDotFlux<Phi<Dim>>>(*packaged_data) = normal_dot_flux_phi;
+  get<Tags::VPlus>(*packaged_data) = v_plus;
+  get<Tags::VMinus>(*packaged_data) = v_minus;
+  auto& normal_times_v_plus = get<NormalTimesVPlus>(*packaged_data);
+  auto& normal_times_v_minus = get<NormalTimesVMinus>(*packaged_data);
+  for (size_t d = 0; d < Dim; ++d) {
+    normal_times_v_plus.get(d) = get(v_plus) * interface_unit_normal.get(d);
+    normal_times_v_minus.get(d) = get(v_minus) * interface_unit_normal.get(d);
+  }
+}
+
+template <size_t Dim>
+void PenaltyFlux<Dim>::operator()(
+    const gsl::not_null<Scalar<DataVector>*> pi_normal_dot_numerical_flux,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        phi_normal_dot_numerical_flux,
+    const gsl::not_null<Scalar<DataVector>*> psi_normal_dot_numerical_flux,
+    const Scalar<DataVector>& normal_dot_flux_pi_interior,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        normal_dot_flux_phi_interior,
+    const Scalar<DataVector>& /* v_plus_interior */,
+    const Scalar<DataVector>& v_minus_interior,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+    /* normal_times_v_plus_interior */,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        normal_times_v_minus_interior,
+    const Scalar<DataVector>& /* minus_normal_dot_flux_pi_exterior */,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+    /* minus_normal_dot_flux_phi_exterior */,
+    const Scalar<DataVector>& v_plus_exterior,
+    const Scalar<DataVector>& /* v_minus_exterior */,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        minus_normal_times_v_plus_exterior,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+    /* minus_normal_times_v_minus_exterior */) const noexcept {
+  constexpr double penalty_factor = 1.;
+
+  // NormalDotNumericalFlux<Psi>
+  std::fill(psi_normal_dot_numerical_flux->get().begin(),
+            psi_normal_dot_numerical_flux->get().end(), 0.);
+  // NormalDotNumericalFlux<Pi>
+  get(*pi_normal_dot_numerical_flux) =
+      get(normal_dot_flux_pi_interior) +
+      0.5 * penalty_factor * (get(v_minus_interior) - get(v_plus_exterior));
+  // NormalDotNumericalFlux<Phi>
+  for (size_t d = 0; d < Dim; ++d) {
+    phi_normal_dot_numerical_flux->get(d) =
+        normal_dot_flux_phi_interior.get(d) -
+        0.5 * penalty_factor *
+            (normal_times_v_minus_interior.get(d) +
+             minus_normal_times_v_plus_exterior.get(d));
   }
 }
 
@@ -151,6 +220,7 @@ using derivative_frame = Frame::Inertial;
   template class ScalarWave::ComputeDuDt<DIM(data)>;                         \
   template class ScalarWave::ComputeNormalDotFluxes<DIM(data)>;              \
   template class ScalarWave::UpwindFlux<DIM(data)>;                          \
+  template class ScalarWave::PenaltyFlux<DIM(data)>;                         \
   template Variables<                                                        \
       db::wrap_tags_in<::Tags::deriv, derivative_tags<DIM(data)>,            \
                        tmpl::size_t<DIM(data)>, derivative_frame>>           \

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/ForceInline.hpp"
@@ -99,19 +100,120 @@ struct ComputeNormalDotFluxes {
 
 /*!
  * \ingroup NumericalFluxesGroup
+ * \brief Computes the penalty flux for the ScalarWave system
+ *
+ * The penalty flux is given by:
+ *
+ * \f{align}
+ * G(\Psi) &= F(\Psi) = 0 \\
+ * G(\Pi) &= (n_i F^i(\Pi))_{\mathrm{int}} +
+ *     \frac{1}{2} p \left(v^{-}_{\mathrm{int}} - v^{+}_{\mathrm{ext}}\right) \\
+ * G(\Phi_i) &= (n_i F(\Phi_i))_{\mathrm{int}} - \frac{1}{2} p \left(
+ *      (n_i v^{-})_{\mathrm{int}} + (n_i v^{+})_{\mathrm{ext}}\right)
+ * \f}
+ *
+ * where \f$G\f$ is the interface normal dotted with numerical flux, the
+ * first terms on the RHS for \f$G(\Pi)\f$ and \f$G(\Phi_i)\f$ are the fluxes
+ * dotted with the interface normal (computed in
+ * ScalarWave::ComputeNormalDotFluxes), and \f$v^{\pm}\f$ are outgoing and
+ * incoming characteristic fields of the system (see characteristic_fields() for
+ * their definition). The penalty factor is chosen to be \f$p=1\f$.
+ */
+template <size_t Dim>
+struct PenaltyFlux {
+ private:
+  struct NormalTimesVPlus {
+    using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+    static std::string name() noexcept { return "NormalTimesVPlus"; }
+  };
+  struct NormalTimesVMinus {
+    using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+    static std::string name() noexcept { return "NormalTimesVMinus"; }
+  };
+
+ public:
+  using options = tmpl::list<>;
+  static constexpr OptionString help = {
+      "Computes the penalty flux for a scalar wave system. It requires no "
+      "options."};
+  static std::string name() noexcept { return "Penalty"; }
+
+  // clang-tidy: non-const reference
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+
+  // This is the data needed to compute the numerical flux.
+  // `dg::SendBoundaryFluxes` calls `package_data` to store these tags in a
+  // Variables. Local and remote values of this data are then combined inside
+  // `operator()`.
+  using package_tags =
+      tmpl::list<::Tags::NormalDotFlux<Pi>, ::Tags::NormalDotFlux<Phi<Dim>>,
+                 Tags::VPlus, Tags::VMinus, NormalTimesVPlus,
+                 NormalTimesVMinus>;
+
+  // These tags on the interface of the element are passed to
+  // `package_data` to provide the data needed to compute the numerical fluxes.
+  using argument_tags =
+      tmpl::list<::Tags::NormalDotFlux<Pi>, ::Tags::NormalDotFlux<Phi<Dim>>,
+                 Tags::VPlus, Tags::VMinus,
+                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
+
+  // pseudo-interface: used internally by Algorithm infrastructure, not
+  // user-level code
+  // Following the not-null pointer to packaged_data, this function expects as
+  // arguments the databox types of the `argument_tags`.
+  void package_data(
+      gsl::not_null<Variables<package_tags>*> packaged_data,
+      const Scalar<DataVector>& normal_dot_flux_pi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_dot_flux_phi,
+      const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
+      const noexcept;
+
+  // pseudo-interface: used internally by Algorithm infrastructure, not
+  // user-level code
+  // The first three arguments are pointers to Tags::NormalDotNumericalFlux<...>
+  // for each variable in the system, then the package_tags on the interior side
+  // of the mortar followed by the package_tags on the exterior side.
+  void operator()(
+      gsl::not_null<Scalar<DataVector>*> pi_normal_dot_numerical_flux,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          phi_normal_dot_numerical_flux,
+      gsl::not_null<Scalar<DataVector>*> psi_normal_dot_numerical_flux,
+      const Scalar<DataVector>& normal_dot_flux_pi_interior,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          normal_dot_flux_phi_interior,
+      const Scalar<DataVector>& v_plus_interior,
+      const Scalar<DataVector>& v_minus_interior,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          normal_times_v_plus_interior,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          normal_times_v_minus_interior,
+      const Scalar<DataVector>& minus_normal_dot_flux_pi_exterior,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          minus_normal_dot_flux_phi_exterior,
+      const Scalar<DataVector>& v_plus_exterior,
+      const Scalar<DataVector>& v_minus_exterior,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          minus_normal_times_v_plus_exterior,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          minus_normal_times_v_minus_exterior) const noexcept;
+};
+
+/*!
+ * \ingroup NumericalFluxesGroup
  * \brief Computes the upwind flux
  *
  * The upwind flux is given by:
  * \f{align}
- * F^*(\Psi) =& 0 \\
- * F^*(\Pi) =& \frac{1}{2}\left(F(\Pi)_{\mathrm{int}} + F(\Pi)_{\mathrm{ext}}
+ * G(\Psi) =& 0 \\
+ * G(\Pi) =& \frac{1}{2}\left(F(\Pi)_{\mathrm{int}} + F(\Pi)_{\mathrm{ext}}
  *                    + \Pi_{\mathrm{int}} - \Pi_{\mathrm{ext}}\right) \\
- * F^*(\Phi_i) =& \frac{1}{2} \left(F(\Phi_i)_{\mathrm{int}}
+ * G(\Phi_i) =& \frac{1}{2} \left(F(\Phi_i)_{\mathrm{int}}
  *                   + F(\Phi_i)_{\mathrm{ext}}
  *                   + (n_i)_{\mathrm{int}} F(\Pi)_{\mathrm{int}}
  *                   - (n_i)_{\mathrm{ext}} F(\Pi)_{\mathrm{ext}}\right)
  * \f}
- * where \f$F^*\f$ is the normal dotted with the numerical flux and \f$F\f$ is
+ * where \f$G\f$ is the normal dotted with the numerical flux and \f$F\f$ is
  * the normal dotted with the flux, which is computed in
  * ScalarWave::ComputeNormalDotFluxes
  */

--- a/tests/Unit/Evolution/Systems/ScalarWave/PenaltyFlux.py
+++ b/tests/Unit/Evolution/Systems/ScalarWave/PenaltyFlux.py
@@ -1,0 +1,28 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+# Functions for testing PenaltyFlux.hpp
+penalty_factor = 1.0
+
+def pi_penalty_flux(n_dot_flux_pi_int, n_dot_flux_phi_int,
+                    v_plus_int, v_minus_int, unit_normal_int,
+                    minus_n_dot_flux_pi_ext, minus_n_dot_flux_phi_ext,
+                    v_plus_ext, v_minus_ext, unit_normal_ext):
+    return n_dot_flux_pi_int + 0.5 * penalty_factor * (v_minus_int - v_plus_ext)
+
+def phi_penalty_flux(n_dot_flux_pi_int, n_dot_flux_phi_int,
+                    v_plus_int, v_minus_int, unit_normal_int,
+                    minus_n_dot_flux_pi_ext, minus_n_dot_flux_phi_ext,
+                    v_plus_ext, v_minus_ext, unit_normal_ext):
+    return n_dot_flux_phi_int - 0.5 * penalty_factor * (\
+        unit_normal_int * v_minus_int + unit_normal_ext * v_plus_ext)
+
+def psi_penalty_flux(n_dot_flux_pi_int, n_dot_flux_phi_int,
+                    v_plus_int, v_minus_int, unit_normal_int,
+                    minus_n_dot_flux_pi_ext, minus_n_dot_flux_phi_ext,
+                    v_plus_ext, v_minus_ext, unit_normal_ext):
+    return n_dot_flux_pi_int * 0
+
+# End functions for testing PenaltyFlux.hpp


### PR DESCRIPTION
## Proposed changes

We add here a numerical flux for the scalar-wave system that reduces the DG boundary term (strong form) to a penalty-type inter-element boundary term.

**Note**: the first commit is from #1751 , please review more recent commits.
**Update**: As #1751 has been merged, ignore the note above please!

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).