### PR TITLE
Widen tolerance for spin-weighted filtering test

### DIFF
--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshFiltering.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshFiltering.cpp
@@ -74,12 +74,19 @@ void test_angular_filtering() noexcept {
 
   filter_swsh_volume_quantity(make_not_null(&to_filter), l_max, l_max - 3, 5.0,
                               2);
-  CHECK_ITERABLE_APPROX(to_filter.data(), expected_post_filter.data());
+  Approx angular_approx =
+      Approx::custom()
+          .epsilon(std::numeric_limits<double>::epsilon() * 1.0e4)
+          .scale(1.0);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(to_filter.data(), expected_post_filter.data(),
+                               angular_approx);
 
   filter_swsh_boundary_quantity(make_not_null(&pre_filter_angular_data), l_max,
                                 l_max - 3);
-  CHECK_ITERABLE_APPROX(pre_filter_angular_data.data(),
-                        expected_post_filter_angular_data.data());
+  CHECK_ITERABLE_CUSTOM_APPROX(pre_filter_angular_data.data(),
+                               expected_post_filter_angular_data.data(),
+                               angular_approx);
 }
 
 template <int Spin>


### PR DESCRIPTION
## Proposed changes

The tolerance seemed too tight for some cases of l_max = 7, so I've loosened it. Previous version failed within 1000 tests, this one ran 5.5 * 10^4 without failure.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
