### PR TITLE
Compute cce integrand inputs

### DIFF
--- a/src/Evolution/Systems/Cce/IntegrandInputSteps.hpp
+++ b/src/Evolution/Systems/Cce/IntegrandInputSteps.hpp
@@ -3,8 +3,13 @@
 
 #pragma once
 
+#include <cmath>
+
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tags.hpp"
 #include "Evolution/Systems/Cce/Equations.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
@@ -25,14 +30,140 @@ template <typename Tag>
 using integrand_temporary_tags =
     typename ComputeBondiIntegrand<Tag>::temporary_tags;
 
+namespace detail {
+// structs containing typelists for organizing the set of tags needed at each
+// step of the CCE hypersurface evaluation steps. These are not directly the
+// tags that are inputs in the `Equations.hpp`, as those would contain
+// redundancy, and not necessarily obtain the derivatives during the most ideal
+// steps. So, the ordering in these structs has been slightly 'designed' in ways
+// that are not trivial to automate with tmpl list manipulation
+template <typename Tag>
+struct TagsToComputeForImpl;
+
+template <>
+struct TagsToComputeForImpl<Tags::BondiBeta> {
+  using pre_swsh_derivative_tags =
+      tmpl::list<Tags::Dy<Tags::BondiJ>, Tags::Dy<Tags::Dy<Tags::BondiJ>>>;
+  using second_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags = tmpl::list<>;
+};
+
+// Note: Due to the order in which Jacobians for the conversion between
+// numerical and Bondi spin-weighted derivatives are evaluated, all of the
+// higher (second) spin-weighted derivatives must be computed AFTER the
+// eth(dy(bondi)) values (which act as inputs to the second derivative
+// conversions to fixed Bondi radius), so must appear later in the
+// `swsh_derivative_tags` typelists.
+template <>
+struct TagsToComputeForImpl<Tags::BondiQ> {
+  using pre_swsh_derivative_tags =
+      tmpl::list<Tags::Dy<Tags::BondiBeta>, Tags::Dy<Tags::Dy<Tags::BondiBeta>>,
+                 ::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>,
+                 ::Tags::Multiplies<Tags::BondiJbar, Tags::Dy<Tags::BondiJ>>>;
+  using swsh_derivative_tags = tmpl::list<
+      Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                       Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiBeta>,
+                                       Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<
+          ::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>,
+          Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<
+          ::Tags::Multiplies<Tags::BondiJbar, Tags::Dy<Tags::BondiJ>>,
+          Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiJ>,
+                                       Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiJ,
+                                       Spectral::Swsh::Tags::Ethbar>>;
+  using second_swsh_derivative_tags = tmpl::list<>;
+};
+
+template <>
+struct TagsToComputeForImpl<Tags::BondiU> {
+  using pre_swsh_derivative_tags =
+      tmpl::list<Tags::Exp2Beta, Tags::Dy<Tags::BondiQ>,
+                 Tags::Dy<Tags::Dy<Tags::BondiQ>>>;
+  using second_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags = tmpl::list<>;
+};
+
+template <>
+struct TagsToComputeForImpl<Tags::BondiW> {
+  using pre_swsh_derivative_tags =
+      tmpl::list<Tags::Dy<Tags::BondiU>, Tags::Dy<Tags::Dy<Tags::BondiU>>,
+                 Tags::Dy<::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>>>;
+  using swsh_derivative_tags = tmpl::list<
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiBeta>,
+                                       Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<
+          Tags::Dy<::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>>,
+          Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<
+          Tags::Dy<::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>>,
+          Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiU>,
+                                       Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiU,
+                                       Spectral::Swsh::Tags::Ethbar>>;
+  // Currently, the `eth_ethbar_j` term is the single instance of a swsh
+  // derivative needing nested `Spectral::Swsh::Tags::Derivatives` steps to
+  // compute. The reason is that if we do not compute the derivative in two
+  // steps, there are intermediate terms in the Jacobian which depend on eth_j,
+  // which is a spin-weight 3 quantity and therefore cannot be computed with
+  // libsharp (the SWSH library being used). If `eth_ethbar_j` becomes not
+  // needed, the remaining `second_swsh_derivative_tags` can be merged to the
+  // end of `swsh_derivative_tags` and the corresponding computational steps
+  // from `SwshDerivatives.hpp` removed.
+  using second_swsh_derivative_tags =
+      tmpl::list<Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                                  Spectral::Swsh::Tags::EthEth>,
+                 Spectral::Swsh::Tags::Derivative<
+                     Tags::BondiBeta, Spectral::Swsh::Tags::EthEthbar>,
+                 Spectral::Swsh::Tags::Derivative<
+                     ::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>,
+                     Spectral::Swsh::Tags::EthEthbar>,
+
+                 Spectral::Swsh::Tags::Derivative<
+                     Tags::BondiJ, Spectral::Swsh::Tags::EthbarEthbar>,
+                 Spectral::Swsh::Tags::Derivative<
+                     Spectral::Swsh::Tags::Derivative<
+                         Tags::BondiJ, Spectral::Swsh::Tags::Ethbar>,
+                     Spectral::Swsh::Tags::Eth>>;
+};
+
+template <>
+struct TagsToComputeForImpl<Tags::BondiH> {
+  using pre_swsh_derivative_tags =
+      tmpl::list<::Tags::Multiplies<Tags::BondiJbar, Tags::BondiU>,
+                 ::Tags::Multiplies<Tags::BondiUbar, Tags::Dy<Tags::BondiJ>>,
+                 Tags::JbarQMinus2EthBeta, Tags::Dy<Tags::BondiW>>;
+  using swsh_derivative_tags = tmpl::list<
+      Spectral::Swsh::Tags::Derivative<Tags::BondiQ, Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiU, Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<
+          ::Tags::Multiplies<Tags::BondiUbar, Tags::Dy<Tags::BondiJ>>,
+          Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<
+          ::Tags::Multiplies<Tags::BondiJbar, Tags::Dy<Tags::BondiJ>>,
+          Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<Tags::JbarQMinus2EthBeta,
+                                       Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<
+          ::Tags::Multiplies<Tags::BondiJbar, Tags::BondiU>,
+          Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiQ,
+                                       Spectral::Swsh::Tags::Ethbar>>;
+  using second_swsh_derivative_tags = tmpl::list<>;
+};
+}  // namespace detail
+
 /*!
- * \brief A type list for the set of `BoundaryValue` tags needed as an input to
- * any of the template specializations of
+ * \brief A typelist for the set of `BoundaryValue` tags needed as an input to
+ * any of the template specializations of `PrecomputeCceDependencies`.
  *
- * `PrecomputeCceDependencies`.
  * \details This is provided for easy and maintainable
  * construction of a `Variables` or \ref DataBoxGroup with all of the quantities
- * necessary for a Cce computation or portion thereof.
+ * necessary for a CCE computation or portion thereof.
  * A container of these tags should have size
  * `Spectral::Swsh::number_of_swsh_collocation_points(l_max)`.
  */
@@ -42,15 +173,15 @@ using pre_computation_boundary_tags =
                BoundaryPrefix<Tags::DuRDividedByR>>;
 
 /*!
- * \brief A type list for the set of tags computed by the set of
+ * \brief A typelist for the set of tags computed by the set of
  * template specializations of `PrecomputeCceDepedencies`.
  *
- * \details This is provided for
- * easy and maintainable construction of a `Variables` or `DataBox` with all of
- * the quantities needed for a Cce computation or component. The data structures
- * represented by these tags should each have size `number_of_radial_points *
- * number_of_swsh_collocation_points(l_max)`. All of these tags may be computed
- * at once if using a \ref DataBoxGroup using the template
+ * \details This is provided for easy and maintainable construction of a
+ * `Variables` or \ref DataBoxGroup with all of the quantities needed for a CCE
+ * computation or component. The data structures represented by these tags
+ * should each have size `number_of_radial_points *
+ * Spectral::Swsh::number_of_swsh_collocation_points(l_max)`. All of these tags
+ * may be computed at once if using a \ref DataBoxGroup using the template
  * `mutate_all_precompute_cce_dependencies` or individually using
  * the template specializations `PrecomputeCceDependencies`.
  */
@@ -59,4 +190,122 @@ using pre_computation_tags =
                Tags::EthEthRDividedByR, Tags::EthEthbarRDividedByR,
                Tags::BondiK, Tags::OneMinusY, Tags::BondiR>;
 
