### PR TITLE
Remove Frame parameter from Domain(creators), Block

### DIFF
--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -9,14 +9,13 @@
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace Frame {
-struct Grid;
 struct Inertial;
 struct Logical;
 }  // namespace Frame
 
-template <size_t VolumeDim, typename TargetFrame>
-Block<VolumeDim, TargetFrame>::Block(
-    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame,
+template <size_t VolumeDim>
+Block<VolumeDim>::Block(
+    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, Frame::Inertial,
                                               VolumeDim>>&& map,
     const size_t id,
     DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors) noexcept
@@ -30,54 +29,49 @@ Block<VolumeDim, TargetFrame>::Block(
   }
 }
 
-template <size_t VolumeDim, typename TargetFrame>
-void Block<VolumeDim, TargetFrame>::pup(PUP::er& p) noexcept {
+template <size_t VolumeDim>
+void Block<VolumeDim>::pup(PUP::er& p) noexcept {
   p | map_;
   p | id_;
   p | neighbors_;
   p | external_boundaries_;
 }
 
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim>
 std::ostream& operator<<(std::ostream& os,
-                         const Block<VolumeDim, TargetFrame>& block) noexcept {
+                         const Block<VolumeDim>& block) noexcept {
   os << "Block " << block.id() << ":\n";
   os << "Neighbors: " << block.neighbors() << '\n';
   os << "External boundaries: " << block.external_boundaries() << '\n';
   return os;
 }
 
-template <size_t VolumeDim, typename TargetFrame>
-bool operator==(const Block<VolumeDim, TargetFrame>& lhs,
-                const Block<VolumeDim, TargetFrame>& rhs) noexcept {
+template <size_t VolumeDim>
+bool operator==(const Block<VolumeDim>& lhs,
+                const Block<VolumeDim>& rhs) noexcept {
   return lhs.id() == rhs.id() and lhs.neighbors() == rhs.neighbors() and
          lhs.external_boundaries() == rhs.external_boundaries() and
          lhs.coordinate_map() == rhs.coordinate_map();
 }
 
-template <size_t VolumeDim, typename TargetFrame>
-bool operator!=(const Block<VolumeDim, TargetFrame>& lhs,
-                const Block<VolumeDim, TargetFrame>& rhs) noexcept {
+template <size_t VolumeDim>
+bool operator!=(const Block<VolumeDim>& lhs,
+                const Block<VolumeDim>& rhs) noexcept {
   return not(lhs == rhs);
 }
 
 #define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define GET_FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATION(r, data)                                               \
-  template class Block<GET_DIM(data), GET_FRAME(data)>;                      \
-  template std::ostream& operator<<(                                         \
-      std::ostream& os, const Block<GET_DIM(data), GET_FRAME(data)>& block); \
-  template bool operator==(                                                  \
-      const Block<GET_DIM(data), GET_FRAME(data)>& lhs,                      \
-      const Block<GET_DIM(data), GET_FRAME(data)>& rhs) noexcept;            \
-  template bool operator!=(                                                  \
-      const Block<GET_DIM(data), GET_FRAME(data)>& lhs,                      \
-      const Block<GET_DIM(data), GET_FRAME(data)>& rhs) noexcept;
+#define INSTANTIATION(r, data)                                          \
+  template class Block<GET_DIM(data)>;                                  \
+  template std::ostream& operator<<(std::ostream& os,                   \
+                                    const Block<GET_DIM(data)>& block); \
+  template bool operator==(const Block<GET_DIM(data)>& lhs,             \
+                           const Block<GET_DIM(data)>& rhs) noexcept;   \
+  template bool operator!=(const Block<GET_DIM(data)>& lhs,             \
+                           const Block<GET_DIM(data)>& rhs) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),
-                        (Frame::Grid, Frame::Inertial))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef GET_DIM
-#undef GET_FRAME
 #undef INSTANTIATION

--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -19,6 +19,7 @@
 /// \cond
 namespace Frame {
 struct Logical;
+struct Inertial;
 }  // namespace Frame
 namespace PUP {
 class er;
@@ -37,16 +38,16 @@ class er;
 /// dimension.  The global coordinates are obtained from the logical
 /// coordinates from the Coordinatemap:  CoordinateMap::operator() takes
 /// Points in the Logical Frame (i.e., logical coordinates) and
-/// returns Points in the Grid Frame (i.e., global coordinates).
-template <size_t VolumeDim, typename TargetFrame>
+/// returns Points in the Inertial Frame (i.e., global coordinates).
+template <size_t VolumeDim>
 class Block {
  public:
   /// \param map the CoordinateMap.
   /// \param id a unique ID.
   /// \param neighbors info about the Blocks that share a codimension 1
   /// boundary with this Block.
-  Block(std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame,
-                                                  VolumeDim>>&& map,
+  Block(std::unique_ptr<domain::CoordinateMapBase<
+            Frame::Logical, Frame::Inertial, VolumeDim>>&& map,
         size_t id,
         DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors) noexcept;
 
@@ -57,7 +58,7 @@ class Block {
   Block& operator=(const Block&) = delete;
   Block& operator=(Block&&) = default;
 
-  const domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>&
+  const domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>&
   coordinate_map() const noexcept {
     return *map_;
   }
@@ -84,21 +85,21 @@ class Block {
 
  private:
   std::unique_ptr<
-      domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>
+      domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>
       map_;
   size_t id_{0};
   DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors_;
   std::unordered_set<Direction<VolumeDim>> external_boundaries_;
 };
 
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim>
 std::ostream& operator<<(std::ostream& os,
-                         const Block<VolumeDim, TargetFrame>& block) noexcept;
+                         const Block<VolumeDim>& block) noexcept;
 
-template <size_t VolumeDim, typename TargetFrame>
-bool operator==(const Block<VolumeDim, TargetFrame>& lhs,
-                const Block<VolumeDim, TargetFrame>& rhs) noexcept;
+template <size_t VolumeDim>
+bool operator==(const Block<VolumeDim>& lhs,
+                const Block<VolumeDim>& rhs) noexcept;
 
-template <size_t VolumeDim, typename TargetFrame>
-bool operator!=(const Block<VolumeDim, TargetFrame>& lhs,
-                const Block<VolumeDim, TargetFrame>& rhs) noexcept;
+template <size_t VolumeDim>
+bool operator!=(const Block<VolumeDim>& lhs,
+                const Block<VolumeDim>& rhs) noexcept;

--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -21,14 +21,14 @@ using block_logical_coord_holder = boost::optional<
     IdPair<domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>>;
 }  // namespace
 
-template <size_t Dim, typename Frame>
+template <size_t Dim>
 std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
-    const Domain<Dim, Frame>& domain,
-    const tnsr::I<DataVector, Dim, Frame>& x) noexcept {
+    const Domain<Dim>& domain,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& x) noexcept {
   const size_t num_pts = get<0>(x).size();
   std::vector<block_logical_coord_holder<Dim>> block_coord_holders(num_pts);
   for (size_t s = 0; s < num_pts; ++s) {
-    tnsr::I<double, Dim, Frame> x_frame(0.0);
+    tnsr::I<double, Dim, Frame::Inertial> x_frame(0.0);
     for (size_t d = 0; d < Dim; ++d) {
       x_frame.get(d) = x.get(d)[s];
     }
@@ -66,18 +66,14 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
 // Explicit instantiations
 /// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATE(_, data)                                  \
   template std::vector<block_logical_coord_holder<DIM(data)>> \
-  block_logical_coordinates(                                  \
-      const Domain<DIM(data), FRAME(data)>& domain,           \
-      const tnsr::I<DataVector, DIM(data), FRAME(data)>& x) noexcept;
+  block_logical_coordinates(const Domain<DIM(data)>& domain,  \
+                            const tnsr::I<DataVector, DIM(data)>& x) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
-                        (Frame::Distorted, Frame::Grid, Frame::Inertial))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
-#undef FRAME
 #undef INSTANTIATE
 /// \endcond

--- a/src/Domain/BlockLogicalCoordinates.hpp
+++ b/src/Domain/BlockLogicalCoordinates.hpp
@@ -14,7 +14,7 @@ namespace domain {
 class BlockId;
 }  // namespace domain
 class DataVector;
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim>
 class Domain;
 template <typename IdType, typename DataType>
 class IdPair;
@@ -23,7 +23,7 @@ class IdPair;
 /// \ingroup ComputationalDomainGroup
 ///
 /// Computes the block logical coordinates and the containing `BlockId`
-/// of a set of points, given coordinates in the `Frame` frame.
+/// of a set of points, given coordinates in the `Frame::Inertial` frame.
 ///
 /// \details Returns a std::vector<boost::optional<IdPair<BlockId,coords>>>,
 /// where the vector runs over the points and is indexed in the same order as
@@ -34,9 +34,9 @@ class IdPair;
 /// If a point is on a shared boundary of two or more `Block`s, it is
 /// returned only once, and is considered to belong to the `Block`
 /// with the smaller `BlockId`.
-template <size_t Dim, typename Frame>
+template <size_t Dim>
 auto block_logical_coordinates(
-    const Domain<Dim, Frame>& domain,
-    const tnsr::I<DataVector, Dim, Frame>& x) noexcept
-    -> std::vector<boost::optional<IdPair<
-        domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>>>;
+    const Domain<Dim>& domain,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& x) noexcept
+    -> std::vector<boost::optional<
+        IdPair<domain::BlockId, tnsr::I<double, Dim, Frame::Logical>>>>;

--- a/src/Domain/CreateInitialElement.cpp
+++ b/src/Domain/CreateInitialElement.cpp
@@ -25,10 +25,10 @@ struct Inertial;  // IWYU pragma: keep
 
 namespace domain {
 namespace Initialization {
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim>
 Element<VolumeDim> create_initial_element(
     const ElementId<VolumeDim>& element_id,
-    const Block<VolumeDim, TargetFrame>& block) noexcept {
+    const Block<VolumeDim>& block) noexcept {
   const auto& neighbors_of_block = block.neighbors();
   const auto& segment_ids = element_id.segment_ids();
 
@@ -97,17 +97,14 @@ Element<VolumeDim> create_initial_element(
 
 /// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE(_, data)                                              \
-  template Element<DIM(data)>                                             \
-  domain::Initialization::create_initial_element<DIM(data), FRAME(data)>( \
-      const ElementId<DIM(data)>&,                                        \
-      const Block<DIM(data), FRAME(data)>&) noexcept;
+#define INSTANTIATE(_, data)                                 \
+  template Element<DIM(data)>                                \
+  domain::Initialization::create_initial_element<DIM(data)>( \
+      const ElementId<DIM(data)>&, const Block<DIM(data)>&) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
-#undef FRAME
 #undef INSTANTIATE
 /// \endcond

--- a/src/Domain/CreateInitialElement.hpp
+++ b/src/Domain/CreateInitialElement.hpp
@@ -8,7 +8,7 @@
 #include "Domain/Element.hpp"
 
 /// \cond
-template <size_t Dim, typename TargetFrame>
+template <size_t Dim>
 class Block;
 template <size_t Dim>
 class ElementId;
@@ -27,9 +27,9 @@ namespace Initialization {
  * an external boundary), with each neighbor at the same refinement level as the
  * element.
  */
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim>
 Element<VolumeDim> create_initial_element(
     const ElementId<VolumeDim>& element_id,
-    const Block<VolumeDim, TargetFrame>& block) noexcept;
+    const Block<VolumeDim>& block) noexcept;
 }  // namespace Initialization
 }  // namespace domain

--- a/src/Domain/Creators/AlignedLattice.cpp
+++ b/src/Domain/Creators/AlignedLattice.cpp
@@ -17,8 +17,8 @@ struct Inertial;
 namespace domain {
 namespace creators {
 
-template <size_t VolumeDim, typename TargetFrame>
-AlignedLattice<VolumeDim, TargetFrame>::AlignedLattice(
+template <size_t VolumeDim>
+AlignedLattice<VolumeDim>::AlignedLattice(
     const typename BlockBounds::type block_bounds,
     const typename IsPeriodicIn::type is_periodic_in,
     const typename InitialRefinement::type initial_refinement_levels,
@@ -32,10 +32,9 @@ AlignedLattice<VolumeDim, TargetFrame>::AlignedLattice(
       initial_number_of_grid_points_(                 // NOLINT
           std::move(initial_number_of_grid_points)),  // NOLINT
       blocks_to_exclude_(std::move(blocks_to_exclude)),
-      number_of_blocks_by_dim_{
-          map_array(block_bounds_, [](const std::vector<double>& v) noexcept {
-            return v.size() - 1;
-          })} {
+      number_of_blocks_by_dim_{map_array(
+          block_bounds_,
+          [](const std::vector<double>& v) noexcept { return v.size() - 1; })} {
   if (not blocks_to_exclude_.empty() and
       alg::any_of(is_periodic_in_, [](const bool t) noexcept { return t; })) {
     ERROR(
@@ -44,40 +43,35 @@ AlignedLattice<VolumeDim, TargetFrame>::AlignedLattice(
   }
 }
 
-template <size_t VolumeDim, typename TargetFrame>
-Domain<VolumeDim, TargetFrame>
-AlignedLattice<VolumeDim, TargetFrame>::create_domain() const noexcept {
+template <size_t VolumeDim>
+Domain<VolumeDim> AlignedLattice<VolumeDim>::create_domain() const noexcept {
   if (blocks_to_exclude_.empty()) {
-    return rectilinear_domain<VolumeDim, TargetFrame>(
+    return rectilinear_domain<VolumeDim>(
         number_of_blocks_by_dim_, block_bounds_, {}, {}, is_periodic_in_);
   }
-  return rectilinear_domain<VolumeDim, TargetFrame>(
+  return rectilinear_domain<VolumeDim>(
       number_of_blocks_by_dim_, block_bounds_,
       {std::vector<Index<VolumeDim>>(blocks_to_exclude_.begin(),
                                      blocks_to_exclude_.end())},
       {}, make_array<VolumeDim>(false));
 }
 
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim>
 std::vector<std::array<size_t, VolumeDim>>
-AlignedLattice<VolumeDim, TargetFrame>::initial_extents() const noexcept {
+AlignedLattice<VolumeDim>::initial_extents() const noexcept {
   return {number_of_blocks_by_dim_.product() - blocks_to_exclude_.size(),
           initial_number_of_grid_points_};
 }
 
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim>
 std::vector<std::array<size_t, VolumeDim>>
-AlignedLattice<VolumeDim, TargetFrame>::initial_refinement_levels() const
-    noexcept {
+AlignedLattice<VolumeDim>::initial_refinement_levels() const noexcept {
   return {number_of_blocks_by_dim_.product() - blocks_to_exclude_.size(),
           initial_refinement_levels_};
 }
 
-template class AlignedLattice<1, Frame::Inertial>;
-template class AlignedLattice<1, Frame::Grid>;
-template class AlignedLattice<2, Frame::Inertial>;
-template class AlignedLattice<2, Frame::Grid>;
-template class AlignedLattice<3, Frame::Inertial>;
-template class AlignedLattice<3, Frame::Grid>;
+template class AlignedLattice<1>;
+template class AlignedLattice<2>;
+template class AlignedLattice<3>;
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/AlignedLattice.hpp
+++ b/src/Domain/Creators/AlignedLattice.hpp
@@ -28,8 +28,8 @@ namespace creators {
 /// \note Adaptive mesh refinement can never join Block%s, so use the fewest
 /// number of Block%s that your problem needs.  More initial Element%s can be
 /// created by specifying a larger `InitialRefinement`.
-template <size_t VolumeDim, typename TargetFrame>
-class AlignedLattice : public DomainCreator<VolumeDim, TargetFrame> {
+template <size_t VolumeDim>
+class AlignedLattice : public DomainCreator<VolumeDim> {
  public:
   struct BlockBounds {
     using type = std::array<std::vector<double>, VolumeDim>;
@@ -95,7 +95,7 @@ class AlignedLattice : public DomainCreator<VolumeDim, TargetFrame> {
   AlignedLattice& operator=(AlignedLattice&&) noexcept = default;
   ~AlignedLattice() override = default;
 
-  Domain<VolumeDim, TargetFrame> create_domain() const noexcept override;
+  Domain<VolumeDim> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, VolumeDim>> initial_extents() const
       noexcept override;

--- a/src/Domain/Creators/Brick.cpp
+++ b/src/Domain/Creators/Brick.cpp
@@ -17,17 +17,14 @@
 
 /// \cond
 namespace Frame {
-struct Grid;
-struct Inertial;
 struct Logical;
+struct Inertial;
 }  // namespace Frame
 /// \endcond
 
 namespace domain {
 namespace creators {
-
-template <typename TargetFrame>
-Brick<TargetFrame>::Brick(
+Brick::Brick(
     typename LowerBound::type lower_xyz, typename UpperBound::type upper_xyz,
     typename IsPeriodicIn::type is_periodic_in_xyz,
     typename InitialRefinement::type initial_refinement_level_xyz,
@@ -42,8 +39,7 @@ Brick<TargetFrame>::Brick(
       initial_number_of_grid_points_in_xyz_(                   // NOLINT
           std::move(initial_number_of_grid_points_in_xyz)) {}  // NOLINT
 
-template <typename TargetFrame>
-Domain<3, TargetFrame> Brick<TargetFrame>::create_domain() const noexcept {
+Domain<3> Brick::create_domain() const noexcept {
   using Affine = CoordinateMaps::Affine;
   using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   std::vector<PairOfFaces> identifications{};
@@ -57,8 +53,8 @@ Domain<3, TargetFrame> Brick<TargetFrame>::create_domain() const noexcept {
     identifications.push_back({{0, 1, 2, 3}, {4, 5, 6, 7}});
   }
 
-  return Domain<3, TargetFrame>{
-      make_vector_coordinate_map_base<Frame::Logical, TargetFrame>(
+  return Domain<3>{
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Affine3D{Affine{-1., 1., lower_xyz_[0], upper_xyz_[0]},
                    Affine{-1., 1., lower_xyz_[1], upper_xyz_[1]},
                    Affine{-1., 1., lower_xyz_[2], upper_xyz_[2]}}),
@@ -66,19 +62,13 @@ Domain<3, TargetFrame> Brick<TargetFrame>::create_domain() const noexcept {
       identifications};
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 3>> Brick<TargetFrame>::initial_extents() const
-    noexcept {
+std::vector<std::array<size_t, 3>> Brick::initial_extents() const noexcept {
   return {initial_number_of_grid_points_in_xyz_};
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 3>>
-Brick<TargetFrame>::initial_refinement_levels() const noexcept {
+std::vector<std::array<size_t, 3>> Brick::initial_refinement_levels() const
+    noexcept {
   return {initial_refinement_level_xyz_};
 }
-
-template class Brick<Frame::Inertial>;
-template class Brick<Frame::Grid>;
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/Brick.hpp
+++ b/src/Domain/Creators/Brick.hpp
@@ -10,22 +10,17 @@
 #include <cstddef>
 #include <vector>
 
+#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
-template <size_t Dim, typename Frame>
-class DomainCreator;  // IWYU pragma: keep
-/// \endcond
-
 namespace domain {
 namespace creators {
 
 /// Create a 3D Domain consisting of a single Block.
-template <typename TargetFrame>
-class Brick : public DomainCreator<3, TargetFrame> {
+class Brick : public DomainCreator<3> {
  public:
   struct LowerBound {
     using type = std::array<double, 3>;
@@ -75,7 +70,7 @@ class Brick : public DomainCreator<3, TargetFrame> {
   Brick& operator=(Brick&&) noexcept = default;
   ~Brick() noexcept override = default;
 
-  Domain<3, TargetFrame> create_domain() const noexcept override;
+  Domain<3> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const noexcept override;
 

--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -18,16 +18,13 @@
 #include "Utilities/MakeArray.hpp"
 
 namespace Frame {
-struct Grid;
-struct Inertial;
 struct Logical;
+struct Inertial;
 }  // namespace Frame
 
 namespace domain {
 namespace creators {
-
-template <typename TargetFrame>
-Cylinder<TargetFrame>::Cylinder(
+Cylinder::Cylinder(
     typename InnerRadius::type inner_radius,
     typename OuterRadius::type outer_radius,
     typename LowerBound::type lower_bound,
@@ -48,8 +45,7 @@ Cylinder<TargetFrame>::Cylinder(
           std::move(initial_number_of_grid_points)),   // NOLINT
       use_equiangular_map_(use_equiangular_map) {}     // NOLINT
 
-template <typename TargetFrame>
-Domain<3, TargetFrame> Cylinder<TargetFrame>::create_domain() const noexcept {
+Domain<3> Cylinder::create_domain() const noexcept {
   using Affine = CoordinateMaps::Affine;
   using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   using Equiangular = CoordinateMaps::Equiangular;
@@ -66,7 +62,7 @@ Domain<3, TargetFrame> Cylinder<TargetFrame>::create_domain() const noexcept {
       {{0, 1, 2, 3, 8, 9, 10, 11}}};   // Center square prism
 
   auto coord_maps =
-      make_vector_coordinate_map_base<Frame::Logical, TargetFrame>(
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Wedge3DPrism{Wedge2D{inner_radius_, outer_radius_, 0.0, 1.0,
                                OrientationMap<2>{std::array<Direction<2>, 2>{
                                    {Direction<2>::upper_xi(),
@@ -94,7 +90,7 @@ Domain<3, TargetFrame> Cylinder<TargetFrame>::create_domain() const noexcept {
 
   if (use_equiangular_map_) {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Equiangular3DPrism{
                 Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
                             inner_radius_ / sqrt(2.0)),
@@ -103,14 +99,14 @@ Domain<3, TargetFrame> Cylinder<TargetFrame>::create_domain() const noexcept {
                 Affine{-1.0, 1.0, lower_bound_, upper_bound_}}));
   } else {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Affine3D{Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
                             inner_radius_ / sqrt(2.0)),
                      Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
                             inner_radius_ / sqrt(2.0)),
                      Affine{-1.0, 1.0, lower_bound_, upper_bound_}}));
   }
-  return Domain<3, TargetFrame>{
+  return Domain<3>{
       std::move(coord_maps), corners,
       is_periodic_in_z_
           ? std::vector<PairOfFaces>{{{0, 1, 2, 3}, {8, 9, 10, 11}},
@@ -121,9 +117,7 @@ Domain<3, TargetFrame> Cylinder<TargetFrame>::create_domain() const noexcept {
           : std::vector<PairOfFaces>{}};
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 3>> Cylinder<TargetFrame>::initial_extents()
-    const noexcept {
+std::vector<std::array<size_t, 3>> Cylinder::initial_extents() const noexcept {
   return {
       initial_number_of_grid_points_,
       initial_number_of_grid_points_,
@@ -133,13 +127,9 @@ std::vector<std::array<size_t, 3>> Cylinder<TargetFrame>::initial_extents()
         initial_number_of_grid_points_[2]}}};
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 3>>
-Cylinder<TargetFrame>::initial_refinement_levels() const noexcept {
+std::vector<std::array<size_t, 3>> Cylinder::initial_refinement_levels() const
+    noexcept {
   return {5, make_array<3>(initial_refinement_)};
 }
-
-template class Cylinder<Frame::Grid>;
-template class Cylinder<Frame::Inertial>;
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -7,24 +7,18 @@
 #include <cstddef>
 #include <vector>
 
+#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
-template <size_t Dim, typename Frame>
-class DomainCreator;  // IWYU pragma: keep
-/// \endcond
-
 namespace domain {
 namespace creators {
-
 /// Create a 3D Domain in the shape of a cylinder where the cross-section
 /// is a square surrounded by four two-dimensional wedges (see Wedge2D).
 ///
 /// \image html Cylinder.png "The Cylinder Domain."
-template <typename TargetFrame>
-class Cylinder : public DomainCreator<3, TargetFrame> {
+class Cylinder : public DomainCreator<3> {
  public:
   struct InnerRadius {
     using type = double;
@@ -107,7 +101,7 @@ class Cylinder : public DomainCreator<3, TargetFrame> {
   Cylinder& operator=(Cylinder&&) noexcept = default;
   ~Cylinder() noexcept override = default;
 
-  Domain<3, TargetFrame> create_domain() const noexcept override;
+  Domain<3> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const noexcept override;
 

--- a/src/Domain/Creators/Disk.cpp
+++ b/src/Domain/Creators/Disk.cpp
@@ -20,7 +20,6 @@
 
 /// \cond
 namespace Frame {
-struct Grid;
 struct Inertial;
 struct Logical;
 }  // namespace Frame
@@ -28,14 +27,11 @@ struct Logical;
 
 namespace domain {
 namespace creators {
-
-template <typename TargetFrame>
-Disk<TargetFrame>::Disk(
-    typename InnerRadius::type inner_radius,
-    typename OuterRadius::type outer_radius,
-    typename InitialRefinement::type initial_refinement,
-    typename InitialGridPoints::type initial_number_of_grid_points,
-    typename UseEquiangularMap::type use_equiangular_map) noexcept
+Disk::Disk(typename InnerRadius::type inner_radius,
+           typename OuterRadius::type outer_radius,
+           typename InitialRefinement::type initial_refinement,
+           typename InitialGridPoints::type initial_number_of_grid_points,
+           typename UseEquiangularMap::type use_equiangular_map) noexcept
     // clang-tidy: trivially copyable
     : inner_radius_(std::move(inner_radius)),         // NOLINT
       outer_radius_(std::move(outer_radius)),         // NOLINT
@@ -45,8 +41,7 @@ Disk<TargetFrame>::Disk(
           std::move(initial_number_of_grid_points)),  // NOLINT
       use_equiangular_map_(use_equiangular_map) {}    // NOLINT
 
-template <typename TargetFrame>
-Domain<2, TargetFrame> Disk<TargetFrame>::create_domain() const noexcept {
+Domain<2> Disk::create_domain() const noexcept {
   using Wedge2DMap = CoordinateMaps::Wedge2D;
   using Affine = CoordinateMaps::Affine;
   using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
@@ -65,7 +60,7 @@ Domain<2, TargetFrame> Disk<TargetFrame>::create_domain() const noexcept {
                                              block4_corners};
 
   auto coord_maps = make_vector_coordinate_map_base<Frame::Logical,
-                                                    TargetFrame>(
+                                                    Frame::Inertial>(
       Wedge2DMap{inner_radius_, outer_radius_, 0.0, 1.0,
                  OrientationMap<2>{std::array<Direction<2>, 2>{
                      {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
@@ -85,25 +80,23 @@ Domain<2, TargetFrame> Disk<TargetFrame>::create_domain() const noexcept {
 
   if (use_equiangular_map_) {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(Equiangular2D{
+        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(Equiangular2D{
             Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
                         inner_radius_ / sqrt(2.0)),
             Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
                         inner_radius_ / sqrt(2.0))}));
   } else {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Affine2D{Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
                             inner_radius_ / sqrt(2.0)),
                      Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
                             inner_radius_ / sqrt(2.0))}));
   }
-  return Domain<2, TargetFrame>{std::move(coord_maps), corners};
+  return Domain<2>{std::move(coord_maps), corners};
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 2>> Disk<TargetFrame>::initial_extents() const
-    noexcept {
+std::vector<std::array<size_t, 2>> Disk::initial_extents() const noexcept {
   return {
       initial_number_of_grid_points_,
       initial_number_of_grid_points_,
@@ -112,13 +105,9 @@ std::vector<std::array<size_t, 2>> Disk<TargetFrame>::initial_extents() const
       {{initial_number_of_grid_points_[1], initial_number_of_grid_points_[1]}}};
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 2>>
-Disk<TargetFrame>::initial_refinement_levels() const noexcept {
+std::vector<std::array<size_t, 2>> Disk::initial_refinement_levels() const
+    noexcept {
   return {5, make_array<2>(initial_refinement_)};
 }
-
-template class Disk<Frame::Grid>;
-template class Disk<Frame::Inertial>;
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/Disk.hpp
+++ b/src/Domain/Creators/Disk.hpp
@@ -7,22 +7,16 @@
 #include <cstddef>
 #include <vector>
 
+#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
-template <size_t Dim, typename Frame>
-class DomainCreator;  // IWYU pragma: keep
-/// \endcond
-
 namespace domain {
 namespace creators {
-
 /// Create a 2D Domain in the shape of a disk from a square surrounded by four
 /// wedges.
-template <typename TargetFrame>
-class Disk : public DomainCreator<2, TargetFrame> {
+class Disk : public DomainCreator<2> {
  public:
   struct InnerRadius {
     using type = double;
@@ -79,7 +73,7 @@ class Disk : public DomainCreator<2, TargetFrame> {
   Disk& operator=(Disk&&) noexcept = default;
   ~Disk() noexcept override = default;
 
-  Domain<2, TargetFrame> create_domain() const noexcept override;
+  Domain<2> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, 2>> initial_extents() const noexcept override;
 

--- a/src/Domain/Creators/DomainCreator.hpp
+++ b/src/Domain/Creators/DomainCreator.hpp
@@ -14,13 +14,13 @@
 #include "Utilities/MakeArray.hpp"
 
 /// \cond
-template <size_t, typename>
+template <size_t>
 class Block;
 namespace domain {
 template <typename, typename, size_t>
 class CoordinateMapBase;
 }  // namespace domain
-template <size_t, typename>
+template <size_t>
 class Domain;
 /// \endcond
 
@@ -29,29 +29,18 @@ namespace domain {
 /// \brief Defines classes that create Domains.
 namespace creators {
 /// \cond
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim>
 class AlignedLattice;
-template <typename TargetFrame>
 class Brick;
-template <typename TargetFrame>
 class Cylinder;
-template <typename TargetFrame>
 class Disk;
-template <typename TargetFrame>
 class Interval;
-template <typename TargetFrame>
 class Rectangle;
-template <typename TargetFrame>
 class RotatedBricks;
-template <typename TargetFrame>
 class RotatedIntervals;
-template <typename TargetFrame>
 class RotatedRectangles;
-template <typename TargetFrame>
 class Shell;
-template <typename TargetFrame>
 class Sphere;
-template <typename TargetFrame>
 class FrustalCloak;
 /// \endcond
 }  // namespace creators
@@ -63,48 +52,44 @@ struct domain_creators;
 
 template <>
 struct domain_creators<1> {
-  template <typename Frame>
-  using creators = tmpl::list<domain::creators::AlignedLattice<1, Frame>,
-                              domain::creators::Interval<Frame>,
-                              domain::creators::RotatedIntervals<Frame>>;
+  using creators = tmpl::list<domain::creators::AlignedLattice<1>,
+                              domain::creators::Interval,
+                              domain::creators::RotatedIntervals>;
 };
 template <>
 struct domain_creators<2> {
-  template <typename Frame>
-  using creators = tmpl::list<domain::creators::AlignedLattice<2, Frame>,
-                              domain::creators::Disk<Frame>,
-                              domain::creators::Rectangle<Frame>,
-                              domain::creators::RotatedRectangles<Frame>>;
+  using creators =
+      tmpl::list<domain::creators::AlignedLattice<2>, domain::creators::Disk,
+                 domain::creators::Rectangle,
+                 domain::creators::RotatedRectangles>;
 };
 template <>
 struct domain_creators<3> {
-  template <typename Frame>
-  using creators = tmpl::list<
-      domain::creators::AlignedLattice<3, Frame>,
-      domain::creators::Brick<Frame>, domain::creators::Cylinder<Frame>,
-      domain::creators::RotatedBricks<Frame>, domain::creators::Shell<Frame>,
-      domain::creators::Sphere<Frame>, domain::creators::FrustalCloak<Frame>>;
+  using creators =
+      tmpl::list<domain::creators::AlignedLattice<3>, domain::creators::Brick,
+                 domain::creators::Cylinder, domain::creators::RotatedBricks,
+                 domain::creators::Shell, domain::creators::Sphere,
+                 domain::creators::FrustalCloak>;
 };
 }  // namespace DomainCreators_detail
 
 /// \ingroup ComputationalDomainGroup
 /// \brief Base class for creating Domains from an option string.
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim>
 class DomainCreator {
  public:
-  using creatable_classes = typename DomainCreators_detail::domain_creators<
-      VolumeDim>::template creators<TargetFrame>;
+  using creatable_classes =
+      typename DomainCreators_detail::domain_creators<VolumeDim>::creators;
 
   DomainCreator() = default;
-  DomainCreator(const DomainCreator<VolumeDim, TargetFrame>&) = delete;
-  DomainCreator(DomainCreator<VolumeDim, TargetFrame>&&) noexcept = default;
-  DomainCreator<VolumeDim, TargetFrame>& operator=(
-      const DomainCreator<VolumeDim, TargetFrame>&) = delete;
-  DomainCreator<VolumeDim, TargetFrame>& operator=(
-      DomainCreator<VolumeDim, TargetFrame>&&) noexcept = default;
+  DomainCreator(const DomainCreator<VolumeDim>&) = delete;
+  DomainCreator(DomainCreator<VolumeDim>&&) noexcept = default;
+  DomainCreator<VolumeDim>& operator=(const DomainCreator<VolumeDim>&) = delete;
+  DomainCreator<VolumeDim>& operator=(DomainCreator<VolumeDim>&&) noexcept =
+      default;
   virtual ~DomainCreator() = default;
 
-  virtual Domain<VolumeDim, TargetFrame> create_domain() const = 0;
+  virtual Domain<VolumeDim> create_domain() const = 0;
 
   /// Obtain the initial grid extents of the Element%s in each block.
   virtual std::vector<std::array<size_t, VolumeDim>> initial_extents() const

--- a/src/Domain/Creators/FrustalCloak.cpp
+++ b/src/Domain/Creators/FrustalCloak.cpp
@@ -17,7 +17,6 @@
 
 /// \cond
 namespace Frame {
-struct Grid;
 struct Inertial;
 struct Logical;
 }  // namespace Frame
@@ -29,9 +28,7 @@ class CoordinateMapBase;
 
 namespace domain {
 namespace creators {
-
-template <typename TargetFrame>
-FrustalCloak<TargetFrame>::FrustalCloak(
+FrustalCloak::FrustalCloak(
     typename InitialRefinement::type initial_refinement_level,
     typename InitialGridPoints::type initial_number_of_grid_points,
     typename UseEquiangularMap::type use_equiangular_map,
@@ -51,36 +48,28 @@ FrustalCloak<TargetFrame>::FrustalCloak(
       length_outer_cube_(length_outer_cube),          // NOLINT
       origin_preimage_(origin_preimage) {}            // NOLINT
 
-template <typename TargetFrame>
-Domain<3, TargetFrame> FrustalCloak<TargetFrame>::create_domain() const
-    noexcept {
+Domain<3> FrustalCloak::create_domain() const noexcept {
   std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
-      coord_maps = frustum_coordinate_maps<TargetFrame>(
+      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+      coord_maps = frustum_coordinate_maps<Frame::Inertial>(
           length_inner_cube_, length_outer_cube_, use_equiangular_map_,
           origin_preimage_, projection_factor_);
-  return Domain<3, TargetFrame>{
-      std::move(coord_maps),
-      corners_for_biradially_layered_domains(0, 1, false, false,
-                                             {{1, 2, 3, 4, 5, 6, 7, 8}})};
+  return Domain<3>{std::move(coord_maps),
+                   corners_for_biradially_layered_domains(
+                       0, 1, false, false, {{1, 2, 3, 4, 5, 6, 7, 8}})};
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 3>> FrustalCloak<TargetFrame>::initial_extents()
-    const noexcept {
+std::vector<std::array<size_t, 3>> FrustalCloak::initial_extents() const
+    noexcept {
   return {
       10,
       {{initial_number_of_grid_points_[1], initial_number_of_grid_points_[1],
         initial_number_of_grid_points_[0]}}};
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 3>>
-FrustalCloak<TargetFrame>::initial_refinement_levels() const noexcept {
+std::vector<std::array<size_t, 3>> FrustalCloak::initial_refinement_levels()
+    const noexcept {
   return {10, make_array<3>(initial_refinement_level_)};
 }
-
-template class FrustalCloak<Frame::Inertial>;
-template class FrustalCloak<Frame::Grid>;
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/FrustalCloak.hpp
+++ b/src/Domain/Creators/FrustalCloak.hpp
@@ -10,22 +10,16 @@
 #include <cstddef>
 #include <vector>
 
+#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
-template <size_t Dim, typename Frame>
-class DomainCreator;  // IWYU pragma: keep
-/// \endcond
-
 namespace domain {
 namespace creators {
-
 /// Create a 3D cubical domain with two equal-sized abutting excised cubes in
 /// the center. This is done by combining ten frusta.
-template <typename TargetFrame>
-class FrustalCloak : public DomainCreator<3, TargetFrame> {
+class FrustalCloak : public DomainCreator<3> {
  public:
   struct InitialRefinement {
     using type = size_t;
@@ -107,7 +101,7 @@ class FrustalCloak : public DomainCreator<3, TargetFrame> {
   FrustalCloak& operator=(FrustalCloak&&) noexcept = default;
   ~FrustalCloak() noexcept override = default;
 
-  Domain<3, TargetFrame> create_domain() const noexcept override;
+  Domain<3> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const noexcept override;
 

--- a/src/Domain/Creators/Interval.cpp
+++ b/src/Domain/Creators/Interval.cpp
@@ -16,7 +16,6 @@
 
 /// \cond
 namespace Frame {
-struct Grid;
 struct Inertial;
 struct Logical;
 }  // namespace Frame
@@ -24,14 +23,12 @@ struct Logical;
 
 namespace domain {
 namespace creators {
-
-template <typename TargetFrame>
-Interval<TargetFrame>::Interval(
-    typename LowerBound::type lower_x, typename UpperBound::type upper_x,
-    typename IsPeriodicIn::type is_periodic_in_x,
-    typename InitialRefinement::type initial_refinement_level_x,
-    typename InitialGridPoints::type
-        initial_number_of_grid_points_in_x) noexcept
+Interval::Interval(typename LowerBound::type lower_x,
+                   typename UpperBound::type upper_x,
+                   typename IsPeriodicIn::type is_periodic_in_x,
+                   typename InitialRefinement::type initial_refinement_level_x,
+                   typename InitialGridPoints::type
+                       initial_number_of_grid_points_in_x) noexcept
     // clang-tidy: trivially copyable
     : lower_x_(std::move(lower_x)),                          // NOLINT
       upper_x_(std::move(upper_x)),                          // NOLINT
@@ -41,29 +38,22 @@ Interval<TargetFrame>::Interval(
       initial_number_of_grid_points_in_x_(                   // NOLINT
           std::move(initial_number_of_grid_points_in_x)) {}  // NOLINT
 
-template <typename TargetFrame>
-Domain<1, TargetFrame> Interval<TargetFrame>::create_domain() const noexcept {
-  return Domain<1, TargetFrame>{
-      make_vector_coordinate_map_base<Frame::Logical, TargetFrame>(
+Domain<1> Interval::create_domain() const noexcept {
+  return Domain<1>{
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           CoordinateMaps::Affine{-1., 1., lower_x_[0], upper_x_[0]}),
       std::vector<std::array<size_t, 2>>{{{1, 2}}},
       is_periodic_in_x_[0] ? std::vector<PairOfFaces>{{{1}, {2}}}
                            : std::vector<PairOfFaces>{}};
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 1>> Interval<TargetFrame>::initial_extents()
-    const noexcept {
+std::vector<std::array<size_t, 1>> Interval::initial_extents() const noexcept {
   return {{{initial_number_of_grid_points_in_x_}}};
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 1>>
-Interval<TargetFrame>::initial_refinement_levels() const noexcept {
+std::vector<std::array<size_t, 1>> Interval::initial_refinement_levels() const
+    noexcept {
   return {{{initial_refinement_level_x_}}};
 }
-
-template class Interval<Frame::Inertial>;
-template class Interval<Frame::Grid>;
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/Interval.hpp
+++ b/src/Domain/Creators/Interval.hpp
@@ -10,22 +10,16 @@
 #include <cstddef>
 #include <vector>
 
+#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
-template <size_t Dim, typename Frame>
-class DomainCreator;  // IWYU pragma: keep
-/// \endcond
-
 namespace domain {
 namespace creators {
-
 /// Create a 1D Domain consisting of a single Block.
-template <typename TargetFrame>
-class Interval : public DomainCreator<1, TargetFrame> {
+class Interval : public DomainCreator<1> {
  public:
   struct LowerBound {
     using type = std::array<double, 1>;
@@ -69,7 +63,7 @@ class Interval : public DomainCreator<1, TargetFrame> {
   Interval& operator=(Interval&&) noexcept = default;
   ~Interval() override = default;
 
-  Domain<1, TargetFrame> create_domain() const noexcept override;
+  Domain<1> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, 1>> initial_extents() const noexcept override;
 

--- a/src/Domain/Creators/Rectangle.cpp
+++ b/src/Domain/Creators/Rectangle.cpp
@@ -17,7 +17,6 @@
 
 /// \cond
 namespace Frame {
-struct Grid;
 struct Inertial;
 struct Logical;
 }  // namespace Frame
@@ -25,9 +24,7 @@ struct Logical;
 
 namespace domain {
 namespace creators {
-
-template <typename TargetFrame>
-Rectangle<TargetFrame>::Rectangle(
+Rectangle::Rectangle(
     typename LowerBound::type lower_xy, typename UpperBound::type upper_xy,
     typename IsPeriodicIn::type is_periodic_in_xy,
     typename InitialRefinement::type initial_refinement_level_xy,
@@ -42,8 +39,7 @@ Rectangle<TargetFrame>::Rectangle(
       initial_number_of_grid_points_in_xy_(                   // NOLINT
           std::move(initial_number_of_grid_points_in_xy)) {}  // NOLINT
 
-template <typename TargetFrame>
-Domain<2, TargetFrame> Rectangle<TargetFrame>::create_domain() const noexcept {
+Domain<2> Rectangle::create_domain() const noexcept {
   using Affine = CoordinateMaps::Affine;
   using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
   std::vector<PairOfFaces> identifications{};
@@ -54,26 +50,20 @@ Domain<2, TargetFrame> Rectangle<TargetFrame>::create_domain() const noexcept {
     identifications.push_back({{0, 1}, {2, 3}});
   }
 
-  return Domain<2, TargetFrame>{
-      make_vector_coordinate_map_base<Frame::Logical, TargetFrame>(
+  return Domain<2>{
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Affine2D{Affine{-1., 1., lower_xy_[0], upper_xy_[0]},
                    Affine{-1., 1., lower_xy_[1], upper_xy_[1]}}),
       std::vector<std::array<size_t, 4>>{{{0, 1, 2, 3}}}, identifications};
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 2>> Rectangle<TargetFrame>::initial_extents()
-    const noexcept {
+std::vector<std::array<size_t, 2>> Rectangle::initial_extents() const noexcept {
   return {initial_number_of_grid_points_in_xy_};
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 2>>
-Rectangle<TargetFrame>::initial_refinement_levels() const noexcept {
+std::vector<std::array<size_t, 2>> Rectangle::initial_refinement_levels() const
+    noexcept {
   return {initial_refinement_level_xy_};
 }
-
-template class Rectangle<Frame::Inertial>;
-template class Rectangle<Frame::Grid>;
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/Rectangle.hpp
+++ b/src/Domain/Creators/Rectangle.hpp
@@ -10,22 +10,16 @@
 #include <cstddef>
 #include <vector>
 
+#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
-template <size_t Dim, typename Frame>
-class DomainCreator;  // IWYU pragma: keep
-/// \endcond
-
 namespace domain {
 namespace creators {
-
 /// Create a 2D Domain consisting of a single Block.
-template <typename TargetFrame>
-class Rectangle : public DomainCreator<2, TargetFrame> {
+class Rectangle : public DomainCreator<2> {
  public:
   struct LowerBound {
     using type = std::array<double, 2>;
@@ -74,7 +68,7 @@ class Rectangle : public DomainCreator<2, TargetFrame> {
   Rectangle& operator=(Rectangle&&) noexcept = default;
   ~Rectangle() noexcept override = default;
 
-  Domain<2, TargetFrame> create_domain() const noexcept override;
+  Domain<2> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, 2>> initial_extents() const noexcept override;
 

--- a/src/Domain/Creators/RotatedBricks.cpp
+++ b/src/Domain/Creators/RotatedBricks.cpp
@@ -9,16 +9,9 @@
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/OrientationMap.hpp"
 
-namespace Frame {
-struct Grid;
-struct Inertial;
-}  // namespace Frame
-
 namespace domain {
 namespace creators {
-
-template <typename TargetFrame>
-RotatedBricks<TargetFrame>::RotatedBricks(
+RotatedBricks::RotatedBricks(
     const typename LowerBound::type lower_xyz,
     const typename Midpoint::type midpoint_xyz,
     const typename UpperBound::type upper_xyz,
@@ -36,10 +29,8 @@ RotatedBricks<TargetFrame>::RotatedBricks(
       initial_number_of_grid_points_in_xyz_(                   // NOLINT
           std::move(initial_number_of_grid_points_in_xyz)) {}  // NOLINT
 
-template <typename TargetFrame>
-Domain<3, TargetFrame> RotatedBricks<TargetFrame>::create_domain() const
-    noexcept {
-  return rectilinear_domain<3, TargetFrame>(
+Domain<3> RotatedBricks::create_domain() const noexcept {
+  return rectilinear_domain<3>(
       Index<3>{2, 2, 2},
       std::array<std::vector<double>, 3>{
           {{lower_xyz_[0], midpoint_xyz_[0], upper_xyz_[0]},
@@ -72,9 +63,8 @@ Domain<3, TargetFrame> RotatedBricks<TargetFrame>::create_domain() const
       is_periodic_in_);
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 3>> RotatedBricks<TargetFrame>::initial_extents()
-    const noexcept {
+std::vector<std::array<size_t, 3>> RotatedBricks::initial_extents() const
+    noexcept {
   const size_t& x_0 = initial_number_of_grid_points_in_xyz_[0][0];
   const size_t& x_1 = initial_number_of_grid_points_in_xyz_[0][1];
   const size_t& y_0 = initial_number_of_grid_points_in_xyz_[1][0];
@@ -86,9 +76,8 @@ std::vector<std::array<size_t, 3>> RotatedBricks<TargetFrame>::initial_extents()
           {{y_1, z_1, x_0}}, {{x_1, y_1, z_1}}};
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 3>>
-RotatedBricks<TargetFrame>::initial_refinement_levels() const noexcept {
+std::vector<std::array<size_t, 3>> RotatedBricks::initial_refinement_levels()
+    const noexcept {
   const size_t& x_0 = initial_refinement_level_xyz_[0];
   const size_t& y_0 = initial_refinement_level_xyz_[1];
   const size_t& z_0 = initial_refinement_level_xyz_[2];
@@ -96,8 +85,5 @@ RotatedBricks<TargetFrame>::initial_refinement_levels() const noexcept {
           {{y_0, z_0, x_0}}, {{y_0, x_0, z_0}}, {{z_0, x_0, y_0}},
           {{y_0, z_0, x_0}}, {{x_0, y_0, z_0}}};
 }
-
-template class RotatedBricks<Frame::Inertial>;
-template class RotatedBricks<Frame::Grid>;
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/RotatedBricks.hpp
+++ b/src/Domain/Creators/RotatedBricks.hpp
@@ -15,7 +15,6 @@
 
 namespace domain {
 namespace creators {
-
 /// Create a 3D Domain consisting of eight rotated Blocks.
 ///
 /// \image html eightcubes_rotated_exploded.png
@@ -71,8 +70,7 @@ namespace creators {
 ///
 /// This DomainCreator is useful for testing code that deals with
 /// unaligned blocks.
-template <typename TargetFrame>
-class RotatedBricks : public DomainCreator<3, TargetFrame> {
+class RotatedBricks : public DomainCreator<3> {
  public:
   struct LowerBound {
     using type = std::array<double, 3>;
@@ -136,7 +134,7 @@ class RotatedBricks : public DomainCreator<3, TargetFrame> {
   RotatedBricks& operator=(RotatedBricks&&) noexcept = default;
   ~RotatedBricks() override = default;
 
-  Domain<3, TargetFrame> create_domain() const noexcept override;
+  Domain<3> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const noexcept override;
 

--- a/src/Domain/Creators/RotatedIntervals.cpp
+++ b/src/Domain/Creators/RotatedIntervals.cpp
@@ -12,17 +12,9 @@
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/OrientationMap.hpp"
 
-/// \cond
-namespace Frame {
-struct Grid;
-struct Inertial;
-}  // namespace Frame
-/// \endcond
-
 namespace domain {
 namespace creators {
-template <typename TargetFrame>
-RotatedIntervals<TargetFrame>::RotatedIntervals(
+RotatedIntervals::RotatedIntervals(
     typename LowerBound::type lower_x, typename Midpoint::type midpoint_x,
     typename UpperBound::type upper_x,
     typename IsPeriodicIn::type is_periodic_in,
@@ -39,31 +31,24 @@ RotatedIntervals<TargetFrame>::RotatedIntervals(
       initial_number_of_grid_points_in_x_(                   // NOLINT
           std::move(initial_number_of_grid_points_in_x)) {}  // NOLINT
 
-template <typename TargetFrame>
-Domain<1, TargetFrame> RotatedIntervals<TargetFrame>::create_domain() const
-    noexcept {
-  return rectilinear_domain<1, TargetFrame>(
+Domain<1> RotatedIntervals::create_domain() const noexcept {
+  return rectilinear_domain<1>(
       Index<1>{2}, {{{lower_x_[0], midpoint_x_[0], upper_x_[0]}}}, {},
       {OrientationMap<1>{}, OrientationMap<1>{std::array<Direction<1>, 1>{
                                 {Direction<1>::lower_xi()}}}},
       is_periodic_in_);
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 1>>
-RotatedIntervals<TargetFrame>::initial_extents() const noexcept {
+std::vector<std::array<size_t, 1>> RotatedIntervals::initial_extents() const
+    noexcept {
   return {{{initial_number_of_grid_points_in_x_[0][0]}},
           {{initial_number_of_grid_points_in_x_[0][1]}}};
 }
 
-template <typename TargetFrame>
 std::vector<std::array<size_t, 1>>
-RotatedIntervals<TargetFrame>::initial_refinement_levels() const noexcept {
+RotatedIntervals ::initial_refinement_levels() const noexcept {
   return {{{initial_refinement_level_x_[0]}},
           {{initial_refinement_level_x_[0]}}};
 }
-
-template class RotatedIntervals<Frame::Inertial>;
-template class RotatedIntervals<Frame::Grid>;
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/RotatedIntervals.hpp
+++ b/src/Domain/Creators/RotatedIntervals.hpp
@@ -11,24 +11,18 @@
 #include <limits>
 #include <vector>
 
+#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
-template <size_t Dim, typename Frame>
-class DomainCreator;  // IWYU pragma: keep
-/// \endcond
-
 namespace domain {
 namespace creators {
-
 /// Create a 1D Domain consisting of two rotated Blocks.
 /// The left block has its logical \f$\xi\f$-axis aligned with the grid x-axis.
 /// The right block has its logical \f$\xi\f$-axis opposite to the grid x-axis.
 /// This is useful for testing code that deals with unaligned blocks.
-template <typename TargetFrame>
-class RotatedIntervals : public DomainCreator<1, TargetFrame> {
+class RotatedIntervals : public DomainCreator<1> {
  public:
   struct LowerBound {
     using type = std::array<double, 1>;
@@ -91,7 +85,7 @@ class RotatedIntervals : public DomainCreator<1, TargetFrame> {
   RotatedIntervals& operator=(RotatedIntervals&&) noexcept = default;
   ~RotatedIntervals() override = default;
 
-  Domain<1, TargetFrame> create_domain() const noexcept override;
+  Domain<1> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, 1>> initial_extents() const noexcept override;
 

--- a/src/Domain/Creators/RotatedRectangles.cpp
+++ b/src/Domain/Creators/RotatedRectangles.cpp
@@ -9,16 +9,9 @@
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/OrientationMap.hpp"
 
-namespace Frame {
-struct Grid;
-struct Inertial;
-}  // namespace Frame
-
 namespace domain {
 namespace creators {
-
-template <typename TargetFrame>
-RotatedRectangles<TargetFrame>::RotatedRectangles(
+RotatedRectangles::RotatedRectangles(
     const typename LowerBound::type lower_xy,
     const typename Midpoint::type midpoint_xy,
     const typename UpperBound::type upper_xy,
@@ -36,10 +29,8 @@ RotatedRectangles<TargetFrame>::RotatedRectangles(
       initial_number_of_grid_points_in_xy_(                   // NOLINT
           std::move(initial_number_of_grid_points_in_xy)) {}  // NOLINT
 
-template <typename TargetFrame>
-Domain<2, TargetFrame> RotatedRectangles<TargetFrame>::create_domain() const
-    noexcept {
-  return rectilinear_domain<2, TargetFrame>(
+Domain<2> RotatedRectangles::create_domain() const noexcept {
+  return rectilinear_domain<2>(
       Index<2>{2, 2},
       std::array<std::vector<double>, 2>{
           {{lower_xy_[0], midpoint_xy_[0], upper_xy_[0]},
@@ -56,9 +47,8 @@ Domain<2, TargetFrame> RotatedRectangles<TargetFrame>::create_domain() const
       is_periodic_in_);
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 2>>
-RotatedRectangles<TargetFrame>::initial_extents() const noexcept {
+std::vector<std::array<size_t, 2>> RotatedRectangles::initial_extents() const
+    noexcept {
   const size_t& x_0 = initial_number_of_grid_points_in_xy_[0][0];
   const size_t& x_1 = initial_number_of_grid_points_in_xy_[0][1];
   const size_t& y_0 = initial_number_of_grid_points_in_xy_[1][0];
@@ -66,15 +56,11 @@ RotatedRectangles<TargetFrame>::initial_extents() const noexcept {
   return {{{x_0, y_0}}, {{x_1, y_0}}, {{y_1, x_0}}, {{y_1, x_1}}};
 }
 
-template <typename TargetFrame>
 std::vector<std::array<size_t, 2>>
-RotatedRectangles<TargetFrame>::initial_refinement_levels() const noexcept {
+RotatedRectangles::initial_refinement_levels() const noexcept {
   const size_t& x_0 = initial_refinement_level_xy_[0];
   const size_t& y_0 = initial_refinement_level_xy_[1];
   return {{{x_0, y_0}}, {{x_0, y_0}}, {{y_0, x_0}}, {{y_0, x_0}}};
 }
-
-template class RotatedRectangles<Frame::Inertial>;
-template class RotatedRectangles<Frame::Grid>;
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/RotatedRectangles.hpp
+++ b/src/Domain/Creators/RotatedRectangles.hpp
@@ -15,7 +15,6 @@
 
 namespace domain {
 namespace creators {
-
 /// Create a 2D Domain consisting of four rotated Blocks.
 /// - The lower left block has its logical \f$\xi\f$-axis aligned with
 /// the grid x-axis.
@@ -31,8 +30,7 @@ namespace creators {
 ///
 /// This DomainCreator is useful for testing code that deals with
 /// unaligned blocks.
-template <typename TargetFrame>
-class RotatedRectangles : public DomainCreator<2, TargetFrame> {
+class RotatedRectangles : public DomainCreator<2> {
  public:
   struct LowerBound {
     using type = std::array<double, 2>;
@@ -96,7 +94,7 @@ class RotatedRectangles : public DomainCreator<2, TargetFrame> {
   RotatedRectangles& operator=(RotatedRectangles&&) noexcept = default;
   ~RotatedRectangles() override = default;
 
-  Domain<2, TargetFrame> create_domain() const noexcept override;
+  Domain<2> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, 2>> initial_extents() const noexcept override;
 

--- a/src/Domain/Creators/Shell.cpp
+++ b/src/Domain/Creators/Shell.cpp
@@ -17,7 +17,6 @@
 
 /// \cond
 namespace Frame {
-struct Grid;
 struct Inertial;
 struct Logical;
 }  // namespace Frame
@@ -25,18 +24,15 @@ struct Logical;
 
 namespace domain {
 namespace creators {
-
-template <typename TargetFrame>
-Shell<TargetFrame>::Shell(
-    typename InnerRadius::type inner_radius,
-    typename OuterRadius::type outer_radius,
-    typename InitialRefinement::type initial_refinement,
-    typename InitialGridPoints::type initial_number_of_grid_points,
-    typename UseEquiangularMap::type use_equiangular_map,
-    typename AspectRatio::type aspect_ratio,
-    typename UseLogarithmicMap::type use_logarithmic_map,
-    typename WhichWedges::type which_wedges,
-    typename RadialBlockLayers::type number_of_layers) noexcept
+Shell::Shell(typename InnerRadius::type inner_radius,
+             typename OuterRadius::type outer_radius,
+             typename InitialRefinement::type initial_refinement,
+             typename InitialGridPoints::type initial_number_of_grid_points,
+             typename UseEquiangularMap::type use_equiangular_map,
+             typename AspectRatio::type aspect_ratio,
+             typename UseLogarithmicMap::type use_logarithmic_map,
+             typename WhichWedges::type which_wedges,
+             typename RadialBlockLayers::type number_of_layers) noexcept
     // clang-tidy: trivially copyable
     : inner_radius_(std::move(inner_radius)),                // NOLINT
       outer_radius_(std::move(outer_radius)),                // NOLINT
@@ -50,23 +46,20 @@ Shell<TargetFrame>::Shell(
       which_wedges_(std::move(which_wedges)),                // NOLINT
       number_of_layers_(std::move(number_of_layers)) {}      // NOLINT
 
-template <typename TargetFrame>
-Domain<3, TargetFrame> Shell<TargetFrame>::create_domain() const noexcept {
+Domain<3> Shell::create_domain() const noexcept {
   std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
-      coord_maps = wedge_coordinate_maps<TargetFrame>(
+      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+      coord_maps = wedge_coordinate_maps<Frame::Inertial>(
           inner_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_, 0.0,
           false, aspect_ratio_, use_logarithmic_map_, which_wedges_,
           number_of_layers_);
-  return Domain<3, TargetFrame>{
+  return Domain<3>{
       std::move(coord_maps),
       corners_for_radially_layered_domains(
           number_of_layers_, false, {{1, 2, 3, 4, 5, 6, 7, 8}}, which_wedges_)};
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 3>> Shell<TargetFrame>::initial_extents() const
-    noexcept {
+std::vector<std::array<size_t, 3>> Shell::initial_extents() const noexcept {
   std::vector<std::array<size_t, 3>>::size_type num_wedges =
       6 * number_of_layers_;
   if (UNLIKELY(which_wedges_ == ShellWedges::FourOnEquator)) {
@@ -79,9 +72,9 @@ std::vector<std::array<size_t, 3>> Shell<TargetFrame>::initial_extents() const
       {{initial_number_of_grid_points_[1], initial_number_of_grid_points_[1],
         initial_number_of_grid_points_[0]}}};
 }
-template <typename TargetFrame>
-std::vector<std::array<size_t, 3>>
-Shell<TargetFrame>::initial_refinement_levels() const noexcept {
+
+std::vector<std::array<size_t, 3>> Shell::initial_refinement_levels() const
+    noexcept {
   std::vector<std::array<size_t, 3>>::size_type num_wedges =
       6 * number_of_layers_;
   if (UNLIKELY(which_wedges_ == ShellWedges::FourOnEquator)) {
@@ -91,8 +84,5 @@ Shell<TargetFrame>::initial_refinement_levels() const noexcept {
   }
   return {num_wedges, make_array<3>(initial_refinement_)};
 }
-
-template class Shell<Frame::Grid>;
-template class Shell<Frame::Inertial>;
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/Shell.hpp
+++ b/src/Domain/Creators/Shell.hpp
@@ -7,19 +7,14 @@
 #include <cstddef>
 #include <vector>
 
+#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
-template <size_t, class>
-class DomainCreator;  // IWYU pragma: keep
-/// \endcond
-
 namespace domain {
 namespace creators {
-
 /*!
  * \brief Creates a 3D Domain in the shape of a hollow spherical shell
  * consisting of six wedges.
@@ -27,8 +22,7 @@ namespace creators {
  * \image html WedgeOrientations.png "The orientation of each wedge in Shell."
  */
 
-template <typename TargetFrame>
-class Shell : public DomainCreator<3, TargetFrame> {
+class Shell : public DomainCreator<3> {
  public:
   struct InnerRadius {
     using type = double;
@@ -122,7 +116,7 @@ class Shell : public DomainCreator<3, TargetFrame> {
   Shell& operator=(Shell&&) noexcept = default;
   ~Shell() noexcept override = default;
 
-  Domain<3, TargetFrame> create_domain() const noexcept override;
+  Domain<3> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const noexcept override;
 

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -19,7 +19,6 @@
 
 /// \cond
 namespace Frame {
-struct Grid;      // IWYU pragma: keep
 struct Inertial;  // IWYU pragma: keep
 struct Logical;   // IWYU pragma: keep
 }  // namespace Frame
@@ -27,14 +26,11 @@ struct Logical;   // IWYU pragma: keep
 
 namespace domain {
 namespace creators {
-
-template <typename TargetFrame>
-Sphere<TargetFrame>::Sphere(
-    typename InnerRadius::type inner_radius,
-    typename OuterRadius::type outer_radius,
-    typename InitialRefinement::type initial_refinement,
-    typename InitialGridPoints::type initial_number_of_grid_points,
-    typename UseEquiangularMap::type use_equiangular_map) noexcept
+Sphere::Sphere(typename InnerRadius::type inner_radius,
+               typename OuterRadius::type outer_radius,
+               typename InitialRefinement::type initial_refinement,
+               typename InitialGridPoints::type initial_number_of_grid_points,
+               typename UseEquiangularMap::type use_equiangular_map) noexcept
     // clang-tidy: trivially copyable
     : inner_radius_(std::move(inner_radius)),                  // NOLINT
       outer_radius_(std::move(outer_radius)),                  // NOLINT
@@ -44,8 +40,7 @@ Sphere<TargetFrame>::Sphere(
           std::move(initial_number_of_grid_points)),           // NOLINT
       use_equiangular_map_(std::move(use_equiangular_map)) {}  // NOLINT
 
-template <typename TargetFrame>
-Domain<3, TargetFrame> Sphere<TargetFrame>::create_domain() const noexcept {
+Domain<3> Sphere::create_domain() const noexcept {
   using Affine = CoordinateMaps::Affine;
   using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   using Equiangular = CoordinateMaps::Equiangular;
@@ -55,12 +50,12 @@ Domain<3, TargetFrame> Sphere<TargetFrame>::create_domain() const noexcept {
       corners_for_radially_layered_domains(1, true);
 
   std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
-      coord_maps = wedge_coordinate_maps<TargetFrame>(
+      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+      coord_maps = wedge_coordinate_maps<Frame::Inertial>(
           inner_radius_, outer_radius_, 0.0, 1.0, use_equiangular_map_);
   if (use_equiangular_map_) {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(Equiangular3D{
+        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(Equiangular3D{
             Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
                         inner_radius_ / sqrt(3.0)),
             Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
@@ -69,7 +64,7 @@ Domain<3, TargetFrame> Sphere<TargetFrame>::create_domain() const noexcept {
                         inner_radius_ / sqrt(3.0))}));
   } else {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Affine3D{Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
                             inner_radius_ / sqrt(3.0)),
                      Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
@@ -77,12 +72,10 @@ Domain<3, TargetFrame> Sphere<TargetFrame>::create_domain() const noexcept {
                      Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
                             inner_radius_ / sqrt(3.0))}));
   }
-  return Domain<3, TargetFrame>(std::move(coord_maps), corners);
+  return Domain<3>(std::move(coord_maps), corners);
 }
 
-template <typename TargetFrame>
-std::vector<std::array<size_t, 3>> Sphere<TargetFrame>::initial_extents() const
-    noexcept {
+std::vector<std::array<size_t, 3>> Sphere::initial_extents() const noexcept {
   std::vector<std::array<size_t, 3>> extents{
       6,
       {{initial_number_of_grid_points_[1], initial_number_of_grid_points_[1],
@@ -92,13 +85,10 @@ std::vector<std::array<size_t, 3>> Sphere<TargetFrame>::initial_extents() const
         initial_number_of_grid_points_[1]}});
   return extents;
 }
-template <typename TargetFrame>
-std::vector<std::array<size_t, 3>>
-Sphere<TargetFrame>::initial_refinement_levels() const noexcept {
+
+std::vector<std::array<size_t, 3>> Sphere::initial_refinement_levels() const
+    noexcept {
   return {7, make_array<3>(initial_refinement_)};
 }
-
-template class Sphere<Frame::Grid>;
-template class Sphere<Frame::Inertial>;
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <vector>
 
+#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
@@ -17,19 +18,12 @@
 
 // IWYU pragma: no_include "DataStructures/Tensor/Tensor.hpp" // Not needed
 
-/// \cond
-template <size_t Dim, typename Frame>
-class DomainCreator;  // IWYU pragma: keep
-/// \endcond
-
 namespace domain {
 namespace creators {
-
 /// Create a 3D Domain in the shape of a sphere consisting of six wedges
 /// and a central cube. For an image showing how the wedges are aligned in
 /// this Domain, see the documentation for Shell.
-template <typename TargetFrame>
-class Sphere : public DomainCreator<3, TargetFrame> {
+class Sphere : public DomainCreator<3> {
  public:
   struct InnerRadius {
     using type = double;
@@ -87,7 +81,7 @@ class Sphere : public DomainCreator<3, TargetFrame> {
   Sphere& operator=(Sphere&&) noexcept = default;
   ~Sphere() noexcept override = default;
 
-  Domain<3, TargetFrame> create_domain() const noexcept override;
+  Domain<3> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const noexcept override;
 

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -15,20 +15,18 @@
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace Frame {
-struct Grid;
 struct Inertial;
 struct Logical;
 }  // namespace Frame
 
-template <size_t VolumeDim, typename TargetFrame>
-Domain<VolumeDim, TargetFrame>::Domain(
-    std::vector<Block<VolumeDim, TargetFrame>> blocks) noexcept
+template <size_t VolumeDim>
+Domain<VolumeDim>::Domain(std::vector<Block<VolumeDim>> blocks) noexcept
     : blocks_(std::move(blocks)) {}
 
-template <size_t VolumeDim, typename TargetFrame>
-Domain<VolumeDim, TargetFrame>::Domain(
+template <size_t VolumeDim>
+Domain<VolumeDim>::Domain(
     std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>
+        domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>>
         maps,
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
@@ -47,21 +45,21 @@ Domain<VolumeDim, TargetFrame>::Domain(
   }
 }
 
-template <size_t VolumeDim, typename TargetFrame>
-bool operator==(const Domain<VolumeDim, TargetFrame>& lhs,
-                const Domain<VolumeDim, TargetFrame>& rhs) noexcept {
+template <size_t VolumeDim>
+bool operator==(const Domain<VolumeDim>& lhs,
+                const Domain<VolumeDim>& rhs) noexcept {
   return lhs.blocks() == rhs.blocks();
 }
 
-template <size_t VolumeDim, typename TargetFrame>
-bool operator!=(const Domain<VolumeDim, TargetFrame>& lhs,
-                const Domain<VolumeDim, TargetFrame>& rhs) noexcept {
+template <size_t VolumeDim>
+bool operator!=(const Domain<VolumeDim>& lhs,
+                const Domain<VolumeDim>& rhs) noexcept {
   return not(lhs == rhs);
 }
 
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim>
 std::ostream& operator<<(std::ostream& os,
-                         const Domain<VolumeDim, TargetFrame>& d) noexcept {
+                         const Domain<VolumeDim>& d) noexcept {
   const auto& blocks = d.blocks();
   os << "Domain with " << blocks.size() << " blocks:\n";
   for (const auto& block : blocks) {
@@ -70,26 +68,24 @@ std::ostream& operator<<(std::ostream& os,
   return os;
 }
 
-template <size_t VolumeDim, typename TargetFrame>
-void Domain<VolumeDim, TargetFrame>::pup(PUP::er& p) noexcept {
+template <size_t VolumeDim>
+void Domain<VolumeDim>::pup(PUP::er& p) noexcept {
   p | blocks_;
 }
 
 /// \cond HIDDEN_SYMBOLS
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define INSTANTIATE(_, data)                               \
-  template class Domain<DIM(data), FRAME(data)>;           \
-  template bool operator==(                                \
-      const Domain<DIM(data), FRAME(data)>& lhs,           \
-      const Domain<DIM(data), FRAME(data)>& rhs) noexcept; \
-  template bool operator!=(                                \
-      const Domain<DIM(data), FRAME(data)>& lhs,           \
-      const Domain<DIM(data), FRAME(data)>& rhs) noexcept; \
-  template std::ostream& operator<<(std::ostream& os,      \
-                                    const Domain<DIM(data), FRAME(data)>& d);
+#define INSTANTIATE(_, data)                                       \
+  template class Domain<DIM(data)>;                                \
+  template bool operator==(const Domain<DIM(data)>& lhs,           \
+                           const Domain<DIM(data)>& rhs) noexcept; \
+  template bool operator!=(const Domain<DIM(data)>& lhs,           \
+                           const Domain<DIM(data)>& rhs) noexcept; \
+  template std::ostream& operator<<(std::ostream& os,              \
+                                    const Domain<DIM(data)>& d);
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef FRAME

--- a/src/Domain/Domain.hpp
+++ b/src/Domain/Domain.hpp
@@ -34,10 +34,10 @@ class CoordinateMapBase;
  *  \brief A wrapper around a vector of Blocks that represent the computational
  * domain.
  */
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim>
 class Domain {
  public:
-  explicit Domain(std::vector<Block<VolumeDim, TargetFrame>> blocks) noexcept;
+  explicit Domain(std::vector<Block<VolumeDim>> blocks) noexcept;
 
   /*!
    * Create a Domain using a corner numbering scheme to encode the Orientations,
@@ -56,8 +56,8 @@ class Domain {
    * \requires `maps.size() == corners_of_all_blocks.size()`, and
    * `identifications.size()` is even.
    */
-  Domain(std::vector<std::unique_ptr<
-             domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>
+  Domain(std::vector<std::unique_ptr<domain::CoordinateMapBase<
+             Frame::Logical, Frame::Inertial, VolumeDim>>>
              maps,
          const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
              corners_of_all_blocks,
@@ -67,12 +67,10 @@ class Domain {
   ~Domain() = default;
   Domain(const Domain&) = delete;
   Domain(Domain&&) = default;
-  Domain<VolumeDim, TargetFrame>& operator=(
-      const Domain<VolumeDim, TargetFrame>&) = delete;
-  Domain<VolumeDim, TargetFrame>& operator=(Domain<VolumeDim, TargetFrame>&&) =
-      default;
+  Domain<VolumeDim>& operator=(const Domain<VolumeDim>&) = delete;
+  Domain<VolumeDim>& operator=(Domain<VolumeDim>&&) = default;
 
-  const std::vector<Block<VolumeDim, TargetFrame>>& blocks() const noexcept {
+  const std::vector<Block<VolumeDim>>& blocks() const noexcept {
     return blocks_;
   }
 
@@ -80,17 +78,16 @@ class Domain {
   void pup(PUP::er& p) noexcept;  // NOLINT
 
  private:
-  std::vector<Block<VolumeDim, TargetFrame>> blocks_{};
+  std::vector<Block<VolumeDim>> blocks_{};
 };
 
-template <size_t VolumeDim, typename TargetFrame>
-bool operator==(const Domain<VolumeDim, TargetFrame>& lhs,
-                const Domain<VolumeDim, TargetFrame>& rhs) noexcept;
+template <size_t VolumeDim>
+bool operator==(const Domain<VolumeDim>& lhs,
+                const Domain<VolumeDim>& rhs) noexcept;
 
-template <size_t VolumeDim, typename TargetFrame>
-bool operator!=(const Domain<VolumeDim, TargetFrame>& lhs,
-                const Domain<VolumeDim, TargetFrame>& rhs) noexcept;
+template <size_t VolumeDim>
+bool operator!=(const Domain<VolumeDim>& lhs,
+                const Domain<VolumeDim>& rhs) noexcept;
 
-template <size_t VolumeDim, typename TargetFrame>
-std::ostream& operator<<(std::ostream& os,
-                         const Domain<VolumeDim, TargetFrame>& d) noexcept;
+template <size_t VolumeDim>
+std::ostream& operator<<(std::ostream& os, const Domain<VolumeDim>& d) noexcept;

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -137,8 +137,8 @@ logical_coords_of_corners(
   std::array<tnsr::I<double, VolumeDim, Frame::Logical>,
              two_to_the(VolumeDim - 1)>
       result{};
-  std::transform(local_ids.begin(), local_ids.end(),
-                 result.begin(), [](const size_t id) noexcept {
+  std::transform(local_ids.begin(), local_ids.end(), result.begin(),
+                 [](const size_t id) noexcept {
                    tnsr::I<double, VolumeDim, Frame::Logical> point{};
                    for (size_t i = 0; i < VolumeDim; i++) {
                      point[i] = 2.0 * get_nth_bit(id, i) - 1.0;
@@ -154,7 +154,7 @@ Direction<VolumeDim> get_direction_normal_to_face(
                      two_to_the(VolumeDim - 1)>& face_pts) noexcept {
   const auto summed_point = alg::accumulate(
       face_pts, tnsr::I<double, VolumeDim, Frame::Logical>(0.0),
-      [](tnsr::I<double, VolumeDim, Frame::Logical> & prior,
+      [](tnsr::I<double, VolumeDim, Frame::Logical>& prior,
          const tnsr::I<double, VolumeDim, Frame::Logical>& point) noexcept {
         for (size_t i = 0; i < prior.size(); i++) {
           prior[i] += point[i];
@@ -1000,8 +1000,8 @@ std::array<size_t, two_to_the(VolumeDim)> discrete_rotation(
   return result;
 }
 
-template <size_t VolumeDim, typename TargetFrame>
-Domain<VolumeDim, TargetFrame> rectilinear_domain(
+template <size_t VolumeDim>
+Domain<VolumeDim> rectilinear_domain(
     const Index<VolumeDim>& domain_extents,
     const std::array<std::vector<double>, VolumeDim>& block_demarcations,
     const std::vector<Index<VolumeDim>>& block_indices_to_exclude,
@@ -1009,7 +1009,7 @@ Domain<VolumeDim, TargetFrame> rectilinear_domain(
     const std::array<bool, VolumeDim>& dimension_is_periodic,
     const std::vector<PairOfFaces>& identifications,
     const bool use_equiangular_map) noexcept {
-  std::vector<Block<VolumeDim, TargetFrame>> blocks{};
+  std::vector<Block<VolumeDim>> blocks{};
   auto corners_of_all_blocks =
       corners_for_rectilinear_domains(domain_extents, block_indices_to_exclude);
   auto rotations_of_all_blocks = orientations_of_all_blocks;
@@ -1018,7 +1018,7 @@ Domain<VolumeDim, TargetFrame> rectilinear_domain(
     rotations_of_all_blocks = std::vector<OrientationMap<VolumeDim>>{
         corners_of_all_blocks.size(), OrientationMap<VolumeDim>{}};
   }
-  auto maps = maps_for_rectilinear_domains<TargetFrame>(
+  auto maps = maps_for_rectilinear_domains<Frame::Inertial>(
       domain_extents, block_demarcations, block_indices_to_exclude,
       rotations_of_all_blocks, use_equiangular_map);
   for (size_t i = 0; i < corners_of_all_blocks.size(); i++) {
@@ -1038,7 +1038,7 @@ Domain<VolumeDim, TargetFrame> rectilinear_domain(
     blocks.emplace_back(std::move(maps[i]), i,
                         std::move(neighbors_of_all_blocks[i]));
   }
-  return Domain<VolumeDim, TargetFrame>(std::move(blocks));
+  return Domain<VolumeDim>(std::move(blocks));
 }
 
 std::ostream& operator<<(std::ostream& os,
@@ -1158,27 +1158,27 @@ frustum_coordinate_maps(const double length_inner_cube,
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE(_, data)                                                \
-  template std::vector<std::unique_ptr<                                     \
-      domain::CoordinateMapBase<Frame::Logical, FRAME(data), DIM(data)>>>   \
-  maps_for_rectilinear_domains(                                             \
-      const Index<DIM(data)>& domain_extents,                               \
-      const std::array<std::vector<double>, DIM(data)>& block_demarcations, \
-      const std::vector<Index<DIM(data)>>& block_indices_to_exclude,        \
-      const std::vector<OrientationMap<DIM(data)>>&                         \
-          orientations_of_all_blocks,                                       \
-      const bool use_equiangular_map) noexcept;                             \
-  template Domain<DIM(data), FRAME(data)> rectilinear_domain(               \
-      const Index<DIM(data)>& domain_extents,                               \
-      const std::array<std::vector<double>, DIM(data)>& block_demarcations, \
-      const std::vector<Index<DIM(data)>>& block_indices_to_exclude,        \
-      const std::vector<OrientationMap<DIM(data)>>&                         \
-          orientations_of_all_blocks,                                       \
-      const std::array<bool, DIM(data)>& dimension_is_periodic,             \
-      const std::vector<PairOfFaces>& identifications,                      \
+#define INSTANTIATE(_, data)                                                  \
+  template std::vector<std::unique_ptr<                                       \
+      domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, DIM(data)>>> \
+  maps_for_rectilinear_domains(                                               \
+      const Index<DIM(data)>& domain_extents,                                 \
+      const std::array<std::vector<double>, DIM(data)>& block_demarcations,   \
+      const std::vector<Index<DIM(data)>>& block_indices_to_exclude,          \
+      const std::vector<OrientationMap<DIM(data)>>&                           \
+          orientations_of_all_blocks,                                         \
+      const bool use_equiangular_map) noexcept;                               \
+  template Domain<DIM(data)> rectilinear_domain(                              \
+      const Index<DIM(data)>& domain_extents,                                 \
+      const std::array<std::vector<double>, DIM(data)>& block_demarcations,   \
+      const std::vector<Index<DIM(data)>>& block_indices_to_exclude,          \
+      const std::vector<OrientationMap<DIM(data)>>&                           \
+          orientations_of_all_blocks,                                         \
+      const std::array<bool, DIM(data)>& dimension_is_periodic,               \
+      const std::vector<PairOfFaces>& identifications,                        \
       const bool use_equiangular_map) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef DTYPE

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -30,7 +30,7 @@ class CoordinateMapBase;
 }  // namespace domain
 template <size_t VolumeDim, typename T>
 class DirectionMap;
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim>
 class Domain;
 template <size_t VolumeDim>
 class OrientationMap;
@@ -233,8 +233,8 @@ auto maps_for_rectilinear_domains(
 /// net for a 3D cube to construct a domain with topology S2. Note: If the user
 /// wishes to rotate the blocks as well as manually identify their faces, the
 /// user must provide the PairOfFaces corresponding to the rotated corners.
-template <size_t VolumeDim, typename TargetFrame>
-Domain<VolumeDim, TargetFrame> rectilinear_domain(
+template <size_t VolumeDim>
+Domain<VolumeDim> rectilinear_domain(
     const Index<VolumeDim>& domain_extents,
     const std::array<std::vector<double>, VolumeDim>& block_demarcations,
     const std::vector<Index<VolumeDim>>& block_indices_to_exclude = {},

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -41,9 +41,9 @@ namespace OptionTags {
 /// \ingroup OptionTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// The input file tag for the DomainCreator to use
-template <size_t Dim, typename TargetFrame>
+template <size_t Dim>
 struct DomainCreator {
-  using type = std::unique_ptr<::DomainCreator<Dim, TargetFrame>>;
+  using type = std::unique_ptr<::DomainCreator<Dim>>;
   static constexpr OptionString help = {"The domain to create initially"};
 };
 }  // namespace OptionTags
@@ -52,15 +52,15 @@ namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// The ::Domain.
-template <size_t VolumeDim, typename Frame>
+template <size_t VolumeDim>
 struct Domain : db::SimpleTag {
   static std::string name() noexcept { return "Domain"; }
-  using type = ::Domain<VolumeDim, Frame>;
-  using option_tags = tmpl::list<::OptionTags::DomainCreator<VolumeDim, Frame>>;
+  using type = ::Domain<VolumeDim>;
+  using option_tags = tmpl::list<::OptionTags::DomainCreator<VolumeDim>>;
 
   template <typename Metavariables>
-  static ::Domain<VolumeDim, Frame> create_from_options(
-      const std::unique_ptr<::DomainCreator<VolumeDim, Frame>>&
+  static ::Domain<VolumeDim> create_from_options(
+      const std::unique_ptr<::DomainCreator<VolumeDim>>&
           domain_creator) noexcept {
     return domain_creator->create_domain();
   }
@@ -74,13 +74,11 @@ template <size_t Dim>
 struct InitialExtents : db::SimpleTag {
   static std::string name() noexcept { return "InitialExtents"; }
   using type = std::vector<std::array<size_t, Dim>>;
-  using option_tags =
-      tmpl::list<::OptionTags::DomainCreator<Dim, Frame::Inertial>>;
+  using option_tags = tmpl::list<::OptionTags::DomainCreator<Dim>>;
 
   template <typename Metavariables>
   static std::vector<std::array<size_t, Dim>> create_from_options(
-      const std::unique_ptr<::DomainCreator<Dim, Frame::Inertial>>&
-          domain_creator) noexcept {
+      const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) noexcept {
     return domain_creator->initial_extents();
   }
 };
@@ -93,13 +91,11 @@ template <size_t Dim>
 struct InitialRefinementLevels : db::SimpleTag {
   static std::string name() noexcept { return "InitialRefinementLevels"; }
   using type = std::vector<std::array<size_t, Dim>>;
-  using option_tags =
-      tmpl::list<::OptionTags::DomainCreator<Dim, Frame::Inertial>>;
+  using option_tags = tmpl::list<::OptionTags::DomainCreator<Dim>>;
 
   template <typename Metavariables>
   static std::vector<std::array<size_t, Dim>> create_from_options(
-      const std::unique_ptr<::DomainCreator<Dim, Frame::Inertial>>&
-          domain_creator) noexcept {
+      const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) noexcept {
     return domain_creator->initial_refinement_levels();
   }
 };

--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -41,8 +41,7 @@ struct DgElementArray {
   using phase_dependent_action_list = PhaseDepActionList;
   using array_index = ElementIndex<volume_dim>;
 
-  using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<volume_dim, Frame::Inertial>>;
+  using const_global_cache_tags = tmpl::list<::Tags::Domain<volume_dim>>;
 
   using array_allocation_tags =
       tmpl::list<::Tags::InitialRefinementLevels<volume_dim>>;
@@ -73,8 +72,7 @@ void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
   auto& local_cache = *(global_cache.ckLocalBranch());
   auto& dg_element_array =
       Parallel::get_parallel_component<DgElementArray>(local_cache);
-  const auto& domain =
-      Parallel::get<::Tags::Domain<volume_dim, Frame::Inertial>>(local_cache);
+  const auto& domain = Parallel::get<::Tags::Domain<volume_dim>>(local_cache);
   const auto& initial_refinement_levels =
       get<::Tags::InitialRefinementLevels<volume_dim>>(initialization_items);
   for (const auto& block : domain.blocks()) {

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -36,8 +36,7 @@ struct DgElementArray {
   using phase_dependent_action_list = PhaseDepActionList;
   using array_index = ElementIndex<volume_dim>;
 
-  using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<volume_dim, Frame::Inertial>>;
+  using const_global_cache_tags = tmpl::list<::Tags::Domain<volume_dim>>;
 
   using array_allocation_tags =
       tmpl::list<::Tags::InitialRefinementLevels<volume_dim>>;
@@ -68,8 +67,7 @@ void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
   auto& local_cache = *(global_cache.ckLocalBranch());
   auto& dg_element_array =
       Parallel::get_parallel_component<DgElementArray>(local_cache);
-  const auto& domain =
-      Parallel::get<::Tags::Domain<volume_dim, Frame::Inertial>>(local_cache);
+  const auto& domain = Parallel::get<::Tags::Domain<volume_dim>>(local_cache);
   const auto& initial_refinement_levels =
       get<::Tags::InitialRefinementLevels<volume_dim>>(initialization_items);
   for (const auto& block : domain.blocks()) {

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -131,7 +131,7 @@ namespace Actions {
 ///
 /// Uses:
 /// - DataBox:
-///   - `::Tags::Domain<3, Frame>`
+///   - `::Tags::Domain<3>`
 ///   - `::ah::Tags::FastFlow`
 ///   - `StrahlkorperTags::CartesianCoords<Frame>`
 ///   - `::Tags::Variables<typename

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
@@ -131,7 +131,7 @@ namespace Actions {
 ///
 /// Uses:
 /// - DataBox:
-///   - `::Tags::Domain<3, Frame>`
+///   - `::Tags::Domain<3>`
 ///   - `::Tags::Variables<typename
 ///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
 ///

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
@@ -121,7 +121,7 @@ namespace Actions {
 ///
 /// Uses:
 /// - DataBox:
-///   - `::Tags::Domain<3, Frame>`
+///   - `::Tags::Domain<3>`
 ///   - `::Tags::Variables<typename
 ///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
 ///

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -189,7 +189,7 @@ namespace Actions {
 ///
 /// Uses:
 /// - DataBox:
-///   - `::Tags::Domain<3, Frame>`
+///   - `::Tags::Domain<3>`
 ///   - `::Tags::Variables<typename
 ///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
 ///

--- a/src/NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp
@@ -42,7 +42,7 @@ void send_points_to_interpolator(
     db::DataBox<DbTags>& box, Parallel::ConstGlobalCache<Metavariables>& cache,
     const tnsr::I<DataVector, VolumeDim, Frame>& target_points,
     const typename Metavariables::temporal_id::type& temporal_id) noexcept {
-  const auto& domain = db::get<::Tags::Domain<VolumeDim, Frame>>(box);
+  const auto& domain = db::get<::Tags::Domain<VolumeDim>>(box);
   auto coords = block_logical_coordinates(domain, target_points);
 
   db::mutate<

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
@@ -85,7 +85,7 @@ struct InitializeDomain {
         ::Tags::MinimumGridSpacing<Dim, Frame::Inertial>>>;
 
     const auto& initial_extents = db::get<::Tags::InitialExtents<Dim>>(box);
-    const auto& domain = db::get<::Tags::Domain<Dim, Frame::Inertial>>(box);
+    const auto& domain = db::get<::Tags::Domain<Dim>>(box);
 
     const ElementId<Dim> element_id{array_index};
     const auto& my_block = domain.blocks()[element_id.block_id()];

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -216,8 +216,7 @@ struct MockMetavariables {
   using component_list =
       tmpl::list<mock_interpolation_target<MockMetavariables, AhA>,
                  mock_interpolator<MockMetavariables>>;
-  using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<3, Frame::Inertial>>;
+  using const_global_cache_tags = tmpl::list<::Tags::Domain<3>>;
 
   enum class Phase { Initialization, Registration, Testing, Exit };
 };
@@ -249,11 +248,11 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
   // inside the domain, and it gives a narrow domain so that we don't
   // need a large number of grid points to resolve the horizon (which
   // would make the test slower).
-  const auto domain_creator = domain::creators::Shell<Frame::Inertial>(
+  const auto domain_creator = domain::creators::Shell(
       1.9, 2.9, 1, {{grid_points_each_dimension, grid_points_each_dimension}},
       false);
 
-  tuples::TaggedTuple<::Tags::Domain<3, Frame::Inertial>,
+  tuples::TaggedTuple<::Tags::Domain<3>,
                       typename ::intrp::Tags::ApparentHorizon<
                           typename metavars::AhA, Frame::Inertial>>
       tuple_of_opts{std::move(domain_creator.create_domain()),
@@ -273,7 +272,7 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
 
   // Create element_ids.
   std::vector<ElementId<3>> element_ids{};
-  Domain<3, Frame::Inertial> domain = domain_creator.create_domain();
+  Domain<3> domain = domain_creator.create_domain();
   for (const auto& block : domain.blocks()) {
     const auto initial_ref_levs =
         domain_creator.initial_refinement_levels()[block.id()];

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -22,66 +22,58 @@ namespace domain {
 namespace {
 template <size_t VolumeDim>
 void test_aligned_blocks(
-    const creators::AlignedLattice<VolumeDim, Frame::Inertial>&
-        aligned_blocks) noexcept {
+    const creators::AlignedLattice<VolumeDim>& aligned_blocks) noexcept {
   const auto domain = aligned_blocks.create_domain();
   test_initial_domain(domain, aligned_blocks.initial_refinement_levels());
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
-  const auto domain_creator_1d =
-      test_factory_creation<DomainCreator<1, Frame::Inertial>>(
-          "  AlignedLattice:\n"
-          "    BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n"
-          "    IsPeriodicIn: [false]\n"
-          "    InitialGridPoints: [3]\n"
-          "    InitialRefinement: [2]\n");
+  const auto domain_creator_1d = test_factory_creation<DomainCreator<1>>(
+      "  AlignedLattice:\n"
+      "    BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n"
+      "    IsPeriodicIn: [false]\n"
+      "    InitialGridPoints: [3]\n"
+      "    InitialRefinement: [2]\n");
   const auto* aligned_blocks_creator_1d =
-      dynamic_cast<const creators::AlignedLattice<1, Frame::Inertial>*>(
-          domain_creator_1d.get());
+      dynamic_cast<const creators::AlignedLattice<1>*>(domain_creator_1d.get());
   test_aligned_blocks(*aligned_blocks_creator_1d);
 
-  const auto domain_creator_2d =
-      test_factory_creation<DomainCreator<2, Frame::Inertial>>(
-          "  AlignedLattice:\n"
-          "    BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2, 8.9]]\n"
-          "    IsPeriodicIn: [false, true]\n"
-          "    InitialGridPoints: [3, 4]\n"
-          "    InitialRefinement: [2, 1]\n");
+  const auto domain_creator_2d = test_factory_creation<DomainCreator<2>>(
+      "  AlignedLattice:\n"
+      "    BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2, 8.9]]\n"
+      "    IsPeriodicIn: [false, true]\n"
+      "    InitialGridPoints: [3, 4]\n"
+      "    InitialRefinement: [2, 1]\n");
   const auto* aligned_blocks_creator_2d =
-      dynamic_cast<const creators::AlignedLattice<2, Frame::Inertial>*>(
-          domain_creator_2d.get());
+      dynamic_cast<const creators::AlignedLattice<2>*>(domain_creator_2d.get());
   test_aligned_blocks(*aligned_blocks_creator_2d);
 
-  const auto domain_creator_3d =
-      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
-          "  AlignedLattice:\n"
-          "    BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n"
-          "    IsPeriodicIn: [false, true, false]\n"
-          "    InitialGridPoints: [3, 4, 5]\n"
-          "    InitialRefinement: [2, 1, 0]\n");
+  const auto domain_creator_3d = test_factory_creation<DomainCreator<3>>(
+      "  AlignedLattice:\n"
+      "    BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n"
+      "    IsPeriodicIn: [false, true, false]\n"
+      "    InitialGridPoints: [3, 4, 5]\n"
+      "    InitialRefinement: [2, 1, 0]\n");
   const auto* aligned_blocks_creator_3d =
-      dynamic_cast<const creators::AlignedLattice<3, Frame::Inertial>*>(
-          domain_creator_3d.get());
+      dynamic_cast<const creators::AlignedLattice<3>*>(domain_creator_3d.get());
   test_aligned_blocks(*aligned_blocks_creator_3d);
 
-  const auto cubical_shell_domain =
-      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
-          "  AlignedLattice:\n"
-          "    BlockBounds: [[0.1, 2.6, 5.1, 6.0], [-0.4, 3.2, 6.2, 7.0], "
-          "[-0.2, 3.2, 4.0, 5.2]]\n"
-          "    IsPeriodicIn: [false, false, false]\n"
-          "    InitialGridPoints: [3, 4, 5]\n"
-          "    InitialRefinement: [2, 1, 0]\n"
-          "    BlocksToExclude: [[1, 1, 1]]");
+  const auto cubical_shell_domain = test_factory_creation<DomainCreator<3>>(
+      "  AlignedLattice:\n"
+      "    BlockBounds: [[0.1, 2.6, 5.1, 6.0], [-0.4, 3.2, 6.2, 7.0], "
+      "[-0.2, 3.2, 4.0, 5.2]]\n"
+      "    IsPeriodicIn: [false, false, false]\n"
+      "    InitialGridPoints: [3, 4, 5]\n"
+      "    InitialRefinement: [2, 1, 0]\n"
+      "    BlocksToExclude: [[1, 1, 1]]");
   const auto* cubical_shell_creator_3d =
-      dynamic_cast<const creators::AlignedLattice<3, Frame::Inertial>*>(
+      dynamic_cast<const creators::AlignedLattice<3>*>(
           cubical_shell_domain.get());
   test_aligned_blocks(*cubical_shell_creator_3d);
 
   const auto unit_cubical_shell_domain =
-      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+      test_factory_creation<DomainCreator<3>>(
           "  AlignedLattice:\n"
           "    BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
           "[-1.5, -0.5, 0.5, 1.5]]\n"
@@ -90,7 +82,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
           "    InitialRefinement: [1, 1, 1]\n"
           "    BlocksToExclude: [[1, 1, 1]]");
   const auto* unit_cubical_shell_creator_3d =
-      dynamic_cast<const creators::AlignedLattice<3, Frame::Inertial>*>(
+      dynamic_cast<const creators::AlignedLattice<3>*>(
           unit_cubical_shell_domain.get());
   test_aligned_blocks(*unit_cubical_shell_creator_3d);
 }
@@ -101,7 +93,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice.Error",
                   "[Unit][ErrorHandling]") {
   ERROR_TEST();
   const auto failed_cubical_shell_domain =
-      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+      test_factory_creation<DomainCreator<3>>(
           "  AlignedLattice:\n"
           "    BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
           "[-1.5, -0.5, 0.5, 1.5]]\n"

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -35,8 +35,7 @@ namespace {
 using Affine = CoordinateMaps::Affine;
 using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 void test_brick_construction(
-    const creators::Brick<Frame::Inertial>& brick,
-    const std::array<double, 3>& lower_bound,
+    const creators::Brick& brick, const std::array<double, 3>& lower_bound,
     const std::array<double, 3>& upper_bound,
     const std::vector<std::array<size_t, 3>>& expected_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level,
@@ -68,9 +67,9 @@ void test_brick() {
   // Default OrientationMap is aligned.
   const OrientationMap<3> aligned_orientation{};
 
-  const creators::Brick<Frame::Inertial> brick{
-      lower_bound, upper_bound, std::array<bool, 3>{{false, false, false}},
-      refinement_level[0], grid_points[0]};
+  const creators::Brick brick{lower_bound, upper_bound,
+                              std::array<bool, 3>{{false, false, false}},
+                              refinement_level[0], grid_points[0]};
   test_brick_construction(brick, lower_bound, upper_bound, grid_points,
                           refinement_level,
                           std::vector<DirectionMap<3, BlockNeighbor<3>>>{{}},
@@ -82,7 +81,7 @@ void test_brick() {
                                {Direction<3>::lower_zeta()},
                                {Direction<3>::upper_zeta()}}});
 
-  const creators::Brick<Frame::Inertial> periodic_x_brick{
+  const creators::Brick periodic_x_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{true, false, false}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -96,7 +95,7 @@ void test_brick() {
            {Direction<3>::lower_zeta()},
            {Direction<3>::upper_zeta()}}});
 
-  const creators::Brick<Frame::Inertial> periodic_y_brick{
+  const creators::Brick periodic_y_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{false, true, false}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -110,7 +109,7 @@ void test_brick() {
            {Direction<3>::lower_zeta()},
            {Direction<3>::upper_zeta()}}});
 
-  const creators::Brick<Frame::Inertial> periodic_z_brick{
+  const creators::Brick periodic_z_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{false, false, true}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -124,7 +123,7 @@ void test_brick() {
            {Direction<3>::lower_eta()},
            {Direction<3>::upper_eta()}}});
 
-  const creators::Brick<Frame::Inertial> periodic_xy_brick{
+  const creators::Brick periodic_xy_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{true, true, false}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -138,7 +137,7 @@ void test_brick() {
       std::vector<std::unordered_set<Direction<3>>>{
           {{Direction<3>::lower_zeta()}, {Direction<3>::upper_zeta()}}});
 
-  const creators::Brick<Frame::Inertial> periodic_yz_brick{
+  const creators::Brick periodic_yz_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{false, true, true}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -154,7 +153,7 @@ void test_brick() {
           {Direction<3>::upper_xi()},
       }});
 
-  const creators::Brick<Frame::Inertial> periodic_xz_brick{
+  const creators::Brick periodic_xz_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{true, false, true}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -168,7 +167,7 @@ void test_brick() {
       std::vector<std::unordered_set<Direction<3>>>{
           {{Direction<3>::lower_eta()}, {Direction<3>::upper_eta()}}});
 
-  const creators::Brick<Frame::Inertial> periodic_xyz_brick{
+  const creators::Brick periodic_xyz_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{true, true, true}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -200,17 +199,15 @@ void test_brick() {
 
 void test_brick_factory() {
   INFO("Brick factory");
-  const auto domain_creator =
-      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
-          "  Brick:\n"
-          "    LowerBound: [0,0,0]\n"
-          "    UpperBound: [1,2,3]\n"
-          "    IsPeriodicIn: [True,False,True]\n"
-          "    InitialGridPoints: [3,4,3]\n"
-          "    InitialRefinement: [2,3,2]\n");
+  const auto domain_creator = test_factory_creation<DomainCreator<3>>(
+      "  Brick:\n"
+      "    LowerBound: [0,0,0]\n"
+      "    UpperBound: [1,2,3]\n"
+      "    IsPeriodicIn: [True,False,True]\n"
+      "    InitialGridPoints: [3,4,3]\n"
+      "    InitialRefinement: [2,3,2]\n");
   const auto* brick_creator =
-      dynamic_cast<const creators::Brick<Frame::Inertial>*>(
-          domain_creator.get());
+      dynamic_cast<const creators::Brick*>(domain_creator.get());
   test_brick_construction(
       *brick_creator, {{0., 0., 0.}}, {{1., 2., 3.}}, {{{3, 4, 3}}},
       {{{2, 3, 2}}},

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -32,10 +32,9 @@
 namespace domain {
 namespace {
 void test_cylinder_construction(
-    const creators::Cylinder<Frame::Inertial>& cylinder,
-    const double inner_radius, const double outer_radius,
-    const double lower_bound, const double upper_bound,
-    const bool is_periodic_in_z,
+    const creators::Cylinder& cylinder, const double inner_radius,
+    const double outer_radius, const double lower_bound,
+    const double upper_bound, const bool is_periodic_in_z,
     const std::array<size_t, 3>& expected_wedge_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level,
     const bool use_equiangular_map) {
@@ -196,7 +195,7 @@ void test_cylinder_boundaries_equiangular() {
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{4, 4, 3}};
 
-  const creators::Cylinder<Frame::Inertial> cylinder{
+  const creators::Cylinder cylinder{
       inner_radius, outer_radius,     lower_bound, upper_bound,
       true,         refinement_level, grid_points, true};
   test_physical_separation(cylinder.create_domain().blocks());
@@ -207,25 +206,24 @@ void test_cylinder_boundaries_equiangular() {
 
 void test_cylinder_factory_equiangular() {
   INFO("Cylinder factory equiangular");
-  const auto cylinder =
-      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
-          "  Cylinder:\n"
-          "    InnerRadius: 1.0\n"
-          "    OuterRadius: 3.0\n"
-          "    LowerBound: -1.2\n"
-          "    UpperBound: 3.7\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: [2,3,4]\n"
-          "    UseEquiangularMap: true\n");
+  const auto cylinder = test_factory_creation<DomainCreator<3>>(
+      "  Cylinder:\n"
+      "    InnerRadius: 1.0\n"
+      "    OuterRadius: 3.0\n"
+      "    LowerBound: -1.2\n"
+      "    UpperBound: 3.7\n"
+      "    InitialRefinement: 2\n"
+      "    InitialGridPoints: [2,3,4]\n"
+      "    UseEquiangularMap: true\n");
 
   const double inner_radius = 1.0, outer_radius = 3.0;
   const double lower_bound = -1.2, upper_bound = 3.7;
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{2, 3, 4}};
-  test_cylinder_construction(
-      dynamic_cast<const creators::Cylinder<Frame::Inertial>&>(*cylinder),
-      inner_radius, outer_radius, lower_bound, upper_bound, true, grid_points,
-      {5, make_array<3>(refinement_level)}, true);
+  test_cylinder_construction(dynamic_cast<const creators::Cylinder&>(*cylinder),
+                             inner_radius, outer_radius, lower_bound,
+                             upper_bound, true, grid_points,
+                             {5, make_array<3>(refinement_level)}, true);
 }
 
 void test_cylinder_boundaries_equidistant() {
@@ -235,7 +233,7 @@ void test_cylinder_boundaries_equidistant() {
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{4, 4, 3}};
 
-  const creators::Cylinder<Frame::Inertial> cylinder{
+  const creators::Cylinder cylinder{
       inner_radius, outer_radius,     lower_bound, upper_bound,
       true,         refinement_level, grid_points, false};
   test_physical_separation(cylinder.create_domain().blocks());
@@ -246,25 +244,24 @@ void test_cylinder_boundaries_equidistant() {
 
 void test_cylinder_factory_equidistant() {
   INFO("Cylinder factory equidistant");
-  const auto cylinder =
-      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
-          "  Cylinder:\n"
-          "    InnerRadius: 1.0\n"
-          "    OuterRadius: 3.0\n"
-          "    LowerBound: -1.2\n"
-          "    UpperBound: 3.7\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: [2,3,4]\n"
-          "    UseEquiangularMap: false\n");
+  const auto cylinder = test_factory_creation<DomainCreator<3>>(
+      "  Cylinder:\n"
+      "    InnerRadius: 1.0\n"
+      "    OuterRadius: 3.0\n"
+      "    LowerBound: -1.2\n"
+      "    UpperBound: 3.7\n"
+      "    InitialRefinement: 2\n"
+      "    InitialGridPoints: [2,3,4]\n"
+      "    UseEquiangularMap: false\n");
 
   const double inner_radius = 1.0, outer_radius = 3.0;
   const double lower_bound = -1.2, upper_bound = 3.7;
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{2, 3, 4}};
-  test_cylinder_construction(
-      dynamic_cast<const creators::Cylinder<Frame::Inertial>&>(*cylinder),
-      inner_radius, outer_radius, lower_bound, upper_bound, true, grid_points,
-      {5, make_array<3>(refinement_level)}, false);
+  test_cylinder_construction(dynamic_cast<const creators::Cylinder&>(*cylinder),
+                             inner_radius, outer_radius, lower_bound,
+                             upper_bound, true, grid_points,
+                             {5, make_array<3>(refinement_level)}, false);
 }
 
 void test_cylinder_boundaries_equiangular_not_periodic_in_z() {
@@ -274,7 +271,7 @@ void test_cylinder_boundaries_equiangular_not_periodic_in_z() {
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{4, 4, 3}};
 
-  const creators::Cylinder<Frame::Inertial> cylinder{
+  const creators::Cylinder cylinder{
       inner_radius, outer_radius,     lower_bound, upper_bound,
       false,        refinement_level, grid_points, true};
   test_physical_separation(cylinder.create_domain().blocks());
@@ -285,26 +282,25 @@ void test_cylinder_boundaries_equiangular_not_periodic_in_z() {
 
 void test_cylinder_factory_equiangular_not_periodic_in_z() {
   INFO("Cylinder factory equiangular not periodic in z");
-  const auto cylinder =
-      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
-          "  Cylinder:\n"
-          "    InnerRadius: 1.0\n"
-          "    OuterRadius: 3.0\n"
-          "    LowerBound: -1.2\n"
-          "    UpperBound: 3.7\n"
-          "    IsPeriodicInZ: false\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: [2,3,4]\n"
-          "    UseEquiangularMap: true\n");
+  const auto cylinder = test_factory_creation<DomainCreator<3>>(
+      "  Cylinder:\n"
+      "    InnerRadius: 1.0\n"
+      "    OuterRadius: 3.0\n"
+      "    LowerBound: -1.2\n"
+      "    UpperBound: 3.7\n"
+      "    IsPeriodicInZ: false\n"
+      "    InitialRefinement: 2\n"
+      "    InitialGridPoints: [2,3,4]\n"
+      "    UseEquiangularMap: true\n");
 
   const double inner_radius = 1.0, outer_radius = 3.0;
   const double lower_bound = -1.2, upper_bound = 3.7;
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{2, 3, 4}};
-  test_cylinder_construction(
-      dynamic_cast<const creators::Cylinder<Frame::Inertial>&>(*cylinder),
-      inner_radius, outer_radius, lower_bound, upper_bound, false, grid_points,
-      {5, make_array<3>(refinement_level)}, true);
+  test_cylinder_construction(dynamic_cast<const creators::Cylinder&>(*cylinder),
+                             inner_radius, outer_radius, lower_bound,
+                             upper_bound, false, grid_points,
+                             {5, make_array<3>(refinement_level)}, true);
 }
 
 void test_cylinder_boundaries_equidistant_not_periodic_in_z() {
@@ -314,7 +310,7 @@ void test_cylinder_boundaries_equidistant_not_periodic_in_z() {
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{4, 4, 3}};
 
-  const creators::Cylinder<Frame::Inertial> cylinder{
+  const creators::Cylinder cylinder{
       inner_radius, outer_radius,     lower_bound, upper_bound,
       false,        refinement_level, grid_points, false};
   test_physical_separation(cylinder.create_domain().blocks());
@@ -325,26 +321,25 @@ void test_cylinder_boundaries_equidistant_not_periodic_in_z() {
 
 void test_cylinder_factory_equidistant_not_periodic_in_z() {
   INFO("Cylinder factory equidistant not periodic in z");
-  const auto cylinder =
-      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
-          "  Cylinder:\n"
-          "    InnerRadius: 1.0\n"
-          "    OuterRadius: 3.0\n"
-          "    LowerBound: -1.2\n"
-          "    UpperBound: 3.7\n"
-          "    IsPeriodicInZ: false\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: [2,3,4]\n"
-          "    UseEquiangularMap: false\n");
+  const auto cylinder = test_factory_creation<DomainCreator<3>>(
+      "  Cylinder:\n"
+      "    InnerRadius: 1.0\n"
+      "    OuterRadius: 3.0\n"
+      "    LowerBound: -1.2\n"
+      "    UpperBound: 3.7\n"
+      "    IsPeriodicInZ: false\n"
+      "    InitialRefinement: 2\n"
+      "    InitialGridPoints: [2,3,4]\n"
+      "    UseEquiangularMap: false\n");
 
   const double inner_radius = 1.0, outer_radius = 3.0;
   const double lower_bound = -1.2, upper_bound = 3.7;
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{2, 3, 4}};
-  test_cylinder_construction(
-      dynamic_cast<const creators::Cylinder<Frame::Inertial>&>(*cylinder),
-      inner_radius, outer_radius, lower_bound, upper_bound, false, grid_points,
-      {5, make_array<3>(refinement_level)}, false);
+  test_cylinder_construction(dynamic_cast<const creators::Cylinder&>(*cylinder),
+                             inner_radius, outer_radius, lower_bound,
+                             upper_bound, false, grid_points,
+                             {5, make_array<3>(refinement_level)}, false);
 }
 }  // namespace
 

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -32,7 +32,7 @@
 namespace domain {
 namespace {
 void test_disk_construction(
-    const creators::Disk<Frame::Inertial>& disk, const double inner_radius,
+    const creators::Disk& disk, const double inner_radius,
     const double outer_radius,
     const std::array<size_t, 2>& expected_wedge_extents,
     const std::vector<std::array<size_t, 2>>& expected_refinement_level,
@@ -132,8 +132,8 @@ void test_disk_boundaries_equiangular() {
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points{{4, 4}};
 
-  const creators::Disk<Frame::Inertial> disk{
-      inner_radius, outer_radius, refinement_level, grid_points, true};
+  const creators::Disk disk{inner_radius, outer_radius, refinement_level,
+                            grid_points, true};
   test_physical_separation(disk.create_domain().blocks());
   test_disk_construction(disk, inner_radius, outer_radius, grid_points,
                          {5, make_array<2>(refinement_level)}, true);
@@ -141,7 +141,7 @@ void test_disk_boundaries_equiangular() {
 
 void test_disk_factory_equiangular() {
   INFO("Disk factory equiangular");
-  const auto disk = test_factory_creation<DomainCreator<2, Frame::Inertial>>(
+  const auto disk = test_factory_creation<DomainCreator<2>>(
       "  Disk:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -152,9 +152,9 @@ void test_disk_factory_equiangular() {
   const double inner_radius = 1.0, outer_radius = 3.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points{{2, 3}};
-  test_disk_construction(
-      dynamic_cast<const creators::Disk<Frame::Inertial>&>(*disk), inner_radius,
-      outer_radius, grid_points, {5, make_array<2>(refinement_level)}, true);
+  test_disk_construction(dynamic_cast<const creators::Disk&>(*disk),
+                         inner_radius, outer_radius, grid_points,
+                         {5, make_array<2>(refinement_level)}, true);
 }
 
 void test_disk_boundaries_equidistant() {
@@ -163,8 +163,8 @@ void test_disk_boundaries_equidistant() {
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points{{4, 4}};
 
-  const creators::Disk<Frame::Inertial> disk{
-      inner_radius, outer_radius, refinement_level, grid_points, false};
+  const creators::Disk disk{inner_radius, outer_radius, refinement_level,
+                            grid_points, false};
   test_physical_separation(disk.create_domain().blocks());
   test_disk_construction(disk, inner_radius, outer_radius, grid_points,
                          {5, make_array<2>(refinement_level)}, false);
@@ -172,7 +172,7 @@ void test_disk_boundaries_equidistant() {
 
 void test_disk_factory_equidistant() {
   INFO("Disk factory equidistant");
-  const auto disk = test_factory_creation<DomainCreator<2, Frame::Inertial>>(
+  const auto disk = test_factory_creation<DomainCreator<2>>(
       "  Disk:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -183,9 +183,9 @@ void test_disk_factory_equidistant() {
   const double inner_radius = 1.0, outer_radius = 3.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points{{2, 3}};
-  test_disk_construction(
-      dynamic_cast<const creators::Disk<Frame::Inertial>&>(*disk), inner_radius,
-      outer_radius, grid_points, {5, make_array<2>(refinement_level)}, false);
+  test_disk_construction(dynamic_cast<const creators::Disk&>(*disk),
+                         inner_radius, outer_radius, grid_points,
+                         {5, make_array<2>(refinement_level)}, false);
 }
 }  // namespace
 

--- a/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
+++ b/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
@@ -19,7 +19,7 @@
 
 namespace {
 void test_frustal_cloak_construction(
-    const domain::creators::FrustalCloak<Frame::Inertial>& frustal_cloak) {
+    const domain::creators::FrustalCloak& frustal_cloak) {
   const auto domain = frustal_cloak.create_domain();
   test_initial_domain(domain, frustal_cloak.initial_refinement_levels());
   test_physical_separation(frustal_cloak.create_domain().blocks());
@@ -36,7 +36,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.FrustalCloak.Connectivity",
   const std::array<double, 3> origin_preimage = {{1.3, 0.2, -3.1}};
 
   for (const bool use_equiangular_map : {true, false}) {
-    const domain::creators::FrustalCloak<Frame::Inertial> frustal_cloak{
+    const domain::creators::FrustalCloak frustal_cloak{
         refinement,          grid_points,
         use_equiangular_map, projective_scale_factor,
         length_inner_cube,   length_outer_cube,
@@ -47,17 +47,15 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.FrustalCloak.Connectivity",
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.FrustalCloak.Factory",
                   "[Domain][Unit]") {
-  const auto frustal_cloak =
-      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
-          "  FrustalCloak:\n"
-          "    InitialRefinement: 3\n"
-          "    InitialGridPoints: [2,3]\n"
-          "    UseEquiangularMap: true\n"
-          "    ProjectionFactor: 0.3\n"
-          "    LengthInnerCube: 15.5\n"
-          "    LengthOuterCube: 42.4\n"
-          "    OriginPreimage: [0.2,0.3,-0.1]");
+  const auto frustal_cloak = test_factory_creation<DomainCreator<3>>(
+      "  FrustalCloak:\n"
+      "    InitialRefinement: 3\n"
+      "    InitialGridPoints: [2,3]\n"
+      "    UseEquiangularMap: true\n"
+      "    ProjectionFactor: 0.3\n"
+      "    LengthInnerCube: 15.5\n"
+      "    LengthOuterCube: 42.4\n"
+      "    OriginPreimage: [0.2,0.3,-0.1]");
   test_frustal_cloak_construction(
-      dynamic_cast<const domain::creators::FrustalCloak<Frame::Inertial>&>(
-          *frustal_cloak));
+      dynamic_cast<const domain::creators::FrustalCloak&>(*frustal_cloak));
 }

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -31,7 +31,7 @@
 namespace domain {
 namespace {
 void test_interval_construction(
-    const creators::Interval<Frame::Inertial>& interval,
+    const creators::Interval& interval,
     const std::array<double, 1>& lower_bound,
     const std::array<double, 1>& upper_bound,
     const std::vector<std::array<size_t, 1>>& expected_extents,
@@ -60,16 +60,16 @@ void test_interval() {
   // default Orientation is aligned
   const OrientationMap<1> aligned_orientation{};
 
-  const creators::Interval<Frame::Inertial> interval{
-      lower_bound, upper_bound, std::array<bool, 1>{{false}},
-      refinement_level[0], grid_points[0]};
+  const creators::Interval interval{lower_bound, upper_bound,
+                                    std::array<bool, 1>{{false}},
+                                    refinement_level[0], grid_points[0]};
   test_interval_construction(
       interval, lower_bound, upper_bound, grid_points, refinement_level,
       std::vector<DirectionMap<1, BlockNeighbor<1>>>{{}},
       std::vector<std::unordered_set<Direction<1>>>{
           {{Direction<1>::lower_xi()}, {Direction<1>::upper_xi()}}});
 
-  const creators::Interval<Frame::Inertial> periodic_interval{
+  const creators::Interval periodic_interval{
       lower_bound, upper_bound, std::array<bool, 1>{{true}},
       refinement_level[0], grid_points[0]};
   test_interval_construction(
@@ -97,17 +97,15 @@ void test_interval() {
 
 void test_interval_factory() {
   INFO("Interval factory");
-  const auto domain_creator =
-      test_factory_creation<DomainCreator<1, Frame::Inertial>>(
-          "  Interval:\n"
-          "    LowerBound: [0]\n"
-          "    UpperBound: [1]\n"
-          "    IsPeriodicIn: [True]\n"
-          "    InitialGridPoints: [3]\n"
-          "    InitialRefinement: [2]\n");
+  const auto domain_creator = test_factory_creation<DomainCreator<1>>(
+      "  Interval:\n"
+      "    LowerBound: [0]\n"
+      "    UpperBound: [1]\n"
+      "    IsPeriodicIn: [True]\n"
+      "    InitialGridPoints: [3]\n"
+      "    InitialRefinement: [2]\n");
   const auto* interval_creator =
-      dynamic_cast<const creators::Interval<Frame::Inertial>*>(
-          domain_creator.get());
+      dynamic_cast<const creators::Interval*>(domain_creator.get());
   test_interval_construction(*interval_creator, {{0.}}, {{1.}}, {{{3}}},
                              {{{2}}},
                              std::vector<DirectionMap<1, BlockNeighbor<1>>>{

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -34,7 +34,7 @@ namespace {
 using Affine = CoordinateMaps::Affine;
 using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
 void test_rectangle_construction(
-    const creators::Rectangle<Frame::Inertial>& rectangle,
+    const creators::Rectangle& rectangle,
     const std::array<double, 2>& lower_bound,
     const std::array<double, 2>& upper_bound,
     const std::vector<std::array<size_t, 2>>& expected_extents,
@@ -64,9 +64,9 @@ void test_rectangle() {
   // default OrientationMap is aligned
   const OrientationMap<2> aligned_orientation{};
 
-  const creators::Rectangle<Frame::Inertial> rectangle{
-      lower_bound, upper_bound, std::array<bool, 2>{{false, false}},
-      refinement_level[0], grid_points[0]};
+  const creators::Rectangle rectangle{lower_bound, upper_bound,
+                                      std::array<bool, 2>{{false, false}},
+                                      refinement_level[0], grid_points[0]};
   test_rectangle_construction(
       rectangle, lower_bound, upper_bound, grid_points, refinement_level,
       std::vector<DirectionMap<2, BlockNeighbor<2>>>{{}},
@@ -76,7 +76,7 @@ void test_rectangle() {
            {Direction<2>::lower_eta()},
            {Direction<2>::upper_eta()}}});
 
-  const creators::Rectangle<Frame::Inertial> periodic_x_rectangle{
+  const creators::Rectangle periodic_x_rectangle{
       lower_bound, upper_bound, std::array<bool, 2>{{true, false}},
       refinement_level[0], grid_points[0]};
   test_rectangle_construction(
@@ -88,7 +88,7 @@ void test_rectangle() {
       std::vector<std::unordered_set<Direction<2>>>{
           {{Direction<2>::lower_eta()}, {Direction<2>::upper_eta()}}});
 
-  const creators::Rectangle<Frame::Inertial> periodic_y_rectangle{
+  const creators::Rectangle periodic_y_rectangle{
       lower_bound, upper_bound, std::array<bool, 2>{{false, true}},
       refinement_level[0], grid_points[0]};
   test_rectangle_construction(
@@ -100,7 +100,7 @@ void test_rectangle() {
       std::vector<std::unordered_set<Direction<2>>>{
           {{Direction<2>::lower_xi()}, {Direction<2>::upper_xi()}}});
 
-  const creators::Rectangle<Frame::Inertial> periodic_xy_rectangle{
+  const creators::Rectangle periodic_xy_rectangle{
       lower_bound, upper_bound, std::array<bool, 2>{{true, true}},
       refinement_level[0], grid_points[0]};
   test_rectangle_construction(
@@ -132,17 +132,15 @@ void test_rectangle() {
 
 void test_rectangle_factory() {
   INFO("Rectangle factory");
-  const auto domain_creator =
-      test_factory_creation<DomainCreator<2, Frame::Inertial>>(
-          "  Rectangle:\n"
-          "    LowerBound: [0,0]\n"
-          "    UpperBound: [1,2]\n"
-          "    IsPeriodicIn: [True,False]\n"
-          "    InitialGridPoints: [3,4]\n"
-          "    InitialRefinement: [2,3]\n");
+  const auto domain_creator = test_factory_creation<DomainCreator<2>>(
+      "  Rectangle:\n"
+      "    LowerBound: [0,0]\n"
+      "    UpperBound: [1,2]\n"
+      "    IsPeriodicIn: [True,False]\n"
+      "    InitialGridPoints: [3,4]\n"
+      "    InitialRefinement: [2,3]\n");
   const auto* rectangle_creator =
-      dynamic_cast<const creators::Rectangle<Frame::Inertial>*>(
-          domain_creator.get());
+      dynamic_cast<const creators::Rectangle*>(domain_creator.get());
   test_rectangle_construction(
       *rectangle_creator, {{0., 0.}}, {{1., 2.}}, {{{3, 4}}}, {{{2, 3}}},
       std::vector<DirectionMap<2, BlockNeighbor<2>>>{

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -28,7 +28,7 @@
 namespace domain {
 namespace {
 void test_rotated_bricks_construction(
-    const creators::RotatedBricks<Frame::Inertial>& rotated_bricks,
+    const creators::RotatedBricks& rotated_bricks,
     const std::array<double, 3>& lower_bound,
     const std::array<double, 3>& midpoint,
     const std::array<double, 3>& upper_bound,
@@ -133,7 +133,7 @@ void test_rotated_bricks() {
   const OrientationMap<3> rotation_F_then_U{std::array<Direction<3>, 3>{
       {Direction<3>::lower_zeta(), Direction<3>::upper_xi(),
        Direction<3>::lower_eta()}}};
-  const creators::RotatedBricks<Frame::Inertial> rotated_bricks{
+  const creators::RotatedBricks rotated_bricks{
       lower_bound,
       midpoint,
       upper_bound,
@@ -190,7 +190,7 @@ void test_rotated_bricks() {
            Direction<3>::upper_zeta()}});
   test_physical_separation(rotated_bricks.create_domain().blocks());
 
-  const creators::RotatedBricks<Frame::Inertial> rotated_periodic_bricks{
+  const creators::RotatedBricks rotated_periodic_bricks{
       lower_bound,
       midpoint,
       upper_bound,
@@ -274,18 +274,16 @@ void test_rotated_bricks_factory() {
   const OrientationMap<3> rotation_F_then_U{std::array<Direction<3>, 3>{
       {Direction<3>::lower_zeta(), Direction<3>::upper_xi(),
        Direction<3>::lower_eta()}}};
-  const auto domain_creator =
-      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
-          "  RotatedBricks:\n"
-          "    LowerBound: [0.1, -0.4, -0.2]\n"
-          "    Midpoint:   [2.6, 3.2, 1.7]\n"
-          "    UpperBound: [5.1, 6.2, 3.2]\n"
-          "    IsPeriodicIn: [false, false, false]\n"
-          "    InitialGridPoints: [[3,2],[1,4],[5,6]]\n"
-          "    InitialRefinement: [2,1,0]\n");
+  const auto domain_creator = test_factory_creation<DomainCreator<3>>(
+      "  RotatedBricks:\n"
+      "    LowerBound: [0.1, -0.4, -0.2]\n"
+      "    Midpoint:   [2.6, 3.2, 1.7]\n"
+      "    UpperBound: [5.1, 6.2, 3.2]\n"
+      "    IsPeriodicIn: [false, false, false]\n"
+      "    InitialGridPoints: [[3,2],[1,4],[5,6]]\n"
+      "    InitialRefinement: [2,1,0]\n");
   const auto* rotated_bricks_creator =
-      dynamic_cast<const creators::RotatedBricks<Frame::Inertial>*>(
-          domain_creator.get());
+      dynamic_cast<const creators::RotatedBricks*>(domain_creator.get());
   test_rotated_bricks_construction(
       *rotated_bricks_creator, {{0.1, -0.4, -0.2}}, {{2.6, 3.2, 1.7}},
       {{5.1, 6.2, 3.2}},

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -29,7 +29,7 @@
 namespace domain {
 namespace {
 void test_rotated_intervals_construction(
-    const creators::RotatedIntervals<Frame::Inertial>& rotated_intervals,
+    const creators::RotatedIntervals& rotated_intervals,
     const std::array<double, 1>& lower_bound,
     const std::array<double, 1>& midpoint,
     const std::array<double, 1>& upper_bound,
@@ -68,7 +68,7 @@ void test_rotated_intervals() {
   const OrientationMap<1> flipped{
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}};
 
-  const creators::RotatedIntervals<Frame::Inertial> rotated_intervals{
+  const creators::RotatedIntervals rotated_intervals{
       lower_bound,         midpoint,
       upper_bound,         std::array<bool, 1>{{false}},
       refinement_level[0], {{{{grid_points[0][0], grid_points[1][0]}}}}};
@@ -82,7 +82,7 @@ void test_rotated_intervals() {
           {Direction<1>::lower_xi()}, {Direction<1>::lower_xi()}});
   test_physical_separation(rotated_intervals.create_domain().blocks());
 
-  const creators::RotatedIntervals<Frame::Inertial> periodic_rotated_intervals{
+  const creators::RotatedIntervals periodic_rotated_intervals{
       lower_bound,         midpoint,
       upper_bound,         std::array<bool, 1>{{true}},
       refinement_level[0], {{{{grid_points[0][0], grid_points[1][0]}}}}};
@@ -101,18 +101,16 @@ void test_rotated_intervals_factory() {
   INFO("Rotated intervals factory");
   const OrientationMap<1> flipped{
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}};
-  const auto domain_creator =
-      test_factory_creation<DomainCreator<1, Frame::Inertial>>(
-          "  RotatedIntervals:\n"
-          "    LowerBound: [0.0]\n"
-          "    Midpoint:   [0.5]\n"
-          "    UpperBound: [1.0]\n"
-          "    IsPeriodicIn: [True]\n"
-          "    InitialGridPoints: [[3,2]]\n"
-          "    InitialRefinement: [2]\n");
+  const auto domain_creator = test_factory_creation<DomainCreator<1>>(
+      "  RotatedIntervals:\n"
+      "    LowerBound: [0.0]\n"
+      "    Midpoint:   [0.5]\n"
+      "    UpperBound: [1.0]\n"
+      "    IsPeriodicIn: [True]\n"
+      "    InitialGridPoints: [[3,2]]\n"
+      "    InitialRefinement: [2]\n");
   const auto* rotated_intervals_creator =
-      dynamic_cast<const creators::RotatedIntervals<Frame::Inertial>*>(
-          domain_creator.get());
+      dynamic_cast<const creators::RotatedIntervals*>(domain_creator.get());
   test_rotated_intervals_construction(
       *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
       {{{2}}, {{2}}},

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -28,7 +28,7 @@
 namespace domain {
 namespace {
 void test_rotated_rectangles_construction(
-    const creators::RotatedRectangles<Frame::Inertial>& rotated_rectangles,
+    const creators::RotatedRectangles& rotated_rectangles,
     const std::array<double, 2>& lower_bound,
     const std::array<double, 2>& midpoint,
     const std::array<double, 2>& upper_bound,
@@ -94,7 +94,7 @@ void test_rotated_rectangles() {
   const OrientationMap<2> quarter_turn_ccw{std::array<Direction<2>, 2>{
       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}};
 
-  const creators::RotatedRectangles<Frame::Inertial> rotated_rectangles{
+  const creators::RotatedRectangles rotated_rectangles{
       lower_bound,
       midpoint,
       upper_bound,
@@ -121,15 +121,14 @@ void test_rotated_rectangles() {
           {Direction<2>::lower_xi(), Direction<2>::upper_eta()}});
   test_physical_separation(rotated_rectangles.create_domain().blocks());
 
-  const creators::RotatedRectangles<Frame::Inertial>
-      rotated_periodic_rectangles{
-          lower_bound,
-          midpoint,
-          upper_bound,
-          {{true, true}},
-          {{refinement_level[0][0], refinement_level[0][1]}},
-          {{{{grid_points[0][0], grid_points[1][0]}},
-            {{grid_points[0][1], grid_points[2][0]}}}}};
+  const creators::RotatedRectangles rotated_periodic_rectangles{
+      lower_bound,
+      midpoint,
+      upper_bound,
+      {{true, true}},
+      {{refinement_level[0][0], refinement_level[0][1]}},
+      {{{{grid_points[0][0], grid_points[1][0]}},
+        {{grid_points[0][1], grid_points[2][0]}}}}};
   test_rotated_rectangles_construction(
       rotated_periodic_rectangles, lower_bound, midpoint, upper_bound,
       grid_points, refinement_level,
@@ -162,18 +161,16 @@ void test_rotated_rectangles_factory() {
   const OrientationMap<2> quarter_turn_ccw{std::array<Direction<2>, 2>{
       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}};
 
-  const auto domain_creator =
-      test_factory_creation<DomainCreator<2, Frame::Inertial>>(
-          "  RotatedRectangles:\n"
-          "    LowerBound: [0.1, -0.4]\n"
-          "    Midpoint:   [2.6, 3.2]\n"
-          "    UpperBound: [5.1, 6.2]\n"
-          "    IsPeriodicIn: [false, false]\n"
-          "    InitialGridPoints: [[3,2],[1,4]]\n"
-          "    InitialRefinement: [2,1]\n");
+  const auto domain_creator = test_factory_creation<DomainCreator<2>>(
+      "  RotatedRectangles:\n"
+      "    LowerBound: [0.1, -0.4]\n"
+      "    Midpoint:   [2.6, 3.2]\n"
+      "    UpperBound: [5.1, 6.2]\n"
+      "    IsPeriodicIn: [false, false]\n"
+      "    InitialGridPoints: [[3,2],[1,4]]\n"
+      "    InitialRefinement: [2,1]\n");
   const auto* rotated_rectangles_creator =
-      dynamic_cast<const creators::RotatedRectangles<Frame::Inertial>*>(
-          domain_creator.get());
+      dynamic_cast<const creators::RotatedRectangles*>(domain_creator.get());
   test_rotated_rectangles_construction(
       *rotated_rectangles_creator, {{0.1, -0.4}}, {{2.6, 3.2}}, {{5.1, 6.2}},
       {{{3, 1}}, {{2, 1}}, {{4, 3}}, {{4, 2}}},

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -47,7 +47,7 @@
 namespace domain {
 namespace {
 void test_shell_construction(
-    const creators::Shell<Frame::Inertial>& shell, const double inner_radius,
+    const creators::Shell& shell, const double inner_radius,
     const double outer_radius, const bool use_equiangular_map,
     const std::array<size_t, 2>& expected_shell_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level,
@@ -261,9 +261,8 @@ void test_shell_boundaries() {
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
 
   for (const auto& use_equiangular_map : {true, false}) {
-    const creators::Shell<Frame::Inertial> shell{
-        inner_radius, outer_radius, refinement_level, grid_points_r_angular,
-        use_equiangular_map};
+    const creators::Shell shell{inner_radius, outer_radius, refinement_level,
+                                grid_points_r_angular, use_equiangular_map};
     test_physical_separation(shell.create_domain().blocks());
     test_shell_construction(shell, inner_radius, outer_radius,
                             use_equiangular_map, grid_points_r_angular,
@@ -273,7 +272,7 @@ void test_shell_boundaries() {
 
 void test_shell_factory_equiangular() {
   INFO("Shell factory equiangular");
-  const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+  const auto shell = test_factory_creation<DomainCreator<3>>(
       "  Shell:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -283,14 +282,13 @@ void test_shell_factory_equiangular() {
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
   test_shell_construction(
-      dynamic_cast<const creators::Shell<Frame::Inertial>&>(*shell),
-      inner_radius, outer_radius, true, grid_points_r_angular,
-      {6, make_array<3>(refinement_level)});
+      dynamic_cast<const creators::Shell&>(*shell), inner_radius, outer_radius,
+      true, grid_points_r_angular, {6, make_array<3>(refinement_level)});
 }
 
 void test_shell_factory_equidistant() {
   INFO("Shell factory equidistant");
-  const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+  const auto shell = test_factory_creation<DomainCreator<3>>(
       "  Shell:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -301,9 +299,8 @@ void test_shell_factory_equidistant() {
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
   test_shell_construction(
-      dynamic_cast<const creators::Shell<Frame::Inertial>&>(*shell),
-      inner_radius, outer_radius, false, grid_points_r_angular,
-      {6, make_array<3>(refinement_level)});
+      dynamic_cast<const creators::Shell&>(*shell), inner_radius, outer_radius,
+      false, grid_points_r_angular, {6, make_array<3>(refinement_level)});
 }
 
 void test_shell_boundaries_aspect_ratio() {
@@ -313,7 +310,7 @@ void test_shell_boundaries_aspect_ratio() {
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
   const double aspect_ratio = 1.3;
 
-  const creators::Shell<Frame::Inertial> shell{
+  const creators::Shell shell{
       inner_radius,          outer_radius, refinement_level,
       grid_points_r_angular, false,        aspect_ratio};
   test_physical_separation(shell.create_domain().blocks());
@@ -324,7 +321,7 @@ void test_shell_boundaries_aspect_ratio() {
 
 void test_shell_factory_aspect_ratio() {
   INFO("Shell factory aspect ratio");
-  const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+  const auto shell = test_factory_creation<DomainCreator<3>>(
       "  Shell:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -336,10 +333,10 @@ void test_shell_factory_aspect_ratio() {
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
   const double aspect_ratio = 2.0;
-  test_shell_construction(
-      dynamic_cast<const creators::Shell<Frame::Inertial>&>(*shell),
-      inner_radius, outer_radius, false, grid_points_r_angular,
-      {6, make_array<3>(refinement_level)}, aspect_ratio);
+  test_shell_construction(dynamic_cast<const creators::Shell&>(*shell),
+                          inner_radius, outer_radius, false,
+                          grid_points_r_angular,
+                          {6, make_array<3>(refinement_level)}, aspect_ratio);
 }
 
 void test_shell_boundaries_logarithmic_map() {
@@ -350,7 +347,7 @@ void test_shell_boundaries_logarithmic_map() {
   const double aspect_ratio = 1.0;
   const bool use_logarithmic_map = true;
 
-  const creators::Shell<Frame::Inertial> shell{
+  const creators::Shell shell{
       inner_radius, outer_radius, refinement_level,   grid_points_r_angular,
       false,        aspect_ratio, use_logarithmic_map};
   test_physical_separation(shell.create_domain().blocks());
@@ -361,7 +358,7 @@ void test_shell_boundaries_logarithmic_map() {
 
 void test_shell_factory_logarithmic_map() {
   INFO("Shell factory logarithmic map");
-  const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+  const auto shell = test_factory_creation<DomainCreator<3>>(
       "  Shell:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -376,14 +373,14 @@ void test_shell_factory_logarithmic_map() {
   const double aspect_ratio = 2.0;
   const bool use_logarithmic_map = true;
   test_shell_construction(
-      dynamic_cast<const creators::Shell<Frame::Inertial>&>(*shell),
-      inner_radius, outer_radius, false, grid_points_r_angular,
-      {6, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map);
+      dynamic_cast<const creators::Shell&>(*shell), inner_radius, outer_radius,
+      false, grid_points_r_angular, {6, make_array<3>(refinement_level)},
+      aspect_ratio, use_logarithmic_map);
 }
 
 void test_shell_factory_wedges_four_on_equator() {
   INFO("Shell factory wedges four on equator");
-  const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+  const auto shell = test_factory_creation<DomainCreator<3>>(
       "  Shell:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -400,15 +397,14 @@ void test_shell_factory_wedges_four_on_equator() {
   const bool use_logarithmic_map = true;
   const ShellWedges which_wedges = ShellWedges::FourOnEquator;
   test_shell_construction(
-      dynamic_cast<const creators::Shell<Frame::Inertial>&>(*shell),
-      inner_radius, outer_radius, false, grid_points_r_angular,
-      {4, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map,
-      which_wedges);
+      dynamic_cast<const creators::Shell&>(*shell), inner_radius, outer_radius,
+      false, grid_points_r_angular, {4, make_array<3>(refinement_level)},
+      aspect_ratio, use_logarithmic_map, which_wedges);
 }
 
 void test_shell_factory_wedges_one_along_minus_x() {
   INFO("Shell factory wedges one along minus x");
-  const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+  const auto shell = test_factory_creation<DomainCreator<3>>(
       "  Shell:\n"
       "    InnerRadius: 2\n"
       "    OuterRadius: 3\n"
@@ -425,10 +421,9 @@ void test_shell_factory_wedges_one_along_minus_x() {
   const bool use_logarithmic_map = false;
   const ShellWedges which_wedges = ShellWedges::OneAlongMinusX;
   test_shell_construction(
-      dynamic_cast<const creators::Shell<Frame::Inertial>&>(*shell),
-      inner_radius, outer_radius, true, grid_points_r_angular,
-      {1, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map,
-      which_wedges);
+      dynamic_cast<const creators::Shell&>(*shell), inner_radius, outer_radius,
+      true, grid_points_r_angular, {1, make_array<3>(refinement_level)},
+      aspect_ratio, use_logarithmic_map, which_wedges);
 }
 
 // Tests that the underlying element structure is the same regardless of
@@ -478,7 +473,7 @@ void test_radial_block_layers(const double inner_radius,
   const auto zero = make_with_value<DataVector>(x_in_block_interior, 0.0);
   tnsr::I<DataVector, 3, Frame::Inertial> interior_inertial_coords{
       {{-x_in_block_interior, zero, zero}}};
-  const creators::Shell<Frame::Inertial> shell{
+  const creators::Shell shell{
       inner_radius,          outer_radius,        refinement_level,
       grid_points_r_angular, use_equiangular_map, aspect_ratio,
       use_logarithmic_map,   which_wedges,        radial_block_layers};
@@ -528,17 +523,16 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell", "[Domain][Unit]") {
 
   {
     INFO("shell factory logarithmic block layers");
-    const auto log_shell =
-        test_factory_creation<DomainCreator<3, Frame::Inertial>>(
-            "  Shell:\n"
-            "    InnerRadius: 1\n"
-            "    OuterRadius: 3\n"
-            "    InitialRefinement: 2\n"
-            "    InitialGridPoints: [2,3]\n"
-            "    UseEquiangularMap: false\n"
-            "    AspectRatio: 2.0        \n"
-            "    UseLogarithmicMap: true\n"
-            "    RadialBlockLayers: 6\n");
+    const auto log_shell = test_factory_creation<DomainCreator<3>>(
+        "  Shell:\n"
+        "    InnerRadius: 1\n"
+        "    OuterRadius: 3\n"
+        "    InitialRefinement: 2\n"
+        "    InitialGridPoints: [2,3]\n"
+        "    UseEquiangularMap: false\n"
+        "    AspectRatio: 2.0        \n"
+        "    UseLogarithmicMap: true\n"
+        "    RadialBlockLayers: 6\n");
   }
   {
     INFO("Radial block layers 1");

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -32,7 +32,7 @@
 namespace domain {
 namespace {
 void test_sphere_construction(
-    const creators::Sphere<Frame::Inertial>& sphere, const double inner_radius,
+    const creators::Sphere& sphere, const double inner_radius,
     const double outer_radius, const bool use_equiangular_map,
     const std::array<size_t, 2>& expected_sphere_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level) {
@@ -195,8 +195,8 @@ void test_sphere_boundaries_equiangular() {
   const size_t refinement = 2;
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
 
-  const creators::Sphere<Frame::Inertial> sphere{
-      inner_radius, outer_radius, refinement, grid_points_r_angular, true};
+  const creators::Sphere sphere{inner_radius, outer_radius, refinement,
+                                grid_points_r_angular, true};
   test_physical_separation(sphere.create_domain().blocks());
 
   test_sphere_construction(sphere, inner_radius, outer_radius, true,
@@ -206,7 +206,7 @@ void test_sphere_boundaries_equiangular() {
 
 void test_sphere_factory_equiangular() {
   INFO("Sphere factory equiangular");
-  const auto sphere = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+  const auto sphere = test_factory_creation<DomainCreator<3>>(
       "  Sphere:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -216,10 +216,10 @@ void test_sphere_factory_equiangular() {
   const double inner_radius = 1.0, outer_radius = 3.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
-  test_sphere_construction(
-      dynamic_cast<const creators::Sphere<Frame::Inertial>&>(*sphere),
-      inner_radius, outer_radius, true, grid_points_r_angular,
-      {7, make_array<3>(refinement_level)});
+  test_sphere_construction(dynamic_cast<const creators::Sphere&>(*sphere),
+                           inner_radius, outer_radius, true,
+                           grid_points_r_angular,
+                           {7, make_array<3>(refinement_level)});
 }
 
 void test_sphere_boundaries_equidistant() {
@@ -228,8 +228,8 @@ void test_sphere_boundaries_equidistant() {
   const size_t refinement = 2;
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
 
-  const creators::Sphere<Frame::Inertial> sphere{
-      inner_radius, outer_radius, refinement, grid_points_r_angular, false};
+  const creators::Sphere sphere{inner_radius, outer_radius, refinement,
+                                grid_points_r_angular, false};
   test_physical_separation(sphere.create_domain().blocks());
 
   test_sphere_construction(sphere, inner_radius, outer_radius, false,
@@ -239,7 +239,7 @@ void test_sphere_boundaries_equidistant() {
 
 void test_sphere_factory_equidistant() {
   INFO("Sphere factory equidistant");
-  const auto sphere = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+  const auto sphere = test_factory_creation<DomainCreator<3>>(
       "  Sphere:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -249,10 +249,10 @@ void test_sphere_factory_equidistant() {
   const double inner_radius = 1.0, outer_radius = 3.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
-  test_sphere_construction(
-      dynamic_cast<const creators::Sphere<Frame::Inertial>&>(*sphere),
-      inner_radius, outer_radius, false, grid_points_r_angular,
-      {7, make_array<3>(refinement_level)});
+  test_sphere_construction(dynamic_cast<const creators::Sphere&>(*sphere),
+                           inner_radius, outer_radius, false,
+                           grid_points_r_angular,
+                           {7, make_array<3>(refinement_level)});
 }
 }  // namespace
 

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -13,7 +13,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
 /// \cond
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim>
 class Block;
 template <size_t VolumeDim>
 class BlockNeighbor;
@@ -26,28 +26,28 @@ template <size_t VolumeDim>
 class Direction;
 template <size_t VolumeDim, typename T>
 class DirectionMap;
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim>
 class Domain;
 template <size_t VolumeDim>
 class ElementId;
 /// \endcond
 
 // Test that the Blocks in the Domain are constructed correctly.
-template <size_t VolumeDim, typename Fr = Frame::Inertial>
+template <size_t VolumeDim>
 void test_domain_construction(
-    const Domain<VolumeDim, Fr>& domain,
+    const Domain<VolumeDim>& domain,
     const std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,
     const std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::Logical, Fr, VolumeDim>>>&
+        domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>>&
         expected_maps) noexcept;
 
 // Test that two neighboring Blocks abut each other.
-template <size_t VolumeDim, typename Fr = Frame::Inertial>
+template <size_t VolumeDim>
 void test_physical_separation(
-    const std::vector<Block<VolumeDim, Fr>>& blocks) noexcept;
+    const std::vector<Block<VolumeDim>>& blocks) noexcept;
 
 // Fraction of the logical volume of a block covered by an element
 // The sum of this over all the elements of a block should be one
@@ -58,13 +58,14 @@ boost::rational<size_t> fraction_of_block_volume(
 // Test that the Elements of the initial domain are connected and cover the
 // computational domain, as well as that neighboring Elements  are at the same
 // refinement level.
-template <size_t VolumeDim, typename Fr = Frame::Inertial>
-void test_initial_domain(const Domain<VolumeDim, Fr>& domain,
+template <size_t VolumeDim>
+void test_initial_domain(const Domain<VolumeDim>& domain,
                          const std::vector<std::array<size_t, VolumeDim>>&
                              initial_refinement_levels) noexcept;
 
-// Euclidean basis vector along the given `Direction` and in the given `Frame`.
-template <size_t SpatialDim, typename Fr = Frame::Inertial>
-tnsr::i<DataVector, SpatialDim, Fr> euclidean_basis_vector(
+// Euclidean basis vector along the given `Direction` and in the given
+// `Frame::Inertial` frame.
+template <size_t SpatialDim>
+tnsr::i<DataVector, SpatialDim, Frame::Inertial> euclidean_basis_vector(
     const Direction<SpatialDim>& direction,
     const DataVector& used_for_size) noexcept;

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -26,13 +26,13 @@ namespace domain {
 namespace {
 template <size_t Dim>
 void test_block() {
-  PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Grid,
+  PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial,
                                        CoordinateMaps::Identity<Dim>>));
 
-  using coordinate_map =
-      CoordinateMap<Frame::Logical, Frame::Grid, CoordinateMaps::Identity<Dim>>;
+  using coordinate_map = CoordinateMap<Frame::Logical, Frame::Inertial,
+                                       CoordinateMaps::Identity<Dim>>;
   const coordinate_map identity_map{CoordinateMaps::Identity<Dim>{}};
-  Block<Dim, Frame::Grid> block(identity_map.get_clone(), 7, {});
+  Block<Dim> block(identity_map.get_clone(), 7, {});
 
   // Test external boundaries:
   CHECK((block.external_boundaries().size()) == 2 * Dim);
@@ -46,7 +46,7 @@ void test_block() {
   // Test that the block's coordinate_map is Identity:
   const auto& map = block.coordinate_map();
   const tnsr::I<double, Dim, Frame::Logical> xi(1.0);
-  const tnsr::I<double, Dim, Frame::Grid> x(1.0);
+  const tnsr::I<double, Dim, Frame::Inertial> x(1.0);
   CHECK(map(xi) == x);
   CHECK(map.inverse(x).get() == xi);
 
@@ -54,7 +54,7 @@ void test_block() {
   test_serialization(block);
 
   // Test move semantics:
-  const Block<Dim, Frame::Grid> block_copy(identity_map.get_clone(), 7, {});
+  const Block<Dim> block_copy(identity_map.get_clone(), 7, {});
   test_move_semantics(std::move(block), block_copy);
 }
 }  // namespace
@@ -75,11 +75,10 @@ SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
   DirectionMap<2, BlockNeighbor<2>> neighbors = {
       {Direction<2>::upper_xi(), block_neighbor1},
       {Direction<2>::lower_eta(), block_neighbor2}};
-  using coordinate_map =
-      CoordinateMap<Frame::Logical, Frame::Grid, CoordinateMaps::Identity<2>>;
+  using coordinate_map = CoordinateMap<Frame::Logical, Frame::Inertial,
+                                       CoordinateMaps::Identity<2>>;
   const coordinate_map identity_map{CoordinateMaps::Identity<2>{}};
-  const Block<2, Frame::Grid> block(identity_map.get_clone(), 3,
-                                    std::move(neighbors));
+  const Block<2> block(identity_map.get_clone(), 3, std::move(neighbors));
 
   // Test external boundaries:
   CHECK((block.external_boundaries().size()) == 2);
@@ -99,8 +98,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
         "External boundaries: (+1,-0)\n");
 
   // Test comparison:
-  const Block<2, Frame::Grid> neighborless_block(identity_map.get_clone(), 7,
-                                                 {});
+  const Block<2> neighborless_block(identity_map.get_clone(), 7, {});
   CHECK(block == block);
   CHECK(block != neighborless_block);
   CHECK(neighborless_block == neighborless_block);

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -24,7 +24,7 @@
 
 namespace {
 void test_create_initial_element(
-    const ElementId<2>& element_id, const Block<2, Frame::Inertial>& block,
+    const ElementId<2>& element_id, const Block<2>& block,
     const DirectionMap<2, Neighbors<2>>& expected_neighbors) noexcept {
   const auto created_element =
       domain::Initialization::create_initial_element(element_id, block);
@@ -41,7 +41,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
   OrientationMap<2> inverse_of_unaligned(
       {{Direction<2>::lower_eta(), Direction<2>::upper_xi()}},
       {{Direction<2>::upper_xi(), Direction<2>::upper_eta()}});
-  Block<2, Frame::Inertial> test_block(
+  Block<2> test_block(
       domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           domain::CoordinateMaps::Identity<2>{}),
       0,

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -35,13 +35,12 @@ namespace domain {
 namespace {
 void test_1d_domains() {
   {
-    CHECK(Tags::Domain<1, Frame::Logical>::name() == "Domain");
-    CHECK(Tags::Domain<1, Frame::Inertial>::name() == "Domain");
+    CHECK(Tags::Domain<1>::name() == "Domain");
     PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial,
                                          CoordinateMaps::Affine>));
 
     // Test construction of two intervals which have anti-aligned logical axes.
-    const Domain<1, Frame::Inertial> domain(
+    const Domain<1> domain(
         make_vector<std::unique_ptr<
             CoordinateMapBase<Frame::Logical, Frame::Inertial, 1>>>(
             std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
@@ -80,14 +79,14 @@ void test_1d_domains() {
                              expected_maps);
 
     auto vector_of_blocks = [&expected_neighbors]() {
-      std::vector<Block<1, Frame::Inertial>> vec;
-      vec.emplace_back(Block<1, Frame::Inertial>{
+      std::vector<Block<1>> vec;
+      vec.emplace_back(Block<1>{
           std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
                                          CoordinateMaps::Affine>>(
               make_coordinate_map<Frame::Logical, Frame::Inertial>(
                   CoordinateMaps::Affine{-1., 1., -2., 0.})),
           0, expected_neighbors[0]});
-      vec.emplace_back(Block<1, Frame::Inertial>{
+      vec.emplace_back(Block<1>{
           std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
                                          CoordinateMaps::Affine>>(
               make_coordinate_map<Frame::Logical, Frame::Inertial>(
@@ -96,9 +95,9 @@ void test_1d_domains() {
       return vec;
     }();
 
-    test_domain_construction(
-        Domain<1, Frame::Inertial>{std::move(vector_of_blocks)},
-        expected_neighbors, expected_boundaries, expected_maps);
+    test_domain_construction(Domain<1>{std::move(vector_of_blocks)},
+                             expected_neighbors, expected_boundaries,
+                             expected_maps);
 
     CHECK(get_output(domain) == "Domain with 2 blocks:\n" +
                                     get_output(domain.blocks()[0]) + "\n" +
@@ -111,7 +110,7 @@ void test_1d_domains() {
         make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             CoordinateMaps::Affine{-1., 1., -2., 2.}));
 
-    const Domain<1, Frame::Inertial> domain{
+    const Domain<1> domain{
         make_vector<std::unique_ptr<
             CoordinateMapBase<Frame::Logical, Frame::Inertial, 1>>>(
             std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
@@ -139,7 +138,7 @@ void test_1d_domains() {
 SPECTRE_TEST_CASE("Unit.Domain.Domain", "[Domain][Unit]") { test_1d_domains(); }
 SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear1D1", "[Domain][Unit]") {
   SECTION("Aligned domain.") {
-    const auto domain = rectilinear_domain<1, Frame::Inertial>(
+    const auto domain = rectilinear_domain<1>(
         Index<1>{3}, std::array<std::vector<double>, 1>{{{0.0, 1.0, 2.0, 3.0}}},
         {}, {}, {{false}}, {}, true);
     const OrientationMap<1> aligned{};
@@ -165,7 +164,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear1D1", "[Domain][Unit]") {
     const OrientationMap<1> aligned{};
     const OrientationMap<1> antialigned{
         std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}};
-    const auto domain = rectilinear_domain<1, Frame::Inertial>(
+    const auto domain = rectilinear_domain<1>(
         Index<1>{3}, std::array<std::vector<double>, 1>{{{0.0, 1.0, 2.0, 3.0}}},
         {}, std::vector<OrientationMap<1>>{aligned, antialigned, aligned},
         {{false}}, {}, true);
@@ -190,7 +189,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear1D1", "[Domain][Unit]") {
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear2D", "[Domain][Unit]") {
-  CHECK(Tags::Domain<2, Frame::Inertial>::name() == "Domain");
+  CHECK(Tags::Domain<2>::name() == "Domain");
   const OrientationMap<2> half_turn{std::array<Direction<2>, 2>{
       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}};
   const OrientationMap<2> quarter_turn_cw{std::array<Direction<2>, 2>{
@@ -203,7 +202,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear2D", "[Domain][Unit]") {
   orientations_of_all_blocks[2] = quarter_turn_cw;
   orientations_of_all_blocks[3] = quarter_turn_ccw;
 
-  const auto domain = rectilinear_domain<2, Frame::Inertial>(
+  const auto domain = rectilinear_domain<2>(
       Index<2>{2, 2},
       std::array<std::vector<double>, 2>{{{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}}},
       {}, orientations_of_all_blocks);
@@ -234,7 +233,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear2D", "[Domain][Unit]") {
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear3D", "[Domain][Unit]") {
-  CHECK(Tags::Domain<3, Frame::Inertial>::name() == "Domain");
+  CHECK(Tags::Domain<3>::name() == "Domain");
   const OrientationMap<3> aligned{};
   const OrientationMap<3> quarter_turn_cw_xi{std::array<Direction<3>, 3>{
       {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
@@ -242,11 +241,11 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear3D", "[Domain][Unit]") {
   auto orientations_of_all_blocks =
       std::vector<OrientationMap<3>>{aligned, quarter_turn_cw_xi};
 
-  const auto domain = rectilinear_domain<3, Frame::Inertial>(
-      Index<3>{2, 1, 1},
-      std::array<std::vector<double>, 3>{
-          {{0.0, 1.0, 2.0}, {0.0, 1.0}, {0.0, 1.0}}},
-      {}, orientations_of_all_blocks);
+  const auto domain =
+      rectilinear_domain<3>(Index<3>{2, 1, 1},
+                            std::array<std::vector<double>, 3>{
+                                {{0.0, 1.0, 2.0}, {0.0, 1.0}, {0.0, 1.0}}},
+                            {}, orientations_of_all_blocks);
   std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{
       {{Direction<3>::upper_xi(), {1, quarter_turn_cw_xi}}},
       {{Direction<3>::lower_xi(), {0, quarter_turn_cw_xi.inverse_map()}}}};
@@ -274,7 +273,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear3D", "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   // NOLINTNEXTLINE(misc-unused-raii)
-  Domain<1, Frame::Inertial>(
+  Domain<1>(
       make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
                       CoordinateMaps::Affine{-1., 1., -1., 1.}),
                   make_coordinate_map_base<Frame::Logical, Frame::Inertial>(

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -1454,7 +1454,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.MapsForRectilinearDomains",
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.SetCartesianPeriodicBoundaries1",
                   "[Domain][Unit]") {
-  const auto domain = rectilinear_domain<3, Frame::Inertial>(
+  const auto domain = rectilinear_domain<3>(
       Index<3>{3, 3, 3},
       std::array<std::vector<double>, 3>{
           {{0.0, 1.0, 2.0, 3.0}, {0.0, 1.0, 2.0, 3.0}, {0.0, 1.0, 2.0, 3.0}}},
@@ -1525,7 +1525,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.SetCartesianPeriodicBoundaries2",
   auto orientations_of_all_blocks =
       std::vector<OrientationMap<2>>{4, OrientationMap<2>{}};
   orientations_of_all_blocks[0] = rotation;
-  const auto domain = rectilinear_domain<2, Frame::Inertial>(
+  const auto domain = rectilinear_domain<2>(
       Index<2>{2, 2},
       std::array<std::vector<double>, 2>{{{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}}},
       {}, orientations_of_all_blocks, std::array<bool, 2>{{true, false}}, {},
@@ -1565,7 +1565,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.SetCartesianPeriodicBoundaries3",
   orientations_of_all_blocks[1] = flipped;
   orientations_of_all_blocks[2] = quarter_turn_cw;
   orientations_of_all_blocks[3] = quarter_turn_ccw;
-  const auto domain = rectilinear_domain<2, Frame::Inertial>(
+  const auto domain = rectilinear_domain<2>(
       Index<2>{2, 2},
       std::array<std::vector<double>, 2>{{{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}}},
       {}, orientations_of_all_blocks, std::array<bool, 2>{{true, true}}, {},

--- a/tests/Unit/Domain/Test_DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainTestHelpers.cpp
@@ -15,18 +15,18 @@
 
 namespace {
 
-template <size_t SpatialDim, typename SpatialFrame>
+template <size_t SpatialDim>
 void test_euclidean_basis_vectors(const DataVector& used_for_size) noexcept {
   for (const auto& direction : Direction<SpatialDim>::all_directions()) {
     auto expected =
-        make_with_value<tnsr::i<DataVector, SpatialDim, SpatialFrame>>(
+        make_with_value<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
             used_for_size, 0.0);
     expected.get(direction.axis()) =
         make_with_value<DataVector>(used_for_size, direction.sign());
 
-    CHECK_ITERABLE_APPROX((euclidean_basis_vector<SpatialDim, SpatialFrame>(
-                              direction, used_for_size)),
-                          std::move(expected));
+    CHECK_ITERABLE_APPROX(
+        (euclidean_basis_vector<SpatialDim>(direction, used_for_size)),
+        std::move(expected));
   }
 }
 
@@ -35,11 +35,7 @@ void test_euclidean_basis_vectors(const DataVector& used_for_size) noexcept {
 SPECTRE_TEST_CASE("Unit.Domain.TestHelpers.BasisVector", "[Unit][Domain]") {
   const DataVector dv(5);
 
-  test_euclidean_basis_vectors<1, Frame::Inertial>(dv);
-  test_euclidean_basis_vectors<2, Frame::Inertial>(dv);
-  test_euclidean_basis_vectors<3, Frame::Inertial>(dv);
-
-  test_euclidean_basis_vectors<1, Frame::Grid>(dv);
-  test_euclidean_basis_vectors<2, Frame::Grid>(dv);
-  test_euclidean_basis_vectors<3, Frame::Grid>(dv);
+  test_euclidean_basis_vectors<1>(dv);
+  test_euclidean_basis_vectors<2>(dv);
+  test_euclidean_basis_vectors<3>(dv);
 }

--- a/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
@@ -109,8 +109,7 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<Dim, Frame::Inertial>>;
+  using const_global_cache_tags = tmpl::list<::Tags::Domain<Dim>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -173,7 +172,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
     INFO("1D");
     // Which element we work with does not matter for this test
     const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
-    const domain::creators::Interval<Frame::Inertial> domain_creator{
+    const domain::creators::Interval domain_creator{
         {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
     // Register the coordinate map for serialization
     PUPable_reg(
@@ -221,7 +220,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
     INFO("2D");
     // Which element we work with does not matter for this test
     const ElementId<2> element_id{0, {{SegmentId{2, 1}, SegmentId{0, 0}}}};
-    const domain::creators::Rectangle<Frame::Inertial> domain_creator{
+    const domain::creators::Rectangle domain_creator{
         {{-0.5, 0.}}, {{1.5, 2.}}, {{false, false}}, {{2, 0}}, {{4, 3}}};
     // Register the coordinate map for serialization
     PUPable_reg(
@@ -271,12 +270,11 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
     // Which element we work with does not matter for this test
     const ElementId<3> element_id{
         0, {{SegmentId{2, 1}, SegmentId{0, 0}, SegmentId{1, 1}}}};
-    const domain::creators::Brick<Frame::Inertial> domain_creator{
-        {{-0.5, 0., -1.}},
-        {{1.5, 2., 3.}},
-        {{false, false, false}},
-        {{2, 0, 1}},
-        {{4, 3, 2}}};
+    const domain::creators::Brick domain_creator{{{-0.5, 0., -1.}},
+                                                 {{1.5, 2., 3.}},
+                                                 {{false, false, false}},
+                                                 {{2, 0, 1}},
+                                                 {{4, 3, 2}}};
     // Register the coordinate map for serialization
     PUPable_reg(SINGLE_ARG(
         domain::CoordinateMap<

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
@@ -109,8 +109,7 @@ struct ElementArray {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<
-                         ::Tags::Domain<Dim, Frame::Inertial>,
-                         ::Tags::InitialExtents<Dim>,
+                         ::Tags::Domain<Dim>, ::Tags::InitialExtents<Dim>,
                          db::add_tag_prefix<
                              ::Tags::FixedSource,
                              typename Metavariables::system::fields_tag>>>,
@@ -184,7 +183,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Actions.InhomogeneousBoundaryConditions",
     //    ^       ^
     // -0.5       1.5
     const ElementId<1> element_id{0, {{SegmentId{2, 0}}}};
-    const domain::creators::Interval<Frame::Inertial> domain_creator{
+    const domain::creators::Interval domain_creator{
         {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
 
     // Expected boundary contribution to source in element X:
@@ -208,7 +207,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Actions.InhomogeneousBoundaryConditions",
     //       ^   ^
     //    -0.5   1.5
     const ElementId<2> element_id{0, {{SegmentId{1, 0}, SegmentId{1, 1}}}};
-    const domain::creators::Rectangle<Frame::Inertial> domain_creator{
+    const domain::creators::Rectangle domain_creator{
         {{-0.5, 0.}}, {{1.5, 1.}}, {{false, false}}, {{1, 1}}, {{3, 3}}};
 
     // Expected boundary contribution to source in element X:
@@ -228,12 +227,11 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Actions.InhomogeneousBoundaryConditions",
     INFO("3D");
     const ElementId<3> element_id{
         0, {{SegmentId{1, 0}, SegmentId{1, 1}, SegmentId{1, 0}}}};
-    const domain::creators::Brick<Frame::Inertial> domain_creator{
-        {{-0.5, 0., -1.}},
-        {{1.5, 1., 3.}},
-        {{false, false, false}},
-        {{1, 1, 1}},
-        {{2, 2, 2}}};
+    const domain::creators::Brick domain_creator{{{-0.5, 0., -1.}},
+                                                 {{1.5, 1., 3.}},
+                                                 {{false, false, false}},
+                                                 {{1, 1, 1}},
+                                                 {{2, 2, 2}}};
 
     // Expected boundary contribution to source in reference element (0, 1, 0):
     //                   7 eta

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
@@ -85,8 +85,7 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<Dim, Frame::Inertial>>;
+  using const_global_cache_tags = tmpl::list<::Tags::Domain<Dim>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -147,10 +146,9 @@ void check_compute_items(
       ::Tags::Flux<ScalarFieldTag, tmpl::size_t<Dim>, Frame::Inertial>{}));
 }
 
-template <size_t Dim, typename DomainFrame>
-void test_initialize_fluxes(
-    const DomainCreator<Dim, DomainFrame>& domain_creator,
-    const ElementId<Dim>& element_id) {
+template <size_t Dim>
+void test_initialize_fluxes(const DomainCreator<Dim>& domain_creator,
+                            const ElementId<Dim>& element_id) {
   using metavariables = Metavariables<Dim>;
   using element_array = typename metavariables::element_array;
 
@@ -183,7 +181,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Actions.InitializeFluxes",
     // Reference element:
     // [X| | | ]-> xi
     const ElementId<1> element_id{0, {{{2, 0}}}};
-    const domain::creators::Interval<Frame::Inertial> domain_creator{
+    const domain::creators::Interval domain_creator{
         {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
 
     test_initialize_fluxes(domain_creator, element_id);
@@ -198,7 +196,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Actions.InitializeFluxes",
     // | | |
     // +-+-+
     const ElementId<2> element_id{0, {{{1, 0}, {1, 1}}}};
-    const domain::creators::Rectangle<Frame::Inertial> domain_creator{
+    const domain::creators::Rectangle domain_creator{
         {{-0.5, 0.}}, {{1.5, 1.}}, {{false, false}}, {{1, 1}}, {{3, 2}}};
 
     test_initialize_fluxes(domain_creator, element_id);
@@ -207,12 +205,11 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Actions.InitializeFluxes",
     INFO("3D");
     const ElementId<3> element_id{
         0, {{SegmentId{1, 0}, SegmentId{1, 1}, SegmentId{1, 0}}}};
-    const domain::creators::Brick<Frame::Inertial> domain_creator{
-        {{-0.5, 0., -1.}},
-        {{1.5, 1., 3.}},
-        {{false, false, false}},
-        {{1, 1, 1}},
-        {{2, 3, 4}}};
+    const domain::creators::Brick domain_creator{{{-0.5, 0., -1.}},
+                                                 {{1.5, 1., 3.}},
+                                                 {{false, false, false}},
+                                                 {{1, 1, 1}},
+                                                 {{2, 3, 4}}};
 
     test_initialize_fluxes(domain_creator, element_id);
   }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -69,7 +69,7 @@ struct mock_interpolation_target {
   using const_global_cache_tags = tmpl::flatten<tmpl::append<
       Parallel::get_const_global_cache_tags_from_actions<tmpl::list<
           typename Metavariables::InterpolationTargetA::compute_target_points>>,
-      tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>>>;
+      tmpl::list<::Tags::Domain<Metavariables::volume_dim>>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -148,9 +148,8 @@ void test_interpolation_target(
                                 typename metavars::InterpolationTargetA>;
   using interp_component = mock_interpolator<metavars>;
 
-  tuples::TaggedTuple<
-      InterpolationTargetOptionTag,
-      ::Tags::Domain<MetaVariables::volume_dim, Frame::Inertial>>
+  tuples::TaggedTuple<InterpolationTargetOptionTag,
+                      ::Tags::Domain<MetaVariables::volume_dim>>
       tuple_of_opts{std::move(options),
                     std::move(domain_creator.create_domain())};
   ActionTesting::MockRuntimeSystem<metavars> runner{std::move(tuple_of_opts)};

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -52,8 +52,7 @@ struct mock_interpolation_target {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<3, Frame::Inertial>>;
+  using const_global_cache_tags = tmpl::list<::Tags::Domain<3>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -107,7 +106,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.AddTemporalIds",
       mock_interpolation_target<metavars, metavars::InterpolationTargetA>;
 
   const auto domain_creator =
-      domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+      domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
 
   ActionTesting::MockRuntimeSystem<metavars> runner{
       {domain_creator.create_domain()}};

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -26,10 +26,6 @@
 
 /// \cond
 class DataVector;
-namespace Tags {
-template <size_t Dim, typename Frame>
-struct Domain;
-}  // namespace Tags
 /// \endcond
 
 namespace {
@@ -39,8 +35,7 @@ struct mock_interpolation_target {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<3, Frame::Inertial>>;
+  using const_global_cache_tags = tmpl::list<::Tags::Domain<3>>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<intrp::Actions::InitializeInterpolationTarget<
@@ -67,7 +62,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Initialize",
       mock_interpolation_target<metavars,
                                 typename metavars::InterpolationTargetA>;
   const auto domain_creator =
-      domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+      domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
 
   ActionTesting::MockRuntimeSystem<metavars> runner{
       {domain_creator.create_domain()}};
@@ -84,7 +79,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Initialize",
             runner, 0)
             .empty());
 
-  CHECK(Parallel::get<::Tags::Domain<3, Frame::Inertial>>(runner.cache()) ==
+  CHECK(Parallel::get<::Tags::Domain<3>>(runner.cache()) ==
         domain_creator.create_domain());
 
   const auto test_vars = db::item_type<

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -78,7 +78,7 @@ SPECTRE_TEST_CASE(
   CHECK(created_opts == apparent_horizon_opts);
 
   const auto domain_creator =
-      domain::creators::Shell<Frame::Inertial>(1.8, 2.2, 1, {{5, 5}}, false);
+      domain::creators::Shell(1.8, 2.2, 1, {{5, 5}}, false);
 
   const auto expected_block_coord_holders =
       [&domain_creator, &center, &radius ]() noexcept {

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -71,7 +71,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.KerrHorizon",
   CHECK(created_opts == kerr_horizon_opts);
 
   const auto domain_creator =
-      domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+      domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
 
   const auto expected_block_coord_holders =
       [&domain_creator, &mass, &center, &dimless_spin ]() noexcept {

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -56,7 +56,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.LineSegment",
   CHECK(created_opts == line_segment_opts);
 
   const auto domain_creator =
-      domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+      domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
 
   const auto expected_block_coord_holders = [&domain_creator]() noexcept {
     const size_t n_pts = 15;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -77,7 +77,7 @@ struct mock_interpolation_target {
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
   using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>;
+      tmpl::list<::Tags::Domain<Metavariables::volume_dim>>;
   using simple_tags =
       db::get_items<typename intrp::Actions::InitializeInterpolationTarget<
           Metavariables, InterpolationTargetTag>::return_tag_list>;
@@ -271,7 +271,7 @@ void test_interpolation_target_receive_vars() noexcept {
                                 typename metavars::InterpolationTargetA>;
 
   const auto domain_creator =
-      domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+      domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
   Slab slab(0.0, 1.0);
   const size_t num_points = 10;
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -53,11 +53,11 @@ void test_r_theta_lgl() noexcept {
       false);
 
   const auto domain_creator =
-      domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+      domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
 
   const size_t num_total = num_radial * num_theta * num_phi;
-  const auto expected_block_coord_holders =
-      [&domain_creator, &num_total ]() noexcept {
+  const auto expected_block_coord_holders = [&domain_creator,
+                                             &num_total]() noexcept {
     tnsr::I<DataVector, 3, Frame::Inertial> points(num_total);
     for (size_t r = 0; r < num_radial; ++r) {
       const double radius =
@@ -82,8 +82,7 @@ void test_r_theta_lgl() noexcept {
       }
     }
     return block_logical_coordinates(domain_creator.create_domain(), points);
-  }
-  ();
+  }();
 
   InterpTargetTestHelpers::test_interpolation_target<
       MockMetavariables,
@@ -102,11 +101,11 @@ void test_r_theta_uniform() noexcept {
       true);
 
   const auto domain_creator =
-      domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+      domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
 
   const size_t num_total = num_radial * num_theta * num_phi;
-  const auto expected_block_coord_holders =
-      [&domain_creator, &num_total ]() noexcept {
+  const auto expected_block_coord_holders = [&domain_creator,
+                                             &num_total]() noexcept {
     tnsr::I<DataVector, 3, Frame::Inertial> points(num_total);
     for (size_t r = 0; r < num_radial; ++r) {
       const double radius = 1.8 + 1.8 * r / (num_radial - 1.0);
@@ -122,8 +121,7 @@ void test_r_theta_uniform() noexcept {
       }
     }
     return block_logical_coordinates(domain_creator.create_domain(), points);
-  }
-  ();
+  }();
 
   InterpTargetTestHelpers::test_interpolation_target<
       MockMetavariables,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -110,7 +110,7 @@ struct mock_interpolation_target {
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
   using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>;
+      tmpl::list<::Tags::Domain<Metavariables::volume_dim>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -168,7 +168,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceivePoints",
                                 typename metavars::InterpolationTargetA>;
   using interp_component = mock_interpolator<metavars>;
   const auto domain_creator =
-      domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{7, 7}}, false);
+      domain::creators::Shell(0.9, 4.9, 1, {{7, 7}}, false);
 
   ActionTesting::MockRuntimeSystem<metavars> runner{
       {domain_creator.create_domain()}};

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -183,7 +183,7 @@ struct mock_interpolation_target {
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
   using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>;
+      tmpl::list<::Tags::Domain<Metavariables::volume_dim>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -250,7 +250,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceiveVolumeData",
 
   // Make an InterpolatedVarsHolders containing the target points.
   const auto domain_creator =
-      domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{7, 7}}, false);
+      domain::creators::Shell(0.9, 4.9, 1, {{7, 7}}, false);
   const auto domain = domain_creator.create_domain();
   Slab slab(0.0, 1.0);
   TimeStepId temporal_id(true, 0, Time(slab, Rational(11, 15)));

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -165,7 +165,7 @@ struct MockInterpolationTarget {
       Parallel::get_const_global_cache_tags_from_actions<tmpl::list<
           typename InterpolationTargetTag::compute_target_points,
           typename InterpolationTargetTag::post_interpolation_callback>>,
-      tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>>>;
+      tmpl::list<::Tags::Domain<Metavariables::volume_dim>>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -299,15 +299,14 @@ SPECTRE_TEST_CASE(
   intrp::OptionHolders::KerrHorizon kerr_horizon_opts_C(10, {{0.0, 0.0, 0.0}},
                                                         1.5, {{0.0, 0.0, 0.0}});
   const auto domain_creator =
-      domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+      domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
   tuples::TaggedTuple<observers::Tags::ReductionFileName,
                       ::intrp::Tags::KerrHorizon<metavars::SurfaceA>,
-                      ::Tags::Domain<3, Frame::Inertial>,
+                      ::Tags::Domain<3>,
                       ::intrp::Tags::KerrHorizon<metavars::SurfaceB>,
                       ::intrp::Tags::KerrHorizon<metavars::SurfaceC>>
       tuple_of_opts{h5_file_prefix, kerr_horizon_opts_A,
-                    domain_creator.create_domain(),
-                    kerr_horizon_opts_B,
+                    domain_creator.create_domain(), kerr_horizon_opts_B,
                     kerr_horizon_opts_C};
 
   ActionTesting::MockRuntimeSystem<metavars> runner{std::move(tuple_of_opts)};

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -180,7 +180,7 @@ struct mock_interpolation_target {
   using const_global_cache_tags = tmpl::flatten<tmpl::append<
       Parallel::get_const_global_cache_tags_from_actions<
           tmpl::list<typename InterpolationTargetTag::compute_target_points>>,
-      tmpl::list<::Tags::Domain<Metavariables::volume_dim, Frame::Inertial>>>>;
+      tmpl::list<::Tags::Domain<Metavariables::volume_dim>>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -275,15 +275,15 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
   intrp::OptionHolders::KerrHorizon kerr_horizon_opts_C(10, {{0.0, 0.0, 0.0}},
                                                         1.0, {{0.0, 0.0, 0.0}});
   const auto domain_creator =
-      domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+      domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
   tuples::TaggedTuple<
       intrp::Tags::LineSegment<metavars::InterpolationTargetA, 3>,
-      ::Tags::Domain<3, Frame::Inertial>,
+      ::Tags::Domain<3>,
       intrp::Tags::LineSegment<metavars::InterpolationTargetB, 3>,
       intrp::Tags::KerrHorizon<metavars::InterpolationTargetC>>
-      tuple_of_opts(
-          std::move(line_segment_opts_A), domain_creator.create_domain(),
-          std::move(line_segment_opts_B), kerr_horizon_opts_C);
+      tuple_of_opts(std::move(line_segment_opts_A),
+                    domain_creator.create_domain(),
+                    std::move(line_segment_opts_B), kerr_horizon_opts_C);
 
   ActionTesting::MockRuntimeSystem<metavars> runner{std::move(tuple_of_opts)};
   runner.set_phase(metavars::Phase::Initialization);

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
@@ -37,8 +37,7 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<Dim, Frame::Inertial>>;
+  using const_global_cache_tags = tmpl::list<::Tags::Domain<Dim>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Initialization,
@@ -90,7 +89,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     // Reference element:
     // [ |X| | ]-> xi
     const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
-    const domain::creators::Interval<Frame::Inertial> domain_creator{
+    const domain::creators::Interval domain_creator{
         {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
     // Register the coordinate map for serialization
     PUPable_reg(
@@ -153,7 +152,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     // | |X| | |
     // +-+-+-+-+
     const ElementId<2> element_id{0, {{SegmentId{2, 1}, SegmentId{0, 0}}}};
-    const domain::creators::Rectangle<Frame::Inertial> domain_creator{
+    const domain::creators::Rectangle domain_creator{
         {{-0.5, 0.}}, {{1.5, 2.}}, {{false, false}}, {{2, 0}}, {{4, 3}}};
     // Register the coordinate map for serialization
     PUPable_reg(
@@ -217,12 +216,11 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     INFO("3D");
     const ElementId<3> element_id{
         0, {{SegmentId{2, 1}, SegmentId{0, 0}, SegmentId{1, 1}}}};
-    const domain::creators::Brick<Frame::Inertial> domain_creator{
-        {{-0.5, 0., -1.}},
-        {{1.5, 2., 3.}},
-        {{false, false, false}},
-        {{2, 0, 1}},
-        {{4, 3, 2}}};
+    const domain::creators::Brick domain_creator{{{-0.5, 0., -1.}},
+                                                 {{1.5, 2., 3.}},
+                                                 {{false, false, false}},
+                                                 {{2, 0, 1}},
+                                                 {{4, 3, 2}}};
     // Register the coordinate map for serialization
     PUPable_reg(SINGLE_ARG(
         domain::CoordinateMap<

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
@@ -63,8 +63,7 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<Dim, Frame::Inertial>>;
+  using const_global_cache_tags = tmpl::list<::Tags::Domain<Dim>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -145,7 +144,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeInterfaces", "[Unit][Actions]") {
     // Reference element:
     // [ |X| | ]-> xi
     const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
-    const domain::creators::Interval<Frame::Inertial> domain_creator{
+    const domain::creators::Interval domain_creator{
         {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
     // Register the coordinate map for serialization
     PUPable_reg(
@@ -178,7 +177,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeInterfaces", "[Unit][Actions]") {
     // | |X| | |
     // +-+-+-+-+
     const ElementId<2> element_id{0, {{SegmentId{2, 1}, SegmentId{0, 0}}}};
-    const domain::creators::Rectangle<Frame::Inertial> domain_creator{
+    const domain::creators::Rectangle domain_creator{
         {{-0.5, 0.}}, {{1.5, 2.}}, {{false, false}}, {{2, 0}}, {{4, 3}}};
     // Register the coordinate map for serialization
     PUPable_reg(
@@ -209,12 +208,11 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeInterfaces", "[Unit][Actions]") {
     INFO("3D");
     const ElementId<3> element_id{
         0, {{SegmentId{2, 1}, SegmentId{0, 0}, SegmentId{1, 1}}}};
-    const domain::creators::Brick<Frame::Inertial> domain_creator{
-        {{-0.5, 0., -1.}},
-        {{1.5, 2., 3.}},
-        {{false, false, false}},
-        {{2, 0, 1}},
-        {{4, 3, 2}}};
+    const domain::creators::Brick domain_creator{{{-0.5, 0., -1.}},
+                                                 {{1.5, 2., 3.}},
+                                                 {{false, false, false}},
+                                                 {{2, 0, 1}},
+                                                 {{4, 3, 2}}};
     // Register the coordinate map for serialization
     PUPable_reg(SINGLE_ARG(
         domain::CoordinateMap<

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
@@ -53,8 +53,7 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<Dim, Frame::Inertial>>;
+  using const_global_cache_tags = tmpl::list<::Tags::Domain<Dim>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -119,7 +118,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeMortars", "[Unit][Actions]") {
     // Reference element:
     // [X| | | ]-> xi
     const ElementId<1> element_id{0, {{{2, 0}}}};
-    const domain::creators::Interval<Frame::Inertial> domain_creator{
+    const domain::creators::Interval domain_creator{
         {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
     // Register the coordinate map for serialization
     PUPable_reg(
@@ -175,7 +174,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeMortars", "[Unit][Actions]") {
     // | | |
     // +-+-+
     const ElementId<2> element_id{0, {{{1, 0}, {1, 1}}}};
-    const domain::creators::Rectangle<Frame::Inertial> domain_creator{
+    const domain::creators::Rectangle domain_creator{
         {{-0.5, 0.}}, {{1.5, 1.}}, {{false, false}}, {{1, 1}}, {{3, 2}}};
     // Register the coordinate map for serialization
     PUPable_reg(
@@ -250,12 +249,11 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeMortars", "[Unit][Actions]") {
     INFO("3D");
     const ElementId<3> element_id{
         0, {{SegmentId{1, 0}, SegmentId{1, 1}, SegmentId{1, 0}}}};
-    const domain::creators::Brick<Frame::Inertial> domain_creator{
-        {{-0.5, 0., -1.}},
-        {{1.5, 1., 3.}},
-        {{false, false, false}},
-        {{1, 1, 1}},
-        {{2, 3, 4}}};
+    const domain::creators::Brick domain_creator{{{-0.5, 0., -1.}},
+                                                 {{1.5, 1., 3.}},
+                                                 {{false, false, false}},
+                                                 {{1, 1, 1}},
+                                                 {{2, 3, 4}}};
     // Register the coordinate map for serialization
     PUPable_reg(SINGLE_ARG(
         domain::CoordinateMap<

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
@@ -172,8 +172,8 @@ void test_solution() noexcept {
   const std::array<double, 3> x{{1.0, 2.3, -0.4}};
   const std::array<double, 3> dx{{1.e-4, 1.e-4, 1.e-4}};
 
-  domain::creators::Brick<Frame::Inertial> brick(
-      x - dx, x + dx, {{false, false, false}}, {{0, 0, 0}}, {{5, 5, 5}});
+  domain::creators::Brick brick(x - dx, x + dx, {{false, false, false}},
+                                {{0, 0, 0}}, {{5, 5, 5}});
   Mesh<3> mesh{brick.initial_extents()[0], Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
   const auto domain = brick.create_domain();

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
@@ -127,8 +127,8 @@ void test_solution() noexcept {
   const std::array<double, 3> x{{4.0, 4.0, 4.0}};
   const std::array<double, 3> dx{{1.e-3, 1.e-3, 1.e-3}};
 
-  domain::creators::Brick<Frame::Inertial> brick(
-      x - dx, x + dx, {{false, false, false}}, {{0, 0, 0}}, {{4, 4, 4}});
+  domain::creators::Brick brick(x - dx, x + dx, {{false, false, false}},
+                                {{0, 0, 0}}, {{4, 4, 4}});
   Mesh<3> mesh{brick.initial_extents()[0], Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
   const auto domain = brick.create_domain();

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_KomissarovShock.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_KomissarovShock.cpp
@@ -201,8 +201,8 @@ void test_solution() noexcept {
   const std::array<double, 3> x{{1.0, 2.3, -0.4}};
   const std::array<double, 3> dx{{1.e-1, 1.e-1, 1.e-1}};
 
-  domain::creators::Brick<Frame::Inertial> brick(
-      x - dx, x + dx, {{false, false, false}}, {{0, 0, 0}}, {{6, 6, 6}});
+  domain::creators::Brick brick(x - dx, x + dx, {{false, false, false}},
+                                {{0, 0, 0}}, {{6, 6, 6}});
   Mesh<3> mesh{brick.initial_extents()[0], Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
   const auto domain = brick.create_domain();

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
@@ -163,8 +163,8 @@ void test_solution() noexcept {
   const std::array<double, 3> x{{4.0, 4.0, 4.0}};
   const std::array<double, 3> dx{{1.e-3, 1.e-3, 1.e-3}};
 
-  domain::creators::Brick<Frame::Inertial> brick(
-      x - dx, x + dx, {{false, false, false}}, {{0, 0, 0}}, {{4, 4, 4}});
+  domain::creators::Brick brick(x - dx, x + dx, {{false, false, false}},
+                                {{0, 0, 0}}, {{4, 4, 4}});
   Mesh<3> mesh{brick.initial_extents()[0], Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
   const auto domain = brick.create_domain();

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/VerifyGrMhdSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/VerifyGrMhdSolution.hpp
@@ -116,8 +116,7 @@ Variables<valencia_tags> numerical_dt(
 /// sixth-order derivative in time for the given `delta_time`. The maximum
 /// residual of the GRMHD equations must be zero within `error_tolerance`
 template <typename Solution>
-void verify_grmhd_solution(const Solution& solution,
-                           const Block<3, Frame::Inertial>& block,
+void verify_grmhd_solution(const Solution& solution, const Block<3>& block,
                            const Mesh<3>& mesh, const double error_tolerance,
                            const double time,
                            const double delta_time) noexcept {

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
@@ -188,8 +188,8 @@ void test_solution() noexcept {
   const std::array<double, 3> x{{5.0, 5.0, 0.0}};
   const std::array<double, 3> dx{{1.e-1, 1.e-1, 1.e-1}};
 
-  domain::creators::Brick<Frame::Inertial> brick(
-      x - dx, x + dx, {{false, false, false}}, {{0, 0, 0}}, {{8, 8, 8}});
+  domain::creators::Brick brick(x - dx, x + dx, {{false, false, false}},
+                                {{0, 0, 0}}, {{8, 8, 8}});
   Mesh<3> mesh{brick.initial_extents()[0], Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
   const auto domain = brick.create_domain();

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
@@ -55,8 +55,8 @@ void verify_solution(const RelativisticEuler::Solutions::TovStar<
                          gr::Solutions::TovSolution>& solution,
                      const std::array<double, 3>& x) noexcept {
   const std::array<double, 3> dx{{1.e-4, 1.e-4, 1.e-4}};
-  domain::creators::Brick<Frame::Inertial> brick(
-      x - dx, x + dx, {{false, false, false}}, {{0, 0, 0}}, {{5, 5, 5}});
+  domain::creators::Brick brick(x - dx, x + dx, {{false, false, false}},
+                                {{0, 0, 0}}, {{5, 5, 5}});
   Mesh<3> mesh{brick.initial_extents()[0], Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
   const auto domain = brick.create_domain();


### PR DESCRIPTION
## Proposed changes

Remove the frame template parameter from:
- Domain (should always go to Physical)
- Block  (should always go to Physical)
- Domain creators (should always go to Physical)

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
