### PR TITLE
Constraint-preserving BCs for CurvedScalarWave

### DIFF
--- a/src/Evolution/ComputeTags.hpp
+++ b/src/Evolution/ComputeTags.hpp
@@ -40,5 +40,29 @@ struct AnalyticCompute
             inertial_coords, time, AnalyticFieldsTagList{})));
   }
 };
+
+/*!
+ * \brief Use the `AnalyticDataTag` to compute the analytic data for the
+ * tags in `AnalyticFieldsTagList`.
+ */
+template <size_t Dim, typename AnalyticDataTag, typename AnalyticFieldsTagList>
+struct AnalyticDataCompute
+    : db::add_tag_prefix<::Tags::Analytic,
+                         ::Tags::Variables<AnalyticFieldsTagList>>,
+      db::ComputeTag {
+  using base = db::add_tag_prefix<::Tags::Analytic,
+                                  ::Tags::Variables<AnalyticFieldsTagList>>;
+  using argument_tags =
+      tmpl::list<AnalyticDataTag,
+                 domain::Tags::Coordinates<Dim, Frame::Inertial>>;
+  static db::const_item_type<base> function(
+      const db::const_item_type<AnalyticDataTag>& analytic_data_computer,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>&
+          inertial_coords) noexcept {
+    return db::const_item_type<base>(
+        variables_from_tagged_tuple(analytic_data_computer.variables(
+            inertial_coords, AnalyticFieldsTagList{})));
+  }
+};
 }  // namespace Tags
 }  // namespace evolution

--- a/src/Evolution/Executables/CMakeLists.txt
+++ b/src/Evolution/Executables/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_subdirectory(Burgers)
 add_subdirectory(Cce)
+add_subdirectory(CurvedScalarWave)
 add_subdirectory(GeneralizedHarmonic)
 add_subdirectory(GrMhd)
 add_subdirectory(NewtonianEuler)

