### PR TITLE
Add function to push a new map into CoordinateMap

### DIFF
--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -336,6 +336,22 @@ class CoordinateMap
     return lhs.maps_ == rhs.maps_;
   }
 
+  template <typename NewMap, typename LocalSourceFrame,
+            typename LocalTargetFrame, typename... LocalMaps, size_t... Is>
+  friend CoordinateMap<LocalSourceFrame, LocalTargetFrame, LocalMaps..., NewMap>
+  // NOLINTNEXTLINE(readability-redundant-declaration,-warnings-as-errors)
+  push_back_impl(
+      CoordinateMap<LocalSourceFrame, LocalTargetFrame, LocalMaps...>&& old_map,
+      NewMap new_map, std::index_sequence<Is...> /*meta*/) noexcept;
+
+  template <typename NewMap, typename LocalSourceFrame,
+            typename LocalTargetFrame, typename... LocalMaps, size_t... Is>
+  friend CoordinateMap<LocalSourceFrame, LocalTargetFrame, NewMap, LocalMaps...>
+  // NOLINTNEXTLINE(readability-redundant-declaration,-warnings-as-errors)
+  push_front_impl(
+      CoordinateMap<LocalSourceFrame, LocalTargetFrame, LocalMaps...>&& old_map,
+      NewMap new_map, std::index_sequence<Is...> /*meta*/) noexcept;
+
   bool is_equal_to(const CoordinateMapBase<SourceFrame, TargetFrame, dim>&
                        other) const override {
     const auto& cast_of_other = dynamic_cast<const CoordinateMap&>(other);
@@ -415,6 +431,24 @@ auto make_vector_coordinate_map_base(std::vector<Map> maps,
                                      const Maps&... remaining_maps) noexcept
     -> std::vector<
         std::unique_ptr<CoordinateMapBase<SourceFrame, TargetFrame, Dim>>>;
+
+/// \ingroup ComputationalDomainGroup
+/// \brief Creates a `CoordinateMap` by appending the new map to the end of the
+/// old maps
+template <typename SourceFrame, typename TargetFrame, typename... Maps,
+          typename NewMap>
+CoordinateMap<SourceFrame, TargetFrame, Maps..., NewMap> push_back(
+    CoordinateMap<SourceFrame, TargetFrame, Maps...> old_map,
+    NewMap new_map) noexcept;
+
+/// \ingroup ComputationalDomainGroup
+/// \brief Creates a `CoordinateMap` by prepending the new map to the beginning
+/// of the old maps
+template <typename SourceFrame, typename TargetFrame, typename... Maps,
+          typename NewMap>
+CoordinateMap<SourceFrame, TargetFrame, NewMap, Maps...> push_front(
+    CoordinateMap<SourceFrame, TargetFrame, Maps...> old_map,
+    NewMap new_map) noexcept;
 
 /// \cond
 template <typename SourceFrame, typename TargetFrame, typename... Maps>

--- a/src/Domain/CoordinateMaps/CoordinateMap.tpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.tpp
@@ -414,5 +414,41 @@ auto make_vector_coordinate_map_base(std::vector<Map> maps,
   }
   return return_vector;
 }
+
+template <typename NewMap, typename SourceFrame, typename TargetFrame,
+          typename... Maps, size_t... Is>
+CoordinateMap<SourceFrame, TargetFrame, Maps..., NewMap> push_back_impl(
+    CoordinateMap<SourceFrame, TargetFrame, Maps...>&& old_map, NewMap new_map,
+    std::index_sequence<Is...> /*meta*/) noexcept {
+  return CoordinateMap<SourceFrame, TargetFrame, Maps..., NewMap>{
+      std::move(std::get<Is>(old_map.maps_))..., std::move(new_map)};
+}
+
+template <typename NewMap, typename SourceFrame, typename TargetFrame,
+          typename... Maps, size_t... Is>
+CoordinateMap<SourceFrame, TargetFrame, NewMap, Maps...> push_front_impl(
+    CoordinateMap<SourceFrame, TargetFrame, Maps...>&& old_map, NewMap new_map,
+    std::index_sequence<Is...> /*meta*/) noexcept {
+  return CoordinateMap<SourceFrame, TargetFrame, Maps..., NewMap>{
+      std::move(new_map), std::move(std::get<Is>(old_map.maps_))...};
+}
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps,
+          typename NewMap>
+CoordinateMap<SourceFrame, TargetFrame, Maps..., NewMap> push_back(
+    CoordinateMap<SourceFrame, TargetFrame, Maps...> old_map,
+    NewMap new_map) noexcept {
+  return push_back_impl(std::move(old_map), std::move(new_map),
+                        std::make_index_sequence<sizeof...(Maps)>{});
+}
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps,
+          typename NewMap>
+CoordinateMap<SourceFrame, TargetFrame, NewMap, Maps...> push_front(
+    CoordinateMap<SourceFrame, TargetFrame, Maps...> old_map,
+    NewMap new_map) noexcept {
+  return push_front_impl(std::move(old_map), std::move(new_map),
+                         std::make_index_sequence<sizeof...(Maps)>{});
+}
 }  // namespace domain
 /// \endcond


### PR DESCRIPTION
## Proposed changes

Add a `push_back` and `push_front` function to `CoordinateMap` to insert a new map into the front or back of the map.

Please only review `Add push_back and push_front for CoordinateMap` the commit. This depends on other PRs only because of include conflicts.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
