### PR TITLE
Implement system for Elasticity

### DIFF
--- a/src/Elliptic/Systems/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Systems/Elasticity/CMakeLists.txt
@@ -2,3 +2,17 @@
 # See LICENSE.txt for details.
 
 set(LIBRARY Elasticity)
+
+set(LIBRARY_SOURCES
+  Equations.cpp
+  )
+
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE DataStructures
+  INTERFACE ErrorHandling
+  INTERFACE LinearOperators
+  INTERFACE Spectral
+  )

--- a/src/Elliptic/Systems/Elasticity/Equations.cpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.cpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/Elasticity/Equations.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Elasticity/FirstOrderSystem.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Elasticity {
+
+template <size_t Dim>
+void primal_fluxes(
+    const gsl::not_null<tnsr::IJ<DataVector, Dim>*> flux_for_displacement,
+    const tnsr::ii<DataVector, Dim>& strain,
+    const ConstitutiveRelations::ConstitutiveRelation<Dim>&
+        constitutive_relation,
+    const tnsr::I<DataVector, Dim>& coordinates) noexcept {
+  const auto stress = constitutive_relation.stress(strain, coordinates);
+  // To set the components of the flux each component of the symmetric stress
+  // tensor is used twice. So the tensor can't be moved in its entirety.
+  for (size_t d = 0; d < Dim; d++) {
+    for (size_t e = 0; e < Dim; e++) {
+      // Also, the stress has lower and the flux upper indices. The minus sign
+      // originates in the definition of the stress \f$T^{ij} = -Y^{ijkl}
+      // S_{kl}\f$.
+      flux_for_displacement->get(d, e) = -stress.get(d, e);
+    }
+  }
+}
+
+template <size_t Dim>
+void auxiliary_fluxes(
+    const gsl::not_null<tnsr::Ijj<DataVector, Dim>*> flux_for_strain,
+    const tnsr::I<DataVector, Dim>& displacement) noexcept {
+  std::fill(flux_for_strain->begin(), flux_for_strain->end(), 0.);
+  // The off-diagonal elements are calculated by going over the upper triangular
+  // matrix (the lower triangular matrix, excluding the diagonal elements, is
+  // set by virtue of the tensor being symmetric in its last two indices) and
+  // the symmetrisation is completed by going over the diagonal elements again.
+  for (size_t d = 0; d < Dim; d++) {
+    flux_for_strain->get(d, d, d) += 0.5 * displacement.get(d);
+    for (size_t e = 0; e < Dim; e++) {
+      flux_for_strain->get(d, e, d) += 0.5 * displacement.get(e);
+    }
+  }
+}
+
+}  // namespace Elasticity
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                             \
+  template void Elasticity::primal_fluxes<DIM(data)>(                    \
+      gsl::not_null<tnsr::IJ<DataVector, DIM(data)>*>,                   \
+      const tnsr::ii<DataVector, DIM(data)>&,                            \
+      const Elasticity::ConstitutiveRelations::ConstitutiveRelation<DIM( \
+          data)>&,                                                       \
+      const tnsr::I<DataVector, DIM(data)>&) noexcept;                   \
+  template void Elasticity::auxiliary_fluxes<DIM(data)>(                 \
+      gsl::not_null<tnsr::Ijj<DataVector, DIM(data)>*>,                  \
+      const tnsr::I<DataVector, DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))
+
+// Instantiate derivative templates
+template <size_t Dim>
+using variables_tag = typename Elasticity::FirstOrderSystem<Dim>::variables_tag;
+template <size_t Dim>
+using fluxes_tags_list = db::get_variables_tags_list<db::add_tag_prefix<
+    ::Tags::Flux, variables_tag<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
+
+#define INSTANTIATE_DERIVS(_, data)                                            \
+  template Variables<db::wrap_tags_in<Tags::div, fluxes_tags_list<DIM(data)>>> \
+  divergence<fluxes_tags_list<DIM(data)>, DIM(data), Frame::Inertial>(         \
+      const Variables<fluxes_tags_list<DIM(data)>>&, const Mesh<DIM(data)>&,   \
+      const InverseJacobian<DataVector, DIM(data), Frame::Logical,             \
+                            Frame::Inertial>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_DERIVS, (2, 3))
+
+#undef INSTANTIATE
+#undef INSTANTIATE_DERIVS
+#undef DIM

