### PR TITLE
fix lapack segfault

### DIFF
--- a/src/NumericalAlgorithms/LinearSolver/Lapack.cpp
+++ b/src/NumericalAlgorithms/LinearSolver/Lapack.cpp
@@ -96,7 +96,8 @@ int general_matrix_linear_solve(const gsl::not_null<DataVector*> solution,
          "LAPACK linear solve is too small for the operation. Vector size is: "
              << rhs.size()
              << " and should be: " << number_of_rhs * rhs_vector_size << ".");
-  std::copy(rhs.begin(), rhs.end(), solution->begin());
+  std::copy(rhs.begin(), rhs.begin() + number_of_rhs * rhs_vector_size,
+            solution->begin());
   return general_matrix_linear_solve(solution, pivots, matrix_operator,
                                      number_of_rhs);
 }


### PR DESCRIPTION
## Proposed changes

There was a `std::copy` that assumed bad things about sizes that only triggered a segfault sometimes, depending on the sizes requested by the random generation (and on mysterious things about where the program memory ended up).
ran for 10^4 iterations without fail, previous version segfaulted within ~10-100

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
