### PR TITLE
Expose mass over radius in TOV solution

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -19,5 +19,4 @@ target_link_libraries(
   INTERFACE ErrorHandling
   INTERFACE GeneralRelativity
   INTERFACE Interpolation
-  INTERFACE RelativisticEulerSolutions
   )

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp
@@ -60,21 +60,29 @@ class TovSolution {
   /// constructing this TovSolution
   double outer_radius() const noexcept;
 
+  /// \brief The mass inside the given radius over the radius
+  /// \f$\frac{m(r)}{r}\f$
+  ///
+  /// \note `r` should be non-negative and not greater than `outer_radius()`.
+  double mass_over_radius(double r) const noexcept;
+
   /// \brief The mass inside the given radius \f$m(r)\f$
   ///
-  /// \note `r` should be non-negative and not greater than outer_radius
-  /// \f$m(R)\f$.
+  /// \warning When computing \f$\frac{m(r)}{r}\f$, use the `mass_over_radius`
+  /// function instead for greater accuracy.
+  ///
+  /// \note `r` should be non-negative and not greater than `outer_radius()`
   double mass(double r) const noexcept;
 
   /// \brief The log of the specific enthalpy at the given radius
   ///
-  /// \note `r` should be non-negative and not greater than outer_radius
+  /// \note `r` should be non-negative and not greater than `outer_radius()`
   double log_specific_enthalpy(double r) const noexcept;
 
   /// \brief The radial variables from which the hydrodynamic quantities and
   /// spacetime metric can be computed.
   ///
-  /// For radii greater than the outer_radius, this returns the appropriate
+  /// For radii greater than the `outer_radius()`, this returns the appropriate
   /// vacuum spacetime.
   ///
   /// \note This solution of the TOV equations is a function of areal radius.
@@ -92,7 +100,7 @@ class TovSolution {
   double total_mass_{std::numeric_limits<double>::signaling_NaN()};
   double log_lapse_at_outer_radius_{
       std::numeric_limits<double>::signaling_NaN()};
-  intrp::BarycentricRational mass_interpolant_;
+  intrp::BarycentricRational mass_over_radius_interpolant_;
   intrp::BarycentricRational log_enthalpy_interpolant_;
 };
 


### PR DESCRIPTION
## Proposed changes

The quantity `m(r) / r` is more commonly needed than the mass function `m(r)` itself, and since it is one of the integration variables we can compute it to greater accuracy by interpolating it directly.

Using this quantity improves the accuracy of the transformation to an isotropic radial coordinate through another numeric integration, which I use as initial guess in conformally-flat XCTS solves for neutron star initial data (future PR).

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
