### PR TITLE
Add GitHub workflow for continuous integration

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -1,0 +1,241 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Continuous integration tests that pull requests are required to pass
+name: Tests
+
+# Note that by default the jobs only run on the base repository, testing pull
+# requests and merge commits. Enable GitHub Actions in your fork's repository
+# settings to also run the tests on every push to one of your branches.
+on:
+  # We run all jobs when pull requests are opened, commits are pushed, or pull
+  # requests are re-opened after being closed.
+  # The jobs triggered by this event run on the base repository of the pull
+  # request, so they have access to its caches.
+  pull_request:
+  # We run those jobs that require no information about a pull request (e.g.
+  # unit tests) also on `push` events. This setup tests merge commits into
+  # `develop` and also builds up caches on `develop` that can be re-used by PRs.
+  # It also runs the jobs on forks if they have GitHub Actions enabled.
+  push:
+    branches-ignore:
+      - gh_pages
+
+jobs:
+  # Make sure no commits are prefixed with `fixup` or similar keywords. See
+  # `tools/CheckCommits.sh` for details.
+  check_commits:
+    name: Commits
+    # Only run on pull requests since we don't check _all_ commits, but only
+    # those that came after the PR's base ref.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Check commits
+        # `CheckCommits.sh` tests against the local `develop` branch, so that's
+        # where we fetch the pull-request's base-branch to. Typically, it is
+        # the upstream `sxs-collaboration/spectre/develop` branch.
+        run: >
+          cd $GITHUB_WORKSPACE
+
+          git remote add upstream
+          https://github.com/${{ github.repository }}.git
+
+          git remote -v
+
+          git fetch upstream ${{ github.base_ref }}:develop
+
+          ./tools/CheckCommits.sh
+
+  # Run simple textual checks over files in the repository, e.g. checking for
+  # a license, line length limits etc. See `tools/CheckFiles.sh` for details.
+  check_files:
+    name: Files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Check files
+        run: |
+          cd $GITHUB_WORKSPACE
+          ./tools/CheckFiles.sh
+
+  # Lint the code that changed in a pull request with clang-tidy.
+  clang_tidy:
+    name: Clang-tidy
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    container:
+      image: sxscollaboration/spectrebuildenv:latest
+    strategy:
+      matrix:
+        build_type: [Debug, Release]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Fetch upstream/develop
+        # We only want to check files that have changed in this pull request,
+        # so we fetch its base branch and pass it to `clang-tidy-hash`.
+        # Typically, it is the `sxs-collaboration/spectre/develop` branch.
+        run: >
+          cd $GITHUB_WORKSPACE
+
+          git remote add upstream
+          https://github.com/${{ github.repository }}.git
+
+          git remote -v
+
+          git fetch upstream ${{ github.base_ref }}
+      - name: Configure with cmake
+        working-directory: /work
+        run: >
+          mkdir build && cd build
+
+          cmake
+          -D CMAKE_C_COMPILER=clang
+          -D CMAKE_CXX_COMPILER=clang++
+          -D CMAKE_Fortran_COMPILER=gfortran-8
+          -D CHARM_ROOT=/work/charm/multicore-linux64-clang
+          -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -D DEBUG_SYMBOLS=OFF
+          -D BUILD_PYTHON_BINDINGS=ON
+          $GITHUB_WORKSPACE
+      - name: Check clang-tidy
+        working-directory: /work/build
+        run: |
+          make clang-tidy-hash HASH=upstream/${{ github.base_ref }}
+
+  # Build the documentation and check for problems, then upload as a workflow
+  # artifact.
+  doc_check:
+    name: Documentation
+    runs-on: ubuntu-latest
+    container:
+      image: sxscollaboration/spectrebuildenv:latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Configure with cmake
+        working-directory: /work
+        run: >
+          mkdir build && cd build
+
+          cmake
+          -D CMAKE_C_COMPILER=clang
+          -D CMAKE_CXX_COMPILER=clang++
+          -D CMAKE_Fortran_COMPILER=gfortran-8
+          -D CHARM_ROOT=/work/charm/multicore-linux64-clang
+          -D CMAKE_BUILD_TYPE=Debug
+          -D DEBUG_SYMBOLS=OFF
+          -D BUILD_PYTHON_BINDINGS=ON
+          $GITHUB_WORKSPACE
+      - name: Check documentation
+        working-directory: /work/build
+        # Append `texlive` to the `PATH` so bibliography generation works.
+        # Can be removed once this is done in the container.
+        run: |
+          PATH=$PATH:/work/texlive/bin/x86_64-linux make doc-check
+      # The `upload-artifact` action doesn't run in the container, so we move
+      # the data to the shared workspace.
+      # Relevant issue: https://github.com/actions/upload-artifact/issues/13
+      - name: Prepare for upload
+        run: |
+          mv /work/build/docs/html $GITHUB_WORKSPACE/docs-html
+      - name: Upload documentation
+        uses: actions/upload-artifact@v1
+        with:
+          name: docs-html
+          # The `path` is relative to the $GITHUB_WORKSPACE on the host machine
+          path: docs-html
+
+  # Build all test executables and run unit tests on a variety of compiler
+  # configurations.
+  unit_tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [gcc-6, gcc-7, gcc-8, gcc-9, clang-4.0, clang-5.0, clang-8]
+        build_type: [Debug, Release]
+    container:
+      image: sxscollaboration/spectrebuildenv:latest
+      env:
+        # We make sure to use a fixed absolute path for the ccache directory
+        CCACHE_DIR: /work/ccache
+        # GitHub Actions currently limits the size of individual caches
+        # to 400 MB.
+        CCACHE_MAXSIZE: 400M
+        CCACHE_COMPRESS: 1
+        CCACHE_COMPRESSLEVEL: 6
+        # In order to make ccache work with precompiled headers we need to:
+        # - Hash the content of the compiler rather than the location and mtime
+        # - Hash the header file in the repo that will generate the precompiled
+        #   header
+        # - Ignore the precompiled header in the build directory
+        CCACHE_COMPILERCHECK: content
+        CCACHE_EXTRAFILES: ${GITHUB_WORKSPACE}/tools/SpectrePch.hpp
+        CCACHE_IGNOREHEADERS:
+          /work/build/SpectrePch.hpp:/work/build/SpectrePch.hpp.gch
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Restore ccache
+        uses: actions/cache@v1
+        with:
+          path: /work/ccache
+          key: ccache-${{ matrix.compiler }}-${{ matrix.build_type }}
+      - name: Configure ccache
+        # Print the ccache configuration and reset statistics
+        run: |
+          ccache -pz
+      - name: Configure build with cmake
+        working-directory: /work
+        # Notes on the build configuration:
+        # - We don't need debug symbols during CI, so we turn them off to reduce
+        #   memory usage.
+        run: >
+          mkdir build && cd build
+
+          if [[ ${{ matrix.compiler }} =~ (gcc|clang)-([0-9\.]+) ]]; then
+            CC=${BASH_REMATCH[1]}-${BASH_REMATCH[2]};
+            CHARM_CC=${BASH_REMATCH[1]};
+            if [[ ${BASH_REMATCH[1]} = gcc ]]; then
+              CXX=g++-${BASH_REMATCH[2]};
+              FC=gfortran-${BASH_REMATCH[2]};
+            else
+              CXX=clang++-${BASH_REMATCH[2]};
+              FC=gfortran-8;
+            fi
+          fi
+
+          cmake
+          -D CMAKE_C_COMPILER=${CC}
+          -D CMAKE_CXX_COMPILER=${CXX}
+          -D CMAKE_Fortran_COMPILER=${FC}
+          -D CHARM_ROOT=/work/charm/multicore-linux64-${CHARM_CC}
+          -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -D DEBUG_SYMBOLS=OFF
+          -D USE_CCACHE=ON
+          -D BUILD_PYTHON_BINDINGS=ON
+          $GITHUB_WORKSPACE
+        # Make sure this runs in bash so the regex matching works
+        shell: bash
+      - name: Build tests
+        working-directory: /work/build
+        run: |
+          make -j2 RunTests
+      # Build the executables in a single thread to reduce memory usage
+      # sufficiently so they compile on the GitHub-hosted runners
+      - name: Build executables
+        working-directory: /work/build
+        run: |
+          make test-executables
+      - name: Diagnose ccache
+        run: |
+          ccache -s
+      - name: Run unit tests
+        working-directory: /work/build
+        run: |
+          ctest -j2 --output-on-failure


