### PR TITLE
Factor shared coordinate map code and metafunctions

### DIFF
--- a/src/Domain/CoordinateMaps/CoordinateMap.tpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.tpp
@@ -22,6 +22,7 @@
 
 #include "DataStructures/Tensor/Identity.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMapHelpers.hpp"
 #include "Domain/CoordinateMaps/TimeDependentHelpers.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Parallel/CharmPupable.hpp"
@@ -33,35 +34,6 @@
 
 /// \cond
 namespace domain {
-// define type-trait to check for time-dependent mapping
-namespace CoordinateMap_detail {
-
-template <typename T, size_t Dim, typename Map>
-void apply_map(
-    const gsl::not_null<std::array<T, Dim>*> t_map_point, const Map& the_map,
-    const double /*t*/,
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-    /*functions_of_time*/,
-    const std::false_type /*is_time_independent*/) {
-  if (LIKELY(not the_map.is_identity())) {
-    *t_map_point = the_map(*t_map_point);
-  }
-}
-
-template <typename T, size_t Dim, typename Map>
-void apply_map(
-    const gsl::not_null<std::array<T, Dim>*> t_map_point, const Map& the_map,
-    const double t,
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time,
-    const std::true_type
-    /*is_time_dependent*/) {
-  *t_map_point = the_map(*t_map_point, t, functions_of_time);
-}
-}  // namespace CoordinateMap_detail
-
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::CoordinateMap(Maps... maps)
     : maps_(std::move(maps)...) {}

--- a/src/Domain/CoordinateMaps/CoordinateMap.tpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.tpp
@@ -22,6 +22,7 @@
 
 #include "DataStructures/Tensor/Identity.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/TimeDependentHelpers.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Parallel/PupStlCpp11.hpp"
@@ -34,11 +35,6 @@
 namespace domain {
 // define type-trait to check for time-dependent mapping
 namespace CoordinateMap_detail {
-template <typename T>
-using is_map_time_dependent_t = tt::is_callable_t<
-    T, std::array<std::decay_t<T>, std::decay_t<T>::dim>, double,
-    std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>>;
 
 template <typename T, size_t Dim, typename Map>
 void apply_map(
@@ -100,7 +96,7 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::call_impl(
          const std::true_type /*is_time_dependent*/) noexcept {
         point = the_map(point, t, funcs_of_time);
       })(std::get<Is>(maps_), mapped_point, time, functions_of_time,
-         CoordinateMap_detail::is_map_time_dependent_t<Maps>{}));
+         domain::is_map_time_dependent_t<Maps>{}));
 
   return tnsr::I<T, dim, TargetFrame>(std::move(mapped_point));
 }
@@ -146,25 +142,13 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::inverse_impl(
         // reversed
       })(std::get<sizeof...(Maps) - 1 - Is>(maps_), mapped_point, time,
          functions_of_time,
-         CoordinateMap_detail::is_map_time_dependent_t<decltype(
+         domain::is_map_time_dependent_t<decltype(
              std::get<sizeof...(Maps) - 1 - Is>(maps_))>{}));
 
   return mapped_point
              ? tnsr::I<T, dim, SourceFrame>(std::move(mapped_point.get()))
              : boost::optional<tnsr::I<T, dim, SourceFrame>>{};
 }
