### PR TITLE
Add CI target that doesn't use python bindings

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -168,6 +168,9 @@ jobs:
           # See issue https://github.com/sxs-collaboration/spectre/issues/1807
           - build_type: Debug
             EXTRA_CXX_FLAGS: "-DBLAZE_USE_VECTORIZATION=0"
+          - compiler: clang-8
+            build_type: Release
+            BUILD_PYTHON_BINDINGS: OFF
     container:
       image: sxscollaboration/spectrebuildenv:latest
       env:
@@ -225,6 +228,8 @@ jobs:
             fi
           fi
 
+          BUILD_PYTHON_BINDINGS=${{ matrix.BUILD_PYTHON_BINDINGS }}
+
           cmake
           -D CMAKE_C_COMPILER=${CC}
           -D CMAKE_CXX_COMPILER=${CXX}
@@ -234,7 +239,7 @@ jobs:
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -D DEBUG_SYMBOLS=OFF
           -D USE_CCACHE=ON
-          -D BUILD_PYTHON_BINDINGS=ON
+          -D BUILD_PYTHON_BINDINGS=${BUILD_PYTHON_BINDINGS:-'ON'}
           $GITHUB_WORKSPACE
         # Make sure this runs in bash so the regex matching works
         shell: bash

--- a/.travis/BuildLinux.sh
+++ b/.travis/BuildLinux.sh
@@ -7,6 +7,11 @@ export PATH=$PATH:/work/texlive/bin/x86_64-linux
 
 ccache -z
 
+BUILD_PYTHON_BINDINGS=ON
+if [ ${BUILD_TYPE} = Release ] && [ ${CC} = clang-8 ]; then
+    BUILD_PYTHON_BINDINGS=OFF
+fi
+
 # We don't need debug symbols during CI, so we turn them off to reduce memory
 # usage (by 1.5x) during compilation.
 cmake -D CMAKE_BUILD_TYPE=${BUILD_TYPE} \
@@ -19,7 +24,7 @@ cmake -D CMAKE_BUILD_TYPE=${BUILD_TYPE} \
       -D USE_PCH=${USE_PCH} \
       -D DEBUG_SYMBOLS=OFF \
       -D COVERAGE=${COVERAGE} \
-      -D BUILD_PYTHON_BINDINGS=ON \
+      -D BUILD_PYTHON_BINDINGS=${BULID_PYTHON_BINDINGS} \
       ../spectre/
 
 # Build all Charm++ modules

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-spectre_add_python_test(
+spectre_add_python_bindings_test(
   "Unit.AnalyticSolutions.GeneralRelativity.Python.Tov"
   "Test_Tov.py"
   "Unit;PointwiseFunctions;Python")

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-spectre_add_python_test(
+spectre_add_python_bindings_test(
   "Unit.Hydro.EquationsOfState.Python.PolytropicFluid"
   "Test_PolytropicFluid.py"
   "Unit;EquationsOfState;Python")

--- a/tests/Unit/Visualization/Python/CMakeLists.txt
+++ b/tests/Unit/Visualization/Python/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-spectre_add_python_test(
+spectre_add_python_bindings_test(
   "Unit.Visualization.Python.GenerateXdmf"
   Test_GenerateXdmf.py
   "unit;visualization;python")


### PR DESCRIPTION
## Proposed changes

We've had a few instances where PRs break builds that don't use the python bindings (e.g. see issue #1834). This PR changes the clang-8 release target to not build python bindings. It also disables some python tests that currently require the bindings. However, since I don't know enough about the tests @nilsleiffischer should check if this requirement can be relaxed.

I'm intentionally not closing #1834 as part of this PR because this PR is meant to be a temporary solution to the break.

closes #1834

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
