### PR TITLE
Cce boundarydata part 3

### DIFF
--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   LinearOperators.cpp
   LinearSolve.cpp
   PrecomputeCceDependencies.cpp
+  ReadBoundaryDataH5.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Evolution/Systems/Cce/ReadBoundaryDataH5.cpp
+++ b/src/Evolution/Systems/Cce/ReadBoundaryDataH5.cpp
@@ -1,0 +1,232 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
+
+#include <algorithm>
+#include <string>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Numeric.hpp"
+
+namespace Cce {
+
+namespace detail {
+std::pair<size_t, size_t> create_span_for_time_value(
+    const double time, const size_t pad, const size_t interpolator_length,
+    const size_t lower_bound, const size_t upper_bound,
+    const DataVector& time_buffer) noexcept {
+  ASSERT(
+      lower_bound < upper_bound,
+      "The supplied `lower_bound` is greater than `upper_bound`, which is not "
+      "permitted");
+  ASSERT(2 * interpolator_length + pad < upper_bound,
+         "The combined `interpolator_length` and `pad` is too large for the "
+         "supplied `upper_bound`");
+
+  size_t range_start = lower_bound;
+  size_t range_end = upper_bound;
+  while (range_end - range_start > 1) {
+    if (time_buffer[(range_start + range_end) / 2] < time) {
+      range_start = (range_start + range_end) / 2;
+    } else {
+      range_end = (range_start + range_end) / 2;
+    }
+  }
+  // always keep the difference between start and end the same, even when
+  // the interpolations starts to get worse
+  size_t span_start = lower_bound;
+  size_t span_end =
+      std::min(interpolator_length * 2 + pad + lower_bound, upper_bound);
+  if (range_end + interpolator_length + pad > upper_bound) {
+    span_start =
+        std::max(upper_bound - (interpolator_length * 2 + pad), lower_bound);
+    span_end = upper_bound;
+  } else if (range_start + 1 > lower_bound + interpolator_length) {
+    span_start = range_start - interpolator_length;
+    span_end = range_end + interpolator_length + pad - 1;
+  }
+
+  return std::make_pair(span_start, span_end);
+}
+}  // namespace detail
+
+SpecWorldtubeH5BufferUpdater::SpecWorldtubeH5BufferUpdater(
+    const std::string& cce_data_filename) noexcept
+    : cce_data_file_{cce_data_filename}, filename_{cce_data_filename} {
+  get<Tags::detail::InputDataSet<Tags::detail::SpatialMetric>>(dataset_names_) =
+      "/g";
+  get<Tags::detail::InputDataSet<
+      Tags::detail::Dr<Tags::detail::SpatialMetric>>>(dataset_names_) = "/Drg";
+  get<Tags::detail::InputDataSet<::Tags::dt<Tags::detail::SpatialMetric>>>(
+      dataset_names_) = "/Dtg";
+
+  get<Tags::detail::InputDataSet<Tags::detail::Shift>>(dataset_names_) =
+      "/Shift";
+  get<Tags::detail::InputDataSet<Tags::detail::Dr<Tags::detail::Shift>>>(
+      dataset_names_) = "/DrShift";
+  get<Tags::detail::InputDataSet<::Tags::dt<Tags::detail::Shift>>>(
+      dataset_names_) = "/DtShift";
+
+  get<Tags::detail::InputDataSet<Tags::detail::Lapse>>(dataset_names_) =
+      "/Lapse";
+  get<Tags::detail::InputDataSet<Tags::detail::Dr<Tags::detail::Lapse>>>(
+      dataset_names_) = "/DrLapse";
+  get<Tags::detail::InputDataSet<::Tags::dt<Tags::detail::Lapse>>>(
+      dataset_names_) = "/DtLapse";
+
+  // We assume that the filename has the extraction radius encoded as an
+  // integer between the first occurrence of 'R' and the first occurrence of
+  // '.'. This is the format provided by SpEC.
+  const size_t r_pos = cce_data_filename.find('R');
+  const size_t dot_pos = cce_data_filename.find('.');
+  const std::string text_radius =
+      cce_data_filename.substr(r_pos + 1, dot_pos - r_pos - 1);
+  extraction_radius_ = stod(text_radius);
+
+  const auto& lapse_data = cce_data_file_.get<h5::Dat>("/Lapse");
+  const auto data_table_dimensions = lapse_data.get_dimensions();
+  const Matrix time_matrix = lapse_data.get_data_subset(
+      std::vector<size_t>{0}, 0, data_table_dimensions[0]);
+  time_buffer_ = DataVector{data_table_dimensions[0]};
+  for (size_t i = 0; i < data_table_dimensions[0]; ++i) {
+    time_buffer_[i] = time_matrix(i, 0);
+  }
+  l_max_ = sqrt(data_table_dimensions[1] / 2) - 1;
+  cce_data_file_.close_current_object();
+}
+
+double SpecWorldtubeH5BufferUpdater::update_buffers_for_time(
+    const gsl::not_null<Variables<detail::cce_input_tags>*> buffers,
+    const gsl::not_null<size_t*> time_span_start,
+    const gsl::not_null<size_t*> time_span_end, const double time,
+    const size_t interpolator_length, const size_t buffer_depth) const
+    noexcept {
+  if (*time_span_end > interpolator_length and
+      time_buffer_[*time_span_end - interpolator_length + 1] > time) {
+    // the next time an update will be required
+    return time_buffer_[*time_span_end - interpolator_length + 1];
+  }
+  // find the time spans that are needed
+  auto new_span_pair = detail::create_span_for_time_value(
+      time, buffer_depth, interpolator_length, 0, time_buffer_.size(),
+      time_buffer_);
+  *time_span_start = new_span_pair.first;
+  *time_span_end = new_span_pair.second;
+  // load the desired time spans into the buffers
+  // spatial metric
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j) {
+      tmpl::for_each<tmpl::list<Tags::detail::SpatialMetric,
+                                Tags::detail::Dr<Tags::detail::SpatialMetric>,
+                                ::Tags::dt<Tags::detail::SpatialMetric>>>([
+        this, &i, &j, &buffers, &time_span_start, &time_span_end
+      ](auto tag_v) noexcept {
+        using tag = typename decltype(tag_v)::type;
+        this->update_buffer(
+            make_not_null(&get<tag>(*buffers).get(i, j)),
+            cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
+                get<Tags::detail::InputDataSet<tag>>(dataset_names_), i, j)),
+            *time_span_start, *time_span_end);
+        cce_data_file_.close_current_object();
+      });
+    }
+    // shift
+    tmpl::for_each<
+        tmpl::list<Tags::detail::Shift, Tags::detail::Dr<Tags::detail::Shift>,
+                   ::Tags::dt<Tags::detail::Shift>>>([
+      this, &i, &buffers, &time_span_start, &time_span_end
+    ](auto tag_v) noexcept {
+      using tag = typename decltype(tag_v)::type;
+      this->update_buffer(
+          make_not_null(&get<tag>(*buffers).get(i)),
+          cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
+              get<Tags::detail::InputDataSet<tag>>(dataset_names_), i)),
+          *time_span_start, *time_span_end);
+      cce_data_file_.close_current_object();
+    });
+  }
+  // lapse
+  tmpl::for_each<
+      tmpl::list<Tags::detail::Lapse, Tags::detail::Dr<Tags::detail::Lapse>,
+                 ::Tags::dt<Tags::detail::Lapse>>>([
+    this, &buffers, &time_span_start, &time_span_end
+  ](auto tag_v) noexcept {
+    using tag = typename decltype(tag_v)::type;
+    this->update_buffer(
+        make_not_null(&get(get<tag>(*buffers))),
+        cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
+            get<Tags::detail::InputDataSet<tag>>(dataset_names_))),
+        *time_span_start, *time_span_end);
+    cce_data_file_.close_current_object();
+  });
+  // the next time an update will be required
+  return time_buffer_[*time_span_end - interpolator_length + 1];
+}
+
+std::unique_ptr<WorldtubeBufferUpdater>
+SpecWorldtubeH5BufferUpdater::get_clone() const noexcept {
+  return std::make_unique<SpecWorldtubeH5BufferUpdater>(
+      SpecWorldtubeH5BufferUpdater{filename_});
+}
+
+bool SpecWorldtubeH5BufferUpdater::time_is_outside_range(
+    const double time) const noexcept {
+  return time < time_buffer_[0] or time > time_buffer_[time_buffer_.size() - 1];
+}
+
+void SpecWorldtubeH5BufferUpdater::pup(PUP::er& p) noexcept {
+  p | time_buffer_;
+  p | filename_;
+  p | l_max_;
+  p | extraction_radius_;
+  p | dataset_names_;
+  if (p.isUnpacking()) {
+    cce_data_file_ = h5::H5File<h5::AccessType::ReadOnly>{filename_};
+  }
+}
+
+void SpecWorldtubeH5BufferUpdater::update_buffer(
+    const gsl::not_null<ComplexModalVector*> buffer_to_update,
+    const h5::Dat& read_data, const size_t time_span_start,
+    const size_t time_span_end) const noexcept {
+  const size_t number_of_columns = read_data.get_dimensions()[1];
+  if (UNLIKELY(buffer_to_update->size() != (time_span_end - time_span_start) *
+                                               (number_of_columns - 1) / 2)) {
+    ERROR("Incorrect storage size for the data to be loaded in.");
+  }
+  auto cols = alg::iota(std::vector<size_t>(number_of_columns - 1), 1u);
+  const Matrix data_matrix = read_data.get_data_subset(
+      cols, time_span_start, time_span_end - time_span_start);
+
+  for (size_t time_row = 0; time_row < time_span_end - time_span_start;
+       ++time_row) {
+    for (int l = 0; l <= static_cast<int>(l_max_); ++l) {
+      for (int m = -l; m <= l; ++m) {
+        (*buffer_to_update)[Spectral::Swsh::goldberg_mode_index(
+                                l_max_, static_cast<size_t>(l), m) *
+                                (time_span_end - time_span_start) +
+                            time_row] =
+            // -m because SpEC format is stored in decending m.
+            std::complex<double>(
+                data_matrix(time_row,
+                            2 * Spectral::Swsh::goldberg_mode_index(
+                                    l_max_, static_cast<size_t>(l), -m)),
+                data_matrix(time_row,
+                            2 * Spectral::Swsh::goldberg_mode_index(
+                                    l_max_, static_cast<size_t>(l), -m) +
+                                1));
+      }
+    }
+  }
+}
+
+/// \cond
+PUP::able::PUP_ID Cce::SpecWorldtubeH5BufferUpdater::my_PUP_ID = 0;
+/// \endcond
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/ReadBoundaryDataH5.hpp
+++ b/src/Evolution/Systems/Cce/ReadBoundaryDataH5.hpp
@@ -1,0 +1,221 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <boost/iterator/zip_iterator.hpp>
+#include <boost/tuple/tuple.hpp>
+#include <boost/tuple/tuple_comparison.hpp>
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "Parallel/CharmPupable.hpp"
+
+namespace Cce {
+namespace Tags {
+namespace detail {
+// tags for use in the buffers for the modal input worldtube data management
+// classes
+using SpatialMetric =
+    gr::Tags::SpatialMetric<3, ::Frame::Inertial, ComplexModalVector>;
+using Shift = gr::Tags::Shift<3, ::Frame::Inertial, ComplexModalVector>;
+using Lapse = gr::Tags::Lapse<ComplexModalVector>;
+
+// radial derivative prefix tag to be used with the modal input worldtube data
+template <typename Tag>
+struct Dr : db::SimpleTag, db::PrefixTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+  static std::string name() noexcept { return "Dr(" + Tag::name() + ")"; }
+};
+
+// tag for the string for accessing the quantity associated with `Tag` in
+// worldtube h5 file
+template <typename Tag>
+struct InputDataSet : db::SimpleTag, db::PrefixTag {
+  using type = std::string;
+  using tag = Tag;
+  static std::string name() noexcept {
+    return "InputDataSet(" + Tag::name() + ")";
+  }
+};
+}  // namespace detail
+}  // namespace Tags
+
+namespace detail {
+// generates the component dataset name in the worldtube file based on the
+// tensor indices requested. For instance, if called with arguments ("/g", 0,1),
+// it returns the dataset name "/gxy".
+template <typename... T>
+std::string dataset_name_for_component(std::string base_name,
+                                       const T... indices) noexcept {
+  const auto add_index = [&base_name](size_t index) noexcept {
+    ASSERT(index < 3, "The character-arithmetic index must be less than 3.");
+    base_name += static_cast<char>('x' + index);
+  };
+  EXPAND_PACK_LEFT_TO_RIGHT(add_index(indices));
+  // void cast so that compilers can tell it's used.
+  (void)add_index;
+  return base_name;
+}
+
+// the full set of tensors to be extracted from the worldtube h5 file
+using cce_input_tags = tmpl::list<
+    Tags::detail::SpatialMetric, Tags::detail::Dr<Tags::detail::SpatialMetric>,
+    ::Tags::dt<Tags::detail::SpatialMetric>, Tags::detail::Shift,
+    Tags::detail::Dr<Tags::detail::Shift>, ::Tags::dt<Tags::detail::Shift>,
+    Tags::detail::Lapse, Tags::detail::Dr<Tags::detail::Lapse>,
+    ::Tags::dt<Tags::detail::Lapse>>;
+
+// creates a pair of indices such that the difference is `2 *
+// interpolator_length + pad`, centered around `time`, and bounded by
+// `lower_bound` and `upper_bound`. If it cannot be centered, it gives a span
+// that is appropriately sized and bounded by the supplied bounds. If the bounds
+// are too constraining for the necessary size, it gives a span that is the
+// correct size starting at `lower bound`, but not constrained by `upper_bound`
+std::pair<size_t, size_t> create_span_for_time_value(
+    double time, size_t pad, size_t interpolator_length, size_t lower_bound,
+    size_t upper_bound, const DataVector& time_buffer) noexcept;
+}  // namespace detail
+
+/// \cond
+class SpecWorldtubeH5BufferUpdater;
+/// \endcond
+
+/*!
+ *  \brief Abstract base class for utilities that are able to perform the buffer
+ *  updating procedure needed by the `WorldtubeDataManager`.
+ *
+ *  \details The methods that are required to be overridden in the derived
+ * classes are:
+ *  - `WorldtubeBufferUpdater::update_buffers_for_time()`:
+ *  updates the buffers passed by pointer and the `time_span_start` and
+ *  `time_span_end` to be appropriate for the requested `time`,
+ *  `interpolator_length`, and `buffer_depth`.
+ *  - `WorldtubeBufferUpdater::get_clone()`
+ *  clone function to obtain a `std::unique_ptr` of the base
+ *  `WorldtubeBufferUpdater`, needed to pass around the factory-created
+ *  object.
+ *  - `WorldtubeBufferUpdater::time_is_outside_range()`
+ *  the override should return `true` if the `time` could be used in a
+ *  `update_buffers_for_time` call given the data available to the derived
+ *  class, and `false` otherwise
+ *  - `WorldtubeBufferUpdater::get_l_max()`
+ *  The override should return the `l_max` it uses in the
+ *  Goldberg modal data placed in the buffers.
+ *  - `WorldtubeBufferUpdater::get_extraction_radius()`
+ *  The override should return the coordinate radius associated with the modal
+ *  worldtube data that it supplies in the buffer update function. This is
+ *  currently assumed to be a single double, but may be generalized in future
+ *  to be time-dependent.
+ *  - `WorldtubeBufferUpdater::get_time_buffer`
+ *  The override should return the vector of times that it can produce modal
+ *  data at. For instance, if associated with a file input, this will be the
+ *  times at each of the rows of the time-series data.
+ */
+class WorldtubeBufferUpdater : public PUP::able {
+  using creatable_classes = tmpl::list<SpecWorldtubeH5BufferUpdater>;
+
+  WRAPPED_PUPable_abstract(WorldtubeBufferUpdater);  // NOLINT
+
+  virtual double update_buffers_for_time(
+      gsl::not_null<Variables<detail::cce_input_tags>*> buffers,
+      gsl::not_null<size_t*> time_span_start,
+      gsl::not_null<size_t*> time_span_end, double time,
+      size_t interpolator_length, size_t buffer_depth) const noexcept = 0;
+
+  virtual std::unique_ptr<WorldtubeBufferUpdater> get_clone() const
+      noexcept = 0;
+
+  virtual bool time_is_outside_range(double time) const noexcept = 0;
+
+  virtual size_t get_l_max() const noexcept = 0;
+
+  virtual double get_extraction_radius() const noexcept = 0;
+
+  virtual DataVector& get_time_buffer() noexcept = 0;
+};
+
+/// A `WorldtubeBufferUpdater` specialized to the CCE input worldtube  H5 file
+/// produced by SpEC.
+class SpecWorldtubeH5BufferUpdater : public WorldtubeBufferUpdater {
+ public:
+  // charm needs the empty constructor
+  SpecWorldtubeH5BufferUpdater() = default;
+
+  /// The constructor takes the filename of the SpEC h5 file that will be used
+  /// for boundary data. Note that this assumes that the input data has
+  /// correctly-normalized radial derivatives, and that the extraction radius is
+  /// encoded as an integer in the filename.
+  explicit SpecWorldtubeH5BufferUpdater(
+      const std::string& cce_data_filename) noexcept;
+
+  WRAPPED_PUPable_decl_template(SpecWorldtubeH5BufferUpdater);  // NOLINT
+
+  explicit SpecWorldtubeH5BufferUpdater(CkMigrateMessage* /*unused*/) noexcept {
+  }
+
+  /// update the `buffers`, `time_span_start`, and `time_span_end` with
+  /// time-varies-fastest, Goldberg modal data and the start and end index in
+  /// the member `time_buffer_` covered by the newly updated `buffers`. The
+  /// function returns the next time at which a full update will occur. If
+  /// called again at times earlier than the next full update time, it will
+  /// leave the `buffers` unchanged and again return the next needed time.
+  double update_buffers_for_time(
+      gsl::not_null<Variables<detail::cce_input_tags>*> buffers,
+      gsl::not_null<size_t*> time_span_start,
+      gsl::not_null<size_t*> time_span_end, double time,
+      size_t interpolator_length, size_t buffer_depth) const noexcept override;
+
+  std::unique_ptr<WorldtubeBufferUpdater> get_clone() const noexcept override;
+
+  /// The time can only be supported in the buffer update if it is between the
+  /// first and last time of the input file.
+  bool time_is_outside_range(double time) const noexcept override;
+
+  /// retrieves the l_max of the input file
+  size_t get_l_max() const noexcept override { return l_max_; }
+
+  /// retrieves the extraction radius encoded in the filename
+  double get_extraction_radius() const noexcept override {
+    return extraction_radius_;
+  }
+
+  /// The time buffer is supplied by non-const reference to allow views to
+  /// easily point into the buffer.
+  ///
+  /// \warning Altering this buffer outside of the constructor of this class
+  /// results in undefined behavior! This should be supplied by const reference
+  /// once there is a convenient method of producing a const view of a vector
+  /// type.
+  DataVector& get_time_buffer() noexcept override { return time_buffer_; }
+
+  /// Serialization for Charm++.
+  void pup(PUP::er& p) noexcept override;
+
+ private:
+  void update_buffer(gsl::not_null<ComplexModalVector*> buffer_to_update,
+                     const h5::Dat& read_data, size_t time_span_start,
+                     size_t time_span_end) const noexcept;
+
+  double extraction_radius_ = 1.0;
+  size_t l_max_ = 0;
+
+  h5::H5File<h5::AccessType::ReadOnly> cce_data_file_;
+  std::string filename_;
+
+  tuples::tagged_tuple_from_typelist<
+      db::wrap_tags_in<Tags::detail::InputDataSet, detail::cce_input_tags>>
+      dataset_names_;
+
+  // stores all the times in the input file
+  DataVector time_buffer_;
+};
+}  // namespace Cce

