### PR TITLE
Cleanup root finder dox and tests

### DIFF
--- a/src/NumericalAlgorithms/RootFinding/NewtonRaphson.hpp
+++ b/src/NumericalAlgorithms/RootFinding/NewtonRaphson.hpp
@@ -20,7 +20,9 @@ namespace RootFinder {
  * \brief Finds the root of the function `f` with the Newton-Raphson method.
  *
  * `f` is a unary invokable that takes a `double` which is the current value at
- * which to evaluate `f`. An example is below.
+ * which to evaluate `f`. `f` must return a `std::pair<double, double>` where
+ * the first element is the function value and the second element is the
+ * derivative of the function.  An example is below.
  *
  * \snippet Test_NewtonRaphson.cpp double_newton_raphson_root_find
  *
@@ -67,6 +69,8 @@ double newton_raphson(const Function& f, const double initial_guess,
  * `f` is a binary invokable that takes a `double` as its first argument and a
  * `size_t` as its second. The `double` is the current value at which to
  * evaluate `f`, and the `size_t` is the current index into the `DataVector`s.
+ *  `f` must return a `std::pair<double, double>` where the first element is
+ * the function value and the second element is the derivative of the function.
  * Below is an example of how to root find different functions by indexing into
  * a lambda-captured `DataVector` using the `size_t` passed to `f`.
  *

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_NewtonRaphson.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_NewtonRaphson.cpp
@@ -26,10 +26,8 @@ struct FuncAndDeriv {
     return std::make_pair(2. - square(x), -2. * x);
   }
 };
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.NewtonRaphson",
-                  "[NumericalAlgorithms][RootFinding][Unit]") {
+void test_simple() noexcept {
   /// [double_newton_raphson_root_find]
   const size_t digits = 8;
   const double correct = sqrt(2.);
@@ -52,8 +50,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.NewtonRaphson",
   CHECK(root_from_free == root_from_functor);
 }
 
-SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.NewtonRaphson.Bounds",
-                  "[NumericalAlgorithms][RootFinding][Unit]") {
+void test_bounds() noexcept {
   const size_t digits = 8;
   const double guess = 1.5;
   double upper = 2.;
@@ -76,8 +73,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.NewtonRaphson.Bounds",
   CHECK(std::abs(root - correct) < 1.0 / std::pow(10, digits));
 }
 
-SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.NewtonRaphson.DataVector",
-                  "[NumericalAlgorithms][RootFinding][Unit]") {
+void test_datavector() noexcept {
   /// [datavector_newton_raphson_root_find]
   const size_t digits = 8;
   const DataVector guess{1.6, 1.9, -1.6, -1.9};
@@ -101,52 +97,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.NewtonRaphson.DataVector",
   }
 }
 
-// [[OutputRegex, The desired accuracy of 100 base-10 digits must be smaller]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Numerical.RootFinding.NewtonRaphson.Digits.Double",
-    "[NumericalAlgorithms][RootFinding][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const size_t digits = 100;
-  const double guess = 1.5;
-  double lower = 1.;
-  double upper = 2.;
-  const auto func_and_deriv_lambda = [](double x) {
-    return std::make_pair(2. - square(x), -2. * x);
-  };
-
-  RootFinder::newton_raphson(func_and_deriv_lambda, guess, lower, upper,
-                             digits);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, The desired accuracy of 100 base-10 digits must be smaller]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Numerical.RootFinding.NewtonRaphson.Digits.DataVector",
-    "[NumericalAlgorithms][RootFinding][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const size_t digits = 100;
-  const DataVector guess{1.6, 1.9, -1.6, -1.9};
-  const DataVector lower{sqrt(2.), sqrt(2.), -2., -3.};
-  const DataVector upper{2., 3., -sqrt(2.), -sqrt(2.)};
-  const DataVector constant{2., 4., 2., 4.};
-
-  const auto func_and_deriv_lambda = [&constant](const double x,
-                                                 const size_t i) noexcept {
-    return std::make_pair(constant[i] - square(x), -2. * x);
-  };
-
-  const auto root = RootFinder::newton_raphson(func_and_deriv_lambda, guess,
-                                               lower, upper, digits);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-SPECTRE_TEST_CASE(
-    "Unit.Numerical.RootFinding.NewtonRaphson.convergence_error.Double",
-    "[NumericalAlgorithms][RootFinding][Unit]") {
+void test_convergence_error_double() noexcept {
   const size_t max_iterations = 2;
   const size_t digits = 8;
   const double guess = 1.5;
@@ -179,9 +130,7 @@ SPECTRE_TEST_CASE(
                         << func_and_deriv(best_result).first));
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Numerical.RootFinding.NewtonRaphson.convergence_error.DataVector",
-    "[NumericalAlgorithms][RootFinding][Unit]") {
+void test_convergence_error_datavector() noexcept {
   const size_t max_iterations = 2;
   const size_t digits = 8;
   const auto digits_binary = std::round(std::log2(std::pow(10, digits)));
@@ -232,3 +181,56 @@ SPECTRE_TEST_CASE(
     }
   }
 }
+
+SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.NewtonRaphson",
+                  "[NumericalAlgorithms][RootFinding][Unit]") {
+  test_simple();
+  test_bounds();
+  test_datavector();
+  test_convergence_error_double();
+  test_convergence_error_datavector();
+}
+
+// [[OutputRegex, The desired accuracy of 100 base-10 digits must be smaller]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Numerical.RootFinding.NewtonRaphson.Digits.Double",
+    "[NumericalAlgorithms][RootFinding][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const size_t digits = 100;
+  const double guess = 1.5;
+  double lower = 1.;
+  double upper = 2.;
+  const auto func_and_deriv_lambda = [](double x) {
+    return std::make_pair(2. - square(x), -2. * x);
+  };
+
+  RootFinder::newton_raphson(func_and_deriv_lambda, guess, lower, upper,
+                             digits);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The desired accuracy of 100 base-10 digits must be smaller]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Numerical.RootFinding.NewtonRaphson.Digits.DataVector",
+    "[NumericalAlgorithms][RootFinding][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const size_t digits = 100;
+  const DataVector guess{1.6, 1.9, -1.6, -1.9};
+  const DataVector lower{sqrt(2.), sqrt(2.), -2., -3.};
+  const DataVector upper{2., 3., -sqrt(2.), -sqrt(2.)};
+  const DataVector constant{2., 4., 2., 4.};
+
+  const auto func_and_deriv_lambda = [&constant](const double x,
+                                                 const size_t i) noexcept {
+    return std::make_pair(constant[i] - square(x), -2. * x);
+  };
+
+  const auto root = RootFinder::newton_raphson(func_and_deriv_lambda, guess,
+                                               lower, upper, digits);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+}  // namespace

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_QuadraticEquation.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_QuadraticEquation.cpp
@@ -42,13 +42,12 @@
 #endif
 }
 
-SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.positive_root",
+SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.QuadraticEquation",
                   "[NumericalAlgorithms][RootFinding][Unit]") {
+  // Positive root
   CHECK(approx(6.31662479035539985) == positive_root(1.0, -6.0, -2.0));
-}
 
-SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.real_roots",
-                  "[NumericalAlgorithms][RootFinding][Unit]") {
+  // Real roots
   const auto roots = real_roots(2.0, -11.0, 5.0);
   CHECK(approx(0.5) == roots[0]);
   CHECK(approx(5.0) == roots[1]);


### PR DESCRIPTION
## Proposed changes

- Make it clear what the return type needs to be for Newton-Raphson calls
- Combine separate test cases for Newton-Raphosn, TOMS748, and quadratic equation.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
