### PR TITLE
Add interface_apply overload for a stateless invokable

### DIFF
--- a/src/Domain/InterfaceComputeTags.hpp
+++ b/src/Domain/InterfaceComputeTags.hpp
@@ -123,7 +123,8 @@ struct InterfaceCompute : Interface<DirectionsTag, Tag>,
   // tags; Both Interface<Dirs, Tag> and Interface<Dirs, Tag::base> will have a
   // name function and so cannot be disambiguated.
   static std::string name() noexcept {
-    return "Interface<" + DirectionsTag::name() + ", " + Tag::name() + ">";
+    return "Interface<" + db::tag_name<DirectionsTag>() + ", " +
+           db::tag_name<Tag>() + ">";
   };
   using tag = Tag;
   using forwarded_argument_tags =
@@ -171,7 +172,9 @@ struct Slice : Interface<DirectionsTag, Tag>, db::ComputeTag {
                     index_to_slice_at(mesh.extents(), direction));
     }
   }
-  static std::string name() { return "Interface<" + Tag::name() + ">"; };
+  static std::string name() {
+    return "Interface<" + db::tag_name<Tag>() + ">";
+  };
   using argument_tags = tmpl::list<Mesh<volume_dim>, DirectionsTag, Tag>;
   using volume_tags = tmpl::list<Mesh<volume_dim>, Tag>;
 };

--- a/src/Domain/InterfaceHelpers.hpp
+++ b/src/Domain/InterfaceHelpers.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DirectionMap.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Tags.hpp"
@@ -100,11 +101,16 @@ SPECTRE_ALWAYS_INLINE constexpr auto interface_apply_impl(
 
 }  // namespace InterfaceHelpers_detail
 
+// @{
 /*!
- * \brief Apply the `interface_invokable` to the `box` on all interfaces given
- * by the `DirectionsTag`.
+ * \brief Apply an invokable to the `box` on all interfaces given by the
+ * `DirectionsTag`.
  *
- * \details The `interface_invokable` is expected to be invokable with the types
+ * This function has an overload that takes an `interface_invokable` as its
+ * first argument, and one that takes an `InterfaceInvokable` class as its first
+ * template parameter instead. For the latter, the `InterfaceInvokable` class
+ * must have a static `apply` function. The `interface_invokable` or static
+ * `apply` function, respectively, is expected to be invokable with the types
  * held by the `ArgumentTags`, followed by the `extra_args`. The `ArgumentTags`
  * will be prefixed as `::Tags::Interface<DirectionsTag, ArgumentTag>` and thus
  * taken from the interface, except for those specified in the `VolumeTags`.
@@ -115,6 +121,15 @@ SPECTRE_ALWAYS_INLINE constexpr auto interface_apply_impl(
  * Here is an example how to use this function:
  *
  * \snippet Test_InterfaceHelpers.cpp interface_apply_example
+ *
+ * Here is another example how to use this function with a stateless invokable
+ * class:
+ *
+ * \snippet Test_InterfaceHelpers.cpp interface_apply_example_stateless
+ *
+ * This is the class that defines the invokable in the example above:
+ *
+ * \snippet Test_InterfaceHelpers.cpp interface_invokable_example
  */
 template <typename DirectionsTag, typename ArgumentTags, typename VolumeTags,
           typename InterfaceInvokable, typename DbTagsList,
@@ -127,3 +142,16 @@ SPECTRE_ALWAYS_INLINE constexpr auto interface_apply(
       std::forward<InterfaceInvokable>(interface_invokable), box,
       ArgumentTags{}, std::forward<ExtraArgs>(extra_args)...);
 }
