### PR TITLE
Improve handling of OutputRegex error tests

### DIFF
--- a/docs/DevGuide/CodeReviewGuide.md
+++ b/docs/DevGuide/CodeReviewGuide.md
@@ -80,7 +80,7 @@ Code Quality Items:
 * Do not add anything to [the `std` namespace]
   (http://en.cppreference.com/w/cpp/language/extending_std).
 * Virtual functions are explicitly overridden using the `override` keyword.
-* `pragma once` is to be used for header guards
+* `#%pragma once` is to be used for header guards
 * Prefer range-based for loops
 * Use `size_t` for positive integers rather than `int`, specifically when
   looping over containers. This is in compliance with what the STL uses.

--- a/docs/DevGuide/Travis.md
+++ b/docs/DevGuide/Travis.md
@@ -54,7 +54,7 @@ true:
   - A file has white space at the end of the line
   - A file has a carriage return character
   - A file is missing the license line
-  - A `*.hpp` file is missing `pragma once`
+  - A `*.hpp` file is missing `#%pragma once`
   - A file does not end with a newline
   - A `c++` file includes any of the following headers
     * `<iostream>`  (useless when running in parallel)

--- a/docs/DevGuide/WritingTests.md
+++ b/docs/DevGuide/WritingTests.md
@@ -175,40 +175,34 @@ The corresponding Python functions are:
 
 #### Testing Failure Cases
 
-Adding the "attribute" `// [[OutputRegex, Regular expression to match]]`
-before the `SPECTRE_TEST_CASE` macro will force ctest to only pass the
-particular test if the regular expression is found. This can be used to test
-error handling. When testing `ASSERT`s you must mark the `SPECTRE_TEST_CASE` as
-`[[noreturn]]`,
-add the macro `ASSERTION_TEST();` to the beginning of the test, and also have
-the test call `ERROR("Failed to trigger ASSERT in an assertion test");` at the
-end of the test body.
+Adding the "attribute" `// [[OutputRegex, Regular expression to
+match]]` before the `SPECTRE_TEST_CASE` macro will force ctest to only
+pass the particular test if the regular expression is found in the
+output of the test. This can be used to test error handling. When
+testing `ASSERT`s you must mark the `SPECTRE_TEST_CASE` as
+`[[noreturn]]`, add the macro `ASSERTION_TEST();` to the beginning of
+the test, and also have the test call `ERROR("Failed to trigger ASSERT
+in an assertion test");` at the end of the test body.  The test body
+should be enclosed between `#%ifdef SPECTRE_DEBUG` and an `#%endif`
 For example,
 
-```cpp
-// [[OutputRegex, Must copy into same size]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.ref_diff_size",
-                               "[DataStructures][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  DataVector data{1.43, 2.83, 3.94, 7.85};
-  DataVector data_ref;
-  data_ref.set_data_ref(data);
-  DataVector data2{1.43, 2.83, 3.94};
-  data_ref = data2;
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-```
-If the `ifdef SPECTRE_DEBUG` is omitted then compilers will correctly flag
-the code as being unreachable which results in warnings.
+\snippet Test_AssertAndError.cpp assertion_test_example
 
-You can also test `ERROR`s inside your code. These tests need to have the
-`OutputRegex`, and also call `ERROR_TEST();` at the beginning. The do not need
-the `ifdef SPECTRE_DEBUG` block, they can just call have the code that triggers
-an `ERROR`. For example,
+If the `#%ifdef SPECTRE_DEBUG` block is omitted then compilers will
+correctly flag the code as being unreachable which results in
+warnings.
 
-\snippet Test_AbortWithErrorMessage.cpp error_test_example
+You can also test `ERROR`s inside your code. These tests need to have
+the `OutputRegex`, and also call `ERROR_TEST();` at the
+beginning. They do not need the `#%ifdef SPECTRE_DEBUG` block, they
+can just call have the code that triggers an `ERROR`. For example,
+
+\snippet Test_AssertAndError.cpp error_test_example
+
+Note that a `OutputRegex` can also be specified in a test that is
+supposed to succeed with output that matches the regular expression.
+In this case, the first line of the test should call the macro
+`OUTPUT_TEST();`.
 
 ### Building and Running A Single Test File
 

--- a/src/Parallel/Printf.hpp
+++ b/src/Parallel/Printf.hpp
@@ -72,6 +72,7 @@ inline const typename std::string::value_type* get_printable_type(
 template <typename Printer, typename... Ts>
 inline void print_helper(Printer&& printer, const std::string& format,
                          Ts&&... t) {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   printer(format.c_str(), get_printable_type(std::forward<Ts>(t))...);
 }
 

--- a/tests/Unit/ErrorHandling/Test_AbortWithErrorMessage.cpp
+++ b/tests/Unit/ErrorHandling/Test_AbortWithErrorMessage.cpp
@@ -5,7 +5,6 @@
 
 #include "ErrorHandling/AbortWithErrorMessage.hpp"
 
-/// [error_test_example]
 // [[OutputRegex, 'a == b' violated!]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.ErrorHandling.AbortWithErrorMessage.Assert",
@@ -15,7 +14,6 @@
                            static_cast<const char*>(__PRETTY_FUNCTION__),
                            "Test Error");
 }
-/// [error_test_example]
 
 // [[OutputRegex, ############ ERROR]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.ErrorHandling.AbortWithErrorMessage.Error",

--- a/tests/Unit/ErrorHandling/Test_AssertAndError.cpp
+++ b/tests/Unit/ErrorHandling/Test_AssertAndError.cpp
@@ -6,16 +6,23 @@
 #include "ErrorHandling/Assert.hpp"
 #include "ErrorHandling/Error.hpp"
 
