### PR TITLE
Cce boundary data part 2

### DIFF
--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -571,8 +571,7 @@ std::ostream& operator<<(
                 "operator<< is not defined for the type you are trying to "
                 "stream in Tensor");
   for (size_t i = 0; i < x.size() - 1; ++i) {
-    os << "T" << x.get_tensor_index(i) << "=" << x[i]
-       << "\n";
+    os << "T" << x.get_tensor_index(i) << "=" << x[i] << "\n";
   }
   size_t i = x.size() - 1;
   os << "T" << x.get_tensor_index(i) << "=" << x[i];
@@ -620,6 +619,65 @@ struct MakeWithValueImpl<Tensor<double, Structure...>, double> {
   static SPECTRE_ALWAYS_INLINE Tensor<double, Structure...> apply(
       const double& /*input*/, const double value) noexcept {
     return Tensor<double, Structure...>(value);
+  }
+};
+
+template <typename... Structure>
+struct MakeWithValueImpl<Tensor<ComplexDataVector, Structure...>, DataVector> {
+  /// \brief Returns a Tensor whose `ComplexDataVector`s are the same size as
+  /// `input`, with each element set to `value`.
+  ///
+  /// \details When setting complex from `double`s, the real part is set to
+  /// the `double` and  imaginary part is set to zero.
+  static SPECTRE_ALWAYS_INLINE Tensor<ComplexDataVector, Structure...> apply(
+      const DataVector& input, const double value) noexcept {
+    return Tensor<ComplexDataVector, Structure...>(
+        ComplexDataVector{input.size(), std::complex<double>(value, 0.0)});
+  }
+};
+
+template <int Spin, typename... Structure>
+struct MakeWithValueImpl<
+    Tensor<SpinWeighted<ComplexDataVector, Spin>, Structure...>, DataVector> {
+  /// \brief Returns a Tensor whose `ComplexDataVector`s are the same size as
+  /// `input`, with each element set to `value`.
+  ///
+  /// \details When setting complex from `double`s, the real part is set to
+  /// the `double` and  imaginary part is set to zero.
+  static SPECTRE_ALWAYS_INLINE
+      Tensor<SpinWeighted<ComplexDataVector, Spin>, Structure...>
+      apply(const DataVector& input, const double value) noexcept {
+    return Tensor<SpinWeighted<ComplexDataVector, Spin>, Structure...>(
+        ComplexDataVector{input.size(), std::complex<double>(value, 0.0)});
+  }
+};
+
+template <int Spin, typename... Structure>
+struct MakeWithValueImpl<
+    Tensor<SpinWeighted<ComplexDataVector, Spin>, Structure...>,
+    ComplexDataVector> {
+  /// \brief Returns a Tensor whose `ComplexDataVector`s are the same size as
+  /// `input`, with each element set to `value`.
+  ///
+  /// \details When setting complex from `double`s, the real part is set to
+  /// the `double` and  imaginary part is set to zero.
+  static SPECTRE_ALWAYS_INLINE
+      Tensor<SpinWeighted<ComplexDataVector, Spin>, Structure...>
+      apply(const ComplexDataVector& input, const double value) noexcept {
+    return Tensor<SpinWeighted<ComplexDataVector, Spin>, Structure...>(
+        ComplexDataVector{input.size(), std::complex<double>(value, 0.0)});
+  }
+};
+
+template <typename... Structure>
+struct MakeWithValueImpl<Tensor<std::complex<double>, Structure...>,
+                         std::complex<double>> {
+  /// \brief Returns a Tensor whose elements are set equal to `value` (`input`
+  /// is ignored).
+  static SPECTRE_ALWAYS_INLINE Tensor<std::complex<double>, Structure...> apply(
+      const std::complex<double>& /*input*/,
+      const std::complex<double> value) noexcept {
+    return Tensor<std::complex<double>, Structure...>(value);
   }
 };
 

--- a/src/Evolution/Systems/Cce/BoundaryDataTags.hpp
+++ b/src/Evolution/Systems/Cce/BoundaryDataTags.hpp
@@ -11,4 +11,29 @@ namespace Frame {
 /// affine parameter along outward-pointing null geodesics.
 struct RadialNull {};
 }  // namespace Frame
