### PR TITLE
Make Python arguments named

### DIFF
--- a/docs/DevGuide/PythonBindings.md
+++ b/docs/DevGuide/PythonBindings.md
@@ -130,3 +130,8 @@ See \ref spectre_using_python "Using SpECTRE's Python"
 - Exceptions should be allowed to propagate through the bindings so that
   error handling via exceptions is possible from python rather than having the
   python interpreter being killed with a call to `abort`.
+- All function arguments in Python bindings should be named using `bp::arg`.
+  See the Python bindings in `IO/H5/` for examples. Using the named arguments in
+  Python code is optional, but preferred when it makes code more readable.
+  In particular, use the argument names in the tests for the Python bindings so
+  they are being tested as well.

--- a/src/IO/H5/Python/Dat.cpp
+++ b/src/IO/H5/Python/Dat.cpp
@@ -29,7 +29,8 @@ void bind_h5dat() {
       .def("append",
            +[](h5::Dat& D, const bp::list& data) {
              D.append(py_list_to_std_vector<double>(data));
-           }, "Requires a list as input")
+           },
+           "Requires a list as input", (bp::arg("data")))
       .def("get_legend",
            +[](h5::Dat& D) -> bp::list {
              return std_vector_to_py_list<std::string>(D.get_legend());
@@ -41,7 +42,8 @@ void bind_h5dat() {
                const size_t num_rows = 1) -> PyObject* {
              return to_numpy(D.get_data_subset(
                  py_list_to_std_vector<size_t>(columns), first_row, num_rows));
-           })
+           },
+           (bp::arg("columns"), bp::arg("first_row"), bp::arg("num_rows")))
       .def("get_dimensions",
            +[](h5::Dat& D) -> bp::list {
              std::array<hsize_t, 2> dimension = D.get_dimensions();

--- a/src/IO/H5/Python/File.cpp
+++ b/src/IO/H5/Python/File.cpp
@@ -26,7 +26,8 @@ namespace py_bindings {
 void bind_h5file() {
   // Wrapper for basic H5File operations
   bp::class_<h5::H5File<h5::AccessType::ReadWrite>, boost::noncopyable>(
-      "H5File", bp::init<std::string, bool>())
+      "H5File", bp::init<std::string, bool>(
+                    (bp::arg("file_name"), bp::arg("append_to_file"))))
       .def("name",
            +[](const h5::H5File<h5::AccessType::ReadWrite>& f) {
              return f.name();
@@ -38,14 +39,16 @@ void bind_h5file() {
                  f.get<h5::Dat>(bp::extract<std::string>(path));
              return dat_file;
            },
-           bp::return_value_policy<bp::reference_existing_object>())
+           bp::return_value_policy<bp::reference_existing_object>(),
+           (bp::arg("path")))
       .def("insert_dat",
            +[](h5::H5File<h5::AccessType::ReadWrite>& f, const bp::str& path,
                const bp::list& legend, uint32_t version) {
              f.insert<h5::Dat>(bp::extract<std::string>(path),
                                py_list_to_std_vector<std::string>(legend),
                                version);
-           })
+           },
+           (bp::arg("path"), bp::arg("legend"), bp::arg("version")))
       .def("close",
            +[](const h5::H5File<h5::AccessType::ReadWrite>& f) {
              f.close_current_object();
@@ -61,11 +64,14 @@ void bind_h5file() {
              const auto& vol_file = f.get<h5::VolumeData>(path);
              return &vol_file;
            },
-           bp::return_value_policy<bp::reference_existing_object>())
+           bp::return_value_policy<bp::reference_existing_object>(),
+           (bp::arg("path")))
 
-      .def("insert_vol", +[](h5::H5File<h5::AccessType::ReadWrite>& f,
-                             const std::string& path, const uint32_t version) {
-        f.insert<h5::VolumeData>(path, version);
-      });
+      .def("insert_vol",
+           +[](h5::H5File<h5::AccessType::ReadWrite>& f,
+               const std::string& path, const uint32_t version) {
+             f.insert<h5::VolumeData>(path, version);
+           },
+           (bp::arg("path"), bp::arg("version")));
 }
 }  // namespace py_bindings

