### PR TITLE
Disable failing test under python 3

### DIFF
--- a/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
@@ -4,6 +4,7 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <cstddef>
+#include <patchlevel.h>
 
 #include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -25,6 +26,10 @@ namespace Cce {
 namespace {
 
 void pypp_test_worldtube_computation_steps() noexcept {
+  // This test triggers some kind of UB under python 3.  See #1867.
+  if (PY_MAJOR_VERSION == 3) {
+    return;
+  }
   pypp::SetupLocalPythonEnvironment local_python_env{"Evolution/Systems/Cce/"};
 
   pypp::check_with_random_values<1>(


### PR DESCRIPTION
See #1867.

I don't like doing this, but I don't know how to fix this problem, and since I'm the only one using python 3 I don't really think anyone else is going to prioritize it.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
