### PR TITLE
Math in Doxygen guidelines

### DIFF
--- a/docs/DevGuide/CodeReviewGuide.md
+++ b/docs/DevGuide/CodeReviewGuide.md
@@ -40,10 +40,9 @@ Stylistic Items:
   5. SpECTRE includes (in alphabetical order)
 * Template definitions in header files are separated from the declaration of
   the class by the following line, which contains exactly 64 equal signs
-
-``` cpp
-// ================================================================
-```
+  ``` cpp
+  // ================================================================
+  ```
 
 * File lists in CMake are alphabetical.
 * No blank lines surrounding Doxygen group comments

--- a/docs/DevGuide/CodeReviewGuide.md
+++ b/docs/DevGuide/CodeReviewGuide.md
@@ -52,6 +52,10 @@ Stylistic Items:
   `or`, `and`, and `not` instead of `||`, `&&`, and `!`.
 * Use C-style Doxygen comments (`/*! ... */`) when using multi-line math,
   otherwise C-style and C++ style comments are accepted.
+* Use the `align` environment instead of `eqnarray`. See the
+  [texfaq](https://texfaq.org/FAQ-eqnarray) for an explanation as to why.
+* Multi-line equations must have a blank Doxygen line before and after the
+  equation.
 * When addressing requests on a PR, the commit message must start with
   `fixup` followed by a descriptive message.
 

--- a/docs/DevGuide/WritingDox.md
+++ b/docs/DevGuide/WritingDox.md
@@ -128,7 +128,31 @@ previous section. One can also use (within a Doxygen comment) the form
 \endverbatim
 
 to put the expression on its own line. We also encourage you to use the latex
-env `align` for formatting these multiple-line equations.
+env `align` for formatting these multiple-line equations. Please prefer the
+`align` environment over the `eqnarray` environment. See the
+[texfaq](https://texfaq.org/FAQ-eqnarray) for an explanation as to why. When
+using out-of-line equations it is important to have a blank Doxygen line above
+and below the equation so that ClangFormat does not merge the equation with
+other lines. For example,
+
+\verbatim
+ * word word word
+ *
+ * \f{align}{
+ *   a &= b \\
+ *   c &= d
+ * \f}
+ *
+ * word word word
+\endverbatim
+
+prevents ClangFormat from changing the code to
+
+\verbatim
+word word word \f{align}{ a &= b \\ c &= d \f}
+\endverbatim
+
+which may not render properly and makes the source code harder to read.
 
 ## Cite publications in your documentation {#writing_dox_citations}
 


### PR DESCRIPTION
## Proposed changes

Adds guidelines we've been using but never added to the documentation. Specifically:
- Use `align` instead of `equnarray`
- Have a blank line before and after multi-line equations to prevent clangformat from messing with them.

Also corrects indentation of a code block in the code review guidelines.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
