### PR TITLE
Add non-Euclidean Poisson system

### DIFF
--- a/src/Elliptic/Executables/Linear/CMakeLists.txt
+++ b/src/Elliptic/Executables/Linear/CMakeLists.txt
@@ -29,7 +29,7 @@ endfunction(add_linear_elliptic_executable)
 # The solution is only implemented in 3D so far
 add_linear_elliptic_executable(
   PoissonLorentzian3D
-  Poisson::FirstOrderSystem<3>
+  "Poisson::FirstOrderSystem<3, Poisson::Geometry::Euclidean>"
   Poisson::Solutions::Lorentzian<3>
   Poisson::Solutions::Lorentzian<3>
   "Poisson;PoissonSolutions"
@@ -40,7 +40,7 @@ add_linear_elliptic_executable(
 function(add_poisson_moustache_executable DIM)
   add_linear_elliptic_executable(
     PoissonMoustache${DIM}D
-    Poisson::FirstOrderSystem<${DIM}>
+    "Poisson::FirstOrderSystem<${DIM}, Poisson::Geometry::Euclidean>"
     Poisson::Solutions::Moustache<${DIM}>
     Poisson::Solutions::Moustache<${DIM}>
     "Poisson;PoissonSolutions"
@@ -53,7 +53,7 @@ add_poisson_moustache_executable(2)
 function(add_poisson_product_of_sinusoids_executable DIM)
   add_linear_elliptic_executable(
     PoissonProductOfSinusoids${DIM}D
-    Poisson::FirstOrderSystem<${DIM}>
+    "Poisson::FirstOrderSystem<${DIM}, Poisson::Geometry::Euclidean>"
     Poisson::Solutions::ProductOfSinusoids<${DIM}>
     Poisson::Solutions::ProductOfSinusoids<${DIM}>
     "Poisson;PoissonSolutions"

--- a/src/Elliptic/Executables/Linear/SolveLinearEllipticProblemFwd.hpp
+++ b/src/Elliptic/Executables/Linear/SolveLinearEllipticProblemFwd.hpp
@@ -5,9 +5,11 @@
 
 #include <cstddef>
 
+#include "Elliptic/Systems/Poisson/Geometry.hpp"
+
 /// \cond
 namespace Poisson {
-template <size_t Dim>
+template <size_t Dim, Geometry BackgroundGeometry>
 struct FirstOrderSystem;
 namespace Solutions {
 template <size_t Dim>

--- a/src/Elliptic/Systems/Poisson/Equations.cpp
+++ b/src/Elliptic/Systems/Poisson/Equations.cpp
@@ -24,7 +24,7 @@ void euclidean_fluxes(
 }
 
 template <size_t Dim>
-void noneuclidean_fluxes(
+void non_euclidean_fluxes(
     const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
         flux_for_field,
     const tnsr::II<DataVector, Dim, Frame::Inertial>& inv_spatial_metric,
@@ -54,7 +54,7 @@ void auxiliary_fluxes(gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*>
   template void Poisson::euclidean_fluxes<DIM(data)>(                        \
       const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>, \
       const tnsr::i<DataVector, DIM(data), Frame::Inertial>&) noexcept;      \
-  template void Poisson::noneuclidean_fluxes<DIM(data)>(                     \
+  template void Poisson::non_euclidean_fluxes<DIM(data)>(                    \
       const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>, \
       const tnsr::II<DataVector, DIM(data), Frame::Inertial>&,               \
       const Scalar<DataVector>&,                                             \

--- a/src/Elliptic/Systems/Poisson/Equations.cpp
+++ b/src/Elliptic/Systems/Poisson/Equations.cpp
@@ -68,12 +68,14 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 // Instantiate derivative templates
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "Elliptic/Systems/Poisson/FirstOrderSystem.hpp"
+#include "Elliptic/Systems/Poisson/Geometry.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/LinearOperators/Divergence.tpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 
 template <size_t Dim>
-using variables_tag = typename Poisson::FirstOrderSystem<Dim>::variables_tag;
+using variables_tag = typename Poisson::FirstOrderSystem<
+    Dim, Poisson::Geometry::Euclidean>::variables_tag;
 template <size_t Dim>
 using fluxes_tags_list = db::get_variables_tags_list<db::add_tag_prefix<
     ::Tags::Flux, variables_tag<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;

--- a/src/Elliptic/Systems/Poisson/Equations.hpp
+++ b/src/Elliptic/Systems/Poisson/Equations.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
@@ -69,6 +70,39 @@ struct EuclideanFluxes {
   static void apply(
       const gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*>
           flux_for_gradient,
+      const Scalar<DataVector>& field) noexcept {
+    auxiliary_fluxes(flux_for_gradient, field);
+  }
+  // clang-tidy: no runtime references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+/*!
+ * \brief Compute the fluxes \f$F^i_A\f$ for the curved-space Poisson equation
+ * on a spatial metric \f$\gamma_{ij}\f$.
+ *
+ * \see Poisson::FirstOrderSystem
+ */
+template <size_t Dim>
+struct NonEuclideanFluxes {
+  using argument_tags = tmpl::list<
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::DetSpatialMetric<DataVector>>;
+  static void apply(
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          flux_for_field,
+      const tnsr::II<DataVector, Dim, Frame::Inertial>& inv_spatial_metric,
+      const Scalar<DataVector>& det_spatial_metric,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          field_gradient) noexcept {
+    noneuclidean_fluxes(flux_for_field, inv_spatial_metric, det_spatial_metric,
+                        field_gradient);
+  }
+  static void apply(
+      const gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*>
+          flux_for_gradient,
+      const tnsr::II<DataVector, Dim, Frame::Inertial>& /*inv_spatial_metric*/,
+      const Scalar<DataVector>& /*det_spatial_metric*/,
       const Scalar<DataVector>& field) noexcept {
     auxiliary_fluxes(flux_for_gradient, field);
   }

--- a/src/Elliptic/Systems/Poisson/Equations.hpp
+++ b/src/Elliptic/Systems/Poisson/Equations.hpp
@@ -34,7 +34,7 @@ void euclidean_fluxes(
  * for the curved-space Poisson equation on a spatial metric \f$\gamma_{ij}\f$.
  */
 template <size_t Dim>
-void noneuclidean_fluxes(
+void non_euclidean_fluxes(
     gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> flux_for_field,
     const tnsr::II<DataVector, Dim, Frame::Inertial>& inv_spatial_metric,
     const Scalar<DataVector>& det_spatial_metric,
@@ -95,8 +95,8 @@ struct NonEuclideanFluxes {
       const Scalar<DataVector>& det_spatial_metric,
       const tnsr::i<DataVector, Dim, Frame::Inertial>&
           field_gradient) noexcept {
-    noneuclidean_fluxes(flux_for_field, inv_spatial_metric, det_spatial_metric,
-                        field_gradient);
+    non_euclidean_fluxes(flux_for_field, inv_spatial_metric, det_spatial_metric,
+                         field_gradient);
   }
   static void apply(
       const gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*>

--- a/src/Elliptic/Systems/Poisson/Geometry.hpp
+++ b/src/Elliptic/Systems/Poisson/Geometry.hpp
@@ -1,0 +1,9 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace Poisson {
+/// \brief Euclidean or non-Euclidean background geometry
+enum class Geometry { Euclidean, NonEuclidean };
+}  // namespace Poisson

--- a/tests/Unit/Elliptic/Systems/Poisson/Equations.py
+++ b/tests/Unit/Elliptic/Systems/Poisson/Equations.py
@@ -8,7 +8,8 @@ def euclidean_fluxes(field_gradient):
     return field_gradient
 
 
-def noneuclidean_fluxes(inv_spatial_metric, det_spatial_metric, field_gradient):
+def non_euclidean_fluxes(inv_spatial_metric, det_spatial_metric,
+                         field_gradient):
     return np.sqrt(det_spatial_metric) * np.einsum(
         'ij,j', inv_spatial_metric, field_gradient)
 

--- a/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
@@ -15,12 +15,15 @@
 #include "Elliptic/Systems/Poisson/Equations.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
 
 namespace {
 
@@ -73,6 +76,57 @@ void test_computers(const DataVector& used_for_size) {
     db::mutate_apply<tmpl::list<auxiliary_flux_tag>, argument_tags>(
         fluxes_computer, make_not_null(&box), get<field_tag>(box));
     auto expected_auxiliary_flux = tnsr::Ij<DataVector, Dim>{num_points, 0.};
+    Poisson::auxiliary_fluxes(make_not_null(&expected_auxiliary_flux),
+                              get<field_tag>(box));
+    CHECK(get<auxiliary_flux_tag>(box) == expected_auxiliary_flux);
+  }
+  {
+    INFO("NonEuclideanFluxes" << Dim << "D");
+    MAKE_GENERATOR(generator);
+    std::uniform_real_distribution<> dist(-0.1, 0.1);
+    const auto nn_generator = make_not_null(&generator);
+    const auto nn_dist = make_not_null(&dist);
+    auto spatial_metric = make_with_random_values<tnsr::ii<DataVector, Dim>>(
+        nn_generator, nn_dist, used_for_size);
+    for (size_t d = 0; d < Dim; d++) {
+      spatial_metric.get(d, d) += 1.;
+    }
+    auto box = db::create<
+        db::AddSimpleTags<
+            field_tag, auxiliary_field_tag, field_flux_tag, auxiliary_flux_tag,
+            gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataVector>>,
+        db::AddComputeTags<gr::Tags::DetAndInverseSpatialMetricCompute<
+            Dim, Frame::Inertial, DataVector>>>(
+        make_with_random_values<Scalar<DataVector>>(nn_generator, nn_dist,
+                                                    used_for_size),
+        make_with_random_values<tnsr::i<DataVector, Dim>>(nn_generator, nn_dist,
+                                                          used_for_size),
+        make_with_value<tnsr::I<DataVector, Dim>>(
+            used_for_size, std::numeric_limits<double>::signaling_NaN()),
+        make_with_value<tnsr::Ij<DataVector, Dim>>(
+            used_for_size, std::numeric_limits<double>::signaling_NaN()),
+        std::move(spatial_metric));
+
+    const Poisson::NonEuclideanFluxes<Dim> fluxes_computer{};
+    using argument_tags =
+        typename Poisson::NonEuclideanFluxes<Dim>::argument_tags;
+
+    db::mutate_apply<tmpl::list<field_flux_tag>, argument_tags>(
+        fluxes_computer, make_not_null(&box), get<auxiliary_field_tag>(box));
+    auto expected_field_flux = make_with_value<tnsr::I<DataVector, Dim>>(
+        used_for_size, std::numeric_limits<double>::signaling_NaN());
+    Poisson::noneuclidean_fluxes(
+        make_not_null(&expected_field_flux),
+        get<gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>(
+            box),
+        get<gr::Tags::DetSpatialMetric<DataVector>>(box),
+        get<auxiliary_field_tag>(box));
+    CHECK(get<field_flux_tag>(box) == expected_field_flux);
+
+    db::mutate_apply<tmpl::list<auxiliary_flux_tag>, argument_tags>(
+        fluxes_computer, make_not_null(&box), get<field_tag>(box));
+    auto expected_auxiliary_flux = make_with_value<tnsr::Ij<DataVector, Dim>>(
+        used_for_size, std::numeric_limits<double>::signaling_NaN());
     Poisson::auxiliary_fluxes(make_not_null(&expected_auxiliary_flux),
                               get<field_tag>(box));
     CHECK(get<auxiliary_flux_tag>(box) == expected_auxiliary_flux);

--- a/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
@@ -32,8 +32,8 @@ void test_equations(const DataVector& used_for_size) {
   pypp::check_with_random_values<1>(&Poisson::euclidean_fluxes<Dim>,
                                     "Equations", {"euclidean_fluxes"},
                                     {{{0., 1.}}}, used_for_size);
-  pypp::check_with_random_values<1>(&Poisson::noneuclidean_fluxes<Dim>,
-                                    "Equations", {"noneuclidean_fluxes"},
+  pypp::check_with_random_values<1>(&Poisson::non_euclidean_fluxes<Dim>,
+                                    "Equations", {"non_euclidean_fluxes"},
                                     {{{0., 1.}}}, used_for_size);
   pypp::check_with_random_values<1>(
       &Poisson::auxiliary_fluxes<Dim>, "Equations",
@@ -115,7 +115,7 @@ void test_computers(const DataVector& used_for_size) {
         fluxes_computer, make_not_null(&box), get<auxiliary_field_tag>(box));
     auto expected_field_flux = make_with_value<tnsr::I<DataVector, Dim>>(
         used_for_size, std::numeric_limits<double>::signaling_NaN());
-    Poisson::noneuclidean_fluxes(
+    Poisson::non_euclidean_fluxes(
         make_not_null(&expected_field_flux),
         get<gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>(
             box),

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
@@ -32,23 +32,67 @@ struct OperatorAppliedTo : db::SimpleTag, db::PrefixTag {
 
 }  // namespace Tags
 
-/// \ingroup TestingFrameworkGroup
-/// Test that the `solution` numerically solves the `System` on the given grid
-/// for the given tolerance
-template <typename System, typename SolutionType, typename... FluxesArgs,
-          typename... SourcesArgs, typename... Maps>
-void verify_solution(
-    const SolutionType& solution,
-    const typename System::fluxes& fluxes_computer,
-    const FluxesArgs&... fluxes_args, const SourcesArgs&... sources_args,
-    const Mesh<System::volume_dim>& mesh,
-    const domain::CoordinateMap<Frame::Logical, Frame::Inertial, Maps...>
-        coord_map,
-    const double tolerance) {
-  constexpr size_t volume_dim = System::volume_dim;
+namespace detail {
+
+template <typename System,
+          typename FluxesArgs =
+              tmpl::transform<typename System::fluxes::argument_tags,
+                              tmpl::bind<db::const_item_type, tmpl::_1>>,
+          typename FluxesArgsIndices =
+              std::make_index_sequence<tmpl::size<FluxesArgs>::value>,
+          typename SourcesArgs =
+              tmpl::transform<typename System::sources::argument_tags,
+                              tmpl::bind<db::const_item_type, tmpl::_1>>,
+          typename SourcesArgsIndices =
+              std::make_index_sequence<tmpl::size<SourcesArgs>::value>>
+struct ExpandTuplesImpl;
+
+template <typename System, typename... FluxesArgs, size_t... FluxesArgsIndices,
+          typename... SourcesArgs, size_t... SourcesArgsIndices>
+struct ExpandTuplesImpl<System, tmpl::list<FluxesArgs...>,
+                        std::index_sequence<FluxesArgsIndices...>,
+                        tmpl::list<SourcesArgs...>,
+                        std::index_sequence<SourcesArgsIndices...>> {
+  static constexpr size_t volume_dim = System::volume_dim;
   using all_fields = db::get_variables_tags_list<typename System::fields_tag>;
   using primal_fields = typename System::primal_fields;
   using auxiliary_fields = typename System::auxiliary_fields;
+
+  static auto first_order_fluxes(
+      const Variables<all_fields>& vars,
+      const typename System::fluxes& fluxes_computer,
+      const std::tuple<FluxesArgs...>& fluxes_args) noexcept {
+    return elliptic::first_order_fluxes<volume_dim, primal_fields,
+                                        auxiliary_fields>(
+        vars, fluxes_computer, get<FluxesArgsIndices>(fluxes_args)...);
+  }
+
+  static auto first_order_sources(
+      const Variables<all_fields>& vars,
+      const std::tuple<SourcesArgs...>& sources_args) noexcept {
+    return elliptic::first_order_sources<primal_fields, auxiliary_fields,
+                                         typename System::sources>(
+        vars, get<SourcesArgsIndices>(sources_args)...);
+  }
+};
+
+}  // namespace detail
+
+/// \ingroup TestingFrameworkGroup
+/// Test that the `solution` numerically solves the `System` on the given grid
+/// for the given tolerance
+template <typename System, typename SolutionType, typename... Maps,
+          typename... FluxesArgs, typename... SourcesArgs>
+void verify_solution(
+    const SolutionType& solution,
+    const typename System::fluxes& fluxes_computer,
+    const Mesh<System::volume_dim>& mesh,
+    const domain::CoordinateMap<Frame::Logical, Frame::Inertial, Maps...>
+        coord_map,
+    const double tolerance,
+    const std::tuple<FluxesArgs...>& fluxes_args = std::tuple<>{},
+    const std::tuple<SourcesArgs...>& sources_args = std::tuple<>{}) {
+  using all_fields = db::get_variables_tags_list<typename System::fields_tag>;
 
   const size_t num_points = mesh.number_of_grid_points();
   const auto logical_coords = logical_coordinates(mesh);
@@ -57,14 +101,12 @@ void verify_solution(
       solution.variables(inertial_coords, all_fields{}));
 
   // Apply operator to solution fields
-  auto fluxes =
-      elliptic::first_order_fluxes<volume_dim, primal_fields, auxiliary_fields>(
-          solution_fields, fluxes_computer, fluxes_args...);
+  auto fluxes = detail::ExpandTuplesImpl<System>::first_order_fluxes(
+      solution_fields, fluxes_computer, fluxes_args);
   auto div_fluxes = divergence(std::move(fluxes), mesh,
                                coord_map.inv_jacobian(logical_coords));
-  auto sources = elliptic::first_order_sources<primal_fields, auxiliary_fields,
-                                               typename System::sources>(
-      solution_fields, sources_args...);
+  auto sources = detail::ExpandTuplesImpl<System>::first_order_sources(
+      solution_fields, sources_args);
   Variables<db::wrap_tags_in<Tags::OperatorAppliedTo, all_fields>>
       operator_applied_to_fields{num_points};
   elliptic::first_order_operator(make_not_null(&operator_applied_to_fields),

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
@@ -16,6 +16,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Mesh.hpp"
 #include "Elliptic/Systems/Poisson/FirstOrderSystem.hpp"
+#include "Elliptic/Systems/Poisson/Geometry.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp"
@@ -81,17 +82,47 @@ SPECTRE_TEST_CASE(
   // 1D and 2D solutions are not implemented yet.
   test_solution<3>();
 
-  // Verify that the solution numerically solves the system and that the
-  // discretization error decreases exponentially with polynomial order
-  using system = Poisson::FirstOrderSystem<3>;
-  const Poisson::Solutions::Lorentzian<3> solution{};
-  const typename system::fluxes fluxes_computer{};
-  using AffineMap = domain::CoordinateMaps::Affine;
-  using AffineMap3D =
-      domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
-  const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap3D>
-      coord_map{
-          {{-1., 1., -0.5, 0.5}, {-1., 1., -0.5, 0.5}, {-1., 1., -0.5, 0.5}}};
-  FirstOrderEllipticSolutionsTestHelpers::verify_smooth_solution<system>(
-      solution, fluxes_computer, coord_map, 5.e1, 1.2);
+  {
+    // Verify that the solution numerically solves the system and that the
+    // discretization error decreases exponentially with polynomial order
+    using system = Poisson::FirstOrderSystem<3, Poisson::Geometry::Euclidean>;
+    const Poisson::Solutions::Lorentzian<3> solution{};
+    const typename system::fluxes fluxes_computer{};
+    using AffineMap = domain::CoordinateMaps::Affine;
+    using AffineMap3D =
+        domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+    const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap3D>
+        coord_map{
+            {{-1., 1., -0.5, 0.5}, {-1., 1., -0.5, 0.5}, {-1., 1., -0.5, 0.5}}};
+    FirstOrderEllipticSolutionsTestHelpers::verify_smooth_solution<system>(
+        solution, fluxes_computer, coord_map, 5.e1, 1.2);
+  }
+
+  {
+    // Verify that the solution also solves the non-euclidean system with a
+    // Euclidean metric. This is more a test of the system than of the solution.
+    using system =
+        Poisson::FirstOrderSystem<3, Poisson::Geometry::NonEuclidean>;
+    const Poisson::Solutions::Lorentzian<3> solution{};
+    const typename system::fluxes fluxes_computer{};
+    using AffineMap = domain::CoordinateMaps::Affine;
+    using AffineMap3D =
+        domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+    const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap3D>
+        coord_map{
+            {{-1., 1., -0.5, 0.5}, {-1., 1., -0.5, 0.5}, {-1., 1., -0.5, 0.5}}};
+    Mesh<3> mesh{8, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+    const DataVector used_for_size{mesh.number_of_grid_points()};
+    auto inv_spatial_metric =
+        make_with_value<tnsr::II<DataVector, 3>>(used_for_size, 0.);
+    get<0, 0>(inv_spatial_metric) = 1.;
+    get<1, 1>(inv_spatial_metric) = 1.;
+    get<2, 2>(inv_spatial_metric) = 1.;
+    const auto det_spatial_metric =
+        make_with_value<Scalar<DataVector>>(used_for_size, 1.);
+    FirstOrderEllipticSolutionsTestHelpers::verify_solution<system>(
+        solution, fluxes_computer, mesh, coord_map, 0.1,
+        std::make_tuple(inv_spatial_metric, det_spatial_metric));
+  }
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
@@ -17,6 +17,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Mesh.hpp"
 #include "Elliptic/Systems/Poisson/FirstOrderSystem.hpp"
+#include "Elliptic/Systems/Poisson/Geometry.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -84,7 +85,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Poisson.Moustache",
     INFO("1D");
     test_solution<1>();
 
-    using system = Poisson::FirstOrderSystem<1>;
+    using system = Poisson::FirstOrderSystem<1, Poisson::Geometry::Euclidean>;
     const Poisson::Solutions::Moustache<1> solution{};
     const typename system::fluxes fluxes_computer{};
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap>
@@ -97,7 +98,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Poisson.Moustache",
     INFO("2D");
     test_solution<2>();
 
-    using system = Poisson::FirstOrderSystem<2>;
+    using system = Poisson::FirstOrderSystem<2, Poisson::Geometry::Euclidean>;
     const Poisson::Solutions::Moustache<2> solution{};
     const typename system::fluxes fluxes_computer{};
     using AffineMap2D =

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
@@ -20,6 +20,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Mesh.hpp"
 #include "Elliptic/Systems/Poisson/FirstOrderSystem.hpp"
+#include "Elliptic/Systems/Poisson/Geometry.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -93,7 +94,7 @@ SPECTRE_TEST_CASE(
     INFO("1D");
     test_solution<1>({{0.5}}, "[0.5]");
 
-    using system = Poisson::FirstOrderSystem<1>;
+    using system = Poisson::FirstOrderSystem<1, Poisson::Geometry::Euclidean>;
     const Poisson::Solutions::ProductOfSinusoids<1> solution{{{0.5}}};
     const typename system::fluxes fluxes_computer{};
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap>
@@ -105,7 +106,7 @@ SPECTRE_TEST_CASE(
     INFO("2D");
     test_solution<2>({{0.5, 1.}}, "[0.5, 1.]");
 
-    using system = Poisson::FirstOrderSystem<2>;
+    using system = Poisson::FirstOrderSystem<2, Poisson::Geometry::Euclidean>;
     const Poisson::Solutions::ProductOfSinusoids<2> solution{{{0.5, 0.5}}};
     const typename system::fluxes fluxes_computer{};
     using AffineMap2D =
@@ -119,7 +120,7 @@ SPECTRE_TEST_CASE(
     INFO("3D");
     test_solution<3>({{1., 0.5, 1.5}}, "[1., 0.5, 1.5]");
 
-    using system = Poisson::FirstOrderSystem<3>;
+    using system = Poisson::FirstOrderSystem<3, Poisson::Geometry::Euclidean>;
     const Poisson::Solutions::ProductOfSinusoids<3> solution{{{0.5, 0.5, 0.5}}};
     const typename system::fluxes fluxes_computer{};
     using AffineMap3D =


### PR DESCRIPTION
## Proposed changes

Add support for solving the Poisson equation on a background metric.

The reason I'm pushing this now is mostly for the second commit, which will be useful for @tomwlodarczyk's upcoming elasticity system.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
