### PR TITLE
Compute tag to take the trace of spatial Christoffel 2nd kind

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
@@ -88,7 +88,7 @@ struct SpatialChristoffelSecondKindCompute
 
 /// Compute item for the trace of the spatial Christoffel symbols
 /// of the first kind
-/// \f$\Gamma_{i} = \Gamma_{ijk}g^{jk}\f$ computed from the
+/// \f$\Gamma_{i} = \Gamma_{ijk}\gamma^{jk}\f$ computed from the
 /// Christoffel symbols of the first kind and the inverse spatial metric.
 ///
 /// Can be retrieved using `gr::Tags::TraceSpatialChristoffelFirstKind`
@@ -105,6 +105,27 @@ struct TraceSpatialChristoffelFirstKindCompute
       &trace_last_indices<DataType, SpatialIndex<SpatialDim, UpLo::Lo, Frame>,
                           SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
   using base = TraceSpatialChristoffelFirstKind<SpatialDim, Frame, DataType>;
+};
+
+/// Compute item for the trace of the spatial Christoffel symbols
+/// of the second kind
+/// \f$\Gamma^{i} = \Gamma^{i}_{jk}\gamma^{jk}\f$ computed from the
+/// Christoffel symbols of the second kind and the inverse spatial metric.
+///
+/// Can be retrieved using `gr::Tags::TraceSpatialChristoffelSecondKind`
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct TraceSpatialChristoffelSecondKindCompute
+    : TraceSpatialChristoffelSecondKind<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>,
+                 InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static constexpr tnsr::I<DataType, SpatialDim, Frame> (*function)(
+      const tnsr::Ijj<DataType, SpatialDim, Frame>&,
+      const tnsr::II<DataType, SpatialDim, Frame>&) =
+      &trace_last_indices<DataType, SpatialIndex<SpatialDim, UpLo::Up, Frame>,
+                          SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
+  using base = TraceSpatialChristoffelSecondKind<SpatialDim, Frame, DataType>;
 };
 
 /// Compute item for spacetime Christoffel symbols of the first kind

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
@@ -87,6 +87,10 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Christoffel",
   CHECK(gr::Tags::SpatialChristoffelSecondKindCompute<3, Frame::Inertial,
                                                       DataVector>::name() ==
         "SpatialChristoffelSecondKind");
+  CHECK(
+      gr::Tags::TraceSpatialChristoffelSecondKindCompute<3, Frame::Inertial,
+                                                         DataVector>::name() ==
+      "TraceSpatialChristoffelSecondKind");
   CHECK(gr::Tags::SpacetimeChristoffelFirstKindCompute<3, Frame::Inertial,
                                                        DataVector>::name() ==
         "SpacetimeChristoffelFirstKind");
@@ -161,6 +165,10 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Christoffel",
   const auto expected_spatial_christoffel_second_kind =
       raise_or_lower_first_index(expected_spatial_christoffel_first_kind,
                                  inverse_spatial_metric);
+  const auto expected_trace_spatial_christoffel_second_kind =
+      trace_last_indices(expected_spatial_christoffel_second_kind,
+                         inverse_spatial_metric);
+
   const auto expected_spacetime_christoffel_first_kind =
       gr::christoffel_first_kind(derivatives_of_spacetime_metric);
   const auto expected_trace_spacetime_christoffel_first_kind =
@@ -184,6 +192,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Christoffel",
                              3, Frame::Inertial, DataVector>,
                          gr::Tags::SpatialChristoffelSecondKindCompute<
                              3, Frame::Inertial, DataVector>,
+                         gr::Tags::TraceSpatialChristoffelSecondKindCompute<
+                             3, Frame::Inertial, DataVector>,
                          gr::Tags::SpacetimeChristoffelFirstKindCompute<
                              3, Frame::Inertial, DataVector>,
                          gr::Tags::TraceSpacetimeChristoffelFirstKindCompute<
@@ -202,6 +212,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Christoffel",
   CHECK(db::get<gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial,
                                                        DataVector>>(box) ==
         expected_spatial_christoffel_second_kind);
+  CHECK(db::get<gr::Tags::TraceSpatialChristoffelSecondKind<3, Frame::Inertial,
+                                                            DataVector>>(box) ==
+        expected_trace_spatial_christoffel_second_kind);
 
   CHECK(db::get<gr::Tags::SpacetimeChristoffelFirstKind<3, Frame::Inertial,
                                                         DataVector>>(box) ==


### PR DESCRIPTION
## Proposed changes

Add a compute tag to take the trace of the spatial Christoffel symbol of the second kind.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
