### PR TITLE
Add GitHub workflow for continuous integration

### DIFF
--- a/.github/workflows/RunTestSuite.yaml
+++ b/.github/workflows/RunTestSuite.yaml
@@ -112,3 +112,72 @@ jobs:
         working-directory: /work/build
         run: |
           PATH=$PATH:/work/texlive/bin/x86_64-linux make doc-check
+
+  unit_tests:
+    name: Run unit tests
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build_type: [Debug, Release]
+        compiler: [gcc-6, gcc-7, gcc-8, gcc-9, clang-4, clang-5, clang-8]
+    container:
+      image: sxscollaboration/spectrebuildenv:latest
+      env:
+        CCACHE_DIR: /work/ccache
+        CCACHE_COMPILERCHECK: content
+        CCACHE_MAXSIZE: 400M
+        CCACHE_COMPRESS: 1
+        CCACHE_COMPRESSLEVEL: 6
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Restore ccache
+        uses: actions/cache@v1
+        with:
+          path: /work/ccache
+          key: ccache-${{ matrix.compiler }}-${{ matrix.build_type }}
+      - name: Configure with cmake
+        working-directory: /work
+        run: >
+          mkdir build && cd build
+
+          if [[ ${{ matrix.compiler }} =~ (gcc|clang)-([0-9\.]+) ]]; then
+            CC=${BASH_REMATCH[1]}-${BASH_REMATCH[2]};
+            CHARM_CC=${BASH_REMATCH[1]};
+            if [[ ${BASH_REMATCH[1]} = gcc ]]; then
+              CXX=g++-${BASH_REMATCH[2]};
+              FC=gfortran-${BASH_REMATCH[2]};
+            else
+              CXX=clang++-${BASH_REMATCH[2]};
+              FC=gfortran-8;
+            fi
+          fi
+
+          cmake
+          -D CMAKE_C_COMPILER=${CC}
+          -D CMAKE_CXX_COMPILER=${CXX}
+          -D CMAKE_Fortran_COMPILER=${FC}
+          -D CHARM_ROOT=/work/charm/multicore-linux64-${CHARM_CC}
+          -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -D DEBUG_SYMBOLS=OFF
+          -D USE_CCACHE=ON
+          -D BUILD_PYTHON_BINDINGS=ON
+          $GITHUB_WORKSPACE
+
+          ccache -pz
+      - name: Build tests
+        working-directory: /work/build
+        run: |
+          make -j2 RunTests
+      - name: Build executables
+        working-directory: /work/build
+        run: |
+          make test-executables
+      - name: Diagnose ccache
+        run: |
+          ccache -s
+      - name: Run unit tests
+        working-directory: /work/build
+        run: |
+          ctest -j2 --output-on-failure

