### PR TITLE
Move functions of time to domain

### DIFF
--- a/src/ControlSystem/FunctionOfTimeUpdater.cpp
+++ b/src/ControlSystem/FunctionOfTimeUpdater.cpp
@@ -25,7 +25,8 @@ void FunctionOfTimeUpdater<DerivOrder>::measure(
 
 template <size_t DerivOrder>
 void FunctionOfTimeUpdater<DerivOrder>::modify(
-    const gsl::not_null<FunctionsOfTime::PiecewisePolynomial<DerivOrder>*>
+    const gsl::not_null<
+        domain::FunctionsOfTime::PiecewisePolynomial<DerivOrder>*>
         f_of_t,
     const double time) noexcept {
   if (averager_(time)) {

--- a/src/ControlSystem/FunctionOfTimeUpdater.hpp
+++ b/src/ControlSystem/FunctionOfTimeUpdater.hpp
@@ -7,8 +7,8 @@
 
 #include "ControlSystem/Averager.hpp"
 #include "ControlSystem/Controller.hpp"
-#include "ControlSystem/PiecewisePolynomial.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 
 // IWYU pragma: no_forward_declare FunctionsOfTime::PiecewisePolynomial
 
@@ -54,7 +54,8 @@ class FunctionOfTimeUpdater {
   /// Computes the control signal, updates the FunctionOfTime and updates the
   /// TimescaleTuner
   void modify(
-      gsl::not_null<FunctionsOfTime::PiecewisePolynomial<DerivOrder>*> f_of_t,
+      gsl::not_null<domain::FunctionsOfTime::PiecewisePolynomial<DerivOrder>*>
+          f_of_t,
       double time) noexcept;
 
  private:

--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_subdirectory(Amr)
 add_subdirectory(CoordinateMaps)
 add_subdirectory(Creators)
+add_subdirectory(FunctionsOfTime)
 
 set(LIBRARY Domain)
 
@@ -41,6 +42,7 @@ target_link_libraries(
   INTERFACE CoordinateMaps
   INTERFACE DataStructures
   INTERFACE ErrorHandling
+  INTERFACE FunctionsOfTime
   INTERFACE LinearOperators
   INTERFACE Spectral
   )

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -26,4 +26,5 @@ target_link_libraries(
   INTERFACE DataStructures
   INTERFACE Domain
   INTERFACE ErrorHandling
+  INTERFACE FunctionsOfTime
   )

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -32,7 +32,11 @@
 
 /// \cond
 class DataVector;
+namespace domain {
+namespace FunctionsOfTime {
 class FunctionOfTime;
+}  // namespace FunctionsOfTime
+}  // namespace domain
 /// \endcond
 
 namespace domain {
@@ -70,16 +74,18 @@ class CoordinateMapBase : public PUP::able {
   virtual tnsr::I<double, Dim, TargetFrame> operator()(
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string, FunctionOfTime&>&
-          functions_of_time =
-              std::unordered_map<std::string, FunctionOfTime&>{}) const
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time = std::unordered_map<
+              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
       noexcept = 0;
   virtual tnsr::I<DataVector, Dim, TargetFrame> operator()(
       tnsr::I<DataVector, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string, FunctionOfTime&>&
-          functions_of_time =
-              std::unordered_map<std::string, FunctionOfTime&>{}) const
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time = std::unordered_map<
+              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
       noexcept = 0;
   // @}
 
@@ -92,9 +98,10 @@ class CoordinateMapBase : public PUP::able {
   virtual boost::optional<tnsr::I<double, Dim, SourceFrame>> inverse(
       tnsr::I<double, Dim, TargetFrame> target_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string, FunctionOfTime&>&
-          functions_of_time =
-              std::unordered_map<std::string, FunctionOfTime&>{}) const
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time = std::unordered_map<
+              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
       noexcept = 0;
   // @}
 
@@ -104,16 +111,19 @@ class CoordinateMapBase : public PUP::able {
   virtual InverseJacobian<double, Dim, SourceFrame, TargetFrame> inv_jacobian(
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string, FunctionOfTime&>&
-          functions_of_time =
-              std::unordered_map<std::string, FunctionOfTime&>{}) const
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time = std::unordered_map<
+              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
       noexcept = 0;
   virtual InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>
-  inv_jacobian(tnsr::I<DataVector, Dim, SourceFrame> source_point,
-               double time = std::numeric_limits<double>::signaling_NaN(),
-               const std::unordered_map<std::string, FunctionOfTime&>&
-                   functions_of_time =
-                       std::unordered_map<std::string, FunctionOfTime&>{}) const
+  inv_jacobian(
+      tnsr::I<DataVector, Dim, SourceFrame> source_point,
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time = std::unordered_map<
+              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
       noexcept = 0;
   // @}
 
@@ -122,16 +132,18 @@ class CoordinateMapBase : public PUP::able {
   virtual Jacobian<double, Dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string, FunctionOfTime&>&
-          functions_of_time =
-              std::unordered_map<std::string, FunctionOfTime&>{}) const
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time = std::unordered_map<
+              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
       noexcept = 0;
   virtual Jacobian<DataVector, Dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<DataVector, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string, FunctionOfTime&>&
-          functions_of_time =
-              std::unordered_map<std::string, FunctionOfTime&>{}) const
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time = std::unordered_map<
+              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
       noexcept = 0;
   // @}
  private:
@@ -202,9 +214,10 @@ class CoordinateMap
   constexpr tnsr::I<double, dim, TargetFrame> operator()(
       tnsr::I<double, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string, FunctionOfTime&>&
-          functions_of_time =
-              std::unordered_map<std::string, FunctionOfTime&>{}) const
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time = std::unordered_map<
+              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
       noexcept override {
     return call_impl(std::move(source_point), time, functions_of_time,
                      std::make_index_sequence<sizeof...(Maps)>{});
@@ -212,9 +225,10 @@ class CoordinateMap
   constexpr tnsr::I<DataVector, dim, TargetFrame> operator()(
       tnsr::I<DataVector, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string, FunctionOfTime&>&
-          functions_of_time =
-              std::unordered_map<std::string, FunctionOfTime&>{}) const
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time = std::unordered_map<
+              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
       noexcept override {
     return call_impl(std::move(source_point), time, functions_of_time,
                      std::make_index_sequence<sizeof...(Maps)>{});
@@ -226,9 +240,10 @@ class CoordinateMap
   constexpr boost::optional<tnsr::I<double, dim, SourceFrame>> inverse(
       tnsr::I<double, dim, TargetFrame> target_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string, FunctionOfTime&>&
-          functions_of_time =
-              std::unordered_map<std::string, FunctionOfTime&>{}) const
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time = std::unordered_map<
+              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
       noexcept override {
     return inverse_impl(std::move(target_point), time, functions_of_time,
                         std::make_index_sequence<sizeof...(Maps)>{});
@@ -241,18 +256,21 @@ class CoordinateMap
   constexpr InverseJacobian<double, dim, SourceFrame, TargetFrame> inv_jacobian(
       tnsr::I<double, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string, FunctionOfTime&>&
-          functions_of_time =
-              std::unordered_map<std::string, FunctionOfTime&>{}) const
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time = std::unordered_map<
+              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
       noexcept override {
     return inv_jacobian_impl(std::move(source_point), time, functions_of_time);
   }
   constexpr InverseJacobian<DataVector, dim, SourceFrame, TargetFrame>
-  inv_jacobian(tnsr::I<DataVector, dim, SourceFrame> source_point,
-               const double time = std::numeric_limits<double>::signaling_NaN(),
-               const std::unordered_map<std::string, FunctionOfTime&>&
-                   functions_of_time =
-                       std::unordered_map<std::string, FunctionOfTime&>{}) const
+  inv_jacobian(
+      tnsr::I<DataVector, dim, SourceFrame> source_point,
+      const double time = std::numeric_limits<double>::signaling_NaN(),
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time = std::unordered_map<
+              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
       noexcept override {
     return inv_jacobian_impl(std::move(source_point), time, functions_of_time);
   }
@@ -263,18 +281,20 @@ class CoordinateMap
   constexpr Jacobian<double, dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<double, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string, FunctionOfTime&>&
-          functions_of_time =
-              std::unordered_map<std::string, FunctionOfTime&>{}) const
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time = std::unordered_map<
+              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
       noexcept override {
     return jacobian_impl(std::move(source_point), time, functions_of_time);
   }
   constexpr Jacobian<DataVector, dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<DataVector, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string, FunctionOfTime&>&
-          functions_of_time =
-              std::unordered_map<std::string, FunctionOfTime&>{}) const
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time = std::unordered_map<
+              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
       noexcept override {
     return jacobian_impl(std::move(source_point), time, functions_of_time);
   }
@@ -307,28 +327,33 @@ class CoordinateMap
   template <typename T, size_t... Is>
   constexpr SPECTRE_ALWAYS_INLINE tnsr::I<T, dim, TargetFrame> call_impl(
       tnsr::I<T, dim, SourceFrame>&& source_point, double time,
-      const std::unordered_map<std::string, FunctionOfTime&>& functions_of_time,
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          functions_of_time,
       std::index_sequence<Is...> /*meta*/) const noexcept;
 
   template <typename T, size_t... Is>
   constexpr SPECTRE_ALWAYS_INLINE boost::optional<tnsr::I<T, dim, SourceFrame>>
-  inverse_impl(
-      tnsr::I<T, dim, TargetFrame>&& target_point, double time,
-      const std::unordered_map<std::string, FunctionOfTime&>& functions_of_time,
-      std::index_sequence<Is...> /*meta*/) const noexcept;
+  inverse_impl(tnsr::I<T, dim, TargetFrame>&& target_point, double time,
+               const std::unordered_map<
+                   std::string, domain::FunctionsOfTime::FunctionOfTime&>&
+                   functions_of_time,
+               std::index_sequence<Is...> /*meta*/) const noexcept;
 
   template <typename T>
   constexpr SPECTRE_ALWAYS_INLINE
       InverseJacobian<T, dim, SourceFrame, TargetFrame>
-      inv_jacobian_impl(tnsr::I<T, dim, SourceFrame>&& source_point,
-                        double time,
-                        const std::unordered_map<std::string, FunctionOfTime&>&
-                            functions_of_time) const noexcept;
+      inv_jacobian_impl(
+          tnsr::I<T, dim, SourceFrame>&& source_point, double time,
+          const std::unordered_map<std::string,
+                                   domain::FunctionsOfTime::FunctionOfTime&>&
+              functions_of_time) const noexcept;
 
   template <typename T>
   constexpr SPECTRE_ALWAYS_INLINE Jacobian<T, dim, SourceFrame, TargetFrame>
   jacobian_impl(tnsr::I<T, dim, SourceFrame>&& source_point, double time,
-                const std::unordered_map<std::string, FunctionOfTime&>&
+                const std::unordered_map<
+                    std::string, domain::FunctionsOfTime::FunctionOfTime&>&
                     functions_of_time) const noexcept;
 
   std::tuple<Maps...> maps_;
@@ -341,14 +366,15 @@ class CoordinateMap
 // define type-trait to check for time-dependent mapping
 namespace CoordinateMap_detail {
 template <typename T>
-using is_map_time_dependent_t =
-    tt::is_callable_t<T, std::array<std::decay_t<T>, std::decay_t<T>::dim>,
-                      double, std::unordered_map<std::string, FunctionOfTime&>>;
+using is_map_time_dependent_t = tt::is_callable_t<
+    T, std::array<std::decay_t<T>, std::decay_t<T>::dim>, double,
+    std::unordered_map<std::string, domain::FunctionsOfTime::FunctionOfTime&>>;
 
 template <typename T, size_t Dim, typename Map>
 void apply_map(const gsl::not_null<std::array<T, Dim>*> t_map_point,
                const Map& the_map, const double /*t*/,
-               const std::unordered_map<std::string, FunctionOfTime&>&
+               const std::unordered_map<
+                   std::string, domain::FunctionsOfTime::FunctionOfTime&>&
                /*functions_of_time*/,
                const std::false_type /*is_time_independent*/) {
   if (LIKELY(not the_map.is_identity())) {
@@ -357,12 +383,13 @@ void apply_map(const gsl::not_null<std::array<T, Dim>*> t_map_point,
 }
 
 template <typename T, size_t Dim, typename Map>
-void apply_map(
-    const gsl::not_null<std::array<T, Dim>*> t_map_point, const Map& the_map,
-    const double t,
-    const std::unordered_map<std::string, FunctionOfTime&>& functions_of_time,
-    const std::true_type
-    /*is_time_dependent*/) {
+void apply_map(const gsl::not_null<std::array<T, Dim>*> t_map_point,
+               const Map& the_map, const double t,
+               const std::unordered_map<
+                   std::string, domain::FunctionsOfTime::FunctionOfTime&>&
+                   functions_of_time,
+               const std::true_type
+               /*is_time_dependent*/) {
   *t_map_point = the_map(*t_map_point, t, functions_of_time);
 }
 }  // namespace CoordinateMap_detail
@@ -378,13 +405,16 @@ constexpr SPECTRE_ALWAYS_INLINE tnsr::I<
     T, CoordinateMap<SourceFrame, TargetFrame, Maps...>::dim, TargetFrame>
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::call_impl(
     tnsr::I<T, dim, SourceFrame>&& source_point, const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& functions_of_time,
+    const std::unordered_map<std::string,
+                             domain::FunctionsOfTime::FunctionOfTime&>&
+        functions_of_time,
     std::index_sequence<Is...> /*meta*/) const noexcept {
   std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
 
   (void)std::initializer_list<char>{make_overloader(
       [](const auto& the_map, std::array<T, dim>& point, const double /*t*/,
-         const std::unordered_map<std::string, FunctionOfTime&>&
+         const std::unordered_map<std::string,
+                                  domain::FunctionsOfTime::FunctionOfTime&>&
          /*funcs_of_time*/,
          const std::false_type /*is_time_independent*/) noexcept {
         if (LIKELY(not the_map.is_identity())) {
@@ -393,7 +423,9 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::call_impl(
         return '0';
       },
       [](const auto& the_map, std::array<T, dim>& point, const double t,
-         const std::unordered_map<std::string, FunctionOfTime&>& funcs_of_time,
+         const std::unordered_map<std::string,
+                                  domain::FunctionsOfTime::FunctionOfTime&>&
+             funcs_of_time,
          const std::true_type /*is_time_dependent*/) noexcept {
         point = the_map(point, t, funcs_of_time);
         return '0';
@@ -409,7 +441,9 @@ constexpr SPECTRE_ALWAYS_INLINE boost::optional<tnsr::I<
     T, CoordinateMap<SourceFrame, TargetFrame, Maps...>::dim, SourceFrame>>
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::inverse_impl(
     tnsr::I<T, dim, TargetFrame>&& target_point, const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& functions_of_time,
+    const std::unordered_map<std::string,
+                             domain::FunctionsOfTime::FunctionOfTime&>&
+        functions_of_time,
     std::index_sequence<Is...> /*meta*/) const noexcept {
   boost::optional<std::array<T, dim>> mapped_point(
       make_array<T, dim>(std::move(target_point)));
@@ -417,7 +451,8 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::inverse_impl(
   (void)std::initializer_list<char>{make_overloader(
       [](const auto& the_map, boost::optional<std::array<T, dim>>& point,
          const double /*t*/,
-         const std::unordered_map<std::string, FunctionOfTime&>&
+         const std::unordered_map<std::string,
+                                  domain::FunctionsOfTime::FunctionOfTime&>&
          /*funcs_of_time*/,
          const std::false_type /*is_time_independent*/) noexcept {
         if (point) {
@@ -429,7 +464,9 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::inverse_impl(
       },
       [](const auto& the_map, boost::optional<std::array<T, dim>>& point,
          const double t,
-         const std::unordered_map<std::string, FunctionOfTime&>& funcs_of_time,
+         const std::unordered_map<std::string,
+                                  domain::FunctionsOfTime::FunctionOfTime&>&
+             funcs_of_time,
          const std::true_type /*is_time_dependent*/) noexcept {
         if (point) {
           point = the_map.inverse(point.get(), t, funcs_of_time);
@@ -454,7 +491,8 @@ template <typename Map, typename T>
 using is_jacobian_time_dependent_t =
     CoordinateMap_detail::is_jacobian_callable_t<
         Map, std::array<std::decay_t<T>, std::decay_t<Map>::dim>, double,
-        std::unordered_map<std::string, FunctionOfTime&>>;
+        std::unordered_map<std::string,
+                           domain::FunctionsOfTime::FunctionOfTime&>>;
 }  // namespace CoordinateMap_detail
 
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
@@ -462,8 +500,10 @@ template <typename T>
 constexpr SPECTRE_ALWAYS_INLINE auto
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_jacobian_impl(
     tnsr::I<T, dim, SourceFrame>&& source_point, const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& functions_of_time)
-    const noexcept -> InverseJacobian<T, dim, SourceFrame, TargetFrame> {
+    const std::unordered_map<std::string,
+                             domain::FunctionsOfTime::FunctionOfTime&>&
+        functions_of_time) const noexcept
+    -> InverseJacobian<T, dim, SourceFrame, TargetFrame> {
   std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
 
   InverseJacobian<T, dim, SourceFrame, TargetFrame> inv_jac{};
@@ -481,7 +521,8 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_jacobian_impl(
             [](const gsl::not_null<tnsr::Ij<T, dim, Frame::NoFrame>*> t_inv_jac,
                const auto& the_map, const std::array<T, dim>& point,
                const double /*t*/,
-               const std::unordered_map<std::string, FunctionOfTime&>&
+               const std::unordered_map<
+                   std::string, domain::FunctionsOfTime::FunctionOfTime&>&
                /*funcs_of_time*/,
                const std::false_type /*is_time_independent*/) {
               if (LIKELY(not the_map.is_identity())) {
@@ -494,7 +535,8 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_jacobian_impl(
             [](const gsl::not_null<tnsr::Ij<T, dim, Frame::NoFrame>*> t_inv_jac,
                const auto& the_map, const std::array<T, dim>& point,
                const double t,
-               const std::unordered_map<std::string, FunctionOfTime&>&
+               const std::unordered_map<
+                   std::string, domain::FunctionsOfTime::FunctionOfTime&>&
                    funcs_of_time,
                const std::true_type /*is_time_dependent*/) {
               *t_inv_jac = the_map.inv_jacobian(point, t, funcs_of_time);
@@ -551,8 +593,10 @@ template <typename T>
 constexpr SPECTRE_ALWAYS_INLINE auto
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(
     tnsr::I<T, dim, SourceFrame>&& source_point, const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& functions_of_time)
-    const noexcept -> Jacobian<T, dim, SourceFrame, TargetFrame> {
+    const std::unordered_map<std::string,
+                             domain::FunctionsOfTime::FunctionOfTime&>&
+        functions_of_time) const noexcept
+    -> Jacobian<T, dim, SourceFrame, TargetFrame> {
   std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
   Jacobian<T, dim, SourceFrame, TargetFrame> jac{};
 
@@ -570,7 +614,8 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(
                    no_frame_jac,
                const auto& the_map, const std::array<T, dim>& point,
                const double /*t*/,
-               const std::unordered_map<std::string, FunctionOfTime&>&
+               const std::unordered_map<
+                   std::string, domain::FunctionsOfTime::FunctionOfTime&>&
                /*funcs_of_time*/,
                const std::false_type /*is_time_independent*/) {
               if (LIKELY(not the_map.is_identity())) {
@@ -584,7 +629,8 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(
                    no_frame_jac,
                const auto& the_map, const std::array<T, dim>& point,
                const double t,
-               const std::unordered_map<std::string, FunctionOfTime&>&
+               const std::unordered_map<
+                   std::string, domain::FunctionsOfTime::FunctionOfTime&>&
                    funcs_of_time,
                const std::true_type /*is_time_dependent*/) {
               *no_frame_jac = the_map.jacobian(point, t, funcs_of_time);

--- a/src/Domain/CoordinateMaps/CubicScale.cpp
+++ b/src/Domain/CoordinateMaps/CubicScale.cpp
@@ -10,9 +10,9 @@
 #include <pup_stl.h>
 #include <utility>
 
-#include "ControlSystem/FunctionOfTime.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "NumericalAlgorithms/RootFinding/NewtonRaphson.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -33,7 +33,8 @@ CubicScale::CubicScale(const double outer_boundary) noexcept
 template <typename T>
 std::array<tt::remove_cvref_wrap_t<T>, 1> CubicScale::operator()(
     const std::array<T, 1>& source_coords, const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    const std::unordered_map<
+        std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list) const
     noexcept {
   const auto a_of_t = map_list.at(f_of_t_a_).func(time)[0][0];
   const auto b_of_t = map_list.at(f_of_t_b_).func(time)[0][0];
@@ -45,7 +46,8 @@ std::array<tt::remove_cvref_wrap_t<T>, 1> CubicScale::operator()(
 template <typename T>
 boost::optional<std::array<tt::remove_cvref_wrap_t<T>, 1>> CubicScale::inverse(
     const std::array<T, 1>& target_coords, const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    const std::unordered_map<
+        std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list) const
     noexcept {
   // the original coordinates are found by solving for the roots
   // of (b-a)/X^2*\xi^3 + a*\xi - x = 0, where a and b are the FunctionsOfTime,
@@ -107,7 +109,8 @@ boost::optional<std::array<tt::remove_cvref_wrap_t<T>, 1>> CubicScale::inverse(
 template <typename T>
 std::array<tt::remove_cvref_wrap_t<T>, 1> CubicScale::frame_velocity(
     const std::array<T, 1>& source_coords, const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    const std::unordered_map<
+        std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list) const
     noexcept {
   const auto dt_a_of_t = map_list.at(f_of_t_a_).func_and_deriv(time)[1][0];
   const auto dt_b_of_t = map_list.at(f_of_t_b_).func_and_deriv(time)[1][0];
@@ -122,7 +125,8 @@ std::array<tt::remove_cvref_wrap_t<T>, 1> CubicScale::frame_velocity(
 template <typename T>
 tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> CubicScale::jacobian(
     const std::array<T, 1>& source_coords, const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    const std::unordered_map<
+        std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list) const
     noexcept {
   const auto a_of_t = map_list.at(f_of_t_a_).func(time)[0][0];
   const auto b_of_t = map_list.at(f_of_t_b_).func(time)[0][0];
@@ -141,7 +145,8 @@ template <typename T>
 tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame>
 CubicScale::inv_jacobian(
     const std::array<T, 1>& source_coords, const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    const std::unordered_map<
+        std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list) const
     noexcept {
   const auto a_of_t = map_list.at(f_of_t_a_).func(time)[0][0];
   const auto b_of_t = map_list.at(f_of_t_b_).func(time)[0][0];
@@ -159,7 +164,8 @@ CubicScale::inv_jacobian(
 template <typename T>
 tnsr::Iaa<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> CubicScale::hessian(
     const std::array<T, 1>& source_coords, const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    const std::unordered_map<
+        std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list) const
     noexcept {
   const auto a_of_t_and_derivs = map_list.at(f_of_t_a_).func_and_2_derivs(time);
   const auto b_of_t_and_derivs = map_list.at(f_of_t_b_).func_and_2_derivs(time);
@@ -201,43 +207,50 @@ bool operator==(const CoordMapsTimeDependent::CubicScale& lhs,
 template boost::optional<std::array<tt::remove_cvref_wrap_t<double>, 1>>
 CubicScale::inverse(
     const std::array<double, 1>& target_coords, const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    const std::unordered_map<
+        std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list) const
     noexcept;
 template boost::optional<std::array<
     tt::remove_cvref_wrap_t<std::reference_wrapper<const double>>, 1>>
 CubicScale::inverse(
     const std::array<std::reference_wrapper<const double>, 1>& target_coords,
     const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    const std::unordered_map<
+        std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list) const
     noexcept;
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                   \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1> CubicScale::    \
-  operator()(const std::array<DTYPE(data), 1>& source_coords,                  \
-             const double time,                                                \
-             const std::unordered_map<std::string, FunctionOfTime&>& map_list) \
-      const noexcept;                                                          \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                 \
-  CubicScale::frame_velocity(                                                  \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list)        \
-      const noexcept;                                                          \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>   \
-  CubicScale::jacobian(                                                        \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list)        \
-      const noexcept;                                                          \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>   \
-  CubicScale::inv_jacobian(                                                    \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list)        \
-      const noexcept;                                                          \
-  template tnsr::Iaa<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>  \
-  CubicScale::hessian(                                                         \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list)        \
+#define INSTANTIATE(_, data)                                                  \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                \
+  CubicScale::operator()(                                                     \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,     \
+      const std::unordered_map<                                               \
+          std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list)   \
+      const noexcept;                                                         \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                \
+  CubicScale::frame_velocity(                                                 \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,     \
+      const std::unordered_map<                                               \
+          std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list)   \
+      const noexcept;                                                         \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>  \
+  CubicScale::jacobian(                                                       \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,     \
+      const std::unordered_map<                                               \
+          std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list)   \
+      const noexcept;                                                         \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>  \
+  CubicScale::inv_jacobian(                                                   \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,     \
+      const std::unordered_map<                                               \
+          std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list)   \
+      const noexcept;                                                         \
+  template tnsr::Iaa<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
+  CubicScale::hessian(                                                        \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,     \
+      const std::unordered_map<                                               \
+          std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list)   \
       const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,

--- a/src/Domain/CoordinateMaps/CubicScale.hpp
+++ b/src/Domain/CoordinateMaps/CubicScale.hpp
@@ -12,8 +12,13 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/TypeTraits.hpp"
+
 /// \cond
+namespace domain {
+namespace FunctionsOfTime {
 class FunctionOfTime;
+}  // namespace FunctionsOfTime
+}  // namespace domain
 namespace PUP {
 class er;
 }  // namespace PUP
@@ -42,39 +47,45 @@ class CubicScale {
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
       const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
-      noexcept;
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          map_list) const noexcept;
 
   /// Returns boost::none if the point is outside the range of the map.
   template <typename T>
   boost::optional<std::array<tt::remove_cvref_wrap_t<T>, 1>> inverse(
       const std::array<T, 1>& target_coords, double time,
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
-      noexcept;
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          map_list) const noexcept;
 
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 1> frame_velocity(
       const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
-      noexcept;
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          map_list) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> inv_jacobian(
       const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
-      noexcept;
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          map_list) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> jacobian(
       const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
-      noexcept;
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          map_list) const noexcept;
 
   template <typename T>
   tnsr::Iaa<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> hessian(
       const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
-      noexcept;
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          map_list) const noexcept;
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/src/Domain/CoordinateMaps/Translation.cpp
+++ b/src/Domain/CoordinateMaps/Translation.cpp
@@ -6,9 +6,9 @@
 #include <pup.h>
 #include <pup_stl.h>
 
-#include "ControlSystem/FunctionOfTime.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Identity.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -19,14 +19,16 @@ namespace CoordMapsTimeDependent {
 template <typename T>
 std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::operator()(
     const std::array<T, 1>& source_coords, const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    const std::unordered_map<
+        std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list) const
     noexcept {
   return {{source_coords[0] + map_list.at(f_of_t_name_).func(time)[0][0]}};
 }
 
 boost::optional<std::array<double, 1>> Translation::inverse(
     const std::array<double, 1>& target_coords, const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    const std::unordered_map<
+        std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list) const
     noexcept {
   return {{{target_coords[0] - map_list.at(f_of_t_name_).func(time)[0][0]}}};
 }
@@ -34,7 +36,8 @@ boost::optional<std::array<double, 1>> Translation::inverse(
 template <typename T>
 std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::frame_velocity(
     const std::array<T, 1>& source_coords, const double time,
-    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    const std::unordered_map<
+        std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list) const
     noexcept {
   return {{make_with_value<tt::remove_cvref_wrap_t<T>>(
       dereference_wrapper(source_coords[0]),
@@ -65,22 +68,24 @@ bool operator==(const CoordMapsTimeDependent::Translation& lhs,
 /// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                   \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1> Translation::   \
-  operator()(const std::array<DTYPE(data), 1>& source_coords,                  \
-             const double time,                                                \
-             const std::unordered_map<std::string, FunctionOfTime&>& map_list) \
-      const noexcept;                                                          \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                 \
-  Translation::frame_velocity(                                                 \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list)        \
-      const noexcept;                                                          \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>   \
-  Translation::jacobian(const std::array<DTYPE(data), 1>& source_coords)       \
-      const noexcept;                                                          \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>   \
-  Translation::inv_jacobian(const std::array<DTYPE(data), 1>& source_coords)   \
+#define INSTANTIATE(_, data)                                                 \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>               \
+  Translation::operator()(                                                   \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,    \
+      const std::unordered_map<                                              \
+          std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list)  \
+      const noexcept;                                                        \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>               \
+  Translation::frame_velocity(                                               \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,    \
+      const std::unordered_map<                                              \
+          std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list)  \
+      const noexcept;                                                        \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
+  Translation::jacobian(const std::array<DTYPE(data), 1>& source_coords)     \
+      const noexcept;                                                        \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
+  Translation::inv_jacobian(const std::array<DTYPE(data), 1>& source_coords) \
       const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,

--- a/src/Domain/CoordinateMaps/Translation.hpp
+++ b/src/Domain/CoordinateMaps/Translation.hpp
@@ -13,7 +13,11 @@
 #include "Utilities/TypeTraits.hpp"
 
 /// \cond
+namespace domain {
+namespace FunctionsOfTime {
 class FunctionOfTime;
+}  // namespace FunctionsOfTime
+}  // namespace domain
 namespace PUP {
 class er;
 }  // namespace PUP
@@ -35,19 +39,22 @@ class Translation {
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
       const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
-      noexcept;
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          map_list) const noexcept;
 
   boost::optional<std::array<double, 1>> inverse(
       const std::array<double, 1>& target_coords, double time,
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
-      noexcept;
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          map_list) const noexcept;
 
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 1> frame_velocity(
       const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
-      noexcept;
+      const std::unordered_map<std::string,
+                               domain::FunctionsOfTime::FunctionOfTime&>&
+          map_list) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> inv_jacobian(

--- a/src/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/src/Domain/FunctionsOfTime/CMakeLists.txt
@@ -1,14 +1,12 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY ControlSystem)
+set(LIBRARY FunctionsOfTime)
 
 set(LIBRARY_SOURCES
-    Averager.cpp
-    Controller.cpp
-    FunctionOfTimeUpdater.cpp
-    TimescaleTuner.cpp
-   )
+  PiecewisePolynomial.cpp
+  SettleToConstant.cpp
+  )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
@@ -16,5 +14,4 @@ target_link_libraries(
   ${LIBRARY}
   INTERFACE DataStructures
   INTERFACE ErrorHandling
-  INTERFACE FunctionsOfTime
   )

--- a/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
@@ -10,7 +10,11 @@
 #include "DataStructures/DataVector.hpp"
 #include "Parallel/CharmPupable.hpp"
 
-/// \ingroup ControlSystemGroup
+namespace domain {
+/// \ingroup ComputationalDomainGroup
+/// Contains functions of time to support the dual frame system.
+namespace FunctionsOfTime {
+/// \ingroup ComputationalDomainGroup
 /// Base class for FunctionsOfTime
 class FunctionOfTime : public PUP::able {
  public:
@@ -30,3 +34,5 @@ class FunctionOfTime : public PUP::able {
 
   WRAPPED_PUPable_abstract(FunctionOfTime);  // NOLINT
 };
+}  // namespace FunctionsOfTime
+}  // namespace domain

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "ControlSystem/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 
 #include <algorithm>
 #include <iterator>
@@ -16,6 +16,7 @@
 #include "Utilities/Literals.hpp"
 #include "Utilities/MakeArray.hpp"
 
+namespace domain {
 namespace FunctionsOfTime {
 template <size_t MaxDeriv>
 PiecewisePolynomial<MaxDeriv>::PiecewisePolynomial(
@@ -68,8 +69,9 @@ void PiecewisePolynomial<MaxDeriv>::update(
 
   if (updated_max_deriv.size() != func.back().size()) {
     ERROR("the number of components trying to be updated ("
-          << updated_max_deriv.size() << ") does "
-                                         "not match the number of components ("
+          << updated_max_deriv.size()
+          << ") does "
+             "not match the number of components ("
           << func.back().size() << ") in the PiecewisePolynomial.");
   }
 
@@ -155,3 +157,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (4), (0, 1, 2, 3, 4))
 #undef INSTANTIATE
 /// \endcond
 }  // namespace FunctionsOfTime
+}  // namespace domain

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
@@ -9,14 +9,13 @@
 #include <pup.h>
 #include <vector>
 
-#include "ControlSystem/FunctionOfTime.hpp"
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Parallel/CharmPupable.hpp"
 
-/// \ingroup ControlSystemGroup
-/// Contains functions of time to support the dual frame system.
+namespace domain {
 namespace FunctionsOfTime {
-/// \ingroup ControlSystemGroup
+/// \ingroup ComputationalDomainGroup
 /// A function that has a piecewise-constant `MaxDeriv`th derivative.
 template <size_t MaxDeriv>
 class PiecewisePolynomial : public FunctionOfTime {
@@ -108,3 +107,4 @@ template <size_t MaxDeriv>
 PUP::able::PUP_ID PiecewisePolynomial<MaxDeriv>::my_PUP_ID = 0;  // NOLINT
 /// \endcond
 }  // namespace FunctionsOfTime
+}  // namespace domain

--- a/src/Domain/FunctionsOfTime/SettleToConstant.cpp
+++ b/src/Domain/FunctionsOfTime/SettleToConstant.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "ControlSystem/SettleToConstant.hpp"
+#include "Domain/FunctionsOfTime/SettleToConstant.hpp"
 
 #include <cmath>
 
@@ -9,6 +9,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 
+namespace domain {
 namespace FunctionsOfTime {
 SettleToConstant::SettleToConstant(
     const std::array<DataVector, 3>& initial_func_and_derivs,
@@ -75,3 +76,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (0, 1, 2))
 #undef INSTANTIATE
 /// \endcond
 }  // namespace FunctionsOfTime
+}  // namespace domain

--- a/src/Domain/FunctionsOfTime/SettleToConstant.hpp
+++ b/src/Domain/FunctionsOfTime/SettleToConstant.hpp
@@ -8,10 +8,11 @@
 #include <limits>
 #include <pup.h>
 
-#include "ControlSystem/FunctionOfTime.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Parallel/CharmPupable.hpp"
 
+namespace domain {
 namespace FunctionsOfTime {
 /// \ingroup ControlSystemGroup
 /// Given an initial function \f$f(t)\f$ and its first two derivatives
@@ -73,3 +74,4 @@ class SettleToConstant : public FunctionOfTime {
   double inv_decay_time_{std::numeric_limits<double>::signaling_NaN()};
 };
 }  // namespace FunctionsOfTime
+}  // namespace domain

--- a/tests/Unit/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/CMakeLists.txt
@@ -7,8 +7,6 @@ set(LIBRARY_SOURCES
   Test_Averager.cpp
   Test_Controller.cpp
   Test_FuntionOfTimeUpdater.cpp
-  Test_PiecewisePolynomial.cpp
-  Test_SettleToConstant.cpp
   Test_TimescaleTuner.cpp
   FoTUpdater_Helper.cpp
   )
@@ -17,5 +15,5 @@ add_test_library(
   ${LIBRARY}
   "ControlSystem"
   "${LIBRARY_SOURCES}"
-  "ControlSystem"
+  "ControlSystem;FunctionsOfTime"
   )

--- a/tests/Unit/ControlSystem/FoTUpdater_Helper.cpp
+++ b/tests/Unit/ControlSystem/FoTUpdater_Helper.cpp
@@ -5,14 +5,8 @@
 
 #include <algorithm>
 
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Utilities/Gsl.hpp"
-
-/// \cond
-namespace FunctionsOfTime {
-template <size_t DerivOrder>
-class PiecewisePolynomial;
-}  // namespace FunctionsOfTime
-/// \endcond
 
 namespace TestHelpers {
 namespace ControlErrors {
@@ -24,7 +18,7 @@ Translation<DerivOrder>::Translation(DataVector target_coords) noexcept
 template <size_t DerivOrder>
 void Translation<DerivOrder>::operator()(
     const gsl::not_null<FunctionOfTimeUpdater<DerivOrder>*> updater,
-    const FunctionsOfTime::PiecewisePolynomial<DerivOrder>& f_of_t,
+    const domain::FunctionsOfTime::PiecewisePolynomial<DerivOrder>& f_of_t,
     const double time, const DataVector& coords) noexcept {
   const DataVector q = coords - target_coords_ - f_of_t.func(time)[0];
   updater->measure(time, q);

--- a/tests/Unit/ControlSystem/FoTUpdater_Helper.hpp
+++ b/tests/Unit/ControlSystem/FoTUpdater_Helper.hpp
@@ -11,10 +11,12 @@
 // IWYU pragma: no_forward_declare FunctionOfTimeUpdater
 
 /// \cond
+namespace domain {
 namespace FunctionsOfTime {
 template <size_t DerivOrder>
 class PiecewisePolynomial;
 }  // namespace FunctionsOfTime
+}  // namespace domain
 namespace gsl {
 template <class T>
 class not_null;
@@ -39,7 +41,7 @@ class Translation {
   // FunctionOfTimeUpdater
   void operator()(
       gsl::not_null<FunctionOfTimeUpdater<DerivOrder>*> updater,
-      const FunctionsOfTime::PiecewisePolynomial<DerivOrder>& f_of_t,
+      const domain::FunctionsOfTime::PiecewisePolynomial<DerivOrder>& f_of_t,
       double time, const DataVector& coords) noexcept;
 
  private:

--- a/tests/Unit/ControlSystem/Test_Controller.cpp
+++ b/tests/Unit/ControlSystem/Test_Controller.cpp
@@ -8,10 +8,10 @@
 #include <cstddef>
 
 #include "ControlSystem/Controller.hpp"
-#include "ControlSystem/FunctionOfTime.hpp"
-#include "ControlSystem/PiecewisePolynomial.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.Controller", "[ControlSystem][Unit]") {
@@ -35,11 +35,11 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller", "[ControlSystem][Unit]") {
   const double freq = 3.0;
 
   // properly initialize the function of time to match our target function
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(
+  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(
       t, {{{std::sin(freq * t)},
            {freq * std::cos(freq * t)},
            {-square(freq) * std::sin(freq * t)}}});
-  FunctionOfTime& f_of_t = f_of_t_derived;
+  domain::FunctionsOfTime::FunctionOfTime& f_of_t = f_of_t_derived;
 
   Controller<deriv_order> control_signal;
   const double t_offset = 0.0;
@@ -99,11 +99,11 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets",
   double avg_time = 0.0;
 
   // properly initialize the function of time to match our target function
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(
+  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(
       t, {{{std::sin(freq * t)},
            {freq * std::cos(freq * t)},
            {-square(freq) * std::sin(freq * t)}}});
-  FunctionOfTime& f_of_t = f_of_t_derived;
+  domain::FunctionsOfTime::FunctionOfTime& f_of_t = f_of_t_derived;
 
   Controller<deriv_order> control_signal;
 
@@ -176,11 +176,11 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets_DontAverageQ",
   double avg_time = 0.0;
 
   // properly initialize the function of time to match our target function
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(
+  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(
       t, {{{std::sin(freq * t)},
            {freq * std::cos(freq * t)},
            {-square(freq) * std::sin(freq * t)}}});
-  FunctionOfTime& f_of_t = f_of_t_derived;
+  domain::FunctionsOfTime::FunctionOfTime& f_of_t = f_of_t_derived;
 
   Controller<deriv_order> control_signal;
 

--- a/tests/Unit/ControlSystem/Test_FuntionOfTimeUpdater.cpp
+++ b/tests/Unit/ControlSystem/Test_FuntionOfTimeUpdater.cpp
@@ -11,9 +11,9 @@
 #include "ControlSystem/Averager.hpp"
 #include "ControlSystem/Controller.hpp"
 #include "ControlSystem/FunctionOfTimeUpdater.hpp"
-#include "ControlSystem/PiecewisePolynomial.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Utilities/Gsl.hpp"
 #include "tests/Unit/ControlSystem/FoTUpdater_Helper.hpp"
 
@@ -53,7 +53,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionOfTimeUpdater.Translation",
   // initialize our FunctionOfTime to agree at t=0
   const std::array<DataVector, deriv_order + 1> init_func{
       {{0.0, 0.0}, {amp1 * omega1, amp2 * omega2}, {0.0, 0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(t, init_func);
+  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(t,
+                                                                   init_func);
 
   Averager<deriv_order> averager(0.25, false);
   Controller<deriv_order> control_signal;

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -25,5 +25,5 @@ add_test_library(
   ${LIBRARY}
   "Domain/CoordinateMaps"
   "${LIBRARY_SOURCES}"
-  "CoordinateMaps;ControlSystem"
+  "CoordinateMaps;FunctionsOfTime"
   )

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -13,7 +13,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "ControlSystem/PiecewisePolynomial.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
@@ -30,14 +29,13 @@
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "tests/Unit/TestHelpers.hpp"
-
-// IWYU pragma: no_forward_declare Tensor
-class FunctionOfTime;
 
 namespace domain {
 namespace {
@@ -903,12 +901,14 @@ void test_time_dependent_map() {
 
   const std::array<DataVector, deriv_order + 1> init_func{
       {{1.0}, {-2.0}, {2.0}, {0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> function_of_time_derived(
-      initial_time, init_func);
-  FunctionOfTime& function_of_time = function_of_time_derived;
+  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>
+      function_of_time_derived(initial_time, init_func);
+  domain::FunctionsOfTime::FunctionOfTime& function_of_time =
+      function_of_time_derived;
 
-  const std::unordered_map<std::string, FunctionOfTime&> functions_of_time = {
-      {"trans", function_of_time}};
+  const std::unordered_map<std::string,
+                           domain::FunctionsOfTime::FunctionOfTime&>
+      functions_of_time = {{"trans", function_of_time}};
   const CoordMapsTimeDependent::Translation trans_map{};
 
   // affine(x) = 1.5 * x + 5.5

--- a/tests/Unit/Domain/CoordinateMaps/Test_CubicScale.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CubicScale.cpp
@@ -9,11 +9,11 @@
 #include <string>
 #include <unordered_map>
 
-#include "ControlSystem/FunctionOfTime.hpp"
-#include "ControlSystem/PiecewisePolynomial.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/CubicScale.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TypeTraits.hpp"
@@ -31,16 +31,20 @@ void cubic_scale_non_invertible(const double a0, const double b0,
 
   const std::array<DataVector, deriv_order + 1> init_func_a{
       {{a0}, {0.0}, {0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_a(t, init_func_a);
-  FunctionOfTime& expansion_a_base = expansion_a;
+  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_a(
+      t, init_func_a);
+  domain::FunctionsOfTime::FunctionOfTime& expansion_a_base = expansion_a;
 
   const std::array<DataVector, deriv_order + 1> init_func_b{
       {{b0}, {0.0}, {0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_b(t, init_func_b);
-  FunctionOfTime& expansions_b_base = expansion_b;
+  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_b(
+      t, init_func_b);
+  domain::FunctionsOfTime::FunctionOfTime& expansions_b_base = expansion_b;
 
-  const std::unordered_map<std::string, FunctionOfTime&> f_of_t_list = {
-      {"expansion_a", expansion_a_base}, {"expansion_b", expansions_b_base}};
+  const std::unordered_map<std::string,
+                           domain::FunctionsOfTime::FunctionOfTime&>
+      f_of_t_list = {{"expansion_a", expansion_a_base},
+                     {"expansion_b", expansions_b_base}};
 
   const CoordMapsTimeDependent::CubicScale scale_map(outer_boundary);
   const std::array<double, 1> point_xi{{19.2}};
@@ -68,16 +72,18 @@ void test_map() {
     double t = -0.5;
     const double dt = 0.6;
 
-    FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_a(t,
-                                                                  init_func_a);
-    FunctionOfTime& expansion_a_base = expansion_a;
+    domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_a(
+        t, init_func_a);
+    domain::FunctionsOfTime::FunctionOfTime& expansion_a_base = expansion_a;
 
-    FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_b(t,
-                                                                  init_func_b);
-    FunctionOfTime& expansions_b_base = expansion_b;
+    domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_b(
+        t, init_func_b);
+    domain::FunctionsOfTime::FunctionOfTime& expansions_b_base = expansion_b;
 
-    const std::unordered_map<std::string, FunctionOfTime&> f_of_t_list = {
-        {"expansion_a", expansion_a_base}, {"expansion_b", expansions_b_base}};
+    const std::unordered_map<std::string,
+                             domain::FunctionsOfTime::FunctionOfTime&>
+        f_of_t_list = {{"expansion_a", expansion_a_base},
+                       {"expansion_b", expansions_b_base}};
 
     const double outer_boundary = outer_b;
     const CoordMapsTimeDependent::CubicScale scale_map(outer_boundary);
@@ -202,16 +208,18 @@ void test_boundaries() {
     const std::array<DataVector, deriv_order + 1> init_func_b{
         {{0.99}, {0.0}, {0.0}}};
 
-    FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_a(t,
-                                                                  init_func_a);
-    FunctionOfTime& expansion_a_base = expansion_a;
+    domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_a(
+        t, init_func_a);
+    domain::FunctionsOfTime::FunctionOfTime& expansion_a_base = expansion_a;
 
-    FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_b(t,
-                                                                  init_func_b);
-    FunctionOfTime& expansions_b_base = expansion_b;
+    domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_b(
+        t, init_func_b);
+    domain::FunctionsOfTime::FunctionOfTime& expansions_b_base = expansion_b;
 
-    const std::unordered_map<std::string, FunctionOfTime&> f_of_t_list = {
-        {"expansion_a", expansion_a_base}, {"expansion_b", expansions_b_base}};
+    const std::unordered_map<std::string,
+                             domain::FunctionsOfTime::FunctionOfTime&>
+        f_of_t_list = {{"expansion_a", expansion_a_base},
+                       {"expansion_b", expansions_b_base}};
 
     const double outer_boundary = 20.0;
     const CoordMapsTimeDependent::CubicScale scale_map(outer_boundary);

--- a/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
@@ -9,11 +9,11 @@
 #include <string>
 #include <unordered_map>
 
-#include "ControlSystem/FunctionOfTime.hpp"
-#include "ControlSystem/PiecewisePolynomial.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Translation.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TypeTraits.hpp"
@@ -31,12 +31,13 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.Translation",
 
   const std::array<DataVector, deriv_order + 1> init_func{
       {{1.0}, {-2.0}, {2.0}, {0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(t,
-                                                                   init_func);
-  FunctionOfTime& f_of_t = f_of_t_derived;
+  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(
+      t, init_func);
+  domain::FunctionsOfTime::FunctionOfTime& f_of_t = f_of_t_derived;
 
-  const std::unordered_map<std::string, FunctionOfTime&> f_of_t_list = {
-      {"trans", f_of_t}};
+  const std::unordered_map<std::string,
+                           domain::FunctionsOfTime::FunctionOfTime&>
+      f_of_t_list = {{"trans", f_of_t}};
   const CoordMapsTimeDependent::Translation trans_map{};
   // test serialized/deserialized map
   const auto trans_map_deserialized = serialize_and_deserialize(trans_map);

--- a/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_FunctionsOfTime")
+
+set(LIBRARY_SOURCES
+  Test_PiecewisePolynomial.cpp
+  Test_SettleToConstant.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Domain/FunctionsOfTime"
+  "${LIBRARY_SOURCES}"
+  "DataStructures;FunctionsOfTime"
+  )

--- a/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
@@ -7,9 +7,9 @@
 #include <cstddef>
 #include <memory>
 
-#include "ControlSystem/FunctionOfTime.hpp"
-#include "ControlSystem/PiecewisePolynomial.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -93,8 +93,8 @@ void test_within_roundoff(const FunctionOfTime& f_of_t) noexcept {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial",
-                  "[ControlSystem][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
+                  "[Domain][Unit]") {
   PUPable_reg(FunctionsOfTime::PiecewisePolynomial<2>);
   PUPable_reg(FunctionsOfTime::PiecewisePolynomial<3>);
 
@@ -201,8 +201,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial",
 // [[OutputRegex, t must be increasing from call to call. Attempted to update at
 // time 1, which precedes the previous update time of 2.]]
 SPECTRE_TEST_CASE(
-    "Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial.BadUpdateTime",
-    "[ControlSystem][Unit]") {
+    "Unit.Domain.FunctionsOfTime.PiecewisePolynomial.BadUpdateTime",
+    "[Domain][Unit]") {
   ERROR_TEST();
   // two component system (x**3 and x**2)
   constexpr size_t deriv_order = 3;
@@ -216,8 +216,8 @@ SPECTRE_TEST_CASE(
 // [[OutputRegex, the number of components trying to be updated \(3\) does not
 // match the number of components \(2\) in the PiecewisePolynomial.]]
 SPECTRE_TEST_CASE(
-    "Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial.BadUpdateSize",
-    "[ControlSystem][Unit]") {
+    "Unit.Domain.FunctionsOfTime.PiecewisePolynomial.BadUpdateSize",
+    "[Domain][Unit]") {
   ERROR_TEST();
   // two component system (x**3 and x**2)
   constexpr size_t deriv_order = 3;
@@ -229,8 +229,8 @@ SPECTRE_TEST_CASE(
 
 // [[OutputRegex, requested time 0.5 precedes earliest time 1 of times.]]
 SPECTRE_TEST_CASE(
-    "Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial.TimeOutOfRange",
-    "[ControlSystem][Unit]") {
+    "Unit.Domain.FunctionsOfTime.PiecewisePolynomial.TimeOutOfRange",
+    "[Domain][Unit]") {
   ERROR_TEST();
   // two component system (x**3 and x**2)
   constexpr size_t deriv_order = 3;

--- a/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstant.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstant.cpp
@@ -6,16 +6,16 @@
 #include <array>
 #include <memory>
 
-#include "ControlSystem/FunctionOfTime.hpp"
-#include "ControlSystem/SettleToConstant.hpp"
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/SettleToConstant.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 namespace {
-void test(const FunctionOfTime& f_of_t, const double match_time,
-          const double f_t0, const double dtf_t0, const double d2tf_t0,
-          const double A) noexcept {
+void test(const domain::FunctionsOfTime::FunctionOfTime& f_of_t,
+          const double match_time, const double f_t0, const double dtf_t0,
+          const double d2tf_t0, const double A) noexcept {
   // check that values agree at the matching time
   const auto lambdas0 = f_of_t.func_and_2_derivs(match_time);
   CHECK(approx(lambdas0[0][0]) == f_t0);
@@ -48,9 +48,9 @@ void test(const FunctionOfTime& f_of_t, const double match_time,
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.SettleToConstant",
-                  "[ControlSystem][Unit]") {
-  PUPable_reg(FunctionsOfTime::SettleToConstant);
+SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.SettleToConstant",
+                  "[Domain][Unit]") {
+  PUPable_reg(domain::FunctionsOfTime::SettleToConstant);
 
   const double match_time = 10.0;
   const double decay_time = 5.0;
@@ -66,23 +66,23 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.SettleToConstant",
 
   {
     INFO("Test with simple construction.");
-    const FunctionsOfTime::SettleToConstant f_of_t_derived(
+    const domain::FunctionsOfTime::SettleToConstant f_of_t_derived(
         init_func, match_time, decay_time);
     test(f_of_t_derived, match_time, f_t0, dtf_t0, d2tf_t0, A);
 
-    const FunctionsOfTime::SettleToConstant f_of_t_derived2 =
+    const domain::FunctionsOfTime::SettleToConstant f_of_t_derived2 =
         serialize_and_deserialize(f_of_t_derived);
     test(f_of_t_derived2, match_time, f_t0, dtf_t0, d2tf_t0, A);
   }
 
   {
     INFO("Test with base class construction.");
-    const std::unique_ptr<FunctionOfTime> f_of_t =
-        std::make_unique<FunctionsOfTime::SettleToConstant>(
+    const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
+        std::make_unique<domain::FunctionsOfTime::SettleToConstant>(
             init_func, match_time, decay_time);
     test(*f_of_t, match_time, f_t0, dtf_t0, d2tf_t0, A);
 
-    const std::unique_ptr<FunctionOfTime> f_of_t2 =
+    const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t2 =
         serialize_and_deserialize(f_of_t);
     test(*f_of_t2, match_time, f_t0, dtf_t0, d2tf_t0, A);
   }


### PR DESCRIPTION
## Proposed changes

We don't need a control system to have time-dependent coordinate maps so the functions of time should be part of the domain rather than the control system.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