+// @{
+/*!
+ * \brief A typelist for the set of tags computed by the set of
+ * template specializations of `ComputePreSwshDerivatives`.
+ *
+ * \details This is provided for easy and maintainable construction of a
+ * `Variables` or \ref DataBoxGroup with all of the quantities needed for a CCE
+ * computation or component. The data structures represented by these tags
+ * should each have size `number_of_radial_points *
+ * Spectral::Swsh::number_of_swsh_collocation_points(l_max)`. All of these tags
+ * (for a given integrated Bondi quantity) may be computed at once if using a
+ * \ref DataBoxGroup using the template
+ * `mutate_all_pre_swsh_derivatives_for_tag` or individually using the template
+ * specializations of `ComputePreSwshDerivatives`. The full set of integrated
+ * Bondi quantities is available from the typelist
+ * `bondi_hypersurface_step_tags`.
+ */
+template <typename Tag>
+struct pre_swsh_derivative_tags_to_compute_for {
+  using type =
+      typename detail::TagsToComputeForImpl<Tag>::pre_swsh_derivative_tags;
+};
+
+template <typename Tag>
+using pre_swsh_derivative_tags_to_compute_for_t =
+    typename pre_swsh_derivative_tags_to_compute_for<Tag>::type;
+// @}
+
+// @{
+/*!
+ * \brief A typelist for the set of tags computed by single spin-weighted
+ * differentiation using utilities from the `Swsh` namespace.
+ */
+template <typename Tag>
+struct single_swsh_derivative_tags_to_compute_for {
+  using type = typename detail::TagsToComputeForImpl<Tag>::swsh_derivative_tags;
+};
+
+template <typename Tag>
+using single_swsh_derivative_tags_to_compute_for_t =
+    typename single_swsh_derivative_tags_to_compute_for<Tag>::type;
+// @}
+
+// @{
+/*!
+ * \brief A typelist for the set of tags computed by multiple spin-weighted
+ * differentiation using utilities from the `Swsh` namespace.
+ */
+template <typename Tag>
+struct second_swsh_derivative_tags_to_compute_for {
+  using type =
+      typename detail::TagsToComputeForImpl<Tag>::second_swsh_derivative_tags;
+};
+
+template <typename Tag>
+using second_swsh_derivative_tags_to_compute_for_t =
+    typename single_swsh_derivative_tags_to_compute_for<Tag>::type;
+// @}
+
+/*!
+ * \brief A typelist for the set of tags computed by spin-weighted
+ * differentiation using utilities from the `Swsh` namespace.
+ *
+ * \details This is provided for easy and maintainable construction of a
+ * `Variables` or \ref DataBoxGroup with all of the quantities needed for a CCE
+ * computation or component. The data structures represented by these tags
+ * should each have size `number_of_radial_points *
+ * Spectral::Swsh::number_of_swsh_collocation_points(l_max)`. All of these tags
+ * (for a given integrated Bondi quantity) may be computed at once if using a
+ * \ref DataBoxGroup using the template `mutate_all_swsh_derivatives_for_tag`.
+ * Individual tag computation is not provided in a convenient interface, as
+ * there is significant savings in aggregating spin-weighted differentiation
+ * steps. The full set of integrated Bondi quantities is available from the
+ * typelist `bondi_hypersurface_step_tags`.
+ */
+using all_swsh_derivative_tags =
+    tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+        bondi_hypersurface_step_tags,
+        tmpl::bind<tmpl::list,
+                   single_swsh_derivative_tags_to_compute_for<tmpl::_1>,
+                   second_swsh_derivative_tags_to_compute_for<tmpl::_1>>>>>;
+
+/*!
+ * \brief A typelist for the full set of coefficient buffers needed to process
+ * all of the tags in `all_swsh_derivative_tags` using batch processing provided
+ * in `mutate_all_swsh_derivatives_for_tag`.
+ *
+ * \details This is provided for easy and maintainable construction of a
+ * `Variables` or \ref DataBoxGroup with all of the quantities needed for a CCE
+ * computation or component. The data structures represented by these tags
+ * should each have size `number_of_radial_points *
+ * Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)`. Providing
+ * buffers associated with these tags is necessary for the use of the aggregated
+ * computation `mutate_all_swsh_derivatives_for_tag`.
+ */
+using all_transform_buffer_tags =
+    tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+        all_swsh_derivative_tags,
+        tmpl::bind<Spectral::Swsh::coefficient_buffer_tags_for_derivative_tag,
+                   tmpl::_1>>>>;
+
+/*!
+ * \brief A typelist for the full set of tags needed as direct or indirect
+ * input to any `ComputeBondiIntegrand` that are computed any specialization of
+ * `ComputePreSwshDerivatives`.
+ *
+ * \details This is provided for easy and maintainable construction of a
+ * `Variables` or \ref DataBoxGroup with all of the quantities needed for a CCE
+ * computation or component. The data structures represented by these tags
+ * should each have size `number_of_radial_points *
+ * Spectral::Swsh::number_of_swsh_collocation_points(l_max)`.
+ */
+using all_pre_swsh_derivative_tags =
+    tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+        bondi_hypersurface_step_tags,
+        tmpl::bind<tmpl::list,
+                   pre_swsh_derivative_tags_to_compute_for<tmpl::_1>, tmpl::_1,
+                   tmpl::bind<Tags::Dy, tmpl::_1>>>>>;
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/PreSwshDerivatives.hpp
+++ b/src/Evolution/Systems/Cce/PreSwshDerivatives.hpp
@@ -1,0 +1,410 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Mesh.hpp"
+#include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
+#include "Evolution/Systems/Cce/LinearOperators.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce {
+
+/*!
+ * \brief A set of procedures for computing the set of inputs to the CCE
+ * integrand computations that are to be performed prior to the spin-weighted
+ * spherical harmonic differentiation (and for the first step in the series of
+ * integrations, after the `PrecomputeCceDependencies`)
+ *
+ * \details For the storage model in which a set of `Variables` are stored in a
+ * `DataBox`, there are type aliases provided in each of the specializations:
+ * - output/input : `pre_swsh_derivatives` type alias. A \ref DataBoxGroup with
+ * tags `all_pre_swsh_derivative_tags` is compatible with all specializations.
+ * - input : `swsh_derivative_tags` type alias. A \ref DataBoxGroup with tags
+ *   `all_swsh_derivative_tags` is compatible with all specializations.
+ * - input : `integrand_tags` type alias. A \ref DataBoxGroup with tags
+ * `Tags::BondiU` and `Tags::BondiBeta` is compatible with all specializations.
+ */
+template <typename Tag>
+struct PreSwshDerivatives;
+
+/*!
+ * \brief Compute \f$\bar{J}\f$.
+ *
+ * \note Computing \f$\bar{J}\f$ should be unnecessary in most execution
+ * procedures, as all quantities should be derived from \f$J\f$ and its
+ * derivatives followed by explicit conjugation operations, which are expected
+ * to be sufficiently cheap to avoid the storage cost of recording the
+ * conjugates. The exception is caching for certain spin-weighted derivatives of
+ * products
+ */
+template <>
+struct PreSwshDerivatives<Tags::BondiJbar> {
+  using pre_swsh_derivative_tags = tmpl::list<Tags::BondiJ>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integrand_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<Tags::BondiJbar>;
+  using argument_tags = pre_swsh_derivative_tags;
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -2>>*> jbar,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& j) noexcept {
+    get(*jbar) = conj(get(j));
+  }
+};
+
+/*!
+ * \brief Compute \f$\bar{U}\f$.
+ *
+ * \note Computing \f$\bar{U}\f$ should be unnecessary in most execution
+ * procedures, as all quantities should be derived from \f$U\f$ and its
+ * derivatives followed by explicit conjugation operations, which are expected
+ * to be sufficiently cheap to avoid the storage cost of recording the
+ * conjugates.
+ */
+template <>
+struct PreSwshDerivatives<Tags::BondiUbar> {
+  using pre_swsh_derivative_tags = tmpl::list<Tags::BondiU>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integrand_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<Tags::BondiUbar>;
+  using argument_tags = pre_swsh_derivative_tags;
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -1>>*> ubar,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& u) noexcept {
+    get(*ubar) = conj(get(u));
+  }
+};
+
+/*!
+ * Compute \f$\bar{Q}\f$.
+ *
+ * \note Computing \f$\bar{Q}\f$ should be unnecessary in most execution
+ * procedures, as all quantities should be derived from \f$Q\f$ and its
+ * derivatives followed by explicit conjugation operations, which are expected
+ * to be sufficiently cheap to avoid the storage cost of recording the
+ * conjugates
+ */
+template <>
+struct PreSwshDerivatives<Tags::BondiQbar> {
+  using pre_swsh_derivative_tags = tmpl::list<Tags::BondiQ>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integrand_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<Tags::BondiQbar>;
+  using argument_tags = pre_swsh_derivative_tags;
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -1>>*> qbar,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& q) noexcept {
+    get(*qbar) = conj(get(q));
+  }
+};
+
+/// Compute the product of `Lhs` and `Rhs`.
+template <typename Lhs, typename Rhs>
+struct PreSwshDerivatives<::Tags::Multiplies<Lhs, Rhs>> {
+  using pre_swsh_derivative_tags = tmpl::list<Lhs, Rhs>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integrand_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<::Tags::Multiplies<Lhs, Rhs>>;
+  using argument_tags = pre_swsh_derivative_tags;
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<
+          ComplexDataVector, ::Tags::Multiplies<Lhs, Rhs>::type::type::spin>>*>
+          result,
+      const Scalar<SpinWeighted<ComplexDataVector, Lhs::type::type::spin>>& lhs,
+      const Scalar<SpinWeighted<ComplexDataVector, Rhs::type::type::spin>>&
+          rhs) noexcept {
+    get(*result) = get(lhs) * get(rhs);
+  }
+};
+
+/*!
+ * \brief Compute the product of \f$\bar{J}\f$ and the quantity represented by
+ * `Rhs`.
+ *
+ * \details In this function, \f$\bar{J}\f$ is obtained via conjugation of
+ * `Tags::BondiJ` inline, rather than accessing `Tags::BondiJbar` in storage.
+ */
+template <typename Rhs>
+struct PreSwshDerivatives<::Tags::Multiplies<Tags::BondiJbar, Rhs>> {
+  using pre_swsh_derivative_tags = tmpl::list<Tags::BondiJ, Rhs>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integrand_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<::Tags::Multiplies<Tags::BondiJbar, Rhs>>;
+  using argument_tags = pre_swsh_derivative_tags;
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<
+          ComplexDataVector,
+          ::Tags::Multiplies<Tags::BondiJbar, Rhs>::type::type::spin>>*>
+          result,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& j,
+      const Scalar<SpinWeighted<ComplexDataVector, Rhs::type::type::spin>>&
+          rhs) noexcept {
+    get(*result) = conj(get(j)) * get(rhs);
+  }
+};
+
+/*!
+ * \brief Compute the product of \f$\bar{J}\f$ and the quantity represented by
+ * `Rhs`.
+ *
+ * \details In this function, \f$\bar{J}\f$ is obtained via conjugation of
+ * `Tags::BondiJ` inline, rather than accessing `Tags::BondiJbar` in storage.
+ */
+template <typename Lhs>
+struct PreSwshDerivatives<::Tags::Multiplies<Lhs, Tags::BondiJbar>> {
+  using pre_swsh_derivative_tags = tmpl::list<Tags::BondiJ, Lhs>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integrand_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<::Tags::Multiplies<Lhs, Tags::BondiJbar>>;
+  using argument_tags = pre_swsh_derivative_tags;
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<
+          ComplexDataVector,
+          ::Tags::Multiplies<Lhs, Tags::BondiJbar>::type::type::spin>>*>
+          result,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& j,
+      const Scalar<SpinWeighted<ComplexDataVector, Lhs::type::type::spin>>&
+          lhs) noexcept {
+    get(*result) = get(lhs) * conj(get(j));
+  }
+};
+
+/*!
+ * \brief Compute the product of \f$\bar{U}\f$ and the quantity represented by
+ * `Rhs`.
+ *
+ * \details In this function, \f$\bar{U}\f$ is obtained via conjugation of
+ * `Tags::BondiU` inline, rather than accessing `Tags::BondiUbar` in storage.
+ */
+template <typename Rhs>
+struct PreSwshDerivatives<::Tags::Multiplies<Tags::BondiUbar, Rhs>> {
+  using pre_swsh_derivative_tags = tmpl::list<Tags::BondiU, Rhs>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integrand_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<::Tags::Multiplies<Tags::BondiUbar, Rhs>>;
+  using argument_tags = pre_swsh_derivative_tags;
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<
+          ComplexDataVector,
+          ::Tags::Multiplies<Tags::BondiUbar, Rhs>::type::type::spin>>*>
+          result,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& u,
+      const Scalar<SpinWeighted<ComplexDataVector, Rhs::type::type::spin>>&
+          rhs) noexcept {
+    get(*result) = conj(get(u)) * get(rhs);
+  }
+};
+
+/*!
+ * \brief Compute \f$\bar{J} * (Q - 2 \eth \beta)\f$.
+ *
+ * \note the conjugates for this are accessed by their non-conjugate
+ * counterparts (`Tags::BondiJ` and `Tags::BondiQ`) then conjugated inline
+ */
+template <>
+struct PreSwshDerivatives<Tags::JbarQMinus2EthBeta> {
+  using pre_swsh_derivative_tags = tmpl::list<Tags::BondiJ, Tags::BondiQ>;
+  using swsh_derivative_tags =
+      tmpl::list<Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                                  Spectral::Swsh::Tags::Eth>>;
+  using integrand_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<Tags::JbarQMinus2EthBeta>;
+  using argument_tags =
+      tmpl::append<pre_swsh_derivative_tags, swsh_derivative_tags>;
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -1>>*>
+          jbar_q_minus_2_eth_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& j,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& q,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_beta) noexcept {
+    get(*jbar_q_minus_2_eth_beta) =
+        conj(get(j)) * (get(q) - 2.0 * get(eth_beta));
+  }
+};
+
+/// Compute \f$\exp(2 \beta)\f$
+template <>
+struct PreSwshDerivatives<Tags::Exp2Beta> {
+  using pre_swsh_derivative_tags = tmpl::list<Tags::BondiBeta>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integrand_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<Tags::Exp2Beta>;
+  using argument_tags = tmpl::append<tmpl::list<pre_swsh_derivative_tags>>;
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+          exp_2_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta) noexcept {
+    get(*exp_2_beta).data() = exp(2.0 * get(beta).data());
+  }
+};
+
+/// Compute the derivative of the quantity represented by `Tag` with respect to
+/// the numerical radial coordinate \f$y\f$.
+template <typename Tag>
+struct PreSwshDerivatives<Tags::Dy<Tag>> {
+  using pre_swsh_derivative_tags = tmpl::list<Tag>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integrand_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<Tags::Dy<Tag>>;
+  using argument_tags = tmpl::append<pre_swsh_derivative_tags,
+                                     tmpl::list<Spectral::Swsh::Tags::LMax>>;
+
+  static void apply(
+      const gsl::not_null<
+          Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>*>
+          dy_val,
+      const Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>& val,
+      const size_t l_max) noexcept {
+    logical_partial_directional_derivative_of_complex(
+        make_not_null(&get(*dy_val).data()), get(val).data(),
+        Mesh<3>{
+            {{Spectral::Swsh::number_of_swsh_theta_collocation_points(l_max),
+              Spectral::Swsh::number_of_swsh_phi_collocation_points(l_max),
+              get(val).size() /
+                  Spectral::Swsh::number_of_swsh_collocation_points(l_max)}},
+            Spectral::Basis::Legendre,
+            Spectral::Quadrature::GaussLobatto},
+        // 2 for differentiating in y; coordinate ordering is:
+        // {\phi, \theta, y}.
+        2);
+  }
+};
+
+/*!
+ * \brief Computes the first derivative with respect to \f$y\f$ of
+ * `Tags::BondiBeta`.
+ *
+ * \details In a CCE evolution, the values of the first derivatives of
+ * `Tags::BondiBeta` can just be copied from its integrand.
+ */
+template <>
+struct PreSwshDerivatives<Tags::Dy<Tags::BondiBeta>> {
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integrand_tags = tmpl::list<Tags::Integrand<Tags::BondiBeta>>;
+
+  using return_tags = tmpl::list<Tags::Dy<Tags::BondiBeta>>;
+  using argument_tags = integrand_tags;
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> dy_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>&
+          integrand_beta) noexcept {
+    *dy_beta = integrand_beta;
+  }
+};
+
+/*!
+ * \brief Computes the first derivative with respect to \f$y\f$ of
+ * `Tags::BondiU`.
+ *
+ * \details In a CCE evolution, the values of the first derivatives of
+ * `Tags::BondiU` can just be copied from its integrand.
+ */
+template <>
+struct PreSwshDerivatives<Tags::Dy<Tags::BondiU>> {
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integrand_tags = tmpl::list<Tags::Integrand<Tags::BondiU>>;
+
+  using return_tags = tmpl::list<Tags::Dy<Tags::BondiU>>;
+  using argument_tags = integrand_tags;
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*> dy_u,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& integrand_u) noexcept {
+    *dy_u = integrand_u;
+  }
+};
+
+/*!
+ * \brief Compute the derivative with respect to the numerical radial coordinate
+ * \f$y\f$ of a quantity which is a spin-weighted spherical harmonic
+ * derivative.
+ *
+ * \details  This is separate from the generic case of a derivative with
+ * respect to \f$y\f$ because the included type aliases arrange the input tags
+ * in different categories.
+ */
+template <typename Tag, typename DerivKind>
+struct PreSwshDerivatives<
+    Tags::Dy<Spectral::Swsh::Tags::Derivative<Tag, DerivKind>>> {
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags =
+      tmpl::list<Spectral::Swsh::Tags::Derivative<Tag, DerivKind>>;
+  using integrand_tags = tmpl::list<>;
+
+  using return_tags =
+      tmpl::list<Tags::Dy<Spectral::Swsh::Tags::Derivative<Tag, DerivKind>>>;
+  using argument_tags = tmpl::append<swsh_derivative_tags,
+                                     tmpl::list<Spectral::Swsh::Tags::LMax>>;
+
+  static constexpr int spin =
+      Spectral::Swsh::Tags::Derivative<Tag, DerivKind>::spin;
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, spin>>*>
+          dy_val,
+      const Scalar<SpinWeighted<ComplexDataVector, spin>>& val,
+      const size_t l_max) noexcept {
+    logical_partial_directional_derivative_of_complex(
+        make_not_null(&get(*dy_val).data()), get(val).data(),
+        Mesh<3>{
+            {{Spectral::Swsh::number_of_swsh_theta_collocation_points(l_max),
+              Spectral::Swsh::number_of_swsh_phi_collocation_points(l_max),
+              get(val).size() /
+                  Spectral::Swsh::number_of_swsh_collocation_points(l_max)}},
+            Spectral::Basis::Legendre,
+            Spectral::Quadrature::GaussLobatto},
+        // 2 for differentiating in y; coordinate ordering is:
+        // {\phi, \theta, y}.
+        2);
+  }
+};
+
+/*!
+ * \brief Evaluates the set of inputs to the CCE integrand for
+ * `BondiValueTag` that do not involve spin-weighted angular differentiation.
+ *
+ * \details This function is to be called on the `DataBox` holding the relevant
+ * CCE data on each hypersurface integration step, prior to evaluating the
+ * spin-weighted derivatives needed for the same CCE integrand. Provided a
+ * `DataBox` with the appropriate tags (including
+ * `all_pre_swsh_derivative_tags`, `all_swsh_derivative_tags` and
+ * `Spectral::Swsh::Tags::LMax`), this function will apply all of the necessary
+ * mutations to update `all_pre_swsh_derivatives_for_tag<BondiValueTag>` to
+ * their correct values for the current values for the remaining (input) tags.
+ */
+template <typename BondiValueTag, typename DataBoxType>
+void mutate_all_pre_swsh_derivatives_for_tag(
+    const gsl::not_null<DataBoxType*> box) noexcept {
+  tmpl::for_each<
+      pre_swsh_derivative_tags_to_compute_for_t<BondiValueTag>>([&box](
+      auto pre_swsh_derivative_tag_v) noexcept {
+    using pre_swsh_derivative_tag =
+        typename decltype(pre_swsh_derivative_tag_v)::type;
+    using mutation = PreSwshDerivatives<pre_swsh_derivative_tag>;
+    db::mutate_apply<mutation>(box);
+  });
+}
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/PrecomputeCceDependencies.cpp
+++ b/src/Evolution/Systems/Cce/PrecomputeCceDependencies.cpp
@@ -41,8 +41,9 @@ void angular_derivative_of_r_divided_by_r_impl(
   ComplexDataVector d_r_divided_by_r_tail_shells{
       d_r_divided_by_r->data().data() + number_of_angular_points,
       (number_of_radial_points - 1) * number_of_angular_points};
-  repeat(make_not_null(&d_r_divided_by_r_tail_shells),
-         d_r_divided_by_r_boundary.data(), number_of_radial_points - 1);
+  fill_with_n_copies(make_not_null(&d_r_divided_by_r_tail_shells),
+                     d_r_divided_by_r_boundary.data(),
+                     number_of_radial_points - 1);
 }
 }  // namespace detail
 