--- a/src/Evolution/Executables/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/CurvedScalarWave/CMakeLists.txt
@@ -1,0 +1,51 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBS_TO_LINK
+    CoordinateMaps
+    CurvedScalarWave
+    CurvedWaveEquationAnalyticData
+    DiscontinuousGalerkin
+    Domain
+    DomainCreators
+    Evolution
+    GeneralRelativity
+    GeneralRelativitySolutions
+    GeneralizedHarmonic
+    GeneralizedHarmonicGaugeSourceFunctions
+    IO
+    Informer
+    LinearOperators
+    MathFunctions
+    Options
+    ScalarWave
+    Time
+    Utilities
+    WaveEquation
+  )
+
+function(add_scalar_wave_executable EXECUTABLE_NAME DIM INITIAL_DATA)
+  add_spectre_parallel_executable(
+    "Evolve${EXECUTABLE_NAME}${DIM}D"
+    EvolveCurvedScalarWave
+    Evolution/Executables/CurvedScalarWave
+    "EvolutionMetavars<${DIM},${INITIAL_DATA}>"
+    "${LIBS_TO_LINK}"
+    )
+endfunction(add_scalar_wave_executable)
+
+function(add_plane_wave_executable DIM)
+  add_scalar_wave_executable(
+    CurvedPlaneWave
+    ${DIM}
+    CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<ScalarWave::Solutions::PlaneWave<${DIM}>>
+    )
+endfunction(add_plane_wave_executable)
+
+add_plane_wave_executable(3)
+
+add_scalar_wave_executable(
+  CurvedRegularSphericalWave
+  3
+  CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<ScalarWave::Solutions::RegularSphericalWave>
+  )

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -1,0 +1,377 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsCharacteresticSpeeds.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "Evolution/Actions/ComputeTimeDerivative.hpp"
+#include "Evolution/ComputeTags.hpp"
+#include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
+#include "Evolution/Initialization/DgDomain.hpp"
+#include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Initialization/GrTagsForHydro.hpp"
+#include "Evolution/Initialization/NonconservativeSystem.hpp"
+#include "Evolution/Initialization/SetVariables.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Constraints.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Equations.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Initialize.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "IO/Observer/Actions.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/RegisterObservers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderSchemeLts.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/ExponentialFilter.hpp"
+#include "NumericalAlgorithms/LinearOperators/FilterAction.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Actions/MutateApply.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/CollectDataForFluxes.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/FluxCommunication.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp"
+#include "ParallelAlgorithms/Events/ObserveErrorNorms.hpp"
+#include "ParallelAlgorithms/Events/ObserveFields.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveKerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Time/Actions/AdvanceTime.hpp"                // IWYU pragma: keep
+#include "Time/Actions/ChangeSlabSize.hpp"             // IWYU pragma: keep
+#include "Time/Actions/ChangeStepSize.hpp"             // IWYU pragma: keep
+#include "Time/Actions/RecordTimeStepperData.hpp"      // IWYU pragma: keep
+#include "Time/Actions/SelfStartActions.hpp"           // IWYU pragma: keep
+#include "Time/Actions/UpdateU.hpp"                    // IWYU pragma: keep
+#include "Time/StepChoosers/ByBlock.hpp"               // IWYU pragma: keep
+#include "Time/StepChoosers/Cfl.hpp"                   // IWYU pragma: keep
+#include "Time/StepChoosers/Constant.hpp"              // IWYU pragma: keep
+#include "Time/StepChoosers/Increase.hpp"              // IWYU pragma: keep
+#include "Time/StepChoosers/PreventRapidIncrease.hpp"  // IWYU pragma: keep
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/StepChoosers/StepToTimes.hpp"
+#include "Time/StepControllers/StepController.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Time/Triggers/TimeTriggers.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Frame {
+// IWYU pragma: no_forward_declare MathFunction
+struct Inertial;
+}  // namespace Frame
+namespace Parallel {
+template <typename Metavariables>
+class CProxy_ConstGlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+template <size_t Dim, typename InitialData>
+struct EvolutionMetavars {
+  static constexpr size_t volume_dim = Dim;
+  // Customization/"input options" to simulation
+  using initial_data = InitialData;
+  using initial_data_tag =
+      tmpl::conditional_t<evolution::is_analytic_solution_v<initial_data>,
+                          Tags::AnalyticSolution<initial_data>,
+                          Tags::AnalyticData<initial_data>>;
+
+  using system = CurvedScalarWave::System<Dim>;
+  using temporal_id = Tags::TimeStepId;
+  static constexpr bool local_time_stepping = true;
+  static constexpr bool bjorhus_external_boundary = false;
+  static constexpr bool moving_mesh = true;
+  using boundary_condition_tag = initial_data_tag;
+  using normal_dot_numerical_flux =
+      Tags::NumericalFlux<CurvedScalarWave::UpwindFlux<Dim>>;
+
+  using step_choosers_common =
+      tmpl::list<StepChoosers::Registrars::ByBlock<volume_dim>,
+                 //  StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial>,
+                 StepChoosers::Registrars::Constant,
+                 StepChoosers::Registrars::Increase>;
+  using step_choosers_for_step_only =
+      tmpl::list<StepChoosers::Registrars::PreventRapidIncrease>;
+  using step_choosers_for_slab_only =
+      tmpl::list<StepChoosers::Registrars::StepToTimes>;
+  using step_choosers = tmpl::conditional_t<
+      local_time_stepping,
+      tmpl::append<step_choosers_common, step_choosers_for_step_only>,
+      tmpl::list<>>;
+  using slab_choosers = tmpl::conditional_t<
+      local_time_stepping,
+      tmpl::append<step_choosers_common, step_choosers_for_slab_only>,
+      tmpl::append<step_choosers_common, step_choosers_for_step_only,
+                   step_choosers_for_slab_only>>;
+
+  using time_stepper_tag = Tags::TimeStepper<
+      tmpl::conditional_t<local_time_stepping, LtsTimeStepper, TimeStepper>>;
+  using boundary_scheme = tmpl::conditional_t<
+      local_time_stepping,
+      dg::FirstOrderScheme::FirstOrderSchemeLts<
+          Dim, typename system::variables_tag, normal_dot_numerical_flux,
+          Tags::TimeStepId, time_stepper_tag>,
+      dg::FirstOrderScheme::FirstOrderScheme<
+          Dim, typename system::variables_tag, normal_dot_numerical_flux,
+          Tags::TimeStepId>>;
+
+  // public for use by the Charm++ registration code
+  using observe_fields = tmpl::append<
+      db::get_variables_tags_list<typename system::variables_tag>,
+      db::wrap_tags_in<
+          temporal_id::template step_prefix,
+          db::get_variables_tags_list<typename system::variables_tag>>,
+      tmpl::list<::Tags::PointwiseL2Norm<
+                     CurvedScalarWave::Tags::OneIndexConstraint<volume_dim>>,
+                 ::Tags::PointwiseL2Norm<
+                     CurvedScalarWave::Tags::TwoIndexConstraint<volume_dim>>>>;
+  using analytic_solution_fields =
+      db::get_variables_tags_list<typename system::variables_tag>;
+
+  using events = tmpl::list<dg::Events::Registrars::ObserveFields<
+                                Dim, Tags::Time, observe_fields, tmpl::list<>>,
+                            Events::Registrars::ChangeSlabSize<slab_choosers>>;
+  using triggers = Triggers::time_triggers;
+
+  // A tmpl::list of tags to be added to the ConstGlobalCache by the
+  // metavariables
+  using const_global_cache_tags =
+      tmpl::list<initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,
+                 Tags::EventsAndTriggers<events, triggers>>;
+
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      typename Event<events>::creatable_classes>;
+
+  // The scalar wave system generally does not require filtering, except
+  // possibly on certain deformed domains.  Here a filter is added in 3D for
+  // testing purposes.  When performing numerical experiments with the scalar
+  // wave system, the user should determine whether this filter can be removed.
+  static constexpr bool use_filtering = (3 == volume_dim);
+
+  enum class Phase {
+    Initialization,
+    RegisterWithObserver,
+    InitializeTimeStepperHistory,
+    Evolve,
+    Exit
+  };
+
+  using initialization_actions = tmpl::list<
+      Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
+      //   dg::Actions::InitializeDomain<volume_dim>,
+      evolution::dg::Initialization::Domain<volume_dim>,
+      Initialization::Actions::NonconservativeSystem,
+      evolution::Initialization::Actions::SetVariables<
+          domain::Tags::Coordinates<Dim, Frame::Logical>>,
+      Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
+      CurvedScalarWave::Actions::InitializeGrVars<volume_dim>,
+      tmpl::conditional_t<
+          bjorhus_external_boundary,
+          tmpl::list<dg::Actions::InitializeInterfaces<
+              system,
+              dg::Initialization::slice_tags_to_face<
+                  domain::Tags::MeshVelocity<volume_dim>,
+                  typename system::variables_tag,
+                  CurvedScalarWave::Tags::ConstraintGamma1,
+                  CurvedScalarWave::Tags::ConstraintGamma2,
+                  gr::Tags::Lapse<DataVector>,
+                  gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>,
+                  gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial,
+                                                 DataVector>>,
+              dg::Initialization::slice_tags_to_exterior<
+                  domain::Tags::MeshVelocity<volume_dim>,
+                  typename system::variables_tag,
+                  CurvedScalarWave::Tags::ConstraintGamma1,
+                  CurvedScalarWave::Tags::ConstraintGamma2,
+                  gr::Tags::Lapse<DataVector>,
+                  gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>,
+                  gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial,
+                                                 DataVector>>,
+              dg::Initialization::face_compute_tags<
+                  domain::Tags::BoundaryCoordinates<volume_dim, moving_mesh>,
+                  CurvedScalarWave::CharacteristicFieldsCompute<volume_dim>,
+                  domain::Tags::CharSpeedCompute<
+                      CurvedScalarWave::CharacteristicSpeedsCompute<volume_dim>,
+                      volume_dim>>,
+              dg::Initialization::exterior_compute_tags<
+                  CurvedScalarWave::CharacteristicFieldsCompute<volume_dim>,
+                  domain::Tags::CharSpeedCompute<
+                      CurvedScalarWave::CharacteristicSpeedsCompute<volume_dim>,
+                      volume_dim>>,
+              !bjorhus_external_boundary, moving_mesh>>,
+          tmpl::list<dg::Actions::InitializeInterfaces<
+              system,
+              dg::Initialization::slice_tags_to_face<
+                  domain::Tags::MeshVelocity<volume_dim>,
+                  typename system::variables_tag,
+                  CurvedScalarWave::Tags::ConstraintGamma1,
+                  CurvedScalarWave::Tags::ConstraintGamma2,
+                  gr::Tags::Lapse<DataVector>,
+                  gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>,
+                  gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial,
+                                                 DataVector>>,
+              dg::Initialization::slice_tags_to_exterior<
+                  domain::Tags::MeshVelocity<volume_dim>,
+                  CurvedScalarWave::Tags::ConstraintGamma1,
+                  CurvedScalarWave::Tags::ConstraintGamma2,
+                  gr::Tags::Lapse<DataVector>,
+                  gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>,
+                  gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial,
+                                                 DataVector>>,
+              dg::Initialization::face_compute_tags<>,
+              dg::Initialization::exterior_compute_tags<>, true, moving_mesh>>>,
+      tmpl::conditional_t<
+          evolution::is_analytic_solution_v<initial_data>,
+          Initialization::Actions::AddComputeTags<
+              tmpl::list<evolution::Tags::AnalyticCompute<
+                  Dim, initial_data_tag, analytic_solution_fields>>>,
+          Initialization::Actions::AddComputeTags<
+              tmpl::list<evolution::Tags::AnalyticDataCompute<
+                  Dim, initial_data_tag, analytic_solution_fields>>>>,
+      CurvedScalarWave::Actions::InitializeConstraints<volume_dim>,
+      dg::Actions::InitializeMortars<boundary_scheme,
+                                     !bjorhus_external_boundary>,
+      Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
+      Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+
+  using step_actions = tmpl::flatten<tmpl::list<
+      dg::Actions::ComputeNonconservativeBoundaryFluxes<
+          domain::Tags::InternalDirections<Dim>>,
+      dg::Actions::CollectDataForFluxes<
+          boundary_scheme, domain::Tags::InternalDirections<volume_dim>>,
+      dg::Actions::SendDataForFluxes<boundary_scheme>,
+      Actions::ComputeTimeDerivative<CurvedScalarWave::ComputeDuDt<volume_dim>>,
+      dg::Actions::ComputeNonconservativeBoundaryFluxes<
+          domain::Tags::BoundaryDirectionsInterior<Dim>>,
+      // Dirichlet boundary conditions can only be applied if there
+      // is an analytic soln available
+      tmpl::conditional_t<
+          evolution::is_analytic_solution_v<initial_data> and
+              !bjorhus_external_boundary,
+          tmpl::list<
+              dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
+              dg::Actions::CollectDataForFluxes<
+                  boundary_scheme,
+                  domain::Tags::BoundaryDirectionsInterior<volume_dim>>>,
+          tmpl::list<>>,
+      dg::Actions::ReceiveDataForFluxes<boundary_scheme>,
+      tmpl::conditional_t<local_time_stepping,
+                          tmpl::list<Actions::RecordTimeStepperData<>,
+                                     Actions::MutateApply<boundary_scheme>>,
+                          tmpl::list<Actions::MutateApply<boundary_scheme>,
+                                     Actions::RecordTimeStepperData<>>>,
+      Actions::UpdateU<>,
+      tmpl::conditional_t<
+          use_filtering,
+          dg::Actions::Filter<
+              Filters::Exponential<0>,
+              tmpl::list<CurvedScalarWave::Pi, CurvedScalarWave::Psi,
+                         CurvedScalarWave::Phi<Dim>>>,
+          tmpl::list<>>>>;
+
+  using component_list = tmpl::list<
+      observers::Observer<EvolutionMetavars>,
+      observers::ObserverWriter<EvolutionMetavars>,
+      DgElementArray<
+          EvolutionMetavars,
+          tmpl::list<
+              Parallel::PhaseActions<Phase, Phase::Initialization,
+                                     initialization_actions>,
+
+              Parallel::PhaseActions<
+                  Phase, Phase::InitializeTimeStepperHistory,
+                  SelfStart::self_start_procedure<step_actions>>,
+
+              Parallel::PhaseActions<
+                  Phase, Phase::RegisterWithObserver,
+                  tmpl::list<observers::Actions::RegisterWithObservers<
+                                 observers::RegisterObservers<
+                                     Tags::Time, element_observation_type>>,
+                             Parallel::Actions::TerminatePhase>>,
+
+              Parallel::PhaseActions<
+                  Phase, Phase::Evolve,
+                  tmpl::flatten<tmpl::list<
+                      Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                      tmpl::conditional_t<
+                          local_time_stepping,
+                          Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
+                      step_actions, Actions::AdvanceTime>>>>>>;
+
+  static constexpr OptionString help{
+      "Evolve a Curved Scalar Wave in Dim spatial dimension.\n\n"
+      "The numerical flux is:    UpwindFlux\n"};
+
+  static Phase determine_next_phase(
+      const Phase& current_phase,
+      const Parallel::CProxy_ConstGlobalCache<
+          EvolutionMetavars>& /*cache_proxy*/) noexcept {
+    switch (current_phase) {
+      case Phase::Initialization:
+        return Phase::InitializeTimeStepperHistory;
+      case Phase::InitializeTimeStepperHistory:
+        return Phase::RegisterWithObserver;
+      case Phase::RegisterWithObserver:
+        return Phase::Evolve;
+      case Phase::Evolve:
+        return Phase::Exit;
+      case Phase::Exit:
+        ERROR(
+            "Should never call determine_next_phase with the current phase "
+            "being 'Exit'");
+      default:
+        ERROR(
+            "Unknown type of phase. Did you static_cast<Phase> an integral "
+            "value?");
+    }
+  }
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling,
+    &domain::creators::register_derived_with_charm,
+    &Parallel::register_derived_classes_with_charm<
+        Event<metavariables::events>>,
+    &Parallel::register_derived_classes_with_charm<MathFunction<1>>,
+    &Parallel::register_derived_classes_with_charm<
+        StepChooser<metavariables::slab_choosers>>,
+    &Parallel::register_derived_classes_with_charm<
+        StepChooser<metavariables::step_choosers>>,
+    &Parallel::register_derived_classes_with_charm<StepController>,
+    &Parallel::register_derived_classes_with_charm<TimeStepper>,
+    &Parallel::register_derived_classes_with_charm<
+        Trigger<metavariables::triggers>>};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWaveFwd.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWaveFwd.hpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+namespace CurvedScalarWave {
+namespace AnalyticData {
+template <typename ScalarFieldSolution>
+class ScalarWaveKerrSchild;
+}  // namespace AnalyticData
+}  // namespace CurvedScalarWave
+
+namespace ScalarWave {
+namespace Solutions {
+template <size_t Dim>
+class PlaneWave;
+
+class RegularSphericalWave;
+}  // namespace Solutions
+}  // namespace ScalarWave
+
+template <size_t Dim, typename InitialData>
+struct EvolutionMetavars;

--- a/src/Evolution/Initialization/DgDomain.cpp
+++ b/src/Evolution/Initialization/DgDomain.cpp
@@ -13,16 +13,17 @@
 #include "Utilities/GenerateInstantiations.hpp"
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define SFRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE(r, data)                                              \
-  template std::unique_ptr<                                               \
-      domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, DIM(data)>> \
-      domain::make_coordinate_map_base<                                   \
-          Frame::Grid, Frame::Inertial,                                   \
-          domain::CoordinateMaps::Identity<DIM(data)>>(                   \
+#define INSTANTIATE(r, data)                                               \
+  template std::unique_ptr<                                                \
+      domain::CoordinateMapBase<SFRAME(data), Frame::Inertial, DIM(data)>> \
+      domain::make_coordinate_map_base<                                    \
+          SFRAME(data), Frame::Inertial,                                   \
+          domain::CoordinateMaps::Identity<DIM(data)>>(                    \
           domain::CoordinateMaps::Identity<DIM(data)> &&) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Logical))
 
 #undef INSTANTIATE
 #undef DIM

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions.hpp
@@ -1,0 +1,329 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/DataOnSlice.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/IndexToSliceAt.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditionsImpl.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Parallel/Abort.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Printf.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+namespace Tags {
+template <typename Tag>
+struct Magnitude;
+}  // namespace Tags
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace CurvedScalarWave {
+namespace Actions {
+
+namespace BoundaryConditions_detail {}  // namespace BoundaryConditions_detail
+
+/// \ingroup ActionsGroup
+/// \brief Computes contributions on the interior side from the volume, and
+/// imposes constraint preserving boundary conditions on the exterior side.
+///
+/// With:
+/// - Boundary<Tag> =
+///   Tags::Interface<Tags::BoundaryDirections<volume_dim>, Tag>
+/// - External<Tag> =
+///   Tags::Interface<Tags::ExternalBoundaryDirections<volume_dim>, Tag>
+///
+/// Uses:
+/// - ConstGlobalCache:
+///   - Metavariables::normal_dot_numerical_flux
+///   - Metavariables::boundary_condition
+/// - DataBox:
+///   - Tags::Element<volume_dim>
+///   - Boundary<Tags listed in
+///               Metavariables::normal_dot_numerical_flux::type::argument_tags>
+///   - External<Tags listed in
+///               Metavariables::normal_dot_numerical_flux::type::argument_tags>
+///   - Boundary<Tags::Mesh<volume_dim - 1>>
+///   - External<Tags::Mesh<volume_dim - 1>>
+///   - Boundary<Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>,
+///   - External<Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>,
+///   - Boundary<Tags::BoundaryCoordinates<volume_dim>>,
+///   - Metavariables::temporal_id
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///      - External<Tags::dt<typename system::variables_tag>>
+///
+template <typename Metavariables>
+struct ImposeBjorhusBoundaryConditions {
+ private:
+  // {VPsi,VZero,VPlus,VMinus}BcMethod are used to select exactly
+  // how to apply the requested boundary condition based on user input. A
+  // specialized `apply_impl` struct is used that implements the boundary
+  // condition calculation for the different types.
+  using VPsiBcMethod = BoundaryConditions_detail::VPsiBcMethod;
+  using VZeroBcMethod = BoundaryConditions_detail::VZeroBcMethod;
+  using VPlusBcMethod = BoundaryConditions_detail::VPlusBcMethod;
+  using VMinusBcMethod = BoundaryConditions_detail::VMinusBcMethod;
+
+ public:
+  using const_global_cache_tags =
+      tmpl::list<typename Metavariables::normal_dot_numerical_flux,
+                 typename Metavariables::boundary_condition_tag>;
+
+ private:
+  /* ------------------------------------------------------------------------
+   * ------------------------------------------------------------------------
+   * ---------------- APPLY BJORHUS BOUNDARY CONDITIONS  --------------------
+   * ------------------------------------------------------------------------
+   * ------------------------------------------------------------------------
+   */
+  template <size_t VolumeDim, VPsiBcMethod VPsiMethod,
+            VZeroBcMethod VZeroMethod, VPlusBcMethod VPlusMethod,
+            VMinusBcMethod VMinusMethod, typename DbTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent,
+            typename... InboxTags>
+  struct apply_impl {
+    static std::tuple<db::DataBox<DbTags>&&> function_impl(
+        db::DataBox<DbTags>& box,
+        tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+        Parallel::ConstGlobalCache<Metavariables>& cache,
+        const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+        const ParallelComponent* const /*meta*/) noexcept {
+      // ------------------------------- (1)
+      // Get information about system:
+      // tags for evolved variables and their time derivatives
+      using system = typename Metavariables::system;
+      using variables_tag = typename system::variables_tag;
+      using dt_variables_tag =
+          db::add_tag_prefix<Metavariables::temporal_id::template step_prefix,
+                             variables_tag>;
+      constexpr const size_t number_of_independent_components =
+          dt_variables_tag::type::number_of_independent_components;
+
+      const db::item_type<domain::Tags::Mesh<VolumeDim>>& mesh =
+          db::get<domain::Tags::Mesh<VolumeDim>>(box);
+      const size_t volume_grid_points = mesh.extents().product();
+      const auto& unit_normal_one_forms = db::get<domain::Tags::Interface<
+          domain::Tags::BoundaryDirectionsInterior<VolumeDim>,
+          ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<
+              VolumeDim, Frame::Inertial>>>>(box);
+      const auto& volume_all_vars = db::get<variables_tag>(box);
+      const auto& volume_all_dt_vars = db::get<dt_variables_tag>(box);
+      const auto& external_bdry_char_speeds = db::get<domain::Tags::Interface<
+          domain::Tags::BoundaryDirectionsInterior<VolumeDim>,
+          Tags::CharacteristicSpeeds<VolumeDim>>>(box);
+
+      // ------------------------------- (2)
+      // Apply the boundary condition
+      // Loop over external boundaries and set dt_volume_vars on them
+      for (auto& external_direction_and_normals : unit_normal_one_forms) {
+        const auto& direction = external_direction_and_normals.first;
+        const size_t dimension = direction.dimension();
+        const auto& unit_normal_one_form =
+            external_direction_and_normals.second;
+        const size_t slice_grid_points =
+            mesh.extents().slice_away(dimension).product();
+        // Get U on this slice
+        const auto vars =
+            data_on_slice(volume_all_vars, mesh.extents(), dimension,
+                          index_to_slice_at(mesh.extents(), direction));
+        ASSERT(vars.number_of_grid_points() == slice_grid_points,
+               "vars_on_slice has wrong number of grid points.  "
+               "Expected "
+                   << slice_grid_points << ", got "
+                   << vars.number_of_grid_points());
+        // Get dt<U> on this slice
+        const auto dt_vars =
+            data_on_slice(volume_all_dt_vars, mesh.extents(), dimension,
+                          index_to_slice_at(mesh.extents(), direction));
+        // Get characteristic speeds
+        const auto& char_speeds = external_bdry_char_speeds.at(direction);
+        // Get constraint damping parameter: gamma2
+        const auto& constraint_gamma2 =
+            (db::get<domain::Tags::Interface<
+                 domain::Tags::BoundaryDirectionsInterior<VolumeDim>,
+                 Tags::ConstraintGamma2>>(box))
+                .at(direction);
+        // For external boundaries that are within a horizon,
+        // all characteristic fields are outgoing (toward the singularity)
+        if (BoundaryConditions_detail::min_characteristic_speed<VolumeDim>(
+                char_speeds) >= 0.) {
+          continue;
+        }
+
+        // ------------------------------- (2)
+        // Create a TempTensor that stores all temporaries computed
+        // here and elsewhere
+        TempBuffer<BoundaryConditions_detail::all_local_vars<VolumeDim>> buffer(
+            slice_grid_points);
+        // ------------------------------- (2.2)
+        // Compute local variables
+        BoundaryConditions_detail::local_variables(
+            make_not_null(&buffer), box, direction, dimension, mesh, vars,
+            dt_vars, unit_normal_one_form, char_speeds, constraint_gamma2);
+
+        db::mutate<dt_variables_tag>(
+            make_not_null(&box),
+            // Function that applies bdry conditions to dt<variables>
+            [
+              &volume_grid_points, &slice_grid_points, &mesh, &dimension,
+              &direction, &buffer, &vars, &dt_vars, &unit_normal_one_form,
+              &char_speeds, &constraint_gamma2
+            ](const gsl::not_null<db::item_type<dt_variables_tag>*>
+                  volume_dt_vars,
+              const double /* time */, const auto& /* boundary_condition */
+              ) noexcept {
+              // Preliminaries
+              ASSERT(
+                  volume_dt_vars->number_of_grid_points() == volume_grid_points,
+                  "volume_dt_vars has wrong number of grid points.  Expected "
+                      << volume_grid_points << ", got "
+                      << volume_dt_vars->number_of_grid_points());
+
+              // Get desired values of CharProjection<dt<U>>
+              //
+              // At all points on the interface where the char speed of any
+              // (given) characteristic field is +ve, we "do nothing", and
+              // when its -ve, we apply Bjorhus BCs. This is achieved through
+              // `set_bc_when_char_speed_is_negative`.
+              const auto bc_dt_u_psi =
+                  BoundaryConditions_detail::set_bc_when_char_speed_is_negative(
+                      get<::Tags::TempScalar<6, DataVector>>(buffer),
+                      BoundaryConditions_detail::set_dt_u_psi<VolumeDim>::apply(
+                          VPsiMethod, buffer, vars, dt_vars,
+                          unit_normal_one_form),
+                      char_speeds.at(0));
+              // copy over the value of bc_dt_u_psi finally set, accounting for
+              // the char speeds of VPsi. This is then used to set Dt<VMinus>
+              get(get<::Tags::TempScalar<6, DataVector>>(buffer)) =
+                  get(bc_dt_u_psi);
+
+              const auto bc_dt_u_zero =
+                  BoundaryConditions_detail::set_bc_when_char_speed_is_negative(
+                      get<::Tags::Tempi<7, VolumeDim, Frame::Inertial,
+                                        DataVector>>(buffer),
+                      BoundaryConditions_detail::set_dt_u_zero<
+                          VolumeDim>::apply(VZeroMethod, buffer, vars, dt_vars,
+                                            unit_normal_one_form),
+                      char_speeds.at(1));
+
+              const auto bc_dt_u_plus =
+                  BoundaryConditions_detail::set_bc_when_char_speed_is_negative(
+                      get<::Tags::TempScalar<8, DataVector>>(buffer),
+                      BoundaryConditions_detail::set_dt_u_plus<
+                          VolumeDim>::apply(VPlusMethod, buffer, vars, dt_vars,
+                                            unit_normal_one_form),
+                      char_speeds.at(2));
+
+              const auto bc_dt_u_minus =
+                  BoundaryConditions_detail::set_bc_when_char_speed_is_negative(
+                      get<::Tags::TempScalar<9, DataVector>>(buffer),
+                      BoundaryConditions_detail::set_dt_u_minus<
+                          VolumeDim>::apply(VMinusMethod, buffer, vars, dt_vars,
+                                            unit_normal_one_form),
+                      char_speeds.at(3));
+              // Convert them to desired values on dt<U>
+              const auto bc_dt_all_u =
+                  evolved_fields_from_characteristic_fields(
+                      constraint_gamma2, bc_dt_u_psi, bc_dt_u_zero,
+                      bc_dt_u_plus, bc_dt_u_minus, unit_normal_one_form);
+
+              // Now store final values of dt<U> in a suitable data structure
+              const tuples::TaggedTuple<
+                  db::add_tag_prefix<
+                      Metavariables::temporal_id::template step_prefix, Pi>,
+                  db::add_tag_prefix<
+                      Metavariables::temporal_id::template step_prefix,
+                      Phi<VolumeDim>>,
+                  db::add_tag_prefix<
+                      Metavariables::temporal_id::template step_prefix, Psi>>
+                  bc_dt_tuple(std::move(get<Pi>(bc_dt_all_u)),
+                              std::move(get<Phi<VolumeDim>>(bc_dt_all_u)),
+                              std::move(get<Psi>(bc_dt_all_u)));
+              const auto slice_data_ = variables_from_tagged_tuple(bc_dt_tuple);
+              const auto* slice_data = slice_data_.data();
+
+              // Assign BC values of dt_volume_vars on external boundary
+              // slices of volume variables
+              auto* const volume_dt_data = volume_dt_vars->data();
+              for (SliceIterator si(
+                       mesh.extents(), dimension,
+                       index_to_slice_at(mesh.extents(), direction));
+                   si; ++si) {
+                for (size_t i = 0; i < number_of_independent_components; ++i) {
+                  // clang-tidy: do not use pointer arithmetic
+                  volume_dt_data[si.volume_offset() +       // NOLINT
+                                 i * volume_grid_points] =  // NOLINT
+                      slice_data[si.slice_offset() +        // NOLINT
+                                 i * slice_grid_points];    // NOLINT
+                }
+              }
+            },
+            db::get<::Tags::Time>(box),
+            get<typename Metavariables::boundary_condition_tag>(cache));
+      }
+
+      return std::forward_as_tuple(std::move(box));
+    }
+  };
+
+ public:
+  template <typename DbTags, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTags>&&> apply(
+      db::DataBox<DbTags>& box, tuples::TaggedTuple<InboxTags...>& inboxes,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ActionList action_list,
+      const ParallelComponent* const parallel_component) noexcept {
+    // Here be user logic that determines / selects from various options for
+    // setting BCs on individual characteristic variables
+    return apply_impl<Metavariables::system::volume_dim,
+                      // BC choice for U_\Psi
+                      VPsiBcMethod::Freezing,
+                      // BC choice for U_0
+                      VZeroBcMethod::Freezing,
+                      // BC choice for U_+
+                      VPlusBcMethod::Freezing,
+                      // BC choice for U_-
+                      VMinusBcMethod::Freezing, DbTags, ArrayIndex, ActionList,
+                      ParallelComponent,
+                      InboxTags...>::function_impl(box, inboxes, cache,
+                                                   array_index, action_list,
+                                                   parallel_component);
+  }
+};
+
+}  // namespace Actions
+}  // namespace CurvedScalarWave

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditionsImpl.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditionsImpl.hpp
@@ -1,0 +1,526 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/DataOnSlice.hpp"
+#include "DataStructures/LeviCivitaIterator.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/IndexToSliceAt.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Constraints.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+namespace Tags {
+template <typename Tag>
+struct Magnitude;
+}  // namespace Tags
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+// debugPK
+constexpr bool debugPK = false;
+
+namespace CurvedScalarWave {
+namespace Actions {
+
+namespace BoundaryConditions_detail {}  // namespace BoundaryConditions_detail
+
+namespace BoundaryConditions_detail {
+enum class VPsiBcMethod { Freezing, ConstraintPreservingBjorhus, Unknown };
+enum class VZeroBcMethod {
+  Freezing,
+  ConstraintPreservingBjorhus,
+  // The condition below is borrowed from SpEC, where it is used as the
+  // BC on VZero when "Constraint" is the requested BC type
+  ConstraintPreservingPenalty,
+  Unknown
+};
+enum class VPlusBcMethod { Freezing, Unknown };
+enum class VMinusBcMethod { Freezing, ConstraintPreservingBjorhus, Unknown };
+
+// Function to compute the smallest positive (or largest negative)
+// characteristic speed
+template <size_t VolumeDim>
+double min_characteristic_speed(
+    const typename CurvedScalarWave::Tags::CharacteristicSpeeds<
+        VolumeDim>::type& char_speeds) noexcept {
+  std::array<double, 4> min_speeds{
+      {min(char_speeds.at(0)), min(char_speeds.at(1)), min(char_speeds.at(2)),
+       min(char_speeds.at(3))}};
+  return *std::min_element(min_speeds.begin(), min_speeds.end());
+}
+
+// Function to apply the newly computed value for evolution RHS
+// wherever the particular characteristic field is incoming, and leaving
+// the RHS unchanged when the same is NOT incoming (including for char speed 0).
+template <typename T, typename DataType>
+T set_bc_when_char_speed_is_negative(const T& rhs_char_dt_u,
+                                     const T& desired_bc_dt_u,
+                                     const DataType& char_speed_u) noexcept {
+  // debugPK
+  bool char_speed_always_positive = true;
+  auto bc_dt_u = rhs_char_dt_u;
+  auto it1 = bc_dt_u.begin();
+  auto it2 = desired_bc_dt_u.begin();
+  for (; it2 != desired_bc_dt_u.end(); ++it1, ++it2) {
+    for (size_t i = 0; i < it1->size(); ++i) {
+      if (char_speed_u[i] < 0.) {
+        (*it1)[i] = (*it2)[i];
+        char_speed_always_positive = false;  // debugPK
+      }
+    }
+  }
+  // debugPK
+  if (char_speed_always_positive and debugPK) {
+    Parallel::printf("Char speeds NEVER NEGATIVE..!\n");
+  }
+  return bc_dt_u;
+}
+
+template <size_t VolumeDim>
+using all_local_vars = tmpl::list<
+    // lapse, shift, and derivatives of lapse, shift
+    gr::Tags::Lapse<DataVector>,
+    gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<VolumeDim>,
+                  Frame::Inertial>,
+    ::Tags::deriv<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>,
+                  tmpl::size_t<VolumeDim>, Frame::Inertial>,
+    // Interface normal vector
+    ::Tags::TempI<0, VolumeDim, Frame::Inertial, DataVector>,
+    // Char speeds
+    ::Tags::TempScalar<1, DataVector>, ::Tags::TempScalar<2, DataVector>,
+    ::Tags::TempScalar<3, DataVector>, ::Tags::TempScalar<4, DataVector>,
+    // C_{jk}
+    Tags::TwoIndexConstraint<VolumeDim>,
+    // Characteristic projected time derivatives of evolved
+    // fields
+    ::Tags::TempScalar<6, DataVector>,
+    ::Tags::Tempi<7, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::TempScalar<8, DataVector>, ::Tags::TempScalar<9, DataVector>,
+    // Constraint damping parameter gamma2
+    Tags::ConstraintGamma2,
+    // derivatives of pi, phi
+    ::Tags::deriv<Pi, tmpl::size_t<VolumeDim>, Frame::Inertial>,
+    ::Tags::deriv<Phi<VolumeDim>, tmpl::size_t<VolumeDim>, Frame::Inertial>,
+    // Preallocated memory to store boundary conditions
+    ::Tags::TempScalar<12, DataVector>,
+    ::Tags::Tempi<13, VolumeDim, Frame::Inertial, DataVector>,
+    ::Tags::TempScalar<14, DataVector>, ::Tags::TempScalar<15, DataVector>>;
+
+// \brief This function computes intermediate variables needed for
+// Bjorhus-type constraint preserving boundary conditions for the
+// CurvedScalarWave system
+template <size_t VolumeDim, typename TagsList, typename DbTags,
+          typename VarsTagsList, typename DtVarsTagsList>
+void local_variables(
+    gsl::not_null<TempBuffer<TagsList>*> buffer, const db::DataBox<DbTags>& box,
+    const Direction<VolumeDim>& direction, const size_t& dimension,
+    const typename domain::Tags::Mesh<VolumeDim>::type& mesh,
+    const Variables<VarsTagsList>& /* vars */,
+    const Variables<DtVarsTagsList>& dt_vars,
+    const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_one_form,
+    const typename Tags::CharacteristicSpeeds<VolumeDim>::type& char_speeds,
+    const Scalar<DataVector>& constraint_gamma2) noexcept {
+  // Extract quantities from databox that are needed to compute
+  // intermediate variables
+  using tags_needed_on_slice = tmpl::list<
+      // lapse, shift, and inverse_spatial_metric
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<VolumeDim, Frame::Inertial, DataVector>,
+      // derivatives of lapse, shift
+      ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<VolumeDim>,
+                    Frame::Inertial>,
+      ::Tags::deriv<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>,
+                    tmpl::size_t<VolumeDim>, Frame::Inertial>,
+      // derivatives of pi and phi
+      ::Tags::deriv<Pi, tmpl::size_t<VolumeDim>, Frame::Inertial>,
+      ::Tags::deriv<Phi<VolumeDim>, tmpl::size_t<VolumeDim>, Frame::Inertial>,
+      Tags::TwoIndexConstraint<VolumeDim>>;
+  const auto vars_on_this_slice = db::data_on_slice(
+      box, mesh.extents(), dimension,
+      index_to_slice_at(mesh.extents(), direction), tags_needed_on_slice{});
+  // -1. spacetime quantities
+  get<gr::Tags::Lapse<DataVector>>(*buffer) =
+      get<gr::Tags::Lapse<DataVector>>(vars_on_this_slice);
+  get<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>>(
+          vars_on_this_slice);
+  get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<VolumeDim>,
+                    Frame::Inertial>>(*buffer) =
+      get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<VolumeDim>,
+                        Frame::Inertial>>(vars_on_this_slice);
+  get<::Tags::deriv<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>,
+                    tmpl::size_t<VolumeDim>, Frame::Inertial>>(*buffer) =
+      get<::Tags::deriv<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>,
+                        tmpl::size_t<VolumeDim>, Frame::Inertial>>(
+          vars_on_this_slice);
+
+  // 0. interface normal vector
+  const auto& inverse_spatial_metric = get<
+      gr::Tags::InverseSpatialMetric<VolumeDim, Frame::Inertial, DataVector>>(
+      vars_on_this_slice);
+  get<::Tags::TempI<0, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      raise_or_lower_index(unit_interface_normal_one_form,
+                           inverse_spatial_metric);
+
+  // 1-4. Characteristic speeds
+  get(get<::Tags::TempScalar<1, DataVector>>(*buffer)) = char_speeds.at(0);
+  get(get<::Tags::TempScalar<2, DataVector>>(*buffer)) = char_speeds.at(1);
+  get(get<::Tags::TempScalar<3, DataVector>>(*buffer)) = char_speeds.at(2);
+  get(get<::Tags::TempScalar<4, DataVector>>(*buffer)) = char_speeds.at(3);
+
+  // 5. C_{ij}
+  get<Tags::TwoIndexConstraint<VolumeDim>>(*buffer) =
+      get<Tags::TwoIndexConstraint<VolumeDim>>(vars_on_this_slice);
+
+  // 6-9. Characteristic projected time derivatives of evolved fields
+  // storage for DT<UChar> = CharProjection(dt<U>)
+  const auto& rhs_dt_psi = get<::Tags::dt<Psi>>(dt_vars);
+  const auto& rhs_dt_pi = get<::Tags::dt<Pi>>(dt_vars);
+  const auto& rhs_dt_phi = get<::Tags::dt<Phi<VolumeDim>>>(dt_vars);
+  const auto char_projected_dt_u = characteristic_fields(
+      constraint_gamma2, inverse_spatial_metric, rhs_dt_psi, rhs_dt_pi,
+      rhs_dt_phi, unit_interface_normal_one_form);
+  get<::Tags::TempScalar<6, DataVector>>(*buffer) =
+      get<Tags::VPsi>(char_projected_dt_u);
+  get<::Tags::Tempi<7, VolumeDim, Frame::Inertial, DataVector>>(*buffer) =
+      get<Tags::VZero<VolumeDim>>(char_projected_dt_u);
+  get<::Tags::TempScalar<8, DataVector>>(*buffer) =
+      get<Tags::VPlus>(char_projected_dt_u);
+  get<::Tags::TempScalar<9, DataVector>>(*buffer) =
+      get<Tags::VMinus>(char_projected_dt_u);
+
+  // 10. Constraint damping parameter
+  get<Tags::ConstraintGamma2>(*buffer) = constraint_gamma2;
+
+  // 11. Spatial derivatives of evolved variables: Pi
+  get<::Tags::deriv<Pi, tmpl::size_t<VolumeDim>, Frame::Inertial>>(*buffer) =
+      get<::Tags::deriv<Pi, tmpl::size_t<VolumeDim>, Frame::Inertial>>(
+          vars_on_this_slice);
+  get<::Tags::deriv<Phi<VolumeDim>, tmpl::size_t<VolumeDim>, Frame::Inertial>>(
+      *buffer) = get<::Tags::deriv<Phi<VolumeDim>, tmpl::size_t<VolumeDim>,
+                                   Frame::Inertial>>(vars_on_this_slice);
+}
+
+// \brief This struct sets boundary condition on dt<VPsi>
+template <size_t VolumeDim>
+struct set_dt_u_psi {
+ private:
+  using ReturnType = typename Tags::VPsi::type;
+
+ public:
+  template <typename TagsList, typename VarsTagsList, typename DtVarsTagsList>
+  static ReturnType apply(const VPsiBcMethod Method,
+                          TempBuffer<TagsList>& buffer,
+                          const Variables<VarsTagsList>& vars,
+                          const Variables<DtVarsTagsList>& /* dt_vars */,
+                          const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+                          /* unit_normal_one_form */) noexcept {
+    const auto& pi = get<Pi>(vars);
+    const auto& phi = get<Phi<VolumeDim>>(vars);
+    const auto& lapse = get<gr::Tags::Lapse<DataVector>>(buffer);
+    const auto& shift =
+        get<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>>(buffer);
+
+    // Memory allocated for return type
+    ReturnType& bc_dt_u_psi = get<::Tags::TempScalar<12, DataVector>>(buffer);
+
+    std::fill(bc_dt_u_psi.begin(), bc_dt_u_psi.end(), 0.);
+    // Switch on prescribed boundary condition method
+    switch (Method) {
+      case VPsiBcMethod::Freezing:
+        return bc_dt_u_psi;
+      case VPsiBcMethod::ConstraintPreservingBjorhus:
+        return apply_bjorhus_constraint_preserving(make_not_null(&bc_dt_u_psi),
+                                                   lapse, shift, phi, pi);
+      case VPsiBcMethod::Unknown:
+      default:
+        ASSERT(false, "Requested BC method for VPsi not implemented!");
+    }
+
+    // dummy return to suppress compiler warning
+    return ReturnType{};
+  }
+
+ private:
+  static ReturnType apply_bjorhus_constraint_preserving(
+      const gsl::not_null<ReturnType*> bc_dt_u_psi,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, VolumeDim, Frame::Inertial>& shift,
+      const tnsr::i<DataVector, VolumeDim, Frame::Inertial>& phi,
+      const Scalar<DataVector>& pi) noexcept {
+    ASSERT(get_size(get(*bc_dt_u_psi)) == get_size(get(pi)),
+           "Size of input variables and temporary memory do not match.");
+    const auto shift_dot_phi = dot_product(shift, phi);
+    get(*bc_dt_u_psi) = get(shift_dot_phi) - get(lapse) * get(pi);
+    return *bc_dt_u_psi;
+  }
+};
+
+// \brief This struct sets boundary condition on dt<VZero>
+template <size_t VolumeDim>
+struct set_dt_u_zero {
+ private:
+  using ReturnType = typename Tags::VZero<VolumeDim>::type;
+
+ public:
+  template <typename TagsList, typename VarsTagsList, typename DtVarsTagsList>
+  static ReturnType apply(const VZeroBcMethod Method,
+                          TempBuffer<TagsList>& buffer,
+                          const Variables<VarsTagsList>& vars,
+                          const Variables<DtVarsTagsList>& /* dt_vars */,
+                          const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+                              unit_normal_one_form) noexcept {
+    // Not using auto below to enforce a loose test on the quantity being
+    // fetched from the buffer
+    const auto& deriv_lapse =
+        get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<VolumeDim>,
+                          Frame::Inertial>>(buffer);
+    const auto& deriv_shift = get<
+        ::Tags::deriv<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>,
+                      tmpl::size_t<VolumeDim>, Frame::Inertial>>(buffer);
+    const auto& deriv_pi =
+        get<::Tags::deriv<Pi, tmpl::size_t<VolumeDim>, Frame::Inertial>>(
+            buffer);
+    const auto& deriv_phi =
+        get<::Tags::deriv<Phi<VolumeDim>, tmpl::size_t<VolumeDim>,
+                          Frame::Inertial>>(buffer);
+
+    const auto& pi = get<Pi>(vars);
+    const auto& phi = get<Phi<VolumeDim>>(vars);
+    const auto& lapse = get<gr::Tags::Lapse<DataVector>>(buffer);
+    const auto& shift =
+        get<gr::Tags::Shift<VolumeDim, Frame::Inertial, DataVector>>(buffer);
+
+    const auto& unit_interface_normal_vector =
+        get<::Tags::TempI<0, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const auto& two_index_constraint =
+        get<Tags::TwoIndexConstraint<VolumeDim>>(buffer);
+    const auto& char_projected_rhs_dt_u_zero =
+        get<::Tags::Tempi<7, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+    const typename Tags::CharacteristicSpeeds<VolumeDim>::type char_speeds{
+        {get(get<::Tags::TempScalar<1, DataVector>>(buffer)),
+         get(get<::Tags::TempScalar<2, DataVector>>(buffer)),
+         get(get<::Tags::TempScalar<3, DataVector>>(buffer)),
+         get(get<::Tags::TempScalar<4, DataVector>>(buffer))}};
+
+    // Memory allocated for return type
+    ReturnType& bc_dt_u_zero =
+        get<::Tags::Tempi<13, VolumeDim, Frame::Inertial, DataVector>>(buffer);
+
+    std::fill(bc_dt_u_zero.begin(), bc_dt_u_zero.end(), 0.);
+    // Switch on prescribed boundary condition method
+    switch (Method) {
+      case VZeroBcMethod::Freezing:
+        return bc_dt_u_zero;
+      case VZeroBcMethod::ConstraintPreservingPenalty:
+        return apply_penalty_constraint_preserving(
+            make_not_null(&bc_dt_u_zero), unit_interface_normal_vector,
+            two_index_constraint, char_projected_rhs_dt_u_zero, char_speeds);
+      case VZeroBcMethod::ConstraintPreservingBjorhus:
+        return apply_bjorhus_constraint_preserving(
+            make_not_null(&bc_dt_u_zero), deriv_lapse, deriv_shift, deriv_phi,
+            deriv_pi, lapse, shift, phi, pi, unit_interface_normal_vector,
+            unit_normal_one_form);
+      case VZeroBcMethod::Unknown:
+      default:
+        ASSERT(false, "Requested BC method fo VZero not implemented!");
+    }
+    // dummy return to suppress compiler warning
+    return ReturnType{};
+  }
+
+ private:
+  // The condition below is borrowed from SpEC, where it is used as the
+  // BC on VZero when "Constraint" is the requested BC type. It applies
+  // penalty-type correction to the RHS for dt<VZero>.
+  static ReturnType apply_penalty_constraint_preserving(
+      const gsl::not_null<ReturnType*> bc_dt_u_zero,
+      const tnsr::I<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_vector,
+      const tnsr::ij<DataVector, VolumeDim, Frame::Inertial>&
+          two_index_constraint,
+      const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+          char_projected_rhs_dt_u_zero,
+      const std::array<DataVector, 4>& char_speeds) noexcept {
+    ASSERT(get_size(get<0>(*bc_dt_u_zero)) ==
+               get_size(get<0>(unit_interface_normal_vector)),
+           "Size of input variables and temporary memory do not match.");
+
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      bc_dt_u_zero->get(i) = char_projected_rhs_dt_u_zero.get(i);
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        // Note: char_speed<VZero> should be identically 0!
+        bc_dt_u_zero->get(i) += char_speeds.at(1) *
+                                unit_interface_normal_vector.get(j) *
+                                two_index_constraint.get(j, i);
+      }
+    }
+    return *bc_dt_u_zero;
+  }
+
+  // According to Holst+ 2004, this condition for VZero also depends on
+  // whether VPsi is incoming or not. SpEC only uses the expression valid for
+  // the case when VPsi is incoming...!
+  static ReturnType apply_bjorhus_constraint_preserving(
+      const gsl::not_null<ReturnType*> bc_dt_u_zero,
+      const tnsr::i<DataVector, VolumeDim, Frame::Inertial>& deriv_lapse,
+      const tnsr::iJ<DataVector, VolumeDim, Frame::Inertial>& deriv_shift,
+      const tnsr::ij<DataVector, VolumeDim, Frame::Inertial>& deriv_phi,
+      const tnsr::i<DataVector, VolumeDim, Frame::Inertial>& deriv_pi,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, VolumeDim, Frame::Inertial>& shift,
+      const tnsr::i<DataVector, VolumeDim, Frame::Inertial>& phi,
+      const Scalar<DataVector>& pi,
+      const tnsr::I<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_vector,
+      const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+          unit_interface_normal_one_form) noexcept {
+    ASSERT(get_size(get<0>(*bc_dt_u_zero)) == get_size(get(pi)),
+           "Size of input variables and temporary memory do not match.");
+
+    auto tmp = make_with_value<tnsr::i<DataVector, VolumeDim, Frame::Inertial>>(
+        pi, 0.);
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      tmp.get(j) = -get(lapse) * deriv_pi.get(j) - get(pi) * deriv_lapse.get(j);
+      for (size_t k = 0; k < VolumeDim; ++k) {
+        tmp.get(j) += deriv_shift.get(j, k) * phi.get(k) +
+                      shift.get(k) * deriv_phi.get(j, k);
+      }
+    }
+
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      bc_dt_u_zero->get(i) = tmp.get(i);
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        bc_dt_u_zero->get(i) -= unit_interface_normal_one_form.get(i) *
+                                unit_interface_normal_vector.get(j) *
+                                tmp.get(j);
+      }
+    }
+
+    return *bc_dt_u_zero;
+  }
+};
+
+// \brief This struct sets boundary condition on dt<VMinus>
+//
+// \note Before calling this struct, one must store the final BC values for
+// dt<VPsi>, i.e. after accounting for whether VPsi is actually incoming or not,
+// in the buffer. This condition needs it.
+// This struct must therefore be applied *after* applying `set_dt_u_psi`.
+template <size_t VolumeDim>
+struct set_dt_u_minus {
+ private:
+  using ReturnType = typename Tags::VMinus::type;
+
+ public:
+  template <typename TagsList, typename VarsTagsList, typename DtVarsTagsList>
+  static ReturnType apply(const VMinusBcMethod Method,
+                          TempBuffer<TagsList>& buffer,
+                          const Variables<VarsTagsList>& /* vars */,
+                          const Variables<DtVarsTagsList>& /* dt_vars */,
+                          const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+                          /* unit_normal_one_form */) noexcept {
+    const auto& constraint_gamma2 = get<Tags::ConstraintGamma2>(buffer);
+    // Note that `bc_dt_u_psi` is the *final* value of dt<VPsi> that has been
+    // set after considering the sign of char speeds of the char field VPsi
+    const auto& bc_dt_u_psi = get<::Tags::TempScalar<6, DataVector>>(buffer);
+
+    // Memory allocated for return type
+    ReturnType& bc_dt_u_minus = get<::Tags::TempScalar<15, DataVector>>(buffer);
+    std::fill(bc_dt_u_minus.begin(), bc_dt_u_minus.end(), 0.);
+    // Switch on prescribed boundary condition method
+    switch (Method) {
+      case VMinusBcMethod::Freezing:
+        return bc_dt_u_minus;
+      case VMinusBcMethod::ConstraintPreservingBjorhus:
+        return apply_bjorhus_constraint_preserving(
+            make_not_null(&bc_dt_u_minus), constraint_gamma2, bc_dt_u_psi);
+      case VMinusBcMethod::Unknown:
+      default:
+        ASSERT(false, "Requested BC method for VMinus is not implemented!");
+    }
+    // dummy return to suppress compiler warning
+    return ReturnType{};
+  }
+
+ private:
+  static ReturnType apply_bjorhus_constraint_preserving(
+      const gsl::not_null<ReturnType*> bc_dt_u_minus,
+      const Scalar<DataVector>& constraint_gamma2,
+      const Scalar<DataVector>& bc_dt_u_psi) noexcept {
+    ASSERT(get_size(get(*bc_dt_u_minus)) == get_size(get(constraint_gamma2)),
+           "Size of input variables and temporary memory do not match.");
+    get(*bc_dt_u_minus) = -get(constraint_gamma2) * get(bc_dt_u_psi);
+    return *bc_dt_u_minus;
+  }
+};
+
+// \brief This struct sets boundary condition on dt<VPlus>
+template <size_t VolumeDim>
+struct set_dt_u_plus {
+ private:
+  using ReturnType = typename Tags::VPlus::type;
+
+ public:
+  template <typename TagsList, typename VarsTagsList, typename DtVarsTagsList>
+  static ReturnType apply(const VPlusBcMethod Method,
+                          TempBuffer<TagsList>& buffer,
+                          const Variables<VarsTagsList>& /* vars */,
+                          const Variables<DtVarsTagsList>& /* dt_vars */,
+                          const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+                          /* unit_normal_one_form */) noexcept {
+    // Memory allocated for return type
+    ReturnType& bc_dt_u_plus = get<::Tags::TempScalar<14, DataVector>>(buffer);
+    std::fill(bc_dt_u_plus.begin(), bc_dt_u_plus.end(), 0.);
+    // Switch on prescribed boundary condition method
+    switch (Method) {
+      case VPlusBcMethod::Freezing:
+        return bc_dt_u_plus;
+      case VPlusBcMethod::Unknown:
+      default:
+        ASSERT(false, "Requested BC method fo VPlus is not implemented!");
+    }
+    // dummy return to suppress compiler warning
+    return ReturnType{};
+  }
+
+ private:
+};
+
+}  // namespace BoundaryConditions_detail
+}  // namespace Actions
+}  // namespace CurvedScalarWave

