### PR TITLE
Clarify error message when unable to find HDF5 file

### DIFF
--- a/src/IO/H5/File.cpp
+++ b/src/IO/H5/File.cpp
@@ -26,7 +26,10 @@ H5File<Access_t>::H5File(std::string file_name, bool append_to_file)
   }
   const bool file_exists = file_system::check_if_file_exists(file_name_);
   if (not file_exists and AccessType::ReadOnly == Access_t) {
-    ERROR("Cannot create a file in ReadOnly mode, '" << file_name_ << "'");
+    ERROR("Trying to open the file '"
+          << file_name_
+          << "' in ReadOnly mode but the file does not exist. If you want to "
+             "create the file you must switch to ReadWrite mode.");
   }
   if (append_to_file and AccessType::ReadOnly == Access_t) {
     ERROR("Cannot append to a file opened in read-only mode. File name is: "

--- a/tests/Unit/IO/Test_H5.cpp
+++ b/tests/Unit/IO/Test_H5.cpp
@@ -155,7 +155,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorNotH5", "[Unit][IO][H5]") {
   h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
 }
 
-// [[OutputRegex, Cannot create a file in ReadOnly mode,
+// [[OutputRegex, Trying to open the file
 // './Unit.IO.H5.FileErrorFileNotExist.h5']]
 SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorFileNotExist", "[Unit][IO][H5]") {
   ERROR_TEST();


### PR DESCRIPTION
## Proposed changes

Clarify error message when unable to find HDF5 file

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
