### PR TITLE
Update Valencia Cons<-->Prim

### DIFF
--- a/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.cpp
@@ -18,7 +18,7 @@ namespace RelativisticEuler {
 namespace Valencia {
 
 template <size_t Dim>
-void conservative_from_primitive(
+void ConservativeFromPrimitive<Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> tilde_d,
     const gsl::not_null<Scalar<DataVector>*> tilde_tau,
     const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> tilde_s,
@@ -60,29 +60,15 @@ void conservative_from_primitive(
   }
 }
 
-}  // namespace Valencia
-}  // namespace RelativisticEuler
-
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(_, data)                                                 \
-  template void RelativisticEuler::Valencia::conservative_from_primitive(      \
-      const gsl::not_null<Scalar<DataVector>*> tilde_d,                        \
-      const gsl::not_null<Scalar<DataVector>*> tilde_tau,                      \
-      const gsl::not_null<tnsr::i<DataVector, DIM(data), Frame::Inertial>*>    \
-          tilde_s,                                                             \
-      const Scalar<DataVector>& rest_mass_density,                             \
-      const Scalar<DataVector>& specific_internal_energy,                      \
-      const Scalar<DataVector>& specific_enthalpy,                             \
-      const Scalar<DataVector>& pressure,                                      \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& spatial_velocity, \
-      const Scalar<DataVector>& lorentz_factor,                                \
-      const Scalar<DataVector>& sqrt_det_spatial_metric,                       \
-      const tnsr::ii<DataVector, DIM(data), Frame::Inertial>&                  \
-          spatial_metric) noexcept;
+#define INSTANTIATION(_, data) \
+  template class ConservativeFromPrimitive<DIM(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef DIM
+}  // namespace Valencia
+}  // namespace RelativisticEuler
 /// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.cpp
