### PR TITLE
Adjust time infrastructure

### DIFF
--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -623,6 +623,16 @@ struct MakeWithValueImpl<Tensor<double, Structure...>, double> {
 };
 
 template <typename... Structure>
+struct MakeWithValueImpl<Tensor<DataVector, Structure...>, size_t> {
+  /// \brief Returns a Tensor whose elements are set equal to `value` of size
+  /// `size`
+  static SPECTRE_ALWAYS_INLINE Tensor<DataVector, Structure...> apply(
+      const size_t size, const double value) noexcept {
+    return Tensor<DataVector, Structure...>(size, value);
+  }
+};
+
+template <typename... Structure>
 struct MakeWithValueImpl<Tensor<ComplexDataVector, Structure...>, DataVector> {
   /// \brief Returns a Tensor whose `ComplexDataVector`s are the same size as
   /// `input`, with each element set to `value`.

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -142,7 +142,7 @@ struct EvolutionMetavars {
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,
-      Actions::UpdateU, Limiters::Actions::SendData<EvolutionMetavars>,
+      Actions::UpdateU<>, Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>>>;
 
   enum class Phase {

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -138,7 +138,7 @@ struct EvolutionMetavars {
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,
                           dg::Actions::ApplyFluxes>,
-      Actions::RecordTimeStepperData,
+      Actions::RecordTimeStepperData<>,
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -228,7 +228,7 @@ struct EvolutionMetavars {
       dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       dg::Actions::ApplyFluxes, Actions::RecordTimeStepperData<>,
-      Actions::UpdateU>>;
+      Actions::UpdateU<>>>;
 
   enum class Phase {
     Initialization,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -227,7 +227,7 @@ struct EvolutionMetavars {
           Tags::BoundaryDirectionsInterior<volume_dim>>,
       dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
-      dg::Actions::ApplyFluxes, Actions::RecordTimeStepperData,
+      dg::Actions::ApplyFluxes, Actions::RecordTimeStepperData<>,
       Actions::UpdateU>>;
 
   enum class Phase {

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -188,7 +188,7 @@ struct EvolutionMetavars {
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,
                           dg::Actions::ApplyFluxes>,
-      Actions::RecordTimeStepperData,
+      Actions::RecordTimeStepperData<>,
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -192,7 +192,7 @@ struct EvolutionMetavars {
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,
-      Actions::UpdateU, Limiters::Actions::SendData<EvolutionMetavars>,
+      Actions::UpdateU<>, Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<
           grmhd::ValenciaDivClean::FixConservatives>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -185,7 +185,7 @@ struct EvolutionMetavars {
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,
-      Actions::UpdateU, Limiters::Actions::SendData<EvolutionMetavars>,
+      Actions::UpdateU<>, Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       // Conservative `UpdatePrimitives` expects system to possess
       // list of recovery schemes so we use `MutateApply` instead.

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -181,7 +181,7 @@ struct EvolutionMetavars {
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,
                           dg::Actions::ApplyFluxes>,
-      Actions::RecordTimeStepperData,
+      Actions::RecordTimeStepperData<>,
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
@@ -164,7 +164,7 @@ struct EvolutionMetavars {
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,
                           dg::Actions::ApplyFluxes>,
-      Actions::RecordTimeStepperData,
+      Actions::RecordTimeStepperData<>,
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
@@ -168,7 +168,7 @@ struct EvolutionMetavars {
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,
-      Actions::UpdateU, Limiters::Actions::SendData<EvolutionMetavars>,
+      Actions::UpdateU<>, Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>, Actions::UpdateM1Closure>>;
 
   enum class Phase {

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -181,7 +181,7 @@ struct EvolutionMetavars {
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,
-      Actions::UpdateU, Limiters::Actions::SendData<EvolutionMetavars>,
+      Actions::UpdateU<>, Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<
           RelativisticEuler::Valencia::FixConservatives<Dim>>,

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -177,7 +177,7 @@ struct EvolutionMetavars {
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,
                           dg::Actions::ApplyFluxes>,
-      Actions::RecordTimeStepperData,
+      Actions::RecordTimeStepperData<>,
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -158,7 +158,7 @@ struct EvolutionMetavars {
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,
-      Actions::UpdateU,
+      Actions::UpdateU<>,
       tmpl::conditional_t<
           use_filtering,
           dg::Actions::Filter<Filters::Exponential<0>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -154,7 +154,7 @@ struct EvolutionMetavars {
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,
                           dg::Actions::ApplyFluxes>,
-      Actions::RecordTimeStepperData,
+      Actions::RecordTimeStepperData<>,
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,

--- a/src/Time/Actions/SelfStartActions.hpp
+++ b/src/Time/Actions/SelfStartActions.hpp
@@ -427,7 +427,7 @@ template <typename StepActions>
 struct self_start_procedure_impl {
   using flat_actions = tmpl::flatten<tmpl::list<StepActions>>;
   static_assert(
-      tmpl::list_contains_v<flat_actions, ::Actions::RecordTimeStepperData>,
+      tmpl::list_contains_v<flat_actions, ::Actions::RecordTimeStepperData<>>,
       "Self-start action loop must call Actions::RecordTimeStepperData to "
       "update the history.");
   // clang-format off
@@ -437,8 +437,8 @@ struct self_start_procedure_impl {
       SelfStart::Actions::CheckForCompletion<detail::PhaseEnd>,
       ::Actions::AdvanceTime,
       SelfStart::Actions::CheckForOrderIncrease,
-      tmpl::replace<flat_actions, ::Actions::RecordTimeStepperData,
-                    tmpl::list<::Actions::RecordTimeStepperData,
+      tmpl::replace<flat_actions, ::Actions::RecordTimeStepperData<>,
+                    tmpl::list<::Actions::RecordTimeStepperData<>,
                                SelfStart::Actions::StartNextOrderIfReady<
                                    detail::PhaseStart>>>,
       ::Actions::Goto<detail::PhaseStart>,

--- a/src/Time/Actions/UpdateU.hpp
+++ b/src/Time/Actions/UpdateU.hpp
@@ -34,7 +34,8 @@ namespace Actions {
 /// Uses:
 /// - ConstGlobalCache: Tags::TimeStepperBase
 /// - DataBox:
-///   - variables_tag
+///   - variables_tag (either the provided `VariablesTag` or the
+///   `system::variables_tag` if none is provided)
 ///   - Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>
 ///   - Tags::TimeStep
 ///
@@ -44,6 +45,7 @@ namespace Actions {
 /// - Modifies:
 ///   - variables_tag
 ///   - Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>
+template <typename VariablesTag = NoSuchType>
 struct UpdateU {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -53,7 +55,10 @@ struct UpdateU {
       const Parallel::ConstGlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {  // NOLINT const
-    using variables_tag = typename Metavariables::system::variables_tag;
+    using variables_tag =
+        tmpl::conditional_t<cpp17::is_same_v<VariablesTag, NoSuchType>,
+                            typename Metavariables::system::variables_tag,
+                            VariablesTag>;
     using dt_variables_tag = db::add_tag_prefix<Tags::dt, variables_tag>;
     using history_tag =
         Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>;

--- a/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
+++ b/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
@@ -9,7 +9,10 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
-#include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"   // IWYU pragma: keep
 #include "Time/Actions/RecordTimeStepperData.hpp"  // IWYU pragma: keep
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
@@ -18,6 +21,8 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
 
 // IWYU pragma: no_include "Time/History.hpp"
 
@@ -25,6 +30,10 @@
 
 namespace {
 struct Var : db::SimpleTag {
+  using type = double;
+};
+
+struct AlternativeVar : db::SimpleTag {
   using type = double;
 };
 
@@ -37,27 +46,55 @@ using dt_variables_tag = Tags::dt<Var>;
 using history_tag =
     Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>;
 
+using alternative_variables_tag = AlternativeVar;
+using dt_alternative_variables_tag = Tags::dt<AlternativeVar>;
+using alternative_history_tag =
+    Tags::HistoryEvolvedVariables<alternative_variables_tag,
+                                  dt_alternative_variables_tag>;
+
 template <typename Metavariables>
 struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using simple_tags = db::AddSimpleTags<Tags::TimeStepId, variables_tag,
-                                        dt_variables_tag, history_tag>;
+  using simple_tags =
+      db::AddSimpleTags<Tags::TimeStepId, variables_tag, dt_variables_tag,
+                        history_tag>;
   using compute_tags = db::AddComputeTags<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<
               ActionTesting::InitializeDataBox<simple_tags, compute_tags>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing,
-                             tmpl::list<Actions::RecordTimeStepperData>>>;
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<Actions::RecordTimeStepperData<>>>>;
+};
+
+template <typename Metavariables>
+struct ComponentWithTemplateSpecifiedVariables {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using simple_tags =
+      db::AddSimpleTags<Tags::TimeStepId, alternative_variables_tag,
+                        dt_alternative_variables_tag, alternative_history_tag>;
+  using compute_tags = db::AddComputeTags<>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<
+              ActionTesting::InitializeDataBox<simple_tags, compute_tags>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<Actions::RecordTimeStepperData<AlternativeVar>>>>;
 };
 
 struct Metavariables {
   using system = System;
-  using component_list = tmpl::list<Component<Metavariables>>;
+  using component_list =
+      tmpl::list<Component<Metavariables>,
+                 ComponentWithTemplateSpecifiedVariables<Metavariables>>;
   enum class Phase { Initialization, Testing, Exit };
 };
 }  // namespace
@@ -69,7 +106,12 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.RecordTimeStepperData",
   history_tag::type history{};
   history.insert(TimeStepId(true, 0, slab.end()), 2., 3.);
 
+  alternative_history_tag::type alternative_history{};
+  alternative_history.insert(TimeStepId(true, 0, slab.end()), 2., 3.);
+
   using component = Component<Metavariables>;
+  using component_with_template_specified_variables =
+      ComponentWithTemplateSpecifiedVariables<Metavariables>;
   using simple_tags = typename component::simple_tags;
   using compute_tags = typename component::compute_tags;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
@@ -78,12 +120,24 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.RecordTimeStepperData",
   ActionTesting::emplace_component_and_initialize<component>(
       &runner, 0,
       {TimeStepId(true, 0, slab.start()), 4., 5., std::move(history)});
+  ActionTesting::emplace_component_and_initialize<
+      component_with_template_specified_variables>(
+      &runner, 0,
+      {TimeStepId(true, 0, slab.start()), 4., 5.,
+       std::move(alternative_history)});
   runner.set_phase(Metavariables::Phase::Testing);
   runner.next_action<component>(0);
+  runner.next_action<component_with_template_specified_variables>(0);
   auto& box =
       ActionTesting::get_databox<component,
                                  tmpl::append<simple_tags, compute_tags>>(
           runner, 0);
+  auto& template_specified_variables_box = ActionTesting::get_databox<
+      component_with_template_specified_variables,
+      tmpl::append<
+          typename component_with_template_specified_variables::simple_tags,
+          typename component_with_template_specified_variables::compute_tags>>(
+      runner, 0);
 
   const auto& new_history = db::get<history_tag>(box);
   CHECK(new_history.size() == 2);
@@ -93,4 +147,22 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.RecordTimeStepperData",
   CHECK(*(new_history.begin() + 1) == slab.start());
   CHECK((new_history.begin() + 1).value() == 4.);
   CHECK((new_history.begin() + 1).derivative() == 5.);
+
+  const auto& new_history_from_template_specified_variables_box =
+      db::get<alternative_history_tag>(template_specified_variables_box);
+  CHECK(new_history_from_template_specified_variables_box.size() == 2);
+  CHECK(*new_history_from_template_specified_variables_box.begin() ==
+        slab.end());
+  CHECK(new_history_from_template_specified_variables_box.begin().value() ==
+        2.);
+  CHECK(
+      new_history_from_template_specified_variables_box.begin().derivative() ==
+      3.);
+  CHECK(*(new_history_from_template_specified_variables_box.begin() + 1) ==
+        slab.start());
+  CHECK(
+      (new_history_from_template_specified_variables_box.begin() + 1).value() ==
+      4.);
+  CHECK((new_history_from_template_specified_variables_box.begin() + 1)
+            .derivative() == 5.);
 }

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -17,8 +17,8 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep
 #include "Evolution/Conservative/UpdatePrimitives.hpp"  // IWYU pragma: keep
-#include "Parallel/PhaseDependentActionList.hpp"   // IWYU pragma: keep
-#include "Time/Actions/RecordTimeStepperData.hpp"  // IWYU pragma: keep
+#include "Parallel/PhaseDependentActionList.hpp"        // IWYU pragma: keep
+#include "Time/Actions/RecordTimeStepperData.hpp"       // IWYU pragma: keep
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"  // IWYU pragma: keep
 #include "Time/Slab.hpp"
@@ -134,8 +134,8 @@ struct Component {
                  Actions::RecordTimeStepperData<>,
                  tmpl::conditional_t<
                      has_primitives,
-                     tmpl::list<Actions::UpdateU, Actions::UpdatePrimitives>,
-                     Actions::UpdateU>>;
+                     tmpl::list<Actions::UpdateU<>, Actions::UpdatePrimitives>,
+                     Actions::UpdateU<>>>;
   using action_list = tmpl::flatten<
       tmpl::list<SelfStart::self_start_procedure<step_actions>, step_actions>>;
   using phase_dependent_action_list = tmpl::list<
@@ -378,8 +378,8 @@ double error_in_step(const size_t order, const double step) noexcept {
 
   run_past<std::is_same<SelfStart::Actions::Cleanup, tmpl::_1>,
            tmpl::bool_<true>>(make_not_null(&runner));
-  run_past<std::is_same<Actions::UpdateU, tmpl::_1>, tmpl::bool_<true>>(
-      make_not_null(&runner));
+  run_past<std::is_same<tmpl::pin<Actions::UpdateU<>>, tmpl::_1>,
+           tmpl::bool_<true>>(make_not_null(&runner));
 
   const double exact = -log(exp(-initial_value) - step);
   return ActionTesting::get_databox_tag<component, Var>(runner, 0) - exact;

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -130,7 +130,8 @@ struct Component {
   static constexpr bool has_primitives = Metavariables::has_primitives;
 
   using step_actions =
-      tmpl::list<Actions::ComputeTimeDerivative, Actions::RecordTimeStepperData,
+      tmpl::list<Actions::ComputeTimeDerivative,
+                 Actions::RecordTimeStepperData<>,
                  tmpl::conditional_t<
                      has_primitives,
                      tmpl::list<Actions::UpdateU, Actions::UpdatePrimitives>,

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -11,6 +11,9 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Time/Actions/UpdateU.hpp"               // IWYU pragma: keep
 #include "Time/Slab.hpp"
@@ -33,6 +36,10 @@ struct Var : db::SimpleTag {
   using type = double;
 };
 
+struct AlternativeVar : db::SimpleTag {
+  using type = double;
+};
+
 struct System {
   using variables_tag = Var;
 };
@@ -41,6 +48,13 @@ using variables_tag = Var;
 using dt_variables_tag = Tags::dt<Var>;
 using history_tag =
     Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>;
+
+
+using alternative_variables_tag = AlternativeVar;
+using dt_alternative_variables_tag = Tags::dt<AlternativeVar>;
+using alternative_history_tag =
+    Tags::HistoryEvolvedVariables<alternative_variables_tag,
+                                  dt_alternative_variables_tag>;
 
 template <typename Metavariables>
 struct Component {
@@ -57,13 +71,33 @@ struct Component {
           tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing,
-                             tmpl::list<Actions::UpdateU>>>;
+                             tmpl::list<Actions::UpdateU<>>>>;
+};
+
+template <typename Metavariables>
+struct ComponentWithTemplateSpecifiedVariables {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using simple_tags =
+      db::AddSimpleTags<Tags::TimeStep, alternative_variables_tag,
+                        alternative_history_tag>;
+  using compute_tags = db::AddComputeTags<>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<
+              ActionTesting::InitializeDataBox<simple_tags, compute_tags>>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Testing,
+                             tmpl::list<Actions::UpdateU<AlternativeVar>>>>;
 };
 
 struct Metavariables {
   using system = System;
-  using component_list = tmpl::list<Component<Metavariables>>;
-
+  using component_list =
+      tmpl::list<Component<Metavariables>,
+                 ComponentWithTemplateSpecifiedVariables<Metavariables>>;
   enum class Phase { Initialization, Testing, Exit };
 };
 }  // namespace
@@ -72,15 +106,22 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
   const Slab slab(1., 3.);
   const TimeDelta time_step = slab.duration() / 2;
 
-  const auto rhs =
-      [](const double t, const double y) { return 2. * t - 2. * (y - t * t); };
+  const auto rhs = [](const auto t, const auto y) {
+    return 2. * t - 2. * (y - t * t);
+  };
 
   using component = Component<Metavariables>;
+  using component_with_template_specified_variables =
+      ComponentWithTemplateSpecifiedVariables<Metavariables>;
   using simple_tags = typename component::simple_tags;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   MockRuntimeSystem runner{{std::make_unique<TimeSteppers::RungeKutta3>()}};
   ActionTesting::emplace_component_and_initialize<component>(
       &runner, 0, {time_step, 1., history_tag::type{}});
+
+  ActionTesting::emplace_component_and_initialize<
+      component_with_template_specified_variables>(
+      &runner, 0, {time_step, 1., alternative_history_tag::type{}});
   runner.set_phase(Metavariables::Phase::Testing);
 
   const std::array<Time, 3> substep_times{
@@ -103,10 +144,35 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
         },
         db::get<variables_tag>(before_box));
 
+    auto& alternative_before_box = ActionTesting::get_databox<
+        component_with_template_specified_variables,
+        typename component_with_template_specified_variables::simple_tags>(
+        make_not_null(&runner), 0);
+    db::mutate<alternative_history_tag>(
+        make_not_null(&alternative_before_box),
+        [&rhs, &substep, &substep_times ](
+            const gsl::not_null<db::item_type<alternative_history_tag>*>
+                alternative_history,
+            const double& alternative_vars) noexcept {
+          const Time& time = gsl::at(substep_times, substep);
+          alternative_history->insert(TimeStepId(true, 0, time),
+                                      alternative_vars,
+                                      rhs(time.value(), alternative_vars));
+        },
+        db::get<alternative_variables_tag>(alternative_before_box));
+
     runner.next_action<component>(0);
+    runner.next_action<component_with_template_specified_variables>(0);
     auto& box = ActionTesting::get_databox<component, simple_tags>(runner, 0);
+    auto& alternative_box = ActionTesting::get_databox<
+        component_with_template_specified_variables,
+        typename component_with_template_specified_variables::simple_tags>(
+        make_not_null(&runner), 0);
 
     CHECK(db::get<variables_tag>(box) ==
+          approx(gsl::at(expected_values, substep)));
+
+    CHECK(db::get<alternative_variables_tag>(alternative_box) ==
           approx(gsl::at(expected_values, substep)));
   }
 }


### PR DESCRIPTION
## Proposed changes
For Cce, and especially for a combined Cce/GH evolution system, we need a bit more flexibility with the time stepper actions. This PR introduces the changes that I think will be sufficient to get those pieces working.

I'm open to alternative suggestions for how to better accomplish the same task. This version does have the unfortunate side-effect of introducing the empty tensor args in several existing executables.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
