### PR TITLE
Add Clenshaw-based Swsh interpolation

### DIFF
--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
     SwshCollocation.cpp
     SwshDerivatives.cpp
     SwshFiltering.cpp
+    SwshInterpolation.cpp
     SwshTags.cpp
     SwshTransform.cpp
     )

--- a/src/NumericalAlgorithms/Spectral/SwshInterpolation.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshInterpolation.cpp
@@ -1,0 +1,630 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
+
+#include <array>
+#include <boost/math/special_functions/binomial.hpp>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/StaticCache.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+
+namespace Spectral {
+namespace Swsh {
+
+SpinWeightedSphericalHarmonic::SpinWeightedSphericalHarmonic(
+    const int spin, const size_t l, const int m) noexcept
+    : spin_{spin}, l_{l}, m_{m} {
+  overall_prefactor_ = 1.0;
+  const double double_l = l;
+  const double double_m = m;
+  const double double_spin = spin;
+  if (std::abs(m) > std::abs(spin)) {
+    for (size_t i = 0; i < static_cast<size_t>(std::abs(m) - std::abs(spin));
+         ++i) {
+      const double double_i = i;
+      overall_prefactor_ *= (double_l + std::abs(double_m) - double_i) /
+                            (double_l - (std::abs(double_spin) + double_i));
+    }
+  } else if (std::abs(spin) > std::abs(m)) {
+    for (size_t i = 0; i < static_cast<size_t>(std::abs(spin) - std::abs(m));
+         ++i) {
+      const double double_i = i;
+      overall_prefactor_ *= (double_l - (std::abs(double_m) + double_i)) /
+                            (double_l + std::abs(double_spin) - double_i);
+    }
+  }
+  // if neither is greater (they are equal), then the prefactor is 1.0
+  overall_prefactor_ *= (2.0 * l + 1.0) / (4.0 * M_PI);
+  overall_prefactor_ = sqrt(overall_prefactor_);
+  overall_prefactor_ *= (m % 2) == 0 ? 1.0 : -1.0;
+
+  // gcc warns about the casts in ways that are impossible to satisfy
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+  if (static_cast<int>(l) < std::abs(spin)) {
+    if (spin < 0) {
+      r_prefactors_ =
+          std::vector<double>(l + static_cast<size_t>(std::abs(spin)) + 1, 0.0);
+    }
+  } else {
+    // the casts in the reserve are in correct order, but clang-format
+    // erroneously requests a change
+    // NOLINTNEXTLINE(misc-misplaced-widening-cast)
+    r_prefactors_.reserve(static_cast<size_t>(static_cast<int>(l) - spin + 1));
+    for (int r = 0; r <= (static_cast<int>(l) - spin); ++r) {
+      if (r + spin - m >= 0 and static_cast<int>(l) - r + m >= 0) {
+        r_prefactors_.push_back(
+            boost::math::binomial_coefficient<double>(
+                static_cast<size_t>(static_cast<int>(l) - spin),
+                static_cast<size_t>(r)) *
+            boost::math::binomial_coefficient<double>(
+                static_cast<size_t>(static_cast<int>(l) + spin),
+                static_cast<size_t>(spin - m + r)) *
+            (((static_cast<int>(l) - r - spin) % 2) == 0 ? 1.0 : -1.0));
+      } else {
+        r_prefactors_.push_back(0.0);
+      }
+    }
+  }
+#pragma GCC diagnostic pop
+}
+
+void SpinWeightedSphericalHarmonic::evaluate(
+    const gsl::not_null<ComplexDataVector*> result, const DataVector& theta,
+    const DataVector& phi, const DataVector& sin_theta_over_2,
+    const DataVector& cos_theta_over_2) const noexcept {
+  result->destructive_resize(theta.size());
+  *result = 0.0;
+  DataVector theta_factor{theta.size()};
+  for (int r = 0; r <= (static_cast<int>(l_) - spin_); ++r) {
+    if (2 * static_cast<int>(l_) > 2 * r + spin_ - m_) {
+      theta_factor = pow(cos_theta_over_2, 2 * r + spin_ - m_) *
+                     pow(sin_theta_over_2,
+                         2 * static_cast<int>(l_) - (2 * r + spin_ - m_));
+    } else if (2 * static_cast<int>(l_) < 2 * r + spin_ - m_) {
+      theta_factor = pow(cos_theta_over_2 / sin_theta_over_2,
+                         2 * r + spin_ - m_ - 2 * static_cast<int>(l_)) *
+                     pow(cos_theta_over_2, 2 * l_);
+    } else {
+      theta_factor = pow(cos_theta_over_2, 2 * l_);
+    }
+    *result += gsl::at(r_prefactors_, r) * theta_factor;
+  }
+  // optimization note: this has not been compared with a complex `exp`
+  // function, and it is not obvious which should be faster in practice.
+  *result *=
+      overall_prefactor_ *
+      (std::complex<double>(1.0, 0.0) * cos(static_cast<double>(m_) * phi) +
+       std::complex<double>(0.0, 1.0) * sin(static_cast<double>(m_) * phi));
+}
+
+ComplexDataVector SpinWeightedSphericalHarmonic::evaluate(
+    const DataVector& theta, const DataVector& phi,
+    const DataVector& sin_theta_over_2,
+    const DataVector& cos_theta_over_2) const noexcept {
+  ComplexDataVector result{theta.size(), 0.0};
+  evaluate(make_not_null(&result), theta, phi, sin_theta_over_2,
+           cos_theta_over_2);
+  return result;
+}
+
+std::complex<double> SpinWeightedSphericalHarmonic::evaluate(
+    const double theta, const double phi) const noexcept {
+  std::complex<double> accumulator = 0.0;
+  const double cos_theta_over_two = cos(0.5 * theta);
+  const double sin_theta_over_two = sin(0.5 * theta);
+  double theta_factor;
+  for (int r = 0; r <= (static_cast<int>(l_) - spin_); ++r) {
+    if (2 * static_cast<int>(l_) > 2 * r + spin_ - m_) {
+      theta_factor = pow(cos_theta_over_two, 2 * r + spin_ - m_) *
+                     pow(sin_theta_over_two,
+                         2 * static_cast<int>(l_) - (2 * r + spin_ - m_));
+    } else if (2 * static_cast<int>(l_) < 2 * r + spin_ - m_) {
+      theta_factor = pow(cos_theta_over_two / sin_theta_over_two,
+                         2 * r + spin_ - m_ - 2 * static_cast<int>(l_)) *
+                     pow(cos_theta_over_two, 2 * l_);
+    } else {
+      theta_factor = pow(cos_theta_over_two, 2 * l_);
+    }
+    accumulator += gsl::at(r_prefactors_, r) *
+                   std::complex<double>(cos(static_cast<double>(m_) * phi),
+                                        sin(static_cast<double>(m_) * phi)) *
+                   theta_factor;
+  }
+  accumulator *= overall_prefactor_;
+  return accumulator;
+}
+
+void SpinWeightedSphericalHarmonic::pup(PUP::er& p) noexcept {
+  p | spin_;
+  p | l_;
+  p | m_;
+  p | overall_prefactor_;
+  p | r_prefactors_;
+}
+
+// A function for indexing a desired element in one of the caches stored
+// in `ClenshawRecurrenceConstants`.
+// Useful for accessing the `beta_constant`, `alpha_constant`, or
+// `alpha_prefactor` recurrence constants.
+size_t clenshaw_cache_index(const size_t l_max, const int spin, const int l,
+                            const int m) noexcept {
+  return goldberg_mode_index(l_max - 2, static_cast<size_t>(l - 2), m) -
+         static_cast<size_t>(square(spin));
+}
+
+// see the detailed doxygen for `SwshInterpolator` for full mathematical details
+// of the recurrence constant computations
+template <int Spin>
+struct ClenshawRecurrenceConstants {
+  ClenshawRecurrenceConstants() = default;
+
+  explicit ClenshawRecurrenceConstants(size_t l_max) noexcept
+      : alpha_prefactor{square(l_max + 1) -
+                        square(static_cast<size_t>(std::abs(Spin)))},
+        alpha_constant{square(l_max + 1) -
+                       square(static_cast<size_t>(std::abs(Spin)))},
+        beta_constant{square(l_max + 1) -
+                      square(static_cast<size_t>(std::abs(Spin)))},
+        harmonic_at_l_min_prefactors{2 * l_max + 1},
+        harmonic_at_l_min_plus_one_recurrence_prefactors{2 * l_max + 1},
+        harmonic_m_recurrence_prefactors{2 * l_max + 1} {
+    ASSERT(static_cast<int>(l_max) > Spin,
+           "l_max must be greater than the spin-weight when computing "
+           "ClenshawRecurrenceConstants");
+    double l_plus_k;
+    double l_min_plus_k;
+    double a;
+    double b;
+    int l_min;
+    double prefactor_accumulator;
+    lambda.reserve(2 * l_max + 1);
+    for (int m = -static_cast<int>(l_max); m <= static_cast<int>(l_max); ++m) {
+      a = static_cast<double>(std::abs(Spin + m));
+      b = static_cast<double>(std::abs(Spin - m));
+      l_min = std::max(std::abs(m), std::abs(Spin));
+
+      // gcc warns about an optimization that doesn't work if we overflow. None
+      // of this will overflow provided l_max is not unreasonably high (less
+      // than ~10^5 will not overflow).
+      for (int l = l_min + 2; l <= static_cast<int>(l_max); ++l) {
+        // start caching at 2 greater than the l_min for a given m. Those are
+        // the last terms needed by (descending) Clenshaw sum.
+        l_plus_k = static_cast<double>(l) - 0.5 * (a + b);
+        alpha_prefactor[clenshaw_cache_index(l_max, Spin, l, m)] =
+            0.5 * sqrt((2.0 * l + 1.0) * (2.0 * l - 1.0) /
+                       (l_plus_k * (l_plus_k + a + b) * (l_plus_k + a) *
+                        (l_plus_k + b)));
+        alpha_constant[clenshaw_cache_index(l_max, Spin, l, m)] =
+            alpha_prefactor[clenshaw_cache_index(l_max, Spin, l, m)] *
+            ((square(a) - square(b)) / (2.0 * l - 2.0));
+        alpha_prefactor[clenshaw_cache_index(l_max, Spin, l, m)] *= (2.0 * l);
+        beta_constant[clenshaw_cache_index(l_max, Spin, l, m)] =
+            -sqrt((2.0 * l + 1.0) * (l_plus_k + a - 1.0) *
+                  (l_plus_k + b - 1.0) * (l_plus_k - 1.0) *
+                  (l_plus_k + a + b - 1.0) /
+                  ((2.0 * l - 3.0) * l_plus_k * (l_plus_k + a + b) *
+                   (l_plus_k + a) * (l_plus_k + b))) *
+            (2.0 * l) / (2.0 * l - 2.0);
+      }
+      lambda.push_back(Spin >= -m ? 0 : Spin + m);
+
+      // pre-compute the prefactors for the lowest order harmonics for each m
+      prefactor_accumulator = 1.0;
+      l_min_plus_k = -0.5 * (std::abs(Spin + m) + b) + l_min;
+      for (int i = 1; i <= b; ++i) {
+        if (l_min_plus_k + a + i > 0.0) {
+          prefactor_accumulator *= static_cast<double>(l_min_plus_k + a + i);
+        }
+        if (l_min_plus_k + i > 0.0) {
+          prefactor_accumulator /= static_cast<double>(l_min_plus_k + i);
+        }
+      }
+      prefactor_accumulator =
+          sqrt(prefactor_accumulator * (2.0 * l_min + 1.0) / (4.0 * M_PI));
+      prefactor_accumulator *=
+          ((m + gsl::at(lambda, m + static_cast<int>(l_max))) % 2) == 0 ? 1.0
+                                                                        : -1.0;
+      // this is the right order of the casts, other orders give the wrong
+      // answer NOLINTNEXTLINE(misc-misplaced-widening-cast)
+      harmonic_at_l_min_prefactors[static_cast<size_t>(
+          m + static_cast<int>(l_max))] = prefactor_accumulator;
+
+      // pre-compute the prefactors for bootstrapping the second-to-lowest order
+      // harmonics for each m
+
+      // this is the right order of the casts, other orders give the wrong
+      // answer NOLINTNEXTLINE(misc-misplaced-widening-cast)
+      harmonic_at_l_min_plus_one_recurrence_prefactors[static_cast<size_t>(
+          m + static_cast<int>(l_max))] =
+          sqrt((2.0 * (l_min) + 3.0) * (l_min_plus_k + 1.0) *
+               (l_min_plus_k + a + b + 1.0) /
+               ((2.0 * (l_min) + 1.0) * (l_min_plus_k + a + 1.0) *
+                (l_min_plus_k + b + 1.0)));
+    }
+    // separate loop because we'll need the lambdas entirely populated for this
+    // set of prefactors
+    int lambda_difference;
+    for (int m = -static_cast<int>(l_max); m <= static_cast<int>(l_max); ++m) {
+      if (std::abs(m) > std::abs(Spin)) {
+        l_min = std::max(std::abs(m), std::abs(Spin));
+        a = std::abs(Spin + m);
+        b = std::abs(Spin - m);
+        l_min_plus_k = -0.5 * (std::abs(Spin + m) + b) + l_min;
+
+        prefactor_accumulator =
+            sqrt((2.0 * std::abs(m) + 1.0) * (l_min_plus_k + a + b - 1.0) *
+                 (l_min_plus_k + a + b) /
+                 ((2.0 * std::abs(m) - 1.0) * (l_min_plus_k + a) *
+                  (l_min_plus_k + b)));
+        // there is an extra `1` in these expressions to account for the -1 out
+        // front of the recurrence relations.
+        lambda_difference = gsl::at(lambda, m + static_cast<int>(l_max)) + 1;
+        if (m > 0) {
+          lambda_difference -= gsl::at(lambda, m - 1 + static_cast<int>(l_max));
+        } else {
+          lambda_difference -= gsl::at(lambda, m + 1 + static_cast<int>(l_max));
+        }
+        prefactor_accumulator *= lambda_difference % 2 == 0 ? 1.0 : -1.0;
+        // this is the right order of the casts, other orders give the wrong
+        // answer NOLINTNEXTLINE(misc-misplaced-widening-cast)
+        harmonic_m_recurrence_prefactors[static_cast<size_t>(
+            m + static_cast<int>(l_max))] = prefactor_accumulator;
+      }
+    }
+  }
+
+  /// Serialization for Charm++.
+  void pup(PUP::er& p) noexcept {  // NOLINT
+    p | alpha_prefactor;
+    p | alpha_constant;
+    p | beta_constant;
+    p | lambda;
+    p | harmonic_at_l_min_prefactors;
+    p | harmonic_at_l_min_plus_one_recurrence_prefactors;
+    p | harmonic_m_recurrence_prefactors;
+  }
+
+  // Tables are stored in a triangular Goldberg style
+  DataVector alpha_prefactor;
+  DataVector alpha_constant;
+  DataVector beta_constant;
+  std::vector<int> lambda;
+  DataVector harmonic_at_l_min_prefactors;
+  DataVector harmonic_at_l_min_plus_one_recurrence_prefactors;
+  DataVector harmonic_m_recurrence_prefactors;
+};
+
+// A lazy static cache interface for retrieving `ClenshawRecurrenceConstants`.
+template <int Spin>
+const ClenshawRecurrenceConstants<Spin>& cached_clenshaw_factors(
+    const size_t l_max) noexcept {
+  const static auto lazy_clenshaw_cache =
+      make_static_cache<CacheRange<0, collocation_maximum_l_max>>(
+          [](const size_t local_l_max) noexcept {
+            return ClenshawRecurrenceConstants<Spin>{local_l_max};
+          });
+  return lazy_clenshaw_cache(l_max);
+}
+
+SwshInterpolator::SwshInterpolator(const DataVector& theta,
+                                   const DataVector& phi,
+                                   const size_t l_max) noexcept
+    : l_max_{l_max},
+      raw_libsharp_coefficient_buffer_{
+          size_of_libsharp_coefficient_vector(l_max)},
+      raw_goldberg_coefficient_buffer_{square(l_max + 1)} {
+  cos_m_phi_ = std::vector<DataVector>(l_max + 1);
+  sin_m_phi_ = std::vector<DataVector>(l_max + 1);
+  cos_theta_ = cos(theta);
+  sin_theta_ = sin(theta);
+  cos_theta_over_two_ = cos(0.5 * theta);
+  sin_theta_over_two_ = sin(0.5 * theta);
+  // evaluate cos(m phi) and sin(m phi) via recurrence
+  cos_m_phi_[0] = DataVector{phi.size(), 1.0};
+  sin_m_phi_[0] = DataVector{phi.size(), 0.0};
+  const DataVector m_phi_beta = sin(phi);
+  const DataVector m_phi_alpha = 2.0 * square(sin(0.5 * phi));
+  for (size_t m = 1; m <= l_max; ++m) {
+    cos_m_phi_[m] = cos_m_phi_[m - 1] - (m_phi_alpha * cos_m_phi_[m - 1] +
+                                         m_phi_beta * sin_m_phi_[m - 1]);
+    sin_m_phi_[m] = sin_m_phi_[m - 1] - (m_phi_alpha * sin_m_phi_[m - 1] -
+                                         m_phi_beta * cos_m_phi_[m - 1]);
+  }
+}
+
+template <int Spin>
+void SwshInterpolator::interpolate(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> interpolated,
+    const SpinWeighted<ComplexModalVector, Spin>& goldberg_modes) const
+    noexcept {
+  interpolated->destructive_resize(cos_theta_.size());
+  interpolated->data() = 0.0;
+
+  // used only if s=0;
+  SpinWeighted<ComplexDataVector, Spin> cached_base_harmonic;
+
+  // used during both recurrence legs
+  SpinWeighted<ComplexDataVector, Spin> current_cached_harmonic;
+  SpinWeighted<ComplexDataVector, Spin> current_cached_harmonic_l_plus_one;
+
+  // perform the Clenshaw sums over positive m >= 0.
+  for (int m = 0; m <= static_cast<int>(l_max_); ++m) {
+    if (std::abs(Spin) >= std::abs(m)) {
+      direct_evaluation_swsh_at_l_min(make_not_null(&current_cached_harmonic),
+                                      m);
+      evaluate_swsh_at_l_min_plus_one(
+          make_not_null(&current_cached_harmonic_l_plus_one),
+          current_cached_harmonic, m);
+    } else {
+      evaluate_swsh_m_recurrence_at_l_min(
+          make_not_null(&current_cached_harmonic), m);
+      evaluate_swsh_at_l_min_plus_one(
+          make_not_null(&current_cached_harmonic_l_plus_one),
+          current_cached_harmonic, m);
+    }
+    if (Spin == 0 and m == 0) {
+      cached_base_harmonic = current_cached_harmonic;
+    }
+    clenshaw_sum(interpolated, current_cached_harmonic,
+                 current_cached_harmonic_l_plus_one, goldberg_modes, m);
+  }
+  // perform the Clenshaw sums over m < 0.
+  for (int m = -1; m >= -static_cast<int>(l_max_); --m) {
+    // initialize the recurrence for negative m
+    if (m == -1 and Spin == 0) {
+      current_cached_harmonic = cached_base_harmonic;
+    }
+    if (std::abs(Spin) >= std::abs(m)) {
+      direct_evaluation_swsh_at_l_min(make_not_null(&current_cached_harmonic),
+                                      m);
+      evaluate_swsh_at_l_min_plus_one(
+          make_not_null(&current_cached_harmonic_l_plus_one),
+          current_cached_harmonic, m);
+    } else {
+      evaluate_swsh_m_recurrence_at_l_min(
+          make_not_null(&current_cached_harmonic), m);
+      evaluate_swsh_at_l_min_plus_one(
+          make_not_null(&current_cached_harmonic_l_plus_one),
+          current_cached_harmonic, m);
+    }
+    clenshaw_sum(interpolated, current_cached_harmonic,
+                 current_cached_harmonic_l_plus_one, goldberg_modes, m);
+  }
+}
+
+template <int Spin>
+void SwshInterpolator::interpolate(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> interpolated,
+    const SpinWeighted<ComplexDataVector, Spin>&
+        libsharp_collocation) noexcept {
+  SpinWeighted<ComplexModalVector, Spin> libsharp_modes;
+  libsharp_modes.set_data_ref(raw_libsharp_coefficient_buffer_.data(),
+                              raw_libsharp_coefficient_buffer_.size());
+  swsh_transform(l_max_, 1, make_not_null(&libsharp_modes),
+                 libsharp_collocation);
+  SpinWeighted<ComplexModalVector, Spin> goldberg_modes;
+  libsharp_to_goldberg_modes(make_not_null(&goldberg_modes), libsharp_modes,
+                             l_max_);
+  interpolate(interpolated, goldberg_modes);
+}
+
+template <int Spin>
+void SwshInterpolator::direct_evaluation_swsh_at_l_min(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> harmonic,
+    const int m) const noexcept {
+  const auto& clenshaw_factors = cached_clenshaw_factors<Spin>(l_max_);
+  // for this evaluation, we don't worry about recurrence because it will only
+  // be called for m between -s and +s, and s should always be small. In
+  // principle, it is probably true that a more complicated recurrence exists
+  // for this case, but would require a bit of derivation work
+  harmonic->data() =
+      // clang-tidy: this is the right order of the casts, other orders give the
+      // wrong answer
+      // NOLINTNEXTLINE(misc-misplaced-widening-cast)
+      clenshaw_factors.harmonic_at_l_min_prefactors[static_cast<size_t>(
+          m + static_cast<int>(l_max_))] *
+      (std::complex<double>(1.0, 0.0) * gsl::at(cos_m_phi_, std::abs(m)) +
+       std::complex<double>(0.0, 1.0) * (m >= 0 ? 1.0 : -1.0) *
+           gsl::at(sin_m_phi_, std::abs(m))) *
+      pow(sin_theta_over_two_, static_cast<size_t>(std::abs(Spin + m))) *
+      pow(cos_theta_over_two_, static_cast<size_t>(std::abs(Spin - m)));
+}
+
+template <int Spin>
+void SwshInterpolator::evaluate_swsh_at_l_min_plus_one(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> harmonic,
+    const SpinWeighted<ComplexDataVector, Spin>& harmonic_at_l_min,
+    const int m) const noexcept {
+  const auto& clenshaw_factors = cached_clenshaw_factors<Spin>(l_max_);
+  const double a = std::abs(Spin + m);
+  const double b = std::abs(Spin - m);
+  harmonic->data() =
+      clenshaw_factors
+          // clang-tidy: this is the right order of the casts, other orders give
+          // the wrong answer
+          // NOLINTNEXTLINE(misc-misplaced-widening-cast)
+          .harmonic_at_l_min_plus_one_recurrence_prefactors[static_cast<size_t>(
+              m + static_cast<int>(l_max_))] *
+      harmonic_at_l_min.data() *
+      (a + 1.0 + 0.5 * (a + b + 2.0) * (cos_theta_ - 1.0));
+}
+
+template <int Spin>
+void SwshInterpolator::evaluate_swsh_m_recurrence_at_l_min(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> harmonic,
+    const int m) const noexcept {
+  const auto& clenshaw_factors = cached_clenshaw_factors<Spin>(l_max_);
+  harmonic->data() =
+      // this is the right order of the casts, other orders give the wrong
+      // answer
+      // NOLINTNEXTLINE(misc-misplaced-widening-cast)
+      clenshaw_factors.harmonic_m_recurrence_prefactors[static_cast<size_t>(
+          m + static_cast<int>(l_max_))] *
+      (sin_theta_ / 2.0) * harmonic->data();
+  if (m > 0) {
+    harmonic->data() *= (std::complex<double>(1.0, 0.0) * cos_m_phi_[1] +
+                         std::complex<double>(0.0, 1.0) * sin_m_phi_[1]);
+  } else {
+    harmonic->data() *= (std::complex<double>(1.0, 0.0) * cos_m_phi_[1] -
+                         std::complex<double>(0.0, 1.0) * sin_m_phi_[1]);
+  }
+}
+
+template <int Spin>
+void SwshInterpolator::clenshaw_sum(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> interpolation,
+    const SpinWeighted<ComplexDataVector, Spin>& l_min_harmonic,
+    const SpinWeighted<ComplexDataVector, Spin>& l_min_plus_one_harmonic,
+    const SpinWeighted<ComplexModalVector, Spin>& goldberg_modes,
+    const int m) const noexcept {
+  // Since we need various combinations of the three-term recurrence constants
+  // up to two orders higher, we write recurrence results to a cyclic
+  // three-element cache
+  std::array<ComplexDataVector, 3> recurrence_cache;
+  recurrence_cache[2] = ComplexDataVector{interpolation->size(), 0.0};
+  recurrence_cache[1] = ComplexDataVector{interpolation->size(), 0.0};
+  recurrence_cache[0] = ComplexDataVector{interpolation->size(), 0.0};
+  const auto& clenshaw_factors = cached_clenshaw_factors<Spin>(l_max_);
+
+  for (auto l = static_cast<int>(l_max_);
+       l > std::max(std::abs(Spin), std::abs(m)); l--) {
+    // We want to define some cache_offset so that we can index the three
+    // elements of recurrence_cache with indices cache_offset%3,
+    // (cache_offset+1)%3, and (cache_offset+2)%3, and so that cache_offset
+    // decreases by one on each iteration. The "obvious" way to do this is to
+    // choose cache_offset = l - l_max, so that cache_offset starts at zero and
+    // then decreases each iteration. However, this gives negative values of
+    // cache_offset, and C++ modular arithmetic doesn't behave the way we'd want
+    // for that process at negative values. But note that adding any multiple of
+    // 3 to the "obvious" value of cache_offset will give identical indexing,
+    // and choosing this multiple of 3 large enough (i.e. larger than l_max)
+    // guarantees that the new cache_offset is positive for all l. So we choose
+    // to add 3*l_max to the "obvious" value of cache_offset; in other words we
+    // define cache_offset = l + 2 l_max.
+    // In future, if this trick needs to be re-implemented in another use-case,
+    // it should instead be factored out into a separate rotating cache utility.
+    const int cache_offset = (l + 2 * static_cast<int>(l_max_));
+    // gcc warns about the casts in ways that are impossible to satisfy
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+    gsl::at(recurrence_cache, (cache_offset) % 3) =
+        goldberg_modes.data()[square(static_cast<size_t>(l)) +
+                              static_cast<size_t>(l + m)];
+    if (l < static_cast<int>(l_max_)) {
+      gsl::at(recurrence_cache, (cache_offset) % 3) +=
+          (clenshaw_factors
+               .alpha_constant[clenshaw_cache_index(l_max_, Spin, l + 1, m)] +
+           cos_theta_ * clenshaw_factors.alpha_prefactor[clenshaw_cache_index(
+                            l_max_, Spin, l + 1, m)]) *
+          gsl::at(recurrence_cache, (cache_offset + 1) % 3);
+    }
+    if (l < static_cast<int>(l_max_) - 1) {
+      gsl::at(recurrence_cache, (cache_offset) % 3) +=
+          clenshaw_factors
+              .beta_constant[clenshaw_cache_index(l_max_, Spin, l + 2, m)] *
+          gsl::at(recurrence_cache, (cache_offset + 2) % 3);
+    }
+  }
+  const int l_min = std::max(std::abs(Spin), std::abs(m));
+  const int cache_offset = (l_min + 2 * static_cast<int>(l_max_));
+
+  if (l_max_ >=
+      static_cast<size_t>(std::max(std::abs(Spin), std::abs(m))) + 2) {
+    *interpolation +=
+        l_min_harmonic *
+            goldberg_modes.data()[square(static_cast<size_t>(l_min)) +
+                                  static_cast<size_t>(l_min + m)] +
+        l_min_plus_one_harmonic *
+            gsl::at(recurrence_cache, (cache_offset + 1) % 3) +
+        l_min_harmonic * gsl::at(recurrence_cache, (cache_offset + 2) % 3) *
+            clenshaw_factors.beta_constant[clenshaw_cache_index(
+                l_max_, Spin, std::max(std::abs(Spin), std::abs(m)) + 2, m)];
+  } else {
+    *interpolation +=
+        l_min_harmonic *
+            goldberg_modes.data()[square(static_cast<size_t>(l_min)) +
+                                  static_cast<size_t>(l_min + m)] +
+        l_min_plus_one_harmonic *
+            gsl::at(recurrence_cache, (cache_offset + 1) % 3);
+  }
+#pragma GCC diagnostic pop
+}
+
+void SwshInterpolator::pup(PUP::er& p) noexcept {
+  p | l_max_;
+  p | cos_theta_;
+  p | sin_theta_;
+  p | cos_theta_over_two_;
+  p | sin_theta_over_two_;
+  p | sin_m_phi_;
+  p | cos_m_phi_;
+  p | raw_libsharp_coefficient_buffer_;
+  p | raw_goldberg_coefficient_buffer_;
+}
+
+#define GET_SPIN(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INTERPOLATION_INSTANTIATION(r, data)                                  \
+  template struct ClenshawRecurrenceConstants<GET_SPIN(data)>;                \
+  template const ClenshawRecurrenceConstants<GET_SPIN(data)>&                 \
+  cached_clenshaw_factors<GET_SPIN(data)>(const size_t l_max) noexcept;       \
+  template void SwshInterpolator::interpolate<GET_SPIN(data)>(                \
+      const gsl::not_null<SpinWeighted<ComplexDataVector, GET_SPIN(data)>*>   \
+          interpolated,                                                       \
+      const SpinWeighted<ComplexModalVector, GET_SPIN(data)>& goldberg_modes) \
+      const noexcept;                                                         \
+  template void SwshInterpolator::interpolate<GET_SPIN(data)>(                \
+      const gsl::not_null<SpinWeighted<ComplexDataVector, GET_SPIN(data)>*>   \
+          interpolated,                                                       \
+      const SpinWeighted<ComplexDataVector, GET_SPIN(data)>&                  \
+          libsharp_collocation) noexcept;                                     \
+  template void                                                               \
+  SwshInterpolator::direct_evaluation_swsh_at_l_min<GET_SPIN(data)>(          \
+      const gsl::not_null<SpinWeighted<ComplexDataVector, GET_SPIN(data)>*>   \
+          harmonic,                                                           \
+      const int m) const noexcept;                                            \
+  template void                                                               \
+  SwshInterpolator::evaluate_swsh_at_l_min_plus_one<GET_SPIN(data)>(          \
+      const gsl::not_null<SpinWeighted<ComplexDataVector, GET_SPIN(data)>*>   \
+          harmonic,                                                           \
+      const SpinWeighted<ComplexDataVector, GET_SPIN(data)>&                  \
+          harmonic_at_l_min,                                                  \
+      const int m) const noexcept;                                            \
+  template void                                                               \
+  SwshInterpolator::evaluate_swsh_m_recurrence_at_l_min<GET_SPIN(data)>(      \
+      const gsl::not_null<SpinWeighted<ComplexDataVector, GET_SPIN(data)>*>   \
+          harmonic,                                                           \
+      const int m) const noexcept;                                            \
+  template void SwshInterpolator::clenshaw_sum<GET_SPIN(data)>(               \
+      const gsl::not_null<SpinWeighted<ComplexDataVector, GET_SPIN(data)>*>   \
+          interpolation,                                                      \
+      const SpinWeighted<ComplexDataVector, GET_SPIN(data)>& l_min_harmonic,  \
+      const SpinWeighted<ComplexDataVector, GET_SPIN(data)>&                  \
+          l_min_plus_one_harmonic,                                            \
+      const SpinWeighted<ComplexModalVector, GET_SPIN(data)>& goldberg_modes, \
+      const int m) const noexcept;
+
+GENERATE_INSTANTIATIONS(INTERPOLATION_INSTANTIATION, (-2, -1, 0, 1, 2))
+
+#undef INTERPOLATION_INSTANTIATION
+#undef GET_SPIN
+
+}  // namespace Swsh
+}  // namespace Spectral
+/// \endcond

