### PR TITLE
Configure ccache in cmake (also for macOS)

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -232,15 +232,9 @@ jobs:
         CCACHE_MAXSIZE: 400M
         CCACHE_COMPRESS: 1
         CCACHE_COMPRESSLEVEL: 6
-        # In order to make ccache work with precompiled headers we need to:
-        # - Hash the content of the compiler rather than the location and mtime
-        # - Hash the header file in the repo that will generate the precompiled
-        #   header
-        # - Ignore the precompiled header in the build directory
+        # We hash the content of the compiler rather than the location and mtime
+        # to make sure the cache works across the different machines
         CCACHE_COMPILERCHECK: content
-        CCACHE_EXTRAFILES: ${GITHUB_WORKSPACE}/tools/SpectrePch.hpp
-        CCACHE_IGNOREHEADERS:
-          /work/build/SpectrePch.hpp:/work/build/SpectrePch.hpp.gch
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1

--- a/cmake/SetupCCache.cmake
+++ b/cmake/SetupCCache.cmake
@@ -5,10 +5,19 @@ option(USE_CCACHE "Use CCache if available of speed up builds" ON)
 if(USE_CCACHE)
   find_program(CCACHE_FOUND ccache)
   if(CCACHE_FOUND)
+    string(CONCAT CCACHE_COMMAND
+      "CCACHE_SLOPPINESS=pch_defines,time_macros "
+      # In order to make ccache work with precompiled headers we need to:
+      # - Hash the header file in the repo that will generate the precompiled
+      #   header
+      # - Ignore the precompiled header in the build directory
+      "CCACHE_EXTRAFILES=${CMAKE_SOURCE_DIR}/tools/SpectrePch.hpp "
+      "CCACHE_IGNOREHEADERS=${CMAKE_BINARY_DIR}/SpectrePch.hpp:${CMAKE_BINARY_DIR}/SpectrePch.hpp.gch "
+      "ccache"
+    )
     # CCache offers no benefit for linking
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE
-      "CCACHE_SLOPPINESS=pch_defines,time_macros ccache")
-    message(STATUS "Using ccache for compilation")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_COMMAND})
+    message(STATUS "Using ccache for compilation. It is invoked as: ${CCACHE_COMMAND}")
   else()
     message(STATUS "Could not find ccache")
   endif(CCACHE_FOUND)

--- a/containers/Dockerfile.travis
+++ b/containers/Dockerfile.travis
@@ -54,18 +54,14 @@ ARG CORE_LIBS
 ENV SPECTRE_BUILD_DIR=/work/build_${BUILD_TYPE}_${CC}
 ENV SPECTRE_SOURCE_DIR=/work/spectre
 
-# In order to have ccache work on TravisCI with a precompiled header we need to:
-# - Hash the content of the compiler rather than the location and mtime
-# - Hash the header file in the repo that will generate the precompiled header
-# - Ignore the precompiled header in the build directory
 # ENV CCACHE_LOGFILE=/work/ccache_log.txt
 ENV CCACHE_COMPRESS=1
 # Default compression is 6
 ENV CCACHE_COMPRESSLEVEL=6
 ENV CCACHE_MAXSIZE=5G
+# We hash the content of the compiler rather than the location and mtime
+# to make sure the cache works across the different machines
 ENV CCACHE_COMPILERCHECK=content
-ENV CCACHE_EXTRAFILES="${SPECTRE_SOURCE_DIR}/tools/SpectrePch.hpp"
-ENV CCACHE_IGNOREHEADERS="${SPECTRE_BUILD_DIR}/SpectrePch.hpp:${SPECTRE_BUILD_DIR}/SpectrePch.hpp.gch"
 
 # Print the ccache configuration out
 RUN ccache -p


### PR DESCRIPTION
## Proposed changes

This ccache configuration works for PCH on our CIi and in the container,
and it also works for macOS builds (which we had trouble with before).

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
