### PR TITLE
Don't remove output files when a test fails

### DIFF
--- a/cmake/AddInputFileTests.cmake
+++ b/cmake/AddInputFileTests.cmake
@@ -148,10 +148,11 @@ file(
   ${PROJECT_BINARY_DIR}/tmp/InputFileExecuteAndClean.sh
   "\
 #!/bin/sh\n\
-${CMAKE_BINARY_DIR}/bin/$1 --input-file $2\n\
-execute_exit=$?\n\
+${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/CleanOutput.py -v --force \
+--input-file $2 --output-dir ${CMAKE_BINARY_DIR}
+${CMAKE_BINARY_DIR}/bin/$1 --input-file $2 && \
 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/CleanOutput.py -v \
---input-file $2 --output-dir ${CMAKE_BINARY_DIR} && exit \${execute_exit}\n"
+--input-file $2 --output-dir ${CMAKE_BINARY_DIR}\n"
 )
 
 add_input_file_tests("${CMAKE_SOURCE_DIR}/tests/InputFiles/")

--- a/tools/CleanOutput.py
+++ b/tools/CleanOutput.py
@@ -14,7 +14,7 @@ class MissingExpectedOutputError(Exception):
             self.missing_files)
 
 
-def clean_output(input_file, output_dir):
+def clean_output(input_file, output_dir, force):
     """
     Deletes output files specified in the `input_file` from the `output_dir`,
     raising an error if the expected output files were not found.
@@ -53,7 +53,7 @@ def clean_output(input_file, output_dir):
                     os.remove(expected_output_file)
                     logging.info("Removed file {}.".format(
                         expected_output_file))
-                else:
+                elif not force:
                     missing_files.append(expected_output_file)
                     logging.error("Expected file {} was not found.".format(
                         expected_output_file))
@@ -84,6 +84,10 @@ def parse_args():
         action='count',
         default=0,
         help="Verbosity (-v, -vv, ...)")
+    parser.add_argument(
+        '--force',
+        action='store_true',
+        help="Suppress all errors")
     return parser.parse_args()
 
 
@@ -93,4 +97,4 @@ if __name__ == "__main__":
     # Set the log level
     logging.basicConfig(level=logging.WARNING - args.verbose * 10)
 
-    clean_output(args.input_file, args.output_dir)
+    clean_output(args.input_file, args.output_dir, args.force)


### PR DESCRIPTION
Fixes #1726

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