+
+template <typename DirectionsTag, typename InterfaceInvokable,
+          typename DbTagsList, typename... ExtraArgs,
+          // Needed to disambiguate the overloads
+          typename ArgumentTags = typename InterfaceInvokable::argument_tags>
+SPECTRE_ALWAYS_INLINE constexpr auto interface_apply(
+    const db::DataBox<DbTagsList>& box, ExtraArgs&&... extra_args) noexcept {
+  return InterfaceHelpers_detail::interface_apply_impl<
+      DirectionsTag, get_volume_tags<InterfaceInvokable>>(
+      &InterfaceInvokable::apply, box, ArgumentTags{},
+      std::forward<ExtraArgs>(extra_args)...);
+}
+// @}

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -280,7 +280,8 @@ template <typename DirectionsTag, typename Tag>
 struct Interface : virtual db::SimpleTag,
                    Interface_detail::GetBaseTagIfPresent<DirectionsTag, Tag> {
   static std::string name() noexcept {
-    return "Interface<" + DirectionsTag::name() + ", " + Tag::name() + ">";
+    return "Interface<" + db::tag_name<DirectionsTag>() + ", " +
+           db::tag_name<Tag>() + ">";
   };
   using tag = Tag;
   // The use of db::const_item_type<Tag> assumes we will never store

--- a/tests/Unit/Domain/Test_InterfaceHelpers.cpp
+++ b/tests/Unit/Domain/Test_InterfaceHelpers.cpp
@@ -21,6 +21,18 @@ struct SomeVolumeArgument : VolumeArgumentBase, db::SimpleTag {
   using type = double;
   static std::string name() noexcept { return "SomeVolumeArgument"; }
 };
+
+/// [interface_invokable_example]
+struct ComputeSomethingOnInterface {
+  using argument_tags = tmpl::list<SomeNumber, SomeVolumeArgument>;
+  using volume_tags = tmpl::list<SomeVolumeArgument>;
+  static double apply(const double& some_number_on_interface,
+                      const double& volume_argument,
+                      const double factor) noexcept {
+    return factor * some_number_on_interface + volume_argument;
+  }
+};
+/// [interface_invokable_example]
 }  // namespace
 
 template <size_t Dim, typename DirectionsTag>
@@ -57,6 +69,16 @@ void test_interface_apply(
   /// [interface_apply_example]
 
   // Test volume base tag
+  // GCC <= 8 can't handle the recursive template instantiations for base tags
+  // in `db::DataBox_detail::storage_type_impl` that occur when instantiating
+  // the `interface_apply` overload for a _stateless_ invokable here, i.e. the
+  // one that is _not_ SFINAE-selected in the function call below. The template
+  // parameter substitutions `InterfaceInvokable=tmpl::list<SomeNumber,
+  // VolumeArgumentBase>` and `DbTagsList=tmpl::list<VolumeArgumentBase>` is
+  // made, which fails the SFINAE-selection but still tries to (unsuccessfully)
+  // instantiate `storage_type_impl` for the `DbTagsList` and the
+  // `VolumeArgumentBase` tag.
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ > 8)
   const auto computed_numbers_with_base_tag =
       interface_apply<DirectionsTag, tmpl::list<SomeNumber, VolumeArgumentBase>,
                       tmpl::list<VolumeArgumentBase>>(
@@ -66,6 +88,14 @@ void test_interface_apply(
           },
           box, 2.);
   CHECK(computed_numbers_with_base_tag == computed_number_on_interfaces);
+#endif  // defined(__clang__) || (defined(__GNUC__) && __GNUC__ > 8)
+
+  // Test overload that takes a stateless invokable
+  /// [interface_apply_example_stateless]
+  const auto computed_numbers_with_struct =
+      interface_apply<DirectionsTag, ComputeSomethingOnInterface>(box, 2.);
+  /// [interface_apply_example_stateless]
+  CHECK(computed_numbers_with_struct == computed_number_on_interfaces);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.InterfaceHelpers", "[Unit][Domain]") {

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <tuple>
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Variables.hpp"
 #include "ErrorHandling/Assert.hpp"
 #include "ErrorHandling/Error.hpp"
@@ -442,7 +443,7 @@ struct check_variables_approx<Variables<TagList>> {
                     Approx& appx = approx) {  // NOLINT
     tmpl::for_each<TagList>([&a, &b, &appx](auto x) {
       using Tag = typename decltype(x)::type;
-      INFO(Tag::name());
+      INFO(db::tag_name<Tag>());
       const auto& a_val = extract_value_for_variables_comparison<Tag>(
           a, is_any_spin_weighted<typename Tag::type::type>{});
       const auto& b_val = extract_value_for_variables_comparison<Tag>(


### PR DESCRIPTION
## Proposed changes

Follows the pattern of `db::apply` and `db::mutate_apply` to add an overload of `db::interface_apply` that takes a class as template parameter that supplies the `argument_tags` and has a static `apply` function.

An application of this overload is for packaging data for numerical fluxes in #1725.


### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
