### PR TITLE
Distinguish between "boundary data" and "mortar data", adding structures

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
@@ -78,7 +78,7 @@ struct FluxCommunicationTypes {
   /// stepping.
   using simple_mortar_data_tag =
       BasedMortars<Tags::VariablesBoundaryData,
-                   Tags::SimpleBoundaryData<
+                   Tags::SimpleMortarData<
                        db::const_item_type<typename Metavariables::temporal_id>,
                        LocalData, PackagedData>,
                    volume_dim>;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/Variables.hpp"
+#include "Domain/OrientationMapHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+template <size_t Dim>
+struct Index;
+template <size_t Dim>
+struct Mesh;
+template <size_t Dim>
+struct OrientationMap;
+namespace Spectral {
+enum class MortarSize;
+}  // namespace Spectral
+/// \endcond
+
+namespace dg {
+
+/*!
+ * \brief Distinguishes between field data, which can be projected to a mortar,
+ * and extra data, which will not be projected.
+ */
+template <typename FieldTags, typename ExtraDataTags = tmpl::list<>>
+struct SimpleBoundaryData {
+  using field_tags = FieldTags;
+  using extra_data_tags = ExtraDataTags;
+
+  /// Data projected to the mortar mesh
+  Variables<FieldTags> field_data;
+
+  /// Data on the element face that needs no projection to the mortar mesh.
+  /// This is a `TaggedTuple` to support non-tensor quantities. It also helps
+  /// supporting an empty list of `ExtraDataTags`.
+  tuples::tagged_tuple_from_typelist<ExtraDataTags> extra_data;
+
+  SimpleBoundaryData() = default;
+  SimpleBoundaryData(const SimpleBoundaryData&) noexcept = default;
+  SimpleBoundaryData& operator=(const SimpleBoundaryData&) noexcept = default;
+  SimpleBoundaryData(SimpleBoundaryData&&) noexcept = default;
+  SimpleBoundaryData& operator=(SimpleBoundaryData&&) noexcept = default;
+  ~SimpleBoundaryData() noexcept = default;
+
+  explicit SimpleBoundaryData(const size_t num_points) noexcept
+      : field_data{num_points}, extra_data{} {}
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept {
+    p | field_data;
+    p | extra_data;
+  }
+
+  /// Project the `field_data` to the mortar
+  ///
+  /// \see `dg::project_to_mortar`
+  template <size_t MortarDim>
+  SimpleBoundaryData<FieldTags, ExtraDataTags> project_to_mortar(
+      const Mesh<MortarDim>& face_mesh, const Mesh<MortarDim>& mortar_mesh,
+      const std::array<Spectral::MortarSize, MortarDim>& mortar_size) const
+      noexcept {
+    SimpleBoundaryData<FieldTags, ExtraDataTags> projected_data{};
+    projected_data.field_data = dg::project_to_mortar(
+        this->field_data, face_mesh, mortar_mesh, mortar_size);
+    projected_data.extra_data = this->extra_data;
+    return projected_data;
+  }
+
+  /// Orient the `field_data`
+  ///
+  /// \see `orient_variables_on_slice`
+  template <size_t MortarDim>
+  void orient_on_slice(
+      const Index<MortarDim>& slice_extents, const size_t sliced_dim,
+      const OrientationMap<MortarDim + 1>& orientation_of_neighbor) noexcept {
+    this->field_data = orient_variables_on_slice(
+        this->field_data, slice_extents, sliced_dim, orientation_of_neighbor);
+  }
+};
+
+}  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp
@@ -35,6 +35,15 @@ class SimpleMortarData {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
+  /// Retrieve the local data at `temporal_id`
+  const LocalVars& local_data(const TemporalId& temporal_id) const noexcept {
+    ASSERT(local_data_, "Local data not available.");
+    ASSERT(temporal_id == temporal_id_,
+           "Only have local data at temporal_id "
+               << temporal_id_ << ", but requesting at " << temporal_id);
+    return *local_data_;
+  };
+
  private:
   TemporalId temporal_id_{};
   boost::optional<LocalVars> local_data_{};

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp
@@ -56,7 +56,8 @@ void SimpleMortarData<TemporalId, LocalVars, RemoteVars>::local_insert(
   ASSERT(not local_data_, "Already received local data.");
   ASSERT(not remote_data_ or temporal_id == temporal_id_,
          "Received local data at " << temporal_id
-         << ", but already have remote data at " << temporal_id_);
+                                   << ", but already have remote data at "
+                                   << temporal_id_);
   temporal_id_ = std::move(temporal_id);
   local_data_ = std::move(vars);
 }
@@ -67,7 +68,8 @@ void SimpleMortarData<TemporalId, LocalVars, RemoteVars>::remote_insert(
   ASSERT(not remote_data_, "Already received remote data.");
   ASSERT(not local_data_ or temporal_id == temporal_id_,
          "Received remote data at " << temporal_id
-         << ", but already have local data at " << temporal_id_);
+                                    << ", but already have local data at "
+                                    << temporal_id_);
   temporal_id_ = std::move(temporal_id);
   remote_data_ = std::move(vars);
 }