--- a/.github/workflows/RunTestSuite.yaml
+++ b/.github/workflows/RunTestSuite.yaml
@@ -1,0 +1,114 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+name: Run test suite
+
+on: [push, pull_request]
+
+jobs:
+  check_commits:
+    name: Check commits
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Check commits
+        # `CheckCommits.sh` tests against the local `develop` branch, so that's
+        # where we fetch the pull-request's base-branch to. Typically, it is
+        # the upstream `sxs-collaboration/spectre/develop` branch.
+        run: >
+          cd $GITHUB_WORKSPACE
+
+          git remote add upstream
+          https://github.com/${{ github.repository }}.git
+
+          git remote -v
+
+          git fetch upstream ${{ github.base_ref }}:develop
+
+          ./tools/CheckCommits.sh
+
+  check_files:
+    name: Check files
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Check files
+        run: |
+          cd $GITHUB_WORKSPACE
+          ./tools/CheckFiles.sh
+
+  clang_tidy:
+    name: Check clang-tidy
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    container:
+      image: sxscollaboration/spectrebuildenv:latest
+    strategy:
+      matrix:
+        build_type: [Debug, Release]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Fetch upstream/develop
+        # We only want to check files that have changed in this pull request,
+        # so we fetch its base branch and pass it to `clang-tidy-hash`.
+        # Typically, it is the `sxs-collaboration/spectre/develop` branch.
+        run: >
+          cd $GITHUB_WORKSPACE
+
+          git remote add upstream
+          https://github.com/${{ github.repository }}.git
+
+          git remote -v
+
+          git fetch upstream ${{ github.base_ref }}
+      - name: Configure with cmake
+        working-directory: /work
+        run: >
+          mkdir build && cd build
+
+          cmake
+          -D CMAKE_C_COMPILER=clang
+          -D CMAKE_CXX_COMPILER=clang++
+          -D CMAKE_Fortran_COMPILER=gfortran-8
+          -D CHARM_ROOT=/work/charm/multicore-linux64-clang
+          -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -D DEBUG_SYMBOLS=OFF
+          -D BUILD_PYTHON_BINDINGS=ON
+          $GITHUB_WORKSPACE
+      - name: Check clang-tidy
+        working-directory: /work/build
+        run: |
+          make clang-tidy-hash HASH=upstream/${{ github.base_ref }}
+
+  doc_check:
+    name: Check documentation
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    container:
+      image: sxscollaboration/spectrebuildenv:latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Configure with cmake
+        working-directory: /work
+        run: >
+          mkdir build && cd build
+
+          cmake
+          -D CMAKE_C_COMPILER=clang
+          -D CMAKE_CXX_COMPILER=clang++
+          -D CMAKE_Fortran_COMPILER=gfortran-8
+          -D CHARM_ROOT=/work/charm/multicore-linux64-clang
+          -D CMAKE_BUILD_TYPE=Debug
+          -D DEBUG_SYMBOLS=OFF
+          -D BUILD_PYTHON_BINDINGS=ON
+          $GITHUB_WORKSPACE
+      - name: Check documentation
+        working-directory: /work/build
+        run: |
+          PATH=$PATH:/work/texlive/bin/x86_64-linux make doc-check

--- a/.github/workflows/TestSuite.yaml
+++ b/.github/workflows/TestSuite.yaml
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [gcc-6, gcc-7, gcc-8, gcc-9, clang-4, clang-5, clang-8]
+        compiler: [gcc-6, gcc-7, gcc-8, gcc-9, clang-4.0, clang-5.0, clang-8]
         build_type: [Debug, Release]
     container:
       image: sxscollaboration/spectrebuildenv:latest

--- a/.github/workflows/TestSuite.yaml
+++ b/.github/workflows/TestSuite.yaml
@@ -1,13 +1,13 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-name: Run test suite
+name: Test suite
 
 on: [push, pull_request]
 
 jobs:
   check_commits:
-    name: Check commits
+    name: Commits
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +30,7 @@ jobs:
           ./tools/CheckCommits.sh
 
   check_files:
-    name: Check files
+    name: Files
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -42,7 +42,7 @@ jobs:
           ./tools/CheckFiles.sh
 
   clang_tidy:
-    name: Check clang-tidy
+    name: Clang-tidy
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     container:
@@ -86,7 +86,7 @@ jobs:
           make clang-tidy-hash HASH=upstream/${{ github.base_ref }}
 
   doc_check:
-    name: Check documentation
+    name: Documentation
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     container:
@@ -114,7 +114,7 @@ jobs:
           PATH=$PATH:/work/texlive/bin/x86_64-linux make doc-check
 
   unit_tests:
-    name: Run unit tests
+    name: Unit tests
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/TestSuite.yaml
+++ b/.github/workflows/TestSuite.yaml
@@ -119,8 +119,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        build_type: [Debug, Release]
         compiler: [gcc-6, gcc-7, gcc-8, gcc-9, clang-4, clang-5, clang-8]
+        build_type: [Debug, Release]
     container:
       image: sxscollaboration/spectrebuildenv:latest
       env:

--- a/.github/workflows/TestSuite.yaml
+++ b/.github/workflows/TestSuite.yaml
@@ -166,6 +166,7 @@ jobs:
           $GITHUB_WORKSPACE
 
           ccache -pz
+        shell: bash
       - name: Build tests
         working-directory: /work/build
         run: |


### PR DESCRIPTION
## Proposed changes

These checks run on the GitHub Actions infrastructure instead of Travis. They perform the same tests that currently run on Travis except for unit tests, with the purpose of trying GitHub Actions as a potential replacement for Travis. You can take a look at an example PR at https://github.com/nilsleiffischer/spectre/pull/1.

I opened #1802 to discuss GitHub Actions vs Travis in general, so we can keep this PR focused on the code changes.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
