### PR TITLE
Cce boundary data part 1

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -35,6 +35,18 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@article{Barkett2019uae,
+      author         = "Barkett, Kevin and Moxon, Jordan and Scheel, Mark A. and
+                        Szilágyi, Béla",
+      title          = "{Spectral Cauchy-characteristic extraction of the
+                        gravitational wave news function}",
+      year           = "2019",
+      eprint         = "1910.09677",
+      archivePrefix  = "arXiv",
+      primaryClass   = "gr-qc",
+      SLACcitation   = "%%CITATION = ARXIV:1910.09677;%%"
+}
+
 @article{Baumgarte1996hh,
   author         = "Baumgarte, Thomas W. and Cook, Gregory B. and Scheel,
                     Mark A. and Shapiro, Stuart L. and Teukolsky, Saul A.",
@@ -98,6 +110,25 @@
   archivePrefix  = "arXiv",
   primaryClass   = "gr-qc",
   url            = "https://doi.org/10.1103/PhysRevD.56.6298",
+}
+
+@incollection{Bishop1998uk,
+      author         = "Bishop, Nigel T. and Gomez, Roberto and Lehner, Luis and
+                        Szilagyi, Bela and Winicour, Jeffrey and Isaacson,
+                        Richard A.",
+      title          = "{Cauchy characteristic matching}",
+      editor         = "Iyer, Bala R. and Bhawal, Biblap",
+      booktitle      = "Black Holes, Gravitational Radiation and the Universe:
+                        Essays in Honor of C.V. Vishveshwara",
+      journal        = "#DONE:In *Iyer, B.R. (ed.) et al.: Black holes,
+                        gravitational radiation and the universe* 383-408",
+      pages          = "383-408",
+      doi            = "10.1007/978-94-017-0934-7_24",
+      year           = "1998",
+      eprint         = "gr-qc/9801070",
+      archivePrefix  = "arXiv",
+      primaryClass   = "gr-qc",
+      SLACcitation   = "%%CITATION = GR-QC/9801070;%%"
 }
 
 @article{Boyle2019kee,

--- a/src/DataStructures/SpinWeighted.hpp
+++ b/src/DataStructures/SpinWeighted.hpp
@@ -489,6 +489,13 @@ SPECTRE_ALWAYS_INLINE bool operator!=(const T& lhs,
 }
 // @}
 
+/// Stream operator simply forwards
+template <typename T, int Spin>
+std::ostream& operator<<(std::ostream& os,
+                         const SpinWeighted<T, Spin>& d) noexcept {
+  return os << d.data();
+}
+
 namespace MakeWithValueImpls {
 template <int Spin1, int Spin2, typename SpinWeightedType1,
           typename SpinWeightedType2>

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /*!
@@ -25,6 +26,7 @@ Scalar<DataType> magnitude(
   return Scalar<DataType>{sqrt(get(dot_product(vector, vector)))};
 }
 
+// @{
 /*!
  * \ingroup TensorGroup
  * \brief Compute the magnitude of a rank-1 tensor
@@ -39,8 +41,22 @@ Scalar<DataType> magnitude(
     const Tensor<DataType, Symmetry<1, 1>,
                  index_list<change_index_up_lo<Index>,
                             change_index_up_lo<Index>>>& metric) noexcept {
-  return Scalar<DataType>{sqrt(get(dot_product(vector, vector, metric)))};
+  Scalar<DataType> local_magnitude{get_size(get<0>(vector))};
+  magnitude(make_not_null(&local_magnitude), vector, metric);
+  return local_magnitude;
 }
+
+template <typename DataType, typename Index>
+void magnitude(
+    const gsl::not_null<Scalar<DataType>*> magnitude,
+    const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector,
+    const Tensor<DataType, Symmetry<1, 1>,
+                 index_list<change_index_up_lo<Index>,
+                            change_index_up_lo<Index>>>& metric) noexcept {
+  dot_product(magnitude, vector, vector, metric);
+  get(*magnitude) = sqrt(get(*magnitude));
+}
+// @}
 
 /// \ingroup TensorGroup
 /// \brief Compute square root of the Euclidean magnitude of a rank-0 tensor
@@ -48,8 +64,7 @@ Scalar<DataType> magnitude(
 /// \details
 /// Computes the square root of the absolute value of the scalar.
 template <typename DataType>
-Scalar<DataType> sqrt_magnitude(
-    const Scalar<DataType>& input) noexcept {
+Scalar<DataType> sqrt_magnitude(const Scalar<DataType>& input) noexcept {
   return Scalar<DataType>{sqrt(abs(get(input)))};
 }
 

--- a/src/DataStructures/Tensor/TypeAliases.hpp
+++ b/src/DataStructures/Tensor/TypeAliases.hpp
@@ -93,9 +93,13 @@ using IJ = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
                   index_list<SpatialIndex<SpatialDim, UpLo::Up, Fr>,
                              SpatialIndex<SpatialDim, UpLo::Up, Fr>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using iA = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+                  index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                             SpacetimeIndex<SpatialDim, UpLo::Up, Fr>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
 using ia = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
-index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
-           SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>>>;
+                  index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                             SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>>>;
 
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>

--- a/src/Evolution/Systems/Cce/BoundaryData.cpp
+++ b/src/Evolution/Systems/Cce/BoundaryData.cpp
@@ -1,0 +1,535 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Math.hpp"
+
+namespace Cce {
+
+void trigonometric_functions_on_swsh_collocation(
+    const gsl::not_null<Scalar<DataVector>*> cos_phi,
+    const gsl::not_null<Scalar<DataVector>*> cos_theta,
+    const gsl::not_null<Scalar<DataVector>*> sin_phi,
+    const gsl::not_null<Scalar<DataVector>*> sin_theta,
+    const size_t l_max) noexcept {
+  const size_t size = Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  destructive_resize_components(cos_phi, size);
+  destructive_resize_components(cos_theta, size);
+  destructive_resize_components(sin_phi, size);
+  destructive_resize_components(sin_theta, size);
+
+  const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
+      Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
+  for (const auto& collocation_point : collocation) {
+    get(*sin_theta)[collocation_point.offset] = sin(collocation_point.theta);
+    get(*cos_theta)[collocation_point.offset] = cos(collocation_point.theta);
+    get(*sin_phi)[collocation_point.offset] = sin(collocation_point.phi);
+    get(*cos_phi)[collocation_point.offset] = cos(collocation_point.phi);
+  }
+}
+
+void cartesian_to_spherical_coordinates_and_jacobians(
+    const gsl::not_null<tnsr::I<DataVector, 3>*> unit_cartesian_coords,
+    const gsl::not_null<jacobian_tensor*> cartesian_to_spherical_jacobian,
+    const gsl::not_null<inverse_jacobian_tensor*>
+        inverse_cartesian_to_spherical_jacobian,
+    const Scalar<DataVector>& cos_phi, const Scalar<DataVector>& cos_theta,
+    const Scalar<DataVector>& sin_phi, const Scalar<DataVector>& sin_theta,
+    const double extraction_radius) noexcept {
+  const size_t size = get(cos_phi).size();
+  destructive_resize_components(unit_cartesian_coords, size);
+  destructive_resize_components(cartesian_to_spherical_jacobian, size);
+  destructive_resize_components(inverse_cartesian_to_spherical_jacobian, size);
+
+  // note: factor of r scaled out
+  get<0>(*unit_cartesian_coords) = get(sin_theta) * get(cos_phi);
+  get<1>(*unit_cartesian_coords) = get(sin_theta) * get(sin_phi);
+  get<2>(*unit_cartesian_coords) = get(cos_theta);
+
+  // dx/dr   dy/dr  dz/dr
+  get<0, 0>(*cartesian_to_spherical_jacobian) = get(sin_theta) * get(cos_phi);
+  get<0, 1>(*cartesian_to_spherical_jacobian) = get(sin_theta) * get(sin_phi);
+  get<0, 2>(*cartesian_to_spherical_jacobian) = get(cos_theta);
+  // dx/dtheta   dy/dtheta  dz/dtheta
+  get<1, 0>(*cartesian_to_spherical_jacobian) =
+      extraction_radius * get(cos_theta) * get(cos_phi);
+  get<1, 1>(*cartesian_to_spherical_jacobian) =
+      extraction_radius * get(cos_theta) * get(sin_phi);
+  get<1, 2>(*cartesian_to_spherical_jacobian) =
+      -extraction_radius * get(sin_theta);
+  // (1/sin(theta)) { dx/dphi,   dy/dphi,  dz/dphi }
+  get<2, 0>(*cartesian_to_spherical_jacobian) =
+      -extraction_radius * get(sin_phi);
+  get<2, 1>(*cartesian_to_spherical_jacobian) =
+      extraction_radius * get(cos_phi);
+  get<2, 2>(*cartesian_to_spherical_jacobian) = 0.0;
+
+  // dr/dx   dtheta/dx   dphi/dx * sin(theta)
+  get<0, 0>(*inverse_cartesian_to_spherical_jacobian) =
+      get(cos_phi) * get(sin_theta);
+  get<0, 1>(*inverse_cartesian_to_spherical_jacobian) =
+      get(cos_phi) * get(cos_theta) / extraction_radius;
+  get<0, 2>(*inverse_cartesian_to_spherical_jacobian) =
+      -get(sin_phi) / (extraction_radius);
+  // dr/dy   dtheta/dy   dphi/dy * sin(theta)
+  get<1, 0>(*inverse_cartesian_to_spherical_jacobian) =
+      get(sin_phi) * get(sin_theta);
+  get<1, 1>(*inverse_cartesian_to_spherical_jacobian) =
+      get(cos_theta) * get(sin_phi) / extraction_radius;
+  get<1, 2>(*inverse_cartesian_to_spherical_jacobian) =
+      get(cos_phi) / (extraction_radius);
+  // dr/dz   dtheta/dz   dphi/dz * sin(theta)
+  get<2, 0>(*inverse_cartesian_to_spherical_jacobian) = get(cos_theta);
+  get<2, 1>(*inverse_cartesian_to_spherical_jacobian) =
+      -get(sin_theta) / extraction_radius;
+  get<2, 2>(*inverse_cartesian_to_spherical_jacobian) = 0.0;
+}
+
+void null_metric_and_derivative(
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::RadialNull>*>
+        du_null_metric,
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::RadialNull>*>
+        null_metric,
+    const jacobian_tensor& cartesian_to_spherical_jacobian,
+    const tnsr::aa<DataVector, 3>& dt_spacetime_metric,
+    const tnsr::aa<DataVector, 3>& spacetime_metric) noexcept {
+  const size_t size = get<0, 0>(spacetime_metric).size();
+  destructive_resize_components(null_metric, size);
+  destructive_resize_components(du_null_metric, size);
+
+  get<0, 0>(*null_metric) = get<0, 0>(spacetime_metric);
+  get<0, 0>(*du_null_metric) = get<0, 0>(dt_spacetime_metric);
+
+  get<0, 1>(*null_metric) = -1.0;
+  get<0, 1>(*du_null_metric) = 0.0;
+
+  for (size_t i = 0; i < 3; ++i) {
+    null_metric->get(1, i + 1) = 0.0;
+    du_null_metric->get(1, i + 1) = 0.0;
+  }
+
+  for (size_t A = 0; A < 2; ++A) {
+    null_metric->get(0, A + 2) = cartesian_to_spherical_jacobian.get(A + 1, 0) *
+                                 spacetime_metric.get(0, 1);
+    du_null_metric->get(0, A + 2) =
+        cartesian_to_spherical_jacobian.get(A + 1, 0) *
+        dt_spacetime_metric.get(0, 1);
+    for (size_t i = 1; i < 3; ++i) {
+      null_metric->get(0, A + 2) +=
+          cartesian_to_spherical_jacobian.get(A + 1, i) *
+          spacetime_metric.get(0, i + 1);
+      du_null_metric->get(0, A + 2) +=
+          cartesian_to_spherical_jacobian.get(A + 1, i) *
+          dt_spacetime_metric.get(0, i + 1);
+    }
+  }
+
+  for (size_t A = 0; A < 2; ++A) {
+    for (size_t B = A; B < 2; ++B) {
+      null_metric->get(A + 2, B + 2) =
+          cartesian_to_spherical_jacobian.get(A + 1, 0) *
+          cartesian_to_spherical_jacobian.get(B + 1, 0) *
+          spacetime_metric.get(1, 1);
+      du_null_metric->get(A + 2, B + 2) =
+          cartesian_to_spherical_jacobian.get(A + 1, 0) *
+          cartesian_to_spherical_jacobian.get(B + 1, 0) *
+          dt_spacetime_metric.get(1, 1);
+
+      for (size_t i = 1; i < 3; ++i) {
+        null_metric->get(A + 2, B + 2) +=
+            cartesian_to_spherical_jacobian.get(A + 1, i) *
+            cartesian_to_spherical_jacobian.get(B + 1, i) *
+            spacetime_metric.get(i + 1, i + 1);
+        du_null_metric->get(A + 2, B + 2) +=
+            cartesian_to_spherical_jacobian.get(A + 1, i) *
+            cartesian_to_spherical_jacobian.get(B + 1, i) *
+            dt_spacetime_metric.get(i + 1, i + 1);
+      }
+
+      for (size_t i = 0; i < 3; ++i) {
+        for (size_t j = i + 1; j < 3; ++j) {
+          // the off-diagonal pieces must be explicitly symmetrized
+          null_metric->get(A + 2, B + 2) +=
+              (cartesian_to_spherical_jacobian.get(A + 1, i) *
+                   cartesian_to_spherical_jacobian.get(B + 1, j) +
+               cartesian_to_spherical_jacobian.get(A + 1, j) *
+                   cartesian_to_spherical_jacobian.get(B + 1, i)) *
+              spacetime_metric.get(i + 1, j + 1);
+          du_null_metric->get(A + 2, B + 2) +=
+              (cartesian_to_spherical_jacobian.get(A + 1, i) *
+                   cartesian_to_spherical_jacobian.get(B + 1, j) +
+               cartesian_to_spherical_jacobian.get(A + 1, j) *
+                   cartesian_to_spherical_jacobian.get(B + 1, i)) *
+              dt_spacetime_metric.get(i + 1, j + 1);
+        }
+      }
+    }
+  }
+
+  for (size_t a = 0; a < 4; ++a) {
+    for (size_t b = 0; b < a; ++b) {
+      null_metric->get(a, b) = null_metric->get(b, a);
+      du_null_metric->get(a, b) = du_null_metric->get(b, a);
+    }
+  }
+}
+
+void worldtube_normal_and_derivatives(
+    const gsl::not_null<tnsr::I<DataVector, 3>*> worldtube_normal,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> dt_worldtube_normal,
+    const Scalar<DataVector>& cos_phi, const Scalar<DataVector>& cos_theta,
+    const tnsr::aa<DataVector, 3>& spacetime_metric,
+    const tnsr::aa<DataVector, 3>& dt_spacetime_metric,
+    const Scalar<DataVector>& sin_phi, const Scalar<DataVector>& sin_theta,
+    const tnsr::II<DataVector, 3>& inverse_spatial_metric) noexcept {
+  const size_t size = get<0, 0>(spacetime_metric).size();
+  destructive_resize_components(worldtube_normal, size);
+  destructive_resize_components(dt_worldtube_normal, size);
+
+  // Allocation
+  Variables<tmpl::list<::Tags::Tempi<0, 3>, ::Tags::TempScalar<1>>>
+      aggregated_buffers{size};
+  tnsr::i<DataVector, 3>& sigma = get<::Tags::Tempi<0, 3>>(aggregated_buffers);
+  get<0>(sigma) = get(cos_phi) * square(get(sin_theta));
+  get<1>(sigma) = get(sin_phi) * square(get(sin_theta));
+  get<2>(sigma) = get(sin_theta) * get(cos_theta);
+
+  // Allocation
+  magnitude(make_not_null(&get<::Tags::TempScalar<1>>(aggregated_buffers)),
+            sigma, inverse_spatial_metric);
+  const DataVector& norm_of_sigma =
+      get(get<::Tags::TempScalar<1>>(aggregated_buffers));
+
+  get<0>(sigma) /= norm_of_sigma;
+  get<1>(sigma) /= norm_of_sigma;
+  get<2>(sigma) /= norm_of_sigma;
+
+  for (size_t i = 0; i < 3; ++i) {
+    worldtube_normal->get(i) = inverse_spatial_metric.get(i, 0) * sigma.get(0);
+    for (size_t j = 1; j < 3; ++j) {
+      worldtube_normal->get(i) +=
+          inverse_spatial_metric.get(i, j) * sigma.get(j);
+    }
+  }
+
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t m = 0; m < 3; ++m) {
+      for (size_t n = 0; n < 3; ++n) {
+        if (UNLIKELY(m == 0 and n == 0)) {
+          dt_worldtube_normal->get(i) =
+              (0.5 * worldtube_normal->get(i) * get<0>(*worldtube_normal) -
+               inverse_spatial_metric.get(i, 0)) *
+              get<0>(*worldtube_normal) * get<1, 1>(dt_spacetime_metric);
+        } else {
+          dt_worldtube_normal->get(i) +=
+              (0.5 * worldtube_normal->get(i) * worldtube_normal->get(m) -
+               inverse_spatial_metric.get(i, m)) *
+              worldtube_normal->get(n) * dt_spacetime_metric.get(m + 1, n + 1);
+        }
+      }
+    }
+  }
+}
+
+void null_vector_l_and_derivatives(
+    const gsl::not_null<tnsr::A<DataVector, 3>*> du_null_l,
+    const gsl::not_null<tnsr::A<DataVector, 3>*> null_l,
+    const tnsr::I<DataVector, 3>& dt_worldtube_normal,
+    const Scalar<DataVector>& dt_lapse,
+    const tnsr::aa<DataVector, 3>& dt_spacetime_metric,
+    const tnsr::I<DataVector, 3>& dt_shift, const Scalar<DataVector>& lapse,
+    const tnsr::aa<DataVector, 3>& spacetime_metric,
+    const tnsr::I<DataVector, 3>& shift,
+    const tnsr::I<DataVector, 3>& worldtube_normal) noexcept {
+  const size_t size = get(lapse).size();
+  destructive_resize_components(du_null_l, size);
+  destructive_resize_components(null_l, size);
+
+  // Allocation
+  Variables<tmpl::list<::Tags::TempScalar<0>, ::Tags::TempScalar<1>,
+                       ::Tags::TempScalar<2>>>
+      aggregated_buffer{size};
+  DataVector& denominator = get(get<::Tags::TempScalar<0>>(aggregated_buffer));
+  DataVector& du_denominator =
+      get(get<::Tags::TempScalar<1>>(aggregated_buffer));
+  DataVector& one_divided_by_lapse =
+      get(get<::Tags::TempScalar<2>>(aggregated_buffer));
+  one_divided_by_lapse = 1.0 / get(lapse);
+  denominator = get(lapse);
+  for (size_t i = 0; i < 3; ++i) {
+    // off-diagonal
+    for (size_t j = i + 1; j < 3; ++j) {
+      denominator -= spacetime_metric.get(i + 1, j + 1) *
+                     (shift.get(i) * worldtube_normal.get(j) +
+                      shift.get(j) * worldtube_normal.get(i));
+    }
+    // diagonal
+    denominator -= spacetime_metric.get(i + 1, i + 1) * shift.get(i) *
+                   worldtube_normal.get(i);
+  }
+  // buffer re-use because we won't need the uninverted denominator after this.
+  DataVector& one_divided_by_denominator =
+      get(get<::Tags::TempScalar<0>>(aggregated_buffer));
+  one_divided_by_denominator = 1.0 / denominator;
+  get<0>(*null_l) = one_divided_by_denominator * one_divided_by_lapse;
+  for (size_t i = 0; i < 3; ++i) {
+    null_l->get(i + 1) =
+        (worldtube_normal.get(i) - shift.get(i) * one_divided_by_lapse) *
+        one_divided_by_denominator;
+  }
+
+  du_denominator = -get(dt_lapse);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i + 1; j < 3; ++j) {
+      // symmetry
+      du_denominator += (dt_shift.get(i) * worldtube_normal.get(j) +
+                         dt_shift.get(j) * worldtube_normal.get(i)) *
+                            spacetime_metric.get(i + 1, j + 1) +
+                        (shift.get(i) * worldtube_normal.get(j) +
+                         shift.get(j) * worldtube_normal.get(i)) *
+                            dt_spacetime_metric.get(i + 1, j + 1) +
+                        (shift.get(i) * dt_worldtube_normal.get(j) +
+                         shift.get(j) * dt_worldtube_normal.get(i)) *
+                            spacetime_metric.get(i + 1, j + 1);
+    }
+    // diagonal
+    du_denominator += dt_shift.get(i) * spacetime_metric.get(i + 1, i + 1) *
+                          worldtube_normal.get(i) +
+                      shift.get(i) * dt_spacetime_metric.get(i + 1, i + 1) *
+                          worldtube_normal.get(i) +
+                      shift.get(i) * spacetime_metric.get(i + 1, i + 1) *
+                          dt_worldtube_normal.get(i);
+  }
+  du_denominator *= square(one_divided_by_denominator);
+
+  get<0>(*du_null_l) = (du_denominator - get(dt_lapse) * one_divided_by_lapse *
+                                             one_divided_by_denominator) *
+                       one_divided_by_lapse;
+  for (size_t i = 0; i < 3; ++i) {
+    du_null_l->get(i + 1) =
+        (dt_worldtube_normal.get(i) - dt_shift.get(i) * one_divided_by_lapse) *
+        one_divided_by_denominator;
+    du_null_l->get(i + 1) += shift.get(i) * get(dt_lapse) *
+                             square(one_divided_by_lapse) *
+                             one_divided_by_denominator;
+    du_null_l->get(i + 1) +=
+        (-shift.get(i) * one_divided_by_lapse + worldtube_normal.get(i)) *
+        du_denominator;
+  }
+}
+
+void dlambda_null_metric_and_inverse(
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::RadialNull>*>
+        dlambda_null_metric,
+    const gsl::not_null<tnsr::AA<DataVector, 3, Frame::RadialNull>*>
+        dlambda_inverse_null_metric,
+    const tnsr::iA<DataVector, 3>& angular_d_null_l,
+    const jacobian_tensor& cartesian_to_spherical_jacobian,
+    const tnsr::iaa<DataVector, 3>& phi,
+    const tnsr::aa<DataVector, 3>& dt_spacetime_metric,
+    const tnsr::A<DataVector, 3>& du_null_l,
+    const tnsr::AA<DataVector, 3>& inverse_null_metric,
+    const tnsr::A<DataVector, 3>& null_l,
+    const tnsr::aa<DataVector, 3>& spacetime_metric) noexcept {
+  // first, the (down-index) null metric
+  const size_t size = get<0, 0>(spacetime_metric).size();
+  destructive_resize_components(dlambda_null_metric, size);
+  destructive_resize_components(dlambda_inverse_null_metric, size);
+
+  get<0, 0>(*dlambda_null_metric) =
+      get<0>(null_l) * get<0, 0>(dt_spacetime_metric) +
+      2.0 * get<0>(du_null_l) * get<0, 0>(spacetime_metric);
+  for (size_t i = 0; i < 3; ++i) {
+    get<0, 0>(*dlambda_null_metric) +=
+        null_l.get(i + 1) * phi.get(i, 0, 0) +
+        2.0 * du_null_l.get(i + 1) * spacetime_metric.get(i + 1, 0);
+  }
+  // A0 component
+  for (size_t A = 0; A < 2; ++A) {
+    dlambda_null_metric->get(0, A + 2) =
+        cartesian_to_spherical_jacobian.get(A + 1, 0) *
+            (get<0>(du_null_l) * get<1, 0>(spacetime_metric) +
+             get<0>(null_l) * get<1, 0>(dt_spacetime_metric)) +
+        angular_d_null_l.get(A + 1, 1) * get<1, 0>(spacetime_metric) +
+        angular_d_null_l.get(A + 1, 0) * get<0, 0>(spacetime_metric);
+    for (size_t k = 1; k < 3; ++k) {
+      dlambda_null_metric->get(0, A + 2) +=
+          cartesian_to_spherical_jacobian.get(A + 1, k) *
+              (get<0>(du_null_l) * spacetime_metric.get(k + 1, 0) +
+               get<0>(null_l) * dt_spacetime_metric.get(k + 1, 0)) +
+          angular_d_null_l.get(A + 1, k + 1) * spacetime_metric.get(k + 1, 0);
+    }
+    for (size_t i = 0; i < 3; ++i) {
+      for (size_t k = 0; k < 3; ++k) {
+        dlambda_null_metric->get(0, A + 2) +=
+            cartesian_to_spherical_jacobian.get(A + 1, k) *
+            (du_null_l.get(i + 1) * spacetime_metric.get(k + 1, i + 1) +
+             null_l.get(i + 1) * phi.get(i, k + 1, 0));
+      }
+    }
+    dlambda_null_metric->get(A + 2, 0) = dlambda_null_metric->get(0, A + 2);
+  }
+  // zero the null directions
+  get<0, 1>(*dlambda_null_metric) = 0.0;
+  for (size_t a = 1; a < 4; ++a) {
+    dlambda_null_metric->get(1, a) = 0.0;
+  }
+
+  for (size_t A = 0; A < 2; ++A) {
+    for (size_t B = 0; B < 2; ++B) {
+      dlambda_null_metric->get(A + 2, B + 2) = 0.0;
+    }
+  }
+
+  for (size_t A = 0; A < 2; ++A) {
+    for (size_t B = A; B < 2; ++B) {
+      for (size_t i = 0; i < 3; ++i) {
+        for (size_t j = 0; j < 3; ++j) {
+          dlambda_null_metric->get(A + 2, B + 2) +=
+              get<0>(null_l) * cartesian_to_spherical_jacobian.get(A + 1, i) *
+              cartesian_to_spherical_jacobian.get(B + 1, j) *
+              dt_spacetime_metric.get(i + 1, j + 1);
+        }
+      }
+    }
+  }
+  for (size_t A = 0; A < 2; ++A) {
+    for (size_t B = A; B < 2; ++B) {
+      for (size_t i = 0; i < 3; ++i) {
+        for (size_t j = 0; j < 3; ++j) {
+          for (size_t k = 0; k < 3; ++k) {
+            dlambda_null_metric->get(A + 2, B + 2) +=
+                null_l.get(k + 1) *
+                cartesian_to_spherical_jacobian.get(A + 1, i) *
+                cartesian_to_spherical_jacobian.get(B + 1, j) *
+                phi.get(k, i + 1, j + 1);
+          }
+        }
+      }
+    }
+  }
+
+  for (size_t A = 0; A < 2; ++A) {
+    for (size_t B = A; B < 2; ++B) {
+      for (size_t i = 0; i < 3; ++i) {
+        for (size_t a = 0; a < 4; ++a) {
+          dlambda_null_metric->get(A + 2, B + 2) +=
+              (angular_d_null_l.get(A + 1, a) *
+                   cartesian_to_spherical_jacobian.get(B + 1, i) +
+               angular_d_null_l.get(B + 1, a) *
+                   cartesian_to_spherical_jacobian.get(A + 1, i)) *
+              spacetime_metric.get(a, i + 1);
+        }
+      }
+    }
+  }
+  for (size_t a = 0; a < 4; ++a) {
+    for (size_t b = 0; b < a; ++b) {
+      dlambda_null_metric->get(a, b) = dlambda_null_metric->get(b, a);
+    }
+  }
+
+  for (size_t a = 0; a < 4; ++a) {
+    for (size_t b = 0; b < 4; ++b) {
+      dlambda_inverse_null_metric->get(a, b) = 0.0;
+    }
+  }
+  for (size_t A = 0; A < 2; ++A) {
+    for (size_t B = A; B < 2; ++B) {
+      for (size_t C = 0; C < 2; ++C) {
+        for (size_t D = 0; D < 2; ++D) {
+          dlambda_inverse_null_metric->get(A + 2, B + 2) -=
+              inverse_null_metric.get(A + 2, C + 2) *
+              inverse_null_metric.get(B + 2, D + 2) *
+              dlambda_null_metric->get(C + 2, D + 2);
+        }
+      }
+    }
+  }
+
+  for (size_t A = 0; A < 2; ++A) {
+    for (size_t B = 0; B < 2; ++B) {
+      dlambda_inverse_null_metric->get(1, A + 2) +=
+          inverse_null_metric.get(A + 2, B + 2) *
+          dlambda_null_metric->get(0, B + 2);
+      for (size_t C = 0; C < 2; ++C) {
+        dlambda_inverse_null_metric->get(1, A + 2) -=
+            inverse_null_metric.get(A + 2, B + 2) *
+            inverse_null_metric.get(1, C + 2) *
+            dlambda_null_metric->get(C + 2, B + 2);
+      }
+    }
+  }
+
+  get<1, 1>(*dlambda_inverse_null_metric) -= get<0, 0>(*dlambda_null_metric);
+
+  for (size_t A = 0; A < 2; ++A) {
+    get<1, 1>(*dlambda_inverse_null_metric) +=
+        2.0 * inverse_null_metric.get(1, A + 2) *
+        dlambda_null_metric->get(0, A + 2);
+    for (size_t B = 0; B < 2; ++B) {
+      get<1, 1>(*dlambda_inverse_null_metric) -=
+          inverse_null_metric.get(1, A + 2) *
+          inverse_null_metric.get(1, B + 2) *
+          dlambda_null_metric->get(A + 2, B + 2);
+    }
+  }
+}
+
+void d_bondi_r(
+    const gsl::not_null<tnsr::a<DataVector, 3, Frame::RadialNull>*> d_bondi_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
+    const tnsr::aa<DataVector, 3, Frame::RadialNull>& dlambda_null_metric,
+    const tnsr::aa<DataVector, 3, Frame::RadialNull>& du_null_metric,
+    const tnsr::AA<DataVector, 3, Frame::RadialNull>& inverse_null_metric,
+    const size_t l_max) noexcept {
+  destructive_resize_components(d_bondi_r,
+                                get<0, 0>(inverse_null_metric).size());
+
+  // compute the time derivative part
+  get<0>(*d_bondi_r) =
+      0.25 * real(get(bondi_r).data()) *
+      (get<2, 2>(inverse_null_metric) * get<2, 2>(du_null_metric) +
+       2.0 * get<2, 3>(inverse_null_metric) * get<2, 3>(du_null_metric) +
+       get<3, 3>(inverse_null_metric) * get<3, 3>(du_null_metric));
+  // compute the lambda derivative part
+  get<1>(*d_bondi_r) =
+      0.25 * real(get(bondi_r).data()) *
+      (get<2, 2>(inverse_null_metric) * get<2, 2>(dlambda_null_metric) +
+       2.0 * get<2, 3>(inverse_null_metric) * get<2, 3>(dlambda_null_metric) +
+       get<3, 3>(inverse_null_metric) * get<3, 3>(dlambda_null_metric));
+
+  // Allocation (of result and coefficient buffer)
+  const auto eth_of_r =
+      Spectral::Swsh::angular_derivative<Spectral::Swsh::Tags::Eth>(
+          l_max, 1, get(bondi_r));
+  d_bondi_r->get(2) = -real(eth_of_r.data());
+  d_bondi_r->get(3) = -imag(eth_of_r.data());
+}
+
+void dyads(
+    const gsl::not_null<tnsr::i<ComplexDataVector, 2, Frame::RadialNull>*>
+        down_dyad,
+    const gsl::not_null<tnsr::I<ComplexDataVector, 2, Frame::RadialNull>*>
+        up_dyad) noexcept {
+  // implicit factors of sin_theta omitted (still normalized as desired, though)
+  get<0>(*down_dyad) = -1.0;
+  get<1>(*down_dyad) = std::complex<double>(0.0, -1.0);
+  get<0>(*up_dyad) = -1.0;
+  get<1>(*up_dyad) = std::complex<double>(0.0, -1.0);
+}
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/BoundaryData.hpp
+++ b/src/Evolution/Systems/Cce/BoundaryData.hpp
@@ -1,0 +1,224 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/BoundaryDataTags.hpp"
+
+/// \cond
+class DataVector;
+class ComplexDataVector;
+/// \endcond
+
+namespace Cce {
+// tensor aliases for brevity
+using jacobian_tensor = Tensor<
+    DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
+    index_list<SpatialIndex<3, UpLo::Lo, ::Frame::Spherical<::Frame::Inertial>>,
+               SpatialIndex<3, UpLo::Up, ::Frame::Inertial>>>;
+
+using inverse_jacobian_tensor =
+    Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
+           index_list<SpatialIndex<3, UpLo::Lo, ::Frame::Inertial>,
+                      SpatialIndex<3, UpLo::Up,
+                                   ::Frame::Spherical<::Frame::Inertial>>>>;
+
+/*!
+ * \brief Constructs the collocation values for \f$\cos(\phi)\f$,
+ * \f$\cos(\theta)\f$, \f$\sin(\phi)\f$, and \f$\sin(\theta)\f$, returned by
+ * `not_null` pointer in that order.
+ *
+ * \details These are needed for coordinate transformations from the input
+ * Cartesian-like coordinates.
+ */
+void trigonometric_functions_on_swsh_collocation(
+    gsl::not_null<Scalar<DataVector>*> cos_phi,
+    gsl::not_null<Scalar<DataVector>*> cos_theta,
+    gsl::not_null<Scalar<DataVector>*> sin_phi,
+    gsl::not_null<Scalar<DataVector>*> sin_theta, size_t l_max) noexcept;
+
+/*!
+ * \brief Creates both the Jacobian and inverse Jacobian between Cartesian and
+ * spherical coordinates, and the coordinates themselves
+ *
+ * \details The `cartesian_to_spherical_jacobian` is
+ * \f$dx^i/d\tilde{x}^{\tilde j}\f$,
+ * where the Cartesian components are in order \f$x^i = \{x, y, z\}\f$
+ * and the spherical coordinates are
+ * \f$\tilde{x}^{\tilde j} = \{r, \theta, \phi\}\f$.
+ * The Cartesian coordinates given are the standard unit sphere coordinates:
+ *
+ * \f{align*}{
+ *  x &= \cos(\phi) \sin(\theta)\\
+ *  y &= \sin(\phi) \sin(\theta)\\
+ *  z &= \cos(\theta)
+ * \f}
+ *
+ * \note These Jacobians are adjusted to improve regularity near the pole, in
+ * particular the \f$\partial \phi / \partial x^i\f$ components have been scaled
+ * by \f$\sin \theta\f$ (omitting a \f$1/\sin(\theta)\f$) and the
+ * \f$\partial x^i/\partial \phi\f$ components have been scaled by
+ * \f$1/\sin(\theta)\f$ (omitting a \f$\sin(\theta)\f$). The reason is that in
+ * most careful calculations, these problematic sin factors can actually be
+ * omitted because they cancel. In cases where they are actually required, they
+ * must be put in by hand.
+ */
+void cartesian_to_spherical_coordinates_and_jacobians(
+    gsl::not_null<tnsr::I<DataVector, 3>*> unit_cartesian_coords,
+    gsl::not_null<jacobian_tensor*> cartesian_to_spherical_jacobian,
+    gsl::not_null<inverse_jacobian_tensor*>
+        inverse_cartesian_to_spherical_jacobian,
+    const Scalar<DataVector>& cos_phi, const Scalar<DataVector>& cos_theta,
+    const Scalar<DataVector>& sin_phi, const Scalar<DataVector>& sin_theta,
+    double extraction_radius) noexcept;
+
+/*!
+ * \brief Computes the spacetime metric and its first derivative in the
+ * intermediate radial null coordinates
+ *
+ * \details These components are obtained by the steps in
+ * Section II-A of \cite Barkett2019uae, which is based on the computation from
+ * Section 4.3 of \cite Bishop1998uk. The most direct comparison is to be made
+ * with equation (31) of \cite Barkett2019uae, which gives the null metric
+ * components explicitly. The time derivative is then (using notation from
+ * equation (31)  of \cite Barkett2019uae):
+ *
+ * \f{align}{
+ * \partial_{\bar u} g_{\bar u \bar \lambda} =
+ * \partial_{\bar u} g_{\bar \lambda \bar \lambda} =
+ * \partial_{\bar u} g_{\bar \lambda \bar A} &= 0 \\
+ * \partial_{\bar u} g_{\bar u \bar u} &=
+ * \partial_{\breve t} g_{\breve t \breve t} \\
+ * \partial_{\bar u} g_{\bar u \bar A} &=
+ * \frac{\partial \breve x^{\breve i}}{\partial \bar x^{\bar A}}\\
+ * g_{\breve i \breve t}
+ * \partial_{\bar u} g_{\bar A \bar B}
+ * &= \frac{\partial \breve x^{\breve i}}{\partial \bar x^{\bar A}}
+ * \frac{\partial \breve x^{\breve j}}{\partial \bar x^{\bar B}}
+ * g_{\breve i \breve j}
+ * \f}
+ */
+void null_metric_and_derivative(
+    gsl::not_null<tnsr::aa<DataVector, 3, Frame::RadialNull>*> du_null_metric,
+    gsl::not_null<tnsr::aa<DataVector, 3, Frame::RadialNull>*> null_metric,
+    const jacobian_tensor& cartesian_to_spherical_jacobian,
+    const tnsr::aa<DataVector, 3>& dt_spacetime_metric,
+    const tnsr::aa<DataVector, 3>& spacetime_metric) noexcept;
+
+/*!
+ * \brief Computes the spatial unit normal vector \f$s^i\f$ to the spherical
+ * worldtube surface and its first time derivative.
+ *
+ * \details Refer to equation (20) of \cite Barkett2019uae for the expression of
+ * the spatial unit normal vector, and equation (23) of \cite Barkett2019uae for
+ * the first time derivative. Refer to \cite Bishop1998uk for more exposition
+ * about the overall construction of the coordinate transformations used for the
+ * intermediate null coordinates.
+ */
+void worldtube_normal_and_derivatives(
+    gsl::not_null<tnsr::I<DataVector, 3>*> worldtube_normal,
+    gsl::not_null<tnsr::I<DataVector, 3>*> dt_worldtube_normal,
+    const Scalar<DataVector>& cos_phi, const Scalar<DataVector>& cos_theta,
+    const tnsr::aa<DataVector, 3>& spacetime_metric,
+    const tnsr::aa<DataVector, 3>& dt_spacetime_metric,
+    const Scalar<DataVector>& sin_phi, const Scalar<DataVector>& sin_theta,
+    const tnsr::II<DataVector, 3>& inverse_spatial_metric) noexcept;
+
+/*!
+ * \brief Computes the null 4-vector \f$l^\mu\f$ on the worldtube surface that
+ * is to be used as the CCE hypersurface generator, and the first time
+ * derivative \f$\partial_u l^\mu\f$.
+ *
+ * \details For mathematical description of our choice of the null generator,
+ * refer to equation (22) of \cite Barkett2019uae, and for the first time
+ * derivative see (25) of \cite Barkett2019uae.  Refer to \cite Bishop1998uk for
+ * more exposition about the overall construction of the coordinate
+ * transformations used for the intermediate null coordinates.
+ */
+void null_vector_l_and_derivatives(
+    gsl::not_null<tnsr::A<DataVector, 3>*> du_null_l,
+    gsl::not_null<tnsr::A<DataVector, 3>*> null_l,
+    const tnsr::I<DataVector, 3>& dt_worldtube_normal,
+    const Scalar<DataVector>& dt_lapse,
+    const tnsr::aa<DataVector, 3>& dt_spacetime_metric,
+    const tnsr::I<DataVector, 3>& dt_shift, const Scalar<DataVector>& lapse,
+    const tnsr::aa<DataVector, 3>& spacetime_metric,
+    const tnsr::I<DataVector, 3>& shift,
+    const tnsr::I<DataVector, 3>& worldtube_normal) noexcept;
+
+/*!
+ * \brief Computes the partial derivative of the spacetime metric and inverse
+ * spacetime metric in the intermediate null radial coordinates with respect to
+ * the null generator \f$l^\mu\f$
+ *
+ * \details For full expressions of the \f$l^\mu \partial_\mu g_{a b}\f$ and
+ * \f$l^\mu \partial_\mu g^{a b}\f$ computed in this function, see equation (31)
+ * and (32) of \cite Barkett2019uae.  Refer to \cite Bishop1998uk for more
+ * exposition about the overall construction of the coordinate transformations
+ * used for the intermediate null coordinates.
+ */
+void dlambda_null_metric_and_inverse(
+    gsl::not_null<tnsr::aa<DataVector, 3, Frame::RadialNull>*>
+        dlambda_null_metric,
+    gsl::not_null<tnsr::AA<DataVector, 3, Frame::RadialNull>*>
+        dlambda_inverse_null_metric,
+    const tnsr::iA<DataVector, 3>& angular_d_null_l,
+    const jacobian_tensor& cartesian_to_spherical_jacobian,
+    const tnsr::iaa<DataVector, 3>& phi,
+    const tnsr::aa<DataVector, 3>& dt_spacetime_metric,
+    const tnsr::A<DataVector, 3>& du_null_l,
+    const tnsr::AA<DataVector, 3>& inverse_null_metric,
+    const tnsr::A<DataVector, 3>& null_l,
+    const tnsr::aa<DataVector, 3>& spacetime_metric) noexcept;
+
+/*!
+ * \brief Computes the full 4-dimensional partial of the Bondi radius with
+ * respect to the intermediate null coordinates.
+ *
+ * \details The expression evaluated is obtained from differentiating the
+ * determinant equation for `bondi_r`, from (35) of \cite Barkett2019uae :
+ *
+ * \f[
+ * \partial_\alpha r = \frac{r}{4} \left(g^{A B} \partial_\alpha g_{A B}
+ * - \frac{\partial_\alpha \det q_{A B}}{\det q_{A B}}\right)
+ * \f]
+ *
+ * Note that for the angular derivatives, we just numerically differentiate
+ * using the utilities in `Spectral::Swsh::angular_derivative()`. For the time
+ * and radial derivatives, the second term in the above equation vanishes.
+ */
+void d_bondi_r(
+    gsl::not_null<tnsr::a<DataVector, 3, Frame::RadialNull>*> d_bondi_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
+    const tnsr::aa<DataVector, 3, Frame::RadialNull>& dlambda_null_metric,
+    const tnsr::aa<DataVector, 3, Frame::RadialNull>& du_null_metric,
+    const tnsr::AA<DataVector, 3, Frame::RadialNull>& inverse_null_metric,
+    size_t l_max) noexcept;
+
+/*!
+ * \brief Compute the complex angular dyads used to define the spin-weighted
+ * scalars in the CCE system.
+ *
+ * \details We use the typically chosen angular dyads in CCE
+ * \cite Barkett2019uae \cite Bishop1997ik :
+ *
+ * \f{align*}{
+ * q_A &= \{-1, -i \sin(\theta)\}\\
+ * q^A &= \left\{-1, -i \frac{1}{\sin \theta}\right\}
+ * \f}
+ *
+ * However, to maintain regularity and for compatibility with the more regular
+ * Jacobians from `Cce::cartesian_to_spherical_coordinates_and_jacobians()`, in
+ * the code we omit the factors of \f$\sin \theta\f$ from the above equations.
+ */
+void dyads(
+    gsl::not_null<tnsr::i<ComplexDataVector, 2, Frame::RadialNull>*> down_dyad,
+    gsl::not_null<tnsr::I<ComplexDataVector, 2, Frame::RadialNull>*>
+        up_dyad) noexcept;
+
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/BoundaryDataTags.hpp
+++ b/src/Evolution/Systems/Cce/BoundaryDataTags.hpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+namespace Cce {
+namespace Frame {
+/// The frame for the spherical metric in which the radial coordinate is an
+/// affine parameter along outward-pointing null geodesics.
+struct RadialNull {};
+}  // namespace Frame
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY Cce)
 
 set(LIBRARY_SOURCES
+  BoundaryData.cpp
   Equations.cpp
   InitializeCce.cpp
   LinearOperators.cpp

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -100,6 +100,13 @@ struct Dr : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept { return "Dr(" + Tag::name() + ")"; }
 };
 
+/// The derivative with respect to Bondi retarded time \f$u\f$
+template <typename Tag>
+struct Du : db::PrefixTag, db::SimpleTag {
+    using type = Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>;
+    using tag = Tag;
+};
+
 // prefix tags associated with the integrands which are used as input to solvers
 // for the CCE equations
 

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -123,6 +123,44 @@ Scalar<DataType> lapse(
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric) noexcept;
 
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the time derivative of the spacetime metric from spatial
+ * metric, lapse, shift, and their time derivatives.
+ *
+ * \details Computes the derivative as:
+ *
+ * \f{align}{
+ * \partial_t g_{tt} &= - 2 \alpha \partial_t \alpha
+ * - 2 \gamma_{i j} \beta^i \partial_t \beta^j
+ * + \beta^i \beta^j \partial_t \gamma_{i j}\\
+ * \partial_t g_{t i} &= \gamma_{j i} \partial_t \beta^j
+ * + \beta^j \partial_t \gamma_{j i}\\
+ * \partial_t g_{i j} &= \partial_t \gamma_{i j},
+ * \f}
+ *
+ * where \f$\alpha, \beta^i, \gamma_{ij}\f$ are the lapse, shift, and spatial
+ * metric respectively.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void time_derivative_of_spacetime_metric(
+    gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame>*> dt_spacetime_metric,
+    const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::aa<DataType, SpatialDim, Frame> time_derivative_of_spacetime_metric(
+    const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric) noexcept;
+//@}
+
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes spacetime derivative of spacetime metric from spatial metric,

--- a/src/Utilities/ContainerHelpers.hpp
+++ b/src/Utilities/ContainerHelpers.hpp
@@ -16,7 +16,7 @@
 /// will cause a compiler error if no such function exists.
 struct GetContainerSize {
   template <typename T>
-  SPECTRE_ALWAYS_INLINE decltype(auto) operator()(const T& t) noexcept {
+  SPECTRE_ALWAYS_INLINE decltype(auto) operator()(const T& t) const noexcept {
     return t.size();
   }
 };
@@ -25,19 +25,30 @@ struct GetContainerSize {
 /// \brief Callable struct for the subscript operator. Returns `t[i]`
 struct GetContainerElement {
   template <typename T>
-  SPECTRE_ALWAYS_INLINE decltype(auto) operator()(T& t,
-                                                  const size_t i) noexcept {
+  SPECTRE_ALWAYS_INLINE decltype(auto) operator()(T& t, const size_t i) const
+      noexcept {
     return t[i];
+  }
+};
+
+/// \ingroup UtilitiesGroup
+/// \brief Callable struct which applies the `t.destructive_resize()` for
+/// operand `t`. This will cause a compiler error if no such function exists.
+struct ContainerDestructiveResize {
+  template <typename T>
+  SPECTRE_ALWAYS_INLINE void operator()(T& t, const size_t size) const
+      noexcept {
+    return t.destructive_resize(size);
   }
 };
 
 namespace ContainerHelpers_detail {
 // implementation struct for get_element and get_size
 template <bool IsFundamentalOrComplexOfFundamental>
-struct GetImpls;
+struct ContainerImpls;
 
 template <>
-struct GetImpls<true> {
+struct ContainerImpls<true> {
   template <typename T, typename SubscriptFunction>
   static SPECTRE_ALWAYS_INLINE decltype(auto) get_element(
       T& t, const size_t /*i*/, const SubscriptFunction /*at*/) noexcept {
@@ -49,10 +60,17 @@ struct GetImpls<true> {
   get_size(const T& /*t*/, const SizeFunction /*size*/) noexcept {
     return 1;
   }
+
+  template <typename T, typename DestructiveResizeFunction>
+  static SPECTRE_ALWAYS_INLINE void apply_destructive_resize(
+      T& /*t*/, const size_t /*i*/,
+      const DestructiveResizeFunction /*destructive_resize*/) noexcept {
+    // no-op for fundamental types.
+  }
 };
 
 template <>
-struct GetImpls<false> {
+struct ContainerImpls<false> {
   template <typename T, typename SubscriptFunction>
   static SPECTRE_ALWAYS_INLINE decltype(auto) get_element(
       T& t, const size_t i, SubscriptFunction at) noexcept {
@@ -63,6 +81,13 @@ struct GetImpls<false> {
   static SPECTRE_ALWAYS_INLINE decltype(auto) get_size(
       const T& t, SizeFunction size) noexcept {
     return size(t);
+  }
+
+  template <typename T, typename DestructiveResizeFunction>
+  static SPECTRE_ALWAYS_INLINE void apply_destructive_resize(
+      T& t, const size_t size,
+      const DestructiveResizeFunction destructive_resize) noexcept {
+    destructive_resize(t, size);
   }
 };
 }  // namespace ContainerHelpers_detail
@@ -91,7 +116,7 @@ template <typename T, typename SubscriptFunction = GetContainerElement>
 SPECTRE_ALWAYS_INLINE decltype(auto) get_element(
     T& t, const size_t i,
     SubscriptFunction at = GetContainerElement{}) noexcept {
-  return ContainerHelpers_detail::GetImpls<(
+  return ContainerHelpers_detail::ContainerImpls<(
       tt::is_complex_of_fundamental_v<std::remove_cv_t<T>> or
       cpp17::is_fundamental_v<std::remove_cv_t<T>>)>::get_element(t, i, at);
 }
@@ -118,7 +143,46 @@ SPECTRE_ALWAYS_INLINE decltype(auto) get_element(
 template <typename T, typename SizeFunction = GetContainerSize>
 SPECTRE_ALWAYS_INLINE decltype(auto) get_size(
     const T& t, SizeFunction size = GetContainerSize{}) noexcept {
-  return ContainerHelpers_detail::GetImpls<(
+  return ContainerHelpers_detail::ContainerImpls<(
       tt::is_complex_of_fundamental_v<std::remove_cv_t<T>> or
       cpp17::is_fundamental_v<std::remove_cv_t<T>>)>::get_size(t, size);
+}
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Checks the size of each component of the container, and resizes if
+ * necessary.
+ *
+ * \details This operation is not permitted when any of the components of the
+ * tensor is non-owning (see `VectorImpl` for ownership details).
+ * \note This utility should NOT be used when it is anticipated that the
+ * components will be the wrong size. In that case, suggest either manual
+ * checking or restructuring so that resizing is less common. The internal
+ * call uses `UNLIKELY` to perform the checks most quickly when resizing is
+ * unnecessary.
+ *
+ * \warning This is typically to be called on `Tensor`s, NOT (for instance)
+ * `DataVector`s. For derived classes of `VectorImpl`, this function will cause
+ * no resize. Instead, use the `VectorImpl` member function
+ * `VectorImpl::destructive_resize()`.
+ *
+ * \note This assumes that a range-based iterator will appropriately loop over
+ * the elements to resize, and that each resized element is either a fundamental
+ * type or a derived class of `VectorImpl`. If either of those assumptions needs
+ * to be relaxed, this function will need to be generalized.
+ */
+template <typename Container,
+          typename DestructiveResizeFunction = ContainerDestructiveResize>
+void SPECTRE_ALWAYS_INLINE destructive_resize_components(
+    const gsl::not_null<Container*> container, const size_t new_size,
+    DestructiveResizeFunction destructive_resize =
+        ContainerDestructiveResize{}) noexcept {
+  for (auto& vector : *container) {
+    ContainerHelpers_detail::ContainerImpls<(
+        tt::is_complex_of_fundamental_v<
+            std::remove_cv_t<typename Container::value_type>> or
+        cpp17::is_fundamental_v<
+            std::remove_cv_t<typename Container::value_type>>)>::
+        apply_destructive_resize(vector, new_size, destructive_resize);
+  }
 }

--- a/tests/Unit/Evolution/Systems/Cce/BoundaryData.py
+++ b/tests/Unit/Evolution/Systems/Cce/BoundaryData.py
@@ -1,0 +1,239 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+import math
+
+
+def cartesian_to_angular_coordinates(cos_phi, cos_theta, sin_phi, sin_theta,
+                                     extraction_radius):
+    return np.array([cos_phi * sin_theta, sin_phi * sin_theta, cos_theta])
+
+
+def cartesian_to_angular_jacobian(cos_phi, cos_theta, sin_phi, sin_theta,
+                                  extraction_radius):
+    return np.array(
+        [[cos_phi * sin_theta, sin_phi * sin_theta, cos_theta],
+         [
+             extraction_radius * cos_phi * cos_theta,
+             extraction_radius * sin_phi * cos_theta,
+             -extraction_radius * sin_theta
+         ], [-extraction_radius * sin_phi, extraction_radius * cos_phi, 0.0]])
+
+
+def cartesian_to_angular_inverse_jacobian(cos_phi, cos_theta, sin_phi,
+                                          sin_theta, extraction_radius):
+    return np.array([[
+        cos_phi * sin_theta, cos_phi * cos_theta / extraction_radius,
+        -sin_phi / extraction_radius
+    ],
+                     [
+                         sin_phi * sin_theta,
+                         cos_theta * sin_phi / extraction_radius,
+                         cos_phi / extraction_radius
+                     ], [cos_theta, -sin_theta / extraction_radius, 0.0]])
+
+
+def null_metric(cartesian_to_angular_jacobian, pi, psi):
+    null_metric = psi.copy()
+    null_metric[1, 1] = 0.0
+
+    null_metric[1, 2:4] = 0.0
+    null_metric[2:4, 1] = 0.0
+
+    null_metric[0, 1] = -1.0
+    null_metric[1, 0] = -1.0
+
+    null_metric[0, 0] = psi[0, 0]
+
+    null_metric[0, 2:4] = np.einsum("Ai,i", cartesian_to_angular_jacobian,
+                                    psi[0, 1:4])[1:3]
+    null_metric[2:4, 0] = null_metric[0, 2:4]
+
+    null_metric[2:4, 2:4] = np.einsum(
+        "Ai,Bj,ij", cartesian_to_angular_jacobian,
+        cartesian_to_angular_jacobian, psi[1:4, 1:4])[1:4, 1:4]
+    return null_metric
+
+
+def du_null_metric(cartesian_to_angular_jacobian, pi, psi):
+    du_null_metric = pi.copy()
+    du_null_metric[1, 0:4] = 0.0
+    du_null_metric[0:4, 1] = 0.0
+
+    du_null_metric[0, 0] = pi[0, 0]
+
+    du_null_metric[0, 2:4] = np.einsum("Ai,i", cartesian_to_angular_jacobian,
+                                       pi[0][1:4])[1:3]
+    du_null_metric[2:4, 0] = du_null_metric[0, 2:4]
+
+    du_null_metric[2:4, 2:4] = np.einsum(
+        "Ai,Bj,ij", cartesian_to_angular_jacobian,
+        cartesian_to_angular_jacobian, pi[1:4, 1:4])[1:4, 1:4]
+
+    return du_null_metric
+
+
+def inverse_null_metric(null_metric):
+    inverse_null_metric = null_metric.copy()
+    inverse_null_metric[1, 0] = -1.0
+    inverse_null_metric[0, 1] = -1.0
+
+    inverse_null_metric[0, 0] = 0.0
+    inverse_null_metric[0, 2:4] = 0.0
+    inverse_null_metric[2:4, 0] = 0.0
+    angular_determinant = (null_metric[2, 2] * null_metric[3, 3] -
+                           null_metric[2, 3] * null_metric[3, 2])
+    inverse_null_metric[2, 2] = null_metric[3, 3] / angular_determinant
+    inverse_null_metric[2, 3] = -null_metric[2, 3] / angular_determinant
+    inverse_null_metric[3, 2] = -null_metric[2, 3] / angular_determinant
+    inverse_null_metric[3, 3] = null_metric[2, 2] / angular_determinant
+
+    inverse_null_metric[1, 2:4] = np.einsum(
+        "AB,B", inverse_null_metric[2:4, 2:4], null_metric[2:4, 0])
+    inverse_null_metric[2:4, 1] = inverse_null_metric[1, 2:4]
+    inverse_null_metric[1, 1] = -null_metric[0, 0] + np.einsum(
+        "A,A", inverse_null_metric[1, 2:4], null_metric[2:4, 0])
+    return inverse_null_metric
+
+
+def worldtube_normal(cos_phi, cos_theta, psi, dt_psi, sin_phi, sin_theta,
+                     inverse_spatial_metric):
+    sigma = inverse_spatial_metric[0, :].copy()
+    sigma[0] = cos_phi * sin_theta**2
+    sigma[1] = sin_phi * sin_theta**2
+    sigma[2] = cos_theta * sin_theta
+    norm_of_sigma = math.sqrt(
+        np.einsum("i,j,ij", sigma, sigma, inverse_spatial_metric))
+
+    worldtube_normal = np.einsum("ij,j", inverse_spatial_metric,
+                                 sigma / norm_of_sigma)
+    return worldtube_normal
+
+
+def dt_worldtube_normal(cos_phi, cos_theta, psi, dt_psi, sin_phi, sin_theta,
+                        inverse_spatial_metric):
+    sigma = inverse_spatial_metric[0, :].copy()
+    sigma[0] = cos_phi * sin_theta**2
+    sigma[1] = sin_phi * sin_theta**2
+    sigma[2] = cos_theta * sin_theta
+    norm_of_sigma = math.sqrt(
+        np.einsum("i,j,ij", sigma, sigma, inverse_spatial_metric))
+
+    worldtube_normal = np.einsum("ij,j", inverse_spatial_metric,
+                                 sigma / norm_of_sigma)
+
+    dt_worldtube_normal = np.einsum(
+        "ij,k,jk", 0.5 * np.outer(worldtube_normal, worldtube_normal) -
+        inverse_spatial_metric, worldtube_normal, dt_psi[1:4, 1:4])
+    return dt_worldtube_normal
+
+
+def null_vector_l(dt_worldtube_normal, dt_lapse, dt_psi, dt_shift, lapse, psi,
+                  shift, worldtube_normal):
+    hypersurface_normal_vector = np.pad(worldtube_normal, ((1, 0)),
+                                        'constant').copy()
+    hypersurface_normal_vector[0] = 1.0 / lapse
+    hypersurface_normal_vector[1:4] = -shift / lapse
+    null_l = np.pad(worldtube_normal, ((1, 0)), 'constant').copy()
+    null_l[0] = hypersurface_normal_vector[0] / (
+        lapse - np.einsum("ij,i,j", psi[1:4, 1:4], shift, worldtube_normal))
+    null_l[1:4] = (hypersurface_normal_vector[1:4] + worldtube_normal) / (
+        lapse - np.einsum("ij,i,j", psi[1:4, 1:4], shift, worldtube_normal))
+    return null_l
+
+
+def du_null_vector_l(dt_worldtube_normal, dt_lapse, dt_psi, dt_shift, lapse,
+                     psi, shift, worldtube_normal):
+    hypersurface_normal_vector = np.pad(worldtube_normal, ((1, 0)),
+                                        'constant').copy()
+    hypersurface_normal_vector[0] = 1.0 / lapse
+    hypersurface_normal_vector[1:4] = -shift / lapse
+
+    denominator = (
+        lapse - np.einsum("ij,i,j", psi[1:4, 1:4], shift, worldtube_normal))
+
+    du_hypersurface_normal = np.pad(shift[:], ((1, 0)), 'constant').copy()
+    du_hypersurface_normal[0] = -dt_lapse / lapse**2
+    du_hypersurface_normal[1:4] = (
+        -(dt_shift / lapse) + (np.outer(dt_lapse, shift) / lapse**2))
+
+    du_null_l = (du_hypersurface_normal) / denominator
+    du_null_l[1:4] += (dt_worldtube_normal) / denominator
+    du_denominator = (-dt_lapse + np.einsum(
+        "ij,i,j", dt_psi[1:4, 1:4], shift, worldtube_normal) + np.einsum(
+            "ij,i,j", psi[1:4, 1:4], dt_shift, worldtube_normal) + np.einsum(
+                "ij,i,j", psi[1:4, 1:4], shift, dt_worldtube_normal))
+
+    du_null_l[
+        0] += du_denominator * hypersurface_normal_vector[0] / denominator**2
+    du_null_l[1:4] += du_denominator * (
+        hypersurface_normal_vector[1:4] + worldtube_normal) / denominator**2
+    return du_null_l
+
+
+def dlambda_null_metric(angular_d_null_l, cartesian_to_angular_jacobian, phi,
+                        pi, du_null_l, inverse_null_metric, null_l, psi):
+    dlambda_null_metric = psi.copy()
+    dlambda_null_metric[0, 0] = (
+        np.einsum("i,i", null_l[1:4], phi[:, 0, 0]) + null_l[0] * pi[0, 0] +
+        2.0 * np.einsum("a,a", du_null_l, psi[:, 0]))
+    dlambda_null_metric[1, :] = 0.0
+    dlambda_null_metric[:, 1] = 0.0
+
+    dlambda_null_metric[0, 2:4] = np.einsum(
+        "Ak,a,ka", cartesian_to_angular_jacobian[1:3, :], du_null_l,
+        psi[1:4, :])
+    dlambda_null_metric[0, 2:4] += null_l[0] * np.einsum(
+        "Ak,k", cartesian_to_angular_jacobian[1:3, :], pi[1:4, 0])
+    dlambda_null_metric[0, 2:4] += np.einsum(
+        "Ak,i,ik", cartesian_to_angular_jacobian[1:3, :], null_l[1:4],
+        phi[:, 1:4, 0])
+    dlambda_null_metric[0, 2:4] += np.einsum("Aa,a", angular_d_null_l[1:3, :],
+                                             psi[:, 0])
+    dlambda_null_metric[2:4, 0] = dlambda_null_metric[0, 2:4]
+
+    dlambda_null_metric[2:4, 2:4] = null_l[0] * np.einsum(
+        "Ak,Bl,kl", cartesian_to_angular_jacobian[1:3, :],
+        cartesian_to_angular_jacobian[1:3, :], pi[1:4, 1:4])
+    dlambda_null_metric[2:4, 2:4] += np.einsum(
+        "Ak,Bl,i,ikl", cartesian_to_angular_jacobian[1:3, :],
+        cartesian_to_angular_jacobian[1:3, :], null_l[1:4], phi[:, 1:4, 1:4])
+    dlambda_null_metric[2:4, 2:4] += np.einsum(
+        "Aa,Bl,al", angular_d_null_l[1:3, :],
+        cartesian_to_angular_jacobian[1:3, :], psi[:, 1:4])
+    dlambda_null_metric[2:4, 2:4] += np.einsum(
+        "Al,Ba,al", cartesian_to_angular_jacobian[1:3, :],
+        angular_d_null_l[1:3, :], psi[:, 1:4])
+    return dlambda_null_metric
+
+
+def inverse_dlambda_null_metric(angular_d_null_l,
+                                cartesian_to_angular_jacobian, phi, pi,
+                                du_null_l, inverse_null_metric, null_l, psi):
+
+    dlambda_null_metric_value = (dlambda_null_metric(
+        angular_d_null_l, cartesian_to_angular_jacobian, phi, pi, du_null_l,
+        inverse_null_metric, null_l, psi))
+
+    inverse_dlambda_null_metric_value = dlambda_null_metric_value.copy()
+
+    inverse_dlambda_null_metric_value[0, :] = 0.0
+    inverse_dlambda_null_metric_value[:, 0] = 0.0
+    inverse_dlambda_null_metric_value[
+        1, 1] = -dlambda_null_metric_value[0, 0] + 2.0 * np.einsum(
+            "a,a", inverse_null_metric[1, 2:4],
+            dlambda_null_metric_value[0, 2:4]) - np.einsum(
+                "a,b,ab", inverse_null_metric[1, 2:4],
+                inverse_null_metric[1, 2:4],
+                dlambda_null_metric_value[2:4, 2:4])
+    inverse_dlambda_null_metric_value[1, 2:4] = np.einsum(
+        "ab, b", inverse_null_metric[2:4, 2:4],
+        dlambda_null_metric_value[0, 2:4]) - np.einsum(
+            "ab, c, cb", inverse_null_metric[2:4, 2:4],
+            inverse_null_metric[1, 2:4], dlambda_null_metric_value[2:4, 2:4])
+    inverse_dlambda_null_metric_value[2:4, 2:4] = -np.einsum(
+        "ac,bd,cd", inverse_null_metric[2:4, 2:4],
+        inverse_null_metric[2:4, 2:4], dlambda_null_metric_value[2:4, 2:4])
+
+    return inverse_dlambda_null_metric_value

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_Cce")
 
 set(LIBRARY_SOURCES
   CceComputationTestHelpers.cpp
+  Test_BoundaryData.cpp
   Test_Equations.cpp
   Test_InitializeCce.cpp
   Test_LinearOperators.cpp

--- a/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
@@ -1,0 +1,234 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Cce {
+namespace {
+
+void pypp_test_worldtube_computation_steps() noexcept {
+  pypp::SetupLocalPythonEnvironment local_python_env{"Evolution/Systems/Cce/"};
+
+  pypp::check_with_random_values<1>(
+      &cartesian_to_spherical_coordinates_and_jacobians, "BoundaryData",
+      {"cartesian_to_angular_coordinates", "cartesian_to_angular_jacobian",
+       "cartesian_to_angular_inverse_jacobian"},
+      {{{0.1, 10.0}}}, DataVector{1});
+
+  pypp::check_with_random_values<1>(&null_metric_and_derivative, "BoundaryData",
+                                    {"du_null_metric", "null_metric"},
+                                    {{{0.1, 10.0}}}, DataVector{1});
+
+  pypp::check_with_random_values<1>(&worldtube_normal_and_derivatives,
+                                    "BoundaryData",
+                                    {"worldtube_normal", "dt_worldtube_normal"},
+                                    {{{0.1, 10.0}}}, DataVector{1});
+
+  pypp::check_with_random_values<1>(
+      &null_vector_l_and_derivatives, "BoundaryData",
+      {"du_null_vector_l", "null_vector_l"}, {{{0.1, 10.0}}}, DataVector{1});
+
+  pypp::check_with_random_values<1>(
+      &dlambda_null_metric_and_inverse, "BoundaryData",
+      {"dlambda_null_metric", "inverse_dlambda_null_metric"}, {{{0.1, 10.0}}},
+      DataVector{1});
+}
+
+template <typename Generator>
+void test_trigonometric_function_identities(
+    const gsl::not_null<Generator*> gen) noexcept {
+  UniformCustomDistribution<size_t> l_dist(3, 6);
+  const size_t l_max = l_dist(*gen);
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  Scalar<DataVector> cos_phi{number_of_angular_points};
+  Scalar<DataVector> cos_theta{number_of_angular_points};
+  Scalar<DataVector> sin_phi{number_of_angular_points};
+  Scalar<DataVector> sin_theta{number_of_angular_points};
+  trigonometric_functions_on_swsh_collocation(
+      make_not_null(&cos_phi), make_not_null(&cos_theta),
+      make_not_null(&sin_phi), make_not_null(&sin_theta), l_max);
+  const DataVector unity{number_of_angular_points, 1.0};
+  {
+    INFO("Trigonometric identities");
+    CHECK_ITERABLE_APPROX(square(get(cos_phi)) + square(get(sin_phi)), unity);
+    CHECK_ITERABLE_APPROX(square(get(cos_theta)) + square(get(sin_theta)),
+                          unity);
+  }
+
+  tnsr::I<DataVector, 3> cartesian_coords{number_of_angular_points};
+  jacobian_tensor cartesian_to_angular_jacobian{number_of_angular_points};
+  inverse_jacobian_tensor inverse_cartesian_to_angular_jacobian{
+      number_of_angular_points};
+  UniformCustomDistribution<double> radius_dist{10.0, 100.0};
+  const double extraction_radius = radius_dist(*gen);
+  cartesian_to_spherical_coordinates_and_jacobians(
+      make_not_null(&cartesian_coords),
+      make_not_null(&cartesian_to_angular_jacobian),
+      make_not_null(&inverse_cartesian_to_angular_jacobian), cos_phi, cos_theta,
+      sin_phi, sin_theta, extraction_radius);
+  DataVector jacobian_identity{number_of_angular_points};
+  const DataVector zero{number_of_angular_points, 0.0};
+  {
+    INFO("Jacobian identity")
+    for (size_t i = 0; i < 3; ++i) {
+      for (size_t j = 0; j < 3; ++j) {
+        jacobian_identity = cartesian_to_angular_jacobian.get(i, 0) *
+                            inverse_cartesian_to_angular_jacobian.get(0, j);
+        for (size_t k = 1; k < 3; ++k) {
+          jacobian_identity += cartesian_to_angular_jacobian.get(i, k) *
+                               inverse_cartesian_to_angular_jacobian.get(k, j);
+        }
+        if (i == j) {
+          CHECK_ITERABLE_APPROX(jacobian_identity, unity);
+        } else {
+          CHECK_ITERABLE_APPROX(jacobian_identity, zero);
+        }
+      }
+    }
+  }
+}
+
+template <typename Generator>
+void test_d_bondi_r_identities(const gsl::not_null<Generator*> gen) noexcept {
+  // more resolution needed because we want high precision on the angular
+  // derivative check.
+  UniformCustomDistribution<size_t> l_dist(8, 12);
+  UniformCustomDistribution<double> value_dist{0.1, 0.5};
+  const size_t l_max = l_dist(*gen);
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  Scalar<SpinWeighted<ComplexDataVector, 0>> bondi_r{number_of_angular_points};
+  // simple test function so that we can easily work out what the expected
+  // angular derivatives should be.
+  const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
+      Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
+  for (const auto& collocation_point : collocation) {
+    get(bondi_r).data()[collocation_point.offset] =
+        5.0 + sin(collocation_point.theta) * cos(collocation_point.phi);
+  }
+  tnsr::aa<DataVector, 3, Frame::RadialNull> null_metric{
+      number_of_angular_points};
+  fill_with_random_values(make_not_null(&null_metric), gen,
+                          make_not_null(&value_dist));
+  const auto inverse_null_metric = determinant_and_inverse(null_metric).second;
+  tnsr::aa<DataVector, 3, Frame::RadialNull> dlambda_null_metric{
+      number_of_angular_points};
+  fill_with_random_values(make_not_null(&dlambda_null_metric), gen,
+                          make_not_null(&value_dist));
+  tnsr::aa<DataVector, 3, Frame::RadialNull> du_null_metric{
+      number_of_angular_points};
+  fill_with_random_values(make_not_null(&du_null_metric), gen,
+                          make_not_null(&value_dist));
+  // initialize the du_null_metric in a way that allows a trace identity to be
+  // used to check the calculation
+  tnsr::ii<DataVector, 2> angular_inverse_null_metric{number_of_angular_points};
+  for (size_t A = 0; A < 2; ++A) {
+    for (size_t B = 0; B < 2; ++B) {
+      angular_inverse_null_metric.get(A, B) =
+          inverse_null_metric.get(A + 2, B + 2);
+    }
+  }
+  const tnsr::II<DataVector, 2> trace_identity_angular_null_metric =
+      determinant_and_inverse(angular_inverse_null_metric).second;
+  double random_scaling = value_dist(*gen);
+  for (size_t A = 0; A < 2; ++A) {
+    for (size_t B = 0; B < 2; ++B) {
+      du_null_metric.get(A + 2, B + 2) =
+          random_scaling * trace_identity_angular_null_metric.get(A, B);
+    }
+  }
+  tnsr::a<DataVector, 3, Frame::RadialNull> d_bondi_r{number_of_angular_points};
+  Cce::d_bondi_r(make_not_null(&d_bondi_r), bondi_r, dlambda_null_metric,
+                 du_null_metric, inverse_null_metric, l_max);
+  DataVector expected_dtheta_r{number_of_angular_points};
+  DataVector expected_dphi_r{number_of_angular_points};
+  for (const auto& collocation_point : collocation) {
+    expected_dtheta_r[collocation_point.offset] =
+        cos(collocation_point.theta) * cos(collocation_point.phi);
+    // note 'pfaffian' derivative with the 1/sin(theta)
+    expected_dphi_r[collocation_point.offset] = -sin(collocation_point.phi);
+  }
+  Approx angular_derivative_approx =
+      Approx::custom()
+          .epsilon(std::numeric_limits<double>::epsilon() * 1.0e5)
+          .scale(1.0);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(get<2>(d_bondi_r), expected_dtheta_r,
+                               angular_derivative_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(get<3>(d_bondi_r), expected_dphi_r,
+                               angular_derivative_approx);
+  // a slightly different calculational path to improve test robustness
+  DataVector expected_dlambda_r{number_of_angular_points, 0.0};
+  for (size_t A = 0; A < 2; ++A) {
+    for (size_t B = 0; B < 2; ++B) {
+      expected_dlambda_r += inverse_null_metric.get(A + 2, B + 2) *
+                            dlambda_null_metric.get(A + 2, B + 2);
+    }
+  }
+  expected_dlambda_r *= 0.25 * real(get(bondi_r).data());
+  CHECK_ITERABLE_APPROX(expected_dlambda_r, get<1>(d_bondi_r));
+
+  // use the trace identity to evaluate the du_r in the contrived case where the
+  // du_null metric is proportional to null_metric.
+  DataVector expected_du_r{number_of_angular_points, random_scaling * 2.0};
+  expected_du_r *= 0.25 * real(get(bondi_r).data());
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_du_r, get<0>(d_bondi_r),
+                               angular_derivative_approx);
+}
+
+template <typename Generator>
+void test_dyad_identities(const gsl::not_null<Generator*> gen) noexcept {
+  UniformCustomDistribution<size_t> l_dist(3, 6);
+  const size_t l_max = l_dist(*gen);
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  tnsr::I<ComplexDataVector, 2, Frame::RadialNull> up_dyad{
+      number_of_angular_points};
+  tnsr::i<ComplexDataVector, 2, Frame::RadialNull> down_dyad{
+      number_of_angular_points};
+  Cce::dyads(make_not_null(&down_dyad), make_not_null(&up_dyad));
+  const ComplexDataVector two{number_of_angular_points,
+                              std::complex<double>(2.0, 0.0)};
+  const ComplexDataVector zero{number_of_angular_points,
+                               std::complex<double>(0.0, 0.0)};
+
+  ComplexDataVector dyad_product{number_of_angular_points, 0.0};
+  for (size_t A = 0; A < 2; ++A) {
+    dyad_product += up_dyad.get(A) * down_dyad.get(A);
+  }
+  CHECK_ITERABLE_APPROX(dyad_product, zero);
+  dyad_product = 0.0;
+  for (size_t A = 0; A < 2; ++A) {
+    dyad_product += up_dyad.get(A) * conj(down_dyad.get(A));
+  }
+  CHECK_ITERABLE_APPROX(dyad_product, two);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.BoundaryData",
+                  "[Unit][Evolution]") {
+  pypp_test_worldtube_computation_steps();
+
+  MAKE_GENERATOR(gen);
+  test_trigonometric_function_identities(make_not_null(&gen));
+  test_d_bondi_r_identities(make_not_null(&gen));
+  test_dyad_identities(make_not_null(&gen));
+}
+}  // namespace Cce

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -54,6 +54,21 @@ void test_compute_inverse_spacetime_metric(const DataType& used_for_size) {
       used_for_size);
 }
 template <size_t Dim, typename DataType>
+void test_compute_time_derivative_of_spacetime_metric(
+    const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::aa<DataType, Dim, Frame::Inertial> (*)(
+          const Scalar<DataType>&, const Scalar<DataType>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&)>(
+          &gr::time_derivative_of_spacetime_metric<Dim, Frame::Inertial,
+                                                   DataType>),
+      "ComputeSpacetimeQuantities", "dt_spacetime_metric", {{{-10., 10.}}},
+      used_for_size);
+}
+template <size_t Dim, typename DataType>
 void test_compute_derivatives_of_spacetime_metric(
     const DataType& used_for_size) {
   pypp::check_with_random_values<1>(
@@ -145,6 +160,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
                                     (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(
       test_compute_derivatives_of_spacetime_metric, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(
+      test_compute_time_derivative_of_spacetime_metric, (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_spacetime_normal_vector,
                                     (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_spacetime_normal_one_form,

--- a/tests/Unit/Utilities/Test_ContainerHelpers.cpp
+++ b/tests/Unit/Utilities/Test_ContainerHelpers.cpp
@@ -8,7 +8,10 @@
 #include <cstddef>
 #include <vector>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 
 /// [get_element_example_indexing_callable]
@@ -115,5 +118,22 @@ SPECTRE_TEST_CASE("Unit.Utilities.ContainerHelpers", "[Unit][Utilities]") {
     CHECK(get_element(spectre_vector, i) == 4.0);
     CHECK(get_element(array_of_arrays, i, ArrayOfArraysIndexFunctor{}) ==
           static_cast<double>(i));
+  }
+
+  // Check the destructive resize function applied to tensors
+  tnsr::i<DataVector, 3> rank_one{static_cast<size_t>(4)};
+  Scalar<ComplexDataVector> complex_scalar{static_cast<size_t>(10)};
+  Scalar<DataVector> right_sized{static_cast<size_t>(5), 2.0};
+
+  destructive_resize_components(make_not_null(&rank_one), 5);
+  destructive_resize_components(make_not_null(&complex_scalar), 5);
+  destructive_resize_components(make_not_null(&right_sized), 5);
+  for (const auto& vector : rank_one) {
+    CHECK(vector.size() == 5);
+  }
+  CHECK(get(complex_scalar).size() == 5);
+  CHECK(get(right_sized).size() == 5);
+  for (const auto& element : get(right_sized)) {
+    CHECK(element == 2.0);
   }
 }


### PR DESCRIPTION
## Proposed changes

This gives the functions needed to move from input Cauchy coordinate values to all of the metric quantities in the intermediate null ('radinull' from Kevin's paper) coordinates. The next step after this is in will be the computation to Bondi scalars, and following that the utilities for pulling in data from an H5 file. I'll add tests against analytic Schwarzschild solutions once the full boundary pipeline is in place.

There were places in the documentation for these functions that I omitted the full expressions that would be long direct transcriptions from Kevin's paper. If it is preferable to have the full expressions, though, I can be more explicit for those functions.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