--- a/src/IO/H5/Python/VolumeData.cpp
+++ b/src/IO/H5/Python/VolumeData.cpp
@@ -48,23 +48,27 @@ void bind_h5vol() {
       .def("get_observation_value",
            +[](const h5::VolumeData& volume_file, const size_t observation_id) {
              return volume_file.get_observation_value(observation_id);
-           })
+           },
+           (bp::arg("observation_id")))
       .def("get_grid_names",
            +[](const h5::VolumeData& volume_file, const size_t observation_id) {
              return std_vector_to_py_list<std::string>(
                  volume_file.get_grid_names(observation_id));
-           })
+           },
+           (bp::arg("observation_id")))
       .def("list_tensor_components",
            +[](const h5::VolumeData& volume_file, const size_t observation_id) {
              return std_vector_to_py_list<std::string>(
                  volume_file.list_tensor_components(observation_id));
-           })
+           },
+           (bp::arg("observation_id")))
       .def("get_tensor_component",
            +[](const h5::VolumeData& volume_file, const size_t observation_id,
                const std::string& tensor_component) {
              return volume_file.get_tensor_component(observation_id,
                                                      tensor_component);
-           })
+           },
+           (bp::arg("observation_id"), bp::arg("tensor_component")))
       .def("get_extents", +[](const h5::VolumeData& volume_file,
                               const size_t observation_id) {
         bp::list total_extents;
@@ -72,6 +76,7 @@ void bind_h5vol() {
           total_extents.append(std_vector_to_py_list<size_t>(extents));
         }
         return total_extents;
-      });
+      },
+      (bp::arg("observation_id")));
 }
 }  // namespace py_bindings

--- a/tests/Unit/IO/Test_H5.py
+++ b/tests/Unit/IO/Test_H5.py
@@ -26,23 +26,28 @@ class TestIOH5File(unittest.TestCase):
 
     # Test whether an H5 file is created correctly,
     def test_name(self):
-        file_spec = spectre_h5.H5File(self.file_name, 1)
+        file_spec = spectre_h5.H5File(
+            file_name=self.file_name, append_to_file=True)
         self.assertEqual(self.file_name, file_spec.name())
         file_spec.close()
 
     # Test whether a dat file can be added correctly
     def test_insert_dat(self):
-        file_spec = spectre_h5.H5File(self.file_name, 1)
-        file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
-        datfile = file_spec.get_dat("/element_data")
+        file_spec = spectre_h5.H5File(
+            file_name=self.file_name, append_to_file=True)
+        file_spec.insert_dat(
+            path="/element_data", legend=["Time", "Value"], version=0)
+        datfile = file_spec.get_dat(path="/element_data")
         self.assertEqual(datfile.get_version(), 0)
         file_spec.close()
 
     # Test whether data can be added to the dat file correctly
     def test_append(self):
-        file_spec = spectre_h5.H5File(self.file_name, 1)
-        file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
-        datfile = file_spec.get_dat("/element_data")
+        file_spec = spectre_h5.H5File(
+            file_name=self.file_name, append_to_file=True)
+        file_spec.insert_dat(
+            path="/element_data", legend=["Time", "Value"], version=0)
+        datfile = file_spec.get_dat(path="/element_data")
         datfile.append(self.data_1)
         outdata_array = datfile.get_data()
         npt.assert_array_equal(outdata_array[0], self.data_1_array)
@@ -50,12 +55,15 @@ class TestIOH5File(unittest.TestCase):
 
     # More complicated test case for getting data subsets and dimensions
     def test_get_data_subset(self):
-        file_spec = spectre_h5.H5File(self.file_name, 1)
-        file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
-        datfile = file_spec.get_dat("/element_data")
+        file_spec = spectre_h5.H5File(
+            file_name=self.file_name, append_to_file=True)
+        file_spec.insert_dat(
+            path="/element_data", legend=["Time", "Value"], version=0)
+        datfile = file_spec.get_dat(path="/element_data")
         datfile.append(self.data_1)
         datfile.append(self.data_2)
-        outdata_array = datfile.get_data_subset([1], 0, 2)
+        outdata_array = datfile.get_data_subset(
+            columns=[1], first_row=0, num_rows=2)
         npt.assert_array_equal(outdata_array,  np.array(
             [self.data_1[1:2], self.data_2[1:2]]))
         self.assertEqual(datfile.get_dimensions()[0], 2)