@@ -4,7 +4,11 @@
 #include "Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp"
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
@@ -20,12 +24,26 @@ void conservative_from_primitive(
     const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> tilde_s,
     const Scalar<DataVector>& rest_mass_density,
     const Scalar<DataVector>& specific_internal_energy,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>& spatial_velocity_oneform,
-    const Scalar<DataVector>& spatial_velocity_squared,
-    const Scalar<DataVector>& lorentz_factor,
     const Scalar<DataVector>& specific_enthalpy,
     const Scalar<DataVector>& pressure,
-    const Scalar<DataVector>& sqrt_det_spatial_metric) noexcept {
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& lorentz_factor,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, Dim, Frame::Inertial>& spatial_metric) noexcept {
+  Variables<tmpl::list<
+      hydro::Tags::SpatialVelocityOneForm<DataVector, Dim, Frame::Inertial>,
+      hydro::Tags::SpatialVelocitySquared<DataVector>>>
+      temp_tensors{get(rest_mass_density).size()};
+  auto& spatial_velocity_oneform = get<
+      hydro::Tags::SpatialVelocityOneForm<DataVector, Dim, Frame::Inertial>>(
+      temp_tensors);
+  raise_or_lower_index(make_not_null(&spatial_velocity_oneform),
+                       spatial_velocity, spatial_metric);
+  auto& spatial_velocity_squared =
+      get<hydro::Tags::SpatialVelocitySquared<DataVector>>(temp_tensors);
+  dot_product(make_not_null(&spatial_velocity_squared), spatial_velocity,
+              spatial_velocity_oneform);
+
   get(*tilde_d) = get(sqrt_det_spatial_metric) * get(rest_mass_density) *
                   get(lorentz_factor);
 
@@ -47,21 +65,21 @@ void conservative_from_primitive(
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(_, data)                                              \
-  template void RelativisticEuler::Valencia::conservative_from_primitive(   \
-      const gsl::not_null<Scalar<DataVector>*> tilde_d,                     \
-      const gsl::not_null<Scalar<DataVector>*> tilde_tau,                   \
-      const gsl::not_null<tnsr::i<DataVector, DIM(data), Frame::Inertial>*> \
-          tilde_s,                                                          \
-      const Scalar<DataVector>& rest_mass_density,                          \
-      const Scalar<DataVector>& specific_internal_energy,                   \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                \
-          spatial_velocity_oneform,                                         \
-      const Scalar<DataVector>& spatial_velocity_squared,                   \
-      const Scalar<DataVector>& lorentz_factor,                             \
-      const Scalar<DataVector>& specific_enthalpy,                          \
-      const Scalar<DataVector>& pressure,                                   \
-      const Scalar<DataVector>& sqrt_det_spatial_metric) noexcept;
+#define INSTANTIATION(_, data)                                                 \
+  template void RelativisticEuler::Valencia::conservative_from_primitive(      \
+      const gsl::not_null<Scalar<DataVector>*> tilde_d,                        \
+      const gsl::not_null<Scalar<DataVector>*> tilde_tau,                      \
+      const gsl::not_null<tnsr::i<DataVector, DIM(data), Frame::Inertial>*>    \
+          tilde_s,                                                             \
+      const Scalar<DataVector>& rest_mass_density,                             \
+      const Scalar<DataVector>& specific_internal_energy,                      \
+      const Scalar<DataVector>& specific_enthalpy,                             \
+      const Scalar<DataVector>& pressure,                                      \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& spatial_velocity, \
+      const Scalar<DataVector>& lorentz_factor,                                \
+      const Scalar<DataVector>& sqrt_det_spatial_metric,                       \
+      const tnsr::ii<DataVector, DIM(data), Frame::Inertial>&                  \
+          spatial_metric) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.cpp
@@ -13,18 +13,19 @@
 namespace RelativisticEuler {
 namespace Valencia {
 
-template <typename DataType, size_t Dim>
+template <size_t Dim>
 void conservative_from_primitive(
-    const gsl::not_null<Scalar<DataType>*> tilde_d,
-    const gsl::not_null<Scalar<DataType>*> tilde_tau,
-    const gsl::not_null<tnsr::i<DataType, Dim, Frame::Inertial>*> tilde_s,
-    const Scalar<DataType>& rest_mass_density,
-    const Scalar<DataType>& specific_internal_energy,
-    const tnsr::i<DataType, Dim, Frame::Inertial>& spatial_velocity_oneform,
-    const Scalar<DataType>& spatial_velocity_squared,
-    const Scalar<DataType>& lorentz_factor,
-    const Scalar<DataType>& specific_enthalpy, const Scalar<DataType>& pressure,
-    const Scalar<DataType>& sqrt_det_spatial_metric) noexcept {
+    const gsl::not_null<Scalar<DataVector>*> tilde_d,
+    const gsl::not_null<Scalar<DataVector>*> tilde_tau,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> tilde_s,
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& spatial_velocity_oneform,
+    const Scalar<DataVector>& spatial_velocity_squared,
+    const Scalar<DataVector>& lorentz_factor,
+    const Scalar<DataVector>& specific_enthalpy,
+    const Scalar<DataVector>& pressure,
+    const Scalar<DataVector>& sqrt_det_spatial_metric) noexcept {
   get(*tilde_d) = get(sqrt_det_spatial_metric) * get(rest_mass_density) *
                   get(lorentz_factor);
 
@@ -44,28 +45,26 @@ void conservative_from_primitive(
 }  // namespace Valencia
 }  // namespace RelativisticEuler
 
-#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(_, data)                                               \
-  template void RelativisticEuler::Valencia::conservative_from_primitive(    \
-      const gsl::not_null<Scalar<DTYPE(data)>*> tilde_d,                     \
-      const gsl::not_null<Scalar<DTYPE(data)>*> tilde_tau,                   \
-      const gsl::not_null<tnsr::i<DTYPE(data), DIM(data), Frame::Inertial>*> \
-          tilde_s,                                                           \
-      const Scalar<DTYPE(data)>& rest_mass_density,                          \
-      const Scalar<DTYPE(data)>& specific_internal_energy,                   \
-      const tnsr::i<DTYPE(data), DIM(data), Frame::Inertial>&                \
-          spatial_velocity_oneform,                                          \
-      const Scalar<DTYPE(data)>& spatial_velocity_squared,                   \
-      const Scalar<DTYPE(data)>& lorentz_factor,                             \
-      const Scalar<DTYPE(data)>& specific_enthalpy,                          \
-      const Scalar<DTYPE(data)>& pressure,                                   \
-      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric) noexcept;
+#define INSTANTIATION(_, data)                                              \
+  template void RelativisticEuler::Valencia::conservative_from_primitive(   \
+      const gsl::not_null<Scalar<DataVector>*> tilde_d,                     \
+      const gsl::not_null<Scalar<DataVector>*> tilde_tau,                   \
+      const gsl::not_null<tnsr::i<DataVector, DIM(data), Frame::Inertial>*> \
+          tilde_s,                                                          \
+      const Scalar<DataVector>& rest_mass_density,                          \
+      const Scalar<DataVector>& specific_internal_energy,                   \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                \
+          spatial_velocity_oneform,                                         \
+      const Scalar<DataVector>& spatial_velocity_squared,                   \
+      const Scalar<DataVector>& lorentz_factor,                             \
+      const Scalar<DataVector>& specific_enthalpy,                          \
+      const Scalar<DataVector>& pressure,                                   \
+      const Scalar<DataVector>& sqrt_det_spatial_metric) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (double, DataVector), (1, 2, 3))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef DIM
-#undef DTYPE
 /// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp
@@ -7,10 +7,14 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
+/// \cond
+class DataVector;
+
 namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
+/// \endcond
 
 namespace RelativisticEuler {
 namespace Valencia {
@@ -38,17 +42,18 @@ namespace Valencia {
  * {\tilde \tau} = \sqrt{\gamma} W^2 \left[ \rho \left( \epsilon + v^2
  * \frac{W}{W + 1} \right) + p v^2 \right] .\f]
  */
-template <typename DataType, size_t Dim>
+template <size_t Dim>
 void conservative_from_primitive(
-    gsl::not_null<Scalar<DataType>*> tilde_d,
-    gsl::not_null<Scalar<DataType>*> tilde_tau,
-    gsl::not_null<tnsr::i<DataType, Dim, Frame::Inertial>*> tilde_s,
-    const Scalar<DataType>& rest_mass_density,
-    const Scalar<DataType>& specific_internal_energy,
-    const tnsr::i<DataType, Dim, Frame::Inertial>& spatial_velocity_oneform,
-    const Scalar<DataType>& spatial_velocity_squared,
-    const Scalar<DataType>& lorentz_factor,
-    const Scalar<DataType>& specific_enthalpy, const Scalar<DataType>& pressure,
-    const Scalar<DataType>& sqrt_det_spatial_metric) noexcept;
+    gsl::not_null<Scalar<DataVector>*> tilde_d,
+    gsl::not_null<Scalar<DataVector>*> tilde_tau,
+    gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> tilde_s,
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& spatial_velocity_oneform,
+    const Scalar<DataVector>& spatial_velocity_squared,
+    const Scalar<DataVector>& lorentz_factor,
+    const Scalar<DataVector>& specific_enthalpy,
+    const Scalar<DataVector>& pressure,
+    const Scalar<DataVector>& sqrt_det_spatial_metric) noexcept;
 }  // namespace Valencia
 }  // namespace RelativisticEuler

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp
@@ -49,11 +49,11 @@ void conservative_from_primitive(
     gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> tilde_s,
     const Scalar<DataVector>& rest_mass_density,
     const Scalar<DataVector>& specific_internal_energy,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>& spatial_velocity_oneform,
-    const Scalar<DataVector>& spatial_velocity_squared,
-    const Scalar<DataVector>& lorentz_factor,
     const Scalar<DataVector>& specific_enthalpy,
     const Scalar<DataVector>& pressure,
-    const Scalar<DataVector>& sqrt_det_spatial_metric) noexcept;
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& lorentz_factor,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, Dim, Frame::Inertial>& spatial_metric) noexcept;
 }  // namespace Valencia
 }  // namespace RelativisticEuler

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp
@@ -6,6 +6,10 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/TagsDeclarations.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
 class DataVector;