--- a/src/Evolution/Systems/Cce/PrecomputeCceDependencies.hpp
+++ b/src/Evolution/Systems/Cce/PrecomputeCceDependencies.hpp
@@ -106,8 +106,8 @@ struct PrecomputeCceDependencies<BoundaryPrefix, Tags::BondiR> {
       const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> r,
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
       const size_t number_of_radial_points) noexcept {
-    repeat(make_not_null(&get(*r).data()), get(boundary_r).data(),
-           number_of_radial_points);
+    fill_with_n_copies(make_not_null(&get(*r).data()), get(boundary_r).data(),
+                       number_of_radial_points);
   }
 };
 
@@ -130,8 +130,9 @@ struct PrecomputeCceDependencies<BoundaryPrefix, Tags::DuRDividedByR> {
       const Scalar<SpinWeighted<ComplexDataVector, 0>>&
           boundary_du_r_divided_by_r,
       const size_t number_of_radial_points) noexcept {
-    repeat(make_not_null(&get(*du_r_divided_by_r).data()),
-           get(boundary_du_r_divided_by_r).data(), number_of_radial_points);
+    fill_with_n_copies(make_not_null(&get(*du_r_divided_by_r).data()),
+                       get(boundary_du_r_divided_by_r).data(),
+                       number_of_radial_points);
   }
 };
 

