### PR TITLE
Rename h5::H5File to h5::File

### DIFF
--- a/src/IO/H5/AccessType.hpp
+++ b/src/IO/H5/AccessType.hpp
@@ -18,7 +18,7 @@
 namespace h5 {
 /*!
  * \ingroup HDF5Group
- * \brief Set the access type to the H5File
+ * \brief Set the access type to the `h5::File`
  */
 enum class AccessType {
   /// Allow read-write access to the file

--- a/src/IO/H5/Dat.hpp
+++ b/src/IO/H5/Dat.hpp
@@ -25,16 +25,17 @@ namespace h5 {
  * \ingroup HDF5Group
  * \brief Represents a multicolumn dat file inside an HDF5 file
  *
- * A Dat object represents a dat file inside an H5File. A dat file is a
+ * A Dat object represents a dat file inside an `h5::File`. A dat file is a
  * multicolumn text file with a header describing what each column represents.
  * Typically dat files are space or tab delimited, and often represent time
  * series data. One common use for them is writing out error norms over the
- * computational domain as a function of time. Inside the H5File they are stored
- * as a string header, and a matrix of doubles holding the data. One problem
- * encountered with dat files is that they quickly increase the file count
- * causing users to run into number of file limitations on HPC systems. Since
- * multiple Dat objects can be stored inside a single H5File the problem of many
- * different dat files being stored as individual files is solved.
+ * computational domain as a function of time. Inside the `h5::File` they are
+ * stored as a string header, and a matrix of doubles holding the data. One
+ * problem encountered with dat files is that they quickly increase the file
+ * count causing users to run into number of file limitations on HPC systems.
+ * Since multiple Dat objects can be stored inside a single `h5::File` the
+ * problem of many different dat files being stored as individual files is
+ * solved.
  *
  * \note This class does not do any caching of data so all data is written as
  * soon as append() is called.

--- a/src/IO/H5/File.cpp
+++ b/src/IO/H5/File.cpp
@@ -18,7 +18,7 @@
 
 namespace h5 {
 template <AccessType Access_t>
-H5File<Access_t>::H5File(std::string file_name, bool append_to_file)
+File<Access_t>::File(std::string file_name, bool append_to_file)
     : file_name_(std::move(file_name)) {
   if (file_name_.size() - 3 != file_name_.find(".h5")) {
     ERROR("All HDF5 file names must end in '.h5'. The path and file name '"
@@ -60,7 +60,7 @@ H5File<Access_t>::H5File(std::string file_name, bool append_to_file)
 
 /// \cond
 template <AccessType Access_t>
-H5File<Access_t>::H5File(H5File&& rhs) noexcept {
+File<Access_t>::File(File&& rhs) noexcept {
   file_name_ = std::move(rhs.file_name_);
   file_id_ = std::move(rhs.file_id_);
   current_object_ = std::move(rhs.current_object_);
@@ -69,7 +69,7 @@ H5File<Access_t>::H5File(H5File&& rhs) noexcept {
 }
 
 template <AccessType Access_t>
-H5File<Access_t>& H5File<Access_t>::operator=(H5File&& rhs) noexcept {
+File<Access_t>& File<Access_t>::operator=(File&& rhs) noexcept {
   if (file_id_ != -1) {
     CHECK_H5(H5Fclose(file_id_),
              "Failed to close file: '" << file_name_ << "'");
@@ -84,7 +84,7 @@ H5File<Access_t>& H5File<Access_t>::operator=(H5File&& rhs) noexcept {
 }
 
 template <AccessType Access_t>
-H5File<Access_t>::~H5File() {
+File<Access_t>::~File() {
   if (file_id_ != -1) {
     CHECK_H5(H5Fclose(file_id_),
              "Failed to close file: '" << file_name_ << "'");
@@ -92,13 +92,13 @@ H5File<Access_t>::~H5File() {
 }
 
 template <>
-void H5File<AccessType::ReadWrite>::insert_source_archive() noexcept {
+void File<AccessType::ReadWrite>::insert_source_archive() noexcept {
   insert<h5::SourceArchive>("/src");
 }
 template <>
-void H5File<AccessType::ReadOnly>::insert_source_archive() noexcept {}
+void File<AccessType::ReadOnly>::insert_source_archive() noexcept {}
 /// \endcond
 }  // namespace h5
 
-template class h5::H5File<h5::AccessType::ReadOnly>;
-template class h5::H5File<h5::AccessType::ReadWrite>;
+template class h5::File<h5::AccessType::ReadOnly>;
+template class h5::File<h5::AccessType::ReadWrite>;

--- a/src/IO/H5/Header.hpp
+++ b/src/IO/H5/Header.hpp
@@ -19,7 +19,7 @@ namespace h5 {
  *
  * A Header object is used to store the ::info_from_build() result in the HDF5
  * files. The Header is automatically added to every single file by the
- * constructor of H5File.
+ * constructor of `h5::File`.
  *
  * \example
  * You can read the header info out of an H5 file as shown in the example:

--- a/src/IO/H5/Python/File.cpp
+++ b/src/IO/H5/Python/File.cpp
@@ -24,15 +24,15 @@ namespace bp = boost::python;
 
 namespace py_bindings {
 void bind_h5file() {
-  // Wrapper for basic H5File operations
-  bp::class_<h5::H5File<h5::AccessType::ReadWrite>, boost::noncopyable>(
-      "H5File", bp::init<std::string, bool>())
+  // Wrapper for basic `h5::File` operations
+  bp::class_<h5::File<h5::AccessType::ReadWrite>, boost::noncopyable>(
+      "File", bp::init<std::string, bool>())
       .def("name",
-           +[](const h5::H5File<h5::AccessType::ReadWrite>& f) {
+           +[](const h5::File<h5::AccessType::ReadWrite>& f) {
              return f.name();
            })
       .def("get_dat",
-           +[](const h5::H5File<h5::AccessType::ReadWrite>& f,
+           +[](const h5::File<h5::AccessType::ReadWrite>& f,
                const bp::str& path) -> const h5::Dat& {
              const auto& dat_file =
                  f.get<h5::Dat>(bp::extract<std::string>(path));
@@ -40,30 +40,30 @@ void bind_h5file() {
            },
            bp::return_value_policy<bp::reference_existing_object>())
       .def("insert_dat",
-           +[](h5::H5File<h5::AccessType::ReadWrite>& f, const bp::str& path,
+           +[](h5::File<h5::AccessType::ReadWrite>& f, const bp::str& path,
                const bp::list& legend, uint32_t version) {
              f.insert<h5::Dat>(bp::extract<std::string>(path),
                                py_list_to_std_vector<std::string>(legend),
                                version);
            })
       .def("close",
-           +[](const h5::H5File<h5::AccessType::ReadWrite>& f) {
+           +[](const h5::File<h5::AccessType::ReadWrite>& f) {
              f.close_current_object();
            })
       .def("groups",
-           +[](const h5::H5File<h5::AccessType::ReadWrite>& f) {
+           +[](const h5::File<h5::AccessType::ReadWrite>& f) {
              return std_vector_to_py_list<std::string>(f.groups());
            })
 
       .def("get_vol",
-           +[](const h5::H5File<h5::AccessType::ReadWrite>& f,
+           +[](const h5::File<h5::AccessType::ReadWrite>& f,
                const std::string& path) {
              const auto& vol_file = f.get<h5::VolumeData>(path);
              return &vol_file;
            },
            bp::return_value_policy<bp::reference_existing_object>())
 
-      .def("insert_vol", +[](h5::H5File<h5::AccessType::ReadWrite>& f,
+      .def("insert_vol", +[](h5::File<h5::AccessType::ReadWrite>& f,
                              const std::string& path, const uint32_t version) {
         f.insert<h5::VolumeData>(path, version);
       });

--- a/src/IO/Observer/ReductionActions.hpp
+++ b/src/IO/Observer/ReductionActions.hpp
@@ -174,7 +174,7 @@ struct WriteReductionData {
     std::vector<double> data_to_append{
         static_cast<double>(std::get<Is>(data))...};
 
-    h5::H5File<h5::AccessType::ReadWrite> h5file(file_prefix + ".h5", true);
+    h5::File<h5::AccessType::ReadWrite> h5file(file_prefix + ".h5", true);
     constexpr size_t version_number = 0;
     auto& time_series_file = h5file.try_insert<h5::Dat>(
         subfile_name, std::move(legend), version_number);

--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -228,7 +228,7 @@ struct WriteVolumeData {
     {
       // Scoping is for closing HDF5 file before we release the lock.
       const auto& file_prefix = Parallel::get<Tags::VolumeFileName>(cache);
-      h5::H5File<h5::AccessType::ReadWrite> h5file(
+      h5::File<h5::AccessType::ReadWrite> h5file(
           file_prefix + std::to_string(Parallel::my_node()) + ".h5", true);
       constexpr size_t version_number = 0;
       auto& volume_file =

--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -122,7 +122,7 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.ReductionObserver", "[Unit][Observers]") {
   REQUIRE(file_system::check_if_file_exists(h5_file_name));
   // Check that the H5 file was written correctly.
   {
-    const auto file = h5::H5File<h5::AccessType::ReadOnly>(h5_file_name);
+    const auto file = h5::File<h5::AccessType::ReadOnly>(h5_file_name);
     const auto& dat_file = file.get<h5::Dat>("/element_data");
     const Matrix written_data = dat_file.get_data();
     const auto& written_legend = dat_file.get_legend();

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -150,7 +150,7 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
 
   REQUIRE(file_system::check_if_file_exists(h5_file_name));
   // Check that the H5 file was written correctly.
-  h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
+  h5::File<h5::AccessType::ReadOnly> my_file(h5_file_name);
   auto& volume_file = my_file.get<h5::VolumeData>("/element_data");
 
   const auto temporal_id =

--- a/tests/Unit/IO/Test_H5.cpp
+++ b/tests/Unit/IO/Test_H5.cpp
@@ -55,7 +55,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.File", "[Unit][IO][H5]") {
     file_system::rm(h5_file_name, true);
   }
   /// [h5file_readwrite_get_header]
-  h5::H5File<h5::AccessType::ReadWrite> my_file0(h5_file_name);
+  h5::File<h5::AccessType::ReadWrite> my_file0(h5_file_name);
   // Check that the header was written correctly
   const std::string header = my_file0.get<h5::Header>("/header").get_header();
   /// [h5file_readwrite_get_header]
@@ -85,7 +85,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.File", "[Unit][IO][H5]") {
           formaline::get_library_versions());
   };
   check_header(my_file0);
-  check_header(h5::H5File<h5::AccessType::ReadOnly>(h5_file_name));
+  check_header(h5::File<h5::AccessType::ReadOnly>(h5_file_name));
 
   const auto check_source_archive = [](const auto& my_file) noexcept {
     const std::vector<char> archive =
@@ -93,7 +93,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.File", "[Unit][IO][H5]") {
     CHECK(archive == formaline::get_archive());
   };
   check_source_archive(my_file0);
-  check_source_archive(h5::H5File<h5::AccessType::ReadOnly>(h5_file_name));
+  check_source_archive(h5::File<h5::AccessType::ReadOnly>(h5_file_name));
 
   if (file_system::check_if_file_exists(h5_file_name)) {
     file_system::rm(h5_file_name, true);
@@ -113,14 +113,14 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileMove", "[Unit][IO][H5]") {
   }
 
   auto my_file =
-      std::make_unique<h5::H5File<h5::AccessType::ReadWrite>>(h5_file_name);
+      std::make_unique<h5::File<h5::AccessType::ReadWrite>>(h5_file_name);
 
-  auto my_file2 = std::make_unique<h5::H5File<h5::AccessType::ReadWrite>>(
+  auto my_file2 = std::make_unique<h5::File<h5::AccessType::ReadWrite>>(
       std::move(*my_file));
   my_file.reset();
   CHECK(my_file == nullptr);
 
-  h5::H5File<h5::AccessType::ReadWrite> my_file3(h5_file_name2);
+  h5::File<h5::AccessType::ReadWrite> my_file3(h5_file_name2);
   my_file3 = std::move(*my_file2);
   my_file2.reset();
 
@@ -140,7 +140,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorObjectNotExist", "[Unit][IO][H5]") {
   if (file_system::check_if_file_exists(file_name)) {
     file_system::rm(file_name, true);
   }
-  h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
+  h5::File<h5::AccessType::ReadWrite> my_file(file_name);
   my_file.get<h5::Header>("/Dummy").get_header();
 }
 
@@ -152,7 +152,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorNotH5", "[Unit][IO][H5]") {
   if (file_system::check_if_file_exists(file_name)) {
     file_system::rm(file_name, true);
   }
-  h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
+  h5::File<h5::AccessType::ReadWrite> my_file(file_name);
 }
 
 // [[OutputRegex, Cannot create a file in ReadOnly mode,
@@ -163,7 +163,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorFileNotExist", "[Unit][IO][H5]") {
   if (file_system::check_if_file_exists(file_name)) {
     file_system::rm(file_name, true);
   }
-  h5::H5File<h5::AccessType::ReadOnly> my_file(file_name);
+  h5::File<h5::AccessType::ReadOnly> my_file(file_name);
 }
 
 // [[OutputRegex, Cannot append to a file opened in read-only mode. File name
@@ -176,8 +176,8 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorCannotAppendReadOnly",
   if (file_system::check_if_file_exists(file_name)) {
     file_system::rm(file_name, true);
   }
-  { h5::H5File<h5::AccessType::ReadWrite> my_file(file_name); }
-  h5::H5File<h5::AccessType::ReadOnly> my_file(file_name, true);
+  { h5::File<h5::AccessType::ReadWrite> my_file(file_name); }
+  h5::File<h5::AccessType::ReadOnly> my_file(file_name, true);
 }
 
 /// [willfail_example_for_dev_doc]
@@ -197,10 +197,10 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorExists", "[Unit][IO][H5]") {
   // terminate called recursively
   {
     /// [h5file_readwrite_file]
-    h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
+    h5::File<h5::AccessType::ReadWrite> my_file(file_name);
     /// [h5file_readwrite_file]
   }
-  h5::H5File<h5::AccessType::ReadWrite> my_file_2(file_name);
+  h5::File<h5::AccessType::ReadWrite> my_file_2(file_name);
 }
 
 // [[OutputRegex, Cannot open the object '/Dummy.hdr' because it does not
@@ -211,7 +211,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorObjectNotExistConst", "[Unit][IO][H5]") {
   if (file_system::check_if_file_exists(file_name)) {
     file_system::rm(file_name, true);
   }
-  const h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
+  const h5::File<h5::AccessType::ReadWrite> my_file(file_name);
   my_file.get<h5::Header>("/Dummy").get_header();
 }
 
@@ -225,7 +225,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorObjectAlreadyExists", "[Unit][IO][H5]") {
     file_system::rm(h5_file_name, true);
   }
   std::vector<std::string> legend{"Time", "Error L2", "Error L1", "Error"};
-  h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
+  h5::File<h5::AccessType::ReadWrite> my_file(h5_file_name);
   {
     auto& error_file =
         my_file.insert<h5::Dat>("/L2_errors///", legend, version_number);
@@ -242,12 +242,12 @@ SPECTRE_TEST_CASE("Unit.IO.H5.Version", "[Unit][IO][H5]") {
   }
   {
     /// [h5file_write_version]
-    h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
+    h5::File<h5::AccessType::ReadWrite> my_file(h5_file_name);
     my_file.insert<h5::Version>("/the_version", version_number);
     /// [h5file_write_version]
   }
 
-  h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
+  h5::File<h5::AccessType::ReadOnly> my_file(h5_file_name);
   /// [h5file_read_version]
   const auto& const_version = my_file.get<h5::Version>("/the_version");
   /// [h5file_read_version]
@@ -267,7 +267,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.Dat", "[Unit][IO][H5]") {
   }
   std::vector<std::string> legend{"Time", "Error L2", "Error L1", "Error"};
 
-  h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
+  h5::File<h5::AccessType::ReadWrite> my_file(h5_file_name);
   my_file.insert<h5::Dat>("/L2_errors", legend, version_number);
 
   // Check that the Dat file is found to be a subgroup of the file
@@ -394,7 +394,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.DatRead", "[Unit][IO][H5]") {
   }
   std::vector<std::string> legend{"Time", "Error L2", "Error L1", "Error"};
   {
-    h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
+    h5::File<h5::AccessType::ReadWrite> my_file(h5_file_name);
     auto& error_file =
         my_file.insert<h5::Dat>("/L2_errors", legend, version_number);
 
@@ -417,7 +417,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.DatRead", "[Unit][IO][H5]") {
     error_file.append(Matrix(0, 0, 0.0));
     error_file.append(std::vector<double>{0.33, 0.66, 0.77, 0.90});
   }
-  h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
+  h5::File<h5::AccessType::ReadOnly> my_file(h5_file_name);
   const auto& error_file = my_file.get<h5::Dat>("/L2_errors");
 
   // Check version info is correctly retrieved from Dat file
@@ -604,12 +604,12 @@ SPECTRE_TEST_CASE("Unit.IO.H5.check_if_object_exists", "[Unit][IO][H5]") {
     file_system::rm(h5_file_name, true);
   }
   {
-    h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
+    h5::File<h5::AccessType::ReadWrite> my_file(h5_file_name);
     my_file.insert<h5::Header>("/");
   }
 
   // Reopen the file to check that the subfile '/' can be opened
-  h5::H5File<h5::AccessType::ReadWrite> reopened_file(h5_file_name, true);
+  h5::File<h5::AccessType::ReadWrite> reopened_file(h5_file_name, true);
   reopened_file.get<h5::Header>("/");
   CHECK(file_system::check_if_file_exists(h5_file_name) == true);
   if (file_system::check_if_file_exists(h5_file_name)) {

--- a/tests/Unit/IO/Test_H5.py
+++ b/tests/Unit/IO/Test_H5.py
@@ -26,13 +26,13 @@ class TestIOH5File(unittest.TestCase):
 
     # Test whether an H5 file is created correctly,
     def test_name(self):
-        file_spec = spectre_h5.H5File(self.file_name, 1)
+        file_spec = spectre_h5.File(self.file_name, 1)
         self.assertEqual(self.file_name, file_spec.name())
         file_spec.close()
 
     # Test whether a dat file can be added correctly
     def test_insert_dat(self):
-        file_spec = spectre_h5.H5File(self.file_name, 1)
+        file_spec = spectre_h5.File(self.file_name, 1)
         file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
         datfile = file_spec.get_dat("/element_data")
         self.assertEqual(datfile.get_version(), 0)
@@ -40,7 +40,7 @@ class TestIOH5File(unittest.TestCase):
 
     # Test whether data can be added to the dat file correctly
     def test_append(self):
-        file_spec = spectre_h5.H5File(self.file_name, 1)
+        file_spec = spectre_h5.File(self.file_name, 1)
         file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
         datfile = file_spec.get_dat("/element_data")
         datfile.append(self.data_1)
@@ -50,7 +50,7 @@ class TestIOH5File(unittest.TestCase):
 
     # More complicated test case for getting data subsets and dimensions
     def test_get_data_subset(self):
-        file_spec = spectre_h5.H5File(self.file_name, 1)
+        file_spec = spectre_h5.File(self.file_name, 1)
         file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
         datfile = file_spec.get_dat("/element_data")
         datfile.append(self.data_1)
@@ -63,7 +63,7 @@ class TestIOH5File(unittest.TestCase):
 
     # Getting Attributes
     def test_get_legend(self):
-        file_spec = spectre_h5.H5File(self.file_name, 1)
+        file_spec = spectre_h5.File(self.file_name, 1)
         file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
         datfile = file_spec.get_dat("/element_data")
         self.assertEqual(datfile.get_legend(), ["Time", "Value"])
@@ -72,14 +72,14 @@ class TestIOH5File(unittest.TestCase):
 
     # The header is not universal, just checking the part that is predictable
     def test_get_header(self):
-        file_spec = spectre_h5.H5File(self.file_name, 1)
+        file_spec = spectre_h5.File(self.file_name, 1)
         file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
         datfile = file_spec.get_dat("/element_data")
         self.assertEqual(datfile.get_header()[0:16], "#\n# File created")
         file_spec.close()
 
     def test_groups(self):
-        file_spec = spectre_h5.H5File(self.file_name, 1)
+        file_spec = spectre_h5.File(self.file_name, 1)
         file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
         file_spec.insert_dat("/element_position", ["x", "y", "z"], 0)
         file_spec.insert_dat("/element_size", ["Time", "Size"], 0)

--- a/tests/Unit/IO/Test_StellarCollapseEos.cpp
+++ b/tests/Unit/IO/Test_StellarCollapseEos.cpp
@@ -30,7 +30,7 @@ namespace {
 // they are random numbers in the range [-10.0, 10.0]
 void test_tabulated(const std::string& file_path,
                     const std::string& subgroup_path) noexcept {
-  h5::H5File<h5::AccessType::ReadOnly> sample_file(file_path);
+  h5::File<h5::AccessType::ReadOnly> sample_file(file_path);
   const auto& sample_data =
       sample_file.get<h5::StellarCollapseEos>(subgroup_path);
 

--- a/tests/Unit/IO/Test_VolumeData.cpp
+++ b/tests/Unit/IO/Test_VolumeData.cpp
@@ -28,7 +28,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
     file_system::rm(h5_file_name, true);
   }
 
-  h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
+  h5::File<h5::AccessType::ReadWrite> my_file(h5_file_name);
   const std::vector<DataVector> tensor_components_and_coords{
       {8.9, 7.6, 3.9, 2.1, 18.9, 17.6, 13.9, 12.1},
       {0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0},
@@ -241,7 +241,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
   if (file_system::check_if_file_exists(h5_file_name)) {
     file_system::rm(h5_file_name, true);
   }
-  h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
+  h5::File<h5::AccessType::ReadWrite> my_file(h5_file_name);
   auto& volume_file =
       my_file.insert<h5::VolumeData>("/element_data", version_number);
   volume_file.write_volume_data(100, 10.0,
@@ -265,7 +265,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData.ComponentFormat1",
   if (file_system::check_if_file_exists(h5_file_name)) {
     file_system::rm(h5_file_name, true);
   }
-  h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
+  h5::File<h5::AccessType::ReadWrite> my_file(h5_file_name);
   auto& volume_file =
       my_file.insert<h5::VolumeData>("/element_data", version_number);
   volume_file.write_volume_data(
@@ -291,7 +291,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData.ComponentFormat1",
   if (file_system::check_if_file_exists(h5_file_name)) {
     file_system::rm(h5_file_name, true);
   }
-  h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
+  h5::File<h5::AccessType::ReadWrite> my_file(h5_file_name);
   auto& volume_file =
       my_file.insert<h5::VolumeData>("/element_data", version_number);
   volume_file.write_volume_data(100, 10.0,

--- a/tests/Unit/IO/Test_VolumeData.py
+++ b/tests/Unit/IO/Test_VolumeData.py
@@ -32,7 +32,7 @@ class TestIOH5VolumeData(unittest.TestCase):
 
     # Testing the VolumeData Insert Function
     def test_insert_vol(self):
-        h5_file = spectre_h5.H5File(self.file_name_w, 1)
+        h5_file = spectre_h5.File(self.file_name_w, 1)
         h5_file.insert_vol("/element_data", 0)
         vol_file = h5_file.get_vol("/element_data")
         self.assertEqual(vol_file.get_version(), 0)
@@ -40,7 +40,7 @@ class TestIOH5VolumeData(unittest.TestCase):
 
     # Test the header was generated correctly
     def test_vol_get_header(self):
-        h5_file = spectre_h5.H5File(self.file_name_w, 1)
+        h5_file = spectre_h5.File(self.file_name_w, 1)
         h5_file.insert_vol("/element_data", 0)
         vol_file = h5_file.get_vol("/element_data")
         self.assertEqual(vol_file.get_header()[0:20], "#\n# File created on ")
@@ -50,7 +50,7 @@ class TestIOH5VolumeData(unittest.TestCase):
     # `VolTestData.h5` which contains spectre output data (see above).
     # Test the observation ids and values are correctly retrived
     def test_observation_id(self):
-        h5_file = spectre_h5.H5File(self.file_name_r, 1)
+        h5_file = spectre_h5.File(self.file_name_r, 1)
         vol_file = h5_file.get_vol("/element_data")
         obs_ids = vol_file.list_observation_ids()
         expected_obs_ids = [16436106908031328247,
@@ -65,7 +65,7 @@ class TestIOH5VolumeData(unittest.TestCase):
 
     # Test to make sure information about the computation elements was found
     def test_grids(self):
-        h5_file = spectre_h5.H5File(self.file_name_r, 1)
+        h5_file = spectre_h5.File(self.file_name_r, 1)
         vol_file = h5_file.get_vol("/element_data")
         obs_id = vol_file.list_observation_ids()[0]
         grid_names =  vol_file.get_grid_names(obs_id)
@@ -79,7 +79,7 @@ class TestIOH5VolumeData(unittest.TestCase):
 
     # Test that the tensor components, and tensor data  are retrieved correctly
     def test_tensor_components(self):
-        h5_file = spectre_h5.H5File(self.file_name_r, 1)
+        h5_file = spectre_h5.File(self.file_name_r, 1)
         vol_file = h5_file.get_vol("/element_data")
         obs_id = vol_file.list_observation_ids()[0]
         tensor_comps = vol_file.list_tensor_components(obs_id)

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -457,7 +457,7 @@ SPECTRE_TEST_CASE(
                                                    "SurfaceIntegralNegate"};
 
   // Check that the H5 file was written correctly.
-  const auto file = h5::H5File<h5::AccessType::ReadOnly>(h5_file_name);
+  const auto file = h5::File<h5::AccessType::ReadOnly>(h5_file_name);
   auto check_file_contents = [&file](
       const std::vector<double>& expected_integral,
       const std::vector<std::string>& expected_legend,


### PR DESCRIPTION
## Proposed changes

Remove the redundant "H5" in the name, also making the name consistent with the `File` class in Python's `h5py`

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