@@ -43,17 +47,35 @@ namespace Valencia {
  * \frac{W}{W + 1} \right) + p v^2 \right] .\f]
  */
 template <size_t Dim>
-void conservative_from_primitive(
-    gsl::not_null<Scalar<DataVector>*> tilde_d,
-    gsl::not_null<Scalar<DataVector>*> tilde_tau,
-    gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> tilde_s,
-    const Scalar<DataVector>& rest_mass_density,
-    const Scalar<DataVector>& specific_internal_energy,
-    const Scalar<DataVector>& specific_enthalpy,
-    const Scalar<DataVector>& pressure,
-    const tnsr::I<DataVector, Dim, Frame::Inertial>& spatial_velocity,
-    const Scalar<DataVector>& lorentz_factor,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const tnsr::ii<DataVector, Dim, Frame::Inertial>& spatial_metric) noexcept;
+struct ConservativeFromPrimitive {
+  using return_tags =
+      tmpl::list<RelativisticEuler::Valencia::Tags::TildeD,
+                 RelativisticEuler::Valencia::Tags::TildeTau,
+                 RelativisticEuler::Valencia::Tags::TildeS<Dim>>;
+
+  using argument_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                 hydro::Tags::SpecificInternalEnergy<DataVector>,
+                 hydro::Tags::SpecificEnthalpy<DataVector>,
+                 hydro::Tags::Pressure<DataVector>,
+                 hydro::Tags::SpatialVelocity<DataVector, Dim, Frame::Inertial>,
+                 hydro::Tags::LorentzFactor<DataVector>,
+                 gr::Tags::SqrtDetSpatialMetric<>,
+                 gr::Tags::SpatialMetric<Dim>>;
+
+  static void apply(
+      gsl::not_null<Scalar<DataVector>*> tilde_d,
+      gsl::not_null<Scalar<DataVector>*> tilde_tau,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> tilde_s,
+      const Scalar<DataVector>& rest_mass_density,
+      const Scalar<DataVector>& specific_internal_energy,
+      const Scalar<DataVector>& specific_enthalpy,
+      const Scalar<DataVector>& pressure,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& spatial_velocity,
+      const Scalar<DataVector>& lorentz_factor,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const tnsr::ii<DataVector, Dim, Frame::Inertial>&
+          spatial_metric) noexcept;
+};
 }  // namespace Valencia
 }  // namespace RelativisticEuler

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
@@ -83,7 +83,7 @@ class FunctionOfZ {
 }  // namespace
 
 template <size_t ThermodynamicDim, size_t Dim>
-void primitive_from_conservative(
+void PrimitiveFromConservative<ThermodynamicDim, Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
     const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
     const gsl::not_null<Scalar<DataVector>*> lorentz_factor,
@@ -146,33 +146,17 @@ void primitive_from_conservative(
   }
 }
 