--- a/src/Evolution/Systems/CurvedScalarWave/Initialize.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Initialize.hpp
@@ -1,0 +1,121 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <utility>  // IWYU pragma: keep
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Norms.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Constraints.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace CurvedScalarWave {
+namespace Actions {
+template <size_t Dim>
+struct InitializeGrVars {
+  using frame = Frame::Inertial;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using system = typename Metavariables::system;
+    static constexpr size_t dim = system::volume_dim;
+    using gr_tag = typename system::spacetime_variables_tag;
+    using simple_tags = db::AddSimpleTags<gr_tag>;
+
+    const double initial_time = db::get<Initialization::Tags::InitialTime>(box);
+    using GrVars = typename gr_tag::type;
+
+    const size_t num_grid_points =
+        db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points();
+    const auto inertial_coords =
+        db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box);
+    // Set initial data from analytic solution
+    GrVars gr_vars{num_grid_points};
+    gr_vars.assign_subset(evolution::initial_data(
+        Parallel::get<::Tags::AnalyticSolutionOrData>(cache), inertial_coords,
+        initial_time, typename GrVars::tags_list{}));
+
+    using compute_tags = db::AddComputeTags<
+        Tags::ConstraintGamma1Compute, Tags::ConstraintGamma2Compute,
+        gr::Tags::SpatialChristoffelFirstKindCompute<Dim, Frame::Inertial,
+                                                     DataVector>,
+        gr::Tags::SpatialChristoffelSecondKindCompute<Dim, Frame::Inertial,
+                                                      DataVector>,
+        gr::Tags::TraceSpatialChristoffelSecondKindCompute<Dim, Frame::Inertial,
+                                                           DataVector>,
+        GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
+            Dim, Frame::Inertial>>;
+
+    return std::make_tuple(
+        Initialization::merge_into_databox<InitializeGrVars, simple_tags,
+                                           compute_tags>(std::move(box),
+                                                         std::move(gr_vars)));
+  }
+};
+
+template <size_t Dim>
+struct InitializeConstraints {
+  using frame = Frame::Inertial;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using compute_tags = db::AddComputeTags<
+        Tags::OneIndexConstraintCompute<Dim>,
+        Tags::TwoIndexConstraintCompute<Dim>,
+        // following tags added to observe constraints
+        ::Tags::PointwiseL2NormCompute<Tags::OneIndexConstraint<Dim>>,
+        ::Tags::PointwiseL2NormCompute<Tags::TwoIndexConstraint<Dim>>>;
+
+    return std::make_tuple(
+        Initialization::merge_into_databox<InitializeConstraints,
+                                           db::AddSimpleTags<>, compute_tags>(
+            std::move(box)));
+  }
+};
+
+}  // namespace Actions
+}  // namespace CurvedScalarWave

