### PR TITLE
Scri plus values

### DIFF
--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   ReadBoundaryDataH5.cpp
   ReducedWorldtubeModeRecorder.cpp
   SpecBoundaryData.cpp
+  ScriPlusValues.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Evolution/Systems/Cce/IntegrandInputSteps.hpp
+++ b/src/Evolution/Systems/Cce/IntegrandInputSteps.hpp
@@ -308,4 +308,39 @@ using all_pre_swsh_derivative_tags =
         tmpl::bind<tmpl::list,
                    pre_swsh_derivative_tags_to_compute_for<tmpl::_1>, tmpl::_1,
                    tmpl::bind<Tags::Dy, tmpl::_1>>>>>;
+
+/// Typelist of steps for `PreSwshDerivatives` mutations needed for scri+
+/// computations
+using all_pre_swsh_derivative_tags_for_scri =
+    tmpl::list<Tags::Dy<Tags::Du<Tags::BondiJ>>,
+               Tags::Dy<Tags::Dy<Tags::BondiW>>,
+               Tags::Dy<Tags::Dy<Tags::Dy<Tags::BondiJ>>>,
+               Tags::ComplexInertialRetardedTime>;
+
+/// Typelist of steps for `SwshDerivatives` mutations called on volume
+/// quantities needed for scri+ computations
+using all_swsh_derivative_tags_for_scri = tmpl::list<
+    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiU>,
+                                     Spectral::Swsh::Tags::Eth>,
+    Spectral::Swsh::Tags::Derivative<
+        Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                         Spectral::Swsh::Tags::EthEthbar>,
+        Spectral::Swsh::Tags::Ethbar>,
+    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::Du<Tags::BondiJ>>,
+                                     Spectral::Swsh::Tags::Ethbar>,
+    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::Dy<Tags::BondiU>>,
+                                     Spectral::Swsh::Tags::Ethbar>,
+    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiQ>,
+                                     Spectral::Swsh::Tags::Ethbar>,
+    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiU>,
+                                     Spectral::Swsh::Tags::Eth>,
+    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::Dy<Tags::BondiBeta>>,
+                                     Spectral::Swsh::Tags::Eth>>;
+
+/// Typelist of steps for `SwshDerivatives` mutations called on boundary
+/// (angular grid only) quantities needed for scri+ computations
+using all_boundary_swsh_derivative_tags_for_scri =
+    tmpl::list<Spectral::Swsh::Tags::Derivative<
+        Tags::ComplexInertialRetardedTime, Spectral::Swsh::Tags::EthEth>>;
+
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/PreSwshDerivatives.hpp
+++ b/src/Evolution/Systems/Cce/PreSwshDerivatives.hpp
@@ -260,6 +260,25 @@ struct PreSwshDerivatives<Tags::Exp2Beta> {
   }
 };
 
+/// Copies the values of the inertial retarded time into a spin-weighted
+/// container so that spin-weighted derivatives can be taken
+template <>
+struct PreSwshDerivatives<Tags::ComplexInertialRetardedTime> {
+  using pre_swsh_derivative_tags = tmpl::list<>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integrand_tags = tmpl::list<>;
+
+  using return_tags = tmpl::list<Tags::ComplexInertialRetardedTime>;
+  using argument_tags = tmpl::list<Tags::InertialRetardedTime>;
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+      complex_inertial_retarded_time,
+      const Scalar<DataVector>& inertial_retarded_time) noexcept {
+    get(*complex_inertial_retarded_time).data() =
+        std::complex<double>(1.0, 0.0) * get(inertial_retarded_time);
+  }
+};
+
 /// Compute the derivative of the quantity represented by `Tag` with respect to
 /// the numerical radial coordinate \f$y\f$.
 template <typename Tag>

