### PR TITLE
Add static assert in base tag storage type metafunction

### DIFF
--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -411,6 +411,19 @@ struct dispatch_storage_type<3> {
   using f = typename Tag::return_type;
 };
 
+template <typename TagList, typename Tag>
+struct get_first_derived_tag_for_base_tag {
+  static_assert(
+      not cpp17::is_same_v<TagList, NoSuchType>,
+      "Can't retrieve the storage type of a base tag without the full tag "
+      "list. If you're using 'item_type' or 'const_item_type' then make sure "
+      "you pass the DataBox's tag list as the second template parameter to "
+      "those metafunctions. The base tag for which the storage type is being"
+      "retrieved is listed as the second template argument to the "
+      "'get_first_derived_tag_for_base_tag' class below");
+  using type = first_matching_tag<TagList, Tag>;
+};
+
 template <>
 struct dispatch_storage_type<4> {
   // base tag item: retrieve the derived tag from the tag list then call
@@ -422,8 +435,9 @@ struct dispatch_storage_type<4> {
   // same, it is undefined behavior if they are not and the user's
   // responsibility.
   template <typename TagList, typename Tag>
-  using f = typename storage_type_impl<TagList,
-                                       first_matching_tag<TagList, Tag>>::type;
+  using f = typename storage_type_impl<
+      TagList,
+      tmpl::type_from<get_first_derived_tag_for_base_tag<TagList, Tag>>>::type;
 };
 
 // The type internally stored in a simple or compute item.  For


### PR DESCRIPTION
## Proposed changes


Adds a static assert that tells people to pass the DbTagsList to `item_type` and `const_item_type` if they want those functions to work with base tags.


### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