--- a/src/NumericalAlgorithms/Spectral/SwshInterpolation.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshInterpolation.hpp
@@ -1,0 +1,363 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+class ComplexDataVector;
+/// \endcond
+
+namespace Spectral {
+namespace Swsh {
+
+/// \ingroup SwshGroup
+/// A utility for evaluating a particular spin-weighted spherical harmonic
+/// function at arbitrary points.
+///
+/// \warning This should NOT be used for interpolation; such an evaluation
+/// strategy is hopelessly slow compared to Clenshaw recurrence strategies.
+/// Instead use `SwshInterpolator`.
+class SpinWeightedSphericalHarmonic {
+ public:
+  // charm needs an empty constructor
+  SpinWeightedSphericalHarmonic() = default;
+
+  SpinWeightedSphericalHarmonic(int spin, size_t l, int m) noexcept;
+
+  /*!
+   *  Return by pointer the values of the spin-weighted spherical harmonic
+   *  evaluated at `theta` and `phi`.
+   *
+   *  \details The additional values `sin_theta_over_2` and `cos_theta_over_2`,
+   *  representing \f$\sin(\theta/2)\f$ and \f$\cos(\theta/2)\f$ are taken as
+   *  required input to improve the speed of evaluation when called more than
+   *  once.
+   *
+   *  The formula we evaluate (with various prefactors precomputed, cached, and
+   *  optimized from the factorials) is \cite Goldberg1966uu
+   *
+   *  \f{align*}{
+   *  {}_s Y_{l m} = (-1)^m \sqrt{\frac{(l + m)! (l-m)! (2l + 1)}
+   *  {4 \pi (l + s)! (l - s)!}} \sin^{2 l}(\theta / 2)
+   *   \sum_{r = 0}^{l - s} {l - s \choose r} {l + s \choose r + s - m}
+   *  (-1)^{l - r - s} e^{i m \phi} \cot^{2 r + s - m}(\theta / 2).
+   *  \f}
+   */
+  void evaluate(gsl::not_null<ComplexDataVector*> result,
+                const DataVector& theta, const DataVector& phi,
+                const DataVector& sin_theta_over_2,
+                const DataVector& cos_theta_over_2) const noexcept;
+
+  /// Return by value the spin-weighted spherical harmonic evaluated at `theta`
+  /// and `phi`.
+  ///
+  /// \details The additional values `sin_theta_over_2` and `cos_theta_over_2`,
+  /// representing \f$\sin(\theta/2)\f$ and \f$\cos(\theta/2)\f$ are taken as
+  /// required input to improve the speed of evaluation when called more than
+  /// once.
+  ComplexDataVector evaluate(const DataVector& theta, const DataVector& phi,
+                             const DataVector& sin_theta_over_2,
+                             const DataVector& cos_theta_over_2) const noexcept;
+
+  /// Return by value the spin-weighted spherical harmonic evaluated at `theta`
+  /// and `phi`.
+  std::complex<double> evaluate(double theta, double phi) const noexcept;
+
+  /// Serialization for Charm++.
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  int spin_ = 0;
+  size_t l_ = 0;
+  int m_ = 0;
+  double overall_prefactor_ = 0.0;
+  std::vector<double> r_prefactors_;
+};
+
+/*!
+ * \ingroup SwshGroup
+ * \brief Performs interpolation for spin-weighted spherical harmonics by
+ * taking advantage of the Clenshaw method of expanding recurrence relations.
+ *
+ * \details During construction, we cache several functions of the target
+ * interpolation points that will be used during the Clenshaw evaluation.
+ * A new `SwshInterpolator` object must be created for each new set of target
+ * points, but the member function `SwshInterpolator::interpolate()` may be
+ * called on several different coefficients or collocation sets, and of
+ * different spin-weights.
+ *
+ * Recurrence constants
+ * --------------------
+ * This utility obtains the Clenshaw interpolation constants from a
+ * `StaticCache`, so that 'universal' quantities can be calculated only once per
+ * execution and re-used on each interpolation.
+ *
+ * We evaluate the recurrence coefficients \f$\alpha_l^{(a,b)}\f$ and
+ * \f$\beta_l^{(a,b)}\f$, where \f$a = |s + m|\f$, \f$b = |s - m|\f$, and
+ *
+ * \f[
+ * {}_sY_{l, m}(\theta, \phi) = \alpha_l^{(a,b)}(\theta) {}_s Y_{l-1, m}
+ * +  \beta_l^{(a, b)} {}_s Y_{l - 2, m}(\theta, \phi)
+ * \f]
+ *
+ * The core Clenshaw recurrence is in the\f$l\f$ modes of the
+ * spin-weighted spherical harmonic. For a set of modes \f$a_l^{(a,b)}\f$ at
+ * fixed \f$m\f$, the function value is evaluated by the recurrence:
+ *
+ * \f{align*}{
+ * y^{(a, b)}_{l_\text{max} + 2} &= y^{(a, b)}_{l_\text{max} + 1} = 0 \\
+ * y^{(a, b)}_{l}(\theta) &= \alpha_{l + 1}^{(a, b)} y^{(a, b)}_{l +
+ * 1}(\theta)
+ * + \beta_{l + 2}^{(a,b)} y^{(a, b)}_{l + 2}(\theta) + a_l^{(a, b)} \\
+ * f_m(\theta, \phi) &= \beta_{l_{\text{min}} + 2}
+ * {}_s Y_{l_{\text{min}}, m}(\theta, \phi) y^{(a, b)}_2(\theta) +
+ * {}_s Y_{l_{\text{min}} + 1, m}(\theta, \phi) y^{(a, b)}_1(\theta) +
+ * a_0^{(a, b)} {}_s Y_{l_{\text{min}}, m}(\theta, \phi),
+ * \f}
+ *
+ * where \f$l_{\text{min}} = \max(|m|, |s|)\f$ is the lowest nonvanishing
+ * \f$l\f$ mode for a given \f$m\f$ and \f$s\f$.
+ *
+ * The coefficients to cache are inferred from a mechanical but lengthy
+ * calculation involving the recurrence relation for the Jacobi polynomials.
+ * The result is:
+ *
+ * \f{align*}{
+ * \alpha_l^{(a, b)} &= \frac{\sqrt{(2l + 1)(2l - 1)}}
+ * {2\sqrt{(l + k)(l + k + a + b)(l + k + a)(l + k + b)}}
+ * \left[2 l \cos(\theta) +
+ * \frac{a^2 - b^2}{2 l - 2}\right] \\
+ * \beta_l^{(a, b)} & = - \sqrt{\frac{(2 l + 1)(l + k + a - 1)(l + k + b - 1)
+ * (l + k - 1)(l + k + a + b - 1)}
+ * {(2l - 3)(l + k)(l + k + a + b)(l + k + a)(l + k + b)}}
+ * \frac{2 l}{2 l - 2},
+ * \f}
+ * where \f$k = - (a + b)/2\f$ (which is always integral due to the properties
+ * of \f$a\f$ and \f$b\f$). Note that because the values of \f$\alpha\f$ and
+ * \f$\beta\f$ in the recurrence relation are not needed for any value below
+ * \f$l_{\text{min}} + 2\f$, so none of the values in the square-roots or
+ * denominators take pathological values for any of the coefficients we require.
+ *
+ * The \f$\beta\f$ constants are filled in member variable `beta_constant`. The
+ * \f$\alpha\f$ values are separately stored as the prefactor for the
+ * \f$\cos(\theta)\f$ term and the constant term in `alpha_prefactor` and
+ * `alpha_constant` member variables.
+ *
+ * In addition, it is efficient to cache recurrence coefficients necessary for
+ * generating the first couple of spin-weighted spherical harmonic functions for
+ * each \f$m\f$ used in the Clenshaw sum.
+ *
+ * The member variable `harmonic_at_l_min_prefactors` holds the prefactors for
+ * directly evaluating the harmonics at \f$s >= m\f$,
+ *
+ * \f{align*}{
+ * {}_s Y_{|s| m}  = {}_s C_{m} e^{i m \phi} \sin^a(\theta/2) \cos^b(\theta/2),
+ * \f}
+ *
+ * where \f${}_s C_m\f$ are the cached prefactors that take the values
+ *
+ * \f{align*}{
+ * {}_s C_m = (-1)^{m + \lambda(m)} \sqrt{\frac{(2 |s| + 1) (|s| + k)!}
+ * {4 \pi (|s| + k + a)! (|s| + k + b)!}}
+ * \f}
+ *
+ * and
+ *
+ * \f{align*}{
+ * \lambda(m) =
+ * \left\{
+ * \begin{array}{ll}
+ * 0 &\text{ for } s \ge -m\\
+ * s + m &\text{ for } s < -m
+ * \end{array} \right..
+ * \f}
+ *
+ * The member variable `harmonic_m_recurrence_prefactors` holds the prefactors
+ * necessary to evaluate the lowest harmonics for each \f$m\f$ from the next
+ * lowest-in-magnitude \f$m\f$, allowing most leading harmonics to recursively
+ * derived.
+ *
+ * \f{align*}{
+ * {}_s Y_{|m|, m} = {}_s D_m  \sin(\theta / 2) \cos(\theta / 2)
+ * \left\{
+ * \begin{array}{ll}
+ * e^{i \phi} {}_s Y_{|m| - 1, m - 1} &\text{ for } m > 0\\
+ * e^{-i \phi} {}_s Y_{|m| - 1, m + 1} &\text{ for } m < 0
+ * \end{array}\right.,
+ * \f}
+ *
+ * where \f${}_s D_m\f$ are the cached prefactors that take the values
+ *
+ * \f{align*}{
+ * {}_s D_m = -(-1)^{\Delta \lambda(m)} \sqrt{
+ * \frac{(2 |m| + 1)(k + |m| + a + b - 1)(k + |m| + a + b)}
+ * {(2 |m| - 1)(k + |m| + a)(k + |m| + b)}},
+ * \f}
+ * and \f$\Delta \lambda(m)\f$ is the difference in \f$\lambda(m)\f$ between
+ * the harmonic on the left-hand side and right-hand side of the above
+ * recurrence relation, that is \f$\lambda(m) - \lambda(m - 1)\f$ for positive
+ * \f$m\f$ and \f$\lambda(m) - \lambda(m + 1)\f$ for negative \f$m\f$.
+ *
+ * Finally, the member variable
+ * `harmonic_at_l_min_plus_one_recurrence_prefactors` holds the prefactors
+ * necessary to evaluate parts of the recurrence relations from the lowest
+ * \f$l\f$ for a given \f$m\f$ to the next-to-lowest \f$l\f$.
+ *
+ * \f{align*}{
+ *   {}_s Y_{l_{\min} + 1, m} = {}_s E_m
+ * \left[(a + 1) + (a + b + 2) \frac{(\cos(\theta) - 1)}{2}\right]
+ * {}_s Y_{l_{\min}, m}.
+ * \f}
+ *
+ * where \f${}_s E_m\f$ are the cached prefactors that take the values
+ *
+ * \f{align*}{
+ * {}_s E_{m} = \sqrt{\frac{2 l_{\min} + 3}{ 2 l_{\min} + 1}}
+ * \sqrt{\frac{(l_{\min} + k + 1)(l_{\min} + k + a + b + 1)}
+ * {(l_{\min} + k + a + 1)(l_{\min} + k + b + 1)}}
+ * \f}
+ */
+class SwshInterpolator {
+ public:
+  SwshInterpolator() = default;
+
+  SwshInterpolator(const DataVector& theta, const DataVector& phi,
+                   size_t l_max) noexcept;
+
+  /*!
+   * \brief Perform the Clenshaw recurrence sum, returning by pointer
+   * `interpolated` of interpolating the `goldberg_modes` at the collocation
+   * points passed to the constructor.
+   *
+   * \details The core Clenshaw recurrence is in the\f$l\f$ modes of the
+   * spin-weighted spherical harmonic. For a set of modes \f$a_l^{(a,b)}\f$ at
+   * fixed \f$m\f$, the function value is evaluated by the recurrence:
+   *
+   * \f{align*}{
+   * y^{(a, b)}_{l_\text{max} + 2} &= y^{(a, b)}_{l_\text{max} + 1} = 0 \\
+   * y^{(a, b)}_{l}(\theta) &= \alpha_{l + 1}^{(a, b)} y^{(a, b)}_{l +
+   * 1}(\theta)
+   * + \beta_{l + 2}^{(a,b)} y^{(a, b)}_{l + 2}(\theta) + a_l^{(a, b)} \\
+   * f_m(\theta, \phi) &= \beta_{l_{\text{min}} + 2}
+   * {}_s Y_{l_{\text{min}}, m}(\theta, \phi) y^{(a, b)}_2(\theta) +
+   * {}_s Y_{l_{\text{min}} + 1, m}(\theta, \phi) y^{(a, b)}_1(\theta) +
+   * a_0^{(a, b)} {}_s Y_{l_{\text{min}}, m}(\theta, \phi)
+   * \f}
+   *
+   * The recurrence in \f$l\f$ accomplishes much of the work, but for full
+   * efficiency, we also recursively evaluate the lowest handful of \f$l\f$s for
+   * each \f$m\f$. The details of those additional recurrence tricks can be
+   * found in the documentation for `ClenshawRecurrenceConstants`.
+   */
+  template <int Spin>
+  void interpolate(
+      gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> interpolated,
+      const SpinWeighted<ComplexModalVector, Spin>& goldberg_modes) const
+      noexcept;
+
+  /*!
+   * \brief Perform the Clenshaw recurrence sum, returning by pointer
+   * `interpolated` of interpolating function represented by
+   * `libsharp_collocation` at the target points passed to the constructor.
+   *
+   * \details The core Clenshaw recurrence is in the\f$l\f$ modes of the
+   * spin-weighted spherical harmonic. For a set of modes \f$a_l^{(a,b)}\f$ at
+   * fixed \f$m\f$, the function value is evaluated by the recurrence:
+   *
+   * \f{align*}{
+   * y^{(a, b)}_{l_\text{max} + 2} &= y^{(a, b)}_{l_\text{max} + 1} = 0 \\
+   * y^{(a, b)}_{l}(\theta) &= \alpha_{l + 1}^{(a, b)} y^{(a, b)}_{l +
+   * 1}(\theta)
+   * + \beta_{l + 2}^{(a,b)} y^{(a, b)}_{l + 2}(\theta) + a_l^{(a, b)} \\
+   * f_m(\theta, \phi) &= \beta_{l_{\text{min}} + 2}
+   * {}_s Y_{l_{\text{min}}, m}(\theta, \phi) y^{(a, b)}_2(\theta) +
+   * {}_s Y_{l_{\text{min}} + 1, m}(\theta, \phi) y^{(a, b)}_1(\theta) +
+   * a_0^{(a, b)} {}_s Y_{l_{\text{min}}, m}(\theta, \phi)
+   * \f}
+   *
+   * The recurrence in \f$l\f$ accomplishes much of the work, but for full
+   * efficiency, we also recursively evaluate the lowest handful of \f$l\f$s for
+   * each \f$m\f$. The details of those additional recurrence tricks can be
+   * found in the documentation for `ClenshawRecurrenceConstants`.
+   */
+  template <int Spin>
+  void interpolate(
+      gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> interpolated,
+      const SpinWeighted<ComplexDataVector, Spin>&
+          libsharp_collocation) noexcept;
+
+  /// \brief Evaluate the SWSH function at the lowest \f$l\f$ value for a given
+  /// \f$m\f$ at the target interpolation points.
+  ///
+  /// \details Included in the public interface for thorough testing, most use
+  /// cases should just use the `SwshInterpolator::interpolate()` member
+  /// function.
+  template <int Spin>
+  void direct_evaluation_swsh_at_l_min(
+      gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> harmonic,
+      int m) const noexcept;
+
+  /// \brief Evaluate the SWSH function at the next-to-lowest \f$l\f$ value for
+  /// a given \f$m\f$ at the target interpolation points, given input harmonic
+  /// values for the lowest \f$l\f$ value.
+  ///
+  /// \details Included in the public interface for thorough testing, most use
+  /// cases should just use the `SwshInterpolator::interpolate()` member
+  /// function.
+  template <int Spin>
+  void evaluate_swsh_at_l_min_plus_one(
+      gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> harmonic,
+      const SpinWeighted<ComplexDataVector, Spin>& harmonic_at_l_min,
+      int m) const noexcept;
+
+  /// \brief Evaluate the SWSH function at the lowest \f$l\f$ value for a given
+  /// \f$m\f$ at the target interpolation points, given harmonic data at the
+  /// next lower \f$m\f$ (by magnitude), passed in by the same pointer used for
+  /// the return.
+  ///
+  /// \details Included in the public interface for thorough testing, most use
+  /// cases should just use the `SwshInterpolator::interpolate()` member
+  /// function.
+  template <int Spin>
+  void evaluate_swsh_m_recurrence_at_l_min(
+      gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> harmonic,
+      int m) const noexcept;
+
+  /// \brief Perform the core Clenshaw interpolation at fixed \f$m\f$,
+  /// accumulating the result in `interpolation`.
+  ///
+  /// \details Included in the public interface for thorough testing, most use
+  /// cases should just use the `interpolate` member function.
+  template <int Spin>
+  void clenshaw_sum(
+      gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> interpolation,
+      const SpinWeighted<ComplexDataVector, Spin>& l_min_harmonic,
+      const SpinWeighted<ComplexDataVector, Spin>& l_min_plus_one_harmonic,
+      const SpinWeighted<ComplexModalVector, Spin>& goldberg_modes, int m) const
+      noexcept;
+
+  /// Serialization for Charm++.
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  size_t l_max_ = 0;
+  DataVector cos_theta_;
+  DataVector sin_theta_;
+  DataVector cos_theta_over_two_;
+  DataVector sin_theta_over_two_;
+  std::vector<DataVector> sin_m_phi_;
+  std::vector<DataVector> cos_m_phi_;
+  ComplexModalVector raw_libsharp_coefficient_buffer_;
+  ComplexModalVector raw_goldberg_coefficient_buffer_;
+};
+}  // namespace Swsh
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBRARY_SOURCES
   Test_SwshCollocation.cpp
   Test_SwshDerivatives.cpp
   Test_SwshFiltering.cpp
+  Test_SwshInterpolation.cpp
   Test_SwshTags.cpp
   Test_SwshTestHelpers.cpp
   Test_SwshTransform.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshInterpolation.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshInterpolation.cpp
@@ -1,0 +1,254 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cmath>
+#include <complex>
+
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Spectral {
+namespace Swsh {
+namespace {
+
+template <typename Generator>
+void test_basis_function(const gsl::not_null<Generator*> generator) noexcept {
+  UniformCustomDistribution<double> phi_dist{0.0, 2.0 * M_PI};
+  const double phi = phi_dist(*generator);
+  UniformCustomDistribution<double> theta_dist{0.01, M_PI - 0.01};
+  const double theta = theta_dist(*generator);
+  UniformCustomDistribution<int> spin_dist{-2, 2};
+  const int spin = spin_dist(*generator);
+  UniformCustomDistribution<size_t> l_dist{static_cast<size_t>(abs(spin)), 16};
+  const size_t l = l_dist(*generator);
+  UniformCustomDistribution<int> m_dist{-static_cast<int>(l),
+                                        static_cast<int>(l)};
+  const int m = m_dist(*generator);
+
+  std::complex<double> expected = TestHelpers::spin_weighted_spherical_harmonic(
+      spin, static_cast<int>(l), m, theta, phi);
+  const auto test_harmonic = SpinWeightedSphericalHarmonic{spin, l, m};
+  std::complex<double> test = test_harmonic.evaluate(theta, phi);
+  CAPTURE(spin);
+  CAPTURE(l);
+  CAPTURE(m);
+  CAPTURE(theta);
+  CAPTURE(phi);
+
+  // need a slightly loose approx to accommodate the explicit factorials in the
+  // simpler TestHelper form
+  Approx factorial_approx =
+      Approx::custom()
+          .epsilon(std::numeric_limits<double>::epsilon() * 1.0e4)
+          .scale(1.0);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(test, expected, factorial_approx);
+  const auto deserialized_test_harmonic =
+      serialize_and_deserialize(test_harmonic);
+  test = deserialized_test_harmonic.evaluate(theta, phi);
+  CHECK_ITERABLE_CUSTOM_APPROX(test, expected, factorial_approx);
+}
+
+template <int spin, typename Generator>
+void test_interpolation(const gsl::not_null<Generator*> generator) noexcept {
+  INFO("Testing interpolation for spin " << spin);
+  UniformCustomDistribution<double> coefficient_distribution{-2.0, 2.0};
+  const size_t l_max = 16;
+  UniformCustomDistribution<double> phi_dist{0.0, 2.0 * M_PI};
+  UniformCustomDistribution<double> theta_dist{0.01, M_PI - 0.01};
+  const size_t number_of_target_points = 10;
+
+  const DataVector target_phi = make_with_random_values<DataVector>(
+      generator, make_not_null(&phi_dist), number_of_target_points);
+  const DataVector target_theta = make_with_random_values<DataVector>(
+      generator, make_not_null(&theta_dist), number_of_target_points);
+
+  SpinWeighted<ComplexModalVector, spin> generated_modes{
+      size_of_libsharp_coefficient_vector(l_max)};
+  TestHelpers::generate_swsh_modes<spin>(
+      make_not_null(&generated_modes.data()), generator,
+      make_not_null(&coefficient_distribution), 1, l_max);
+
+  const auto generated_collocation =
+      inverse_swsh_transform(l_max, 1, generated_modes);
+
+  const auto goldberg_modes =
+      libsharp_to_goldberg_modes(generated_modes, l_max);
+
+  SpinWeighted<ComplexDataVector, spin> expected{number_of_target_points, 0.0};
+  SpinWeighted<ComplexDataVector, spin> another_expected{
+      number_of_target_points, 0.0};
+  auto interpolator = SwshInterpolator{target_theta, target_phi, l_max};
+  const auto deserialized_interpolator =
+      serialize_and_deserialize(interpolator);
+  for (int l = 0; l <= static_cast<int>(l_max); ++l) {
+    for(int m = -l; m <= l; ++m) {
+      auto sYlm =
+          SpinWeightedSphericalHarmonic{spin, static_cast<size_t>(l), m};
+      if (l == std::max(abs(m), abs(spin))) {
+        SpinWeighted<ComplexDataVector, spin> harmonic_test;
+        interpolator.direct_evaluation_swsh_at_l_min(
+            make_not_null(&harmonic_test), m);
+        for(size_t i = 0; i < number_of_target_points; ++i) {
+          CHECK_ITERABLE_APPROX(sYlm.evaluate(target_theta[i], target_phi[i]),
+                                harmonic_test.data()[i]);
+        }
+      }
+      if (l == std::max(abs(m), abs(spin)) + 1) {
+        SpinWeighted<ComplexDataVector, spin> harmonic_test_l_min;
+        interpolator.direct_evaluation_swsh_at_l_min(
+            make_not_null(&harmonic_test_l_min), m);
+
+        SpinWeighted<ComplexDataVector, spin> harmonic_test_l_min_plus_one;
+        interpolator.evaluate_swsh_at_l_min_plus_one(
+            make_not_null(&harmonic_test_l_min_plus_one), harmonic_test_l_min,
+            m);
+
+        for(size_t i = 0; i < number_of_target_points; ++i) {
+          CHECK_ITERABLE_APPROX(sYlm.evaluate(target_theta[i], target_phi[i]),
+                                harmonic_test_l_min_plus_one.data()[i]);
+        }
+      }
+      if (l == std::max(abs(m), abs(spin)) and abs(m) > abs(spin)) {
+        if(m > 0) {
+          SpinWeighted<ComplexDataVector, spin> harmonic_test;
+          interpolator.direct_evaluation_swsh_at_l_min(
+              make_not_null(&harmonic_test), m - 1);
+          interpolator.evaluate_swsh_m_recurrence_at_l_min(
+              make_not_null(&harmonic_test), m);
+          INFO("checking l=" << l <<" m=" << m);
+          for(size_t i = 0; i < number_of_target_points; ++i) {
+            CHECK_ITERABLE_APPROX(sYlm.evaluate(target_theta[i], target_phi[i]),
+                                  harmonic_test.data()[i]);
+          }
+
+          // check the serialization hasn't harmed the interpolator
+          deserialized_interpolator.direct_evaluation_swsh_at_l_min(
+              make_not_null(&harmonic_test), m - 1);
+          deserialized_interpolator.evaluate_swsh_m_recurrence_at_l_min(
+              make_not_null(&harmonic_test), m);
+          INFO("checking l=" << l << " m=" << m);
+          for(size_t i = 0; i < number_of_target_points; ++i) {
+            CHECK_ITERABLE_APPROX(sYlm.evaluate(target_theta[i], target_phi[i]),
+                                  harmonic_test.data()[i]);
+          }
+
+        } else {
+          SpinWeighted<ComplexDataVector, spin> harmonic_test;
+          interpolator.direct_evaluation_swsh_at_l_min(
+              make_not_null(&harmonic_test), m + 1);
+          interpolator.evaluate_swsh_m_recurrence_at_l_min(
+              make_not_null(&harmonic_test), m);
+          INFO("checking l=" << l <<" m=" << m);
+          for(size_t i = 0; i < number_of_target_points; ++i) {
+            CHECK_ITERABLE_APPROX(sYlm.evaluate(target_theta[i], target_phi[i]),
+                                  harmonic_test.data()[i]);
+          }
+
+          // check the serialization hasn't harmed the interpolator
+          deserialized_interpolator.direct_evaluation_swsh_at_l_min(
+              make_not_null(&harmonic_test), m + 1);
+          deserialized_interpolator.evaluate_swsh_m_recurrence_at_l_min(
+              make_not_null(&harmonic_test), m);
+          INFO("checking l=" << l <<" m=" << m);
+          for(size_t i = 0; i < number_of_target_points; ++i) {
+            CHECK_ITERABLE_APPROX(sYlm.evaluate(target_theta[i], target_phi[i]),
+                                  harmonic_test.data()[i]);
+          }
+        }
+      }
+      for(size_t i = 0; i < number_of_target_points; ++i) {
+        // gcc warns about the casts in ways that are impossible to satisfy
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+        expected.data()[i] +=
+            goldberg_modes.data()[
+                square(static_cast<size_t>(l)) + static_cast<size_t>(l + m)] *
+            TestHelpers::spin_weighted_spherical_harmonic(
+                spin, l, m, target_theta[i], target_phi[i]);
+        another_expected.data()[i] +=
+            goldberg_modes.data()[square(static_cast<size_t>(l)) +
+                                  static_cast<size_t>(l + m)] *
+            sYlm.evaluate(target_theta[i], target_phi[i]);
+      }
+    }
+  }
+
+  Approx factorial_approx =
+      Approx::custom()
+      .epsilon(std::numeric_limits<double>::epsilon() * 1.0e5)
+      .scale(1.0);
+  // direct test Clenshaw sums
+  for(int m = -static_cast<int>(l_max); m <= static_cast<int>(l_max); ++m) {
+    SpinWeighted<ComplexDataVector, spin> expected_clenshaw_sum{
+        number_of_target_points, 0.0};
+    for (int l = std::max(abs(m), abs(spin)); l <= static_cast<int>(l_max);
+         ++l) {
+      auto sYlm =
+          SpinWeightedSphericalHarmonic{spin, static_cast<size_t>(l), m};
+      for(size_t i = 0; i < number_of_target_points; ++i) {
+        expected_clenshaw_sum.data()[i] +=
+            goldberg_modes.data()[square(static_cast<size_t>(l)) +
+                                  static_cast<size_t>(l + m)] *
+            sYlm.evaluate(target_theta[i], target_phi[i]);
+      }
+    }
+#pragma GCC diagnostic pop
+    SpinWeighted<ComplexDataVector, spin> clenshaw{number_of_target_points,
+                                                   0.0};
+
+    SpinWeighted<ComplexDataVector, spin> harmonic_test_l_min;
+    interpolator.direct_evaluation_swsh_at_l_min(
+        make_not_null(&harmonic_test_l_min), m);
+
+    SpinWeighted<ComplexDataVector, spin> harmonic_test_l_min_plus_one;
+    interpolator.evaluate_swsh_at_l_min_plus_one(
+        make_not_null(&harmonic_test_l_min_plus_one), harmonic_test_l_min, m);
+
+    interpolator.clenshaw_sum(
+        make_not_null(&clenshaw), harmonic_test_l_min,
+        harmonic_test_l_min_plus_one,
+        libsharp_to_goldberg_modes(
+            swsh_transform(l_max, 1, generated_collocation), l_max),
+        m);
+    INFO("checking clenshaw sum for m=" << m);
+    for(size_t i = 0; i < number_of_target_points; ++i) {
+      CHECK_ITERABLE_CUSTOM_APPROX(clenshaw.data()[i],
+                                   expected_clenshaw_sum.data()[i],
+                                   factorial_approx);
+    }
+  }
+
+  SpinWeighted<ComplexDataVector, spin> clenshaw_interpolation;
+  interpolator.interpolate(
+      make_not_null(&clenshaw_interpolation),
+      libsharp_to_goldberg_modes(
+          swsh_transform(l_max, 1, generated_collocation), l_max));
+
+  CHECK_ITERABLE_CUSTOM_APPROX(expected, another_expected, factorial_approx);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(clenshaw_interpolation, expected,
+                               factorial_approx);
+}
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshInterpolation",
+                  "[Unit][NumericalAlgorithms]") {
+  MAKE_GENERATOR(generator);
+  // test a few points on each run of the test, these are cheap.
+  for(size_t i = 0; i < 10; ++i) {
+    test_basis_function(make_not_null(&generator));
+  }
+
+  test_interpolation<-1>(make_not_null(&generator));
+  test_interpolation<0>(make_not_null(&generator));
+  test_interpolation<2>(make_not_null(&generator));
+}
+}  // namespace
+}  // namespace Swsh
+}  // namespace Spectral


### PR DESCRIPTION
## Proposed changes

This is an important utility for working with spin-weighted spherical harmonics when moving between different collocation grids. This operation is performed often in the gauge transformation utilities that will be in the next CCE pull request.

Apologies for the unpleasant mathematics. I'm pretty sure it can't be helped.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