--- a/src/Evolution/Systems/CurvedScalarWave/System.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/System.hpp
@@ -5,7 +5,9 @@
 
 #include <cstddef>
 
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/VariablesTag.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Equations.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "Utilities/TMPL.hpp"
@@ -21,8 +23,34 @@ struct System {
   static constexpr bool is_in_flux_conservative_form = false;
   static constexpr bool has_primitive_and_conservative_vars = false;
   static constexpr size_t volume_dim = Dim;
+  static constexpr bool is_euclidean = false;
 
   using variables_tag = ::Tags::Variables<tmpl::list<Pi, Phi<Dim>, Psi>>;
   using gradients_tags = tmpl::list<Pi, Phi<Dim>, Psi>;
+  using spacetime_variables_tag = ::Tags::Variables<tmpl::list<
+      gr::Tags::Lapse<DataVector>, ::Tags::dt<gr::Tags::Lapse<DataVector>>,
+      ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
+                    Frame::Inertial>,
+      gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>,
+      ::Tags::dt<gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>>,
+      ::Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
+                    tmpl::size_t<Dim>, Frame::Inertial>,
+      gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataVector>,
+      ::Tags::dt<
+          gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataVector>>,
+      ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataVector>,
+                    tmpl::size_t<Dim>, Frame::Inertial>,
+      gr::Tags::SqrtDetSpatialMetric<DataVector>,
+      gr::Tags::ExtrinsicCurvature<volume_dim, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial, DataVector>>>;
+
+  using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;
+  using char_speeds_tag = CharacteristicSpeedsCompute<Dim>;
+  using compute_largest_characteristic_speed =
+      ComputeLargestCharacteristicSpeed<Dim>;
+
+  template <typename Tag>
+  using magnitude_tag = ::Tags::NonEuclideanMagnitude<
+      Tag, gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>;
 };
 }  // namespace CurvedScalarWave