--- a/src/Elliptic/Systems/Elasticity/Equations.hpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.hpp
@@ -1,0 +1,103 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace Elasticity {
+namespace ConstitutiveRelations {
+template <size_t Dim>
+class ConstitutiveRelation;
+}  // namespace ConstitutiveRelations
+}  // namespace Elasticity
+/// \endcond
+
+namespace Elasticity {
+
+/*!
+ * \brief Compute the fluxes \f$F^{ij}=Y^{ijkl}(x) S_{kl}(x)\f$ for
+ * the Elasticity equation on a flat spatial metric in Cartesian coordinates.
+ */
+template <size_t Dim>
+void primal_fluxes(
+    gsl::not_null<tnsr::IJ<DataVector, Dim>*> flux_for_displacement,
+    const tnsr::ii<DataVector, Dim>& strain,
+    const ConstitutiveRelations::ConstitutiveRelation<Dim>&
+        constitutive_relation,
+    const tnsr::I<DataVector, Dim>& coordinates) noexcept;
+
+/*!
+ * \brief Compute the fluxes \f$F^i_{jk}=\delta^{i}_{(j} \xi_{k)}\f$ for the
+ * auxiliary field in the first-order formulation of the Elasticity equation.
+ *
+ * \see Elasticity::FirstOrderSystem
+ */
+template <size_t Dim>
+void auxiliary_fluxes(
+    gsl::not_null<tnsr::Ijj<DataVector, Dim>*> flux_for_strain,
+    const tnsr::I<DataVector, Dim>& displacement) noexcept;
+
+/*!
+ * \brief Compute the fluxes \f$F^i_A\f$ for the Elasticity equation on a flat
+ * metric in Cartesian coordinates.
+ *
+ * \see Elasticity::FirstOrderSystem
+ */
+template <size_t Dim>
+struct Fluxes {
+  using argument_tags =
+      tmpl::list<Tags::ConstitutiveRelationBase,
+                 domain::Tags::Coordinates<Dim, Frame::Inertial>>;
+  static void apply(
+      const gsl::not_null<tnsr::IJ<DataVector, Dim>*> flux_for_displacement,
+      const ConstitutiveRelations::ConstitutiveRelation<Dim>&
+          constitutive_relation,
+      const tnsr::I<DataVector, Dim>& coordinates,
+      const tnsr::ii<DataVector, Dim>& strain) noexcept {
+    primal_fluxes(flux_for_displacement, strain, constitutive_relation,
+                  coordinates);
+  }
+  static void apply(
+      const gsl::not_null<tnsr::Ijj<DataVector, Dim>*> flux_for_strain,
+      const ConstitutiveRelations::ConstitutiveRelation<
+          Dim>& /*constitutive_relation*/,
+      const tnsr::I<DataVector, Dim>& /*coordinates*/,
+      const tnsr::I<DataVector, Dim>& displacement) noexcept {
+    auxiliary_fluxes(flux_for_strain, displacement);
+  }
+  // clang-tidy: no runtime references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+/*!
+ * \brief Compute the sources \f$S_A\f$ for the Elasticity equation.
+ *
+ * \see Elasticity::FirstOrderSystem
+ */
+template <size_t Dim>
+struct Sources {
+  using argument_tags = tmpl::list<>;
+  static void apply(
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> source_for_displacement,
+      const tnsr::I<DataVector, Dim>& /*displacement*/) noexcept {
+    for (size_t d = 0; d < Dim; d++) {
+      source_for_displacement->get(d) = 0.;
+    }
+  }
+};
+
+}  // namespace Elasticity

--- a/src/Elliptic/Systems/Elasticity/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Elasticity/FirstOrderSystem.hpp
@@ -1,0 +1,96 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "Elliptic/Systems/Elasticity/Equations.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "ParallelAlgorithms/LinearSolver/Tags.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Tags {
+template <typename>
+class Variables;
+}  // namespace Tags
+
+namespace LinearSolver {
+namespace Tags {
+template <typename>
+struct Operand;
+}  // namespace Tags
+}  // namespace LinearSolver
+/// \endcond
+
+namespace Elasticity {
+
+/*!
+ * \brief The linear elasticity equation formulated as a set of coupled
+ * first-order PDEs.
+ *
+ * This system formulates the elasticity equation \f$\nabla_i T^{ij} =
+ * f_\mathrm{ext}^j\f$ (see `Elasticity`). It introduces the symmetric strain
+ * tensor \f$S_{kl}\f$ as an auxiliary variable which satisfies the
+ * `Elasticity::ConstitutiveRelations` \f$T^{ij} = -Y^{ijkl} S_{kl}\f$ with the
+ * material-specific elasticity tensor \f$Y^{ijkl}\f$. Written as a set of
+ * coupled first-order PDEs, we get
+ *
+ * \f{align*}
+ * -\nabla_i Y^{ijkl} S_{kl} = f_\mathrm{ext}^j \\
+ * -\nabla_{(k} \xi_{l)} + S_{kl} = 0
+ * \f}
+ *
+ * The fluxes and sources in terms of the system variables
+ * \f$\xi^j\f$ and \f$S_{kl}\f$ are given by
+ *
+ * \f{align*}
+ * F^i_{\xi^j} &=  Y^{ijkl}_{(\xi, S)} S_{kl} \\
+ * S_{\xi^j} &= 0 \\
+ * f_{\xi^j} &= f_\mathrm{ext}^j \\
+ * F^i_{S_{kl}} &= \delta^{i}_{(k} \xi_{l)} \\
+ * S_{S_{kl}} &= S_{kl} \\
+ * f_{S_{kl}} &= 0 \text{.}
+ * \f}
+ *
+ * See `Poisson::FirstOrderSystem` for details on the first-order
+ * flux-formulation.
+ */
+template <size_t Dim>
+struct FirstOrderSystem {
+ private:
+  using displacement = Tags::Displacement<Dim>;
+  using gradient_of_displacement =
+      ::Tags::deriv<displacement, tmpl::size_t<Dim>, Frame::Inertial>;
+  using strain = Tags::Strain<Dim>;
+
+ public:
+  static constexpr size_t volume_dim = Dim;
+
+  // The physical fields to solve for
+  using primal_fields = tmpl::list<displacement>;
+  using auxiliary_fields = tmpl::list<strain>;
+  using fields_tag =
+      ::Tags::Variables<tmpl::append<primal_fields, auxiliary_fields>>;
+
+  // The variables to compute bulk contributions and fluxes for.
+  using variables_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
+  using primal_variables =
+      db::wrap_tags_in<LinearSolver::Tags::Operand, primal_fields>;
+  using auxiliary_variables =
+      db::wrap_tags_in<LinearSolver::Tags::Operand, auxiliary_fields>;
+
+  using fluxes = Fluxes<Dim>;
+  using sources = Sources<Dim>;
+
+  // The tag of the operator to compute magnitudes on the manifold, e.g. to
+  // normalize vectors on the faces of an element
+  template <typename Tag>
+  using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;
+};
+}  // namespace Elasticity

--- a/src/Elliptic/Systems/Elasticity/Tags.hpp
+++ b/src/Elliptic/Systems/Elasticity/Tags.hpp
@@ -17,19 +17,25 @@ class DataVector;
  * \brief Items related to solving elasticity problems
  *
  * \details In elasticity problems we solve for the displacement vector
- * field \f$\boldsymbol{u}\f$ in an elastic material that responds to external
+ * field \f$\boldsymbol{\xi}\f$ in an elastic material that responds to external
  * forces, stresses or deformations. In this static approximation the
- * equations of motion reduce to the elliptic equations \f[
+ * equations of motion reduce to the elliptic equations
+ *
+ * \f[
  * \nabla_i T^{ij} = f_\mathrm{ext}^j
- * \f] that describes a state of equilibrium between the stresses \f$T^{ij}\f$
+ * \f]
+ *
+ * that describes a state of equilibrium between the stresses \f$T^{ij}\f$
  * within the material and the external body forces
  * \f$\boldsymbol{f}_\mathrm{ext}\f$ (Eqns. 11.13 and 11.14 in
- * \cite ThorneBlandford2017). For small deformations (see e.g.
- * \cite ThorneBlandford2017, Section 11.3.2 for a discussion) the stress is
- * related to the strain \f$S_{ij}=\nabla_{(i}u_{j)}\f$ by a linear constitutive
- * relation \f$T^{ij}=-Y^{ijkl}S_{kl}\f$ (Eq. 11.17 in
- * \cite ThorneBlandford2017) that describes the elastic properties of the
- * material (see `Elasticity::ConstitutiveRelations::ConstitutiveRelation`).
+ * \cite ThorneBlandford2017 with the counteracting internal forces
+ * \f$\boldsymbol{f} = -\boldsymbol{f}_\mathrm{ext}\f$). For small
+ * deformations (see e.g. \cite ThorneBlandford2017, Section 11.3.2 for a
+ * discussion) the stress is related to the strain
+ * \f$S_{ij}=\nabla_{(i}\xi_{j)}\f$ by a linear constitutive relation
+ * \f$T^{ij}=-Y^{ijkl}S_{kl}\f$ (Eq. 11.17 in \cite ThorneBlandford2017) that
+ * describes the elastic properties of the material (see
+ * `Elasticity::ConstitutiveRelations::ConstitutiveRelation`).
  */
 namespace Elasticity {
 namespace Tags {

--- a/src/Evolution/Systems/Burgers/Fluxes.cpp
+++ b/src/Evolution/Systems/Burgers/Fluxes.cpp
@@ -13,9 +13,11 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
+/// \cond
 namespace Burgers {
 void Fluxes::apply(const gsl::not_null<tnsr::I<DataVector, 1>*> flux,
                    const Scalar<DataVector>& u) noexcept {
   get<0>(*flux) = 0.5 * square(get(u));
 }
 }  // namespace Burgers
+/// \endcond

--- a/tests/Unit/Elliptic/Systems/Elasticity/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Elasticity/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Elasticity")
 
 set(LIBRARY_SOURCES
+  Test_Equations.cpp
   Test_Tags.cpp
   )
 
@@ -11,5 +12,5 @@ add_test_library(
   ${LIBRARY}
   "Elliptic/Systems/Elasticity/"
   "${LIBRARY_SOURCES}"
-  ""
+  "ConstitutiveRelations;Elasticity"
   )

--- a/tests/Unit/Elliptic/Systems/Elasticity/Equations.py
+++ b/tests/Unit/Elliptic/Systems/Elasticity/Equations.py
@@ -1,0 +1,40 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def constitutive_relation_2d(strain, bulk_modulus, shear_modulus):
+    lame_constant = bulk_modulus - 2. / 3. * shear_modulus
+    return -2. * shear_modulus * lame_constant / (
+        lame_constant + 2. * shear_modulus
+    ) * np.trace(strain) * np.eye(2) - 2. * shear_modulus * strain
+
+
+def constitutive_relation_3d(strain, bulk_modulus, shear_modulus):
+    lame_constant = bulk_modulus - 2. / 3. * shear_modulus
+    return -2. * shear_modulus * strain - lame_constant * np.trace(
+        strain) * np.eye(3)
+
+
+def primal_fluxes_2d(strain, coordinates, bulk_modulus, shear_modulus):
+    return -constitutive_relation_2d(strain, bulk_modulus, shear_modulus)
+
+
+def primal_fluxes_3d(strain, coordinates, bulk_modulus, shear_modulus):
+    return -constitutive_relation_3d(strain, bulk_modulus, shear_modulus)
+
+
+def auxiliary_fluxes(field, dim):
+    # Compute the tensor product with a Kronecker delta and symmetrize the last
+    # two indices.
+    tensor_product = np.tensordot(np.eye(dim), field, axes=0)
+    return 0.5 * (tensor_product + np.transpose(tensor_product, (0, 2, 1)))
+
+
+def auxiliary_fluxes_2d(field):
+    return auxiliary_fluxes(field, 2)
+
+
+def auxiliary_fluxes_3d(field):
+    return auxiliary_fluxes(field, 3)

--- a/tests/Unit/Elliptic/Systems/Elasticity/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/Test_Equations.cpp
@@ -1,0 +1,131 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Systems/Elasticity/Equations.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+namespace {
+
+template <size_t Dim>
+void primal_fluxes(
+    // This wrapper function is needed to construct a constitutive relation for
+    // the random values of its parameters.
+    const gsl::not_null<tnsr::IJ<DataVector, Dim, Frame::Inertial>*>
+        flux_for_displacement,
+    const tnsr::ii<DataVector, Dim, Frame::Inertial>& strain,
+    const tnsr::I<DataVector, Dim>& coordinates, const double bulk_modulus,
+    const double shear_modulus) noexcept {
+  Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>
+      constitutive_relation{bulk_modulus, shear_modulus};
+  Elasticity::primal_fluxes<Dim>(flux_for_displacement, strain,
+                                 std::move(constitutive_relation), coordinates);
+}
+
+template <size_t Dim>
+void test_equations(const DataVector& used_for_size) {
+  pypp::check_with_random_values<4>(
+      &primal_fluxes<Dim>, "Equations",
+      {MakeString{} << "primal_fluxes_" << Dim << "d"},
+      {{{-1., 1.}, {-1., 1.}, {0., 1.}, {0., 1.}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      &Elasticity::auxiliary_fluxes<Dim>, "Equations",
+      {MakeString{} << "auxiliary_fluxes_" << Dim << "d"}, {{{-1., 1.}}},
+      used_for_size);
+}
+
+template <size_t Dim>
+void test_computers(const DataVector& used_for_size) {
+  using field_tag = Elasticity::Tags::Displacement<Dim>;
+  using auxiliary_field_tag = Elasticity::Tags::Strain<Dim>;
+  using field_flux_tag =
+      ::Tags::Flux<field_tag, tmpl::size_t<Dim>, Frame::Inertial>;
+  using auxiliary_flux_tag =
+      ::Tags::Flux<auxiliary_field_tag, tmpl::size_t<Dim>, Frame::Inertial>;
+  using field_source_tag = ::Tags::Source<field_tag>;
+  using constitutive_relation_tag = Elasticity::Tags::ConstitutiveRelation<
+      Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>>;
+  using coordinates_tag = domain::Tags::Coordinates<Dim, Frame::Inertial>;
+  const size_t num_points = used_for_size.size();
+  {
+    INFO("Fluxes" << Dim << "D");
+    auto box = db::create<db::AddSimpleTags<
+        field_tag, auxiliary_field_tag, field_flux_tag, auxiliary_flux_tag,
+        constitutive_relation_tag, coordinates_tag>>(
+        tnsr::I<DataVector, Dim>{num_points, 1.},
+        tnsr::ii<DataVector, Dim>{num_points, 2.},
+        tnsr::IJ<DataVector, Dim>{num_points,
+                                  std::numeric_limits<double>::signaling_NaN()},
+        tnsr::Ijj<DataVector, Dim>{
+            num_points, std::numeric_limits<double>::signaling_NaN()},
+        Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>{1., 2.},
+        tnsr::I<DataVector, Dim>{num_points, 6.});
+
+    const Elasticity::Fluxes<Dim> fluxes_computer{};
+    using argument_tags = typename Elasticity::Fluxes<Dim>::argument_tags;
+
+    db::mutate_apply<tmpl::list<field_flux_tag>, argument_tags>(
+        fluxes_computer, make_not_null(&box), get<auxiliary_field_tag>(box));
+    auto expected_field_flux = tnsr::IJ<DataVector, Dim>{
+        num_points, std::numeric_limits<double>::signaling_NaN()};
+    Elasticity::primal_fluxes(
+        make_not_null(&expected_field_flux), get<auxiliary_field_tag>(box),
+        get<constitutive_relation_tag>(box), get<coordinates_tag>(box));
+    CHECK(get<field_flux_tag>(box) == expected_field_flux);
+
+    db::mutate_apply<tmpl::list<auxiliary_flux_tag>, argument_tags>(
+        fluxes_computer, make_not_null(&box), get<field_tag>(box));
+    auto expected_auxiliary_flux = tnsr::Ijj<DataVector, Dim>{
+        num_points, std::numeric_limits<double>::signaling_NaN()};
+    Elasticity::auxiliary_fluxes(make_not_null(&expected_auxiliary_flux),
+                                 get<field_tag>(box));
+    CHECK(get<auxiliary_flux_tag>(box) == expected_auxiliary_flux);
+  }
+  {
+    INFO("Sources" << Dim << "D");
+    auto box = db::create<db::AddSimpleTags<field_tag, field_source_tag>>(
+        tnsr::I<DataVector, Dim>{num_points,
+                                 std::numeric_limits<double>::signaling_NaN()},
+        tnsr::I<DataVector, Dim>{num_points,
+                                 std::numeric_limits<double>::signaling_NaN()});
+
+    const Elasticity::Sources<Dim> sources_computer{};
+    using argument_tags = typename Elasticity::Sources<Dim>::argument_tags;
+
+    db::mutate_apply<tmpl::list<field_source_tag>, argument_tags>(
+        sources_computer, make_not_null(&box), get<field_tag>(box));
+    auto expected_field_source = tnsr::I<DataVector, Dim>{num_points, 0.};
+    CHECK(get<field_source_tag>(box) == expected_field_source);
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Elasticity", "[Unit][Elliptic]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Elliptic/Systems/Elasticity"};
+
+  GENERATE_UNINITIALIZED_DATAVECTOR;
+  CHECK_FOR_DATAVECTORS(test_equations, (2, 3));
+  CHECK_FOR_DATAVECTORS(test_computers, (2, 3));
+}


### PR DESCRIPTION
## Proposed changes
Constructs first order system for Elasticity in analogy to first order system for Poisson. 
The fluxes listed in FirstOrderSystem.hpp are calculated by the function in Equations.cpp;
- `primal_fluxes()` takes the strain and returns the stress by applying the constitutive relation
- `auxiliary_fluxes()` takes the displacement and returns a tensor of 3rd order whose divergence is the strain. The off-diagonal elements are calculated by going over the upper triangular matrix (the lower triangular matrix, excluding the diagonal elements, is set by virtue of the tensor being symmetrical in its last two indices) and the symmetrisation is completed by going over the diagonal elements again.
<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

- [x] Swap displacement u for xi
- [x] Delete comments from line 69 onwards from Test_Equations.cpp
