### PR TITLE
Make can_change_step_size valid for GTS steppers

### DIFF
--- a/src/Time/TimeSteppers/RungeKutta3.hpp
+++ b/src/Time/TimeSteppers/RungeKutta3.hpp
@@ -68,6 +68,14 @@ class RungeKutta3 : public TimeStepper::Inherit {
   TimeStepId next_time_id(const TimeStepId& current_id,
                           const TimeDelta& time_step) const noexcept override;
 
+  template <typename Vars, typename DerivVars>
+  bool can_change_step_size(
+      const TimeStepId& time_id,
+      const TimeSteppers::History<Vars, DerivVars>& /*history*/) const
+      noexcept {
+    return time_id.substep() == 0;
+  }
+
   WRAPPED_PUPable_decl_template(RungeKutta3);  // NOLINT
 
   explicit RungeKutta3(CkMigrateMessage* /*unused*/) noexcept {}

--- a/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.cpp
+++ b/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "tests/Unit/TestingFramework.hpp"
+
 #include "tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp"
 
 #include <algorithm>
@@ -68,6 +70,24 @@ void initialize_history(
   }
 }
 }  // namespace
+
+void check_multistep_properties(const TimeStepper& stepper) noexcept {
+  CHECK(stepper.number_of_substeps() == 1);
+}
+
+void check_substep_properties(const TimeStepper& stepper) noexcept {
+  CHECK(stepper.number_of_past_steps() == 0);
+
+  const Slab slab(0., 1.);
+  TimeStepId id(true, 3, slab.start() + slab.duration() / 2);
+  TimeSteppers::History<double, double> history;
+  CHECK(stepper.can_change_step_size(id, history));
+  id = stepper.next_time_id(id, slab.duration() / 2);
+  if (id.substep() != 0) {
+    history.insert(id.substep_time(), 0.0, 0.0);
+    CHECK(not stepper.can_change_step_size(id, history));
+  }
+}
 
 void integrate_test(const TimeStepper& stepper,
                     const size_t number_of_past_steps,

--- a/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp
+++ b/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp
@@ -3,21 +3,18 @@
 
 #pragma once
 
-#include "tests/Unit/TestingFramework.hpp"
-
 #include <cstddef>
 
-#include "Time/TimeSteppers/TimeStepper.hpp"
+/// \cond
+class LtsTimeStepper;
+class TimeStepper;
+/// \endcond
 
 namespace TimeStepperTestUtils {
 
-inline void check_multistep_properties(const TimeStepper& stepper) noexcept {
-  CHECK(stepper.number_of_substeps() == 1);
-}
+void check_multistep_properties(const TimeStepper& stepper) noexcept;
 
-inline void check_substep_properties(const TimeStepper& stepper) noexcept {
-  CHECK(stepper.number_of_past_steps() == 0);
-}
+void check_substep_properties(const TimeStepper& stepper) noexcept;
 
 void integrate_test(const TimeStepper& stepper, size_t number_of_past_steps,
                     double integration_time, double epsilon) noexcept;


### PR DESCRIPTION
It will be used for slab size changing (which will also cause a step
size change).

This conflicts with #1790 in a way that will not cause a git conflict, but the resolution is trivial.  (See a soon-to-be-posted comment in that PR.)

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
