### PR TITLE
Disable tests that use Pybindings when they are not built

### DIFF
--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-spectre_add_python_test(
+spectre_add_python_bindings_test(
   "Unit.AnalyticSolutions.GeneralRelativity.Python.Tov"
   "Test_Tov.py"
   "Unit;PointwiseFunctions;Python")

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-spectre_add_python_test(
+spectre_add_python_bindings_test(
   "Unit.Hydro.EquationsOfState.Python.PolytropicFluid"
   "Test_PolytropicFluid.py"
   "Unit;EquationsOfState;Python")

--- a/tests/Unit/Visualization/Python/CMakeLists.txt
+++ b/tests/Unit/Visualization/Python/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-spectre_add_python_test(
+spectre_add_python_bindings_test(
   "Unit.Visualization.Python.GenerateXdmf"
   Test_GenerateXdmf.py
   "unit;visualization;python")


### PR DESCRIPTION
## Proposed changes

Fixes a mistake I made in #1764. Closes #1834. Feel free to close this PR if #1836 is merged and fixes this, just want to offer a quick way to fix the bug with this PR :)

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
