### PR TITLE
Add tags for elastic constitutive relations

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
@@ -81,10 +81,12 @@ class BentBeam {
         "The bending moment applied to the beam"};
     static type lower_bound() noexcept { return 0.0; }
   };
+  struct Material {
+    using type = constitutive_relation_type;
+    static constexpr OptionString help{"The material properties of the beam"};
+  };
 
-  using options = tmpl::list<
-      Length, Height, BendingMoment,
-      Elasticity::Tags::ConstitutiveRelation<constitutive_relation_type>>;
+  using options = tmpl::list<Length, Height, BendingMoment, Material>;
   static constexpr OptionString help{
       "A 2D slice through an elastic beam which is subject to a bending "
       "moment. The bending moment is applied along the length of the beam, "

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp
@@ -51,11 +51,13 @@ namespace ConstitutiveRelations {
 template <size_t Dim>
 class ConstitutiveRelation : public PUP::able {
  public:
+  static constexpr size_t volume_dim = Dim;
+
   using creatable_classes = tmpl::list<IsotropicHomogeneous<Dim>>;
 
   ConstitutiveRelation() = default;
-  ConstitutiveRelation(const ConstitutiveRelation&) = delete;
-  ConstitutiveRelation& operator=(const ConstitutiveRelation&) = delete;
+  ConstitutiveRelation(const ConstitutiveRelation&) = default;
+  ConstitutiveRelation& operator=(const ConstitutiveRelation&) = default;
   ConstitutiveRelation(ConstitutiveRelation&&) = default;
   ConstitutiveRelation& operator=(ConstitutiveRelation&&) = default;
   ~ConstitutiveRelation() override = default;

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp
@@ -94,6 +94,8 @@ namespace ConstitutiveRelations {
 template <size_t Dim>
 class IsotropicHomogeneous : public ConstitutiveRelation<Dim> {
  public:
+  static constexpr size_t volume_dim = Dim;
+
   struct BulkModulus {
     using type = double;
     static constexpr OptionString help = {
@@ -116,8 +118,8 @@ class IsotropicHomogeneous : public ConstitutiveRelation<Dim> {
       "respectively. Both are measured in units of stress, typically Pascals."};
 
   IsotropicHomogeneous() = default;
-  IsotropicHomogeneous(const IsotropicHomogeneous&) = delete;
-  IsotropicHomogeneous& operator=(const IsotropicHomogeneous&) = delete;
+  IsotropicHomogeneous(const IsotropicHomogeneous&) = default;
+  IsotropicHomogeneous& operator=(const IsotropicHomogeneous&) = default;
   IsotropicHomogeneous(IsotropicHomogeneous&&) = default;
   IsotropicHomogeneous& operator=(IsotropicHomogeneous&&) = default;
   ~IsotropicHomogeneous() override = default;

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp
@@ -3,24 +3,8 @@
 
 #pragma once
 
-#include <string>
-
 #include "DataStructures/DataBox/Tag.hpp"
-#include "DataStructures/Tensor/TypeAliases.hpp"
-#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp"
-
-/// \cond
-namespace Elasticity {
-namespace Tags {
-template <size_t Dim>
-struct Stress;
-}  // namespace Tags
-}  // namespace Elasticity
-namespace Tags {
-template <size_t Dim, typename Frame>
-struct Coordinates;
-}  // namespace Tags
-/// \endcond
+#include "Utilities/TMPL.hpp"
 
 namespace Elasticity {
 namespace Tags {
@@ -28,12 +12,30 @@ namespace Tags {
 /// Base tag for the constitutive relation
 struct ConstitutiveRelationBase : db::BaseTag {};
 
+/*!
+ * \brief The elastic material's constitutive relation.
+ *
+ * When constructing from options, copies the constitutive relation from the
+ * `Metavariables::constitutive_relation_provider_option_tag` by calling its
+ * constructed object's `constitutive_relation()` member function.
+ *
+ * The constitutive relation can be retrieved from the DataBox using its base
+ * `Elasticity::Tags::ConstitutiveRelation` tag.
+ *
+ * \see `Elasticity::ConstitutiveRelations::ConstitutiveRelation`
+ */
 template <typename ConstitutiveRelationType>
 struct ConstitutiveRelation : ConstitutiveRelationBase, db::SimpleTag {
-  static constexpr OptionString help = {
-      "The constitutive relation of the elastic material"};
   using type = ConstitutiveRelationType;
-  static std::string name() noexcept { return "Material"; }
+
+  static constexpr bool pass_metavariables = true;
+  template <typename Metavariables>
+  using option_tags = tmpl::list<
+      typename Metavariables::constitutive_relation_provider_option_tag>;
+  template <typename Metavariables, typename ProviderType>
+  static type create_from_options(const ProviderType& provider) noexcept {
+    return provider.constitutive_relation();
+  }
 };
 
 }  // namespace Tags

--- a/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/Test_IsotropicHomogeneous.cpp
+++ b/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/Test_IsotropicHomogeneous.cpp
@@ -34,6 +34,7 @@ void test_type_traits() {
   CHECK(relation !=
         Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>{2., 2.});
   test_serialization(relation);
+  test_copy_semantics(relation);
   const auto created_relation = TestHelpers::test_creation<
       Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>>(
       "BulkModulus: 1.\n"

--- a/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/Test_Tags.cpp
@@ -5,17 +5,54 @@
 
 #include <string>
 
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Parallel/CreateFromOptions.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
 
+namespace Elasticity {
+namespace ConstitutiveRelations {
+
 namespace {
-struct SomeConstitutiveRelation;
+struct Provider {
+  using constitutive_relation_type = IsotropicHomogeneous<3>;
+  static constitutive_relation_type constitutive_relation() { return {1., 2.}; }
+};
+
+struct ProviderOptionTag {
+  using type = Provider;
+};
+
+struct Metavariables {
+  using constitutive_relation_provider_option_tag = ProviderOptionTag;
+};
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Elasticity.Tags", "[Unit][Elasticity]") {
+SPECTRE_TEST_CASE("Unit.Elasticity.ConstitutiveRelations.Tags",
+                  "[Unit][Elasticity]") {
   TestHelpers::db::test_base_tag<Elasticity::Tags::ConstitutiveRelationBase>(
       "ConstitutiveRelationBase");
   TestHelpers::db::test_simple_tag<
-      Elasticity::Tags::ConstitutiveRelation<SomeConstitutiveRelation>>(
-      "Material");
+      Elasticity::Tags::ConstitutiveRelation<IsotropicHomogeneous<3>>>(
+      "ConstitutiveRelation");
+  {
+    INFO("Constitutive relation from provider option");
+    // Fake some output of option-parsing
+    const tuples::TaggedTuple<ProviderOptionTag> options{Provider{}};
+    // Dispatch the `create_from_options` function call that constructs the
+    // constitutive relation from the options.
+    const auto constructed_data = Parallel::create_from_options<Metavariables>(
+        options,
+        tmpl::list<
+            Elasticity::Tags::ConstitutiveRelation<IsotropicHomogeneous<3>>>{});
+    // Since the result is a tagged tuple we can't use base tags to retrieve it
+    const auto& constructed_constitutive_relation = tuples::get<
+        Elasticity::Tags::ConstitutiveRelation<IsotropicHomogeneous<3>>>(
+        constructed_data);
+    CHECK(constructed_constitutive_relation == IsotropicHomogeneous<3>{1., 2.});
+  }
 }
+
+}  // namespace ConstitutiveRelations
+}  // namespace Elasticity


### PR DESCRIPTION
## Proposed changes

<s>Adds a simple tag that holds an `Elasticity::ConstitutiveRelations::ConstitutiveRelation` as a `std::unique_ptr`</s> (since it's an abstract base class, similar to our equations of state). Also adds a tag that constructs from options, e.g. from the analytic solution.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
