### PR TITLE
Add time dependent product maps

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -185,7 +185,7 @@ jobs:
         # - `-march=x86-64`: Make sure we are building on a consistent
         #   architecture so caching works. This is necessary because GitHub
         #   may run the job on different hardware.
-        CXXFLAGS: "-Werror -march=x86-64"
+        CXXFLAGS: "-Werror"
         # We make sure to use a fixed absolute path for the ccache directory
         CCACHE_DIR: /work/ccache
         # GitHub Actions currently limits the size of individual caches
@@ -244,6 +244,7 @@ jobs:
           -D CMAKE_CXX_COMPILER=${CXX}
           -D CMAKE_Fortran_COMPILER=${FC}
           -D CMAKE_CXX_FLAGS="${CXXFLAGS} ${{ matrix.EXTRA_CXX_FLAGS }}"
+          -D OVERRIDE_ARCH=x86-64
           -D CHARM_ROOT=/work/charm/multicore-linux64-${CHARM_CC}
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -D DEBUG_SYMBOLS=OFF

--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -3,6 +3,8 @@
 
 option(DEBUG_SYMBOLS "Add -g to CMAKE_CXX_FLAGS if ON, -g0 if OFF." ON)
 
+option(OVERRIDE_ARCH "The architecture to use. Default is native." OFF)
+
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DSPECTRE_DEBUG")
 
 if(NOT ${DEBUG_SYMBOLS})
@@ -16,8 +18,12 @@ if(${DEBUG_SYMBOLS})
 endif(${DEBUG_SYMBOLS})
 
 # Always compile only for the current architecture. This can be overridden
-# by passing `-D CMAKE_CXX_FLAGS="-march=THE_ARCHITECTURE"` to CMake
-set(CMAKE_CXX_FLAGS "-march=native ${CMAKE_CXX_FLAGS}")
+# by passing `-D OVERRIDE_ARCH=THE_ARCHITECTURE` to CMake
+if(NOT "${OVERRIDE_ARCH}" STREQUAL "OFF")
+  set(CMAKE_CXX_FLAGS "-march=${OVERRIDE_ARCH} ${CMAKE_CXX_FLAGS}")
+else()
+  set(CMAKE_CXX_FLAGS "-march=native ${CMAKE_CXX_FLAGS}")
+endif()
 
 # We always want a detailed backtrace of template errors to make debugging them
 # easier

--- a/src/Domain/CoordinateMaps/CoordinateMapHelpers.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMapHelpers.hpp
@@ -56,6 +56,211 @@ void apply_map(
       "The time must not be NaN for time-dependent maps.");
   *t_map_point = the_map(*t_map_point, t, functions_of_time);
 }
+
+template <typename T, size_t Dim, typename Map>
+auto apply_map(
+    const Map& the_map, const std::array<T, Dim>& source_points,
+    const double /*t*/,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+    /*functions_of_time*/,
+    const std::false_type /*is_time_independent*/) {
+  if (LIKELY(not the_map.is_identity())) {
+    return the_map(source_points);
+  }
+  std::decay_t<decltype(the_map(source_points))> result{};
+  for (size_t i = 0; i < result.size(); ++i) {
+    gsl::at(result, i) = gsl::at(source_points, i);
+  }
+  return result;
+}
+
+template <typename T, size_t Dim, typename Map>
+auto apply_map(
+    const Map& the_map, const std::array<T, Dim>& source_points, const double t,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const std::true_type
+    /*is_time_dependent*/) {
+  // Note: We don't forward to the return-by-not-null version to avoid
+  // additional allocations of the target points array. That is, we would
+  // allocate the target points array once here, and then again inside the call
+  // to the coordinate map.
+  ASSERT(not functions_of_time.empty(),
+         "A function of time must be present if the maps are time-dependent.");
+  ASSERT(
+      [t]() noexcept {
+        disable_floating_point_exceptions();
+        const bool isnan = std::isnan(t);
+        enable_floating_point_exceptions();
+        return not isnan;
+      }(),
+      "The time must not be NaN for time-dependent maps.");
+  return the_map(source_points, t, functions_of_time);
+}
+// @}
+
+// @{
+template <typename T, size_t Dim, typename Map>
+auto apply_inverse_map(
+    const Map& the_map, const std::array<T, Dim>& target_points,
+    const double /*t*/,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+    /*functions_of_time*/,
+    const std::false_type /*is_time_independent*/) {
+  if (LIKELY(not the_map.is_identity())) {
+    return the_map.inverse(target_points);
+  }
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  std::decay_t<decltype(the_map.inverse(target_points))> result{
+      std::array<UnwrappedT, Dim>{}};
+  for (size_t i = 0; i < target_points.size(); ++i) {
+    gsl::at(*result, i) = gsl::at(target_points, i);
+  }
+  return result;
+}
+
+template <typename T, size_t Dim, typename Map>
+auto apply_inverse_map(
+    const Map& the_map, const std::array<T, Dim>& target_points, const double t,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const std::true_type
+    /*is_time_dependent*/) {
+  ASSERT(not functions_of_time.empty(),
+         "A function of time must be present if the maps are time-dependent.");
+  ASSERT(
+      [t]() noexcept {
+        disable_floating_point_exceptions();
+        const bool isnan = std::isnan(t);
+        enable_floating_point_exceptions();
+        return not isnan;
+      }(),
+      "The time must not be NaN for time-dependent maps.");
+  return the_map.inverse(target_points, t, functions_of_time);
+}
+// @}
+
+// @{
+/// Compute the frame velocity
+template <typename T, size_t Dim, typename Map>
+auto apply_frame_velocity(
+    const Map& /*the_map*/, const std::array<T, Dim>& source_points,
+    const double /*t*/,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+    /*functions_of_time*/,
+    const std::false_type /*is_time_independent*/) {
+  return make_array<Map::dim, tt::remove_cvref_wrap_t<T>>(
+      make_with_value<tt::remove_cvref_wrap_t<T>>(
+          dereference_wrapper(source_points[0]), 0.0));
+}
+
+template <typename T, size_t Dim, typename Map>
+auto apply_frame_velocity(
+    const Map& the_map, const std::array<T, Dim>& source_points, const double t,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const std::true_type
+    /*is_time_dependent*/) {
+  ASSERT(not functions_of_time.empty(),
+         "A function of time must be present if the maps are time-dependent.");
+  ASSERT(
+      [t]() noexcept {
+        disable_floating_point_exceptions();
+        const bool isnan = std::isnan(t);
+        enable_floating_point_exceptions();
+        return not isnan;
+      }(),
+      "The time must not be NaN for time-dependent maps.");
+  return the_map.frame_velocity(source_points, t, functions_of_time);
+}
+// @}
+
+// @{
+/// Compute the Jacobian
+template <typename T, size_t Dim, typename Map>
+auto apply_jacobian(
+    const Map& the_map, const std::array<T, Dim>& source_points,
+    const double /*t*/,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+    /*functions_of_time*/,
+    const std::false_type /*is_time_independent*/) {
+  if (LIKELY(not the_map.is_identity())) {
+    return the_map.jacobian(source_points);
+  }
+  return identity<Dim>(dereference_wrapper(source_points[0]));
+}
+
+template <typename T, size_t Dim, typename Map>
+auto apply_jacobian(
+    const Map& the_map, const std::array<T, Dim>& source_points, const double t,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const std::true_type
+    /*is_time_dependent*/) {
+  ASSERT(not functions_of_time.empty(),
+         "A function of time must be present if the maps are time-dependent.");
+  ASSERT(
+      [t]() noexcept {
+        disable_floating_point_exceptions();
+        const bool isnan = std::isnan(t);
+        enable_floating_point_exceptions();
+        return not isnan;
+      }(),
+      "The time must not be NaN for time-dependent maps.");
+  if (LIKELY(not the_map.is_identity())) {
+    return the_map.jacobian(source_points, t, functions_of_time);
+  }
+  return identity<Dim>(dereference_wrapper(source_points[0]));
+}
+// @}
+
+// @{
+/// Compute the Jacobian
+template <typename T, size_t Dim, typename Map>
+auto apply_inverse_jacobian(
+    const Map& the_map, const std::array<T, Dim>& source_points,
+    const double /*t*/,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+    /*functions_of_time*/,
+    const std::false_type /*is_time_independent*/) {
+  if (LIKELY(not the_map.is_identity())) {
+    return the_map.inv_jacobian(source_points);
+  }
+  return identity<Dim>(dereference_wrapper(source_points[0]));
+}
+
+template <typename T, size_t Dim, typename Map>
+auto apply_inverse_jacobian(
+    const Map& the_map, const std::array<T, Dim>& source_points, const double t,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const std::true_type
+    /*is_time_dependent*/) {
+  ASSERT(not functions_of_time.empty(),
+         "A function of time must be present if the maps are time-dependent.");
+  ASSERT(
+      [t]() noexcept {
+        disable_floating_point_exceptions();
+        const bool isnan = std::isnan(t);
+        enable_floating_point_exceptions();
+        return not isnan;
+      }(),
+      "The time must not be NaN for time-dependent maps.");
+  if (LIKELY(not the_map.is_identity())) {
+    return the_map.inv_jacobian(source_points, t, functions_of_time);
+  }
+  return identity<Dim>(dereference_wrapper(source_points[0]));
+}
 // @}
 }  // namespace CoordinateMap_detail
 }  // namespace domain