--- a/src/Evolution/Systems/Cce/SwshDerivatives.hpp
+++ b/src/Evolution/Systems/Cce/SwshDerivatives.hpp
@@ -1,0 +1,642 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+#include <type_traits>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Mesh.hpp"
+#include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace Cce {
+namespace detail {
+// Precomputation routines for supplying the additional quantities necessary
+// to correct the output of the angular derivative routines from the angular
+// derivatives evaluated at constant numerical coordinates (which is what is
+// returned after the libsharp evaluation) to the angular derivatives at
+// constant Bondi radius (which is what appears in the literature equations
+// and is simple to combine to obtain the hypersurface integrands).
+//
+// Warning: this 'on demand' template is a way of taking advantage of the blaze
+// expression templates in a generic, modular way. However, this can be
+// dangerous. The returned value MUST be a blaze expression template directly,
+// and not a wrapper type (like `SpinWeighted`). Otherwise, some information is
+// lost on the stack and the expression template is corrupted. So, in these 'on
+// demand' returns, the arguments must be fully unpacked to vector types.
+//
+// The `Select` operand is a `cpp17::bool_constant` that ensures mutual
+// exclusivity of the template specializations.
+template <typename Tag, typename SpinConstant, typename Select>
+struct OnDemandInputsForSwshJacobianImpl;
+
+// default to just retrieving it from the box if not providing an expression
+// template shortcut
+template <typename Tag>
+struct OnDemandInputsForSwshJacobianImpl<
+    Tags::Dy<Tag>, std::integral_constant<int, Tag::type::type::spin>,
+    cpp17::bool_constant<not tt::is_a_v<::Tags::Multiplies, Tag> and
+                         not tt::is_a_v<Tags::Dy, Tag>>> {
+  template <typename DataBoxTagList>
+  SPECTRE_ALWAYS_INLINE decltype(auto) operator()(
+      const db::DataBox<DataBoxTagList>& box) noexcept {
+    return get(db::get<Tags::Dy<Tag>>(box)).data();
+  }
+};
+
+// default to retrieving from the box if the requested tag is a second
+// derivative without an additional evaluation channel
+template <typename Tag>
+struct OnDemandInputsForSwshJacobianImpl<
+    Tags::Dy<Tags::Dy<Tag>>, std::integral_constant<int, Tag::type::type::spin>,
+    cpp17::bool_constant<not tt::is_a_v<::Tags::Multiplies, Tag>>> {
+  template <typename DataBoxTagList>
+  SPECTRE_ALWAYS_INLINE decltype(auto) operator()(
+      const db::DataBox<DataBoxTagList>& box) noexcept {
+    return get(db::get<Tags::Dy<Tags::Dy<Tag>>>(box)).data();
+  }
+};
+
+// use the product rule to provide an expression template for derivatives of
+// products
+template <typename LhsTag, typename RhsTag>
+struct OnDemandInputsForSwshJacobianImpl<
+    Tags::Dy<::Tags::Multiplies<LhsTag, RhsTag>>,
+    std::integral_constant<int,
+                           LhsTag::type::type::spin + RhsTag::type::type::spin>,
+    cpp17::bool_constant<not cpp17::is_same_v<LhsTag, Tags::BondiJbar> and
+                         not cpp17::is_same_v<LhsTag, Tags::BondiUbar> and
+                         not cpp17::is_same_v<RhsTag, Tags::BondiJbar>>> {
+  template <typename DataBoxTagList>
+  SPECTRE_ALWAYS_INLINE decltype(auto) operator()(
+      const db::DataBox<DataBoxTagList>& box) noexcept {
+    decltype(auto) lhs = get(db::get<LhsTag>(box)).data();
+    decltype(auto) dy_lhs = get(db::get<Tags::Dy<LhsTag>>(box)).data();
+    decltype(auto) rhs = get(db::get<RhsTag>(box)).data();
+    decltype(auto) dy_rhs = get(db::get<Tags::Dy<RhsTag>>(box)).data();
+    return lhs * dy_rhs + dy_lhs * rhs;
+  }
+};
+
+// use the product rule and an explicit conjugate to provide an expression
+// template for derivatives of products with `Tags::BondiJbar` as the right-hand
+// operand
+template <typename LhsTag>
+struct OnDemandInputsForSwshJacobianImpl<
+    Tags::Dy<::Tags::Multiplies<LhsTag, Tags::BondiJbar>>,
+    std::integral_constant<int, LhsTag::type::type::spin - 2>, std::true_type> {
+  template <typename DataBoxTagList>
+  SPECTRE_ALWAYS_INLINE decltype(auto) operator()(
+      const db::DataBox<DataBoxTagList>& box) noexcept {
+    decltype(auto) lhs = get(get<LhsTag>(box)).data();
+    decltype(auto) dy_lhs = get(get<Tags::Dy<LhsTag>>(box)).data();
+    decltype(auto) jbar = conj(get(get<Tags::BondiJ>(box)).data());
+    decltype(auto) dy_jbar = conj(get(get<Tags::Dy<Tags::BondiJ>>(box)).data());
+    return lhs * dy_jbar + dy_lhs * jbar;
+  }
+};
+
+// use the product rule and an explicit conjugate to provide an expression
+// template for derivatives of products with `Tags::BondiJbar` as the left-hand
+// operand.
+template <typename RhsTag>
+struct OnDemandInputsForSwshJacobianImpl<
+    Tags::Dy<::Tags::Multiplies<Tags::BondiJbar, RhsTag>>,
+    std::integral_constant<int, RhsTag::type::type::spin - 2>, std::true_type> {
+  template <typename DataBoxTagList>
+  SPECTRE_ALWAYS_INLINE decltype(auto) operator()(
+      const db::DataBox<DataBoxTagList>& box) noexcept {
+    decltype(auto) rhs = get(get<RhsTag>(box)).data();
+    decltype(auto) dy_rhs = get(get<Tags::Dy<RhsTag>>(box)).data();
+    decltype(auto) jbar = conj(get(get<Tags::BondiJ>(box)).data());
+    decltype(auto) dy_jbar = conj(get(get<Tags::Dy<Tags::BondiJ>>(box)).data());
+    return dy_jbar * rhs + jbar * dy_rhs;
+  }
+};
+
+// use the product rule and an explicit conjugate to provide an expression
+// template for derivatives of products with `Tags::BondiUbar` as the left-hand
+// operand.
+template <typename RhsTag>
+struct OnDemandInputsForSwshJacobianImpl<
+    Tags::Dy<::Tags::Multiplies<Tags::BondiUbar, RhsTag>>,
+    std::integral_constant<int, RhsTag::type::type::spin - 1>, std::true_type> {
+  template <typename DataBoxTagList>
+  SPECTRE_ALWAYS_INLINE decltype(auto) operator()(
+      const db::DataBox<DataBoxTagList>& box) noexcept {
+    decltype(auto) ubar = conj(get(get<Tags::BondiU>(box)).data());
+    decltype(auto) dy_ubar = conj(get(get<Tags::Dy<Tags::BondiU>>(box)).data());
+    decltype(auto) rhs = get(get<RhsTag>(box)).data();
+    decltype(auto) dy_rhs = get(get<Tags::Dy<RhsTag>>(box)).data();
+    return ubar * dy_rhs + dy_ubar * rhs;
+  }
+};
+
+// use the product rule and an explicit conjugate to provide an expression
+// template for second derivatives of products with `Tags::BondiJbar` as the
+// right-hand operand.
+template <typename LhsTag>
+struct OnDemandInputsForSwshJacobianImpl<
+    Tags::Dy<Tags::Dy<::Tags::Multiplies<LhsTag, Tags::BondiJbar>>>,
+    std::integral_constant<int, LhsTag::type::type::spin - 2>, std::true_type> {
+  template <typename DataBoxTagList>
+  SPECTRE_ALWAYS_INLINE decltype(auto) operator()(
+      const db::DataBox<DataBoxTagList>& box) noexcept {
+    decltype(auto) lhs = get(get<LhsTag>(box)).data();
+    decltype(auto) dy_lhs = get(get<Tags::Dy<LhsTag>>(box)).data();
+    decltype(auto) dy_dy_lhs = get(get<Tags::Dy<Tags::Dy<LhsTag>>>(box)).data();
+    decltype(auto) jbar = conj(get(get<Tags::BondiJ>(box)).data());
+    decltype(auto) dy_jbar = conj(get(get<Tags::Dy<Tags::BondiJ>>(box)).data());
+    decltype(auto) dy_dy_jbar =
+        conj(get(get<Tags::Dy<Tags::Dy<Tags::BondiJ>>>(box)).data());
+    return lhs * dy_dy_jbar + 2.0 * dy_lhs * dy_jbar + dy_dy_lhs * jbar;
+  }
+};
+
+// default to extracting directly from the box for spin-weighted derivatives of
+// radial (y) derivatives
+template <typename Tag, typename DerivKind>
+struct OnDemandInputsForSwshJacobianImpl<
+    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tag>, DerivKind>,
+    std::integral_constant<
+        int, Spectral::Swsh::Tags::Derivative<Tags::Dy<Tag>, DerivKind>::spin>,
+    std::true_type> {
+  template <typename DataBoxTagList>
+  SPECTRE_ALWAYS_INLINE decltype(auto) operator()(
+      const db::DataBox<DataBoxTagList>& box) noexcept {
+    return get(get<Spectral::Swsh::Tags::Derivative<Tags::Dy<Tag>, DerivKind>>(
+                   box))
+        .data();
+  }
+};
+
+// compute the derivative of the `jbar * (q - 2 eth_beta)` using the product
+// rule and the commutation rule for the partials with respect to y and the
+// spin_weighted derivatives
+template <>
+struct OnDemandInputsForSwshJacobianImpl<Tags::Dy<Tags::JbarQMinus2EthBeta>,
+                                         std::integral_constant<int, -1>,
+                                         std::true_type> {
+  template <typename DataBoxTagList>
+  SPECTRE_ALWAYS_INLINE decltype(auto) operator()(
+      const db::DataBox<DataBoxTagList>& box) noexcept {
+    decltype(auto) dy_beta = get(get<Tags::Dy<Tags::BondiBeta>>(box)).data();
+    decltype(auto) dy_j = get(get<Tags::Dy<Tags::BondiJ>>(box)).data();
+    decltype(auto) dy_q = get(get<Tags::Dy<Tags::BondiQ>>(box)).data();
+    decltype(auto) eth_beta =
+        get(get<Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                                 Spectral::Swsh::Tags::Eth>>(
+                box))
+            .data();
+    decltype(auto) eth_dy_beta =
+        get(get<Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiBeta>,
+                                                 Spectral::Swsh::Tags::Eth>>(
+                box))
+            .data();
+    decltype(auto) eth_r_divided_by_r =
+        get(get<Tags::EthRDividedByR>(box)).data();
+    decltype(auto) j = get(get<Tags::BondiJ>(box)).data();
+    decltype(auto) q = get(get<Tags::BondiQ>(box)).data();
+    return conj(j) * dy_q + conj(dy_j) * q - 2.0 * conj(j) * eth_dy_beta -
+           2.0 * eth_beta * conj(dy_j) -
+           2.0 * conj(j) * eth_r_divided_by_r * dy_beta;
+  }
+};
+}  // namespace detail
+
+/// Provide an expression template or reference to `Tag`, intended for
+/// situations for which a repeated computation is more
+/// desirable than storing a value in the \ref DataBoxGroup (e.g. for
+/// conjugation and simple product rule expansion).
+template <typename Tag>
+using OnDemandInputsForSwshJacobian = detail::OnDemandInputsForSwshJacobianImpl<
+    Tag, std::integral_constant<int, Tag::type::type::spin>, std::true_type>;
+
+/*!
+ * \brief Performs a mutation to a spin-weighted spherical harmonic derivative
+ * value from the numerical coordinate (the spin-weighted derivative at
+ * fixed \f$y\f$) to the Bondi coordinates (the spin-weighted derivative at
+ * fixed \f$r\f$), inplace to the requested tag.
+ *
+ * \details This should be performed only once for each derivative evaluation
+ * for each tag, as a repeated inplace evaluation will compound and result in
+ * incorrect values in the \ref DataBoxGroup. This is compatible with acting as
+ * a mutation in `db::mutate_apply`.
+ * \note In each specialization, there is an additional type alias
+ * `on_demand_argument_tags` that contains tags that represent additional
+ * quantities to be passed as arguments that need not be in the \ref
+ * DataBoxGroup. These quantities are suggested to be evaluated by the 'on
+ * demand' mechanism provided by `Cce::OnDemandInputsForSwshJacobian`, which
+ * provides the additional quantities as blaze expression templates rather than
+ * unnecessarily caching intermediate results that aren't re-used.
+ */
+template <typename DerivativeTag>
+struct ApplySwshJacobianInplace;
+
+/*!
+ * \brief Specialization for the spin-weighted derivative \f$\eth\f$.
+ *
+ * \details The implemented equation is:
+ *
+ * \f[ \eth F = \eth^\prime F - (1 - y) \frac{\eth R}{R} \partial_y F,
+ * \f]
+ *
+ * where \f$\eth\f$ is the derivative at constant Bondi radius \f$r\f$ and
+ * \f$\eth^\prime\f$ is the derivative at constant numerical radius \f$y\f$.
+ */
+template <typename ArgumentTag>
+struct ApplySwshJacobianInplace<
+    Spectral::Swsh::Tags::Derivative<ArgumentTag, Spectral::Swsh::Tags::Eth>> {
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integration_independent_tags =
+      tmpl::list<Tags::OneMinusY, Tags::EthRDividedByR>;
+
+  using return_tags = tmpl::list<
+      Spectral::Swsh::Tags::Derivative<ArgumentTag, Spectral::Swsh::Tags::Eth>>;
+  using argument_tags = tmpl::append<integration_independent_tags>;
+  using on_demand_argument_tags = tmpl::list<Tags::Dy<ArgumentTag>>;
+
+  static constexpr int spin =
+      Spectral::Swsh::Tags::Derivative<ArgumentTag,
+                                       Spectral::Swsh::Tags::Eth>::spin;
+  template <typename DyArgumentType>
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, spin>>*>
+          eth_argument,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+      const DyArgumentType& dy_argument) {
+    get(*eth_argument) -= get(one_minus_y) * get(eth_r_divided_by_r) *
+                          SpinWeighted<DyArgumentType, spin - 1>{dy_argument};
+  }
+};
+
+/*!
+ * \brief Specialization for the spin-weighted derivative \f$\bar{\eth}\f$.
+ *
+ * \details The implemented equation is:
+ *
+ * \f[
+ * \bar{\eth} F = \bar{\eth}^\prime F
+ * - (1 - y) \frac{\bar{\eth} R}{R} \partial_y F,
+ *\f]
+ *
+ * where \f$\bar{\eth}\f$ is the derivative at constant Bondi radius \f$r\f$ and
+ * \f$\bar{\eth}^\prime\f$ is the derivative at constant numerical radius
+ * \f$y\f$.
+ */
+template <typename ArgumentTag>
+struct ApplySwshJacobianInplace<Spectral::Swsh::Tags::Derivative<
+    ArgumentTag, Spectral::Swsh::Tags::Ethbar>> {
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integration_independent_tags =
+      tmpl::list<Tags::OneMinusY, Tags::EthRDividedByR>;
+
+  using return_tags = tmpl::list<Spectral::Swsh::Tags::Derivative<
+      ArgumentTag, Spectral::Swsh::Tags::Ethbar>>;
+  using argument_tags = tmpl::append<integration_independent_tags>;
+  using on_demand_argument_tags = tmpl::list<Tags::Dy<ArgumentTag>>;
+
+  static constexpr int spin =
+      Spectral::Swsh::Tags::Derivative<ArgumentTag,
+                                       Spectral::Swsh::Tags::Ethbar>::spin;
+  template <typename DyArgumentType>
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, spin>>*>
+          ethbar_argument,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+      const DyArgumentType& dy_argument) {
+    get(*ethbar_argument) -=
+        get(one_minus_y) * conj(get(eth_r_divided_by_r)) *
+        SpinWeighted<DyArgumentType, spin + 1>{dy_argument};
+  }
+};
+
+/*!
+ * \brief Specialization for the spin-weighted derivative \f$\eth \bar{\eth}\f$.
+ *
+ * \details The implemented equation is:
+ *
+ * \f[
+ * \eth \bar{\eth} F = \eth^\prime \bar{\eth}^\prime F
+ * - \frac{\eth R \bar{\eth} R}{R^2} (1 - y)^2 \partial_y^2 F
+ * - (1 - y)\left(\frac{\eth R}{R} \bar{\eth} \partial_y F
+ * + \frac{\bar{\eth} R}{R} \eth \partial_y F
+ * + \frac{\eth \bar\eth R}{R} \partial_y F\right),
+ * \f]
+ *
+ * where \f$\eth \bar{\eth}\f$ is the derivative at constant Bondi radius
+ * \f$r\f$ and \f$\eth^\prime \bar{\eth}^\prime\f$ is the derivative at constant
+ * numerical radius \f$y\f$.
+ */
+template <typename ArgumentTag>
+struct ApplySwshJacobianInplace<Spectral::Swsh::Tags::Derivative<
+    ArgumentTag, Spectral::Swsh::Tags::EthEthbar>> {
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integration_independent_tags =
+      tmpl::list<Tags::OneMinusY, Tags::EthRDividedByR,
+                 Tags::EthEthbarRDividedByR>;
+
+  using return_tags = tmpl::list<Spectral::Swsh::Tags::Derivative<
+      ArgumentTag, Spectral::Swsh::Tags::EthEthbar>>;
+  using argument_tags = tmpl::append<integration_independent_tags>;
+  using on_demand_argument_tags =
+      tmpl::list<Tags::Dy<ArgumentTag>, Tags::Dy<Tags::Dy<ArgumentTag>>,
+                 Spectral::Swsh::Tags::Derivative<Tags::Dy<ArgumentTag>,
+                                                  Spectral::Swsh::Tags::Eth>,
+                 Spectral::Swsh::Tags::Derivative<
+                     Tags::Dy<ArgumentTag>, Spectral::Swsh::Tags::Ethbar>>;
+
+  static constexpr int spin =
+      Spectral::Swsh::Tags::Derivative<ArgumentTag,
+                                       Spectral::Swsh::Tags::EthEthbar>::spin;
+  template <typename DyArgumentType, typename DyDyArgumentType,
+            typename EthDyArgumentType, typename EthbarDyArgumentType>
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, spin>>*>
+          eth_ethbar_argument,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>&
+          eth_ethbar_r_divided_by_r,
+      const DyArgumentType& dy_argument, const DyDyArgumentType& dy_dy_argument,
+      const EthDyArgumentType& eth_dy_argument,
+      const EthbarDyArgumentType ethbar_dy_argument) {
+    get(*eth_ethbar_argument) -=
+        get(eth_r_divided_by_r) * conj(get(eth_r_divided_by_r)) *
+            (square(get(one_minus_y)) *
+             SpinWeighted<DyDyArgumentType, spin>{dy_dy_argument}) +
+        get(one_minus_y) *
+            (get(eth_r_divided_by_r) *
+                 SpinWeighted<EthbarDyArgumentType, spin - 1>{
+                     ethbar_dy_argument} +
+             conj(get(eth_r_divided_by_r)) *
+                 SpinWeighted<EthDyArgumentType, spin + 1>{eth_dy_argument} +
+             get(eth_ethbar_r_divided_by_r) *
+                 SpinWeighted<DyArgumentType, spin>{dy_argument});
+  }
+};
+
+/*!
+ * \brief Specialization for the spin-weighted derivative \f$\bar{\eth} \eth\f$.
+ *
+ * \details The implemented equation is:
+ *
+ * \f[
+ * \bar{\eth} \eth F = \bar{\eth}^\prime \eth^\prime F
+ * - \frac{\eth R \bar{\eth} R}{R^2} (1 - y)^2 \partial_y^2 F
+ * - (1 - y)\left(\frac{\eth R}{R} \bar{\eth} \partial_y F
+ * + \frac{\bar{\eth} R}{R} \eth \partial_y F
+ * + \frac{\eth \bar\eth R}{R} \partial_y F\right),
+ * \f]
+ *
+ * where \f$\bar{\eth} \eth\f$ is the derivative at constant Bondi radius
+ * \f$r\f$ and \f$\bar{\eth}^\prime \eth^\prime\f$ is the derivative at constant
+ * numerical radius \f$y\f$.
+ */
+template <typename ArgumentTag>
+struct ApplySwshJacobianInplace<Spectral::Swsh::Tags::Derivative<
+    ArgumentTag, Spectral::Swsh::Tags::EthbarEth>> {
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integration_independent_tags =
+      tmpl::list<Tags::OneMinusY, Tags::EthRDividedByR,
+                 Tags::EthEthbarRDividedByR>;
+
+  using return_tags = tmpl::list<Spectral::Swsh::Tags::Derivative<
+      ArgumentTag, Spectral::Swsh::Tags::EthbarEth>>;
+  using argument_tags = tmpl::append<integration_independent_tags>;
+  using on_demand_argument_tags =
+      tmpl::list<Tags::Dy<ArgumentTag>, Tags::Dy<Tags::Dy<ArgumentTag>>,
+                 Spectral::Swsh::Tags::Derivative<Tags::Dy<ArgumentTag>,
+                                                  Spectral::Swsh::Tags::Eth>,
+                 Spectral::Swsh::Tags::Derivative<
+                     Tags::Dy<ArgumentTag>, Spectral::Swsh::Tags::Ethbar>>;
+
+  static constexpr int spin =
+      Spectral::Swsh::Tags::Derivative<ArgumentTag,
+                                       Spectral::Swsh::Tags::EthbarEth>::spin;
+  template <typename DyArgumentType, typename DyDyArgumentType,
+            typename EthDyArgumentType, typename EthbarDyArgumentType>
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, spin>>*>
+          ethbar_eth_argument,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>&
+          eth_ethbar_r_divided_by_r,
+      const DyArgumentType& dy_argument, const DyDyArgumentType& dy_dy_argument,
+      const EthDyArgumentType& eth_dy_argument,
+      const EthbarDyArgumentType ethbar_dy_argument) {
+    get(*ethbar_eth_argument) -=
+        get(eth_r_divided_by_r) * conj(get(eth_r_divided_by_r)) *
+            (square(get(one_minus_y)) *
+             SpinWeighted<DyDyArgumentType, spin>{dy_dy_argument}) +
+        get(one_minus_y) *
+            (get(eth_r_divided_by_r) *
+                 SpinWeighted<EthbarDyArgumentType, spin - 1>{
+                     ethbar_dy_argument} +
+             conj(get(eth_r_divided_by_r)) *
+                 SpinWeighted<EthDyArgumentType, spin + 1>{eth_dy_argument} +
+             get(eth_ethbar_r_divided_by_r) *
+                 SpinWeighted<DyArgumentType, spin>{dy_argument});
+  }
+};
+
+/*!
+ * \brief Specialization for the spin-weighted derivative \f$\eth \eth\f$.
+ *
+ * \details The implemented equation is:
+ *
+ * \f[
+ * \eth \eth F = \eth^\prime \eth^\prime F
+ * - (1 - y)^2 \frac{(\eth R)^2}{R^2} \partial_y^2 F
+ * - (1 - y) \left( 2 \frac{\eth R}{R} \eth \partial_y F
+ * + \frac{\eth \eth R}{R} \partial_y F\right),
+ * \f]
+ *
+ * where \f$\eth \eth\f$ is the derivative at constant Bondi radius \f$r\f$ and
+ * \f$\eth^\prime \eth^\prime\f$ is the derivative at constant numerical radius
+ * \f$y\f$.
+ */
+template <typename ArgumentTag>
+struct ApplySwshJacobianInplace<Spectral::Swsh::Tags::Derivative<
+    ArgumentTag, Spectral::Swsh::Tags::EthEth>> {
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integration_independent_tags =
+      tmpl::list<Tags::OneMinusY, Tags::EthRDividedByR,
+                 Tags::EthEthRDividedByR>;
+
+  using return_tags = tmpl::list<Spectral::Swsh::Tags::Derivative<
+      ArgumentTag, Spectral::Swsh::Tags::EthEth>>;
+  using argument_tags = tmpl::append<integration_independent_tags>;
+  using on_demand_argument_tags =
+      tmpl::list<Tags::Dy<ArgumentTag>, Tags::Dy<Tags::Dy<ArgumentTag>>,
+                 Spectral::Swsh::Tags::Derivative<Tags::Dy<ArgumentTag>,
+                                                  Spectral::Swsh::Tags::Eth>>;
+
+  static constexpr int spin =
+      Spectral::Swsh::Tags::Derivative<ArgumentTag,
+                                       Spectral::Swsh::Tags::EthEth>::spin;
+  template <typename DyArgumentType, typename DyDyArgumentType,
+            typename EthDyArgumentType>
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, spin>>*>
+          eth_eth_argument,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& eth_eth_r_divided_by_r,
+      const DyArgumentType& dy_argument, const DyDyArgumentType& dy_dy_argument,
+      const EthDyArgumentType& eth_dy_argument) {
+    get(*eth_eth_argument) -=
+        square(get(eth_r_divided_by_r)) *
+            (square(get(one_minus_y)) *
+             SpinWeighted<DyDyArgumentType, spin - 2>{dy_dy_argument}) +
+        get(one_minus_y) *
+            (2.0 * get(eth_r_divided_by_r) *
+                 SpinWeighted<EthDyArgumentType, spin - 1>{eth_dy_argument} +
+             get(eth_eth_r_divided_by_r) *
+                 SpinWeighted<DyArgumentType, spin - 2>{dy_argument});
+  }
+};
+
+/*!
+ * \brief Specialization for the spin-weighted derivative \f$\bar{\eth}
+ * \bar{\eth}\f$.
+ *
+ * \details The implemented equation is:
+ *
+ * \f[
+ * \bar{\eth} \bar{\eth} F = \bar{\eth}^\prime \bar{\eth}^\prime F
+ * - (1 - y)^2 \frac{(\bar{\eth} R)^2}{R^2} \partial_y^2 F
+ * - (1 - y) \left( 2 \frac{\bar{\eth} R}{R} \bar{\eth} \partial_y F
+ * + \frac{\bar{\eth} \bar{\eth} R}{R} \partial_y F\right),
+ * \f]
+ *
+ * where \f$\bar{\eth} \bar{\eth}\f$ is the derivative at constant Bondi radius
+ * \f$r\f$ and \f$\bar{\eth}^\prime \bar{\eth}^\prime\f$ is the derivative at
+ * constant numerical radius \f$y\f$.
+ */
+template <typename ArgumentTag>
+struct ApplySwshJacobianInplace<Spectral::Swsh::Tags::Derivative<
+    ArgumentTag, Spectral::Swsh::Tags::EthbarEthbar>> {
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integration_independent_tags =
+      tmpl::list<Tags::OneMinusY, Tags::EthRDividedByR,
+                 Tags::EthEthRDividedByR>;
+
+  using return_tags = tmpl::list<Spectral::Swsh::Tags::Derivative<
+      ArgumentTag, Spectral::Swsh::Tags::EthbarEthbar>>;
+  using argument_tags = tmpl::append<integration_independent_tags>;
+  using on_demand_argument_tags =
+      tmpl::list<Tags::Dy<ArgumentTag>, Tags::Dy<Tags::Dy<ArgumentTag>>,
+                 Spectral::Swsh::Tags::Derivative<
+                     Tags::Dy<ArgumentTag>, Spectral::Swsh::Tags::Ethbar>>;
+
+  static constexpr int spin = Spectral::Swsh::Tags::Derivative<
+      ArgumentTag, Spectral::Swsh::Tags::EthbarEthbar>::spin;
+  template <typename DyArgumentType, typename DyDyArgumentType,
+            typename EthbarDyArgumentType>
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, spin>>*>
+          ethbar_ethbar_argument,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& eth_eth_r_divided_by_r,
+      const DyArgumentType& dy_argument, const DyDyArgumentType& dy_dy_argument,
+      const EthbarDyArgumentType& ethbar_dy_argument) {
+    get(*ethbar_ethbar_argument) -=
+        square(conj(get(eth_r_divided_by_r))) *
+            (square(get(one_minus_y)) *
+             SpinWeighted<DyDyArgumentType, spin + 2>{dy_dy_argument}) +
+        get(one_minus_y) *
+            (2.0 * conj(get(eth_r_divided_by_r)) *
+                 SpinWeighted<EthbarDyArgumentType, spin + 1>{
+                     ethbar_dy_argument} +
+             conj(get(eth_eth_r_divided_by_r)) *
+                 SpinWeighted<DyArgumentType, spin + 2>{dy_argument});
+  }
+};
+
+namespace detail {
+// A helper to forward to the `ApplySwshJacobianInplace` mutators that takes
+// advantage of the `OnDemandInputsForSwshJacobian`, which computes blaze
+// template expressions for those quantities for which it is anticipated to be
+// sufficiently cheap to repeatedly compute that it is worth saving the cost of
+// additional storage (e.g. conjugates and derivatives for which the product
+// rule applies)
+template <typename DerivativeTag, typename DataBoxTagList,
+          typename... OnDemandTags>
+void apply_swsh_jacobian_helper(
+    const gsl::not_null<db::DataBox<DataBoxTagList>*> box,
+    tmpl::list<OnDemandTags...> /*meta*/) noexcept {
+  db::mutate_apply<ApplySwshJacobianInplace<DerivativeTag>>(
+      box, OnDemandInputsForSwshJacobian<OnDemandTags>{}(*box)...);
+}
+}  // namespace detail
+
+/*!
+ * \brief This routine evaluates the set of inputs to the CCE integrand for
+ * `BondiValueTag` which are spin-weighted angular derivatives.
+
+ * \details This function is called on the \ref DataBoxGroup holding the
+ * relevant CCE data during each hypersurface integration step, after evaluating
+ * `mutate_all_pre_swsh_derivatives_for_tag()` with template argument
+ * `BondiValueTag` and before evaluating `ComputeBondiIntegrand<BondiValueTag>`.
+ * Provided a \ref DataBoxGroup with the appropriate tags (including
+ * `Cce::all_pre_swsh_derivative_tags`, `Cce::all_swsh_derivative_tags`,
+ * `Cce::all_transform_buffer_tags`,  `Cce::pre_computation_tags`, and
+ * `Spectral::Swsh::Tags::LMax`), this function will apply all of the necessary
+ * mutations to update
+ * `Cce::single_swsh_derivative_tags_to_compute_for<BondiValueTag>` and
+ * `Cce::second_swsh_derivative_tags_to_compute_for<BondiValueTag>` to their
+ * correct values for the current values of the remaining (input) tags.
+ */
+template <typename BondiValueTag, typename DataBoxTagList>
+void mutate_all_swsh_derivatives_for_tag(
+    const gsl::not_null<db::DataBox<DataBoxTagList>*> box) noexcept {
+  // The collection of spin-weighted derivatives cannot be applied as individual
+  // compute items, because it is better to aggregate similar spins and dispatch
+  // to libsharp in groups. So, we supply a bulk mutate operation which takes in
+  // multiple Variables from the presumed DataBox, and alters their values as
+  // necessary.
+  db::mutate_apply<Spectral::Swsh::AngularDerivatives<
+      single_swsh_derivative_tags_to_compute_for_t<BondiValueTag>>>(box);
+  tmpl::for_each<single_swsh_derivative_tags_to_compute_for_t<BondiValueTag>>(
+      [&box](auto derivative_tag_v) noexcept {
+        using derivative_tag = typename decltype(derivative_tag_v)::type;
+        detail::apply_swsh_jacobian_helper<derivative_tag>(
+            box, typename ApplySwshJacobianInplace<
+                     derivative_tag>::on_demand_argument_tags{});
+      });
+
+  db::mutate_apply<Spectral::Swsh::AngularDerivatives<
+      second_swsh_derivative_tags_to_compute_for_t<BondiValueTag>>>(box);
+  tmpl::for_each<second_swsh_derivative_tags_to_compute_for_t<BondiValueTag>>(
+      [&box](auto derivative_tag_v) noexcept {
+        using derivative_tag = typename decltype(derivative_tag_v)::type;
+        detail::apply_swsh_jacobian_helper<derivative_tag>(
+            box, typename ApplySwshJacobianInplace<
+                     derivative_tag>::on_demand_argument_tags{});
+      });
+}
+}  // namespace Cce

