### PR TITLE
Variable slab sizes

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -75,6 +75,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/ChangeSlabSize.hpp"
 #include "Time/Actions/ChangeStepSize.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"  // IWYU pragma: keep
@@ -82,6 +83,7 @@
 #include "Time/StepChoosers/Cfl.hpp"
 #include "Time/StepChoosers/Constant.hpp"
 #include "Time/StepChoosers/Increase.hpp"
+#include "Time/StepChoosers/PreventRapidIncrease.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepControllers/StepController.hpp"
 #include "Time/Tags.hpp"
@@ -131,6 +133,23 @@ struct EvolutionMetavars {
                     grmhd::ValenciaDivClean::Tags::TildeS<Frame::Inertial>,
                     grmhd::ValenciaDivClean::Tags::TildeB<Frame::Inertial>>>>;
 
+  using step_choosers_common =
+      tmpl::list<StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial>,
+                 StepChoosers::Registrars::Constant,
+                 StepChoosers::Registrars::Increase>;
+  using step_choosers_for_step_only =
+      tmpl::list<StepChoosers::Registrars::PreventRapidIncrease>;
+  using step_choosers_for_slab_only = tmpl::list<>;
+  using step_choosers = tmpl::conditional_t<
+      local_time_stepping,
+      tmpl::append<step_choosers_common, step_choosers_for_step_only>,
+      tmpl::list<>>;
+  using slab_choosers = tmpl::conditional_t<
+      local_time_stepping,
+      tmpl::append<step_choosers_common, step_choosers_for_slab_only>,
+      tmpl::append<step_choosers_common, step_choosers_for_step_only,
+                   step_choosers_for_slab_only>>;
+
   // public for use by the Charm++ registration code
   using events = tmpl::flatten<tmpl::list<
       tmpl::conditional_t<evolution::is_analytic_solution_v<initial_data>,
@@ -144,13 +163,10 @@ struct EvolutionMetavars {
               db::get_variables_tags_list<
                   typename system::primitive_variables_tag>>,
           tmpl::conditional_t<evolution::is_analytic_solution_v<initial_data>,
-                              analytic_variables_tags, tmpl::list<>>>>>;
+                              analytic_variables_tags, tmpl::list<>>>,
+      Events::Registrars::ChangeSlabSize<slab_choosers>>>;
   using triggers = Triggers::time_triggers;
 
-  using step_choosers =
-      tmpl::list<StepChoosers::Registrars::Cfl<3, Frame::Inertial>,
-                 StepChoosers::Registrars::Constant,
-                 StepChoosers::Registrars::Increase>;
   using ordered_list_of_primitive_recovery_schemes = tmpl::list<
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin,
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>;
@@ -245,6 +261,7 @@ struct EvolutionMetavars {
                                                           thermodynamic_dim>>,
                       Actions::UpdateConservatives,
                       Actions::RunEventsAndTriggers,
+                      Actions::ChangeSlabSize,
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
@@ -291,6 +308,8 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::creators::register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<
         Event<metavariables::events>>,
+    &Parallel::register_derived_classes_with_charm<
+        StepChooser<metavariables::slab_choosers>>,
     &Parallel::register_derived_classes_with_charm<
         StepChooser<metavariables::step_choosers>>,
     &Parallel::register_derived_classes_with_charm<StepController>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
@@ -58,6 +58,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/ChangeSlabSize.hpp"
 #include "Time/Actions/ChangeStepSize.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"  // IWYU pragma: keep
@@ -65,6 +66,7 @@
 #include "Time/StepChoosers/Cfl.hpp"
 #include "Time/StepChoosers/Constant.hpp"
 #include "Time/StepChoosers/Increase.hpp"
+#include "Time/StepChoosers/PreventRapidIncrease.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepControllers/StepController.hpp"
 #include "Time/Tags.hpp"
@@ -111,6 +113,23 @@ struct EvolutionMetavars {
   using limiter = Tags::Limiter<
       Limiters::Minmod<3, typename system::variables_tag::tags_list>>;
 
+  using step_choosers_common =
+      tmpl::list<//StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial>,
+                 StepChoosers::Registrars::Constant,
+                 StepChoosers::Registrars::Increase>;
+  using step_choosers_for_step_only =
+      tmpl::list<StepChoosers::Registrars::PreventRapidIncrease>;
+  using step_choosers_for_slab_only = tmpl::list<>;
+  using step_choosers = tmpl::conditional_t<
+      local_time_stepping,
+      tmpl::append<step_choosers_common, step_choosers_for_step_only>,
+      tmpl::list<>>;
+  using slab_choosers = tmpl::conditional_t<
+      local_time_stepping,
+      tmpl::append<step_choosers_common, step_choosers_for_slab_only>,
+      tmpl::append<step_choosers_common, step_choosers_for_step_only,
+                   step_choosers_for_slab_only>>;
+
   // public for use by the Charm++ registration code
   using events = tmpl::flatten<tmpl::list<
       tmpl::conditional_t<evolution::is_analytic_solution_v<initial_data>,
@@ -124,13 +143,9 @@ struct EvolutionMetavars {
               db::get_variables_tags_list<
                   typename system::primitive_variables_tag>>,
           tmpl::conditional_t<evolution::is_analytic_solution_v<initial_data>,
-                              analytic_variables_tags, tmpl::list<>>>>>;
+                              analytic_variables_tags, tmpl::list<>>>,
+      Events::Registrars::ChangeSlabSize<slab_choosers>>>;
   using triggers = Triggers::time_triggers;
-
-  using step_choosers =
-      tmpl::list<StepChoosers::Registrars::Cfl<3, Frame::Inertial>,
-                 StepChoosers::Registrars::Constant,
-                 StepChoosers::Registrars::Increase>;
 
   struct ObservationType {};
   using element_observation_type = ObservationType;
@@ -214,6 +229,7 @@ struct EvolutionMetavars {
                   Phase, Phase::Evolve,
                   tmpl::list<
                       Actions::RunEventsAndTriggers,
+                      Actions::ChangeSlabSize,
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
@@ -258,6 +274,8 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::creators::register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<
         Event<metavariables::events>>,
+    &Parallel::register_derived_classes_with_charm<
+        StepChooser<metavariables::slab_choosers>>,
     &Parallel::register_derived_classes_with_charm<
         StepChooser<metavariables::step_choosers>>,
     &Parallel::register_derived_classes_with_charm<StepController>,

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -61,6 +61,7 @@
 #include "PointwiseFunctions/Hydro/SoundSpeedSquared.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/ChangeSlabSize.hpp"
 #include "Time/Actions/ChangeStepSize.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
@@ -68,6 +69,7 @@
 #include "Time/StepChoosers/Cfl.hpp"
 #include "Time/StepChoosers/Constant.hpp"
 #include "Time/StepChoosers/Increase.hpp"
+#include "Time/StepChoosers/PreventRapidIncrease.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepControllers/StepController.hpp"
 #include "Time/Tags.hpp"
@@ -125,6 +127,23 @@ struct EvolutionMetavars {
                       RelativisticEuler::Valencia::Tags::TildeTau,
                       RelativisticEuler::Valencia::Tags::TildeS<Dim>>>>;
 
+  using step_choosers_common =
+      tmpl::list<//StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial>,
+                 StepChoosers::Registrars::Constant,
+                 StepChoosers::Registrars::Increase>;
+  using step_choosers_for_step_only =
+      tmpl::list<StepChoosers::Registrars::PreventRapidIncrease>;
+  using step_choosers_for_slab_only = tmpl::list<>;
+  using step_choosers = tmpl::conditional_t<
+      local_time_stepping,
+      tmpl::append<step_choosers_common, step_choosers_for_step_only>,
+      tmpl::list<>>;
+  using slab_choosers = tmpl::conditional_t<
+      local_time_stepping,
+      tmpl::append<step_choosers_common, step_choosers_for_slab_only>,
+      tmpl::append<step_choosers_common, step_choosers_for_step_only,
+                   step_choosers_for_slab_only>>;
+
   using events = tmpl::list<
       tmpl::conditional_t<evolution::is_analytic_solution_v<initial_data>,
                           dg::Events::Registrars::ObserveErrorNorms<
@@ -137,13 +156,9 @@ struct EvolutionMetavars {
               db::get_variables_tags_list<
                   typename system::primitive_variables_tag>>,
           tmpl::conditional_t<evolution::is_analytic_solution_v<initial_data>,
-                              analytic_variables_tags, tmpl::list<>>>>;
+                              analytic_variables_tags, tmpl::list<>>>,
+      Events::Registrars::ChangeSlabSize<slab_choosers>>;
   using triggers = Triggers::time_triggers;
-
-  using step_choosers =
-      tmpl::list<StepChoosers::Registrars::Cfl<Dim, Frame::Inertial>,
-                 StepChoosers::Registrars::Constant,
-                 StepChoosers::Registrars::Increase>;
 
   struct ObservationType {};
   using element_observation_type = ObservationType;
@@ -242,6 +257,7 @@ struct EvolutionMetavars {
                                                           thermodynamic_dim>>,
                       Actions::UpdateConservatives,
                       Actions::RunEventsAndTriggers,
+                      Actions::ChangeSlabSize,
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
@@ -286,6 +302,8 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::creators::register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<
         Event<metavariables::events>>,
+    &Parallel::register_derived_classes_with_charm<
+        StepChooser<metavariables::slab_choosers>>,
     &Parallel::register_derived_classes_with_charm<
         StepChooser<metavariables::step_choosers>>,
     &Parallel::register_derived_classes_with_charm<StepController>,

--- a/src/Time/Actions/ChangeSlabSize.hpp
+++ b/src/Time/Actions/ChangeSlabSize.hpp
@@ -1,0 +1,345 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/functional/hash.hpp>  // IWYU pragma: keep
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <memory>
+#include <ostream>
+#include <pup.h>
+#include <tuple>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Reduction.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Registration.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+template <typename StepChooserRegistrars>
+class StepChooser;
+namespace Tags {
+struct DataBox;
+template <typename Tag>
+struct Next;
+}  // namespace Tags
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace ChangeSlabSize_detail {
+struct NewSlabSizeInbox {
+  using temporal_id = int64_t;
+  using type = std::map<temporal_id, std::unordered_multiset<double>>;
+};
+
+// This inbox doesn't receive any data, it just counts messages (using
+// the size of the multiset).  Whenever a message is sent to the
+// NewSlabSizeInbox, another message is sent here synchronously, so
+// the count here is the number of messages we expect in the
+// NewSlabSizeInbox.
+struct NumberOfExpectedMessagesInbox {
+  using temporal_id = int64_t;
+  using NoData = std::tuple<>;
+  using type = std::map<temporal_id,
+                        std::unordered_multiset<NoData, boost::hash<NoData>>>;
+};
+
+struct StoreNewSlabSize {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(const db::DataBox<DbTags>& /*box*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index, const int64_t slab_number,
+                    const double slab_size) noexcept {
+    Parallel::receive_data<ChangeSlabSize_detail::NewSlabSizeInbox>(
+        *Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
+             .ckLocal(),
+        slab_number, slab_size);
+  }
+};
+}  // namespace ChangeSlabSize_detail
+
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \ingroup TimeGroup
+/// Adjust the slab size based on previous executions of
+/// Events::ChangeSlabSize
+///
+/// Uses:
+/// - ConstGlobalCache:
+///   - Tags::TimeStepperBase
+/// - DataBox:
+///   - Tags::HistoryEvolvedVariables
+///   - Tags::TimeStep
+///   - Tags::TimeStepId
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - Tags::Next<Tags::TimeStepId>
+///   - Tags::TimeStep
+///   - Tags::TimeStepId
+struct ChangeSlabSize {
+  using inbox_tags =
+      tmpl::list<ChangeSlabSize_detail::NumberOfExpectedMessagesInbox,
+                 ChangeSlabSize_detail::NewSlabSizeInbox>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTags>&&> apply(
+      db::DataBox<DbTags>& box, tuples::TaggedTuple<InboxTags...>& inboxes,
+      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const auto& time_step_id = db::get<Tags::TimeStepId>(box);
+
+    if (not time_step_id.is_at_slab_boundary()) {
+      return std::forward_as_tuple(std::move(box));
+    }
+
+    auto& message_count_inbox =
+        tuples::get<ChangeSlabSize_detail::NumberOfExpectedMessagesInbox>(
+            inboxes);
+    if (message_count_inbox.empty() or
+        message_count_inbox.begin()->first != time_step_id.slab_number()) {
+      return std::forward_as_tuple(std::move(box));
+    }
+    message_count_inbox.erase(message_count_inbox.begin());
+
+    auto& new_slab_size_inbox =
+        tuples::get<ChangeSlabSize_detail::NewSlabSizeInbox>(inboxes);
+    const double new_slab_size =
+        *alg::min_element(new_slab_size_inbox.begin()->second);
+    new_slab_size_inbox.erase(new_slab_size_inbox.begin());
+
+    const TimeStepper& time_stepper =
+        Parallel::get<Tags::TimeStepperBase>(cache);
+
+    // Sometimes time steppers need to run with a fixed step size.
+    // This is generally at the start of an evolution when the history
+    // is in an unusual state.
+    if (not time_stepper.can_change_step_size(
+            time_step_id, db::get<Tags::HistoryEvolvedVariables<>>(box))) {
+      return std::forward_as_tuple(std::move(box));
+    }
+
+    const auto& current_step = db::get<Tags::TimeStep>(box);
+    const auto& current_slab = current_step.slab();
+
+    const auto new_slab =
+        current_step.is_positive()
+            ? current_slab.with_duration_from_start(new_slab_size)
+            : current_slab.with_duration_to_end(new_slab_size);
+
+    const auto new_step = current_step.with_slab(new_slab);
+
+    // We are at a slab boundary, so the substep is 0.
+    const auto new_time_step_id =
+        TimeStepId(time_step_id.time_runs_forward(), time_step_id.slab_number(),
+                   time_step_id.step_time().with_slab(new_slab));
+
+    const auto new_next_time_step_id =
+        time_stepper.next_time_id(new_time_step_id, new_step);
+
+    db::mutate<Tags::Next<Tags::TimeStepId>, Tags::TimeStep, Tags::TimeStepId>(
+        make_not_null(&box),
+        [&new_next_time_step_id, &new_step, &new_time_step_id](
+            const gsl::not_null<TimeStepId*> next_time_step_id,
+            const gsl::not_null<TimeDelta*> time_step,
+            const gsl::not_null<TimeStepId*> local_time_step_id) noexcept {
+          *next_time_step_id = new_next_time_step_id;
+          *time_step = new_step;
+          *local_time_step_id = new_time_step_id;
+        });
+
+    return std::forward_as_tuple(std::move(box));
+  }
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex>
+  static bool is_ready(
+      const db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& inboxes,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/) noexcept {
+    const auto& time_step_id = db::get<Tags::TimeStepId>(box);
+    if (not time_step_id.is_at_slab_boundary()) {
+      return true;
+    }
+
+    const auto& message_count_inbox =
+        tuples::get<ChangeSlabSize_detail::NumberOfExpectedMessagesInbox>(
+            inboxes);
+    const auto& new_slab_size_inbox =
+        tuples::get<ChangeSlabSize_detail::NewSlabSizeInbox>(inboxes);
+
+    const auto slab_number = time_step_id.slab_number();
+    const auto number_of_changes = [&slab_number](
+                                       const auto& inbox) noexcept->size_t {
+      if (inbox.empty()) {
+        return 0;
+      }
+      if (inbox.begin()->first == slab_number) {
+        return inbox.begin()->second.size();
+      }
+      ASSERT(inbox.begin()->first >= slab_number,
+             "Received data for a change at slab " << inbox.begin()->first
+             << " but it is already slab " << slab_number);
+      return 0;
+    };
+
+    const size_t expected_messages = number_of_changes(message_count_inbox);
+    const size_t received_messages = number_of_changes(new_slab_size_inbox);
+    ASSERT(expected_messages >= received_messages,
+           "Received " << received_messages << " size change messages at slab "
+                       << slab_number << ", but only expected "
+                       << expected_messages);
+    return expected_messages == received_messages;
+  }
+};
+}  // namespace Actions
+
+namespace Events {
+template <typename StepChooserRegistrars, typename EventRegistrars>
+class ChangeSlabSize;
+
+namespace Registrars {
+template <typename StepChooserRegistrars>
+using ChangeSlabSize =
+    Registration::Registrar<Events::ChangeSlabSize, StepChooserRegistrars>;
+}  // namespace Registrars
+
+/// \ingroup TimeGroup
+/// %Trigger a slab size change.
+///
+/// The new size will be the minimum suggested by any of the provided
+/// step choosers on any element.  This requires a global reduction,
+/// so it is possible to delay the change until a later slab to avoid
+/// a global synchronization.  The actual change is carried out by
+/// Actions::ChangeSlabSize.
+///
+/// When running with global time-stepping, the slab size and step
+/// size are the same, so this adjusts the step size used by the time
+/// integration.  With local time-stepping this controls the interval
+/// between times when the sequences of steps on all elements are
+/// forced to align.
+template <typename StepChooserRegistrars,
+          typename EventRegistrars =
+              tmpl::list<Registrars::ChangeSlabSize<StepChooserRegistrars>>>
+class ChangeSlabSize : public Event<EventRegistrars> {
+  using ReductionData = Parallel::ReductionData<
+      Parallel::ReductionDatum<int64_t, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<double, funcl::Min<>>>;
+
+ public:
+  /// \cond
+  explicit ChangeSlabSize(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ChangeSlabSize);  // NOLINT
+  /// \endcond
+
+  struct StepChoosers {
+    static constexpr OptionString help = "Limits on slab size";
+    using type =
+        std::vector<std::unique_ptr<StepChooser<StepChooserRegistrars>>>;
+    static size_t lower_bound_on_size() noexcept { return 1; }
+  };
+
+  struct DelayChange {
+    static constexpr OptionString help = "Slabs to wait before changing";
+    using type = uint64_t;
+  };
+
+  using options = tmpl::list<StepChoosers, DelayChange>;
+  static constexpr OptionString help =
+      "Trigger a slab size change chosen by the provided step choosers.\n"
+      "The actual changing of the slab size can be delayed until a later\n"
+      "slab to improve parallelization.";
+
+  ChangeSlabSize() = default;
+  ChangeSlabSize(
+      std::vector<std::unique_ptr<StepChooser<StepChooserRegistrars>>>
+          step_choosers,
+      const uint64_t delay_change) noexcept
+      : step_choosers_(std::move(step_choosers)), delay_change_(delay_change) {}
+
+  using argument_tags = tmpl::list<Tags::TimeStepId, Tags::DataBox>;
+
+  template <typename DbTags, typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
+  void operator()(const TimeStepId& time_step_id,
+                  const db::DataBox<DbTags>& box_for_step_choosers,
+                  Parallel::ConstGlobalCache<Metavariables>& cache,
+                  const ArrayIndex& array_index,
+                  const ParallelComponent* const /*meta*/) const noexcept {
+    const auto next_changable_slab = time_step_id.is_at_slab_boundary()
+                                         ? time_step_id.slab_number()
+                                         : time_step_id.slab_number() + 1;
+    const auto slab_to_change =
+        next_changable_slab + static_cast<int64_t>(delay_change_);
+
+    double desired_slab_size = std::numeric_limits<double>::infinity();
+    for (const auto& step_chooser : step_choosers_) {
+      desired_slab_size =
+          std::min(desired_slab_size,
+                   step_chooser->desired_step(
+                       time_step_id.step_time().slab().duration().value(),
+                       box_for_step_choosers, cache));
+    }
+
+    const auto& component_proxy =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+    const auto& self_proxy = component_proxy[array_index];
+    // This message is sent synchronously, so it is guaranteed to
+    // arrive before the ChangeSlabSize action is called.
+    Parallel::receive_data<
+        ChangeSlabSize_detail::NumberOfExpectedMessagesInbox>(
+        *self_proxy.ckLocal(), slab_to_change,
+        ChangeSlabSize_detail::NumberOfExpectedMessagesInbox::NoData{});
+    Parallel::contribute_to_reduction<ChangeSlabSize_detail::StoreNewSlabSize>(
+        ReductionData(slab_to_change, desired_slab_size), self_proxy,
+        component_proxy);
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept override {
+    Event<EventRegistrars>::pup(p);
+    p | step_choosers_;
+    p | delay_change_;
+  }
+
+ private:
+  std::vector<std::unique_ptr<StepChooser<StepChooserRegistrars>>>
+      step_choosers_;
+  uint64_t delay_change_ = std::numeric_limits<uint64_t>::max();
+};
+
+/// \cond
+template <typename StepChooserRegistrars, typename EventRegistrars>
+PUP::able::PUP_ID
+    ChangeSlabSize<StepChooserRegistrars, EventRegistrars>::my_PUP_ID =
+        0;  // NOLINT
+/// \endcond
+}  // namespace Events

--- a/src/Time/Actions/ChangeStepSize.hpp
+++ b/src/Time/Actions/ChangeStepSize.hpp
@@ -7,8 +7,6 @@
 #include <tuple>
 
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
@@ -19,6 +17,10 @@
 /// \cond
 class TimeDelta;
 class TimeStepId;
+namespace Tags {
+template <typename Tag>
+struct Next;
+}  // namespace Tags
 // IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
 
@@ -64,21 +66,27 @@ struct ChangeStepSize {
     const auto& step_controller = Parallel::get<Tags::StepController>(cache);
 
     const auto& time_id = db::get<Tags::TimeStepId>(box);
+    const auto& history = db::get<Tags::HistoryEvolvedVariables<>>(box);
 
-    if (not time_stepper.can_change_step_size(
-            time_id, db::get<Tags::HistoryEvolvedVariables<>>(box))) {
+    if (not time_stepper.can_change_step_size(time_id, history)) {
       return std::forward_as_tuple(std::move(box));
     }
 
     const auto& current_step = db::get<Tags::TimeStep>(box);
+
+    const double last_step_size =
+        history.size() > 0 ? abs(time_id.step_time() -
+                                 (history.end() - 1).time_step_id().step_time())
+                                 .value()
+                           : std::numeric_limits<double>::infinity();
 
     // The step choosers return the magnitude of the desired step, so
     // we always want the minimum requirement, but we have to negate
     // the final answer if time is running backwards.
     double desired_step = std::numeric_limits<double>::infinity();
     for (const auto& step_chooser : step_choosers) {
-      desired_step =
-          std::min(desired_step, step_chooser->desired_step(box, cache));
+      desired_step = std::min(
+          desired_step, step_chooser->desired_step(last_step_size, box, cache));
     }
     if (not current_step.is_positive()) {
       desired_step = -desired_step;

--- a/src/Time/StepChoosers/ByBlock.hpp
+++ b/src/Time/StepChoosers/ByBlock.hpp
@@ -67,9 +67,10 @@ class ByBlock : public StepChooser<StepChooserRegistrars> {
   using argument_tags = tmpl::list<Tags::Element<Dim>>;
 
   template <typename Metavariables>
-  double operator()(const Element<Dim>& element,
-                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/)
-      const noexcept {
+  double operator()(
+      const Element<Dim>& element, const double /*last_step_magnitude*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/) const
+      noexcept {
     const size_t block = element.id().block_id();
     if (block >= sizes_.size()) {
       ERROR("Step size not specified for block " << block);

--- a/src/Time/StepChoosers/Cfl.hpp
+++ b/src/Time/StepChoosers/Cfl.hpp
@@ -3,23 +3,25 @@
 
 #pragma once
 
+#include <cstddef>
 #include <limits>
 #include <pup.h>
 
-#include "Domain/MinimumGridSpacing.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"  // IWYU pragma: keep
-#include "Time/Tags.hpp"
-#include "Utilities/Registration.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-namespace Parallel {
-template <typename Metavariables>
-class ConstGlobalCache;
-}  // namespace Parallel
+namespace Tags {
+struct DataBox;
+struct TimeStepperBase;
+template <size_t Dim, typename Frame>
+struct MinimumGridSpacing;
+}  // namespace Tags
+// IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
 
 namespace StepChoosers {
@@ -67,6 +69,7 @@ class Cfl : public StepChooser<StepChooserRegistrars> {
   template <typename Metavariables, typename DbTags>
   double operator()(
       const double minimum_grid_spacing, const db::DataBox<DbTags>& box,
+      const double /*last_step_magnitude*/,
       const Parallel::ConstGlobalCache<Metavariables>& cache) const noexcept {
     using compute_largest_characteristic_speed =
         typename Metavariables::system::compute_largest_characteristic_speed;

--- a/src/Time/StepChoosers/Constant.hpp
+++ b/src/Time/StepChoosers/Constant.hpp
@@ -48,7 +48,8 @@ class Constant : public StepChooser<StepChooserRegistrars> {
   using argument_tags = tmpl::list<>;
 
   template <typename Metavariables>
-  double operator()(const Parallel::ConstGlobalCache<Metavariables>& /*cache*/)
+  double operator()(const double /*last_step_magnitude*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/)
       const noexcept {
     return value_;
   }

--- a/src/Time/StepChoosers/Increase.hpp
+++ b/src/Time/StepChoosers/Increase.hpp
@@ -19,9 +19,6 @@ namespace Parallel {
 template <typename Metavariables>
 class ConstGlobalCache;
 }  // namespace Parallel
-namespace Tags {
-struct TimeStep;
-}  // namespace Tags
 /// \endcond
 
 namespace StepChoosers {
@@ -54,13 +51,13 @@ class Increase : public StepChooser<StepChooserRegistrars> {
 
   explicit Increase(const double factor) noexcept : factor_(factor) {}
 
-  using argument_tags = tmpl::list<Tags::TimeStep>;
+  using argument_tags = tmpl::list<>;
 
   template <typename Metavariables>
-  double operator()(const TimeDelta& current_step,
+  double operator()(const double last_step_magnitude,
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/)
       const noexcept {
-    return std::abs(current_step.value()) * factor_;
+    return last_step_magnitude * factor_;
   }
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -67,6 +67,20 @@ EventsAndTriggers:
   ? SpecifiedSlabs:
       Slabs: [10]
   : - Completion
+  ? EveryNSlabs:
+      N: 1
+  : - ChangeSlabSize:
+        # DelayChange: 0 forces a synchronization after every slab.
+        # It is more efficient to use a higher value.  This is for
+        # testing.
+        DelayChange: 0
+        StepChoosers:
+          - Constant: 0.05
+          - Increase:
+              Factor: 2
+          - Cfl:
+              SafetyFactor: 0.2
+          - PreventRapidIncrease
 
 Observers:
   VolumeFileName: "GrMhdVolume"

--- a/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
@@ -50,6 +50,15 @@ EventsAndTriggers:
   ? SpecifiedSlabs:
       Slabs: [10]
   : - Completion
+  ? EveryNSlabs:
+      N: 2
+  : - ChangeSlabSize:
+        DelayChange: 3
+        StepChoosers:
+          # Based on the step size choices above, this should aim for
+          # about 100 steps per slab.
+          - Cfl:
+              SafetyFactor: 20
 
 Observers:
   VolumeFileName: "ScalarWave1DPeriodicVolume"

--- a/tests/Unit/Time/Actions/CMakeLists.txt
+++ b/tests/Unit/Time/Actions/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   Actions/Test_AdvanceTime.cpp
+  Actions/Test_ChangeSlabSize.cpp
   Actions/Test_ChangeStepSize.cpp
   Actions/Test_RecordTimeStepperData.cpp
   Actions/Test_SelfStartActions.cpp

--- a/tests/Unit/Time/Actions/Test_ChangeSlabSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeSlabSize.cpp
@@ -1,0 +1,242 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// The event portion of slab size changing relies on a reduction, so
+// it cannot currently be tested with the mocking code.  This tests
+// the action portion.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <initializer_list>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
+#include "Time/Actions/ChangeSlabSize.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/RungeKutta3.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+/// \cond
+// IWYU pragma: no_forward_declare ActionTesting::InitializeDataBox
+namespace Tags {
+template <typename Tag>
+struct Next;
+template <typename Tag>
+struct dt;
+}  // namespace Tags
+/// \endcond
+
+namespace {
+struct Var : db::SimpleTag {
+  using type = double;
+};
+
+struct Component;
+
+struct Metavariables {
+  using component_list = tmpl::list<Component>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+
+  using const_global_cache_tags = tmpl::list<Tags::TimeStepper<TimeStepper>>;
+
+  using simple_tags =
+      tmpl::list<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
+                 Tags::HistoryEvolvedVariables<Var, Tags::dt<Var>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Testing,
+                             tmpl::list<Actions::ChangeSlabSize>>>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeSlabSize", "[Unit][Time][Actions]") {
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      {std::make_unique<TimeSteppers::RungeKutta3>()}};
+
+  ActionTesting::emplace_component_and_initialize<Component>(&runner, 0, {});
+  runner.set_phase(Metavariables::Phase::Testing);
+
+  auto& box = ActionTesting::get_databox<Component, Component::simple_tags>(
+      make_not_null(&runner), 0);
+
+  for (const bool time_runs_forward : {true, false}) {
+    Slab slab(1.5, 2.0);
+    Time start_time;
+
+    const auto resize_slab = [&slab, &start_time, &time_runs_forward](
+        const double length) noexcept {
+      if (time_runs_forward) {
+        slab = slab.with_duration_from_start(length);
+        start_time = slab.start();
+      } else {
+        slab = slab.with_duration_to_end(length);
+        start_time = slab.end();
+      }
+    };
+
+    resize_slab(slab.duration().value());
+
+    const auto get_step = [](const TimeStepId& id) noexcept {
+      return (id.time_runs_forward() ? 1 : -1) *
+             id.step_time().slab().duration() / 2;
+    };
+
+    db::mutate<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep>(
+        make_not_null(&box),
+        [&get_step, &start_time, &time_runs_forward](
+            const gsl::not_null<TimeStepId*> id,
+            const gsl::not_null<TimeStepId*> next_id,
+            const gsl::not_null<TimeDelta*> step,
+            const TimeStepper& stepper) noexcept {
+          *id = TimeStepId(time_runs_forward, 3, start_time);
+          *step = get_step(*id);
+          *next_id = stepper.next_time_id(*id, *step);
+        },
+        db::get<Tags::TimeStepperBase>(box));
+
+    using ExpectedMessages =
+        ChangeSlabSize_detail::NumberOfExpectedMessagesInbox;
+    using NewSize = ChangeSlabSize_detail::NewSlabSizeInbox;
+    auto& inboxes = runner.inboxes<Component>().at(0);
+
+    const auto check_box = [&box, &get_step](const TimeStepId& id) noexcept {
+      CHECK(db::get<Tags::TimeStepId>(box) == id);
+      CHECK(db::get<Tags::TimeStep>(box) == get_step(id));
+      CHECK(db::get<Tags::Next<Tags::TimeStepId>>(box) ==
+            db::get<Tags::TimeStepperBase>(box).next_time_id(
+                db::get<Tags::TimeStepId>(box), db::get<Tags::TimeStep>(box)));
+    };
+
+    // Nothing to do
+    {
+      CHECK(ActionTesting::is_ready<Component>(runner, 0));
+      runner.next_action<Component>(0);
+      check_box(TimeStepId(time_runs_forward, 3, start_time));
+    }
+
+    // Simple case
+    {
+      get<ExpectedMessages>(inboxes)[3].insert(ExpectedMessages::NoData{});
+      CHECK(not ActionTesting::is_ready<Component>(runner, 0));
+      get<NewSize>(inboxes)[3].insert(1.0);
+      CHECK(ActionTesting::is_ready<Component>(runner, 0));
+      runner.next_action<Component>(0);
+      resize_slab(1.0);
+      check_box(TimeStepId(time_runs_forward, 3, start_time));
+      CHECK(get<ExpectedMessages>(inboxes).empty());
+      CHECK(get<NewSize>(inboxes).empty());
+      get<ExpectedMessages>(inboxes).clear();
+      get<NewSize>(inboxes).clear();
+    }
+
+    // Multiple messages at multiple times
+    {
+      get<ExpectedMessages>(inboxes)[3].insert(ExpectedMessages::NoData{});
+      get<ExpectedMessages>(inboxes)[3].insert(ExpectedMessages::NoData{});
+      get<ExpectedMessages>(inboxes)[4].insert(ExpectedMessages::NoData{});
+      CHECK(not ActionTesting::is_ready<Component>(runner, 0));
+      get<NewSize>(inboxes)[3].insert(2.0);
+      CHECK(not ActionTesting::is_ready<Component>(runner, 0));
+      get<NewSize>(inboxes)[4].insert(0.5);
+      CHECK(not ActionTesting::is_ready<Component>(runner, 0));
+      get<ExpectedMessages>(inboxes)[4].insert(ExpectedMessages::NoData{});
+      get<NewSize>(inboxes)[3].insert(3.0);
+      CHECK(ActionTesting::is_ready<Component>(runner, 0));
+      runner.next_action<Component>(0);
+      resize_slab(2.0);
+      check_box(TimeStepId(time_runs_forward, 3, start_time));
+      CHECK(get<ExpectedMessages>(inboxes).size() == 1);
+      CHECK(get<ExpectedMessages>(inboxes).count(4) == 1);
+      CHECK(get<NewSize>(inboxes).size() == 1);
+      CHECK(get<NewSize>(inboxes).count(4) == 1);
+      get<ExpectedMessages>(inboxes).clear();
+      get<NewSize>(inboxes).clear();
+    }
+
+    // Check interior of slab
+    {
+      db::mutate<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>>(
+          make_not_null(&box),
+          [&start_time, &time_runs_forward](
+              const gsl::not_null<TimeStepId*> id,
+              const gsl::not_null<TimeStepId*> next_id, const TimeDelta& step,
+              const TimeStepper& stepper) noexcept {
+            *id = TimeStepId(time_runs_forward, 3, start_time + step);
+            *next_id = stepper.next_time_id(*id, step);
+          },
+          db::get<Tags::TimeStep>(box), db::get<Tags::TimeStepperBase>(box));
+      const TimeStepId initial_id = db::get<Tags::TimeStepId>(box);
+      CHECK(ActionTesting::is_ready<Component>(runner, 0));
+      get<ExpectedMessages>(inboxes)[3].insert(ExpectedMessages::NoData{});
+      get<ExpectedMessages>(inboxes)[4].insert(ExpectedMessages::NoData{});
+      CHECK(ActionTesting::is_ready<Component>(runner, 0));
+      runner.next_action<Component>(0);
+      check_box(initial_id);
+      CHECK(get<ExpectedMessages>(inboxes).size() == 2);
+      CHECK(get<ExpectedMessages>(inboxes).count(3) == 1);
+      CHECK(get<ExpectedMessages>(inboxes).count(4) == 1);
+      CHECK(get<NewSize>(inboxes).empty());
+      get<NewSize>(inboxes)[3].insert(0.1);
+      get<NewSize>(inboxes)[4].insert(0.1);
+      CHECK(ActionTesting::is_ready<Component>(runner, 0));
+      runner.next_action<Component>(0);
+      check_box(initial_id);
+      get<ExpectedMessages>(inboxes).clear();
+      get<NewSize>(inboxes).clear();
+    }
+
+    // Check at a substep
+    {
+      db::mutate<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>>(
+          make_not_null(&box),
+          [](const gsl::not_null<TimeStepId*> id,
+             const gsl::not_null<TimeStepId*> next_id, const TimeDelta& step,
+             const TimeStepper& stepper) noexcept {
+            while (not id->substep_time().is_at_slab_boundary()) {
+              *id = *next_id;
+              REQUIRE(id->substep() != 0);
+              *next_id = stepper.next_time_id(*id, step);
+            }
+          },
+          db::get<Tags::TimeStep>(box), db::get<Tags::TimeStepperBase>(box));
+      const TimeStepId initial_id = db::get<Tags::TimeStepId>(box);
+      CHECK(ActionTesting::is_ready<Component>(runner, 0));
+      get<ExpectedMessages>(inboxes)[3].insert(ExpectedMessages::NoData{});
+      get<ExpectedMessages>(inboxes)[4].insert(ExpectedMessages::NoData{});
+      CHECK(ActionTesting::is_ready<Component>(runner, 0));
+      runner.next_action<Component>(0);
+      check_box(initial_id);
+      CHECK(get<ExpectedMessages>(inboxes).size() == 2);
+      CHECK(get<ExpectedMessages>(inboxes).count(3) == 1);
+      CHECK(get<ExpectedMessages>(inboxes).count(4) == 1);
+      CHECK(get<NewSize>(inboxes).empty());
+      get<NewSize>(inboxes)[3].insert(0.1);
+      get<NewSize>(inboxes)[4].insert(0.1);
+      CHECK(ActionTesting::is_ready<Component>(runner, 0));
+      runner.next_action<Component>(0);
+      check_box(initial_id);
+      get<ExpectedMessages>(inboxes).clear();
+      get<NewSize>(inboxes).clear();
+    }
+  }
+}

--- a/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
@@ -14,6 +14,7 @@
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/StepChoosers/ByBlock.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/Time.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -41,6 +42,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ByBlock", "[Unit][Time]") {
   const std::unique_ptr<StepChooserType> by_block_base =
       std::make_unique<ByBlock>(by_block);
 
+  const double current_step = std::numeric_limits<double>::infinity();
   const Parallel::ConstGlobalCache<Metavariables> cache{{}};
   for (size_t block = 0; block < 3; ++block) {
     const Element<volume_dim> element(ElementId<volume_dim>(block), {});
@@ -48,11 +50,12 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ByBlock", "[Unit][Time]") {
         db::create<db::AddSimpleTags<Tags::Element<volume_dim>>>(element);
     const double expected = 0.5 * (block + 5);
 
-    CHECK(by_block(element, cache) == expected);
-    CHECK(by_block_base->desired_step(box, cache) == expected);
-    CHECK(serialize_and_deserialize(by_block)(element, cache) == expected);
-    CHECK(serialize_and_deserialize(by_block_base)->desired_step(box, cache) ==
+    CHECK(by_block(element, current_step, cache) == expected);
+    CHECK(by_block_base->desired_step(current_step, box, cache) == expected);
+    CHECK(serialize_and_deserialize(by_block)(element, current_step, cache) ==
           expected);
+    CHECK(serialize_and_deserialize(by_block_base)
+              ->desired_step(current_step, box, cache) == expected);
   }
 
   TestHelpers::test_factory_creation<StepChooserType>(

--- a/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
@@ -20,6 +20,7 @@
 #include "Time/StepChoosers/Cfl.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags.hpp"  // IWYU pragma: keep
+#include "Time/Time.hpp"
 #include "Time/TimeSteppers/AdamsBashforthN.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/TestCreation.hpp"
@@ -72,11 +73,13 @@ double get_suggestion(const size_t stepper_order, const double safety_factor,
   const Cfl cfl{safety_factor};
   const std::unique_ptr<StepChooserType> cfl_base = std::make_unique<Cfl>(cfl);
 
-  const double result = cfl(grid_spacing, box, cache);
-  CHECK(cfl_base->desired_step(box, cache) == result);
-  CHECK(serialize_and_deserialize(cfl)(grid_spacing, box, cache) == result);
-  CHECK(serialize_and_deserialize(cfl_base)->desired_step(box, cache) ==
-        result);
+  const double current_step = std::numeric_limits<double>::infinity();
+  const double result = cfl(grid_spacing, box, current_step, cache);
+  CHECK(cfl_base->desired_step(current_step, box, cache) == result);
+  CHECK(serialize_and_deserialize(cfl)(grid_spacing, box, current_step,
+                                       cache) == result);
+  CHECK(serialize_and_deserialize(cfl_base)->desired_step(current_step, box,
+                                                          cache) == result);
   return result;
 }
 }  // namespace

--- a/tests/Unit/Time/StepChoosers/Test_Constant.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Constant.cpp
@@ -10,6 +10,7 @@
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/StepChoosers/Constant.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/Time.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -38,11 +39,12 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Constant", "[Unit][Time]") {
   const std::unique_ptr<StepChooserType> constant_base =
       std::make_unique<Constant>(constant);
 
-  CHECK(constant(cache) == 5.4);
-  CHECK(constant_base->desired_step(box, cache) == 5.4);
-  CHECK(serialize_and_deserialize(constant)(cache) == 5.4);
-  CHECK(serialize_and_deserialize(constant_base)->desired_step(box, cache) ==
-        5.4);
+  const double current_step = std::numeric_limits<double>::infinity();
+  CHECK(constant(current_step, cache) == 5.4);
+  CHECK(constant_base->desired_step(current_step, box, cache) == 5.4);
+  CHECK(serialize_and_deserialize(constant)(current_step, cache) == 5.4);
+  CHECK(serialize_and_deserialize(constant_base)
+            ->desired_step(current_step, box, cache) == 5.4);
 
   TestHelpers::test_factory_creation<StepChooserType>("Constant: 5.4");
 }


### PR DESCRIPTION
## Proposed changes

There will be one more PR in this series that will add code to explicitly place slab boundaries so useful observations can be made without dense output.

Ping @geoffrey4444, because you expressed interest in this.


### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
