### PR TITLE
Coordinate maps take function of time as unique ptr

### DIFF
--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -22,6 +22,7 @@
 
 #include "DataStructures/Tensor/Identity.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Parallel/PupStlCpp11.hpp"
 #include "Utilities/ForceInline.hpp"
@@ -32,11 +33,6 @@
 
 /// \cond
 class DataVector;
-namespace domain {
-namespace FunctionsOfTime {
-class FunctionOfTime;
-}  // namespace FunctionsOfTime
-}  // namespace domain
 /// \endcond
 
 namespace domain {
@@ -74,18 +70,22 @@ class CoordinateMapBase : public PUP::able {
   virtual tnsr::I<double, Dim, TargetFrame> operator()(
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time = std::unordered_map<
-              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
   virtual tnsr::I<DataVector, Dim, TargetFrame> operator()(
       tnsr::I<DataVector, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time = std::unordered_map<
-              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
   // @}
 
@@ -98,10 +98,12 @@ class CoordinateMapBase : public PUP::able {
   virtual boost::optional<tnsr::I<double, Dim, SourceFrame>> inverse(
       tnsr::I<double, Dim, TargetFrame> target_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time = std::unordered_map<
-              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
   // @}
 
@@ -111,19 +113,23 @@ class CoordinateMapBase : public PUP::able {
   virtual InverseJacobian<double, Dim, SourceFrame, TargetFrame> inv_jacobian(
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time = std::unordered_map<
-              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
   virtual InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>
   inv_jacobian(
       tnsr::I<DataVector, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time = std::unordered_map<
-              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
   // @}
 
@@ -132,18 +138,22 @@ class CoordinateMapBase : public PUP::able {
   virtual Jacobian<double, Dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time = std::unordered_map<
-              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
   virtual Jacobian<DataVector, Dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<DataVector, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time = std::unordered_map<
-              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
   // @}
  private:
@@ -214,10 +224,12 @@ class CoordinateMap
   constexpr tnsr::I<double, dim, TargetFrame> operator()(
       tnsr::I<double, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time = std::unordered_map<
-              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept override {
     return call_impl(std::move(source_point), time, functions_of_time,
                      std::make_index_sequence<sizeof...(Maps)>{});
@@ -225,10 +237,12 @@ class CoordinateMap
   constexpr tnsr::I<DataVector, dim, TargetFrame> operator()(
       tnsr::I<DataVector, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time = std::unordered_map<
-              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept override {
     return call_impl(std::move(source_point), time, functions_of_time,
                      std::make_index_sequence<sizeof...(Maps)>{});
@@ -240,10 +254,12 @@ class CoordinateMap
   constexpr boost::optional<tnsr::I<double, dim, SourceFrame>> inverse(
       tnsr::I<double, dim, TargetFrame> target_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time = std::unordered_map<
-              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept override {
     return inverse_impl(std::move(target_point), time, functions_of_time,
                         std::make_index_sequence<sizeof...(Maps)>{});
@@ -256,10 +272,12 @@ class CoordinateMap
   constexpr InverseJacobian<double, dim, SourceFrame, TargetFrame> inv_jacobian(
       tnsr::I<double, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time = std::unordered_map<
-              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept override {
     return inv_jacobian_impl(std::move(source_point), time, functions_of_time);
   }
@@ -267,10 +285,12 @@ class CoordinateMap
   inv_jacobian(
       tnsr::I<DataVector, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time = std::unordered_map<
-              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept override {
     return inv_jacobian_impl(std::move(source_point), time, functions_of_time);
   }
@@ -281,20 +301,24 @@ class CoordinateMap
   constexpr Jacobian<double, dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<double, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time = std::unordered_map<
-              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept override {
     return jacobian_impl(std::move(source_point), time, functions_of_time);
   }
   constexpr Jacobian<DataVector, dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<DataVector, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time = std::unordered_map<
-              std::string, domain::FunctionsOfTime::FunctionOfTime&>{}) const
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept override {
     return jacobian_impl(std::move(source_point), time, functions_of_time);
   }
@@ -327,8 +351,9 @@ class CoordinateMap
   template <typename T, size_t... Is>
   constexpr SPECTRE_ALWAYS_INLINE tnsr::I<T, dim, TargetFrame> call_impl(
       tnsr::I<T, dim, SourceFrame>&& source_point, double time,
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time,
       std::index_sequence<Is...> /*meta*/) const noexcept;
 
@@ -336,7 +361,8 @@ class CoordinateMap
   constexpr SPECTRE_ALWAYS_INLINE boost::optional<tnsr::I<T, dim, SourceFrame>>
   inverse_impl(tnsr::I<T, dim, TargetFrame>&& target_point, double time,
                const std::unordered_map<
-                   std::string, domain::FunctionsOfTime::FunctionOfTime&>&
+                   std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
                    functions_of_time,
                std::index_sequence<Is...> /*meta*/) const noexcept;
 
@@ -345,15 +371,17 @@ class CoordinateMap
       InverseJacobian<T, dim, SourceFrame, TargetFrame>
       inv_jacobian_impl(
           tnsr::I<T, dim, SourceFrame>&& source_point, double time,
-          const std::unordered_map<std::string,
-                                   domain::FunctionsOfTime::FunctionOfTime&>&
+          const std::unordered_map<
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
               functions_of_time) const noexcept;
 
   template <typename T>
   constexpr SPECTRE_ALWAYS_INLINE Jacobian<T, dim, SourceFrame, TargetFrame>
   jacobian_impl(tnsr::I<T, dim, SourceFrame>&& source_point, double time,
                 const std::unordered_map<
-                    std::string, domain::FunctionsOfTime::FunctionOfTime&>&
+                    std::string,
+                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
                     functions_of_time) const noexcept;
 
   std::tuple<Maps...> maps_;
@@ -368,28 +396,31 @@ namespace CoordinateMap_detail {
 template <typename T>
 using is_map_time_dependent_t = tt::is_callable_t<
     T, std::array<std::decay_t<T>, std::decay_t<T>::dim>, double,
-    std::unordered_map<std::string, domain::FunctionsOfTime::FunctionOfTime&>>;
+    std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>>;
 
 template <typename T, size_t Dim, typename Map>
-void apply_map(const gsl::not_null<std::array<T, Dim>*> t_map_point,
-               const Map& the_map, const double /*t*/,
-               const std::unordered_map<
-                   std::string, domain::FunctionsOfTime::FunctionOfTime&>&
-               /*functions_of_time*/,
-               const std::false_type /*is_time_independent*/) {
+void apply_map(
+    const gsl::not_null<std::array<T, Dim>*> t_map_point, const Map& the_map,
+    const double /*t*/,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+    /*functions_of_time*/,
+    const std::false_type /*is_time_independent*/) {
   if (LIKELY(not the_map.is_identity())) {
     *t_map_point = the_map(*t_map_point);
   }
 }
 
 template <typename T, size_t Dim, typename Map>
-void apply_map(const gsl::not_null<std::array<T, Dim>*> t_map_point,
-               const Map& the_map, const double t,
-               const std::unordered_map<
-                   std::string, domain::FunctionsOfTime::FunctionOfTime&>&
-                   functions_of_time,
-               const std::true_type
-               /*is_time_dependent*/) {
+void apply_map(
+    const gsl::not_null<std::array<T, Dim>*> t_map_point, const Map& the_map,
+    const double t,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const std::true_type
+    /*is_time_dependent*/) {
   *t_map_point = the_map(*t_map_point, t, functions_of_time);
 }
 }  // namespace CoordinateMap_detail
@@ -405,16 +436,17 @@ constexpr SPECTRE_ALWAYS_INLINE tnsr::I<
     T, CoordinateMap<SourceFrame, TargetFrame, Maps...>::dim, TargetFrame>
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::call_impl(
     tnsr::I<T, dim, SourceFrame>&& source_point, const double time,
-    const std::unordered_map<std::string,
-                             domain::FunctionsOfTime::FunctionOfTime&>&
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time,
     std::index_sequence<Is...> /*meta*/) const noexcept {
   std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
 
   (void)std::initializer_list<char>{make_overloader(
       [](const auto& the_map, std::array<T, dim>& point, const double /*t*/,
-         const std::unordered_map<std::string,
-                                  domain::FunctionsOfTime::FunctionOfTime&>&
+         const std::unordered_map<
+             std::string,
+             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
          /*funcs_of_time*/,
          const std::false_type /*is_time_independent*/) noexcept {
         if (LIKELY(not the_map.is_identity())) {
@@ -423,8 +455,9 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::call_impl(
         return '0';
       },
       [](const auto& the_map, std::array<T, dim>& point, const double t,
-         const std::unordered_map<std::string,
-                                  domain::FunctionsOfTime::FunctionOfTime&>&
+         const std::unordered_map<
+             std::string,
+             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
              funcs_of_time,
          const std::true_type /*is_time_dependent*/) noexcept {
         point = the_map(point, t, funcs_of_time);
@@ -441,8 +474,8 @@ constexpr SPECTRE_ALWAYS_INLINE boost::optional<tnsr::I<
     T, CoordinateMap<SourceFrame, TargetFrame, Maps...>::dim, SourceFrame>>
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::inverse_impl(
     tnsr::I<T, dim, TargetFrame>&& target_point, const double time,
-    const std::unordered_map<std::string,
-                             domain::FunctionsOfTime::FunctionOfTime&>&
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time,
     std::index_sequence<Is...> /*meta*/) const noexcept {
   boost::optional<std::array<T, dim>> mapped_point(
@@ -451,8 +484,9 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::inverse_impl(
   (void)std::initializer_list<char>{make_overloader(
       [](const auto& the_map, boost::optional<std::array<T, dim>>& point,
          const double /*t*/,
-         const std::unordered_map<std::string,
-                                  domain::FunctionsOfTime::FunctionOfTime&>&
+         const std::unordered_map<
+             std::string,
+             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
          /*funcs_of_time*/,
          const std::false_type /*is_time_independent*/) noexcept {
         if (point) {
@@ -464,8 +498,9 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::inverse_impl(
       },
       [](const auto& the_map, boost::optional<std::array<T, dim>>& point,
          const double t,
-         const std::unordered_map<std::string,
-                                  domain::FunctionsOfTime::FunctionOfTime&>&
+         const std::unordered_map<
+             std::string,
+             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
              funcs_of_time,
          const std::true_type /*is_time_dependent*/) noexcept {
         if (point) {
@@ -491,8 +526,9 @@ template <typename Map, typename T>
 using is_jacobian_time_dependent_t =
     CoordinateMap_detail::is_jacobian_callable_t<
         Map, std::array<std::decay_t<T>, std::decay_t<Map>::dim>, double,
-        std::unordered_map<std::string,
-                           domain::FunctionsOfTime::FunctionOfTime&>>;
+        std::unordered_map<
+            std::string,
+            std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>>;
 }  // namespace CoordinateMap_detail
 
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
@@ -500,8 +536,8 @@ template <typename T>
 constexpr SPECTRE_ALWAYS_INLINE auto
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_jacobian_impl(
     tnsr::I<T, dim, SourceFrame>&& source_point, const double time,
-    const std::unordered_map<std::string,
-                             domain::FunctionsOfTime::FunctionOfTime&>&
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const noexcept
     -> InverseJacobian<T, dim, SourceFrame, TargetFrame> {
   std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
@@ -522,7 +558,8 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_jacobian_impl(
                const auto& the_map, const std::array<T, dim>& point,
                const double /*t*/,
                const std::unordered_map<
-                   std::string, domain::FunctionsOfTime::FunctionOfTime&>&
+                   std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
                /*funcs_of_time*/,
                const std::false_type /*is_time_independent*/) {
               if (LIKELY(not the_map.is_identity())) {
@@ -536,7 +573,8 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_jacobian_impl(
                const auto& the_map, const std::array<T, dim>& point,
                const double t,
                const std::unordered_map<
-                   std::string, domain::FunctionsOfTime::FunctionOfTime&>&
+                   std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
                    funcs_of_time,
                const std::true_type /*is_time_dependent*/) {
               *t_inv_jac = the_map.inv_jacobian(point, t, funcs_of_time);
@@ -593,8 +631,8 @@ template <typename T>
 constexpr SPECTRE_ALWAYS_INLINE auto
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(
     tnsr::I<T, dim, SourceFrame>&& source_point, const double time,
-    const std::unordered_map<std::string,
-                             domain::FunctionsOfTime::FunctionOfTime&>&
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const noexcept
     -> Jacobian<T, dim, SourceFrame, TargetFrame> {
   std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
@@ -615,7 +653,8 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(
                const auto& the_map, const std::array<T, dim>& point,
                const double /*t*/,
                const std::unordered_map<
-                   std::string, domain::FunctionsOfTime::FunctionOfTime&>&
+                   std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
                /*funcs_of_time*/,
                const std::false_type /*is_time_independent*/) {
               if (LIKELY(not the_map.is_identity())) {
@@ -630,7 +669,8 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(
                const auto& the_map, const std::array<T, dim>& point,
                const double t,
                const std::unordered_map<
-                   std::string, domain::FunctionsOfTime::FunctionOfTime&>&
+                   std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
                    funcs_of_time,
                const std::true_type /*is_time_dependent*/) {
               *no_frame_jac = the_map.jacobian(point, t, funcs_of_time);

--- a/src/Domain/CoordinateMaps/CubicScale.hpp
+++ b/src/Domain/CoordinateMaps/CubicScale.hpp
@@ -47,45 +47,51 @@ class CubicScale {
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
       const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
-          map_list) const noexcept;
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
+      const noexcept;
 
   /// Returns boost::none if the point is outside the range of the map.
   template <typename T>
   boost::optional<std::array<tt::remove_cvref_wrap_t<T>, 1>> inverse(
       const std::array<T, 1>& target_coords, double time,
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
-          map_list) const noexcept;
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
+      const noexcept;
 
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 1> frame_velocity(
       const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
-          map_list) const noexcept;
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
+      const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> inv_jacobian(
       const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
-          map_list) const noexcept;
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
+      const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> jacobian(
       const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
-          map_list) const noexcept;
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
+      const noexcept;
 
   template <typename T>
   tnsr::Iaa<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> hessian(
       const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
-          map_list) const noexcept;
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
+      const noexcept;
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/src/Domain/CoordinateMaps/ProductMaps.hpp
+++ b/src/Domain/CoordinateMaps/ProductMaps.hpp
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <array>
-#include <boost/none.hpp>
 #include <boost/optional.hpp>
 #include <cstddef>
 #include <functional>
@@ -27,75 +26,6 @@ class er;
 
 namespace domain {
 namespace CoordinateMaps {
-
-namespace product_detail {
-template <typename T, size_t Size, typename Map1, typename Map2,
-          typename Function, size_t... Is, size_t... Js>
-std::array<tt::remove_cvref_wrap_t<T>, Size> apply_call(
-    const std::array<T, Size>& coords, const Map1& map1, const Map2& map2,
-    const Function func, std::integer_sequence<size_t, Is...> /*meta*/,
-    std::integer_sequence<size_t, Js...> /*meta*/) noexcept {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
-  return {
-      {func(
-           std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Is)>{
-               {coords[Is]...}},
-           map1)[Is]...,
-       func(
-           std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Js)>{
-               {coords[Map1::dim + Js]...}},
-           map2)[Js]...}};
-}
-
-template <size_t Size, typename Map1, typename Map2, typename Function,
-          size_t... Is, size_t... Js>
-boost::optional<std::array<double, Size>> apply_inverse(
-    const std::array<double, Size>& coords, const Map1& map1, const Map2& map2,
-    const Function func, std::integer_sequence<size_t, Is...> /*meta*/,
-    std::integer_sequence<size_t, Js...> /*meta*/) noexcept {
-  auto map1_func =
-      func(std::array<double, sizeof...(Is)>{{coords[Is]...}}, map1);
-  auto map2_func = func(
-      std::array<double, sizeof...(Js)>{{coords[Map1::dim + Js]...}}, map2);
-  if (map1_func and map2_func) {
-    return {{{map1_func.get()[Is]..., map2_func.get()[Js]...}}};
-  } else {
-    return boost::none;
-  }
-}
-
-template <typename T, size_t Size, typename Map1, typename Map2,
-          typename Function, size_t... Is, size_t... Js>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, Size, Frame::NoFrame> apply_jac(
-    const std::array<T, Size>& source_coords, const Map1& map1,
-    const Map2& map2, const Function func,
-    std::integer_sequence<size_t, Is...> /*meta*/,
-    std::integer_sequence<size_t, Js...> /*meta*/) noexcept {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
-  auto map1_jac = func(
-      std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Is)>{
-          {source_coords[Is]...}},
-      map1);
-  auto map2_jac = func(
-      std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Js)>{
-          {source_coords[Map1::dim + Js]...}},
-      map2);
-  tnsr::Ij<UnwrappedT, Size, Frame::NoFrame> jac{
-      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
-  for (size_t i = 0; i < Map1::dim; ++i) {
-    for (size_t j = 0; j < Map1::dim; ++j) {
-      jac.get(i, j) = std::move(map1_jac.get(i, j));
-    }
-  }
-  for (size_t i = 0; i < Map2::dim; ++i) {
-    for (size_t j = 0; j < Map2::dim; ++j) {
-      jac.get(Map1::dim + i, Map1::dim + j) = std::move(map2_jac.get(i, j));
-    }
-  }
-  return jac;
-}
-}  // namespace product_detail
-
 /// \ingroup CoordinateMapsGroup
 /// \brief Product of two codimension=0 CoordinateMaps.
 ///
@@ -147,76 +77,8 @@ class ProductOf2Maps {
 };
 
 template <typename Map1, typename Map2>
-ProductOf2Maps<Map1, Map2>::ProductOf2Maps(Map1 map1, Map2 map2) noexcept
-    : map1_(std::move(map1)),
-      map2_(std::move(map2)),
-      is_identity_(map1_.is_identity() and map2_.is_identity()) {}
-
-template <typename Map1, typename Map2>
-template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim>
-ProductOf2Maps<Map1, Map2>::operator()(
-    const std::array<T, dim>& source_coords) const noexcept {
-  return product_detail::apply_call(
-      source_coords, map1_,
-      map2_, [](const auto& point,
-                const auto& map) noexcept { return map(point); },
-      std::make_index_sequence<Map1::dim>{},
-      std::make_index_sequence<Map2::dim>{});
-}
-
-template <typename Map1, typename Map2>
-boost::optional<std::array<double, ProductOf2Maps<Map1, Map2>::dim>>
-ProductOf2Maps<Map1, Map2>::inverse(
-    const std::array<double, dim>& target_coords) const noexcept {
-  return product_detail::apply_inverse(
-      target_coords, map1_,
-      map2_, [](const auto& point,
-                const auto& map) noexcept { return map.inverse(point); },
-      std::make_index_sequence<Map1::dim>{},
-      std::make_index_sequence<Map2::dim>{});
-}
-
-template <typename Map1, typename Map2>
-template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim,
-         Frame::NoFrame>
-ProductOf2Maps<Map1, Map2>::inv_jacobian(
-    const std::array<T, dim>& source_coords) const noexcept {
-  return product_detail::apply_jac(
-      source_coords, map1_,
-      map2_, [](const auto& point,
-                const auto& map) noexcept { return map.inv_jacobian(point); },
-      std::make_index_sequence<Map1::dim>{},
-      std::make_index_sequence<Map2::dim>{});
-}
-
-template <typename Map1, typename Map2>
-template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim,
-         Frame::NoFrame>
-ProductOf2Maps<Map1, Map2>::jacobian(
-    const std::array<T, dim>& source_coords) const noexcept {
-  return product_detail::apply_jac(
-      source_coords, map1_,
-      map2_, [](const auto& point,
-                const auto& map) noexcept { return map.jacobian(point); },
-      std::make_index_sequence<Map1::dim>{},
-      std::make_index_sequence<Map2::dim>{});
-}
-
-template <typename Map1, typename Map2>
-void ProductOf2Maps<Map1, Map2>::pup(PUP::er& p) {
-  p | map1_;
-  p | map2_;
-  p | is_identity_;
-}
-
-template <typename Map1, typename Map2>
 bool operator!=(const ProductOf2Maps<Map1, Map2>& lhs,
-                const ProductOf2Maps<Map1, Map2>& rhs) noexcept {
-  return not(lhs == rhs);
-}
+                const ProductOf2Maps<Map1, Map2>& rhs) noexcept;
 
 /// \ingroup CoordinateMapsGroup
 /// \brief Product of three one-dimensional CoordinateMaps.
@@ -266,94 +128,7 @@ class ProductOf3Maps {
 };
 
 template <typename Map1, typename Map2, typename Map3>
-ProductOf3Maps<Map1, Map2, Map3>::ProductOf3Maps(Map1 map1, Map2 map2,
-                                                 Map3 map3) noexcept
-    : map1_(std::move(map1)),
-      map2_(std::move(map2)),
-      map3_(std::move(map3)),
-      is_identity_(map1_.is_identity() and map2_.is_identity() and
-                   map3_.is_identity()) {}
-
-template <typename Map1, typename Map2, typename Map3>
-template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim>
-ProductOf3Maps<Map1, Map2, Map3>::operator()(
-    const std::array<T, dim>& source_coords) const noexcept {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
-  return {{map1_(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-               {source_coords[0]}})[0],
-           map2_(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-               {source_coords[1]}})[0],
-           map3_(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-               {source_coords[2]}})[0]}};
-}
-
-template <typename Map1, typename Map2, typename Map3>
-boost::optional<std::array<double, ProductOf3Maps<Map1, Map2, Map3>::dim>>
-ProductOf3Maps<Map1, Map2, Map3>::inverse(
-    const std::array<double, dim>& target_coords) const noexcept {
-  auto c1 = map1_.inverse(std::array<double, 1>{{target_coords[0]}});
-  auto c2 = map2_.inverse(std::array<double, 1>{{target_coords[1]}});
-  auto c3 = map3_.inverse(std::array<double, 1>{{target_coords[2]}});
-  if (c1 and c2 and c3) {
-    return {{{c1.get()[0], c2.get()[0], c3.get()[0]}}};
-  } else {
-    return boost::none;
-  }
-}
-
-template <typename Map1, typename Map2, typename Map3>
-template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim,
-         Frame::NoFrame>
-ProductOf3Maps<Map1, Map2, Map3>::inv_jacobian(
-    const std::array<T, dim>& source_coords) const noexcept {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
-  tnsr::Ij<UnwrappedT, dim, Frame::NoFrame> inv_jacobian_matrix{
-      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
-  get<0, 0>(inv_jacobian_matrix) = get<0, 0>(map1_.inv_jacobian(
-      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[0]}}));
-  get<1, 1>(inv_jacobian_matrix) = get<0, 0>(map2_.inv_jacobian(
-      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[1]}}));
-  get<2, 2>(inv_jacobian_matrix) = get<0, 0>(map3_.inv_jacobian(
-      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[2]}}));
-  return inv_jacobian_matrix;
-}
-template <typename Map1, typename Map2, typename Map3>
-template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim,
-         Frame::NoFrame>
-ProductOf3Maps<Map1, Map2, Map3>::jacobian(
-    const std::array<T, dim>& source_coords) const noexcept {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
-  tnsr::Ij<UnwrappedT, dim, Frame::NoFrame> jacobian_matrix{
-      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
-  get<0, 0>(jacobian_matrix) = get<0, 0>(
-      map1_.jacobian(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[0]}}));
-  get<1, 1>(jacobian_matrix) = get<0, 0>(
-      map2_.jacobian(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[1]}}));
-  get<2, 2>(jacobian_matrix) = get<0, 0>(
-      map3_.jacobian(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[2]}}));
-  return jacobian_matrix;
-}
-template <typename Map1, typename Map2, typename Map3>
-void ProductOf3Maps<Map1, Map2, Map3>::pup(PUP::er& p) noexcept {
-  p | map1_;
-  p | map2_;
-  p | map3_;
-  p | is_identity_;
-}
-
-template <typename Map1, typename Map2, typename Map3>
 bool operator!=(const ProductOf3Maps<Map1, Map2, Map3>& lhs,
-                const ProductOf3Maps<Map1, Map2, Map3>& rhs) noexcept {
-  return not(lhs == rhs);
-}
+                const ProductOf3Maps<Map1, Map2, Map3>& rhs) noexcept;
 }  // namespace CoordinateMaps
 }  // namespace domain

--- a/src/Domain/CoordinateMaps/ProductMaps.tpp
+++ b/src/Domain/CoordinateMaps/ProductMaps.tpp
@@ -1,0 +1,259 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+
+#include <array>
+#include <boost/none.hpp>
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <functional>
+#include <pup.h>
+#include <utility>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace domain {
+namespace CoordinateMaps {
+
+namespace product_detail {
+template <typename T, size_t Size, typename Map1, typename Map2,
+          typename Function, size_t... Is, size_t... Js>
+std::array<tt::remove_cvref_wrap_t<T>, Size> apply_call(
+    const std::array<T, Size>& coords, const Map1& map1, const Map2& map2,
+    const Function func, std::integer_sequence<size_t, Is...> /*meta*/,
+    std::integer_sequence<size_t, Js...> /*meta*/) noexcept {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  return {
+      {func(
+           std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Is)>{
+               {coords[Is]...}},
+           map1)[Is]...,
+       func(
+           std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Js)>{
+               {coords[Map1::dim + Js]...}},
+           map2)[Js]...}};
+}
+
+template <size_t Size, typename Map1, typename Map2, typename Function,
+          size_t... Is, size_t... Js>
+boost::optional<std::array<double, Size>> apply_inverse(
+    const std::array<double, Size>& coords, const Map1& map1, const Map2& map2,
+    const Function func, std::integer_sequence<size_t, Is...> /*meta*/,
+    std::integer_sequence<size_t, Js...> /*meta*/) noexcept {
+  auto map1_func =
+      func(std::array<double, sizeof...(Is)>{{coords[Is]...}}, map1);
+  auto map2_func = func(
+      std::array<double, sizeof...(Js)>{{coords[Map1::dim + Js]...}}, map2);
+  if (map1_func and map2_func) {
+    return {{{map1_func.get()[Is]..., map2_func.get()[Js]...}}};
+  } else {
+    return boost::none;
+  }
+}
+
+template <typename T, size_t Size, typename Map1, typename Map2,
+          typename Function, size_t... Is, size_t... Js>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, Size, Frame::NoFrame> apply_jac(
+    const std::array<T, Size>& source_coords, const Map1& map1,
+    const Map2& map2, const Function func,
+    std::integer_sequence<size_t, Is...> /*meta*/,
+    std::integer_sequence<size_t, Js...> /*meta*/) noexcept {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  auto map1_jac = func(
+      std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Is)>{
+          {source_coords[Is]...}},
+      map1);
+  auto map2_jac = func(
+      std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Js)>{
+          {source_coords[Map1::dim + Js]...}},
+      map2);
+  tnsr::Ij<UnwrappedT, Size, Frame::NoFrame> jac{
+      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
+  for (size_t i = 0; i < Map1::dim; ++i) {
+    for (size_t j = 0; j < Map1::dim; ++j) {
+      jac.get(i, j) = std::move(map1_jac.get(i, j));
+    }
+  }
+  for (size_t i = 0; i < Map2::dim; ++i) {
+    for (size_t j = 0; j < Map2::dim; ++j) {
+      jac.get(Map1::dim + i, Map1::dim + j) = std::move(map2_jac.get(i, j));
+    }
+  }
+  return jac;
+}
+}  // namespace product_detail
+
+template <typename Map1, typename Map2>
+ProductOf2Maps<Map1, Map2>::ProductOf2Maps(Map1 map1, Map2 map2) noexcept
+    : map1_(std::move(map1)),
+      map2_(std::move(map2)),
+      is_identity_(map1_.is_identity() and map2_.is_identity()) {}
+
+template <typename Map1, typename Map2>
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim>
+ProductOf2Maps<Map1, Map2>::operator()(
+    const std::array<T, dim>& source_coords) const noexcept {
+  return product_detail::apply_call(
+      source_coords, map1_, map2_,
+      [](const auto& point, const auto& map) noexcept { return map(point); },
+      std::make_index_sequence<Map1::dim>{},
+      std::make_index_sequence<Map2::dim>{});
+}
+
+template <typename Map1, typename Map2>
+boost::optional<std::array<double, ProductOf2Maps<Map1, Map2>::dim>>
+ProductOf2Maps<Map1, Map2>::inverse(
+    const std::array<double, dim>& target_coords) const noexcept {
+  return product_detail::apply_inverse(
+      target_coords, map1_, map2_,
+      [](const auto& point, const auto& map) noexcept {
+        return map.inverse(point);
+      },
+      std::make_index_sequence<Map1::dim>{},
+      std::make_index_sequence<Map2::dim>{});
+}
+
+template <typename Map1, typename Map2>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim,
+         Frame::NoFrame>
+ProductOf2Maps<Map1, Map2>::inv_jacobian(
+    const std::array<T, dim>& source_coords) const noexcept {
+  return product_detail::apply_jac(
+      source_coords, map1_, map2_,
+      [](const auto& point, const auto& map) noexcept {
+        return map.inv_jacobian(point);
+      },
+      std::make_index_sequence<Map1::dim>{},
+      std::make_index_sequence<Map2::dim>{});
+}
+
+template <typename Map1, typename Map2>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim,
+         Frame::NoFrame>
+ProductOf2Maps<Map1, Map2>::jacobian(
+    const std::array<T, dim>& source_coords) const noexcept {
+  return product_detail::apply_jac(
+      source_coords, map1_, map2_,
+      [](const auto& point, const auto& map) noexcept {
+        return map.jacobian(point);
+      },
+      std::make_index_sequence<Map1::dim>{},
+      std::make_index_sequence<Map2::dim>{});
+}
+
+template <typename Map1, typename Map2>
+void ProductOf2Maps<Map1, Map2>::pup(PUP::er& p) {
+  p | map1_;
+  p | map2_;
+  p | is_identity_;
+}
+
+template <typename Map1, typename Map2>
+bool operator!=(const ProductOf2Maps<Map1, Map2>& lhs,
+                const ProductOf2Maps<Map1, Map2>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+template <typename Map1, typename Map2, typename Map3>
+ProductOf3Maps<Map1, Map2, Map3>::ProductOf3Maps(Map1 map1, Map2 map2,
+                                                 Map3 map3) noexcept
+    : map1_(std::move(map1)),
+      map2_(std::move(map2)),
+      map3_(std::move(map3)),
+      is_identity_(map1_.is_identity() and map2_.is_identity() and
+                   map3_.is_identity()) {}
+
+template <typename Map1, typename Map2, typename Map3>
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim>
+ProductOf3Maps<Map1, Map2, Map3>::operator()(
+    const std::array<T, dim>& source_coords) const noexcept {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  return {{map1_(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+               {source_coords[0]}})[0],
+           map2_(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+               {source_coords[1]}})[0],
+           map3_(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+               {source_coords[2]}})[0]}};
+}
+
+template <typename Map1, typename Map2, typename Map3>
+boost::optional<std::array<double, ProductOf3Maps<Map1, Map2, Map3>::dim>>
+ProductOf3Maps<Map1, Map2, Map3>::inverse(
+    const std::array<double, dim>& target_coords) const noexcept {
+  auto c1 = map1_.inverse(std::array<double, 1>{{target_coords[0]}});
+  auto c2 = map2_.inverse(std::array<double, 1>{{target_coords[1]}});
+  auto c3 = map3_.inverse(std::array<double, 1>{{target_coords[2]}});
+  if (c1 and c2 and c3) {
+    return {{{c1.get()[0], c2.get()[0], c3.get()[0]}}};
+  } else {
+    return boost::none;
+  }
+}
+
+template <typename Map1, typename Map2, typename Map3>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim,
+         Frame::NoFrame>
+ProductOf3Maps<Map1, Map2, Map3>::inv_jacobian(
+    const std::array<T, dim>& source_coords) const noexcept {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  tnsr::Ij<UnwrappedT, dim, Frame::NoFrame> inv_jacobian_matrix{
+      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
+  get<0, 0>(inv_jacobian_matrix) = get<0, 0>(map1_.inv_jacobian(
+      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+          {source_coords[0]}}));
+  get<1, 1>(inv_jacobian_matrix) = get<0, 0>(map2_.inv_jacobian(
+      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+          {source_coords[1]}}));
+  get<2, 2>(inv_jacobian_matrix) = get<0, 0>(map3_.inv_jacobian(
+      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+          {source_coords[2]}}));
+  return inv_jacobian_matrix;
+}
+
+template <typename Map1, typename Map2, typename Map3>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim,
+         Frame::NoFrame>
+ProductOf3Maps<Map1, Map2, Map3>::jacobian(
+    const std::array<T, dim>& source_coords) const noexcept {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  tnsr::Ij<UnwrappedT, dim, Frame::NoFrame> jacobian_matrix{
+      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
+  get<0, 0>(jacobian_matrix) = get<0, 0>(
+      map1_.jacobian(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+          {source_coords[0]}}));
+  get<1, 1>(jacobian_matrix) = get<0, 0>(
+      map2_.jacobian(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+          {source_coords[1]}}));
+  get<2, 2>(jacobian_matrix) = get<0, 0>(
+      map3_.jacobian(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+          {source_coords[2]}}));
+  return jacobian_matrix;
+}
+template <typename Map1, typename Map2, typename Map3>
+void ProductOf3Maps<Map1, Map2, Map3>::pup(PUP::er& p) noexcept {
+  p | map1_;
+  p | map2_;
+  p | map3_;
+  p | is_identity_;
+}
+
+template <typename Map1, typename Map2, typename Map3>
+bool operator!=(const ProductOf3Maps<Map1, Map2, Map3>& lhs,
+                const ProductOf3Maps<Map1, Map2, Map3>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Translation.cpp
+++ b/src/Domain/CoordinateMaps/Translation.cpp
@@ -20,28 +20,28 @@ template <typename T>
 std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::operator()(
     const std::array<T, 1>& source_coords, const double time,
     const std::unordered_map<
-        std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list) const
-    noexcept {
-  return {{source_coords[0] + map_list.at(f_of_t_name_).func(time)[0][0]}};
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        map_list) const noexcept {
+  return {{source_coords[0] + map_list.at(f_of_t_name_)->func(time)[0][0]}};
 }
 
 boost::optional<std::array<double, 1>> Translation::inverse(
     const std::array<double, 1>& target_coords, const double time,
     const std::unordered_map<
-        std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list) const
-    noexcept {
-  return {{{target_coords[0] - map_list.at(f_of_t_name_).func(time)[0][0]}}};
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        map_list) const noexcept {
+  return {{{target_coords[0] - map_list.at(f_of_t_name_)->func(time)[0][0]}}};
 }
 
 template <typename T>
 std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::frame_velocity(
     const std::array<T, 1>& source_coords, const double time,
     const std::unordered_map<
-        std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list) const
-    noexcept {
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        map_list) const noexcept {
   return {{make_with_value<tt::remove_cvref_wrap_t<T>>(
       dereference_wrapper(source_coords[0]),
-      map_list.at(f_of_t_name_).func_and_deriv(time)[1][0])}};
+      map_list.at(f_of_t_name_)->func_and_deriv(time)[1][0])}};
 }
 
 template <typename T>
@@ -68,24 +68,26 @@ bool operator==(const CoordMapsTimeDependent::Translation& lhs,
 /// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                 \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>               \
-  Translation::operator()(                                                   \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,    \
-      const std::unordered_map<                                              \
-          std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list)  \
-      const noexcept;                                                        \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>               \
-  Translation::frame_velocity(                                               \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,    \
-      const std::unordered_map<                                              \
-          std::string, domain::FunctionsOfTime::FunctionOfTime&>& map_list)  \
-      const noexcept;                                                        \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
-  Translation::jacobian(const std::array<DTYPE(data), 1>& source_coords)     \
-      const noexcept;                                                        \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
-  Translation::inv_jacobian(const std::array<DTYPE(data), 1>& source_coords) \
+#define INSTANTIATE(_, data)                                                   \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                 \
+  Translation::operator()(                                                     \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
+      const std::unordered_map<                                                \
+          std::string,                                                         \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
+      const noexcept;                                                          \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                 \
+  Translation::frame_velocity(                                                 \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
+      const std::unordered_map<                                                \
+          std::string,                                                         \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
+      const noexcept;                                                          \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>   \
+  Translation::jacobian(const std::array<DTYPE(data), 1>& source_coords)       \
+      const noexcept;                                                          \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>   \
+  Translation::inv_jacobian(const std::array<DTYPE(data), 1>& source_coords)   \
       const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,

--- a/src/Domain/CoordinateMaps/Translation.hpp
+++ b/src/Domain/CoordinateMaps/Translation.hpp
@@ -39,22 +39,25 @@ class Translation {
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
       const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
-          map_list) const noexcept;
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
+      const noexcept;
 
   boost::optional<std::array<double, 1>> inverse(
       const std::array<double, 1>& target_coords, double time,
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
-          map_list) const noexcept;
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
+      const noexcept;
 
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 1> frame_velocity(
       const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<std::string,
-                               domain::FunctionsOfTime::FunctionOfTime&>&
-          map_list) const noexcept;
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
+      const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> inv_jacobian(

--- a/src/Domain/Creators/Brick.cpp
+++ b/src/Domain/Creators/Brick.cpp
@@ -11,6 +11,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"

--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -9,6 +9,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Direction.hpp"

--- a/src/Domain/Creators/Disk.cpp
+++ b/src/Domain/Creators/Disk.cpp
@@ -11,6 +11,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Direction.hpp"

--- a/src/Domain/Creators/Rectangle.cpp
+++ b/src/Domain/Creators/Rectangle.cpp
@@ -11,6 +11,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"

--- a/src/Domain/Creators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/RegisterDerivedWithCharm.cpp
@@ -14,6 +14,7 @@
 #include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -12,6 +12,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -22,6 +22,7 @@
 #include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/DirectionMap.hpp"

--- a/src/Executables/Benchmark/Benchmark.cpp
+++ b/src/Executables/Benchmark/Benchmark.cpp
@@ -15,6 +15,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Element.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"

--- a/tests/Unit/ControlSystem/Test_Controller.cpp
+++ b/tests/Unit/ControlSystem/Test_Controller.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
+#include <memory>
 
 #include "ControlSystem/Controller.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
@@ -35,11 +36,16 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller", "[ControlSystem][Unit]") {
   const double freq = 3.0;
 
   // properly initialize the function of time to match our target function
-  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(
-      t, {{{std::sin(freq * t)},
-           {freq * std::cos(freq * t)},
-           {-square(freq) * std::sin(freq * t)}}});
-  domain::FunctionsOfTime::FunctionOfTime& f_of_t = f_of_t_derived;
+  std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
+      std::make_unique<
+          domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>>(
+          t, std::array<DataVector, deriv_order + 1>{
+                 {{std::sin(freq * t)},
+                  {freq * std::cos(freq * t)},
+                  {-square(freq) * std::sin(freq * t)}}});
+  auto& f_of_t_derived =
+      dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>&>(
+          *f_of_t);
 
   Controller<deriv_order> control_signal;
   const double t_offset = 0.0;
@@ -49,7 +55,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller", "[ControlSystem][Unit]") {
         {{std::sin(freq * t)},
          {freq * std::cos(freq * t)},
          {-square(freq) * std::sin(freq * t)}}};
-    const auto lambda = f_of_t.func_and_2_derivs(t);
+    const auto lambda = f_of_t->func_and_2_derivs(t);
     // check that the error is within the specified tolerance, which is
     // maintained by the TimescaleTuner adjusting the damping time
     CHECK(fabs(target_func[0][0] - lambda[0][0]) <
@@ -99,11 +105,16 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets",
   double avg_time = 0.0;
 
   // properly initialize the function of time to match our target function
-  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(
-      t, {{{std::sin(freq * t)},
-           {freq * std::cos(freq * t)},
-           {-square(freq) * std::sin(freq * t)}}});
-  domain::FunctionsOfTime::FunctionOfTime& f_of_t = f_of_t_derived;
+  std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
+      std::make_unique<
+          domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>>(
+          t, std::array<DataVector, deriv_order + 1>{
+                 {{std::sin(freq * t)},
+                  {freq * std::cos(freq * t)},
+                  {-square(freq) * std::sin(freq * t)}}});
+  auto& f_of_t_derived =
+      dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>&>(
+          *f_of_t);
 
   Controller<deriv_order> control_signal;
 
@@ -112,7 +123,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets",
         {{std::sin(freq * t)},
          {freq * std::cos(freq * t)},
          {-square(freq) * std::sin(freq * t)}}};
-    const auto lambda = f_of_t.func_and_2_derivs(t);
+    const auto lambda = f_of_t->func_and_2_derivs(t);
     // check that the error is within the specified tolerance, which is
     // maintained by the TimescaleTuner adjusting the damping time
     CHECK(fabs(target_func[0][0] - lambda[0][0]) <
@@ -176,11 +187,16 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets_DontAverageQ",
   double avg_time = 0.0;
 
   // properly initialize the function of time to match our target function
-  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(
-      t, {{{std::sin(freq * t)},
-           {freq * std::cos(freq * t)},
-           {-square(freq) * std::sin(freq * t)}}});
-  domain::FunctionsOfTime::FunctionOfTime& f_of_t = f_of_t_derived;
+  std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
+      std::make_unique<
+          domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>>(
+          t, std::array<DataVector, deriv_order + 1>{
+                 {{std::sin(freq * t)},
+                  {freq * std::cos(freq * t)},
+                  {-square(freq) * std::sin(freq * t)}}});
+  auto& f_of_t_derived =
+      dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>&>(
+          *f_of_t);
 
   Controller<deriv_order> control_signal;
 
@@ -189,7 +205,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets_DontAverageQ",
         {{std::sin(freq * t)},
          {freq * std::cos(freq * t)},
          {-square(freq) * std::sin(freq * t)}}};
-    const auto lambda = f_of_t.func_and_2_derivs(t);
+    const auto lambda = f_of_t->func_and_2_derivs(t);
     // check that the error is within the specified tolerance, which is
     // maintained by the TimescaleTuner adjusting the damping time
     CHECK(fabs(target_func[0][0] - lambda[0][0]) <

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(FunctionsOfTime)
+
 set(LIBRARY "Test_Domain")
 
 set(LIBRARY_SOURCES

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -23,6 +23,7 @@
 #include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
 #include "Domain/CoordinateMaps/SpecialMobius.hpp"
 #include "Domain/CoordinateMaps/Translation.hpp"

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -902,14 +902,13 @@ void test_time_dependent_map() {
 
   const std::array<DataVector, deriv_order + 1> init_func{
       {{1.0}, {-2.0}, {2.0}, {0.0}}};
-  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>
-      function_of_time_derived(initial_time, init_func);
-  domain::FunctionsOfTime::FunctionOfTime& function_of_time =
-      function_of_time_derived;
+  using Polynomial = domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  functions_of_time["trans"] =
+      std::make_unique<Polynomial>(initial_time, init_func);
 
-  const std::unordered_map<std::string,
-                           domain::FunctionsOfTime::FunctionOfTime&>
-      functions_of_time = {{"trans", function_of_time}};
   const CoordMapsTimeDependent::Translation trans_map{};
 
   // affine(x) = 1.5 * x + 5.5

--- a/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
@@ -14,6 +14,7 @@
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/OrientationMap.hpp"

--- a/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
@@ -13,6 +13,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"

--- a/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
@@ -31,13 +31,14 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.Translation",
 
   const std::array<DataVector, deriv_order + 1> init_func{
       {{1.0}, {-2.0}, {2.0}, {0.0}}};
-  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(
-      t, init_func);
-  domain::FunctionsOfTime::FunctionOfTime& f_of_t = f_of_t_derived;
 
-  const std::unordered_map<std::string,
-                           domain::FunctionsOfTime::FunctionOfTime&>
-      f_of_t_list = {{"trans", f_of_t}};
+  using Polynomial = domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
+  using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
+  std::unordered_map<std::string, FoftPtr> f_of_t_list{};
+  f_of_t_list["trans"] = std::make_unique<Polynomial>(t, init_func);
+
+  const FoftPtr& f_of_t = f_of_t_list.at("trans");
+
   const CoordMapsTimeDependent::Translation trans_map{};
   // test serialized/deserialized map
   const auto trans_map_deserialized = serialize_and_deserialize(trans_map);
@@ -46,7 +47,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.Translation",
 
   while (t < final_time) {
     const std::array<double, 1> trans_x{{square(t)}};
-    const std::array<double, 1> frame_vel{{f_of_t.func_and_deriv(t)[1][0]}};
+    const std::array<double, 1> frame_vel{{f_of_t->func_and_deriv(t)[1][0]}};
 
     CHECK_ITERABLE_APPROX(trans_map(point_xi, t, f_of_t_list),
                           point_xi + trans_x);

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -16,6 +16,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/Brick.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -18,6 +18,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/Creators/Cylinder.hpp"
 #include "Domain/Creators/DomainCreator.hpp"

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -18,6 +18,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/Creators/Disk.hpp"
 #include "Domain/Creators/DomainCreator.hpp"

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -16,6 +16,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/Rectangle.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -16,6 +16,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/RotatedBricks.hpp"
 #include "Domain/Direction.hpp"

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -16,6 +16,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/RotatedRectangles.hpp"
 #include "Domain/Direction.hpp"

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -18,6 +18,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/Sphere.hpp"

--- a/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
@@ -14,9 +14,10 @@
 #include "Utilities/Gsl.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 template <size_t DerivOrder>
-void test(const gsl::not_null<FunctionOfTime*> f_of_t,
+void test(const gsl::not_null<FunctionsOfTime::FunctionOfTime*> f_of_t,
           const gsl::not_null<FunctionsOfTime::PiecewisePolynomial<DerivOrder>*>
               f_of_t_derived,
           double t, const double dt, const double final_time) noexcept {
@@ -50,7 +51,7 @@ void test(const gsl::not_null<FunctionOfTime*> f_of_t,
 
 template <size_t DerivOrder>
 void test_non_const_deriv(
-    const gsl::not_null<FunctionOfTime*> f_of_t,
+    const gsl::not_null<FunctionsOfTime::FunctionOfTime*> f_of_t,
     const gsl::not_null<FunctionsOfTime::PiecewisePolynomial<DerivOrder>*>
         f_of_t_derived,
     double t, const double dt, const double final_time) noexcept {
@@ -74,7 +75,8 @@ void test_non_const_deriv(
 }
 
 template <size_t DerivOrder>
-void test_within_roundoff(const FunctionOfTime& f_of_t) noexcept {
+void test_within_roundoff(
+    const FunctionsOfTime::FunctionOfTime& f_of_t) noexcept {
   const auto lambdas0 = f_of_t.func_and_2_derivs(1.0 - 5.0e-16);
   CHECK(approx(lambdas0[0][0]) == 1.0);
   CHECK(approx(lambdas0[1][0]) == 3.0);
@@ -119,10 +121,10 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
     }
     {
       INFO("Test with base class construction.");
-      std::unique_ptr<FunctionOfTime> f_of_t =
+      std::unique_ptr<FunctionsOfTime::FunctionOfTime> f_of_t =
           std::make_unique<FunctionsOfTime::PiecewisePolynomial<deriv_order>>(
               t, init_func);
-      std::unique_ptr<FunctionOfTime> f_of_t2 =
+      std::unique_ptr<FunctionsOfTime::FunctionOfTime> f_of_t2 =
           serialize_and_deserialize(f_of_t);
 
       test(make_not_null(f_of_t.get()),
@@ -160,10 +162,10 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
     }
     {
       INFO("Test with base class construction.");
-      std::unique_ptr<FunctionOfTime> f_of_t =
+      std::unique_ptr<FunctionsOfTime::FunctionOfTime> f_of_t =
           std::make_unique<FunctionsOfTime::PiecewisePolynomial<deriv_order>>(
               t, init_func);
-      std::unique_ptr<FunctionOfTime> f_of_t2 =
+      std::unique_ptr<FunctionsOfTime::FunctionOfTime> f_of_t2 =
           serialize_and_deserialize(f_of_t);
 
       test_non_const_deriv(
@@ -240,3 +242,4 @@ SPECTRE_TEST_CASE(
   f_of_t.update(2.0, {6.0, 0.0});
   f_of_t.func(0.5);
 }
+}  // namespace domain

--- a/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstant.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstant.cpp
@@ -13,44 +13,47 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 namespace {
-void test(const domain::FunctionsOfTime::FunctionOfTime& f_of_t,
-          const double match_time, const double f_t0, const double dtf_t0,
-          const double d2tf_t0, const double A) noexcept {
+void test(
+    const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>& f_of_t,
+    const double match_time, const double f_t0, const double dtf_t0,
+    const double d2tf_t0, const double A) noexcept {
   // check that values agree at the matching time
-  const auto lambdas0 = f_of_t.func_and_2_derivs(match_time);
+  const auto lambdas0 = f_of_t->func_and_2_derivs(match_time);
   CHECK(approx(lambdas0[0][0]) == f_t0);
   CHECK(approx(lambdas0[1][0]) == dtf_t0);
   CHECK(approx(lambdas0[2][0]) == d2tf_t0);
 
-  const auto lambdas1 = f_of_t.func_and_deriv(match_time);
+  const auto lambdas1 = f_of_t->func_and_deriv(match_time);
   CHECK(approx(lambdas1[0][0]) == f_t0);
   CHECK(approx(lambdas1[1][0]) == dtf_t0);
 
-  const auto lambdas2 = f_of_t.func(match_time);
+  const auto lambdas2 = f_of_t->func(match_time);
   CHECK(approx(lambdas2[0][0]) == f_t0);
 
   // check that asymptotic values approach f = A = const.
-  const auto lambdas3 = f_of_t.func_and_2_derivs(1.0e5);
+  const auto lambdas3 = f_of_t->func_and_2_derivs(1.0e5);
   CHECK(approx(lambdas3[0][0]) == A);
   CHECK(approx(lambdas3[1][0]) == 0.0);
   CHECK(approx(lambdas3[2][0]) == 0.0);
 
-  const auto lambdas4 = f_of_t.func_and_deriv(1.0e5);
+  const auto lambdas4 = f_of_t->func_and_deriv(1.0e5);
   CHECK(approx(lambdas4[0][0]) == A);
   CHECK(approx(lambdas4[1][0]) == 0.0);
 
-  const auto lambdas5 = f_of_t.func(1.0e5);
+  const auto lambdas5 = f_of_t->func(1.0e5);
   CHECK(approx(lambdas5[0][0]) == A);
 
   // test time_bounds function
-  const auto t_bounds = f_of_t.time_bounds();
+  const auto t_bounds = f_of_t->time_bounds();
   CHECK(t_bounds[0] == 10.0);
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.SettleToConstant",
                   "[Domain][Unit]") {
-  PUPable_reg(domain::FunctionsOfTime::SettleToConstant);
+  using SettleToConstant = domain::FunctionsOfTime::SettleToConstant;
+
+  PUPable_reg(SettleToConstant);
 
   const double match_time = 10.0;
   const double decay_time = 5.0;
@@ -64,26 +67,13 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.SettleToConstant",
   const double A = f_t0 - B;
   const std::array<DataVector, 3> init_func{{{f_t0}, {dtf_t0}, {d2tf_t0}}};
 
-  {
-    INFO("Test with simple construction.");
-    const domain::FunctionsOfTime::SettleToConstant f_of_t_derived(
-        init_func, match_time, decay_time);
-    test(f_of_t_derived, match_time, f_t0, dtf_t0, d2tf_t0, A);
+  INFO("Test with base class construction.");
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
+      std::make_unique<domain::FunctionsOfTime::SettleToConstant>(
+          init_func, match_time, decay_time);
+  test(f_of_t, match_time, f_t0, dtf_t0, d2tf_t0, A);
 
-    const domain::FunctionsOfTime::SettleToConstant f_of_t_derived2 =
-        serialize_and_deserialize(f_of_t_derived);
-    test(f_of_t_derived2, match_time, f_t0, dtf_t0, d2tf_t0, A);
-  }
-
-  {
-    INFO("Test with base class construction.");
-    const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
-        std::make_unique<domain::FunctionsOfTime::SettleToConstant>(
-            init_func, match_time, decay_time);
-    test(*f_of_t, match_time, f_t0, dtf_t0, d2tf_t0, A);
-
-    const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t2 =
-        serialize_and_deserialize(f_of_t);
-    test(*f_of_t2, match_time, f_t0, dtf_t0, d2tf_t0, A);
-  }
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t2 =
+      serialize_and_deserialize(f_of_t);
+  test(f_of_t2, match_time, f_t0, dtf_t0, d2tf_t0, A);
 }

--- a/tests/Unit/Domain/Test_CoordinatesTag.cpp
+++ b/tests/Unit/Domain/Test_CoordinatesTag.cpp
@@ -9,6 +9,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/LogicalCoordinates.hpp"  // IWYU pragma: keep

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -21,6 +21,7 @@
 #include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/DirectionMap.hpp"

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -15,6 +15,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -21,6 +21,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/Direction.hpp"

--- a/tests/Unit/Domain/Test_LogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_LogicalCoordinates.cpp
@@ -13,6 +13,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Direction.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"

--- a/tests/Unit/Domain/Test_OrientationMapHelpers.cpp
+++ b/tests/Unit/Domain/Test_OrientationMapHelpers.cpp
@@ -18,6 +18,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Direction.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"

--- a/tests/Unit/Domain/Test_SizeOfElement.cpp
+++ b/tests/Unit/Domain/Test_SizeOfElement.cpp
@@ -15,6 +15,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/LogicalCoordinates.hpp"

--- a/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
@@ -16,6 +16,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/Brick.hpp"
 #include "Domain/Creators/Interval.hpp"
 #include "Domain/Creators/Rectangle.hpp"

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
@@ -22,6 +22,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Element.hpp"
 #include "Domain/ElementId.hpp"

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
@@ -23,6 +23,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Element.hpp"
 #include "Domain/ElementId.hpp"

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
@@ -18,6 +18,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Element.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/ElementIndex.hpp"

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -20,6 +20,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -19,6 +19,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -19,6 +19,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"  // IWYU pragma: keep

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -22,6 +22,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Element.hpp"
 #include "Domain/ElementId.hpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -28,6 +28,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Element.hpp"
 #include "Domain/ElementId.hpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -23,6 +23,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Element.hpp"
 #include "Domain/ElementId.hpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
@@ -16,6 +16,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Direction.hpp"
 #include "Domain/FaceNormal.hpp"
 #include "Domain/Mesh.hpp"

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -20,6 +20,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
@@ -19,6 +19,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp"

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -20,6 +20,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -23,6 +23,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
@@ -14,6 +14,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/Brick.hpp"
 #include "Domain/Creators/Interval.hpp"
 #include "Domain/Creators/Rectangle.hpp"

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
@@ -14,6 +14,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/Brick.hpp"
 #include "Domain/Creators/Interval.hpp"
 #include "Domain/Creators/Rectangle.hpp"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
@@ -17,6 +17,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -20,6 +20,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
@@ -17,6 +17,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"


### PR DESCRIPTION
## Proposed changes

- Previously the coordinate maps took functions of time by reference to the base class. This changes that to `unique_ptr` since that is what we will actually have in the DataBox.

Depends on:
- #1845 in the sense that there are some include conflicts. Please review only the unique_ptr commit.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