--- a/src/NumericalAlgorithms/Spectral/SwshTags.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTags.hpp
@@ -103,6 +103,11 @@ std::string compose_spin_weighted_derivative_name(
 
 }  // namespace detail
 
+/// Convenience metafunction for accessing the tag from which a `Derivative` was
+/// derived.
+template <typename Tag>
+using derived_from = typename Tag::derived_from;
+
 /// \ingroup SwshGroup
 /// \brief Prefix tag representing the spin-weighted derivative of a
 /// spin-weighted scalar.

--- a/src/Utilities/VectorAlgebra.hpp
+++ b/src/Utilities/VectorAlgebra.hpp
@@ -40,7 +40,9 @@ ResultVectorType outer_product(const LhsVectorType& lhs,
 
 // @{
 /// \ingroup UtilitiesGroup
-/// \brief Repeats a vector `times_to_repeat` times.
+/// \brief Creates or fills a vector with data from `to_repeat` copied
+/// `times_to_repeat`  times in sequence.
+///
 /// \details This can be useful for generating data that consists of the same
 /// block of values duplicated a number of times. For instance, this can be used
 /// to create a vector representing three-dimensional volume data from a
@@ -49,21 +51,23 @@ ResultVectorType outer_product(const LhsVectorType& lhs,
 /// three-dimensional representation. The result would then be uniform in the
 /// slowest-varying direction of the three dimensional grid.
 template <typename VectorType>
-void repeat(const gsl::not_null<VectorType*> result,
-            const VectorType& to_repeat,
-            const size_t times_to_repeat) noexcept {
-  result->destructive_resize(to_repeat.size() * times_to_repeat);
-  for (size_t i = 0; i < times_to_repeat; ++i) {
-    VectorType view{result->data() + i * to_repeat.size(), to_repeat.size()};
-    view = to_repeat;
+void fill_with_n_copies(const gsl::not_null<VectorType*> result,
+                        const VectorType& to_copy,
+                        const size_t times_to_copy) noexcept {
+  result->destructive_resize(to_copy.size() * times_to_copy);
+  for (size_t i = 0; i < times_to_copy; ++i) {
+    VectorType view{result->data() + i * to_copy.size(), to_copy.size()};
+    view = to_copy;
   }
 }
 
+// clang-tidy incorrectly believes this to be a forward-declaration
 template <typename VectorType>
-VectorType repeat(const VectorType& to_repeat,
-                  const size_t times_to_repeat) noexcept {
-  auto result = VectorType{to_repeat.size() * times_to_repeat};
-  repeat(make_not_null(&result), to_repeat, times_to_repeat);
+VectorType create_vector_of_n_copies(
+    const VectorType& to_copy,
+    const size_t times_to_copy) noexcept {  // NOLINT
+  auto result = VectorType{to_copy.size() * times_to_copy};
+  fill_with_n_copies(make_not_null(&result), to_copy, times_to_copy);
   return result;
 }
 // @}

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_Cce")
 
 set(LIBRARY_SOURCES
   CceComputationTestHelpers.cpp
+  Test_PreSwshDerivatives.cpp
   Test_Equations.cpp
   Test_InitializeCce.cpp
   Test_LinearOperators.cpp

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -5,12 +5,13 @@ set(LIBRARY "Test_Cce")
 
 set(LIBRARY_SOURCES
   CceComputationTestHelpers.cpp
-  Test_PreSwshDerivatives.cpp
   Test_Equations.cpp
   Test_InitializeCce.cpp
   Test_LinearOperators.cpp
   Test_LinearSolve.cpp
+  Test_PreSwshDerivatives.cpp
   Test_PrecomputeCceDependencies.cpp
+  Test_SwshDerivatives.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/Cce/CceComputationTestHelpers.hpp
+++ b/tests/Unit/Evolution/Systems/Cce/CceComputationTestHelpers.hpp
@@ -5,16 +5,23 @@
 
 #include <cstddef>
 
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tags.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/VectorAlgebra.hpp"
 #include "tests/Unit/TestingFramework.hpp"
-
-/// \cond
-class ComplexDataVector;
-class ComplexModalVector;
-/// \endcond
+#include "tests/Utilities/MakeWithRandomValues.hpp"
 
 namespace Cce {
 namespace TestHelpers {
@@ -46,7 +53,7 @@ ComplexDataVector power(const ComplexDataVector& value,
                         size_t exponent) noexcept;
 
 // A utility for copying a set of tags from one DataBox to another. Useful in
-// the Cce tests, where often an expected input needs to be copied to the box
+// the CCE tests, where often an expected input needs to be copied to the box
 // which is to be tested.
 template <typename... Tags>
 struct CopyDataBoxTags {
@@ -56,8 +63,8 @@ struct CopyDataBoxTags {
     db::mutate<Tags...>(
         to_data_box,
         [](const gsl::not_null<db::item_type<Tags>*>... to_value,
-           const typename Tags::type&... from_value) {
-          auto assign = [](auto to, auto from) {
+           const typename Tags::type&... from_value) noexcept {
+          const auto assign = [](auto to, const auto& from) noexcept {
             *to = from;
             return 0;
           };
@@ -66,5 +73,313 @@ struct CopyDataBoxTags {
         db::get<Tags>(from_data_box)...);
   }
 };
+
+// Given the angular and radial dependence separately, assembles the volume data
+// by computing the tensor product.
+void generate_volume_data_from_separated_values(
+    gsl::not_null<ComplexDataVector*> volume_data,
+    gsl::not_null<ComplexDataVector*> one_divided_by_r,
+    const ComplexDataVector& angular_collocation,
+    const ComplexModalVector& radial_coefficients, size_t l_max,
+    size_t number_of_radial_grid_points) noexcept;
+
+// A utility for separately verifying the values in several computation
+// routines in the CCE quantity derivations. These are an independent
+// computation of similar quantities needed in the CCE systems under the
+// assumption that the values are separable, i.e. can be written as F(theta,
+// phi, r) = f(theta, phi) * g(r), and performing semi-analytic manipulations
+// using simplifications from separability and an explicit decomposition of g in
+// inverse powers of r.
+template <typename Tag>
+struct CalculateSeparatedTag;
+
+template <typename Tag>
+struct CalculateSeparatedTag<Tags::Dy<Tag>> {
+  // d x/dy = d x /dr * (2 R / (1-y)^2) = dx/dr * r^2 / (2 R)
+  // So, for x = r^(-n),
+  // d (r^(-n))/dy = -n * r^(-n - 1) * r^2 / (2 R) = -n / (2 R) r^(-n + 1)
+  // except when n=0, then the result is zero. So, the entire process actually
+  // moves the polynomials down in order
+  template <typename AngularTagList, typename RadialCoefficientTagList>
+  void operator()(
+      const gsl::not_null<Variables<AngularTagList>*> angular_collocation,
+      const gsl::not_null<Variables<RadialCoefficientTagList>*>
+          radial_coefficients,
+      const ComplexDataVector& /*one_divided_by_r*/,
+      const ComplexDataVector& boundary_r, const size_t /*l_max*/) noexcept {
+    get(get<AngularCollocationsFor<Tags::Dy<Tag>>>(*angular_collocation))
+        .data() =
+        get(get<AngularCollocationsFor<Tag>>(*angular_collocation)).data() /
+        (2.0 * boundary_r);
+
+    ComplexModalVector& dy_radial_values = get(
+        get<RadialPolyCoefficientsFor<Tags::Dy<Tag>>>(*radial_coefficients));
+    const ComplexModalVector& radial_values =
+        get(get<RadialPolyCoefficientsFor<Tag>>(*radial_coefficients));
+
+    for (size_t radial_power = 1;
+         radial_power < radial_coefficients->number_of_grid_points();
+         ++radial_power) {
+      dy_radial_values[radial_power - 1] =
+          -static_cast<double>(radial_power) * radial_values[radial_power];
+    }
+    dy_radial_values[radial_coefficients->number_of_grid_points() - 1] = 0.0;
+  }
+};
+
+template <typename Tag, typename DerivKind>
+struct CalculateSeparatedTag<Spectral::Swsh::Tags::Derivative<Tag, DerivKind>> {
+  template <typename AngularTagList, typename RadialCoefficientTagList>
+  void operator()(
+      const gsl::not_null<Variables<AngularTagList>*> angular_collocation,
+      const gsl::not_null<Variables<RadialCoefficientTagList>*>
+          radial_coefficients,
+      const ComplexDataVector& /*one_divided_by_r*/,
+      const ComplexDataVector& /*boundary_r*/, const size_t l_max) noexcept {
+    get(get<AngularCollocationsFor<
+            Spectral::Swsh::Tags::Derivative<Tag, DerivKind>>>(
+        *angular_collocation)) =
+        Spectral::Swsh::angular_derivative<DerivKind>(
+            l_max, 1,
+            get(get<AngularCollocationsFor<Tag>>(*angular_collocation)));
+    // The spin-weighted derivatives are evaluated at constant r, so the radial
+    // coefficients are unaltered.
+    get(get<RadialPolyCoefficientsFor<
+            Spectral::Swsh::Tags::Derivative<Tag, DerivKind>>>(
+        *radial_coefficients)) =
+        get(get<RadialPolyCoefficientsFor<Tag>>(*radial_coefficients));
+  }
+};
+
+template <typename LhsTag, typename RhsTag>
+struct CalculateSeparatedTag<::Tags::Multiplies<LhsTag, RhsTag>> {
+  template <typename AngularTagList, typename RadialCoefficientTagList>
+  void operator()(
+      const gsl::not_null<Variables<AngularTagList>*> angular_collocation,
+      const gsl::not_null<Variables<RadialCoefficientTagList>*>
+          radial_coefficients,
+      const ComplexDataVector& /*one_divided_by_r*/,
+      const ComplexDataVector& /*boundary_r*/,
+      const size_t /*l_max*/) noexcept {
+    get(get<AngularCollocationsFor<::Tags::Multiplies<LhsTag, RhsTag>>>(
+        *angular_collocation)) =
+        get(get<AngularCollocationsFor<LhsTag>>(*angular_collocation)) *
+        get(get<AngularCollocationsFor<RhsTag>>(*angular_collocation));
+
+    ComplexModalVector& multiplied_radial_values =
+        get(get<RadialPolyCoefficientsFor<::Tags::Multiplies<LhsTag, RhsTag>>>(
+            *radial_coefficients));
+    const ComplexModalVector& lhs_radial_values =
+        get(get<RadialPolyCoefficientsFor<LhsTag>>(*radial_coefficients));
+    const ComplexModalVector& rhs_radial_values =
+        get(get<RadialPolyCoefficientsFor<RhsTag>>(*radial_coefficients));
+    multiplied_radial_values = 0.0;
+    for (size_t lhs_radial_power = 0;
+         lhs_radial_power < radial_coefficients->number_of_grid_points();
+         ++lhs_radial_power) {
+      for (size_t rhs_radial_power = 0;
+           rhs_radial_power <
+           radial_coefficients->number_of_grid_points() - lhs_radial_power;
+           ++rhs_radial_power) {
+        multiplied_radial_values[lhs_radial_power + rhs_radial_power] +=
+            lhs_radial_values[lhs_radial_power] *
+            rhs_radial_values[rhs_radial_power];
+      }
+    }
+  }
+};
+
+template <>
+struct CalculateSeparatedTag<Tags::BondiJbar> {
+  template <typename AngularTagList, typename RadialCoefficientTagList>
+  void operator()(
+      const gsl::not_null<Variables<AngularTagList>*> angular_collocation,
+      const gsl::not_null<Variables<RadialCoefficientTagList>*>
+          radial_coefficients,
+      const ComplexDataVector& /*one_divided_by_r*/,
+      const ComplexDataVector& /*boundary_r*/,
+      const size_t /*l_max*/) noexcept {
+    get(get<AngularCollocationsFor<Tags::BondiJbar>>(*angular_collocation)) =
+        conj(get(
+            get<AngularCollocationsFor<Tags::BondiJ>>(*angular_collocation)));
+    get(get<RadialPolyCoefficientsFor<Tags::BondiJbar>>(*radial_coefficients)) =
+        conj(get(get<RadialPolyCoefficientsFor<Tags::BondiJ>>(
+            *radial_coefficients)));
+  }
+};
+
+template <>
+struct CalculateSeparatedTag<Tags::BondiUbar> {
+  template <typename AngularTagList, typename RadialCoefficientTagList>
+  void operator()(
+      const gsl::not_null<Variables<AngularTagList>*> angular_collocation,
+      const gsl::not_null<Variables<RadialCoefficientTagList>*>
+          radial_coefficients,
+      const ComplexDataVector& /*one_divided_by_r*/,
+      const ComplexDataVector& /*boundary_r*/,
+      const size_t /*l_max*/) noexcept {
+    get(get<AngularCollocationsFor<Tags::BondiUbar>>(*angular_collocation)) =
+        conj(get(
+            get<AngularCollocationsFor<Tags::BondiU>>(*angular_collocation)));
+    get(get<RadialPolyCoefficientsFor<Tags::BondiUbar>>(*radial_coefficients)) =
+        conj(get(get<RadialPolyCoefficientsFor<Tags::BondiU>>(
+            *radial_coefficients)));
+  }
+};
+
+template <>
+struct CalculateSeparatedTag<Tags::BondiQbar> {
+  template <typename AngularTagList, typename RadialCoefficientTagList>
+  void operator()(
+      const gsl::not_null<Variables<AngularTagList>*> angular_collocation,
+      const gsl::not_null<Variables<RadialCoefficientTagList>*>
+          radial_coefficients,
+      const ComplexDataVector& /*one_divided_by_r*/,
+      const ComplexDataVector& /*boundary_r*/,
+      const size_t /*l_max*/) noexcept {
+    get(get<AngularCollocationsFor<Tags::BondiQbar>>(*angular_collocation)) =
+        conj(get(
+            get<AngularCollocationsFor<Tags::BondiQ>>(*angular_collocation)));
+    get(get<RadialPolyCoefficientsFor<Tags::BondiQbar>>(*radial_coefficients)) =
+        conj(get(get<RadialPolyCoefficientsFor<Tags::BondiQ>>(
+            *radial_coefficients)));
+  }
+};
+
+// A generation function used in the tests of the CCE computations for the
+// inputs to the integrand computation (`Test_PreSwshDerivatives.cpp`,
+// and `Test_ComputeSwshDerivatives.cpp`). This function first generates the set
+// of inputs specified by `InputTagList`, then emulates the cascaded
+// computations of those utilities, using the tag lists as though the integrands
+// that we wanted to compute were of the tags in `TargetTagList`. Instead of
+// computing the values using the utilities in the main code base, though, the
+// generation creates the expected values using the separable computations
+// above. While this is also a fairly complicated computation (though simpler
+// due to the assumption of separability), it is a completely independent method
+// so can be regarded as a robust way of verifying the utilities in the main
+// code base.
+template <typename InputTagList, typename TargetTagList,
+          typename PreSwshDerivativesTagList, typename SwshDerivativesTagList,
+          typename AngularCollocationTagList,
+          typename PreSwshDerivativesRadialModeTagList, typename Generator>
+void generate_separable_expected(
+    const gsl::not_null<Variables<PreSwshDerivativesTagList>*>
+        pre_swsh_derivatives,
+    const gsl::not_null<Variables<SwshDerivativesTagList>*> swsh_derivatives,
+    const gsl::not_null<Variables<AngularCollocationTagList>*>
+        angular_collocations,
+    const gsl::not_null<Variables<PreSwshDerivativesRadialModeTagList>*>
+        radial_modes,
+    const gsl::not_null<Generator*> generator,
+    const SpinWeighted<ComplexDataVector, 0>& boundary_r, const size_t l_max,
+    const size_t number_of_radial_points) noexcept {
+  const ComplexDataVector y = outer_product(
+      ComplexDataVector{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max), 1.0},
+      Spectral::collocation_points<Spectral::Basis::Legendre,
+                                   Spectral::Quadrature::GaussLobatto>(
+          number_of_radial_points));
+
+  // generate the separable variables
+  UniformCustomDistribution<double> dist(0.1, 1.0);
+
+  ComplexDataVector one_divided_by_r =
+      (1.0 - y) / (2.0 * repeat(boundary_r.data(), number_of_radial_points));
+
+  // the generation step for the 'input' tags
+  tmpl::for_each<InputTagList>([
+    &angular_collocations, &radial_modes, &pre_swsh_derivatives, &dist,
+    &generator, &l_max, &number_of_radial_points, &one_divided_by_r
+  ](auto tag_v) noexcept {
+    using tag = typename decltype(tag_v)::type;
+    using radial_polynomial_tag = RadialPolyCoefficientsFor<tag>;
+    using angular_collocation_tag = AngularCollocationsFor<tag>;
+    // generate the angular part randomly
+    get(get<angular_collocation_tag>(*angular_collocations)).data() =
+        make_with_random_values<ComplexDataVector>(
+            generator, make_not_null(&dist),
+            Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+    Spectral::Swsh::filter_swsh_boundary_quantity(
+        make_not_null(
+            &get(get<angular_collocation_tag>(*angular_collocations))),
+        l_max, 2);
+    // generate the radial part
+    auto& radial_polynomial = get(get<radial_polynomial_tag>(*radial_modes));
+    fill_with_random_values(make_not_null(&radial_polynomial), generator,
+                            make_not_null(&dist));
+    // filtering to make sure the results are reasonable,
+    // filter function: exp(-10.0 * (i / N)**2)
+    for (size_t i = 0; i < radial_polynomial.size(); ++i) {
+      radial_polynomial[i] *= exp(
+          -10.0 * square(static_cast<double>(i) /
+                         static_cast<double>(radial_polynomial.size() - 1)));
+      // aggressive Heaviside needed to get acceptable test precision at the low
+      // resolutions needed to keep tests fast.
+      if (i > 3) {
+        radial_polynomial[i] = 0.0;
+      }
+    }
+
+    generate_volume_data_from_separated_values(
+        make_not_null(&get(get<tag>(*pre_swsh_derivatives)).data()),
+        make_not_null(&one_divided_by_r),
+        get(get<angular_collocation_tag>(*angular_collocations)).data(),
+        radial_polynomial, l_max, number_of_radial_points);
+  });
+
+  // Compute the expected versions using the separable mathematics from above
+  // utilities
+  const auto calculate_separable_for_pre_swsh_derivative = [
+    &angular_collocations, &radial_modes, &pre_swsh_derivatives, &l_max,
+    &number_of_radial_points, &one_divided_by_r, &boundary_r
+  ](auto pre_swsh_derivative_tag_v) noexcept {
+    using pre_swsh_derivative_tag =
+        typename decltype(pre_swsh_derivative_tag_v)::type;
+    CalculateSeparatedTag<pre_swsh_derivative_tag>{}(
+        angular_collocations, radial_modes, one_divided_by_r, boundary_r.data(),
+        l_max);
+    generate_volume_data_from_separated_values(
+        make_not_null(
+            &get(get<pre_swsh_derivative_tag>(*pre_swsh_derivatives)).data()),
+        make_not_null(&one_divided_by_r),
+        get(get<AngularCollocationsFor<pre_swsh_derivative_tag>>(
+                *angular_collocations))
+            .data(),
+        get(get<RadialPolyCoefficientsFor<pre_swsh_derivative_tag>>(
+            *radial_modes)),
+        l_max, number_of_radial_points);
+  };
+
+  const auto calculate_separable_for_swsh_derivative = [
+    &angular_collocations, &radial_modes, &swsh_derivatives, &l_max,
+    &number_of_radial_points, &one_divided_by_r, &boundary_r
+  ](auto swsh_derivative_tag_v) noexcept {
+    using swsh_derivative_tag = typename decltype(swsh_derivative_tag_v)::type;
+    CalculateSeparatedTag<swsh_derivative_tag>{}(angular_collocations,
+                                                 radial_modes, one_divided_by_r,
+                                                 boundary_r.data(), l_max);
+    generate_volume_data_from_separated_values(
+        make_not_null(&get(get<swsh_derivative_tag>(*swsh_derivatives)).data()),
+        make_not_null(&one_divided_by_r),
+        get(get<AngularCollocationsFor<swsh_derivative_tag>>(
+                *angular_collocations))
+            .data(),
+        get(get<RadialPolyCoefficientsFor<swsh_derivative_tag>>(*radial_modes)),
+        l_max, number_of_radial_points);
+  };
+
+  tmpl::for_each<TargetTagList>([
+    &calculate_separable_for_pre_swsh_derivative, &
+    calculate_separable_for_swsh_derivative
+  ](auto target_tag_v) noexcept {
+    using target_tag = typename decltype(target_tag_v)::type;
+    tmpl::for_each<pre_swsh_derivative_tags_to_compute_for_t<target_tag>>(
+        calculate_separable_for_pre_swsh_derivative);
+    tmpl::for_each<single_swsh_derivative_tags_to_compute_for_t<target_tag>>(
+        calculate_separable_for_swsh_derivative);
+    tmpl::for_each<second_swsh_derivative_tags_to_compute_for_t<target_tag>>(
+        calculate_separable_for_swsh_derivative);
+  });
+}
 }  // namespace TestHelpers
 }  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/CceComputationTestHelpers.hpp
+++ b/tests/Unit/Evolution/Systems/Cce/CceComputationTestHelpers.hpp
@@ -284,7 +284,8 @@ void generate_separable_expected(
   UniformCustomDistribution<double> dist(0.1, 1.0);
 
   ComplexDataVector one_divided_by_r =
-      (1.0 - y) / (2.0 * repeat(boundary_r.data(), number_of_radial_points));
+      (1.0 - y) / (2.0 * create_vector_of_n_copies(boundary_r.data(),
+                                                   number_of_radial_points));
 
   // the generation step for the 'input' tags
   tmpl::for_each<InputTagList>([

--- a/tests/Unit/Evolution/Systems/Cce/Test_PreSwshDerivatives.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_PreSwshDerivatives.cpp
@@ -1,0 +1,220 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <complex>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
+#include "Evolution/Systems/Cce/PreSwshDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/Evolution/Systems/Cce/CceComputationTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Cce {
+
+namespace {
+template <int Spin>
+struct TestSpinWeightedScalar : db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, Spin>>;
+  static std::string name() noexcept { return "TestSpinWeightedScalar"; }
+};
+
+using test_pre_swsh_derivative_dependencies =
+    tmpl::list<Tags::BondiBeta, Tags::BondiJ, Tags::BondiQ, Tags::BondiU>;
+}  // namespace
+
+namespace detail {
+// these are provided as a slimmed-down representation of a computational
+// procedure that suffices to demonstrate that all of the template
+// specializations of `PreSwshDerivatives` work correctly, rather than executing
+// the full sequence of CCE steps, which would be too heavy for this test.
+template <>
+struct TagsToComputeForImpl<TestSpinWeightedScalar<0>> {
+  using pre_swsh_derivative_tags =
+      tmpl::list<Tags::Dy<Tags::BondiJ>, Tags::Dy<Tags::Dy<Tags::BondiJ>>,
+                 Tags::Dy<Tags::BondiBeta>, Tags::Dy<Tags::Dy<Tags::BondiBeta>>,
+                 Tags::Dy<Tags::BondiU>, Tags::Dy<Tags::Dy<Tags::BondiU>>,
+                 Tags::Dy<Tags::BondiQ>, Tags::Dy<Tags::Dy<Tags::BondiQ>>>;
+  using second_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags = tmpl::list<>;
+};
+
+template <>
+struct TagsToComputeForImpl<TestSpinWeightedScalar<1>> {
+  using pre_swsh_derivative_tags = tmpl::list<
+      Tags::BondiJbar, Tags::BondiUbar, Tags::BondiQbar,
+      ::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>,
+      Tags::Dy<::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>>,
+      Tags::Dy<Tags::Dy<::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>>>,
+      ::Tags::Multiplies<Tags::BondiJbar, Tags::Dy<Tags::BondiJ>>,
+      ::Tags::Multiplies<Tags::BondiUbar, Tags::Dy<Tags::BondiJ>>,
+      Tags::Dy<::Tags::Multiplies<Tags::BondiUbar, Tags::Dy<Tags::BondiJ>>>,
+      Tags::Dy<::Tags::Multiplies<Tags::BondiJbar, Tags::Dy<Tags::BondiJ>>>>;
+  using second_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags = tmpl::list<>;
+};
+}  // namespace detail
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.PreSwshDerivatives",
+                  "[Unit][Evolution]") {
+  MAKE_GENERATOR(generator);
+  const size_t l_max = 8;
+  const size_t number_of_radial_grid_points = 8;
+
+  using pre_swsh_derivative_tag_list = tmpl::append<
+      pre_swsh_derivative_tags_to_compute_for_t<TestSpinWeightedScalar<0>>,
+      pre_swsh_derivative_tags_to_compute_for_t<TestSpinWeightedScalar<1>>,
+      test_pre_swsh_derivative_dependencies>;
+
+  using pre_swsh_derivatives_variables_tag =
+      ::Tags::Variables<pre_swsh_derivative_tag_list>;
+  using swsh_derivatives_variables_tag =
+      ::Tags::Variables<tmpl::list<Spectral::Swsh::Tags::Derivative<
+          Tags::BondiBeta, Spectral::Swsh::Tags::Eth>>>;
+  using separated_pre_swsh_derivatives_angular_data =
+      ::Tags::Variables<db::wrap_tags_in<TestHelpers::AngularCollocationsFor,
+                                         pre_swsh_derivative_tag_list>>;
+  using separated_pre_swsh_derivatives_radial_modes =
+      ::Tags::Variables<db::wrap_tags_in<TestHelpers::RadialPolyCoefficientsFor,
+                                         pre_swsh_derivative_tag_list>>;
+
+  const size_t number_of_grid_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
+      number_of_radial_grid_points;
+
+  auto expected_box = db::create<db::AddSimpleTags<
+      pre_swsh_derivatives_variables_tag, swsh_derivatives_variables_tag,
+      separated_pre_swsh_derivatives_angular_data,
+      separated_pre_swsh_derivatives_radial_modes>>(
+      typename pre_swsh_derivatives_variables_tag::type{number_of_grid_points},
+      typename swsh_derivatives_variables_tag::type{number_of_grid_points, 0.0},
+      typename separated_pre_swsh_derivatives_angular_data::type{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max)},
+      typename separated_pre_swsh_derivatives_radial_modes::type{
+          number_of_radial_grid_points});
+
+  db::mutate<pre_swsh_derivatives_variables_tag, swsh_derivatives_variables_tag,
+             separated_pre_swsh_derivatives_angular_data,
+             separated_pre_swsh_derivatives_radial_modes>(
+      make_not_null(&expected_box),
+      [&generator](
+          const gsl::not_null<
+              typename pre_swsh_derivatives_variables_tag::type*>
+              pre_swsh_derivatives,
+          const gsl::not_null<typename swsh_derivatives_variables_tag::type*>
+              swsh_derivatives,
+          const gsl::not_null<
+              typename separated_pre_swsh_derivatives_angular_data::type*>
+              pre_swsh_separated_angular_data,
+          const gsl::not_null<
+              typename separated_pre_swsh_derivatives_radial_modes::type*>
+              pre_swsh_separated_radial_modes) {
+        UniformCustomDistribution<double> dist(0.1, 1.0);
+        SpinWeighted<ComplexDataVector, 0> boundary_r;
+        boundary_r.data() =
+            (10.0 +
+             std::complex<double>(1.0, 0.0) *
+                 make_with_random_values<DataVector>(
+                     make_not_null(&generator), make_not_null(&dist),
+                     Spectral::Swsh::number_of_swsh_collocation_points(l_max)));
+        Spectral::Swsh::filter_swsh_boundary_quantity(
+            make_not_null(&boundary_r), l_max, l_max - 3);
+        TestHelpers::generate_separable_expected<
+            test_pre_swsh_derivative_dependencies,
+            tmpl::list<TestSpinWeightedScalar<0>, TestSpinWeightedScalar<1>>>(
+            pre_swsh_derivatives, swsh_derivatives,
+            pre_swsh_separated_angular_data, pre_swsh_separated_radial_modes,
+            make_not_null(&generator), boundary_r, l_max,
+            number_of_radial_grid_points);
+      });
+
+  auto computation_box = db::create<db::AddSimpleTags<
+      Spectral::Swsh::Tags::LMax, Tags::Integrand<Tags::BondiBeta>,
+      Tags::Integrand<Tags::BondiU>, pre_swsh_derivatives_variables_tag,
+      swsh_derivatives_variables_tag>>(
+      l_max, db::get<Tags::Dy<Tags::BondiBeta>>(expected_box),
+      db::get<Tags::Dy<Tags::BondiU>>(expected_box),
+      typename pre_swsh_derivatives_variables_tag::type{number_of_grid_points,
+                                                        0.0},
+      typename swsh_derivatives_variables_tag::type{number_of_grid_points,
+                                                    0.0});
+
+  // duplicate the 'input' values to the computation box
+  TestHelpers::CopyDataBoxTags<
+      Tags::BondiBeta, Tags::BondiJ, Tags::BondiQ,
+      Tags::BondiU>::apply(make_not_null(&computation_box), expected_box);
+
+  mutate_all_pre_swsh_derivatives_for_tag<TestSpinWeightedScalar<0>>(
+      make_not_null(&computation_box));
+  mutate_all_pre_swsh_derivatives_for_tag<TestSpinWeightedScalar<1>>(
+      make_not_null(&computation_box));
+  // approximation needs a little bit of loosening to accommodate the comparison
+  // between the 'separable' math and the more standard numerical procedures.
+  Approx cce_approx =
+      Approx::custom()
+          .epsilon(std::numeric_limits<double>::epsilon() * 1.0e5)
+          .scale(1.0);
+
+  CHECK_VARIABLES_CUSTOM_APPROX(
+      db::get<pre_swsh_derivatives_variables_tag>(computation_box),
+      db::get<pre_swsh_derivatives_variables_tag>(expected_box), cce_approx);
+
+  // separately test the nonseparable Tags::JbarQMinus2EthBeta
+  using pre_swsh_spare_variables_tag = ::Tags::Variables<
+      tmpl::list<Tags::BondiJ, Tags::BondiQ, Tags::JbarQMinus2EthBeta>>;
+  using swsh_derivatives_spare_variables_tag =
+      ::Tags::Variables<tmpl::list<Spectral::Swsh::Tags::Derivative<
+          Tags::BondiBeta, Spectral::Swsh::Tags::Eth>>>;
+  auto spare_computation_box =
+      db::create<db::AddSimpleTags<Spectral::Swsh::Tags::LMax,
+                                   pre_swsh_spare_variables_tag,
+                                   swsh_derivatives_spare_variables_tag>>(
+          l_max,
+          typename pre_swsh_spare_variables_tag::type{number_of_grid_points,
+                                                      0.0},
+          typename swsh_derivatives_spare_variables_tag::type{
+              number_of_grid_points, 0.0});
+  UniformCustomDistribution<double> dist(0.1, 1.0);
+  ComplexDataVector generated_j = make_with_random_values<ComplexDataVector>(
+      make_not_null(&generator), make_not_null(&dist), number_of_grid_points);
+  ComplexDataVector generated_q = make_with_random_values<ComplexDataVector>(
+      make_not_null(&generator), make_not_null(&dist), number_of_grid_points);
+  ComplexDataVector generated_eth_beta =
+      make_with_random_values<ComplexDataVector>(make_not_null(&generator),
+                                                 make_not_null(&dist),
+                                                 number_of_grid_points);
+  db::mutate<Tags::BondiJ, Tags::BondiQ,
+             Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                              Spectral::Swsh::Tags::Eth>>(
+      make_not_null(&spare_computation_box),
+      [&generated_j, &generated_q, &generated_eth_beta](
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*> q,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*>
+              eth_beta) {
+        get(*j) = generated_j;
+        get(*q) = generated_q;
+        get(*eth_beta) = generated_eth_beta;
+      });
+  db::mutate_apply<PreSwshDerivatives<Tags::JbarQMinus2EthBeta>>(
+      make_not_null(&spare_computation_box));
+  CHECK_ITERABLE_APPROX(
+      get(db::get<Tags::JbarQMinus2EthBeta>(spare_computation_box)).data(),
+      conj(generated_j) * (generated_q - 2.0 * generated_eth_beta));
+}
+}  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Test_PrecomputeCceDependencies.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_PrecomputeCceDependencies.cpp
@@ -69,11 +69,12 @@ void generate_boundary_values_and_expected(
         // prevent aliasing; some terms are nonlinear in R
         Spectral::Swsh::filter_swsh_boundary_quantity(
             make_not_null(&get(*boundary_r)), l_max, l_max - 3);
-        repeat(make_not_null(&get(*r).data()), get(*boundary_r).data(),
-               number_of_radial_grid_points);
-        repeat(make_not_null(&get(*du_r_divided_by_r).data()),
-               get(*boundary_du_r_divided_by_r).data(),
-               number_of_radial_grid_points);
+        fill_with_n_copies(make_not_null(&get(*r).data()),
+                           get(*boundary_r).data(),
+                           number_of_radial_grid_points);
+        fill_with_n_copies(make_not_null(&get(*du_r_divided_by_r).data()),
+                           get(*boundary_du_r_divided_by_r).data(),
+                           number_of_radial_grid_points);
         get(*one_minus_y).data() = 1.0 - y;
         get(*j).data() = make_with_random_values<ComplexDataVector>(
             generator, make_not_null(&dist),

--- a/tests/Unit/Evolution/Systems/Cce/Test_SwshDerivatives.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_SwshDerivatives.cpp
@@ -175,7 +175,8 @@ struct GenerateStartingData {
     }
     ComplexDataVector one_divided_by_r =
         (1.0 - y) /
-        (2.0 * repeat(get(*boundary_r).data(), number_of_radial_grid_points));
+        (2.0 * create_vector_of_n_copies(get(*boundary_r).data(),
+                                         number_of_radial_grid_points));
     TestHelpers::generate_volume_data_from_separated_values(
         make_not_null(&get(*j).data()), make_not_null(&one_divided_by_r),
         get(*angular_collocations_for_j).data(), get(*radial_polynomials_for_j),

--- a/tests/Unit/Evolution/Systems/Cce/Test_SwshDerivatives.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_SwshDerivatives.cpp
@@ -1,0 +1,353 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <complex>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
+#include "Evolution/Systems/Cce/PreSwshDerivatives.hpp"
+#include "Evolution/Systems/Cce/PrecomputeCceDependencies.hpp"
+#include "Evolution/Systems/Cce/SwshDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/Evolution/Systems/Cce/CceComputationTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Cce {
+
+namespace {
+template <int Spin>
+struct TestSpinWeightedScalar : db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, Spin>>;
+  static std::string name() noexcept { return "TestSpinWeightedScalar"; }
+};
+
+// note: J must be omitted from this due to the need for the Precomputation step
+// in this test that was able to be omitted from the PreSwshDerivatives
+// test.
+using test_swsh_derivative_dependencies =
+    tmpl::list<Tags::BondiBeta, Tags::BondiQ, Tags::BondiU>;
+}  // namespace
+
+namespace detail {
+template <>
+struct TagsToComputeForImpl<TestSpinWeightedScalar<0>> {
+  using pre_swsh_derivative_tags =
+      tmpl::list<Tags::Dy<Tags::BondiJ>, Tags::Dy<Tags::Dy<Tags::BondiJ>>,
+                 Tags::Dy<Tags::BondiBeta>, Tags::Dy<Tags::Dy<Tags::BondiBeta>>,
+                 Tags::Dy<Tags::BondiU>, Tags::Dy<Tags::Dy<Tags::BondiU>>,
+                 Tags::Dy<Tags::BondiQ>, Tags::Dy<Tags::Dy<Tags::BondiQ>>>;
+  using second_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags = tmpl::list<
+      Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                       Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiBeta>,
+                                       Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiBeta>,
+                                       Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                       Spectral::Swsh::Tags::EthEth>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                       Spectral::Swsh::Tags::EthEthbar>,
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiJ>,
+                                       Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiJ,
+                                       Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiJ,
+                                       Spectral::Swsh::Tags::EthbarEthbar>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiU,
+                                       Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiQ, Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiU,
+                                       Spectral::Swsh::Tags::Eth>>;
+};
+
+template <>
+struct TagsToComputeForImpl<TestSpinWeightedScalar<1>> {
+  using pre_swsh_derivative_tags = tmpl::list<
+      Tags::BondiJbar, Tags::BondiUbar, Tags::BondiQbar,
+      ::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>,
+      Tags::Dy<::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>>,
+      Tags::Dy<Tags::Dy<::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>>>,
+      ::Tags::Multiplies<Tags::BondiJbar, Tags::Dy<Tags::BondiJ>>,
+      ::Tags::Multiplies<Tags::BondiUbar, Tags::Dy<Tags::BondiJ>>,
+      Tags::Dy<Spectral::Swsh::Tags::Derivative<Tags::BondiJ,
+                                                Spectral::Swsh::Tags::Ethbar>>,
+      Tags::Dy<::Tags::Multiplies<Tags::BondiUbar, Tags::Dy<Tags::BondiJ>>>,
+      Tags::Dy<::Tags::Multiplies<Tags::BondiJbar, Tags::Dy<Tags::BondiJ>>>>;
+  using second_swsh_derivative_tags =
+      tmpl::list<Spectral::Swsh::Tags::Derivative<
+          Spectral::Swsh::Tags::Derivative<Tags::BondiJ,
+                                           Spectral::Swsh::Tags::Ethbar>,
+          Spectral::Swsh::Tags::Eth>>;
+  using swsh_derivative_tags = tmpl::list<
+      Spectral::Swsh::Tags::Derivative<
+          ::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>,
+          Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<
+          Tags::Dy<::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>>,
+          Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<
+          Tags::Dy<::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>>,
+          Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<
+          ::Tags::Multiplies<Tags::BondiJ, Tags::BondiJbar>,
+          Spectral::Swsh::Tags::EthEthbar>,
+      Spectral::Swsh::Tags::Derivative<
+          ::Tags::Multiplies<Tags::BondiUbar, Tags::Dy<Tags::BondiJ>>,
+          Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<
+          ::Tags::Multiplies<Tags::BondiJbar, Tags::Dy<Tags::BondiJ>>,
+          Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<
+          ::Tags::Multiplies<Tags::BondiJbar, Tags::Dy<Tags::BondiJ>>,
+          Spectral::Swsh::Tags::Ethbar>>;
+};
+}  // namespace detail
+
+namespace {
+struct GenerateStartingData {
+  template <typename Generator, typename Distribution>
+  void operator()(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+          boundary_r,
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+          boundary_du_r_divided_by_r,
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
+          angular_collocations_for_j,
+      const gsl::not_null<Scalar<ComplexModalVector>*> radial_polynomials_for_j,
+      const gsl::not_null<Generator*> generator,
+      const gsl::not_null<Distribution*> dist, const size_t l_max,
+      const size_t number_of_radial_grid_points,
+      const ComplexDataVector& y) noexcept {
+    get(*boundary_r).data() =
+        (10.0 +
+         std::complex<double>(1.0, 0.0) *
+             make_with_random_values<DataVector>(
+                 generator, dist,
+                 Spectral::Swsh::number_of_swsh_collocation_points(l_max)));
+    get(*boundary_du_r_divided_by_r).data() =
+        std::complex<double>(1.0, 0.0) *
+        make_with_random_values<DataVector>(
+            generator, dist,
+            Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+    // prevent aliasing; some terms are nonlinear in R
+    Spectral::Swsh::filter_swsh_boundary_quantity(
+        make_not_null(&get(*boundary_r)), l_max, 2);
+    Spectral::Swsh::filter_swsh_boundary_quantity(
+        make_not_null(&get(*boundary_du_r_divided_by_r)), l_max, 2);
+    // generate the separable j needed for precomputation step
+    get(*angular_collocations_for_j).data() =
+        make_with_random_values<ComplexDataVector>(
+            generator, dist,
+            Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+    Spectral::Swsh::filter_swsh_boundary_quantity(
+        make_not_null(&get(*angular_collocations_for_j)), l_max, 2);
+    get(*radial_polynomials_for_j) =
+        make_with_random_values<ComplexModalVector>(
+            generator, dist, number_of_radial_grid_points);
+    for (size_t i = 0; i < number_of_radial_grid_points; ++i) {
+      get(*radial_polynomials_for_j)[i] *=
+          exp(-10.0 *
+              pow<2>(static_cast<double>(i) /
+                     static_cast<double>(number_of_radial_grid_points - 1)));
+      if (i > 3){
+        get(*radial_polynomials_for_j)[i] = 0.0;
+      }
+    }
+    ComplexDataVector one_divided_by_r =
+        (1.0 - y) /
+        (2.0 * repeat(get(*boundary_r).data(), number_of_radial_grid_points));
+    TestHelpers::generate_volume_data_from_separated_values(
+        make_not_null(&get(*j).data()), make_not_null(&one_divided_by_r),
+        get(*angular_collocations_for_j).data(), get(*radial_polynomials_for_j),
+        l_max, number_of_radial_grid_points);
+  }
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.SwshDerivatives",
+                  "[Unit][Evolution]") {
+  MAKE_GENERATOR(generator);
+  const size_t l_max = 10;
+  const size_t number_of_radial_grid_points = 7;
+  const size_t number_of_grid_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
+      number_of_radial_grid_points;
+
+  using pre_swsh_derivative_tag_list = tmpl::append<
+      pre_swsh_derivative_tags_to_compute_for_t<TestSpinWeightedScalar<0>>,
+      pre_swsh_derivative_tags_to_compute_for_t<TestSpinWeightedScalar<1>>,
+      test_swsh_derivative_dependencies, tmpl::list<Tags::BondiJ>>;
+
+  using swsh_derivative_tag_list = tmpl::remove_duplicates<tmpl::append<
+      single_swsh_derivative_tags_to_compute_for_t<TestSpinWeightedScalar<0>>,
+      second_swsh_derivative_tags_to_compute_for_t<TestSpinWeightedScalar<0>>,
+      single_swsh_derivative_tags_to_compute_for_t<TestSpinWeightedScalar<1>>,
+      second_swsh_derivative_tags_to_compute_for_t<TestSpinWeightedScalar<1>>>>;
+
+  using boundary_value_variables_tag =
+      ::Tags::Variables<pre_computation_boundary_tags<Tags::BoundaryValue>>;
+  using integration_independent_variables_tag =
+      ::Tags::Variables<pre_computation_tags>;
+  using pre_swsh_derivatives_variables_tag =
+      ::Tags::Variables<pre_swsh_derivative_tag_list>;
+  using swsh_derivatives_variables_tag =
+      ::Tags::Variables<swsh_derivative_tag_list>;
+  using swsh_derivatives_coefficient_buffer_variables_tag =
+      ::Tags::Variables<tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+          swsh_derivative_tag_list,
+          tmpl::bind<Spectral::Swsh::coefficient_buffer_tags_for_derivative_tag,
+                     tmpl::_1>>>>>;
+  using separated_angular_data_variables_tag = ::Tags::Variables<
+      db::wrap_tags_in<TestHelpers::AngularCollocationsFor,
+                       tmpl::append<pre_swsh_derivative_tag_list,
+                                    swsh_derivative_tag_list>>>;
+  using separated_radial_modes_variables_tag = ::Tags::Variables<
+      db::wrap_tags_in<TestHelpers::RadialPolyCoefficientsFor,
+                       tmpl::append<pre_swsh_derivative_tag_list,
+                                    swsh_derivative_tag_list>>>;
+
+  auto expected_box = db::create<db::AddSimpleTags<
+    Spectral::Swsh::Tags::LMax, Spectral::Swsh::Tags::NumberOfRadialPoints,
+      boundary_value_variables_tag, integration_independent_variables_tag,
+      pre_swsh_derivatives_variables_tag, swsh_derivatives_variables_tag,
+      separated_angular_data_variables_tag,
+      separated_radial_modes_variables_tag>>(
+      l_max, number_of_radial_grid_points,
+      typename boundary_value_variables_tag::type{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max), 0.0},
+      typename integration_independent_variables_tag::type{
+          number_of_grid_points, 0.0},
+      typename pre_swsh_derivatives_variables_tag::type{number_of_grid_points},
+      typename swsh_derivatives_variables_tag::type{number_of_grid_points, 0.0},
+      typename separated_angular_data_variables_tag::type{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max)},
+      typename separated_radial_modes_variables_tag::type{
+          number_of_radial_grid_points});
+
+  // generate necessary boundary and integration-independent data for the rest
+  // of the computation
+  UniformCustomDistribution<double> dist(0.1, 1.0);
+  const ComplexDataVector y = outer_product(
+      ComplexDataVector{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max), 1.0},
+      Spectral::collocation_points<Spectral::Basis::Legendre,
+                                   Spectral::Quadrature::GaussLobatto>(
+          number_of_radial_grid_points));
+
+  db::mutate<Tags::BoundaryValue<Tags::BondiR>,
+             Tags::BoundaryValue<Tags::DuRDividedByR>, Tags::BondiJ,
+             TestHelpers::AngularCollocationsFor<Tags::BondiJ>,
+             TestHelpers::RadialPolyCoefficientsFor<Tags::BondiJ>>(
+      make_not_null(&expected_box), GenerateStartingData{},
+      make_not_null(&generator), make_not_null(&dist), l_max,
+      number_of_radial_grid_points, y);
+
+  // apply the separable computation for all of the pre_swsh_derivatives and
+  // swsh_derivative quantities
+  db::mutate<pre_swsh_derivatives_variables_tag, swsh_derivatives_variables_tag,
+             separated_angular_data_variables_tag,
+             separated_radial_modes_variables_tag>(
+      make_not_null(&expected_box),
+      [&generator](
+          const gsl::not_null<
+              typename pre_swsh_derivatives_variables_tag::type*>
+              pre_swsh_derivatives,
+          const gsl::not_null<typename swsh_derivatives_variables_tag::type*>
+              swsh_derivatives,
+          const gsl::not_null<
+              typename separated_angular_data_variables_tag::type*>
+              separated_angular_data,
+          const gsl::not_null<
+              typename separated_radial_modes_variables_tag::type*>
+              separated_radial_modes,
+          const SpinWeighted<ComplexDataVector, 0>& boundary_r) {
+        TestHelpers::generate_separable_expected<
+            test_swsh_derivative_dependencies,
+            tmpl::list<TestSpinWeightedScalar<0>, TestSpinWeightedScalar<1>>>(
+            pre_swsh_derivatives, swsh_derivatives, separated_angular_data,
+            separated_radial_modes, make_not_null(&generator), boundary_r,
+            l_max, number_of_radial_grid_points);
+      },
+      get(db::get<Tags::BoundaryValue<Tags::BondiR>>(expected_box)));
+
+  auto computation_box = db::create<db::AddSimpleTags<
+      Spectral::Swsh::Tags::LMax, Spectral::Swsh::Tags::NumberOfRadialPoints,
+      Tags::Integrand<Tags::BondiBeta>, Tags::Integrand<Tags::BondiU>,
+      boundary_value_variables_tag, integration_independent_variables_tag,
+      pre_swsh_derivatives_variables_tag, swsh_derivatives_variables_tag,
+      swsh_derivatives_coefficient_buffer_variables_tag>>(
+      l_max, number_of_radial_grid_points,
+      db::get<Tags::Dy<Tags::BondiBeta>>(expected_box),
+      db::get<Tags::Dy<Tags::BondiU>>(expected_box),
+      typename boundary_value_variables_tag::type{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max), 0.0},
+      typename integration_independent_variables_tag::type{
+          number_of_grid_points, 0.0},
+      typename pre_swsh_derivatives_variables_tag::type{number_of_grid_points,
+                                                        0.0},
+      typename swsh_derivatives_variables_tag::type{number_of_grid_points, 0.0},
+      typename swsh_derivatives_coefficient_buffer_variables_tag::type{
+          Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max) *
+              number_of_radial_grid_points,
+          0.0});
+
+  TestHelpers::CopyDataBoxTags<
+      Tags::BoundaryValue<Tags::BondiR>,
+      Tags::BoundaryValue<Tags::DuRDividedByR>,
+      Tags::BondiJ>::apply(make_not_null(&computation_box), expected_box);
+
+  mutate_all_precompute_cce_dependencies<Tags::BoundaryValue>(
+      make_not_null(&computation_box));
+  mutate_all_precompute_cce_dependencies<Tags::BoundaryValue>(
+      make_not_null(&expected_box));
+
+  // duplicate the 'input' values to the computation box
+  TestHelpers::CopyDataBoxTags<
+      Tags::BondiBeta, Tags::BondiJ, Tags::BondiQ,
+      Tags::BondiU>::apply(make_not_null(&computation_box), expected_box);
+
+  mutate_all_pre_swsh_derivatives_for_tag<TestSpinWeightedScalar<0>>(
+      make_not_null(&computation_box));
+
+  mutate_all_swsh_derivatives_for_tag<TestSpinWeightedScalar<0>>(
+      make_not_null(&computation_box));
+
+  mutate_all_pre_swsh_derivatives_for_tag<TestSpinWeightedScalar<1>>(
+      make_not_null(&computation_box));
+
+  mutate_all_swsh_derivatives_for_tag<TestSpinWeightedScalar<1>>(
+      make_not_null(&computation_box));
+
+  // this can be tightened at the cost of needing a higher resolution due to the
+  // inherent aliasing in this system. A loose approx allows the test to be
+  // (relatively) fast
+  Approx loose_cce_approx =
+      Approx::custom()
+          .epsilon(std::numeric_limits<double>::epsilon() * 1.0e8)
+          .scale(1.0);
+
+  CHECK_VARIABLES_CUSTOM_APPROX(
+      db::get<swsh_derivatives_variables_tag>(computation_box),
+      db::get<swsh_derivatives_variables_tag>(expected_box), loose_cce_approx);
+}
+}  // namespace Cce

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshFiltering.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshFiltering.cpp
@@ -56,8 +56,8 @@ void test_angular_filtering() noexcept {
   }
   auto pre_filter_angular_data =
       inverse_swsh_transform(l_max, 1, generated_modes);
-  SpinWeighted<ComplexDataVector, Spin> to_filter{
-      repeat(pre_filter_angular_data.data(), number_of_radial_points)};
+  SpinWeighted<ComplexDataVector, Spin> to_filter{create_vector_of_n_copies(
+      pre_filter_angular_data.data(), number_of_radial_points)};
 
   // remove the top few modes, emulating the filter process
   for (const auto& mode : cached_coefficients_metadata(l_max)) {
@@ -68,8 +68,9 @@ void test_angular_filtering() noexcept {
   }
   const auto expected_post_filter_angular_data =
       inverse_swsh_transform(l_max, 1, generated_modes);
-  const SpinWeighted<ComplexDataVector, Spin> expected_post_filter{repeat(
-      expected_post_filter_angular_data.data(), number_of_radial_points)};
+  const SpinWeighted<ComplexDataVector, Spin> expected_post_filter{
+      create_vector_of_n_copies(expected_post_filter_angular_data.data(),
+                                number_of_radial_points)};
 
   filter_swsh_volume_quantity(make_not_null(&to_filter), l_max, l_max - 3, 5.0,
                               2);

--- a/tests/Unit/Utilities/Test_VectorAlgebra.cpp
+++ b/tests/Unit/Utilities/Test_VectorAlgebra.cpp
@@ -43,7 +43,7 @@ void test_outer_product() {
 }
 
 template <typename VectorType>
-void test_repeat() {
+void test_n_copies() {
   MAKE_GENERATOR(gen);
   UniformCustomDistribution<size_t> size_distribution{5, 10};
   UniformCustomDistribution<
@@ -53,7 +53,7 @@ void test_repeat() {
       make_not_null(&gen), make_not_null(&element_distribution),
       size_distribution(gen));
   size_t repeats = size_distribution(gen);
-  const auto repeated = repeat(to_repeat, repeats);
+  const auto repeated = create_vector_of_n_copies(to_repeat, repeats);
   for (size_t i = 0; i < repeats; ++i) {
     for (size_t j = 0; j < to_repeat.size(); ++j) {
       CHECK(to_repeat[j] == repeated[j + i * to_repeat.size()]);
@@ -68,7 +68,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.VectorAlgebra",
   test_outer_product<ComplexDataVector, DataVector>();
   test_outer_product<DataVector, DataVector>();
 
-  test_repeat<DataVector>();
-  test_repeat<ComplexDataVector>();
-  test_repeat<ModalVector>();
+  test_n_copies<DataVector>();
+  test_n_copies<ComplexDataVector>();
+  test_n_copies<ModalVector>();
 }


### PR DESCRIPTION
## Proposed changes

Computes the rest of the inputs to the CCE hypersurface integrands, largely consisting of arithmetic operations, radial derivatives and angular derivatives acting on the intermediate hypersurface quantities.

I've also changed the name of the `repeat` function from `VectorAlgebra.hpp`

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