+
+// tensor aliases for brevity
+using SphericaliCartesianJ = Tensor<
+    DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
+    index_list<SpatialIndex<3, UpLo::Lo, ::Frame::Spherical<::Frame::Inertial>>,
+               SpatialIndex<3, UpLo::Lo, ::Frame::Inertial>>>;
+
+using CartesianiSphericalJ =
+    Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
+           index_list<SpatialIndex<3, UpLo::Lo, ::Frame::Inertial>,
+                      SpatialIndex<3, UpLo::Up,
+                                   ::Frame::Spherical<::Frame::Inertial>>>>;
+
+using AngulariCartesianA = Tensor<
+  DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
+  index_list<SpatialIndex<2, UpLo::Lo, ::Frame::Spherical<::Frame::Inertial>>,
+             SpacetimeIndex<3, UpLo::Lo, ::Frame::Inertial>>>;
+
+using SphericaliCartesianjj = Tensor<
+    DataVector, tmpl::integral_list<std::int32_t, 2, 1, 1>,
+    index_list<SpatialIndex<3, UpLo::Lo, ::Frame::Spherical<::Frame::Inertial>>,
+               SpatialIndex<3, UpLo::Lo, ::Frame::Inertial>,
+               SpatialIndex<3, UpLo::Lo, ::Frame::Inertial>>>;
+
+
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/BoundaryDataTags.hpp
+++ b/src/Evolution/Systems/Cce/BoundaryDataTags.hpp
@@ -35,5 +35,69 @@ using SphericaliCartesianjj = Tensor<
                SpatialIndex<3, UpLo::Lo, ::Frame::Inertial>,
                SpatialIndex<3, UpLo::Lo, ::Frame::Inertial>>>;
 
+namespace Tags {
+namespace detail {
+// this provides a set of tags for the purposes of allocating once in the entire
+// Boundary data computation; these tags are currently not used outside
+// intermediate steps of the procedure in `BoundaryData.hpp`
 
+struct CosPhi : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct CosTheta : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct SinPhi : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct SinTheta : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct CartesianCoordinates : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3>;
+};
+
+struct CartesianToSphericalJacobian : db::SimpleTag {
+  using type = SphericaliCartesianJ;
+};
+
+struct InverseCartesianToSphericalJacobian : db::SimpleTag {
+  using type = CartesianiSphericalJ;
+};
+
+struct WorldtubeNormal : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3>;
+};
+
+struct UpDyad : db::SimpleTag {
+  using type = tnsr::I<ComplexDataVector, 2, Frame::RadialNull>;
+};
+
+struct DownDyad : db::SimpleTag {
+  using type = tnsr::i<ComplexDataVector, 2, Frame::RadialNull>;
+};
+
+struct RealBondiR : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct AngularDNullL : db::SimpleTag {
+  using type = AngulariCartesianA;
+};
+
+struct NullL : db::SimpleTag {
+  using type = tnsr::A<DataVector, 3>;
+};
+
+template <typename Tag>
+struct DLambda : db::SimpleTag {
+  using type = db::item_type<Tag>;
+};
+
+}  // namespace detail
+}  // namespace Tags
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -89,7 +89,9 @@ struct Dy : db::PrefixTag, db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>;
   using tag = Tag;
   static const size_t dimension_to_differentiate = 2;
-  static std::string name() noexcept { return "Dy(" + Tag::name() + ")"; }
+  static std::string name() noexcept {
+    return "Dy(" + db::tag_name<Tag>() + ")";
+  }
 };
 
 /// The derivative with respect to Bondi \f$r\f$
@@ -97,14 +99,19 @@ template <typename Tag>
 struct Dr : db::PrefixTag, db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>;
   using tag = Tag;
-  static std::string name() noexcept { return "Dr(" + Tag::name() + ")"; }
+  static std::string name() noexcept {
+    return "Dr(" + db::tag_name<Tag>() + ")";
+  }
 };
 
 /// The derivative with respect to Bondi retarded time \f$u\f$
 template <typename Tag>
 struct Du : db::PrefixTag, db::SimpleTag {
-    using type = Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>;
-    using tag = Tag;
+  using type = Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>;
+  using tag = Tag;
+  static std::string name() noexcept {
+    return "Du(" + db::tag_name<Tag>() + ")";
+  }
 };
 
 // prefix tags associated with the integrands which are used as input to solvers
