### PR TITLE
Increase timeout for KerrSchild input file test

### DIFF
--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -3,7 +3,7 @@
 
 # Executable: EvolveGeneralizedHarmonic
 # Check: execute
-# Timeout: 5
+# Timeout: 8
 # ExpectedOutput:
 #   GhKerrSchildReductionData.h5
 #   GhKerrSchildVolumeData0.h5


### PR DESCRIPTION
## Proposed changes

See issue #1713 for a discussion. Increasing the timeout prevents test failures under load.

Since I configured GitHub Actions to run unit tests on 2 threads, the KerrSchild often times out because of this issue.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
