### PR TITLE
Make clang-tidy-hash fail when it finds problems

### DIFF
--- a/cmake/SetupClangTidy.cmake
+++ b/cmake/SetupClangTidy.cmake
@@ -57,6 +57,8 @@ if (CLANG_TIDY_BIN)
       ${CLANG_TIDY_BIN}
       -header-filter=${CMAKE_SOURCE_DIR}
       -checks=${CLANG_TIDY_IGNORE_CHECKS}
+      # Make the build target fail when any warnings occur
+      -warnings-as-errors=*
       -p ${CMAKE_BINARY_DIR}
       \${FILE}
   )

--- a/tools/ClangTidyHash.sh
+++ b/tools/ClangTidyHash.sh
@@ -27,11 +27,17 @@ do
     fi
 done
 
-# Go to build directory and then run clang-tidy, writing output to file
+# Go to build directory and run clang-tidy
 cd ${BUILD_DIR}
 
+printf "\nRunning clang-tidy on:\n"
+printf "%s\n" "${MODIFIED_FILES[@]}"
+
+EXIT_CODE=0
 for FILENAME in ${MODIFIED_FILES[@]}
 do
-    printf "\n\nRunning clang-tidy on file $FILENAME\n"
-    make clang-tidy FILE=$SOURCE_DIR/${FILENAME}
+    printf "\nChecking file $FILENAME...\n"
+    make clang-tidy FILE=$SOURCE_DIR/${FILENAME} || EXIT_CODE=1
 done
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Proposed changes

Fixes an issue with the new GitHub Actions CI that makes builds pass even though `clang-tidy` found problems (see e.g. https://github.com/sxs-collaboration/spectre/pull/1655/checks?check_run_id=316428355). This PR makes the `clang-tidy-hash` build target fail with a non-zero exit code when problems are found (as it does on Travis) with an output like this:

```
root@44d785a48e26:/work/spectre-develop# make clang-tidy-hash HASH=upstream/develop
[  0%] Built target module_ConstGlobalCache
[  0%] Built target module_Test_ConstGlobalCache
[  0%] Built target PCH_SPECTRE_DEPENDENCIES
[100%] Built target pch
[100%] Built target module_Main
[100%] Built target module_RunTests

Running clang-tidy on:
src/Elliptic/Systems/Poisson/Equations.cpp


clang-tidy found problems! Output:


Running clang-tidy on file src/Elliptic/Systems/Poisson/Equations.cpp
50051 warnings generated.
/Users/nlf/Projects/spectre/develop/src/Elliptic/Systems/Poisson/Equations.hpp:28:5: warning: parameter 'flux_for_field' is const-qualified in the fun
ction declaration; const-qualification of parameters only has an effect in function definitions [readability-avoid-const-params-in-decls]
    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
    ^~~~~~~~~
Suppressed 50356 warnings (50050 in non-user code, 306 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
CMakeFiles/clang-tidy-hash.dir/build.make:57: recipe for target 'CMakeFiles/clang-tidy-hash' failed
make[3]: *** [CMakeFiles/clang-tidy-hash] Error 1
CMakeFiles/Makefile2:355: recipe for target 'CMakeFiles/clang-tidy-hash.dir/all' failed
make[2]: *** [CMakeFiles/clang-tidy-hash.dir/all] Error 2
CMakeFiles/Makefile2:362: recipe for target 'CMakeFiles/clang-tidy-hash.dir/rule' failed
make[1]: *** [CMakeFiles/clang-tidy-hash.dir/rule] Error 2
Makefile:233: recipe for target 'clang-tidy-hash' failed
make: *** [clang-tidy-hash] Error 2
```

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