@@ -117,7 +124,7 @@ struct Integrand : db::PrefixTag, db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>;
   using tag = Tag;
   static std::string name() noexcept {
-    return "Integrand(" + Tag::name() + ")";
+    return "Integrand(" + db::tag_name<Tag>() + ")";
   }
 };
 
@@ -128,7 +135,7 @@ struct BoundaryValue : db::PrefixTag, db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>;
   using tag = Tag;
   static std::string name() noexcept {
-    return "BoundaryValue(" + Tag::name() + ")";
+    return "BoundaryValue(" + db::tag_name<Tag>() + ")";
   }
 };
 
@@ -139,7 +146,7 @@ struct PoleOfIntegrand : db::PrefixTag, db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>;
   using tag = Tag;
   static std::string name() noexcept {
-    return "PoleOfIntegrand(" + Tag::name() + ")";
+    return "PoleOfIntegrand(" + db::tag_name<Tag>() + ")";
   }
 };
 
@@ -150,7 +157,7 @@ struct RegularIntegrand : db::PrefixTag, db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>;
   using tag = Tag;
   static std::string name() noexcept {
-    return "RegularIntegrand(" + Tag::name() + ")";
+    return "RegularIntegrand(" + db::tag_name<Tag>() + ")";
   }
 };
 
@@ -163,7 +170,7 @@ struct LinearFactor : db::PrefixTag, db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
   using tag = Tag;
   static std::string name() noexcept {
-    return "LinearFactor(" + Tag::name() + ")";
+    return "LinearFactor(" + db::tag_name<Tag>() + ")";
   }
 };
 
@@ -177,7 +184,7 @@ struct LinearFactorForConjugate : db::PrefixTag, db::SimpleTag {
       Scalar<SpinWeighted<ComplexDataVector, 2 * Tag::type::type::spin>>;
   using tag = Tag;
   static std::string name() noexcept {
-    return "LinearFactorForConjugate(" + Tag::name() + ")";
+    return "LinearFactorForConjugate(" + db::tag_name<Tag>() + ")";
   }
 };
 

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -63,6 +63,44 @@ struct deriv<Tag, Dim, Frame,
   static std::string name() noexcept { return "deriv(" + Tag::name() + ")"; }
 };
 
+/*!
+ * \ingroup DataBoxTagsGroup
+ * \brief Prefix indicating spacetime derivatives
+ *
+ * Prefix indicating the spacetime derivatives of a Tensor or that a Variables
+ * contains spatial derivatives of Tensors.
+ *
+ * \tparam Tag The tag to wrap
+ * \tparam Dim The volume dim as a type (e.g. `tmpl::size_t<Dim>`)
+ * \tparam Frame The frame of the derivative index
+ */
+template <typename Tag, typename Dim, typename Frame, typename = std::nullptr_t>
+struct spacetime_deriv;
+
+template <typename Tag, typename Dim, typename Frame>
+struct spacetime_deriv<Tag, Dim, Frame,
+                       Requires<tt::is_a_v<Tensor, db::const_item_type<Tag>>>>
+    : db::PrefixTag, db::SimpleTag {
+  using type =
+      TensorMetafunctions::prepend_spacetime_index<db::const_item_type<Tag>,
+                                                   Dim::value, UpLo::Lo, Frame>;
+  using tag = Tag;
+  static std::string name() noexcept {
+    return "spacetime_deriv(" + db::tag_name<Tag>() + ")";
+  }
+};
+template <typename Tag, typename Dim, typename Frame>
+struct spacetime_deriv<
+    Tag, Dim, Frame,
+    Requires<tt::is_a_v<::Variables, db::const_item_type<Tag>>>>
+    : db::PrefixTag, db::SimpleTag {
+  using type = db::const_item_type<Tag>;
+  using tag = Tag;
+  static std::string name() noexcept {
+    return "spacetime_deriv(" + db::tag_name<Tag>() + ")";
+  }
+};
+
 }  // namespace Tags
 
 // @{

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.cpp
@@ -225,6 +225,38 @@ tnsr::ijj<DataType, SpatialDim, Frame> deriv_spatial_metric(
 }
 
 template <size_t SpatialDim, typename Frame, typename DataType>
