### PR TITLE
Update docker image, pip3 remove MPI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -137,17 +137,15 @@ jobs:
           $GITHUB_WORKSPACE
       - name: Check documentation
         working-directory: /work/build
-        # Append `texlive` to the `PATH` so bibliography generation works.
-        # Can be removed once this is done in the container.
         run: |
-          PATH=$PATH:/work/texlive/bin/x86_64-linux make doc-check
+          make doc-check
       # Re-build with coverage information on pushes to develop for deployment
       # to gh-pages.
       - name: Build documentation with coverage
         if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
         working-directory: /work/build
         run: |
-          PATH=$PATH:/work/texlive/bin/x86_64-linux make doc-coverage
+          make doc-coverage
       # The `upload-artifact` action doesn't run in the container, so we move
       # the data to the shared workspace.
       # Relevant issue: https://github.com/actions/upload-artifact/issues/13

--- a/.travis/BuildLinux.sh
+++ b/.travis/BuildLinux.sh
@@ -3,8 +3,6 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-export PATH=$PATH:/work/texlive/bin/x86_64-linux
-
 ccache -z
 
 BUILD_PYTHON_BINDINGS=ON

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -193,7 +193,6 @@ RUN wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz \
     && wget https://raw.githubusercontent.com/sxs-collaboration/spectre/develop/support/TeXLive/texlive.profile \
     && install-tl-*/install-tl -profile=texlive.profile \
     && rm -r install-tl-* texlive.profile install-tl.log \
-    && echo "export PATH=\$PATH:/work/texlive/bin/x86_64-linux" \
-            >> /root/.bashrc \
     && /work/texlive/bin/x86_64-linux/tlmgr install bibtex
+ENV PATH="${PATH}:/work/texlive/bin/x86_64-linux"
 WORKDIR /work

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -105,7 +105,7 @@ RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.2.tar.gz -O bla
     && sed -i 's/march=native/march=x86-64/' configure.ac \
     && autoconf \
     && ./configure --prefix=/usr/local --disable-openmp \
-    && make -j4 \
+    && make $PARALLEL_MAKE_ARG \
     && mv auto/bin/* /usr/local/bin \
     && mv auto/include/* /usr/local/include \
     && mv auto/lib/* /usr/local/lib \
@@ -128,7 +128,7 @@ RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.2.tar.gz -O bla
              -D YAML_CPP_BUILD_CONTRIB=OFF \
              -D YAML_CPP_BUILD_TOOLS=ON \
              -D CMAKE_INSTALL_PREFIX=/usr/local/ .. \
-    && make -j4 \
+    && make $PARALLEL_MAKE_ARG \
     && make install \
     && cd ../.. \
     && rm -rf yaml-cpp*
@@ -146,7 +146,7 @@ RUN wget https://github.com/include-what-you-use/include-what-you-use/archive/cl
     && cmake -D CMAKE_CXX_COMPILER=clang++-5.0 \
         -D CMAKE_C_COMPILER=clang-5.0 \
         -D IWYU_LLVM_ROOT_PATH=/usr/lib/llvm-5.0 .. \
-    && make -j2 \
+    && make $PARALLEL_MAKE_ARG \
     && make install \
     && cd /work \
     && rm -rf /work/include-what-you-use-clang_5.0

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -55,7 +55,8 @@ RUN apt-get update -y \
 RUN apt-get install -y ccache doxygen
 
 # Install Python packages
-RUN apt-get install -y python-pip \
+RUN apt-get install -y python-pip python3-pip \
+    && pip3 install numpy scipy \
     && pip install autopep8 flake8 \
     && pip install numpy scipy matplotlib pandas h5py jupyterlab \
     && pip install coverxygen beautifulsoup4 pybtex

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -24,6 +24,13 @@ RUN apt-get update -y \
     && add-apt-repository ppa:ubuntu-toolchain-r/test
 
 # Install required packages for SpECTRE
+#
+# We intentionally don't install libboost-all-dev because that installs
+# Boost.MPI, which installs OpenMPI into the container. When MPI is
+# installed inside the container it makes it very difficult to use
+# Singularity on HPC systems to interface with the system MPI library.
+# The system MPI libraries are usually configured to take advantage of
+# InfiniBand or various other networking layers.
 RUN apt-get update -y \
     && apt-get install -y gcc-6 g++-6 gfortran-6 \
                           gcc-7 g++-7 gfortran-7 \
@@ -36,7 +43,10 @@ RUN apt-get update -y \
                           clang-5.0 clang-format-5.0 clang-tidy-5.0 \
                           libclang-5.0-dev wget libncurses-dev \
                           lcov cppcheck \
-                          libboost-all-dev libssl-dev libbenchmark-dev
+                          libboost-dev libboost-program-options-dev \
+                          libboost-python-dev libboost-thread-dev \
+                          libboost-tools-dev libssl-dev \
+                          libbenchmark-dev
 
 # Add clang 4 and 8
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \


### PR DESCRIPTION
## Proposed changes

- @geoffrey4444 requested having pip3 available inside the Docker image
- While getting Singularity containers set up on @geoffrey4444's cluster `Ocean` we noticed that OpenMPI was installed inside the container and Charm++'s configure script refused to find anything other than the container MPI. In order to get jobs inside the container to launch we had to compile Charm++ with the system MPI but inside the container. It turns out that `libboost-all-dev` on Ubuntu installs Boost.MPI, which caused OpenMPI to be installed. We now install the Boost libs we use (more can be installed if necessary).
- The number of cores to build on was hard coded in a few places in the Dockerfile. We replace them with the env variable that specifies it instead.

### Types of changes:

- [x] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