--- a/src/Evolution/Systems/Cce/ScriPlusValues.cpp
+++ b/src/Evolution/Systems/Cce/ScriPlusValues.cpp
@@ -1,0 +1,364 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/ScriPlusValues.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
+#include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
+
+namespace Cce {
+
+void CalculateScriPlusValue<Tags::News>::apply(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -2>>*> news,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_du_bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_beta,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& eth_eth_beta,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+    const size_t l_max, const size_t number_of_radial_points) noexcept {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  const SpinWeighted<ComplexDataVector, 2> dy_du_j_at_scri;
+  make_const_view(make_not_null(&dy_du_j_at_scri), get(dy_du_bondi_j),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 0> beta_at_scri;
+  make_const_view(make_not_null(&beta_at_scri), get(beta),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 1> eth_beta_at_scri;
+  make_const_view(make_not_null(&eth_beta_at_scri), get(eth_beta),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 2> eth_eth_beta_at_scri;
+  make_const_view(make_not_null(&eth_eth_beta_at_scri), get(eth_eth_beta),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  // Note: -2 * r extra factor due to derivative l to y
+  // Note also: extra factor of 2.0 for conversion to strain.
+  get(*news) =
+      2.0 * conj(-get(boundary_r) * exp(-2.0 * beta_at_scri) * dy_du_j_at_scri +
+                 eth_eth_beta_at_scri + 2.0 * square(eth_beta_at_scri));
+}
+
+void CalculateScriPlusValue<Tags::TimeIntegral<Tags::ScriPlus<Tags::Psi4>>>::
+    apply(const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -2>>*>
+              integral_of_psi_4,
+          const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta,
+          const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_bondi_u,
+          const Scalar<SpinWeighted<ComplexDataVector, 2>>& eth_dy_bondi_u,
+          const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_du_bondi_j,
+          const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+          const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+          const size_t l_max, const size_t number_of_radial_points) noexcept {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  const SpinWeighted<ComplexDataVector, 0> exp_2_beta_at_scri;
+  make_const_view(make_not_null(&exp_2_beta_at_scri), get(exp_2_beta),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 1> dy_u_at_scri;
+  make_const_view(make_not_null(&dy_u_at_scri), get(dy_bondi_u),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+  const SpinWeighted<ComplexDataVector, 2> eth_dy_u_at_scri;
+  make_const_view(make_not_null(&eth_dy_u_at_scri), get(eth_dy_bondi_u),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 1> eth_r_divided_by_r_view;
+  make_const_view(make_not_null(&eth_r_divided_by_r_view),
+                  get(eth_r_divided_by_r),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 2> dy_du_j_at_scri;
+  make_const_view(make_not_null(&dy_du_j_at_scri), get(dy_du_bondi_j),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  get(*integral_of_psi_4) =
+      get(boundary_r) *
+      ((conj(eth_dy_u_at_scri) +
+        conj(eth_r_divided_by_r_view) * conj(dy_u_at_scri)) +
+       conj(dy_du_j_at_scri)) /
+      exp_2_beta_at_scri;
+}
+
+void CalculateScriPlusValue<Tags::ScriPlusFactor<Tags::Psi4>>::apply(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+        scri_plus_factor,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta,
+    const size_t l_max, const size_t number_of_radial_points) noexcept {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  const SpinWeighted<ComplexDataVector, 0> exp_2_beta_at_scri;
+  make_const_view(make_not_null(&exp_2_beta_at_scri), get(exp_2_beta),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  // extra factor of 2 for tetrad matching to SXS conventions
+  get(*scri_plus_factor) = 2.0 / exp_2_beta_at_scri;
+}
+
+void CalculateScriPlusValue<Tags::ScriPlus<Tags::Psi3>>::apply(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -1>>*> psi_3,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_beta,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& eth_ethbar_beta,
+    const Scalar<SpinWeighted<ComplexDataVector, -1>>& ethbar_eth_ethbar_beta,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_du_bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& ethbar_dy_du_bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+    const size_t l_max, const size_t number_of_radial_points) noexcept {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  const SpinWeighted<ComplexDataVector, 0> exp_2_beta_at_scri;
+  make_const_view(make_not_null(&exp_2_beta_at_scri), get(exp_2_beta),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 1> eth_beta_at_scri;
+  make_const_view(make_not_null(&eth_beta_at_scri), get(eth_beta),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 0> eth_ethbar_beta_at_scri;
+  make_const_view(make_not_null(&eth_ethbar_beta_at_scri), get(eth_ethbar_beta),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, -1> ethbar_eth_ethbar_beta_at_scri;
+  make_const_view(make_not_null(&ethbar_eth_ethbar_beta_at_scri),
+                  get(ethbar_eth_ethbar_beta),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 1> eth_r_divided_by_r_view;
+  make_const_view(make_not_null(&eth_r_divided_by_r_view),
+                  get(eth_r_divided_by_r),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 2> dy_du_j_at_scri;
+  make_const_view(make_not_null(&dy_du_j_at_scri), get(dy_du_bondi_j),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 1> ethbar_dy_du_j_at_scri;
+  make_const_view(make_not_null(&ethbar_dy_du_j_at_scri),
+                  get(ethbar_dy_du_bondi_j),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  // Attempting the consensus form; math still needs re-examining
+  // extra factor of * -sqrt(2) to agree with SpEC tetrad normalization
+  get(*psi_3) = 2.0 * conj(eth_beta_at_scri) +
+                4.0 * conj(eth_beta_at_scri) * eth_ethbar_beta_at_scri +
+                ethbar_eth_ethbar_beta_at_scri +
+                get(boundary_r) *
+                    (-(conj(ethbar_dy_du_j_at_scri) +
+                       eth_r_divided_by_r_view * conj(dy_du_j_at_scri)) +
+                     2.0 * eth_beta_at_scri * conj(dy_du_j_at_scri)) /
+                    exp_2_beta_at_scri;
+}
+
+void CalculateScriPlusValue<Tags::ScriPlus<Tags::Psi2>>::apply(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> psi_2,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_bondi_q,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& ethbar_dy_bondi_q,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_bondi_u,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& eth_dy_bondi_u,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_dy_bondi_u,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& ethbar_dy_dy_bondi_u,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& dy_dy_bondi_w,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_du_bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+    const size_t l_max, const size_t number_of_radial_points) noexcept {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  const SpinWeighted<ComplexDataVector, 2> dy_du_j_at_scri;
+  make_const_view(make_not_null(&dy_du_j_at_scri), get(dy_du_bondi_j),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 0> dy_dy_w_at_scri;
+  make_const_view(make_not_null(&dy_dy_w_at_scri), get(dy_dy_bondi_w),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 2> dy_j_at_scri;
+  make_const_view(make_not_null(&dy_j_at_scri), get(dy_bondi_j),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 1> dy_q_at_scri;
+  make_const_view(make_not_null(&dy_q_at_scri), get(dy_bondi_q),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+  const SpinWeighted<ComplexDataVector, 0> ethbar_dy_q_at_scri;
+  make_const_view(make_not_null(&ethbar_dy_q_at_scri), get(ethbar_dy_bondi_q),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 1> dy_u_at_scri;
+  make_const_view(make_not_null(&dy_u_at_scri), get(dy_bondi_u),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+  const SpinWeighted<ComplexDataVector, 2> eth_dy_u_at_scri;
+  make_const_view(make_not_null(&eth_dy_u_at_scri), get(eth_dy_bondi_u),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 1> dy_dy_u_at_scri;
+  make_const_view(make_not_null(&dy_dy_u_at_scri), get(dy_dy_bondi_u),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+  const SpinWeighted<ComplexDataVector, 0> ethbar_dy_dy_u_at_scri;
+  make_const_view(make_not_null(&ethbar_dy_dy_u_at_scri),
+                  get(ethbar_dy_dy_bondi_u),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 0> exp_2_beta_at_scri;
+  make_const_view(make_not_null(&exp_2_beta_at_scri), get(exp_2_beta),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 1> eth_r_divided_by_r_view;
+  make_const_view(make_not_null(&eth_r_divided_by_r_view),
+                  get(eth_r_divided_by_r),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  get(*psi_2) =
+      -0.5 * get(boundary_r) *
+      (-exp_2_beta_at_scri * (conj(ethbar_dy_q_at_scri) +
+                              eth_r_divided_by_r_view * conj(dy_q_at_scri)) +
+       get(boundary_r) * (ethbar_dy_dy_u_at_scri +
+                          conj(eth_r_divided_by_r_view) * dy_dy_u_at_scri +
+                          conj(ethbar_dy_dy_u_at_scri) +
+                          eth_r_divided_by_r_view * conj(dy_dy_u_at_scri)) +
+       2.0 * get(boundary_r) *
+           (dy_j_at_scri *
+                (conj(eth_dy_u_at_scri) +
+                 conj(eth_r_divided_by_r_view) * conj(dy_u_at_scri)) +
+            dy_j_at_scri * conj(dy_du_j_at_scri) - dy_dy_w_at_scri)) /
+      exp_2_beta_at_scri;
+}
+
+void CalculateScriPlusValue<Tags::ScriPlus<Tags::Psi1>>::apply(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*> psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& dy_dy_bondi_beta,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_dy_dy_bondi_beta,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_bondi_q,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_dy_bondi_q,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+    const size_t l_max, const size_t number_of_radial_points) noexcept {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  const SpinWeighted<ComplexDataVector, 0> dy_dy_beta_at_scri;
+  make_const_view(make_not_null(&dy_dy_beta_at_scri), get(dy_dy_bondi_beta),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 1> eth_dy_dy_beta_at_scri;
+  make_const_view(make_not_null(&eth_dy_dy_beta_at_scri),
+                  get(eth_dy_dy_bondi_beta),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 2> dy_j_at_scri;
+  make_const_view(make_not_null(&dy_j_at_scri), get(dy_bondi_j),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+  const SpinWeighted<ComplexDataVector, 1> dy_q_at_scri;
+  make_const_view(make_not_null(&dy_q_at_scri), get(dy_bondi_q),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 1> dy_dy_q_at_scri;
+  make_const_view(make_not_null(&dy_dy_q_at_scri), get(dy_dy_bondi_q),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 1> eth_r_divided_by_r_view;
+  make_const_view(make_not_null(&eth_r_divided_by_r_view),
+                  get(eth_r_divided_by_r),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  // extra -1/sqrt(2) factor to agree with SXS tetrad normalization
+  get(*psi_1) = -0.5 * square(get(boundary_r)) *
+                (6.0 * (eth_dy_dy_beta_at_scri +
+                        eth_r_divided_by_r_view * dy_dy_beta_at_scri) -
+                 dy_j_at_scri * conj(dy_q_at_scri) - dy_dy_q_at_scri);
+}
+
+void CalculateScriPlusValue<Tags::ScriPlus<Tags::Psi0>>::apply(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> psi_0,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_dy_dy_bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+    const size_t l_max, const size_t number_of_radial_points) noexcept {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  const SpinWeighted<ComplexDataVector, 2> dy_dy_dy_j_at_scri;
+  make_const_view(make_not_null(&dy_dy_dy_j_at_scri), get(dy_dy_dy_bondi_j),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  const SpinWeighted<ComplexDataVector, 2> dy_j_at_scri;
+  make_const_view(make_not_null(&dy_j_at_scri), get(dy_bondi_j),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  // extra 1/2 factor to agree with SXS tetrad normalization
+  get(*psi_0) = -pow<3>(get(boundary_r)) *
+                (3.0 * conj(dy_j_at_scri) * square(dy_j_at_scri) -
+                 2.0 * dy_dy_dy_j_at_scri);
+}
+
+void CalculateScriPlusValue<Tags::ScriPlus<Tags::Strain>>::apply(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -2>>*> strain,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& eth_eth_retarded_time,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+    const size_t l_max, const size_t number_of_radial_points) noexcept {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  const SpinWeighted<ComplexDataVector, 2> dy_j_at_scri;
+  make_const_view(make_not_null(&dy_j_at_scri), get(dy_bondi_j),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  // conjugate to retrieve the spin -2 quantity everyone else in the world
+  // uses.
+  get(*strain) =
+      conj(-2.0 * get(boundary_r) * dy_j_at_scri + get(eth_eth_retarded_time));
+}
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/ScriPlusValues.cpp
+++ b/src/Evolution/Systems/Cce/ScriPlusValues.cpp
@@ -361,4 +361,14 @@ void CalculateScriPlusValue<Tags::ScriPlus<Tags::Strain>>::apply(
   get(*strain) =
       conj(-2.0 * get(boundary_r) * dy_j_at_scri + get(eth_eth_retarded_time));
 }
+
+void CalculateScriPlusValue<::Tags::dt<Tags::InertialRetardedTime>>::apply(
+    const gsl::not_null<Scalar<DataVector>*> dt_inertial_time,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta) noexcept {
+  const SpinWeighted<ComplexDataVector, 0> exp_2_beta_at_scri;
+  make_const_view(make_not_null(&exp_2_beta_at_scri), get(exp_2_beta),
+                  get(exp_2_beta).size() - get(*dt_inertial_time).size(),
+                  get(*dt_inertial_time).size());
+  get(*dt_inertial_time) = real(exp_2_beta_at_scri.data());
+}
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/ScriPlusValues.hpp
+++ b/src/Evolution/Systems/Cce/ScriPlusValues.hpp
@@ -400,4 +400,44 @@ struct CalculateScriPlusValue<Tags::ScriPlus<Tags::Strain>> {
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
       size_t l_max, size_t number_of_radial_points) noexcept;
 };
+
+/*!
+ * \brief Assign the time derivative of the asymptotically inertial time
+ * coordinate.
+ *
+ * \details The asymptotically inertial time coordinate \f$\mathring u\f$ obeys
+ * the differential equation:
+ *
+ * \f{align*}{
+ * \partial_u \mathring u = e^{2 \beta}.
+ * \f}
+ */
+template <>
+struct CalculateScriPlusValue<::Tags::dt<Tags::InertialRetardedTime>> {
+  using return_tags = tmpl::list<::Tags::dt<Tags::InertialRetardedTime>>;
+  using argument_tags = tmpl::list<Tags::Exp2Beta>;
+
+  static void apply(
+      gsl::not_null<Scalar<DataVector>*> dt_inertial_time,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta) noexcept;
+};
+
+/// \cond
+template <typename Tag>
+struct InitializeScriPlusValue;
+/// \endcond
+
+/// Initialize the inertial retarded time to the value provided in the mutator
+/// arguments.
+template <>
+struct InitializeScriPlusValue<Tags::InertialRetardedTime> {
+  using argument_tags = tmpl::list<>;
+  using return_tags = tmpl::list<Tags::InertialRetardedTime>;
+
+  static void apply(const gsl::not_null<Scalar<DataVector>*> inertial_time,
+                    const double initial_time = 0.0) noexcept {
+    // this is arbitrary, and has to do with choosing a BMS frame.
+    get(*inertial_time) = initial_time;
+  }
+};
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/ScriPlusValues.hpp
+++ b/src/Evolution/Systems/Cce/ScriPlusValues.hpp
@@ -1,0 +1,403 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+
+namespace Cce {
+
+template <typename Tag>
+struct CalculateScriPlusValue;
+
+/*!
+ * \brief Compute the Bondi news from the evolution quantities.
+ *
+ * \details In the gauge used for regularity-preserving CCE,
+ * the Bondi news takes the convenient form
+ *
+ * \f{align*}{
+ * N = e^{-2 \beta^{(0)}} \left( (\partial_u \bar J)^{(1)}
+ * + \bar \eth \bar \eth e^{2 \beta^{(0)}}\right),
+ * \f}
+ *
+ * where \f$(0)\f$ and \f$(1)\f$ in the superscripts denote the zeroth and first
+ * order in an expansion in \f$1/r\f$ near \f$\mathcal{I}^+\f$.
+ */
+template <>
+struct CalculateScriPlusValue<Tags::News> {
+  using return_tags = tmpl::list<Tags::News>;
+  // extra typelist for more convenient testing
+  using tensor_argument_tags =
+      tmpl::list<Tags::Dy<Tags::Du<Tags::BondiJ>>, Tags::BondiBeta,
+                 Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                                  Spectral::Swsh::Tags::Eth>,
+                 Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                                  Spectral::Swsh::Tags::EthEth>,
+                 Tags::EvolutionGaugeBoundaryValue<Tags::BondiR>>;
+  using argument_tags =
+      tmpl::append<tensor_argument_tags,
+                   tmpl::list<Spectral::Swsh::Tags::LMax,
+                              Spectral::Swsh::Tags::NumberOfRadialPoints>>;
+
+  static void apply(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -2>>*> news,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_du_bondi_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& eth_eth_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+      size_t l_max, size_t number_of_radial_points) noexcept;
+};
+
+/*!
+ * \brief Compute the contribution to the leading \f$\Psi_4\f$ that corresponds
+ * to a total time derivative.
+ *
+ * \details The value \f$\Psi_4\f$ scales asymptotically as \f$r^{-1}\f$, and
+ * has the form
+ *
+ * \f{align*}{
+ * \Psi_4^{(1)} = A \partial_u B,
+ * \f}
+ *
+ * where superscripts denote orders in the expansion in powers of \f$r^{-1}\f$.
+ * This mutator computes \f$B\f$:
+ *
+ * \f{align*}{
+ * B = e^{-2 \beta^{(0)}} (\bar \eth \bar U^{(1)} + \partial_u \bar J)
+ * \f}
+ */
+template <>
+struct CalculateScriPlusValue<Tags::TimeIntegral<Tags::ScriPlus<Tags::Psi4>>> {
+  using return_tags =
+      tmpl::list<Tags::TimeIntegral<Tags::ScriPlus<Tags::Psi4>>>;
+  // extra typelist for more convenient testing
+  using tensor_argument_tags =
+      tmpl::list<Tags::Exp2Beta, Tags::Dy<Tags::BondiU>,
+                 Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiU>,
+                                                  Spectral::Swsh::Tags::Eth>,
+                 Tags::Dy<Tags::Du<Tags::BondiJ>>,
+                 Tags::EvolutionGaugeBoundaryValue<Tags::BondiR>,
+                 Tags::EthRDividedByR>;
+  using argument_tags =
+      tmpl::append<tensor_argument_tags,
+                   tmpl::list<Spectral::Swsh::Tags::LMax,
+                              Spectral::Swsh::Tags::NumberOfRadialPoints>>;
+
+  static void apply(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -2>>*>
+          integral_of_psi_4,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_bondi_u,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& eth_dy_bondi_u,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_du_bondi_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+      size_t l_max, size_t number_of_radial_points) noexcept;
+};
+
+/*!
+ * \brief Compute the contribution to the leading \f$\Psi_4\f$ that multiplies
+ * the total time derivative
+ *
+ * \details The value \f$\Psi_4\f$ scales asymptotically as \f$r^{-1}\f$, and
+ * has the form
+ *
+ * \f{align*}{
+ * \Psi_4^{(1)} = A \partial_u B,
+ * \f}
+ *
+ * where superscripts denote orders in the expansion in powers of \f$r^{-1}\f$.
+ * This mutator computes \f$A\f$:
+ *
+ * \f{align*}{
+ * A = e^{-2 \beta^{(0)}}
+ * \f}
+ */
+template <>
+struct CalculateScriPlusValue<Tags::ScriPlusFactor<Tags::Psi4>> {
+  using return_tags = tmpl::list<Tags::ScriPlusFactor<Tags::Psi4>>;
+  // extra typelist for more convenient testing
+  using tensor_argument_tags = tmpl::list<Tags::Exp2Beta>;
+  using argument_tags =
+      tmpl::append<tensor_argument_tags,
+                   tmpl::list<Spectral::Swsh::Tags::LMax,
+                              Spectral::Swsh::Tags::NumberOfRadialPoints>>;
+
+  static void apply(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+          scri_plus_factor,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta,
+      size_t l_max, size_t number_of_radial_points) noexcept;
+};
+
+/*!
+ * \brief Computes the leading part of \f$\Psi_3\f$ near \f$\mathcal I^+\f$.
+ *
+ * \details The value \f$\Psi_3\f$ scales asymptotically as \f$r^{-2}\f$, and
+ * has the form (in the coordinates used for regularity preserving CCE)
+ *
+ * \f{align*}{
+ * \Psi_3^{(2)} = 2 \bar \eth \beta^{(0)}
+ * + 4 \bar \eth \beta^{(0)} \eth \bar \eth \beta^{(0)}
+ * + \bar \eth  \eth \bar \eth \beta^{(0)}
+ * + \frac{e^{-2  \beta^{(0)}}}{2}  \eth \partial_u \bar J^{(1)}
+ * - e^{-2  \beta^{(0)}}  \eth  \beta^{(0)}  \partial_u \bar J^{(1)}
+ * \f},
+ *
+ * where \f$J^{(n)}\f$ is the \f$1/r^n\f$ part of \f$J\f$ evaluated at
+ * \f$\mathcal I^+\f$, so
+ *
+ * \f{align*}{
+ * J^{(1)} = (-2 R \partial_y J)|_{y = 1},
+ * \f}
+ *
+ * where the expansion is determined by the conversion between Bondi and
+ * numerical radii \f$r = 2 R / (1 - y)\f$.
+ */
+template <>
+struct CalculateScriPlusValue<Tags::ScriPlus<Tags::Psi3>> {
+  using return_tags = tmpl::list<Tags::ScriPlus<Tags::Psi3>>;
+  // extra typelist for more convenient testing
+  using tensor_argument_tags = tmpl::list<
+      Tags::Exp2Beta,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                       Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                       Spectral::Swsh::Tags::EthEthbar>,
+      Spectral::Swsh::Tags::Derivative<
+          Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                           Spectral::Swsh::Tags::EthEthbar>,
+          Spectral::Swsh::Tags::Ethbar>,
+      Tags::Dy<Tags::Du<Tags::BondiJ>>,
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::Du<Tags::BondiJ>>,
+                                       Spectral::Swsh::Tags::Ethbar>,
+      Tags::EvolutionGaugeBoundaryValue<Tags::BondiR>, Tags::EthRDividedByR>;
+  using argument_tags =
+      tmpl::append<tensor_argument_tags,
+                   tmpl::list<Spectral::Swsh::Tags::LMax,
+                              Spectral::Swsh::Tags::NumberOfRadialPoints>>;
+
+  static void apply(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -1>>*> psi_3,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& eth_ethbar_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, -1>>& ethbar_eth_ethbar_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_du_bondi_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& ethbar_dy_du_bondi_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+      size_t l_max, size_t number_of_radial_points) noexcept;
+};
+
+/*!
+ * \brief Computes the leading part of \f$\Psi_2\f$ near \f$\mathcal I^+\f$.
+ *
+ * \details The value \f$\Psi_2\f$ scales asymptotically as \f$r^{-3}\f$, and
+ * has the form (in the coordinates used for regularity preserving CCE)
+ *
+ * \f{align*}{
+ * \Psi_2^{(3)} = -\frac{e^{-2  \beta^{(0)}}}{4}
+ * \left(e^{2 \beta^{(0)}} \eth \bar Q^{(1)} +  \eth \bar U^{(2)}
+ * + \bar \eth  U^{(2)} + J^{(1)} \bar \eth \bar U^{(1)}
+ * +  J^{(1)} \bar \partial_u J^{(1)} - 2 W^{(2)}\right)
+ * \f},
+ *
+ * where \f$A^{(n)}\f$ is the \f$1/r^n\f$ part of \f$A\f$ evaluated at
+ * \f$\mathcal I^+\f$, so for any quantity \f$A\f$,
+ *
+ * \f{align*}{
+ * \eth  A^{(1)} &= (-2 R \eth  \partial_y  A
+ * - 2 \eth R \partial_y  A)|_{y = 1} \notag\\
+ * \eth  A^{(2)} &= (2 R^2 \eth \partial_y^2 A
+ * + 2 R \eth R \partial^2_y  A)|_{y = 1}, \notag\\
+ * A^{(1)} &= (- 2 R \partial_y A)|_{y = 1}, \notag\\
+ * A^{(2)} &= (2 R^2 \partial_y^2 A)|_{y = 1},
+ * \f}
+ *
+ * where the expansion is determined by the conversion between Bondi and
+ * numerical radii \f$r = 2 R / (1 - y)\f$.
+ */
+template <>
+struct CalculateScriPlusValue<Tags::ScriPlus<Tags::Psi2>> {
+  using return_tags = tmpl::list<Tags::ScriPlus<Tags::Psi2>>;
+  // extra typelist for more convenient testing
+  using tensor_argument_tags = tmpl::list<
+      Tags::Exp2Beta, Tags::Dy<Tags::BondiQ>,
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiQ>,
+                                       Spectral::Swsh::Tags::Ethbar>,
+      Tags::Dy<Tags::BondiU>,
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiU>,
+                                       Spectral::Swsh::Tags::Eth>,
+      Tags::Dy<Tags::Dy<Tags::BondiU>>,
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::Dy<Tags::BondiU>>,
+                                       Spectral::Swsh::Tags::Ethbar>,
+      Tags::Dy<Tags::Dy<Tags::BondiW>>, Tags::Dy<Tags::BondiJ>,
+      Tags::Dy<Tags::Du<Tags::BondiJ>>,
+      Tags::EvolutionGaugeBoundaryValue<Tags::BondiR>, Tags::EthRDividedByR>;
+  using argument_tags =
+      tmpl::append<tensor_argument_tags,
+                   tmpl::list<Spectral::Swsh::Tags::LMax,
+                              Spectral::Swsh::Tags::NumberOfRadialPoints>>;
+
+  static void apply(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> psi_2,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_bondi_q,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& ethbar_dy_bondi_q,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_bondi_u,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& eth_dy_bondi_u,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_dy_bondi_u,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& ethbar_dy_dy_bondi_u,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& dy_dy_bondi_w,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_bondi_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_du_bondi_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+      size_t l_max, size_t number_of_radial_points) noexcept;
+};
+
+/*!
+ * \brief Computes the leading part of \f$\Psi_1\f$ near \f$\mathcal I^+\f$.
+ *
+ * \details The value \f$\Psi_1\f$ scales asymptotically as \f$r^{-4}\f$, and
+ * has the form (in the coordinates used for regularity preserving CCE)
+ *
+ * \f{align*}{
+ * \Psi_1^{(4)} = \frac{1}{8} \left(- 12 \eth \beta^{(2)} + J^{(1)} \bar Q^{(1)}
+ * + 2 Q^{(2)}\right)
+ * \f}
+ *
+ * where \f$A^{(n)}\f$ is the \f$1/r^n\f$ part of \f$A\f$ evaluated at
+ * \f$\mathcal I^+\f$, so for any quantity \f$A\f$,
+ *
+ * \f{align*}{
+ * \eth A^{(2)} &= (2 R^2 \eth \partial_y^2 A
+ * + 2 R \eth R \partial^2_y  A)|_{y = 1}, \notag\\
+ * A^{(1)} &= (- 2 R \partial_y A)|_{y = 1}, \notag\\
+ * A^{(2)} &= (2 R^2 \partial_y^2 A)|_{y = 1},
+ * \f}
+ *
+ * where the expansion is determined by the conversion between Bondi and
+ * numerical radii \f$r = 2 R / (1 - y)\f$.
+ */
+template <>
+struct CalculateScriPlusValue<Tags::ScriPlus<Tags::Psi1>> {
+  using return_tags = tmpl::list<Tags::ScriPlus<Tags::Psi1>>;
+  // extra typelist for more convenient testing
+  using tensor_argument_tags = tmpl::list<
+      Tags::Dy<Tags::Dy<Tags::BondiBeta>>,
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::Dy<Tags::BondiBeta>>,
+                                       Spectral::Swsh::Tags::Eth>,
+      Tags::Dy<Tags::BondiJ>, Tags::Dy<Tags::BondiQ>,
+      Tags::Dy<Tags::Dy<Tags::BondiQ>>,
+      Tags::EvolutionGaugeBoundaryValue<Tags::BondiR>, Tags::EthRDividedByR>;
+  using argument_tags =
+      tmpl::append<tensor_argument_tags,
+                   tmpl::list<Spectral::Swsh::Tags::LMax,
+                              Spectral::Swsh::Tags::NumberOfRadialPoints>>;
+
+  static void apply(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*> psi_1,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& dy_dy_bondi_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_dy_dy_bondi_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_bondi_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_bondi_q,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_dy_bondi_q,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+      size_t l_max, size_t number_of_radial_points) noexcept;
+};
+
+/*!
+ * \brief Computes the leading part of \f$\Psi_0\f$ near \f$\mathcal I^+\f$.
+ *
+ * \details The value \f$\Psi_0\f$ scales asymptotically as \f$r^{-5}\f$, and
+ * has the form (in the coordinates used for regularity preserving CCE)
+ *
+ * \f{align*}{
+ * \Psi_0^{(5)} = \frac{3}{2}\left(\frac{1}{4}\bar J^{(1)} J^{(1)} {}^2
+ * - J^{(3)}\right)
+ * \f}
+ *
+ * where \f$A^{(n)}\f$ is the \f$1/r^n\f$ part of \f$A\f$ evaluated at
+ * \f$\mathcal I^+\f$, so for any quantity \f$A\f$,
+ *
+ * \f{align*}{
+ * A^{(1)} &= (- 2 R \partial_y A)|_{y = 1} \notag\\
+ * A^{(3)} &= \left(-\frac{4}{3} R^3 \partial_y^3 A\right)|_{y = 1},
+ * \f}
+ *
+ * where the expansion is determined by the conversion between Bondi and
+ * numerical radii \f$r = 2 R / (1 - y)\f$.
+ */
+template <>
+struct CalculateScriPlusValue<Tags::ScriPlus<Tags::Psi0>> {
+  using return_tags = tmpl::list<Tags::ScriPlus<Tags::Psi0>>;
+  // extra typelist for more convenient testing
+  using tensor_argument_tags =
+      tmpl::list<Tags::Dy<Tags::BondiJ>,
+                 Tags::Dy<Tags::Dy<Tags::Dy<Tags::BondiJ>>>,
+                 Tags::EvolutionGaugeBoundaryValue<Tags::BondiR>>;
+  using argument_tags =
+      tmpl::append<tensor_argument_tags,
+                   tmpl::list<Spectral::Swsh::Tags::LMax,
+                              Spectral::Swsh::Tags::NumberOfRadialPoints>>;
+
+  static void apply(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> psi_0,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_bondi_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_dy_dy_bondi_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+      size_t l_max, size_t number_of_radial_points) noexcept;
+};
+
+/*!
+ * \brief Computes the leading part of the strain \f$h\f$ near \f$\mathcal
+ * I^+\f$.
+ *
+ * \details The value \f$h\f$ scales asymptotically as \f$r^{-1}\f$, and
+ * has the form (in the coordinates used for regularity preserving CCE)
+ *
+ * \f{align*}{
+ * h = \bar J^{(1)} + \bar \eth \bar \eth u^{(0)},
+ * \f}
+ *
+ * where \f$u^{(0)}\f$ is the asymptotically inertial retarded time, and
+ * \f$A^{(n)}\f$ is the \f$1/r^n\f$ part of \f$A\f$ evaluated at
+ * \f$\mathcal I^+\f$, so for any quantity \f$A\f$,
+ *
+ * \f{align*}{
+ * A^{(1)} = (- 2 R \partial_y A)|_{y = 1},
+ * \f}
+ *
+ * where the expansion is determined by the conversion between Bondi and
+ * numerical radii \f$r = 2 R / (1 - y)\f$.
+ */
+template <>
+struct CalculateScriPlusValue<Tags::ScriPlus<Tags::Strain>> {
+  using return_tags = tmpl::list<Tags::ScriPlus<Tags::Strain>>;
+  // extra typelist for more convenient testing
+  using tensor_argument_tags = tmpl::list<
+      Tags::Dy<Tags::BondiJ>,
+      Spectral::Swsh::Tags::Derivative<Tags::ComplexInertialRetardedTime,
+                                       Spectral::Swsh::Tags::EthEth>,
+      Tags::EvolutionGaugeBoundaryValue<Tags::BondiR>>;
+  using argument_tags =
+      tmpl::append<tensor_argument_tags,
+                   tmpl::list<Spectral::Swsh::Tags::LMax,
+                              Spectral::Swsh::Tags::NumberOfRadialPoints>>;
+
+  static void apply(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -2>>*> strain,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_bondi_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& eth_eth_retarded_time,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+      size_t l_max, size_t number_of_radial_points) noexcept;
+};
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -155,6 +155,18 @@ struct CauchyCartesianCoords : db::SimpleTag {
   using type = tnsr::i<DataVector, 3>;
 };
 
+/// The asymptotically inertial retarded time in terms of the evolution time
+/// variable
+struct InertialRetardedTime : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/// Complex storage form for the asymptotically inertial retarded time, for
+/// taking spin-weighted derivatives
+struct ComplexInertialRetardedTime : db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
+};
+
 // prefix tags associated with the integrands which are used as input to solvers
 // for the CCE equations
 

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -139,6 +139,10 @@ struct GaugeOmega : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
 };
 
+struct News : db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, -2>>;
+};
+
 // For expressing the Cauchy angular coordinates for the worldtube data in terms
 // of the evolution angular coordinates.
 struct CauchyAngularCoords : db::SimpleTag {
@@ -309,6 +313,67 @@ struct BondiR : db::SimpleTag {
 /// A simple tag for the `WorldtubeDataManager`
 struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
   using type = WorldtubeDataManager;
+};
+
+/// The Weyl scalar \f$\Psi_0\f$
+struct Psi0 : db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, 2>>;
+};
+
+/// The Weyl scalar \f$\Psi_1\f$
+struct Psi1 : db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, 1>>;
+};
+
+/// The Weyl scalar \f$\Psi_2\f$
+struct Psi2 : db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
+};
+
+/// The Weyl scalar \f$\Psi_3\f$
+struct Psi3 : db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, -1>>;
+};
+
+/// The Weyl scalar \f$\Psi_4\f$
+struct Psi4 : db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, -2>>;
+};
+
+/// The gravitational wave strain \f$h\f$
+struct Strain : db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, -2>>;
+};
+
+/// A prefix tag representing the time integral of the value it prefixes
+template <typename Tag>
+struct TimeIntegral : db::PrefixTag, db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>;
+  using tag = Tag;
+  static std::string name() noexcept {
+    return "TimeIntegral(" + db::tag_name<Tag>() + ")";
+  }
+};
+
+/// A prefix tag representing the value at \f$\mathcal I^+\f$
+template <typename Tag>
+struct ScriPlus : db::PrefixTag, db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>;
+  using tag = Tag;
+  static std::string name() noexcept {
+    return "ScriPlus(" + db::tag_name<Tag>() + ")";
+  }
+};
+
+/// A prefix tag representing an additional correction factor necessary to
+/// compute the quantity at \f$\mathcal I^+\f$
+template <typename Tag>
+struct ScriPlusFactor : db::PrefixTag, db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
+  using tag = Tag;
+  static std::string name() noexcept {
+    return "ScriPlusFactor(" + db::tag_name<Tag>() + ")";
+  }
 };
 }  // namespace Tags
 }  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Test_PreSwshDerivatives.cpp
   Test_PrecomputeCceDependencies.cpp
   Test_ReadBoundaryDataH5.cpp
+  Test_ScriPlusValues.cpp
   Test_SwshDerivatives.cpp
   Test_Tags.cpp
   )

--- a/tests/Unit/Evolution/Systems/Cce/ScriPlusValues.py
+++ b/tests/Unit/Evolution/Systems/Cce/ScriPlusValues.py
@@ -1,0 +1,66 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def news(dy_du_bondi_j, beta, eth_beta, eth_eth_beta, boundary_r):
+    return 2.0 * np.conj(-boundary_r * np.exp(-2.0 * beta) * dy_du_bondi_j +
+                         eth_eth_beta + 2.0 * eth_beta**2)
+
+
+def time_integral_psi_4(exp_2_beta, dy_bondi_u, eth_dy_bondi_u, dy_du_bondi_j,
+                        boundary_r, eth_r_divided_by_r):
+    return (boundary_r / exp_2_beta) * np.conj(
+        eth_dy_bondi_u + eth_r_divided_by_r * dy_bondi_u + dy_du_bondi_j)
+
+
+def constant_factor_psi_4(exp_2_beta):
+    return 2.0 / exp_2_beta
+
+
+def psi_3(exp_2_beta, eth_beta, eth_ethbar_beta, ethbar_eth_ethbar_beta,
+          dy_du_bondi_j, ethbar_dy_du_bondi_j, boundary_r, eth_r_divided_by_r):
+    return 2.0 * np.conj(eth_beta) + 4.0 * np.conj(
+        eth_beta
+    ) * eth_ethbar_beta + ethbar_eth_ethbar_beta + 2.0 * boundary_r * (
+        np.conj(dy_du_bondi_j) * eth_beta / exp_2_beta) - 2.0 * boundary_r * (
+            0.5 / exp_2_beta) * (np.conj(ethbar_dy_du_bondi_j) +
+                                 eth_r_divided_by_r * np.conj(dy_du_bondi_j))
+
+
+def psi_2(exp_2_beta, dy_bondi_q, ethbar_dy_bondi_q, dy_bondi_u,
+          eth_dy_bondi_u, dy_dy_bondi_u, ethbar_dy_dy_bondi_u, dy_dy_bondi_w,
+          dy_bondi_j, dy_du_bondi_j, boundary_r, eth_r_divided_by_r):
+    return -0.25 / exp_2_beta * (
+        exp_2_beta * (-2.0 * boundary_r) *
+        (np.conj(ethbar_dy_bondi_q) + eth_r_divided_by_r * np.conj(dy_bondi_q))
+        + 2.0 * boundary_r**2 *
+        (np.conj(ethbar_dy_dy_bondi_u) +
+         eth_r_divided_by_r * np.conj(dy_dy_bondi_u) + ethbar_dy_dy_bondi_u +
+         np.conj(eth_r_divided_by_r) * dy_dy_bondi_u) +
+        (-2.0 * boundary_r * dy_bondi_j) *
+        (-2.0 * boundary_r *
+         (np.conj(eth_dy_bondi_u) + np.conj(eth_r_divided_by_r * dy_bondi_u) +
+          np.conj(dy_du_bondi_j))) - 4.0 * boundary_r**2 * dy_dy_bondi_w)
+
+
+def psi_1(dy_dy_bondi_beta, eth_dy_dy_bondi_beta, dy_bondi_j, dy_bondi_q,
+          dy_dy_bondi_q, boundary_r, eth_r_divided_by_r):
+    return 0.125 * (
+        -12.0 * (2.0 * boundary_r**2) *
+        (eth_dy_dy_bondi_beta + eth_r_divided_by_r * dy_dy_bondi_beta) +
+        (-2.0 * boundary_r * dy_bondi_j) *
+        (-2.0 * boundary_r * np.conj(dy_bondi_q)) + 2.0 *
+        (2.0 * boundary_r**2 * dy_dy_bondi_q))
+
+
+def psi_0(dy_bondi_j, dy_dy_dy_bondi_j, boundary_r):
+    return 1.5 * (0.25 * (-2.0 * boundary_r * np.conj(dy_bondi_j)) *
+                  (-2.0 * boundary_r * dy_bondi_j)**2 +
+                  4.0 / 3.0 * boundary_r**3 * dy_dy_dy_bondi_j)
+
+
+def strain(dy_bondi_j, eth_eth_retarded_time, boundary_r):
+    return -2.0 * np.conj(boundary_r * dy_bondi_j) + np.conj(
+        eth_eth_retarded_time)

--- a/tests/Unit/Evolution/Systems/Cce/Test_ScriPlusValues.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_ScriPlusValues.cpp
@@ -98,10 +98,69 @@ void pypp_test_scri_plus_computation_steps() noexcept {
       "ScriPlusValues", {"strain"}, {{{0.1, 1.0}}},
       DataVector{Spectral::Swsh::number_of_swsh_collocation_points(l_max)});
 }
+
+void check_inertial_retarded_time_utilities() noexcept {
+  MAKE_GENERATOR(gen);
+
+  UniformCustomDistribution<double> value_dist{0.1, 0.5};
+  UniformCustomDistribution<size_t> l_dist(12, 18);
+  const size_t l_max = l_dist(gen);
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  const size_t number_of_radial_points = 5;
+
+  auto time_box = db::create<db::AddSimpleTags<
+      Tags::InertialRetardedTime, Tags::ComplexInertialRetardedTime,
+      Tags::Exp2Beta, ::Tags::dt<Tags::InertialRetardedTime>>>(
+      Scalar<DataVector>{number_of_angular_points},
+      Scalar<SpinWeighted<ComplexDataVector, 0>>{number_of_angular_points},
+      Scalar<SpinWeighted<ComplexDataVector, 0>>{number_of_angular_points *
+                                                 number_of_radial_points},
+      Scalar<DataVector>{number_of_angular_points});
+
+  db::mutate<Tags::Exp2Beta>(
+      make_not_null(&time_box),
+      [&gen, &value_dist ](
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+              exp_2_beta) noexcept {
+        fill_with_random_values(make_not_null(&get(*exp_2_beta).data()),
+                                make_not_null(&gen),
+                                make_not_null(&value_dist));
+      });
+  const double random_time = value_dist(gen);
+
+  db::mutate_apply<InitializeScriPlusValue<Tags::InertialRetardedTime>>(
+      make_not_null(&time_box), random_time);
+
+  for (auto val : get(db::get<Tags::InertialRetardedTime>(time_box))) {
+    CHECK(val == random_time);
+  }
+  db::mutate_apply<PreSwshDerivatives<Tags::ComplexInertialRetardedTime>>(
+      make_not_null(&time_box));
+
+  const std::complex<double> complex_random_time{random_time, 0.0};
+  for (auto val :
+       get(db::get<Tags::ComplexInertialRetardedTime>(time_box)).data()) {
+    CHECK(val == complex_random_time);
+  }
+
+  db::mutate_apply<
+      CalculateScriPlusValue<::Tags::dt<Tags::InertialRetardedTime>>>(
+      make_not_null(&time_box));
+
+  for (size_t i = 0; i < number_of_angular_points; ++i) {
+    CHECK(get(db::get<::Tags::dt<Tags::InertialRetardedTime>>(time_box))[i] ==
+          real(get(db::get<Tags::Exp2Beta>(time_box))
+                   .data()[i + number_of_angular_points *
+                                   (number_of_radial_points - 1)]));
+  }
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.ScriPlusValues",
                   "[Unit][Evolution]") {
   pypp_test_scri_plus_computation_steps();
+
+  check_inertial_retarded_time_utilities();
 }
 }  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Test_ScriPlusValues.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_ScriPlusValues.cpp
@@ -1,0 +1,107 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "Evolution/Systems/Cce/PreSwshDerivatives.hpp"
+#include "Evolution/Systems/Cce/ScriPlusValues.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+namespace Cce {
+
+namespace {
+
+template <size_t FixedLMax, size_t FixedNumberOfRadialPoints, typename Mutator,
+          typename ReturnType, typename ArgumentTypeList>
+struct WrapScriPlusComputationImpl;
+
+template <size_t FixedLMax, size_t FixedNumberOfRadialPoints, typename Mutator,
+          typename ReturnType, typename... Arguments>
+struct WrapScriPlusComputationImpl<FixedLMax, FixedNumberOfRadialPoints,
+                                   Mutator, ReturnType,
+                                   tmpl::list<Arguments...>> {
+  static void apply(const gsl::not_null<ReturnType*> pass_by_pointer,
+                    const Arguments&... arguments) noexcept {
+    Mutator::apply(pass_by_pointer, arguments..., FixedLMax,
+                   FixedNumberOfRadialPoints);
+  }
+};
+
+template <size_t FixedLMax, size_t FixedNumberOfRadialPoints, typename Mutator>
+using WrapScriPlusComputation = WrapScriPlusComputationImpl<
+    FixedLMax, FixedNumberOfRadialPoints, Mutator,
+    typename db::item_type<tmpl::front<typename Mutator::return_tags>>,
+    tmpl::transform<typename Mutator::tensor_argument_tags,
+                    tmpl::bind<db::item_type, tmpl::_1>>>;
+
+void pypp_test_scri_plus_computation_steps() noexcept {
+  pypp::SetupLocalPythonEnvironment local_python_env{"Evolution/Systems/Cce/"};
+
+  constexpr size_t l_max = 3;
+  constexpr size_t number_of_radial_points = 1;
+
+  pypp::check_with_random_values<1>(
+      &WrapScriPlusComputation<l_max, number_of_radial_points,
+                               CalculateScriPlusValue<Tags::News>>::apply,
+      "ScriPlusValues", {"news"}, {{{0.1, 1.0}}},
+      DataVector{Spectral::Swsh::number_of_swsh_collocation_points(l_max)});
+
+  pypp::check_with_random_values<1>(
+      &WrapScriPlusComputation<l_max, number_of_radial_points,
+                               CalculateScriPlusValue<Tags::TimeIntegral<
+                                   Tags::ScriPlus<Tags::Psi4>>>>::apply,
+      "ScriPlusValues", {"time_integral_psi_4"}, {{{0.1, 1.0}}},
+      DataVector{Spectral::Swsh::number_of_swsh_collocation_points(l_max)});
+
+  pypp::check_with_random_values<1>(
+      &WrapScriPlusComputation<
+          l_max, number_of_radial_points,
+          CalculateScriPlusValue<Tags::ScriPlusFactor<Tags::Psi4>>>::apply,
+      "ScriPlusValues", {"constant_factor_psi_4"}, {{{0.1, 1.0}}},
+      DataVector{Spectral::Swsh::number_of_swsh_collocation_points(l_max)});
+
+  pypp::check_with_random_values<1>(
+      &WrapScriPlusComputation<
+          l_max, number_of_radial_points,
+          CalculateScriPlusValue<Tags::ScriPlus<Tags::Psi3>>>::apply,
+      "ScriPlusValues", {"psi_3"}, {{{0.1, 1.0}}},
+      DataVector{Spectral::Swsh::number_of_swsh_collocation_points(l_max)});
+
+  pypp::check_with_random_values<1>(
+      &WrapScriPlusComputation<
+          l_max, number_of_radial_points,
+          CalculateScriPlusValue<Tags::ScriPlus<Tags::Psi2>>>::apply,
+      "ScriPlusValues", {"psi_2"}, {{{0.1, 1.0}}},
+      DataVector{Spectral::Swsh::number_of_swsh_collocation_points(l_max)});
+
+  pypp::check_with_random_values<1>(
+      &WrapScriPlusComputation<
+          l_max, number_of_radial_points,
+          CalculateScriPlusValue<Tags::ScriPlus<Tags::Psi1>>>::apply,
+      "ScriPlusValues", {"psi_1"}, {{{0.1, 1.0}}},
+      DataVector{Spectral::Swsh::number_of_swsh_collocation_points(l_max)});
+
+  pypp::check_with_random_values<1>(
+      &WrapScriPlusComputation<
+          l_max, number_of_radial_points,
+          CalculateScriPlusValue<Tags::ScriPlus<Tags::Psi0>>>::apply,
+      "ScriPlusValues", {"psi_0"}, {{{0.1, 1.0}}},
+      DataVector{Spectral::Swsh::number_of_swsh_collocation_points(l_max)});
+
+  pypp::check_with_random_values<1>(
+      &WrapScriPlusComputation<
+          l_max, number_of_radial_points,
+          CalculateScriPlusValue<Tags::ScriPlus<Tags::Strain>>>::apply,
+      "ScriPlusValues", {"strain"}, {{{0.1, 1.0}}},
+      DataVector{Spectral::Swsh::number_of_swsh_collocation_points(l_max)});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.ScriPlusValues",
+                  "[Unit][Evolution]") {
+  pypp_test_scri_plus_computation_steps();
+}
+}  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
@@ -37,4 +37,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Tags", "[Unit][Cce]") {
           Cce::WorldtubeDataManager{});
   CHECK(db::get<Cce::Tags::H5WorldtubeBoundaryDataManager>(box).get_l_max() ==
         0);
+
+  CHECK(db::tag_name<Cce::Tags::TimeIntegral<SomeTag>>() ==
+        "TimeIntegral(SomeTag)");
+  CHECK(db::tag_name<Cce::Tags::ScriPlus<SomeTag>>() == "ScriPlus(SomeTag)");
+  CHECK(db::tag_name<Cce::Tags::ScriPlusFactor<SomeTag>>() ==
+        "ScriPlusFactor(SomeTag)");
 }


### PR DESCRIPTION
## Proposed changes

Add the mutators for computing scri+ waveform quantities strain, news, weyl scalars, and asymptotically inertial time in terms of the regularity-preserving coordinates.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies
- [x] #1869 
- [x] #1892 