### PR TITLE
Remove unused variable in Cce/Test_ReadBoundaryDataH5

### DIFF
--- a/tests/Unit/Evolution/Systems/Cce/Test_ReadBoundaryDataH5.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_ReadBoundaryDataH5.cpp
@@ -332,7 +332,6 @@ void test_data_manager_with_dummy_buffer_updater(
   const double target_time = 50.0 * value_dist(*gen);
 
   const size_t buffer_size = 8;
-  const size_t interpolator_length = 3;
   const size_t l_max = 8;
 
   DataVector time_buffer{30};


### PR DESCRIPTION
## Proposed changes

Remove unused variable in Cce/Test_ReadBoundaryDataH5

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
