### PR TITLE
Pass Metavariables to create_from_options

### DIFF
--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -58,6 +58,7 @@ struct Domain : db::SimpleTag {
   using type = ::Domain<VolumeDim, Frame>;
   using option_tags = tmpl::list<::OptionTags::DomainCreator<VolumeDim, Frame>>;
 
+  template <typename Metavariables>
   static ::Domain<VolumeDim, Frame> create_from_options(
       const std::unique_ptr<::DomainCreator<VolumeDim, Frame>>&
           domain_creator) noexcept {
@@ -76,6 +77,7 @@ struct InitialExtents : db::SimpleTag {
   using option_tags =
       tmpl::list<::OptionTags::DomainCreator<Dim, Frame::Inertial>>;
 
+  template <typename Metavariables>
   static std::vector<std::array<size_t, Dim>> create_from_options(
       const std::unique_ptr<::DomainCreator<Dim, Frame::Inertial>>&
           domain_creator) noexcept {
@@ -94,6 +96,7 @@ struct InitialRefinementLevels : db::SimpleTag {
   using option_tags =
       tmpl::list<::OptionTags::DomainCreator<Dim, Frame::Inertial>>;
 
+  template <typename Metavariables>
   static std::vector<std::array<size_t, Dim>> create_from_options(
       const std::unique_ptr<::DomainCreator<Dim, Frame::Inertial>>&
           domain_creator) noexcept {

--- a/src/Elliptic/Tags.hpp
+++ b/src/Elliptic/Tags.hpp
@@ -29,6 +29,8 @@ struct FluxesComputer : db::SimpleTag {
     return pretty_type::short_name<FluxesComputerType>();
   }
   using option_tags = tmpl::list<>;
+
+  template <typename Metavariables>
   static FluxesComputerType create_from_options() {
     return FluxesComputerType{};
   }

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp
@@ -38,6 +38,8 @@ struct Limiter : db::SimpleTag {
   static std::string name() noexcept { return "Limiter"; }
   using type = LimiterType;
   using option_tags = tmpl::list<::OptionTags::Limiter<LimiterType>>;
+
+  template <typename Metavariables>
   static LimiterType create_from_options(const LimiterType& limiter) noexcept {
     return limiter;
   }

--- a/src/Evolution/Initialization/Tags.hpp
+++ b/src/Evolution/Initialization/Tags.hpp
@@ -20,6 +20,7 @@ struct InitialTime : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::InitialTime>;
 
+  template <typename Metavariables>
   static double create_from_options(const double initial_time) noexcept {
     return initial_time;
   }
@@ -30,6 +31,7 @@ struct InitialTimeDelta : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::InitialTimeStep>;
 
+  template <typename Metavariables>
   static double create_from_options(const double initial_time_step) noexcept {
     return initial_time_step;
   }
@@ -41,6 +43,7 @@ struct InitialSlabSize : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::InitialSlabSize>;
 
+  template <typename Metavariables>
   static double create_from_options(const double initial_slab_size) noexcept {
     return initial_slab_size;
   }
@@ -52,6 +55,7 @@ struct InitialSlabSize<false> : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::InitialTimeStep>;
 
+  template <typename Metavariables>
   static double create_from_options(const double initial_time_step) noexcept {
     return std::abs(initial_time_step);
   }

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -68,6 +68,8 @@ struct GaugeHRollOnStartTime : db::SimpleTag {
   using type = double;
   static std::string name() noexcept { return "GaugeHRollOnStartTime"; }
   using option_tags = tmpl::list<OptionTags::GaugeHRollOnStart>;
+
+  template <typename Metavariables>
   static double create_from_options(
       const double gauge_roll_on_start_time) noexcept {
     return gauge_roll_on_start_time;
@@ -86,6 +88,8 @@ struct GaugeHRollOnTimeWindow : db::SimpleTag {
   using type = double;
   static std::string name() noexcept { return "GaugeHRollOnTimeWindow"; }
   using option_tags = tmpl::list<OptionTags::GaugeHRollOnWindow>;
+
+  template <typename Metavariables>
   static double create_from_options(
       const double gauge_roll_on_window) noexcept {
     return gauge_roll_on_window;
@@ -109,6 +113,8 @@ struct GaugeHSpatialWeightDecayWidth : db::SimpleTag {
   using type = double;
   static std::string name() noexcept { return "GaugeHSpatialWeightDecayWidth"; }
   using option_tags = tmpl::list<OptionTags::GaugeHSpatialDecayWidth<Frame>>;
+
+  template <typename Metavariables>
   static double create_from_options(
       const double gauge_spatial_decay_width) noexcept {
     return gauge_spatial_decay_width;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
@@ -87,6 +87,8 @@ struct ConstraintDampingParameter : db::SimpleTag {
   static std::string name() noexcept { return "ConstraintDampingParameter"; }
   using type = double;
   using option_tags = tmpl::list<OptionTags::DampingParameter>;
+
+  template <typename Metavariables>
   static double create_from_options(
       const double constraint_damping_parameter) noexcept {
     return constraint_damping_parameter;

--- a/src/Evolution/Systems/NewtonianEuler/Tags.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Tags.hpp
@@ -103,6 +103,8 @@ struct SourceTerm : SourceTermBase, db::SimpleTag {
                           ::OptionTags::AnalyticSolution<InitialDataType>,
                           ::OptionTags::AnalyticData<InitialDataType>>>;
   static std::string name() noexcept { return "SourceTerm"; }
+
+  template <typename Metavariables>
   static type create_from_options(
       const InitialDataType& initial_data) noexcept {
     return initial_data.source_term();

--- a/src/Evolution/VariableFixing/Tags.hpp
+++ b/src/Evolution/VariableFixing/Tags.hpp
@@ -42,6 +42,8 @@ struct VariableFixer : db::SimpleTag {
   using type = VariableFixerType;
   using option_tags =
       tmpl::list<::OptionTags::VariableFixer<VariableFixerType>>;
+
+  template <typename Metavariables>
   static VariableFixerType create_from_options(
       const VariableFixerType& variable_fixer) noexcept {
     return variable_fixer;

--- a/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
+++ b/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
@@ -32,6 +32,8 @@ struct Name : db::SimpleTag {
   using type = std::string;
   static std::string name() noexcept { return "Name"; }
   using option_tags = tmpl::list<OptionTags::Name>;
+
+  template <typename Metavariables>
   static std::string create_from_options(const std::string& name) noexcept {
     return name;
   }

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -167,6 +167,8 @@ struct VolumeFileName : db::SimpleTag {
   static std::string name() noexcept { return "VolumeFileName"; }
   using type = std::string;
   using option_tags = tmpl::list<::observers::OptionTags::VolumeFileName>;
+
+  template <typename Metavariables>
   static std::string create_from_options(
       const std::string& volume_file_name) noexcept {
     return volume_file_name;
@@ -177,6 +179,8 @@ struct ReductionFileName : db::SimpleTag {
   static std::string name() noexcept { return "ReductionFileName"; }
   using type = std::string;
   using option_tags = tmpl::list<::observers::OptionTags::ReductionFileName>;
+
+  template <typename Metavariables>
   static std::string create_from_options(
       const std::string& reduction_file_name) noexcept {
     return reduction_file_name;

--- a/src/Informer/Tags.hpp
+++ b/src/Informer/Tags.hpp
@@ -28,6 +28,8 @@ struct Verbosity : db::SimpleTag {
   static std::string name() noexcept { return "Verbosity"; }
   using type = ::Verbosity;
   using option_tags = tmpl::list<OptionTags::Verbosity>;
+
+  template <typename Metavariables>
   static ::Verbosity create_from_options(
       const ::Verbosity& verbosity) noexcept {
     return verbosity;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -87,6 +87,8 @@ struct NumericalFlux : db::SimpleTag {
   using type = NumericalFluxType;
   using option_tags =
       tmpl::list<::OptionTags::NumericalFlux<NumericalFluxType>>;
+
+  template <typename Metavariables>
   static NumericalFluxType create_from_options(
       const NumericalFluxType& numerical_flux) noexcept {
     return numerical_flux;

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -111,6 +111,8 @@ struct ApparentHorizon : db::SimpleTag {
   using type = OptionHolders::ApparentHorizon<Frame>;
   using option_tags =
       tmpl::list<OptionTags::ApparentHorizon<InterpolationTargetTag, Frame>>;
+
+  template <typename Metavariables>
   static type create_from_options(const type& option) noexcept {
     return option;
   }

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
@@ -106,6 +106,8 @@ struct KerrHorizon : db::SimpleTag {
   using type = OptionHolders::KerrHorizon;
   using option_tags =
       tmpl::list<OptionTags::KerrHorizon<InterpolationTargetTag>>;
+
+  template <typename Metavariables>
   static type create_from_options(const type& option) noexcept {
     return option;
   }

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
@@ -107,6 +107,8 @@ struct LineSegment : db::SimpleTag {
   using type = OptionHolders::LineSegment<VolumeDim>;
   using option_tags =
       tmpl::list<OptionTags::LineSegment<InterpolationTargetTag, VolumeDim>>;
+
+  template <typename Metavariables>
   static type create_from_options(const type& option) noexcept {
     return option;
   }

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -175,6 +175,8 @@ struct WedgeSectionTorus : db::SimpleTag {
   using type = OptionHolders::WedgeSectionTorus;
   using option_tags =
       tmpl::list<OptionTags::WedgeSectionTorus<InterpolationTargetTag>>;
+
+  template <typename Metavariables>
   static type create_from_options(const type& option) noexcept {
     return option;
   }

--- a/src/NumericalAlgorithms/LinearOperators/Tags.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Tags.hpp
@@ -41,6 +41,8 @@ struct Filter : db::SimpleTag {
   static std::string name() noexcept { return "Filter"; }
   using type = FilterType;
   using option_tags = tmpl::list<::OptionTags::Filter<FilterType>>;
+
+  template <typename Metavariables>
   static FilterType create_from_options(const FilterType& filter) noexcept {
     return filter;
   }

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -245,8 +245,8 @@ Main<Metavariables>::Main(CkArgMsg* msg) noexcept
           });
 
   const_global_cache_proxy_ = CProxy_ConstGlobalCache<Metavariables>::ckNew(
-      Parallel::create_from_options(items_from_options,
-                                    const_global_cache_tags{}));
+      Parallel::create_from_options<Metavariables>(items_from_options,
+                                                   const_global_cache_tags{}));
 
   tuples::tagged_tuple_from_typelist<parallel_component_tag_list>
       the_parallel_components;
@@ -272,7 +272,7 @@ Main<Metavariables>::Main(CkArgMsg* msg) noexcept
     tuples::get<tmpl::type_<ParallelComponentProxy>>(the_parallel_components) =
         ParallelComponentProxy::ckNew(
             const_global_cache_proxy_,
-            Parallel::create_from_options(
+            Parallel::create_from_options<Metavariables>(
                 items_from_options,
                 typename parallel_component::initialization_tags{}),
             &const_global_cache_dependency);
@@ -292,7 +292,7 @@ Main<Metavariables>::Main(CkArgMsg* msg) noexcept
     tuples::get<tmpl::type_<ParallelComponentProxy>>(the_parallel_components) =
         ParallelComponentProxy::ckNew(
             const_global_cache_proxy_,
-            Parallel::create_from_options(
+            Parallel::create_from_options<Metavariables>(
                 items_from_options,
                 typename parallel_component::initialization_tags{}));
   });
@@ -365,7 +365,7 @@ void Main<Metavariables>::
     using parallel_component = tmpl::type_from<decltype(parallel_component_v)>;
     parallel_component::allocate_array(
         const_global_cache_proxy_,
-        Parallel::create_from_options(
+        Parallel::create_from_options<Metavariables>(
             items_from_options,
             typename parallel_component::initialization_tags{}));
   });

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -166,11 +166,13 @@ using get_option_tags = tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
     detail::get_option_tags_from_initialization_tag<tmpl::_1>>>>;
 
 namespace detail {
-template <typename Tag, typename... OptionTags, typename... OptionTagsForTag>
+template <typename Metavariables, typename Tag, typename... OptionTags,
+          typename... OptionTagsForTag>
 typename Tag::type create_initialization_item_from_options(
     const tuples::TaggedTuple<OptionTags...>& options,
     tmpl::list<OptionTagsForTag...> /*meta*/) noexcept {
-  return Tag::create_from_options(tuples::get<OptionTagsForTag>(options)...);
+  return Tag::template create_from_options<Metavariables>(
+      tuples::get<OptionTagsForTag>(options)...);
 }
 }  // namespace detail
 
@@ -178,11 +180,11 @@ typename Tag::type create_initialization_item_from_options(
 /// \brief Given a list of tags and a tagged tuple containing items
 /// created from input options, return a tagged tuple of items constructed
 /// by calls to create_from_options for each tag in the list.
-template <typename... Tags, typename... OptionTags>
+template <typename Metavariables, typename... Tags, typename... OptionTags>
 tuples::TaggedTuple<Tags...> create_from_options(
     const tuples::TaggedTuple<OptionTags...>& options,
     tmpl::list<Tags...> /*meta*/) noexcept {
-  return {detail::create_initialization_item_from_options<Tags>(
+  return {detail::create_initialization_item_from_options<Metavariables, Tags>(
       options, typename Tags::option_tags{})...};
 }
 

--- a/src/ParallelAlgorithms/EventsAndTriggers/Tags.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Tags.hpp
@@ -51,6 +51,8 @@ struct EventsAndTriggers : EventsAndTriggersBase, db::SimpleTag {
   using type = ::EventsAndTriggers<EventRegistrars, TriggerRegistrars>;
   using option_tags = tmpl::list<
       ::OptionTags::EventsAndTriggers<EventRegistrars, TriggerRegistrars>>;
+
+  template <typename Metavariables>
   static type create_from_options(const type& events_and_triggers) noexcept {
     return deserialize<type>(serialize<type>(events_and_triggers).data());
   }

--- a/src/ParallelAlgorithms/LinearSolver/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Tags.hpp
@@ -294,6 +294,8 @@ struct ConvergenceCriteria : db::SimpleTag {
   using type = Convergence::Criteria;
   static std::string name() noexcept { return "ConvergenceCriteria"; }
   using option_tags = tmpl::list<LinearSolver::OptionTags::ConvergenceCriteria>;
+
+  template <typename Metavariables>
   static Convergence::Criteria create_from_options(
       const Convergence::Criteria& convergence_criteria) noexcept {
     return convergence_criteria;
@@ -304,6 +306,8 @@ struct Verbosity : db::SimpleTag {
   static std::string name() noexcept { return "Verbosity"; }
   using type = ::Verbosity;
   using option_tags = tmpl::list<LinearSolver::OptionTags::Verbosity>;
+
+  template <typename Metavariables>
   static ::Verbosity create_from_options(
       const ::Verbosity& verbosity) noexcept {
     return verbosity;

--- a/src/PointwiseFunctions/AnalyticData/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Tags.hpp
@@ -39,6 +39,8 @@ struct AnalyticData : AnalyticDataBase, db::SimpleTag {
   static std::string name() noexcept { return "AnalyticData"; }
   using type = DataType;
   using option_tags = tmpl::list<::OptionTags::AnalyticData<DataType>>;
+
+  template <typename Metavariables>
   static DataType create_from_options(
       const DataType& analytic_solution) noexcept {
     return deserialize<type>(serialize<type>(analytic_solution).data());

--- a/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
@@ -50,6 +50,8 @@ struct AnalyticSolution : AnalyticSolutionBase, db::SimpleTag {
   static std::string name() noexcept { return "AnalyticSolution"; }
   using type = SolutionType;
   using option_tags = tmpl::list<::OptionTags::AnalyticSolution<SolutionType>>;
+
+  template <typename Metavariables>
   static SolutionType create_from_options(
       const SolutionType& analytic_solution) noexcept {
     return deserialize<type>(serialize<type>(analytic_solution).data());
@@ -63,6 +65,8 @@ struct BoundaryCondition : BoundaryConditionBase, db::SimpleTag {
   using type = BoundaryConditionType;
   using option_tags =
       tmpl::list<::OptionTags::BoundaryCondition<BoundaryConditionType>>;
+
+  template <typename Metavariables>
   static BoundaryConditionType create_from_options(
       const BoundaryConditionType& boundary_condition) noexcept {
     return boundary_condition;

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -184,6 +184,8 @@ struct TimeStepper : TimeStepperBase, db::SimpleTag {
   static std::string name() noexcept { return "TimeStepper"; }
   using type = std::unique_ptr<StepperType>;
   using option_tags = tmpl::list<::OptionTags::TimeStepper<StepperType>>;
+
+  template <typename Metavariables>
   static std::unique_ptr<StepperType> create_from_options(
       const std::unique_ptr<StepperType>& time_stepper) noexcept {
     return deserialize<type>(serialize<type>(time_stepper).data());
@@ -196,6 +198,8 @@ struct StepChoosers : db::SimpleTag {
   static std::string name() noexcept { return "StepChoosers"; }
   using type = std::vector<std::unique_ptr<::StepChooser<Registrars>>>;
   using option_tags = tmpl::list<::OptionTags::StepChoosers<Registrars>>;
+
+  template <typename Metavariables>
   static type create_from_options(const type& step_choosers) noexcept {
     return deserialize<type>(serialize<type>(step_choosers).data());
   }
@@ -206,6 +210,8 @@ struct StepController : db::SimpleTag {
   static std::string name() noexcept { return "StepController"; }
   using type = std::unique_ptr<::StepController>;
   using option_tags = tmpl::list<::OptionTags::StepController>;
+
+  template <typename Metavariables>
   static std::unique_ptr<::StepController> create_from_options(
       const std::unique_ptr<::StepController>& step_controller) noexcept {
     return deserialize<type>(serialize<type>(step_controller).data());

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -61,6 +61,7 @@ struct NumberOfElements : db::SimpleTag {
   using type = int;
   using option_tags = tmpl::list<OptionTags::NumberOfElements>;
 
+  template <typename Metavariables>
   static int create_from_options(const size_t number_of_elements) noexcept {
     return number_of_elements;
   }
@@ -96,6 +97,7 @@ struct LinearOperator : db::SimpleTag {
   using type = std::vector<DenseMatrix<double, blaze::columnMajor>>;
   using option_tags = tmpl::list<OptionTags::LinearOperator>;
 
+  template <typename Metavariables>
   static std::vector<DenseMatrix<double, blaze::columnMajor>>
   create_from_options(
       const std::vector<DenseMatrix<double, blaze::columnMajor>>&
@@ -109,6 +111,7 @@ struct Source : db::SimpleTag {
   using type = std::vector<DenseVector<double>>;
   using option_tags = tmpl::list<OptionTags::Source>;
 
+  template <typename Metavariables>
   static std::vector<DenseVector<double>> create_from_options(
       const std::vector<DenseVector<double>>& source) noexcept {
     return source;
@@ -120,6 +123,7 @@ struct ExpectedResult : db::SimpleTag {
   using type = std::vector<DenseVector<double>>;
   using option_tags = tmpl::list<OptionTags::ExpectedResult>;
 
+  template <typename Metavariables>
   static std::vector<DenseVector<double>> create_from_options(
       const std::vector<DenseVector<double>>& expected_result) noexcept {
     return expected_result;

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -63,6 +63,7 @@ struct LinearOperator : db::SimpleTag {
   using type = DenseMatrix<double>;
   using option_tags = tmpl::list<OptionTags::LinearOperator>;
 
+  template <typename Metavariables>
   static DenseMatrix<double> create_from_options(
       const DenseMatrix<double>& linear_operator) noexcept {
     return linear_operator;
@@ -74,6 +75,7 @@ struct Source : db::SimpleTag {
   using type = DenseVector<double>;
   using option_tags = tmpl::list<OptionTags::Source>;
 
+  template <typename Metavariables>
   static DenseVector<double> create_from_options(
       const DenseVector<double>& source) noexcept {
     return source;
@@ -85,6 +87,7 @@ struct InitialGuess : db::SimpleTag {
   using type = DenseVector<double>;
   using option_tags = tmpl::list<OptionTags::InitialGuess>;
 
+  template <typename Metavariables>
   static DenseVector<double> create_from_options(
       const DenseVector<double>& initial_guess) noexcept {
     return initial_guess;
@@ -96,6 +99,7 @@ struct ExpectedResult : db::SimpleTag {
   using type = DenseVector<double>;
   using option_tags = tmpl::list<OptionTags::ExpectedResult>;
 
+  template <typename Metavariables>
   static DenseVector<double> create_from_options(
       const DenseVector<double>& expected_result) noexcept {
     return expected_result;


### PR DESCRIPTION
#  Proposed changes

Since when creating options the metavariables are available, it makes sense they
also be available when combining options. This will be useful for cartoon and
boundary conditions. This commit adds support for metavariables in the `create_from_options` functions.

Note: the documentation grabs an example from the tests and so is updated through that. The relevant file is `docs/DevGuide/Parallelization.md`. Please let me know if wording changes to the documentation for `create_from_options` there would be useful.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