@@ -77,8 +79,8 @@ std::pair<LocalVars, RemoteVars>
 SimpleMortarData<TemporalId, LocalVars, RemoteVars>::extract() noexcept {
   ASSERT(local_data_ and remote_data_,
          "Tried to extract boundary data, but do not have "
-         << (local_data_ ? "remote" : remote_data_ ? "local" : "any")
-         << " data.");
+             << (local_data_ ? "remote" : remote_data_ ? "local" : "any")
+             << " data.");
   const auto result =
       std::make_pair(std::move(*local_data_), std::move(*remote_data_));
   local_data_ = boost::none;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp
@@ -20,7 +20,7 @@ namespace dg {
 /// Typically, values are inserted into this container by the flux
 /// communication actions.
 template <typename TemporalId, typename LocalVars, typename RemoteVars>
-class SimpleBoundaryData {
+class SimpleMortarData {
  public:
   /// Add a value.  This function must be called once between calls to
   /// extract.
@@ -42,7 +42,7 @@ class SimpleBoundaryData {
 };
 
 template <typename TemporalId, typename LocalVars, typename RemoteVars>
-void SimpleBoundaryData<TemporalId, LocalVars, RemoteVars>::local_insert(
+void SimpleMortarData<TemporalId, LocalVars, RemoteVars>::local_insert(
     TemporalId temporal_id, LocalVars vars) noexcept {
   ASSERT(not local_data_, "Already received local data.");
   ASSERT(not remote_data_ or temporal_id == temporal_id_,
@@ -53,7 +53,7 @@ void SimpleBoundaryData<TemporalId, LocalVars, RemoteVars>::local_insert(
 }
 
 template <typename TemporalId, typename LocalVars, typename RemoteVars>
-void SimpleBoundaryData<TemporalId, LocalVars, RemoteVars>::remote_insert(
+void SimpleMortarData<TemporalId, LocalVars, RemoteVars>::remote_insert(
     TemporalId temporal_id, RemoteVars vars) noexcept {
   ASSERT(not remote_data_, "Already received remote data.");
   ASSERT(not local_data_ or temporal_id == temporal_id_,
@@ -65,7 +65,7 @@ void SimpleBoundaryData<TemporalId, LocalVars, RemoteVars>::remote_insert(
 
 template <typename TemporalId, typename LocalVars, typename RemoteVars>
 std::pair<LocalVars, RemoteVars>
-SimpleBoundaryData<TemporalId, LocalVars, RemoteVars>::extract() noexcept {
+SimpleMortarData<TemporalId, LocalVars, RemoteVars>::extract() noexcept {
   ASSERT(local_data_ and remote_data_,
          "Tried to extract boundary data, but do not have "
          << (local_data_ ? "remote" : remote_data_ ? "local" : "any")
@@ -78,7 +78,7 @@ SimpleBoundaryData<TemporalId, LocalVars, RemoteVars>::extract() noexcept {
 }
 
 template <typename TemporalId, typename LocalVars, typename RemoteVars>
-void SimpleBoundaryData<TemporalId, LocalVars, RemoteVars>::pup(
+void SimpleMortarData<TemporalId, LocalVars, RemoteVars>::pup(
     PUP::er& p) noexcept {
   p | temporal_id_;
   p | local_data_;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -13,7 +13,7 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "Domain/Direction.hpp"  // IWYU pragma: keep
 #include "Domain/ElementId.hpp"  // IWYU pragma: keep
-#include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "Options/Options.hpp"
 
@@ -22,9 +22,8 @@ namespace Tags {
 /// \ingroup DiscontinuousGalerkinGroup
 /// \brief Simple boundary communication data
 template <typename TemporalId, typename LocalData, typename RemoteData>
-struct SimpleBoundaryData : db::SimpleTag {
-  static std::string name() noexcept { return "SimpleBoundaryData"; }
-  using type = dg::SimpleBoundaryData<TemporalId, LocalData, RemoteData>;
+struct SimpleMortarData : db::SimpleTag {
+  using type = dg::SimpleMortarData<TemporalId, LocalData, RemoteData>;
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
@@ -48,7 +48,7 @@
 
 // IWYU pragma: no_include <boost/functional/hash/extensions.hpp>
 
-// IWYU pragma: no_include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
+// IWYU pragma: no_include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp"
 // IWYU pragma: no_include "Parallel/PupStlCpp11.hpp"
 
 // IWYU pragma: no_forward_declare ActionTesting::InitializeDataBox

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyFluxes.cpp
@@ -27,7 +27,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
-#include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
@@ -165,7 +165,7 @@ SPECTRE_TEST_CASE("Unit.DG.Actions.ApplyFluxes",
       const tnsr::I<DataVector, 1>& remote_extra_data,
       const Scalar<DataVector>& local_flux,
       const Scalar<DataVector>& local_magnitude_face_normal) noexcept {
-    dg::SimpleBoundaryData<size_t, LocalData, PackagedData> data;
+    dg::SimpleMortarData<size_t, LocalData, PackagedData> data;
 
     LocalData local_data{};
     local_data.mortar_data.initialize(3);

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -60,7 +60,7 @@
 // IWYU pragma: no_include <boost/variant/get.hpp>
 
 // IWYU pragma: no_include "DataStructures/VariablesHelpers.hpp"  // for Variables
-// IWYU pragma: no_include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
+// IWYU pragma: no_include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp"
 // IWYU pragma: no_include "Parallel/PupStlCpp11.hpp"
 
 // IWYU pragma: no_forward_declare ActionTesting::InitializeDataBox

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -52,7 +52,7 @@
 // IWYU pragma: no_include <boost/variant/get.hpp>
 
 // IWYU pragma: no_include "DataStructures/VariablesHelpers.hpp"  // for Variables
-// IWYU pragma: no_include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
+// IWYU pragma: no_include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp"
 // IWYU pragma: no_include "Parallel/PupStlCpp11.hpp"
 
 // IWYU pragma: no_forward_declare ActionTesting::InitializeDataBox

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -51,7 +51,7 @@
 // IWYU pragma: no_include <boost/functional/hash/extensions.hpp>
 
 // IWYU pragma: no_include "DataStructures/VariablesHelpers.hpp"  // for Variables
-// IWYU pragma: no_include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
+// IWYU pragma: no_include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp"
 // IWYU pragma: no_include "Parallel/PupStlCpp11.hpp"
 
 // IWYU pragma: no_forward_declare ActionTesting::InitializeDataBox

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_LiftFlux.cpp
   Test_MortarHelpers.cpp
   Test_NormalDotFlux.cpp
+  Test_SimpleBoundaryData.cpp
   Test_SimpleMortarData.cpp
   Test_Tags.cpp
   )

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -7,7 +7,7 @@ set(LIBRARY_SOURCES
   Test_LiftFlux.cpp
   Test_MortarHelpers.cpp
   Test_NormalDotFlux.cpp
-  Test_SimpleBoundaryData.cpp
+  Test_SimpleMortarData.cpp
   Test_Tags.cpp
   )
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleBoundaryData.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleBoundaryData.cpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "Domain/OrientationMapHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+
+struct SomeField {
+  using type = Scalar<DataVector>;
+};
+
+struct ExtraData {
+  using type = int;
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DG.SimpleBoundaryData", "[Unit][NumericalAlgorithms]") {
+  const size_t num_points = 5;
+  dg::SimpleBoundaryData<tmpl::list<SomeField>, tmpl::list<ExtraData>> data{
+      num_points};
+  const Scalar<DataVector> field{num_points, 1.};
+  get<SomeField>(data.field_data) = field;
+  get<ExtraData>(data.extra_data) = 2;
+
+  // Test serialization
+  data = serialize_and_deserialize(data);
+  CHECK(get<SomeField>(data.field_data) == field);
+  CHECK(get<ExtraData>(data.extra_data) == 2);
+
+  // Test projections
+  const Mesh<1> face_mesh{num_points, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<1> mortar_mesh{num_points + 1, Spectral::Basis::Legendre,
+                            Spectral::Quadrature::GaussLobatto};
+  const std::array<Spectral::MortarSize, 1> mortar_size{
+      {Spectral::MortarSize::UpperHalf}};
+  const auto projected_data =
+      data.project_to_mortar(face_mesh, mortar_mesh, mortar_size);
+  CHECK(projected_data.field_data ==
+        dg::project_to_mortar(data.field_data, face_mesh, mortar_mesh,
+                              mortar_size));
+  CHECK(projected_data.extra_data == data.extra_data);
+
+  // Test orientation
+  const size_t sliced_dim = 1;
+  const auto slice_extents = face_mesh.extents();
+  const OrientationMap<2> orientation_of_neighbor{
+      {{Direction<2>::lower_xi(), Direction<2>::lower_eta()}},
+      {{Direction<2>::upper_eta(), Direction<2>::lower_xi()}}};
+  auto oriented_data = data;
+  oriented_data.orient_on_slice(slice_extents, sliced_dim,
+                                orientation_of_neighbor);
+  CHECK(oriented_data.field_data ==
+        orient_variables_on_slice(data.field_data, slice_extents, sliced_dim,
+                                  orientation_of_neighbor));
+  CHECK(oriented_data.extra_data == data.extra_data);
+}

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleMortarData.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleMortarData.cpp
@@ -28,6 +28,31 @@ SPECTRE_TEST_CASE("Unit.DG.SimpleMortarData", "[Unit][NumericalAlgorithms]") {
   CHECK(data.extract() == std::make_pair("string 2"s, 2.345));
 }
 
+// [[OutputRegex, Local data not available.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.DG.SimpleMortarData.no_local_data",
+                               "[Unit][NumericalAlgorithms]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  dg::SimpleMortarData<size_t, std::string, double> data;
+  data.remote_insert(0, 1.234);
+  data.local_data(0);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Only have local data at temporal_id]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DG.SimpleMortarData.no_local_data_at_time",
+    "[Unit][NumericalAlgorithms]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  dg::SimpleMortarData<size_t, std::string, double> data;
+  data.local_insert(1, "");
+  data.local_data(0);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
 // [[OutputRegex, Received local data at 1, but already have remote
 // data at 0]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.DG.SimpleMortarData.wrong_time.local",

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleMortarData.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleMortarData.cpp
@@ -8,14 +8,14 @@
 #include <utility>
 
 #include "ErrorHandling/Error.hpp"
-#include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp"
 #include "Utilities/Literals.hpp"  // IWYU pragma: keep
 #include "tests/Unit/TestHelpers.hpp"
 
 // IWYU pragma: no_include <type_traits>  // for __decay_and_strip<>::__type
 
-SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
-  dg::SimpleBoundaryData<size_t, std::string, double> data;
+SPECTRE_TEST_CASE("Unit.DG.SimpleMortarData", "[Unit][NumericalAlgorithms]") {
+  dg::SimpleMortarData<size_t, std::string, double> data;
   data = serialize_and_deserialize(data);
   data.local_insert(0, "string 1");
   data = serialize_and_deserialize(data);
@@ -30,11 +30,11 @@ SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
 
 // [[OutputRegex, Received local data at 1, but already have remote
 // data at 0]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData.wrong_time.local",
-                               "[Unit][Time]") {
+[[noreturn]] SPECTRE_TEST_CASE("Unit.DG.SimpleMortarData.wrong_time.local",
+                               "[Unit][NumericalAlgorithms]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  dg::SimpleBoundaryData<size_t, std::string, double> data;
+  dg::SimpleMortarData<size_t, std::string, double> data;
   data.remote_insert(0, 0.);
   data.local_insert(1, "");
   ERROR("Failed to trigger ASSERT in an assertion test");
@@ -43,11 +43,11 @@ SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
 
 // [[OutputRegex, Received remote data at 0, but already have local
 // data at 1]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData.wrong_time.remote",
-                               "[Unit][Time]") {
+[[noreturn]] SPECTRE_TEST_CASE("Unit.DG.SimpleMortarData.wrong_time.remote",
+                                "[Unit][NumericalAlgorithms]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  dg::SimpleBoundaryData<size_t, std::string, double> data;
+  dg::SimpleMortarData<size_t, std::string, double> data;
   data.local_insert(1, "");
   data.remote_insert(0, 0.);
   ERROR("Failed to trigger ASSERT in an assertion test");
@@ -55,11 +55,11 @@ SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
 }
 
 // [[OutputRegex, Already received local data]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Time.SimpleBoundaryData.double_insert.local", "[Unit][Time]") {
+[[noreturn]] SPECTRE_TEST_CASE("Unit.DG.SimpleMortarData.double_insert.local",
+                               "[Unit][NumericalAlgorithms]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  dg::SimpleBoundaryData<size_t, std::string, double> data;
+  dg::SimpleMortarData<size_t, std::string, double> data;
   data.local_insert(1, "");
   data.local_insert(1, "");
   ERROR("Failed to trigger ASSERT in an assertion test");
@@ -68,10 +68,11 @@ SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
 
 // [[OutputRegex, Already received remote data]]
 [[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Time.SimpleBoundaryData.double_insert.remote", "[Unit][Time]") {
+    "Unit.DG.SimpleMortarData.double_insert.remote",
+    "[Unit][NumericalAlgorithms]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  dg::SimpleBoundaryData<size_t, std::string, double> data;
+  dg::SimpleMortarData<size_t, std::string, double> data;
   data.remote_insert(0, 0.);
   data.remote_insert(0, 0.);
   ERROR("Failed to trigger ASSERT in an assertion test");
@@ -79,11 +80,11 @@ SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
 }
 
 // [[OutputRegex, Tried to extract boundary data, but do not have any data]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Time.SimpleBoundaryData.bad_extract.none", "[Unit][Time]") {
+[[noreturn]] SPECTRE_TEST_CASE("Unit.DG.SimpleMortarData.bad_extract.none",
+                               "[Unit][NumericalAlgorithms]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  dg::SimpleBoundaryData<size_t, std::string, double> data;
+  dg::SimpleMortarData<size_t, std::string, double> data;
   data.extract();
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
@@ -91,10 +92,11 @@ SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
 
 // [[OutputRegex, Tried to extract boundary data, but do not have remote data]]
 [[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Time.SimpleBoundaryData.bad_extract.no_remote", "[Unit][Time]") {
+    "Unit.DG.SimpleMortarData.bad_extract.no_remote",
+    "[Unit][NumericalAlgorithms]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  dg::SimpleBoundaryData<size_t, std::string, double> data;
+  dg::SimpleMortarData<size_t, std::string, double> data;
   data.local_insert(1, "");
   data.extract();
   ERROR("Failed to trigger ASSERT in an assertion test");
@@ -102,11 +104,11 @@ SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
 }
 
 // [[OutputRegex, Tried to extract boundary data, but do not have local data]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Time.SimpleBoundaryData.bad_extract.no_local", "[Unit][Time]") {
+[[noreturn]] SPECTRE_TEST_CASE("Unit.DG.SimpleMortarData.bad_extract.no_local",
+                               "[Unit][NumericalAlgorithms]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  dg::SimpleBoundaryData<size_t, std::string, double> data;
+  dg::SimpleMortarData<size_t, std::string, double> data;
   data.remote_insert(0, 0.);
   data.extract();
   ERROR("Failed to trigger ASSERT in an assertion test");

--- a/tests/Unit/Time/Test_History.cpp
+++ b/tests/Unit/Time/Test_History.cpp
@@ -255,6 +255,13 @@ SPECTRE_TEST_CASE("Unit.Time.BoundaryHistory", "[Unit][Time]") {
   history.local_insert_initial(make_time_id(-1.), get_output(-1));
   history.local_insert(make_time_id(2.), get_output(2));
 
+  {
+    INFO("Test `local_data` member function");
+    CHECK(history.local_data(make_time_id(0.)) == get_output(0));
+    CHECK(history.local_data(make_time_id(-1.)) == get_output(-1));
+    CHECK(history.local_data(make_time_id(2.)) == get_output(2));
+  }
+
   history.remote_insert(make_time_id(1.), std::vector<int>{1});
   history.remote_insert_initial(make_time_id(0.), std::vector<int>{0});
   history.remote_insert_initial(make_time_id(-1.), std::vector<int>{-1});


### PR DESCRIPTION
## Proposed changes

Distinguishes between "boundary data" (data on an element face that can be projected to a mortar) and "mortar data" (boundary data collected from both sides of a mortar). Used in #1725.

**Note to reviewers:** Because of the renaming it's easier to look at the commits one-by-one.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
