### PR TITLE
Test simple tags in Time

### DIFF
--- a/src/ParallelAlgorithms/EventsAndTriggers/Tags.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Tags.hpp
@@ -47,7 +47,6 @@ struct EventsAndTriggersBase : db::BaseTag {};
 /// Contains the events and triggers
 template <typename EventRegistrars, typename TriggerRegistrars>
 struct EventsAndTriggers : EventsAndTriggersBase, db::SimpleTag {
-  static std::string name() noexcept { return "EventsAndTriggers"; }
   using type = ::EventsAndTriggers<EventRegistrars, TriggerRegistrars>;
   using option_tags = tmpl::list<
       ::OptionTags::EventsAndTriggers<EventRegistrars, TriggerRegistrars>>;

--- a/src/ParallelAlgorithms/LinearSolver/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Tags.hpp
@@ -50,7 +50,7 @@ template <typename Tag>
 struct Operand : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
     // Add "Linear" prefix to abbreviate the namespace for uniqueness
-    return "LinearOperand(" + Tag::name() + ")";
+    return "LinearOperand(" + db::tag_name<Tag>() + ")";
   }
   using type = typename Tag::type;
   using tag = Tag;
@@ -63,7 +63,7 @@ template <typename Tag>
 struct OperatorAppliedTo : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
     // Add "Linear" prefix to abbreviate the namespace for uniqueness
-    return "LinearOperatorAppliedTo(" + Tag::name() + ")";
+    return "LinearOperatorAppliedTo(" + db::tag_name<Tag>() + ")";
   }
   using type = typename Tag::type;
   using tag = Tag;
@@ -90,7 +90,7 @@ template <typename Tag>
 struct Residual : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
     // Add "Linear" prefix to abbreviate the namespace for uniqueness
-    return "LinearResidual(" + Tag::name() + ")";
+    return "LinearResidual(" + db::tag_name<Tag>() + ")";
   }
   using type = typename Tag::type;
   using tag = Tag;
@@ -98,7 +98,9 @@ struct Residual : db::PrefixTag, db::SimpleTag {
 
 template <typename Tag>
 struct Initial : db::PrefixTag, db::SimpleTag {
-  static std::string name() noexcept { return "Initial(" + Tag::name() + ")"; }
+  static std::string name() noexcept {
+    return "Initial(" + db::tag_name<Tag>() + ")";
+  }
   using type = typename Tag::type;
   using tag = Tag;
 };
@@ -111,7 +113,7 @@ template <typename Tag>
 struct MagnitudeSquare : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
     // Add "Linear" prefix to abbreviate the namespace for uniqueness
-    return "LinearMagnitudeSquare(" + Tag::name() + ")";
+    return "LinearMagnitudeSquare(" + db::tag_name<Tag>() + ")";
   }
   using type = double;
   using tag = Tag;
@@ -125,7 +127,7 @@ template <typename Tag>
 struct Magnitude : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
     // Add "Linear" prefix to abbreviate the namespace for uniqueness
-    return "LinearMagnitude(" + Tag::name() + ")";
+    return "LinearMagnitude(" + db::tag_name<Tag>() + ")";
   }
   using type = double;
   using tag = Tag;
@@ -153,7 +155,7 @@ template <typename Tag>
 struct Orthogonalization : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
     // Add "Linear" prefix to abbreviate the namespace for uniqueness
-    return "LinearOrthogonalization(" + Tag::name() + ")";
+    return "LinearOrthogonalization(" + db::tag_name<Tag>() + ")";
   }
   using type = typename Tag::type;
   using tag = Tag;
@@ -166,7 +168,7 @@ template <typename Tag>
 struct OrthogonalizationHistory : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
     // Add "Linear" prefix to abbreviate the namespace for uniqueness
-    return "LinearOrthogonalizationHistory(" + Tag::name() + ")";
+    return "LinearOrthogonalizationHistory(" + db::tag_name<Tag>() + ")";
   }
   using type = DenseMatrix<double>;
   using tag = Tag;
