### PR TITLE
Allow VariableFixerType to specify a name function

### DIFF
--- a/src/Evolution/VariableFixing/Tags.hpp
+++ b/src/Evolution/VariableFixing/Tags.hpp
@@ -3,8 +3,10 @@
 
 #pragma once
 
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "Options/Options.hpp"
-#include "Utilities/PrettyType.hpp"
 
 namespace OptionTags {
 /*!
@@ -26,7 +28,7 @@ struct VariableFixer {
   static constexpr OptionString help = "Options for the variable fixer";
   using type = VariableFixerType;
   static std::string name() noexcept {
-    return pretty_type::short_name<VariableFixerType>();
+    return option_name<VariableFixerType>();
   }
   using group = VariableFixingGroup;
 };


### PR DESCRIPTION
## Proposed changes

Fixes a bug that prevented a `VariableFixerType` with an overriding `name()` function to be created using the name returned by its `name()` function.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
