### PR TITLE
Allow specifying name of function of time for translation

### DIFF
--- a/src/Domain/CoordinateMaps/Translation.cpp
+++ b/src/Domain/CoordinateMaps/Translation.cpp
@@ -5,6 +5,7 @@
 
 #include <pup.h>
 #include <pup_stl.h>
+#include <utility>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Identity.hpp"
@@ -15,6 +16,9 @@
 
 namespace domain {
 namespace CoordMapsTimeDependent {
+
+Translation::Translation(std::string function_of_time_name) noexcept
+    : f_of_t_name_(std::move(function_of_time_name)) {}
 
 template <typename T>
 std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::operator()(

--- a/src/Domain/CoordinateMaps/Translation.hpp
+++ b/src/Domain/CoordinateMaps/Translation.hpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <boost/optional.hpp>
 #include <cstddef>
+#include <memory>
 #include <string>
 #include <unordered_map>
 
@@ -35,6 +36,9 @@ namespace CoordMapsTimeDependent {
 class Translation {
  public:
   static constexpr size_t dim = 1;
+
+  Translation() = default;
+  explicit Translation(std::string function_of_time_name) noexcept;
 
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(

--- a/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <boost/optional.hpp>
 #include <cstddef>
+#include <memory>
 #include <string>
 #include <unordered_map>
 
@@ -35,11 +36,11 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.Translation",
   using Polynomial = domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
   using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
   std::unordered_map<std::string, FoftPtr> f_of_t_list{};
-  f_of_t_list["trans"] = std::make_unique<Polynomial>(t, init_func);
+  f_of_t_list["translation"] = std::make_unique<Polynomial>(t, init_func);
 
-  const FoftPtr& f_of_t = f_of_t_list.at("trans");
+  const FoftPtr& f_of_t = f_of_t_list.at("translation");
 
-  const CoordMapsTimeDependent::Translation trans_map{};
+  const CoordMapsTimeDependent::Translation trans_map{"translation"};
   // test serialized/deserialized map
   const auto trans_map_deserialized = serialize_and_deserialize(trans_map);
 


### PR DESCRIPTION
## Proposed changes

Allow specifying name of function of time for translation

This is needed when using different translation maps in say `x,y,z` directions.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
