### PR TITLE
Add yapf python formatter to container and CI check

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -49,14 +49,21 @@ jobs:
 
           ./tools/CheckCommits.sh
 
-  # Run simple textual checks over files in the repository, e.g. checking for
-  # a license, line length limits etc. See `tools/CheckFiles.sh` for details.
-  check_files:
-    name: Files
+  # - Run simple textual checks over files in the repository, e.g. checking for
+  #   a license, line length limits etc. See `tools/CheckFiles.sh` for details.
+  # - Run format checker for python to make sure the code is formatted correctly
+  check_files_and_formatting:
+    name: File and formatting checks
     runs-on: ubuntu-latest
+    container:
+      image: sxscollaboration/spectrebuildenv:latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
+      - name: Check python formatting
+        run: |
+          cd $GITHUB_WORKSPACE
+          ./tools/CheckPythonFormatting.sh
       - name: Test script
         run: |
           cd $GITHUB_WORKSPACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ include(CheckCompilerVersion)
 include(ProhibitInSourceBuild)
 include(SetupNinjaColors)
 include(SetOutputDirectory)
+# We need yapf before we set up the git hooks
+include(SetupYapf)
 include(SetupGitHooks)
 include(SetBuildType)
 include(SetupPic)

--- a/cmake/SetupYapf.cmake
+++ b/cmake/SetupYapf.cmake
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+find_program(YAPF_EXECUTABLE yapf PATHS ENV PATH)
+
+if (YAPF_EXECUTABLE)
+  execute_process(
+    COMMAND ${YAPF_EXECUTABLE} --version
+    OUTPUT_VARIABLE YAPF_VERSION)
+  message(STATUS "yapf found at: ${YAPF_EXECUTABLE}")
+  message(STATUS "yapf version: ${YAPF_VERSION}")
+else()
+  message(STATUS
+    "yapf not available. Please install "
+    "YAPF (https://github.com/google/yapf)")
+endif()

--- a/docs/DevGuide/CodeReviewGuide.md
+++ b/docs/DevGuide/CodeReviewGuide.md
@@ -58,6 +58,8 @@ Stylistic Items:
   equation.
 * When addressing requests on a PR, the commit message must start with
   `fixup` followed by a descriptive message.
+* All python code must comply with the yapf (v0.29.0 currently) formatting
+  specified by the `.style.yapf` file in the directory.
 
 Code Quality Items:
 

--- a/docs/DevGuide/PythonBindings.md
+++ b/docs/DevGuide/PythonBindings.md
@@ -131,6 +131,9 @@ Python code that does not use bindings must also be tested. You can register the
 test file using the `spectre_add_python_test` CMake function with the same
 signature as shown above.
 
+Please note that the tests must be formatted according to the `.style.yapf` file
+in the root of the repository.
+
 ## Using The Bindings
 
 See \ref spectre_using_python "Using SpECTRE's Python"

--- a/docs/DevGuide/Travis.md
+++ b/docs/DevGuide/Travis.md
@@ -46,8 +46,8 @@ indicate that a pull request should not be merged in its current state.
   - testing
   - rebase
 * CHECK_FILES runs the script `tools/CheckFiles.sh` (which also runs the script
-`tools/FileTestDefs.sh`) and fails the build if any of the following checks are
-true:
+`tools/FileTestDefs.sh`), and `tools/CheckPythonFormatting.sh`. The checks fail
+if any of the following are true:
   - A `c++` file (i.e. `*.hpp`, `*.cpp`, or `*.tpp` file) contains a
   line over 80 characters
   - A file contains a tab character
@@ -68,6 +68,8 @@ true:
   - A `c++` test uses either:
     * `TEST_CASE` (use `SPECTRE_TEST_CASE` instead)
     * `Approx` (use `approx` instead)
+  - A python file is not formatted according to the `.style.yapf` file in the
+    root of the repository.
 * RUN_CLANG_TIDY runs the script `.travis/RunClangTidy.sh` which runs
 `clang-tidy` on all files which were modified.  This is done for both `Release`
 and `Debug` builds.