### PR DESCRIPTION
## Proposed changes

These checks run on the GitHub Actions infrastructure instead of Travis. They perform the same tests that currently run on Travis (unit tests, clang-tidy, documentation and file+commit checks), with the purpose of trying GitHub Actions as a potential replacement for Travis. You can take a look at an example PR at https://github.com/nilsleiffischer/spectre/pull/1.

I opened #1802 to discuss GitHub Actions vs Travis in general, so we can keep this PR focused on the code changes.

Details:
- The suggestion is to run both GitHub Actions and Travis in parallel for a few weeks to see if it works fine in practice.
- Caching with `ccache` works correctly now (I get ~99% cache hits when rebuilding the same code). According to the documentation we have 2 GB of cache storage which is not enough to cache all compiler configurations. I haven't hit this limit in my tests for some reason, and we'll have to see how it works out in practice, how it impacts build times and how build times compare to Travis.
- Because we get 20 concurrent jobs with a 6h time limit each with GitHub Actions over Travis' 5 concurrent jobs and 50min time limits, I find that CI runs complete in 1-2 hours for a PR, which would be a significant improvement over the current ~10h run times on Travis. Again, we'll have to see if this holds up in practice.
- Currently, Travis still deploys the documentation to spectre-code.org. This can be switched over to GitHub Actions if we decide to do so. We can also set up the workflow to upload the built documentation as an "artifact" in every PR so it's available during code review.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