--- a/src/PointwiseFunctions/AnalyticData/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/CMakeLists.txt
@@ -3,3 +3,4 @@
 
 add_subdirectory(Burgers)
 add_subdirectory(GrMhd)
+add_subdirectory(CurvedWaveEquation)

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/AnalyticData.hpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/AnalyticData.hpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace CurvedScalarWave {
+/*!
+ * \ingroup AnalyticDataGroup
+ * \brief Holds classes implementing analytic data for the CurvedScalarWave
+ * system.
+ */
+namespace AnalyticData {}
+}  // namespace CurvedScalarWave

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY CurvedWaveEquationAnalyticData)
+
+set(LIBRARY_SOURCES
+  ScalarWaveKerrSchild.cpp
+  )
+
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE DataStructures
+  INTERFACE ErrorHandling
+  INTERFACE GeneralRelativity
+  INTERFACE GeneralRelativitySolutions
+  INTERFACE Spectral
+  INTERFACE Utilities
+  )

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveKerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveKerrSchild.cpp
@@ -1,0 +1,169 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveKerrSchild.hpp"
+
+#include <pup.h>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Equations.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+namespace CurvedScalarWave {
+namespace AnalyticData {
+
+// Enable or disable this constructor based on ScalarFieldSolution
+template <>
+template <typename Dummy,
+          Requires<std::is_same<ScalarWave::Solutions::RegularSphericalWave,
+                                Dummy>::value>>
+ScalarWaveKerrSchild<ScalarWave::Solutions::RegularSphericalWave>::
+    ScalarWaveKerrSchild(
+        const double mass,
+        const std::array<double, volume_dim> dimensionless_spin,
+        const std::array<double, volume_dim> center,
+        std::unique_ptr<MathFunction<1>> profile,
+        const OptionContext& context) noexcept
+    : flat_space_wave_soln_(std::move(profile)),
+      kerr_schild_soln_(mass, dimensionless_spin, center, context) {}
+
+// Enable or disable this constructor based on ScalarFieldSolution
+template <>
+template <
+    typename Dummy,
+    Requires<std::is_same<ScalarWave::Solutions::PlaneWave<3>, Dummy>::value>>
+ScalarWaveKerrSchild<ScalarWave::Solutions::PlaneWave<3>>::ScalarWaveKerrSchild(
+    const double mass, const std::array<double, volume_dim> dimensionless_spin,
+    const std::array<double, volume_dim> center,
+    const std::array<double, volume_dim> wave_vector,
+    const std::array<double, volume_dim> wave_center,
+    std::unique_ptr<MathFunction<1>> profile,
+    const OptionContext& context) noexcept
+    : flat_space_wave_soln_(wave_vector, wave_center, std::move(profile)),
+      kerr_schild_soln_(mass, dimensionless_spin, center, context) {}
+
+template <typename ScalarFieldSolution>
+void ScalarWaveKerrSchild<ScalarFieldSolution>::pup(PUP::er& p) noexcept {
+  p | flat_space_wave_soln_;
+  p | kerr_schild_soln_;
+}
+
+template <typename ScalarFieldSolution>
+tuples::TaggedTuple<Pi> ScalarWaveKerrSchild<ScalarFieldSolution>::variables(
+    const tnsr::I<DataVector, volume_dim>& x, tmpl::list<Pi> /*meta*/) const
+    noexcept {
+  constexpr double default_initial_time = 0.;
+  const auto flat_space_scalar_wave_vars = flat_space_wave_soln_.variables(
+      x, default_initial_time,
+      tmpl::list<ScalarWave::Pi, ScalarWave::Phi<volume_dim>,
+                 ScalarWave::Psi>{});
+  const auto flat_space_dt_scalar_wave_vars = flat_space_wave_soln_.variables(
+      x, default_initial_time,
+      tmpl::list<::Tags::dt<ScalarWave::Pi>,
+                 ::Tags::dt<ScalarWave::Phi<volume_dim>>,
+                 ::Tags::dt<ScalarWave::Psi>>{});
+  const auto kerr_schild_spacetime_variables = kerr_schild_soln_.variables(
+      x, default_initial_time, spacetime_tags<DataVector>{});
+  auto result = make_with_value<tuples::TaggedTuple<Pi>>(x, 0.);
+
+  {
+    const auto shift_dot_dpsi = dot_product(
+        get<gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>>(
+            kerr_schild_spacetime_variables),
+        get<ScalarWave::Phi<volume_dim>>(flat_space_scalar_wave_vars));
+
+    get(get<Pi>(result)) =
+        (get(shift_dot_dpsi) - get(get<::Tags::dt<ScalarWave::Psi>>(
+                                   flat_space_dt_scalar_wave_vars))) /
+        get(get<gr::Tags::Lapse<DataVector>>(kerr_schild_spacetime_variables));
+  }
+
+  return result;
+}
+
+template <typename LocalScalarFieldSolution>
+bool operator==(
+    const ScalarWaveKerrSchild<LocalScalarFieldSolution>& lhs,
+    const ScalarWaveKerrSchild<LocalScalarFieldSolution>& rhs) noexcept {
+  return lhs.mass() == rhs.mass() and
+         lhs.dimensionless_spin() == rhs.dimensionless_spin() and
+         lhs.center() == rhs.center();
+}
+
+template <typename LocalScalarFieldSolution>
+bool operator!=(
+    const ScalarWaveKerrSchild<LocalScalarFieldSolution>& lhs,
+    const ScalarWaveKerrSchild<LocalScalarFieldSolution>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+// Generate instantiations
+#define STYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATE(_, data)                                  \
+  template class ScalarWaveKerrSchild<STYPE(data)>;           \
+  template bool operator==(                                   \
+      const ScalarWaveKerrSchild<STYPE(data)>& lhs,           \
+      const ScalarWaveKerrSchild<STYPE(data)>& rhs) noexcept; \
+  template bool operator!=(                                   \
+      const ScalarWaveKerrSchild<STYPE(data)>& lhs,           \
+      const ScalarWaveKerrSchild<STYPE(data)>& rhs) noexcept;
+
+#define INSTANTIATE_CONSTRUCTOR1(_, data)                           \
+  template ScalarWaveKerrSchild<STYPE(data)>::ScalarWaveKerrSchild( \
+      const double mass,                                            \
+      const std::array<double, volume_dim> dimensionless_spin,      \
+      const std::array<double, volume_dim> center,                  \
+      std::unique_ptr<MathFunction<1>> profile,                     \
+      const OptionContext& context) noexcept;
+
+#define INSTANTIATE_CONSTRUCTOR2(_, data)                           \
+  template ScalarWaveKerrSchild<STYPE(data)>::ScalarWaveKerrSchild( \
+      const double mass,                                            \
+      const std::array<double, volume_dim> dimensionless_spin,      \
+      const std::array<double, volume_dim> center,                  \
+      std::array<double, volume_dim> wave_vector,                   \
+      std::array<double, volume_dim> wave_center,                   \
+      std::unique_ptr<MathFunction<1>> profile,                     \
+      const OptionContext& context) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (ScalarWave::Solutions::RegularSphericalWave,
+                         ScalarWave::Solutions::PlaneWave<3>))
+GENERATE_INSTANTIATIONS(INSTANTIATE_CONSTRUCTOR1,
+                        (ScalarWave::Solutions::RegularSphericalWave))
+GENERATE_INSTANTIATIONS(INSTANTIATE_CONSTRUCTOR2,
+                        (ScalarWave::Solutions::PlaneWave<3>))
+
+#undef INSTANTIATE
+#undef INSTANTIATE_CONSTRUCTOR1
+#undef INSTANTIATE_CONSTRUCTOR2
+#undef STYPE
+}  // namespace AnalyticData
+}  // namespace CurvedScalarWave
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveKerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveKerrSchild.hpp
@@ -1,0 +1,230 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+namespace PUP {
+class er;  // IWYU pragma: keep
+}  // namespace PUP
+namespace Tags {
+template <typename Tag>
+struct dt;
+}  // namespace Tags
+/// \endcond
+
+// IWYU pragma: no_include <pup.h>
+
+namespace CurvedScalarWave {
+namespace AnalyticData {
+/*!
+ * \brief Analytic initial data for scalar waves in \f$3+1\f$D Kerr spacetime
+ *
+ * \details When evolving a scalar field propagating through curved spacetime,
+ * this class provides methods to initialize the scalar-field and spacetime
+ * variables using analytic solutions to the flat-space scalar-wave equation
+ * and a Kerr background spacetime. That the coordinate profile of the scalar
+ * field \f$\psi\f$ in curved spacetime is the same as that in flat spacetime
+ * is our primary identification, allowing it to be initialized using any
+ * member class of `ScalarWave::Solutions`. Solving constraints of the
+ * `CurvedScalarWave` system, we also identify the coordinate spatial derivative
+ * of the scalar field \f$\Phi_i\f$ in curved spacetime with the same in flat
+ * spacetime. The definition of \f$\Pi\f$ comes from requiring it to be the
+ * future-directed time derivative of the scalar field:
+ *
+ * \f{align}
+ * \Pi := -n^a \partial_a \psi
+ *     =  \frac{1}{N}\left(N^k \Phi_k - {\partial_t\psi}\right),
+ * \f}
+ *
+ * where \f$n^a\f$ is the unit normal to spatial slices of the spacetime
+ * foliation.
+ */
+template <typename ScalarFieldSolution>
+class ScalarWaveKerrSchild : public MarkAsAnalyticData {
+ public:
+  static constexpr size_t volume_dim = 3;
+
+  struct WaveVector {
+    using type = std::array<double, volume_dim>;
+    static constexpr OptionString help = {
+        "The propagation vector for the plane wave."};
+  };
+  struct WaveCenter {
+    using type = std::array<double, volume_dim>;
+    static constexpr OptionString help = {
+        "The initial center of the plane wave."};
+  };
+  struct WaveProfile {
+    using type = std::unique_ptr<MathFunction<1>>;
+    static constexpr OptionString help = {
+        "The radial profile of the spherical wave."};
+  };
+  struct BlackHoleMass {
+    using type = double;
+    static constexpr OptionString help = {"Mass of the black hole"};
+    static type default_value() noexcept { return 1.; }
+    static type lower_bound() noexcept { return 0.; }
+  };
+  struct BlackHoleSpin {
+    using type = std::array<double, volume_dim>;
+    static constexpr OptionString help = {
+        "The [x,y,z] dimensionless spin of the black hole"};
+    static type default_value() noexcept { return {{0., 0., 0.}}; }
+  };
+  struct BlackHoleCenter {
+    using type = std::array<double, volume_dim>;
+    static constexpr OptionString help = {
+        "The [x,y,z] center of the black hole"};
+    static type default_value() noexcept { return {{0., 0., 0.}}; }
+  };
+  using options = tmpl::conditional_t<
+      std::is_same_v<ScalarFieldSolution,
+                     ScalarWave::Solutions::RegularSphericalWave>,
+      tmpl::list<BlackHoleMass, BlackHoleSpin, BlackHoleCenter, WaveProfile>,
+      tmpl::list<BlackHoleMass, BlackHoleSpin, BlackHoleCenter, WaveVector,
+                 WaveCenter, WaveProfile>>;
+  static constexpr OptionString help{
+      "A scalar wave with a Kerr black hole (in Kerr-Schild coordinates)\n"
+      " as background\n\n"};
+  static std::string name() noexcept { return "ScalarWaveKerr"; };
+
+  // Enable or disable this constructor based on ScalarFieldSolution
+  template <typename Dummy = ScalarWave::Solutions::RegularSphericalWave,
+            Requires<std::is_same<ScalarFieldSolution, Dummy>::value> = nullptr>
+  explicit ScalarWaveKerrSchild(
+      double mass, std::array<double, volume_dim> dimensionless_spin,
+      std::array<double, volume_dim> center,
+      std::unique_ptr<MathFunction<1>> profile,
+      const OptionContext& context = {}) noexcept;
+
+  // Enable or disable this constructor based on ScalarFieldSolution
+  template <typename Dummy = ScalarWave::Solutions::PlaneWave<volume_dim>,
+            Requires<std::is_same<ScalarFieldSolution, Dummy>::value> = nullptr>
+  explicit ScalarWaveKerrSchild(
+      double mass, std::array<double, volume_dim> dimensionless_spin,
+      std::array<double, volume_dim> center,
+      std::array<double, volume_dim> wave_vector,
+      std::array<double, volume_dim> wave_center,
+      std::unique_ptr<MathFunction<1>> profile,
+      const OptionContext& context = {}) noexcept;
+
+  explicit ScalarWaveKerrSchild(CkMigrateMessage* /*unused*/) noexcept {}
+
+  ScalarWaveKerrSchild() = default;
+  ScalarWaveKerrSchild(const ScalarWaveKerrSchild& /*rhs*/) = delete;
+  ScalarWaveKerrSchild& operator=(const ScalarWaveKerrSchild& /*rhs*/) = delete;
+  ScalarWaveKerrSchild(ScalarWaveKerrSchild&& /*rhs*/) noexcept = default;
+  ScalarWaveKerrSchild& operator=(ScalarWaveKerrSchild&& /*rhs*/) noexcept =
+      default;
+  ~ScalarWaveKerrSchild() = default;
+
+  // Tags
+  template <typename DataType>
+  using spacetime_tags = gr::Solutions::KerrSchild::tags<DataType>;
+  using tags = tmpl::append<spacetime_tags<DataVector>,
+                            tmpl::list<Pi, Phi<volume_dim>, Psi>>;
+
+  /// Retrieve spacetime variables
+  template <
+      typename DataType, typename Tag,
+      Requires<tmpl::list_contains_v<spacetime_tags<DataType>, Tag>> = nullptr>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, volume_dim>& x,
+                                     tmpl::list<Tag> /*meta*/) const noexcept {
+    constexpr double default_initial_time = 0.;
+    return {std::move(get<Tag>(kerr_schild_soln_.variables(
+        x, default_initial_time, spacetime_tags<DataType>{})))};
+  }
+
+  /// Retrieve scalar wave variables
+  tuples::TaggedTuple<Pi> variables(const tnsr::I<DataVector, volume_dim>& x,
+                                    tmpl::list<Pi> /*meta*/) const noexcept;
+  tuples::TaggedTuple<Phi<volume_dim>> variables(
+      const tnsr::I<DataVector, volume_dim>& x,
+      tmpl::list<Phi<volume_dim>> /*meta*/) const noexcept {
+    constexpr double default_initial_time = 0.;
+    return {std::move(
+        get<ScalarWave::Phi<volume_dim>>(flat_space_wave_soln_.variables(
+            x, default_initial_time,
+            tmpl::list<ScalarWave::Pi, ScalarWave::Phi<volume_dim>,
+                       ScalarWave::Psi>{})))};
+  }
+  tuples::TaggedTuple<Psi> variables(const tnsr::I<DataVector, volume_dim>& x,
+                                     tmpl::list<Psi> /*meta*/) const noexcept {
+    constexpr double default_initial_time = 0.;
+    return {std::move(get<ScalarWave::Psi>(flat_space_wave_soln_.variables(
+        x, default_initial_time,
+        tmpl::list<ScalarWave::Pi, ScalarWave::Phi<volume_dim>,
+                   ScalarWave::Psi>{})))};
+  }
+
+  // Retrieve one or more tags
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, volume_dim>& x,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
+    static_assert(sizeof...(Tags) > 1,
+                  "This generic template will recurse infinitely if only one "
+                  "tag is being retrieved through it.");
+
+    static_assert(tmpl2::flat_all_v<tmpl::list_contains_v<tags, Tags>...>,
+                  "At least one of the requested tags is not supported.");
+
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  SPECTRE_ALWAYS_INLINE double mass() const noexcept {
+    return kerr_schild_soln_.mass();
+  }
+  SPECTRE_ALWAYS_INLINE const std::array<double, volume_dim>& center() const
+      noexcept {
+    return kerr_schild_soln_.center();
+  }
+  SPECTRE_ALWAYS_INLINE const std::array<double, volume_dim>&
+  dimensionless_spin() const noexcept {
+    return kerr_schild_soln_.dimensionless_spin();
+  }
+
+ private:
+  template <typename LocalScalarFieldSolution>
+  friend bool operator==(
+      const ScalarWaveKerrSchild<LocalScalarFieldSolution>& lhs,
+      const ScalarWaveKerrSchild<LocalScalarFieldSolution>& rhs) noexcept;
+
+  ScalarFieldSolution flat_space_wave_soln_;
+  gr::Solutions::KerrSchild kerr_schild_soln_;
+};
+
+template <typename LocalScalarFieldSolution>
+bool operator!=(
+    const ScalarWaveKerrSchild<LocalScalarFieldSolution>& lhs,
+    const ScalarWaveKerrSchild<LocalScalarFieldSolution>& rhs) noexcept;
+
+}  // namespace AnalyticData
+}  // namespace CurvedScalarWave

