### PR TITLE
Extend type trait generation macros

### DIFF
--- a/src/Utilities/TypeTraits.hpp
+++ b/src/Utilities/TypeTraits.hpp
@@ -906,6 +906,38 @@ using is_callable_t = typename is_callable<T, Args...>::type;
   using is_##METHOD_NAME##_callable_t =                                        \
       is_##METHOD_NAME##_callable_r_t<AnyReturnType##METHOD_NAME, T, Args...>;
 
+/*!
+ * \ingroup TypeTraitsGroup
+ * \brief Generate a type trait to check if a class has a `static constexpr`
+ * variable, optionally also checking its type.
+ *
+ * \example
+ * \snippet Utilities/Test_TypeTraits.cpp CREATE_HAS_EXAMPLE
+ *
+ * \see `CREATE_IS_CALLABLE`
+ */
+// Use `NoSuchType*****` to represent any `VariableType`, i.e. not checking the
+// variable type at all. If someone has that many pointers to a thing that isn't
+// useful, it's their fault...
+#define CREATE_HAS_STATIC_MEMBER_VARIABLE(CONSTEXPR_NAME)                    \
+  template <typename CheckingType, typename VariableType = NoSuchType*****,  \
+            typename = cpp17::void_t<>>                                      \
+  struct has_##CONSTEXPR_NAME : std::false_type {};                          \
+                                                                             \
+  template <typename CheckingType, typename VariableType>                    \
+  struct has_##CONSTEXPR_NAME<CheckingType, VariableType,                    \
+                              cpp17::void_t<std::remove_const_t<decltype(    \
+                                  CheckingType::CONSTEXPR_NAME)>>>           \
+      : cpp17::bool_constant<                                                \
+            cpp17::is_same_v<VariableType, NoSuchType*****> or               \
+            cpp17::is_same_v<                                                \
+                std::remove_const_t<decltype(CheckingType::CONSTEXPR_NAME)>, \
+                VariableType>> {};                                           \
+                                                                             \
+  template <typename CheckingType, typename VariableType = NoSuchType*****>  \
+  static constexpr const bool has_##CONSTEXPR_NAME##_v =                     \
+      has_##CONSTEXPR_NAME<CheckingType, VariableType>::value;
+
 // @{
 /// \ingroup TypeTraitsGroup
 /// \brief Check if std::hash and std::equal_to are defined for type T

--- a/tests/Unit/Utilities/Test_TypeTraits.cpp
+++ b/tests/Unit/Utilities/Test_TypeTraits.cpp
@@ -395,14 +395,20 @@ namespace  {
 CREATE_IS_CALLABLE(foo)
 CREATE_IS_CALLABLE(foobar)
 struct bar {
-  void foo(int /*unused*/, double /*unused*/) {}
+  size_t foo(int /*unused*/, double /*unused*/) { return size_t{0}; }
 };
 
 static_assert(is_foo_callable_v<bar, int, double>,
               "Failed testing CREATE_IS_CALLABLE");
+static_assert(is_foo_callable_r_v<size_t, bar, int, double>,
+              "Failed testing CREATE_IS_CALLABLE");
 static_assert(not is_foo_callable_v<bar, int>,
               "Failed testing CREATE_IS_CALLABLE");
 static_assert(not is_foo_callable_v<bar>,
+              "Failed testing CREATE_IS_CALLABLE");
+static_assert(not is_foobar_callable_r_v<size_t, bar, int, double>,
+              "Failed testing CREATE_IS_CALLABLE");
+static_assert(not is_foo_callable_r_v<int, bar, int, double>,
               "Failed testing CREATE_IS_CALLABLE");
 static_assert(not is_foobar_callable_v<bar, int, double>,
               "Failed testing CREATE_IS_CALLABLE");

--- a/tests/Unit/Utilities/Test_TypeTraits.cpp
+++ b/tests/Unit/Utilities/Test_TypeTraits.cpp
@@ -413,6 +413,26 @@ static_assert(not is_foo_callable_r_v<int, bar, int, double>,
 static_assert(not is_foobar_callable_v<bar, int, double>,
               "Failed testing CREATE_IS_CALLABLE");
 /// [CREATE_IS_CALLABLE_EXAMPLE]
+
+/// [CREATE_HAS_EXAMPLE]
+CREATE_HAS_STATIC_MEMBER_VARIABLE(foo)
+CREATE_HAS_STATIC_MEMBER_VARIABLE(foobar)
+struct testing_create_has_static_member_variable {
+  static constexpr size_t foo = 1;
+};
+
+static_assert(has_foo_v<testing_create_has_static_member_variable>,
+              "Failed testing CREATE_HAS_STATIC_MEMBER_VARIABLE");
+static_assert(has_foo_v<testing_create_has_static_member_variable, size_t>,
+              "Failed testing CREATE_HAS_STATIC_MEMBER_VARIABLE");
+static_assert(not has_foo_v<testing_create_has_static_member_variable, int>,
+              "Failed testing CREATE_HAS_STATIC_MEMBER_VARIABLE");
+static_assert(not has_foobar_v<testing_create_has_static_member_variable>,
+              "Failed testing CREATE_HAS_STATIC_MEMBER_VARIABLE");
+static_assert(
+    not has_foobar_v<testing_create_has_static_member_variable, size_t>,
+    "Failed testing CREATE_HAS_STATIC_MEMBER_VARIABLE");
+/// [CREATE_HAS_EXAMPLE]
 }  // namespace
 
 /// [is_hashable_example]


### PR DESCRIPTION
## Proposed changes

- Extend the `CREATE_IS_CALLABLE` macro with the ability to check return types
- Add a similar `CREATE_HAS` macro that generates metafunctions to check if a type has a particular alias, and to optionally check the type of the alias.

These type trait macros are useful to check protocol conformance (see #1769).

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