-}  // namespace Valencia
-}  // namespace RelativisticEuler
-
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define THERMODIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATION(_, data)                                                \
-  template void                                                               \
-  RelativisticEuler::Valencia::primitive_from_conservative<THERMODIM(data)>(  \
-      const gsl::not_null<Scalar<DataVector>*> rest_mass_density,             \
-      const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,      \
-      const gsl::not_null<Scalar<DataVector>*> lorentz_factor,                \
-      const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,             \
-      const gsl::not_null<Scalar<DataVector>*> pressure,                      \
-      const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>   \
-          spatial_velocity,                                                   \
-      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau, \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& tilde_s,         \
-      const tnsr::II<DataVector, DIM(data), Frame::Inertial>&                 \
-          inv_spatial_metric,                                                 \
-      const Scalar<DataVector>& sqrt_det_spatial_metric,                      \
-      const EquationsOfState::EquationOfState<true, THERMODIM(data)>&         \
-          equation_of_state) noexcept;
+#define INSTANTIATION(_, data) \
+  template class PrimitiveFromConservative<THERMODIM(data), DIM(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
 
 #undef INSTANTIATION
 #undef THERMODIM
 #undef DIM
+}  // namespace Valencia
+}  // namespace RelativisticEuler
 /// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
@@ -3,6 +3,7 @@
 
 #include "Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.hpp"
 
+#include <boost/none.hpp>
 #include <cmath>
 #include <limits>
 
@@ -110,11 +111,19 @@ void PrimitiveFromConservative<ThermodynamicDim, Dim>::apply(
       FunctionOfZ<ThermodynamicDim>{tilde_d, tilde_tau, tilde_s_magnitude,
                                     sqrt_det_spatial_metric, equation_of_state};
 
-  const auto z =
-      // NOLINTNEXTLINE(clang-analyzer-core)
-      RootFinder::toms748(f_of_z, lower_bound, upper_bound,
-                          10.0 * std::numeric_limits<double>::epsilon(),
-                          10.0 * std::numeric_limits<double>::epsilon(), 100);
+  DataVector z;
+  try {
+    // NOLINTNEXTLINE(clang-analyzer-core)
+    z = RootFinder::toms748(f_of_z, lower_bound, upper_bound,
+                            10.0 * std::numeric_limits<double>::epsilon(),
+                            10.0 * std::numeric_limits<double>::epsilon(), 100);
+  } catch (std::exception& exception) {
+    ERROR(
+        "Failed to find the intermediate variable z with TOMS748 root finder "
+        "while computing the primitive variables from the conserved variables. "
+        "Got exception message:\n"
+        << exception.what());
+  }
   get(*lorentz_factor) = sqrt(1.0 + square(z));
   get(*rest_mass_density) =
       get(tilde_d) / (get(*lorentz_factor) * get(sqrt_det_spatial_metric));

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.hpp
@@ -6,7 +6,11 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/TagsDeclarations.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
 class DataVector;
@@ -56,18 +60,37 @@ namespace Valencia {
  * see the paper for details.
  */
 template <size_t ThermodynamicDim, size_t Dim>
-void primitive_from_conservative(
-    gsl::not_null<Scalar<DataVector>*> rest_mass_density,
-    gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
-    gsl::not_null<Scalar<DataVector>*> lorentz_factor,
-    gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
-    gsl::not_null<Scalar<DataVector>*> pressure,
-    gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> spatial_velocity,
-    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>& tilde_s,
-    const tnsr::II<DataVector, Dim, Frame::Inertial>& inv_spatial_metric,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-        equation_of_state) noexcept;
+struct PrimitiveFromConservative {
+  using return_tags = tmpl::list<
+      hydro::Tags::RestMassDensity<DataVector>,
+      hydro::Tags::SpecificInternalEnergy<DataVector>,
+      hydro::Tags::LorentzFactor<DataVector>,
+      hydro::Tags::SpecificEnthalpy<DataVector>,
+      hydro::Tags::Pressure<DataVector>,
+      hydro::Tags::SpatialVelocity<DataVector, Dim, Frame::Inertial>>;
+
+  using argument_tags =
+      tmpl::list<RelativisticEuler::Valencia::Tags::TildeD,
+                 RelativisticEuler::Valencia::Tags::TildeTau,
+                 RelativisticEuler::Valencia::Tags::TildeS<Dim>,
+                 gr::Tags::InverseSpatialMetric<Dim>,
+                 gr::Tags::SqrtDetSpatialMetric<>,
+                 hydro::Tags::EquationOfStateBase>;
+
+  static void apply(
+      gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+      gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+      gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+      gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+      gsl::not_null<Scalar<DataVector>*> pressure,
+      gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          spatial_velocity,
+      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& tilde_s,
+      const tnsr::II<DataVector, Dim, Frame::Inertial>& inv_spatial_metric,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+          equation_of_state) noexcept;
+};
 }  // namespace Valencia
 }  // namespace RelativisticEuler

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.hpp
@@ -9,6 +9,8 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 
 /// \cond
