### PR TITLE
Clean up tag collections

### DIFF
--- a/src/Elliptic/Systems/Xcts/Tags.hpp
+++ b/src/Elliptic/Systems/Xcts/Tags.hpp
@@ -38,5 +38,9 @@ struct ConformalFactorGradient : db::SimpleTag {
   static std::string name() noexcept { return "ConformalFactorGradient"; }
 };
 
+/// All (primal, i.e. non-auxiliary) XCTS tags
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+using all = tmpl::list<ConformalFactor<DataType>>;
+
 }  // namespace Tags
 }  // namespace Xcts

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
@@ -46,7 +46,7 @@ struct System {
       EquationOfStateType::thermodynamic_dim;
 
   using primitive_variables_tag =
-      ::Tags::Variables<hydro::grmhd_tags<DataVector>>;
+      ::Tags::Variables<hydro::Tags::all_mhd_primitive<DataVector, volume_dim>>;
 
   using variables_tag =
       ::Tags::Variables<tmpl::list<Tags::TildeD, Tags::TildeTau, Tags::TildeS<>,

--- a/src/Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp
@@ -37,6 +37,13 @@ struct SoundSpeedSquaredCompute;
 struct SourceTermBase;
 template <typename InitialDataType>
 struct SourceTerm;
+
+/// All primitive NewtonianEuler tags
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+using all_primitive =
+    tmpl::list<MassDensity<DataType>, SpecificInternalEnergy<DataType>,
+               Velocity<DataType, Dim, Frame>, Pressure<DataType>>;
+
 }  // namespace Tags
 }  // namespace NewtonianEuler
 /// \endcond

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
@@ -224,8 +224,8 @@ class BondiHoyleAccretion : public MarkAsAnalyticData {
 
   /// Retrieve the metric variables at `x`
   template <typename DataType, typename Tag,
-            Requires<not tmpl::list_contains_v<hydro::grmhd_tags<DataType>,
-                                               Tag>> = nullptr>
+            Requires<not tmpl::list_contains_v<
+                hydro::Tags::all_mhd_primitive<DataType, 3>, Tag>> = nullptr>
   tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, 3>& x,
                                      tmpl::list<Tag> /*meta*/) const noexcept {
     constexpr double dummy_time = 0.0;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
@@ -142,7 +142,8 @@ class MagnetizedFmDisk
         tmpl2::flat_any_v<(
             cpp17::is_same_v<Tags, hydro::Tags::SpatialVelocity<DataType, 3>> or
             cpp17::is_same_v<Tags, hydro::Tags::LorentzFactor<DataType>> or
-            not tmpl::list_contains_v<hydro::grmhd_tags<DataType>, Tags>)...>>
+            not tmpl::list_contains_v<
+                hydro::Tags::all_mhd_primitive<DataType, 3>, Tags>)...>>
         vars(bh_spin_a_, background_spacetime_, x, dummy_time,
              index_helper(
                  tmpl::index_of<tmpl::list<Tags...>,
@@ -165,7 +166,8 @@ class MagnetizedFmDisk
         DataType,
         cpp17::is_same_v<Tag, hydro::Tags::SpatialVelocity<DataType, 3>> or
             cpp17::is_same_v<Tag, hydro::Tags::LorentzFactor<DataType>> or
-            not tmpl::list_contains_v<hydro::grmhd_tags<DataType>, Tag>>
+            not tmpl::list_contains_v<
+                hydro::Tags::all_mhd_primitive<DataType, 3>, Tag>>
         intermediate_vars(bh_spin_a_, background_spacetime_, x, dummy_time,
                           std::numeric_limits<size_t>::max(),
                           std::numeric_limits<size_t>::max());

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp
@@ -134,8 +134,8 @@ class OrszagTangVortex : public MarkAsAnalyticData {
 
   /// Retrieve the metric variables
   template <typename DataType, typename Tag,
-            Requires<not tmpl::list_contains_v<hydro::grmhd_tags<DataType>,
-                                               Tag>> = nullptr>
+            Requires<not tmpl::list_contains_v<
+                hydro::Tags::all_mhd_primitive<DataType, 3>, Tag>> = nullptr>
   tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, 3>& x,
                                      tmpl::list<Tag> /*meta*/) const noexcept {
     constexpr double dummy_time = 0.;

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
@@ -9,6 +9,7 @@
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsCollections.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/TMPL.hpp"
@@ -254,19 +255,9 @@ class KerrSchild : public MarkAsAnalyticSolution {
   using DerivSpatialMetric = ::Tags::deriv<
       gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataType>,
       tmpl::size_t<volume_dim>, Frame::Inertial>;
+
   template <typename DataType>
-  using tags = tmpl::list<
-      gr::Tags::Lapse<DataType>, ::Tags::dt<gr::Tags::Lapse<DataType>>,
-      DerivLapse<DataType>,
-      gr::Tags::Shift<volume_dim, Frame::Inertial, DataType>,
-      ::Tags::dt<gr::Tags::Shift<volume_dim, Frame::Inertial, DataType>>,
-      DerivShift<DataType>,
-      gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataType>,
-      ::Tags::dt<
-          gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataType>>,
-      DerivSpatialMetric<DataType>, gr::Tags::SqrtDetSpatialMetric<DataType>,
-      gr::Tags::ExtrinsicCurvature<volume_dim, Frame::Inertial, DataType>,
-      gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial, DataType>>;
+  using tags = gr::Tags::all_spacetime_three_plus_one<DataType, volume_dim>;
 
   template <typename DataType>
   tuples::tagged_tuple_from_typelist<tags<DataType>> variables(

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp
@@ -10,6 +10,7 @@
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsCollections.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -60,17 +61,10 @@ class Minkowski : public MarkAsAnalyticSolution {
   using DerivSpatialMetric =
       ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
                     tmpl::size_t<Dim>, Frame::Inertial>;
+
   template <typename DataType>
-  using tags = tmpl::list<
-      gr::Tags::Lapse<DataType>, ::Tags::dt<gr::Tags::Lapse<DataType>>,
-      DerivLapse<DataType>, gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
-      ::Tags::dt<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>,
-      DerivShift<DataType>,
-      gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
-      ::Tags::dt<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>,
-      DerivSpatialMetric<DataType>, gr::Tags::SqrtDetSpatialMetric<DataType>,
-      gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, DataType>,
-      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType>>;
+  using tags = gr::Tags::all_spacetime_three_plus_one<DataType, volume_dim>;
+
   template <typename DataType, typename... Tags>
   tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, Dim>& x,
                                          double t,

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
@@ -249,8 +249,8 @@ class BondiMichel : public MarkAsAnalyticSolution {
         sonic_radius_,
         sonic_density_,
         x,
-        tmpl2::flat_any_v<
-            not tmpl::list_contains_v<hydro::grmhd_tags<DataType>, Tags>...>,
+        tmpl2::flat_any_v<not tmpl::list_contains_v<
+            hydro::Tags::all_mhd_primitive<DataType, 3>, Tags>...>,
         background_spacetime_};
     return {get<Tags>(variables(x, tmpl::list<Tags>{}, intermediate_vars))...};
   }
@@ -266,7 +266,8 @@ class BondiMichel : public MarkAsAnalyticSolution {
             mass_, polytropic_constant_, polytropic_exponent_,
             bernoulli_constant_squared_minus_one_, sonic_radius_,
             sonic_density_, x,
-            not tmpl::list_contains_v<hydro::grmhd_tags<DataType>, Tag>,
+            not tmpl::list_contains_v<
+                hydro::Tags::all_mhd_primitive<DataType, 3>, Tag>,
             background_spacetime_});
   }
 
@@ -338,8 +339,8 @@ class BondiMichel : public MarkAsAnalyticSolution {
       -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
 
   template <typename DataType, typename Tag,
-            Requires<not tmpl::list_contains_v<hydro::grmhd_tags<DataType>,
-                                               Tag>> = nullptr>
+            Requires<not tmpl::list_contains_v<
+                hydro::Tags::all_mhd_primitive<DataType, 3>, Tag>> = nullptr>
   tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, 3>& /*x*/,
                                      tmpl::list<Tag> /*meta*/,
                                      IntermediateVars<DataType>& vars) const

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -266,7 +266,8 @@ class FishboneMoncriefDisk : public MarkAsAnalyticSolution {
         tmpl2::flat_any_v<(
             cpp17::is_same_v<Tags, hydro::Tags::SpatialVelocity<DataType, 3>> or
             cpp17::is_same_v<Tags, hydro::Tags::LorentzFactor<DataType>> or
-            not tmpl::list_contains_v<hydro::grmhd_tags<DataType>, Tags>)...>>
+            not tmpl::list_contains_v<
+                hydro::Tags::all_mhd_primitive<DataType, 3>, Tags>)...>>
         vars(bh_spin_a_, background_spacetime_, x, t,
              index_helper(
                  tmpl::index_of<tmpl::list<Tags...>,
@@ -289,7 +290,8 @@ class FishboneMoncriefDisk : public MarkAsAnalyticSolution {
         DataType,
         cpp17::is_same_v<Tag, hydro::Tags::SpatialVelocity<DataType, 3>> or
             cpp17::is_same_v<Tag, hydro::Tags::LorentzFactor<DataType>> or
-            not tmpl::list_contains_v<hydro::grmhd_tags<DataType>, Tag>>
+            not tmpl::list_contains_v<
+                hydro::Tags::all_mhd_primitive<DataType, 3>, Tag>>
         intermediate_vars(bh_spin_a_, background_spacetime_, x, t,
                           std::numeric_limits<size_t>::max(),
                           std::numeric_limits<size_t>::max());
@@ -369,8 +371,8 @@ class FishboneMoncriefDisk : public MarkAsAnalyticSolution {
 
   // Grab the metric variables
   template <typename DataType, typename Tag,
-            Requires<not tmpl::list_contains_v<hydro::grmhd_tags<DataType>,
-                                               Tag>> = nullptr>
+            Requires<not tmpl::list_contains_v<
+                hydro::Tags::all_mhd_primitive<DataType, 3>, Tag>> = nullptr>
   tuples::TaggedTuple<Tag> variables(
       const tnsr::I<DataType, 3>& /*x*/, tmpl::list<Tag> /*meta*/,
       IntermediateVariables<DataType, true>& vars, const size_t index) const

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
 namespace gr {

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -8,8 +8,7 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
-#include "TagsDeclarations.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 
 namespace gr {
 namespace Tags {
@@ -188,22 +187,4 @@ struct WeylElectric : db::SimpleTag {
   static std::string name() noexcept { return "WeylElectric"; }
 };
 }  // namespace Tags
-
-/// The tags for the variables returned by GR analytic solutions.
-template <size_t Dim, typename DataType>
-using analytic_solution_tags = tmpl::list<
-    gr::Tags::Lapse<DataType>, ::Tags::dt<gr::Tags::Lapse<DataType>>,
-    ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<Dim>,
-                  Frame::Inertial>,
-    gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
-    ::Tags::dt<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>,
-    ::Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
-                  tmpl::size_t<Dim>, Frame::Inertial>,
-    gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
-    ::Tags::dt<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>,
-    ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
-                  tmpl::size_t<Dim>, Frame::Inertial>,
-    gr::Tags::SqrtDetSpatialMetric<DataType>,
-    gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, DataType>,
-    gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType>>;
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/TagsCollections.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsCollections.hpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/*!
+ * \file
+ * \brief Defines lists of `gr::Tags`.
+ *
+ * With this separate file we avoid having to include `Tags.hpp` where it's
+ * unnecessary and we avoid including prefix tags in `TagsDeclarations.hpp`.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+
+namespace gr {
+namespace Tags {
+
+/// All tags for spacetime quantities in the 3+1 decomposition
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+using all_spacetime_three_plus_one = tmpl::list<
+    gr::Tags::Lapse<DataType>, ::Tags::dt<gr::Tags::Lapse<DataType>>,
+    ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<Dim>, Frame>,
+    gr::Tags::Shift<Dim, Frame, DataType>,
+    ::Tags::dt<gr::Tags::Shift<Dim, Frame, DataType>>,
+    ::Tags::deriv<gr::Tags::Shift<Dim, Frame, DataType>, tmpl::size_t<Dim>,
+                  Frame>,
+    gr::Tags::SpatialMetric<Dim, Frame, DataType>,
+    ::Tags::dt<gr::Tags::SpatialMetric<Dim, Frame, DataType>>,
+    ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame, DataType>,
+                  tmpl::size_t<Dim>, Frame>,
+    gr::Tags::SqrtDetSpatialMetric<DataType>,
+    gr::Tags::ExtrinsicCurvature<Dim, Frame, DataType>,
+    gr::Tags::InverseSpatialMetric<Dim, Frame, DataType>>;
+
+/// All tags for source quantities in the 3+1 decomposition
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+using all_source_three_plus_one = tmpl::list<EnergyDensity<DataType>>;
+
+}  // namespace Tags
+}  // namespace gr

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -220,13 +220,7 @@ struct MassFlux : db::SimpleTag {
 
 /// The tags for the primitive variables for GRMHD.
 template <typename DataType>
-using grmhd_tags =
-    tmpl::list<hydro::Tags::RestMassDensity<DataType>,
-               hydro::Tags::SpecificInternalEnergy<DataType>,
-               hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>,
-               hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>,
-               hydro::Tags::DivergenceCleaningField<DataType>,
-               hydro::Tags::LorentzFactor<DataType>,
-               hydro::Tags::Pressure<DataType>,
-               hydro::Tags::SpecificEnthalpy<DataType>>;
+using grmhd_tags
+    [[deprecated("Use `hydro::Tags::all_mhd_primitive` instead")]] =
+        Tags::all_mhd_primitive<DataType, 3>;
 }  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
@@ -60,6 +60,21 @@ template <typename DataType>
 struct SpecificInternalEnergy;
 template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
 struct MassFlux;
+
+// All tags for primitive relativistic fluid quantities
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+using all_relativistic_primitive =
+    tmpl::list<RestMassDensity<DataType>, SpecificInternalEnergy<DataType>,
+               SpatialVelocity<DataType, Dim, Frame>, LorentzFactor<DataType>,
+               Pressure<DataType>, SpecificEnthalpy<DataType>>;
+
+// All tags for primitive relativistic magneto-hydrodynamic quantities
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+using all_mhd_primitive =
+    tmpl::append<all_relativistic_primitive<DataType, Dim, Frame>,
+                 tmpl::list<MagneticField<DataType, Dim, Frame>,
+                            DivergenceCleaningField<DataType>>>;
+
 }  // namespace Tags
 }  // namespace hydro
 /// \endcond


### PR DESCRIPTION
## Proposed changes

We have a few collections of tags such as `hydro::grmhd_tags` that are mostly used in analytic solutions right now. This PR cleans them up and adds a few more that will come in useful when making the analytic solutions conform to a consistent interface (see #1769).

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
