### PR TITLE
Factor coordinate map into an hpp and a tpp

### DIFF
--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -382,7 +382,7 @@ class CoordinateMap
 /// \ingroup ComputationalDomainGroup
 /// \brief Creates a `CoordinateMap` of `maps...`
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
-auto make_coordinate_map(Maps&&... maps)
+auto make_coordinate_map(Maps&&... maps) noexcept
     -> CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>;
 
 /// \ingroup ComputationalDomainGroup

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -6,30 +6,24 @@
 
 #pragma once
 
-#include <algorithm>
-#include <array>
 #include <boost/optional.hpp>
 #include <cstddef>
-#include <cstdint>
-#include <initializer_list>
+#include <limits>
 #include <memory>
 #include <pup.h>
+#include <string>
 #include <tuple>
 #include <type_traits>
 #include <typeinfo>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
-#include "DataStructures/Tensor/Identity.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Parallel/PupStlCpp11.hpp"
-#include "Utilities/ForceInline.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/Tuple.hpp"
 
 /// \cond
 class DataVector;
@@ -212,7 +206,7 @@ class CoordinateMap
   CoordinateMap& operator=(CoordinateMap&& /*rhs*/) = default;
   ~CoordinateMap() override = default;
 
-  constexpr explicit CoordinateMap(Maps... maps);
+  explicit CoordinateMap(Maps... maps);
 
   std::unique_ptr<CoordinateMapBase<SourceFrame, TargetFrame, dim>> get_clone()
       const override {
@@ -349,7 +343,7 @@ class CoordinateMap
   }
 
   template <typename T, size_t... Is>