+class DataVector;
+
 namespace gsl {
 template <typename T>
 class not_null;
@@ -53,18 +55,18 @@ namespace Valencia {
  * \todo The method also will make corrections if physical bounds are violated,
  * see the paper for details.
  */
-template <size_t ThermodynamicDim, typename DataType, size_t Dim>
+template <size_t ThermodynamicDim, size_t Dim>
 void primitive_from_conservative(
-    gsl::not_null<Scalar<DataType>*> rest_mass_density,
-    gsl::not_null<Scalar<DataType>*> specific_internal_energy,
-    gsl::not_null<Scalar<DataType>*> lorentz_factor,
-    gsl::not_null<Scalar<DataType>*> specific_enthalpy,
-    gsl::not_null<Scalar<DataType>*> pressure,
-    gsl::not_null<tnsr::I<DataType, Dim, Frame::Inertial>*> spatial_velocity,
-    const Scalar<DataType>& tilde_d, const Scalar<DataType>& tilde_tau,
-    const tnsr::i<DataType, Dim, Frame::Inertial>& tilde_s,
-    const tnsr::II<DataType, Dim, Frame::Inertial>& inv_spatial_metric,
-    const Scalar<DataType>& sqrt_det_spatial_metric,
+    gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+    gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+    gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+    gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+    gsl::not_null<Scalar<DataVector>*> pressure,
+    gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> spatial_velocity,
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& tilde_s,
+    const tnsr::II<DataVector, Dim, Frame::Inertial>& inv_spatial_metric,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state) noexcept;
 }  // namespace Valencia

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/TestFunctions.py
@@ -4,6 +4,15 @@
 import numpy as np
 
 
+def spatial_velocity_oneform(spatial_velocity, spatial_metric):
+    return np.einsum("a, ia", spatial_velocity, spatial_metric)
+
+
+def spatial_velocity_squared(spatial_velocity, spatial_metric):
+    return np.einsum("ab, ab", spatial_metric,
+                     np.outer(spatial_velocity, spatial_velocity))
+
+
 # Functions for testing Characteristics.cpp
 def characteristic_speeds(lapse, shift, spatial_velocity, spatial_velocity_sqrd,
                           sound_speed_sqrd, normal_oneform):
@@ -27,26 +36,27 @@ def characteristic_speeds(lapse, shift, spatial_velocity, spatial_velocity_sqrd,
 
 
 # Functions for testing ConservativeFromPrimitive.cpp
-def tilde_d(rest_mass_density, specific_internal_energy,
-            spatial_velocity_oneform, spatial_velocity_squared, lorentz_factor,
-            specific_enthalpy, pressure, sqrt_det_spatial_metric):
+def tilde_d(rest_mass_density, specific_internal_energy, specific_enthalpy,
+            pressure, spatial_velocity, lorentz_factor, sqrt_det_spatial_metric,
+            spatial_metric):
     return lorentz_factor * rest_mass_density * sqrt_det_spatial_metric
 
 
-def tilde_tau(rest_mass_density, specific_internal_energy,
-              spatial_velocity_oneform, spatial_velocity_squared,
-              lorentz_factor, specific_enthalpy, pressure,
-              sqrt_det_spatial_metric):
-    return ((pressure * spatial_velocity_squared
-             + (lorentz_factor/(1.0 + lorentz_factor) * spatial_velocity_squared
+def tilde_tau(rest_mass_density, specific_internal_energy, specific_enthalpy,
+              pressure, spatial_velocity, lorentz_factor,
+              sqrt_det_spatial_metric, spatial_metric):
+    v_squared = spatial_velocity_squared(spatial_velocity, spatial_metric)
+    return ((pressure * v_squared
+             + (lorentz_factor/(1.0 + lorentz_factor) * v_squared
                 + specific_internal_energy) * rest_mass_density)
             * lorentz_factor**2 * sqrt_det_spatial_metric)
 
 
-def tilde_s(rest_mass_density, specific_internal_energy,
-            spatial_velocity_oneform, spatial_velocity_squared, lorentz_factor,
-            specific_enthalpy, pressure, sqrt_det_spatial_metric):
-    return (spatial_velocity_oneform * lorentz_factor**2 * specific_enthalpy
+def tilde_s(rest_mass_density, specific_internal_energy, specific_enthalpy,
+            pressure, spatial_velocity, lorentz_factor, sqrt_det_spatial_metric,
+            spatial_metric):
+    return (spatial_velocity_oneform(spatial_velocity, spatial_metric)
+            * lorentz_factor**2 * specific_enthalpy
             * rest_mass_density * sqrt_det_spatial_metric)
 
 

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_ConservativeFromPrimitive.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_ConservativeFromPrimitive.cpp
@@ -15,7 +15,7 @@ namespace {
 template <size_t Dim, typename DataType>
 void test_conservative_from_primitive(const DataType& used_for_size) noexcept {
   pypp::check_with_random_values<1>(
-      &RelativisticEuler::Valencia::conservative_from_primitive<DataType, Dim>,
+      &RelativisticEuler::Valencia::conservative_from_primitive<Dim>,
       "TestFunctions", {"tilde_d", "tilde_tau", "tilde_s"}, {{{0.0, 1.0}}},
       used_for_size);
 }
@@ -26,6 +26,6 @@ SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.ConservativeFromPrimitive",
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/RelativisticEuler/Valencia"};
 
-  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
-  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_conservative_from_primitive, (1, 2, 3))
+  GENERATE_UNINITIALIZED_DATAVECTOR;
+  CHECK_FOR_DATAVECTORS(test_conservative_from_primitive, (1, 2, 3))
 }

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_ConservativeFromPrimitive.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_ConservativeFromPrimitive.cpp
@@ -15,7 +15,7 @@ namespace {
 template <size_t Dim, typename DataType>
 void test_conservative_from_primitive(const DataType& used_for_size) noexcept {
   pypp::check_with_random_values<1>(
-      &RelativisticEuler::Valencia::conservative_from_primitive<Dim>,
+      &RelativisticEuler::Valencia::ConservativeFromPrimitive<Dim>::apply,
       "TestFunctions", {"tilde_d", "tilde_tau", "tilde_s"}, {{{0.0, 1.0}}},
       used_for_size);
 }

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
@@ -159,7 +159,7 @@ void test_primitive_from_conservative(
   auto tilde_tau = make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
   auto tilde_s = make_with_value<tnsr::i<DataVector, Dim>>(used_for_size, 0.0);
 
-  RelativisticEuler::Valencia::conservative_from_primitive(
+  RelativisticEuler::Valencia::ConservativeFromPrimitive<Dim>::apply(
       make_not_null(&tilde_d), make_not_null(&tilde_tau),
       make_not_null(&tilde_s), expected_rest_mass_density,
       expected_specific_internal_energy, expected_specific_enthalpy,

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
@@ -28,36 +28,34 @@
 
 namespace {
 
-template <typename DataType>
-Scalar<DataType> random_density(const gsl::not_null<std::mt19937*> generator,
-                                const DataType& used_for_size) noexcept {
+Scalar<DataVector> random_density(const gsl::not_null<std::mt19937*> generator,
+                                  const DataVector& used_for_size) noexcept {
   // 1 g/cm^3 = 1.62e-18 in geometric units
   constexpr double minimum_density = 1.0e-5;
   constexpr double maximum_density = 1.0e-3;
   std::uniform_real_distribution<> distribution(log(minimum_density),
                                                 log(maximum_density));
-  return Scalar<DataType>{exp(make_with_random_values<DataType>(
+  return Scalar<DataVector>{exp(make_with_random_values<DataVector>(
       generator, make_not_null(&distribution), used_for_size))};
 }
 
-template <typename DataType>
-Scalar<DataType> random_lorentz_factor(
+Scalar<DataVector> random_lorentz_factor(
     const gsl::not_null<std::mt19937*> generator,
-    const DataType& used_for_size) noexcept {
+    const DataVector& used_for_size) noexcept {
   std::uniform_real_distribution<> distribution(-10.0, 3.0);
-  return Scalar<DataType>{
-      1.0 + exp(make_with_random_values<DataType>(
+  return Scalar<DataVector>{
+      1.0 + exp(make_with_random_values<DataVector>(
                 generator, make_not_null(&distribution), used_for_size))};
 }
 
-template <typename DataType, size_t Dim>
-tnsr::I<DataType, Dim> random_velocity(
+template <size_t Dim>
+tnsr::I<DataVector, Dim> random_velocity(
     const gsl::not_null<std::mt19937*> generator,
-    const Scalar<DataType>& lorentz_factor,
-    const tnsr::ii<DataType, Dim>& spatial_metric) noexcept {
-  tnsr::I<DataType, Dim> spatial_velocity =
+    const Scalar<DataVector>& lorentz_factor,
+    const tnsr::ii<DataVector, Dim>& spatial_metric) noexcept {
+  tnsr::I<DataVector, Dim> spatial_velocity =
       random_unit_normal(generator, spatial_metric);
-  const DataType v = sqrt(1.0 - 1.0 / square(get(lorentz_factor)));
+  const DataVector v = sqrt(1.0 - 1.0 / square(get(lorentz_factor)));
   for (size_t d = 0; d < Dim; ++d) {
     spatial_velocity.get(d) *= v;
   }
@@ -65,44 +63,41 @@ tnsr::I<DataType, Dim> random_velocity(
 }
 
 // temperature in MeV
-template <typename DataType>
-Scalar<DataType> random_temperature(
+Scalar<DataVector> random_temperature(
     const gsl::not_null<std::mt19937*> generator,
-    const DataType& used_for_size) noexcept {
+    const DataVector& used_for_size) noexcept {
   constexpr double minimum_temperature = 1.0;
   constexpr double maximum_temperature = 50.0;
   std::uniform_real_distribution<> distribution(log(minimum_temperature),
                                                 log(maximum_temperature));
-  return Scalar<DataType>{exp(make_with_random_values<DataType>(
+  return Scalar<DataVector>{exp(make_with_random_values<DataVector>(
       generator, make_not_null(&distribution), used_for_size))};
 }
 
-template <typename DataType>
-Scalar<DataType> random_specific_internal_energy(
+Scalar<DataVector> random_specific_internal_energy(
     const gsl::not_null<std::mt19937*> generator,
-    const DataType& used_for_size) noexcept {
+    const DataVector& used_for_size) noexcept {
   // assumes Ideal gas with gamma = 4/3
   // For ideal fluid T = (m/k_b)(gamma - 1) epsilon
   // where m = atomic mass unit, k_b = Boltzmann constant
-  return Scalar<DataType>{3.21e-3 *
-                          get(random_temperature(generator, used_for_size))};
+  return Scalar<DataVector>{3.21e-3 *
+                            get(random_temperature(generator, used_for_size))};
 }
 
-template <typename DataType>
-Scalar<DataType> specific_enthalpy(
-    const Scalar<DataType>& rest_mass_density,
-    const Scalar<DataType>& specific_internal_energy,
-    const Scalar<DataType>& pressure) noexcept {
-  return Scalar<DataType>{1.0 + get(specific_internal_energy) +
-                          get(pressure) / get(rest_mass_density)};
+Scalar<DataVector> specific_enthalpy(
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
+    const Scalar<DataVector>& pressure) noexcept {
+  return Scalar<DataVector>{1.0 + get(specific_internal_energy) +
+                            get(pressure) / get(rest_mass_density)};
 }
 
-template <typename DataType, size_t Dim>
-tnsr::ii<DataType, Dim> random_spatial_metric(
+template <size_t Dim>
+tnsr::ii<DataVector, Dim> random_spatial_metric(
     const gsl::not_null<std::mt19937*> generator,
-    const DataType& used_for_size) noexcept {
+    const DataVector& used_for_size) noexcept {
   std::uniform_real_distribution<> distribution(-0.05, 0.05);
-  auto spatial_metric = make_with_random_values<tnsr::ii<DataType, Dim>>(
+  auto spatial_metric = make_with_random_values<tnsr::ii<DataVector, Dim>>(
       generator, make_not_null(&distribution), used_for_size);
   for (size_t d = 0; d < Dim; ++d) {
     spatial_metric.get(d, d) += 1.0;
@@ -110,18 +105,18 @@ tnsr::ii<DataType, Dim> random_spatial_metric(
   return spatial_metric;
 }
 
-template <size_t Dim, size_t ThermodynamicDim, typename DataType>
+template <size_t Dim, size_t ThermodynamicDim>
 void test_primitive_from_conservative(
     const gsl::not_null<std::mt19937*> generator,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state,
-    const DataType& used_for_size) noexcept {
+    const DataVector& used_for_size) noexcept {
   const auto expected_rest_mass_density =
       random_density(generator, used_for_size);
   const auto expected_lorentz_factor =
       random_lorentz_factor(generator, used_for_size);
   const auto spatial_metric =
-      random_spatial_metric<DataType, Dim>(generator, used_for_size);
+      random_spatial_metric<Dim>(generator, used_for_size);
   const auto expected_spatial_velocity =
       random_velocity(generator, expected_lorentz_factor, spatial_metric);
   const auto expected_specific_internal_energy = make_overloader(
@@ -157,16 +152,16 @@ void test_primitive_from_conservative(
 
   const auto det_and_inv = determinant_and_inverse(spatial_metric);
   const auto& inv_spatial_metric = det_and_inv.second;
-  const Scalar<DataType> sqrt_det_spatial_metric =
-      Scalar<DataType>{sqrt(get(det_and_inv.first))};
+  const Scalar<DataVector> sqrt_det_spatial_metric =
+      Scalar<DataVector>{sqrt(get(det_and_inv.first))};
   const auto spatial_velocity_oneform =
       raise_or_lower_index(expected_spatial_velocity, spatial_metric);
   const auto spatial_velocity_squared =
       dot_product(spatial_velocity_oneform, expected_spatial_velocity);
 
-  auto tilde_d = make_with_value<Scalar<DataType>>(used_for_size, 0.0);
-  auto tilde_tau = make_with_value<Scalar<DataType>>(used_for_size, 0.0);
-  auto tilde_s = make_with_value<tnsr::i<DataType, Dim>>(used_for_size, 0.0);
+  auto tilde_d = make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+  auto tilde_tau = make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+  auto tilde_s = make_with_value<tnsr::i<DataVector, Dim>>(used_for_size, 0.0);
 
   RelativisticEuler::Valencia::conservative_from_primitive(
       make_not_null(&tilde_d), make_not_null(&tilde_tau),
@@ -176,15 +171,15 @@ void test_primitive_from_conservative(
       expected_specific_enthalpy, expected_pressure, sqrt_det_spatial_metric);
 
   auto rest_mass_density =
-      make_with_value<Scalar<DataType>>(used_for_size, 0.0);
+      make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
   auto specific_internal_energy =
-      make_with_value<Scalar<DataType>>(used_for_size, 0.0);
-  auto lorentz_factor = make_with_value<Scalar<DataType>>(used_for_size, 0.0);
+      make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+  auto lorentz_factor = make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
   auto specific_enthalpy =
-      make_with_value<Scalar<DataType>>(used_for_size, 0.0);
-  auto pressure = make_with_value<Scalar<DataType>>(used_for_size, 0.0);
+      make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+  auto pressure = make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
   auto spatial_velocity =
-      make_with_value<tnsr::I<DataType, Dim>>(used_for_size, 0.0);
+      make_with_value<tnsr::I<DataVector, Dim>>(used_for_size, 0.0);
 
   RelativisticEuler::Valencia::primitive_from_conservative<ThermodynamicDim>(
       make_not_null(&rest_mass_density),
@@ -215,14 +210,6 @@ SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.PrimitiveFromConservative",
 
   EquationsOfState::PolytropicFluid<true> polytropic_fluid(100.0, 2.0);
   EquationsOfState::IdealFluid<true> ideal_fluid(4.0 / 3.0);
-  const double d = std::numeric_limits<double>::signaling_NaN();
-  test_primitive_from_conservative<1, 1>(&generator, polytropic_fluid, d);
-  test_primitive_from_conservative<2, 1>(&generator, polytropic_fluid, d);
-  test_primitive_from_conservative<3, 1>(&generator, polytropic_fluid, d);
-  test_primitive_from_conservative<1, 2>(&generator, ideal_fluid, d);
-  test_primitive_from_conservative<2, 2>(&generator, ideal_fluid, d);
-  test_primitive_from_conservative<3, 2>(&generator, ideal_fluid, d);
-
   const DataVector dv(5);
   test_primitive_from_conservative<1, 1>(&generator, polytropic_fluid, dv);
   test_primitive_from_conservative<2, 1>(&generator, polytropic_fluid, dv);

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
@@ -154,10 +154,6 @@ void test_primitive_from_conservative(
   const auto& inv_spatial_metric = det_and_inv.second;
   const Scalar<DataVector> sqrt_det_spatial_metric =
       Scalar<DataVector>{sqrt(get(det_and_inv.first))};
-  const auto spatial_velocity_oneform =
-      raise_or_lower_index(expected_spatial_velocity, spatial_metric);
-  const auto spatial_velocity_squared =
-      dot_product(spatial_velocity_oneform, expected_spatial_velocity);
 
   auto tilde_d = make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
   auto tilde_tau = make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
@@ -166,9 +162,9 @@ void test_primitive_from_conservative(
   RelativisticEuler::Valencia::conservative_from_primitive(
       make_not_null(&tilde_d), make_not_null(&tilde_tau),
       make_not_null(&tilde_s), expected_rest_mass_density,
-      expected_specific_internal_energy, spatial_velocity_oneform,
-      spatial_velocity_squared, expected_lorentz_factor,
-      expected_specific_enthalpy, expected_pressure, sqrt_det_spatial_metric);
+      expected_specific_internal_energy, expected_specific_enthalpy,
+      expected_pressure, expected_spatial_velocity, expected_lorentz_factor,
+      sqrt_det_spatial_metric, spatial_metric);
 
   auto rest_mass_density =
       make_with_value<Scalar<DataVector>>(used_for_size, 0.0);

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
@@ -177,12 +177,15 @@ void test_primitive_from_conservative(
   auto spatial_velocity =
       make_with_value<tnsr::I<DataVector, Dim>>(used_for_size, 0.0);
 
-  RelativisticEuler::Valencia::primitive_from_conservative<ThermodynamicDim>(
-      make_not_null(&rest_mass_density),
-      make_not_null(&specific_internal_energy), make_not_null(&lorentz_factor),
-      make_not_null(&specific_enthalpy), make_not_null(&pressure),
-      make_not_null(&spatial_velocity), tilde_d, tilde_tau, tilde_s,
-      inv_spatial_metric, sqrt_det_spatial_metric, equation_of_state);
+  RelativisticEuler::Valencia::PrimitiveFromConservative<
+      ThermodynamicDim, Dim>::apply(make_not_null(&rest_mass_density),
+                                    make_not_null(&specific_internal_energy),
+                                    make_not_null(&lorentz_factor),
+                                    make_not_null(&specific_enthalpy),
+                                    make_not_null(&pressure),
+                                    make_not_null(&spatial_velocity), tilde_d,
+                                    tilde_tau, tilde_s, inv_spatial_metric,
+                                    sqrt_det_spatial_metric, equation_of_state);
 
   Approx larger_approx =
       Approx::custom().epsilon(std::numeric_limits<double>::epsilon() * 1.e6);


### PR DESCRIPTION
## Proposed changes

Update Valencia functions computing conservatives <--> primitives so Valencia can be evolved with the current infrastructure for evolution systems. 

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
