### PR TITLE
Increase minimum macOS version to 10.9

### DIFF
--- a/cmake/SetupMacOsx.cmake
+++ b/cmake/SetupMacOsx.cmake
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 if(APPLE)
-  set(SPECTRE_MACOSX_MIN "10.7")
+  set(SPECTRE_MACOSX_MIN "10.9")
   if(DEFINED MACOSX_MIN)
     set(SPECTRE_MACOSX_MIN "${MACOSX_MIN}")
   endif()


### PR DESCRIPTION
## Proposed changes

When building spectre on macOS 10.15, I found that the workaround in PR #841 fails, causing the test `Checking for broken std::array<..., 0>` to incorrectly return `broken.` Actually, `std::array<..., 0>` works fine. A linker error complaining that `-libstdc++` is deprecated, and that I should use `-libc++` instead by setting the minimum macOS version to 10.9. Sure enough, making that change eliminates the incorrect `broken` result from this workaround.

macOS version 10.9 shipped in 2013, while macOS 10.7 shipped in 2011. I think there's no reason to support 10.7 or 10.8, as the vast majority of Mac users have upgraded. More than 3/4 Mac users are on 10.13, 10.14, or 10.15 (via https://gs.statcounter.com/os-version-market-share/macos/desktop/worldwide).

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
