### PR TITLE
Worldtube component

### DIFF
--- a/cmake/SpectreParseTests.py
+++ b/cmake/SpectreParseTests.py
@@ -10,6 +10,7 @@ allowed_tags = [
                 "Actions",
                 "ApparentHorizons",
                 "Burgers",
+                "Cce",
                 "CompilationTest",
                 "ControlSystem",
                 "DataStructures",

--- a/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/SpanInterpolator.hpp"
+#include "Parallel/Algorithm.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Cce {
+/*!
+ * \ingroup ActionsGroup
+ * \brief Initializes a H5WorldtubeBoundary
+ *
+ * \details Uses:
+ * - initialization tag
+ * `Cce::InitializationTags::H5WorldtubeBoundaryDataManager`,
+ * - const global cache tag `Spectral::Swsh::Tags::LMax`.
+ *
+ * Databox changes:
+ * - Adds:
+ *   - `Cce::Tags::H5WorldtubeBoundaryDataManager`
+ *   - `Tags::Variables<typename
+ * Metavariables::cce_boundary_communication_tags>`
+ * - Removes: nothing
+ * - Modifies: nothing
+ */
+struct InitializeH5WorldtubeBoundary {
+  using initialization_tags =
+      tmpl::list<InitializationTags::H5WorldtubeBoundaryDataManager>;
+
+  using const_global_cache_tags = tmpl::list<Spectral::Swsh::Tags::LMax>;
+
+  template <class Metavariables>
+  using h5_boundary_manager_simple_tags = db::AddSimpleTags<
+      ::Tags::Variables<
+          typename Metavariables::cce_boundary_communication_tags>,
+      Tags::H5WorldtubeBoundaryDataManager>;
+
+  template <class Metavariables>
+  using return_tag_list = h5_boundary_manager_simple_tags<Metavariables>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::list_contains_v<
+                DbTags, InitializationTags::H5WorldtubeBoundaryDataManager>> =
+                nullptr>
+  static auto apply(db::DataBox<DbTags>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    const size_t l_max = Parallel::get<Spectral::Swsh::Tags::LMax>(cache);
+    Variables<typename Metavariables::cce_boundary_communication_tags>
+        boundary_variables{
+            Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+
+    WorldtubeDataManager boundary_data_manager;
+    db::mutate<InitializationTags::H5WorldtubeBoundaryDataManager>(
+        make_not_null(&box),
+        [&boundary_data_manager](const gsl::not_null<WorldtubeDataManager*>
+                                     initialization_data_manager) noexcept {
+          boundary_data_manager = std::move(*initialization_data_manager);
+        });
+    auto initial_box = Initialization::merge_into_databox<
+        InitializeH5WorldtubeBoundary,
+        h5_boundary_manager_simple_tags<Metavariables>, db::AddComputeTags<>,
+        Initialization::MergePolicy::Overwrite>(
+        std::move(box), std::move(boundary_variables),
+        std::move(boundary_data_manager));
+
+    return std::make_tuple(std::move(initial_box));
+  }
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<not tmpl::list_contains_v<
+                DbTags, InitializationTags::H5WorldtubeBoundaryDataManager>> =
+                nullptr>
+  static auto apply(db::DataBox<DbTags>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    return std::make_tuple(std::move(box));
+  }
+};
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+
+namespace Cce {
+
+/*!
+ * \brief Component that supplies CCE worldtube boundary data.
+ *
+ * \details The \ref DataBoxGroup associated with the worldtube boundary
+ * component contains a data manager (e.g. `WorldtubeDataManager`) linked to
+ * an H5 file. The data manager handles buffering and interpolating to desired
+ * target time points when requested via the simple action
+ * `BoundaryComputeAndSendToEvolution`, at which point it will send the required
+ * collection of boundary quantities to the identified 'CharacteristicEvolution'
+ * component. It is assumed that the simple action
+ * `BoundaryComputeAndSendToEvolution` will only be called during the
+ * `Evolve` phase.
+ *
+ * Uses const global tags:
+ * - `Spectral::Swsh::Tags::LMax`
+ *
+ * `Metavariables` must contain:
+ * - the `enum` `Phase` with at least `Initialization` and `Evolve` phases.
+ * - a type alias `cce_boundary_communication_tags` for the set of tags to send
+ * from the worldtube to the evolution component. This will typically be
+ * `Cce::Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>`.
+ */
+template <class Metavariables>
+struct H5WorldtubeBoundary {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using metavariables = Metavariables;
+  using initialize_action_list =
+      tmpl::list<InitializeH5WorldtubeBoundary,
+                 Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+  using initialization_tags =
+      Parallel::get_initialization_tags<initialize_action_list>;
+
+  using worldtube_boundary_computation_steps = tmpl::list<>;
+
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        initialize_action_list>,
+                 Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Evolve,
+                                        worldtube_boundary_computation_steps>>;
+
+  using const_global_cache_tag_list =
+      Parallel::detail::get_const_global_cache_tags_from_pdal<
+          phase_dependent_action_list>;
+
+  using options = tmpl::list<>;
+
+  static void initialize(Parallel::CProxy_ConstGlobalCache<
+                         Metavariables>& /*global_cache*/) noexcept {}
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      const Parallel::CProxy_ConstGlobalCache<Metavariables>&
+          global_cache) noexcept {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    if (next_phase == Metavariables::Phase::Evolve) {
+      Parallel::get_parallel_component<H5WorldtubeBoundary>(local_cache)
+          .perform_algorithm();
+    }
+  }
+};
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -1,0 +1,119 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
+#include "NumericalAlgorithms/Interpolation/SpanInterpolator.hpp"
+#include "Options/Options.hpp"
+
+namespace Cce {
+/// \cond
+class Interpolator;
+/// \endcond
+
+namespace OptionTags {
+
+/// Option group
+struct Cce {
+  static constexpr OptionString help = {"Options for the Cce evolution system"};
+};
+
+struct LMax {
+  using type = size_t;
+  static constexpr OptionString help{
+      "Maximum l value for spin-weighted spherical harmonics"};
+  using group = Cce;
+};
+
+struct ObservationLMax {
+  using type = size_t;
+  static constexpr OptionString help{"Maximum l value for swsh output"};
+  using group = Cce;
+};
+
+struct NumberOfRadialPoints {
+  using type = size_t;
+  static constexpr OptionString help{
+      "Number of radial grid points in the spherical domain"};
+  using group = Cce;
+};
+
+struct EndTime {
+  using type = double;
+  static constexpr OptionString help{"End time for the Cce Evolution."};
+  static double default_value() noexcept {
+    return std::numeric_limits<double>::infinity();
+  }
+  using group = Cce;
+};
+
+struct StartTime {
+  using type = double;
+  static constexpr OptionString help{
+      "Cce Start time (default to earliest possible time)."};
+  static double default_value() noexcept {
+    return -std::numeric_limits<double>::infinity();
+  }
+  using group = Cce;
+};
+
+struct TargetStepSize {
+  using type = double;
+  static constexpr OptionString help{"Target time step size for Cce Evolution"};
+  using group = Cce;
+};
+
+struct BoundaryDataFilename {
+  using type = std::string;
+  static constexpr OptionString help{
+      "H5 file to read the wordltube data from."};
+  using group = Cce;
+};
+
+struct H5LookaheadTimes {
+  using type = size_t;
+  static constexpr OptionString help{
+      "Number of times steps from the h5 to cache each read."};
+  static size_t default_value() noexcept { return 200; }
+  using group = Cce;
+};
+
+struct H5Interpolator {
+  using type = std::unique_ptr<Interpolator>;
+  static constexpr OptionString help{
+      "The interpolator for imported h5 worldtube data."};
+  using group = Cce;
+};
+
+struct ScriInterpolationOrder {
+  static std::string name() noexcept { return "ScriInterpOrder"; }
+  using type = size_t;
+  static constexpr OptionString help{"Order of time interpolation at scri+."};
+  static size_t default_value() noexcept { return 5; }
+  using group = Cce;
+};
+}  // namespace OptionTags
+
+namespace InitializationTags {
+/// An initialization tag that constructs a `WorldtubeDataManager` from options
+struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
+  using type = WorldtubeDataManager;
+  using option_tags =
+      tmpl::list<OptionTags::LMax, OptionTags::BoundaryDataFilename,
+                 OptionTags::H5LookaheadTimes, OptionTags::H5Interpolator>;
+
+  static WorldtubeDataManager create_from_options(
+      const size_t l_max, const std::string& filename,
+      const size_t number_of_lookahead_times,
+      const std::unique_ptr<intrp::SpanInterpolator>& interpolator) noexcept {
+    return WorldtubeDataManager{
+        std::make_unique<SpecWorldtubeH5BufferUpdater>(filename), l_max,
+        number_of_lookahead_times, interpolator->get_clone()};
+  }
+};
+
+}  // namespace InitializationTags
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/ReadBoundaryDataH5.hpp
+++ b/src/Evolution/Systems/Cce/ReadBoundaryDataH5.hpp
@@ -59,7 +59,7 @@ namespace detail {
 // it returns the dataset name "/gxy".
 template <typename... T>
 std::string dataset_name_for_component(std::string base_name,
-                                       const T... indices) noexcept {
+                                       const T... indices) noexcept {  // NOLINT
   const auto add_index = [&base_name](size_t index) noexcept {
     ASSERT(index < 3, "The character-arithmetic index must be less than 3.");
     base_name += static_cast<char>('x' + index);

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -11,6 +11,10 @@
 
 namespace Cce {
 
+/// \cond
+struct WorldtubeDataManager;
+/// \endcond
+
 /// Tags for Cauchy Characteristic Extraction routines
 namespace Tags {
 
@@ -300,6 +304,11 @@ struct JbarQMinus2EthBeta : db::SimpleTag {
 struct BondiR : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
   static std::string name() noexcept { return "R"; }
+};
+
+/// A simple tag for the `WorldtubeDataManager`
+struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
+  using type = WorldtubeDataManager;
 };
 }  // namespace Tags
 }  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_Cce_Actions")
+
+set(LIBRARY_SOURCES
+  Test_InitializeWorldtubeBoundary.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Evolution/Systems/Cce/Actions/"
+  "${LIBRARY_SOURCES}"
+  "Cce"
+  )

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -30,7 +30,7 @@ namespace Cce {
 
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.Cce.Actions.InitializeWorldtubeBoundary",
-    "[Unit]") {
+    "[Unit][Cce]") {
   using component = mock_h5_worldtube_boundary<metavariables>;
   // this probably needs to be adjusted for the const global tags and option
   // tags we need.

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -1,0 +1,99 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp"
+#include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp"
+#include "tests/Unit/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Cce {
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.Cce.Actions.InitializeWorldtubeBoundary",
+    "[Unit]") {
+  using component = mock_h5_worldtube_boundary<metavariables>;
+  // this probably needs to be adjusted for the const global tags and option
+  // tags we need.
+  const size_t l_max = 8;
+  ActionTesting::MockRuntimeSystem<metavariables> runner{{l_max}};
+
+  const size_t buffer_size = 8;
+  const std::string filename = "test_CceR0100.h5";
+
+  // create the test file, because on initialization the manager will need to
+  // get basic data out of the file
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<double> value_dist{0.1, 0.5};
+  // first prepare the input for the modal version
+  const double mass = value_dist(gen);
+  const std::array<double, 3> spin{
+      {value_dist(gen), value_dist(gen), value_dist(gen)}};
+  const std::array<double, 3> center{
+      {value_dist(gen), value_dist(gen), value_dist(gen)}};
+  gr::Solutions::KerrSchild solution{mass, spin, center};
+
+  const double extraction_radius = 100.0;
+  const double frequency = 0.1 * value_dist(gen);
+  const double amplitude = 0.1 * value_dist(gen);
+  const double target_time = 50.0 * value_dist(gen);
+  TestHelpers::write_test_file(solution, filename, target_time,
+                               extraction_radius, frequency, amplitude, l_max);
+
+  runner.set_phase(metavariables::Phase::Initialization);
+  ActionTesting::emplace_component<component>(
+      &runner, 0,
+      InitializationTags::H5WorldtubeBoundaryDataManager::create_from_options(
+          l_max, filename, buffer_size,
+          std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u,
+                                                                       4u)));
+
+  // this should run the initialization
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  runner.set_phase(metavariables::Phase::Extraction);
+  // check that the h5 data manager copied out of the databox has the correct
+  // properties that we can examine without running the other actions
+  const auto& data_manager =
+      ActionTesting::get_databox_tag<component,
+                                     Tags::H5WorldtubeBoundaryDataManager>(
+          runner, 0);
+  CHECK(data_manager.get_l_max() == l_max);
+  const auto time_span = data_manager.get_time_span();
+  CHECK(time_span.first == 0);
+  CHECK(time_span.second == 0);
+
+  // check that the Variables is in the expected state (here we just make sure
+  // it has the right size - it shouldn't have been written to yet)
+  const auto& variables = ActionTesting::get_databox_tag<
+      component, ::Tags::Variables<
+                     typename metavariables::cce_boundary_communication_tags>>(
+      runner, 0);
+
+  CHECK(get(get<Tags::BoundaryValue<Tags::BondiBeta>>(variables)).size() ==
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+}
+}  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp
@@ -1,0 +1,51 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace Cce {
+
+template <typename Metavariables>
+struct mock_h5_worldtube_boundary {
+  using component_being_mocked = H5WorldtubeBoundary<Metavariables>;
+  using replace_these_simple_actions = tmpl::list<>;
+  using with_these_simple_actions = tmpl::list<>;
+
+  using initialize_action_list =
+      tmpl::list<InitializeH5WorldtubeBoundary,
+                 Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+  using initialization_tags =
+      Parallel::get_initialization_tags<initialize_action_list>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  using simple_tags = tmpl::list<>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             initialize_action_list>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Extraction, tmpl::list<>>>;
+};
+
+struct metavariables {
+  using cce_boundary_communication_tags =
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>;
+  using const_global_cache_tag_list = tmpl::list<Spectral::Swsh::Tags::LMax>;
+  using component_list = tmpl::list<mock_h5_worldtube_boundary<metavariables>>;
+  enum class Phase { Initialization, Extraction, Exit };
+};
+}  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_InitializeCce.cpp
   Test_LinearOperators.cpp
   Test_LinearSolve.cpp
+  Test_OptionTags.cpp
   Test_PreSwshDerivatives.cpp
   Test_PrecomputeCceDependencies.cpp
   Test_ReadBoundaryDataH5.cpp

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Actions)
+
 set(LIBRARY "Test_Cce")
 
 set(LIBRARY_SOURCES

--- a/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
@@ -614,7 +614,7 @@ void test_schwarzschild_solution(const gsl::not_null<Generator*> gen) noexcept {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.BoundaryData",
-                  "[Unit][Evolution]") {
+                  "[Unit][Cce]") {
   pypp_test_worldtube_computation_steps();
 
   MAKE_GENERATOR(gen);

--- a/tests/Unit/Evolution/Systems/Cce/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_Equations.cpp
@@ -152,7 +152,7 @@ struct python_function_for_bondi_integrand<
   }
 };
 
-SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Equations", "[Unit][Evolution]") {
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Equations", "[Unit][Cce]") {
   pypp::SetupLocalPythonEnvironment local_python_env{"Evolution/Systems/Cce/"};
 
   using all_bondi_tags = tmpl::list<Tags::BondiBeta, Tags::BondiQ, Tags::BondiU,

--- a/tests/Unit/Evolution/Systems/Cce/Test_GaugeTransformBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_GaugeTransformBoundaryData.cpp
@@ -531,7 +531,7 @@ void test_gauge_transforms_via_inverse_coordinate_map(
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.GaugeTransformBoundaryData",
-                  "[Unit][NumericalAlgorithms]") {
+                  "[Unit][Cce]") {
   MAKE_GENERATOR(gen);
   test_gauge_transforms_via_inverse_coordinate_map(make_not_null(&gen));
 }

--- a/tests/Unit/Evolution/Systems/Cce/Test_InitializeCce.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_InitializeCce.cpp
@@ -21,7 +21,7 @@
 namespace Cce {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.InitializeJ",
-                  "[Unit][Evolution]") {
+                  "[Unit][Cce]") {
   MAKE_GENERATOR(generator);
   UniformCustomDistribution<size_t> sdist{5, 8};
   const size_t l_max = sdist(generator);

--- a/tests/Unit/Evolution/Systems/Cce/Test_LinearOperators.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_LinearOperators.cpp
@@ -16,7 +16,7 @@
 #include "tests/Utilities/MakeWithRandomValues.hpp"
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.LinearOperators",
-                  "[Unit][Evolution]") {
+                  "[Unit][Cce]") {
   MAKE_GENERATOR(generator);
   const size_t l_max = 6;
   const size_t number_of_radial_points = 6;

--- a/tests/Unit/Evolution/Systems/Cce/Test_LinearSolve.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_LinearSolve.cpp
@@ -470,7 +470,7 @@ void test_pole_integration_with_linear_operator(
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.LinearSolve",
-                  "[Unit][Evolution]") {
+                  "[Unit][Cce]") {
   MAKE_GENERATOR(gen);
   UniformCustomDistribution<size_t> sdist{3, 6};
   const size_t l_max = sdist(gen);

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -15,8 +15,7 @@
 #include "tests/Unit/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
 
-SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags",
-                  "[Unit][Evolution]") {
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::LMax>("8") == 8_st);
   CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::ObservationLMax>(
             "6") == 6_st);

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
+#include "NumericalAlgorithms/Interpolation/CubicSpanInterpolator.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Literals.hpp"
+#include "tests/Unit/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
+#include "tests/Unit/TestCreation.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags",
+                  "[Unit][Evolution]") {
+  CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::LMax>("8") == 8_st);
+  CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::ObservationLMax>(
+            "6") == 6_st);
+  CHECK(
+      TestHelpers::test_creation<size_t, Cce::OptionTags::NumberOfRadialPoints>(
+          "3") == 3_st);
+  CHECK(TestHelpers::test_creation<double, Cce::OptionTags::EndTime>("4.0") ==
+        4.0);
+  CHECK(TestHelpers::test_creation<double, Cce::OptionTags::StartTime>("2.0") ==
+        2.0);
+  CHECK(TestHelpers::test_creation<double, Cce::OptionTags::TargetStepSize>(
+            "0.5") == 0.5);
+  CHECK(TestHelpers::test_creation<std::string,
+                                   Cce::OptionTags::BoundaryDataFilename>(
+            "CceR0100.h5") == "CceR0100.h5");
+  CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::H5LookaheadTimes>(
+            "5") == 5_st);
+  CHECK(TestHelpers::test_creation<size_t,
+                                   Cce::OptionTags::ScriInterpolationOrder>(
+            "4") == 4_st);
+  const std::string filename = "OptionTagsTestCceR0100.h5";
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+  Cce::TestHelpers::write_test_file(
+      gr::Solutions::KerrSchild{1.0, {{0.2, 0.2, 0.2}}, {{0.0, 0.0, 0.0}}},
+      filename, 4.0, 100.0, 0.0, 0.1, 8);
+
+  CHECK(
+      Cce::InitializationTags::H5WorldtubeBoundaryDataManager::
+          create_from_options(8, filename, 3,
+                              std::make_unique<intrp::CubicSpanInterpolator>())
+              .get_l_max() == 8);
+
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+}