--- a/docs/DevGuide/WritingTests.md
+++ b/docs/DevGuide/WritingTests.md
@@ -159,6 +159,8 @@ guidelines:
   PointwiseFunction.GeneralRelativity.Christoffel as christoffel`) or use
   relative imports like `from . import Christoffel as christoffel`. Don't assume
   the Python environment is set up in a subdirectory of `tests/Unit/`.
+- The python code is formatted according to the `.style.yapf` file in the root
+  of the repository.
 
 It is possible to test C++ functions that return by value and ones that return
 by `gsl::not_null`. In the latter case, since it is possible to return multiple

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -56,6 +56,7 @@ installation_on_clusters "Installation on clusters" page.
   code in a clear and consistent fashion
 * [Clang-Tidy](http://clang.llvm.org/extra/clang-tidy/) — to "lint" C++ code
 * [Cppcheck](http://cppcheck.sourceforge.net/) — to analyze C++ code
+* [yapf](https://github.com/google/yapf) 0.29.0 - to format python code
 
 ## Using Docker to obtain a SpECTRE environment
 

--- a/docs/References.bib
+++ b/docs/References.bib
@@ -285,6 +285,21 @@
   volume   = "207",
 }
 
+@ARTICLE{Font1998,
+  author =       {{Font}, Jos{\'e} A. and {Ib{\'a}{\~n}ez}, J.~M.},
+  title =        "{A Numerical Study of Relativistic Bondi-Hoyle Accretion onto
+                  a Moving Black Hole: Axisymmetric Computations in a
+                  Schwarzschild Background}",
+  journal =      {\apj},
+  year =         1998,
+  month =        "Feb",
+  volume =       494,
+  number =       1,
+  pages =        {297-316},
+  doi =          {10.1086/305205},
+  adsurl =       {https://ui.adsabs.harvard.edu/abs/1998ApJ...494..297F},
+}
+
 @article{Foucart2015vpa,
   author         = "Foucart, Francois and O'Connor, Evan and Roberts, Luke
                     and Duez, Matthew D. and Haas, Roland and Kidder,
@@ -657,6 +672,23 @@
   archivePrefix  = "arXiv",
   primaryClass   = "gr-qc",
   SLACcitation   = "%%CITATION = ARXIV:1708.07325;%%"
+}
+
+@article{Penner2011,
+  author =       {{Penner}, A.~J.},
+  title =        "{General relativistic magnetohydrodynamic Bondi-Hoyle
+                  accretion}",
+  journal =      {\mnras},
+  year =         2011,
+  month =        "Jun",
+  volume =       414,
+  number =       2,
+  pages =        {1467-1482},
+  doi =          {10.1111/j.1365-2966.2011.18480.x},
+  archivePrefix ={arXiv},
+  eprint =       {1011.2976},
+  primaryClass = {astro-ph.HE},
+  adsurl =       {https://ui.adsabs.harvard.edu/abs/2011MNRAS.414.1467P},
 }
 
 @article{Porth2016rfi,

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
@@ -33,10 +33,9 @@ namespace AnalyticData {
  *
  * In the context of studying Bondi-Hoyle accretion, i.e. non-spherical
  * accretion on to a Kerr black hole moving relative to a gas cloud, this class
- * implements the method proposed by Font & Ibáñez (1998) \ref font_98 "[1]" to
- * initialize the GRMHD variables. The fluid quantities are initialized with
- * their (constant) values far from the black hole, e.g.
- * \f$\rho = \rho_\infty\f$. Here we assume a
+ * implements the method proposed by \cite Font1998 to initialize the GRMHD
+ * variables. The fluid quantities are initialized with their (constant) values
+ * far from the black hole, e.g. \f$\rho = \rho_\infty\f$. Here we assume a
  * polytropic equation of state, so only the rest mass density, as well as the
  * polytropic constant and the polytropic exponent, are provided as inputs.
  * The spatial velocity is initialized using a field that ensures that the
@@ -52,8 +51,7 @@ namespace AnalyticData {
  *
  * where \f$\gamma_{ij} = g_{ij}\f$ is the spatial metric, and \f$v_\infty\f$
  * is the flow speed far from the black hole. Note that
- * \f$v_\infty^2 = v_i v^i\f$. Finally, following the work by
- * Penner (2011) \ref penner_11 "[2]",
+ * \f$v_\infty^2 = v_i v^i\f$. Finally, following the work by \cite Penner2011,
  * the magnetic field is initialized using Wald's solution to Maxwell's
  * equations in Kerr black hole spacetime. In Kerr ("spherical
  * Kerr-Schild") coordinates, the spatial components of the Faraday tensor read
@@ -78,12 +76,6 @@ namespace AnalyticData {
  *
  * where \f$\gamma = \text{det}(\gamma_{ij})\f$. Wald's solution reproduces a
  * uniform magnetic field far from the black hole.
- *
- * \anchor font_98 [1] J.A. Font & J.M. Ibáñez, ApJ
- * [494 (1998) 297](http://esoads.eso.org/abs/1998ApJ...494..297F)
- *
- * \anchor penner_11 [2] A.J. Penner, MNRAS
- * [414 (2011) 1467](http://cdsads.u-strasbg.fr/abs/2011MNRAS.414.1467P)
  */
 class BondiHoyleAccretion : public MarkAsAnalyticData {
  public:

--- a/tests/Unit/DataStructures/Tensor/EagerMath/TestFunctions.py
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/TestFunctions.py
@@ -3,10 +3,12 @@
 
 import numpy as np
 
+
 # Curved-space cross product returning a vector, given vectors a, b
 def cross_product_up(a, b, inverse_metric, det_metric):
     return np.einsum('ij,j', inverse_metric, np.cross(a, b)) * \
         np.sqrt(det_metric)
+
 
 # Curved-space cross product returning a covector, given vector a, covector b
 def cross_product_lo(a, b, inverse_metric, det_metric):

--- a/tests/Unit/DataStructures/Test_DataVector.py
+++ b/tests/Unit/DataStructures/Test_DataVector.py
@@ -13,7 +13,6 @@ class TestDataVector(unittest.TestCase):
         a = DataVector(5, 6.7)
         self.assertEqual(len(a), 5)
 
-
     def test_math_double(self):
         a = DataVector(5, 6.7)
         self.assertEqual(a + 2.3, DataVector(5, 9.0))
@@ -47,7 +46,6 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual((b / 2.0)[0], 3.6)
         self.assertEqual((b / 2.0)[1], -1.95)
 
-
     def test_math_datavector(self):
         a = DataVector(5, 6.7)
         b = DataVector(5, 8.7)
@@ -67,14 +65,12 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual((c / d)[0], 0.5)
         self.assertEqual((c / d)[1], 1.0 / 3.0)
 
-
     def test_negate(self):
         a = DataVector(5, 6.7)
         self.assertEqual(-a, DataVector(5, -6.7))
         b = DataVector([1.5, 3.7])
         self.assertEqual((-b)[0], -1.5)
         self.assertEqual((-b)[1], -3.7)
-
 
     def test_bounds_check(self):
         a = DataVector(5, 6.7)
@@ -85,13 +81,11 @@ class TestDataVector(unittest.TestCase):
 
         self.assertRaises(RuntimeError, assignment_test)
 
-
     def test_output(self):
         a = DataVector(5, 6.7)
         self.assertEqual(str(a), "(6.7,6.7,6.7,6.7,6.7)")
         b = DataVector([3.8, 7.2])
         self.assertEqual(str(b), "(3.8,7.2)")
-
 
     def test_abs(self):
         a = DataVector(5, -6.0)
@@ -100,14 +94,12 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.abs()[0], 1.0)
         self.assertEqual(b.abs()[1], 2.0)
 
-
     def test_acos(self):
         a = DataVector(5, 0.67)
         self.assertEqual(a.acos()[0], math.acos(0.67))
         b = DataVector([1.0, -0.5])
         self.assertEqual(b.acos()[0], 0)
         self.assertEqual(b.acos()[1], math.acos(-.5))
-
 
     def test_acosh(self):
         a = DataVector(5, 1.0)
@@ -116,14 +108,12 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.acosh()[0], 0.0)
         self.assertEqual(b.acosh()[1], math.acosh(2.0))
 
-
     def test_asin(self):
         a = DataVector(5, 0.67)
         self.assertEqual(a.asin(), DataVector(5, math.asin(0.67)))
         b = DataVector([0.0, -0.5])
         self.assertEqual(b.asin()[0], 0.0)
         self.assertEqual(b.asin()[1], math.asin(-0.5))
-
 
     def test_asinh(self):
         a = DataVector(5, 4.0)
@@ -132,7 +122,6 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.asinh()[0], 0.0)
         self.assertEqual(b.asinh()[1], math.asinh(-0.5))
 
-
     def test_atan(self):
         a = DataVector(5, 0.67)
         self.assertEqual(a.atan(), DataVector(5, math.atan(0.67)))
@@ -140,16 +129,14 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.atan()[0], 0.0)
         self.assertEqual(b.atan()[1], math.atan(-0.5))
 
-
     def test_atan2(self):
         a = DataVector(5, 0.67)
         b = DataVector(5, -4.0)
         self.assertEqual(a.atan2(b), DataVector(5, math.atan2(0.67, -4.0)))
         x = DataVector([3, 100])
         y = DataVector([1, -3])
-        z = DataVector([math.atan2(3,1), math.atan2(100, -3)])
+        z = DataVector([math.atan2(3, 1), math.atan2(100, -3)])
         self.assertEqual(x.atan2(y), z)
-
 
     def test_atanh(self):
         a = DataVector(5, 0.67)
@@ -158,22 +145,19 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.atanh()[0], 0.0)
         self.assertEqual(b.atanh()[1], math.atanh(-0.5))
 
-
     def test_cbrt(self):
         a = DataVector(5, 8.0)
-        self.assertEqual(a.cbrt(),DataVector(5, 2.0))
+        self.assertEqual(a.cbrt(), DataVector(5, 2.0))
         b = DataVector([1.0, 64.0])
         self.assertEqual(b.cbrt()[0], 1.0)
         self.assertEqual(b.cbrt()[1], 4.0)
 
-
     def test_cos(self):
         a = DataVector(5, 0.67)
-        self.assertEqual(a.cos(),DataVector(5, math.cos(0.67)))
+        self.assertEqual(a.cos(), DataVector(5, math.cos(0.67)))
         b = DataVector([0.0, -0.5])
         self.assertEqual(b.cos()[0], 1.0)
         self.assertEqual(b.cos()[1], math.cos(-0.5))
-
 
     def test_cosh(self):
         a = DataVector(5, 1.0)
@@ -182,14 +166,12 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.cosh()[0], 1.0)
         self.assertEqual(b.cosh()[1], math.cosh(-0.5))
 
-
     def test_erf(self):
         a = DataVector(5, 1.0)
         self.assertAlmostEqual(a.erf()[0], math.erf(1.0))
         b = DataVector([2.0, 3.0])
         self.assertAlmostEqual(b.erf()[0], math.erf(2.0))
         self.assertAlmostEqual(b.erf()[1], math.erf(3.0))
-
 
     def test_erfc(self):
         a = DataVector(5, 1)
@@ -198,7 +180,6 @@ class TestDataVector(unittest.TestCase):
         self.assertAlmostEqual(b.erfc()[0], math.erfc(2.0))
         self.assertAlmostEqual(b.erfc()[1], math.erfc(3.0))
 
-
     def test_exp(self):
         a = DataVector(5, 1.0)
         self.assertEqual(a.exp(), DataVector(5, math.exp(1.0)))
@@ -206,14 +187,12 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.exp()[0], math.exp(2.0))
         self.assertEqual(b.exp()[1], math.exp(-0.5))
 
-
     def test_exp2(self):
         a = DataVector(5, 1.0)
-        self.assertEqual(a.exp2(), DataVector(5,2.0))
+        self.assertEqual(a.exp2(), DataVector(5, 2.0))
         b = DataVector([2.0, -0.5])
         self.assertAlmostEqual(b.exp2()[0], 4.0)
         self.assertAlmostEqual(b.exp2()[1], 1.0 / math.sqrt(2.0))
-
 
     def test_exp10(self):
         a = DataVector(5, 1.0)
@@ -222,14 +201,12 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.exp10()[0], 100.0)
         self.assertEqual(b.exp10()[1], 1.0 / math.sqrt(10.0))
 
-
     def test_fabs(self):
         a = DataVector(5, -0.67)
         self.assertEqual(a.fabs(), DataVector(5, 0.67))
         b = DataVector([2.0, -0.5])
         self.assertEqual(b.fabs()[0], 2.0)
         self.assertEqual(b.fabs()[1], 0.5)
-
 
     def test_hypot(self):
         a = DataVector(5, 3.0)
@@ -239,14 +216,12 @@ class TestDataVector(unittest.TestCase):
         y = DataVector([5.0, 4.0])
         self.assertEqual(x.hypot(y), DataVector(2, 5.0))
 
-
     def test_invcbrt(self):
         a = DataVector(5, 8.0)
         self.assertEqual(a.invcbrt(), DataVector(5, 0.5))
         b = DataVector([1.0, -64.0])
         self.assertEqual(b.invcbrt()[0], 1.0)
         self.assertEqual(b.invcbrt()[1], -0.25)
-
 
     def test_invsqrt(self):
         a = DataVector(5, 4.0)
@@ -255,14 +230,12 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.invsqrt()[0], 1.0)
         self.assertEqual(b.invsqrt()[1], 0.25)
 
-
     def test_log(self):
         a = DataVector(5, 4.0)
         self.assertEqual(a.log(), DataVector(5, math.log(4.0)))
         b = DataVector([1.0, 0.5])
         self.assertEqual(b.log()[0], 0.0)
         self.assertEqual(b.log()[1], math.log(0.5))
-
 
     def test_log2(self):
         a = DataVector(5, 4.0)
@@ -271,7 +244,6 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.log2()[0], 0.0)
         self.assertEqual(b.log2()[1], -1.0)
 
-
     def test_log10(self):
         a = DataVector(5, 100.0)
         self.assertEqual(a.log10(), DataVector(5, 2.0))
@@ -279,20 +251,17 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.log10()[0], 0.0)
         self.assertEqual(b.log10()[1], -1.0)
 
-
     def test_max(self):
         a = DataVector([4.0, 5.0, 4.0, 4.0, 4.0])
         self.assertEqual(a.max(), 5.0)
         b = DataVector([1.0, 0.5])
         self.assertEqual(b.max(), 1.0)
 
-
     def test_min(self):
         a = DataVector([4.0, 2.0, 4.0, 4.0, 4.0])
         self.assertEqual(a.min(), 2.0)
         b = DataVector([1.0, -0.5])
-        self.assertEqual(b.min(),-0.5)
-
+        self.assertEqual(b.min(), -0.5)
 
     def test_pow(self):
         a = DataVector(5, 4.0)
@@ -301,14 +270,12 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.pow(2)[0], 1.0)
         self.assertEqual(b.pow(2)[1], 0.25)
 
-
     def test_sin(self):
         a = DataVector(5, 6.7)
-        self.assertEqual(a.sin(),DataVector(5, math.sin(6.7)))
+        self.assertEqual(a.sin(), DataVector(5, math.sin(6.7)))
         b = DataVector([0.0, -0.5])
         self.assertEqual(b.sin()[0], 0.0)
         self.assertEqual(b.sin()[1], math.sin(-0.5))
-
 
     def test_sinh(self):
         a = DataVector(5, 3.0)
@@ -317,7 +284,6 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.sinh()[0], 0.0)
         self.assertEqual(b.sinh()[1], math.sinh(-0.5))
 
-
     def test_sqrt(self):
         a = DataVector(5, 4.0)
         self.assertEqual(a.sqrt(), DataVector(5, 2.0))
@@ -325,14 +291,12 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.sqrt()[0], 1.0)
         self.assertEqual(b.sqrt()[1], 0.5)
 
-
     def test_step_function(self):
         a = DataVector(5, 4.0)
-        self.assertEqual(a.step_function(),DataVector(5, 1.0))
+        self.assertEqual(a.step_function(), DataVector(5, 1.0))
         b = DataVector([1.0, -0.5])
         self.assertEqual(b.step_function()[0], 1.0)
         self.assertEqual(b.step_function()[1], 0.0)
-
 
     def test_tan(self):
         a = DataVector(5, 4.0)
@@ -341,14 +305,12 @@ class TestDataVector(unittest.TestCase):
         self.assertEqual(b.tan()[0], 0.0)
         self.assertEqual(b.tan()[1], math.tan(-0.5))
 
-
     def test_tanh(self):
         a = DataVector(5, 4.0)
         self.assertEqual(a.tanh(), DataVector(5, math.tanh(4.0)))
         b = DataVector([0.0, -0.5])
         self.assertEqual(b.tanh()[0], 0.0)
         self.assertEqual(b.tanh()[1], math.tanh(-0.5))
-
 
     def test_numpy_compatibility(self):
         b = np.array([1.0, 2.0, 3.0])
@@ -376,17 +338,14 @@ class TestDataVector(unittest.TestCase):
         b_dv_reference[2] = 4.0
         self.assertEqual(b[2], 4.0)
 
-
     def test_iterator(self):
         a = DataVector([1.0, 2.0, 3.0, 4.0, 5.0])
         for i, val in enumerate(a):
             self.assertEqual(val, a[i])
 
-
     def test_size_constructor(self):
         a = DataVector(3)
         self.assertEqual(len(a), 3)
-
 
     def test_list_constructor(self):
         a = DataVector([1.0, 2.0, 3.0, 4.0, 5.0])

--- a/tests/Unit/DataStructures/Test_Matrix.py
+++ b/tests/Unit/DataStructures/Test_Matrix.py
@@ -27,8 +27,9 @@ class TestMatrix(unittest.TestCase):
         M[0, 1] = 2
         M[1, 0] = 3
         M[1, 1] = 4
-        self.assertEqual(str(M),
-        '(            1            2 )\n(            3            4 )\n')
+        self.assertEqual(
+            str(M),
+            '(            1            2 )\n(            3            4 )\n')
 
     def test_bounds_check(self):
         a = Matrix(2, 2)

--- a/tests/Unit/Domain/NormalDotFlux.py
+++ b/tests/Unit/Domain/NormalDotFlux.py
@@ -3,5 +3,6 @@
 
 import numpy as np
 
+
 def normal_dot_flux(normal, flux_tensor):
     return np.einsum('i,i...', normal, flux_tensor)

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.py
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.py
@@ -20,27 +20,22 @@ def flux_for_auxiliary_field(field, fluxes_argument, dim):
     return np.diag(np.repeat(fluxes_argument * field, dim))
 
 
-def normal_dot_numerical_flux_for_field(
-        n_dot_aux_flux_int, n_dot_aux_flux_ext,
-        div_aux_flux_int, div_aux_flux_ext,
-        fluxes_argument, penalty_parameter,
-        face_normal_int):
+def normal_dot_numerical_flux_for_field(n_dot_aux_flux_int, n_dot_aux_flux_ext,
+                                        div_aux_flux_int, div_aux_flux_ext,
+                                        fluxes_argument, penalty_parameter,
+                                        face_normal_int):
     sigma = penalty_parameter
-    return np.dot(face_normal_int,
-                  average(
-                      flux_for_field(div_aux_flux_int, fluxes_argument),
-                      flux_for_field(div_aux_flux_ext, fluxes_argument)
-                  ) - sigma * jump(
-                      flux_for_field(n_dot_aux_flux_int, fluxes_argument),
-                      flux_for_field(-n_dot_aux_flux_ext, fluxes_argument)
-                  ))
+    return np.dot(
+        face_normal_int,
+        average(flux_for_field(div_aux_flux_int, fluxes_argument),
+                flux_for_field(div_aux_flux_ext, fluxes_argument)) -
+        sigma * jump(flux_for_field(n_dot_aux_flux_int, fluxes_argument),
+                     flux_for_field(-n_dot_aux_flux_ext, fluxes_argument)))
 
 
 def normal_dot_numerical_flux_for_auxiliary_field(
-        n_dot_aux_flux_int, minus_n_dot_aux_flux_ext,
-        div_aux_flux_int, div_aux_flux_ext,
-        fluxes_argument, penalty_parameter,
-        face_normal_int):
+    n_dot_aux_flux_int, minus_n_dot_aux_flux_ext, div_aux_flux_int,
+    div_aux_flux_ext, fluxes_argument, penalty_parameter, face_normal_int):
     # `minus_n_dot_aux_flux_ext` is from the element on the other side of the
     # interface, so it is _minus_ the same quantity if it was computed with the
     # normal from this element (assuming normals don't depend on the dynamic
@@ -49,16 +44,16 @@ def normal_dot_numerical_flux_for_auxiliary_field(
     return average(n_dot_aux_flux_int, -minus_n_dot_aux_flux_ext)
 
 
-def normal_dot_dirichlet_flux_for_field(
-        dirichlet_field, fluxes_argument, penalty_parameter, face_normal, dim):
+def normal_dot_dirichlet_flux_for_field(dirichlet_field, fluxes_argument,
+                                        penalty_parameter, face_normal, dim):
     sigma = penalty_parameter
     return 2. * sigma * np.dot(
         face_normal,
         flux_for_field(
             np.dot(
                 face_normal,
-                flux_for_auxiliary_field(dirichlet_field, fluxes_argument, dim)
-            ), fluxes_argument))
+                flux_for_auxiliary_field(dirichlet_field, fluxes_argument,
+                                         dim)), fluxes_argument))
 
 
 def normal_dot_dirichlet_flux_for_field_1d(*args, **kwargs):
@@ -73,20 +68,28 @@ def normal_dot_dirichlet_flux_for_field_3d(*args, **kwargs):
     return normal_dot_dirichlet_flux_for_field(*args, dim=3, **kwargs)
 
 
-def normal_dot_dirichlet_flux_for_auxiliary_field(
-        dirichlet_field, fluxes_argument, penalty_parameter, face_normal, dim):
+def normal_dot_dirichlet_flux_for_auxiliary_field(dirichlet_field,
+                                                  fluxes_argument,
+                                                  penalty_parameter,
+                                                  face_normal, dim):
     return np.dot(
         face_normal,
         flux_for_auxiliary_field(dirichlet_field, fluxes_argument, dim))
 
 
 def normal_dot_dirichlet_flux_for_auxiliary_field_1d(*args, **kwargs):
-    return normal_dot_dirichlet_flux_for_auxiliary_field(*args, dim=1, **kwargs)
+    return normal_dot_dirichlet_flux_for_auxiliary_field(*args,
+                                                         dim=1,
+                                                         **kwargs)
 
 
 def normal_dot_dirichlet_flux_for_auxiliary_field_2d(*args, **kwargs):
-    return normal_dot_dirichlet_flux_for_auxiliary_field(*args, dim=2, **kwargs)
+    return normal_dot_dirichlet_flux_for_auxiliary_field(*args,
+                                                         dim=2,
+                                                         **kwargs)
 
 
 def normal_dot_dirichlet_flux_for_auxiliary_field_3d(*args, **kwargs):
-    return normal_dot_dirichlet_flux_for_auxiliary_field(*args, dim=3, **kwargs)
+    return normal_dot_dirichlet_flux_for_auxiliary_field(*args,
+                                                         dim=3,
+                                                         **kwargs)

--- a/tests/Unit/Elliptic/Systems/Poisson/Equations.py
+++ b/tests/Unit/Elliptic/Systems/Poisson/Equations.py
@@ -10,8 +10,8 @@ def euclidean_fluxes(field_gradient):
 
 def non_euclidean_fluxes(inv_spatial_metric, det_spatial_metric,
                          field_gradient):
-    return np.sqrt(det_spatial_metric) * np.einsum(
-        'ij,j', inv_spatial_metric, field_gradient)
+    return np.sqrt(det_spatial_metric) * np.einsum('ij,j', inv_spatial_metric,
+                                                   field_gradient)
 
 
 def auxiliary_fluxes(field, dim):

--- a/tests/Unit/Evolution/Systems/Cce/Equations.py
+++ b/tests/Unit/Evolution/Systems/Cce/Equations.py
@@ -22,9 +22,9 @@ def integrand_for_q_pole_part(eth_beta):
     return -4.0 * eth_beta
 
 
-def integrand_for_q_regular_part(
-        _, dy_beta, dy_j, j, eth_dy_beta, eth_j_jbar, eth_jbar_dy_j,
-        ethbar_dy_j, ethbar_j, eth_r_divided_by_r, k):
+def integrand_for_q_regular_part(_, dy_beta, dy_j, j, eth_dy_beta, eth_j_jbar,
+                                 eth_jbar_dy_j, ethbar_dy_j, ethbar_j,
+                                 eth_r_divided_by_r, k):
     # script_aq input is unused, needed only to match function signature from
     # the C++
     eth_dy_jbar = np.conj(ethbar_dy_j)
@@ -59,10 +59,11 @@ def integrand_for_w_pole_part(ethbar_u):
     return eth_ubar + ethbar_u
 
 
-def integrand_for_w_regular_part(
-        _, dy_u, exp_2_beta, j, q, eth_beta, eth_eth_beta,
-        eth_ethbar_beta, eth_ethbar_j, eth_ethbar_j_jbar, eth_j_jbar,
-        ethbar_dy_u, ethbar_ethbar_j, ethbar_j, eth_r_divided_by_r, k, r):
+def integrand_for_w_regular_part(_, dy_u, exp_2_beta, j, q, eth_beta,
+                                 eth_eth_beta, eth_ethbar_beta, eth_ethbar_j,
+                                 eth_ethbar_j_jbar, eth_j_jbar, ethbar_dy_u,
+                                 ethbar_ethbar_j, ethbar_j, eth_r_divided_by_r,
+                                 k, r):
     # script_av input is unused, needed only to match function signature from
     # the C++
     dy_ubar = np.conj(dy_u)
@@ -95,7 +96,7 @@ def integrand_for_w_regular_part(
 
 
 def integrand_for_h_pole_part(j, u, w, eth_u, ethbar_j, ethbar_jbar_u,
-                                      ethbar_u, k):
+                              ethbar_u, k):
     eth_ubar = np.conj(ethbar_u)
     eth_j_ubar = np.conj(ethbar_jbar_u)
     return - 1.0 / 2.0 * eth_j_ubar - j * eth_ubar - 1.0 / 2.0 * j * ethbar_u \
@@ -103,12 +104,11 @@ def integrand_for_h_pole_part(j, u, w, eth_u, ethbar_j, ethbar_jbar_u,
 
 
 def integrand_for_h_regular_part(
-        _0, _1, _2, dy_dy_j, dy_j, dy_w, exp_2_beta, j, q,
-        u, w, eth_beta, eth_eth_beta, eth_ethbar_beta, eth_ethbar_j,
-        eth_ethbar_j_jbar, eth_j_jbar, eth_q, eth_u, eth_ubar_dy_j,
-        ethbar_dy_j, ethbar_ethbar_j, ethbar_j, ethbar_jbar_dy_j,
-        ethbar_jbar_q_minus_2_eth_beta, ethbar_q, ethbar_u, du_r_divided_by_r,
-        eth_r_divided_by_r, k, one_minus_y, r):
+    _0, _1, _2, dy_dy_j, dy_j, dy_w, exp_2_beta, j, q, u, w, eth_beta,
+    eth_eth_beta, eth_ethbar_beta, eth_ethbar_j, eth_ethbar_j_jbar, eth_j_jbar,
+    eth_q, eth_u, eth_ubar_dy_j, ethbar_dy_j, ethbar_ethbar_j, ethbar_j,
+    ethbar_jbar_dy_j, ethbar_jbar_q_minus_2_eth_beta, ethbar_q, ethbar_u,
+    du_r_divided_by_r, eth_r_divided_by_r, k, one_minus_y, r):
     # script_aj, script_bj, and script_cj input is unused, needed only to match
     # function signature from the C++
     jbar = np.conj(j)

--- a/tests/Unit/Evolution/Systems/Cce/ScriPlusValues.py
+++ b/tests/Unit/Evolution/Systems/Cce/ScriPlusValues.py
@@ -62,5 +62,5 @@ def psi_0(dy_bondi_j, dy_dy_dy_bondi_j, boundary_r):
 
 
 def strain(dy_bondi_j, eth_eth_retarded_time, boundary_r):
-    return -2.0 * np.conj(boundary_r * dy_bondi_j) + np.conj(
-        eth_eth_retarded_time)
+    return -2.0 * np.conj(
+        boundary_r * dy_bondi_j) + np.conj(eth_eth_retarded_time)

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Characteristics.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Characteristics.py
@@ -7,32 +7,33 @@ import numpy as np
 
 
 def char_speed_vpsi(gamma1, lapse, shift, unit_normal):
-    return - (1. + gamma1) * np.dot(shift, unit_normal)
+    return -(1. + gamma1) * np.dot(shift, unit_normal)
 
 
 def char_speed_vzero(gamma1, lapse, shift, unit_normal):
-    return - np.dot(shift, unit_normal)
+    return -np.dot(shift, unit_normal)
 
 
 def char_speed_vplus(gamma1, lapse, shift, unit_normal):
-    return - np.dot(shift, unit_normal) + lapse
+    return -np.dot(shift, unit_normal) + lapse
 
 
 def char_speed_vminus(gamma1, lapse, shift, unit_normal):
-    return - np.dot(shift, unit_normal) - lapse
+    return -np.dot(shift, unit_normal) - lapse
+
 
 # End test functions for characteristic speeds
 
-
 # Test functions for characteristic fields
 
-def char_field_vpsi(gamma2, inverse_spatial_metric, psi,
-                    pi, phi, normal_one_form):
+
+def char_field_vpsi(gamma2, inverse_spatial_metric, psi, pi, phi,
+                    normal_one_form):
     return psi
 
 
-def char_field_vzero(gamma2, inverse_spatial_metric, psi,
-                     pi, phi, normal_one_form):
+def char_field_vzero(gamma2, inverse_spatial_metric, psi, pi, phi,
+                     normal_one_form):
     normal_vector =\
         np.einsum('ij,j', inverse_spatial_metric, normal_one_form)
     projection_tensor = np.identity(len(normal_vector)) -\
@@ -40,17 +41,17 @@ def char_field_vzero(gamma2, inverse_spatial_metric, psi,
     return np.einsum('ij,j->i', projection_tensor, phi)
 
 
-def char_field_vplus(gamma2, inverse_spatial_metric, psi,
-                     pi, phi, normal_one_form):
-    phi_dot_normal = np.einsum(
-        'ij,i,j', inverse_spatial_metric, normal_one_form, phi)
+def char_field_vplus(gamma2, inverse_spatial_metric, psi, pi, phi,
+                     normal_one_form):
+    phi_dot_normal = np.einsum('ij,i,j', inverse_spatial_metric,
+                               normal_one_form, phi)
     return pi + phi_dot_normal - (gamma2 * psi)
 
 
-def char_field_vminus(gamma2, inverse_spatial_metric, psi,
-                      pi, phi, normal_one_form):
-    phi_dot_normal = np.einsum(
-        'ij,i,j', inverse_spatial_metric, normal_one_form, phi)
+def char_field_vminus(gamma2, inverse_spatial_metric, psi, pi, phi,
+                      normal_one_form):
+    phi_dot_normal = np.einsum('ij,i,j', inverse_spatial_metric,
+                               normal_one_form, phi)
     return pi - phi_dot_normal - (gamma2 * psi)
 
 
@@ -65,5 +66,6 @@ def evol_field_pi(gamma2, vpsi, vzero, vplus, vminus, normal_one_form):
 def evol_field_phi(gamma2, vpsi, vzero, vplus, vminus, normal_one_form):
     udiff = 0.5 * (vplus - vminus)
     return (normal_one_form * udiff) + vzero
+
 
 # End test functions for characteristic fields

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Constraints.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Constraints.py
@@ -5,14 +5,18 @@ import numpy as np
 
 # Test functions for one-index constraint
 
+
 def one_index_constraint(d_psi, phi):
     return d_psi - phi
+
 
 # End test functions for one-index constraint
 
 # Test functions for two-index constraint
 
+
 def two_index_constraint(d_phi):
     return d_phi - np.transpose(d_phi)
+
 
 # End test functions for two-index constraint

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.py
@@ -6,17 +6,15 @@ import os
 import sys
 from PointwiseFunctions.GeneralRelativity.ComputeGhQuantities import (
     spacetime_deriv_detg, deriv_lapse, dt_lapse, deriv_spatial_metric,
-    dt_spatial_metric, deriv_shift, dt_shift
-)
+    dt_spatial_metric, deriv_shift, dt_shift)
 from PointwiseFunctions.GeneralRelativity.ComputeSpacetimeQuantities import (
     derivatives_of_spacetime_metric, inverse_spacetime_metric,
-    spacetime_normal_vector
-)
+    spacetime_normal_vector)
 
 
 def weight_function(coords, r_max):
     r2 = np.sum([coords[i]**2 for i in range(len(coords))])
-    return np.exp(- r2 / r_max / r_max)
+    return np.exp(-r2 / r_max / r_max)
 
 
 def spacetime_deriv_weight_function(coords, r_max):
@@ -29,14 +27,14 @@ def spacetime_deriv_weight_function(coords, r_max):
 def roll_on_function(time, t_start, sigma_t):
     if time < t_start:
         return 0.
-    return 1. - np.exp(- ((time - t_start) / sigma_t)**4)
+    return 1. - np.exp(-((time - t_start) / sigma_t)**4)
 
 
 def time_deriv_roll_on_function(time, t_start, sigma_t):
     if time < t_start:
         return 0.
     tnrm = (time - t_start) / sigma_t
-    return np.exp(- tnrm**4) * 4 * tnrm**3 / sigma_t
+    return np.exp(-tnrm**4) * 4 * tnrm**3 / sigma_t
 
 
 def log_fac(lapse, sqrt_det_spatial_metric, exponent):
@@ -49,9 +47,8 @@ def spacetime_deriv_log_fac(lapse, shift, spacetime_unit_normal,
                             dt_spatial_metric, pi, phi, exponent):
     spatial_dim = len(shift)
     detg = sqrt_det_spatial_metric**2
-    dg = spacetime_deriv_detg(sqrt_det_spatial_metric,
-                                   inverse_spatial_metric, dt_spatial_metric,
-                                   phi)
+    dg = spacetime_deriv_detg(sqrt_det_spatial_metric, inverse_spatial_metric,
+                              dt_spatial_metric, phi)
     d0N = dt_lapse(lapse, shift, spacetime_unit_normal, phi, pi)
     d3N = deriv_lapse(lapse, spacetime_unit_normal, phi)
     d4N = np.zeros(1 + spatial_dim)
@@ -63,15 +60,14 @@ def spacetime_deriv_log_fac(lapse, shift, spacetime_unit_normal,
 
 
 def spacetime_deriv_pow_log_fac(lapse, shift, spacetime_unit_normal,
-                                inverse_spatial_metric, sqrt_det_spatial_metric,
-                                dt_spatial_metric,
-                                pi, phi, g_exponent, exponent):
+                                inverse_spatial_metric,
+                                sqrt_det_spatial_metric, dt_spatial_metric, pi,
+                                phi, g_exponent, exponent):
     exponent = int(exponent)
     dlogfac = spacetime_deriv_log_fac(lapse, shift, spacetime_unit_normal,
                                       inverse_spatial_metric,
                                       sqrt_det_spatial_metric,
-                                      dt_spatial_metric,
-                                      pi, phi, g_exponent)
+                                      dt_spatial_metric, pi, phi, g_exponent)
     logfac = log_fac(lapse, sqrt_det_spatial_metric, g_exponent)
     return exponent * np.power(logfac, exponent - 1) * dlogfac
 
@@ -105,14 +101,10 @@ def damped_harmonic_gauge_source_function(gauge_h_init, lapse, shift,
         np.einsum('ai,i->a', spacetime_metric[:, 1:], shift)
 
 
-def spacetime_deriv_damped_harmonic_gauge_source_function(gauge_h_init,
-                                                dgauge_h_init, lapse, shift,
-                                                spacetime_unit_normal_one_form,
-                                                sqrt_det_spatial_metric,
-                                                inverse_spatial_metric,
-                                                spacetime_metric, pi, phi, time,
-                                                t_start, sigma_t, coords,
-                                                r_max):
+def spacetime_deriv_damped_harmonic_gauge_source_function(
+    gauge_h_init, dgauge_h_init, lapse, shift, spacetime_unit_normal_one_form,
+    sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric, pi, phi,
+    time, t_start, sigma_t, coords, r_max):
     spatial_dim = len(shift)
     spacetime_unit_normal = spacetime_normal_vector(lapse, shift)
     spatial_metric = spatial_metric_from_spacetime_metric(spacetime_metric)
@@ -145,8 +137,8 @@ def spacetime_deriv_damped_harmonic_gauge_source_function(gauge_h_init,
     d4_RW = R * d4_W
     d4_RW[0] += W * d0_R
 
-    d4_g = spacetime_deriv_detg(sqrt_det_spatial_metric, inverse_spatial_metric,
-                                d0_spatial_metric, phi)
+    d4_g = spacetime_deriv_detg(sqrt_det_spatial_metric,
+                                inverse_spatial_metric, d0_spatial_metric, phi)
 
     d0_N = dt_lapse(lapse, shift, spacetime_unit_normal, phi, pi)
     d3_N = deriv_lapse(lapse, spacetime_unit_normal, phi)
@@ -155,11 +147,11 @@ def spacetime_deriv_damped_harmonic_gauge_source_function(gauge_h_init,
     d4_N[1:] = d3_N
 
     d0_shift = dt_shift(lapse, shift, inverse_spatial_metric,
-                             spacetime_unit_normal, phi, pi)
-    d3_shift = deriv_shift(lapse, inv_spacetime_metric,
-                                spacetime_unit_normal, phi)
-    d4_shift = np.einsum('a,b->ab',
-                         np.zeros(spatial_dim + 1), np.zeros(spatial_dim + 1))
+                        spacetime_unit_normal, phi, pi)
+    d3_shift = deriv_shift(lapse, inv_spacetime_metric, spacetime_unit_normal,
+                           phi)
+    d4_shift = np.einsum('a,b->ab', np.zeros(spatial_dim + 1),
+                         np.zeros(spatial_dim + 1))
     d4_shift[0, 1:] = d0_shift
     d4_shift[1:, 1:] = d3_shift
 
@@ -172,17 +164,15 @@ def spacetime_deriv_damped_harmonic_gauge_source_function(gauge_h_init,
         prefac1 * (d4_g / det_spatial_metric - 2. * one_over_lapse * d4_N)
     d4_mu2 = log_one_over_lapse_pow5 * d4_RW + prefac2 * d4_N
 
-    d4_normal_one_form = np.einsum('a,b->ab',
-                                   np.zeros(spatial_dim + 1),
+    d4_normal_one_form = np.einsum('a,b->ab', np.zeros(spatial_dim + 1),
                                    np.zeros(spatial_dim + 1))
     d4_normal_one_form[:, 0] = -d4_N
 
     d4_muS_over_N = one_over_lapse * d4_muL1 - muL1 * one_over_lapse**2 * d4_N
 
-    d4_psi = derivatives_of_spacetime_metric(lapse, d0_N, d3_N,
-                                             shift, d0_shift, d3_shift,
-                                             spatial_metric,
-                                             d0_spatial_metric,
+    d4_psi = derivatives_of_spacetime_metric(lapse, d0_N, d3_N, shift,
+                                             d0_shift, d3_shift,
+                                             spatial_metric, d0_spatial_metric,
                                              d3_spatial_metric)
 
     dT1 = (1. - R) * dgauge_h_init
@@ -191,8 +181,8 @@ def spacetime_deriv_damped_harmonic_gauge_source_function(gauge_h_init,
     dT2 = (mu1 + mu2) * d4_normal_one_form +\
         np.einsum('a,b->ab', d4_mu1 + d4_mu2, spacetime_unit_normal_one_form)
 
-    dT3 = np.einsum('a,b->ab',
-                    np.zeros(spatial_dim + 1), np.zeros(spatial_dim + 1))
+    dT3 = np.einsum('a,b->ab', np.zeros(spatial_dim + 1),
+                    np.zeros(spatial_dim + 1))
     dT3 -= np.einsum('a,b->ab', d4_muS_over_N,
                      np.einsum('bi,i->b', spacetime_metric[:, 1:], shift))
     dT3 -= muS_over_N * np.einsum('abi,i->ab', d4_psi[:, :, 1:], shift)

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
@@ -3,14 +3,13 @@
 
 import numpy as np
 
-
 # Test functions for normal dot fluxes
 
 
 def spacetime_metric_normal_dot_flux(spacetime_metric, pi, phi, gamma1, gamma2,
                                      lapse, shift, inverse_spatial_metric,
                                      unit_normal):
-    return - (1. + gamma1) * np.dot(shift, unit_normal) * spacetime_metric
+    return -(1. + gamma1) * np.dot(shift, unit_normal) * spacetime_metric
 
 
 def pi_normal_dot_flux(spacetime_metric, pi, phi, gamma1, gamma2, lapse, shift,
@@ -27,6 +26,7 @@ def phi_dot_flux(spacetime_metric, pi, phi, gamma1, gamma2, lapse, shift,
         + lapse * np.einsum("i,ab->iab", unit_normal, pi) \
            - gamma2 * lapse * np.einsum("i,ab->iab", unit_normal,
                                         spacetime_metric)
+
 
 # End test functions for normal dot fluxes
 
@@ -50,6 +50,7 @@ def gauge_constraint(gauge_function, spacetime_normal_one_form,
         - 0.5 * np.einsum("a,bc,bc->a", spacetime_normal_one_form,
                           inverse_spacetime_metric, pi)
     return constraint
+
 
 # End test functions for gauge constraint
 
@@ -93,12 +94,10 @@ def two_index_constraint_term_6_of_11(spacetime_normal_vector,
     spacetime_normal_vector_I = spacetime_normal_vector[1:]
     phi_acd = np.pad(phi, ((1, 0), (0, 0), (0, 0)), 'constant')
     term = np.einsum("acd,ief,ce,df->ia", phi_acd, phi,
-                     inverse_spacetime_metric,
-                     inverse_spacetime_metric)
+                     inverse_spacetime_metric, inverse_spacetime_metric)
     term += np.einsum("j,a,jcd,ief,ce,df->ia", spacetime_normal_vector_I,
                       spacetime_normal_one_form, phi, phi,
-                      inverse_spacetime_metric,
-                      inverse_spacetime_metric)
+                      inverse_spacetime_metric, inverse_spacetime_metric)
     return 0.5 * term
 
 
@@ -107,10 +106,9 @@ def two_index_constraint_term_7_of_11(inverse_spatial_metric, phi,
                                       spacetime_normal_vector,
                                       spacetime_normal_one_form):
     phi_ike = phi[:, 1:, :]
-    return 0.5 * np.einsum("jk,jcd,ike,cd,e,a->ia", inverse_spatial_metric, phi,
-                           phi_ike, inverse_spacetime_metric,
-                           spacetime_normal_vector,
-                           spacetime_normal_one_form)
+    return 0.5 * np.einsum("jk,jcd,ike,cd,e,a->ia", inverse_spatial_metric,
+                           phi, phi_ike, inverse_spacetime_metric,
+                           spacetime_normal_vector, spacetime_normal_one_form)
 
 
 def two_index_constraint_term_8_of_11(inverse_spatial_metric, phi):
@@ -128,8 +126,8 @@ def two_index_constraint_term_9_of_11(phi, pi, spacetime_normal_one_form,
                            inverse_spacetime_metric)
     term += 0.25 * np.einsum("icd,be,a,be,c,d->ia", phi, pi,
                              spacetime_normal_one_form,
-                             inverse_spacetime_metric,
-                             spacetime_normal_vector, spacetime_normal_vector)
+                             inverse_spacetime_metric, spacetime_normal_vector,
+                             spacetime_normal_vector)
     return term
 
 
@@ -147,27 +145,26 @@ def two_index_constraint_term_11_of_11(gamma2, spacetime_normal_one_form,
                                        inverse_spacetime_metric,
                                        spacetime_normal_vector,
                                        three_index_constraint):
-    term = 0.5 * gamma2 * np.einsum("a,cd,icd->ia",
-                                    spacetime_normal_one_form,
+    term = 0.5 * gamma2 * np.einsum("a,cd,icd->ia", spacetime_normal_one_form,
                                     inverse_spacetime_metric,
                                     three_index_constraint)
-    term -= gamma2 * np.einsum("d,iad->ia",
-                               spacetime_normal_vector, three_index_constraint)
+    term -= gamma2 * np.einsum("d,iad->ia", spacetime_normal_vector,
+                               three_index_constraint)
     return term
 
 
 def two_index_constraint(d_gauge_function, spacetime_normal_one_form,
                          spacetime_normal_vector, inverse_spatial_metric,
-                         inverse_spacetime_metric, pi, phi, d_pi, d_phi, gamma2,
-                         three_index_constraint):
-    constraint = two_index_constraint_term_1_of_11(
-        inverse_spatial_metric, d_phi)
+                         inverse_spacetime_metric, pi, phi, d_pi, d_phi,
+                         gamma2, three_index_constraint):
+    constraint = two_index_constraint_term_1_of_11(inverse_spatial_metric,
+                                                   d_phi)
     constraint += two_index_constraint_term_2_of_11(spacetime_normal_vector,
                                                     spacetime_normal_one_form,
                                                     inverse_spacetime_metric,
                                                     d_phi)
-    constraint += two_index_constraint_term_3_of_11(
-        spacetime_normal_vector, d_pi)
+    constraint += two_index_constraint_term_3_of_11(spacetime_normal_vector,
+                                                    d_pi)
     constraint += two_index_constraint_term_4_of_11(spacetime_normal_one_form,
                                                     inverse_spacetime_metric,
                                                     d_pi)
@@ -176,28 +173,30 @@ def two_index_constraint(d_gauge_function, spacetime_normal_one_form,
                                                     spacetime_normal_one_form,
                                                     phi,
                                                     inverse_spacetime_metric)
-    constraint += two_index_constraint_term_7_of_11(inverse_spatial_metric, phi,
+    constraint += two_index_constraint_term_7_of_11(inverse_spatial_metric,
+                                                    phi,
                                                     inverse_spacetime_metric,
                                                     spacetime_normal_vector,
                                                     spacetime_normal_one_form)
-    constraint += two_index_constraint_term_8_of_11(
-        inverse_spatial_metric, phi)
+    constraint += two_index_constraint_term_8_of_11(inverse_spatial_metric,
+                                                    phi)
     constraint += two_index_constraint_term_9_of_11(phi, pi,
                                                     spacetime_normal_one_form,
                                                     inverse_spacetime_metric,
                                                     spacetime_normal_vector)
-    constraint += two_index_constraint_term_10_of_11(
-        phi, pi, spacetime_normal_vector, inverse_spacetime_metric)
-    constraint += two_index_constraint_term_11_of_11(gamma2,
-                                                     spacetime_normal_one_form,
-                                                     inverse_spacetime_metric,
+    constraint += two_index_constraint_term_10_of_11(phi, pi,
                                                      spacetime_normal_vector,
-                                                     three_index_constraint)
+                                                     inverse_spacetime_metric)
+    constraint += two_index_constraint_term_11_of_11(
+        gamma2, spacetime_normal_one_form, inverse_spacetime_metric,
+        spacetime_normal_vector, three_index_constraint)
     return constraint
+
 
 # End test functions for two-index constraint
 
 # Test functions for four-index constraint
+
 
 def four_index_constraint(d_phi):
     e_ijk = np.zeros((3, 3, 3))
@@ -206,35 +205,38 @@ def four_index_constraint(d_phi):
     constraint = np.einsum("ijk,jkab->iab", e_ijk, d_phi)
     return constraint
 
+
 # End test functions for four-index constraint
+
 
 # Test functions for characteristic speeds
 def char_speed_upsi(gamma1, lapse, shift, unit_normal):
-    return - (1. + gamma1) * np.dot(shift, unit_normal)
+    return -(1. + gamma1) * np.dot(shift, unit_normal)
 
 
 def char_speed_uzero(gamma1, lapse, shift, unit_normal):
-    return - np.dot(shift, unit_normal)
+    return -np.dot(shift, unit_normal)
 
 
 def char_speed_uplus(gamma1, lapse, shift, unit_normal):
-    return - np.dot(shift, unit_normal) + lapse
+    return -np.dot(shift, unit_normal) + lapse
 
 
 def char_speed_uminus(gamma1, lapse, shift, unit_normal):
-    return - np.dot(shift, unit_normal) - lapse
+    return -np.dot(shift, unit_normal) - lapse
+
 
 # End test functions for characteristic speeds
 
 
 # Test functions for characteristic fields
-def char_field_upsi(gamma2, inverse_spatial_metric, spacetime_metric,
-                    pi, phi, normal_one_form):
+def char_field_upsi(gamma2, inverse_spatial_metric, spacetime_metric, pi, phi,
+                    normal_one_form):
     return spacetime_metric
 
 
-def char_field_uzero(gamma2, inverse_spatial_metric, spacetime_metric,
-                     pi, phi, normal_one_form):
+def char_field_uzero(gamma2, inverse_spatial_metric, spacetime_metric, pi, phi,
+                     normal_one_form):
     normal_vector =\
         np.einsum('ij,j', inverse_spatial_metric, normal_one_form)
     projection_tensor = np.identity(len(normal_vector)) -\
@@ -242,20 +244,21 @@ def char_field_uzero(gamma2, inverse_spatial_metric, spacetime_metric,
     return np.einsum('ij,jab->iab', projection_tensor, phi)
 
 
-def char_field_uplus(gamma2, inverse_spatial_metric, spacetime_metric,
-                     pi, phi, normal_one_form):
+def char_field_uplus(gamma2, inverse_spatial_metric, spacetime_metric, pi, phi,
+                     normal_one_form):
     normal_vector =\
         np.einsum('ij,j', inverse_spatial_metric, normal_one_form)
     phi_dot_normal = np.einsum('i,iab->ab', normal_vector, phi)
-    return pi + 1*phi_dot_normal - (gamma2 * spacetime_metric)
+    return pi + 1 * phi_dot_normal - (gamma2 * spacetime_metric)
 
 
-def char_field_uminus(gamma2, inverse_spatial_metric, spacetime_metric,
-                      pi, phi, normal_one_form):
+def char_field_uminus(gamma2, inverse_spatial_metric, spacetime_metric, pi,
+                      phi, normal_one_form):
     normal_vector =\
         np.einsum('ij,j', inverse_spatial_metric, normal_one_form)
     phi_dot_normal = np.einsum('i,iab->ab', normal_vector, phi)
     return pi - phi_dot_normal - (gamma2 * spacetime_metric)
+
 
 # Test functions for evolved fields
 
@@ -272,6 +275,7 @@ def evol_field_phi(gamma2, upsi, uzero, uplus, uminus, normal_one_form):
     udiff = 0.5 * (uplus - uminus)
     return np.einsum('i,ab->iab', normal_one_form, udiff) + uzero
 
+
 # End test functions for characteristic fields
 
 # Test functions for F constraint
@@ -284,7 +288,8 @@ def f_constraint_term_1_of_25(spacetime_normal_one_form,
     d_pi_abc = np.pad(d_pi, ((1, 0), (0, 0), (0, 0)), 'constant')
     term = np.einsum("bc,abc", inverse_spacetime_metric, d_pi_abc)
     term += np.einsum("a,i,bc,ibc", spacetime_normal_one_form,
-                      spacetime_normal_vector_I, inverse_spacetime_metric, d_pi)
+                      spacetime_normal_vector_I, inverse_spacetime_metric,
+                      d_pi)
     return 0.5 * term
 
 
@@ -300,31 +305,29 @@ def f_constraint_term_3_of_25(inverse_spatial_metric, spacetime_normal_vector,
 
 
 def f_constraint_term_4_of_25(spacetime_normal_one_form,
-                              inverse_spacetime_metric,
-                              inverse_spatial_metric, d_phi):
+                              inverse_spacetime_metric, inverse_spatial_metric,
+                              d_phi):
     return 0.5 * np.einsum("a,bc,ij,ijbc", spacetime_normal_one_form,
-                           inverse_spacetime_metric,
-                           inverse_spatial_metric, d_phi)
+                           inverse_spacetime_metric, inverse_spatial_metric,
+                           d_phi)
 
 
-def f_constraint_term_5_of_25(spacetime_normal_one_form, inverse_spatial_metric,
-                              d_gauge_function):
+def f_constraint_term_5_of_25(spacetime_normal_one_form,
+                              inverse_spatial_metric, d_gauge_function):
     d_gauge_function_ij = d_gauge_function[:, 1:]
     return np.einsum("a,ij,ij", spacetime_normal_one_form,
-                     inverse_spatial_metric,
-                     d_gauge_function_ij)
+                     inverse_spatial_metric, d_gauge_function_ij)
 
 
 def f_constraint_term_6_of_25(spacetime_normal_one_form,
-                              spacetime_normal_vector,
-                              phi, inverse_spatial_metric,
+                              spacetime_normal_vector, phi,
+                              inverse_spatial_metric,
                               inverse_spacetime_metric):
     spacetime_normal_vector_I = spacetime_normal_vector[1:]
     phi_ijb = phi[:, 1:, :]
     phi_ajb = np.pad(phi, ((1, 0), (0, 0), (0, 0)), 'constant')[:, 1:, :]
     term = np.einsum("ajb,jk,kcd,bd,c", phi_ajb, inverse_spatial_metric, phi,
-                     inverse_spacetime_metric,
-                     spacetime_normal_vector)
+                     inverse_spacetime_metric, spacetime_normal_vector)
     return term + np.einsum("a,i,ijb,jk,kcd,bd,c", spacetime_normal_one_form,
                             spacetime_normal_vector_I, phi_ijb,
                             inverse_spatial_metric, phi,
@@ -332,34 +335,30 @@ def f_constraint_term_6_of_25(spacetime_normal_one_form,
 
 
 def f_constraint_term_7_of_25(spacetime_normal_one_form,
-                              spacetime_normal_vector,
-                              phi, inverse_spatial_metric,
+                              spacetime_normal_vector, phi,
+                              inverse_spatial_metric,
                               inverse_spacetime_metric):
     spacetime_normal_vector_I = spacetime_normal_vector[1:]
     phi_ijb = phi[:, 1:, :]
     phi_ajb = np.pad(phi, ((1, 0), (0, 0), (0, 0)), 'constant')[:, 1:, :]
     term = np.einsum("ajb,jk,kcd,cd,b", phi_ajb, inverse_spatial_metric, phi,
-                     inverse_spacetime_metric,
-                     spacetime_normal_vector)
-    return -0.5 * (term + np.einsum("a,i,ijb,jk,kcd,cd,b",
-                                    spacetime_normal_one_form,
-                                    spacetime_normal_vector_I, phi_ijb,
-                                    inverse_spatial_metric, phi,
-                                    inverse_spacetime_metric,
-                                    spacetime_normal_vector))
+                     inverse_spacetime_metric, spacetime_normal_vector)
+    return -0.5 * (term + np.einsum(
+        "a,i,ijb,jk,kcd,cd,b", spacetime_normal_one_form,
+        spacetime_normal_vector_I, phi_ijb, inverse_spatial_metric, phi,
+        inverse_spacetime_metric, spacetime_normal_vector))
 
 
 def f_constraint_term_8_of_25(spacetime_normal_one_form,
-                              spacetime_normal_vector,
-                              d_gauge_function):
-    d_gauge_function_ab = np.pad(
-        d_gauge_function, ((1, 0), (0, 0)), 'constant')
+                              spacetime_normal_vector, d_gauge_function):
+    d_gauge_function_ab = np.pad(d_gauge_function, ((1, 0), (0, 0)),
+                                 'constant')
     spacetime_normal_vector_I = spacetime_normal_vector[1:]
     term = -1.0 * np.einsum("b,ab", spacetime_normal_vector,
                             d_gauge_function_ab)
     return term - np.einsum("a,i,b,ib", spacetime_normal_one_form,
-                            spacetime_normal_vector_I,
-                            spacetime_normal_vector, d_gauge_function)
+                            spacetime_normal_vector_I, spacetime_normal_vector,
+                            d_gauge_function)
 
 
 def f_constraint_term_9_of_25(inverse_spatial_metric, phi,
@@ -383,7 +382,8 @@ def f_constraint_term_11_of_25(spacetime_normal_one_form,
                                inverse_spacetime_metric):
     return -0.25 * np.einsum("a,ij,icd,jbe,cb,de", spacetime_normal_one_form,
                              inverse_spatial_metric, phi, phi,
-                             inverse_spacetime_metric, inverse_spacetime_metric)
+                             inverse_spacetime_metric,
+                             inverse_spacetime_metric)
 
 
 def f_constraint_term_12_of_25(spacetime_normal_one_form, pi,
@@ -423,9 +423,9 @@ def f_constraint_term_15_of_25(inverse_spacetime_metric,
 def f_constraint_term_16_of_25(spacetime_normal_one_form, pi,
                                inverse_spacetime_metric,
                                spacetime_normal_vector):
-    return 0.5 * np.einsum("a,cd,be,ce,d,b", spacetime_normal_one_form,
-                           pi, pi, inverse_spacetime_metric,
-                           spacetime_normal_vector, spacetime_normal_vector)
+    return 0.5 * np.einsum("a,cd,be,ce,d,b", spacetime_normal_one_form, pi, pi,
+                           inverse_spacetime_metric, spacetime_normal_vector,
+                           spacetime_normal_vector)
 
 
 def f_constraint_term_17_of_25(inverse_spacetime_metric,
@@ -490,8 +490,8 @@ def f_constraint_term_22_of_25(gamma2, inverse_spacetime_metric,
     term -= 0.5 * np.einsum("cd,acd", inverse_spacetime_metric,
                             three_index_constraint_acd)
     term -= 0.5 * np.einsum("a,i,cd,icd", spacetime_normal_one_form,
-                            spacetime_normal_vector_I, inverse_spacetime_metric,
-                            three_index_constraint)
+                            spacetime_normal_vector_I,
+                            inverse_spacetime_metric, three_index_constraint)
     return gamma2 * term
 
 
@@ -513,8 +513,8 @@ def f_constraint_term_24_of_25(spacetime_normal_one_form,
 
 
 def f_constraint_term_25_of_25(spacetime_normal_one_form,
-                               inverse_spatial_metric, gauge_function,
-                               phi, inverse_spacetime_metric):
+                               inverse_spatial_metric, gauge_function, phi,
+                               inverse_spacetime_metric):
     gauge_function_i = gauge_function[1:]
     return 0.5 * np.einsum("a,ij,i,jcd,cd", spacetime_normal_one_form,
                            inverse_spatial_metric, gauge_function_i, phi,
@@ -538,12 +538,12 @@ def f_constraint(gauge_function, d_gauge_function, spacetime_normal_one_form,
                                             inverse_spatial_metric,
                                             d_gauge_function)
     constraint += f_constraint_term_6_of_25(spacetime_normal_one_form,
-                                            spacetime_normal_vector,
-                                            phi, inverse_spatial_metric,
+                                            spacetime_normal_vector, phi,
+                                            inverse_spatial_metric,
                                             inverse_spacetime_metric)
     constraint += f_constraint_term_7_of_25(spacetime_normal_one_form,
-                                            spacetime_normal_vector,
-                                            phi, inverse_spatial_metric,
+                                            spacetime_normal_vector, phi,
+                                            inverse_spatial_metric,
                                             inverse_spacetime_metric)
     constraint += f_constraint_term_8_of_25(spacetime_normal_one_form,
                                             spacetime_normal_vector,
@@ -592,14 +592,15 @@ def f_constraint(gauge_function, d_gauge_function, spacetime_normal_one_form,
                                              gauge_function,
                                              spacetime_normal_vector)
     constraint += f_constraint_term_24_of_25(spacetime_normal_one_form,
-                                             inverse_spatial_metric,
-                                             phi, gauge_function,
+                                             inverse_spatial_metric, phi,
+                                             gauge_function,
                                              inverse_spacetime_metric)
     constraint += f_constraint_term_25_of_25(spacetime_normal_one_form,
                                              inverse_spatial_metric,
                                              gauge_function, phi,
                                              inverse_spacetime_metric)
     return constraint
+
 
 # End test functions for F constraint
 
@@ -629,5 +630,6 @@ def constraint_energy(gauge_constraint, f_constraint, two_index_constraint,
         * np.einsum("iab,jab,ij", four_index_constraint,
                     four_index_constraint, inverse_spatial_metric)
     return energy
+
 
 # End test functions for constraint energy

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
@@ -27,19 +27,17 @@ def spatial_velocity_one_form(spatial_velocity, spatial_metric):
 
 
 def stress_tensor(spatial_velocity, magnetic_field, rest_mass_density,
-                  specific_enthalpy, lorentz_factor, pressure,
-                  spatial_metric, inv_spatial_metric, sqrt_det_spatial_metric):
+                  specific_enthalpy, lorentz_factor, pressure, spatial_metric,
+                  inv_spatial_metric, sqrt_det_spatial_metric):
     bsq_ = bsq(magnetic_field, spatial_metric)
     b_dot_v_ = b_dot_v(magnetic_field, spatial_velocity, spatial_metric)
-    return (sqrt_det_spatial_metric *
-            ((specific_enthalpy * rest_mass_density * lorentz_factor**2 +
-              bsq_) *
-             np.outer(spatial_velocity, spatial_velocity) +
-             p_star(pressure, b_dot_v_, bsq_, lorentz_factor) *
-             inv_spatial_metric -
-             b_dot_v_ * (np.outer(magnetic_field, spatial_velocity) +
-                         np.outer(spatial_velocity, magnetic_field)) -
-             np.outer(magnetic_field, magnetic_field) / lorentz_factor**2))
+    return (sqrt_det_spatial_metric * (
+        (specific_enthalpy * rest_mass_density * lorentz_factor**2 + bsq_) *
+        np.outer(spatial_velocity, spatial_velocity) +
+        p_star(pressure, b_dot_v_, bsq_, lorentz_factor) * inv_spatial_metric -
+        b_dot_v_ * (np.outer(magnetic_field, spatial_velocity) +
+                    np.outer(spatial_velocity, magnetic_field)) -
+        np.outer(magnetic_field, magnetic_field) / lorentz_factor**2))
 
 
 def vsq(spatial_velocity, spatial_metric):
@@ -48,18 +46,18 @@ def vsq(spatial_velocity, spatial_metric):
 
 
 # Functions for testing Characteristics.cpp
-def characteristic_speeds(lapse, shift, spatial_velocity, spatial_velocity_sqrd,
-                          sound_speed_sqrd, alfven_speed_sqrd, normal_oneform):
+def characteristic_speeds(lapse, shift, spatial_velocity,
+                          spatial_velocity_sqrd, sound_speed_sqrd,
+                          alfven_speed_sqrd, normal_oneform):
     normal_velocity = np.dot(spatial_velocity, normal_oneform)
     normal_shift = np.dot(shift, normal_oneform)
     sound_speed_sqrd += alfven_speed_sqrd * (1.0 - sound_speed_sqrd)
     prefactor = lapse / (1.0 - spatial_velocity_sqrd * sound_speed_sqrd)
     first_term = prefactor * normal_velocity * (1.0 - sound_speed_sqrd)
-    second_term = (prefactor * np.sqrt(sound_speed_sqrd) *
-                   np.sqrt((1.0 - spatial_velocity_sqrd) *
-                           (1.0 - spatial_velocity_sqrd * sound_speed_sqrd
-                            - normal_velocity * normal_velocity *
-                            (1.0 - sound_speed_sqrd))))
+    second_term = (prefactor * np.sqrt(sound_speed_sqrd) * np.sqrt(
+        (1.0 - spatial_velocity_sqrd) *
+        (1.0 - spatial_velocity_sqrd * sound_speed_sqrd -
+         normal_velocity * normal_velocity * (1.0 - sound_speed_sqrd))))
     result = [-lapse - normal_shift]
     result.append(first_term - second_term - normal_shift)
     for i in range(0, spatial_velocity.size + 2):
@@ -75,7 +73,8 @@ def characteristic_speeds(lapse, shift, spatial_velocity, spatial_velocity_sqrd,
 # Functions for testing ConservativeFromPrimitive.cpp
 def tilde_d(rest_mass_density, specific_internal_energy, specific_enthalpy,
             pressure, spatial_velocity, lorentz_factor, magnetic_field,
-            sqrt_det_spatial_metric, spatial_metric, divergence_cleaning_field):
+            sqrt_det_spatial_metric, spatial_metric,
+            divergence_cleaning_field):
     return lorentz_factor * rest_mass_density * sqrt_det_spatial_metric
 
 
@@ -84,30 +83,32 @@ def tilde_tau(rest_mass_density, specific_internal_energy, specific_enthalpy,
               sqrt_det_spatial_metric, spatial_metric,
               divergence_cleaning_field):
     spatial_velocity_squared = vsq(spatial_velocity, spatial_metric)
-    return ((((pressure * spatial_velocity_squared
-             + (lorentz_factor/(1.0 + lorentz_factor) * spatial_velocity_squared
-                + specific_internal_energy) * rest_mass_density)
-               * lorentz_factor**2) +
+    return (((
+        (pressure * spatial_velocity_squared +
+         (lorentz_factor / (1.0 + lorentz_factor) * spatial_velocity_squared +
+          specific_internal_energy) * rest_mass_density) * lorentz_factor**2) +
              0.5 * bsq(magnetic_field, spatial_metric) *
-             (1.0 + spatial_velocity_squared) -
-             0.5 * np.square(b_dot_v(magnetic_field, spatial_velocity,
-               spatial_metric))) * sqrt_det_spatial_metric)
+             (1.0 + spatial_velocity_squared) - 0.5 * np.square(
+                 b_dot_v(magnetic_field, spatial_velocity, spatial_metric))) *
+            sqrt_det_spatial_metric)
 
 
 def tilde_s(rest_mass_density, specific_internal_energy, specific_enthalpy,
             pressure, spatial_velocity, lorentz_factor, magnetic_field,
-            sqrt_det_spatial_metric, spatial_metric, divergence_cleaning_field):
+            sqrt_det_spatial_metric, spatial_metric,
+            divergence_cleaning_field):
     return ((spatial_velocity_one_form(spatial_velocity, spatial_metric) *
-             (lorentz_factor**2 * specific_enthalpy * rest_mass_density + bsq(
-                 magnetic_field, spatial_metric)) -
-             magnetic_field_one_form(magnetic_field, spatial_metric) * b_dot_v(
-                 magnetic_field, spatial_velocity, spatial_metric)) *
+             (lorentz_factor**2 * specific_enthalpy * rest_mass_density +
+              bsq(magnetic_field, spatial_metric)) -
+             magnetic_field_one_form(magnetic_field, spatial_metric) *
+             b_dot_v(magnetic_field, spatial_velocity, spatial_metric)) *
             sqrt_det_spatial_metric)
 
 
 def tilde_b(rest_mass_density, specific_internal_energy, specific_enthalpy,
             pressure, spatial_velocity, lorentz_factor, magnetic_field,
-            sqrt_det_spatial_metric, spatial_metric, divergence_cleaning_field):
+            sqrt_det_spatial_metric, spatial_metric,
+            divergence_cleaning_field):
     return sqrt_det_spatial_metric * magnetic_field
 
 
@@ -133,9 +134,9 @@ def tilde_tau_flux(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, lapse,
                    inv_spatial_metric, pressure, spatial_velocity,
                    lorentz_factor, magnetic_field):
     b_dot_v_ = b_dot_v(magnetic_field, spatial_velocity, spatial_metric)
-    return (sqrt_det_spatial_metric * lapse * p_star(
-        pressure, b_dot_v_, bsq(magnetic_field, spatial_metric),
-        lorentz_factor) * spatial_velocity + tilde_tau *
+    return (sqrt_det_spatial_metric * lapse *
+            p_star(pressure, b_dot_v_, bsq(magnetic_field, spatial_metric),
+                   lorentz_factor) * spatial_velocity + tilde_tau *
             (lapse * spatial_velocity - shift) - lapse * b_dot_v_ * tilde_b)
 
 
@@ -143,14 +144,15 @@ def tilde_s_flux(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, lapse, shift,
                  sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric,
                  pressure, spatial_velocity, lorentz_factor, magnetic_field):
     b_dot_v_ = b_dot_v(magnetic_field, spatial_velocity, spatial_metric)
-    b_i = (magnetic_field_one_form(magnetic_field, spatial_metric)
-           / lorentz_factor + spatial_velocity_one_form(
-               spatial_velocity, spatial_metric) * lorentz_factor * b_dot_v_)
+    b_i = (magnetic_field_one_form(magnetic_field, spatial_metric) /
+           lorentz_factor +
+           spatial_velocity_one_form(spatial_velocity, spatial_metric) *
+           lorentz_factor * b_dot_v_)
     result = np.outer(lapse * spatial_velocity - shift, tilde_s)
     result -= lapse / lorentz_factor * np.outer(tilde_b, b_i)
-    result += (sqrt_det_spatial_metric * lapse * p_star(
-        pressure, b_dot_v_, bsq(magnetic_field, spatial_metric),
-        lorentz_factor) * np.identity(shift.size))
+    result += (sqrt_det_spatial_metric * lapse *
+               p_star(pressure, b_dot_v_, bsq(magnetic_field, spatial_metric),
+                      lorentz_factor) * np.identity(shift.size))
     return result
 
 
@@ -176,39 +178,38 @@ def tilde_phi_flux(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, lapse,
 # Functions for testing Sources.cpp
 def source_tilde_tau(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi,
                      spatial_velocity, magnetic_field, rest_mass_density,
-                     specific_enthalpy, lorentz_factor, pressure,
-                     lapse, d_lapse, d_shift, spatial_metric, d_spatial_metric,
+                     specific_enthalpy, lorentz_factor, pressure, lapse,
+                     d_lapse, d_shift, spatial_metric, d_spatial_metric,
                      inv_spatial_metric, sqrt_det_spatial_metric,
                      extrinsic_curvature, constraint_damping_parameter):
     stress_tensor_ = stress_tensor(spatial_velocity, magnetic_field,
                                    rest_mass_density, specific_enthalpy,
                                    lorentz_factor, pressure, spatial_metric,
                                    inv_spatial_metric, sqrt_det_spatial_metric)
-    return (lapse * np.einsum("ab, ab", stress_tensor_, extrinsic_curvature)
-            - np.einsum("ab, ab", inv_spatial_metric,
-                        np.outer(tilde_s, d_lapse)))
+    return (
+        lapse * np.einsum("ab, ab", stress_tensor_, extrinsic_curvature) -
+        np.einsum("ab, ab", inv_spatial_metric, np.outer(tilde_s, d_lapse)))
 
 
 def source_tilde_s(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi,
                    spatial_velocity, magnetic_field, rest_mass_density,
-                   specific_enthalpy, lorentz_factor, pressure,
-                   lapse, d_lapse, d_shift, spatial_metric, d_spatial_metric,
+                   specific_enthalpy, lorentz_factor, pressure, lapse, d_lapse,
+                   d_shift, spatial_metric, d_spatial_metric,
                    inv_spatial_metric, sqrt_det_spatial_metric,
                    extrinsic_curvature, constraint_damping_parameter):
     stress_tensor_ = stress_tensor(spatial_velocity, magnetic_field,
                                    rest_mass_density, specific_enthalpy,
                                    lorentz_factor, pressure, spatial_metric,
                                    inv_spatial_metric, sqrt_det_spatial_metric)
-    return (0.5 * lapse *
-            np.einsum("ab, iab", stress_tensor_, d_spatial_metric) +
-            np.einsum("a, ia", tilde_s, d_shift) -
-            (tilde_d + tilde_tau) * d_lapse)
+    return (
+        0.5 * lapse * np.einsum("ab, iab", stress_tensor_, d_spatial_metric) +
+        np.einsum("a, ia", tilde_s, d_shift) - (tilde_d + tilde_tau) * d_lapse)
 
 
 def source_tilde_b(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi,
                    spatial_velocity, magnetic_field, rest_mass_density,
-                   specific_enthalpy, lorentz_factor, pressure,
-                   lapse, d_lapse, d_shift, spatial_metric, d_spatial_metric,
+                   specific_enthalpy, lorentz_factor, pressure, lapse, d_lapse,
+                   d_shift, spatial_metric, d_spatial_metric,
                    inv_spatial_metric, sqrt_det_spatial_metric,
                    extrinsic_curvature, constraint_damping_parameter):
     term_one = np.einsum("ab, iab", inv_spatial_metric, d_spatial_metric)
@@ -221,8 +222,8 @@ def source_tilde_b(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi,
 
 def source_tilde_phi(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi,
                      spatial_velocity, magnetic_field, rest_mass_density,
-                     specific_enthalpy, lorentz_factor, pressure,
-                     lapse, d_lapse, d_shift, spatial_metric, d_spatial_metric,
+                     specific_enthalpy, lorentz_factor, pressure, lapse,
+                     d_lapse, d_shift, spatial_metric, d_spatial_metric,
                      inv_spatial_metric, sqrt_det_spatial_metric,
                      extrinsic_curvature, constraint_damping_parameter):
     return (lapse * tilde_phi *

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.py
@@ -11,12 +11,12 @@ def sound_speed(mass_density, pressure):
 
 
 def signal_speed_star(mass_density_int, pressure_int, n_dot_f_mass_density_int,
-                      normal_velocity_int, signal_speed_int,
-                      mass_density_ext, pressure_ext, n_dot_f_mass_density_ext,
+                      normal_velocity_int, signal_speed_int, mass_density_ext,
+                      pressure_ext, n_dot_f_mass_density_ext,
                       normal_velocity_ext, signal_speed_ext):
     return ((pressure_int + n_dot_f_mass_density_int *
-             (normal_velocity_int - signal_speed_int) -
-             pressure_ext - n_dot_f_mass_density_ext *
+             (normal_velocity_int - signal_speed_int) - pressure_ext -
+             n_dot_f_mass_density_ext *
              (normal_velocity_ext - signal_speed_ext)) /
             (n_dot_f_mass_density_int - signal_speed_int * mass_density_int -
              n_dot_f_mass_density_ext + signal_speed_ext * mass_density_ext))
@@ -41,10 +41,9 @@ def apply_flux(n_dot_f_int, u_int, vector_d_int, mass_density_int,
                sound_speed_ext, n_dot_f_mass_density_ext, normal_ext):
     normal_velocity_int = np.dot(velocity_int, normal_int)
     normal_velocity_ext = np.dot(velocity_ext, normal_ext)
-    all_char_speeds = (characteristic_speeds(velocity_int, sound_speed_int,
-                                             normal_int) +
-                       characteristic_speeds(velocity_ext, sound_speed_ext,
-                                             normal_ext))
+    all_char_speeds = (
+        characteristic_speeds(velocity_int, sound_speed_int, normal_int) +
+        characteristic_speeds(velocity_ext, sound_speed_ext, normal_ext))
     c_min = min(all_char_speeds)
     c_max = max(all_char_speeds)
     c_star = signal_speed_star(mass_density_int, pressure_int,
@@ -57,32 +56,37 @@ def apply_flux(n_dot_f_int, u_int, vector_d_int, mass_density_int,
     elif (c_max <= 0.0):
         return n_dot_f_ext
     elif (c_min < 0.0 and c_star >= 0.0):
-        return flux_star(n_dot_f_int, u_int, c_min, vector_d_int, c_star,
-                         pressure_star(mass_density_int, pressure_int,
-                                       normal_velocity_int, c_min, c_star))
-    elif(c_star < 0.0 and c_max > 0.0):
-        return flux_star(n_dot_f_ext, u_ext, c_max, vector_d_ext, c_star,
-                         pressure_star(mass_density_ext, pressure_ext,
-                                       normal_velocity_ext, c_max, c_star))
+        return flux_star(
+            n_dot_f_int, u_int, c_min, vector_d_int, c_star,
+            pressure_star(mass_density_int, pressure_int, normal_velocity_int,
+                          c_min, c_star))
+    elif (c_star < 0.0 and c_max > 0.0):
+        return flux_star(
+            n_dot_f_ext, u_ext, c_max, vector_d_ext, c_star,
+            pressure_star(mass_density_ext, pressure_ext, normal_velocity_ext,
+                          c_max, c_star))
     else:
         raise Error("Signal speeds not valid.")
 
 
 def n_dot_num_f_mass_density(mass_density_int, momentum_density_int,
-                             energy_density_int, pressure_int, mass_density_ext,
-                             momentum_density_ext, energy_density_ext,
-                             pressure_ext, interface_normal):
+                             energy_density_int, pressure_int,
+                             mass_density_ext, momentum_density_ext,
+                             energy_density_ext, pressure_ext,
+                             interface_normal):
     velocity_int = momentum_density_int / mass_density_int
     normal_velocity_int = np.dot(velocity_int, interface_normal)
     velocity_ext = momentum_density_ext / mass_density_ext
     normal_velocity_ext = np.dot(velocity_ext, interface_normal)
     return apply_flux(mass_density_int * normal_velocity_int, mass_density_int,
-                      0.0, mass_density_int, momentum_density_int, velocity_int,
-                      pressure_int, sound_speed(mass_density_int, pressure_int),
+                      0.0, mass_density_int, momentum_density_int,
+                      velocity_int, pressure_int,
+                      sound_speed(mass_density_int, pressure_int),
                       mass_density_int * normal_velocity_int, interface_normal,
                       mass_density_ext * normal_velocity_ext, mass_density_ext,
-                      0.0, mass_density_ext, momentum_density_ext, velocity_ext,
-                      pressure_ext, sound_speed(mass_density_ext, pressure_ext),
+                      0.0, mass_density_ext, momentum_density_ext,
+                      velocity_ext, pressure_ext,
+                      sound_speed(mass_density_ext, pressure_ext),
                       mass_density_ext * normal_velocity_ext, interface_normal)
 
 
@@ -95,18 +99,18 @@ def n_dot_num_f_momentum_density(mass_density_int, momentum_density_int,
     normal_velocity_int = np.dot(velocity_int, interface_normal)
     velocity_ext = momentum_density_ext / mass_density_ext
     normal_velocity_ext = np.dot(velocity_ext, interface_normal)
-    return apply_flux(momentum_density_int * normal_velocity_int +
-                      pressure_int * interface_normal, momentum_density_int,
-                      interface_normal, mass_density_int, momentum_density_int,
-                      velocity_int, pressure_int,
-                      sound_speed(mass_density_int, pressure_int),
-                      mass_density_int * normal_velocity_int, interface_normal,
-                      momentum_density_ext * normal_velocity_ext +
-                      pressure_ext * interface_normal, momentum_density_ext,
-                      interface_normal, mass_density_ext, momentum_density_ext,
-                      velocity_ext, pressure_ext,
-                      sound_speed(mass_density_ext, pressure_ext),
-                      mass_density_ext * normal_velocity_ext, interface_normal)
+    return apply_flux(
+        momentum_density_int * normal_velocity_int +
+        pressure_int * interface_normal, momentum_density_int,
+        interface_normal, mass_density_int,
+        momentum_density_int, velocity_int, pressure_int,
+        sound_speed(mass_density_int,
+                    pressure_int), mass_density_int * normal_velocity_int,
+        interface_normal, momentum_density_ext * normal_velocity_ext +
+        pressure_ext * interface_normal, momentum_density_ext,
+        interface_normal, mass_density_ext, momentum_density_ext, velocity_ext,
+        pressure_ext, sound_speed(mass_density_ext, pressure_ext),
+        mass_density_ext * normal_velocity_ext, interface_normal)
 
 
 def n_dot_num_f_energy_density(mass_density_int, momentum_density_int,
@@ -120,27 +124,24 @@ def n_dot_num_f_energy_density(mass_density_int, momentum_density_int,
     velocity_ext = momentum_density_ext / mass_density_ext
     sound_speed_ext = sound_speed(mass_density_ext, pressure_ext)
     normal_velocity_ext = np.dot(velocity_ext, interface_normal)
-    all_char_speeds = (characteristic_speeds(velocity_int, sound_speed_int,
-                                             interface_normal) +
-                       characteristic_speeds(velocity_ext, sound_speed_ext,
-                                             interface_normal))
+    all_char_speeds = (
+        characteristic_speeds(velocity_int, sound_speed_int,
+                              interface_normal) +
+        characteristic_speeds(velocity_ext, sound_speed_ext, interface_normal))
     c_min = min(all_char_speeds)
     c_max = max(all_char_speeds)
     c_star = signal_speed_star(mass_density_int, pressure_int,
                                mass_density_int * normal_velocity_int,
-                               normal_velocity_int, c_min,
-                               mass_density_ext, pressure_ext,
+                               normal_velocity_int, c_min, mass_density_ext,
+                               pressure_ext,
                                mass_density_ext * normal_velocity_ext,
                                normal_velocity_ext, c_max)
-    return apply_flux((energy_density_int + pressure_int) * normal_velocity_int,
-                      energy_density_int, c_star, mass_density_int,
-                      momentum_density_int, velocity_int, pressure_int,
-                      sound_speed_int, mass_density_int * normal_velocity_int,
-                      interface_normal,
-                      (energy_density_ext + pressure_ext) * normal_velocity_ext,
-                      energy_density_ext, c_star, mass_density_ext,
-                      momentum_density_ext, velocity_ext, pressure_ext,
-                      sound_speed_ext, mass_density_ext * normal_velocity_ext,
-                      interface_normal)
-
-
+    return apply_flux(
+        (energy_density_int + pressure_int) * normal_velocity_int,
+        energy_density_int, c_star, mass_density_int, momentum_density_int,
+        velocity_int, pressure_int, sound_speed_int,
+        mass_density_int * normal_velocity_int, interface_normal,
+        (energy_density_ext + pressure_ext) * normal_velocity_ext,
+        energy_density_ext, c_star, mass_density_ext, momentum_density_ext,
+        velocity_ext, pressure_ext, sound_speed_ext,
+        mass_density_ext * normal_velocity_ext, interface_normal)

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Sources/UniformAcceleration.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Sources/UniformAcceleration.py
@@ -4,11 +4,10 @@
 import numpy as np
 
 
-def source_momentum_density(mass_density, momentum_density, acceleration_field):
+def source_momentum_density(mass_density, momentum_density,
+                            acceleration_field):
     return mass_density * np.array(acceleration_field)
 
 
 def source_energy_density(mass_density, momentum_density, acceleration_field):
     return np.dot(momentum_density, np.array(acceleration_field))
-
-

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Sources/VortexPerturbation.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Sources/VortexPerturbation.py
@@ -11,43 +11,39 @@ from PointwiseFunctions.AnalyticSolutions.NewtonianEuler.IsentropicVortex \
 def source_mass_density_cons(x, t, adiabatic_index, perturbation_amplitude,
                              vortex_center, vortex_mean_velocity,
                              vortex_strength):
-    return (perturbation_amplitude *
-            mass_density(x, t, adiabatic_index, vortex_center,
-                         vortex_mean_velocity, vortex_strength,
-                         perturbation_amplitude) *
+    return (perturbation_amplitude * mass_density(
+        x, t, adiabatic_index, vortex_center, vortex_mean_velocity,
+        vortex_strength, perturbation_amplitude) *
             deriv_of_perturbation_profile(x[2]))
 
 
 def source_momentum_density(x, t, adiabatic_index, perturbation_amplitude,
                             vortex_center, vortex_mean_velocity,
                             vortex_strength):
-    result = (perturbation_amplitude *
-              velocity(x, t, adiabatic_index, vortex_center,
-                       vortex_mean_velocity, vortex_strength,
-                       perturbation_amplitude) *
-              mass_density(x, t, adiabatic_index, vortex_center,
-                           vortex_mean_velocity, vortex_strength,
-                           perturbation_amplitude) *
+    result = (perturbation_amplitude * velocity(
+        x, t, adiabatic_index, vortex_center, vortex_mean_velocity,
+        vortex_strength, perturbation_amplitude) * mass_density(
+            x, t, adiabatic_index, vortex_center, vortex_mean_velocity,
+            vortex_strength, perturbation_amplitude) *
               deriv_of_perturbation_profile(x[2]))
     result[2] *= 2.0
     return result
 
 
 def source_energy_density(x, t, adiabatic_index, perturbation_amplitude,
-                          vortex_center, vortex_mean_velocity, vortex_strength):
+                          vortex_center, vortex_mean_velocity,
+                          vortex_strength):
     dens = mass_density(x, t, adiabatic_index, vortex_center,
                         vortex_mean_velocity, vortex_strength,
                         perturbation_amplitude)
-    veloc = velocity(x, t, adiabatic_index, vortex_center, vortex_mean_velocity,
-                     vortex_strength, perturbation_amplitude)
-    return (perturbation_amplitude *
-            (dens *
-             (0.5 * np.dot(veloc, veloc) +
-              specific_internal_energy(x, t, adiabatic_index, vortex_center,
-                                       vortex_mean_velocity, vortex_strength,
-                                       perturbation_amplitude))
-             + pressure(x, t, adiabatic_index, vortex_center,
-                        vortex_mean_velocity, vortex_strength,
-                        perturbation_amplitude) + dens * (veloc[2])**2) *
-            deriv_of_perturbation_profile(x[2]))
-
+    veloc = velocity(x, t, adiabatic_index, vortex_center,
+                     vortex_mean_velocity, vortex_strength,
+                     perturbation_amplitude)
+    return (
+        perturbation_amplitude *
+        (dens * (0.5 * np.dot(veloc, veloc) + specific_internal_energy(
+            x, t, adiabatic_index, vortex_center, vortex_mean_velocity,
+            vortex_strength, perturbation_amplitude)) +
+         pressure(x, t, adiabatic_index, vortex_center, vortex_mean_velocity,
+                  vortex_strength, perturbation_amplitude) + dens *
+         (veloc[2])**2) * deriv_of_perturbation_profile(x[2]))

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/TestFunctions.py
@@ -35,12 +35,13 @@ def energy_density(mass_density, velocity, specific_internal_energy):
 
 
 # Functions for testing Fluxes.cpp
-def mass_density_cons_flux(momentum_density, energy_density,
-                           velocity, pressure):
+def mass_density_cons_flux(momentum_density, energy_density, velocity,
+                           pressure):
     return momentum_density
 
 
-def momentum_density_flux(momentum_density, energy_density, velocity, pressure):
+def momentum_density_flux(momentum_density, energy_density, velocity,
+                          pressure):
     result = np.outer(momentum_density, velocity)
     result += pressure * np.identity(velocity.size)
     return result
@@ -75,9 +76,8 @@ def pressure_1d(mass_density_cons, momentum_density, energy_density):
 
 # Hard-coded for IdealFluid (representative ThermoDim = 2 case)
 def pressure_2d(mass_density_cons, momentum_density, energy_density):
-    return ((2.0 / 3.0) * mass_density_cons *
-            specific_internal_energy(mass_density_cons, momentum_density,
-                                     energy_density))
+    return ((2.0 / 3.0) * mass_density_cons * specific_internal_energy(
+        mass_density_cons, momentum_density, energy_density))
 
 
 # End functions for testing PrimitiveFromConservative.cpp

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Fluxes.py
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Fluxes.py
@@ -5,19 +5,18 @@ import numpy as np
 
 
 # Functions for testing Fluxes.cpp
-def tilde_e_flux(tilde_e, tilde_s, tilde_p, lapse,
-                   shift, spatial_metric, inv_spatial_metric):
+def tilde_e_flux(tilde_e, tilde_s, tilde_p, lapse, shift, spatial_metric,
+                 inv_spatial_metric):
     result = (lapse * (np.einsum("a, ia", tilde_s, inv_spatial_metric)) -
               shift * tilde_e)
     return result
 
 
-def tilde_s_flux(tilde_e, tilde_s, tilde_p, lapse,
-                 shift, spatial_metric, inv_spatial_metric):
-    result = (lapse * (np.einsum("ia, aj", tilde_p, spatial_metric))-
+def tilde_s_flux(tilde_e, tilde_s, tilde_p, lapse, shift, spatial_metric,
+                 inv_spatial_metric):
+    result = (lapse * (np.einsum("ia, aj", tilde_p, spatial_metric)) -
               np.outer(shift, tilde_s))
     return result
 
 
 # End of functions for testing Fluxes.cpp
-

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Sources.py
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Sources.py
@@ -5,24 +5,19 @@ import numpy as np
 
 
 # Functions for testing Sources.cpp
-def source_tilde_e(tilde_e,tilde_s,tilde_p,lapse,
-                   d_lapse,d_shift,d_spatial_metric,
-                   inv_spatial_metric,extrinsic_curvature):
-    result = (lapse * np.einsum("ab, ab",tilde_p,extrinsic_curvature) -
-              np.einsum("ab, ab", inv_spatial_metric,
-                       np.outer(tilde_s, d_lapse)))
+def source_tilde_e(tilde_e, tilde_s, tilde_p, lapse, d_lapse, d_shift,
+                   d_spatial_metric, inv_spatial_metric, extrinsic_curvature):
+    result = (
+        lapse * np.einsum("ab, ab", tilde_p, extrinsic_curvature) -
+        np.einsum("ab, ab", inv_spatial_metric, np.outer(tilde_s, d_lapse)))
     return result
 
 
-def source_tilde_s(tilde_e,tilde_s,tilde_p,lapse,
-                   d_lapse,d_shift,d_spatial_metric,
-                   inv_spatial_metric,extrinsic_curvature):
-    result = (0.5 * lapse *
-              np.einsum("ab, iab", tilde_p, d_spatial_metric) +
-              np.einsum("a, ia", tilde_s, d_shift) -
-              tilde_e * d_lapse)
+def source_tilde_s(tilde_e, tilde_s, tilde_p, lapse, d_lapse, d_shift,
+                   d_spatial_metric, inv_spatial_metric, extrinsic_curvature):
+    result = (0.5 * lapse * np.einsum("ab, iab", tilde_p, d_spatial_metric) +
+              np.einsum("a, ia", tilde_s, d_shift) - tilde_e * d_lapse)
     return result
 
 
 # End of functions for testing Sources.cpp
-

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/TestFunctions.py
@@ -14,17 +14,17 @@ def spatial_velocity_squared(spatial_velocity, spatial_metric):
 
 
 # Functions for testing Characteristics.cpp
-def characteristic_speeds(lapse, shift, spatial_velocity, spatial_velocity_sqrd,
-                          sound_speed_sqrd, normal_oneform):
+def characteristic_speeds(lapse, shift, spatial_velocity,
+                          spatial_velocity_sqrd, sound_speed_sqrd,
+                          normal_oneform):
     normal_velocity = np.dot(spatial_velocity, normal_oneform)
     normal_shift = np.dot(shift, normal_oneform)
     prefactor = lapse / (1.0 - spatial_velocity_sqrd * sound_speed_sqrd)
     first_term = prefactor * normal_velocity * (1.0 - sound_speed_sqrd)
-    second_term = (prefactor * np.sqrt(sound_speed_sqrd) *
-                   np.sqrt((1.0 - spatial_velocity_sqrd) *
-                           (1.0 - spatial_velocity_sqrd * sound_speed_sqrd
-                            - normal_velocity * normal_velocity *
-                            (1.0 - sound_speed_sqrd))))
+    second_term = (prefactor * np.sqrt(sound_speed_sqrd) * np.sqrt(
+        (1.0 - spatial_velocity_sqrd) *
+        (1.0 - spatial_velocity_sqrd * sound_speed_sqrd -
+         normal_velocity * normal_velocity * (1.0 - sound_speed_sqrd))))
     result = [first_term - second_term - normal_shift]
     for i in range(0, spatial_velocity.size):
         result.append(lapse * normal_velocity - normal_shift)
@@ -37,8 +37,8 @@ def characteristic_speeds(lapse, shift, spatial_velocity, spatial_velocity_sqrd,
 
 # Functions for testing ConservativeFromPrimitive.cpp
 def tilde_d(rest_mass_density, specific_internal_energy, specific_enthalpy,
-            pressure, spatial_velocity, lorentz_factor, sqrt_det_spatial_metric,
-            spatial_metric):
+            pressure, spatial_velocity, lorentz_factor,
+            sqrt_det_spatial_metric, spatial_metric):
     return lorentz_factor * rest_mass_density * sqrt_det_spatial_metric
 
 
@@ -46,18 +46,18 @@ def tilde_tau(rest_mass_density, specific_internal_energy, specific_enthalpy,
               pressure, spatial_velocity, lorentz_factor,
               sqrt_det_spatial_metric, spatial_metric):
     v_squared = spatial_velocity_squared(spatial_velocity, spatial_metric)
-    return ((pressure * v_squared
-             + (lorentz_factor/(1.0 + lorentz_factor) * v_squared
-                + specific_internal_energy) * rest_mass_density)
-            * lorentz_factor**2 * sqrt_det_spatial_metric)
+    return ((pressure * v_squared +
+             (lorentz_factor /
+              (1.0 + lorentz_factor) * v_squared + specific_internal_energy) *
+             rest_mass_density) * lorentz_factor**2 * sqrt_det_spatial_metric)
 
 
 def tilde_s(rest_mass_density, specific_internal_energy, specific_enthalpy,
-            pressure, spatial_velocity, lorentz_factor, sqrt_det_spatial_metric,
-            spatial_metric):
-    return (spatial_velocity_oneform(spatial_velocity, spatial_metric)
-            * lorentz_factor**2 * specific_enthalpy
-            * rest_mass_density * sqrt_det_spatial_metric)
+            pressure, spatial_velocity, lorentz_factor,
+            sqrt_det_spatial_metric, spatial_metric):
+    return (spatial_velocity_oneform(spatial_velocity, spatial_metric) *
+            lorentz_factor**2 * specific_enthalpy * rest_mass_density *
+            sqrt_det_spatial_metric)
 
 
 # End functions for testing ConservativeFromPrimitive.cpp
@@ -69,13 +69,13 @@ def source_tilde_tau(tilde_d, tilde_tau, tilde_s, spatial_velocity, pressure,
                      inv_spatial_metric, sqrt_det_spatial_metric,
                      extrinsic_curvature):
     upper_tilde_s = np.einsum("a, ia", tilde_s, inv_spatial_metric)
-    densitized_stress = (0.5 * np.outer(upper_tilde_s, spatial_velocity)
-                         + 0.5 * np.outer(spatial_velocity, upper_tilde_s)
-                         + sqrt_det_spatial_metric * pressure
-                         * inv_spatial_metric)
-    return (lapse * np.einsum("ab, ab", densitized_stress, extrinsic_curvature)
-            - np.einsum("ab, ab", inv_spatial_metric,
-                        np.outer(tilde_s, d_lapse)))
+    densitized_stress = (
+        0.5 * np.outer(upper_tilde_s, spatial_velocity) +
+        0.5 * np.outer(spatial_velocity, upper_tilde_s) +
+        sqrt_det_spatial_metric * pressure * inv_spatial_metric)
+    return (
+        lapse * np.einsum("ab, ab", densitized_stress, extrinsic_curvature) -
+        np.einsum("ab, ab", inv_spatial_metric, np.outer(tilde_s, d_lapse)))
 
 
 def source_tilde_s(tilde_d, tilde_tau, tilde_s, spatial_velocity, pressure,
@@ -83,13 +83,12 @@ def source_tilde_s(tilde_d, tilde_tau, tilde_s, spatial_velocity, pressure,
                    inv_spatial_metric, sqrt_det_spatial_metric,
                    extrinsic_curvature):
     upper_tilde_s = np.einsum("a, ia", tilde_s, inv_spatial_metric)
-    densitized_stress = (np.outer(upper_tilde_s, spatial_velocity)
-                         + sqrt_det_spatial_metric * pressure
-                         * inv_spatial_metric)
-    return (np.einsum("a, ia", tilde_s, d_shift)
-            - d_lapse * (tilde_tau + tilde_d)
-            + 0.5 * lapse * np.einsum("ab, iab", densitized_stress,
-                                      d_spatial_metric))
+    densitized_stress = (
+        np.outer(upper_tilde_s, spatial_velocity) +
+        sqrt_det_spatial_metric * pressure * inv_spatial_metric)
+    return (np.einsum("a, ia", tilde_s, d_shift) - d_lapse *
+            (tilde_tau + tilde_d) + 0.5 * lapse *
+            np.einsum("ab, iab", densitized_stress, d_spatial_metric))
 
 
 # End functions for testing Sources.cpp
@@ -103,15 +102,15 @@ def tilde_d_flux(tilde_d, tilde_tau, tilde_s, lapse, shift,
 
 def tilde_tau_flux(tilde_d, tilde_tau, tilde_s, lapse, shift,
                    sqrt_det_spatial_metric, pressure, spatial_velocity):
-    return (sqrt_det_spatial_metric * lapse * pressure * spatial_velocity
-            + tilde_tau * (lapse * spatial_velocity - shift))
+    return (sqrt_det_spatial_metric * lapse * pressure * spatial_velocity +
+            tilde_tau * (lapse * spatial_velocity - shift))
 
 
 def tilde_s_flux(tilde_d, tilde_tau, tilde_s, lapse, shift,
                  sqrt_det_spatial_metric, pressure, spatial_velocity):
     result = np.outer(lapse * spatial_velocity - shift, tilde_s)
-    result += (sqrt_det_spatial_metric * lapse * pressure
-               * np.identity(shift.size))
+    result += (sqrt_det_spatial_metric * lapse * pressure *
+               np.identity(shift.size))
     return result
 
 

--- a/tests/Unit/Evolution/Systems/ScalarWave/Characteristics.py
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Characteristics.py
@@ -20,6 +20,7 @@ def char_speed_vplus(unit_normal):
 def char_speed_vminus(unit_normal):
     return -1.
 
+
 # End test functions for characteristic speeds
 
 
@@ -46,7 +47,9 @@ def char_field_vminus(gamma2, psi, pi, phi, normal_one_form):
     phi_dot_normal = np.einsum('i,i->', normal_vector, phi)
     return pi - phi_dot_normal - (gamma2 * psi)
 
+
 # End test functions for characteristic fields
+
 
 # Test functions for evolved fields
 def evol_field_psi(gamma2, vpsi, vzero, vplus, vminus, normal_one_form):
@@ -59,5 +62,6 @@ def evol_field_pi(gamma2, vpsi, vzero, vplus, vminus, normal_one_form):
 
 def evol_field_phi(gamma2, vpsi, vzero, vplus, vminus, normal_one_form):
     return 0.5 * (vplus - vminus) * normal_one_form + vzero
+
 
 # End test functions for evolved fields

--- a/tests/Unit/Evolution/Systems/ScalarWave/PenaltyFlux.py
+++ b/tests/Unit/Evolution/Systems/ScalarWave/PenaltyFlux.py
@@ -6,23 +6,28 @@ import numpy as np
 # Functions for testing PenaltyFlux.hpp
 penalty_factor = 1.0
 
-def pi_penalty_flux(n_dot_flux_pi_int, n_dot_flux_phi_int,
-                    v_plus_int, v_minus_int, unit_normal_int,
-                    minus_n_dot_flux_pi_ext, minus_n_dot_flux_phi_ext,
-                    v_plus_ext, v_minus_ext, unit_normal_ext):
-    return n_dot_flux_pi_int + 0.5 * penalty_factor * (v_minus_int - v_plus_ext)
 
-def phi_penalty_flux(n_dot_flux_pi_int, n_dot_flux_phi_int,
-                    v_plus_int, v_minus_int, unit_normal_int,
-                    minus_n_dot_flux_pi_ext, minus_n_dot_flux_phi_ext,
-                    v_plus_ext, v_minus_ext, unit_normal_ext):
+def pi_penalty_flux(n_dot_flux_pi_int, n_dot_flux_phi_int, v_plus_int,
+                    v_minus_int, unit_normal_int, minus_n_dot_flux_pi_ext,
+                    minus_n_dot_flux_phi_ext, v_plus_ext, v_minus_ext,
+                    unit_normal_ext):
+    return n_dot_flux_pi_int + 0.5 * penalty_factor * (v_minus_int -
+                                                       v_plus_ext)
+
+
+def phi_penalty_flux(n_dot_flux_pi_int, n_dot_flux_phi_int, v_plus_int,
+                     v_minus_int, unit_normal_int, minus_n_dot_flux_pi_ext,
+                     minus_n_dot_flux_phi_ext, v_plus_ext, v_minus_ext,
+                     unit_normal_ext):
     return n_dot_flux_phi_int - 0.5 * penalty_factor * (\
         unit_normal_int * v_minus_int + unit_normal_ext * v_plus_ext)
 
-def psi_penalty_flux(n_dot_flux_pi_int, n_dot_flux_phi_int,
-                    v_plus_int, v_minus_int, unit_normal_int,
-                    minus_n_dot_flux_pi_ext, minus_n_dot_flux_phi_ext,
-                    v_plus_ext, v_minus_ext, unit_normal_ext):
+
+def psi_penalty_flux(n_dot_flux_pi_int, n_dot_flux_phi_int, v_plus_int,
+                     v_minus_int, unit_normal_int, minus_n_dot_flux_pi_ext,
+                     minus_n_dot_flux_phi_ext, v_plus_ext, v_minus_ext,
+                     unit_normal_ext):
     return n_dot_flux_pi_int * 0
+
 
 # End functions for testing PenaltyFlux.hpp

--- a/tests/Unit/IO/Test_H5.py
+++ b/tests/Unit/IO/Test_H5.py
@@ -26,27 +26,29 @@ class TestIOH5File(unittest.TestCase):
 
     # Test whether an H5 file is created correctly,
     def test_name(self):
-        file_spec = spectre_h5.H5File(
-            file_name=self.file_name, append_to_file=True)
+        file_spec = spectre_h5.H5File(file_name=self.file_name,
+                                      append_to_file=True)
         self.assertEqual(self.file_name, file_spec.name())
         file_spec.close()
 
     # Test whether a dat file can be added correctly
     def test_insert_dat(self):
-        file_spec = spectre_h5.H5File(
-            file_name=self.file_name, append_to_file=True)
-        file_spec.insert_dat(
-            path="/element_data", legend=["Time", "Value"], version=0)
+        file_spec = spectre_h5.H5File(file_name=self.file_name,
+                                      append_to_file=True)
+        file_spec.insert_dat(path="/element_data",
+                             legend=["Time", "Value"],
+                             version=0)
         datfile = file_spec.get_dat(path="/element_data")
         self.assertEqual(datfile.get_version(), 0)
         file_spec.close()
 
     # Test whether data can be added to the dat file correctly
     def test_append(self):
-        file_spec = spectre_h5.H5File(
-            file_name=self.file_name, append_to_file=True)
-        file_spec.insert_dat(
-            path="/element_data", legend=["Time", "Value"], version=0)
+        file_spec = spectre_h5.H5File(file_name=self.file_name,
+                                      append_to_file=True)
+        file_spec.insert_dat(path="/element_data",
+                             legend=["Time", "Value"],
+                             version=0)
         datfile = file_spec.get_dat(path="/element_data")
         datfile.append(self.data_1)
         outdata_array = np.asarray(datfile.get_data())
@@ -55,26 +57,29 @@ class TestIOH5File(unittest.TestCase):
 
     # More complicated test case for getting data subsets and dimensions
     def test_get_data_subset(self):
-        file_spec = spectre_h5.H5File(
-            file_name=self.file_name, append_to_file=True)
-        file_spec.insert_dat(
-            path="/element_data", legend=["Time", "Value"], version=0)
+        file_spec = spectre_h5.H5File(file_name=self.file_name,
+                                      append_to_file=True)
+        file_spec.insert_dat(path="/element_data",
+                             legend=["Time", "Value"],
+                             version=0)
         datfile = file_spec.get_dat(path="/element_data")
         datfile.append(self.data_1)
         datfile.append(self.data_2)
-        outdata_array = datfile.get_data_subset(
-            columns=[1], first_row=0, num_rows=2)
-        npt.assert_array_equal(outdata_array,  np.array(
-            [self.data_1[1:2], self.data_2[1:2]]))
+        outdata_array = datfile.get_data_subset(columns=[1],
+                                                first_row=0,
+                                                num_rows=2)
+        npt.assert_array_equal(outdata_array,
+                               np.array([self.data_1[1:2], self.data_2[1:2]]))
         self.assertEqual(datfile.get_dimensions()[0], 2)
         file_spec.close()
 
     # Getting Attributes
     def test_get_legend(self):
-        file_spec = spectre_h5.H5File(
-            file_name=self.file_name, append_to_file=True)
-        file_spec.insert_dat(
-            path="/element_data", legend=["Time", "Value"], version=0)
+        file_spec = spectre_h5.H5File(file_name=self.file_name,
+                                      append_to_file=True)
+        file_spec.insert_dat(path="/element_data",
+                             legend=["Time", "Value"],
+                             version=0)
         datfile = file_spec.get_dat(path="/element_data")
         self.assertEqual(datfile.get_legend(), ["Time", "Value"])
         self.assertEqual(datfile.get_version(), 0)
@@ -82,25 +87,31 @@ class TestIOH5File(unittest.TestCase):
 
     # The header is not universal, just checking the part that is predictable
     def test_get_header(self):
-        file_spec = spectre_h5.H5File(
-            file_name=self.file_name, append_to_file=True)
-        file_spec.insert_dat(
-            path="/element_data", legend=["Time", "Value"], version=0)
+        file_spec = spectre_h5.H5File(file_name=self.file_name,
+                                      append_to_file=True)
+        file_spec.insert_dat(path="/element_data",
+                             legend=["Time", "Value"],
+                             version=0)
         datfile = file_spec.get_dat(path="/element_data")
         self.assertEqual(datfile.get_header()[0:16], "#\n# File created")
         file_spec.close()
 
     def test_groups(self):
-        file_spec = spectre_h5.H5File(
-            file_name=self.file_name, append_to_file=True)
-        file_spec.insert_dat(
-            path="/element_data", legend=["Time", "Value"], version=0)
-        file_spec.insert_dat(
-            path="/element_position", legend=["x", "y", "z"], version=0)
-        file_spec.insert_dat(
-            path="/element_size", legend=["Time", "Size"], version=0)
-        groups_spec = ["element_data.dat", "element_position.dat",
-                       "element_size.dat", "src.tar.gz"]
+        file_spec = spectre_h5.H5File(file_name=self.file_name,
+                                      append_to_file=True)
+        file_spec.insert_dat(path="/element_data",
+                             legend=["Time", "Value"],
+                             version=0)
+        file_spec.insert_dat(path="/element_position",
+                             legend=["x", "y", "z"],
+                             version=0)
+        file_spec.insert_dat(path="/element_size",
+                             legend=["Time", "Size"],
+                             version=0)
+        groups_spec = [
+            "element_data.dat", "element_position.dat", "element_size.dat",
+            "src.tar.gz"
+        ]
         for group_name in groups_spec:
             self.assertTrue(group_name in file_spec.groups())
         file_spec.close()

--- a/tests/Unit/IO/Test_VolumeData.py
+++ b/tests/Unit/IO/Test_VolumeData.py
@@ -9,6 +9,7 @@ import numpy as np
 import os
 import numpy.testing as npt
 
+
 class TestIOH5VolumeData(unittest.TestCase):
     # Test Fixtures
     def setUp(self):
@@ -32,8 +33,8 @@ class TestIOH5VolumeData(unittest.TestCase):
 
     # Testing the VolumeData Insert Function
     def test_insert_vol(self):
-        h5_file = spectre_h5.H5File(
-            file_name=self.file_name_w, append_to_file=True)
+        h5_file = spectre_h5.H5File(file_name=self.file_name_w,
+                                    append_to_file=True)
         h5_file.insert_vol(path="/element_data", version=0)
         vol_file = h5_file.get_vol(path="/element_data")
         self.assertEqual(vol_file.get_version(), 0)
@@ -41,8 +42,8 @@ class TestIOH5VolumeData(unittest.TestCase):
 
     # Test the header was generated correctly
     def test_vol_get_header(self):
-        h5_file = spectre_h5.H5File(
-            file_name=self.file_name_w, append_to_file=True)
+        h5_file = spectre_h5.H5File(file_name=self.file_name_w,
+                                    append_to_file=True)
         h5_file.insert_vol(path="/element_data", version=0)
         vol_file = h5_file.get_vol(path="/element_data")
         self.assertEqual(vol_file.get_header()[0:20], "#\n# File created on ")
@@ -52,13 +53,15 @@ class TestIOH5VolumeData(unittest.TestCase):
     # `VolTestData.h5` which contains spectre output data (see above).
     # Test the observation ids and values are correctly retrived
     def test_observation_id(self):
-        h5_file = spectre_h5.H5File(
-            file_name=self.file_name_r, append_to_file=True)
+        h5_file = spectre_h5.H5File(file_name=self.file_name_r,
+                                    append_to_file=True)
         vol_file = h5_file.get_vol(path="/element_data")
         obs_ids = set(vol_file.list_observation_ids())
         expected_obs_ids = set([16436106908031328247, 17615288952477351885])
-        expected_obs_values = {16436106908031328247: 0.01,
-                               17615288952477351885: 0.00}
+        expected_obs_values = {
+            16436106908031328247: 0.01,
+            17615288952477351885: 0.00
+        }
         self.assertEqual(obs_ids, expected_obs_ids)
         for obs_id in expected_obs_ids:
             self.assertEqual(
@@ -68,23 +71,22 @@ class TestIOH5VolumeData(unittest.TestCase):
 
     # Test to make sure information about the computation elements was found
     def test_grids(self):
-        h5_file = spectre_h5.H5File(
-            file_name=self.file_name_r, append_to_file=True)
+        h5_file = spectre_h5.H5File(file_name=self.file_name_r,
+                                    append_to_file=True)
         vol_file = h5_file.get_vol("/element_data")
         obs_id = vol_file.list_observation_ids()[0]
         grid_names = vol_file.get_grid_names(observation_id=obs_id)
-        expected_grid_names  = ['[B0,(L0I0,L0I0,L0I0)]']
+        expected_grid_names = ['[B0,(L0I0,L0I0,L0I0)]']
         self.assertEqual(grid_names, expected_grid_names)
         extents = vol_file.get_extents(observation_id=obs_id)
         expected_extents = [[2, 2, 2]]
         self.assertEqual(extents, expected_extents)
         h5_file.close()
 
-
     # Test that the tensor components, and tensor data  are retrieved correctly
     def test_tensor_components(self):
-        h5_file = spectre_h5.H5File(
-            file_name=self.file_name_r, append_to_file=True)
+        h5_file = spectre_h5.H5File(file_name=self.file_name_r,
+                                    append_to_file=True)
         vol_file = h5_file.get_vol(path="/element_data")
         obs_id = vol_file.list_observation_ids()[0]
         tensor_comps = set(
@@ -94,62 +96,57 @@ class TestIOH5VolumeData(unittest.TestCase):
             'InertialCoordinates_y', 'InertialCoordinates_z'
         ])
         self.assertEqual(tensor_comps, expected_tensor_comps)
-        expected_Psi_tensor_data = np.array([-0.0173205080756888,
-                                             -0.0173205080756888,
-                                             -0.0173205080756888,
-                                             -0.0173205080756888,
-                                             -0.0173205080756888,
-                                             -0.0173205080756888,
-                                             -0.0173205080756888,
-                                             -0.0173205080756888
-                                         ])
-        expected_Error_tensor_data = np.array([-8.66012413502926e-07,
-                                               -8.66012413502926e-07,
-                                               -8.66012413502926e-07,
-                                               -8.66012413502926e-07,
-                                               -8.66012413502926e-07,
-                                               -8.66012413502926e-07,
-                                               -8.66012413502926e-07,
-                                               -8.66012413502926e-07
-                                           ])
-        expected_xcoord_tensor_data = np.array([0.0, 6.28318530717959,
-                                                0.0, 6.28318530717959,
-                                                0.0, 6.28318530717959,
-                                                0.0, 6.28318530717959
-                                            ])
-        expected_ycoord_tensor_data = np.array([0.0, 0.0,
-                                                6.28318530717959,
-                                                6.28318530717959,
-                                                0.0, 0.0,
-                                                6.28318530717959,
-                                                6.28318530717959
-                                            ])
-        expected_zcoord_tensor_data = np.array([0.0, 0.0, 0.0, 0.0,
-                                                 6.28318530717959,
-                                                 6.28318530717959,
-                                                 6.28318530717959,
-                                                 6.28318530717959
-                                            ])
+        expected_Psi_tensor_data = np.array([
+            -0.0173205080756888, -0.0173205080756888, -0.0173205080756888,
+            -0.0173205080756888, -0.0173205080756888, -0.0173205080756888,
+            -0.0173205080756888, -0.0173205080756888
+        ])
+        expected_Error_tensor_data = np.array([
+            -8.66012413502926e-07, -8.66012413502926e-07,
+            -8.66012413502926e-07, -8.66012413502926e-07,
+            -8.66012413502926e-07, -8.66012413502926e-07,
+            -8.66012413502926e-07, -8.66012413502926e-07
+        ])
+        expected_xcoord_tensor_data = np.array([
+            0.0, 6.28318530717959, 0.0, 6.28318530717959, 0.0,
+            6.28318530717959, 0.0, 6.28318530717959
+        ])
+        expected_ycoord_tensor_data = np.array([
+            0.0, 0.0, 6.28318530717959, 6.28318530717959, 0.0, 0.0,
+            6.28318530717959, 6.28318530717959
+        ])
+        expected_zcoord_tensor_data = np.array([
+            0.0, 0.0, 0.0, 0.0, 6.28318530717959, 6.28318530717959,
+            6.28318530717959, 6.28318530717959
+        ])
         # Checking whether two numpy arrays are "almost equal" is easy, so
         # we convert everything to numpy arrays for comparison.
-        Psi_tensor_data = np.asarray(vol_file.get_tensor_component(
-            observation_id=obs_id, tensor_component='Psi'))
+        Psi_tensor_data = np.asarray(
+            vol_file.get_tensor_component(observation_id=obs_id,
+                                          tensor_component='Psi'))
         npt.assert_array_almost_equal(Psi_tensor_data,
                                       expected_Psi_tensor_data)
-        Error_tensor_data = np.asarray(vol_file.get_tensor_component(
-            observation_id=obs_id, tensor_component='Error(Psi)'))
+        Error_tensor_data = np.asarray(
+            vol_file.get_tensor_component(observation_id=obs_id,
+                                          tensor_component='Error(Psi)'))
         npt.assert_array_almost_equal(Error_tensor_data,
                                       expected_Error_tensor_data)
-        xcoord_tensor_data = np.asarray(vol_file.get_tensor_component(
-            observation_id=obs_id, tensor_component='InertialCoordinates_x'))
+        xcoord_tensor_data = np.asarray(
+            vol_file.get_tensor_component(
+                observation_id=obs_id,
+                tensor_component='InertialCoordinates_x'))
         npt.assert_array_almost_equal(xcoord_tensor_data,
                                       expected_xcoord_tensor_data)
-        ycoord_tensor_data = np.asarray(vol_file.get_tensor_component(
-            observation_id=obs_id, tensor_component='InertialCoordinates_y'))
+        ycoord_tensor_data = np.asarray(
+            vol_file.get_tensor_component(
+                observation_id=obs_id,
+                tensor_component='InertialCoordinates_y'))
         npt.assert_array_almost_equal(ycoord_tensor_data,
                                       expected_ycoord_tensor_data)
-        zcoord_tensor_data = np.asarray(vol_file.get_tensor_component(
-            observation_id=obs_id, tensor_component='InertialCoordinates_z'))
+        zcoord_tensor_data = np.asarray(
+            vol_file.get_tensor_component(
+                observation_id=obs_id,
+                tensor_component='InertialCoordinates_z'))
         npt.assert_array_almost_equal(zcoord_tensor_data,
                                       expected_zcoord_tensor_data)
         h5_file.close()

--- a/tests/Unit/Informer/Test_InfoAtCompile.py
+++ b/tests/Unit/Informer/Test_InfoAtCompile.py
@@ -11,6 +11,7 @@ class TestInformer(unittest.TestCase):
             str(Info.spectre_minor_version()) + "." + \
             str(Info.spectre_patch_version())
         self.assertEqual(num_ver, Info.spectre_version())
+
     # The unit test path is unpredictable, but the last 12 characters must be
     # '/tests/Unit/'
     def test_unit_test_path(self):

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestFunctions.py
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestFunctions.py
@@ -5,27 +5,30 @@ import numpy as np
 
 
 def characteristic_speeds(var_1, var_2, var_3):
-    return [np.cos(i) * var_1 - (1.0 - np.sin(i)) * np.dot(var_2, var_3)
-            for i in range((var_2.size + 1) * (var_2.size + 1))]
+    return [
+        np.cos(i) * var_1 - (1.0 - np.sin(i)) * np.dot(var_2, var_3)
+        for i in range((var_2.size + 1) * (var_2.size + 1))
+    ]
 
 
 # Functions for testing Hll.hpp
-def hll_flux(ndotf_int, minus_ndotf_ext, var_int, var_ext,
-             min_signal_speed, max_signal_speed):
-    return ((max_signal_speed * ndotf_int + min_signal_speed * minus_ndotf_ext
-             - max_signal_speed * min_signal_speed * (var_int - var_ext)) /
-            (max_signal_speed - min_signal_speed))
+def hll_flux(ndotf_int, minus_ndotf_ext, var_int, var_ext, min_signal_speed,
+             max_signal_speed):
+    return (
+        (max_signal_speed * ndotf_int + min_signal_speed * minus_ndotf_ext -
+         max_signal_speed * min_signal_speed * (var_int - var_ext)) /
+        (max_signal_speed - min_signal_speed))
 
 
 def apply_var_1_hll_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
                          var_1_int, var_2_int, var_3_int, var_4_int,
                          minus_ndotf_1_ext, minus_ndotf_2_ext,
-                         minus_ndotf_3_ext, minus_ndotf_4_ext,
-                         var_1_ext, var_2_ext, var_3_ext, var_4_ext):
-    char_speeds = (characteristic_speeds(var_1_int, var_2_int, var_3_int) +
-                   [-c for c in
-                    characteristic_speeds(var_1_ext, var_2_ext, var_3_ext)] +
-                   [0.0])
+                         minus_ndotf_3_ext, minus_ndotf_4_ext, var_1_ext,
+                         var_2_ext, var_3_ext, var_4_ext):
+    char_speeds = (
+        characteristic_speeds(var_1_int, var_2_int, var_3_int) +
+        [-c for c in characteristic_speeds(var_1_ext, var_2_ext, var_3_ext)] +
+        [0.0])
     return hll_flux(ndotf_1_int, minus_ndotf_1_ext, var_1_int, var_1_ext,
                     min(char_speeds), max(char_speeds))
 
@@ -33,12 +36,12 @@ def apply_var_1_hll_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
 def apply_var_2_hll_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
                          var_1_int, var_2_int, var_3_int, var_4_int,
                          minus_ndotf_1_ext, minus_ndotf_2_ext,
-                         minus_ndotf_3_ext, minus_ndotf_4_ext,
-                         var_1_ext, var_2_ext, var_3_ext, var_4_ext):
-    char_speeds = (characteristic_speeds(var_1_int, var_2_int, var_3_int) +
-                   [-c for c in
-                    characteristic_speeds(var_1_ext, var_2_ext, var_3_ext)] +
-                   [0.0])
+                         minus_ndotf_3_ext, minus_ndotf_4_ext, var_1_ext,
+                         var_2_ext, var_3_ext, var_4_ext):
+    char_speeds = (
+        characteristic_speeds(var_1_int, var_2_int, var_3_int) +
+        [-c for c in characteristic_speeds(var_1_ext, var_2_ext, var_3_ext)] +
+        [0.0])
     return hll_flux(ndotf_2_int, minus_ndotf_2_ext, var_2_int, var_2_ext,
                     min(char_speeds), max(char_speeds))
 
@@ -46,12 +49,12 @@ def apply_var_2_hll_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
 def apply_var_3_hll_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
                          var_1_int, var_2_int, var_3_int, var_4_int,
                          minus_ndotf_1_ext, minus_ndotf_2_ext,
-                         minus_ndotf_3_ext, minus_ndotf_4_ext,
-                         var_1_ext, var_2_ext, var_3_ext, var_4_ext):
-    char_speeds = (characteristic_speeds(var_1_int, var_2_int, var_3_int) +
-                   [-c for c in
-                    characteristic_speeds(var_1_ext, var_2_ext, var_3_ext)] +
-                   [0.0])
+                         minus_ndotf_3_ext, minus_ndotf_4_ext, var_1_ext,
+                         var_2_ext, var_3_ext, var_4_ext):
+    char_speeds = (
+        characteristic_speeds(var_1_int, var_2_int, var_3_int) +
+        [-c for c in characteristic_speeds(var_1_ext, var_2_ext, var_3_ext)] +
+        [0.0])
     return hll_flux(ndotf_3_int, minus_ndotf_3_ext, var_3_int, var_3_ext,
                     min(char_speeds), max(char_speeds))
 
@@ -59,12 +62,12 @@ def apply_var_3_hll_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
 def apply_var_4_hll_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
                          var_1_int, var_2_int, var_3_int, var_4_int,
                          minus_ndotf_1_ext, minus_ndotf_2_ext,
-                         minus_ndotf_3_ext, minus_ndotf_4_ext,
-                         var_1_ext, var_2_ext, var_3_ext, var_4_ext):
-    char_speeds = (characteristic_speeds(var_1_int, var_2_int, var_3_int) +
-                   [-c for c in
-                    characteristic_speeds(var_1_ext, var_2_ext, var_3_ext)] +
-                   [0.0])
+                         minus_ndotf_3_ext, minus_ndotf_4_ext, var_1_ext,
+                         var_2_ext, var_3_ext, var_4_ext):
+    char_speeds = (
+        characteristic_speeds(var_1_int, var_2_int, var_3_int) +
+        [-c for c in characteristic_speeds(var_1_ext, var_2_ext, var_3_ext)] +
+        [0.0])
     return hll_flux(ndotf_4_int, minus_ndotf_4_ext, var_4_int, var_4_ext,
                     min(char_speeds), max(char_speeds))
 
@@ -78,47 +81,52 @@ def max_abs_speed(var_1, var_2, var_3):
 
 
 def llf_flux(ndotf_int, minus_ndotf_ext, var_int, var_ext, max_speed):
-    return 0.5 * (ndotf_int - minus_ndotf_ext + max_speed * (var_int - var_ext))
+    return 0.5 * (ndotf_int - minus_ndotf_ext + max_speed *
+                  (var_int - var_ext))
 
 
 def apply_var_1_llf_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
                          var_1_int, var_2_int, var_3_int, var_4_int,
                          minus_ndotf_1_ext, minus_ndotf_2_ext,
-                         minus_ndotf_3_ext, minus_ndotf_4_ext,
-                         var_1_ext, var_2_ext, var_3_ext, var_4_ext):
-    return llf_flux(ndotf_1_int, minus_ndotf_1_ext, var_1_int, var_1_ext,
-                    max(max_abs_speed(var_1_int, var_2_int, var_3_int),
-                        max_abs_speed(var_1_ext, var_2_ext, var_3_ext)))
+                         minus_ndotf_3_ext, minus_ndotf_4_ext, var_1_ext,
+                         var_2_ext, var_3_ext, var_4_ext):
+    return llf_flux(
+        ndotf_1_int, minus_ndotf_1_ext, var_1_int, var_1_ext,
+        max(max_abs_speed(var_1_int, var_2_int, var_3_int),
+            max_abs_speed(var_1_ext, var_2_ext, var_3_ext)))
 
 
 def apply_var_2_llf_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
                          var_1_int, var_2_int, var_3_int, var_4_int,
                          minus_ndotf_1_ext, minus_ndotf_2_ext,
-                         minus_ndotf_3_ext, minus_ndotf_4_ext,
-                         var_1_ext, var_2_ext, var_3_ext, var_4_ext):
-    return llf_flux(ndotf_2_int, minus_ndotf_2_ext, var_2_int, var_2_ext,
-                    max(max_abs_speed(var_1_int, var_2_int, var_3_int),
-                        max_abs_speed(var_1_ext, var_2_ext, var_3_ext)))
+                         minus_ndotf_3_ext, minus_ndotf_4_ext, var_1_ext,
+                         var_2_ext, var_3_ext, var_4_ext):
+    return llf_flux(
+        ndotf_2_int, minus_ndotf_2_ext, var_2_int, var_2_ext,
+        max(max_abs_speed(var_1_int, var_2_int, var_3_int),
+            max_abs_speed(var_1_ext, var_2_ext, var_3_ext)))
 
 
 def apply_var_3_llf_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
                          var_1_int, var_2_int, var_3_int, var_4_int,
                          minus_ndotf_1_ext, minus_ndotf_2_ext,
-                         minus_ndotf_3_ext, minus_ndotf_4_ext,
-                         var_1_ext, var_2_ext, var_3_ext, var_4_ext):
-    return llf_flux(ndotf_3_int, minus_ndotf_3_ext, var_3_int, var_3_ext,
-                    max(max_abs_speed(var_1_int, var_2_int, var_3_int),
-                        max_abs_speed(var_1_ext, var_2_ext, var_3_ext)))
+                         minus_ndotf_3_ext, minus_ndotf_4_ext, var_1_ext,
+                         var_2_ext, var_3_ext, var_4_ext):
+    return llf_flux(
+        ndotf_3_int, minus_ndotf_3_ext, var_3_int, var_3_ext,
+        max(max_abs_speed(var_1_int, var_2_int, var_3_int),
+            max_abs_speed(var_1_ext, var_2_ext, var_3_ext)))
 
 
 def apply_var_4_llf_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
                          var_1_int, var_2_int, var_3_int, var_4_int,
                          minus_ndotf_1_ext, minus_ndotf_2_ext,
-                         minus_ndotf_3_ext, minus_ndotf_4_ext,
-                         var_1_ext, var_2_ext, var_3_ext, var_4_ext):
-    return llf_flux(ndotf_4_int, minus_ndotf_4_ext, var_4_int, var_4_ext,
-                    max(max_abs_speed(var_1_int, var_2_int, var_3_int),
-                        max_abs_speed(var_1_ext, var_2_ext, var_3_ext)))
+                         minus_ndotf_3_ext, minus_ndotf_4_ext, var_1_ext,
+                         var_2_ext, var_3_ext, var_4_ext):
+    return llf_flux(
+        ndotf_4_int, minus_ndotf_4_ext, var_4_int, var_4_ext,
+        max(max_abs_speed(var_1_int, var_2_int, var_3_int),
+            max_abs_speed(var_1_ext, var_2_ext, var_3_ext)))
 
 
 # End functions for testing LocalLaxFriedrichs.hpp

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.py
@@ -24,8 +24,7 @@ def spatial_velocity(x, bh_mass, bh_dimless_spin, rest_mass_density,
     sigma = r_squared + a_squared * cos_theta_squared
 
     result[0] = (flow_speed * cos_theta /
-                 np.sqrt(1.0 + 2.0 * bh_mass * np.sqrt(r_squared) /
-                         sigma))
+                 np.sqrt(1.0 + 2.0 * bh_mass * np.sqrt(r_squared) / sigma))
     result[1] = - flow_speed * \
         np.sqrt(1.0 - cos_theta_squared) / np.sqrt(sigma)
 
@@ -61,13 +60,12 @@ def magnetic_field(x, bh_mass, bh_dimless_spin, rest_mass_density, flow_speed,
     result[0:] = mag_field_strength / np.sqrt(sigma * (sigma + two_m_r))
     result[0] *= (r_squared - two_m_r + a_squared + two_m_r *
                   (r_squared**2 - a_squared**2) / sigma**2) * cos_theta
-    result[1] *= -((np.sqrt(r_squared) +
-                    bh_mass * a_squared *
+    result[1] *= -((np.sqrt(r_squared) + bh_mass * a_squared *
                     (r_squared - a_squared * cos_theta_squared) *
                     (1.0 + cos_theta_squared) / sigma**2) *
                    np.sqrt(1.0 - cos_theta_squared))
-    result[2] *= spin_a * (1.0 + two_m_r * (r_squared - a_squared) /
-                           sigma**2) * cos_theta
+    result[2] *= spin_a * (1.0 + two_m_r *
+                           (r_squared - a_squared) / sigma**2) * cos_theta
     return ks_coords.cartesian_from_spherical_ks(result, x, bh_mass,
                                                  bh_dimless_spin)
 

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.py
@@ -34,10 +34,9 @@ def spatial_velocity(x, inner_radius, outer_radius, inner_density,
 def specific_internal_energy(x, inner_radius, outer_radius, inner_density,
                              outer_density, inner_pressure, outer_pressure,
                              magnetic_field, adiabatic_index):
-    return (1.0 / (adiabatic_index - 1.0) *
-            pressure(x, inner_radius, outer_radius, inner_density,
-                     outer_density, inner_pressure, outer_pressure,
-                     magnetic_field, adiabatic_index) /
+    return (1.0 / (adiabatic_index - 1.0) * pressure(
+        x, inner_radius, outer_radius, inner_density, outer_density,
+        inner_pressure, outer_pressure, magnetic_field, adiabatic_index) /
             rest_mass_density(x, inner_radius, outer_radius, inner_density,
                               outer_density, inner_pressure, outer_pressure,
                               magnetic_field, adiabatic_index))
@@ -58,11 +57,9 @@ def lorentz_factor(x, inner_radius, outer_radius, inner_density, outer_density,
 def specific_enthalpy(x, inner_radius, outer_radius, inner_density,
                       outer_density, inner_pressure, outer_pressure,
                       magnetic_field, adiabatic_index):
-    return (1.0 + adiabatic_index *
-            specific_internal_energy(x, inner_radius, outer_radius,
-                                     inner_density, outer_density,
-                                     inner_pressure, outer_pressure,
-                                     magnetic_field, adiabatic_index))
+    return (1.0 + adiabatic_index * specific_internal_energy(
+        x, inner_radius, outer_radius, inner_density, outer_density,
+        inner_pressure, outer_pressure, magnetic_field, adiabatic_index))
 
 
 def magnetic_field(x, inner_radius, outer_radius, inner_density, outer_density,

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.py
@@ -10,34 +10,33 @@ def compute_rest_mass_density(x, pressure, rest_mass_density, adiabatic_index,
     return rest_mass_density
 
 
-def compute_pressure(x, pressure, rest_mass_density,
-                     adiabatic_index, advection_velocity,
-                     magnetic_field_strength, inner_radius, outer_radius):
+def compute_pressure(x, pressure, rest_mass_density, adiabatic_index,
+                     advection_velocity, magnetic_field_strength, inner_radius,
+                     outer_radius):
     return pressure
 
 
 def specific_internal_energy(x, pressure, rest_mass_density, adiabatic_index,
                              advection_velocity, magnetic_field_strength,
                              inner_radius, outer_radius):
-    return (1.0 / (adiabatic_index - 1.0) *
-            compute_pressure(x, pressure, rest_mass_density, adiabatic_index,
-                             advection_velocity, magnetic_field_strength,
-                             inner_radius, outer_radius) /
+    return (1.0 / (adiabatic_index - 1.0) * compute_pressure(
+        x, pressure, rest_mass_density, adiabatic_index, advection_velocity,
+        magnetic_field_strength, inner_radius, outer_radius) /
             compute_rest_mass_density(x, pressure, rest_mass_density,
                                       adiabatic_index, advection_velocity,
-                                      magnetic_field_strength,
-                                      inner_radius, outer_radius))
+                                      magnetic_field_strength, inner_radius,
+                                      outer_radius))
 
 
 def spatial_velocity(x, pressure, rest_mass_density, adiabatic_index,
-                     advection_velocity, magnetic_field_strength,
-                     inner_radius, outer_radius):
+                     advection_velocity, magnetic_field_strength, inner_radius,
+                     outer_radius):
     return np.array(advection_velocity)
 
 
 def lorentz_factor(x, pressure, rest_mass_density, adiabatic_index,
-                   advection_velocity, magnetic_field_strength,
-                   inner_radius, outer_radius):
+                   advection_velocity, magnetic_field_strength, inner_radius,
+                   outer_radius):
     v = spatial_velocity(x, pressure, rest_mass_density, adiabatic_index,
                          advection_velocity, magnetic_field_strength,
                          inner_radius, outer_radius)
@@ -47,31 +46,33 @@ def lorentz_factor(x, pressure, rest_mass_density, adiabatic_index,
 def specific_enthalpy(x, pressure, rest_mass_density, adiabatic_index,
                       advection_velocity, magnetic_field_strength,
                       inner_radius, outer_radius):
-    return (1. + specific_internal_energy(x, pressure, rest_mass_density,
-                                          adiabatic_index, advection_velocity,
-                                          magnetic_field_strength,
-                                          inner_radius, outer_radius)
-            + compute_pressure(x, pressure, rest_mass_density, adiabatic_index,
-                               advection_velocity, magnetic_field_strength,
-                               inner_radius, outer_radius) /
+    return (1. + specific_internal_energy(
+        x, pressure, rest_mass_density, adiabatic_index, advection_velocity,
+        magnetic_field_strength, inner_radius, outer_radius) +
+            compute_pressure(x, pressure, rest_mass_density, adiabatic_index,
+                             advection_velocity, magnetic_field_strength,
+                             inner_radius, outer_radius) /
             compute_rest_mass_density(x, pressure, rest_mass_density,
                                       adiabatic_index, advection_velocity,
-                                      magnetic_field_strength,
-                                      inner_radius, outer_radius))
+                                      magnetic_field_strength, inner_radius,
+                                      outer_radius))
 
 
 def magnetic_field(x, pressure, rest_mass_density, adiabatic_index,
-                   advection_velocity, magnetic_field_strength,
-                   inner_radius, outer_radius):
+                   advection_velocity, magnetic_field_strength, inner_radius,
+                   outer_radius):
     radius = np.sqrt(np.square(x[0]) + np.square(x[1]))
     if (radius > outer_radius):
         return np.array([0.0, 0.0, 0.0])
     if (radius < inner_radius):
-        return np.array([-magnetic_field_strength * x[1]/inner_radius,
-        magnetic_field_strength * x[0] / inner_radius, 0.])
+        return np.array([
+            -magnetic_field_strength * x[1] / inner_radius,
+            magnetic_field_strength * x[0] / inner_radius, 0.
+        ])
     return np.array([
-        -magnetic_field_strength * x[1]/radius,
-        magnetic_field_strength * x[0] / radius, 0.])
+        -magnetic_field_strength * x[1] / radius,
+        magnetic_field_strength * x[0] / radius, 0.
+    ])
 
 
 def divergence_cleaning_field(x, pressure, rest_mass_density, adiabatic_index,

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.py
@@ -12,64 +12,53 @@ def compute_piecewise(x, rotor_radius, inner_value, outer_value):
         return inner_value
 
 
-def rest_mass_density(x, rotor_radius, inner_density,
-                      outer_density, pressure, angular_velocity,
-                      magnetic_field, adiabatic_index):
-    return compute_piecewise(x, rotor_radius, inner_density,
-                             outer_density)
+def rest_mass_density(x, rotor_radius, inner_density, outer_density, pressure,
+                      angular_velocity, magnetic_field, adiabatic_index):
+    return compute_piecewise(x, rotor_radius, inner_density, outer_density)
 
 
-def spatial_velocity(x, rotor_radius, inner_density,
-                     outer_density, pressure, angular_velocity,
-                     magnetic_field, adiabatic_index):
+def spatial_velocity(x, rotor_radius, inner_density, outer_density, pressure,
+                     angular_velocity, magnetic_field, adiabatic_index):
     omega = compute_piecewise(x, rotor_radius, angular_velocity, 0.0)
-    return np.array([-x[1]*omega, x[0]*omega, 0.0])
+    return np.array([-x[1] * omega, x[0] * omega, 0.0])
 
 
-def specific_internal_energy(x, rotor_radius, inner_density,
-                             outer_density, pressure, angular_velocity,
-                             magnetic_field, adiabatic_index):
-    return (1.0 / (adiabatic_index - 1.0) *
-            compute_pressure(x, rotor_radius, inner_density,
-                             outer_density, pressure, angular_velocity,
-                             magnetic_field, adiabatic_index) /
-            rest_mass_density(x, rotor_radius, inner_density,
-                              outer_density, pressure, angular_velocity,
-                              magnetic_field, adiabatic_index))
+def specific_internal_energy(x, rotor_radius, inner_density, outer_density,
+                             pressure, angular_velocity, magnetic_field,
+                             adiabatic_index):
+    return (1.0 / (adiabatic_index - 1.0) * compute_pressure(
+        x, rotor_radius, inner_density, outer_density, pressure,
+        angular_velocity, magnetic_field, adiabatic_index) / rest_mass_density(
+            x, rotor_radius, inner_density, outer_density, pressure,
+            angular_velocity, magnetic_field, adiabatic_index))
 
 
-def compute_pressure(x, rotor_radius, inner_density, outer_density,
-                     pressure, angular_velocity, magnetic_field,
-                     adiabatic_index):
+def compute_pressure(x, rotor_radius, inner_density, outer_density, pressure,
+                     angular_velocity, magnetic_field, adiabatic_index):
     return pressure
 
 
-def lorentz_factor(x, rotor_radius, inner_density, outer_density,
-                   pressure, angular_velocity, magnetic_field,
-                   adiabatic_index):
-    v = spatial_velocity(x, rotor_radius, inner_density,
-                         outer_density, pressure, angular_velocity,
-                         magnetic_field, adiabatic_index)
+def lorentz_factor(x, rotor_radius, inner_density, outer_density, pressure,
+                   angular_velocity, magnetic_field, adiabatic_index):
+    v = spatial_velocity(x, rotor_radius, inner_density, outer_density,
+                         pressure, angular_velocity, magnetic_field,
+                         adiabatic_index)
     return 1. / np.sqrt(1. - np.dot(v, v))
 
 
-def specific_enthalpy(x, rotor_radius, inner_density,
-                      outer_density, pressure, angular_velocity,
-                      magnetic_field, adiabatic_index):
-    return (1.0 + adiabatic_index *
-            specific_internal_energy(x, rotor_radius,
-                                     inner_density, outer_density,
-                                     pressure, angular_velocity,
-                                     magnetic_field, adiabatic_index))
+def specific_enthalpy(x, rotor_radius, inner_density, outer_density, pressure,
+                      angular_velocity, magnetic_field, adiabatic_index):
+    return (1.0 + adiabatic_index * specific_internal_energy(
+        x, rotor_radius, inner_density, outer_density, pressure,
+        angular_velocity, magnetic_field, adiabatic_index))
 
 
-def magnetic_field(x, rotor_radius, inner_density, outer_density,
-                   pressure, angular_velocity, magnetic_field,
-                   adiabatic_index):
+def magnetic_field(x, rotor_radius, inner_density, outer_density, pressure,
+                   angular_velocity, magnetic_field, adiabatic_index):
     return np.array(magnetic_field)
 
 
-def divergence_cleaning_field(x, rotor_radius, inner_density,
-                              outer_density, pressure, angular_velocity,
-                              magnetic_field, adiabatic_index):
+def divergence_cleaning_field(x, rotor_radius, inner_density, outer_density,
+                              pressure, angular_velocity, magnetic_field,
+                              adiabatic_index):
     return 0.0

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.py
@@ -8,7 +8,6 @@ import PointwiseFunctions.AnalyticSolutions.\
 import PointwiseFunctions.GeneralRelativity.KerrSchildCoords as ks_coords
 
 
-
 def rest_mass_density(x, bh_mass, bh_dimless_spin, dimless_r_in, dimless_r_max,
                       polytropic_constant, polytropic_exponent,
                       threshold_density, plasma_beta):
@@ -53,8 +52,8 @@ def magnetic_potential(r, sin_theta_sqrd, m, a, rin, rmax, polytropic_constant,
     Win = fm_disk.potential(l, rin**2, 1.0, m, a)
     h = np.exp(Win - fm_disk.potential(l, r**2, sin_theta_sqrd, m, a))
     return pow((h - 1.0) * (polytropic_exponent - 1.0) /
-               (polytropic_constant * polytropic_exponent),
-               1.0 / (polytropic_exponent - 1.0)) - threshold_rest_mass_density
+               (polytropic_constant * polytropic_exponent), 1.0 /
+               (polytropic_exponent - 1.0)) - threshold_rest_mass_density
 
 
 def magnetic_field(x, bh_mass, bh_dimless_spin, dimless_r_in, dimless_r_max,
@@ -69,12 +68,9 @@ def magnetic_field(x, bh_mass, bh_dimless_spin, dimless_r_in, dimless_r_max,
                                     dimless_r_in, dimless_r_max,
                                     polytropic_constant, polytropic_exponent)
     x_max = np.array([r_max, spin_a, 0.0])
-    threshold_rho = (threshold_density *
-                     (fm_disk.rest_mass_density(x_max, dummy_time, bh_mass,
-                                                bh_dimless_spin, dimless_r_in,
-                                                dimless_r_max,
-                                                polytropic_constant,
-                                                polytropic_exponent)))
+    threshold_rho = (threshold_density * (fm_disk.rest_mass_density(
+        x_max, dummy_time, bh_mass, bh_dimless_spin, dimless_r_in,
+        dimless_r_max, polytropic_constant, polytropic_exponent)))
     if (rho > threshold_rho):
         small = 0.0001 * bh_mass
         a_squared = spin_a**2
@@ -88,31 +84,27 @@ def magnetic_field(x, bh_mass, bh_dimless_spin, dimless_r_in, dimless_r_max,
         sigma = r_squared + a_squared * x[2]**2 / r_squared
         prefactor = np.sqrt(sigma * (sigma + 2.0 * bh_mass * r)) * sin_theta
         prefactor = 1.0 / (2.0 * small * prefactor)
-        result[0] = ((magnetic_potential(r, sin_theta_squared + small, bh_mass,
-                                         spin_a, r_in, r_max,
-                                         polytropic_constant,
-                                         polytropic_exponent, threshold_rho) -
-                      magnetic_potential(r, sin_theta_squared - small, bh_mass,
-                                         spin_a, r_in, r_max,
-                                         polytropic_constant,
-                                         polytropic_exponent, threshold_rho)) *
-                     2.0 * prefactor * sin_theta * x[2]) / r
-        result[1] = (magnetic_potential(r - small, sin_theta_squared, bh_mass,
-                                        spin_a, r_in, r_max,
-                                        polytropic_constant,
-                                        polytropic_exponent, threshold_rho) -
-                     magnetic_potential(r + small, sin_theta_squared, bh_mass,
-                                        spin_a, r_in, r_max,
-                                        polytropic_constant,
-                                        polytropic_exponent,
-                                        threshold_rho)) * prefactor
+        result[0] = (
+            (magnetic_potential(r, sin_theta_squared + small, bh_mass, spin_a,
+                                r_in, r_max, polytropic_constant,
+                                polytropic_exponent, threshold_rho) -
+             magnetic_potential(r, sin_theta_squared - small, bh_mass, spin_a,
+                                r_in, r_max, polytropic_constant,
+                                polytropic_exponent, threshold_rho)) * 2.0 *
+            prefactor * sin_theta * x[2]) / r
+        result[1] = (
+            magnetic_potential(r - small, sin_theta_squared, bh_mass, spin_a,
+                               r_in, r_max, polytropic_constant,
+                               polytropic_exponent, threshold_rho) -
+            magnetic_potential(r + small, sin_theta_squared, bh_mass, spin_a,
+                               r_in, r_max, polytropic_constant,
+                               polytropic_exponent, threshold_rho)) * prefactor
 
     # This normalization is specific for the default normalization resolution
     # grid and for the specific member variables of the disk in test_variables
     normalization = 1.7162625566578704
-    return (normalization *
-            ks_coords.cartesian_from_spherical_ks(result, x, bh_mass,
-                                                  bh_dimless_spin))
+    return (normalization * ks_coords.cartesian_from_spherical_ks(
+        result, x, bh_mass, bh_dimless_spin))
 
 
 def divergence_cleaning_field(x, bh_mass, bh_dimless_spin, dimless_r_in,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.py
@@ -4,8 +4,8 @@
 import numpy as np
 
 
-def displacement(
-        x, length, height, bending_moment, bulk_modulus, shear_modulus):
+def displacement(x, length, height, bending_moment, bulk_modulus,
+                 shear_modulus):
     youngs_modulus = 9. * bulk_modulus * shear_modulus / \
         (3. * bulk_modulus + shear_modulus)
     poisson_ratio = (3. * bulk_modulus - 2. * shear_modulus) / \

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.py
@@ -76,15 +76,15 @@ def gauge_wave_sqrt_det_spatial_metric(x, t, amplitude, wavelength):
 
 def gauge_wave_extrinsic_curvature(x, t, amplitude, wavelength):
     extrinsic_curvature = np.zeros((len(x), len(x)))
-    extrinsic_curvature[0, 0] = gauge_wave_dh_over_2_sqrt_h(x, t, amplitude,
-                                                            wavelength)
+    extrinsic_curvature[0, 0] = gauge_wave_dh_over_2_sqrt_h(
+        x, t, amplitude, wavelength)
     return extrinsic_curvature
 
 
 def gauge_wave_inverse_spatial_metric(x, t, amplitude, wavelength):
     inverse_spatial_metric = np.zeros((len(x), len(x)))
-    inverse_spatial_metric[0, 0] = 1.0 / gauge_wave_h(x, t, amplitude,
-                                                      wavelength)
+    inverse_spatial_metric[0,
+                           0] = 1.0 / gauge_wave_h(x, t, amplitude, wavelength)
     inverse_spatial_metric[1, 1] = 1.0
     inverse_spatial_metric[2, 2] = 1.0
     return inverse_spatial_metric

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Test_Tov.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Test_Tov.py
@@ -12,10 +12,10 @@ import numpy.testing as npt
 
 class TestTov(unittest.TestCase):
     def test_creation(self):
-        eos = spectre_eos.RelativisticPolytropicFluid(
-            polytropic_constant=8, polytropic_exponent=2)
-        tov = spectre_gr_solutions.Tov(
-            equation_of_state=eos, central_mass_density=1e-3)
+        eos = spectre_eos.RelativisticPolytropicFluid(polytropic_constant=8,
+                                                      polytropic_exponent=2)
+        tov = spectre_gr_solutions.Tov(equation_of_state=eos,
+                                       central_mass_density=1e-3)
         # Just making sure we can call the member functions
         outer_radius = tov.outer_radius()
         self.assertAlmostEqual(outer_radius, 3.4685521362)
@@ -28,7 +28,7 @@ class TestTov(unittest.TestCase):
         radii = np.array([0., outer_radius])
         npt.assert_allclose(tov.mass(radii), np.array([0., expected_mass]))
         npt.assert_allclose(
-            tov.mass_over_radius(radii)*radii, np.array([0., expected_mass]))
+            tov.mass_over_radius(radii) * radii, np.array([0., expected_mass]))
         # Testing `log_specific_enthalpy` only at outer radius because we
         # haven't wrapped any EOS functions yet, so it's not trivial to compute
         # the specific enthalpy at other points

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TestFunctions.py
@@ -5,18 +5,19 @@ import numpy as np
 
 # Functions for testing KerrHorizon.cpp
 
-def kerr_horizon_radius(theta, phi, mass, dimless_spin_magnitude,
-                        spin_theta, spin_phi):
+
+def kerr_horizon_radius(theta, phi, mass, dimless_spin_magnitude, spin_theta,
+                        spin_phi):
     spin_a = mass*dimless_spin_magnitude* \
              np.array((np.sin(spin_theta)*np.cos(spin_phi),
                        np.sin(spin_theta)*np.sin(spin_phi),
                        np.cos(spin_theta)))
-    a_squared = np.dot(spin_a,spin_a)
-    r_plus    = mass+np.sqrt(mass**2-a_squared)
-    n_hat     = np.array((np.sin(theta)*np.cos(phi),
-                          np.sin(theta)*np.sin(phi),
-                          np.cos(theta)))
+    a_squared = np.dot(spin_a, spin_a)
+    r_plus = mass + np.sqrt(mass**2 - a_squared)
+    n_hat = np.array((np.sin(theta) * np.cos(phi), np.sin(theta) * np.sin(phi),
+                      np.cos(theta)))
     return np.sqrt(r_plus**2*(r_plus**2+a_squared)/ \
                    (r_plus**2+np.dot(spin_a,n_hat)**2))
+
 
 # End functions for testing KerrHorizon.cpp

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.py
@@ -5,33 +5,43 @@ import numpy as np
 
 # Functions for Test_KomissarovShock.cpp
 
+
 def parse_vars(*args, **kwargs):
     assert not kwargs, "Found unexpected labeled arguments:\n{}".format(kwargs)
     assert len(args) is 10, "Expected 10 arguments, but got {}".format(
         len(args))
-    return dict(zip(['adiabatic_index', 'left_rest_mass_density',
+    return dict(
+        zip([
+            'adiabatic_index', 'left_rest_mass_density',
             'right_rest_mass_density', 'left_pressure', 'right_pressure',
             'left_spatial_velocity', 'right_spatial_velocity',
-            'left_magnetic_field', 'right_magnetic_field', 'shock_speed'],
-            args))
+            'left_magnetic_field', 'right_magnetic_field', 'shock_speed'
+        ], args))
+
 
 def piecewise(x, shock_position, left_value, right_value):
     return left_value if x[0] < shock_position else right_value
 
+
 def rest_mass_density(x, t, *args, **kwargs):
     vars = parse_vars(*args, **kwargs)
     return piecewise(x, t * vars['shock_speed'],
-        vars['left_rest_mass_density'], vars['right_rest_mass_density'])
+                     vars['left_rest_mass_density'],
+                     vars['right_rest_mass_density'])
+
 
 def spatial_velocity(x, t, *args, **kwargs):
     vars = parse_vars(*args, **kwargs)
-    return np.asarray(piecewise(x, t * vars['shock_speed'],
-        vars['left_spatial_velocity'], vars['right_spatial_velocity']))
+    return np.asarray(
+        piecewise(x, t * vars['shock_speed'], vars['left_spatial_velocity'],
+                  vars['right_spatial_velocity']))
+
 
 def pressure(x, t, *args, **kwargs):
     vars = parse_vars(*args, **kwargs)
-    return piecewise(x, t * vars['shock_speed'],
-        vars['left_pressure'], vars['right_pressure'])
+    return piecewise(x, t * vars['shock_speed'], vars['left_pressure'],
+                     vars['right_pressure'])
+
 
 def specific_internal_energy(x, t, *args, **kwargs):
     vars = parse_vars(*args, **kwargs)
@@ -39,19 +49,24 @@ def specific_internal_energy(x, t, *args, **kwargs):
     rho = rest_mass_density(x, t, *args, **kwargs)
     return p / ((vars['adiabatic_index'] - 1.0) * rho)
 
+
 def specific_enthalpy(x, t, *args, **kwargs):
     vars = parse_vars(*args, **kwargs)
     e = specific_internal_energy(x, t, *args, **kwargs)
     return 1.0 + vars['adiabatic_index'] * e
 
+
 def lorentz_factor(x, t, *args, **kwargs):
     v = spatial_velocity(x, t, *args, **kwargs)
     return 1.0 / np.sqrt(1.0 - np.sum(v**2))
 
+
 def magnetic_field(x, t, *args, **kwargs):
     vars = parse_vars(*args, **kwargs)
-    return np.asarray(piecewise(x, t * vars['shock_speed'],
-        vars['left_magnetic_field'], vars['right_magnetic_field']))
+    return np.asarray(
+        piecewise(x, t * vars['shock_speed'], vars['left_magnetic_field'],
+                  vars['right_magnetic_field']))
+
 
 def divergence_cleaning_field(x, t, *args, **kwargs):
     return 0.0

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/TestFunctions.py
@@ -4,13 +4,13 @@
 import numpy as np
 import scipy.optimize as opt
 
+
 # Functions for testing SmoothFlow.cpp
 def smooth_flow_rest_mass_density(x, t, mean_velocity, wave_vector, pressure,
                                   adiabatic_index, density_amplitude):
     return (1.0 + (density_amplitude * np.sin(
-        np.dot(
-            np.asarray(wave_vector),
-            np.asarray(x) - np.asarray(mean_velocity) * t))))
+        np.dot(np.asarray(wave_vector),
+               np.asarray(x) - np.asarray(mean_velocity) * t))))
 
 
 def smooth_flow_spatial_velocity(x, t, mean_velocity, wave_vector, pressure,
@@ -21,10 +21,10 @@ def smooth_flow_spatial_velocity(x, t, mean_velocity, wave_vector, pressure,
 def smooth_flow_specific_internal_energy(x, t, mean_velocity, wave_vector,
                                          pressure, adiabatic_index,
                                          density_amplitude):
-    return (
-        pressure / ((adiabatic_index - 1.0) * smooth_flow_rest_mass_density(
-            x, t, mean_velocity, wave_vector, pressure, adiabatic_index,
-            density_amplitude)))
+    return (pressure /
+            ((adiabatic_index - 1.0) * smooth_flow_rest_mass_density(
+                x, t, mean_velocity, wave_vector, pressure, adiabatic_index,
+                density_amplitude)))
 
 
 def smooth_flow_pressure(x, t, mean_velocity, wave_vector, pressure,
@@ -147,7 +147,6 @@ def alfven_divergence_cleaning_field(x, t, wavenumber, pressure,
 
 # End functions for testing AlfvenWave.cpp
 
-
 # Functions for testing BondiMichelMHD.cpp
 
 
@@ -176,9 +175,8 @@ def bondi_michel_bernoulli_constant_squared_minus_one(n_s_c_2, u_c_2, g):
       (n_s_c_2 / (g - 1.0) * (2.0 + n_s_c_2 / (g - 1.0)))
 
 
-def bondi_michel_bernoulli_equation_lhs_squared_minus_one(rho, r, g, k,
-                                                          m_dot_over_four_pi,
-                                                          mass):
+def bondi_michel_bernoulli_equation_lhs_squared_minus_one(
+    rho, r, g, k, m_dot_over_four_pi, mass):
     u = m_dot_over_four_pi / (r**2 * rho)
     g_minus_one = g - 1.0
     #polytropic_index times newtonian_sound_speed_squared:
@@ -188,11 +186,13 @@ def bondi_michel_bernoulli_equation_lhs_squared_minus_one(rho, r, g, k,
     h2 = h2_minus_one + 1.0
     return h2_minus_one + h2 * (-2.0 * mass / r + u**2)
 
+
 def bondi_michel_bernoulli_root_function(rho, r, g, k, m_dot_over_four_pi,
                                          n_s_c_2, u_c_2, mass):
     return bondi_michel_bernoulli_equation_lhs_squared_minus_one(
         rho, r, g, k, m_dot_over_four_pi, mass) \
         - bondi_michel_bernoulli_constant_squared_minus_one(n_s_c_2, u_c_2, g)
+
 
 def bondi_michel_sound_speed_at_infinity_squared(g, c_s_c_2):
     g_minus_one = g - 1.0
@@ -200,8 +200,10 @@ def bondi_michel_sound_speed_at_infinity_squared(g, c_s_c_2):
 
 
 def bondi_michel_rest_mass_density_at_infinity(g, rho_c, c_s_inf_2, c_s_c_2):
-    return rho_c * pow(c_s_inf_2 / (c_s_c_2 * np.sqrt(1.0 + 3.0 * c_s_c_2)),
-                       1.0 / (g - 1.0))
+    return rho_c * pow(c_s_inf_2 /
+                       (c_s_c_2 * np.sqrt(1.0 + 3.0 * c_s_c_2)), 1.0 /
+                       (g - 1.0))
+
 
 def bondi_michel_rest_mass_density_at_horizon(g, rho_c, u_c_2):
     return 0.0625 * rho_c * pow(u_c_2, -1.5)
@@ -217,7 +219,7 @@ def bondi_michel_shift(mass, radius):
 
 def bondi_michel_fluid_four_velocity_u_t(mass, radius, abs_u_r):
     if radius == 2.0 * mass:
-       return abs_u_r + 0.5 / abs_u_r
+        return abs_u_r + 0.5 / abs_u_r
     return (-2.0 * mass * abs_u_r + radius * \
            np.sqrt(abs_u_r**2 + 1.0 - 2.0 * mass / radius)) / \
            (radius - 2.0 * mass)
@@ -235,14 +237,12 @@ def bondi_michel_intermediate_variables(mass, sonic_radius, sonic_density,
         sonic_radius, sonic_density, u_c_2)
     h_inf_2 = bondi_michel_bernoulli_constant_squared_minus_one(
         n_s_c_2, u_c_2, adiabatic_exponent) + 1.0
-    c_s_inf_2 = bondi_michel_sound_speed_at_infinity_squared(adiabatic_exponent,
-                                                             c_s_c_2)
-    rho_inf = bondi_michel_rest_mass_density_at_infinity(adiabatic_exponent,
-                                                         sonic_density,
-                                                         c_s_inf_2, c_s_c_2)
-    rho_horizon = bondi_michel_rest_mass_density_at_horizon(adiabatic_exponent,
-                                                            sonic_density,
-                                                            u_c_2)
+    c_s_inf_2 = bondi_michel_sound_speed_at_infinity_squared(
+        adiabatic_exponent, c_s_c_2)
+    rho_inf = bondi_michel_rest_mass_density_at_infinity(
+        adiabatic_exponent, sonic_density, c_s_inf_2, c_s_c_2)
+    rho_horizon = bondi_michel_rest_mass_density_at_horizon(
+        adiabatic_exponent, sonic_density, u_c_2)
     return {"sonic_fluid_speed_squared": u_c_2, \
             "sonic_sound_speed_squared": c_s_c_2, \
             "sonic_newtonian_sound_speed_squared": n_s_c_2, \
@@ -261,13 +261,13 @@ def bondi_michel_rest_mass_density(x, mass, sonic_radius, sonic_density,
                                                     adiabatic_exponent)
     radius = np.sqrt(x[0]**2 + x[1]**2 + x[2]**2)
     if radius < sonic_radius:
-      upper_bound = variables["mass_accretion_rate_over_four_pi"] * \
-        np.sqrt(2.0 / (mass * radius**3))
-      lower_bound = variables["rest_mass_density_at_infinity"]
+        upper_bound = variables["mass_accretion_rate_over_four_pi"] * \
+          np.sqrt(2.0 / (mass * radius**3))
+        lower_bound = variables["rest_mass_density_at_infinity"]
     if radius >= sonic_radius:
-      upper_bound = sonic_density
-      lower_bound = variables["mass_accretion_rate_over_four_pi"] * \
-        np.sqrt(2.0 / (mass * radius**3))
+        upper_bound = sonic_density
+        lower_bound = variables["mass_accretion_rate_over_four_pi"] * \
+          np.sqrt(2.0 / (mass * radius**3))
     return opt.brentq( \
       bondi_michel_bernoulli_root_function, \
       lower_bound, upper_bound, xtol = 1.e-15, rtol = 1.e-15, args = ( \
@@ -278,6 +278,7 @@ def bondi_michel_rest_mass_density(x, mass, sonic_radius, sonic_density,
         variables["sonic_newtonian_sound_speed_squared"], \
         variables["sonic_fluid_speed_squared"], \
         mass))
+
 
 def bondi_michel_lorentz_factor(x, mass, sonic_radius, sonic_density,
                                 adiabatic_exponent, magnetic_field):
@@ -344,8 +345,9 @@ def bondi_michel_pressure(x, mass, sonic_radius, sonic_density,
         pow(rest_mass_density, adiabatic_exponent)
 
 
-def bondi_michel_divergence_cleaning_field(x, mass, sonic_radius, sonic_density,
-                                           adiabatic_exponent, magnetic_field):
+def bondi_michel_divergence_cleaning_field(x, mass, sonic_radius,
+                                           sonic_density, adiabatic_exponent,
+                                           magnetic_field):
     return 0.0
 
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.py
@@ -12,8 +12,8 @@ def deriv_of_perturbation_profile(z):
     return np.cos(z)
 
 
-def mass_density(x, t, adiabatic_index, center, mean_velocity,
-                 strength, perturbation_amplitude):
+def mass_density(x, t, adiabatic_index, center, mean_velocity, strength,
+                 perturbation_amplitude):
     x_tilde = x - center - t * np.array(mean_velocity)
     temp = (1.0 - strength * strength * (adiabatic_index - 1.0) *
             np.exp(1.0 - np.dot(x_tilde[:2], x_tilde[:2])) /
@@ -21,8 +21,8 @@ def mass_density(x, t, adiabatic_index, center, mean_velocity,
     return np.power(temp, 1.0 / (adiabatic_index - 1.0))
 
 
-def velocity(x, t, adiabatic_index, center, mean_velocity,
-             strength, perturbation_amplitude):
+def velocity(x, t, adiabatic_index, center, mean_velocity, strength,
+             perturbation_amplitude):
     x_tilde = x - center - t * np.array(mean_velocity)
     temp = (0.5 * strength *
             np.exp(0.5 * (1.0 - np.dot(x_tilde[:2], x_tilde[:2]))) / np.pi)
@@ -36,15 +36,14 @@ def velocity(x, t, adiabatic_index, center, mean_velocity,
 
 def specific_internal_energy(x, t, adiabatic_index, center, mean_velocity,
                              strength, perturbation_amplitude):
-    return (np.power(mass_density(x, t, adiabatic_index, center, mean_velocity,
-                                  strength, perturbation_amplitude),
-                     adiabatic_index - 1.0) / (adiabatic_index - 1.0))
+    return (np.power(
+        mass_density(x, t, adiabatic_index, center, mean_velocity, strength,
+                     perturbation_amplitude), adiabatic_index - 1.0) /
+            (adiabatic_index - 1.0))
 
 
-def pressure(x, t, adiabatic_index, center, mean_velocity,
-             strength, perturbation_amplitude):
-    return np.power(mass_density(x, t, adiabatic_index, center, mean_velocity,
-                                 strength, perturbation_amplitude),
-                    adiabatic_index)
-
-
+def pressure(x, t, adiabatic_index, center, mean_velocity, strength,
+             perturbation_amplitude):
+    return np.power(
+        mass_density(x, t, adiabatic_index, center, mean_velocity, strength,
+                     perturbation_amplitude), adiabatic_index)

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.py
@@ -12,10 +12,10 @@ def gravitational_field(x, central_mass_density, polytropic_constant):
     if (radius < outer_radius):
         xi = radius / alpha
         enclosed_mass = mass_scale * (np.sin(xi) - xi * np.cos(xi))
-        return - x * enclosed_mass / radius**3
+        return -x * enclosed_mass / radius**3
     else:
         total_mass = mass_scale * np.pi
-        return - x * total_mass / radius**3
+        return -x * total_mass / radius**3
 
 
 def mass_density(x, t, central_mass_density, polytropic_constant):

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 
-
 # Note: Values for p_* and u_* correspond to those
 # values obtained for the initial data of the Sod tube test.
 
@@ -15,64 +14,64 @@ def sound_speed(adiabatic_index, mass_density, pressure):
 def fan_density(x_shifted, t, adiabatic_index, mass_density, velocity,
                 pressure, direction):
     s = (x_shifted / t) if t > 0.0 else 0.0
-    return (mass_density *
-            np.power((2.0 -
-                      direction * (adiabatic_index - 1.0) * (velocity - s) /
-                      sound_speed(adiabatic_index, mass_density, pressure))
-                     / (adiabatic_index + 1.0), 2.0 / (adiabatic_index - 1.0)))
+    return (mass_density * np.power(
+        (2.0 - direction * (adiabatic_index - 1.0) *
+         (velocity - s) / sound_speed(adiabatic_index, mass_density, pressure))
+        / (adiabatic_index + 1.0), 2.0 / (adiabatic_index - 1.0)))
 
 
 def fan_velocity(x_shifted, t, adiabatic_index, mass_density, velocity,
                  pressure, direction):
     s = (x_shifted / t) if t > 0.0 else 0.0
-    return (2.0 * (0.5 * (adiabatic_index - 1.0) * velocity + s - direction *
-                   sound_speed(adiabatic_index, mass_density, pressure)) /
-            (adiabatic_index + 1.0))
+    return (
+        2.0 *
+        (0.5 * (adiabatic_index - 1.0) * velocity + s -
+         direction * sound_speed(adiabatic_index, mass_density, pressure)) /
+        (adiabatic_index + 1.0))
 
 
 def fan_pressure(x_shifted, t, adiabatic_index, mass_density, velocity,
                  pressure, direction):
     s = (x_shifted / t) if t > 0.0 else 0.0
-    return (pressure *
-            np.power((2.0 -
-                      direction * (adiabatic_index - 1.0) * (velocity - s) /
-                      sound_speed(adiabatic_index, mass_density, pressure))
-                     / (adiabatic_index + 1.0), 2.0 * adiabatic_index /
-                     (adiabatic_index - 1.0)))
+    return (pressure * np.power(
+        (2.0 - direction * (adiabatic_index - 1.0) *
+         (velocity - s) / sound_speed(adiabatic_index, mass_density, pressure))
+        / (adiabatic_index + 1.0), 2.0 * adiabatic_index /
+        (adiabatic_index - 1.0)))
 
 
 def rarefaction(x_shifted, t, quantity, quantity_star, adiabatic_index,
-                velocity_star, pressure_star, fan, mass_density,
-                velocity, pressure, direction):
+                velocity_star, pressure_star, fan, mass_density, velocity,
+                pressure, direction):
     pressure_ratio = pressure_star / pressure
     sound_speed_ = sound_speed(adiabatic_index, mass_density, pressure)
-    sound_speed_star = sound_speed_ * np.power(pressure_ratio,
-                                              0.5 * (adiabatic_index - 1.0)
-                                              / adiabatic_index)
+    sound_speed_star = sound_speed_ * np.power(
+        pressure_ratio, 0.5 * (adiabatic_index - 1.0) / adiabatic_index)
     head_speed = velocity + direction * sound_speed_
     tail_speed = velocity_star + direction * sound_speed_star
-    return (quantity_star if direction * (x_shifted - tail_speed * t) < 0.0 else
+    return (quantity_star if direction *
+            (x_shifted - tail_speed * t) < 0.0 else
             (fan(x_shifted, t, adiabatic_index, mass_density, velocity,
-                 pressure, direction)
-             if (direction * (x_shifted - tail_speed * t) >= 0.0 and
-                 direction * (x_shifted - head_speed * t) < 0.0)
-             else quantity))
+                 pressure, direction) if
+             (direction * (x_shifted - tail_speed * t) >= 0.0 and direction *
+              (x_shifted - head_speed * t) < 0.0) else quantity))
 
 
 def shock(x_shifted, t, quantity, quantity_star, adiabatic_index,
           pressure_star, mass_density, velocity, pressure, direction):
-    shock_speed = (velocity + direction *
-                   sound_speed(adiabatic_index, mass_density, pressure) *
-                   np.sqrt(0.5 * ((adiabatic_index + 1.0) *
-                                  (pressure_star / pressure) +
-                                  adiabatic_index - 1.0) /
-                           adiabatic_index))
-    return (quantity_star if direction * (x_shifted - shock_speed * t) < 0.0
-            else quantity)
+    shock_speed = (
+        velocity +
+        direction * sound_speed(adiabatic_index, mass_density, pressure) *
+        np.sqrt(0.5 * ((adiabatic_index + 1.0) *
+                       (pressure_star / pressure) + adiabatic_index - 1.0) /
+                adiabatic_index))
+    return (quantity_star if direction *
+            (x_shifted - shock_speed * t) < 0.0 else quantity)
 
 
-def mass_density(x, t, adiabatic_index, initial_pos, l_mass_density, l_velocity,
-                 l_pressure, r_mass_density, r_velocity, r_pressure):
+def mass_density(x, t, adiabatic_index, initial_pos, l_mass_density,
+                 l_velocity, l_pressure, r_mass_density, r_velocity,
+                 r_pressure):
     velocity_star = 0.9274526526
     pressure_star = 0.3031302631
 
@@ -90,12 +89,11 @@ def mass_density(x, t, adiabatic_index, initial_pos, l_mass_density, l_velocity,
     x_shifted = x[0] - initial_pos
     return (rarefaction(x_shifted, t, l_mass_density, l_density_star,
                         adiabatic_index, velocity_star, pressure_star,
-                        fan_density, l_mass_density, l_velocity[0],
-                        l_pressure, -1.0)
-            if x_shifted < velocity_star * t else
-            shock(x_shifted, t, r_mass_density, r_density_star,
-                  adiabatic_index, pressure_star, r_mass_density, r_velocity[0],
-                  r_pressure, 1.0))
+                        fan_density, l_mass_density, l_velocity[0], l_pressure,
+                        -1.0)
+            if x_shifted < velocity_star * t else shock(
+                x_shifted, t, r_mass_density, r_density_star, adiabatic_index,
+                pressure_star, r_mass_density, r_velocity[0], r_pressure, 1.0))
 
 
 def velocity(x, t, adiabatic_index, initial_pos, l_mass_density, l_velocity,
@@ -105,20 +103,19 @@ def velocity(x, t, adiabatic_index, initial_pos, l_mass_density, l_velocity,
 
     velocity = np.zeros(x.size)
     x_shifted = x[0] - initial_pos
-    velocity[0] = (rarefaction(x_shifted, t, l_velocity[0], velocity_star,
-                               adiabatic_index, velocity_star, pressure_star,
-                               fan_velocity, l_mass_density, l_velocity[0],
-                               l_pressure, -1.0)
-                   if x_shifted < velocity_star * t else
+    velocity[0] = (rarefaction(
+        x_shifted, t, l_velocity[0], velocity_star, adiabatic_index,
+        velocity_star, pressure_star, fan_velocity, l_mass_density,
+        l_velocity[0], l_pressure, -1.0) if x_shifted < velocity_star * t else
                    shock(x_shifted, t, r_velocity[0], velocity_star,
                          adiabatic_index, pressure_star, r_mass_density,
                          r_velocity[0], r_pressure, 1.0))
     if (x.size > 1):
-        velocity[1] = (l_velocity[1] if x_shifted < velocity_star * t
-                       else r_velocity[1])
+        velocity[1] = (l_velocity[1]
+                       if x_shifted < velocity_star * t else r_velocity[1])
     if (x.size > 2):
-        velocity[2] = (l_velocity[2] if x_shifted < velocity_star * t
-                       else r_velocity[2])
+        velocity[2] = (l_velocity[2]
+                       if x_shifted < velocity_star * t else r_velocity[2])
     return velocity
 
 
@@ -132,19 +129,17 @@ def pressure(x, t, adiabatic_index, initial_pos, l_mass_density, l_velocity,
                         adiabatic_index, velocity_star, pressure_star,
                         fan_pressure, l_mass_density, l_velocity[0],
                         l_pressure, -1.0)
-            if x_shifted < velocity_star * t else
-            shock(x_shifted, t, r_pressure, pressure_star, adiabatic_index,
-                  pressure_star, r_mass_density, r_velocity[0], r_pressure,
-                  1.0))
+            if x_shifted < velocity_star * t else shock(
+                x_shifted, t, r_pressure, pressure_star, adiabatic_index,
+                pressure_star, r_mass_density, r_velocity[0], r_pressure, 1.0))
 
 
-def specific_internal_energy(x, t, adiabatic_index, initial_pos, l_mass_density,
-                             l_velocity, l_pressure, r_mass_density, r_velocity,
-                             r_pressure):
-    return (pressure(x, t, adiabatic_index, initial_pos, l_mass_density,
-                     l_velocity, l_pressure, r_mass_density, r_velocity,
-                     r_pressure) /
-            mass_density(x, t, adiabatic_index, initial_pos, l_mass_density,
-                         l_velocity, l_pressure, r_mass_density, r_velocity,
-                         r_pressure) / (adiabatic_index - 1.0))
-
+def specific_internal_energy(x, t, adiabatic_index, initial_pos,
+                             l_mass_density, l_velocity, l_pressure,
+                             r_mass_density, r_velocity, r_pressure):
+    return (pressure(
+        x, t, adiabatic_index, initial_pos, l_mass_density, l_velocity,
+        l_pressure, r_mass_density, r_velocity, r_pressure) / mass_density(
+            x, t, adiabatic_index, initial_pos, l_mass_density, l_velocity,
+            l_pressure, r_mass_density, r_velocity, r_pressure) /
+            (adiabatic_index - 1.0))

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.py
@@ -17,10 +17,10 @@ def field_gradient(x):
         return np.abs(x - 0.5) * poly(x, [0.25, -3, 7.5, -5])
     elif len(x) == 2:
         return np.sqrt(np.sum((x - 0.5)**2)) * np.array([
-            x[d - 1] * (1. - x[d - 1]) * (poly(x[d], [
-                0.5, poly(x[d - 1], [-3.5, 2, -2]), 7.5, -5
-            ]) + poly(x[d - 1], [0, -1, 1]))
-            for d in range(len(x))])
+            x[d - 1] * (1. - x[d - 1]) *
+            (poly(x[d], [0.5, poly(x[d - 1], [-3.5, 2, -2]), 7.5, -5]) +
+             poly(x[d - 1], [0, -1, 1])) for d in range(len(x))
+        ])
 
 
 def source(x):
@@ -28,7 +28,6 @@ def source(x):
         return np.abs(x[0] - 0.5) * (20. * (x[0] - 0.5)**2 - 1.5)
     elif len(x) == 2:
         r = np.linalg.norm(x - 0.5)
-        return r * (
-            -0.5625 + 6.25 * r**2 - 6.125 * r**4 + 4.125 * (x[0] - 0.5)**4
-            - 24.75 * (x[0] - 0.5)**2 * (x[1] - 0.5)**2
-            + 4.125 * (x[1] - 0.5)**4)
+        return r * (-0.5625 + 6.25 * r**2 - 6.125 * r**4 + 4.125 *
+                    (x[0] - 0.5)**4 - 24.75 * (x[0] - 0.5)**2 *
+                    (x[1] - 0.5)**2 + 4.125 * (x[1] - 0.5)**4)

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/TestFunctions.py
@@ -4,25 +4,25 @@
 import numpy as np
 import scipy.optimize as opt
 
+
 # Functions for testing ConstantM1.cpp
-def constant_m1_spatial_velocity(x, t, mean_velocity,
-                                 comoving_energy_density):
+def constant_m1_spatial_velocity(x, t, mean_velocity, comoving_energy_density):
     return np.asarray(mean_velocity)
 
 
-def constant_m1_lorentz_factor(x, t, mean_velocity,
-                                 comoving_energy_density):
+def constant_m1_lorentz_factor(x, t, mean_velocity, comoving_energy_density):
     return 1.0 / np.sqrt(1.0 - np.linalg.norm(np.asarray(mean_velocity))**2)
 
-def constant_m1_tildeE(x, t, mean_velocity,
-                                 comoving_energy_density):
-    w_sqr = 1.0 / (1.0 - np.linalg.norm(np.asarray(mean_velocity))**2)
-    return comoving_energy_density/3.*(4.*w_sqr-1.)
 
-def constant_m1_tildeS(x, t, mean_velocity,
-                                 comoving_energy_density):
+def constant_m1_tildeE(x, t, mean_velocity, comoving_energy_density):
     w_sqr = 1.0 / (1.0 - np.linalg.norm(np.asarray(mean_velocity))**2)
-    prefactor = 4./3.*comoving_energy_density*w_sqr
-    return np.asarray(mean_velocity)*prefactor
+    return comoving_energy_density / 3. * (4. * w_sqr - 1.)
+
+
+def constant_m1_tildeS(x, t, mean_velocity, comoving_energy_density):
+    w_sqr = 1.0 / (1.0 - np.linalg.norm(np.asarray(mean_velocity))**2)
+    prefactor = 4. / 3. * comoving_energy_density * w_sqr
+    return np.asarray(mean_velocity) * prefactor
+
 
 # End Functions for testing ConstantM1.cpp

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.py
@@ -17,13 +17,13 @@ def ucase_a(r_sqrd, sin_theta_sqrd, m, a):
 
 
 def boyer_lindquist_gtf(r_sqrd, sin_theta_sqrd, m, a):
-    return (-2.0 * m * np.sqrt(r_sqrd) * a * sin_theta_sqrd / sigma(
-        r_sqrd, sin_theta_sqrd, a))
+    return (-2.0 * m * np.sqrt(r_sqrd) * a * sin_theta_sqrd /
+            sigma(r_sqrd, sin_theta_sqrd, a))
 
 
 def boyer_lindquist_gff(r_sqrd, sin_theta_sqrd, m, a):
-    return (ucase_a(r_sqrd, sin_theta_sqrd, m, a) * sin_theta_sqrd / sigma(
-        r_sqrd, sin_theta_sqrd, a))
+    return (ucase_a(r_sqrd, sin_theta_sqrd, m, a) * sin_theta_sqrd /
+            sigma(r_sqrd, sin_theta_sqrd, a))
 
 
 def boyer_lindquist_r_sqrd(x, a):
@@ -57,8 +57,9 @@ def kerr_schild_lapse(x, m, a):
 
 def kerr_schild_shift(x, m, a):
     null_vector_0 = -1.0
-    return ((-2.0 * kerr_schild_h(x, m, a) * null_vector_0 * kerr_schild_lapse(
-        x, m, a)**2) * kerr_schild_spatial_null_form(x, m, a))
+    return ((-2.0 * kerr_schild_h(x, m, a) * null_vector_0 *
+             kerr_schild_lapse(x, m, a)**2) *
+            kerr_schild_spatial_null_form(x, m, a))
 
 
 def kerr_schild_spatial_metric(x, m, a):
@@ -68,21 +69,21 @@ def kerr_schild_spatial_metric(x, m, a):
 
 
 def angular_momentum(m, a, rmax):
-    return (
-        np.sqrt(m) * ((np.power(rmax, 1.5) + a * np.sqrt(m)) *
-                      (a**2 - 2.0 * a * np.sqrt(m) * np.sqrt(rmax) + rmax**2) /
-                      (2.0 * a * np.sqrt(m) * np.power(rmax, 1.5) +
-                       (rmax - 3.0 * m) * rmax**2)))
+    return (np.sqrt(m) *
+            ((np.power(rmax, 1.5) + a * np.sqrt(m)) *
+             (a**2 - 2.0 * a * np.sqrt(m) * np.sqrt(rmax) + rmax**2) /
+             (2.0 * a * np.sqrt(m) * np.power(rmax, 1.5) +
+              (rmax - 3.0 * m) * rmax**2)))
 
 
 def angular_velocity(angular_momentum, r_sqrd, sin_theta_sqrd, m, a):
     prefactor = (
         2.0 * angular_momentum * delta(r_sqrd, m, a) * sin_theta_sqrd /
         np.power(boyer_lindquist_gff(r_sqrd, sin_theta_sqrd, m, a), 2.0))
-    return (
-        prefactor / (1.0 + np.sqrt(1.0 + 2.0 * angular_momentum * prefactor)) -
-        (boyer_lindquist_gtf(r_sqrd, sin_theta_sqrd, m, a) /
-         boyer_lindquist_gff(r_sqrd, sin_theta_sqrd, m, a)))
+    return (prefactor /
+            (1.0 + np.sqrt(1.0 + 2.0 * angular_momentum * prefactor)) -
+            (boyer_lindquist_gtf(r_sqrd, sin_theta_sqrd, m, a) /
+             boyer_lindquist_gff(r_sqrd, sin_theta_sqrd, m, a)))
 
 
 def u_t(angular_momentum, r_sqrd, sin_theta_sqrd, m, a):
@@ -94,9 +95,9 @@ def u_t(angular_momentum, r_sqrd, sin_theta_sqrd, m, a):
 
 
 def potential(angular_momentum, r_sqrd, sin_theta_sqrd, m, a):
-    return (angular_momentum * angular_velocity(
-        angular_momentum, r_sqrd, sin_theta_sqrd, m, a) - np.log(
-            u_t(angular_momentum, r_sqrd, sin_theta_sqrd, m, a)))
+    return (angular_momentum *
+            angular_velocity(angular_momentum, r_sqrd, sin_theta_sqrd, m, a) -
+            np.log(u_t(angular_momentum, r_sqrd, sin_theta_sqrd, m, a)))
 
 
 def specific_enthalpy(x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
@@ -131,8 +132,8 @@ def specific_internal_energy(x, t, bh_mass, bh_dimless_a, dimless_r_in,
     return (polytropic_constant * np.power(
         rest_mass_density(x, t, bh_mass, bh_dimless_a, dimless_r_in,
                           dimless_r_max, polytropic_constant,
-                          polytropic_exponent),
-        polytropic_exponent - 1.0) / (polytropic_exponent - 1.0))
+                          polytropic_exponent), polytropic_exponent - 1.0) /
+            (polytropic_exponent - 1.0))
 
 
 def pressure(x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
@@ -158,8 +159,8 @@ def spatial_velocity(x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
         if (W < Win):
             result += ((np.array([-x[1], x[0], 0.0]) * angular_velocity(
                 l, r_sqrd, sin_theta_sqrd, bh_mass, bh_spin_a) +
-                        kerr_schild_shift(x, bh_mass, bh_spin_a))
-                       / kerr_schild_lapse(x, bh_mass, bh_spin_a))
+                        kerr_schild_shift(x, bh_mass, bh_spin_a)) /
+                       kerr_schild_lapse(x, bh_mass, bh_spin_a))
     return result
 
 
@@ -167,9 +168,9 @@ def lorentz_factor(x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
                    polytropic_constant, polytropic_exponent):
     bh_spin_a = bh_mass * bh_dimless_a
     spatial_metric = kerr_schild_spatial_metric(x, bh_mass, bh_spin_a)
-    velocity = spatial_velocity(
-        x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
-        polytropic_constant, polytropic_exponent)
+    velocity = spatial_velocity(x, t, bh_mass, bh_dimless_a, dimless_r_in,
+                                dimless_r_max, polytropic_constant,
+                                polytropic_exponent)
     return 1.0 / np.sqrt(
         1.0 - np.einsum("i,j,ij", velocity, velocity, spatial_metric))
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.py
@@ -7,9 +7,8 @@ import numpy as np
 def rest_mass_density(x, t, mean_velocity, wave_vector, pressure,
                       adiabatic_index, density_amplitude):
     return (1.0 + (density_amplitude * np.sin(
-        np.dot(
-            np.asarray(wave_vector),
-            np.asarray(x) - np.asarray(mean_velocity) * t))))
+        np.dot(np.asarray(wave_vector),
+               np.asarray(x) - np.asarray(mean_velocity) * t))))
 
 
 def spatial_velocity(x, t, mean_velocity, wave_vector, pressure,
@@ -19,10 +18,10 @@ def spatial_velocity(x, t, mean_velocity, wave_vector, pressure,
 
 def specific_internal_energy(x, t, mean_velocity, wave_vector, pressure,
                              adiabatic_index, density_amplitude):
-    return (
-        pressure / ((adiabatic_index - 1.0) * rest_mass_density(
-            x, t, mean_velocity, wave_vector, pressure, adiabatic_index,
-            density_amplitude)))
+    return (pressure /
+            ((adiabatic_index - 1.0) *
+             rest_mass_density(x, t, mean_velocity, wave_vector, pressure,
+                               adiabatic_index, density_amplitude)))
 
 
 def pressure(x, t, mean_velocity, wave_vector, pressure, adiabatic_index,
@@ -37,7 +36,6 @@ def specific_enthalpy(x, t, mean_velocity, wave_vector, pressure,
         density_amplitude)
 
 
-def lorentz_factor(x, t, mean_velocity, wave_vector, pressure,
-                   adiabatic_index, density_amplitude):
+def lorentz_factor(x, t, mean_velocity, wave_vector, pressure, adiabatic_index,
+                   density_amplitude):
     return 1.0 / np.sqrt(1.0 - np.linalg.norm(np.asarray(mean_velocity))**2)
-

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.py
@@ -21,7 +21,7 @@ def sobolov(r, alpha, radius):
 
 def conformal_factor(x, density, radius):
     alpha = compute_alpha(density, radius)
-    C = (3. / (2. * np.pi * density))**(1./4.)
+    C = (3. / (2. * np.pi * density))**(1. / 4.)
     r = np.linalg.norm(x)
     if r <= radius:
         return C * sobolov(r, alpha, radius)

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Christoffel.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Christoffel.py
@@ -6,5 +6,7 @@ import numpy as np
 
 def christoffel_first_kind(d_metric):
     dim = d_metric.shape[0]
-    return 0.5 * np.array([[[d_metric[b, c, a] + d_metric[a, c, b] - d_metric[
-        c, a, b] for b in range(dim)] for a in range(dim)] for c in range(dim)])
+    return 0.5 * np.array([[[
+        d_metric[b, c, a] + d_metric[a, c, b] - d_metric[c, a, b]
+        for b in range(dim)
+    ] for a in range(dim)] for c in range(dim)])

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.py
@@ -3,8 +3,8 @@
 
 import numpy as np
 
-from .ComputeSpacetimeQuantities import (
-    spatial_deriv_spacetime_metric, dt_spacetime_metric)
+from .ComputeSpacetimeQuantities import (spatial_deriv_spacetime_metric,
+                                         dt_spacetime_metric)
 
 
 def phi(lapse, deriv_lapse, shift, deriv_shift, spatial_metric,
@@ -16,9 +16,9 @@ def phi(lapse, deriv_lapse, shift, deriv_shift, spatial_metric,
 
 def pi(lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric,
        phi):
-    return (np.einsum("iab,i", phi, shift) - dt_spacetime_metric(
-        lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric)
-    ) / lapse
+    return (np.einsum("iab,i", phi, shift) -
+            dt_spacetime_metric(lapse, dt_lapse, shift, dt_shift,
+                                spatial_metric, dt_spatial_metric)) / lapse
 
 
 def gauge_source(lapse, dt_lapse, deriv_lapse, shift, dt_shift, deriv_shift,
@@ -62,8 +62,8 @@ def deriv_shift(lapse, inverse_spacetime_metric, spacetime_unit_normal, phi):
     return t1 + t2
 
 
-def dt_shift(lapse, shift, inverse_spatial_metric, spacetime_unit_normal,
-             phi, pi):
+def dt_shift(lapse, shift, inverse_spatial_metric, spacetime_unit_normal, phi,
+             pi):
     t1 = np.einsum('a,ja->j', spacetime_unit_normal, pi[1:, :])
     t1 = np.einsum('j,ij->i', t1, inverse_spatial_metric)
     t2 = np.einsum('jka,a->jk', phi[:, 1:, :], spacetime_unit_normal)
@@ -85,8 +85,9 @@ def dt_lower_shift(lapse, shift, spatial_metric, spacetime_unit_normal, phi,
 
 
 def spacetime_deriv_norm_shift(lapse, shift, spatial_metric,
-                               inverse_spatial_metric, inverse_spacetime_metric,
-                               spacetime_unit_normal, phi, pi):
+                               inverse_spatial_metric,
+                               inverse_spacetime_metric, spacetime_unit_normal,
+                               phi, pi):
     lower_shift = np.einsum('ij,j->i', spatial_metric, shift)
     deriv_shift_ = deriv_shift(lapse, inverse_spacetime_metric,
                                spacetime_unit_normal, phi)
@@ -110,6 +111,7 @@ def deriv_spatial_metric(phi):
 
 def dt_spatial_metric(lapse, shift, phi, pi):
     return (-lapse * pi + np.einsum('k,kab->ab', shift, phi))[1:, 1:]
+
 
 def gh_dt_spacetime_metric(lapse, shift, pi, phi):
     return (-lapse * pi + np.einsum('k,kab', shift, phi))

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.py
@@ -63,9 +63,10 @@ def derivatives_of_spacetime_metric(lapse, dt_lapse, deriv_lapse, shift,
     # Spatial derivatives
     d4_psi[0, :, :] = dt_spacetime_metric(lapse, dt_lapse, shift, dt_shift,
                                           spatial_metric, dt_spatial_metric)
-    d4_psi[1:, :, :] = spatial_deriv_spacetime_metric(
-        lapse, deriv_lapse, shift, deriv_shift, spatial_metric,
-        deriv_spatial_metric)
+    d4_psi[1:, :, :] = spatial_deriv_spacetime_metric(lapse, deriv_lapse,
+                                                      shift, deriv_shift,
+                                                      spatial_metric,
+                                                      deriv_spatial_metric)
     return d4_psi
 
 

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/KerrSchildCoords.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/KerrSchildCoords.py
@@ -17,11 +17,11 @@ def jacobian(coords, bh_mass, bh_dimless_spin):
     a_squared = spin_a**2
     r_squared = r_coord_squared(coords, bh_mass, bh_dimless_spin)
     r = np.sqrt(r_squared)
-    sin_theta = np.sqrt((coords[0]**2 + coords[1]**2) /
-                        (r_squared + a_squared))
+    sin_theta = np.sqrt(
+        (coords[0]**2 + coords[1]**2) / (r_squared + a_squared))
     cos_theta = coords[2] / r
-    inv_denom = 1.0 / np.sqrt((coords[0]**2 + coords[1]**2) *
-                              (r_squared + a_squared))
+    inv_denom = 1.0 / np.sqrt(
+        (coords[0]**2 + coords[1]**2) * (r_squared + a_squared))
     sin_phi = (coords[1] * r - spin_a * coords[0]) * inv_denom
     cos_phi = (coords[0] * r + spin_a * coords[1]) * inv_denom
 

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Ricci.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Ricci.py
@@ -5,7 +5,8 @@ import numpy as np
 
 
 def ricci_tensor(christoffel, deriv_christoffel):
-    return (np.einsum("ccab", deriv_christoffel) - 0.5 * (np.einsum(
-        "bcac", deriv_christoffel) + np.einsum("acbc", deriv_christoffel)) +
-        np.einsum("dab,ccd", christoffel, christoffel) -
-        np.einsum("dac,cbd", christoffel, christoffel))
+    return (np.einsum("ccab", deriv_christoffel) - 0.5 *
+            (np.einsum("bcac", deriv_christoffel) +
+             np.einsum("acbc", deriv_christoffel)) +
+            np.einsum("dab,ccd", christoffel, christoffel) -
+            np.einsum("dac,cbd", christoffel, christoffel))

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/WeylElectric.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/WeylElectric.py
@@ -7,8 +7,7 @@ import numpy as np
 def weyl_electric_tensor(spatial_ricci, extrinsic_curvature,
                          inverse_spatial_metric):
     return (np.einsum("ij", spatial_ricci) +
-           np.einsum("kl,kl,ij", extrinsic_curvature,
-           inverse_spatial_metric, extrinsic_curvature) -
-           np.einsum("il,kl,kj",
-           extrinsic_curvature, inverse_spatial_metric,
-           extrinsic_curvature))
+            np.einsum("kl,kl,ij", extrinsic_curvature, inverse_spatial_metric,
+                      extrinsic_curvature) -
+            np.einsum("il,kl,kj", extrinsic_curvature, inverse_spatial_metric,
+                      extrinsic_curvature))

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/Test_PolytropicFluid.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/Test_PolytropicFluid.py
@@ -10,8 +10,8 @@ class TestPolytropicFluid(unittest.TestCase):
     def test_creation(self):
         # This class currently exposes no functionality, so we can't test
         # anything but its base class and that it can be instantiated.
-        eos = spectre_eos.RelativisticPolytropicFluid(
-            polytropic_constant=100., polytropic_exponent=2.)
+        eos = spectre_eos.RelativisticPolytropicFluid(polytropic_constant=100.,
+                                                      polytropic_exponent=2.)
         self.assertTrue(
             isinstance(eos, spectre_eos.RelativisticEquationOfState1D))
 

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/TestFunctions.py
@@ -6,33 +6,34 @@ import numpy as np
 
 # Functions for testing DarkEnergyFluid.cpp
 def dark_energy_fluid_pressure_from_density_and_energy(
-        rest_mass_density, specific_internal_energy, parameter_w):
+    rest_mass_density, specific_internal_energy, parameter_w):
     return parameter_w * rest_mass_density * (1.0 + specific_internal_energy)
 
 
 def dark_energy_fluid_rel_pressure_from_density_and_enthalpy(
-        rest_mass_density, specific_enthalpy, parameter_w):
+    rest_mass_density, specific_enthalpy, parameter_w):
     return (parameter_w * rest_mass_density * specific_enthalpy /
             (parameter_w + 1.0))
 
 
 def dark_energy_fluid_rel_specific_enthalpy_from_density_and_energy(
-        rest_mass_density, specific_internal_energy, parameter_w):
+    rest_mass_density, specific_internal_energy, parameter_w):
     return (parameter_w + 1.0) * (1.0 + specific_internal_energy)
 
 
 def dark_energy_fluid_specific_internal_energy_from_density_and_pressure(
-        rest_mass_density, pressure, parameter_w):
+    rest_mass_density, pressure, parameter_w):
     return pressure / (parameter_w * rest_mass_density) - 1.0
 
 
-def dark_energy_fluid_chi_from_density_and_energy(
-        rest_mass_density, specific_internal_energy, parameter_w):
+def dark_energy_fluid_chi_from_density_and_energy(rest_mass_density,
+                                                  specific_internal_energy,
+                                                  parameter_w):
     return parameter_w * (1.0 + specific_internal_energy)
 
 
 def dark_energy_fluid_kappa_times_p_over_rho_squared_from_density_and_energy(
-        rest_mass_density, specific_internal_energy, parameter_w):
+    rest_mass_density, specific_internal_energy, parameter_w):
     return parameter_w**2 * (1.0 + specific_internal_energy)
 
 
@@ -40,46 +41,49 @@ def dark_energy_fluid_kappa_times_p_over_rho_squared_from_density_and_energy(
 
 
 # Functions for testing IdealFluid.cpp
-def ideal_fluid_pressure_from_density_and_energy(
-        rest_mass_density, specific_internal_energy, adiabatic_index):
-    return rest_mass_density * specific_internal_energy * (
-        adiabatic_index - 1.0)
+def ideal_fluid_pressure_from_density_and_energy(rest_mass_density,
+                                                 specific_internal_energy,
+                                                 adiabatic_index):
+    return rest_mass_density * specific_internal_energy * (adiabatic_index -
+                                                           1.0)
 
 
-def ideal_fluid_rel_pressure_from_density_and_enthalpy(
-        rest_mass_density, specific_enthalpy, adiabatic_index):
+def ideal_fluid_rel_pressure_from_density_and_enthalpy(rest_mass_density,
+                                                       specific_enthalpy,
+                                                       adiabatic_index):
     return (rest_mass_density * (specific_enthalpy - 1.0) *
             (adiabatic_index - 1.0) / adiabatic_index)
 
 
 def ideal_fluid_newt_pressure_from_density_and_enthalpy(
-        rest_mass_density, specific_enthalpy, adiabatic_index):
+    rest_mass_density, specific_enthalpy, adiabatic_index):
     return (rest_mass_density * specific_enthalpy * (adiabatic_index - 1.0) /
             adiabatic_index)
 
 
 def ideal_fluid_rel_specific_enthalpy_from_density_and_energy(
-        rest_mass_density, specific_internal_energy, adiabatic_index):
+    rest_mass_density, specific_internal_energy, adiabatic_index):
     return 1.0 + adiabatic_index * specific_internal_energy
 
 
 def ideal_fluid_newt_specific_enthalpy_from_density_and_energy(
-        rest_mass_density, specific_internal_energy, adiabatic_index):
+    rest_mass_density, specific_internal_energy, adiabatic_index):
     return adiabatic_index * specific_internal_energy
 
 
 def ideal_fluid_specific_internal_energy_from_density_and_pressure(
-        rest_mass_density, pressure, adiabatic_index):
+    rest_mass_density, pressure, adiabatic_index):
     return pressure / (adiabatic_index - 1.0) / rest_mass_density
 
 
-def ideal_fluid_chi_from_density_and_energy(
-        rest_mass_density, specific_internal_energy, adiabatic_index):
+def ideal_fluid_chi_from_density_and_energy(rest_mass_density,
+                                            specific_internal_energy,
+                                            adiabatic_index):
     return specific_internal_energy * (adiabatic_index - 1.0)
 
 
 def ideal_fluid_kappa_times_p_over_rho_squared_from_density_and_energy(
-        rest_mass_density, specific_internal_energy, adiabatic_index):
+    rest_mass_density, specific_internal_energy, adiabatic_index):
     return specific_internal_energy * (adiabatic_index - 1.0)**2
 
 
@@ -92,36 +96,41 @@ def polytropic_pressure_from_density(rest_mass_density, polytropic_constant,
     return polytropic_constant * rest_mass_density**polytropic_exponent
 
 
-def polytropic_rel_rest_mass_density_from_enthalpy(
-        specific_enthalpy, polytropic_constant, polytropic_exponent):
+def polytropic_rel_rest_mass_density_from_enthalpy(specific_enthalpy,
+                                                   polytropic_constant,
+                                                   polytropic_exponent):
     return ((polytropic_exponent - 1.0) /
             (polytropic_constant * polytropic_exponent) *
             (specific_enthalpy - 1.0))**(1.0 / (polytropic_exponent - 1.0))
 
 
-def polytropic_newt_rest_mass_density_from_enthalpy(
-        specific_enthalpy, polytropic_constant, polytropic_exponent):
+def polytropic_newt_rest_mass_density_from_enthalpy(specific_enthalpy,
+                                                    polytropic_constant,
+                                                    polytropic_exponent):
     return ((polytropic_exponent - 1.0) /
             (polytropic_constant * polytropic_exponent) *
             (specific_enthalpy))**(1.0 / (polytropic_exponent - 1.0))
 
 
-def polytropic_rel_specific_enthalpy_from_density(
-        rest_mass_density, polytropic_constant, polytropic_exponent):
+def polytropic_rel_specific_enthalpy_from_density(rest_mass_density,
+                                                  polytropic_constant,
+                                                  polytropic_exponent):
     return 1.0 + polytropic_constant * polytropic_exponent / (
-        polytropic_exponent - 1.0) * rest_mass_density**(
-            polytropic_exponent - 1.0)
+        polytropic_exponent - 1.0) * rest_mass_density**(polytropic_exponent -
+                                                         1.0)
 
 
-def polytropic_newt_specific_enthalpy_from_density(
-        rest_mass_density, polytropic_constant, polytropic_exponent):
+def polytropic_newt_specific_enthalpy_from_density(rest_mass_density,
+                                                   polytropic_constant,
+                                                   polytropic_exponent):
     return polytropic_constant * polytropic_exponent / (
-        polytropic_exponent - 1.0) * rest_mass_density**(
-            polytropic_exponent - 1.0)
+        polytropic_exponent - 1.0) * rest_mass_density**(polytropic_exponent -
+                                                         1.0)
 
 
-def polytropic_specific_internal_energy_from_density(
-        rest_mass_density, polytropic_constant, polytropic_exponent):
+def polytropic_specific_internal_energy_from_density(rest_mass_density,
+                                                     polytropic_constant,
+                                                     polytropic_exponent):
     return polytropic_constant * rest_mass_density**(
         polytropic_exponent - 1.0) / (polytropic_exponent - 1.0)
 
@@ -133,7 +142,7 @@ def polytropic_chi_from_density(rest_mass_density, polytropic_constant,
 
 
 def polytropic_kappa_times_p_over_rho_squared_from_density(
-        rest_mass_density, polytropic_constant, polytropic_exponent):
+    rest_mass_density, polytropic_constant, polytropic_exponent):
     return 0.0
 
 

--- a/tests/Unit/PointwiseFunctions/Hydro/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/TestFunctions.py
@@ -16,8 +16,8 @@ def lorentz_factor(spatial_velocity, spatial_velocity_one_form):
 # Functions for testing MassFlux.cpp
 
 
-def mass_flux(rest_mass_density, spatial_velocity,
-              lorentz_factor, lapse, shift, sqrt_det_spatial_metric):
+def mass_flux(rest_mass_density, spatial_velocity, lorentz_factor, lapse,
+              shift, sqrt_det_spatial_metric):
     return rest_mass_density * lorentz_factor * sqrt_det_spatial_metric * \
         (lapse * spatial_velocity - shift)
 

--- a/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
+++ b/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
@@ -10,19 +10,17 @@ import os
 
 class TestGenerateXdmf(unittest.TestCase):
     def test_generate_xdmf(self):
-        data_file_prefix = os.path.join(
-            spectre_informer.unit_test_path(), 'IO',
-            'VolTestData')
+        data_file_prefix = os.path.join(spectre_informer.unit_test_path(),
+                                        'IO', 'VolTestData')
         output_filename = 'Test_GenerateXdmf_output'
         if os.path.isfile(output_filename + '.xmf'):
             os.remove(output_filename + '.xmf')
 
-        generate_xdmf(
-            file_prefix=data_file_prefix,
-            output_filename=output_filename,
-            start_time=0.,
-            stop_time=1.,
-            stride=1)
+        generate_xdmf(file_prefix=data_file_prefix,
+                      output_filename=output_filename,
+                      start_time=0.,
+                      stop_time=1.,
+                      stride=1)
 
         # The script is quite opaque right now, so we only test that we can run
         # it and it produces output without raising and error. To test more

--- a/tools/CheckPythonFormatting.sh
+++ b/tools/CheckPythonFormatting.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Find all python files in src, support, tests, and tools, then run
+# them through yapf.
+if ! find ./src/ \
+     ./support/ \
+     ./tests/ \
+     ./tools/ \
+     -type f \
+     -name "*.py" \
+     -print0 \
+        | xargs -0 yapf --parallel -d
+then
+    printf "\n\nFound bad formatting in python files. See diff above \n" \
+           "for details. You can run yapf on a file as:\n" \
+           "  yapf -i PYTHON_FILE.py\n" \
+           "or on the entire repository by running:\n" \
+           "  ./tools/FormatPythonCode.py\n" \
+           "in the SpECTRE root directory.\n"
+    exit 1
+fi
+
+printf "Python formatting is okay."

--- a/tools/CleanOutput.py
+++ b/tools/CleanOutput.py
@@ -9,6 +9,7 @@ import re
 class MissingExpectedOutputError(Exception):
     def __init__(self, missing_files):
         self.missing_files = missing_files
+
     def __str__(self):
         return "Expected output files are missing: {}".format(
             self.missing_files)
@@ -39,20 +40,21 @@ def clean_output(input_file, output_dir, force):
             # Now collect the output files listed in the comment.
             # We look for lines that are indented by two spaces relative to the
             # preceding `ExpectedOutput` comment
-            matched_output_file = re.match(
-                '#' + found_indentation + '(.+)', line)
+            matched_output_file = re.match('#' + found_indentation + '(.+)',
+                                           line)
             if matched_output_file is None:
                 logging.debug("Reached end of expected output file list.")
                 break
             else:
                 expected_output_file = os.path.join(
-                    output_dir, matched_output_file.groups()[0])
+                    output_dir,
+                    matched_output_file.groups()[0])
                 logging.debug("Attempting to remove file {}...".format(
                     expected_output_file))
                 if os.path.exists(expected_output_file):
                     os.remove(expected_output_file)
-                    logging.info("Removed file {}.".format(
-                        expected_output_file))
+                    logging.info(
+                        "Removed file {}.".format(expected_output_file))
                 elif not force:
                     missing_files.append(expected_output_file)
                     logging.error("Expected file {} was not found.".format(
@@ -68,26 +70,21 @@ def clean_output(input_file, output_dir, force):
 
 def parse_args():
     import argparse as ap
-    parser = ap.ArgumentParser(
-        description="")
-    parser.add_argument(
-        '--input-file',
-        required=True,
-        help="Path to the input file of the run to clean up")
-    parser.add_argument(
-        '--output-dir',
-        required=True,
-        help="Output directory of the run to clean up")
-    parser.add_argument(
-        '-v',
-        '--verbose',
-        action='count',
-        default=0,
-        help="Verbosity (-v, -vv, ...)")
-    parser.add_argument(
-        '--force',
-        action='store_true',
-        help="Suppress all errors")
+    parser = ap.ArgumentParser(description="")
+    parser.add_argument('--input-file',
+                        required=True,
+                        help="Path to the input file of the run to clean up")
+    parser.add_argument('--output-dir',
+                        required=True,
+                        help="Output directory of the run to clean up")
+    parser.add_argument('-v',
+                        '--verbose',
+                        action='count',
+                        default=0,
+                        help="Verbosity (-v, -vv, ...)")
+    parser.add_argument('--force',
+                        action='store_true',
+                        help="Suppress all errors")
     return parser.parse_args()
 
 

--- a/tools/FormatPythonCode.sh
+++ b/tools/FormatPythonCode.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Find all python files in src, support, tests, and tools, then run
+# them through yapf.
+find ./src/ \
+     ./support/ \
+     ./tests/ \
+     ./tools/ \
+     -type f \
+     -name "*.py" \
+     -print0 \
+    | xargs -0 yapf --parallel -i

--- a/tools/Hooks/ClangFormat.py
+++ b/tools/Hooks/ClangFormat.py
@@ -10,11 +10,10 @@ import re
 
 # List of all the clang-format versions we are willing to use
 # The general case is needed on a Mac
-clang_format_list = ["git-clang-format",
-                     "git-clang-format-6.0",
-                     "git-clang-format-4.0",
-                     "git-clang-format-3.9",
-                     "git-clang-format-3.8"]
+clang_format_list = [
+    "git-clang-format", "git-clang-format-6.0", "git-clang-format-4.0",
+    "git-clang-format-3.9", "git-clang-format-3.8"
+]
 
 git_executable = "@GIT_EXECUTABLE@"
 
@@ -37,6 +36,7 @@ def which(program):
 
     return None
 
+
 # Check each of the allowed versions
 clang_format = ""
 for version in clang_format_list:
@@ -56,17 +56,19 @@ clang_format_version = subprocess.check_output([clang_format, "--version"])
 clang_format_version = re.search("clang-format version ([0-9]+)\.([0-9]+)",
                                  str(clang_format_version))
 
-if (int(clang_format_version.group(1)) < 4 and
-        int(clang_format_version.group(2)) < 8):
+if (int(clang_format_version.group(1)) < 4
+        and int(clang_format_version.group(2)) < 8):
     print("clang-format version %s.%s is too low. Must have at least 3.8" %
-              (clang_format_version.group(1), clang_format_version.group(2)))
+          (clang_format_version.group(1), clang_format_version.group(2)))
     sys.exit(0)
 
-output = subprocess.check_output([git_executable, clang_format, "--diff"
-                                  ]).decode('ascii')
+output = subprocess.check_output([git_executable, clang_format,
+                                  "--diff"]).decode('ascii')
 
-if output not in ['\n', '', 'no modified files to format\n',
-                  'clang-format did not modify any files\n']:
+if output not in [
+        '\n', '', 'no modified files to format\n',
+        'clang-format did not modify any files\n'
+]:
     output_file_name = "@CMAKE_SOURCE_DIR@/.clang_format_diff.patch"
     output_file = open(output_file_name, 'w')
     output_file.write("%s" % (output))
@@ -78,8 +80,7 @@ if output not in ['\n', '', 'no modified files to format\n',
           "  cd @CMAKE_SOURCE_DIR@\n"
           "  git apply %s\n"
           "and then staging the modified files and amending your original "
-          "commit.\n" %
-          (output_file_name, output_file_name))
+          "commit.\n" % (output_file_name, output_file_name))
     sys.exit(1)
 
 sys.exit(0)

--- a/tools/Hooks/pre-commit.sh
+++ b/tools/Hooks/pre-commit.sh
@@ -35,6 +35,30 @@ printf '%s\0' "${commit_files[@]}" | run_checks "${standard_checks[@]}"
 # Use git-clang-format to check for any suspicious formatting of code.
 @PYTHON_EXECUTABLE@ @CMAKE_SOURCE_DIR@/.git/hooks/ClangFormat.py
 
+###############################################################################
+# Use yapf to check python file formatting, only if it is installed.
+if command -v @YAPF_EXECUTABLE@ >/dev/null 2>&1; then
+    python_files=()
+
+    for commit_file in ${commit_files[@]}
+    do
+        if [[ $commit_file =~ .*\.py$ ]]; then
+            python_files+=("${commit_file}")
+        fi
+    done
+
+    if [ ${#python_files[@]} -ne 0 ]; then
+        @YAPF_EXECUTABLE@ -q ${python_files[@]}
+        if [ $? -ne 0 ]; then
+            found_error=1
+            printf "Found python formatting errors. Please run the script\n"
+            printf "'tools/FormatPythonCode.sh' to format the whole repo\n"
+            printf "or run yapf on the files you've added directly.\n"
+        fi
+    fi
+fi
+
+###############################################################################
 if [ "$found_error" -eq "1" ]; then
     exit 1
 fi

--- a/tools/latex2dox.py
+++ b/tools/latex2dox.py
@@ -15,13 +15,11 @@ def parse_file(input_file_name, output_file_name):
     # Replace equations, etc.
     out_string = re.sub("\\\\begin{(align\*?|equation\*?|eqnarray\*?)}",
                         r"\\f{\1}{", tex_string)
-    out_string = re.sub("\\\\end{(align\*?|equation\*?|eqnarray\*?)}",
-                        r"\\f}", out_string)
+    out_string = re.sub("\\\\end{(align\*?|equation\*?|eqnarray\*?)}", r"\\f}",
+                        out_string)
     # Replace section and subsection
-    out_string = re.sub("\\\\section{([^}]+)}",
-                        r"## \1", out_string)
-    out_string = re.sub("\\\\subsection{([^}]+)}",
-                        r"### \1", out_string)
+    out_string = re.sub("\\\\section{([^}]+)}", r"## \1", out_string)
+    out_string = re.sub("\\\\subsection{([^}]+)}", r"### \1", out_string)
     # Get inline math to work
     out_string = re.sub("([^\\\\])\$", r"\1\\f$", out_string)
     # Wrap \ref in math to get references to work
@@ -34,9 +32,9 @@ def parse_file(input_file_name, output_file_name):
         command_string = "%s\\f$%s\\f$\n" % (command_string, newcommand)
 
     # Extract contents inside document
-    is_doc = re.search(re.compile("\\\\begin{document}(.*)\\\\end{document}",
-                                  re.DOTALL),
-                       out_string)
+    is_doc = re.search(
+        re.compile("\\\\begin{document}(.*)\\\\end{document}", re.DOTALL),
+        out_string)
     if is_doc:
         out_string = is_doc.group(1)
 
@@ -55,12 +53,12 @@ def parse_args():
         'tweaking but the goal of this script is to automate the majority'
         ' of the work.',
         formatter_class=ap.ArgumentDefaultsHelpFormatter)
-    parser.add_argument(
-        '--tex-file', required=True, help="The name LaTeX file to process")
-    parser.add_argument(
-        '--output-file',
-        required=True,
-        help="The name of the file to write the output to")
+    parser.add_argument('--tex-file',
+                        required=True,
+                        help="The name LaTeX file to process")
+    parser.add_argument('--output-file',
+                        required=True,
+                        help="The name of the file to write the output to")
     return vars(parser.parse_args())
 
 


### PR DESCRIPTION
## Proposed changes

- Add yapf python formatter to Docker container
- Add a check script to check for python formatting
- Add a script to use yapf to format code base
- Add a CI target that checks that python files are formatted correctly.

Depends on #1889 because they both modify the Docker env. Please only check the commits:

 * Add Python formatting check to CI
 * Format all python code
 * Add shell script to check for python formatting
 * Add script to apply yapf to code base
 * Add yapf to Docker container

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
