### PR TITLE
Deploy docs to gh-pages from GitHub CI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -141,6 +141,13 @@ jobs:
         # Can be removed once this is done in the container.
         run: |
           PATH=$PATH:/work/texlive/bin/x86_64-linux make doc-check
+      # Re-build with coverage information on pushes to develop for deployment
+      # to gh-pages.
+      - name: Build documentation with coverage
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        working-directory: /work/build
+        run: |
+          PATH=$PATH:/work/texlive/bin/x86_64-linux make doc-coverage
       # The `upload-artifact` action doesn't run in the container, so we move
       # the data to the shared workspace.
       # Relevant issue: https://github.com/actions/upload-artifact/issues/13
@@ -153,6 +160,38 @@ jobs:
           name: docs-html
           # The `path` is relative to the $GITHUB_WORKSPACE on the host machine
           path: docs-html
+
+  # Deploy built documentation to `gh-pages` on pushes to `develop`.
+  doc_deploy:
+    name: Deploy documentation
+    needs: doc_check
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Download built documentation
+        uses: actions/download-artifact@v1
+        with:
+          name: docs-html
+      - name: Add custom domain
+        if: github.repository == 'sxs-collaboration/spectre'
+        working-directory: ./docs-html
+        run: |
+          echo "spectre-code.org" > CNAME
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v2
+        env:
+          # There's an issue with using the `GITHUB_TOKEN` for gh-pages
+          # deployment as of Jan 8, 2020, so we use a personal access token
+          # instead until the issue is resolved. See:
+          # https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869
+          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_TOKEN: ${{ secrets.GH_PAGES_DEPLOY_TOKEN }}
+          PUBLISH_BRANCH: gh-pages
+          PUBLISH_DIR: docs-html
+        with:
+          forceOrphan: true
 
   # Build all test executables and run unit tests on a variety of compiler
   # configurations.

--- a/.travis/BuildLinux.sh
+++ b/.travis/BuildLinux.sh
@@ -92,7 +92,10 @@ if [ -z "${RUN_CLANG_TIDY}" ] \
 fi
 
 # Build documentation and doc coverage and deploy to GitHub pages.
+# Disabled since this is done with GitHub actions instead of Travis.
+DEPLOY_DOC=false
 if [ ${BUILD_DOC} ] \
+       && [ ${DEPLOY_DOC} = true ] \
        && [ ${TRAVIS_SECURE_ENV_VARS} = true ] \
        && [ ${TRAVIS_BRANCH} = ${GH_PAGES_SOURCE_BRANCH} ] \
        && [ ${TRAVIS_PULL_REQUEST} == false ]; then

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -241,6 +241,7 @@ HTML_EXTRA_FILES       = @PROJECT_SOURCE_DIR@/docs/config/icons/octicons.eot \
                          @PROJECT_SOURCE_DIR@/docs/config/js/bootstrap.min.js \
                          @PROJECT_SOURCE_DIR@/docs/config/js/jquery.js \
                          @PROJECT_SOURCE_DIR@/docs/config/js/spectre.js \
+                         @PROJECT_SOURCE_DIR@/docs/.nojekyll \
                          @PROJECT_SOURCE_DIR@/LICENSE.txt
 
 # This is not the recommended way of using a completely custom style sheet.

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -302,6 +302,7 @@ license() {
               '.github/ISSUE_TEMPLATE.md' \
               '.github/PULL_REQUEST_TEMPLATE.md' \
               '.h5' \
+              '.nojekyll' \
               '.png' \
               '.svg' \
               '.clang-format$' \
@@ -407,7 +408,7 @@ standard_checks+=(pragma_once)
 
 # Check for a newline at end of file
 final_newline() {
-    whitelist "$1" '.h5' '.png' '.svg' &&
+    whitelist "$1" '.h5' '.nojekyll' '.png' '.svg' &&
     # Bash strips trailing newlines from $() output
     [ "$(tail -c 1 "$1" ; echo x)" != $'\n'x ]
 }


### PR DESCRIPTION
## Proposed changes

Switches the docs deployment from Travis to GitHub CI.

Requires a GitHub personal access token named `GH_PAGES_DEPLOY_TOKEN` to be added to the repository's "Settings" > "Secrets" page. [This page](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) describes how to create such a token. It must include the `public_repo` permissions. Once [an issue](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869) with GitHub Actions is resolved, we can just use the automatic `secrets.GITHUB_TOKEN` instead, so no personal access token is required anymore.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
