### PR TITLE
Analytic data for scalar wave in Kerr spacetime

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/CMakeLists.txt
@@ -2,5 +2,6 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Burgers)
+add_subdirectory(CurvedWaveEquation)
 add_subdirectory(GrMhd)
 add_subdirectory(NewtonianEuler)

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/AnalyticData.hpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/AnalyticData.hpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace CurvedScalarWave {
+/*!
+ * \ingroup AnalyticDataGroup
+ * \brief Holds classes implementing analytic data for the CurvedScalarWave
+ * system.
+ */
+namespace AnalyticData {}
+}  // namespace CurvedScalarWave

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY CurvedWaveEquationAnalyticData)
+
+set(LIBRARY_SOURCES
+  PlaneWave3DKerrSchild.cpp
+  RegularSphericalWave3DKerrSchild.cpp
+  )
+
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE DataStructures
+  INTERFACE ErrorHandling
+  INTERFACE GeneralRelativity
+  INTERFACE GeneralRelativitySolutions
+  INTERFACE Spectral
+  INTERFACE Utilities
+  )

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWave3DKerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWave3DKerrSchild.cpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWave3DKerrSchild.hpp"
+
+/// \cond
+namespace CurvedScalarWave ::AnalyticData {
+template class ScalarWaveGr<ScalarWave::Solutions::PlaneWave<3>,
+                            gr::Solutions::KerrSchild>;
+template bool operator==(
+    const ScalarWaveGr<ScalarWave::Solutions::PlaneWave<3>,
+                       gr::Solutions::KerrSchild>& lhs,
+    const ScalarWaveGr<ScalarWave::Solutions::PlaneWave<3>,
+                       gr::Solutions::KerrSchild>& rhs) noexcept;
+template bool operator!=(
+    const ScalarWaveGr<ScalarWave::Solutions::PlaneWave<3>,
+                       gr::Solutions::KerrSchild>& lhs,
+    const ScalarWaveGr<ScalarWave::Solutions::PlaneWave<3>,
+                       gr::Solutions::KerrSchild>& rhs) noexcept;
+}  // namespace CurvedScalarWave::AnalyticData
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWave3DKerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWave3DKerrSchild.hpp
@@ -1,0 +1,9 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.tpp"
+
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/RegularSphericalWave3DKerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/RegularSphericalWave3DKerrSchild.cpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/RegularSphericalWave3DKerrSchild.hpp"
+
+/// \cond
+namespace CurvedScalarWave ::AnalyticData {
+template class ScalarWaveGr<ScalarWave::Solutions::RegularSphericalWave,
+                            gr::Solutions::KerrSchild>;
+template bool operator==(
+    const ScalarWaveGr<ScalarWave::Solutions::RegularSphericalWave,
+                       gr::Solutions::KerrSchild>& lhs,
+    const ScalarWaveGr<ScalarWave::Solutions::RegularSphericalWave,
+                       gr::Solutions::KerrSchild>& rhs) noexcept;
+template bool operator!=(
+    const ScalarWaveGr<ScalarWave::Solutions::RegularSphericalWave,
+                       gr::Solutions::KerrSchild>& lhs,
+    const ScalarWaveGr<ScalarWave::Solutions::RegularSphericalWave,
+                       gr::Solutions::KerrSchild>& rhs) noexcept;
+}  // namespace CurvedScalarWave::AnalyticData
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/RegularSphericalWave3DKerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/RegularSphericalWave3DKerrSchild.hpp
@@ -1,0 +1,9 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.tpp"
+
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.hpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.hpp
@@ -1,0 +1,168 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <utility>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+
+/// \cond
+namespace PUP {
+class er;  // IWYU pragma: keep
+}  // namespace PUP
+/// \endcond
+
+// IWYU pragma: no_include <pup.h>
+
+namespace CurvedScalarWave {
+namespace AnalyticData {
+/*!
+ * \brief Analytic initial data for scalar waves in curved spacetime
+ *
+ * \details When evolving a scalar field propagating through curved spacetime,
+ * this class provides a method to initialize the scalar-field and spacetime
+ * variables using analytic solution(s) of the flat-space scalar-wave equation
+ * and of the Einstein equations. Note that the coordinate profile of the scalar
+ * field \f$\Psi\f$ in curved spacetime being the same as \f$\Psi\f$ in flat
+ * spacetime is our primary identification, allowing it to be initialized using
+ * any member class of `ScalarWave::Solutions`. We initialize \f$\Phi_i\f$ in
+ * curved spacetime to the coordinate spatial derivative of \f$\Psi\f$ in flat
+ * spacetime. The definition of \f$\Pi\f$ comes from requiring it to be the
+ * future-directed time derivative of the scalar field in curved spacetime:
+ *
+ * \f{align}
+ * \Pi :=& -n^a \partial_a \Psi \\
+ *     =&  \frac{1}{\alpha}\left(\beta^k \Phi_k - {\partial_t\Psi}\right),\\
+ *     =&  \frac{1}{\alpha}\left(\beta^k \Phi_k + {\Pi}_{\mathrm{flat}}\right),
+ * \f}
+ *
+ * where \f$n^a\f$ is the unit normal to spatial slices of the spacetime
+ * foliation, and \f${\Pi}_{\mathrm{flat}}\f$ comes from the flat spacetime
+ * solution.
+ */
+template <typename ScalarFieldData, typename BackgroundGrData>
+class ScalarWaveGr : public MarkAsAnalyticData {
+  static_assert(
+      ScalarFieldData::volume_dim == BackgroundGrData::volume_dim,
+      "Scalar field data and background spacetime data should have the same "
+      "spatial dimensionality. Currently provided template arguments do not.");
+
+ public:
+  static constexpr size_t volume_dim = ScalarFieldData::volume_dim;
+
+  struct ScalarField {
+    using type = ScalarFieldData;
+    static constexpr OptionString help = {"Flat space scalar field."};
+  };
+  struct Background {
+    using type = BackgroundGrData;
+    static constexpr OptionString help = {"Background spacetime."};
+  };
+
+  using options = tmpl::list<Background, ScalarField>;
+  static constexpr OptionString help{
+      "A scalar field in curved background spacetime\n\n"};
+  static std::string name() noexcept { return "ScalarWaveGr"; };
+
+  // Construct from options
+  ScalarWaveGr(BackgroundGrData background,
+               ScalarFieldData scalar_field) noexcept
+      : flat_space_scalar_wave_data_(std::move(scalar_field)),
+        background_gr_data_(std::move(background)) {}
+
+  explicit ScalarWaveGr(CkMigrateMessage* /*unused*/) noexcept {}
+
+  ScalarWaveGr() = default;
+  ScalarWaveGr(const ScalarWaveGr& /*rhs*/) = delete;
+  ScalarWaveGr& operator=(const ScalarWaveGr& /*rhs*/) = delete;
+  ScalarWaveGr(ScalarWaveGr&& /*rhs*/) noexcept = default;
+  ScalarWaveGr& operator=(ScalarWaveGr&& /*rhs*/) noexcept = default;
+  ~ScalarWaveGr() = default;
+
+  // Tags
+  template <typename DataType>
+  using spacetime_tags = typename BackgroundGrData::template tags<DataType>;
+  using tags = tmpl::append<spacetime_tags<DataVector>,
+                            tmpl::list<Pi, Phi<volume_dim>, Psi>>;
+
+  /// Retrieve spacetime variables
+  template <
+      typename DataType, typename Tag,
+      Requires<tmpl::list_contains_v<spacetime_tags<DataType>, Tag>> = nullptr>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, volume_dim>& x,
+                                     tmpl::list<Tag> /*meta*/) const noexcept {
+    constexpr double default_initial_time = 0.;
+    return {std::move(get<Tag>(background_gr_data_.variables(
+        x, default_initial_time, spacetime_tags<DataType>{})))};
+  }
+
+  /// Retrieve scalar wave variables
+  tuples::TaggedTuple<Pi> variables(const tnsr::I<DataVector, volume_dim>& x,
+                                    tmpl::list<Pi> /*meta*/) const noexcept;
+
+  tuples::TaggedTuple<Phi<volume_dim>> variables(
+      const tnsr::I<DataVector, volume_dim>& x,
+      tmpl::list<Phi<volume_dim>> /*meta*/) const noexcept {
+    constexpr double default_initial_time = 0.;
+    return {std::move(
+        get<ScalarWave::Phi<volume_dim>>(flat_space_scalar_wave_data_.variables(
+            x, default_initial_time,
+            tmpl::list<ScalarWave::Pi, ScalarWave::Phi<volume_dim>,
+                       ScalarWave::Psi>{})))};
+  }
+  tuples::TaggedTuple<Psi> variables(const tnsr::I<DataVector, volume_dim>& x,
+                                     tmpl::list<Psi> /*meta*/) const noexcept {
+    constexpr double default_initial_time = 0.;
+    return {
+        std::move(get<ScalarWave::Psi>(flat_space_scalar_wave_data_.variables(
+            x, default_initial_time,
+            tmpl::list<ScalarWave::Pi, ScalarWave::Phi<volume_dim>,
+                       ScalarWave::Psi>{})))};
+  }
+
+  // Retrieve one or more tags
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, volume_dim>& x,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
+    static_assert(sizeof...(Tags) > 1,
+                  "This generic template will recurse infinitely if only one "
+                  "tag is being retrieved through it.");
+
+    static_assert(tmpl2::flat_all_v<tmpl::list_contains_v<tags, Tags>...>,
+                  "At least one of the requested tags is not supported.");
+
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  template <typename LocalScalarFieldData,                  // NOLINT
+            typename LocalBackgroundData>                   // NOLINT
+  friend bool                                               // NOLINT
+  operator==(const ScalarWaveGr<LocalScalarFieldData,       // NOLINT
+                                LocalBackgroundData>& lhs,  // NOLINT
+             const ScalarWaveGr<LocalScalarFieldData,       // NOLINT
+                                LocalBackgroundData>& rhs)  // NOLINT
+      noexcept;                                             // NOLINT
+
+  ScalarFieldData flat_space_scalar_wave_data_;
+  BackgroundGrData background_gr_data_;
+};
+
+template <typename ScalarFieldData, typename BackgroundData>
+bool operator!=(
+    const ScalarWaveGr<ScalarFieldData, BackgroundData>& lhs,
+    const ScalarWaveGr<ScalarFieldData, BackgroundData>& rhs) noexcept;
+
+}  // namespace AnalyticData
+}  // namespace CurvedScalarWave

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.tpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.tpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.hpp"
+
+#include <pup.h>
+
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace CurvedScalarWave ::AnalyticData {
+
+template <typename ScalarFieldData, typename BackgroundGrData>
+void ScalarWaveGr<ScalarFieldData, BackgroundGrData>::pup(PUP::er& p) noexcept {
+  p | flat_space_scalar_wave_data_;
+  p | background_gr_data_;
+}
+
+template <typename ScalarFieldData, typename BackgroundGrData>
+tuples::TaggedTuple<Pi>
+ScalarWaveGr<ScalarFieldData, BackgroundGrData>::variables(
+    const tnsr::I<DataVector, volume_dim>& x, tmpl::list<Pi> /*meta*/) const
+    noexcept {
+  constexpr double default_initial_time = 0.;
+  const auto flat_space_scalar_wave_vars =
+      flat_space_scalar_wave_data_.variables(
+          x, default_initial_time,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<volume_dim>,
+                     ScalarWave::Psi>{});
+  const auto spacetime_variables = background_gr_data_.variables(
+      x, default_initial_time, spacetime_tags<DataVector>{});
+  auto result = make_with_value<tuples::TaggedTuple<Pi>>(x, 0.);
+
+  const auto shift_dot_dpsi = dot_product(
+      get<gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>>(
+          spacetime_variables),
+      get<ScalarWave::Phi<volume_dim>>(flat_space_scalar_wave_vars));
+
+  get(get<Pi>(result)) =
+      (get(shift_dot_dpsi) +
+       get(get<ScalarWave::Pi>(flat_space_scalar_wave_vars))) /
+      get(get<gr::Tags::Lapse<DataVector>>(spacetime_variables));
+
+  return result;
+}
+
+template <typename LocalScalarFieldData, typename LocalBackgroundData>
+bool operator==(
+    const ScalarWaveGr<LocalScalarFieldData, LocalBackgroundData>& lhs,
+    const ScalarWaveGr<LocalScalarFieldData, LocalBackgroundData>&
+        rhs) noexcept {
+  return lhs.background_gr_data_ == rhs.background_gr_data_;
+}
+
+template <typename ScalarFieldData, typename BackgroundData>
+bool operator!=(
+    const ScalarWaveGr<ScalarFieldData, BackgroundData>& lhs,
+    const ScalarWaveGr<ScalarFieldData, BackgroundData>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace CurvedScalarWave::AnalyticData
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -54,6 +54,7 @@ namespace Solutions {
 template <size_t Dim>
 class PlaneWave : public MarkAsAnalyticSolution {
  public:
+  static constexpr size_t volume_dim = Dim;
   struct WaveVector {
     using type = std::array<double, Dim>;
     static constexpr OptionString help = {

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
@@ -65,6 +65,7 @@ namespace Solutions {
  */
 class RegularSphericalWave : public MarkAsAnalyticSolution {
  public:
+  static constexpr size_t volume_dim = 3;
   struct Profile {
     using type = std::unique_ptr<MathFunction<1>>;
     static constexpr OptionString help = {

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticData/TestHelpers.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticData/TestHelpers.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace TestHelpers {
+/// \ingroup TestingFrameworkGroup
+/// Functions for testing analytic data
+namespace AnalyticData {
+/// Checks that tags can be retrieved both individually and all at
+/// once.
+template <typename Solution, typename Coords, typename TagsList>
+void test_tag_retrieval(const Solution& solution, const Coords& coords,
+                        const TagsList /*meta*/) noexcept {
+  const auto vars_from_all_tags = solution.variables(coords, TagsList{});
+  const auto vars_from_all_tags_reversed =
+      solution.variables(coords, tmpl::reverse<TagsList>{});
+  tmpl::for_each<TagsList>([&](const auto tag_v) noexcept {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    const auto single_var = solution.variables(coords, tmpl::list<tag>{});
+    CHECK(tuples::get<tag>(single_var) == tuples::get<tag>(vars_from_all_tags));
+    CHECK(tuples::get<tag>(single_var) ==
+          tuples::get<tag>(vars_from_all_tags_reversed));
+  });
+}
+}  // namespace AnalyticData
+}  // namespace TestHelpers

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CMakeLists.txt
@@ -15,5 +15,6 @@ add_test_library(
   )
 
 add_subdirectory(Burgers)
+add_subdirectory(CurvedWaveEquation)
 add_subdirectory(GrMhd)
 add_subdirectory(NewtonianEuler)

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+
+set(LIBRARY "Test_CurvedWaveEquationAnalyticData")
+
+set(LIBRARY_SOURCES
+  Test_ScalarWaveGr.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "PointwiseFunctions/AnalyticData/CurvedWaveEquation/"
+  "${LIBRARY_SOURCES}"
+  "CurvedWaveEquationAnalyticData;GeneralRelativitySolutions;GeneralRelativity;MathFunctions;Utilities;WaveEquation"
+  )

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveGr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveGr.cpp
@@ -1,0 +1,410 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <memory>
+#include <utility>
+
+#include "Evolution/Systems/ScalarWave/System.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/AnalyticData/TestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+template <typename ScalarFieldData>
+struct ScalarWaveKerr {
+  using type =
+      CurvedScalarWave::AnalyticData::ScalarWaveGr<ScalarFieldData,
+                                                   gr::Solutions::KerrSchild>;
+  static constexpr OptionString help{"A scalar wave in Kerr spacetime"};
+};
+
+template <typename ScalarFieldData>
+void test_tag_retrieval(const CurvedScalarWave::AnalyticData::ScalarWaveGr<
+                        ScalarFieldData, gr::Solutions::KerrSchild>&
+                            curved_wave_data) noexcept {
+  const tnsr::I<DataVector, 3> x{std::array<DataVector, 3>{
+      {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),
+       DataVector({0., 0., 0., 0.})}}};
+
+  // Evaluate solution
+  TestHelpers::AnalyticData::test_tag_retrieval(
+      curved_wave_data, x,
+      typename CurvedScalarWave::AnalyticData::ScalarWaveGr<
+          ScalarFieldData, gr::Solutions::KerrSchild>::tags());
+}
+
+template <typename ScalarFieldData>
+void test_no_hole(
+    const CurvedScalarWave::AnalyticData::ScalarWaveGr<
+        ScalarFieldData, gr::Solutions::KerrSchild>& curved_wave_data,
+    const ScalarFieldData& flat_wave_solution) noexcept {
+  const tnsr::I<DataVector, 3> x{std::array<DataVector, 3>{
+      {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),
+       DataVector({0., 0., 0., 0.})}}};
+  auto vars = curved_wave_data.variables(
+      x, tmpl::list<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
+                    CurvedScalarWave::Psi>{});
+  auto flat_vars = flat_wave_solution.variables(
+      x, 0., tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{});
+  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Psi>(vars)),
+                        get(get<ScalarWave::Psi>(flat_vars)));
+  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Pi>(vars)),
+                        get(get<ScalarWave::Pi>(flat_vars)));
+  CHECK_ITERABLE_APPROX(get<0>(get<CurvedScalarWave::Phi<3>>(vars)),
+                        get<0>(get<ScalarWave::Phi<3>>(flat_vars)));
+  CHECK_ITERABLE_APPROX(get<1>(get<CurvedScalarWave::Phi<3>>(vars)),
+                        get<1>(get<ScalarWave::Phi<3>>(flat_vars)));
+  CHECK_ITERABLE_APPROX(get<2>(get<CurvedScalarWave::Phi<3>>(vars)),
+                        get<2>(get<ScalarWave::Phi<3>>(flat_vars)));
+}
+
+template <typename ScalarFieldData>
+void test_kerr(
+    const CurvedScalarWave::AnalyticData::ScalarWaveGr<
+        ScalarFieldData, gr::Solutions::KerrSchild>& curved_wave_data,
+    const gr::Solutions::KerrSchild& bh_solution,
+    const ScalarFieldData& flat_wave_solution) noexcept {
+  const tnsr::I<DataVector, 3> x{std::array<DataVector, 3>{
+      {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),
+       DataVector({0., 0., 0., 0.})}}};
+  auto vars = curved_wave_data.variables(
+      x, tmpl::list<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
+                    CurvedScalarWave::Psi>{});
+
+  const auto flat_wave_vars = flat_wave_solution.variables(
+      x, 0., ScalarWave::System<3>::variables_tag::tags_list{});
+
+  const auto kerr_variables = bh_solution.variables(
+      x, 0., gr::Solutions::KerrSchild::tags<DataVector>{});
+
+  // construct the expected vars in-situ
+  const auto& local_psi = get<ScalarWave::Psi>(flat_wave_vars);
+  const auto& local_phi = get<ScalarWave::Phi<3>>(flat_wave_vars);
+  auto local_pi = make_with_value<Scalar<DataVector>>(x, 0.);
+  {
+    const auto shift_dot_dpsi = dot_product(
+        get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(kerr_variables),
+        get<ScalarWave::Phi<3>>(flat_wave_vars));
+    get(local_pi) =
+        (get(shift_dot_dpsi) + get(get<ScalarWave::Pi>(flat_wave_vars))) /
+        get(get<gr::Tags::Lapse<DataVector>>(kerr_variables));
+  }
+
+  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Psi>(vars)), get(local_psi));
+  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Pi>(vars)), get(local_pi));
+  CHECK_ITERABLE_APPROX(get<0>(get<CurvedScalarWave::Phi<3>>(vars)),
+                        get<0>(local_phi));
+  CHECK_ITERABLE_APPROX(get<1>(get<CurvedScalarWave::Phi<3>>(vars)),
+                        get<1>(local_phi));
+  CHECK_ITERABLE_APPROX(get<2>(get<CurvedScalarWave::Phi<3>>(vars)),
+                        get<2>(local_phi));
+}
+
+template <typename ScalarFieldData>
+void test_kerr_schild_vars(
+    const CurvedScalarWave::AnalyticData::ScalarWaveGr<
+        ScalarFieldData, gr::Solutions::KerrSchild>& curved_wave_data,
+    const gr::Solutions::KerrSchild& bh_solution) noexcept {
+  const tnsr::I<DataVector, 3> x{std::array<DataVector, 3>{
+      {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),
+       DataVector({0., 0., 0., 0.})}}};
+
+  tuples::tagged_tuple_from_typelist<
+      typename gr::Solutions::KerrSchild::tags<DataVector>>
+      vars = curved_wave_data.variables(
+          x, typename gr::Solutions::KerrSchild::tags<DataVector>{});
+
+  // Now get Kerr background vars directly
+  const auto kerr_variables = bh_solution.variables(
+      x, 0., gr::Solutions::KerrSchild::tags<DataVector>{});
+
+  tmpl::for_each<gr::Solutions::KerrSchild::tags<DataVector>>(
+      [&vars, &kerr_variables](auto x_) {
+        using tag = typename decltype(x_)::type;
+        CHECK_ITERABLE_APPROX(get<tag>(vars), get<tag>(kerr_variables));
+      });
+}
+
+void test_construct_from_options() noexcept {
+  {  // test with wave profile = spherical
+    Options<
+        tmpl::list<ScalarWaveKerr<ScalarWave::Solutions::RegularSphericalWave>>>
+        opts("");
+    opts.parse(
+        "ScalarWaveKerr:\n"
+        "  Background:\n"
+        "    Mass: 0.7\n"
+        "    Spin: [0.1, -0.2, 0.3]\n"
+        "    Center: [0.7,0.6,-2.]\n"
+        "  ScalarField:\n"
+        "    Profile:\n"
+        "      Gaussian:\n"
+        "        Amplitude: 11.\n"
+        "        Width: 1.4\n"
+        "        Center: 0.3");
+    const auto curved_wave_data_constructed_from_opts =
+        opts.get<ScalarWaveKerr<ScalarWave::Solutions::RegularSphericalWave>>();
+
+    // construct internals of data constructed from options
+    const gr::Solutions::KerrSchild bh_solution(0.7, {{0.1, -0.2, 0.3}},
+                                                {{0.7, 0.6, -2.}});
+    const ScalarWave::Solutions::RegularSphericalWave flat_wave_solution{
+        std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)};
+
+    CHECK(curved_wave_data_constructed_from_opts ==
+          CurvedScalarWave::AnalyticData::ScalarWaveGr<
+              ScalarWave::Solutions::RegularSphericalWave,
+              gr::Solutions::KerrSchild>(
+              bh_solution,
+              // cannot use `flat_wave_solution` in construction here
+              // as it has a `std::unique_ptr` member
+              ScalarWave::Solutions::RegularSphericalWave(
+                  std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3))));
+
+    test_kerr(curved_wave_data_constructed_from_opts, bh_solution,
+              flat_wave_solution);
+  }
+  {  // test with wave profile = plane
+    Options<tmpl::list<ScalarWaveKerr<ScalarWave::Solutions::PlaneWave<3>>>>
+        opts("");
+    opts.parse(
+        "ScalarWaveKerr:\n"
+        "  Background:\n"
+        "    Mass: 0.7\n"
+        "    Spin: [0.1, -0.2, 0.3]\n"
+        "    Center: [0.7,0.6,-2.]\n"
+        "  ScalarField:\n"
+        "    WaveVector: [1.0, 1.0, 1.0]\n"
+        "    Center: [0.0, 0.0, 0.0]\n"
+        "    Profile:\n"
+        "      Gaussian:\n"
+        "        Amplitude: 11.\n"
+        "        Width: 1.4\n"
+        "        Center: 0.3");
+    const auto curved_wave_data_constructed_from_opts =
+        opts.get<ScalarWaveKerr<ScalarWave::Solutions::PlaneWave<3>>>();
+
+    // construct internals of data constructed from options
+    const gr::Solutions::KerrSchild bh_solution(0.7, {{0.1, -0.2, 0.3}},
+                                                {{0.7, 0.6, -2.}});
+    const ScalarWave::Solutions::PlaneWave<3> flat_wave_solution{
+        {{1.0, 1.0, 1.0}},
+        {{0.0, 0.0, 0.0}},
+        std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)};
+
+    CHECK(curved_wave_data_constructed_from_opts ==
+          CurvedScalarWave::AnalyticData::ScalarWaveGr<
+              ScalarWave::Solutions::PlaneWave<3>, gr::Solutions::KerrSchild>(
+              bh_solution,
+              // cannot use `flat_wave_solution` in construction here
+              // as it has a `std::unique_ptr` member
+              ScalarWave::Solutions::PlaneWave<3>(
+                  {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}},
+                  std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3))));
+
+    test_kerr(curved_wave_data_constructed_from_opts, bh_solution,
+              flat_wave_solution);
+  }
+}
+
+void test_serialize(const double mass, const std::array<double, 3>& spin,
+                    const std::array<double, 3>& center) noexcept {
+  {  // test with wave profile = spherical
+    CurvedScalarWave::AnalyticData::ScalarWaveGr<
+        ScalarWave::Solutions::RegularSphericalWave, gr::Solutions::KerrSchild>
+        curved_wave_data(
+            gr::Solutions::KerrSchild(mass, spin, center),
+            ScalarWave::Solutions::RegularSphericalWave(
+                std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)));
+    Parallel::register_derived_classes_with_charm<MathFunction<1>>();
+    const auto snd_curved_wave_data =
+        serialize_and_deserialize(curved_wave_data);
+    CHECK(curved_wave_data == snd_curved_wave_data);
+
+    // test internals of deserialized data
+    const gr::Solutions::KerrSchild bh_solution(mass, spin, center);
+    const ScalarWave::Solutions::RegularSphericalWave flat_wave_solution{
+        std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)};
+
+    test_kerr(snd_curved_wave_data, bh_solution, flat_wave_solution);
+  }
+  {  // test with wave profile = plane
+    CurvedScalarWave::AnalyticData::ScalarWaveGr<
+        ScalarWave::Solutions::PlaneWave<3>, gr::Solutions::KerrSchild>
+        curved_wave_data(
+            gr::Solutions::KerrSchild(mass, spin, center),
+            ScalarWave::Solutions::PlaneWave<3>(
+                {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}},
+                std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)));
+    Parallel::register_derived_classes_with_charm<MathFunction<1>>();
+    const auto snd_curved_wave_data =
+        serialize_and_deserialize(curved_wave_data);
+    CHECK(curved_wave_data == snd_curved_wave_data);
+
+    // test internals of deserialized data
+    const gr::Solutions::KerrSchild bh_solution(mass, spin, center);
+    const ScalarWave::Solutions::PlaneWave<3> flat_wave_solution{
+        {{1.0, 1.0, 1.0}},
+        {{0.0, 0.0, 0.0}},
+        std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)};
+
+    test_kerr(snd_curved_wave_data, bh_solution, flat_wave_solution);
+  }
+}
+
+void test_move(const double mass, const std::array<double, 3>& spin,
+               const std::array<double, 3>& center) noexcept {
+  {  // test with wave profile = spherical
+    CurvedScalarWave::AnalyticData::ScalarWaveGr<
+        ScalarWave::Solutions::RegularSphericalWave, gr::Solutions::KerrSchild>
+        curved_wave_data(
+            gr::Solutions::KerrSchild(mass, spin, center),
+            ScalarWave::Solutions::RegularSphericalWave(
+                std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)));
+    // since it can't actually be copied
+    CurvedScalarWave::AnalyticData::ScalarWaveGr<
+        ScalarWave::Solutions::RegularSphericalWave, gr::Solutions::KerrSchild>
+        copy_of_curved_wave_data(
+            gr::Solutions::KerrSchild(mass, spin, center),
+            ScalarWave::Solutions::RegularSphericalWave(
+                std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)));
+    test_move_semantics(std::move(curved_wave_data), copy_of_curved_wave_data);
+  }
+  {  // test with wave profile = plane
+    CurvedScalarWave::AnalyticData::ScalarWaveGr<
+        ScalarWave::Solutions::PlaneWave<3>, gr::Solutions::KerrSchild>
+        curved_wave_data(
+            gr::Solutions::KerrSchild(mass, spin, center),
+            ScalarWave::Solutions::PlaneWave<3>(
+                {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}},
+                std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)));
+    // since it can't actually be copied
+    CurvedScalarWave::AnalyticData::ScalarWaveGr<
+        ScalarWave::Solutions::PlaneWave<3>, gr::Solutions::KerrSchild>
+        copy_of_curved_wave_data(
+            gr::Solutions::KerrSchild(mass, spin, center),
+            ScalarWave::Solutions::PlaneWave<3>(
+                {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}},
+                std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)));
+    test_move_semantics(std::move(curved_wave_data), copy_of_curved_wave_data);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGr",
+                  "[PointwiseFunctions][Unit]") {
+  const double mass = 0.7;
+  const std::array<double, 3> spin{{0.1, -0.2, 0.3}};
+  const std::array<double, 3> center{{0.3, 0.2, 0.4}};
+  const gr::Solutions::KerrSchild bh_solution(mass, spin, center);
+
+  test_construct_from_options();
+  test_serialize(mass, spin, center);
+  test_move(mass, spin, center);
+
+  using background_tag = gr::Solutions::KerrSchild;
+
+  {  // test with wave profile = spherical
+    using sw_tag = ScalarWave::Solutions::RegularSphericalWave;
+    const CurvedScalarWave::AnalyticData::ScalarWaveGr<sw_tag, background_tag>
+        curved_wave_data_bh_far_away{
+            background_tag(mass, spin, {{1.e20, 1., 1.}}),
+            sw_tag(std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.))};
+    const CurvedScalarWave::AnalyticData::ScalarWaveGr<sw_tag, background_tag>
+        curved_wave_data{
+            background_tag(mass, spin, center),
+            sw_tag(std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.))};
+    const sw_tag flat_wave_solution{
+        std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.)};
+
+    test_tag_retrieval(curved_wave_data_bh_far_away);
+    test_tag_retrieval(curved_wave_data);
+    test_no_hole(curved_wave_data_bh_far_away, flat_wave_solution);
+    test_kerr(curved_wave_data, bh_solution, flat_wave_solution);
+    test_kerr_schild_vars(curved_wave_data, bh_solution);
+  }
+  {  // test with wave profile = plane
+    using sw_tag = ScalarWave::Solutions::PlaneWave<3>;
+    const CurvedScalarWave::AnalyticData::ScalarWaveGr<sw_tag, background_tag>
+        curved_wave_data_bh_far_away{
+            background_tag(mass, spin, {{1.e20, 1., 1.}}),
+            sw_tag({{1., 1., 1.}}, {{0., 0., 0.}},
+                   std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.))};
+    const CurvedScalarWave::AnalyticData::ScalarWaveGr<sw_tag, background_tag>
+        curved_wave_data{
+            background_tag(mass, spin, center),
+            sw_tag({{1., 1., 1.}}, {{0., 0., 0.}},
+                   std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.))};
+    const sw_tag flat_wave_solution{
+        {{1., 1., 1.}},
+        {{0., 0., 0.}},
+        std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.)};
+
+    test_tag_retrieval(curved_wave_data_bh_far_away);
+    test_tag_retrieval(curved_wave_data);
+    test_no_hole(curved_wave_data_bh_far_away, flat_wave_solution);
+    test_kerr(curved_wave_data, bh_solution, flat_wave_solution);
+    test_kerr_schild_vars(curved_wave_data, bh_solution);
+  }
+}
+
+/// Check restrictions on input options below
+
+// [[OutputRegex, Mass must be non-negative]]
+SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGrMass",
+                  "[PointwiseFunctions][Unit]") {
+  ERROR_TEST();
+  CurvedScalarWave::AnalyticData::ScalarWaveGr<
+      ScalarWave::Solutions::RegularSphericalWave, gr::Solutions::KerrSchild>
+      solution(gr::Solutions::KerrSchild(-0.2, {{0.1, -0.2, 0.3}},
+                                         {{0.3, 0.2, 0.4}}),
+               ScalarWave::Solutions::RegularSphericalWave(
+                   std::make_unique<MathFunctions::Gaussian>(1., 1., 0.)));
+}
+
+// [[OutputRegex, In string:.*At line 3 column 11:.Value -0.5 is below the
+// lower bound of 0]]
+SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGrOptM",
+                  "[PointwiseFunctions][Unit]") {
+  ERROR_TEST();
+  Options<
+      tmpl::list<ScalarWaveKerr<ScalarWave::Solutions::RegularSphericalWave>>>
+      opts("");
+  opts.parse(
+      "ScalarWaveKerr:\n"
+      "  Background:\n"
+      "    Mass: -0.5\n"
+      "    Spin: [0.1, -0.2, 0.3]\n"
+      "    Center: [0.7,0.6,-2.]\n"
+      "  ScalarField:\n"
+      "    Profile:\n"
+      "      Gaussian:\n"
+      "        Amplitude: 11.\n"
+      "        Width: 1.4\n"
+      "        Center: 0.3");
+  opts.get<ScalarWaveKerr<ScalarWave::Solutions::RegularSphericalWave>>();
+}
+
+// [[OutputRegex, Spin magnitude must be < 1]]
+SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGrSpin",
+                  "[PointwiseFunctions][Unit]") {
+  ERROR_TEST();
+  CurvedScalarWave::AnalyticData::ScalarWaveGr<
+      ScalarWave::Solutions::RegularSphericalWave, gr::Solutions::KerrSchild>
+      solution(
+          gr::Solutions::KerrSchild(0.2, {{1.0, 1.0, 1.0}}, {{0.3, 0.2, 0.4}}),
+          ScalarWave::Solutions::RegularSphericalWave(
+              std::make_unique<MathFunctions::Gaussian>(1., 1., 0.)));
+}


### PR DESCRIPTION
## Proposed changes

Analytic data for scalar wave in Kerr spacetime that can be used as initial data for starting a CurvedScalarWave evolution. This is templated on both the spacetime background and the flat-space scalar field profile (which can c.f. any class in `ScalarWave::Solutions`).

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration