### PR TITLE
Change History to record TimeStepId

### DIFF
--- a/src/Time/Actions/RecordTimeStepperData.hpp
+++ b/src/Time/Actions/RecordTimeStepperData.hpp
@@ -13,10 +13,8 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
-// IWYU pragma: no_include "Time/Time.hpp" // for Time
-
 /// \cond
-// IWYU pragma: no_forward_declare Time
+class TimeStepId;
 namespace Parallel {
 template <typename Metavariables>
 class ConstGlobalCache;
@@ -38,7 +36,7 @@ namespace Actions {
 ///   - variables_tag
 ///   - dt_variables_tag
 ///   - Tags::HistoryEvolvedVariables<system::variables_tag, dt_variables_tag>
-///   - Tags::Time
+///   - Tags::TimeStepId
 ///
 /// DataBox changes:
 /// - Adds: nothing
@@ -65,10 +63,10 @@ struct RecordTimeStepperData {
         [](const gsl::not_null<db::item_type<dt_variables_tag>*> dt_vars,
            const gsl::not_null<db::item_type<history_tag>*> history,
            const db::const_item_type<variables_tag>& vars,
-           const db::const_item_type<Tags::SubstepTime>& time) noexcept {
-          history->insert(time, vars, std::move(*dt_vars));
+           const db::const_item_type<Tags::TimeStepId>& time_step_id) noexcept {
+          history->insert(time_step_id, vars, std::move(*dt_vars));
         },
-        db::get<variables_tag>(box), db::get<Tags::SubstepTime>(box));
+        db::get<variables_tag>(box), db::get<Tags::TimeStepId>(box));
 
     return std::forward_as_tuple(std::move(box));
   }

--- a/src/Time/History.hpp
+++ b/src/Time/History.hpp
@@ -3,14 +3,23 @@
 
 #pragma once
 
+#include <cstddef>
 #include <deque>
 #include <iterator>
-#include <pup.h>
 #include <tuple>
 #include <utility>
 
-#include "Parallel/PupStlCpp11.hpp"
+#include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep  // p | deque, tuple
 #include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+
+// IWYU pragma: no_include <unordered_set>  // for swap?
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
 
 namespace TimeSteppers {
 
@@ -43,11 +52,13 @@ class History {
   /// value.  The different argument types for `value` and `deriv`
   /// reflect the common use of this class, which wants `value` to
   /// remain unchanged but does not care about `deriv`.
-  void insert(Time time, const Vars& value, DerivVars&& deriv) noexcept;
+  void insert(TimeStepId time_step_id, const Vars& value,
+              DerivVars&& deriv) noexcept;
 
   /// Add a new set of values to the front of the history.  This is
   /// often convenient for setting initial data.
-  void insert_initial(Time time, Vars value, DerivVars deriv) noexcept;
+  void insert_initial(TimeStepId time_step_id, Vars value,
+                      DerivVars deriv) noexcept;
 
   /// Mark all data before the passed point in history as unneeded so
   /// it can be removed.  Calling this directly should not often be
@@ -80,7 +91,9 @@ class History {
   }
 
   const_reference front() const noexcept { return *begin(); }
-  const_reference back() const noexcept { return std::get<0>(data_.back()); }
+  const_reference back() const noexcept {
+    return std::get<0>(data_.back()).substep_time();
+  }
   //@}
 
   // clang-tidy: google-runtime-references
@@ -93,7 +106,7 @@ class History {
   }
 
  private:
-  std::deque<std::tuple<Time, Vars, DerivVars>> data_;
+  std::deque<std::tuple<TimeStepId, Vars, DerivVars>> data_;
   size_t first_needed_entry_{0};
 };
 
@@ -102,8 +115,8 @@ class History {
 /// details.
 template <typename Vars, typename DerivVars>
 class HistoryIterator {
-  using Base =
-      typename std::deque<std::tuple<Time, Vars, DerivVars>>::const_iterator;
+  using Base = typename std::deque<
+      std::tuple<TimeStepId, Vars, DerivVars>>::const_iterator;
 
  public:
   using iterator_category =
@@ -115,10 +128,12 @@ class HistoryIterator {
 
   HistoryIterator() = default;
 
-  reference operator*() const noexcept { return std::get<0>(*base_); }
-  pointer operator->() const noexcept { return &std::get<0>(*base_); }
-  reference operator[](difference_type n) const noexcept {
-    return std::get<0>(base_[n]);
+  reference operator*() const noexcept {
+    return std::get<0>(*base_).substep_time();
+  }
+  pointer operator->() const noexcept { return &**this; }
+  reference operator[](const difference_type n) const noexcept {
+    return std::get<0>(base_[n]).substep_time();
   }
   HistoryIterator& operator++() noexcept { ++base_; return *this; }
   // clang-tidy: return const... Really? What?
@@ -135,6 +150,9 @@ class HistoryIterator {
     return *this;
   }
 
+  const TimeStepId& time_step_id() const noexcept {
+    return std::get<0>(*base_);
+  }
   const Vars& value() const noexcept { return std::get<1>(*base_); }
   const DerivVars& derivative() const noexcept { return std::get<2>(*base_); }
 
@@ -168,18 +186,19 @@ class HistoryIterator {
 // ================================================================
 
 template <typename Vars, typename DerivVars>
-void History<Vars, DerivVars>::insert(Time time, const Vars& value,
+void History<Vars, DerivVars>::insert(TimeStepId time_step_id,
+                                      const Vars& value,
                                       DerivVars&& deriv) noexcept {
   if (first_needed_entry_ == 0) {
-    // clang-tidy: move of trivially-copyable type
-    data_.emplace_back(std::move(time), value, deriv);  // NOLINT
+    // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
+    data_.emplace_back(std::move(time_step_id), value, deriv);
   } else {
     // Move an unneeded entry into the arguments so the caller can
     // reuse any resources the entry contained.
     using std::swap;
     auto& old_entry = data_.front();
-    // clang-tidy: move of trivially-copyable type
-    std::get<0>(old_entry) = std::move(time);  // NOLINT
+    // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
+    std::get<0>(old_entry) = std::move(time_step_id);
     std::get<1>(old_entry) = value;
     swap(std::get<2>(old_entry), deriv);
     data_.push_back(std::move(old_entry));
@@ -189,11 +208,12 @@ void History<Vars, DerivVars>::insert(Time time, const Vars& value,
 }
 
 template <typename Vars, typename DerivVars>
-inline void History<Vars, DerivVars>::insert_initial(Time time, Vars value,
+inline void History<Vars, DerivVars>::insert_initial(TimeStepId time_step_id,
+                                                     Vars value,
                                                      DerivVars deriv) noexcept {
-  // clang-tidy: move of trivially-copyable type
-  data_.emplace_front(std::move(time), // NOLINT
-                      std::move(value), std::move(deriv));
+  // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
+  data_.emplace_front(std::move(time_step_id), std::move(value),
+                      std::move(deriv));
 }
 
 template <typename Vars, typename DerivVars>

--- a/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
+++ b/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
@@ -14,11 +14,10 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
-
-// IWYU pragma: no_include <unordered_map>
 
 // IWYU pragma: no_include "Time/History.hpp"
 
@@ -44,7 +43,7 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using simple_tags = db::AddSimpleTags<Tags::SubstepTime, variables_tag,
+  using simple_tags = db::AddSimpleTags<Tags::TimeStepId, variables_tag,
                                         dt_variables_tag, history_tag>;
   using compute_tags = db::AddComputeTags<>;
   using phase_dependent_action_list = tmpl::list<
@@ -69,7 +68,7 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.RecordTimeStepperData",
   const Slab slab(1., 3.);
 
   history_tag::type history{};
-  history.insert(slab.end(), 2., 3.);
+  history.insert(TimeStepId(true, 0, slab.end()), 2., 3.);
 
   using component = Component<Metavariables>;
   using simple_tags = typename component::simple_tags;
@@ -78,7 +77,8 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.RecordTimeStepperData",
   MockRuntimeSystem runner{{}};
 
   ActionTesting::emplace_component_and_initialize<component>(
-      &runner, 0, {slab.start(), 4., 5., std::move(history)});
+      &runner, 0,
+      {TimeStepId(true, 0, slab.start()), 4., 5., std::move(history)});
   runner.set_phase(Metavariables::Phase::Testing);
   runner.next_action<component>(0);
   auto& box =

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -16,12 +16,11 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
-
-// IWYU pragma: no_include <unordered_map>
 
 // IWYU pragma: no_include "Time/History.hpp"
 
@@ -100,7 +99,8 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
             const gsl::not_null<db::item_type<history_tag>*> history,
             const double& vars) noexcept {
           const Time& time = gsl::at(substep_times, substep);
-          history->insert(time, vars, rhs(time.value(), vars));
+          history->insert(TimeStepId(true, 0, time), vars,
+                          rhs(time.value(), vars));
         },
         db::get<variables_tag>(before_box));
 


### PR DESCRIPTION
This provides a way to determine the start of the current step.  It
also makes the interface more consistent with BoundaryHistory.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