@@ -63,26 +71,34 @@ class TestIOH5File(unittest.TestCase):
 
     # Getting Attributes
     def test_get_legend(self):
-        file_spec = spectre_h5.H5File(self.file_name, 1)
-        file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
-        datfile = file_spec.get_dat("/element_data")
+        file_spec = spectre_h5.H5File(
+            file_name=self.file_name, append_to_file=True)
+        file_spec.insert_dat(
+            path="/element_data", legend=["Time", "Value"], version=0)
+        datfile = file_spec.get_dat(path="/element_data")
         self.assertEqual(datfile.get_legend(), ["Time", "Value"])
         self.assertEqual(datfile.get_version(), 0)
         file_spec.close()
 
     # The header is not universal, just checking the part that is predictable
     def test_get_header(self):
-        file_spec = spectre_h5.H5File(self.file_name, 1)
-        file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
-        datfile = file_spec.get_dat("/element_data")
+        file_spec = spectre_h5.H5File(
+            file_name=self.file_name, append_to_file=True)
+        file_spec.insert_dat(
+            path="/element_data", legend=["Time", "Value"], version=0)
+        datfile = file_spec.get_dat(path="/element_data")
         self.assertEqual(datfile.get_header()[0:16], "#\n# File created")
         file_spec.close()
 
     def test_groups(self):
-        file_spec = spectre_h5.H5File(self.file_name, 1)
-        file_spec.insert_dat("/element_data", ["Time", "Value"], 0)
-        file_spec.insert_dat("/element_position", ["x", "y", "z"], 0)
-        file_spec.insert_dat("/element_size", ["Time", "Size"], 0)
+        file_spec = spectre_h5.H5File(
+            file_name=self.file_name, append_to_file=True)
+        file_spec.insert_dat(
+            path="/element_data", legend=["Time", "Value"], version=0)
+        file_spec.insert_dat(
+            path="/element_position", legend=["x", "y", "z"], version=0)
+        file_spec.insert_dat(
+            path="/element_size", legend=["Time", "Size"], version=0)
         groups_spec = ["element_data.dat", "element_position.dat",
                        "element_size.dat", "src.tar.gz"]
         for group_name in groups_spec:

--- a/tests/Unit/IO/Test_VolumeData.py
+++ b/tests/Unit/IO/Test_VolumeData.py
@@ -32,17 +32,19 @@ class TestIOH5VolumeData(unittest.TestCase):
 
     # Testing the VolumeData Insert Function
     def test_insert_vol(self):
-        h5_file = spectre_h5.H5File(self.file_name_w, 1)
-        h5_file.insert_vol("/element_data", 0)
-        vol_file = h5_file.get_vol("/element_data")
+        h5_file = spectre_h5.H5File(
+            file_name=self.file_name_w, append_to_file=True)
+        h5_file.insert_vol(path="/element_data", version=0)
+        vol_file = h5_file.get_vol(path="/element_data")
         self.assertEqual(vol_file.get_version(), 0)
         h5_file.close()
 
     # Test the header was generated correctly
     def test_vol_get_header(self):
-        h5_file = spectre_h5.H5File(self.file_name_w, 1)
-        h5_file.insert_vol("/element_data", 0)
-        vol_file = h5_file.get_vol("/element_data")
+        h5_file = spectre_h5.H5File(
+            file_name=self.file_name_w, append_to_file=True)
+        h5_file.insert_vol(path="/element_data", version=0)
+        vol_file = h5_file.get_vol(path="/element_data")
         self.assertEqual(vol_file.get_header()[0:20], "#\n# File created on ")
         h5_file.close()
 
@@ -50,8 +52,9 @@ class TestIOH5VolumeData(unittest.TestCase):
     # `VolTestData.h5` which contains spectre output data (see above).
     # Test the observation ids and values are correctly retrived
     def test_observation_id(self):
-        h5_file = spectre_h5.H5File(self.file_name_r, 1)
-        vol_file = h5_file.get_vol("/element_data")
+        h5_file = spectre_h5.H5File(
+            file_name=self.file_name_r, append_to_file=True)
+        vol_file = h5_file.get_vol(path="/element_data")
         obs_ids = vol_file.list_observation_ids()
         expected_obs_ids = [16436106908031328247,
                             17615288952477351885]
