### PR TITLE
Fix #1149 (warn when using GenerateXdmf.py with python 2)

### DIFF
--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -5,7 +5,9 @@
 
 import glob
 import h5py
+import logging
 import numpy as np
+import sys
 
 
 def generate_xdmf(file_prefix, output_filename, start_time, stop_time, stride):
@@ -13,6 +15,11 @@ def generate_xdmf(file_prefix, output_filename, start_time, stop_time, stride):
     Generate one XDMF file that ParaView and VisIt can use to load the data
     out of the HDF5 files.
     """
+    if sys.version_info < (3, 0):
+        logging.warning("You are attempting to run this script with "
+                        "python 2, which is deprecated. GenerateXdmf.py might "
+                        "hang or run very slowly using python 2. Please use "
+                        "python 3 instead.")
     h5files = [(h5py.File(filename, 'r'), filename)
                for filename in glob.glob(file_prefix + "*.h5")]
 
@@ -247,6 +254,7 @@ def parse_args():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     input_args = parse_args()
     generate_xdmf(input_args.file_prefix, input_args.output,
                   input_args.start_time, input_args.stop_time,


### PR DESCRIPTION
Resolves #1149.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
