### PR TITLE
Run algorithm after simple and reduction actions

### DIFF
--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -467,6 +467,7 @@ void AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
                                   std::make_index_sequence<Arg::pack_size()>{});
   performing_action_ = false;
   unlock(&node_lock_);
+  perform_algorithm();
 }
 
 template <typename ParallelComponent, typename... PhaseDepActionListsPack>
@@ -488,6 +489,7 @@ void AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
                                   std::make_index_sequence<sizeof...(Args)>{});
   performing_action_ = false;
   unlock(&node_lock_);
+  perform_algorithm();
 }
 
 template <typename ParallelComponent, typename... PhaseDepActionListsPack>
@@ -510,6 +512,7 @@ void AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
       static_cast<const array_index&>(array_index_));
   performing_action_ = false;
   unlock(&node_lock_);
+  perform_algorithm();
 }
 
 template <typename ParallelComponent, typename... PhaseDepActionListsPack>


### PR DESCRIPTION
The tests for the parallelization framework are complicated, and I do not know what the best way to test this change is.  Suggestions are welcome.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