@@ -190,7 +192,7 @@ struct KrylovSubspaceBasis : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
     // No "Linear" prefix since a Krylov subspace always refers to a linear
     // operator
-    return "KrylovSubspaceBasis(" + Tag::name() + ")";
+    return "KrylovSubspaceBasis(" + db::tag_name<Tag>() + ")";
   }
   using type =
       std::vector<db::const_item_type<db::add_tag_prefix<Operand, Tag>>>;
@@ -292,7 +294,6 @@ namespace Tags {
  */
 struct ConvergenceCriteria : db::SimpleTag {
   using type = Convergence::Criteria;
-  static std::string name() noexcept { return "ConvergenceCriteria"; }
   using option_tags = tmpl::list<LinearSolver::OptionTags::ConvergenceCriteria>;
 
   template <typename Metavariables>
@@ -303,7 +304,6 @@ struct ConvergenceCriteria : db::SimpleTag {
 };
 
 struct Verbosity : db::SimpleTag {
-  static std::string name() noexcept { return "Verbosity"; }
   using type = ::Verbosity;
   using option_tags = tmpl::list<LinearSolver::OptionTags::Verbosity>;
 

--- a/src/Time/Actions/SelfStartActions.hpp
+++ b/src/Time/Actions/SelfStartActions.hpp
@@ -100,7 +100,7 @@ namespace Tags {
 template <typename Tag>
 struct InitialValue : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
-    return "InitialValue(" + Tag::name() + ")";
+    return "InitialValue(" + db::tag_name<Tag>() + ")";
   }
   using tag = Tag;
   using type = std::tuple<db::const_item_type<Tag>>;

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -30,7 +30,6 @@ namespace Tags {
 /// \ingroup TimeGroup
 /// \brief Tag for ::TimeStepId for the algorithm state
 struct TimeStepId : db::SimpleTag {
-  static std::string name() noexcept { return "TimeStepId"; }
   using type = ::TimeStepId;
   template <typename Tag>
   using step_prefix = typename Tags::dt<Tag>;
@@ -40,7 +39,6 @@ struct TimeStepId : db::SimpleTag {
 /// \ingroup TimeGroup
 /// \brief Tag for step size
 struct TimeStep : db::SimpleTag {
-  static std::string name() noexcept { return "TimeStep"; }
   using type = ::TimeDelta;
 };
 
@@ -70,7 +68,6 @@ struct SubstepTimeCompute : SubstepTime, db::ComputeTag {
 /// \ingroup TimeGroup
 /// \brief Tag for the current time as a double
 struct Time : db::SimpleTag {
-  static std::string name() noexcept { return "Time"; }
   using type = double;
 };
 
@@ -101,7 +98,6 @@ struct HistoryEvolvedVariables : HistoryEvolvedVariables<>, db::SimpleTag {
 /// Tag for TimeStepper boundary history
 template <typename LocalVars, typename RemoteVars, typename CouplingResult>
 struct BoundaryHistory : db::SimpleTag {
-  static std::string name() noexcept { return "BoundaryHistory"; }
   using type =
       TimeSteppers::BoundaryHistory<LocalVars, RemoteVars, CouplingResult>;
 };
@@ -172,16 +168,16 @@ struct InitialSlabSize {
 }  // namespace OptionTags
 
 namespace Tags {
+/// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
-/// \brief The ::TimeStepper
+/// \brief Base tag for simple tag Tags::TimeStepper
 struct TimeStepperBase : db::BaseTag {};
 
+/// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
-/// \brief The ::TimeStepper, specifying a (base) type.  Can be
-/// retrieved through Tags::TimeStepper.
+/// \brief Tag for a ::TimeStepper of type `StepperType`.
 template <typename StepperType>
 struct TimeStepper : TimeStepperBase, db::SimpleTag {
-  static std::string name() noexcept { return "TimeStepper"; }
   using type = std::unique_ptr<StepperType>;
   using option_tags = tmpl::list<::OptionTags::TimeStepper<StepperType>>;
 
@@ -192,10 +188,11 @@ struct TimeStepper : TimeStepperBase, db::SimpleTag {
   }
 };
 
+/// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
+/// \brief Tag for a vector of ::StepChooser%s
 template <typename Registrars>
 struct StepChoosers : db::SimpleTag {
-  static std::string name() noexcept { return "StepChoosers"; }
   using type = std::vector<std::unique_ptr<::StepChooser<Registrars>>>;
   using option_tags = tmpl::list<::OptionTags::StepChoosers<Registrars>>;
 
@@ -205,9 +202,10 @@ struct StepChoosers : db::SimpleTag {
   }
 };
 
+/// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
+/// \brief Tag for a ::StepController
 struct StepController : db::SimpleTag {
-  static std::string name() noexcept { return "StepController"; }
   using type = std::unique_ptr<::StepController>;
   using option_tags = tmpl::list<::OptionTags::StepController>;
 

--- a/tests/Unit/DataStructures/DataBox/TestHelpers.hpp
+++ b/tests/Unit/DataStructures/DataBox/TestHelpers.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace TestHelpers {
+
+namespace db {
+
+namespace detail {
+CREATE_IS_CALLABLE(name)
+}  // namespace detail
+
+template <typename Tag>
+void test_simple_tag(const std::string& expected_name) {
+  static_assert(cpp17::is_base_of_v<::db::SimpleTag, Tag> and
+                    not cpp17::is_base_of_v<::db::ComputeTag, Tag>,
+                "A simple tag must be derived from "
+                "db::SimpleTag, but not db::ComputeTag");
+  static_assert(not cpp17::is_same_v<Tag, typename Tag::type>,
+                "A type cannot be its own tag.");
+  CHECK(::db::tag_name<Tag>() == expected_name);
+  if (detail::is_name_callable_v<Tag>) {
+    INFO("Do not define name for Tag '" << ::db::tag_name<Tag>() << "',");
+    INFO("as it will automatically be generated with that name.");
+    CHECK(::db::tag_name<Tag>() != pretty_type::short_name<Tag>());
+  }
+}
+
+}  // namespace db
+
+}  // namespace TestHelpers

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_MutateApply.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_MutateApply.cpp
@@ -16,12 +16,10 @@ namespace {
 
 struct SomeNumber : db::SimpleTag {
   using type = int;
-  static std::string name() noexcept { return "SomeNumber"; }
 };
 
 struct TestValue : db::SimpleTag {
   using type = int;
-  static std::string name() noexcept { return "TestValue"; }
 };
 
 struct AddTheNumber {

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
@@ -31,12 +31,10 @@ namespace {
 
 struct ScalarFieldTag : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "ScalarFieldTag"; }
 };
 
 struct OtherDataTag : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "OtherDataTag"; }
 };
 
 template <typename VarsTag>

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
@@ -40,12 +40,10 @@
 namespace {
 
 struct TemporalId : db::SimpleTag {
-  static std::string name() noexcept { return "TemporalId"; };
   using type = int;
 };
 
 struct ScalarFieldTag : db::SimpleTag {
-  static std::string name() noexcept { return "ScalarFieldTag"; };
   using type = Scalar<DataVector>;
 };
 

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
@@ -60,7 +60,6 @@ namespace {
 
 struct ObservationTimeTag : db::SimpleTag {
   using type = double;
-  static std::string name() { return "ObservationTimeTag"; };
 };
 
 struct MockContributeReductionData {

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -68,7 +68,6 @@ namespace {
 
 struct ObservationTimeTag : db::SimpleTag {
   using type = double;
-  static std::string name() { return "ObservationTimeTag"; };
 };
 
 struct MockContributeVolumeData {

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_EventsAndTriggers")
 
 set(LIBRARY_SOURCES
   Test_EventsAndTriggers.cpp
+  Test_Tags.cpp
   )
 
 add_test_library(

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_Tags.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+struct DummyType {};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.EventsAndTriggers.Tags",
+                  "[Unit][ParallelAlgorithms]") {
+  TestHelpers::db::test_simple_tag<
+      Tags::EventsAndTriggers<DummyType, DummyType>>("EventsAndTriggers");
+}

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddComputeTags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddComputeTags.cpp
@@ -18,12 +18,10 @@
 namespace {
 struct SomeNumber : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "SomeNumber"; }
 };
 
 struct SquareNumber : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "SquareNumber"; }
 };
 
 struct SquareNumberCompute : SquareNumber, db::ComputeTag {

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
@@ -25,12 +25,10 @@ struct TemporalId {};
 
 struct InitialTime : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "InitialTime"; }
 };
 
 struct InitialMass : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "InitialMass"; }
 };
 
 struct DummyTimeTag : db::SimpleTag {

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ElementActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ElementActions.cpp
@@ -27,7 +27,6 @@ namespace {
 
 struct VectorTag : db::SimpleTag {
   using type = DenseVector<double>;
-  static std::string name() noexcept { return "VectorTag"; }
 };
 
 using fields_tag = VectorTag;

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
@@ -54,7 +54,6 @@ namespace {
 
 struct VectorTag : db::SimpleTag {
   using type = DenseVector<double>;
-  static std::string name() noexcept { return "VectorTag"; }
 };
 
 using fields_tag = VectorTag;
@@ -69,7 +68,6 @@ using initial_residual_magnitude_tag = db::add_tag_prefix<
 
 struct CheckValueTag : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "CheckValueTag"; }
 };
 
 using CheckConvergedTag = LinearSolver::Tags::HasConverged;

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -57,7 +57,6 @@ struct NumberOfElements {
 namespace Initialization {
 namespace Tags {
 struct NumberOfElements : db::SimpleTag {
-  static std::string name() noexcept { return "NumberOfElements"; }
   using type = int;
   using option_tags = tmpl::list<OptionTags::NumberOfElements>;
 
@@ -93,7 +92,6 @@ struct ExpectedResult {
 }  // namespace OptionTags
 
 struct LinearOperator : db::SimpleTag {
-  static std::string name() noexcept { return "LinearOperator"; }
   using type = std::vector<DenseMatrix<double, blaze::columnMajor>>;
   using option_tags = tmpl::list<OptionTags::LinearOperator>;
 
@@ -107,7 +105,6 @@ struct LinearOperator : db::SimpleTag {
 };
 
 struct Source : db::SimpleTag {
-  static std::string name() noexcept { return "Source"; }
   using type = std::vector<DenseVector<double>>;
   using option_tags = tmpl::list<OptionTags::Source>;
 
@@ -119,7 +116,6 @@ struct Source : db::SimpleTag {
 };
 
 struct ExpectedResult : db::SimpleTag {
-  static std::string name() noexcept { return "ExpectedResult"; }
   using type = std::vector<DenseVector<double>>;
   using option_tags = tmpl::list<OptionTags::ExpectedResult>;
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
@@ -28,7 +28,6 @@ namespace {
 
 struct VectorTag : db::SimpleTag {
   using type = DenseVector<double>;
-  static std::string name() noexcept { return "VectorTag"; }
 };
 
 using fields_tag = VectorTag;

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
@@ -57,7 +57,6 @@ namespace {
 
 struct VectorTag : db::SimpleTag {
   using type = DenseVector<double>;
-  static std::string name() noexcept { return "VectorTag"; }
 };
 
 using fields_tag = VectorTag;
@@ -73,12 +72,10 @@ using orthogonalization_history_tag =
 
 struct CheckValueTag : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "CheckValueTag"; }
 };
 
 struct CheckVectorTag : db::SimpleTag {
   using type = DenseVector<double>;
-  static std::string name() noexcept { return "CheckVectorTag"; }
 };
 
 using CheckConvergedTag = LinearSolver::Tags::HasConverged;

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -59,7 +59,6 @@ struct ExpectedResult {
 }  // namespace OptionTags
 
 struct LinearOperator : db::SimpleTag {
-  static std::string name() noexcept { return "LinearOperator"; }
   using type = DenseMatrix<double>;
   using option_tags = tmpl::list<OptionTags::LinearOperator>;
 
@@ -71,7 +70,6 @@ struct LinearOperator : db::SimpleTag {
 };
 
 struct Source : db::SimpleTag {
-  static std::string name() noexcept { return "Source"; }
   using type = DenseVector<double>;
   using option_tags = tmpl::list<OptionTags::Source>;
 
@@ -83,7 +81,6 @@ struct Source : db::SimpleTag {
 };
 
 struct InitialGuess : db::SimpleTag {
-  static std::string name() noexcept { return "InitialGuess"; }
   using type = DenseVector<double>;
   using option_tags = tmpl::list<OptionTags::InitialGuess>;
 
@@ -95,7 +92,6 @@ struct InitialGuess : db::SimpleTag {
 };
 
 struct ExpectedResult : db::SimpleTag {
-  static std::string name() noexcept { return "ExpectedResult"; }
   using type = DenseVector<double>;
   using option_tags = tmpl::list<OptionTags::ExpectedResult>;
 
@@ -109,7 +105,6 @@ struct ExpectedResult : db::SimpleTag {
 // The vector `x` we want to solve for
 struct VectorTag : db::SimpleTag {
   using type = DenseVector<double>;
-  static std::string name() noexcept { return "VectorTag"; }
 };
 
 using fields_tag = VectorTag;

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ResidualMonitorActionsTestHelpers.hpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ResidualMonitorActionsTestHelpers.hpp
@@ -25,22 +25,18 @@ namespace ResidualMonitorActionsTestHelpers {
 
 struct CheckObservationIdTag : db::SimpleTag {
   using type = observers::ObservationId;
-  static std::string name() noexcept { return "CheckObservationIdTag"; }
 };
 
 struct CheckSubfileNameTag : db::SimpleTag {
   using type = std::string;
-  static std::string name() noexcept { return "CheckSubfileNameTag"; }
 };
 
 struct CheckReductionNamesTag : db::SimpleTag {
   using type = std::vector<std::string>;
-  static std::string name() noexcept { return "CheckReductionNamesTag"; }
 };
 
 struct CheckReductionDataTag : db::SimpleTag {
   using type = std::tuple<size_t, double>;
-  static std::string name() noexcept { return "CheckReductionDataTag"; }
 };
 
 using observer_writer_tags =

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Test_Tags.cpp
@@ -13,10 +13,10 @@
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace {
 struct Tag : db::SimpleTag {
-  static std::string name() noexcept { return "Tag"; }
   using type = int;
 };
 using magnitude_square_tag = LinearSolver::Tags::MagnitudeSquare<Tag>;
@@ -32,7 +32,10 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Tags",
   CHECK(LinearSolver::Tags::Operand<Tag>::name() == "LinearOperand(Tag)");
   CHECK(LinearSolver::Tags::OperatorAppliedTo<Tag>::name() ==
         "LinearOperatorAppliedTo(Tag)");
-  CHECK(LinearSolver::Tags::HasConverged::name() == "LinearSolverHasConverged");
+  TestHelpers::db::test_simple_tag<LinearSolver::Tags::IterationId>(
+      "LinearIterationId");
+  TestHelpers::db::test_simple_tag<LinearSolver::Tags::HasConverged>(
+      "LinearSolverHasConverged");
   CHECK(LinearSolver::Tags::Residual<Tag>::name() == "LinearResidual(Tag)");
   CHECK(LinearSolver::Tags::Initial<Tag>::name() == "Initial(Tag)");
   CHECK(LinearSolver::Tags::MagnitudeSquare<Tag>::name() ==
@@ -44,8 +47,9 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Tags",
         "LinearOrthogonalizationHistory(Tag)");
   CHECK(LinearSolver::Tags::KrylovSubspaceBasis<Tag>::name() ==
         "KrylovSubspaceBasis(Tag)");
-  CHECK(LinearSolver::Tags::ConvergenceCriteria::name() ==
-        "ConvergenceCriteria");
+  TestHelpers::db::test_simple_tag<LinearSolver::Tags::ConvergenceCriteria>(
+      "ConvergenceCriteria");
+  TestHelpers::db::test_simple_tag<LinearSolver::Tags::Verbosity>("Verbosity");
 
   {
     INFO("HasConvergedCompute");

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -37,7 +37,6 @@ using step_choosers = tmpl::list<StepChoosers::Registrars::Constant>;
 using change_step_size = Actions::ChangeStepSize<step_choosers>;
 
 struct Var : db::SimpleTag {
-  static std::string name() noexcept { return "Var"; }
   using type = double;
 };
 

--- a/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
+++ b/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
@@ -25,7 +25,6 @@
 
 namespace {
 struct Var : db::SimpleTag {
-  static std::string name() noexcept { return "Var"; }
   using type = double;
 };
 

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -48,12 +48,10 @@ struct TemporalId {
 };
 
 struct Var : db::SimpleTag {
-  static std::string name() noexcept { return "Var"; }
   using type = double;
 };
 
 struct PrimitiveVar : db::SimpleTag {
-  static std::string name() noexcept { return "PrimitiveVar"; }
   using type = double;
 };
 

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -30,7 +30,6 @@ class TimeStepper;
 
 namespace {
 struct Var : db::SimpleTag {
-  static std::string name() noexcept { return "Var"; }
   using type = double;
 };
 

--- a/tests/Unit/Time/CMakeLists.txt
+++ b/tests/Unit/Time/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_EvolutionOrdering.cpp
   Test_History.cpp
   Test_Slab.cpp
+  Test_Tags.cpp
   Test_Time.cpp
   Test_TimeStepId.cpp
   )

--- a/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
@@ -40,7 +40,6 @@ using StepChooserType =
 using Cfl = StepChoosers::Cfl<dim, frame>;
 
 struct CharacteristicSpeed : db::SimpleTag {
-  static std::string name() noexcept { return "CharacteristicSpeed"; }
   using type = double;
 };
 

--- a/tests/Unit/Time/Test_Tags.cpp
+++ b/tests/Unit/Time/Test_Tags.cpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "Time/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+struct DummyType {};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Time.Tags", "[Unit][Time]") {
+  TestHelpers::db::test_simple_tag<Tags::TimeStepId>("TimeStepId");
+  TestHelpers::db::test_simple_tag<Tags::TimeStep>("TimeStep");
+  TestHelpers::db::test_simple_tag<Tags::SubstepTime>("SubstepTime");
+  TestHelpers::db::test_simple_tag<Tags::Time>("Time");
+  TestHelpers::db::test_simple_tag<
+      Tags::HistoryEvolvedVariables<DummyType, DummyType>>(
+      "HistoryEvolvedVariables");
+  TestHelpers::db::test_simple_tag<
+      Tags::BoundaryHistory<DummyType, DummyType, DummyType>>(
+      "BoundaryHistory");
+  TestHelpers::db::test_simple_tag<Tags::TimeStepper<DummyType>>("TimeStepper");
+  TestHelpers::db::test_simple_tag<Tags::StepChoosers<DummyType>>(
+      "StepChoosers");
+  TestHelpers::db::test_simple_tag<Tags::StepController>("StepController");
+}


### PR DESCRIPTION
## Proposed changes

Add a test helper for testing simple tags.
Use it to test simple tags in Time directory.
Remove unnecessary name functions in simple Time tags.
Cleanup some documentation of simple Time tags.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
