### PR TITLE
Loosen tolerance in LinOp/Test_Filtering

### DIFF
--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
@@ -121,6 +121,9 @@ void test_exponential_filter_action(const double alpha,
   CAPTURE(QuadratureType);
   CAPTURE(disable_for_debugging);
 
+  // Need to increase approx slightly on some hardware
+  Approx custom_approx = Approx::custom().epsilon(1.0e-13);
+
   using metavariables = Metavariables<Dim, FilterIndividually>;
   using component = Component<metavariables>;
 
@@ -181,14 +184,15 @@ void test_exponential_filter_action(const double alpha,
                      get<Tags::VectorVar<Dim>>(initial_vars).get(d),
                      mesh.extents());
     }
-    CHECK_ITERABLE_APPROX(
+    CHECK_ITERABLE_CUSTOM_APPROX(
         expected_scalar,
-        (ActionTesting::get_databox_tag<component, Tags::ScalarVar>(runner,
-                                                                    0)));
-    CHECK_ITERABLE_APPROX(
+        (ActionTesting::get_databox_tag<component, Tags::ScalarVar>(runner, 0)),
+        custom_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(
         expected_vector,
         (ActionTesting::get_databox_tag<component, Tags::VectorVar<Dim>>(runner,
-                                                                         0)));
+                                                                         0)),
+        custom_approx);
   }
 }
 


### PR DESCRIPTION
## Proposed changes

On some hardware the filtering tests are slightly above the default tolerance of 1.0e-14

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