--- a/src/IO/H5/File.hpp
+++ b/src/IO/H5/File.hpp
@@ -59,6 +59,10 @@ namespace h5 {
 template <AccessType Access_t>
 class H5File {
  public:
+  // empty constructor for classes which store an H5File and need to be
+  // charm-compatible.
+  H5File() noexcept = default;
+
   /*!
    * \requires `file_name` is a valid path and ends in `.h5`.
    * \effects On object creation opens the HDF5 file at `file_name`
@@ -145,6 +149,12 @@ class H5File {
    * \effects Closes the current object, if there is none then has no effect
    */
   void close_current_object() const noexcept { current_object_ = nullptr; }
+
+  template <typename ObjectType>
+  bool exists(const std::string& path) noexcept {
+    auto exists_group_name = check_if_object_exists<ObjectType>(path);
+    return std::get<0>(exists_group_name);
+  }
 
  private:
   /// \cond HIDDEN_SYMBOLS
@@ -317,12 +327,12 @@ H5File<Access_t>::check_if_object_exists(const std::string& path) const {
                           Access_t);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-  const bool exists =
+  const bool object_exists =
       name_with_extension == "/" or
       H5Lexists(group.id(), name_with_extension.c_str(), H5P_DEFAULT) or
       H5Aexists(group.id(), name_with_extension.c_str());
 #pragma GCC diagnostic pop
-  return std::make_tuple(exists, std::move(group), std::move(name_only));
+  return std::make_tuple(object_exists, std::move(group), std::move(name_only));
 }
 
 template <>

--- a/src/NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.cpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
+
+#include <boost/math/interpolators/barycentric_rational.hpp>
+#include <complex>
+#include <cstddef>
+
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace intrp {
+
+BarycentricRationalSpanInterpolator::BarycentricRationalSpanInterpolator(
+    size_t min_order, size_t max_order) noexcept
+    : min_order_{min_order}, max_order_{max_order} {
+  ASSERT(min_order <= max_order,
+         "The minimum order for the Barycentric rational interpolator must be "
+         "less than the maximum order.");
+}
+
+double BarycentricRationalSpanInterpolator::interpolate(
+    const gsl::span<const double>& source_points,
+    const gsl::span<const double>& values, const double target_point) const
+    noexcept {
+  if (UNLIKELY(source_points.size() < min_order_ + 1)) {
+    ERROR("provided independent values for interpolation too small.");
+  }
+  boost::math::barycentric_rational<double> interpolant(
+      source_points.data(), values.data(), source_points.size(),
+      std::min(source_points.size() - 1, max_order_));
+  return interpolant(target_point);
+}
+
+/// \cond
+PUP::able::PUP_ID intrp::BarycentricRationalSpanInterpolator::my_PUP_ID = 0;
+/// \endcond
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+
+#include "NumericalAlgorithms/Interpolation/SpanInterpolator.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace intrp {
+
+/// \brief Performs a barycentric interpolation with an order in a range fixed
+/// at construction; this class can be chosen via the options factory mechanism
+/// as a possible `SpanInterpolator`.
+///
+/// \details This will call a barycentric interpolation on a fixed minimum
+/// length, so that buffers that adjust length based on
+/// `required_points_before_and_after()` can be forced to use an interpolator of
+/// a target order.
+class BarycentricRationalSpanInterpolator : public SpanInterpolator {
+ public:
+  struct MinOrder {
+    using type = size_t;
+    static constexpr OptionString help = {"Order of barycentric interpolation"};
+    static type lower_bound() noexcept { return 1; }
+  };
+
+  struct MaxOrder {
+    using type = size_t;
+    static constexpr OptionString help = {"Order of barycentric interpolation"};
+    static type upper_bound() noexcept { return 10; }
+  };
+
+  using options = tmpl::list<MinOrder, MaxOrder>;
+  static constexpr OptionString help = {
+      "Barycentric interpolator of option-defined maximum and minimum order."};
+
+  explicit BarycentricRationalSpanInterpolator(
+      CkMigrateMessage* /*unused*/) noexcept {}
+
+  WRAPPED_PUPable_decl_template(BarycentricRationalSpanInterpolator);  // NOLINT
+
+  // clang-tidy: do not pass by non-const reference
+  void pup(PUP::er& p) noexcept override {  // NOLINT
+    p | min_order_;
+    p | max_order_;
+  }
+
+  BarycentricRationalSpanInterpolator() = default;
+  BarycentricRationalSpanInterpolator(
+      const BarycentricRationalSpanInterpolator&) noexcept = default;
+  BarycentricRationalSpanInterpolator& operator=(
+      const BarycentricRationalSpanInterpolator&) noexcept = default;
+  BarycentricRationalSpanInterpolator(
+      BarycentricRationalSpanInterpolator&&) noexcept = default;
+  BarycentricRationalSpanInterpolator& operator=(
+      BarycentricRationalSpanInterpolator&&) noexcept = default;
+  ~BarycentricRationalSpanInterpolator() noexcept override = default;
+
+  explicit BarycentricRationalSpanInterpolator(size_t min_order,
+                                               size_t max_order) noexcept;
+
+  std::unique_ptr<SpanInterpolator> get_clone() const noexcept override {
+    return std::make_unique<BarycentricRationalSpanInterpolator>(*this);
+  }
+
+  // to get the generic overload:
+  using SpanInterpolator::interpolate;
+
+  double interpolate(const gsl::span<const double>& source_points,
+                     const gsl::span<const double>& values,
+                     double target_point) const noexcept override;
+
+  size_t required_number_of_points_before_and_after() const noexcept override {
+    return min_order_ / 2 + 1;
+  }
+
+ private:
+  size_t min_order_ = 1;
+  size_t max_order_ = 10;
+};
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -5,13 +5,17 @@ set(LIBRARY Interpolation)
 
 set(LIBRARY_SOURCES
   BarycentricRational.cpp
+  BarycentricRationalSpanInterpolator.cpp
+  CubicSpanInterpolator.cpp
   CubicSpline.cpp
   InterpolationTargetApparentHorizon.cpp
   InterpolationTargetKerrHorizon.cpp
   InterpolationTargetLineSegment.cpp
   InterpolationTargetWedgeSectionTorus.cpp
   IrregularInterpolant.cpp
+  LinearSpanInterpolator.cpp
   RegularGridInterpolant.cpp
+  SpanInterpolator.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/NumericalAlgorithms/Interpolation/CubicSpanInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/CubicSpanInterpolator.cpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/CubicSpanInterpolator.hpp"
+#include "Utilities/ForceInline.hpp"
+
+#include "Parallel/CharmPupable.hpp"
+
+namespace intrp {
+
+namespace {
+template <typename ValueType>
+SPECTRE_ALWAYS_INLINE ValueType
+interpolate_impl(const gsl::span<const double>& source_points,
+                 const gsl::span<const ValueType>& values,
+                 const double target_point) noexcept {
+  const double t0 = source_points[0];
+  const double t1 = source_points[1];
+  const double t2 = source_points[2];
+  const double t3 = source_points[3];
+
+  const auto d0 = values[0];
+  const auto d1 = values[1];
+  const auto d2 = values[2];
+  const auto d3 = values[3];
+
+  return (-((target_point - t2) *
+            (d3 * (target_point - t0) * (target_point - t1) * (t0 - t1) *
+                 (t0 - t2) * (t1 - t2) +
+             (d1 * (target_point - t0) * (t0 - t2) * (t0 - t3) -
+              d0 * (target_point - t1) * (t1 - t2) * (t1 - t3)) *
+                 (target_point - t3) * (t2 - t3))) +
+          d2 * (target_point - t0) * (target_point - t1) * (t0 - t1) *
+              (target_point - t3) * (t0 - t3) * (t1 - t3)) /
+         ((t0 - t1) * (t0 - t2) * (t1 - t2) * (t0 - t3) * (t1 - t3) *
+          (t2 - t3));
+}
+}  // namespace
+
+double CubicSpanInterpolator::interpolate(
+    const gsl::span<const double>& source_points,
+    const gsl::span<const double>& values, double target_point) const noexcept {
+  return interpolate_impl(source_points, values, target_point);
+}
+
+std::complex<double> CubicSpanInterpolator::interpolate(
+    const gsl::span<const double>& source_points,
+    const gsl::span<const std::complex<double>>& values,
+    double target_point) const noexcept {
+  return interpolate_impl(source_points, values, target_point);
+}
+
+/// \cond
+PUP::able::PUP_ID intrp::CubicSpanInterpolator::my_PUP_ID = 0;
+/// \endcond
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/CubicSpanInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/CubicSpanInterpolator.hpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "NumericalAlgorithms/Interpolation/SpanInterpolator.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace intrp {
+
+/// \brief Performs a cubic interpolation; this class can be chosen via the
+/// options factory mechanism as a possible `SpanInterpolator`.
+///
+/// \details This interpolator is hand-coded to be identical to the SpEC
+/// implementation used for SpEC CCE so that comparison results can be as close
+/// as possible for diagnostics.
+class CubicSpanInterpolator : public SpanInterpolator {
+ public:
+  using options = tmpl::list<>;
+  static constexpr OptionString help = {"Cubic interpolator."};
+
+  CubicSpanInterpolator() = default;
+  CubicSpanInterpolator(const CubicSpanInterpolator&) noexcept = default;
+  CubicSpanInterpolator& operator=(const CubicSpanInterpolator&) noexcept =
+      default;
+  CubicSpanInterpolator(CubicSpanInterpolator&&) noexcept = default;
+  CubicSpanInterpolator& operator=(CubicSpanInterpolator&&) noexcept = default;
+  ~CubicSpanInterpolator() noexcept override = default;
+
+  explicit CubicSpanInterpolator(CkMigrateMessage* /*unused*/) noexcept {}
+
+  WRAPPED_PUPable_decl_template(CubicSpanInterpolator);  // NOLINT
+
+  // clang-tidy: do not pass by non-const reference
+  void pup(PUP::er& /*p*/) noexcept override {}
+
+  std::unique_ptr<SpanInterpolator> get_clone() const noexcept override {
+    return std::make_unique<CubicSpanInterpolator>(*this);
+  }
+
+  double interpolate(const gsl::span<const double>& source_points,
+                     const gsl::span<const double>& values,
+                     double target_point) const noexcept override;
+
+  std::complex<double> interpolate(
+      const gsl::span<const double>& source_points,
+      const gsl::span<const std::complex<double>>& values,
+      double target_point) const noexcept;
+
+  size_t required_number_of_points_before_and_after() const noexcept override {
+    return 2;
+  }
+};
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/LinearSpanInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/LinearSpanInterpolator.cpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/LinearSpanInterpolator.hpp"
+#include "Utilities/ForceInline.hpp"
+
+#include "Parallel/CharmPupable.hpp"
+
+namespace intrp {
+
+namespace {
+template <typename ValueType>
+SPECTRE_ALWAYS_INLINE ValueType
+interpolate_impl(const gsl::span<const double>& source_points,
+                 const gsl::span<const ValueType>& values,
+                 const double target_point) noexcept {
+  return values[0] + (values[1] - values[0]) /
+                         (source_points[1] - source_points[0]) *
+                         (target_point - source_points[0]);
+}
+}  // namespace
+
+double LinearSpanInterpolator::interpolate(
+    const gsl::span<const double>& source_points,
+    const gsl::span<const double>& values, const double target_point) const
+    noexcept {
+  return interpolate_impl(source_points, values, target_point);
+}
+
+std::complex<double> LinearSpanInterpolator::interpolate(
+    const gsl::span<const double>& source_points,
+    const gsl::span<const std::complex<double>>& values,
+    const double target_point) const noexcept {
+  return interpolate_impl(source_points, values, target_point);
+}
+
+/// \cond
+PUP::able::PUP_ID intrp::LinearSpanInterpolator::my_PUP_ID = 0;
+/// \endcond
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/LinearSpanInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/LinearSpanInterpolator.hpp
@@ -1,0 +1,59 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "NumericalAlgorithms/Interpolation/SpanInterpolator.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace intrp {
+
+/// \brief Performs a linear interpolation; this class can be chosen via the
+/// options factory mechanism as a possible `SpanInterpolator`
+class LinearSpanInterpolator : public SpanInterpolator {
+ public:
+  using options = tmpl::list<>;
+  static constexpr OptionString help = {"Linear interpolator."};
+
+  LinearSpanInterpolator() = default;
+  LinearSpanInterpolator(const LinearSpanInterpolator&) noexcept = default;
+  LinearSpanInterpolator& operator=(const LinearSpanInterpolator&) noexcept =
+      default;
+  LinearSpanInterpolator(LinearSpanInterpolator&&) noexcept = default;
+  LinearSpanInterpolator& operator=(LinearSpanInterpolator&&) noexcept =
+      default;
+  ~LinearSpanInterpolator() noexcept override = default;
+
+  WRAPPED_PUPable_decl_template(LinearSpanInterpolator);  // NOLINT
+
+  explicit LinearSpanInterpolator(CkMigrateMessage* /*unused*/) noexcept {}
+
+  // clang-tidy: do not pass by non-const reference
+  void pup(PUP::er& /*p*/) noexcept override {}
+
+  std::unique_ptr<SpanInterpolator> get_clone() const noexcept override {
+    return std::make_unique<LinearSpanInterpolator>(*this);
+  }
+
+  double interpolate(const gsl::span<const double>& source_points,
+                     const gsl::span<const double>& values,
+                     double target_point) const noexcept override;
+
+  std::complex<double> interpolate(
+      const gsl::span<const double>& source_points,
+      const gsl::span<const std::complex<double>>& values,
+      double target_point) const noexcept;
+
+  size_t required_number_of_points_before_and_after() const noexcept override {
+    return 1;
+  }
+};
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/SpanInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/SpanInterpolator.cpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/SpanInterpolator.hpp"
+
+#include <complex>
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace intrp {
+
+std::complex<double> SpanInterpolator::interpolate(
+    const gsl::span<const double>& source_points,
+    const gsl::span<const std::complex<double>>& values,
+    const double target_point) const noexcept {
+  // the operation below to get the real and imag parts does not alter the
+  // contents of the span, so the const-cast is safe.
+  const ComplexDataVector view{
+      const_cast<std::complex<double>*>(values.data()),  // NOLINT
+      values.size()};
+  const DataVector real_part = real(view);
+  const DataVector imag_part = imag(view);
+  return std::complex<double>{
+      interpolate(source_points,
+                  gsl::span<const double>(real_part.data(), real_part.size()),
+                  target_point),
+      interpolate(source_points,
+                  gsl::span<const double>(imag_part.data(), imag_part.size()),
+                  target_point)};
+}
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/SpanInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/SpanInterpolator.hpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace intrp {
+
+class LinearSpanInterpolator;
+class CubicSpanInterpolator;
+class BarycentricRationalSpanInterpolator;
+
+/// \brief Base class for interpolators so that the factory options
+/// mechanism can be used.
+///
+/// \details The virtual functions in this class demand only that the real
+/// `interpolate` function, `get_clone` function, and
+/// `required_number_of_points_before_and_after` function be overridden in the
+/// derived class. The `interpolate` for complex values can just be used from
+/// this base class, which calls the real version for each component. If it is
+/// possible to make a specialized complex version that avoids allocations, that
+/// is probably more efficient.
+class SpanInterpolator : public PUP::able {
+ public:
+  using creatable_classes =
+      tmpl::list<LinearSpanInterpolator, CubicSpanInterpolator,
+                 BarycentricRationalSpanInterpolator>;
+
+  WRAPPED_PUPable_abstract(SpanInterpolator);  // NOLINT
+
+  /// Produce a `std::unique_ptr` that points to a copy of `*this``
+  virtual std::unique_ptr<SpanInterpolator> get_clone() const noexcept = 0;
+
+  /// Perform the interpolation of function represented by `values` at
+  /// `source_points` to the requested `target_point`, returning the
+  /// interpolation result.
+  virtual double interpolate(const gsl::span<const double>& source_points,
+                             const gsl::span<const double>& values,
+                             double target_point) const noexcept = 0;
+
+  /// Perform the interpolation of function represented by complex `values` at
+  /// `source_points` to the requested `target_point`, returning the
+  /// (complex) interpolation result.
+  std::complex<double> interpolate(
+      const gsl::span<const double>& source_points,
+      const gsl::span<const std::complex<double>>& values,
+      double target_point) const noexcept;
+
+  /// The number of domain points that should be both before and after the
+  /// requested target point for best interpolation. For instance, for a linear
+  /// interpolator, this function would return `1` to request that the target is
+  /// between the two domain points passed to `source_points`.
+  virtual size_t required_number_of_points_before_and_after() const
+      noexcept = 0;
+};
+}  // namespace intrp

--- a/tests/Unit/Evolution/Systems/Cce/BoundaryTestHelpers.hpp
+++ b/tests/Unit/Evolution/Systems/Cce/BoundaryTestHelpers.hpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/iterator/zip_iterator.hpp>
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Cce {
+namespace TestHelpers {
+
+template <typename... Structure>
+Tensor<ComplexModalVector, Structure...> tensor_to_goldberg_coefficients(
+    const Tensor<DataVector, Structure...>& nodal_data,
+    const size_t l_max) noexcept {
+  Tensor<ComplexModalVector, Structure...> goldberg_modal_data{
+      square(l_max + 1)};
+  SpinWeighted<ComplexDataVector, 0> transform_buffer{
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  for (size_t i = 0; i < nodal_data.size(); ++i) {
+    transform_buffer.data() = std::complex<double>(1.0, 0.0) * nodal_data[i];
+    goldberg_modal_data[i] =
+        Spectral::Swsh::libsharp_to_goldberg_modes(
+            Spectral::Swsh::swsh_transform(l_max, 1, transform_buffer), l_max)
+            .data();
+  }
+  return goldberg_modal_data;
+}
+
+template <typename... Structure>
+Tensor<ComplexModalVector, Structure...> tensor_to_libsharp_coefficients(
+    const Tensor<DataVector, Structure...>& nodal_data,
+    const size_t l_max) noexcept {
+  Tensor<ComplexModalVector, Structure...> libsharp_modal_data{
+      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+  SpinWeighted<ComplexDataVector, 0> transform_buffer{
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  for (size_t i = 0; i < nodal_data.size(); ++i) {
+    transform_buffer.data() = std::complex<double>(1.0, 0.0) * nodal_data[i];
+    libsharp_modal_data[i] =
+        Spectral::Swsh::swsh_transform(l_max, 1, transform_buffer).data();
+  }
+  return libsharp_modal_data;
+}
+}  // namespace TestHelpers
+}  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_LinearSolve.cpp
   Test_PreSwshDerivatives.cpp
   Test_PrecomputeCceDependencies.cpp
+  Test_ReadBoundaryDataH5.cpp
   Test_SwshDerivatives.cpp
   Test_Tags.cpp
   )

--- a/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
@@ -16,6 +16,7 @@
 #include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
 #include "Utilities/Gsl.hpp"
+#include "tests/Unit/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Utilities/MakeWithRandomValues.hpp"
@@ -379,22 +380,6 @@ void dispatch_to_gh_worldtube_computation_from_analytic(
   create_bondi_boundary_data(box, phi, pi, psi, extraction_radius, l_max);
 }
 
-template <typename... Structure>
-Tensor<ComplexModalVector, Structure...> tensor_to_libsharp_coefficients(
-    const Tensor<DataVector, Structure...>& nodal_data,
-    const size_t l_max) noexcept {
-  Tensor<ComplexModalVector, Structure...> libsharp_modal_data{
-      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
-  SpinWeighted<ComplexDataVector, 0> transform_buffer{
-      Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
-  for (size_t i = 0; i < nodal_data.size(); ++i) {
-    transform_buffer.data() = std::complex<double>(1.0, 0.0) * nodal_data[i];
-    libsharp_modal_data[i] =
-        Spectral::Swsh::swsh_transform(l_max, 1, transform_buffer).data();
-  }
-  return libsharp_modal_data;
-}
-
 template <typename DataBoxTagList, typename AnalyticSolution>
 void dispatch_to_modal_worldtube_computation_from_analytic(
     const gsl::not_null<db::DataBox<DataBoxTagList>*> box,
@@ -470,24 +455,26 @@ void dispatch_to_modal_worldtube_computation_from_analytic(
     }
   }
 
-  const auto lapse_coefficients = tensor_to_libsharp_coefficients(lapse, l_max);
+  const auto lapse_coefficients =
+      TestHelpers::tensor_to_libsharp_coefficients(lapse, l_max);
   const auto dt_lapse_coefficients =
-      tensor_to_libsharp_coefficients(dt_lapse, l_max);
+      TestHelpers::tensor_to_libsharp_coefficients(dt_lapse, l_max);
   const auto dr_lapse_coefficients =
-      tensor_to_libsharp_coefficients(dr_lapse, l_max);
+      TestHelpers::tensor_to_libsharp_coefficients(dr_lapse, l_max);
 
-  const auto shift_coefficients = tensor_to_libsharp_coefficients(shift, l_max);
+  const auto shift_coefficients =
+      TestHelpers::tensor_to_libsharp_coefficients(shift, l_max);
   const auto dt_shift_coefficients =
-      tensor_to_libsharp_coefficients(dt_shift, l_max);
+      TestHelpers::tensor_to_libsharp_coefficients(dt_shift, l_max);
   const auto dr_shift_coefficients =
-      tensor_to_libsharp_coefficients(dr_shift, l_max);
+      TestHelpers::tensor_to_libsharp_coefficients(dr_shift, l_max);
 
   const auto spatial_metric_coefficients =
-      tensor_to_libsharp_coefficients(spatial_metric, l_max);
+      TestHelpers::tensor_to_libsharp_coefficients(spatial_metric, l_max);
   const auto dt_spatial_metric_coefficients =
-      tensor_to_libsharp_coefficients(dt_spatial_metric, l_max);
+      TestHelpers::tensor_to_libsharp_coefficients(dt_spatial_metric, l_max);
   const auto dr_spatial_metric_coefficients =
-      tensor_to_libsharp_coefficients(dr_spatial_metric, l_max);
+      TestHelpers::tensor_to_libsharp_coefficients(dr_spatial_metric, l_max);
 
   create_bondi_boundary_data(
       box, spatial_metric_coefficients, dt_spatial_metric_coefficients,

--- a/tests/Unit/Evolution/Systems/Cce/Test_ReadBoundaryDataH5.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_ReadBoundaryDataH5.cpp
@@ -1,0 +1,449 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
+#include "tests/Unit/Evolution/Systems/Cce/WriteToWorldtubeH5.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Cce {
+
+namespace {
+template <typename AnalyticSolution>
+void create_fake_time_varying_modal_data(
+    const gsl::not_null<tnsr::ii<ComplexModalVector, 3>*>
+        spatial_metric_coefficients,
+    const gsl::not_null<tnsr::ii<ComplexModalVector, 3>*>
+        dt_spatial_metric_coefficients,
+    const gsl::not_null<tnsr::ii<ComplexModalVector, 3>*>
+        dr_spatial_metric_coefficients,
+    const gsl::not_null<tnsr::I<ComplexModalVector, 3>*> shift_coefficients,
+    const gsl::not_null<tnsr::I<ComplexModalVector, 3>*> dt_shift_coefficients,
+    const gsl::not_null<tnsr::I<ComplexModalVector, 3>*> dr_shift_coefficients,
+    const gsl::not_null<Scalar<ComplexModalVector>*> lapse_coefficients,
+    const gsl::not_null<Scalar<ComplexModalVector>*> dt_lapse_coefficients,
+    const gsl::not_null<Scalar<ComplexModalVector>*> dr_lapse_coefficients,
+    const AnalyticSolution& solution, const double extraction_radius,
+    const double amplitude, const double frequency, const double time,
+    const size_t l_max, const bool convert_to_goldberg = true) noexcept {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  // create the vector of collocation points that we want to interpolate to
+
+  tnsr::I<DataVector, 3> collocation_points{number_of_angular_points};
+  const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
+      Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
+  for (const auto& collocation_point : collocation) {
+    get<0>(collocation_points)[collocation_point.offset] =
+        extraction_radius * (1.0 + amplitude * sin(frequency * time)) *
+        sin(collocation_point.theta) * cos(collocation_point.phi);
+    get<1>(collocation_points)[collocation_point.offset] =
+        extraction_radius * (1.0 + amplitude * sin(frequency * time)) *
+        sin(collocation_point.theta) * sin(collocation_point.phi);
+    get<2>(collocation_points)[collocation_point.offset] =
+        extraction_radius * (1.0 + amplitude * sin(frequency * time)) *
+        cos(collocation_point.theta);
+  }
+
+  const auto kerr_schild_variables = solution.variables(
+      collocation_points, 0.0, gr::Solutions::KerrSchild::tags<DataVector>{});
+
+  const Scalar<DataVector>& lapse =
+      get<gr::Tags::Lapse<DataVector>>(kerr_schild_variables);
+  const Scalar<DataVector>& dt_lapse =
+      get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(kerr_schild_variables);
+  const auto& d_lapse = get<gr::Solutions::KerrSchild::DerivLapse<DataVector>>(
+      kerr_schild_variables);
+
+  const auto& shift = get<gr::Tags::Shift<3, ::Frame::Inertial, DataVector>>(
+      kerr_schild_variables);
+  const auto& dt_shift =
+      get<::Tags::dt<gr::Tags::Shift<3, ::Frame::Inertial, DataVector>>>(
+          kerr_schild_variables);
+  const auto& d_shift = get<gr::Solutions::KerrSchild::DerivShift<DataVector>>(
+      kerr_schild_variables);
+
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<3, ::Frame::Inertial, DataVector>>(
+          kerr_schild_variables);
+  const auto& dt_spatial_metric = get<
+      ::Tags::dt<gr::Tags::SpatialMetric<3, ::Frame::Inertial, DataVector>>>(
+      kerr_schild_variables);
+  const auto& d_spatial_metric =
+      get<gr::Solutions::KerrSchild::DerivSpatialMetric<DataVector>>(
+          kerr_schild_variables);
+
+  Scalar<DataVector> dr_lapse{number_of_angular_points};
+  get(dr_lapse) = (get<0>(collocation_points) * get<0>(d_lapse) +
+                   get<1>(collocation_points) * get<1>(d_lapse) +
+                   get<2>(collocation_points) * get<2>(d_lapse)) /
+                  extraction_radius;
+  tnsr::I<DataVector, 3> dr_shift{number_of_angular_points};
+  for (size_t i = 0; i < 3; ++i) {
+    dr_shift.get(i) = (get<0>(collocation_points) * d_shift.get(0, i) +
+                       get<1>(collocation_points) * d_shift.get(1, i) +
+                       get<2>(collocation_points) * d_shift.get(2, i)) /
+                      extraction_radius;
+  }
+  tnsr::ii<DataVector, 3> dr_spatial_metric{number_of_angular_points};
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j) {
+      dr_spatial_metric.get(i, j) =
+          (get<0>(collocation_points) * d_spatial_metric.get(0, i, j) +
+           get<1>(collocation_points) * d_spatial_metric.get(1, i, j) +
+           get<2>(collocation_points) * d_spatial_metric.get(2, i, j)) /
+          extraction_radius;
+    }
+  }
+
+  if (convert_to_goldberg) {
+    *lapse_coefficients =
+        TestHelpers::tensor_to_goldberg_coefficients(lapse, l_max);
+    *dt_lapse_coefficients =
+        TestHelpers::tensor_to_goldberg_coefficients(dt_lapse, l_max);
+    *dr_lapse_coefficients =
+        TestHelpers::tensor_to_goldberg_coefficients(dr_lapse, l_max);
+
+    *shift_coefficients =
+        TestHelpers::tensor_to_goldberg_coefficients(shift, l_max);
+    *dt_shift_coefficients =
+        TestHelpers::tensor_to_goldberg_coefficients(dt_shift, l_max);
+    *dr_shift_coefficients =
+        TestHelpers::tensor_to_goldberg_coefficients(dr_shift, l_max);
+
+    *spatial_metric_coefficients =
+        TestHelpers::tensor_to_goldberg_coefficients(spatial_metric, l_max);
+    *dt_spatial_metric_coefficients =
+        TestHelpers::tensor_to_goldberg_coefficients(dt_spatial_metric, l_max);
+    *dr_spatial_metric_coefficients =
+        TestHelpers::tensor_to_goldberg_coefficients(dr_spatial_metric, l_max);
+  } else {
+    *lapse_coefficients =
+        TestHelpers::tensor_to_libsharp_coefficients(lapse, l_max);
+    *dt_lapse_coefficients =
+        TestHelpers::tensor_to_libsharp_coefficients(dt_lapse, l_max);
+    *dr_lapse_coefficients =
+        TestHelpers::tensor_to_libsharp_coefficients(dr_lapse, l_max);
+
+    *shift_coefficients =
+        TestHelpers::tensor_to_libsharp_coefficients(shift, l_max);
+    *dt_shift_coefficients =
+        TestHelpers::tensor_to_libsharp_coefficients(dt_shift, l_max);
+    *dr_shift_coefficients =
+        TestHelpers::tensor_to_libsharp_coefficients(dr_shift, l_max);
+
+    *spatial_metric_coefficients =
+        TestHelpers::tensor_to_libsharp_coefficients(spatial_metric, l_max);
+    *dt_spatial_metric_coefficients =
+        TestHelpers::tensor_to_libsharp_coefficients(dt_spatial_metric, l_max);
+    *dr_spatial_metric_coefficients =
+        TestHelpers::tensor_to_libsharp_coefficients(dr_spatial_metric, l_max);
+  }
+}
+
+template <typename AnalyticSolution>
+class DummyBufferUpdater : public WorldtubeBufferUpdater {
+ public:
+  DummyBufferUpdater(DataVector time_buffer, const AnalyticSolution& solution,
+                     const double extraction_radius,
+                     const double coordinate_amplitude,
+                     const double coordinate_frequency,
+                     const size_t l_max) noexcept
+      : time_buffer_{std::move(time_buffer)},
+        solution_{solution},
+        extraction_radius_{extraction_radius},
+        coordinate_amplitude_{coordinate_amplitude},
+        coordinate_frequency_{coordinate_frequency},
+        l_max_{l_max} {}
+
+  WRAPPED_PUPable_decl_template(              // NOLINT
+      DummyBufferUpdater<AnalyticSolution>);  // NOLINT
+
+  explicit DummyBufferUpdater(CkMigrateMessage* /*unused*/) noexcept
+      : extraction_radius_{1.0},
+        coordinate_amplitude_{0.0},
+        coordinate_frequency_{0.0},
+        l_max_{0} {}
+
+  double update_buffers_for_time(
+      const gsl::not_null<Variables<detail::cce_input_tags>*> buffers,
+      const gsl::not_null<size_t*> time_span_start,
+      const gsl::not_null<size_t*> time_span_end, const double time,
+      const size_t interpolator_length, const size_t buffer_depth) const
+      noexcept override {
+    if (*time_span_end > interpolator_length and
+        time_buffer_[*time_span_end - interpolator_length + 1] > time) {
+      // the next time an update will be required
+      return time_buffer_[*time_span_end - interpolator_length + 1];
+    }
+    // find the time spans that are needed
+    auto new_span_pair = detail::create_span_for_time_value(
+        time, buffer_depth, interpolator_length, 0, time_buffer_.size(),
+        time_buffer_);
+    *time_span_start = new_span_pair.first;
+    *time_span_end = new_span_pair.second;
+
+    const size_t goldberg_size = square(l_max_ + 1);
+    tnsr::ii<ComplexModalVector, 3> spatial_metric_coefficients{goldberg_size};
+    tnsr::ii<ComplexModalVector, 3> dt_spatial_metric_coefficients{
+        goldberg_size};
+    tnsr::ii<ComplexModalVector, 3> dr_spatial_metric_coefficients{
+        goldberg_size};
+    tnsr::I<ComplexModalVector, 3> shift_coefficients{goldberg_size};
+    tnsr::I<ComplexModalVector, 3> dt_shift_coefficients{goldberg_size};
+    tnsr::I<ComplexModalVector, 3> dr_shift_coefficients{goldberg_size};
+    Scalar<ComplexModalVector> lapse_coefficients{goldberg_size};
+    Scalar<ComplexModalVector> dt_lapse_coefficients{goldberg_size};
+    Scalar<ComplexModalVector> dr_lapse_coefficients{goldberg_size};
+    for (size_t time_index = 0; time_index < *time_span_end - *time_span_start;
+         ++time_index) {
+      create_fake_time_varying_modal_data(
+          make_not_null(&spatial_metric_coefficients),
+          make_not_null(&dt_spatial_metric_coefficients),
+          make_not_null(&dr_spatial_metric_coefficients),
+          make_not_null(&shift_coefficients),
+          make_not_null(&dt_shift_coefficients),
+          make_not_null(&dr_shift_coefficients),
+          make_not_null(&lapse_coefficients),
+          make_not_null(&dt_lapse_coefficients),
+          make_not_null(&dr_lapse_coefficients), solution_, extraction_radius_,
+          coordinate_amplitude_, coordinate_frequency_,
+          time_buffer_[time_index + *time_span_start], l_max_);
+
+      update_tensor_buffer_with_tensor_at_time_index(
+          make_not_null(&get<Tags::detail::SpatialMetric>(*buffers)),
+          spatial_metric_coefficients, time_index,
+          *time_span_end - *time_span_start);
+      update_tensor_buffer_with_tensor_at_time_index(
+          make_not_null(
+              &get<Tags::detail::Dr<Tags::detail::SpatialMetric>>(*buffers)),
+          dr_spatial_metric_coefficients, time_index,
+          *time_span_end - *time_span_start);
+      update_tensor_buffer_with_tensor_at_time_index(
+          make_not_null(
+              &get<::Tags::dt<Tags::detail::SpatialMetric>>(*buffers)),
+          dt_spatial_metric_coefficients, time_index,
+          *time_span_end - *time_span_start);
+
+      update_tensor_buffer_with_tensor_at_time_index(
+          make_not_null(&get<Tags::detail::Shift>(*buffers)),
+          shift_coefficients, time_index, *time_span_end - *time_span_start);
+      update_tensor_buffer_with_tensor_at_time_index(
+          make_not_null(&get<Tags::detail::Dr<Tags::detail::Shift>>(*buffers)),
+          dr_shift_coefficients, time_index, *time_span_end - *time_span_start);
+      update_tensor_buffer_with_tensor_at_time_index(
+          make_not_null(&get<::Tags::dt<Tags::detail::Shift>>(*buffers)),
+          dt_shift_coefficients, time_index, *time_span_end - *time_span_start);
+
+      update_tensor_buffer_with_tensor_at_time_index(
+          make_not_null(&get<Tags::detail::Lapse>(*buffers)),
+          lapse_coefficients, time_index, *time_span_end - *time_span_start);
+      update_tensor_buffer_with_tensor_at_time_index(
+          make_not_null(&get<Tags::detail::Dr<Tags::detail::Lapse>>(*buffers)),
+          dr_lapse_coefficients, time_index, *time_span_end - *time_span_start);
+      update_tensor_buffer_with_tensor_at_time_index(
+          make_not_null(&get<::Tags::dt<Tags::detail::Lapse>>(*buffers)),
+          dt_lapse_coefficients, time_index, *time_span_end - *time_span_start);
+    }
+    return time_buffer_[*time_span_end - interpolator_length + 1];
+  }
+
+  std::unique_ptr<WorldtubeBufferUpdater> get_clone() const noexcept override {
+    return std::make_unique<DummyBufferUpdater>(*this);
+  }
+
+  bool time_is_outside_range(const double time) const noexcept override {
+    return time < time_buffer_[0] or
+           time > time_buffer_[time_buffer_.size() - 1];
+  }
+
+  size_t get_l_max() const noexcept override { return l_max_; }
+
+  double get_extraction_radius() const noexcept override {
+    return extraction_radius_;
+  }
+
+  DataVector& get_time_buffer() noexcept override { return time_buffer_; }
+
+ private:
+  template <typename... Structure>
+  void update_tensor_buffer_with_tensor_at_time_index(
+      const gsl::not_null<Tensor<ComplexModalVector, Structure...>*>
+          tensor_buffer,
+      const Tensor<ComplexModalVector, Structure...>& tensor_at_time,
+      const size_t time_index, const size_t time_span_extent) const noexcept {
+    for (size_t i = 0; i < tensor_at_time.size(); ++i) {
+      for (size_t k = 0; k < tensor_at_time[i].size(); ++k) {
+        (*tensor_buffer)[i][time_index + k * time_span_extent] =
+            tensor_at_time[i][k];
+      }
+    }
+  }
+
+  DataVector time_buffer_;
+  AnalyticSolution solution_;
+  double extraction_radius_;
+  double coordinate_amplitude_;
+  double coordinate_frequency_;
+  size_t l_max_;
+};
+
+template <>
+PUP::able::PUP_ID
+    Cce::DummyBufferUpdater<gr::Solutions::KerrSchild>::my_PUP_ID = 0;
+
+template <typename Generator>
+void test_spec_worldtube_buffer_updater(
+    const gsl::not_null<Generator*> gen) noexcept {
+  UniformCustomDistribution<double> value_dist{0.1, 0.5};
+  // first prepare the input for the modal version
+  const double mass = value_dist(*gen);
+  const std::array<double, 3> spin{
+      {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
+  const std::array<double, 3> center{
+      {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
+  gr::Solutions::KerrSchild solution{mass, spin, center};
+
+  const double extraction_radius = 100;
+
+  // acceptable parameters for the fake sinusoid variation in the input
+  // parameters
+  const double frequency = 0.1 * value_dist(*gen);
+  const double amplitude = 0.1 * value_dist(*gen);
+  const double target_time = 50 * value_dist(*gen);
+
+  const size_t buffer_size = 8;
+  const size_t interpolator_length = 3;
+  const size_t l_max = 8;
+
+  Variables<detail::cce_input_tags> coefficients_buffers_from_file{
+      (buffer_size + 2 * interpolator_length) * square(l_max + 1)};
+  Variables<detail::cce_input_tags> expected_coefficients_buffers{
+      (buffer_size + 2 * interpolator_length) * square(l_max + 1)};
+  size_t goldberg_size = square(l_max + 1);
+  tnsr::ii<ComplexModalVector, 3> spatial_metric_coefficients{goldberg_size};
+  tnsr::ii<ComplexModalVector, 3> dt_spatial_metric_coefficients{goldberg_size};
+  tnsr::ii<ComplexModalVector, 3> dr_spatial_metric_coefficients{goldberg_size};
+  tnsr::I<ComplexModalVector, 3> shift_coefficients{goldberg_size};
+  tnsr::I<ComplexModalVector, 3> dt_shift_coefficients{goldberg_size};
+  tnsr::I<ComplexModalVector, 3> dr_shift_coefficients{goldberg_size};
+  Scalar<ComplexModalVector> lapse_coefficients{goldberg_size};
+  Scalar<ComplexModalVector> dt_lapse_coefficients{goldberg_size};
+  Scalar<ComplexModalVector> dr_lapse_coefficients{goldberg_size};
+
+  // write times to file for several steps before and after the target time
+  const std::string filename = "test_CceR0100.h5";
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+  // scoped to close the file
+  {
+    TestHelpers::WorldtubeModeRecorder recorder{filename, l_max};
+    for (size_t t = 0; t < 30; ++t) {
+      const double time = 0.1 * t + target_time - 1.5;
+      create_fake_time_varying_modal_data(
+          make_not_null(&spatial_metric_coefficients),
+          make_not_null(&dt_spatial_metric_coefficients),
+          make_not_null(&dr_spatial_metric_coefficients),
+          make_not_null(&shift_coefficients),
+          make_not_null(&dt_shift_coefficients),
+          make_not_null(&dr_shift_coefficients),
+          make_not_null(&lapse_coefficients),
+          make_not_null(&dt_lapse_coefficients),
+          make_not_null(&dr_lapse_coefficients), solution, extraction_radius,
+          amplitude, frequency, time, l_max);
+      for (size_t i = 0; i < 3; ++i) {
+        for (size_t j = i; j < 3; ++j) {
+          recorder.append_worldtube_mode_data(
+              detail::dataset_name_for_component("/g", i, j), time,
+              spatial_metric_coefficients.get(i, j), l_max);
+          recorder.append_worldtube_mode_data(
+              detail::dataset_name_for_component("/Drg", i, j), time,
+              dr_spatial_metric_coefficients.get(i, j), l_max);
+          recorder.append_worldtube_mode_data(
+              detail::dataset_name_for_component("/Dtg", i, j), time,
+              dt_spatial_metric_coefficients.get(i, j), l_max);
+        }
+        recorder.append_worldtube_mode_data(
+            detail::dataset_name_for_component("/Shift", i), time,
+            shift_coefficients.get(i), l_max);
+        recorder.append_worldtube_mode_data(
+            detail::dataset_name_for_component("/DrShift", i), time,
+            dr_shift_coefficients.get(i), l_max);
+        recorder.append_worldtube_mode_data(
+            detail::dataset_name_for_component("/DtShift", i), time,
+            dt_shift_coefficients.get(i), l_max);
+      }
+      recorder.append_worldtube_mode_data(
+          detail::dataset_name_for_component("/Lapse"), time,
+          get(lapse_coefficients), l_max);
+      recorder.append_worldtube_mode_data(
+          detail::dataset_name_for_component("/DrLapse"), time,
+          get(dr_lapse_coefficients), l_max);
+      recorder.append_worldtube_mode_data(
+          detail::dataset_name_for_component("/DtLapse"), time,
+          get(dt_lapse_coefficients), l_max);
+    }
+  }
+  // request an appropriate buffer
+  SpecWorldtubeH5BufferUpdater buffer_updater{filename};
+  size_t time_span_start = 0;
+  size_t time_span_end = 0;
+  buffer_updater.update_buffers_for_time(
+      make_not_null(&coefficients_buffers_from_file),
+      make_not_null(&time_span_start), make_not_null(&time_span_end),
+      target_time, interpolator_length, buffer_size);
+
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+  time_span_start = 0;
+  time_span_end = 0;
+  const auto& time_buffer = buffer_updater.get_time_buffer();
+  for (size_t i = 0; i < time_buffer.size(); ++i) {
+    CHECK(time_buffer[i] == approx(target_time - 1.5 + 0.1 * i));
+  }
+
+  const DummyBufferUpdater<gr::Solutions::KerrSchild> dummy_buffer_updater{
+      time_buffer, solution, extraction_radius, amplitude, frequency, l_max};
+  dummy_buffer_updater.update_buffers_for_time(
+      make_not_null(&expected_coefficients_buffers),
+      make_not_null(&time_span_start), make_not_null(&time_span_end),
+      target_time, interpolator_length, buffer_size);
+  // check that the data in the buffer matches the expected analytic data.
+  tmpl::for_each<detail::cce_input_tags>([
+    &expected_coefficients_buffers, &coefficients_buffers_from_file
+  ](auto tag_v) noexcept {
+    using tag = typename decltype(tag_v)::type;
+    INFO(tag::name());
+    const auto& test_lhs = get<tag>(expected_coefficients_buffers);
+    const auto& test_rhs = get<tag>(coefficients_buffers_from_file);
+    CHECK_ITERABLE_APPROX(test_lhs, test_rhs);
+  });
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.ReadBoundaryDataH5",
+                  "[Unit][Evolution]") {
+  MAKE_GENERATOR(gen);
+  test_spec_worldtube_buffer_updater(make_not_null(&gen));
+}
+}  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/WriteToWorldtubeH5.hpp
+++ b/tests/Unit/Evolution/Systems/Cce/WriteToWorldtubeH5.hpp
@@ -1,0 +1,64 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/ComplexModalVector.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+
+namespace Cce {
+namespace TestHelpers {
+
+// records worldtube data in the SpEC h5 style.
+struct WorldtubeModeRecorder {
+ public:
+  WorldtubeModeRecorder(const std::string& filename,
+                        const size_t l_max) noexcept
+      : output_file_{filename} {
+    file_legend_.emplace_back("time");
+    for (int l = 0; l <= static_cast<int>(l_max); ++l) {
+      for (int m = -l; m <= l; ++m) {
+        file_legend_.push_back("Real Y_" + std::to_string(l) + "," +
+                               std::to_string(m));
+        file_legend_.push_back("Imag Y_" + std::to_string(l) + "," +
+                               std::to_string(m));
+      }
+    }
+  }
+
+  // append to `dataset_path` the vector created by `time` followed by the
+  // `modes` rearranged to be compatible with SpEC h5 format.
+  void append_worldtube_mode_data(const std::string& dataset_path,
+                                  const double time,
+                                  const ComplexModalVector& modes,
+                                  const size_t l_max) noexcept {
+    auto& output_mode_dataset =
+        output_file_.try_insert<h5::Dat>(dataset_path, file_legend_, 0);
+    const size_t output_size = square(l_max + 1);
+    std::vector<double> data_to_write(2 * output_size + 1);
+    data_to_write[0] = time;
+    for (int l = 0; l <= static_cast<int>(l_max); ++l) {
+      for (int m = -l; m <= l; ++m) {
+        data_to_write[2 * Spectral::Swsh::goldberg_mode_index(
+                              l_max, static_cast<size_t>(l), -m) +
+                      1] =
+            real(modes[Spectral::Swsh::goldberg_mode_index(
+                l_max, static_cast<size_t>(l), m)]);
+        data_to_write[2 * Spectral::Swsh::goldberg_mode_index(
+                              l_max, static_cast<size_t>(l), -m) +
+                      2] =
+            imag(modes[Spectral::Swsh::goldberg_mode_index(
+                l_max, static_cast<size_t>(l), m)]);
+      }
+    }
+    output_mode_dataset.append(data_to_write);
+    output_file_.close_current_object();
+  }
+
+ private:
+  h5::H5File<h5::AccessType::ReadWrite> output_file_;
+  std::vector<std::string> file_legend_;
+};
+}  // namespace TestHelpers
+}  // namespace Cce

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIBRARY_SOURCES
   Test_ObserveTimeSeriesOnSurface.cpp
   Test_ParallelInterpolator.cpp
   Test_RegularGridInterpolant.cpp
+  Test_SpanInterpolators.cpp
   )
 
 add_test_library(

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_SpanInterpolators.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_SpanInterpolators.cpp
@@ -1,0 +1,192 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/CubicSpanInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/LinearSpanInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/SpanInterpolator.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace intrp {
+
+template <typename Generator>
+void test_linear_interpolator(const gsl::not_null<Generator*> gen) noexcept {
+  UniformCustomDistribution<double> value_dist{0.1, 1.0};
+  // cannot be const due to participation in the `span`
+  auto linear_interpolator_values = make_with_random_values<DataVector>(
+      gen, value_dist, static_cast<size_t>(2));
+  auto linear_interpolator_complex_values =
+      make_with_random_values<ComplexDataVector>(gen, value_dist,
+                                                 static_cast<size_t>(2));
+  const DataVector linear_interpolator_points = {{0.0, 1.0}};
+  const double target_point = value_dist(*gen);
+  const LinearSpanInterpolator test_linear_interpolator{};
+  const double real_linear_interpolation = test_linear_interpolator.interpolate(
+      gsl::span<const double>{linear_interpolator_points.data(),
+                              linear_interpolator_points.size()},
+      gsl::span<const double>{linear_interpolator_values.data(),
+                              linear_interpolator_values.size()},
+      target_point);
+  CHECK(real_linear_interpolation ==
+        approx(target_point * linear_interpolator_values[1] +
+               (1.0 - target_point) * linear_interpolator_values[0]));
+  const std::complex<double> complex_linear_interpolation =
+      test_linear_interpolator.interpolate(
+          gsl::span<const double>{linear_interpolator_points.data(),
+                                  linear_interpolator_points.size()},
+          gsl::span<const std::complex<double>>{
+              linear_interpolator_complex_values.data(),
+              linear_interpolator_complex_values.size()},
+          target_point);
+  CHECK_COMPLEX_APPROX(
+      complex_linear_interpolation,
+      target_point * linear_interpolator_complex_values[1] +
+          (1.0 - target_point) * linear_interpolator_complex_values[0]);
+}
+
+template <typename VectorType, typename InterpolatorType, typename Generator>
+void test_interpolator_approximate_fidelity(
+    const gsl::not_null<Generator*> gen, const InterpolatorType& interpolator,
+    Approx interpolator_approx) noexcept {
+  UniformCustomDistribution<double> value_dist{0.1, 1.0};
+  DataVector interpolator_points{
+      2 * interpolator.required_number_of_points_before_and_after()};
+  VectorType interpolator_values{
+      2 * interpolator.required_number_of_points_before_and_after()};
+  const double frequency = value_dist(*gen);
+  const typename VectorType::value_type amplitude = value_dist(*gen);
+  // only sample a small span to give the low-order interpolators an easier time
+  for (size_t i = 0; i < interpolator_points.size(); ++i) {
+    interpolator_points[i] = 0.01 * i / interpolator_points.size();
+    interpolator_values[i] =
+        amplitude * cos(frequency * interpolator_points[i]);
+  }
+  const double target_time = value_dist(*gen) / 100.0;
+  const auto interpolator_result = interpolator.interpolate(
+      gsl::span<const double>{interpolator_points.data(),
+                              interpolator_points.size()},
+      gsl::span<const typename VectorType::value_type>{
+          interpolator_values.data(), interpolator_points.size()},
+      target_time);
+
+  CHECK_COMPLEX_CUSTOM_APPROX(interpolator_result,
+                              amplitude * cos(frequency * target_time),
+                              interpolator_approx);
+}
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolation.SpanInterpolators",
+                  "[Unit][NumericalAlgorithms]") {
+  MAKE_GENERATOR(gen);
+  test_linear_interpolator(make_not_null(&gen));
+
+  {
+    // Linear interpolator will not get terribly close, but that's okay.
+    Approx interpolator_approx = Approx::custom().epsilon(1.0e-2).scale(1.0);
+
+    INFO("testing LinearSpanInterpolator")
+    test_interpolator_approximate_fidelity<DataVector>(
+        make_not_null(&gen), LinearSpanInterpolator{}, interpolator_approx);
+    test_interpolator_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen), LinearSpanInterpolator{}, interpolator_approx);
+
+    // verify the the construction from options is successful
+    const auto option_created_linear_interpolator =
+        TestHelpers::test_factory_creation<intrp::SpanInterpolator>(
+            "LinearSpanInterpolator");
+    test_interpolator_approximate_fidelity<DataVector>(
+        make_not_null(&gen), *option_created_linear_interpolator,
+        interpolator_approx);
+    test_interpolator_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen), *option_created_linear_interpolator,
+        interpolator_approx);
+
+    // verify that the interpolator can be serialized and deserialized
+    test_interpolator_approximate_fidelity<DataVector>(
+        make_not_null(&gen),
+        serialize_and_deserialize(LinearSpanInterpolator{}),
+        interpolator_approx);
+    test_interpolator_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen),
+        serialize_and_deserialize(LinearSpanInterpolator{}),
+        interpolator_approx);
+  }
+
+  {
+    Approx interpolator_approx =
+        Approx::custom()
+            .epsilon(std::numeric_limits<double>::epsilon() * 1.0e8)
+            .scale(1.0);
+
+    INFO("testing CubicSpanInterpolator")
+    test_interpolator_approximate_fidelity<DataVector>(
+        make_not_null(&gen), CubicSpanInterpolator{}, interpolator_approx);
+    test_interpolator_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen), CubicSpanInterpolator{}, interpolator_approx);
+
+    // verify the the construction from options is successful
+    const auto option_created_cubic_interpolator =
+        TestHelpers::test_factory_creation<intrp::SpanInterpolator>(
+            "CubicSpanInterpolator");
+    test_interpolator_approximate_fidelity<DataVector>(
+        make_not_null(&gen), *option_created_cubic_interpolator,
+        interpolator_approx);
+    test_interpolator_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen), *option_created_cubic_interpolator,
+        interpolator_approx);
+
+    // verify that the interpolator can be serialized and deserialized
+    test_interpolator_approximate_fidelity<DataVector>(
+        make_not_null(&gen), serialize_and_deserialize(CubicSpanInterpolator{}),
+        interpolator_approx);
+    test_interpolator_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen), serialize_and_deserialize(CubicSpanInterpolator{}),
+        interpolator_approx);
+  }
+
+  {
+    Approx interpolator_approx =
+        Approx::custom()
+            .epsilon(std::numeric_limits<double>::epsilon() * 1.0e5)
+            .scale(1.0);
+
+    INFO("testing BarycentricRationalSpanInterpolator")
+    test_interpolator_approximate_fidelity<DataVector>(
+        make_not_null(&gen), BarycentricRationalSpanInterpolator{5u, 6u},
+        interpolator_approx);
+    test_interpolator_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen), BarycentricRationalSpanInterpolator{5u, 6u},
+        interpolator_approx);
+
+    // verify the the construction from options is successful
+    const auto option_created_barycentric_interpolator =
+        TestHelpers::test_factory_creation<intrp::SpanInterpolator>(
+            "BarycentricRationalSpanInterpolator:\n"
+            "  MinOrder: 5\n"
+            "  MaxOrder: 6");
+    test_interpolator_approximate_fidelity<DataVector>(
+        make_not_null(&gen), *option_created_barycentric_interpolator,
+        interpolator_approx);
+    test_interpolator_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen), *option_created_barycentric_interpolator,
+        interpolator_approx);
+
+    // verify that the interpolator can be serialized and deserialized
+    test_interpolator_approximate_fidelity<DataVector>(
+        make_not_null(&gen),
+        serialize_and_deserialize(BarycentricRationalSpanInterpolator{5u, 6u}),
+        interpolator_approx);
+    test_interpolator_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen),
+        serialize_and_deserialize(BarycentricRationalSpanInterpolator{5u, 6u}),
+        interpolator_approx);
+  }
+}
+}  // namespace intrp


### PR DESCRIPTION
## Proposed changes

Adds in the utilities for reading a SpEC-created boundary data h5 file, interpolating, and dispatching to the gauge transformations in the other PRs.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).