-  constexpr SPECTRE_ALWAYS_INLINE tnsr::I<T, dim, TargetFrame> call_impl(
+  tnsr::I<T, dim, TargetFrame> call_impl(
       tnsr::I<T, dim, SourceFrame>&& source_point, double time,
       const std::unordered_map<
           std::string,
@@ -358,385 +352,38 @@ class CoordinateMap
       std::index_sequence<Is...> /*meta*/) const noexcept;
 
   template <typename T, size_t... Is>
-  constexpr SPECTRE_ALWAYS_INLINE boost::optional<tnsr::I<T, dim, SourceFrame>>
-  inverse_impl(tnsr::I<T, dim, TargetFrame>&& target_point, double time,
-               const std::unordered_map<
-                   std::string,
-                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-                   functions_of_time,
-               std::index_sequence<Is...> /*meta*/) const noexcept;
+  boost::optional<tnsr::I<T, dim, SourceFrame>> inverse_impl(
+      tnsr::I<T, dim, TargetFrame>&& target_point, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time,
+      std::index_sequence<Is...> /*meta*/) const noexcept;
 
   template <typename T>
-  constexpr SPECTRE_ALWAYS_INLINE
-      InverseJacobian<T, dim, SourceFrame, TargetFrame>
-      inv_jacobian_impl(
-          tnsr::I<T, dim, SourceFrame>&& source_point, double time,
-          const std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-              functions_of_time) const noexcept;
+  InverseJacobian<T, dim, SourceFrame, TargetFrame> inv_jacobian_impl(
+      tnsr::I<T, dim, SourceFrame>&& source_point, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
 
   template <typename T>
-  constexpr SPECTRE_ALWAYS_INLINE Jacobian<T, dim, SourceFrame, TargetFrame>
-  jacobian_impl(tnsr::I<T, dim, SourceFrame>&& source_point, double time,
-                const std::unordered_map<
-                    std::string,
-                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-                    functions_of_time) const noexcept;
+  Jacobian<T, dim, SourceFrame, TargetFrame> jacobian_impl(
+      tnsr::I<T, dim, SourceFrame>&& source_point, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
 
   std::tuple<Maps...> maps_;
 };
 
-////////////////////////////////////////////////////////////////
-// CoordinateMap definitions
-////////////////////////////////////////////////////////////////
-
-// define type-trait to check for time-dependent mapping
-namespace CoordinateMap_detail {
-template <typename T>
-using is_map_time_dependent_t = tt::is_callable_t<
-    T, std::array<std::decay_t<T>, std::decay_t<T>::dim>, double,
-    std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>>;
-
-template <typename T, size_t Dim, typename Map>
-void apply_map(
-    const gsl::not_null<std::array<T, Dim>*> t_map_point, const Map& the_map,
-    const double /*t*/,
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-    /*functions_of_time*/,
-    const std::false_type /*is_time_independent*/) {
-  if (LIKELY(not the_map.is_identity())) {
-    *t_map_point = the_map(*t_map_point);
-  }
-}
-
-template <typename T, size_t Dim, typename Map>
-void apply_map(
-    const gsl::not_null<std::array<T, Dim>*> t_map_point, const Map& the_map,
-    const double t,
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time,
-    const std::true_type
-    /*is_time_dependent*/) {
-  *t_map_point = the_map(*t_map_point, t, functions_of_time);
-}
-}  // namespace CoordinateMap_detail
-
-template <typename SourceFrame, typename TargetFrame, typename... Maps>
-constexpr CoordinateMap<SourceFrame, TargetFrame, Maps...>::CoordinateMap(
-    Maps... maps)
-    : maps_(std::move(maps)...) {}
-
-template <typename SourceFrame, typename TargetFrame, typename... Maps>
-template <typename T, size_t... Is>
-constexpr SPECTRE_ALWAYS_INLINE tnsr::I<
-    T, CoordinateMap<SourceFrame, TargetFrame, Maps...>::dim, TargetFrame>
-CoordinateMap<SourceFrame, TargetFrame, Maps...>::call_impl(
-    tnsr::I<T, dim, SourceFrame>&& source_point, const double time,
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time,
-    std::index_sequence<Is...> /*meta*/) const noexcept {
-  std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
-
-  (void)std::initializer_list<char>{make_overloader(
-      [](const auto& the_map, std::array<T, dim>& point, const double /*t*/,
-         const std::unordered_map<
-             std::string,
-             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-         /*funcs_of_time*/,
-         const std::false_type /*is_time_independent*/) noexcept {
-        if (LIKELY(not the_map.is_identity())) {
-          point = the_map(point);
-        }
-        return '0';
-      },
-      [](const auto& the_map, std::array<T, dim>& point, const double t,
-         const std::unordered_map<
-             std::string,
-             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-             funcs_of_time,
-         const std::true_type /*is_time_dependent*/) noexcept {
-        point = the_map(point, t, funcs_of_time);
-        return '0';
-      })(std::get<Is>(maps_), mapped_point, time, functions_of_time,
-         CoordinateMap_detail::is_map_time_dependent_t<Maps>{})...};
-
-  return tnsr::I<T, dim, TargetFrame>(std::move(mapped_point));
-}
-
-template <typename SourceFrame, typename TargetFrame, typename... Maps>
-template <typename T, size_t... Is>
-constexpr SPECTRE_ALWAYS_INLINE boost::optional<tnsr::I<
-    T, CoordinateMap<SourceFrame, TargetFrame, Maps...>::dim, SourceFrame>>
-CoordinateMap<SourceFrame, TargetFrame, Maps...>::inverse_impl(
-    tnsr::I<T, dim, TargetFrame>&& target_point, const double time,
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time,
-    std::index_sequence<Is...> /*meta*/) const noexcept {
-  boost::optional<std::array<T, dim>> mapped_point(
-      make_array<T, dim>(std::move(target_point)));
-
-  (void)std::initializer_list<char>{make_overloader(
-      [](const auto& the_map, boost::optional<std::array<T, dim>>& point,
-         const double /*t*/,
-         const std::unordered_map<
-             std::string,
-             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-         /*funcs_of_time*/,
-         const std::false_type /*is_time_independent*/) noexcept {
-        if (point) {
-          if (LIKELY(not the_map.is_identity())) {
-            point = the_map.inverse(point.get());
-          }
-        }
-        return '0';
-      },
-      [](const auto& the_map, boost::optional<std::array<T, dim>>& point,
-         const double t,
-         const std::unordered_map<
-             std::string,
-             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-             funcs_of_time,
-         const std::true_type /*is_time_dependent*/) noexcept {
-        if (point) {
-          point = the_map.inverse(point.get(), t, funcs_of_time);
-        }
-        return '0';
-        // this is the inverse function, so the iterator sequence below is
-        // reversed
-      })(std::get<sizeof...(Maps) - 1 - Is>(maps_), mapped_point, time,
-         functions_of_time,
-         CoordinateMap_detail::is_map_time_dependent_t<decltype(
-             std::get<sizeof...(Maps) - 1 - Is>(maps_))>{})...};
-
-  return mapped_point
-             ? tnsr::I<T, dim, SourceFrame>(std::move(mapped_point.get()))
-             : boost::optional<tnsr::I<T, dim, SourceFrame>>{};
-}
-
-// define type-trait to check for time-dependent jacobian
-namespace CoordinateMap_detail {
-CREATE_IS_CALLABLE(jacobian)
-template <typename Map, typename T>
-using is_jacobian_time_dependent_t =
-    CoordinateMap_detail::is_jacobian_callable_t<
-        Map, std::array<std::decay_t<T>, std::decay_t<Map>::dim>, double,
-        std::unordered_map<
-            std::string,
-            std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>>;
-}  // namespace CoordinateMap_detail
-
-template <typename SourceFrame, typename TargetFrame, typename... Maps>
-template <typename T>
-constexpr SPECTRE_ALWAYS_INLINE auto
-CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_jacobian_impl(
-    tnsr::I<T, dim, SourceFrame>&& source_point, const double time,
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time) const noexcept
-    -> InverseJacobian<T, dim, SourceFrame, TargetFrame> {
-  std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
-
-  InverseJacobian<T, dim, SourceFrame, TargetFrame> inv_jac{};
-
-  tuple_transform(
-      maps_,
-      [&inv_jac, &mapped_point, time, &functions_of_time](
-          const auto& map, auto index, const std::tuple<Maps...>& maps) {
-        constexpr const size_t count = decltype(index)::value;
-
-        tnsr::Ij<T, dim, Frame::NoFrame> temp_inv_jac{};
-
-        // chooses the correct call based on time-dependence of jacobian
-        auto inv_jac_overload = make_overloader(
-            [](const gsl::not_null<tnsr::Ij<T, dim, Frame::NoFrame>*> t_inv_jac,
-               const auto& the_map, const std::array<T, dim>& point,
-               const double /*t*/,
-               const std::unordered_map<
-                   std::string,
-                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-               /*funcs_of_time*/,
-               const std::false_type /*is_time_independent*/) {
-              if (LIKELY(not the_map.is_identity())) {
-                *t_inv_jac = the_map.inv_jacobian(point);
-              } else {
-                *t_inv_jac = identity<dim>(point[0]);
-              }
-              return nullptr;
-            },
-            [](const gsl::not_null<tnsr::Ij<T, dim, Frame::NoFrame>*> t_inv_jac,
-               const auto& the_map, const std::array<T, dim>& point,
-               const double t,
-               const std::unordered_map<
-                   std::string,
-                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-                   funcs_of_time,
-               const std::true_type /*is_time_dependent*/) {
-              *t_inv_jac = the_map.inv_jacobian(point, t, funcs_of_time);
-              return nullptr;
-            });
-
-        if (LIKELY(count != 0)) {
-          const auto& map_in_loop =
-              std::get<(count != 0 ? count - 1 : 0)>(maps);
-          if (LIKELY(not map_in_loop.is_identity())) {
-            CoordinateMap_detail::apply_map(
-                make_not_null(&mapped_point), map_in_loop, time,
-                functions_of_time,
-                CoordinateMap_detail::is_map_time_dependent_t<decltype(
-                    map_in_loop)>{});
-            inv_jac_overload(&temp_inv_jac, map, mapped_point, time,
-                             functions_of_time,
-                             CoordinateMap_detail::is_jacobian_time_dependent_t<
-                                 decltype(map), T>{});
-            std::array<T, dim> temp{};
-            for (size_t source = 0; source < dim; ++source) {
-              for (size_t target = 0; target < dim; ++target) {
-                gsl::at(temp, target) =
-                    inv_jac.get(source, 0) * temp_inv_jac.get(0, target);
-                for (size_t dummy = 1; dummy < dim; ++dummy) {
-                  gsl::at(temp, target) += inv_jac.get(source, dummy) *
-                                           temp_inv_jac.get(dummy, target);
-                }
-              }
-              for (size_t target = 0; target < dim; ++target) {
-                inv_jac.get(source, target) = std::move(gsl::at(temp, target));
-              }
-            }
-          }
-        } else {
-          inv_jac_overload(
-              &temp_inv_jac, map, mapped_point, time, functions_of_time,
-              CoordinateMap_detail::is_jacobian_time_dependent_t<decltype(map),
-                                                                 T>{});
-          for (size_t source = 0; source < dim; ++source) {
-            for (size_t target = 0; target < dim; ++target) {
-              inv_jac.get(source, target) =
-                  std::move(temp_inv_jac.get(source, target));
-            }
-          }
-        }
-      },
-      maps_);
-  return inv_jac;
-}
-
-template <typename SourceFrame, typename TargetFrame, typename... Maps>
-template <typename T>
-constexpr SPECTRE_ALWAYS_INLINE auto
-CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(
-    tnsr::I<T, dim, SourceFrame>&& source_point, const double time,
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time) const noexcept
-    -> Jacobian<T, dim, SourceFrame, TargetFrame> {
-  std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
-  Jacobian<T, dim, SourceFrame, TargetFrame> jac{};
-
-  tuple_transform(
-      maps_,
-      [&jac, &mapped_point, time, &functions_of_time](
-          const auto& map, auto index, const std::tuple<Maps...>& maps) {
-        constexpr const size_t count = decltype(index)::value;
-
-        tnsr::Ij<T, dim, Frame::NoFrame> noframe_jac{};
-
-        // chooses the correct call based on time-dependence of jacobian
-        auto jac_overload = make_overloader(
-            [](const gsl::not_null<tnsr::Ij<T, dim, Frame::NoFrame>*>
-                   no_frame_jac,
-               const auto& the_map, const std::array<T, dim>& point,
-               const double /*t*/,
-               const std::unordered_map<
-                   std::string,
-                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-               /*funcs_of_time*/,
-               const std::false_type /*is_time_independent*/) {
-              if (LIKELY(not the_map.is_identity())) {
-                *no_frame_jac = the_map.jacobian(point);
-              } else {
-                *no_frame_jac = identity<dim>(point[0]);
-              }
-              return nullptr;
-            },
-            [](const gsl::not_null<tnsr::Ij<T, dim, Frame::NoFrame>*>
-                   no_frame_jac,
-               const auto& the_map, const std::array<T, dim>& point,
-               const double t,
-               const std::unordered_map<
-                   std::string,
-                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-                   funcs_of_time,
-               const std::true_type /*is_time_dependent*/) {
-              *no_frame_jac = the_map.jacobian(point, t, funcs_of_time);
-              return nullptr;
-            });
-
-        if (LIKELY(count != 0)) {
-          const auto& map_in_loop =
-              std::get<(count != 0 ? count - 1 : 0)>(maps);
-          if (LIKELY(not map_in_loop.is_identity())) {
-            CoordinateMap_detail::apply_map(
-                make_not_null(&mapped_point), map_in_loop, time,
-                functions_of_time,
-                CoordinateMap_detail::is_map_time_dependent_t<decltype(
-                    map_in_loop)>{});
-            jac_overload(&noframe_jac, map, mapped_point, time,
-                         functions_of_time,
-                         CoordinateMap_detail::is_jacobian_time_dependent_t<
-                             decltype(map), T>{});
-            std::array<T, dim> temp{};
-            for (size_t source = 0; source < dim; ++source) {
-              for (size_t target = 0; target < dim; ++target) {
-                gsl::at(temp, target) =
-                    noframe_jac.get(target, 0) * jac.get(0, source);
-                for (size_t dummy = 1; dummy < dim; ++dummy) {
-                  gsl::at(temp, target) +=
-                      noframe_jac.get(target, dummy) * jac.get(dummy, source);
-                }
-              }
-              for (size_t target = 0; target < dim; ++target) {
-                jac.get(target, source) = std::move(gsl::at(temp, target));
-              }
-            }
-          }
-        } else {
-          jac_overload(
-              &noframe_jac, map, mapped_point, time, functions_of_time,
-              CoordinateMap_detail::is_jacobian_time_dependent_t<decltype(map),
-                                                                 T>{});
-          for (size_t target = 0; target < dim; ++target) {
-            for (size_t source = 0; source < dim; ++source) {
-              jac.get(target, source) =
-                  std::move(noframe_jac.get(target, source));
-            }
-          }
-        }
-      },
-      maps_);
-  return jac;
-}
-
-template <typename SourceFrame, typename TargetFrame, typename... Maps>
-bool operator!=(
-    const CoordinateMap<SourceFrame, TargetFrame, Maps...>& lhs,
-    const CoordinateMap<SourceFrame, TargetFrame, Maps...>& rhs) noexcept {
-  return not(lhs == rhs);
-}
-
 /// \ingroup ComputationalDomainGroup
 /// \brief Creates a `CoordinateMap` of `maps...`
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
-constexpr auto make_coordinate_map(Maps&&... maps)
-    -> CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...> {
-  return CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>(
-      std::forward<Maps>(maps)...);
-}
+auto make_coordinate_map(Maps&&... maps)
+    -> CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>;
 
 /// \ingroup ComputationalDomainGroup
 /// \brief Creates a `std::unique_ptr<CoordinateMapBase>` of `maps...`
@@ -744,11 +391,7 @@ template <typename SourceFrame, typename TargetFrame, typename... Maps>
 auto make_coordinate_map_base(Maps&&... maps) noexcept
     -> std::unique_ptr<CoordinateMapBase<
         SourceFrame, TargetFrame,
-        CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>::dim>> {
-  return std::make_unique<
-      CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>>(
-      std::forward<Maps>(maps)...);
-}
+        CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>::dim>>;
 
 /// \ingroup ComputationalDomainGroup
 /// \brief Creates a `std::vector<std::unique_ptr<CoordinateMapBase>>`
@@ -759,20 +402,7 @@ template <typename SourceFrame, typename TargetFrame, typename Arg0,
 auto make_vector_coordinate_map_base(Arg0&& arg_0,
                                      Args&&... remaining_args) noexcept
     -> std::vector<std::unique_ptr<
-        CoordinateMapBase<SourceFrame, TargetFrame, std::decay_t<Arg0>::dim>>> {
-  std::vector<std::unique_ptr<
-      CoordinateMapBase<SourceFrame, TargetFrame, std::decay_t<Arg0>::dim>>>
-      return_vector;
-  return_vector.reserve(sizeof...(Args) + 1);
-  return_vector.emplace_back(make_coordinate_map_base<SourceFrame, TargetFrame>(
-      std::forward<Arg0>(arg_0)));
-  (void)std::initializer_list<int>{
-      (((void)return_vector.emplace_back(
-           make_coordinate_map_base<SourceFrame, TargetFrame>(
-               std::forward<Args>(remaining_args)))),
-       0)...};
-  return return_vector;
-}
+        CoordinateMapBase<SourceFrame, TargetFrame, std::decay_t<Arg0>::dim>>>;
 
 /// \ingroup ComputationalDomainGroup
 /// \brief Creates a `std::vector<std::unique_ptr<CoordinateMapBase>>`
@@ -784,17 +414,7 @@ template <typename SourceFrame, typename TargetFrame, size_t Dim, typename Map,
 auto make_vector_coordinate_map_base(std::vector<Map> maps,
                                      const Maps&... remaining_maps) noexcept
     -> std::vector<
-        std::unique_ptr<CoordinateMapBase<SourceFrame, TargetFrame, Dim>>> {
-  std::vector<std::unique_ptr<CoordinateMapBase<SourceFrame, TargetFrame, Dim>>>
-      return_vector;
-  return_vector.reserve(sizeof...(Maps) + 1);
-  for (auto& map : maps) {
-    return_vector.emplace_back(
-        make_coordinate_map_base<SourceFrame, TargetFrame>(std::move(map),
-                                                           remaining_maps...));
-  }
-  return return_vector;
-}
+        std::unique_ptr<CoordinateMapBase<SourceFrame, TargetFrame, Dim>>>;
 
 /// \cond
 template <typename SourceFrame, typename TargetFrame, typename... Maps>

--- a/src/Domain/CoordinateMaps/CoordinateMap.tpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.tpp
@@ -1,0 +1,418 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+
+#include <algorithm>
+#include <array>
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <typeinfo>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/Tensor/Identity.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/Tuple.hpp"
+
+/// \cond
+namespace domain {
+// define type-trait to check for time-dependent mapping
+namespace CoordinateMap_detail {
+template <typename T>
+using is_map_time_dependent_t = tt::is_callable_t<
+    T, std::array<std::decay_t<T>, std::decay_t<T>::dim>, double,
+    std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>>;
+
+template <typename T, size_t Dim, typename Map>
+void apply_map(
+    const gsl::not_null<std::array<T, Dim>*> t_map_point, const Map& the_map,
+    const double /*t*/,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+    /*functions_of_time*/,
+    const std::false_type /*is_time_independent*/) {
+  if (LIKELY(not the_map.is_identity())) {
+    *t_map_point = the_map(*t_map_point);
+  }
+}
+
+template <typename T, size_t Dim, typename Map>
+void apply_map(
+    const gsl::not_null<std::array<T, Dim>*> t_map_point, const Map& the_map,
+    const double t,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const std::true_type
+    /*is_time_dependent*/) {
+  *t_map_point = the_map(*t_map_point, t, functions_of_time);
+}
+}  // namespace CoordinateMap_detail
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+CoordinateMap<SourceFrame, TargetFrame, Maps...>::CoordinateMap(Maps... maps)
+    : maps_(std::move(maps)...) {}
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+template <typename T, size_t... Is>
+tnsr::I<T, CoordinateMap<SourceFrame, TargetFrame, Maps...>::dim, TargetFrame>
+CoordinateMap<SourceFrame, TargetFrame, Maps...>::call_impl(
+    tnsr::I<T, dim, SourceFrame>&& source_point, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    std::index_sequence<Is...> /*meta*/) const noexcept {
+  std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
+
+  EXPAND_PACK_LEFT_TO_RIGHT(make_overloader(
+      [](const auto& the_map, std::array<T, dim>& point, const double /*t*/,
+         const std::unordered_map<
+             std::string,
+             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+         /*funcs_of_time*/,
+         const std::false_type /*is_time_independent*/) noexcept {
+        if (LIKELY(not the_map.is_identity())) {
+          point = the_map(point);
+        }
+      },
+      [](const auto& the_map, std::array<T, dim>& point, const double t,
+         const std::unordered_map<
+             std::string,
+             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+             funcs_of_time,
+         const std::true_type /*is_time_dependent*/) noexcept {
+        point = the_map(point, t, funcs_of_time);
+      })(std::get<Is>(maps_), mapped_point, time, functions_of_time,
+         CoordinateMap_detail::is_map_time_dependent_t<Maps>{}));
+
+  return tnsr::I<T, dim, TargetFrame>(std::move(mapped_point));
+}
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+template <typename T, size_t... Is>
+boost::optional<tnsr::I<
+    T, CoordinateMap<SourceFrame, TargetFrame, Maps...>::dim, SourceFrame>>
+CoordinateMap<SourceFrame, TargetFrame, Maps...>::inverse_impl(
+    tnsr::I<T, dim, TargetFrame>&& target_point, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    std::index_sequence<Is...> /*meta*/) const noexcept {
+  boost::optional<std::array<T, dim>> mapped_point(
+      make_array<T, dim>(std::move(target_point)));
+
+  EXPAND_PACK_LEFT_TO_RIGHT(make_overloader(
+      [](const auto& the_map, boost::optional<std::array<T, dim>>& point,
+         const double /*t*/,
+         const std::unordered_map<
+             std::string,
+             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+         /*funcs_of_time*/,
+         const std::false_type /*is_time_independent*/) noexcept {
+        if (point) {
+          if (LIKELY(not the_map.is_identity())) {
+            point = the_map.inverse(point.get());
+          }
+        }
+      },
+      [](const auto& the_map, boost::optional<std::array<T, dim>>& point,
+         const double t,
+         const std::unordered_map<
+             std::string,
+             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+             funcs_of_time,
+         const std::true_type /*is_time_dependent*/) noexcept {
+        if (point) {
+          point = the_map.inverse(point.get(), t, funcs_of_time);
+        }
+        // this is the inverse function, so the iterator sequence below is
+        // reversed
+      })(std::get<sizeof...(Maps) - 1 - Is>(maps_), mapped_point, time,
+         functions_of_time,
+         CoordinateMap_detail::is_map_time_dependent_t<decltype(
+             std::get<sizeof...(Maps) - 1 - Is>(maps_))>{}));
+
+  return mapped_point
+             ? tnsr::I<T, dim, SourceFrame>(std::move(mapped_point.get()))
+             : boost::optional<tnsr::I<T, dim, SourceFrame>>{};
+}
+
+// define type-trait to check for time-dependent jacobian
+namespace CoordinateMap_detail {
+CREATE_IS_CALLABLE(jacobian)
+template <typename Map, typename T>
+using is_jacobian_time_dependent_t =
+    CoordinateMap_detail::is_jacobian_callable_t<
+        Map, std::array<std::decay_t<T>, std::decay_t<Map>::dim>, double,
+        std::unordered_map<
+            std::string,
+            std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>>;
+}  // namespace CoordinateMap_detail
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+template <typename T>
+auto CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_jacobian_impl(
+    tnsr::I<T, dim, SourceFrame>&& source_point, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept
+    -> InverseJacobian<T, dim, SourceFrame, TargetFrame> {
+  std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
+
+  InverseJacobian<T, dim, SourceFrame, TargetFrame> inv_jac{};
+
+  tuple_transform(
+      maps_,
+      [&inv_jac, &mapped_point, time, &functions_of_time](
+          const auto& map, auto index, const std::tuple<Maps...>& maps) {
+        constexpr const size_t count = decltype(index)::value;
+
+        tnsr::Ij<T, dim, Frame::NoFrame> temp_inv_jac{};
+
+        // chooses the correct call based on time-dependence of jacobian
+        auto inv_jac_overload = make_overloader(
+            [](const gsl::not_null<tnsr::Ij<T, dim, Frame::NoFrame>*> t_inv_jac,
+               const auto& the_map, const std::array<T, dim>& point,
+               const double /*t*/,
+               const std::unordered_map<
+                   std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+               /*funcs_of_time*/,
+               const std::false_type /*is_time_independent*/) noexcept {
+              if (LIKELY(not the_map.is_identity())) {
+                *t_inv_jac = the_map.inv_jacobian(point);
+              } else {
+                *t_inv_jac = identity<dim>(point[0]);
+              }
+              return nullptr;
+            },
+            [](const gsl::not_null<tnsr::Ij<T, dim, Frame::NoFrame>*> t_inv_jac,
+               const auto& the_map, const std::array<T, dim>& point,
+               const double t,
+               const std::unordered_map<
+                   std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                   funcs_of_time,
+               const std::true_type /*is_time_dependent*/) noexcept {
+              *t_inv_jac = the_map.inv_jacobian(point, t, funcs_of_time);
+              return nullptr;
+            });
+
+        if (LIKELY(count != 0)) {
+          const auto& map_in_loop =
+              std::get<(count != 0 ? count - 1 : 0)>(maps);
+          if (LIKELY(not map_in_loop.is_identity())) {
+            CoordinateMap_detail::apply_map(
+                make_not_null(&mapped_point), map_in_loop, time,
+                functions_of_time,
+                CoordinateMap_detail::is_map_time_dependent_t<decltype(
+                    map_in_loop)>{});
+            inv_jac_overload(&temp_inv_jac, map, mapped_point, time,
+                             functions_of_time,
+                             CoordinateMap_detail::is_jacobian_time_dependent_t<
+                                 decltype(map), T>{});
+            std::array<T, dim> temp{};
+            for (size_t source = 0; source < dim; ++source) {
+              for (size_t target = 0; target < dim; ++target) {
+                gsl::at(temp, target) =
+                    inv_jac.get(source, 0) * temp_inv_jac.get(0, target);
+                for (size_t dummy = 1; dummy < dim; ++dummy) {
+                  gsl::at(temp, target) += inv_jac.get(source, dummy) *
+                                           temp_inv_jac.get(dummy, target);
+                }
+              }
+              for (size_t target = 0; target < dim; ++target) {
+                inv_jac.get(source, target) = std::move(gsl::at(temp, target));
+              }
+            }
+          }
+        } else {
+          inv_jac_overload(
+              &temp_inv_jac, map, mapped_point, time, functions_of_time,
+              CoordinateMap_detail::is_jacobian_time_dependent_t<decltype(map),
+                                                                 T>{});
+          for (size_t source = 0; source < dim; ++source) {
+            for (size_t target = 0; target < dim; ++target) {
+              inv_jac.get(source, target) =
+                  std::move(temp_inv_jac.get(source, target));
+            }
+          }
+        }
+      },
+      maps_);
+  return inv_jac;
+}
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+template <typename T>
+auto CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(
+    tnsr::I<T, dim, SourceFrame>&& source_point, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept
+    -> Jacobian<T, dim, SourceFrame, TargetFrame> {
+  std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
+  Jacobian<T, dim, SourceFrame, TargetFrame> jac{};
+
+  tuple_transform(
+      maps_,
+      [&jac, &mapped_point, time, &functions_of_time](
+          const auto& map, auto index,
+          const std::tuple<Maps...>& maps) noexcept {
+        constexpr const size_t count = decltype(index)::value;
+
+        tnsr::Ij<T, dim, Frame::NoFrame> noframe_jac{};
+
+        // chooses the correct call based on time-dependence of jacobian
+        auto jac_overload = make_overloader(
+            [](const gsl::not_null<tnsr::Ij<T, dim, Frame::NoFrame>*>
+                   no_frame_jac,
+               const auto& the_map, const std::array<T, dim>& point,
+               const double /*t*/,
+               const std::unordered_map<
+                   std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+               /*funcs_of_time*/,
+               const std::false_type /*is_time_independent*/) noexcept {
+              if (LIKELY(not the_map.is_identity())) {
+                *no_frame_jac = the_map.jacobian(point);
+              } else {
+                *no_frame_jac = identity<dim>(point[0]);
+              }
+              return nullptr;
+            },
+            [](const gsl::not_null<tnsr::Ij<T, dim, Frame::NoFrame>*>
+                   no_frame_jac,
+               const auto& the_map, const std::array<T, dim>& point,
+               const double t,
+               const std::unordered_map<
+                   std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                   funcs_of_time,
+               const std::true_type /*is_time_dependent*/) noexcept {
+              *no_frame_jac = the_map.jacobian(point, t, funcs_of_time);
+              return nullptr;
+            });
+
+        if (LIKELY(count != 0)) {
+          const auto& map_in_loop =
+              std::get<(count != 0 ? count - 1 : 0)>(maps);
+          if (LIKELY(not map_in_loop.is_identity())) {
+            CoordinateMap_detail::apply_map(
+                make_not_null(&mapped_point), map_in_loop, time,
+                functions_of_time,
+                CoordinateMap_detail::is_map_time_dependent_t<decltype(
+                    map_in_loop)>{});
+            jac_overload(&noframe_jac, map, mapped_point, time,
+                         functions_of_time,
+                         CoordinateMap_detail::is_jacobian_time_dependent_t<
+                             decltype(map), T>{});
+            std::array<T, dim> temp{};
+            for (size_t source = 0; source < dim; ++source) {
+              for (size_t target = 0; target < dim; ++target) {
+                gsl::at(temp, target) =
+                    noframe_jac.get(target, 0) * jac.get(0, source);
+                for (size_t dummy = 1; dummy < dim; ++dummy) {
+                  gsl::at(temp, target) +=
+                      noframe_jac.get(target, dummy) * jac.get(dummy, source);
+                }
+              }
+              for (size_t target = 0; target < dim; ++target) {
+                jac.get(target, source) = std::move(gsl::at(temp, target));
+              }
+            }
+          }
+        } else {
+          jac_overload(
+              &noframe_jac, map, mapped_point, time, functions_of_time,
+              CoordinateMap_detail::is_jacobian_time_dependent_t<decltype(map),
+                                                                 T>{});
+          for (size_t target = 0; target < dim; ++target) {
+            for (size_t source = 0; source < dim; ++source) {
+              jac.get(target, source) =
+                  std::move(noframe_jac.get(target, source));
+            }
+          }
+        }
+      },
+      maps_);
+  return jac;
+}
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+bool operator!=(
+    const CoordinateMap<SourceFrame, TargetFrame, Maps...>& lhs,
+    const CoordinateMap<SourceFrame, TargetFrame, Maps...>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+auto make_coordinate_map(Maps&&... maps)
+    -> CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...> {
+  return CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>(
+      std::forward<Maps>(maps)...);
+}
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+auto make_coordinate_map_base(Maps&&... maps) noexcept
+    -> std::unique_ptr<CoordinateMapBase<
+        SourceFrame, TargetFrame,
+        CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>::dim>> {
+  return std::make_unique<
+      CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>>(
+      std::forward<Maps>(maps)...);
+}
+
+template <typename SourceFrame, typename TargetFrame, typename Arg0,
+          typename... Args>
+auto make_vector_coordinate_map_base(Arg0&& arg_0,
+                                     Args&&... remaining_args) noexcept
+    -> std::vector<std::unique_ptr<
+        CoordinateMapBase<SourceFrame, TargetFrame, std::decay_t<Arg0>::dim>>> {
+  std::vector<std::unique_ptr<
+      CoordinateMapBase<SourceFrame, TargetFrame, std::decay_t<Arg0>::dim>>>
+      return_vector;
+  return_vector.reserve(sizeof...(Args) + 1);
+  return_vector.emplace_back(make_coordinate_map_base<SourceFrame, TargetFrame>(
+      std::forward<Arg0>(arg_0)));
+  EXPAND_PACK_LEFT_TO_RIGHT(return_vector.emplace_back(
+      make_coordinate_map_base<SourceFrame, TargetFrame>(
+          std::forward<Args>(remaining_args))));
+  return return_vector;
+}
+
+template <typename SourceFrame, typename TargetFrame, size_t Dim, typename Map,
+          typename... Maps>
+auto make_vector_coordinate_map_base(std::vector<Map> maps,
+                                     const Maps&... remaining_maps) noexcept
+    -> std::vector<
+        std::unique_ptr<CoordinateMapBase<SourceFrame, TargetFrame, Dim>>> {
+  std::vector<std::unique_ptr<CoordinateMapBase<SourceFrame, TargetFrame, Dim>>>
+      return_vector;
+  return_vector.reserve(sizeof...(Maps) + 1);
+  for (auto& map : maps) {
+    return_vector.emplace_back(
+        make_coordinate_map_base<SourceFrame, TargetFrame>(std::move(map),
+                                                           remaining_maps...));
+  }
+  return return_vector;
+}
+}  // namespace domain
+/// \endcond

--- a/src/Domain/CoordinateMaps/CoordinateMap.tpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.tpp
@@ -364,7 +364,7 @@ bool operator!=(
 }
 
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
-auto make_coordinate_map(Maps&&... maps)
+auto make_coordinate_map(Maps&&... maps) noexcept
     -> CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...> {
   return CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>(
       std::forward<Maps>(maps)...);

--- a/src/Domain/Creators/Brick.cpp
+++ b/src/Domain/Creators/Brick.cpp
@@ -10,6 +10,7 @@
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep

--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -7,6 +7,7 @@
 
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"

--- a/src/Domain/Creators/Disk.cpp
+++ b/src/Domain/Creators/Disk.cpp
@@ -9,6 +9,7 @@
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"

--- a/src/Domain/Creators/Interval.cpp
+++ b/src/Domain/Creators/Interval.cpp
@@ -10,6 +10,7 @@
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"

--- a/src/Domain/Creators/Rectangle.cpp
+++ b/src/Domain/Creators/Rectangle.cpp
@@ -10,6 +10,7 @@
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep

--- a/src/Domain/Creators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/RegisterDerivedWithCharm.cpp
@@ -8,6 +8,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"

--- a/src/Domain/Creators/Shell.cpp
+++ b/src/Domain/Creators/Shell.cpp
@@ -9,7 +9,7 @@
 #include "Domain/Block.hpp"                         // IWYU pragma: keep
 #include "Domain/BlockNeighbor.hpp"                 // IWYU pragma: keep
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"  // IWYU pragma: keep
-#include "Domain/Creators/DomainCreator.hpp"        // IWYU pragma: keep
+#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Utilities/Gsl.hpp"

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -10,6 +10,7 @@
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -16,6 +16,7 @@
 #include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"

--- a/src/Executables/Benchmark/Benchmark.cpp
+++ b/src/Executables/Benchmark/Benchmark.cpp
@@ -14,6 +14,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Element.hpp"

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -17,6 +17,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/DomainHelpers.hpp"

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -18,6 +18,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/BulgedCube.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Frustum.hpp"

--- a/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -15,6 +15,7 @@
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/Brick.hpp"

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -16,6 +16,7 @@
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -16,6 +16,7 @@
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -15,6 +15,7 @@
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/Interval.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -15,6 +15,7 @@
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/DomainCreator.hpp"

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -14,6 +14,7 @@
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -15,6 +15,7 @@
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/RotatedIntervals.hpp"

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -14,6 +14,7 @@
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -20,6 +20,7 @@
 #include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/CreateInitialElement.hpp"

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -16,6 +16,7 @@
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -15,6 +15,7 @@
 #include "Domain/Block.hpp"
 #include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/DirectionMap.hpp"

--- a/tests/Unit/Domain/Test_CoordinatesTag.cpp
+++ b/tests/Unit/Domain/Test_CoordinatesTag.cpp
@@ -8,6 +8,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/ElementId.hpp"

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -11,6 +11,7 @@
 #include "Domain/Block.hpp"
 #include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CreateInitialElement.hpp"
 #include "Domain/Direction.hpp"

--- a/tests/Unit/Domain/Test_CreateInitialMesh.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialMesh.cpp
@@ -5,7 +5,6 @@
 
 #include <cstddef>
 
-#include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CreateInitialMesh.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/ElementId.hpp"

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -18,6 +18,7 @@
 #include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/Direction.hpp"
 #include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -16,6 +16,7 @@
 #include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/Frustum.hpp"

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -14,6 +14,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -20,6 +20,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -22,6 +22,7 @@
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesHelpers.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Element.hpp"

--- a/tests/Unit/Domain/Test_LogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_LogicalCoordinates.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Direction.hpp"

--- a/tests/Unit/Domain/Test_OrientationMapHelpers.cpp
+++ b/tests/Unit/Domain/Test_OrientationMapHelpers.cpp
@@ -16,6 +16,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"

--- a/tests/Unit/Domain/Test_SizeOfElement.cpp
+++ b/tests/Unit/Domain/Test_SizeOfElement.cpp
@@ -13,6 +13,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
@@ -21,6 +21,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Direction.hpp"

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
@@ -22,6 +22,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Direction.hpp"

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
@@ -17,6 +17,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Element.hpp"

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -19,6 +19,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -18,6 +18,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -18,6 +18,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -21,6 +21,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Direction.hpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -26,6 +26,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -23,6 +23,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/DirectionMap.hpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -22,6 +22,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Direction.hpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
@@ -15,6 +15,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Direction.hpp"

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -19,6 +19,7 @@
 #include "DataStructures/VariablesHelpers.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
@@ -18,6 +18,7 @@
 #include "DataStructures/VariablesHelpers.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -19,6 +19,7 @@
 #include "DataStructures/Variables.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -22,6 +22,7 @@
 #include "DataStructures/VariablesHelpers.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
@@ -16,6 +16,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -19,6 +19,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
@@ -16,6 +16,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"


### PR DESCRIPTION
## Proposed changes

- `CoordinateMap.hpp` contains a lot of template-heavy code. This factors the function definitions into a `tpp` file that is include in various `cpp` files.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