--- a/src/Domain/CoordinateMaps/ProductMapsTimeDep.hpp
+++ b/src/Domain/CoordinateMaps/ProductMapsTimeDep.hpp
@@ -1,0 +1,198 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <functional>
+#include <limits>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/TimeDependentHelpers.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain {
+namespace CoordMapsTimeDependent {
+/// \ingroup CoordMapsTimeDependentGroup
+/// \brief Product of two codimension=0 CoordinateMaps, where one or both must
+/// be time-dependent.
+///
+/// \tparam Map1 the map for the first coordinate(s)
+/// \tparam Map2 the map for the second coordinate(s)
+template <typename Map1, typename Map2>
+class ProductOf2Maps {
+ public:
+  static constexpr size_t dim = Map1::dim + Map2::dim;
+  using map_list = tmpl::list<Map1, Map2>;
+  static_assert(dim == 2 or dim == 3,
+                "Only 2D and 3D maps are supported by ProductOf2Maps");
+  static_assert(
+      domain::is_map_time_dependent_v<Map1> or
+          domain::is_map_time_dependent_v<Map2>,
+      "Either Map1 or Map2 must be time-dependent for time-dependent product "
+      "maps. A time-independent product map exists in domain::CoordinateMaps.");
+
+  // Needed for Charm++ serialization
+  ProductOf2Maps() = default;
+
+  ProductOf2Maps(Map1 map1, Map2 map2) noexcept;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, dim> operator()(
+      const std::array<T, dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  boost::optional<std::array<double, dim>> inverse(
+      const std::array<double, dim>& target_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, dim> frame_velocity(
+      const std::array<T, dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, dim, Frame::NoFrame> inv_jacobian(
+      const std::array<T, dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, dim, Frame::NoFrame> jacobian(
+      const std::array<T, dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p);  // NOLINT
+
+  bool is_identity() const noexcept {
+    return map1_.is_identity() and map2_.is_identity();
+  }
+
+ private:
+  friend bool operator==(const ProductOf2Maps& lhs,
+                         const ProductOf2Maps& rhs) noexcept {
+    return lhs.map1_ == rhs.map1_ and lhs.map2_ == rhs.map2_;
+  }
+
+  Map1 map1_;
+  Map2 map2_;
+};
+
+template <typename Map1, typename Map2>
+bool operator!=(const ProductOf2Maps<Map1, Map2>& lhs,
+                const ProductOf2Maps<Map1, Map2>& rhs) noexcept;
+
+/// \ingroup CoordinateMapsGroup
+/// \brief Product of three one-dimensional CoordinateMaps.
+template <typename Map1, typename Map2, typename Map3>
+class ProductOf3Maps {
+ public:
+  static constexpr size_t dim = Map1::dim + Map2::dim + Map3::dim;
+  using map_list = tmpl::list<Map1, Map2, Map3>;
+  static_assert(dim == 3, "Only 3D maps are implemented for ProductOf3Maps");
+  static_assert(
+      domain::is_map_time_dependent_v<Map1> or
+          domain::is_map_time_dependent_v<Map2> or
+          domain::is_map_time_dependent_v<Map3>,
+      "Either Map1, Map2, or Map3 must be time-dependent for time-dependent "
+      "product maps. A time-independent product map exists in "
+      "domain::CoordinateMaps.");
+
+  // Needed for Charm++ serialization
+  ProductOf3Maps() = default;
+
+  ProductOf3Maps(Map1 map1, Map2 map2, Map3 map3) noexcept;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, dim> operator()(
+      const std::array<T, dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  boost::optional<std::array<double, dim>> inverse(
+      const std::array<double, dim>& target_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, dim> frame_velocity(
+      const std::array<T, dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, dim, Frame::NoFrame> inv_jacobian(
+      const std::array<T, dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, dim, Frame::NoFrame> jacobian(
+      const std::array<T, dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  bool is_identity() const noexcept {
+    return map1_.is_identity() and map2_.is_identity() and map3_.is_identity();
+  }
+
+ private:
+  friend bool operator==(const ProductOf3Maps& lhs,
+                         const ProductOf3Maps& rhs) noexcept {
+    return lhs.map1_ == rhs.map1_ and lhs.map2_ == rhs.map2_ and
+           lhs.map3_ == rhs.map3_;
+  }
+
+  Map1 map1_;
+  Map2 map2_;
+  Map3 map3_;
+};
+
+template <typename Map1, typename Map2, typename Map3>
+bool operator!=(const ProductOf3Maps<Map1, Map2, Map3>& lhs,
+                const ProductOf3Maps<Map1, Map2, Map3>& rhs) noexcept;
+}  // namespace CoordMapsTimeDependent
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/ProductMapsTimeDep.tpp
+++ b/src/Domain/CoordinateMaps/ProductMapsTimeDep.tpp
@@ -1,0 +1,408 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.hpp"
+
+#include <array>
+#include <boost/none.hpp>
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <functional>
+#include <pup.h>
+#include <utility>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMapHelpers.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace domain {
+namespace CoordMapsTimeDependent {
+namespace product_detail {
+template <typename T, size_t Size, typename Map1, typename Map2, size_t... Is,
+          size_t... Js>
+std::array<tt::remove_cvref_wrap_t<T>, Size> apply_map(
+    const std::array<T, Size>& coords, const Map1& map1, const Map2& map2,
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    std::integer_sequence<size_t, Is...> /*meta*/,
+    std::integer_sequence<size_t, Js...> /*meta*/) noexcept {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  return {
+      {CoordinateMap_detail::apply_map(
+           map1,
+           std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Is)>{
+               {coords[Is]...}},
+           time, functions_of_time,
+           domain::is_map_time_dependent_t<Map1>{})[Is]...,
+       CoordinateMap_detail::apply_map(
+           map2,
+           std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Js)>{
+               {coords[Map1::dim + Js]...}},
+           time, functions_of_time,
+           domain::is_map_time_dependent_t<Map2>{})[Js]...}};
+}
+
+template <size_t Size, typename Map1, typename Map2, size_t... Is, size_t... Js>
+boost::optional<std::array<double, Size>> apply_inverse(
+    const std::array<double, Size>& coords, const Map1& map1, const Map2& map2,
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    std::integer_sequence<size_t, Is...> /*meta*/,
+    std::integer_sequence<size_t, Js...> /*meta*/) noexcept {
+  auto map1_func = CoordinateMap_detail::apply_inverse_map(
+      map1, std::array<double, sizeof...(Is)>{{coords[Is]...}}, time,
+      functions_of_time, domain::is_map_time_dependent_t<Map1>{});
+  auto map2_func = CoordinateMap_detail::apply_inverse_map(
+      map2, std::array<double, sizeof...(Js)>{{coords[Map1::dim + Js]...}},
+      time, functions_of_time, domain::is_map_time_dependent_t<Map2>{});
+  if (map1_func and map2_func) {
+    return {{{map1_func.get()[Is]..., map2_func.get()[Js]...}}};
+  } else {
+    return boost::none;
+  }
+}
+
+template <typename T, size_t Size, typename Map1, typename Map2, size_t... Is,
+          size_t... Js>
+std::array<tt::remove_cvref_wrap_t<T>, Size> apply_frame_velocity(
+    const std::array<T, Size>& coords, const Map1& map1, const Map2& map2,
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    std::integer_sequence<size_t, Is...> /*meta*/,
+    std::integer_sequence<size_t, Js...> /*meta*/) noexcept {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  return {
+      {domain::CoordinateMap_detail::apply_frame_velocity(
+           map1,
+           std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Is)>{
+               {coords[Is]...}},
+           time, functions_of_time,
+           domain::is_map_time_dependent_t<Map1>{})[Is]...,
+       domain::CoordinateMap_detail::apply_frame_velocity(
+           map2,
+           std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Js)>{
+               {coords[Map1::dim + Js]...}},
+           time, functions_of_time,
+           domain::is_map_time_dependent_t<Map2>{})[Js]...}};
+}
+
+template <typename T, size_t Size, typename Map1, typename Map2,
+          typename Function, size_t... Is, size_t... Js>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, Size, Frame::NoFrame> apply_jac(
+    const std::array<T, Size>& source_coords, const Map1& map1,
+    const Map2& map2, const Function func,
+    std::integer_sequence<size_t, Is...> /*meta*/,
+    std::integer_sequence<size_t, Js...> /*meta*/) noexcept {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  auto map1_jac = func(
+      std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Is)>{
+          {source_coords[Is]...}},
+      map1);
+  auto map2_jac = func(
+      std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Js)>{
+          {source_coords[Map1::dim + Js]...}},
+      map2);
+  tnsr::Ij<UnwrappedT, Size, Frame::NoFrame> jac{
+      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
+  for (size_t i = 0; i < Map1::dim; ++i) {
+    for (size_t j = 0; j < Map1::dim; ++j) {
+      jac.get(i, j) = std::move(map1_jac.get(i, j));
+    }
+  }
+  for (size_t i = 0; i < Map2::dim; ++i) {
+    for (size_t j = 0; j < Map2::dim; ++j) {
+      jac.get(Map1::dim + i, Map1::dim + j) = std::move(map2_jac.get(i, j));
+    }
+  }
+  return jac;
+}
+}  // namespace product_detail
+
+template <typename Map1, typename Map2>
+ProductOf2Maps<Map1, Map2>::ProductOf2Maps(Map1 map1, Map2 map2) noexcept
+    : map1_(std::move(map1)), map2_(std::move(map2)) {}
+
+template <typename Map1, typename Map2>
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim>
+ProductOf2Maps<Map1, Map2>::operator()(
+    const std::array<T, dim>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  return product_detail::apply_map(source_coords, map1_, map2_, time,
+                                   functions_of_time,
+                                   std::make_index_sequence<Map1::dim>{},
+                                   std::make_index_sequence<Map2::dim>{});
+}
+
+template <typename Map1, typename Map2>
+boost::optional<std::array<double, ProductOf2Maps<Map1, Map2>::dim>>
+ProductOf2Maps<Map1, Map2>::inverse(
+    const std::array<double, dim>& target_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  return product_detail::apply_inverse(target_coords, map1_, map2_, time,
+                                       functions_of_time,
+                                       std::make_index_sequence<Map1::dim>{},
+                                       std::make_index_sequence<Map2::dim>{});
+}
+
+template <typename Map1, typename Map2>
+template <typename T>
+auto ProductOf2Maps<Map1, Map2>::frame_velocity(
+    const std::array<T, dim>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept
+    -> std::array<tt::remove_cvref_wrap_t<T>, dim> {
+  return product_detail::apply_frame_velocity(
+      source_coords, map1_, map2_, time, functions_of_time,
+      std::make_index_sequence<Map1::dim>{},
+      std::make_index_sequence<Map2::dim>{});
+}
+
+template <typename Map1, typename Map2>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim,
+         Frame::NoFrame>
+ProductOf2Maps<Map1, Map2>::inv_jacobian(
+    const std::array<T, dim>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  return product_detail::apply_jac(
+      source_coords, map1_, map2_,
+      [&time, &functions_of_time](const auto& point, const auto& map) noexcept {
+        return CoordinateMap_detail::apply_inverse_jacobian(
+            map, point, time, functions_of_time,
+            domain::is_jacobian_time_dependent_t<
+                std::decay_t<decltype(map)>,
+                std::reference_wrapper<const UnwrappedT>>{});
+      },
+      std::make_index_sequence<Map1::dim>{},
+      std::make_index_sequence<Map2::dim>{});
+}
+
+template <typename Map1, typename Map2>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim,
+         Frame::NoFrame>
+ProductOf2Maps<Map1, Map2>::jacobian(
+    const std::array<T, dim>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  return product_detail::apply_jac(
+      source_coords, map1_, map2_,
+      [&time, &functions_of_time](const auto& point, const auto& map) noexcept {
+        return CoordinateMap_detail::apply_jacobian(
+            map, point, time, functions_of_time,
+            domain::is_jacobian_time_dependent_t<
+                std::decay_t<decltype(map)>,
+                std::reference_wrapper<const UnwrappedT>>{});
+      },
+      std::make_index_sequence<Map1::dim>{},
+      std::make_index_sequence<Map2::dim>{});
+}
+
+template <typename Map1, typename Map2>
+void ProductOf2Maps<Map1, Map2>::pup(PUP::er& p) {
+  p | map1_;
+  p | map2_;
+}
+
+template <typename Map1, typename Map2>
+bool operator!=(const ProductOf2Maps<Map1, Map2>& lhs,
+                const ProductOf2Maps<Map1, Map2>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+template <typename Map1, typename Map2, typename Map3>
+ProductOf3Maps<Map1, Map2, Map3>::ProductOf3Maps(Map1 map1, Map2 map2,
+                                                 Map3 map3) noexcept
+    : map1_(std::move(map1)), map2_(std::move(map2)), map3_(std::move(map3)) {}
+
+template <typename Map1, typename Map2, typename Map3>
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim>
+ProductOf3Maps<Map1, Map2, Map3>::operator()(
+    const std::array<T, dim>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  return {
+      {CoordinateMap_detail::apply_map(
+           map1_,
+           std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+               {source_coords[0]}},
+           time, functions_of_time, domain::is_map_time_dependent_t<Map1>{})[0],
+       CoordinateMap_detail::apply_map(
+           map2_,
+           std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+               {source_coords[1]}},
+           time, functions_of_time, domain::is_map_time_dependent_t<Map2>{})[0],
+       CoordinateMap_detail::apply_map(
+           map3_,
+           std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+               {source_coords[2]}},
+           time, functions_of_time,
+           domain::is_map_time_dependent_t<Map3>{})[0]}};
+}
+
+template <typename Map1, typename Map2, typename Map3>
+boost::optional<std::array<double, ProductOf3Maps<Map1, Map2, Map3>::dim>>
+ProductOf3Maps<Map1, Map2, Map3>::inverse(
+    const std::array<double, dim>& target_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  const auto c1 = CoordinateMap_detail::apply_inverse_map(
+      map1_, std::array<double, 1>{{target_coords[0]}}, time, functions_of_time,
+      domain::is_map_time_dependent_t<Map1>{});
+  const auto c2 = CoordinateMap_detail::apply_inverse_map(
+      map2_, std::array<double, 1>{{target_coords[1]}}, time, functions_of_time,
+      domain::is_map_time_dependent_t<Map2>{});
+  const auto c3 = CoordinateMap_detail::apply_inverse_map(
+      map3_, std::array<double, 1>{{target_coords[2]}}, time, functions_of_time,
+      domain::is_map_time_dependent_t<Map3>{});
+  if (c1 and c2 and c3) {
+    return {{{c1.get()[0], c2.get()[0], c3.get()[0]}}};
+  } else {
+    return boost::none;
+  }
+}
+
+template <typename Map1, typename Map2, typename Map3>
+template <typename T>
+auto ProductOf3Maps<Map1, Map2, Map3>::frame_velocity(
+    const std::array<T, dim>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept
+    -> std::array<tt::remove_cvref_wrap_t<T>, dim> {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  return {
+      {CoordinateMap_detail::apply_frame_velocity(
+           map1_,
+           std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+               {source_coords[0]}},
+           time, functions_of_time, domain::is_map_time_dependent_t<Map1>{})[0],
+       CoordinateMap_detail::apply_frame_velocity(
+           map2_,
+           std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+               {source_coords[1]}},
+           time, functions_of_time, domain::is_map_time_dependent_t<Map2>{})[0],
+       CoordinateMap_detail::apply_frame_velocity(
+           map3_,
+           std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+               {source_coords[2]}},
+           time, functions_of_time,
+           domain::is_map_time_dependent_t<Map3>{})[0]}};
+}
+
+template <typename Map1, typename Map2, typename Map3>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim,
+         Frame::NoFrame>
+ProductOf3Maps<Map1, Map2, Map3>::inv_jacobian(
+    const std::array<T, dim>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  tnsr::Ij<UnwrappedT, dim, Frame::NoFrame> inv_jacobian_matrix{
+      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
+  get<0, 0>(inv_jacobian_matrix) =
+      get<0, 0>(CoordinateMap_detail::apply_inverse_jacobian(
+          map1_,
+          std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+              {source_coords[0]}},
+          time, functions_of_time,
+          domain::is_jacobian_time_dependent_t<
+              Map1, std::reference_wrapper<const UnwrappedT>>{}));
+  get<1, 1>(inv_jacobian_matrix) =
+      get<0, 0>(CoordinateMap_detail::apply_inverse_jacobian(
+          map2_,
+          std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+              {source_coords[1]}},
+          time, functions_of_time,
+          domain::is_jacobian_time_dependent_t<
+              Map2, std::reference_wrapper<const UnwrappedT>>{}));
+  get<2, 2>(inv_jacobian_matrix) =
+      get<0, 0>(CoordinateMap_detail::apply_inverse_jacobian(
+          map3_,
+          std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+              {source_coords[2]}},
+          time, functions_of_time,
+          domain::is_jacobian_time_dependent_t<
+              Map3, std::reference_wrapper<const UnwrappedT>>{}));
+  return inv_jacobian_matrix;
+}
+
+template <typename Map1, typename Map2, typename Map3>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim,
+         Frame::NoFrame>
+ProductOf3Maps<Map1, Map2, Map3>::jacobian(
+    const std::array<T, dim>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  tnsr::Ij<UnwrappedT, dim, Frame::NoFrame> jacobian_matrix{
+      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
+  get<0, 0>(jacobian_matrix) = get<0, 0>(CoordinateMap_detail::apply_jacobian(
+      map1_,
+      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+          {source_coords[0]}},
+      time, functions_of_time,
+      domain::is_jacobian_time_dependent_t<
+          Map1, std::reference_wrapper<const UnwrappedT>>{}));
+  get<1, 1>(jacobian_matrix) = get<0, 0>(CoordinateMap_detail::apply_jacobian(
+      map2_,
+      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+          {source_coords[1]}},
+      time, functions_of_time,
+      domain::is_jacobian_time_dependent_t<
+          Map1, std::reference_wrapper<const UnwrappedT>>{}
+
+      ));
+  get<2, 2>(jacobian_matrix) = get<0, 0>(CoordinateMap_detail::apply_jacobian(
+      map3_,
+      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
+          {source_coords[2]}},
+      time, functions_of_time,
+      domain::is_jacobian_time_dependent_t<
+          Map1, std::reference_wrapper<const UnwrappedT>>{}));
+  return jacobian_matrix;
+}
+template <typename Map1, typename Map2, typename Map3>
+void ProductOf3Maps<Map1, Map2, Map3>::pup(PUP::er& p) noexcept {
+  p | map1_;
+  p | map2_;
+  p | map3_;
+}
+
+template <typename Map1, typename Map2, typename Map3>
+bool operator!=(const ProductOf3Maps<Map1, Map2, Map3>& lhs,
+                const ProductOf3Maps<Map1, Map2, Map3>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace CoordMapsTimeDependent
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   Test_Frustum.cpp
   Test_Identity.cpp
   Test_ProductMaps.cpp
+  Test_ProductMapsTimeDep.cpp
   Test_Rotation.cpp
   Test_SpecialMobius.cpp
   Test_TimeDependentHelpers.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_ProductMapsTimeDep.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_ProductMapsTimeDep.cpp
@@ -1,0 +1,784 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.hpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.tpp"
+#include "Domain/CoordinateMaps/Translation.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace domain {
+namespace {
+template <typename Map1, typename Map2>
+void test_product_of_2_maps_time_dep(
+    const CoordMapsTimeDependent::ProductOf2Maps<Map1, Map2>& map2d,
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const double x_source_a, const double x_source_b, const double x_target_a,
+    const double x_target_b, const double xi, const double x, const double eta,
+    const double y, const double y_source_a, const double y_source_b,
+    const double y_target_a, const double y_target_b,
+    const std::array<double, 2>& expected_frame_velocity) noexcept {
+  using AffineMap = CoordinateMaps::Affine;
+  using TranslationMap = CoordMapsTimeDependent::Translation;
+  static_assert(cpp17::is_same_v<Map1, AffineMap> or
+                    cpp17::is_same_v<Map1, TranslationMap>,
+                "Map1 must be either an affine map or a translation map");
+  static_assert(cpp17::is_same_v<Map2, AffineMap> or
+                    cpp17::is_same_v<Map2, TranslationMap>,
+                "Map2 must be either an affine map or a translation map");
+
+  const std::array<double, 2> point_source_a{{x_source_a, y_source_a}};
+  const std::array<double, 2> point_source_b{{x_source_b, y_source_b}};
+  const std::array<double, 2> point_xi{{xi, eta}};
+  const std::array<double, 2> point_target_a{{x_target_a, y_target_a}};
+  const std::array<double, 2> point_target_b{{x_target_b, y_target_b}};
+  const std::array<double, 2> point_x{{x, y}};
+
+  CHECK(map2d(point_source_a, time, functions_of_time) == point_target_a);
+  CHECK(map2d(point_source_b, time, functions_of_time) == point_target_b);
+  CHECK(map2d(point_xi, time, functions_of_time) == point_x);
+
+  CHECK(map2d.inverse(point_target_a, time, functions_of_time).get() ==
+        point_source_a);
+  CHECK(map2d.inverse(point_target_b, time, functions_of_time).get() ==
+        point_source_b);
+  CHECK_ITERABLE_APPROX(map2d.inverse(point_x, time, functions_of_time).get(),
+                        point_xi);
+
+  const double inv_jacobian_00 =
+      (x_source_b - x_source_a) / (x_target_b - x_target_a);
+  const double inv_jacobian_11 =
+      (y_source_b - y_source_a) / (y_target_b - y_target_a);
+  const auto inv_jac_A =
+      map2d.inv_jacobian(point_source_a, time, functions_of_time);
+  const auto inv_jac_B =
+      map2d.inv_jacobian(point_source_b, time, functions_of_time);
+  const auto inv_jac_xi = map2d.inv_jacobian(point_xi, time, functions_of_time);
+
+  const auto check_jac = [](const auto& jac, const auto& expected_jac_00,
+                            const auto& expected_jac_11) noexcept {
+    CHECK(get<0, 0>(jac) == expected_jac_00);
+    CHECK(get<0, 1>(jac) == 0.0);
+    CHECK(get<1, 0>(jac) == 0.0);
+    CHECK(get<1, 1>(jac) == expected_jac_11);
+  };
+
+  check_jac(inv_jac_A, inv_jacobian_00, inv_jacobian_11);
+  check_jac(inv_jac_B, inv_jacobian_00, inv_jacobian_11);
+  check_jac(inv_jac_xi, inv_jacobian_00, inv_jacobian_11);
+
+  const double jacobian_00 =
+      (x_target_b - x_target_a) / (x_source_b - x_source_a);
+  const double jacobian_11 =
+      (y_target_b - y_target_a) / (y_source_b - y_source_a);
+  const auto jac_A = map2d.jacobian(point_source_a, time, functions_of_time);
+  const auto jac_B = map2d.jacobian(point_source_b, time, functions_of_time);
+  const auto jac_xi = map2d.jacobian(point_xi, time, functions_of_time);
+
+  check_jac(jac_A, jacobian_00, jacobian_11);
+  check_jac(jac_B, jacobian_00, jacobian_11);
+  check_jac(jac_xi, jacobian_00, jacobian_11);
+
+  CHECK(map2d.frame_velocity(point_source_a, time, functions_of_time) ==
+        expected_frame_velocity);
+  CHECK(map2d.frame_velocity(point_source_b, time, functions_of_time) ==
+        expected_frame_velocity);
+  CHECK(map2d.frame_velocity(point_xi, time, functions_of_time) ==
+        expected_frame_velocity);
+
+  // Check Jacobians for DataVectors
+  const Mesh<2> mesh{8, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const auto tensor_logical_coords = logical_coordinates(mesh);
+  const std::array<DataVector, 2> logical_coords{
+      {get<0>(tensor_logical_coords), get<1>(tensor_logical_coords)}};
+  const auto volume_inv_jac =
+      map2d.inv_jacobian(logical_coords, time, functions_of_time);
+  const auto volume_jac =
+      map2d.jacobian(logical_coords, time, functions_of_time);
+  for (size_t i = 0; i < 2; ++i) {
+    for (size_t j = 0; j < 2; ++j) {
+      if (i == j) {
+        CHECK(volume_inv_jac.get(i, j) ==
+              DataVector(logical_coords[0].size(),
+                         i == 0 ? inv_jacobian_00 : inv_jacobian_11));
+        CHECK(volume_jac.get(i, j) ==
+              DataVector(logical_coords[0].size(),
+                         i == 0 ? jacobian_00 : jacobian_11));
+      } else {
+        CHECK(volume_inv_jac.get(i, j) ==
+              DataVector(logical_coords[0].size(), 0.0));
+        CHECK(volume_jac.get(i, j) ==
+              DataVector(logical_coords[0].size(), 0.0));
+      }
+    }
+  }
+
+  // Check frame velocity with DataVectors
+  std::array<DataVector, 2> expected_frame_velocity_datavector{
+      {DataVector(logical_coords[0].size(), expected_frame_velocity[0]),
+       DataVector(logical_coords[1].size(), expected_frame_velocity[1])}};
+
+  CHECK(map2d.frame_velocity(logical_coords, time, functions_of_time) ==
+        expected_frame_velocity_datavector);
+
+  CHECK(map2d == map2d);
+  CHECK_FALSE(map2d != map2d);
+}
+
+void test_product_of_2_maps_time_dep() noexcept {
+  INFO("Product of two maps with time dependence");
+  constexpr size_t deriv_order = 3;
+  using affine_map = CoordinateMaps::Affine;
+  using translation_map = CoordMapsTimeDependent::Translation;
+
+  const std::string f_of_t_name{"translation"};
+  const double time = 2.0;
+  const std::array<DataVector, deriv_order + 1> init_func{
+      {{1.0}, {-2.0}, {2.0}, {0.0}}};
+  using Polynomial = domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
+  using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
+  std::unordered_map<std::string, FoftPtr> functions_of_time{};
+  functions_of_time[f_of_t_name] = std::make_unique<Polynomial>(0.0, init_func);
+
+  {
+    // Test one time-dependent and one time-independent map case.
+    const double x_source_a = -1.0;
+    const double x_source_b = 1.0;
+    const double x_target_a = -2.0;
+    const double x_target_b = 2.0;
+
+    const double xi = 0.5 * (x_source_a + x_source_b);
+    const double x =
+        x_target_b * (xi - x_source_a) / (x_source_b - x_source_a) +
+        x_target_a * (x_source_b - xi) / (x_source_b - x_source_a);
+    const double eta = 0.7;
+    const double y = eta + functions_of_time.at(f_of_t_name)->func(time)[0][0];
+
+    const double y_source_a = -1.0;
+    const double y_source_b = 1.0;
+    const double y_target_a =
+        -1.0 + functions_of_time.at(f_of_t_name)->func(time)[0][0];
+    const double y_target_b =
+        1.0 + functions_of_time.at(f_of_t_name)->func(time)[0][0];
+
+    affine_map affine_map_x(x_source_a, x_source_b, x_target_a, x_target_b);
+    translation_map translation_map_y{f_of_t_name};
+
+    using Map2d =
+        CoordMapsTimeDependent::ProductOf2Maps<affine_map, translation_map>;
+    Map2d map2d(affine_map_x, translation_map_y);
+
+    test_product_of_2_maps_time_dep(
+        map2d, time, functions_of_time, x_source_a, x_source_b, x_target_a,
+        x_target_b, xi, x, eta, y, y_source_a, y_source_b, y_target_a,
+        y_target_b,
+        {{0.0, functions_of_time.at(f_of_t_name)->func_and_deriv(time)[1][0]}});
+    test_product_of_2_maps_time_dep(
+        serialize_and_deserialize(map2d), time, functions_of_time, x_source_a,
+        x_source_b, x_target_a, x_target_b, xi, x, eta, y, y_source_a,
+        y_source_b, y_target_a, y_target_b,
+        {{0.0, functions_of_time.at(f_of_t_name)->func_and_deriv(time)[1][0]}});
+
+    using Map2d_b =
+        CoordMapsTimeDependent::ProductOf2Maps<translation_map, affine_map>;
+    Map2d_b map2d_b(translation_map_y, affine_map_x);
+
+    test_product_of_2_maps_time_dep(
+        map2d_b, time, functions_of_time, y_source_a, y_source_b, y_target_a,
+        y_target_b, eta, y, xi, x, x_source_a, x_source_b, x_target_a,
+        x_target_b,
+        {{functions_of_time.at(f_of_t_name)->func_and_deriv(time)[1][0], 0.0}});
+    test_product_of_2_maps_time_dep(
+        serialize_and_deserialize(map2d_b), time, functions_of_time, y_source_a,
+        y_source_b, y_target_a, y_target_b, eta, y, xi, x, x_source_a,
+        x_source_b, x_target_a, x_target_b,
+        {{functions_of_time.at(f_of_t_name)->func_and_deriv(time)[1][0], 0.0}});
+  }
+
+  {
+    using Map2d = CoordMapsTimeDependent::ProductOf2Maps<translation_map,
+                                                         translation_map>;
+
+    const std::string f_of_t_name_x{"translation_x"};
+    const std::string f_of_t_name_y{"translation_y"};
+
+    translation_map translation_map_x{f_of_t_name_x};
+    translation_map translation_map_y{f_of_t_name_y};
+    Map2d map2d(translation_map_x, translation_map_y);
+
+    functions_of_time[f_of_t_name_x] = std::make_unique<Polynomial>(
+        0.0,
+        std::array<DataVector, deriv_order + 1>{{{1.0}, {-3.0}, {2.0}, {0.0}}});
+    functions_of_time[f_of_t_name_y] = std::make_unique<Polynomial>(
+        0.0,
+        std::array<DataVector, deriv_order + 1>{{{1.0}, {2.4}, {2.0}, {0.0}}});
+
+    const double x_source_a = -1.0;
+    const double x_source_b = 1.0;
+    const double x_target_a =
+        -1.0 + functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+    const double x_target_b =
+        1.0 + +functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+
+    const double xi = 0.5;
+    const double x = xi + functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+    const double eta = 0.7;
+    const double y =
+        eta + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+
+    const double y_source_a = -1.0;
+    const double y_source_b = 1.0;
+    const double y_target_a =
+        -1.0 + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+    const double y_target_b =
+        1.0 + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+
+    test_product_of_2_maps_time_dep(
+        map2d, time, functions_of_time, x_source_a, x_source_b, x_target_a,
+        x_target_b, xi, x, eta, y, y_source_a, y_source_b, y_target_a,
+        y_target_b,
+        {{functions_of_time.at(f_of_t_name_x)->func_and_deriv(time)[1][0],
+          functions_of_time.at(f_of_t_name_y)->func_and_deriv(time)[1][0]}});
+    test_product_of_2_maps_time_dep(
+        serialize_and_deserialize(map2d), time, functions_of_time, x_source_a,
+        x_source_b, x_target_a, x_target_b, xi, x, eta, y, y_source_a,
+        y_source_b, y_target_a, y_target_b,
+        {{functions_of_time.at(f_of_t_name_x)->func_and_deriv(time)[1][0],
+          functions_of_time.at(f_of_t_name_y)->func_and_deriv(time)[1][0]}});
+  }
+}
+
+template <typename Map1, typename Map2, typename Map3>
+void test_product_of_3_maps_time_dep(
+    const CoordMapsTimeDependent::ProductOf3Maps<Map1, Map2, Map3>& map3d,
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const double x_source_a, const double x_source_b, const double x_target_a,
+    const double x_target_b, const double xi, const double x, const double eta,
+    const double y, const double zeta, const double z, const double y_source_a,
+    const double y_source_b, const double y_target_a, const double y_target_b,
+    const double z_source_a, const double z_source_b, const double z_target_a,
+    const double z_target_b,
+    const std::array<double, 3>& expected_frame_velocity) noexcept {
+  using AffineMap = CoordinateMaps::Affine;
+  using TranslationMap = CoordMapsTimeDependent::Translation;
+  static_assert(cpp17::is_same_v<Map1, AffineMap> or
+                    cpp17::is_same_v<Map1, TranslationMap>,
+                "Map1 must be either an affine map or a translation map");
+  static_assert(cpp17::is_same_v<Map2, AffineMap> or
+                    cpp17::is_same_v<Map2, TranslationMap>,
+                "Map2 must be either an affine map or a translation map");
+  static_assert(cpp17::is_same_v<Map3, AffineMap> or
+                    cpp17::is_same_v<Map3, TranslationMap>,
+                "Map3 must be either an affine map or a translation map");
+
+  const std::array<double, 3> point_source_a{
+      {x_source_a, y_source_a, z_source_a}};
+  const std::array<double, 3> point_source_b{
+      {x_source_b, y_source_b, z_source_b}};
+  const std::array<double, 3> point_xi{{xi, eta, zeta}};
+  const std::array<double, 3> point_target_a{
+      {x_target_a, y_target_a, z_target_a}};
+  const std::array<double, 3> point_target_b{
+      {x_target_b, y_target_b, z_target_b}};
+  const std::array<double, 3> point_x{{x, y, z}};
+
+  CHECK(map3d(point_source_a, time, functions_of_time) == point_target_a);
+  CHECK(map3d(point_source_b, time, functions_of_time) == point_target_b);
+  CHECK(map3d(point_xi, time, functions_of_time) == point_x);
+
+  CHECK(map3d.inverse(point_target_a, time, functions_of_time).get() ==
+        point_source_a);
+  CHECK(map3d.inverse(point_target_b, time, functions_of_time).get() ==
+        point_source_b);
+  CHECK_ITERABLE_APPROX(map3d.inverse(point_x, time, functions_of_time).get(),
+                        point_xi);
+
+  const double inv_jacobian_00 =
+      (x_source_b - x_source_a) / (x_target_b - x_target_a);
+  const double inv_jacobian_11 =
+      (y_source_b - y_source_a) / (y_target_b - y_target_a);
+  const double inv_jacobian_22 =
+      (z_source_b - z_source_a) / (z_target_b - z_target_a);
+  const auto inv_jac_A =
+      map3d.inv_jacobian(point_source_a, time, functions_of_time);
+  const auto inv_jac_B =
+      map3d.inv_jacobian(point_source_b, time, functions_of_time);
+  const auto inv_jac_xi = map3d.inv_jacobian(point_xi, time, functions_of_time);
+
+  const auto check_jac = [](const auto& jac, const auto& expected_jac_00,
+                            const auto& expected_jac_11,
+                            const auto& expected_jac_22) noexcept {
+    CHECK(get<0, 0>(jac) == expected_jac_00);
+    CHECK(get<1, 1>(jac) == expected_jac_11);
+    CHECK(get<2, 2>(jac) == expected_jac_22);
+    CHECK(get<0, 1>(jac) == 0.0);
+    CHECK(get<0, 2>(jac) == 0.0);
+    CHECK(get<1, 0>(jac) == 0.0);
+    CHECK(get<2, 0>(jac) == 0.0);
+    CHECK(get<1, 2>(jac) == 0.0);
+    CHECK(get<2, 1>(jac) == 0.0);
+  };
+
+  check_jac(inv_jac_A, inv_jacobian_00, inv_jacobian_11, inv_jacobian_22);
+  check_jac(inv_jac_B, inv_jacobian_00, inv_jacobian_11, inv_jacobian_22);
+  check_jac(inv_jac_xi, inv_jacobian_00, inv_jacobian_11, inv_jacobian_22);
+
+  const double jacobian_00 =
+      (x_target_b - x_target_a) / (x_source_b - x_source_a);
+  const double jacobian_11 =
+      (y_target_b - y_target_a) / (y_source_b - y_source_a);
+  const double jacobian_22 =
+      (z_target_b - z_target_a) / (z_source_b - z_source_a);
+  const auto jac_A = map3d.jacobian(point_source_a, time, functions_of_time);
+  const auto jac_B = map3d.jacobian(point_source_b, time, functions_of_time);
+  const auto jac_xi = map3d.jacobian(point_xi, time, functions_of_time);
+
+  check_jac(jac_A, jacobian_00, jacobian_11, jacobian_22);
+  check_jac(jac_B, jacobian_00, jacobian_11, jacobian_22);
+  check_jac(jac_xi, jacobian_00, jacobian_11, jacobian_22);
+
+  CHECK(map3d == map3d);
+  CHECK_FALSE(map3d != map3d);
+
+  CHECK(map3d.frame_velocity(point_source_a, time, functions_of_time) ==
+        expected_frame_velocity);
+  CHECK(map3d.frame_velocity(point_source_b, time, functions_of_time) ==
+        expected_frame_velocity);
+  CHECK(map3d.frame_velocity(point_xi, time, functions_of_time) ==
+        expected_frame_velocity);
+
+  // Check Jacobians for DataVectors
+  const Mesh<3> mesh{8, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const auto tensor_logical_coords = logical_coordinates(mesh);
+  const std::array<DataVector, 3> logical_coords{
+      {get<0>(tensor_logical_coords), get<1>(tensor_logical_coords),
+       get<2>(tensor_logical_coords)}};
+  const auto volume_inv_jac =
+      map3d.inv_jacobian(logical_coords, time, functions_of_time);
+  const auto volume_jac =
+      map3d.jacobian(logical_coords, time, functions_of_time);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      if (i == j) {
+        CHECK(volume_inv_jac.get(i, j) ==
+              DataVector(logical_coords[0].size(),
+                         i == 0 ? inv_jacobian_00
+                                : i == 1 ? inv_jacobian_11 : inv_jacobian_22));
+        CHECK(volume_jac.get(i, j) ==
+              DataVector(
+                  logical_coords[0].size(),
+                  i == 0 ? jacobian_00 : i == 1 ? jacobian_11 : jacobian_22));
+      } else {
+        CHECK(volume_inv_jac.get(i, j) ==
+              DataVector(logical_coords[0].size(), 0.0));
+        CHECK(volume_jac.get(i, j) ==
+              DataVector(logical_coords[0].size(), 0.0));
+      }
+    }
+  }
+
+  // Check frame velocity with DataVectors
+  std::array<DataVector, 3> expected_frame_velocity_datavector{
+      {DataVector(logical_coords[0].size(), expected_frame_velocity[0]),
+       DataVector(logical_coords[1].size(), expected_frame_velocity[1]),
+       DataVector(logical_coords[2].size(), expected_frame_velocity[2])}};
+
+  CHECK(map3d.frame_velocity(logical_coords, time, functions_of_time) ==
+        expected_frame_velocity_datavector);
+
+  CHECK(map3d == map3d);
+  CHECK_FALSE(map3d != map3d);
+}
+
+void test_product_of_3_maps() noexcept {
+  INFO("Product of 3 maps");
+  constexpr size_t deriv_order = 3;
+  using affine_map = CoordinateMaps::Affine;
+  using translation_map = CoordMapsTimeDependent::Translation;
+
+  const std::string f_of_t_name_x{"translation_x"};
+  const std::string f_of_t_name_y{"translation_y"};
+  const std::string f_of_t_name_z{"translation_z"};
+
+  const double time = 2.0;
+  using Polynomial = domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
+  using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
+  std::unordered_map<std::string, FoftPtr> functions_of_time{};
+  functions_of_time[f_of_t_name_x] = std::make_unique<Polynomial>(
+      0.0,
+      std::array<DataVector, deriv_order + 1>{{{1.0}, {-3.0}, {1.3}, {0.0}}});
+  functions_of_time[f_of_t_name_y] = std::make_unique<Polynomial>(
+      0.0,
+      std::array<DataVector, deriv_order + 1>{{{1.0}, {2.4}, {2.0}, {0.0}}});
+  functions_of_time[f_of_t_name_z] = std::make_unique<Polynomial>(
+      0.0,
+      std::array<DataVector, deriv_order + 1>{{{1.0}, {0.4}, {4.0}, {0.0}}});
+
+  {
+    // Test one time-dependent and two time-independent map case.
+    const double x_source_a = -1.0;
+    const double x_source_b = 1.0;
+    const double x_target_a = -2.0;
+    const double x_target_b = 2.0;
+    affine_map affine_map_x(x_source_a, x_source_b, x_target_a, x_target_b);
+
+    const double y_source_a = -2.0;
+    const double y_source_b = 3.0;
+    const double y_target_a = 5.0;
+    const double y_target_b = -2.0;
+    affine_map affine_map_y(y_source_a, y_source_b, y_target_a, y_target_b);
+
+    const double xi = 0.5 * (x_source_a + x_source_b);
+    const double x =
+        x_target_b * (xi - x_source_a) / (x_source_b - x_source_a) +
+        x_target_a * (x_source_b - xi) / (x_source_b - x_source_a);
+    const double eta = 0.5 * (y_source_a + y_source_b);
+    const double y =
+        y_target_b * (eta - y_source_a) / (y_source_b - y_source_a) +
+        y_target_a * (y_source_b - eta) / (y_source_b - y_source_a);
+
+    {
+      INFO("Check with z-direction map time-dependent");
+      const double z_source_a = -1.0;
+      const double z_source_b = 1.0;
+      const double z_target_a =
+          -1.0 + functions_of_time.at(f_of_t_name_z)->func(time)[0][0];
+      const double z_target_b =
+          1.0 + functions_of_time.at(f_of_t_name_z)->func(time)[0][0];
+
+      const double zeta = 0.7;
+      const double z =
+          zeta + functions_of_time.at(f_of_t_name_z)->func(time)[0][0];
+
+      translation_map translation_map_z{f_of_t_name_z};
+      using Map3d =
+          CoordMapsTimeDependent::ProductOf3Maps<affine_map, affine_map,
+                                                 translation_map>;
+      Map3d map3d{affine_map_x, affine_map_y, translation_map_z};
+
+      test_product_of_3_maps_time_dep(
+          map3d, time, functions_of_time, x_source_a, x_source_b, x_target_a,
+          x_target_b, xi, x, eta, y, zeta, z, y_source_a, y_source_b,
+          y_target_a, y_target_b, z_source_a, z_source_b, z_target_a,
+          z_target_b,
+          {{0.0, 0.0,
+            functions_of_time.at(f_of_t_name_z)->func_and_deriv(time)[1][0]}});
+      test_product_of_3_maps_time_dep(
+          serialize_and_deserialize(map3d), time, functions_of_time, x_source_a,
+          x_source_b, x_target_a, x_target_b, xi, x, eta, y, zeta, z,
+          y_source_a, y_source_b, y_target_a, y_target_b, z_source_a,
+          z_source_b, z_target_a, z_target_b,
+          {{0.0, 0.0,
+            functions_of_time.at(f_of_t_name_z)->func_and_deriv(time)[1][0]}});
+    }
+    {
+      INFO("Check with y-direction map time-dependent");
+      const double z_source_a = -1.0;
+      const double z_source_b = 1.0;
+      const double z_target_a =
+          -1.0 + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+      const double z_target_b =
+          1.0 + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+
+      const double zeta = 0.7;
+      const double z =
+          zeta + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+
+      translation_map translation_map_z{f_of_t_name_y};
+      using Map3d =
+          CoordMapsTimeDependent::ProductOf3Maps<affine_map, translation_map,
+                                                 affine_map>;
+      Map3d map3d{affine_map_x, translation_map_z, affine_map_y};
+
+      test_product_of_3_maps_time_dep(
+          map3d, time, functions_of_time, x_source_a, x_source_b, x_target_a,
+          x_target_b, xi, x, zeta, z, eta, y, z_source_a, z_source_b,
+          z_target_a, z_target_b, y_source_a, y_source_b, y_target_a,
+          y_target_b,
+          {{0.0,
+            functions_of_time.at(f_of_t_name_y)->func_and_deriv(time)[1][0],
+            0.0}});
+      test_product_of_3_maps_time_dep(
+          serialize_and_deserialize(map3d), time, functions_of_time, x_source_a,
+          x_source_b, x_target_a, x_target_b, xi, x, zeta, z, eta, y,
+          z_source_a, z_source_b, z_target_a, z_target_b, y_source_a,
+          y_source_b, y_target_a, y_target_b,
+          {{0.0,
+            functions_of_time.at(f_of_t_name_y)->func_and_deriv(time)[1][0],
+            0.0}});
+    }
+    {
+      INFO("Check with x-direction map time-dependent");
+      const double z_source_a = -1.0;
+      const double z_source_b = 1.0;
+      const double z_target_a =
+          -1.0 + functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+      const double z_target_b =
+          1.0 + functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+
+      const double zeta = 0.7;
+      const double z =
+          zeta + functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+
+      translation_map translation_map_z{f_of_t_name_x};
+      using Map3d =
+          CoordMapsTimeDependent::ProductOf3Maps<translation_map, affine_map,
+                                                 affine_map>;
+      Map3d map3d{translation_map_z, affine_map_y, affine_map_x};
+
+      test_product_of_3_maps_time_dep(
+          map3d, time, functions_of_time, z_source_a, z_source_b, z_target_a,
+          z_target_b, zeta, z, eta, y, xi, x, y_source_a, y_source_b,
+          y_target_a, y_target_b, x_source_a, x_source_b, x_target_a,
+          x_target_b,
+          {{functions_of_time.at(f_of_t_name_x)->func_and_deriv(time)[1][0],
+            0.0, 0.0}});
+      test_product_of_3_maps_time_dep(
+          serialize_and_deserialize(map3d), time, functions_of_time, z_source_a,
+          z_source_b, z_target_a, z_target_b, zeta, z, eta, y, xi, x,
+          y_source_a, y_source_b, y_target_a, y_target_b, x_source_a,
+          x_source_b, x_target_a, x_target_b,
+          {{functions_of_time.at(f_of_t_name_x)->func_and_deriv(time)[1][0],
+            0.0, 0.0}});
+    }
+  }
+
+  {
+    // Test two time-dependent and one time-independent map case.
+    const double x_source_a = -1.0;
+    const double x_source_b = 1.0;
+    const double x_target_a = -2.0;
+    const double x_target_b = 2.0;
+    affine_map affine_map_x(x_source_a, x_source_b, x_target_a, x_target_b);
+
+    const double xi = 0.5 * (x_source_a + x_source_b);
+    const double x =
+        x_target_b * (xi - x_source_a) / (x_source_b - x_source_a) +
+        x_target_a * (x_source_b - xi) / (x_source_b - x_source_a);
+    {
+      INFO("Check with x-direction map time-independent");
+      const double y_source_a = -1.0;
+      const double y_source_b = 1.0;
+      const double y_target_a =
+          -1.0 + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+      const double y_target_b =
+          1.0 + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+      const double z_source_a = -1.0;
+      const double z_source_b = 1.0;
+      const double z_target_a =
+          -1.0 + functions_of_time.at(f_of_t_name_z)->func(time)[0][0];
+      const double z_target_b =
+          1.0 + functions_of_time.at(f_of_t_name_z)->func(time)[0][0];
+
+      const double eta = 0.7;
+      const double y =
+          eta + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+      const double zeta = 0.7;
+      const double z =
+          zeta + functions_of_time.at(f_of_t_name_z)->func(time)[0][0];
+
+      translation_map translation_map_y{f_of_t_name_y};
+      translation_map translation_map_z{f_of_t_name_z};
+      using Map3d =
+          CoordMapsTimeDependent::ProductOf3Maps<affine_map, translation_map,
+                                                 translation_map>;
+      Map3d map3d{affine_map_x, translation_map_y, translation_map_z};
+
+      test_product_of_3_maps_time_dep(
+          map3d, time, functions_of_time, x_source_a, x_source_b, x_target_a,
+          x_target_b, xi, x, eta, y, zeta, z, y_source_a, y_source_b,
+          y_target_a, y_target_b, z_source_a, z_source_b, z_target_a,
+          z_target_b,
+          {{0.0,
+            functions_of_time.at(f_of_t_name_y)->func_and_deriv(time)[1][0],
+            functions_of_time.at(f_of_t_name_z)->func_and_deriv(time)[1][0]}});
+      test_product_of_3_maps_time_dep(
+          serialize_and_deserialize(map3d), time, functions_of_time, x_source_a,
+          x_source_b, x_target_a, x_target_b, xi, x, eta, y, zeta, z,
+          y_source_a, y_source_b, y_target_a, y_target_b, z_source_a,
+          z_source_b, z_target_a, z_target_b,
+          {{0.0,
+            functions_of_time.at(f_of_t_name_y)->func_and_deriv(time)[1][0],
+            functions_of_time.at(f_of_t_name_z)->func_and_deriv(time)[1][0]}});
+    }
+    {
+      INFO("Check with y-direction map time-independent");
+      const double y_source_a = -1.0;
+      const double y_source_b = 1.0;
+      const double y_target_a =
+          -1.0 + functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+      const double y_target_b =
+          1.0 + functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+      const double z_source_a = -1.0;
+      const double z_source_b = 1.0;
+      const double z_target_a =
+          -1.0 + functions_of_time.at(f_of_t_name_z)->func(time)[0][0];
+      const double z_target_b =
+          1.0 + functions_of_time.at(f_of_t_name_z)->func(time)[0][0];
+
+      const double eta = 0.7;
+      const double y =
+          eta + functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+      const double zeta = 0.7;
+      const double z =
+          zeta + functions_of_time.at(f_of_t_name_z)->func(time)[0][0];
+
+      translation_map translation_map_y{f_of_t_name_x};
+      translation_map translation_map_z{f_of_t_name_z};
+      using Map3d =
+          CoordMapsTimeDependent::ProductOf3Maps<translation_map, affine_map,
+                                                 translation_map>;
+      Map3d map3d{translation_map_y, affine_map_x, translation_map_z};
+
+      test_product_of_3_maps_time_dep(
+          map3d, time, functions_of_time, y_source_a, y_source_b, y_target_a,
+          y_target_b, eta, y, xi, x, zeta, z, x_source_a, x_source_b,
+          x_target_a, x_target_b, z_source_a, z_source_b, z_target_a,
+          z_target_b,
+          {{functions_of_time.at(f_of_t_name_x)->func_and_deriv(time)[1][0],
+            0.0,
+            functions_of_time.at(f_of_t_name_z)->func_and_deriv(time)[1][0]}});
+      test_product_of_3_maps_time_dep(
+          serialize_and_deserialize(map3d), time, functions_of_time, y_source_a,
+          y_source_b, y_target_a, y_target_b, eta, y, xi, x, zeta, z,
+          x_source_a, x_source_b, x_target_a, x_target_b, z_source_a,
+          z_source_b, z_target_a, z_target_b,
+          {{functions_of_time.at(f_of_t_name_x)->func_and_deriv(time)[1][0],
+            0.0,
+            functions_of_time.at(f_of_t_name_z)->func_and_deriv(time)[1][0]}});
+    }
+    {
+      INFO("Check with z-direction map time-independent");
+      const double y_source_a = -1.0;
+      const double y_source_b = 1.0;
+      const double y_target_a =
+          -1.0 + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+      const double y_target_b =
+          1.0 + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+      const double z_source_a = -1.0;
+      const double z_source_b = 1.0;
+      const double z_target_a =
+          -1.0 + functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+      const double z_target_b =
+          1.0 + functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+
+      const double eta = 0.7;
+      const double y =
+          eta + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+      const double zeta = 0.7;
+      const double z =
+          zeta + functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+
+      translation_map translation_map_y{f_of_t_name_y};
+      translation_map translation_map_z{f_of_t_name_x};
+      using Map3d =
+          CoordMapsTimeDependent::ProductOf3Maps<translation_map,
+                                                 translation_map, affine_map>;
+      Map3d map3d{translation_map_z, translation_map_y, affine_map_x};
+
+      test_product_of_3_maps_time_dep(
+          map3d, time, functions_of_time, z_source_a, z_source_b, z_target_a,
+          z_target_b, zeta, z, eta, y, xi, x, y_source_a, y_source_b,
+          y_target_a, y_target_b, x_source_a, x_source_b, x_target_a,
+          x_target_b,
+          {{functions_of_time.at(f_of_t_name_x)->func_and_deriv(time)[1][0],
+            functions_of_time.at(f_of_t_name_y)->func_and_deriv(time)[1][0],
+            0.0}});
+      test_product_of_3_maps_time_dep(
+          serialize_and_deserialize(map3d), time, functions_of_time, z_source_a,
+          z_source_b, z_target_a, z_target_b, zeta, z, eta, y, xi, x,
+          y_source_a, y_source_b, y_target_a, y_target_b, x_source_a,
+          x_source_b, x_target_a, x_target_b,
+          {{functions_of_time.at(f_of_t_name_x)->func_and_deriv(time)[1][0],
+            functions_of_time.at(f_of_t_name_y)->func_and_deriv(time)[1][0],
+            0.0}});
+    }
+  }
+  {
+    INFO("Check only time-dependent maps");
+    const double x_source_a = -1.0;
+    const double x_source_b = 1.0;
+    const double x_target_a =
+        -1.0 + functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+    const double x_target_b =
+        1.0 + functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+    const double y_source_a = -1.0;
+    const double y_source_b = 1.0;
+    const double y_target_a =
+        -1.0 + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+    const double y_target_b =
+        1.0 + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+    const double z_source_a = -1.0;
+    const double z_source_b = 1.0;
+    const double z_target_a =
+        -1.0 + functions_of_time.at(f_of_t_name_z)->func(time)[0][0];
+    const double z_target_b =
+        1.0 + functions_of_time.at(f_of_t_name_z)->func(time)[0][0];
+
+    const double xi = 0.3;
+    const double x = xi + functions_of_time.at(f_of_t_name_x)->func(time)[0][0];
+    const double eta = 0.7;
+    const double y =
+        eta + functions_of_time.at(f_of_t_name_y)->func(time)[0][0];
+    const double zeta = 0.7;
+    const double z =
+        zeta + functions_of_time.at(f_of_t_name_z)->func(time)[0][0];
+
+    translation_map translation_map_x{f_of_t_name_x};
+    translation_map translation_map_y{f_of_t_name_y};
+    translation_map translation_map_z{f_of_t_name_z};
+    using Map3d =
+        CoordMapsTimeDependent::ProductOf3Maps<translation_map, translation_map,
+                                               translation_map>;
+    Map3d map3d{translation_map_x, translation_map_y, translation_map_z};
+
+    test_product_of_3_maps_time_dep(
+        map3d, time, functions_of_time, x_source_a, x_source_b, x_target_a,
+        x_target_b, xi, x, eta, y, zeta, z, y_source_a, y_source_b, y_target_a,
+        y_target_b, z_source_a, z_source_b, z_target_a, z_target_b,
+        {{functions_of_time.at(f_of_t_name_x)->func_and_deriv(time)[1][0],
+          functions_of_time.at(f_of_t_name_y)->func_and_deriv(time)[1][0],
+          functions_of_time.at(f_of_t_name_z)->func_and_deriv(time)[1][0]}});
+    test_product_of_3_maps_time_dep(
+        serialize_and_deserialize(map3d), time, functions_of_time, x_source_a,
+        x_source_b, x_target_a, x_target_b, xi, x, eta, y, zeta, z, y_source_a,
+        y_source_b, y_target_a, y_target_b, z_source_a, z_source_b, z_target_a,
+        z_target_b,
+        {{functions_of_time.at(f_of_t_name_x)->func_and_deriv(time)[1][0],
+          functions_of_time.at(f_of_t_name_y)->func_and_deriv(time)[1][0],
+          functions_of_time.at(f_of_t_name_z)->func_and_deriv(time)[1][0]}});
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.ProductMaps",
+                  "[Domain][Unit]") {
+  test_product_of_2_maps_time_dep();
+  test_product_of_3_maps();
+}
+}  // namespace domain


### PR DESCRIPTION
## Proposed changes

Adds `ProductOf2Maps` and `ProductOf3Maps` where one or more of the maps must be time-dependent. Only the last commit, `Add time-dependent product maps` is new in this PR.

Depends on:
- [x] #1874 
- [x] #1873 

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
