### PR TITLE
Allow some Time comparisons on overlapping slabs

### DIFF
--- a/src/Time/Slab.cpp
+++ b/src/Time/Slab.cpp
@@ -59,6 +59,10 @@ bool Slab::is_preceeded_by(const Slab& other) const noexcept {
   return other.is_followed_by(*this);
 }
 
+bool Slab::overlaps(const Slab& other) const noexcept {
+  return not(end_ <= other.start_ or start_ >= other.end_);
+}
+
 void Slab::pup(PUP::er& p) noexcept {
   p | start_;
   p | end_;

--- a/src/Time/Slab.hpp
+++ b/src/Time/Slab.hpp
@@ -70,6 +70,9 @@ class Slab {
   /// Check if this slab is immediately preceeded by the other slab.
   bool is_preceeded_by(const Slab& other) const noexcept;
 
+  /// Check if slabs overlap.  Abutting slabs do not overlap.
+  bool overlaps(const Slab& other) const noexcept;
+
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT
 

--- a/src/Time/Time.cpp
+++ b/src/Time/Time.cpp
@@ -172,10 +172,18 @@ bool operator==(const Time& a, const Time& b) noexcept {
 bool operator!=(const Time& a, const Time& b) noexcept { return not(a == b); }
 
 bool operator<(const Time& a, const Time& b) noexcept {
-  // Non-equality test in second clause is required to avoid
-  // assertions in Slab.
-  return (a.slab() == b.slab() and a.fraction() < b.fraction()) or
-         (a != b and a.slab() < b.slab());
+  if (a.slab() == b.slab()) {
+    return a.fraction() < b.fraction();
+  }
+  if (not a.slab().overlaps(b.slab())) {
+    return a != b and a.slab() < b.slab();
+  }
+  if ((a.slab().start() == b.slab().start() and a.is_at_slab_start()) or
+      (a.slab().end() == b.slab().end() and a.is_at_slab_end())) {
+    return a.with_slab(b.slab()) < b;
+  } else {
+    return a < b.with_slab(a.slab());
+  }
 }
 
 bool operator>(const Time& a, const Time& b) noexcept { return b < a; }

--- a/tests/Unit/Time/Test_Slab.cpp
+++ b/tests/Unit/Time/Test_Slab.cpp
@@ -75,6 +75,22 @@ SPECTRE_TEST_CASE("Unit.Time.Slab", "[Unit][Time]") {
   CHECK(slab != Slab(tend2_d / 2., tend_d));
   CHECK(slab != Slab(tend_d, tend2_d));
 
+  {
+    const auto check_overlaps =
+        [](const Slab& a, const Slab& b, const bool expected) noexcept {
+      CAPTURE(a);
+      CAPTURE(b);
+      CHECK(a.overlaps(b) == expected);
+      CHECK(b.overlaps(a) == expected);
+    };
+    check_overlaps(slab, slab, true);
+    check_overlaps(slab, slab.advance(), false);
+    check_overlaps(slab, slab.advance().advance(), false);
+    check_overlaps(slab, Slab(tstart_d, tend_d + 1.0), true);
+    check_overlaps(slab, Slab(tstart_d - 1.0, tend_d), true);
+    check_overlaps(slab, Slab(tstart_d - 1.0, tend_d + 1.0), true);
+  }
+
   check_cmp(Slab(1, 2), Slab(3, 4));
   check_cmp(Slab(1, 2), Slab(2, 4));
 

--- a/tests/Unit/Time/Test_Time.cpp
+++ b/tests/Unit/Time/Test_Time.cpp
@@ -162,9 +162,7 @@ SPECTRE_TEST_CASE("Unit.Time.Time_slab_comparison", "[Unit][Time]") {
       CHECK(t1 <= t2);
       CHECK(t1 >= t2);
     }
-  }
 
-  for (const auto& t1 : {a, c}) {
     for (const auto& t2 : {b.slab().start(), d.slab().start()}) {
       CHECK_FALSE(t1 == t2);
       CHECK_FALSE(t2 == t1);
@@ -179,8 +177,7 @@ SPECTRE_TEST_CASE("Unit.Time.Time_slab_comparison", "[Unit][Time]") {
       CHECK(t1 >= t2);
       CHECK(t2 <= t1);
     }
-  }
-  for (const auto& t1 : {b, d}) {
+
     for (const auto& t2 : {a.slab().end(), c.slab().end()}) {
       CHECK_FALSE(t1 == t2);
       CHECK_FALSE(t2 == t1);
@@ -387,7 +384,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
 #endif
 }
 
-// [[OutputRegex, Cannot compare overlapping slabs]]
+// [[OutputRegex, Can't move .* to slab]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Time.Time.overlap", "[Unit][Time]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG


### PR DESCRIPTION
In particular, when the slabs share an endpoint and one of the times
is at that endpoint.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