+void time_derivative_of_spacetime_metric(
+    const gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame>*>
+        dt_spacetime_metric,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
+  destructive_resize_components(dt_spacetime_metric, get_size(get(lapse)));
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = a; b < SpatialDim + 1; ++b) {
+      dt_spacetime_metric->get(a, b) = -pi.get(a, b) * get(lapse);
+      for (size_t i = 0; i < SpatialDim; ++i) {
+        dt_spacetime_metric->get(a, b) += shift.get(i) * phi.get(i, a, b);
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::aa<DataType, SpatialDim, Frame> time_derivative_of_spacetime_metric(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
+  tnsr::aa<DataType, SpatialDim, Frame> dt_spacetime_metric{
+      get_size(get(lapse))};
+  time_derivative_of_spacetime_metric(make_not_null(&dt_spacetime_metric),
+                                      lapse, shift, pi, phi);
+  return dt_spacetime_metric;
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
 void spatial_deriv_of_lapse(
     const gsl::not_null<tnsr::i<DataType, SpatialDim, Frame>*> deriv_lapse,
     const Scalar<DataType>& lapse,
@@ -780,6 +812,19 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_norm_of_shift(
       const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
   template tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>                     \
   GeneralizedHarmonic::deriv_spatial_metric(                                  \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
+  template tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>                      \
+  GeneralizedHarmonic::time_derivative_of_spacetime_metric(                   \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,                \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
+  template void GeneralizedHarmonic::time_derivative_of_spacetime_metric(     \
+      const gsl::not_null<tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>*>     \
+          dt_spacetime_metric,                                                \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,                \
       const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
   template void GeneralizedHarmonic::time_deriv_of_spatial_metric(            \
       const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*>     \

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -190,6 +190,35 @@ tnsr::ijj<DataType, SpatialDim, Frame> deriv_spatial_metric(
 // @{
 /*!
  * \ingroup GeneralRelativityGroup
+ * \brief Computes the time derivative of the spacetime metric from the
+ * generalized harmonic quantities \f$\Pi_{a b}\f$, \f$\Phi_{i a b}\f$, and the
+ * lapse \f$\alpha\f$ and shift \f$\beta^i\f$.
+ *
+ * \details Computes the derivative as:
+ *
+ * \f{align}{
+ * \partial_t \psi_{a b} = \beta^i \Phi_{i a b} - \alpha \Pi_{a b}.
+ * \f}
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void time_derivative_of_spacetime_metric(
+    gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame>*> dt_spacetime_metric,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::aa<DataType, SpatialDim, Frame> time_derivative_of_spacetime_metric(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+//@}
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
  * \brief Computes time derivative of the spatial metric.
  *
  * \details Let the generalized harmonic conjugate momentum and spatial

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -58,6 +58,7 @@ tnsr::aa<DataType, SpatialDim, Frame> spacetime_metric(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric) noexcept;
 // @}
 
+// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute spatial metric from spacetime metric.
@@ -66,6 +67,12 @@ tnsr::aa<DataType, SpatialDim, Frame> spacetime_metric(
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ii<DataType, SpatialDim, Frame> spatial_metric(
     const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spatial_metric(
+    gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*> spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric) noexcept;
+// @}
 
 /*!
  * \ingroup GeneralRelativityGroup
@@ -88,6 +95,7 @@ tnsr::AA<DataType, SpatialDim, Frame> inverse_spacetime_metric(
     const tnsr::II<DataType, SpatialDim, Frame>&
         inverse_spatial_metric) noexcept;
 
+// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute shift from spacetime metric and inverse spatial metric.
@@ -106,6 +114,14 @@ tnsr::I<DataType, SpatialDim, Frame> shift(
     const tnsr::II<DataType, SpatialDim, Frame>&
         inverse_spatial_metric) noexcept;
 
+template <size_t SpatialDim, typename Frame, typename DataType>
+void shift(gsl::not_null<tnsr::I<DataType, SpatialDim, Frame>*> shift,
+           const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric,
+           const tnsr::II<DataType, SpatialDim, Frame>&
+               inverse_spatial_metric) noexcept;
+// @}
+
+// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute lapse from shift and spacetime metric
@@ -122,6 +138,13 @@ template <size_t SpatialDim, typename Frame, typename DataType>
 Scalar<DataType> lapse(
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void lapse(
+    gsl::not_null<Scalar<DataType>*> lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric) noexcept;
+// @}
 
 // @{
 /*!
@@ -202,6 +225,7 @@ template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::a<DataType, SpatialDim, Frame> spacetime_normal_one_form(
     const Scalar<DataType>& lapse) noexcept;
 
+// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief  Computes spacetime normal vector from lapse and shift.
@@ -214,6 +238,14 @@ template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::A<DataType, SpatialDim, Frame> spacetime_normal_vector(
     const Scalar<DataType>& lapse,
     const tnsr::I<DataType, SpatialDim, Frame>& shift) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_normal_vector(
+    gsl::not_null<tnsr::A<DataType, SpatialDim, Frame>*>
+        spacetime_normal_vector,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift) noexcept;
+// @}
 
 /*!
  * \ingroup GeneralRelativityGroup
@@ -269,7 +301,10 @@ struct SpacetimeNormalVectorCompute
   using argument_tags =
       tmpl::list<Lapse<DataType>, Shift<SpatialDim, Frame, DataType>>;
   static constexpr auto function =
-      &spacetime_normal_vector<SpatialDim, Frame, DataType>;
+      static_cast<tnsr::A<DataType, SpatialDim, Frame> (*)(
+          const Scalar<DataType>&,
+          const tnsr::I<DataType, SpatialDim, Frame>&)>(
+          &spacetime_normal_vector<SpatialDim, Frame, DataType>);
   using base = SpacetimeNormalVector<SpatialDim, Frame, DataType>;
 };
 
@@ -322,7 +357,10 @@ struct SpatialMetricCompute : SpatialMetric<SpatialDim, Frame, DataType>,
                               db::ComputeTag {
   using argument_tags =
       tmpl::list<SpacetimeMetric<SpatialDim, Frame, DataType>>;
-  static constexpr auto function = &spatial_metric<SpatialDim, Frame, DataType>;
+  static constexpr auto function =
+      static_cast<tnsr::ii<DataType, SpatialDim, Frame> (*)(
+          const tnsr::aa<DataType, SpatialDim, Frame>&)>(
+          &spatial_metric<SpatialDim, Frame, DataType>);
   using base = SpatialMetric<SpatialDim, Frame, DataType>;
 };
 
@@ -440,7 +478,11 @@ struct ShiftCompute : Shift<SpatialDim, Frame, DataType>, db::ComputeTag {
   using argument_tags =
       tmpl::list<SpacetimeMetric<SpatialDim, Frame, DataType>,
                  InverseSpatialMetric<SpatialDim, Frame, DataType>>;
-  static constexpr auto function = &shift<SpatialDim, Frame, DataType>;
+  static constexpr auto function =
+      static_cast<tnsr::I<DataType, SpatialDim, Frame> (*)(
+          const tnsr::aa<DataType, SpatialDim, Frame>&,
+          const tnsr::II<DataType, SpatialDim, Frame>&)>(
+          &shift<SpatialDim, Frame, DataType>);
   using base = Shift<SpatialDim, Frame, DataType>;
 };
 
@@ -455,7 +497,10 @@ struct LapseCompute : Lapse<DataType>, db::ComputeTag {
   using argument_tags =
       tmpl::list<Shift<SpatialDim, Frame, DataType>,
                  SpacetimeMetric<SpatialDim, Frame, DataType>>;
-  static constexpr auto function = &lapse<SpatialDim, Frame, DataType>;
+  static constexpr auto function = static_cast<Scalar<DataType> (*)(
+      const tnsr::I<DataType, SpatialDim, Frame>&,
+      const tnsr::aa<DataType, SpatialDim, Frame>&)>(
+      &lapse<SpatialDim, Frame, DataType>);
   using base = Lapse<DataType>;
 };
 }  // namespace Tags

--- a/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
@@ -4,6 +4,7 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
+#include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
@@ -13,7 +14,9 @@
 #include <utility>
 #include <vector>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Utilities/GetOutput.hpp"
@@ -1369,3 +1372,40 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Frames",
   CHECK("NoFrame" == get_output(Frame::NoFrame{}));
 }
 /// [example_spectre_test_case]
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.MakeWithValue",
+                  "[Unit][DataStructures]") {
+  auto complex_tensor =
+      make_with_value<tnsr::i<ComplexDataVector, 3>>(DataVector{5}, 2.0);
+  std::complex<double> expected_value{2.0, 0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 5; ++j) {
+      CHECK(complex_tensor.get(i)[j] == expected_value);
+    }
+  }
+
+  auto complex_tensor_made_with_complex_values =
+      make_with_value<tnsr::i<std::complex<double>, 3>>(
+          std::complex<double>{-1.0, -1.0}, std::complex<double>{3.0, 1.0});
+  expected_value = std::complex<double>{3.0, 1.0};
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK(complex_tensor_made_with_complex_values.get(i) == expected_value);
+  }
+
+  auto spin_weighted_complex =
+      make_with_value<Scalar<SpinWeighted<ComplexDataVector, 2>>>(DataVector{5},
+                                                                  3.0);
+  expected_value = std::complex<double>{3.0, 0.0};
+  for (size_t j = 0; j < 5; ++j) {
+    CHECK(get(spin_weighted_complex).data()[j] == expected_value);
+  }
+
+  auto spin_weighted_complex_from_complex_vector =
+      make_with_value<Scalar<SpinWeighted<ComplexDataVector, 2>>>(
+          ComplexDataVector{5}, 4.0);
+  expected_value = std::complex<double>{4.0, 0.0};
+  for (size_t j = 0; j < 5; ++j) {
+    CHECK(get(spin_weighted_complex_from_complex_vector).data()[j] ==
+          expected_value);
+  }
+}

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_PreSwshDerivatives.cpp
   Test_PrecomputeCceDependencies.cpp
   Test_SwshDerivatives.cpp
+  Test_Tags.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "Evolution/Systems/Cce/Tags.hpp"
+
+namespace {
+struct SomeTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Tags", "[Unit][Evolution]") {
+  CHECK(db::tag_name<Cce::Tags::Dy<SomeTag>>() == "Dy(SomeTag)");
+  CHECK(db::tag_name<Cce::Tags::Du<SomeTag>>() == "Du(SomeTag)");
+  CHECK(db::tag_name<Cce::Tags::Dr<SomeTag>>() == "Dr(SomeTag)");
+  CHECK(db::tag_name<Cce::Tags::Integrand<SomeTag>>() == "Integrand(SomeTag)");
+  CHECK(db::tag_name<Cce::Tags::BoundaryValue<SomeTag>>() ==
+        "BoundaryValue(SomeTag)");
+  CHECK(db::tag_name<Cce::Tags::PoleOfIntegrand<SomeTag>>() ==
+        "PoleOfIntegrand(SomeTag)");
+  CHECK(db::tag_name<Cce::Tags::LinearFactor<SomeTag>>() ==
+        "LinearFactor(SomeTag)");
+  CHECK(db::tag_name<Cce::Tags::LinearFactorForConjugate<SomeTag>>() ==
+        "LinearFactorForConjugate(SomeTag)");
+}

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -462,6 +462,12 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs",
   CHECK(Tags::deriv<Tags::Variables<tmpl::list<Var1<3>>>, tmpl::size_t<3>,
                     Frame::Grid>::name() ==
         "deriv(" + Tags::Variables<tmpl::list<Var1<3>>>::name() + ")");
+  CHECK(Tags::spacetime_deriv<Var1<3>, tmpl::size_t<3>, Frame::Grid>::name() ==
+        "spacetime_deriv(" + Var1<3>::name() + ")");
+  CHECK(Tags::spacetime_deriv<Tags::Variables<tmpl::list<Var1<3>>>,
+                              tmpl::size_t<3>, Frame::Grid>::name() ==
+        "spacetime_deriv(" + Tags::Variables<tmpl::list<Var1<3>>>::name() +
+            ")");
 }
 
 namespace {

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.py
@@ -111,6 +111,9 @@ def deriv_spatial_metric(phi):
 def dt_spatial_metric(lapse, shift, phi, pi):
     return (-lapse * pi + np.einsum('k,kab->ab', shift, phi))[1:, 1:]
 
+def gh_dt_spacetime_metric(lapse, shift, pi, phi):
+    return (-lapse * pi + np.einsum('k,kab', shift, phi))
+
 
 def spacetime_deriv_detg(sqrt_det_spatial_metric, inverse_spatial_metric,
                          dt_spatial_metric, phi):

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -202,6 +202,20 @@ void test_gij_deriv_functions(const DataVector& used_for_size) noexcept {
       {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size);
 }
 
+template <typename DataType, size_t SpatialDim, typename Frame>
+void test_spacetime_metric_deriv_functions(
+    const DataVector& used_for_size) noexcept {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::aa<DataType, SpatialDim, Frame> (*)(
+          const Scalar<DataType>&, const tnsr::I<DataType, SpatialDim, Frame>&,
+          const tnsr::aa<DataType, SpatialDim, Frame>&,
+          const tnsr::iaa<DataType, SpatialDim, Frame>&)>(
+          &::GeneralizedHarmonic::time_derivative_of_spacetime_metric<
+              SpatialDim, Frame, DataType>),
+      "GeneralRelativity.ComputeGhQuantities", "gh_dt_spacetime_metric",
+      {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size);
+}
+
 // Test computation of derivs of lapse by comparing to Kerr-Schild
 template <typename Solution>
 void test_lapse_deriv_functions_analytic(
@@ -564,6 +578,19 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
   test_gij_deriv_functions<DataVector, 1, Frame::Inertial>(used_for_size);
   test_gij_deriv_functions<DataVector, 2, Frame::Inertial>(used_for_size);
   test_gij_deriv_functions<DataVector, 3, Frame::Inertial>(used_for_size);
+
+  test_spacetime_metric_deriv_functions<DataVector, 1, Frame::Grid>(
+      used_for_size);
+  test_spacetime_metric_deriv_functions<DataVector, 2, Frame::Grid>(
+      used_for_size);
+  test_spacetime_metric_deriv_functions<DataVector, 3, Frame::Grid>(
+      used_for_size);
+  test_spacetime_metric_deriv_functions<DataVector, 1, Frame::Inertial>(
+      used_for_size);
+  test_spacetime_metric_deriv_functions<DataVector, 2, Frame::Inertial>(
+      used_for_size);
+  test_spacetime_metric_deriv_functions<DataVector, 3, Frame::Inertial>(
+      used_for_size);
 
   test_shift_deriv_functions<DataVector, 1, Frame::Grid>(used_for_size);
   test_shift_deriv_functions<DataVector, 2, Frame::Grid>(used_for_size);

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -79,7 +79,10 @@ void test_compute_derivatives_of_spacetime_metric(
 template <size_t Dim, typename DataType>
 void test_compute_spacetime_normal_vector(const DataType& used_for_size) {
   pypp::check_with_random_values<1>(
-      &gr::spacetime_normal_vector<Dim, Frame::Inertial, DataType>,
+      static_cast<tnsr::A<DataType, Dim, Frame::Inertial> (*)(
+          const Scalar<DataType>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&)>(
+          &gr::spacetime_normal_vector<Dim, Frame::Inertial, DataType>),
       "ComputeSpacetimeQuantities", "spacetime_normal_vector", {{{-10., 10.}}},
       used_for_size);
 }

--- a/tests/Unit/Pypp/PyppPyTests.py
+++ b/tests/Unit/Pypp/PyppPyTests.py
@@ -240,3 +240,16 @@ def check_solution_scalar(x, t, a, b):
 def check_solution_vector(x, t, a, b):
     # b is passed in as a list so must be explicitly converted to an array
     return a * x - t * np.array(b)
+
+
+# returns a complex scalar
+def mixed_complex_real_function_1(spin_weighted, complex_tensor, real_tensor):
+    return spin_weighted * complex_tensor[0] / real_tensor[1]
+
+
+# returns a real rank one tensor of dimension 2
+def mixed_complex_real_function_2(spin_weighted, complex_tensor, real_tensor):
+    return np.array([
+        np.real(spin_weighted * complex_tensor[0] * real_tensor[1]),
+        np.imag(complex_tensor[1] * real_tensor[0] / spin_weighted)
+    ])


### PR DESCRIPTION
## Proposed changes

Implements the remaining boundary computations necessary to bring the inputs supplied by either a Generalized Harmonic worldtube interpolation or from a CCE input data (spherepack modes) to the interior boundary data values needed by the CCE linear solve routines.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