--- a/tests/Unit/Evolution/Systems/Cce/Test_PreSwshDerivatives.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_PreSwshDerivatives.cpp
@@ -71,7 +71,7 @@ struct TagsToComputeForImpl<TestSpinWeightedScalar<1>> {
 }  // namespace detail
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.PreSwshDerivatives",
-                  "[Unit][Evolution]") {
+                  "[Unit][Cce]") {
   MAKE_GENERATOR(generator);
   const size_t l_max = 8;
   const size_t number_of_radial_grid_points = 8;

--- a/tests/Unit/Evolution/Systems/Cce/Test_PrecomputeCceDependencies.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_PrecomputeCceDependencies.cpp
@@ -118,7 +118,7 @@ void generate_boundary_values_and_expected(
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.PrecomputeCceDependencies",
-                  "[Unit][Evolution]") {
+                  "[Unit][Cce]") {
   // Initialize the Variables that we need
   MAKE_GENERATOR(generator);
   UniformCustomDistribution<size_t> sdist{5, 8};

--- a/tests/Unit/Evolution/Systems/Cce/Test_ReadBoundaryDataH5.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_ReadBoundaryDataH5.cpp
@@ -471,71 +471,10 @@ void test_spec_worldtube_buffer_updater(
       (buffer_size + 2 * interpolator_length) * square(l_max + 1)};
   Variables<detail::cce_input_tags> expected_coefficients_buffers{
       (buffer_size + 2 * interpolator_length) * square(l_max + 1)};
-  size_t goldberg_size = square(l_max + 1);
-  tnsr::ii<ComplexModalVector, 3> spatial_metric_coefficients{goldberg_size};
-  tnsr::ii<ComplexModalVector, 3> dt_spatial_metric_coefficients{goldberg_size};
-  tnsr::ii<ComplexModalVector, 3> dr_spatial_metric_coefficients{goldberg_size};
-  tnsr::I<ComplexModalVector, 3> shift_coefficients{goldberg_size};
-  tnsr::I<ComplexModalVector, 3> dt_shift_coefficients{goldberg_size};
-  tnsr::I<ComplexModalVector, 3> dr_shift_coefficients{goldberg_size};
-  Scalar<ComplexModalVector> lapse_coefficients{goldberg_size};
-  Scalar<ComplexModalVector> dt_lapse_coefficients{goldberg_size};
-  Scalar<ComplexModalVector> dr_lapse_coefficients{goldberg_size};
-
-  // write times to file for several steps before and after the target time
   const std::string filename = "test_CceR0100.h5";
-  if (file_system::check_if_file_exists(filename)) {
-    file_system::rm(filename, true);
-  }
-  // scoped to close the file
-  {
-    TestHelpers::WorldtubeModeRecorder recorder{filename, l_max};
-    for (size_t t = 0; t < 30; ++t) {
-      const double time = 0.1 * t + target_time - 1.5;
-      TestHelpers::create_fake_time_varying_modal_data(
-          make_not_null(&spatial_metric_coefficients),
-          make_not_null(&dt_spatial_metric_coefficients),
-          make_not_null(&dr_spatial_metric_coefficients),
-          make_not_null(&shift_coefficients),
-          make_not_null(&dt_shift_coefficients),
-          make_not_null(&dr_shift_coefficients),
-          make_not_null(&lapse_coefficients),
-          make_not_null(&dt_lapse_coefficients),
-          make_not_null(&dr_lapse_coefficients), solution, extraction_radius,
-          amplitude, frequency, time, l_max);
-      for (size_t i = 0; i < 3; ++i) {
-        for (size_t j = i; j < 3; ++j) {
-          recorder.append_worldtube_mode_data(
-              detail::dataset_name_for_component("/g", i, j), time,
-              spatial_metric_coefficients.get(i, j), l_max);
-          recorder.append_worldtube_mode_data(
-              detail::dataset_name_for_component("/Drg", i, j), time,
-              dr_spatial_metric_coefficients.get(i, j), l_max);
-          recorder.append_worldtube_mode_data(
-              detail::dataset_name_for_component("/Dtg", i, j), time,
-              dt_spatial_metric_coefficients.get(i, j), l_max);
-        }
-        recorder.append_worldtube_mode_data(
-            detail::dataset_name_for_component("/Shift", i), time,
-            shift_coefficients.get(i), l_max);
-        recorder.append_worldtube_mode_data(
-            detail::dataset_name_for_component("/DrShift", i), time,
-            dr_shift_coefficients.get(i), l_max);
-        recorder.append_worldtube_mode_data(
-            detail::dataset_name_for_component("/DtShift", i), time,
-            dt_shift_coefficients.get(i), l_max);
-      }
-      recorder.append_worldtube_mode_data(
-          detail::dataset_name_for_component("/Lapse"), time,
-          get(lapse_coefficients), l_max);
-      recorder.append_worldtube_mode_data(
-          detail::dataset_name_for_component("/DrLapse"), time,
-          get(dr_lapse_coefficients), l_max);
-      recorder.append_worldtube_mode_data(
-          detail::dataset_name_for_component("/DtLapse"), time,
-          get(dt_lapse_coefficients), l_max);
-    }
-  }
+  TestHelpers::write_test_file(solution, filename, target_time,
+                               extraction_radius, frequency, amplitude, l_max);
+
   // request an appropriate buffer
   SpecWorldtubeH5BufferUpdater buffer_updater{filename};
   size_t time_span_start = 0;

--- a/tests/Unit/Evolution/Systems/Cce/Test_ReadBoundaryDataH5.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_ReadBoundaryDataH5.cpp
@@ -675,7 +675,7 @@ void test_reduced_spec_worldtube_buffer_updater(
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.ReadBoundaryDataH5",
-                  "[Unit][Evolution]") {
+                  "[Unit][Cce]") {
   MAKE_GENERATOR(gen);
   test_spec_worldtube_buffer_updater(make_not_null(&gen));
   test_data_manager_with_dummy_buffer_updater<WorldtubeDataManager,

--- a/tests/Unit/Evolution/Systems/Cce/Test_SwshDerivatives.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_SwshDerivatives.cpp
@@ -186,7 +186,7 @@ struct GenerateStartingData {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.SwshDerivatives",
-                  "[Unit][Evolution]") {
+                  "[Unit][Cce]") {
   MAKE_GENERATOR(generator);
   const size_t l_max = 10;
   const size_t number_of_radial_grid_points = 7;

--- a/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
@@ -4,7 +4,10 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <string>
+#include <type_traits>
 
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
 
 namespace {
@@ -26,4 +29,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Tags", "[Unit][Evolution]") {
         "LinearFactor(SomeTag)");
   CHECK(db::tag_name<Cce::Tags::LinearFactorForConjugate<SomeTag>>() ==
         "LinearFactorForConjugate(SomeTag)");
+
+  CHECK(db::tag_name<Cce::Tags::H5WorldtubeBoundaryDataManager>() ==
+        "H5WorldtubeBoundaryDataManager");
+  auto box =
+      db::create<db::AddSimpleTags<Cce::Tags::H5WorldtubeBoundaryDataManager>>(
+          Cce::WorldtubeDataManager{});
+  CHECK(db::get<Cce::Tags::H5WorldtubeBoundaryDataManager>(box).get_l_max() ==
+        0);
 }

--- a/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
@@ -16,7 +16,7 @@ struct SomeTag {
 };
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Tags", "[Unit][Evolution]") {
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Tags", "[Unit][Cce]") {
   CHECK(db::tag_name<Cce::Tags::Dy<SomeTag>>() == "Dy(SomeTag)");
   CHECK(db::tag_name<Cce::Tags::Du<SomeTag>>() == "Du(SomeTag)");
   CHECK(db::tag_name<Cce::Tags::Dr<SomeTag>>() == "Dr(SomeTag)");


### PR DESCRIPTION
## Proposed changes
Add worldtube h5 component and initializer. The remaining actions to interface between components will have to wait until after the PRs introducing the other CCE singletons. 

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies
- [x] #1869 
- [x] #1892 