### PR TITLE
Fix Latex in IsotropicHomogeneous docs

### DIFF
--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp
@@ -34,12 +34,17 @@ namespace ConstitutiveRelations {
  * \details A constitutive relation, in the context of elasticity, relates the
  * Stress \f$T^{ij}\f$ and Strain \f$S_{ij}=\nabla_{(i}u_{j)}\f$ within an
  * elastic material (see \ref Elasticity). For small stresses it is approximated
- * by the linear relation \f[ T^{ij} = -Y^{ijkl}S_{kl} \f] (Eq. 11.17 in
- * \cite ThorneBlandford2017) that is referred to as _Hooke's law_. The
- * constitutive relation in this linear approximation is determined by the
- * elasticity (or _Young's_) tensor \f$Y^{ijkl}=Y^{(ij)(kl)}=Y^{klij}\f$ that
- * generalizes a simple proportionality to a three-dimensional and (possibly)
- * anisotropic material.
+ * by the linear relation
+ *
+ * \f[
+ * T^{ij} = -Y^{ijkl}S_{kl}
+ * \f]
+ *
+ * (Eq. 11.17 in \cite ThorneBlandford2017) that is referred to as _Hooke's
+ * law_. The constitutive relation in this linear approximation is determined by
+ * the elasticity (or _Young's_) tensor \f$Y^{ijkl}=Y^{(ij)(kl)}=Y^{klij}\f$
+ * that generalizes a simple proportionality to a three-dimensional and
+ * (possibly) anisotropic material.
  *
  * \note We assume a Euclidean metric in Cartesian coordinates here (for now).
  */

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp
@@ -24,28 +24,50 @@ namespace ConstitutiveRelations {
  * \brief An isotropic and homogeneous material
  *
  * \details For an isotropic and homogeneous material the linear constitutive
- * relation \f$T^{ij}=-Y^{ijkl}S_{kl}\f$ reduces to \f[
+ * relation \f$T^{ij}=-Y^{ijkl}S_{kl}\f$ reduces to
+ *
+ * \f[
  * Y^{ijkl} = \lambda \delta^{ij}\delta^{kl} + \mu
  * \left(\delta^{ik}\delta^{jl} + \delta^{il}\delta^{jk}\right) \\
  * \implies \quad T^{ij} = -\lambda \mathrm{Tr}(S) \delta^{ij} - 2\mu S^{ij}
- * \f] with the _Lamé parameter_ \f$\lambda\f$ and the _shear modulus_ (or
+ * \f]
+ *
+ * with the _Lamé parameter_ \f$\lambda\f$ and the _shear modulus_ (or
  * _rigidity_) \f$\mu\f$. In the parametrization chosen in this implementation
- * we use the _bulk modulus_ (or _incompressibility_) \f[
+ * we use the _bulk modulus_ (or _incompressibility_)
+ *
+ * \f[
  * K=\lambda + \frac{2}{3}\mu
- * \f] instead of the Lamé parameter. In this parametrization the
- * stress-strain relation \f[
+ * \f]
+ *
+ * instead of the Lamé parameter. In this parametrization the
+ * stress-strain relation
+ *
+ * \f[
  * T^{ij} = -K \mathrm{Tr}(S) \delta^{ij} - 2\mu\left(S^{ij} -
- * \frac{1}{3}\mathrm{Tr}(S)\delta^{ij}\right) \f]
+ * \frac{1}{3}\mathrm{Tr}(S)\delta^{ij}\right)
+ * \f]
+ *
  * decomposes into a scalar and a traceless part (Eq. 11.18 in
  * \cite ThorneBlandford2017). Parameters also often used in this context are
- * the _Young's modulus_ \f[
+ * the _Young's modulus_
+ *
+ * \f[
  * E=\frac{9K\mu}{3K+\mu}=\frac{\mu(3\lambda+2\mu)}{\lambda+\mu}
- * \f] and the _Poisson ratio_ \f[
- * \nu=\frac{3K-2\mu}{2(3K+\mu)}=\frac{\lambda}{2(\lambda+\mu)}
- * \f]. Inversely, these relations read: \f[
- * K &=\frac{E}{3(1-2\nu)} \\
- * \lambda &=\frac{E\nu}{(1+\nu)(1-2\nu)} \\
- * \mu &=\frac{E}{2(1+\nu)}
+ * \f]
+ *
+ * and the _Poisson ratio_
+ *
+ * \f[
+ * \nu=\frac{3K-2\mu}{2(3K+\mu)}=\frac{\lambda}{2(\lambda+\mu)}\text{.}
+ * \f]
+ *
+ * Inversely, these relations read:
+ *
+ * \f[
+ * K =\frac{E}{3(1-2\nu)}, \quad
+ * \lambda =\frac{E\nu}{(1+\nu)(1-2\nu)}, \quad
+ * \mu =\frac{E}{2(1+\nu)}
  * \f]
  *
  * **In two dimensions** this implementation reduces to the plane-stress
@@ -55,11 +77,15 @@ namespace ConstitutiveRelations {
  * \f$T^{i3}=0=T^{3i}\f$ we find \f$\mathrm{Tr}(S)=\frac{2\mu}{\lambda +
  * 2\mu}\mathrm{Tr}^{(2)}(S)\f$, where \f$\mathrm{Tr}^{(2)}\f$ denotes that the
  * trace only applies to the two dimensions within the plane. The constitutive
- * relation thus reduces to \f[
- * T^{ij}&=-\frac{2\lambda\mu}{\lambda + 2\mu}\mathrm{Tr}^{(2)}\delta^{ij} -
+ * relation thus reduces to
+ *
+ * \f{align}
+ * T^{ij}=&-\frac{2\lambda\mu}{\lambda + 2\mu}\mathrm{Tr}^{(2)}\delta^{ij} -
  * 2\mu S^{ij} \\
- * &=-\frac{E\nu}{1-\nu^2}\mathrm{Tr}^{(2)}\delta^{ij} - \frac{E}{1+\nu}S^{ij}
- * \f] which is non-zero only in the directions of the plane. Since the stresses
+ * =&-\frac{E\nu}{1-\nu^2}\mathrm{Tr}^{(2)}\delta^{ij} - \frac{E}{1+\nu}S^{ij}
+ * \f}
+ *
+ * which is non-zero only in the directions of the plane. Since the stresses
  * are also assumed to be constant along the thickness of the plane
  * \f$\partial_3T^{ij}=0\f$ the elasticity problem \f$-\partial_i T^{ij}=F^j\f$
  * reduces to two dimensions.

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp
@@ -80,9 +80,10 @@ namespace ConstitutiveRelations {
  * relation thus reduces to
  *
  * \f{align}
- * T^{ij}=&-\frac{2\lambda\mu}{\lambda + 2\mu}\mathrm{Tr}^{(2)}\delta^{ij} -
+ * T^{ij}=&-\frac{2\lambda\mu}{\lambda + 2\mu}\mathrm{Tr}^{(2)}(S)\delta^{ij} -
  * 2\mu S^{ij} \\
- * =&-\frac{E\nu}{1-\nu^2}\mathrm{Tr}^{(2)}\delta^{ij} - \frac{E}{1+\nu}S^{ij}
+ * =&-\frac{E\nu}{1-\nu^2}\mathrm{Tr}^{(2)}(S)\delta^{ij} -
+ * \frac{E}{1+\nu}S^{ij}
  * \f}
  *
  * which is non-zero only in the directions of the plane. Since the stresses


### PR DESCRIPTION
## Proposed changes
fixes Latex code in IsotropicHomogeneous to correctly display, because it didn't render correctly before
<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