+/// [assertion_test_example]
 // [[OutputRegex, Testing assert]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.ErrorHandling.Assert",
                                "[Unit][ErrorHandling]") {
   ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
   ASSERT(false, "Testing assert");
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
 }
+/// [assertion_test_example]
 
+/// [error_test_example]
 // [[OutputRegex, Testing error]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.ErrorHandling.Error",
                                "[Unit][ErrorHandling]") {
   ERROR_TEST();
   ERROR("Testing error");
 }
+/// [error_test_example]

--- a/tests/Unit/Parallel/Test_Parallel.cpp
+++ b/tests/Unit/Parallel/Test_Parallel.cpp
@@ -40,9 +40,11 @@ std::ostream& operator<<(std::ostream& os, const TestEnum& t) noexcept {
 
 }  // namespace
 
+/// [output_test_example]
 // [[OutputRegex, -100 3000000000 1.0000000000000000000e\+00 \(0,4,8,-7\) test 1
 // 2 3 abf a o e u Value 2]]
 SPECTRE_TEST_CASE("Unit.Parallel.printf", "[Unit][Parallel]") {
+  OUTPUT_TEST();
   const char c_string0[40] = {"test 1 2 3"};
   auto* c_string1 = new char[80];
   // clang-tidy: do not use pointer arithmetic
@@ -54,10 +56,8 @@ SPECTRE_TEST_CASE("Unit.Parallel.printf", "[Unit][Parallel]") {
   Parallel::printf("%d %lld %s %s %s %s %s\n", -100, 3000000000, TestStream{},
                    c_string0, c_string1, c_string2, TestEnum::Value2);
   delete[] c_string1;
-  // Catch requires us to have at least one CHECK in each test
-  // The Unit.Parallel.printf does not need to check anything
-  CHECK(true);
 }
+/// [output_test_example]
 
 SPECTRE_TEST_CASE("Unit.Parallel.NodeAndPes", "[Unit][Parallel]") {
   CHECK(1 == Parallel::number_of_procs());

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_RiemannProblem.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_RiemannProblem.cpp
@@ -166,9 +166,9 @@ SPECTRE_TEST_CASE(
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.RiemannProblem.PositP",
     "[Unit][PointwiseFunctions]") {
+  ASSERTION_TEST();
   pypp::SetupLocalPythonEnvironment local_python_env{
       "PointwiseFunctions/AnalyticSolutions/NewtonianEuler"};
-  ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   NewtonianEuler::Solutions::RiemannProblem<1> solution(
       1.4, 0.7, 1.0, {{0.0}}, 1.0, 0.125, {{30.0}}, 1.1);
@@ -181,10 +181,10 @@ SPECTRE_TEST_CASE(
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.RiemannProblem.Dens",
     "[Unit][PointwiseFunctions]") {
+  ASSERTION_TEST();
   // clang-format on
   pypp::SetupLocalPythonEnvironment local_python_env{
       "PointwiseFunctions/AnalyticSolutions/NewtonianEuler"};
-  ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   NewtonianEuler::Solutions::RiemannProblem<2> solution(
       1.4, 0.7, -1.0, {{0.0}}, 1.0, 0.125, {{30.0}}, 1.1);
@@ -196,9 +196,9 @@ SPECTRE_TEST_CASE(
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.RiemannProblem.Pres",
     "[Unit][PointwiseFunctions]") {
+  ASSERTION_TEST();
   pypp::SetupLocalPythonEnvironment local_python_env{
       "PointwiseFunctions/AnalyticSolutions/NewtonianEuler"};
-  ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   NewtonianEuler::Solutions::RiemannProblem<3> solution(
       1.4, 0.7, 1.0, {{0.0}}, -1.0, 0.125, {{30.0}}, 1.1);

--- a/tests/Unit/Test_TestingFramework.cpp
+++ b/tests/Unit/Test_TestingFramework.cpp
@@ -34,10 +34,8 @@ SPECTRE_TEST_CASE("Unit.TestingFramework.Approx", "[Unit]") {
   /// [approx_new_custom]
 }
 
-/// [error_test]
 // [[OutputRegex, I failed]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.TestingFramework.Abort", "[Unit]") {
   ERROR_TEST();
-  /// [error_test]
   Parallel::abort("I failed");
 }

--- a/tests/Unit/TestingFramework.hpp
+++ b/tests/Unit/TestingFramework.hpp
@@ -320,7 +320,7 @@ struct check_matrix_approx {
  * the SPECTRE_TEST_CASE.
  *
  * \example
- * \snippet Test_TestingFramework.cpp error_test
+ * \snippet Test_AssertAndError.cpp error_test_example
  */
 #define ERROR_TEST()                                      \
   do {                                                    \
@@ -359,3 +359,20 @@ struct check_matrix_approx {
     Parallel::abort("### No ASSERT tests in release mode ###"); \
   } while (false)
 #endif
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Mark a test as checking the output with a regular expression
+ *
+ * \details
+ * The OUTPUT_TEST() macro should be the first line in the SPECTRE_TEST_CASE.
+ * Catch requires at least one CHECK in each test to pass, so we add one in
+ * case nothing but the output is checked.
+ *
+ * \example
+ * \snippet Test_Parallel.cpp output_test_example
+ */
+#define OUTPUT_TEST() \
+  do {                \
+    CHECK(true);      \
+  } while (false)


### PR DESCRIPTION
## Proposed changes

Fix #546 by requiring all code tests that specify an OutputRegex to also call a macro as the first line of the test.  This prevents error tests from automatically passing when the OutputRegex is missing or ill-formed.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [x] Documentation
- [x] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