--- a/tests/InputFiles/CurvedScalarWave/Input3DRegularSphericalWave.yaml
+++ b/tests/InputFiles/CurvedScalarWave/Input3DRegularSphericalWave.yaml
@@ -1,0 +1,66 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveCurvedRegularSphericalWave3D
+# Check: parse;execute
+# ExpectedOutput:
+#   CurvedScalarWave3DRegSphWaveVolume0.h5
+
+AnalyticData:
+  ScalarWaveKerr:
+    BlackHoleMass: 1.
+    BlackHoleSpin: [0., 0., 0.]
+    BlackHoleCenter: [0., 0., 0.]
+    WaveProfile:
+      Gaussian:
+        Amplitude: 1.
+        Width: 1.
+        Center: 3.
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.002
+  InitialSlabSize: 0.01
+  TimeStepper:
+    AdamsBashforthN:
+      Order: 3
+  StepController: BinaryFraction
+  StepChoosers:
+    - Constant: 0.05
+    - Increase:
+        Factor: 2
+  #  - Cfl:
+  #      SafetyFactor: 0.2
+
+DomainCreator:
+    Shell:
+      InnerRadius: 1.9
+      OuterRadius: 10.0
+      InitialRefinement: 2
+      InitialGridPoints: [6, 6]
+      UseEquiangularMap: true
+      AspectRatio: 1.0
+      UseLogarithmicMap: true
+      RadialBlockLayers: 4
+
+NumericalFlux:
+  UpwindFlux:
+
+# Filtering is being tested by the 3D executable (see EvolveCurvedScalarWave.hpp)
+Filtering:
+  ExpFilter0:
+    Alpha: 12
+    HalfPower: 32
+
+EventsAndTriggers:
+  ? EveryNSlabs:
+      N: 5
+      Offset: 0
+  : - ObserveFields
+  ? SpecifiedSlabs:
+      Slabs: [6]
+  : - Completion
+
+Observers:
+  VolumeFileName: "CurvedScalarWave3DRegSphWaveVolume"
+  ReductionFileName: "CurvedScalarWave3DRegSphWaveReductions"

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticData/TestHelpers.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticData/TestHelpers.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace TestHelpers {
+/// \ingroup TestingFrameworkGroup
+/// Functions for testing analytic data
+namespace AnalyticData {
+/// Checks that tags can be retrieved both individually and all at
+/// once.
+template <typename Solution, typename Coords, typename TagsList>
+void test_tag_retrieval(const Solution& solution, const Coords& coords,
+                        const TagsList /*meta*/) noexcept {
+  const auto vars_from_all_tags = solution.variables(coords, TagsList{});
+  const auto vars_from_all_tags_reversed =
+      solution.variables(coords, tmpl::reverse<TagsList>{});
+  tmpl::for_each<TagsList>([&](const auto tag_v) noexcept {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    const auto single_var = solution.variables(coords, tmpl::list<tag>{});
+    CHECK(tuples::get<tag>(single_var) == tuples::get<tag>(vars_from_all_tags));
+    CHECK(tuples::get<tag>(single_var) ==
+          tuples::get<tag>(vars_from_all_tags_reversed));
+  });
+}
+}  // namespace AnalyticData
+}  // namespace TestHelpers

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CMakeLists.txt
@@ -15,4 +15,5 @@ add_test_library(
   )
 
 add_subdirectory(Burgers)
