### PR TITLE
Increase FConstraint tolerance

### DIFF
--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -400,9 +400,7 @@ void test_f_constraint_random(const DataType& used_for_size) noexcept {
           const Scalar<DataType>&,
           const tnsr::iaa<DataType, SpatialDim, Frame>&)>(
           &GeneralizedHarmonic::f_constraint<SpatialDim, Frame, DataType>),
-      "TestFunctions", "f_constraint", {{{-10.0, 10.0}}}, used_for_size,
-      1.0e-9);  // Loosen tolerance to avoid occasional failures of this test
-                // (suspected accumulated roundoff error)
+      "TestFunctions", "f_constraint", {{{-1.0, 1.0}}}, used_for_size);
 }
 
 // Test the return-by-reference F constraint


### PR DESCRIPTION
## Proposed changes
Fixes #1458 by increasing the tolerance. The F constraint has many terms, each of which is a summation of several factors. Because there are so many terms, roundoff error accumulates.

I ran the python test (which uses `np.einsum`), printing out the value of each of the 26 terms as well as the constraint. I also printed each term and the total after shifting each input by 1.0e-15 (roundoff). Then, I subtracted the value of each term with and without the roundoff shift. For the seed I tried (801541510), I found that the roundoff error increases with the number of spatial dimensions, which makes sense, since higher dimensions means more terms in the summations. I found for 3 spatial dimensions for this seed, roundoff error is O(1e-8) for the F constraint. 

Term 6/25 has the largest roundoff error, but many other terms have roundoff errors almost as large. I don’t see any obvious way to simplify this term (but I welcome suggestions!). 

Based on these observations, I recommend setting the tolerance to 1.0e-7. This PR does that.

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