-
-// define type-trait to check for time-dependent jacobian
-namespace CoordinateMap_detail {
-CREATE_IS_CALLABLE(jacobian)
-template <typename Map, typename T>
-using is_jacobian_time_dependent_t =
-    CoordinateMap_detail::is_jacobian_callable_t<
-        Map, std::array<std::decay_t<T>, std::decay_t<Map>::dim>, double,
-        std::unordered_map<
-            std::string,
-            std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>>;
-}  // namespace CoordinateMap_detail
 
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 template <typename T>
@@ -222,12 +206,10 @@ auto CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_jacobian_impl(
             CoordinateMap_detail::apply_map(
                 make_not_null(&mapped_point), map_in_loop, time,
                 functions_of_time,
-                CoordinateMap_detail::is_map_time_dependent_t<decltype(
-                    map_in_loop)>{});
-            inv_jac_overload(&temp_inv_jac, map, mapped_point, time,
-                             functions_of_time,
-                             CoordinateMap_detail::is_jacobian_time_dependent_t<
-                                 decltype(map), T>{});
+                domain::is_map_time_dependent_t<decltype(map_in_loop)>{});
+            inv_jac_overload(
+                &temp_inv_jac, map, mapped_point, time, functions_of_time,
+                domain::is_jacobian_time_dependent_t<decltype(map), T>{});
             std::array<T, dim> temp{};
             for (size_t source = 0; source < dim; ++source) {
               for (size_t target = 0; target < dim; ++target) {
@@ -246,8 +228,7 @@ auto CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_jacobian_impl(
         } else {
           inv_jac_overload(
               &temp_inv_jac, map, mapped_point, time, functions_of_time,
-              CoordinateMap_detail::is_jacobian_time_dependent_t<decltype(map),
-                                                                 T>{});
+              domain::is_jacobian_time_dependent_t<decltype(map), T>{});
           for (size_t source = 0; source < dim; ++source) {
             for (size_t target = 0; target < dim; ++target) {
               inv_jac.get(source, target) =
@@ -318,12 +299,10 @@ auto CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(
             CoordinateMap_detail::apply_map(
                 make_not_null(&mapped_point), map_in_loop, time,
                 functions_of_time,
-                CoordinateMap_detail::is_map_time_dependent_t<decltype(
-                    map_in_loop)>{});
-            jac_overload(&noframe_jac, map, mapped_point, time,
-                         functions_of_time,
-                         CoordinateMap_detail::is_jacobian_time_dependent_t<
-                             decltype(map), T>{});
+                domain::is_map_time_dependent_t<decltype(map_in_loop)>{});
+            jac_overload(
+                &noframe_jac, map, mapped_point, time, functions_of_time,
+                domain::is_jacobian_time_dependent_t<decltype(map), T>{});
             std::array<T, dim> temp{};
             for (size_t source = 0; source < dim; ++source) {
               for (size_t target = 0; target < dim; ++target) {
@@ -342,8 +321,7 @@ auto CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(
         } else {
           jac_overload(
               &noframe_jac, map, mapped_point, time, functions_of_time,
-              CoordinateMap_detail::is_jacobian_time_dependent_t<decltype(map),
-                                                                 T>{});
+              domain::is_jacobian_time_dependent_t<decltype(map), T>{});
           for (size_t target = 0; target < dim; ++target) {
             for (size_t source = 0; source < dim; ++source) {
               jac.get(target, source) =

--- a/src/Domain/CoordinateMaps/CoordinateMapHelpers.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMapHelpers.hpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+
+#include "DataStructures/Tensor/Identity.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace domain {
+namespace CoordinateMap_detail {
+// @{
+/// Call the map passing in the time and FunctionsOfTime if the map is
+/// time-dependent
+template <typename T, size_t Dim, typename Map>
+void apply_map(
+    const gsl::not_null<std::array<T, Dim>*> t_map_point, const Map& the_map,
+    const double /*t*/,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+    /*functions_of_time*/,
+    const std::false_type /*is_time_independent*/) {
+  if (LIKELY(not the_map.is_identity())) {
+    *t_map_point = the_map(*t_map_point);
+  }
+}
+
+template <typename T, size_t Dim, typename Map>
+void apply_map(
+    const gsl::not_null<std::array<T, Dim>*> t_map_point, const Map& the_map,
+    const double t,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const std::true_type
+    /*is_time_dependent*/) {
+  ASSERT(not functions_of_time.empty(),
+         "A function of time must be present if the maps are time-dependent.");
+  ASSERT(
+      [t]() noexcept {
+        disable_floating_point_exceptions();
+        const bool isnan = std::isnan(t);
+        enable_floating_point_exceptions();
+        return not isnan;
+      }(),
+      "The time must not be NaN for time-dependent maps.");
+  *t_map_point = the_map(*t_map_point, t, functions_of_time);
+}
+// @}
+}  // namespace CoordinateMap_detail
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/TimeDependentHelpers.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependentHelpers.hpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace domain {
+/// Check if the call to the coordinate map is time-dependent
+template <typename T>
+using is_map_time_dependent_t = tt::is_callable_t<
+    T, std::array<std::decay_t<T>, std::decay_t<T>::dim>, double,
+    std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>>;
+
+/// Check if the call to the coordinate map is time-dependent
+template <typename T>
+constexpr bool is_map_time_dependent_v = is_map_time_dependent_t<T>::value;
+
+namespace detail {
+CREATE_IS_CALLABLE(jacobian)
+}  // namespace detail
+
+/// Check if the call to the Jacobian of the coordinate map is time-dependent
+template <typename Map, typename T>
+using is_jacobian_time_dependent_t = detail::is_jacobian_callable_t<
+    Map, std::array<std::decay_t<T>, std::decay_t<Map>::dim>, double,
+    std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>>;
+
+/// Check if the call to the Jacobian of the coordinate map is time-dependent
+template <typename Map, typename T>
+constexpr bool is_jacobian_time_dependent_v =
+    is_jacobian_time_dependent_t<Map, T>::value;
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/TimeDependentHelpers.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependentHelpers.hpp
@@ -14,14 +14,16 @@
 #include "Utilities/TypeTraits.hpp"
 
 namespace domain {
-/// Check if the call to the coordinate map is time-dependent
+/// Check if the calls to the coordinate map and its inverse map are
+/// time-dependent
 template <typename T>
 using is_map_time_dependent_t = tt::is_callable_t<
     T, std::array<std::decay_t<T>, std::decay_t<T>::dim>, double,
     std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>>;
 
-/// Check if the call to the coordinate map is time-dependent
+/// Check if the calls to the coordinate map and its inverse map are
+/// time-dependent
 template <typename T>
 constexpr bool is_map_time_dependent_v = is_map_time_dependent_t<T>::value;
 
@@ -29,14 +31,16 @@ namespace detail {
 CREATE_IS_CALLABLE(jacobian)
 }  // namespace detail
 
-/// Check if the call to the Jacobian of the coordinate map is time-dependent
+/// Check if the calls to the Jacobian and inverse Jacobian of the coordinate
+/// map are time-dependent
 template <typename Map, typename T>
 using is_jacobian_time_dependent_t = detail::is_jacobian_callable_t<
     Map, std::array<std::decay_t<T>, std::decay_t<Map>::dim>, double,
     std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>>;
 
-/// Check if the call to the Jacobian of the coordinate map is time-dependent
+/// Check if the calls to the Jacobian and inverse Jacobian of the coordinate
+/// map are time-dependent
 template <typename Map, typename T>
 constexpr bool is_jacobian_time_dependent_v =
     is_jacobian_time_dependent_t<Map, T>::value;

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
   Test_ProductMaps.cpp
   Test_Rotation.cpp
   Test_SpecialMobius.cpp
+  Test_TimeDependentHelpers.cpp
   Test_Translation.cpp
   Test_Wedge2D.cpp
   Test_Wedge3D.cpp

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -19,6 +19,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/TimeDependentHelpers.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/OrientationMap.hpp"
@@ -278,11 +279,9 @@ void test_coordinate_map_argument_types(
         return nullptr;
       });
 
-  jac_overloader(
-      make_array_data_vector, add_reference_wrapper, map, test_point,
-      domain::CoordinateMap_detail::is_jacobian_time_dependent_t<decltype(map),
-                                                                 double>{},
-      args...);
+  jac_overloader(make_array_data_vector, add_reference_wrapper, map, test_point,
+                 domain::is_jacobian_time_dependent_t<decltype(map), double>{},
+                 args...);
 }
 
 /*!

--- a/tests/Unit/Domain/CoordinateMaps/Test_TimeDependentHelpers.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_TimeDependentHelpers.cpp
@@ -1,0 +1,149 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/TimeDependentHelpers.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+class DataVector;
+
+namespace domain {
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
+}  // namespace domain
+/// \endcond
+
+namespace {
+template <size_t Dim>
+struct TimeDepMap {
+  static constexpr size_t dim = Dim;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> operator()(
+      const std::array<T, Dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
+      const noexcept;
+};
+template <size_t Dim>
+struct TimeIndepMap {
+  static constexpr size_t dim = Dim;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> operator()(
+      const std::array<T, Dim>& source_coords) const noexcept;
+};
+
+template <size_t Dim>
+struct TimeDepJac {
+  static constexpr size_t dim = Dim;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> jacobian(
+      const std::array<T, Dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
+      const noexcept;
+};
+template <size_t Dim>
+struct TimeIndepJac {
+  static constexpr size_t dim = Dim;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> jacobian(
+      const std::array<T, Dim>& source_coords) const noexcept;
+};
+}  // namespace
+
+namespace domain {
+static_assert(is_map_time_dependent_t<TimeDepMap<1>>::value,
+              "Failed testing is_map_time_dependent_t");
+static_assert(is_map_time_dependent_t<TimeDepMap<2>>::value,
+              "Failed testing is_map_time_dependent_t");
+static_assert(is_map_time_dependent_t<TimeDepMap<3>>::value,
+              "Failed testing is_map_time_dependent_t");
+static_assert(not is_map_time_dependent_t<TimeIndepMap<1>>::value,
+              "Failed testing is_map_time_dependent_t");
+static_assert(not is_map_time_dependent_t<TimeIndepMap<2>>::value,
+              "Failed testing is_map_time_dependent_t");
+static_assert(not is_map_time_dependent_t<TimeIndepMap<3>>::value,
+              "Failed testing is_map_time_dependent_t");
+
+static_assert(is_map_time_dependent_v<TimeDepMap<1>>,
+              "Failed testing is_map_time_dependent_v");
+static_assert(is_map_time_dependent_v<TimeDepMap<2>>,
+              "Failed testing is_map_time_dependent_v");
+static_assert(is_map_time_dependent_v<TimeDepMap<3>>,
+              "Failed testing is_map_time_dependent_v");
+static_assert(not is_map_time_dependent_v<TimeIndepMap<1>>,
+              "Failed testing is_map_time_dependent_v");
+static_assert(not is_map_time_dependent_v<TimeIndepMap<2>>,
+              "Failed testing is_map_time_dependent_v");
+static_assert(not is_map_time_dependent_v<TimeIndepMap<3>>,
+              "Failed testing is_map_time_dependent_v");
+
+static_assert(is_jacobian_time_dependent_t<TimeDepJac<1>, DataVector>::value,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(is_jacobian_time_dependent_t<TimeDepJac<1>, double>::value,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(is_jacobian_time_dependent_t<TimeDepJac<2>, DataVector>::value,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(is_jacobian_time_dependent_t<TimeDepJac<2>, double>::value,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(is_jacobian_time_dependent_t<TimeDepJac<3>, DataVector>::value,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(is_jacobian_time_dependent_t<TimeDepJac<3>, double>::value,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(
+    not is_jacobian_time_dependent_t<TimeIndepJac<1>, DataVector>::value,
+    "Failed testing is_jacobian_time_dependent_t");
+static_assert(not is_jacobian_time_dependent_t<TimeIndepJac<1>, double>::value,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(
+    not is_jacobian_time_dependent_t<TimeIndepJac<2>, DataVector>::value,
+    "Failed testing is_jacobian_time_dependent_t");
+static_assert(not is_jacobian_time_dependent_t<TimeIndepJac<2>, double>::value,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(
+    not is_jacobian_time_dependent_t<TimeIndepJac<3>, DataVector>::value,
+    "Failed testing is_jacobian_time_dependent_t");
+static_assert(not is_jacobian_time_dependent_t<TimeIndepJac<3>, double>::value,
+              "Failed testing is_jacobian_time_dependent_t");
+
+static_assert(is_jacobian_time_dependent_v<TimeDepJac<1>, DataVector>,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(is_jacobian_time_dependent_v<TimeDepJac<1>, double>,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(is_jacobian_time_dependent_v<TimeDepJac<2>, DataVector>,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(is_jacobian_time_dependent_v<TimeDepJac<2>, double>,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(is_jacobian_time_dependent_v<TimeDepJac<3>, DataVector>,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(is_jacobian_time_dependent_v<TimeDepJac<3>, double>,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(not is_jacobian_time_dependent_v<TimeIndepJac<1>, DataVector>,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(not is_jacobian_time_dependent_v<TimeIndepJac<1>, double>,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(not is_jacobian_time_dependent_v<TimeIndepJac<2>, DataVector>,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(not is_jacobian_time_dependent_v<TimeIndepJac<2>, double>,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(not is_jacobian_time_dependent_v<TimeIndepJac<3>, DataVector>,
+              "Failed testing is_jacobian_time_dependent_t");
+static_assert(not is_jacobian_time_dependent_v<TimeIndepJac<3>, double>,
+              "Failed testing is_jacobian_time_dependent_t");
+}  // namespace domain


### PR DESCRIPTION
## Proposed changes

Some of the metafunctions used by `CoordinateMap` is useful in time-dependent product maps, and possibly other time-dependent composition-type maps. The same is true for some of the helper functions for invoking different maps.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