+add_subdirectory(CurvedWaveEquation)
 add_subdirectory(GrMhd)

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+
+set(LIBRARY "Test_CurvedWaveEquationAnalyticData")
+
+set(LIBRARY_SOURCES
+  Test_ScalarWaveKerrSchild.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "PointwiseFunctions/AnalyticData/CurvedWaveEquation/"
+  "${LIBRARY_SOURCES}"
+  "CurvedWaveEquationAnalyticData;GeneralRelativitySolutions;GeneralRelativity;MathFunctions;Utilities;WaveEquation"
+  )

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveKerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveKerrSchild.cpp
@@ -1,0 +1,393 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <memory>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/ScalarWave/System.hpp"      // IWYU pragma: keep
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/AnalyticData/TestHelpers.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveKerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+template <typename ScalarFieldSolution>
+struct ScalarWaveKerr {
+  using type =
+      CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<ScalarFieldSolution>;
+  static constexpr OptionString help{"A scalar wave in Kerr spacetime"};
+};
+
+template <typename ScalarFieldSolution>
+void test_tag_retrieval(
+    const CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+        ScalarFieldSolution>& curved_wave_data) noexcept {
+  const tnsr::I<DataVector, 3> x{std::array<DataVector, 3>{
+      {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),
+       DataVector({0., 0., 0., 0.})}}};
+
+  // Evaluate solution
+  TestHelpers::AnalyticData::test_tag_retrieval(
+      curved_wave_data, x,
+      typename CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+          ScalarFieldSolution>::tags());
+}
+
+template <typename ScalarFieldSolution>
+void test_no_hole(const CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+                      ScalarFieldSolution>& curved_wave_data,
+                  const ScalarFieldSolution& flat_wave_solution) noexcept {
+  const tnsr::I<DataVector, 3> x{std::array<DataVector, 3>{
+      {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),
+       DataVector({0., 0., 0., 0.})}}};
+  auto vars = curved_wave_data.variables(
+      x, tmpl::list<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
+                    CurvedScalarWave::Psi>{});
+  auto flat_vars = flat_wave_solution.variables(
+      x, 0., tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{});
+  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Psi>(vars)),
+                        get(get<ScalarWave::Psi>(flat_vars)));
+  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Pi>(vars)),
+                        get(get<ScalarWave::Pi>(flat_vars)));
+  CHECK_ITERABLE_APPROX(get<0>(get<CurvedScalarWave::Phi<3>>(vars)),
+                        get<0>(get<ScalarWave::Phi<3>>(flat_vars)));
+  CHECK_ITERABLE_APPROX(get<1>(get<CurvedScalarWave::Phi<3>>(vars)),
+                        get<1>(get<ScalarWave::Phi<3>>(flat_vars)));
+  CHECK_ITERABLE_APPROX(get<2>(get<CurvedScalarWave::Phi<3>>(vars)),
+                        get<2>(get<ScalarWave::Phi<3>>(flat_vars)));
+}
+
+template <typename ScalarFieldSolution>
+void test_kerr(const CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+                   ScalarFieldSolution>& curved_wave_data,
+               const gr::Solutions::KerrSchild& bh_solution,
+               const ScalarFieldSolution& flat_wave_solution) noexcept {
+  const tnsr::I<DataVector, 3> x{std::array<DataVector, 3>{
+      {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),
+       DataVector({0., 0., 0., 0.})}}};
+  auto vars = curved_wave_data.variables(
+      x, tmpl::list<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
+                    CurvedScalarWave::Psi>{});
+
+  const auto flat_wave_vars = flat_wave_solution.variables(
+      x, 0., ScalarWave::System<3>::variables_tag::tags_list{});
+  const auto flat_wave_dt_vars = flat_wave_solution.variables(
+      x, 0.,
+      tmpl::list<::Tags::dt<ScalarWave::Pi>, ::Tags::dt<ScalarWave::Phi<3>>,
+                 ::Tags::dt<ScalarWave::Psi>>{});
+
+  const auto kerr_variables = bh_solution.variables(
+      x, 0., gr::Solutions::KerrSchild::tags<DataVector>{});
+
+  // construct the vars in-situ
+  const auto& local_psi = get<ScalarWave::Psi>(flat_wave_vars);
+  const auto& local_phi = get<ScalarWave::Phi<3>>(flat_wave_vars);
+  auto local_pi = make_with_value<Scalar<DataVector>>(x, 0.);
+  {
+    const auto shift_dot_dpsi = dot_product(
+        get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(kerr_variables),
+        get<ScalarWave::Phi<3>>(flat_wave_vars));
+    get(local_pi) = (get(shift_dot_dpsi) -
+                     get(get<::Tags::dt<ScalarWave::Psi>>(flat_wave_dt_vars))) /
+                    get(get<gr::Tags::Lapse<DataVector>>(kerr_variables));
+  }
+
+  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Psi>(vars)), get(local_psi));
+  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Pi>(vars)), get(local_pi));
+  CHECK_ITERABLE_APPROX(get<0>(get<CurvedScalarWave::Phi<3>>(vars)),
+                        get<0>(local_phi));
+  CHECK_ITERABLE_APPROX(get<1>(get<CurvedScalarWave::Phi<3>>(vars)),
+                        get<1>(local_phi));
+  CHECK_ITERABLE_APPROX(get<2>(get<CurvedScalarWave::Phi<3>>(vars)),
+                        get<2>(local_phi));
+}
+
+template <typename ScalarFieldSolution>
+void test_kerr_schild_vars(
+    const CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+        ScalarFieldSolution>& curved_wave_data,
+    const gr::Solutions::KerrSchild& bh_solution) noexcept {
+  const tnsr::I<DataVector, 3> x{std::array<DataVector, 3>{
+      {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),
+       DataVector({0., 0., 0., 0.})}}};
+
+  tuples::tagged_tuple_from_typelist<
+      typename gr::Solutions::KerrSchild::tags<DataVector>>
+      vars = curved_wave_data.variables(
+          x, typename gr::Solutions::KerrSchild::tags<DataVector>{});
+
+  // Now get Kerr background vars directly
+  const auto kerr_variables = bh_solution.variables(
+      x, 0., gr::Solutions::KerrSchild::tags<DataVector>{});
+
+  tmpl::for_each<gr::Solutions::KerrSchild::tags<DataVector>>(
+      [&vars, &kerr_variables](auto x_) {
+        using tag = typename decltype(x_)::type;
+        CHECK_ITERABLE_APPROX(get<tag>(vars), get<tag>(kerr_variables));
+      });
+}
+
+void test_construct_from_options() noexcept {
+  {  // test with wave profile = spherical
+    Options<
+        tmpl::list<ScalarWaveKerr<ScalarWave::Solutions::RegularSphericalWave>>>
+        opts("");
+    opts.parse(
+        "ScalarWaveKerr:\n"
+        "  BlackHoleMass: 0.7\n"
+        "  BlackHoleSpin: [0.1,-0.2,0.3]\n"
+        "  BlackHoleCenter: [0.7,0.6,-2.]\n"
+        "  WaveProfile:\n"
+        "    Gaussian:\n"
+        "      Amplitude: 11.\n"
+        "      Width: 1.4\n"
+        "      Center: 0.3");
+    const auto curved_wave_data_constructed_from_opts =
+        opts.get<ScalarWaveKerr<ScalarWave::Solutions::RegularSphericalWave>>();
+    CHECK(curved_wave_data_constructed_from_opts ==
+          CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+              ScalarWave::Solutions::RegularSphericalWave>(
+              0.7, {{0.1, -0.2, 0.3}}, {{0.7, 0.6, -2.}},
+              std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)));
+
+    // test internals of data constructed from options
+    const gr::Solutions::KerrSchild bh_solution(0.7, {{0.1, -0.2, 0.3}},
+                                                {{0.7, 0.6, -2.}});
+    const ScalarWave::Solutions::RegularSphericalWave flat_wave_solution{
+        std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)};
+
+    test_kerr(curved_wave_data_constructed_from_opts, bh_solution,
+              flat_wave_solution);
+  }
+  {  // test with wave profile = plane
+    Options<tmpl::list<ScalarWaveKerr<ScalarWave::Solutions::PlaneWave<3>>>>
+        opts("");
+    opts.parse(
+        "ScalarWaveKerr:\n"
+        "  BlackHoleMass: 0.7\n"
+        "  BlackHoleSpin: [0.1,-0.2,0.3]\n"
+        "  BlackHoleCenter: [0.7,0.6,-2.]\n"
+        "  WaveVector: [1.0, 1.0, 1.0]\n"
+        "  WaveCenter: [0.0, 0.0, 0.0]\n"
+        "  WaveProfile:\n"
+        "    Gaussian:\n"
+        "      Amplitude: 11.\n"
+        "      Width: 1.4\n"
+        "      Center: 0.3");
+    const auto curved_wave_data_constructed_from_opts =
+        opts.get<ScalarWaveKerr<ScalarWave::Solutions::PlaneWave<3>>>();
+    CHECK(curved_wave_data_constructed_from_opts ==
+          CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+              ScalarWave::Solutions::PlaneWave<3>>(
+              0.7, {{0.1, -0.2, 0.3}}, {{0.7, 0.6, -2.}}, {{1.0, 1.0, 1.0}},
+              {{0.0, 0.0, 0.0}},
+              std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)));
+
+    // test internals of data constructed from options
+    const gr::Solutions::KerrSchild bh_solution(0.7, {{0.1, -0.2, 0.3}},
+                                                {{0.7, 0.6, -2.}});
+    const ScalarWave::Solutions::PlaneWave<3> flat_wave_solution{
+        {{1.0, 1.0, 1.0}},
+        {{0.0, 0.0, 0.0}},
+        std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)};
+
+    test_kerr(curved_wave_data_constructed_from_opts, bh_solution,
+              flat_wave_solution);
+  }
+}
+
+void test_serialize(const double mass, const std::array<double, 3>& spin,
+                    const std::array<double, 3>& center) noexcept {
+  {  // test with wave profile = spherical
+    CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+        ScalarWave::Solutions::RegularSphericalWave>
+        curved_wave_data(
+            mass, spin, center,
+            std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3));
+    Parallel::register_derived_classes_with_charm<MathFunction<1>>();
+    const auto snd_curved_wave_data =
+        serialize_and_deserialize(curved_wave_data);
+    CHECK(curved_wave_data == snd_curved_wave_data);
+
+    // test internals of deserialized data
+    const gr::Solutions::KerrSchild bh_solution(mass, spin, center);
+    const ScalarWave::Solutions::RegularSphericalWave flat_wave_solution{
+        std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)};
+
+    test_kerr(snd_curved_wave_data, bh_solution, flat_wave_solution);
+  }
+  {  // test with wave profile = plane
+    CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+        ScalarWave::Solutions::PlaneWave<3>>
+        curved_wave_data(
+            mass, spin, center, {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}},
+            std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3));
+    Parallel::register_derived_classes_with_charm<MathFunction<1>>();
+    const auto snd_curved_wave_data =
+        serialize_and_deserialize(curved_wave_data);
+    CHECK(curved_wave_data == snd_curved_wave_data);
+
+    // test internals of deserialized data
+    const gr::Solutions::KerrSchild bh_solution(mass, spin, center);
+    const ScalarWave::Solutions::PlaneWave<3> flat_wave_solution{
+        {{1.0, 1.0, 1.0}},
+        {{0.0, 0.0, 0.0}},
+        std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)};
+
+    test_kerr(snd_curved_wave_data, bh_solution, flat_wave_solution);
+  }
+}
+
+void test_move(const double mass, const std::array<double, 3>& spin,
+               const std::array<double, 3>& center) noexcept {
+  {  // test with wave profile = spherical
+    CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+        ScalarWave::Solutions::RegularSphericalWave>
+        curved_wave_data(
+            mass, spin, center,
+            std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3));
+    // since it can't actually be copied
+    CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+        ScalarWave::Solutions::RegularSphericalWave>
+        copy_of_curved_wave_data(
+            mass, spin, center,
+            std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3));
+    test_move_semantics(std::move(curved_wave_data), copy_of_curved_wave_data);
+  }
+  {  // test with wave profile = plane
+    CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+        ScalarWave::Solutions::PlaneWave<3>>
+        curved_wave_data(
+            mass, spin, center, {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}},
+            std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3));
+    // since it can't actually be copied
+    CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+        ScalarWave::Solutions::PlaneWave<3>>
+        copy_of_curved_wave_data(
+            mass, spin, center, {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}},
+            std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3));
+    test_move_semantics(std::move(curved_wave_data), copy_of_curved_wave_data);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveKerrSchild",
+                  "[PointwiseFunctions][Unit]") {
+  const double mass = 0.7;
+  const std::array<double, 3> spin{{0.1, -0.2, 0.3}};
+  const std::array<double, 3> center{{0.3, 0.2, 0.4}};
+  const gr::Solutions::KerrSchild bh_solution(mass, spin, center);
+
+  test_construct_from_options();
+  test_serialize(mass, spin, center);
+  test_move(mass, spin, center);
+
+  {  // test with wave profile = spherical
+    using sw_tag = ScalarWave::Solutions::RegularSphericalWave;
+    const CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<sw_tag>
+        curved_wave_data_bh_far_away{
+            mass,
+            spin,
+            {{1.e20, 1., 1.}},
+            std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.)};
+    const CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<sw_tag>
+        curved_wave_data{
+            mass, spin, center,
+            std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.)};
+    const sw_tag flat_wave_solution{
+        std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.)};
+
+    test_tag_retrieval(curved_wave_data_bh_far_away);
+    test_tag_retrieval(curved_wave_data);
+    test_no_hole(curved_wave_data_bh_far_away, flat_wave_solution);
+    test_kerr(curved_wave_data, bh_solution, flat_wave_solution);
+    test_kerr_schild_vars(curved_wave_data, bh_solution);
+  }
+  {  // test with wave profile = plane
+    using sw_tag = ScalarWave::Solutions::PlaneWave<3>;
+    const CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<sw_tag>
+        curved_wave_data_bh_far_away{
+            mass,
+            spin,
+            {{1.e20, 1., 1.}},
+            {{1., 1., 1.}},
+            {{0., 0., 0.}},
+            std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.)};
+    const CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<sw_tag>
+        curved_wave_data{
+            mass,
+            spin,
+            center,
+            {{1., 1., 1.}},
+            {{0., 0., 0.}},
+            std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.)};
+    const sw_tag flat_wave_solution{
+        {{1., 1., 1.}},
+        {{0., 0., 0.}},
+        std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.)};
+
+    test_tag_retrieval(curved_wave_data_bh_far_away);
+    test_tag_retrieval(curved_wave_data);
+    test_no_hole(curved_wave_data_bh_far_away, flat_wave_solution);
+    test_kerr(curved_wave_data, bh_solution, flat_wave_solution);
+    test_kerr_schild_vars(curved_wave_data, bh_solution);
+  }
+}
+
+/// Check restrictions on input options below
+
+// [[OutputRegex, Mass must be non-negative]]
+SPECTRE_TEST_CASE(
+    "Unit.AnalyticData.CurvedWaveEquation.ScalarWaveKerrSchildMass",
+    "[PointwiseFunctions][Unit]") {
+  ERROR_TEST();
+  CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+      ScalarWave::Solutions::RegularSphericalWave>
+      solution(-0.2, {{0.1, -0.2, 0.3}}, {{0.3, 0.2, 0.4}},
+               std::make_unique<MathFunctions::Gaussian>(1., 1., 0.));
+}
+
+// [[OutputRegex, In string:.*At line 2 column 18:.Value -0.5 is below the
+// lower bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.AnalyticData.CurvedWaveEquation.ScalarWaveKerrSchildOptM",
+    "[PointwiseFunctions][Unit]") {
+  ERROR_TEST();
+  Options<
+      tmpl::list<ScalarWaveKerr<ScalarWave::Solutions::RegularSphericalWave>>>
+      opts("");
+  opts.parse(
+      "ScalarWaveKerr:\n"
+      "  BlackHoleMass: -0.5\n"
+      "  BlackHoleSpin: [0.1,0.2,0.3]\n"
+      "  BlackHoleCenter: [1.0,3.0,2.0]\n"
+      "  WaveProfile:\n"
+      "    Gaussian:\n"
+      "      Amplitude: 1.\n"
+      "      Width: 1.\n"
+      "      Center: 0.");
+  opts.get<ScalarWaveKerr<ScalarWave::Solutions::RegularSphericalWave>>();
+}
+
+// [[OutputRegex, Spin magnitude must be < 1]]
+SPECTRE_TEST_CASE(
+    "Unit.AnalyticData.CurvedWaveEquation.ScalarWaveKerrSchildSpin",
+    "[PointwiseFunctions][Unit]") {
+  ERROR_TEST();
+  CurvedScalarWave::AnalyticData::ScalarWaveKerrSchild<
+      ScalarWave::Solutions::RegularSphericalWave>
+      solution(0.2, {{1.0, 1.0, 1.0}}, {{0.3, 0.2, 0.4}},
+               std::make_unique<MathFunctions::Gaussian>(1., 1., 0.));
+}


### PR DESCRIPTION
## Proposed changes

This PR adds constraint preserving Bjorhus boundary conditions, for the CurvedScalarWave evolution system.


### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
