### PR TITLE
Minor cleanup doxygen comments

### DIFF
--- a/src/Domain/OrientationMapHelpers.hpp
+++ b/src/Domain/OrientationMapHelpers.hpp
@@ -76,10 +76,10 @@ std::vector<size_t> oriented_offset_on_slice(
 
 }  // namespace OrientationMapHelpers_detail
 
+// @{
 /// \ingroup ComputationalDomainGroup
 /// Orient variables to the data-storage order of a neighbor element with
 /// the given orientation.
-/// @{
 template <size_t VolumeDim, typename TagsList>
 Variables<TagsList> orient_variables(
     const Variables<TagsList>& variables, const Index<VolumeDim>& extents,
@@ -133,4 +133,4 @@ Variables<TagsList> orient_variables_on_slice(
 
   return oriented_variables;
 }
-/// }@
+// }@

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -33,7 +33,7 @@ struct Mesh;
 /// Prefix indicating the divergence of a Tensor or that a Variables
 /// contains divergences of Tensors.
 ///
-/// \snippet Test_Divergence.cpp divergence_name
+/// \snippet LinearOperators/Test_Divergence.cpp divergence_name
 ///
 /// \see Tags::DivCompute
 template <typename Tag, typename = std::nullptr_t>

--- a/src/Utilities/TypeTraits.hpp
+++ b/src/Utilities/TypeTraits.hpp
@@ -1399,7 +1399,7 @@ using get_fundamental_type_t = typename get_fundamental_type<T>::type;
 /// \brief Determines if a type `T` is a `std::complex` of a fundamental type,
 /// is a `std::true_type` if so, and otherwise is a `std::false_type`
 ///
-/// \snippet Test_TypeTraits.cpp is_complex_of_fundamental
+/// \snippet Utilities/Test_TypeTraits.cpp is_complex_of_fundamental
 template <typename T, typename = cpp17::bool_constant<true>>
 struct is_complex_of_fundamental : std::false_type {};
 /// \cond
@@ -1512,7 +1512,7 @@ using function_info = tt_detail::function_info_impl<F>;
  * \brief Given a type `T` and possibly a `size_t` evaluates to `T`. Useful for
  * turning a `std::index_sequence` into a pack expansion of types.
  *
- * \snippet Test_TypeTraits.cpp example_identity_t
+ * \snippet Utilities/Test_TypeTraits.cpp example_identity_t
  */
 template <typename T, size_t = 0>
 using identity_t = T;


### PR DESCRIPTION
## Proposed changes

- Ambiguous file names in snippets (`Utilities/TypeTraits`, also made `Divergence` more specific)
- Incorrect grouping comment in `OrientationMapHelpers.hpp`

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
