### PR TITLE
Loosen tolerance BarycentricRational interpolation, dox MAKE_GENERATOR

### DIFF
--- a/docs/DevGuide/WritingTests.md
+++ b/docs/DevGuide/WritingTests.md
@@ -173,6 +173,18 @@ The corresponding Python functions are:
 
 \snippet PyppPyTests.py python_two_not_null
 
+The random number generator is set up using:
+```cpp
+MAKE_GENERATOR(gen);
+```
+The generator `gen` can then be passed to distribution classes such as
+`std::uniform_real_distribution` or `UniformCustomDistribution`. Furthermore, if
+a test case fails with a particular seed, the seed can be played back by
+changing the `MAKE_GENERATOR(gen);` line in a test to
+```cpp
+MAKE_GENERATOR(gen, PROBLEMATIC_SEED_TO_DEBUG);
+```
+
 #### Testing Failure Cases
 
 Adding the "attribute" `// [[OutputRegex, Regular expression to match]]`

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_BarycentricRational.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_BarycentricRational.cpp
@@ -28,7 +28,7 @@ void test_barycentric_rational(const F& function, const double lower_bound,
   intrp::BarycentricRational interpolant{x_values, y_values, order};
 
   const auto deserialized_interpolant = serialize_and_deserialize(interpolant);
-  Approx custom_approx = Approx::custom().epsilon(1.e-12).scale(1.0);
+  Approx custom_approx = Approx::custom().epsilon(3.e-12).scale(1.0);
   for (size_t i = 0; i < 10 * size; ++i) {
     const double x_value = lower_bound + i * delta_x * 0.1 + 0.1 * dis(gen);
     CAPTURE(x_value);


### PR DESCRIPTION
## Proposed changes

- Loosen the tolerance slightly in the barycentric rational interpolation test to avoid random failures.
- Document `MAKE_GENERATOR` in the writing unit tests dev guide. Specifically, explain how to replay a seed value.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