@@ -59,19 +62,21 @@ class TestIOH5VolumeData(unittest.TestCase):
                                17615288952477351885: 0.00}
         self.assertItemsEqual(obs_ids, expected_obs_ids)
         for obs_id in expected_obs_ids:
-            self.assertEqual(vol_file.get_observation_value(obs_id),
-                             expected_obs_values[obs_id])
+            self.assertEqual(
+                vol_file.get_observation_value(observation_id=obs_id),
+                expected_obs_values[obs_id])
         h5_file.close()
 
     # Test to make sure information about the computation elements was found
     def test_grids(self):
-        h5_file = spectre_h5.H5File(self.file_name_r, 1)
+        h5_file = spectre_h5.H5File(
+            file_name=self.file_name_r, append_to_file=True)
         vol_file = h5_file.get_vol("/element_data")
         obs_id = vol_file.list_observation_ids()[0]
-        grid_names =  vol_file.get_grid_names(obs_id)
+        grid_names = vol_file.get_grid_names(observation_id=obs_id)
         expected_grid_names  = ['[B0,(L0I0,L0I0,L0I0)]']
         self.assertEqual(grid_names, expected_grid_names)
-        extents = vol_file.get_extents(obs_id)
+        extents = vol_file.get_extents(observation_id=obs_id)
         expected_extents = [[2, 2, 2]]
         self.assertEqual(extents, expected_extents)
         h5_file.close()
@@ -79,10 +84,11 @@ class TestIOH5VolumeData(unittest.TestCase):
 
     # Test that the tensor components, and tensor data  are retrieved correctly
     def test_tensor_components(self):
-        h5_file = spectre_h5.H5File(self.file_name_r, 1)
-        vol_file = h5_file.get_vol("/element_data")
+        h5_file = spectre_h5.H5File(
+            file_name=self.file_name_r, append_to_file=True)
+        vol_file = h5_file.get_vol(path="/element_data")
         obs_id = vol_file.list_observation_ids()[0]
-        tensor_comps = vol_file.list_tensor_components(obs_id)
+        tensor_comps = vol_file.list_tensor_components(observation_id=obs_id)
         expected_tensor_comps = ['Psi', 'Error(Psi)',
                                  'InertialCoordinates_x',
                                  'InertialCoordinates_y',
@@ -127,23 +133,23 @@ class TestIOH5VolumeData(unittest.TestCase):
         # Checking whether two numpy arrays are "almost equal" is easy, so
         # we convert everything to numpy arrays for comparison.
         Psi_tensor_data = np.asarray(vol_file.get_tensor_component(
-            obs_id, 'Psi'))
+            observation_id=obs_id, tensor_component='Psi'))
         npt.assert_array_almost_equal(Psi_tensor_data,
                                       expected_Psi_tensor_data)
         Error_tensor_data = np.asarray(vol_file.get_tensor_component(
-                obs_id, 'Error(Psi)'))
+            observation_id=obs_id, tensor_component='Error(Psi)'))
         npt.assert_array_almost_equal(Error_tensor_data,
                                       expected_Error_tensor_data)
         xcoord_tensor_data = np.asarray(vol_file.get_tensor_component(
-                obs_id, 'InertialCoordinates_x'))
+            observation_id=obs_id, tensor_component='InertialCoordinates_x'))
         npt.assert_array_almost_equal(xcoord_tensor_data,
                                       expected_xcoord_tensor_data)
         ycoord_tensor_data = np.asarray(vol_file.get_tensor_component(
-                obs_id, 'InertialCoordinates_y'))
+            observation_id=obs_id, tensor_component='InertialCoordinates_y'))
         npt.assert_array_almost_equal(ycoord_tensor_data,
                                       expected_ycoord_tensor_data)
         zcoord_tensor_data = np.asarray(vol_file.get_tensor_component(
-                obs_id, 'InertialCoordinates_z'))
+            observation_id=obs_id, tensor_component='InertialCoordinates_z'))
         npt.assert_array_almost_equal(zcoord_tensor_data,
                                       expected_zcoord_tensor_data)
         h5_file.close()


### PR DESCRIPTION
## Proposed changes

With `bp::arg()` we can add information on argument names to the Python bindings. I think we should do that for all bindings we add in the future. (It is optional whether or not the argument names are used when calling the functions in Python, but it improves the function signature from `arg0`, `arg1` etc to useful argument names)

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
