### PR TITLE
Add more tests of DataBox tags

### DIFF
--- a/src/ApparentHorizons/ComputeItems.hpp
+++ b/src/ApparentHorizons/ComputeItems.hpp
@@ -38,6 +38,7 @@ struct InverseSpatialMetricCompute : gr::Tags::InverseSpatialMetric<Dim, Frame>,
     return determinant_and_inverse(gr::spatial_metric(psi)).second;
   };
   using argument_tags = tmpl::list<gr::Tags::SpacetimeMetric<Dim, Frame>>;
+  using base = gr::Tags::InverseSpatialMetric<Dim, Frame>;
 };
 template <size_t Dim, typename Frame>
 struct ExtrinsicCurvatureCompute : gr::Tags::ExtrinsicCurvature<Dim, Frame>,
@@ -55,6 +56,7 @@ struct ExtrinsicCurvatureCompute : gr::Tags::ExtrinsicCurvature<Dim, Frame>,
                                    GeneralizedHarmonic::Tags::Pi<Dim, Frame>,
                                    GeneralizedHarmonic::Tags::Phi<Dim, Frame>,
                                    gr::Tags::InverseSpatialMetric<Dim, Frame>>;
+  using base = gr::Tags::ExtrinsicCurvature<Dim, Frame>;
 };
 template <size_t Dim, typename Frame>
 struct SpatialChristoffelSecondKindCompute
@@ -70,6 +72,7 @@ struct SpatialChristoffelSecondKindCompute
   }
   using argument_tags = tmpl::list<GeneralizedHarmonic::Tags::Phi<Dim, Frame>,
                                    gr::Tags::InverseSpatialMetric<Dim, Frame>>;
+  using base = ::gr::Tags::SpatialChristoffelSecondKind<Dim, Frame>;
 };
 // }@
 }  // namespace Tags

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -290,7 +290,7 @@ struct AreaElement : db::ComputeTag {
 template <typename IntegrandTag, typename Frame>
 struct SurfaceIntegral : db::ComputeTag {
   static std::string name() noexcept {
-    return "SurfaceIntegral" + IntegrandTag::name();
+    return "SurfaceIntegral" + db::tag_name<IntegrandTag>();
   }
   static constexpr auto function = surface_integral_of_scalar<Frame>;
   using argument_tags = tmpl::list<AreaElement<Frame>, IntegrandTag,

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -24,7 +24,6 @@ class FastFlow;
 namespace ah {
 namespace Tags {
 struct FastFlow : db::SimpleTag {
-  static std::string name() noexcept { return "FastFlow"; }
   using type = ::FastFlow;
 };
 }  // namespace Tags
@@ -37,7 +36,6 @@ namespace StrahlkorperTags {
 /// Tag referring to a `::Strahlkorper`
 template <typename Frame>
 struct Strahlkorper : db::SimpleTag {
-  static std::string name() noexcept { return "Strahlkorper"; }
   using type = ::Strahlkorper<Frame>;
 };
 
@@ -231,7 +229,7 @@ struct EuclideanAreaElement : db::ComputeTag {
 template <typename IntegrandTag, typename Frame>
 struct EuclideanSurfaceIntegral : db::ComputeTag {
   static std::string name() noexcept {
-    return "EuclideanSurfaceIntegral" + IntegrandTag::name();
+    return "EuclideanSurfaceIntegral(" + db::tag_name<IntegrandTag>() + ")";
   }
   static constexpr auto function =
       ::StrahlkorperGr::surface_integral_of_scalar<Frame>;
@@ -248,7 +246,8 @@ struct EuclideanSurfaceIntegral : db::ComputeTag {
 template <typename IntegrandTag, typename Frame>
 struct EuclideanSurfaceIntegralVector : db::ComputeTag {
   static std::string name() noexcept {
-    return "EuclideanSurfaceIntegralVector(" + IntegrandTag::name() + ")";
+    return "EuclideanSurfaceIntegralVector(" + db::tag_name<IntegrandTag>() +
+           ")";
   }
   static constexpr auto function =
       ::StrahlkorperGr::euclidean_surface_integral_of_vector<Frame>;
@@ -290,7 +289,7 @@ struct AreaElement : db::ComputeTag {
 template <typename IntegrandTag, typename Frame>
 struct SurfaceIntegral : db::ComputeTag {
   static std::string name() noexcept {
-    return "SurfaceIntegral" + db::tag_name<IntegrandTag>();
+    return "SurfaceIntegral(" + db::tag_name<IntegrandTag>() + ")";
   }
   static constexpr auto function = surface_integral_of_scalar<Frame>;
   using argument_tags = tmpl::list<AreaElement<Frame>, IntegrandTag,

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -77,7 +77,7 @@ namespace Tags {
 template <typename Tag>
 struct Magnitude : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
-    return "Magnitude(" + Tag::name() + ")";
+    return "Magnitude(" + db::tag_name<Tag>() + ")";
   }
   using tag = Tag;
   using type = Scalar<DataVector>;
@@ -118,7 +118,7 @@ struct NonEuclideanMagnitude : Magnitude<Tag>, db::ComputeTag {
 template <typename Tag>
 struct Normalized : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
-    return "Normalized(" + Tag::name() + ")";
+    return "Normalized(" + db::tag_name<Tag>() + ")";
   }
   using tag = Tag;
   using type = db::const_item_type<Tag>;
@@ -152,7 +152,9 @@ struct NormalizedCompute : Normalized<Tag>, db::ComputeTag {
 /// \snippet Test_Magnitude.cpp sqrt_name
 template <typename Tag>
 struct Sqrt : db::ComputeTag {
-  static std::string name() noexcept { return "Sqrt(" + Tag::name() + ")"; }
+  static std::string name() noexcept {
+    return "Sqrt(" + db::tag_name<Tag>() + ")";
+  }
   static constexpr Scalar<DataVector> (*function)(
       const db::const_item_type<Tag>&) = sqrt_magnitude;
   using argument_tags = tmpl::list<Tag>;

--- a/src/Domain/InterfaceComputeTags.hpp
+++ b/src/Domain/InterfaceComputeTags.hpp
@@ -172,7 +172,9 @@ struct Slice : Interface<DirectionsTag, Tag>, db::ComputeTag {
                     index_to_slice_at(mesh.extents(), direction));
     }
   }
-  static std::string name() { return "Interface<" + Tag::name() + ">"; };
+  static std::string name() {
+    return "Interface<" + db::tag_name<Tag>() + ">";
+  };
   using argument_tags = tmpl::list<Mesh<volume_dim>, DirectionsTag, Tag>;
   using volume_tags = tmpl::list<Mesh<volume_dim>, Tag>;
 };

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -296,7 +296,8 @@ template <typename DirectionsTag, typename Tag>
 struct Interface : virtual db::SimpleTag,
                    Interface_detail::GetBaseTagIfPresent<DirectionsTag, Tag> {
   static std::string name() noexcept {
-    return "Interface<" + DirectionsTag::name() + ", " + Tag::name() + ">";
+    return "Interface<" + DirectionsTag::name() + ", " + db::tag_name<Tag>() +
+           ">";
   };
   using tag = Tag;
   // The use of db::const_item_type<Tag> assumes we will never store

--- a/src/Elliptic/Systems/Elasticity/Tags.hpp
+++ b/src/Elliptic/Systems/Elasticity/Tags.hpp
@@ -40,7 +40,6 @@ namespace Tags {
 template <size_t Dim>
 struct Displacement : db::SimpleTag {
   using type = tnsr::I<DataVector, Dim>;
-  static std::string name() noexcept { return "Displacement"; }
 };
 
 /*!
@@ -50,7 +49,6 @@ struct Displacement : db::SimpleTag {
 template <size_t Dim>
 struct Strain : db::SimpleTag {
   using type = tnsr::ii<DataVector, Dim>;
-  static std::string name() noexcept { return "Strain"; }
 };
 
 /*!
@@ -60,7 +58,6 @@ struct Strain : db::SimpleTag {
 template <size_t Dim>
 struct Stress : db::SimpleTag {
   using type = tnsr::II<DataVector, Dim>;
-  static std::string name() noexcept { return "Stress"; }
 };
 
 }  // namespace Tags

--- a/src/Elliptic/Systems/Poisson/Tags.hpp
+++ b/src/Elliptic/Systems/Poisson/Tags.hpp
@@ -27,7 +27,6 @@ namespace Tags {
  */
 struct Field : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "Field"; }
 };
 
 }  // namespace Tags

--- a/src/Elliptic/Systems/Xcts/Tags.hpp
+++ b/src/Elliptic/Systems/Xcts/Tags.hpp
@@ -23,7 +23,6 @@ namespace Tags {
 template <typename DataType>
 struct ConformalFactor : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "ConformalFactor"; }
 };
 
 /*!
@@ -35,7 +34,6 @@ struct ConformalFactor : db::SimpleTag {
 template <size_t Dim, typename Frame, typename DataType>
 struct ConformalFactorGradient : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "ConformalFactorGradient"; }
 };
 
 }  // namespace Tags

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "Options/Options.hpp"
 
 namespace OptionTags {
@@ -35,7 +38,6 @@ namespace Tags {
  */
 template <typename LimiterType>
 struct Limiter : db::SimpleTag {
-  static std::string name() noexcept { return "Limiter"; }
   using type = LimiterType;
   using option_tags = tmpl::list<::OptionTags::Limiter<LimiterType>>;
 

--- a/src/Evolution/Initialization/Tags.hpp
+++ b/src/Evolution/Initialization/Tags.hpp
@@ -16,7 +16,6 @@ namespace Initialization {
 /// \brief %Tags used during initialization of parallel components.
 namespace Tags {
 struct InitialTime : db::SimpleTag {
-  static std::string name() noexcept { return "InitialTime"; }
   using type = double;
   using option_tags = tmpl::list<OptionTags::InitialTime>;
 
@@ -27,7 +26,6 @@ struct InitialTime : db::SimpleTag {
 };
 
 struct InitialTimeDelta : db::SimpleTag {
-  static std::string name() noexcept { return "InitialTimeDelta"; }
   using type = double;
   using option_tags = tmpl::list<OptionTags::InitialTimeStep>;
 
@@ -39,7 +37,6 @@ struct InitialTimeDelta : db::SimpleTag {
 
 template <bool UsingLocalTimeStepping>
 struct InitialSlabSize : db::SimpleTag {
-  static std::string name() noexcept { return "InitialSlabSize"; }
   using type = double;
   using option_tags = tmpl::list<OptionTags::InitialSlabSize>;
 
@@ -51,7 +48,6 @@ struct InitialSlabSize : db::SimpleTag {
 
 template <>
 struct InitialSlabSize<false> : db::SimpleTag {
-  static std::string name() noexcept { return "InitialSlabSize"; }
   using type = double;
   using option_tags = tmpl::list<OptionTags::InitialTimeStep>;
 

--- a/src/Evolution/Systems/Burgers/Tags.hpp
+++ b/src/Evolution/Systems/Burgers/Tags.hpp
@@ -12,7 +12,6 @@
 namespace Burgers {
 namespace Tags {
 struct U : db::SimpleTag {
-  static std::string name() noexcept { return "U"; }
   using type = Scalar<DataVector>;
 };
 }  // namespace Tags

--- a/src/Evolution/Systems/Cce/ReadBoundaryDataH5.hpp
+++ b/src/Evolution/Systems/Cce/ReadBoundaryDataH5.hpp
@@ -37,7 +37,9 @@ template <typename Tag>
 struct Dr : db::SimpleTag, db::PrefixTag {
   using type = typename Tag::type;
   using tag = Tag;
-  static std::string name() noexcept { return "Dr(" + Tag::name() + ")"; }
+  static std::string name() noexcept {
+    return "Dr(" + db::tag_name<Tag>() + ")";
+  }
 };
 
 // tag for the string for accessing the quantity associated with `Tag` in
@@ -47,7 +49,7 @@ struct InputDataSet : db::SimpleTag, db::PrefixTag {
   using type = std::string;
   using tag = Tag;
   static std::string name() noexcept {
-    return "InputDataSet(" + Tag::name() + ")";
+    return "InputDataSet(" + db::tag_name<Tag>() + ")";
   }
 };
 }  // namespace detail

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -24,7 +24,6 @@ namespace Tags {
 /// Bondi parameter \f$\beta\f$
 struct BondiBeta : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
-  static std::string name() noexcept { return "BondiBeta"; }
 };
 
 /// \brief Bondi parameter \f$H = \partial_u J\f$.
@@ -260,7 +259,6 @@ struct LinearFactorForConjugate : db::PrefixTag, db::SimpleTag {
 /// implementing functions
 struct OneMinusY : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
-  static std::string name() noexcept { return "OneMinusY"; }
 };
 
 /// A tag for the first time derivative of the worldtube parameter
@@ -268,14 +266,12 @@ struct OneMinusY : db::SimpleTag {
 /// radius of the worldtube.
 struct DuR : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
-  static std::string name() noexcept { return "DuR"; }
 };
 
 /// The value \f$\partial_u R / R\f$, where \f$R(u, \theta, \phi)\f$ is Bondi
 /// radius of the worldtube.
 struct DuRDividedByR : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
-  static std::string name() noexcept { return "DuRDividedByR"; }
 };
 
 /// The value \f$\eth R / R\f$, where \f$R(u, \theta, \phi)\f$ is Bondi
@@ -284,7 +280,6 @@ struct EthRDividedByR : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 1>>;
   using derivative_kind = Spectral::Swsh::Tags::Eth;
   static constexpr int spin = 1;
-  static std::string name() noexcept { return "EthRDividedByR"; }
 };
 
 /// The value \f$\eth \eth R / R\f$, where \f$R(u, \theta, \phi)\f$ is Bondi
@@ -293,7 +288,6 @@ struct EthEthRDividedByR : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 2>>;
   using derivative_kind = Spectral::Swsh::Tags::EthEth;
   static constexpr int spin = 2;
-  static std::string name() noexcept { return "EthEthRDividedByR"; }
 };
 
 /// The value \f$\eth \bar{\eth} R / R\f$, where \f$R(u, \theta, \phi)\f$ is
@@ -302,19 +296,16 @@ struct EthEthbarRDividedByR : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
   using derivative_kind = Spectral::Swsh::Tags::EthEthbar;
   static constexpr int spin = 0;
-  static std::string name() noexcept { return "EthEthbarRDividedByR"; }
 };
 
 /// The value \f$\exp(2\beta)\f$.
 struct Exp2Beta : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
-  static std::string name() noexcept { return "Exp2Beta"; }
 };
 
 /// The value \f$ \bar{J} (Q - 2 \eth \beta ) \f$.
 struct JbarQMinus2EthBeta : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, -1>>;
-  static std::string name() noexcept { return "JbarQMinus2EthBeta"; }
 };
 
 /// The Bondi radius \f$R(u, \theta, \phi)\f$ is of the worldtube.

--- a/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
@@ -22,18 +22,15 @@ class Variables;
 namespace CurvedScalarWave {
 struct Psi : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "Psi"; }
 };
 
 struct Pi : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "Pi"; }
 };
 
 template <size_t SpatialDim>
 struct Phi : db::SimpleTag {
   using type = tnsr::i<DataVector, SpatialDim>;
-  static std::string name() noexcept { return "Phi"; }
 };
 
 namespace Tags {

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -125,6 +125,7 @@ void damped_harmonic_h(
 template <size_t SpatialDim, typename Frame>
 struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
                                 db::ComputeTag {
+  using base = Tags::GaugeH<SpatialDim, Frame>;
   using argument_tags = tmpl::list<
       Tags::InitialGaugeH<SpatialDim, Frame>, ::gr::Tags::Lapse<DataVector>,
       ::gr::Tags::Shift<SpatialDim, Frame, DataVector>,
@@ -267,6 +268,7 @@ template <size_t SpatialDim, typename Frame>
 struct SpacetimeDerivDampedHarmonicHCompute
     : Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>,
       db::ComputeTag {
+  using base = Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>;
   using argument_tags = tmpl::list<
       Tags::InitialGaugeH<SpatialDim, Frame>,
       Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -28,7 +28,6 @@ namespace Tags {
 template <size_t Dim, typename Frame>
 struct Pi : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame>;
-  static std::string name() noexcept { return "Pi"; }
 };
 
 /*!
@@ -40,20 +39,16 @@ struct Pi : db::SimpleTag {
 template <size_t Dim, typename Frame>
 struct Phi : db::SimpleTag {
   using type = tnsr::iaa<DataVector, Dim, Frame>;
-  static std::string name() noexcept { return "Phi"; }
 };
 
 struct ConstraintGamma0 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "ConstraintGamma0"; }
 };
 struct ConstraintGamma1 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "ConstraintGamma1"; }
 };
 struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "ConstraintGamma2"; }
 };
 
 /*!
@@ -66,7 +61,6 @@ struct ConstraintGamma2 : db::SimpleTag {
  */
 struct GaugeHRollOnStartTime : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "GaugeHRollOnStartTime"; }
   using option_tags = tmpl::list<OptionTags::GaugeHRollOnStart>;
 
   template <typename Metavariables>
@@ -86,7 +80,6 @@ struct GaugeHRollOnStartTime : db::SimpleTag {
  */
 struct GaugeHRollOnTimeWindow : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "GaugeHRollOnTimeWindow"; }
   using option_tags = tmpl::list<OptionTags::GaugeHRollOnWindow>;
 
   template <typename Metavariables>
@@ -111,7 +104,6 @@ struct GaugeHRollOnTimeWindow : db::SimpleTag {
 template <typename Frame>
 struct GaugeHSpatialWeightDecayWidth : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "GaugeHSpatialWeightDecayWidth"; }
   using option_tags = tmpl::list<OptionTags::GaugeHSpatialDecayWidth<Frame>>;
 
   template <typename Metavariables>
@@ -132,7 +124,6 @@ struct GaugeHSpatialWeightDecayWidth : db::SimpleTag {
 template <size_t Dim, typename Frame>
 struct GaugeH : db::SimpleTag {
   using type = tnsr::a<DataVector, Dim, Frame>;
-  static std::string name() noexcept { return "GaugeH"; }
 };
 
 /*!
@@ -147,7 +138,6 @@ struct GaugeH : db::SimpleTag {
 template <size_t Dim, typename Frame>
 struct SpacetimeDerivGaugeH : db::SimpleTag {
   using type = tnsr::ab<DataVector, Dim, Frame>;
-  static std::string name() noexcept { return "SpacetimeDerivGaugeH"; }
 };
 
 /*!
@@ -163,7 +153,6 @@ struct SpacetimeDerivGaugeH : db::SimpleTag {
 template <size_t Dim, typename Frame>
 struct InitialGaugeH : db::SimpleTag {
   using type = tnsr::a<DataVector, Dim, Frame>;
-  static std::string name() noexcept { return "InitialGaugeH"; }
 };
 
 /*!
@@ -179,7 +168,6 @@ struct InitialGaugeH : db::SimpleTag {
 template <size_t Dim, typename Frame>
 struct SpacetimeDerivInitialGaugeH : db::SimpleTag {
   using type = tnsr::ab<DataVector, Dim, Frame>;
-  static std::string name() noexcept { return "SpacetimeDerivInitialGaugeH"; }
 };
 
 // @{
@@ -191,36 +179,30 @@ struct SpacetimeDerivInitialGaugeH : db::SimpleTag {
 template <size_t Dim, typename Frame>
 struct UPsi : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame>;
-  static std::string name() noexcept { return "UPsi"; }
 };
 template <size_t Dim, typename Frame>
 struct UZero : db::SimpleTag {
   using type = tnsr::iaa<DataVector, Dim, Frame>;
-  static std::string name() noexcept { return "UZero"; }
 };
 template <size_t Dim, typename Frame>
 struct UPlus : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame>;
-  static std::string name() noexcept { return "UPlus"; }
 };
 template <size_t Dim, typename Frame>
 struct UMinus : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame>;
-  static std::string name() noexcept { return "UMinus"; }
 };
 // @}
 
 template <size_t Dim, typename Frame>
 struct CharacteristicSpeeds : db::SimpleTag {
   using type = std::array<DataVector, 4>;
-  static std::string name() noexcept { return "CharacteristicSpeeds"; }
 };
 
 template <size_t Dim, typename Frame>
 struct CharacteristicFields : db::SimpleTag {
   using type = Variables<tmpl::list<UPsi<Dim, Frame>, UZero<Dim, Frame>,
                                     UPlus<Dim, Frame>, UMinus<Dim, Frame>>>;
-  static std::string name() noexcept { return "CharacteristicFields"; }
 };
 
 template <size_t Dim, typename Frame>
@@ -228,9 +210,6 @@ struct EvolvedFieldsFromCharacteristicFields : db::SimpleTag {
   using type =
       Variables<tmpl::list<gr::Tags::SpacetimeMetric<Dim, Frame, DataVector>,
                            Pi<Dim, Frame>, Phi<Dim, Frame>>>;
-  static std::string name() noexcept {
-    return "EvolvedFieldsFromCharacteristicFields";
-  }
 };
 
 /*!
@@ -244,37 +223,31 @@ struct EvolvedFieldsFromCharacteristicFields : db::SimpleTag {
 template <size_t SpatialDim, typename Frame>
 struct GaugeConstraint : db::SimpleTag {
   using type = tnsr::a<DataVector, SpatialDim, Frame>;
-  static std::string name() noexcept { return "GaugeConstraint"; }
 };
 /// \copydoc GaugeConstraint
 template <size_t SpatialDim, typename Frame>
 struct FConstraint : db::SimpleTag {
   using type = tnsr::a<DataVector, SpatialDim, Frame>;
-  static std::string name() noexcept { return "FConstraint"; }
 };
 /// \copydoc GaugeConstraint
 template <size_t SpatialDim, typename Frame>
 struct TwoIndexConstraint : db::SimpleTag {
   using type = tnsr::ia<DataVector, SpatialDim, Frame>;
-  static std::string name() noexcept { return "TwoIndexConstraint"; }
 };
 /// \copydoc GaugeConstraint
 template <size_t SpatialDim, typename Frame>
 struct ThreeIndexConstraint : db::SimpleTag {
   using type = tnsr::iaa<DataVector, SpatialDim, Frame>;
-  static std::string name() noexcept { return "ThreeIndexConstraint"; }
 };
 /// \copydoc GaugeConstraint
 template <size_t SpatialDim, typename Frame>
 struct FourIndexConstraint : db::SimpleTag {
   using type = tnsr::iaa<DataVector, SpatialDim, Frame>;
-  static std::string name() noexcept { return "FourIndexConstraint"; }
 };
 /// \copydoc GaugeConstraint
 template <size_t SpatialDim, typename Frame>
 struct ConstraintEnergy : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "ConstraintEnergy"; }
 };
 }  // namespace Tags
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
@@ -130,6 +130,7 @@ namespace Tags {
 template <typename EquationOfStateType>
 struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds,
                                      db::ComputeTag {
+  using base = Tags::CharacteristicSpeeds;
   using argument_tags =
       tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
                  hydro::Tags::SpecificInternalEnergy<DataVector>,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
@@ -25,19 +25,16 @@ namespace Tags {
 /// The characteristic speeds
 struct CharacteristicSpeeds : db::SimpleTag {
   using type = std::array<DataVector, 9>;
-  static std::string name() noexcept { return "CharacteristicSpeeds"; }
 };
 
 /// The densitized rest-mass density \f${\tilde D}\f$
 struct TildeD : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "TildeD"; }
 };
 
 /// The densitized energy density \f${\tilde \tau}\f$
 struct TildeTau : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "TildeTau"; }
 };
 
 /// The densitized momentum density \f${\tilde S_i}\f$
@@ -57,7 +54,6 @@ struct TildeB : db::SimpleTag {
 /// The densitized divergence-cleaning field \f${\tilde \Phi}\f$
 struct TildePhi : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "TildePhi"; }
 };
 
 }  // namespace Tags
@@ -84,7 +80,6 @@ struct DampingParameter {
 namespace Tags {
 /// The constraint damping parameter for divergence cleaning
 struct ConstraintDampingParameter : db::SimpleTag {
-  static std::string name() noexcept { return "ConstraintDampingParameter"; }
   using type = double;
   using option_tags = tmpl::list<OptionTags::DampingParameter>;
 

--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
@@ -118,6 +118,7 @@ namespace Tags {
 
 template <size_t Dim>
 struct CharacteristicSpeedsCompute : CharacteristicSpeeds<Dim>, db::ComputeTag {
+  using base =  CharacteristicSpeeds<Dim>;
   using argument_tags =
       tmpl::list<Velocity<DataVector, Dim>, SoundSpeed<DataVector>,
                  ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;

--- a/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp
@@ -36,6 +36,7 @@ namespace Tags {
 /// Can be retrieved using `NewtonianEuler::Tags::SoundSpeedSquared`
 template <typename DataType>
 struct SoundSpeedSquaredCompute : SoundSpeedSquared<DataType>, db::ComputeTag {
+  using base = SoundSpeedSquared<DataType>;
   template <typename EquationOfStateType>
   static Scalar<DataType> function(
       const Scalar<DataType>& mass_density,
@@ -54,6 +55,7 @@ struct SoundSpeedSquaredCompute : SoundSpeedSquared<DataType>, db::ComputeTag {
 /// Can be retrieved using `NewtonianEuler::Tags::SoundSpeed`
 template <typename DataType>
 struct SoundSpeedCompute : SoundSpeed<DataType>, db::ComputeTag {
+  using base = SoundSpeed<DataType>;
   static Scalar<DataType> function(
       const Scalar<DataType>& sound_speed_squared) noexcept {
     return Scalar<DataType>{sqrt(get(sound_speed_squared))};

--- a/src/Evolution/Systems/NewtonianEuler/Tags.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Tags.hpp
@@ -21,21 +21,18 @@ namespace Tags {
 template <size_t Dim>
 struct CharacteristicSpeeds : db::SimpleTag {
   using type = std::array<DataVector, Dim + 2>;
-  static std::string name() noexcept { return "CharacteristicSpeeds"; }
 };
 
 /// The mass density of the fluid.
 template <typename DataType>
 struct MassDensity : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "MassDensity"; }
 };
 
 /// The mass density of the fluid (as a conservative variable).
 template <typename DataType>
 struct MassDensityCons : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "MassDensityCons"; }
 };
 
 /// The momentum density of the fluid.
@@ -51,7 +48,6 @@ struct MomentumDensity : db::SimpleTag {
 template <typename DataType>
 struct EnergyDensity : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "EnergyDensity"; }
 };
 
 /// The macroscopic or flow velocity of the fluid.
@@ -67,32 +63,28 @@ struct Velocity : db::SimpleTag {
 template <typename DataType>
 struct SpecificInternalEnergy : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "SpecificInternalEnergy"; }
 };
 
 /// The fluid pressure.
 template <typename DataType>
 struct Pressure : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "Pressure"; }
 };
 
 /// The sound speed.
 template <typename DataType>
 struct SoundSpeed : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "SoundSpeed"; }
 };
 
 /// The square of the sound speed.
 template <typename DataType>
 struct SoundSpeedSquared : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "SoundSpeedSquared"; }
 };
 
 /// Base tag for the source term
-struct SourceTermBase {};
+struct SourceTermBase : db::BaseTag {};
 
 /// The source term in the evolution equations
 template <typename InitialDataType>
@@ -102,7 +94,6 @@ struct SourceTerm : SourceTermBase, db::SimpleTag {
       tmpl::conditional_t<evolution::is_analytic_solution_v<InitialDataType>,
                           ::OptionTags::AnalyticSolution<InitialDataType>,
                           ::OptionTags::AnalyticData<InitialDataType>>>;
-  static std::string name() noexcept { return "SourceTerm"; }
 
   template <typename Metavariables>
   static type create_from_options(

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY M1Grey)
 
 set(LIBRARY_SOURCES
+  Characteristics.cpp
   Fluxes.cpp
   M1Closure.cpp
   Sources.cpp

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Characteristics.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Characteristics.cpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/RadiationTransport/M1Grey/Characteristics.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace RadiationTransport {
+namespace M1Grey {
+
+void characteristic_speeds(
+    const gsl::not_null<std::array<DataVector, 4>*> pchar_speeds,
+    const Scalar<DataVector>& lapse) noexcept {
+  const size_t num_grid_points = get(lapse).size();
+  auto& char_speeds = *pchar_speeds;
+  if (char_speeds[0].size() != num_grid_points) {
+    char_speeds[0] = DataVector(num_grid_points);
+  }
+  char_speeds[0] = 1.;
+  if (char_speeds[1].size() != num_grid_points) {
+    char_speeds[1] = DataVector(num_grid_points);
+  }
+  char_speeds[1] = -1.;
+  for (size_t i = 2; i < 4; i++) {
+    gsl::at(char_speeds, i) = char_speeds[0];
+  }
+}
+}  // namespace M1Grey
+}  // namespace RadiationTransport

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Characteristics.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Characteristics.hpp
@@ -52,6 +52,7 @@ namespace Tags {
 ///
 struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds,
                                      db::ComputeTag {
+  using base = Tags::CharacteristicSpeeds;
   using argument_tags = tmpl::list<gr::Tags::Lapse<>>;
 
   using return_type = std::array<DataVector, 4>;

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Characteristics.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Characteristics.hpp
@@ -10,17 +10,19 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"  // IWYU pragma: keep
-#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
 class DataVector;
 /// \endcond
 
 namespace RadiationTransport {
 namespace M1Grey {
 
-// @{
 /*!
  * \brief Compute the characteristic speeds for the M1 system
  *
@@ -29,23 +31,8 @@ namespace M1Grey {
  * use the correct speed values.
  */
 void characteristic_speeds(
-    const gsl::not_null<std::array<DataVector, 4>*> pchar_speeds,
-    const Scalar<DataVector>& lapse) noexcept {
-  const size_t num_grid_points = get(lapse).size();
-  auto& char_speeds = *pchar_speeds;
-  if (char_speeds[0].size() != num_grid_points) {
-    char_speeds[0] = DataVector(num_grid_points);
-  }
-  char_speeds[0] = 1.;
-  if (char_speeds[1].size() != num_grid_points) {
-    char_speeds[1] = DataVector(num_grid_points);
-  }
-  char_speeds[1] = -1.;
-  for (size_t i = 2; i < 4; i++) {
-    char_speeds[i] = char_speeds[0];
-  }
-}
-// @}
+    gsl::not_null<std::array<DataVector, 4>*> pchar_speeds,
+    const Scalar<DataVector>& lapse) noexcept;
 
 namespace Tags {
 /// \brief Compute the characteristic speeds for the M1 system

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp
@@ -23,7 +23,6 @@ namespace Tags {
 /// The characteristic speeds
 struct CharacteristicSpeeds : db::SimpleTag {
   using type = std::array<DataVector, 4>;
-  static std::string name() noexcept { return "CharacteristicSpeeds"; }
 };
 
 /// The densitized energy density of neutrinos of a given species

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Characteristics.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Characteristics.hpp
@@ -79,6 +79,7 @@ namespace Tags {
 template <size_t Dim>
 struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim>,
                                      db::ComputeTag {
+  using base = Tags::CharacteristicSpeeds<Dim>;
   using argument_tags =
       tmpl::list<gr::Tags::Lapse<>, gr::Tags::Shift<Dim>,
                  gr::Tags::SpatialMetric<Dim>,

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp
@@ -22,19 +22,16 @@ namespace Tags {
 template <size_t Dim>
 struct CharacteristicSpeeds : db::SimpleTag {
   using type = std::array<DataVector, Dim + 2>;
-  static std::string name() noexcept { return "CharacteristicSpeeds"; }
 };
 
 /// The densitized rest-mass density \f${\tilde D}\f$
 struct TildeD : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "TildeD"; }
 };
 
 /// The densitized energy density \f${\tilde \tau}\f$
 struct TildeTau : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "TildeTau"; }
 };
 
 /// The densitized momentum density \f${\tilde S_i}\f$

--- a/src/Executables/Benchmark/Benchmark.cpp
+++ b/src/Executables/Benchmark/Benchmark.cpp
@@ -86,11 +86,12 @@ void bench_all_gradient(benchmark::State& state) {  // NOLINT
   constexpr const size_t Dim = 3;
   const Mesh<Dim> mesh{pts_1d, Spectral::Basis::Legendre,
                        Spectral::Quadrature::GaussLobatto};
-  CoordinateMaps::Affine map1d(-1.0, 1.0, -1.0, 1.0);
-  using Map3d = CoordinateMaps::ProductOf3Maps<CoordinateMaps::Affine,
-                                               CoordinateMaps::Affine,
-                                               CoordinateMaps::Affine>;
-  CoordinateMap<Frame::Logical, Frame::Grid, Map3d> map(
+  domain::CoordinateMaps::Affine map1d(-1.0, 1.0, -1.0, 1.0);
+  using Map3d =
+      domain::CoordinateMaps::ProductOf3Maps<domain::CoordinateMaps::Affine,
+                                             domain::CoordinateMaps::Affine,
+                                             domain::CoordinateMaps::Affine>;
+  domain::CoordinateMap<Frame::Logical, Frame::Grid, Map3d> map(
       Map3d{map1d, map1d, map1d});
 
   using VarTags = tmpl::list<Kappa<Dim>, Psi<Dim>>;

--- a/src/Executables/Benchmark/Benchmark.cpp
+++ b/src/Executables/Benchmark/Benchmark.cpp
@@ -74,12 +74,10 @@ namespace {
 template <size_t Dim>
 struct Kappa : db::SimpleTag {
   using type = tnsr::abb<DataVector, Dim, Frame::Grid>;
-  static std::string name() noexcept { return "Kappa"; }
 };
 template <size_t Dim>
 struct Psi : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame::Grid>;
-  static std::string name() noexcept { return "Psi"; }
 };
 
 // clang-tidy: don't pass be non-const reference

--- a/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
+++ b/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
@@ -30,7 +30,6 @@ struct Name {
 namespace Tags {
 struct Name : db::SimpleTag {
   using type = std::string;
-  static std::string name() noexcept { return "Name"; }
   using option_tags = tmpl::list<OptionTags::Name>;
 
   template <typename Metavariables>

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -26,26 +26,22 @@ namespace Tags {
 struct NumberOfEvents : db::SimpleTag {
   using type =
       std::unordered_map<ArrayComponentId, std::unique_ptr<std::atomic_int>>;
-  static std::string name() noexcept { return "NumberOfEvents"; }
 };
 
 /// All the ids of all the components registered to an observer for doing
 /// reduction observations.
 struct ReductionArrayComponentIds : db::SimpleTag {
   using type = std::unordered_set<ArrayComponentId>;
-  static std::string name() noexcept { return "ReductionArrayComponentIds"; }
 };
 
 /// All the ids of all the components registered to an observer for doing
 /// volume observations.
 struct VolumeArrayComponentIds : db::SimpleTag {
   using type = std::unordered_set<ArrayComponentId>;
-  static std::string name() noexcept { return "VolumeArrayComponentIds"; }
 };
 
 /// Volume tensor data to be written to disk.
 struct TensorData : db::SimpleTag {
-  static std::string name() noexcept { return "TensorData"; }
   using type =
       std::unordered_map<observers::ObservationId,
                          std::unordered_map<observers::ArrayComponentId,
@@ -60,7 +56,6 @@ struct ReductionDataNames;
 /// Reduction data to be written to disk.
 template <class... ReductionDatums>
 struct ReductionData : db::SimpleTag {
-  static std::string name() noexcept { return "ReductionData"; }
   using type = std::unordered_map<observers::ObservationId,
                                   Parallel::ReductionData<ReductionDatums...>>;
   using names_tag = ReductionDataNames<ReductionDatums...>;
@@ -69,7 +64,6 @@ struct ReductionData : db::SimpleTag {
 /// Names of the reduction data to be written to disk.
 template <class... ReductionDatums>
 struct ReductionDataNames : db::SimpleTag {
-  static std::string name() noexcept { return "ReductionDataNames"; }
   using type =
       std::unordered_map<observers::ObservationId, std::vector<std::string>>;
   using data_tag = ReductionData<ReductionDatums...>;
@@ -80,14 +74,12 @@ struct ReductionDataNames : db::SimpleTag {
 /// The key of the map is the `observation_type_hash` of the `ObservationId`.
 /// The set contains all the processing elements it has registered on.
 struct VolumeObserversRegistered : db::SimpleTag {
-  static std::string name() noexcept { return "VolumeObserversRegistered"; }
   using type = std::unordered_map<size_t, std::set<size_t>>;
 };
 
 /// The number of observer components that have contributed data at the
 /// observation ids.
 struct VolumeObserversContributed : db::SimpleTag {
-  static std::string name() noexcept { return "VolumeObserversContributed"; }
   using type = std::unordered_map<observers::ObservationId, size_t>;
 };
 
@@ -101,7 +93,6 @@ struct VolumeObserversContributed : db::SimpleTag {
 /// Observer group will call the local ObserverWriter nodegroup during
 /// a reduction.
 struct ReductionObserversRegistered : db::SimpleTag {
-  static std::string name() noexcept { return "ReductionObserversRegistered"; }
   using type = std::unordered_map<size_t, std::set<size_t>>;
 };
 
@@ -109,16 +100,12 @@ struct ReductionObserversRegistered : db::SimpleTag {
 /// The key of the map is the `observation_type_hash` of the `ObservationId`.
 /// The set contains all the nodes that have been registered.
 struct ReductionObserversRegisteredNodes : db::SimpleTag {
-  static std::string name() noexcept {
-    return "ReductionObserversRegisteredNodes";
-  }
   using type = std::unordered_map<size_t, std::set<size_t>>;
 };
 
 /// The number of observer components that have contributed data at the
 /// observation ids.
 struct ReductionObserversContributed : db::SimpleTag {
-  static std::string name() noexcept { return "ReductionObserversContributed"; }
   using type = std::unordered_map<observers::ObservationId, size_t>;
 };
 
@@ -128,7 +115,6 @@ struct ReductionObserversContributed : db::SimpleTag {
 /// require a thread-safe HDF5 installation. In the future we will need to
 /// experiment with different HDF5 configurations.
 struct H5FileLock : db::SimpleTag {
-  static std::string name() noexcept { return "H5FileLock"; }
   using type = CmiNodeLock;
 };
 }  // namespace Tags
@@ -164,7 +150,6 @@ struct ReductionFileName {
 
 namespace Tags {
 struct VolumeFileName : db::SimpleTag {
-  static std::string name() noexcept { return "VolumeFileName"; }
   using type = std::string;
   using option_tags = tmpl::list<::observers::OptionTags::VolumeFileName>;
 
@@ -176,7 +161,6 @@ struct VolumeFileName : db::SimpleTag {
 };
 
 struct ReductionFileName : db::SimpleTag {
-  static std::string name() noexcept { return "ReductionFileName"; }
   using type = std::string;
   using option_tags = tmpl::list<::observers::OptionTags::ReductionFileName>;
 

--- a/src/Informer/Tags.hpp
+++ b/src/Informer/Tags.hpp
@@ -25,7 +25,6 @@ namespace Tags {
 /// \ingroup LoggingGroup
 /// \brief Tag for putting `::Verbosity` in a DataBox.
 struct Verbosity : db::SimpleTag {
-  static std::string name() noexcept { return "Verbosity"; }
   using type = ::Verbosity;
   using option_tags = tmpl::list<OptionTags::Verbosity>;
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -45,7 +45,6 @@ struct Mortars : db::PrefixTag, db::SimpleTag {
 /// of the face that it covers.
 template <size_t Dim>
 struct MortarSize : db::SimpleTag {
-  static std::string name() noexcept { return "MortarSize"; }
   using type = std::array<Spectral::MortarSize, Dim>;
 };
 }  // namespace Tags
@@ -82,7 +81,6 @@ namespace Tags {
  */
 template <typename NumericalFluxType>
 struct NumericalFlux : db::SimpleTag {
-  static std::string name() noexcept { return "NumericalFlux"; }
   using type = NumericalFluxType;
   using option_tags =
       tmpl::list<::OptionTags::NumericalFlux<NumericalFluxType>>;

--- a/src/NumericalAlgorithms/Interpolation/Tags.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Tags.hpp
@@ -14,6 +14,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/Mesh.hpp"
 #include "NumericalAlgorithms/Interpolation/InterpolatedVars.hpp"
+#include "Options/Options.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
 /// \cond
@@ -40,7 +41,6 @@ namespace Tags {
 
 /// Keeps track of which points have been filled with interpolated data.
 struct IndicesOfFilledInterpPoints : db::SimpleTag {
-  static std::string name() noexcept { return "IndicesOfFilledInterpPoints"; }
   using type = std::unordered_set<size_t>;
 };
 
@@ -51,7 +51,6 @@ struct IndicesOfFilledInterpPoints : db::SimpleTag {
 /// cases one might wish to fill these points with a default value or
 /// take some other action.
 struct IndicesOfInvalidInterpPoints : db::SimpleTag {
-  static std::string name() noexcept { return "IndicesOfInvalidInterpPoints"; }
   using type = std::unordered_set<size_t>;
 };
 
@@ -59,7 +58,6 @@ struct IndicesOfInvalidInterpPoints : db::SimpleTag {
 template <typename Metavariables>
 struct TemporalIds : db::SimpleTag {
   using type = std::deque<typename Metavariables::temporal_id::type>;
-  static std::string name() noexcept { return "TemporalIds"; }
 };
 
 /// `temporal_id`s that we have already interpolated onto.
@@ -68,7 +66,6 @@ struct TemporalIds : db::SimpleTag {
 template <typename Metavariables>
 struct CompletedTemporalIds : db::SimpleTag {
   using type = std::deque<typename Metavariables::temporal_id::type>;
-  static std::string name() noexcept { return "CompletedTemporalIds"; }
 };
 
 /// Volume variables at all `temporal_id`s for all local `Element`s.
@@ -86,7 +83,6 @@ struct VolumeVarsInfo : db::SimpleTag {
   using type = std::unordered_map<
       typename Metavariables::temporal_id::type,
       std::unordered_map<ElementId<Metavariables::volume_dim>, Info>>;
-  static std::string name() noexcept { return "VolumeVarsInfo"; }
 };
 
 namespace holders_detail {
@@ -106,12 +102,10 @@ struct InterpolatedVarsHolders : db::SimpleTag {
   using type = tuples::tagged_tuple_from_typelist<db::wrap_tags_in<
       holders_detail::WrappedHolderTag,
       typename Metavariables::interpolation_target_tags, Metavariables>>;
-  static std::string name() noexcept { return "InterpolatedVarsHolders"; }
 };
 
 /// Number of local `Element`s.
 struct NumberOfElements : db::SimpleTag {
-  static std::string name() noexcept { return "NumberOfElements"; }
   using type = size_t;
 };
 

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -33,8 +33,6 @@ struct Mesh;
 /// Prefix indicating the divergence of a Tensor or that a Variables
 /// contains divergences of Tensors.
 ///
-/// \snippet LinearOperators/Test_Divergence.cpp divergence_name
-///
 /// \see Tags::DivCompute
 template <typename Tag, typename = std::nullptr_t>
 struct div;
@@ -43,7 +41,9 @@ struct div;
 template <typename Tag>
 struct div<Tag, Requires<tt::is_a_v<Tensor, db::const_item_type<Tag>>>>
     : db::PrefixTag, db::SimpleTag {
-  static std::string name() noexcept { return "div(" + Tag::name() + ")"; }
+  static std::string name() noexcept {
+    return "div(" + db::tag_name<Tag>() + ")";
+  }
   using tag = Tag;
   using type =
       TensorMetafunctions::remove_first_index<db::const_item_type<Tag>>;
@@ -52,7 +52,9 @@ struct div<Tag, Requires<tt::is_a_v<Tensor, db::const_item_type<Tag>>>>
 template <typename Tag>
 struct div<Tag, Requires<tt::is_a_v<::Variables, db::const_item_type<Tag>>>>
     : db::PrefixTag, db::SimpleTag {
-  static std::string name() noexcept { return "div(" + Tag::name() + ")"; }
+  static std::string name() noexcept {
+    return "div(" + db::tag_name<Tag>() + ")";
+  }
   using tag = Tag;
   using type = db::const_item_type<Tag>;
 };

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -52,7 +52,9 @@ struct deriv<Tag, Dim, Frame,
       TensorMetafunctions::prepend_spatial_index<db::const_item_type<Tag>,
                                                  Dim::value, UpLo::Lo, Frame>;
   using tag = Tag;
-  static std::string name() noexcept { return "deriv(" + Tag::name() + ")"; }
+  static std::string name() noexcept {
+    return "deriv(" + db::tag_name<Tag>() + ")";
+  }
 };
 template <typename Tag, typename Dim, typename Frame>
 struct deriv<Tag, Dim, Frame,
@@ -60,7 +62,9 @@ struct deriv<Tag, Dim, Frame,
     : db::PrefixTag, db::SimpleTag {
   using type = db::const_item_type<Tag>;
   using tag = Tag;
-  static std::string name() noexcept { return "deriv(" + Tag::name() + ")"; }
+  static std::string name() noexcept {
+    return "deriv(" + db::tag_name<Tag>() + ")";
+  }
 };
 
 /*!

--- a/src/NumericalAlgorithms/Spectral/SwshTags.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTags.hpp
@@ -186,7 +186,6 @@ struct SwshTransform : db::PrefixTag, db::SimpleTag {
 /// resolution.
 struct LMax : db::SimpleTag {
   using type = size_t;
-  static std::string name() noexcept { return "LMax"; }
 };
 
 /// \ingroup SwshGroup
@@ -194,7 +193,6 @@ struct LMax : db::SimpleTag {
 /// representation of radially concentric spherical shells
 struct NumberOfRadialPoints : db::SimpleTag {
   using type = size_t;
-  static std::string name() noexcept { return "NumberOfRadialPoints"; }
 };
 
 /// \ingroup SwshGroup

--- a/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
@@ -159,7 +159,7 @@ class ObserveErrorNorms<ObservationValueTag, tmpl::list<Tensors...>,
         std::string{"/element_data"},
         std::vector<std::string>{db::tag_name<ObservationValueTag>(),
                                  "NumberOfPoints",
-                                 ("Error(" + Tensors::name() + ")")...},
+                                 ("Error(" + db::tag_name<Tensors>() + ")")...},
         ReductionData{
             static_cast<double>(observation_value), num_points,
             std::move(get<LocalSquareError<Tensors>>(local_square_errors))...});

--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -122,7 +122,9 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
   struct VariablesToObserve {
     static constexpr OptionString help = "Subset of variables to observe";
     using type = std::vector<std::string>;
-    static type default_value() noexcept { return {Tensors::name()...}; }
+    static type default_value() noexcept {
+      return {db::tag_name<Tensors>()...};
+    }
     static size_t lower_bound_on_size() noexcept { return 1; }
   };
 
@@ -145,13 +147,14 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
                          const OptionContext& context = {})
       : variables_to_observe_(variables_to_observe.begin(),
                               variables_to_observe.end()) {
-    const std::unordered_set<std::string> valid_tensors{Tensors::name()...};
+    const std::unordered_set<std::string> valid_tensors{
+        db::tag_name<Tensors>()...};
     for (const auto& name : variables_to_observe_) {
       if (valid_tensors.count(name) != 1) {
         PARSE_ERROR(
             context,
             name << " is not an available variable.  Available variables:\n"
-                 << (std::vector<std::string>{Tensors::name()...}));
+                 << (std::vector<std::string>{db::tag_name<Tensors>()...}));
       }
       if (alg::count(variables_to_observe, name) != 1) {
         PARSE_ERROR(context, name << " specified multiple times");
@@ -197,11 +200,11 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
     const auto record_tensor_components = [ this, &components, &element_name ](
         const auto tensor_tag_v, const auto& tensor) noexcept {
       using tensor_tag = tmpl::type_from<decltype(tensor_tag_v)>;
-      if (variables_to_observe_.count(tensor_tag::name()) == 1) {
+      if (variables_to_observe_.count(db::tag_name<tensor_tag>()) == 1) {
         for (size_t i = 0; i < tensor.size(); ++i) {
-          components.emplace_back(
-              element_name + tensor_tag::name() + component_suffix(tensor, i),
-              tensor[i]);
+          components.emplace_back(element_name + db::tag_name<tensor_tag>() +
+                                      component_suffix(tensor, i),
+                                  tensor[i]);
         }
       }
     };
@@ -216,11 +219,12 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
         const auto tensor_tag_v, const auto& tensor,
         const auto& analytic_tensor) noexcept {
       using tensor_tag = tmpl::type_from<decltype(tensor_tag_v)>;
-      if (variables_to_observe_.count(tensor_tag::name()) == 1) {
+      if (variables_to_observe_.count(db::tag_name<tensor_tag>()) == 1) {
         for (size_t i = 0; i < tensor.size(); ++i) {
           DataVector error = tensor[i] - analytic_tensor[i];
-          components.emplace_back(element_name + "Error(" + tensor_tag::name() +
-                                      ")" + component_suffix(tensor, i),
+          components.emplace_back(element_name + "Error(" +
+                                      db::tag_name<tensor_tag>() + ")" +
+                                      component_suffix(tensor, i),
                                   std::move(error));
         }
       }

--- a/src/PointwiseFunctions/AnalyticData/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Tags.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/Serialize.hpp"
 
@@ -38,7 +39,6 @@ struct AnalyticDataBase : AnalyticSolutionOrData {};
 /// template parameter
 template <typename DataType>
 struct AnalyticData : AnalyticDataBase, db::SimpleTag {
-  static std::string name() noexcept { return "AnalyticData"; }
   using type = DataType;
   using option_tags = tmpl::list<::OptionTags::AnalyticData<DataType>>;
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/Serialize.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
@@ -48,7 +49,6 @@ struct BoundaryConditionBase : db::BaseTag {};
 /// template parameter
 template <typename SolutionType>
 struct AnalyticSolution : AnalyticSolutionBase, db::SimpleTag {
-  static std::string name() noexcept { return "AnalyticSolution"; }
   using type = SolutionType;
   using option_tags = tmpl::list<::OptionTags::AnalyticSolution<SolutionType>>;
 
@@ -62,7 +62,6 @@ struct AnalyticSolution : AnalyticSolutionBase, db::SimpleTag {
 /// The boundary condition to be applied at all external boundaries.
 template <typename BoundaryConditionType>
 struct BoundaryCondition : BoundaryConditionBase, db::SimpleTag {
-  static std::string name() noexcept { return "BoundaryCondition"; }
   using type = BoundaryConditionType;
   using option_tags =
       tmpl::list<::OptionTags::BoundaryCondition<BoundaryConditionType>>;

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
@@ -47,6 +47,7 @@ struct RicciTensorCompute : RicciTensor<SpatialDim, Frame, DataType>,
       const tnsr::Ijj<DataType, SpatialDim, Frame>&,
       const tnsr::iJkk<DataType, SpatialDim, Frame>&) =
       &ricci_tensor<SpatialDim, Frame, IndexType::Spatial, DataType>;
+  using base = RicciTensor<SpatialDim, Frame, DataType>;
 };
 }  // namespace Tags
 } // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -16,18 +16,15 @@ namespace Tags {
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeMetric : db::SimpleTag {
   using type = tnsr::aa<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "SpacetimeMetric"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct InverseSpacetimeMetric : db::SimpleTag {
   using type = tnsr::AA<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "InverseSpacetimeMetric"; }
 };
 
 template <size_t Dim, typename Frame, typename DataType>
 struct SpatialMetric : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "SpatialMetric"; }
 };
 /*!
  * \brief Inverse of the spatial metric.
@@ -35,7 +32,6 @@ struct SpatialMetric : db::SimpleTag {
 template <size_t Dim, typename Frame, typename DataType>
 struct InverseSpatialMetric : db::SimpleTag {
   using type = tnsr::II<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "InverseSpatialMetric"; }
 };
 /*!
  * \brief Determinant of the spatial metric.
@@ -43,22 +39,18 @@ struct InverseSpatialMetric : db::SimpleTag {
 template <typename DataType>
 struct DetSpatialMetric : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "DetSpatialMetric"; }
 };
 template <typename DataType>
 struct SqrtDetSpatialMetric : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "SqrtDetSpatialMetric"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct Shift : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "Shift"; }
 };
 template <typename DataType>
 struct Lapse : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "Lapse"; }
 };
 /*!
  * \brief Spacetime derivatives of the spacetime metric
@@ -70,7 +62,6 @@ struct Lapse : db::SimpleTag {
 template <size_t Dim, typename Frame, typename DataType>
 struct DerivSpacetimeMetric : db::SimpleTag {
   using type = tnsr::iaa<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "DerivSpacetimeMetric"; }
 };
 /*!
  * \brief Spacetime derivatives of the spacetime metric
@@ -82,46 +73,34 @@ struct DerivSpacetimeMetric : db::SimpleTag {
 template <size_t Dim, typename Frame, typename DataType>
 struct DerivativesOfSpacetimeMetric : db::SimpleTag {
   using type = tnsr::abb<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "DerivativesOfSpacetimeMetric"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::abb<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "SpacetimeChristoffelFirstKind"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::Abb<DataType, Dim, Frame>;
-  static std::string name() noexcept {
-    return "SpacetimeChristoffelSecondKind";
-  }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SpatialChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::ijj<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "SpatialChristoffelFirstKind"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SpatialChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::Ijj<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "SpatialChristoffelSecondKind"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeNormalOneForm : db::SimpleTag {
   using type = tnsr::a<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "SpacetimeNormalOneForm"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeNormalVector : db::SimpleTag {
   using type = tnsr::A<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "SpacetimeNormalVector"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct TraceSpacetimeChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::a<DataType, Dim, Frame>;
-  static std::string name() noexcept {
-    return "TraceSpacetimeChristoffelFirstKind";
-  }
 };
 /*!
  * \brief Trace of the spatial Christoffel symbols of the first kind
@@ -132,27 +111,19 @@ struct TraceSpacetimeChristoffelFirstKind : db::SimpleTag {
 template <size_t Dim, typename Frame, typename DataType>
 struct TraceSpatialChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::i<DataType, Dim, Frame>;
-  static std::string name() noexcept {
-    return "TraceSpatialChristoffelFirstKind";
-  }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct TraceSpatialChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
-  static std::string name() noexcept {
-    return "TraceSpatialChristoffelSecondKind";
-  }
 };
 
 template <size_t Dim, typename Frame, typename DataType>
 struct ExtrinsicCurvature : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "ExtrinsicCurvature"; }
 };
 template <typename DataType>
 struct TraceExtrinsicCurvature : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "TraceExtrinsicCurvature"; }
 };
 
 /*!
@@ -163,7 +134,6 @@ struct TraceExtrinsicCurvature : db::SimpleTag {
 template <size_t Dim, typename Frame, typename DataType>
 struct RicciTensor : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "RicciTensor"; }
 };
 
 /*!
@@ -173,7 +143,6 @@ struct RicciTensor : db::SimpleTag {
 template <typename DataType>
 struct EnergyDensity : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "EnergyDensity"; }
 };
 
 /*!
@@ -185,7 +154,6 @@ struct EnergyDensity : db::SimpleTag {
 template <size_t Dim, typename Frame, typename DataType>
 struct WeylElectric : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "WeylElectric"; }
 };
 }  // namespace Tags
 

--- a/src/PointwiseFunctions/GeneralRelativity/WeylElectric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylElectric.hpp
@@ -58,6 +58,7 @@ struct WeylElectricCompute : WeylElectric<SpatialDim, Frame, DataType>,
       gr::Tags::RicciTensor<SpatialDim, Frame, DataType>,
       gr::Tags::ExtrinsicCurvature<SpatialDim, Frame, DataType>,
       gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  using base = WeylElectric<SpatialDim, Frame, DataType>;
 };
 }  // namespace Tags
 }  // namespace gr

--- a/src/PointwiseFunctions/Hydro/LorentzFactor.hpp
+++ b/src/PointwiseFunctions/Hydro/LorentzFactor.hpp
@@ -32,6 +32,7 @@ struct LorentzFactorCompute : LorentzFactor<DataType>, db::ComputeTag {
   static constexpr auto function = &lorentz_factor<DataType, Dim, Fr>;
   using argument_tags = tmpl::list<SpatialVelocity<DataType, Dim, Fr>,
                                    SpatialVelocityOneForm<DataType, Dim, Fr>>;
+  using base = LorentzFactor<DataType>;
 };
 }  // namespace Tags
 }  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/MassFlux.hpp
+++ b/src/PointwiseFunctions/Hydro/MassFlux.hpp
@@ -59,6 +59,7 @@ struct MassFluxCompute : MassFlux<DataType, Dim, Frame>,
                  ::gr::Tags::Lapse<DataType>,
                  ::gr::Tags::Shift<Dim, Frame, DataType>,
                  ::gr::Tags::SqrtDetSpatialMetric<DataType>>;
+  using base = MassFlux<DataType, Dim, Frame>;
 };
 }  // namespace Tags
 }  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/SoundSpeedSquared.hpp
+++ b/src/PointwiseFunctions/Hydro/SoundSpeedSquared.hpp
@@ -55,6 +55,7 @@ struct SoundSpeedSquaredCompute : SoundSpeedSquared<DataType>, db::ComputeTag {
   using argument_tags =
       tmpl::list<RestMassDensity<DataType>, SpecificInternalEnergy<DataType>,
                  SpecificEnthalpy<DataType>, hydro::Tags::EquationOfStateBase>;
+  using base = SoundSpeedSquared<DataType>;
 };
 }  // namespace Tags
 }  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/SpecificEnthalpy.hpp
+++ b/src/PointwiseFunctions/Hydro/SpecificEnthalpy.hpp
@@ -32,6 +32,7 @@ struct SpecificEnthalpyCompute : SpecificEnthalpy<DataType>, db::ComputeTag {
   using argument_tags =
       tmpl::list<RestMassDensity<DataType>, SpecificInternalEnergy<DataType>,
                  Pressure<DataType>>;
+  using base = SpecificEnthalpy<DataType>;
 };
 }  // namespace Tags
 }  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -22,7 +22,6 @@ namespace Tags {
 template <typename DataType>
 struct AlfvenSpeedSquared : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "AlfvenSpeedSquared"; }
 };
 
 /// The magnetic field \f$b^\mu = u_\nu {}^\star\!F^{\mu \nu}\f$
@@ -43,14 +42,12 @@ struct ComovingMagneticField : db::SimpleTag {
 template <typename DataType>
 struct ComovingMagneticFieldSquared : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "ComovingMagneticFieldSquared"; }
 };
 
 /// The divergence-cleaning field \f$\Phi\f$.
 template <typename DataType>
 struct DivergenceCleaningField : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "DivergenceCleaningField"; }
 };
 
 /// Base tag for the equation of state
@@ -60,7 +57,6 @@ struct EquationOfStateBase : db::BaseTag {};
 template <typename EquationOfStateType>
 struct EquationOfState : EquationOfStateBase, db::SimpleTag {
   using type = EquationOfStateType;
-  static std::string name() noexcept { return "EquationOfState"; }
 };
 
 /// The Lorentz factor \f$W = (1-v^iv_i)^{-1/2}\f$, where \f$v^i\f$ is
@@ -68,14 +64,12 @@ struct EquationOfState : EquationOfStateBase, db::SimpleTag {
 template <typename DataType>
 struct LorentzFactor : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "LorentzFactor"; }
 };
 
 /// The square of the Lorentz factor \f$W^2\f$.
 template <typename DataType>
-struct LorentzFactorSquared {
+struct LorentzFactorSquared : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "LorentzFactorSquared"; }
 };
 
 /// The magnetic field \f$B^i = n_\mu {}^\star\!F^{i \mu}\f$ measured by an
@@ -96,9 +90,6 @@ struct MagneticField : db::SimpleTag {
 template <typename DataType>
 struct MagneticFieldDotSpatialVelocity : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept {
-    return "MagneticFieldDotSpatialVelocity";
-  }
 };
 
 /// The one-form of the magnetic field.  Note that \f$B^i\f$ is raised
@@ -116,35 +107,30 @@ struct MagneticFieldOneForm : db::SimpleTag {
 template <typename DataType>
 struct MagneticFieldSquared : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "MagneticFieldSquared"; }
 };
 
 /// The magnetic pressure \f$p_m\f$.
 template <typename DataType>
 struct MagneticPressure : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "MagneticPressure"; }
 };
 
 /// The fluid pressure \f$p\f$.
 template <typename DataType>
 struct Pressure : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "Pressure"; }
 };
 
 /// The rest-mass density \f$\rho\f$.
 template <typename DataType>
 struct RestMassDensity : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "RestMassDensity"; }
 };
 
 /// The sound speed squared \f$c_s^2\f$.
 template <typename DataType>
 struct SoundSpeedSquared : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "SoundSpeedSquared"; }
 };
 
 /// The spatial velocity \f$v^i\f$ of the fluid,
@@ -175,21 +161,18 @@ struct SpatialVelocityOneForm : db::SimpleTag {
 template <typename DataType>
 struct SpatialVelocitySquared : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "SpatialVelocitySquared"; }
 };
 
 /// The relativistic specific enthalpy \f$h\f$.
 template <typename DataType>
 struct SpecificEnthalpy : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "SpecificEnthalpy"; }
 };
 
 /// The specific internal energy \f$\epsilon\f$.
 template <typename DataType>
 struct SpecificInternalEnergy : db::SimpleTag {
   using type = Scalar<DataType>;
-  static std::string name() noexcept { return "SpecificInternalEnergy"; }
 };
 
 /// The vector \f$J^i\f$ in \f$\dot{M} = -\int J^i s_i d^2S\f$,

--- a/src/Time/Actions/SelfStartActions.hpp
+++ b/src/Time/Actions/SelfStartActions.hpp
@@ -13,6 +13,7 @@
 #include "Parallel/Actions/Goto.hpp"     // IWYU pragma: keep
 #include "Parallel/Actions/TerminatePhase.hpp"     // IWYU pragma: keep
 #include "Time/Actions/AdvanceTime.hpp"  // IWYU pragma: keep
+#include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"  // IWYU pragma: keep // for item_type<Tags::TimeStep>
 #include "Time/Time.hpp"

--- a/tests/Unit/ApparentHorizons/Test_ComputeItems.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ComputeItems.cpp
@@ -19,6 +19,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 #include "tests/Utilities/MakeWithRandomValues.hpp"
 
@@ -112,4 +113,13 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.ComputeItems",
   const DataVector used_for_size(20);
   // Need only Dim=3 and DataVectors for apparent horizons.
   test_strahlkorper_compute_items<3, Frame::Inertial>(used_for_size);
+  TestHelpers::db::test_compute_tag<
+      ah::Tags::InverseSpatialMetricCompute<3, Frame::Inertial>>(
+      "InverseSpatialMetric");
+  TestHelpers::db::test_compute_tag<
+      ah::Tags::ExtrinsicCurvatureCompute<3, Frame::Inertial>>(
+      "ExtrinsicCurvature");
+  TestHelpers::db::test_compute_tag<
+      ah::Tags::SpatialChristoffelSecondKindCompute<3, Frame::Inertial>>(
+      "SpatialChristoffelSecondKind");
 }

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -13,6 +13,7 @@
 #include "ApparentHorizons/Tags.hpp"  // IWYU pragma: keep
 #include "ApparentHorizons/YlmSpherepack.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -20,6 +21,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ApparentHorizons/YlmTestFunctions.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace {
 
@@ -281,6 +283,11 @@ void test_normals() {
   const auto normal_mag = magnitude(normal_one_form, invg);
   CHECK_ITERABLE_APPROX(expected_normal_mag, get(normal_mag));
 }
+
+struct SomeType {};
+struct SomeTag : db::SimpleTag {
+  using type = SomeType;
+};
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
@@ -288,5 +295,46 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   test_average_radius();
   test_radius_and_derivs();
   test_normals();
-  CHECK(ah::Tags::FastFlow::name() == "FastFlow");
+  TestHelpers::db::test_simple_tag<ah::Tags::FastFlow>("FastFlow");
+  TestHelpers::db::test_simple_tag<
+      StrahlkorperTags::Strahlkorper<Frame::Inertial>>("Strahlkorper");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::ThetaPhi<Frame::Inertial>>("ThetaPhi");
+  TestHelpers::db::test_compute_tag<StrahlkorperTags::Rhat<Frame::Inertial>>(
+      "Rhat");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::Jacobian<Frame::Inertial>>("Jacobian");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::InvJacobian<Frame::Inertial>>("InvJacobian");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::InvHessian<Frame::Inertial>>("InvHessian");
+  TestHelpers::db::test_compute_tag<StrahlkorperTags::Radius<Frame::Inertial>>(
+      "Radius");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::CartesianCoords<Frame::Inertial>>("CartesianCoords");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::DxRadius<Frame::Inertial>>("DxRadius");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::D2xRadius<Frame::Inertial>>("D2xRadius");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::LaplacianRadius<Frame::Inertial>>("LaplacianRadius");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::NormalOneForm<Frame::Inertial>>("NormalOneForm");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::Tangents<Frame::Inertial>>("Tangents");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::EuclideanAreaElement<Frame::Inertial>>(
+      "EuclideanAreaElement");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::EuclideanSurfaceIntegral<SomeTag, Frame::Inertial>>(
+      "EuclideanSurfaceIntegral(SomeTag)");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::EuclideanSurfaceIntegralVector<SomeTag,
+                                                       Frame::Inertial>>(
+      "EuclideanSurfaceIntegralVector(SomeTag)");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperGr::Tags::AreaElement<Frame::Inertial>>("AreaElement");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperGr::Tags::SurfaceIntegral<SomeTag, Frame::Inertial>>(
+      "SurfaceIntegral(SomeTag)");
 }

--- a/tests/Unit/DataStructures/DataBox/Test_BaseTags.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_BaseTags.cpp
@@ -27,7 +27,6 @@ struct VectorBase : db::BaseTag {};
 template <int I>
 struct Vector : db::SimpleTag, VectorBase<I> {
   using type = std::vector<double>;
-  static std::string name() noexcept { return "Vector"; }
 };
 /// [vector_base_definitions]
 
@@ -38,7 +37,6 @@ struct ArrayBase : db::BaseTag {};
 template <int I>
 struct Array : virtual db::SimpleTag, ArrayBase<I> {
   using type = std::array<int, 3>;
-  static std::string name() noexcept { return "Array"; }
 };
 /// [array_base_definitions]
 
@@ -215,7 +213,6 @@ struct ParentBase : db::BaseTag {};
 
 template <size_t N, bool Compute = false, bool DependsOnComputeItem = false>
 struct Parent : ParentBase<N>, db::SimpleTag {
-  static std::string name() noexcept { return "Parent"; }
   using type = std::pair<Boxed<int>, Boxed<double>>;
 };
 template <size_t N, bool DependsOnComputeItem>
@@ -232,14 +229,12 @@ struct Parent<N, true, DependsOnComputeItem> : ParentBase<N>, db::ComputeTag {
 
 template <size_t N>
 struct First : FirstBase<N>, db::SimpleTag {
-  static std::string name() noexcept { return "First"; }
   using type = Boxed<int>;
 
   static constexpr size_t index = 0;
 };
 template <size_t N>
 struct Second : SecondBase<N>, db::SimpleTag {
-  static std::string name() noexcept { return "Second"; }
   using type = Boxed<double>;
 
   static constexpr size_t index = 1;

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -52,17 +52,14 @@ namespace test_databox_tags {
 /// [databox_tag_example]
 struct Tag0 : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "Tag0"; }
 };
 /// [databox_tag_example]
 struct Tag1 : db::SimpleTag {
   using type = std::vector<double>;
-  static std::string name() noexcept { return "Tag1"; }
 };
 struct Tag2Base : db::BaseTag {};
 struct Tag2 : db::SimpleTag, Tag2Base {
   using type = std::string;
-  static std::string name() noexcept { return "Tag2"; }
 };
 struct Tag3 : db::SimpleTag {
   using type = std::string;
@@ -116,7 +113,7 @@ struct TagPrefix : db::PrefixTag, db::SimpleTag {
   using type = typename Tag::type;
   using tag = Tag;
   static std::string name() noexcept {
-    return "TagPrefix(" + Tag::name() + ")";
+    return "TagPrefix(" + db::tag_name<Tag>() + ")";
   }
 };
 /// [databox_prefix_tag_example]
@@ -381,12 +378,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
 
 namespace ArgumentTypeTags {
 struct NonCopyable : db::SimpleTag {
-  static std::string name() noexcept { return "NonCopyable"; }
   using type = ::NonCopyable;
 };
 template <size_t N>
 struct String : db::SimpleTag {
-  static std::string name() noexcept { return "String"; }
   using type = std::string;
 };
 }  // namespace ArgumentTypeTags
@@ -773,14 +768,12 @@ namespace {
 auto get_vector() { return tnsr::I<DataVector, 3, Frame::Grid>(5_st, 2.0); }
 
 struct Var1 : db::ComputeTag {
-  static std::string name() noexcept { return "Var1"; }
   static constexpr auto function = get_vector;
   using argument_tags = tmpl::list<>;
 };
 
 struct Var2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "Var2"; }
 };
 
 template <class Tag, class VolumeDim, class Frame>
@@ -830,35 +823,27 @@ namespace test_databox_tags {
 struct ScalarTagBase : db::BaseTag {};
 struct ScalarTag : db::SimpleTag, ScalarTagBase {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "ScalarTag"; }
 };
 struct VectorTag : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
-  static std::string name() noexcept { return "VectorTag"; }
 };
 struct ScalarTag2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "ScalarTag2"; }
 };
 struct VectorTag2 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
-  static std::string name() noexcept { return "VectorTag2"; }
 };
 struct ScalarTag3 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "ScalarTag3"; }
 };
 struct VectorTag3 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
-  static std::string name() noexcept { return "VectorTag3"; }
 };
 struct ScalarTag4 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "ScalarTag4"; }
 };
 struct VectorTag4 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
-  static std::string name() noexcept { return "VectorTag4"; }
 };
 }  // namespace test_databox_tags
 
@@ -1148,11 +1133,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Variables",
 namespace {
 struct Tag1 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "Tag1"; }
 };
 struct Tag2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "Tag2"; }
 };
 }  // namespace
 
@@ -1209,11 +1192,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.reset_compute_items",
 namespace ExtraResetTags {
 struct Var : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "Var"; }
 };
 struct Int : db::SimpleTag {
   using type = int;
-  static std::string name() noexcept { return "Int"; }
 };
 struct CheckReset : db::ComputeTag {
   static std::string name() noexcept { return "CheckReset"; }
@@ -1668,17 +1649,14 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutating_compute_item",
 namespace DataBoxTest_detail {
 struct vector : db::SimpleTag {
   using type = tnsr::I<DataVector, 3, Frame::Grid>;
-  static std::string name() noexcept { return "vector"; }
 };
 
 struct scalar : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "scalar"; }
 };
 
 struct vector2 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3, Frame::Grid>;
-  static std::string name() noexcept { return "vector2"; }
 };
 }  // namespace DataBoxTest_detail
 
@@ -1890,7 +1868,6 @@ class Boxed {
 
 template <size_t N, bool Compute = false, bool DependsOnComputeItem = false>
 struct Parent : db::SimpleTag {
-  static std::string name() noexcept { return "Parent"; }
   using type = std::pair<Boxed<int>, Boxed<double>>;
 };
 template <size_t N, bool DependsOnComputeItem>
@@ -1912,14 +1889,12 @@ int Parent<N, true, DependsOnComputeItem>::count = 0;
 
 template <size_t N>
 struct First : db::SimpleTag {
-  static std::string name() noexcept { return "First"; }
   using type = Boxed<int>;
 
   static constexpr size_t index = 0;
 };
 template <size_t N>
 struct Second : db::SimpleTag {
-  static std::string name() noexcept { return "Second"; }
   using type = Boxed<double>;
 
   static constexpr size_t index = 1;
@@ -2194,7 +2169,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.create_copy_error",
 namespace test_databox_tags {
 struct Tag0Int : db::SimpleTag {
   using type = int;
-  static std::string name() noexcept { return "Tag0Int"; }
 };
 /// [overload_compute_tag_type]
 template <typename ArgumentTag>
@@ -2283,7 +2257,6 @@ struct MyTag1 {
 };
 
 struct TupleTag : db::SimpleTag {
-  static std::string name() noexcept { return "TupleTag"; }
   using type = tuples::TaggedTuple<MyTag0, MyTag1>;
 };
 }  // namespace
@@ -2890,12 +2863,10 @@ struct PureBaseTag : db::BaseTag {};
 
 struct SimpleTag : PureBaseTag, db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "SimpleTag"; }
 };
 
 struct DummyTag : db::SimpleTag {
   using type = int;
-  static std::string name() noexcept { return "DummyTag"; }
 };
 }  // namespace tags_types
 

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxDocumentation.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxDocumentation.cpp
@@ -279,23 +279,18 @@ namespace proper{
 /// [proper_databox_tags]
 struct Velocity : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "Velocity"; }
 };
 struct Radius : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "Radius"; }
 };
 struct Density : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "Density"; }
 };
 struct Volume : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "Volume"; }
 };
 struct Mass : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "Mass"; }
 };
 /// [proper_databox_tags]
 
@@ -333,7 +328,6 @@ double acceleration_from_velocity_and_radius(
 
 struct Acceleration : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "Acceleration"; }
 };
 
 struct AccelerationCompute : db::ComputeTag, Acceleration {
@@ -345,7 +339,6 @@ struct AccelerationCompute : db::ComputeTag, Acceleration {
 /// [compute_tags_force_compute]
 struct Force : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "Force"; }
 };
 
 struct ForceCompute : db::ComputeTag, Force {
@@ -361,22 +354,18 @@ struct ForceCompute : db::ComputeTag, Force {
 /// [mutate_tags]
 struct Time : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "Time"; }
 };
 
 struct TimeStep : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "TimeStep"; }
 };
 
 struct EarthGravity : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "EarthGravity"; }
 };
 
 struct FallingSpeed : db::SimpleTag {
   using type = double;
-  static std::string name() noexcept { return "FallingSpeed"; }
 };
 /// [mutate_tags]
 

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 class DataVector;
 // IWYU pragma: no_forward_declare Tags::Flux
@@ -27,40 +28,36 @@ struct TensorTag : db::SimpleTag {
 SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Prefixes",
                   "[Unit][DataStructures]") {
   /// [dt_name]
-  CHECK(db::tag_name<Tags::dt<Tag>>() == "dt(" + db::tag_name<Tag>() + ")");
+  TestHelpers::db::test_prefix_tag<Tags::dt<Tag>>("dt(Tag)");
   /// [dt_name]
   /// [analytic_name]
-  CHECK(db::tag_name<Tags::Analytic<Tag>>() ==
-        "Analytic(" + db::tag_name<Tag>() + ")");
+  TestHelpers::db::test_prefix_tag<Tags::Analytic<Tag>>("Analytic(Tag)");
   /// [analytic_name]
   using Dim = tmpl::size_t<2>;
   using Frame = Frame::Inertial;
   using VariablesTag = Tags::Variables<tmpl::list<TensorTag>>;
   /// [flux_name]
-  CHECK(db::tag_name<Tags::Flux<TensorTag, Dim, Frame>>() ==
-        "Flux(" + db::tag_name<TensorTag>() + ")");
-  CHECK(db::tag_name<Tags::Flux<VariablesTag, Dim, Frame>>() ==
-        "Flux(" + db::tag_name<VariablesTag>() + ")");
+  TestHelpers::db::test_prefix_tag<Tags::Flux<TensorTag, Dim, Frame>>(
+      "Flux(TensorTag)");
+  TestHelpers::db::test_prefix_tag<Tags::Flux<VariablesTag, Dim, Frame>>(
+      "Flux(Variables(TensorTag))");
   /// [flux_name]
   /// [source_name]
-  CHECK(db::tag_name<Tags::Source<Tag>>() ==
-        "Source(" + db::tag_name<Tag>() + ")");
+  TestHelpers::db::test_prefix_tag<Tags::Source<Tag>>("Source(Tag)");
   /// [source_name]
-  CHECK(db::tag_name<Tags::FixedSource<Tag>>() ==
-        "FixedSource(" + db::tag_name<Tag>() + ")");
+  TestHelpers::db::test_prefix_tag<Tags::FixedSource<Tag>>("FixedSource(Tag)");
   /// [initial_name]
-  CHECK(db::tag_name<Tags::Initial<Tag>>() ==
-        "Initial(" + db::tag_name<Tag>() + ")");
+  TestHelpers::db::test_prefix_tag<Tags::Initial<Tag>>("Initial(Tag)");
   /// [initial_name]
   /// [normal_dot_flux_name]
-  CHECK(db::tag_name<Tags::NormalDotFlux<Tag>>() ==
-        "NormalDotFlux(" + db::tag_name<Tag>() + ")");
+  TestHelpers::db::test_prefix_tag<Tags::NormalDotFlux<Tag>>(
+      "NormalDotFlux(Tag)");
   /// [normal_dot_flux_name]
   /// [normal_dot_numerical_flux_name]
-  CHECK(db::tag_name<Tags::NormalDotNumericalFlux<Tag>>() ==
-        "NormalDotNumericalFlux(" + db::tag_name<Tag>() + ")");
+  TestHelpers::db::test_prefix_tag<Tags::NormalDotNumericalFlux<Tag>>(
+      "NormalDotNumericalFlux(Tag)");
   /// [normal_dot_numerical_flux_name]
   /// [next_name]
-  CHECK(db::tag_name<Tags::Next<Tag>>() == "Next(" + db::tag_name<Tag>() + ")");
+  TestHelpers::db::test_prefix_tag<Tags::Next<Tag>>("Next(Tag)");
   /// [next_name]
 }

--- a/tests/Unit/DataStructures/Tensor/EagerMath/Test_Norms.cpp
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/Test_Norms.cpp
@@ -17,33 +17,29 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Numeric.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
 
 namespace {
 struct MyScalar : db::SimpleTag {
-  static std::string name() noexcept { return "MyScalar"; }
   using type = Scalar<DataVector>;
 };
 template <size_t Dim, typename Frame>
 struct Vector : db::SimpleTag {
-  static std::string name() noexcept { return "Vector"; }
   using type = tnsr::I<DataVector, Dim, Frame>;
 };
 template <size_t Dim, typename Frame>
 struct Covector : db::SimpleTag {
-  static std::string name() noexcept { return "Covector"; }
   using type = tnsr::i<DataVector, Dim, Frame>;
 };
 template <size_t Dim, typename Frame>
 struct Metric : db::SimpleTag {
-  static std::string name() noexcept { return "Metric"; }
   using type = tnsr::ii<DataVector, Dim, Frame>;
 };
 template <size_t Dim, typename Frame>
 struct InverseMetric : db::SimpleTag {
-  static std::string name() noexcept { return "InverseMetric"; }
   using type = tnsr::II<DataVector, Dim, Frame>;
 };
 
@@ -247,13 +243,13 @@ void test_l2_norm_tag() {
 
   // Check tag names
   using Tag = MyScalar;
-  CHECK(Tags::PointwiseL2Norm<Tag>::name() ==
-        "PointwiseL2Norm(" + db::tag_name<Tag>() + ")");
-  CHECK(Tags::PointwiseL2NormCompute<Tag>::name() ==
-        "PointwiseL2Norm(" + db::tag_name<Tag>() + ")");
-  CHECK(Tags::L2Norm<Tag>::name() == "L2Norm(" + db::tag_name<Tag>() + ")");
-  CHECK(Tags::L2NormCompute<Tag>::name() ==
-        "L2Norm(" + db::tag_name<Tag>() + ")");
+  TestHelpers::db::test_simple_tag<Tags::PointwiseL2Norm<Tag>>(
+      "PointwiseL2Norm(MyScalar)");
+  TestHelpers::db::test_compute_tag<Tags::PointwiseL2NormCompute<Tag>>(
+      "PointwiseL2Norm(MyScalar)");
+  TestHelpers::db::test_simple_tag<Tags::L2Norm<Tag>>("L2Norm(MyScalar)");
+  TestHelpers::db::test_compute_tag<Tags::L2NormCompute<Tag>>(
+      "L2Norm(MyScalar)");
 }
 }  // namespace
 

--- a/tests/Unit/DataStructures/Test_Tags.cpp
+++ b/tests/Unit/DataStructures/Test_Tags.cpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tags.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 class ComplexDataVector;
 class DataVector;
@@ -48,9 +49,9 @@ void test_mean_tag() noexcept {
   static_assert(cpp17::is_same_v<typename Tags::Mean<VectorTag<3>>::type,
                                  tnsr::I<double, 3>>,
                 "Failed testing Tags::Mean<ScalarTag>");
-  CHECK(Tags::Mean<ScalarTag>::name() == "Mean(Scalar)");
-  CHECK(Tags::Mean<VectorTag<1>>::name() == "Mean(I<1>)");
-  CHECK(Tags::Mean<VectorTag<3>>::name() == "Mean(I<3>)");
+  TestHelpers::db::test_prefix_tag<Tags::Mean<ScalarTag>>("Mean(Scalar)");
+  TestHelpers::db::test_prefix_tag<Tags::Mean<VectorTag<1>>>("Mean(I<1>)");
+  TestHelpers::db::test_prefix_tag<Tags::Mean<VectorTag<3>>>("Mean(I<3>)");
 }
 
 void test_modal_tag() noexcept {
@@ -63,9 +64,9 @@ void test_modal_tag() noexcept {
   static_assert(cpp17::is_same_v<typename Tags::Modal<VectorTag<3>>::type,
                                  tnsr::I<ModalVector, 3>>,
                 "Failed testing Tags::Modal<VectorTag<3>>");
-  CHECK(Tags::Modal<ScalarTag>::name() == "Modal(Scalar)");
-  CHECK(Tags::Modal<VectorTag<1>>::name() == "Modal(I<1>)");
-  CHECK(Tags::Modal<VectorTag<3>>::name() == "Modal(I<3>)");
+  TestHelpers::db::test_prefix_tag<Tags::Modal<ScalarTag>>("Modal(Scalar)");
+  TestHelpers::db::test_prefix_tag<Tags::Modal<VectorTag<1>>>("Modal(I<1>)");
+  TestHelpers::db::test_prefix_tag<Tags::Modal<VectorTag<3>>>("Modal(I<3>)");
 }
 
 void test_spin_weighted_tag() noexcept {
@@ -75,8 +76,8 @@ void test_spin_weighted_tag() noexcept {
                                       std::integral_constant<int, 1>>::type,
           Scalar<SpinWeighted<ComplexDataVector, 1>>>,
       "Failed testing Tags::SpinWeighted<ScalarTag>");
-  CHECK(Tags::SpinWeighted<ComplexScalarTag,
-                           std::integral_constant<int, -2>>::name() ==
+  TestHelpers::db::test_prefix_tag<Tags::SpinWeighted<ComplexScalarTag,
+                           std::integral_constant<int, -2>>>(
         "SpinWeighted(ComplexScalar, -2)");
 }
 
@@ -89,7 +90,7 @@ void test_multiplies_tag() noexcept {
       cpp17::is_same_v<db::const_item_type<test_multiplies_tag>,
                        Scalar<SpinWeighted<ComplexDataVector, -1>>>,
       "Failed testing Tags::Multiplies for Tags::SpinWeighted operands");
-  CHECK(test_multiplies_tag::name() ==
+  TestHelpers::db::test_prefix_tag<test_multiplies_tag>(
         "Multiplies(SpinWeighted(ComplexScalar, 1), "
         "SpinWeighted(ComplexScalar, -2))");
 }

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -27,6 +27,7 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 #include "tests/Utilities/MakeWithRandomValues.hpp"
 
@@ -250,11 +251,10 @@ void test_variables_construction_and_access() noexcept {
 #endif  // defined(__clang__) && __clang_major__ > 6
   CHECK(filled_variables == another_filled_variables);
 
-  CHECK(
-      Tags::Variables<
-          tmpl::list<VariablesTestTags_detail::tensor<VectorType>,
-                     VariablesTestTags_detail::scalar<VectorType>,
-                     VariablesTestTags_detail::scalar2<VectorType>>>::name() ==
+  TestHelpers::db::test_simple_tag<Tags::Variables<
+      tmpl::list<VariablesTestTags_detail::tensor<VectorType>,
+                 VariablesTestTags_detail::scalar<VectorType>,
+                 VariablesTestTags_detail::scalar2<VectorType>>>>(
       "Variables(tensor name,scalar name,scalar2 name)");
 }
 
@@ -1081,6 +1081,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
     test_variables_from_tagged_tuple<DataVector>();
     // test_variables_from_tagged_tuple<ModalVector>();
   }
+  TestHelpers::db::test_simple_tag<Tags::TempScalar<1>>("TempTensor1");
 }
 }  // namespace
 

--- a/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
@@ -34,13 +34,11 @@
 namespace {
 
 struct ScalarFieldTag : db::SimpleTag {
-  static std::string name() noexcept { return "ScalarFieldTag"; };
   using type = Scalar<DataVector>;
 };
 
 template <size_t Dim>
 struct AuxiliaryFieldTag : db::SimpleTag {
-  static std::string name() noexcept { return "AuxiliaryFieldTag"; };
   using type = tnsr::i<DataVector, Dim>;
 };
 

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/Test_FirstOrderInternalPenalty.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/Test_FirstOrderInternalPenalty.cpp
@@ -53,7 +53,6 @@ struct Fluxes {
 template <size_t Dim>
 struct FluxesComputerTag : db::SimpleTag {
   using type = Fluxes<Dim>;
-  static std::string name() noexcept { return "FluxesComputerTag"; }
 };
 
 template <size_t Dim>

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
@@ -66,14 +66,12 @@ namespace {
 constexpr size_t Dim = 2;
 
 struct TemporalId : db::SimpleTag {
-  static std::string name() noexcept { return "TemporalId"; }
   using type = int;
   template <typename Tag>
   using step_prefix = Tags::dt<Tag>;
 };
 
 struct ScalarField : db::SimpleTag {
-  static std::string name() noexcept { return "ScalarField"; }
   using type = Scalar<DataVector>;
 };
 
@@ -81,14 +79,12 @@ using field_tag = ScalarField;
 using vars_tag = Tags::Variables<tmpl::list<field_tag>>;
 
 struct OtherData : db::SimpleTag {
-  static std::string name() noexcept { return "OtherData"; }
   using type = Scalar<DataVector>;
 };
 
 class NumericalFlux {
  public:
   struct ExtraData : db::SimpleTag {
-    static std::string name() noexcept { return "ExtraTag"; }
     using type = tnsr::I<DataVector, 1>;
   };
 

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
@@ -49,7 +49,6 @@ class er;
 
 namespace {
 struct ScalarFieldTag : db::SimpleTag {
-  static std::string name() noexcept { return "ScalarFieldTag"; };
   using type = Scalar<DataVector>;
 };
 

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
@@ -36,13 +36,11 @@
 
 namespace {
 struct ScalarFieldTag : db::SimpleTag {
-  static std::string name() noexcept { return "ScalarFieldTag"; };
   using type = Scalar<DataVector>;
 };
 
 template <size_t Dim>
 struct AuxiliaryFieldTag : db::SimpleTag {
-  static std::string name() noexcept { return "AuxiliaryFieldTag"; };
   using type = tnsr::i<DataVector, Dim>;
 };
 

--- a/tests/Unit/Elliptic/Systems/Elasticity/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/Test_Tags.cpp
@@ -6,10 +6,12 @@
 #include <string>
 
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Elasticity.Tags",
                   "[Unit][Elliptic]") {
-  CHECK(Elasticity::Tags::Displacement<1>::name() == "Displacement");
-  CHECK(Elasticity::Tags::Strain<1>::name() == "Strain");
-  CHECK(Elasticity::Tags::Stress<1>::name() == "Stress");
+  TestHelpers::db::test_simple_tag<Elasticity::Tags::Displacement<1>>(
+      "Displacement");
+  TestHelpers::db::test_simple_tag<Elasticity::Tags::Strain<1>>("Strain");
+  TestHelpers::db::test_simple_tag<Elasticity::Tags::Stress<1>>("Stress");
 }

--- a/tests/Unit/Elliptic/Systems/Poisson/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Test_Tags.cpp
@@ -6,7 +6,8 @@
 #include <string>
 
 #include "Elliptic/Systems/Poisson/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Poisson.Tags", "[Unit][Elliptic]") {
-  CHECK(db::tag_name<Poisson::Tags::Field>() == "Field");
+  TestHelpers::db::test_simple_tag<Poisson::Tags::Field> ("Field");
 }

--- a/tests/Unit/Elliptic/Systems/Xcts/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/Test_Tags.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 struct DataVector;
 namespace Frame {
@@ -13,8 +14,9 @@ struct Inertial;
 }  // namespace Frame
 
 SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Xcts.Tags", "[Unit][Elliptic]") {
-  CHECK(Xcts::Tags::ConformalFactor<DataVector>::name() == "ConformalFactor");
-  CHECK(Xcts::Tags::ConformalFactorGradient<3, Frame::Inertial,
-                                            DataVector>::name() ==
-        "ConformalFactorGradient");
+  TestHelpers::db::test_simple_tag<Xcts::Tags::ConformalFactor<DataVector>>(
+      "ConformalFactor");
+  TestHelpers::db::test_simple_tag<
+      Xcts::Tags::ConformalFactorGradient<3, Frame::Inertial, DataVector>>(
+      "ConformalFactorGradient");
 }

--- a/tests/Unit/Elliptic/Test_FirstOrderComputeTags.cpp
+++ b/tests/Unit/Elliptic/Test_FirstOrderComputeTags.cpp
@@ -13,6 +13,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Elliptic/FirstOrderComputeTags.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace {
 
@@ -80,6 +81,11 @@ void test_first_order_compute_tags() {
       elliptic::Tags::FirstOrderFluxesCompute<system>;
   using first_order_sources_compute_tag =
       elliptic::Tags::FirstOrderSourcesCompute<system>;
+
+  TestHelpers::db::test_compute_tag<first_order_fluxes_compute_tag>(
+      "Flux(Variables(Flux(FieldTag),Flux(AuxiliaryFieldTag)))");
+  TestHelpers::db::test_compute_tag<first_order_sources_compute_tag>(
+      "Source(Variables(Source(FieldTag),Source(AuxiliaryFieldTag)))");
 
   // Construct some field data
   static constexpr size_t num_points = 3;

--- a/tests/Unit/Elliptic/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Test_Tags.cpp
@@ -6,12 +6,13 @@
 #include <string>
 
 #include "Elliptic/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace {
 struct SomeFluxesComputer {};
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Elliptic.Tags", "[Unit][Elliptic]") {
-  CHECK(db::tag_name<elliptic::Tags::FluxesComputer<SomeFluxesComputer>>() ==
-        "SomeFluxesComputer");
+  TestHelpers::db::test_simple_tag<
+      elliptic::Tags::FluxesComputer<SomeFluxesComputer>>("SomeFluxesComputer");
 }

--- a/tests/Unit/Evolution/Actions/Test_ComputeTimeDerivative.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeTimeDerivative.cpp
@@ -29,7 +29,6 @@ struct TemporalId {
 
 struct var_tag : db::SimpleTag {
   using type = int;
-  static std::string name() noexcept { return "var_tag"; }
 };
 
 struct ComputeDuDt {

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
@@ -28,12 +28,10 @@ namespace {
 constexpr size_t dim = 2;
 
 struct Var1 : db::SimpleTag {
-  static std::string name() noexcept { return "Var1"; }
   using type = Scalar<double>;
 };
 
 struct Var2 : db::SimpleTag {
-  static std::string name() noexcept { return "Var2"; }
   using type = tnsr::I<double, dim, Frame::Inertial>;
 };
 

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
@@ -33,17 +33,14 @@ namespace {
 constexpr size_t dim = 2;
 
 struct Var1 : db::SimpleTag {
-  static std::string name() noexcept { return "Var1"; }
   using type = Scalar<DataVector>;
 };
 
 struct Var2 : db::SimpleTag {
-  static std::string name() noexcept { return "Var2"; }
   using type = tnsr::I<DataVector, dim, Frame::Inertial>;
 };
 
 struct Var3 : db::SimpleTag {
-  static std::string name() noexcept { return "Var3"; }
   using type = Scalar<DataVector>;
 };
 

--- a/tests/Unit/Evolution/CMakeLists.txt
+++ b/tests/Unit/Evolution/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_subdirectory(Actions)
 add_subdirectory(Conservative)
 add_subdirectory(DiscontinuousGalerkin)
+add_subdirectory(Initialization)
 add_subdirectory(Systems)
 add_subdirectory(VariableFixing)
 

--- a/tests/Unit/Evolution/Conservative/Test_ConservativeDuDt.cpp
+++ b/tests/Unit/Evolution/Conservative/Test_ConservativeDuDt.cpp
@@ -26,12 +26,10 @@ using frame = Frame::Inertial;
 constexpr size_t volume_dim = 2;
 
 struct Var1 : db::SimpleTag {
-  static std::string name() noexcept { return "Var1"; }
   using type = Scalar<DataVector>;
 };
 
 struct Var2 : db::SimpleTag {
-  static std::string name() noexcept { return "Var2"; }
   using type = tnsr::i<DataVector, volume_dim, frame>;
 };
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_Minmod.cpp
   Test_MinmodTci.cpp
   Test_MinmodType.cpp
+  Test_Tags.cpp
   Test_Weno.cpp
   Test_WenoGridHelpers.cpp
   Test_WenoOscillationIndicator.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
@@ -48,12 +48,10 @@
 
 namespace {
 struct TemporalId : db::SimpleTag {
-  static std::string name() noexcept { return "TemporalId"; }
   using type = int;
 };
 
 struct Var : db::SimpleTag {
-  static std::string name() noexcept { return "Var"; }
   using type = Scalar<DataVector>;
 };
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
@@ -43,12 +43,10 @@
 
 namespace {
 struct TemporalId : db::SimpleTag {
-  static std::string name() noexcept { return "TemporalId"; }
   using type = int;
 };
 
 struct Var : db::SimpleTag {
-  static std::string name() noexcept { return "Var"; }
   using type = Scalar<DataVector>;
 };
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Tags.cpp
@@ -1,0 +1,16 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include "Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+struct SomeType {};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DiscontinuousGalerkin.Limiters.Tags",
+                  "[Unit][Evolution]") {
+  TestHelpers::db::test_simple_tag<Tags::Limiter<SomeType>>("Limiter");
+}

--- a/tests/Unit/Evolution/Initialization/CMakeLists.txt
+++ b/tests/Unit/Evolution/Initialization/CMakeLists.txt
@@ -1,17 +1,15 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY "Test_Burgers")
+set(LIBRARY "Test_EvolutionInitialization")
 
 set(LIBRARY_SOURCES
-  Test_Characteristics.cpp
-  Test_Fluxes.cpp
   Test_Tags.cpp
   )
 
 add_test_library(
   ${LIBRARY}
-  "Evolution/Systems/Burgers/"
+  "Evolution/Initialization/"
   "${LIBRARY_SOURCES}"
-  "Burgers"
+  ""
   )

--- a/tests/Unit/Evolution/Initialization/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_Tags.cpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+#include "Evolution/Initialization/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Initialization.Tags",
+                  "[Unit][Evolution]") {
+  TestHelpers::db::test_simple_tag<Initialization::Tags::InitialTime>(
+      "InitialTime");
+  TestHelpers::db::test_simple_tag<Initialization::Tags::InitialTimeDelta>(
+      "InitialTimeDelta");
+  TestHelpers::db::test_simple_tag<Initialization::Tags::InitialSlabSize<true>>(
+      "InitialSlabSize");
+  TestHelpers::db::test_simple_tag<
+      Initialization::Tags::InitialSlabSize<false>>("InitialSlabSize");
+}

--- a/tests/Unit/Evolution/Systems/Burgers/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Test_Characteristics.cpp
@@ -11,8 +11,11 @@
 #include "Evolution/Systems/Burgers/Characteristics.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Burgers.Characteristics", "[Unit][Burgers]") {
+  TestHelpers::db::test_compute_tag<Burgers::Tags::CharacteristicSpeedsCompute>(
+      "CharacteristicSpeeds");
   {
     const auto box = db::create<
         db::AddSimpleTags<Burgers::Tags::U, Tags::UnnormalizedFaceNormal<1>>,

--- a/tests/Unit/Evolution/Systems/Burgers/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Test_Tags.cpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include "Evolution/Systems/Burgers/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Tags", "[Unit][Burgers]") {
+  TestHelpers::db::test_simple_tag<Burgers::Tags::U>("U");
+}

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -296,7 +296,7 @@ SPECTRE_TEST_CASE(
   tmpl::for_each<bondi_calculation_result_tags>(
       [&runner, &boundary_box](auto tag_v) {
         using tag = typename decltype(tag_v)::type;
-        INFO(tag::name());
+        INFO(db::tag_name<tag>());
         const auto& test_lhs =
             ActionTesting::get_databox_tag<component, tag>(runner, 0);
         const auto& test_rhs = db::get<tag>(boundary_box);

--- a/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
@@ -535,7 +535,7 @@ void test_kerr_schild_boundary_consistency(
       [&gh_boundary_box, &modal_boundary_box,
        &angular_derivative_approx](auto tag_v) {
         using tag = typename decltype(tag_v)::type;
-        INFO(tag::name());
+        INFO(db::tag_name<tag>());
         const auto& test_lhs = db::get<tag>(gh_boundary_box);
         const auto& test_rhs = db::get<tag>(modal_boundary_box);
         CHECK_ITERABLE_CUSTOM_APPROX(test_lhs, test_rhs,
@@ -601,7 +601,7 @@ void test_schwarzschild_solution(const gsl::not_null<Generator*> gen) noexcept {
       [&gh_boundary_box, &modal_boundary_box, &expected_box,
        &angular_derivative_approx](auto tag_v) {
         using tag = typename decltype(tag_v)::type;
-        INFO(tag::name());
+        INFO(db::tag_name<tag>());
         const auto& test_lhs_0 = db::get<tag>(gh_boundary_box);
         const auto& test_rhs_0 = db::get<tag>(expected_box);
         CHECK_ITERABLE_CUSTOM_APPROX(test_lhs_0, test_rhs_0,

--- a/tests/Unit/Evolution/Systems/Cce/Test_GaugeTransformBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_GaugeTransformBoundaryData.cpp
@@ -275,7 +275,7 @@ void test_gauge_transforms_via_inverse_coordinate_map(
       [&forward_transform_box, &inverse_transform_box, &
        interpolation_approx ](auto tag_v) noexcept {
     using tag = typename decltype(tag_v)::type;
-    INFO("computing tag : " << tag::name());
+    INFO("computing tag : " << db::tag_name<tag>());
     db::mutate_apply<GaugeAdjustedBoundaryValue<tag>>(
         make_not_null(&forward_transform_box));
     db::mutate<Tags::BoundaryValue<tag>>(

--- a/tests/Unit/Evolution/Systems/Cce/Test_PreSwshDerivatives.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_PreSwshDerivatives.cpp
@@ -31,7 +31,6 @@ namespace {
 template <int Spin>
 struct TestSpinWeightedScalar : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, Spin>>;
-  static std::string name() noexcept { return "TestSpinWeightedScalar"; }
 };
 
 using test_pre_swsh_derivative_dependencies =

--- a/tests/Unit/Evolution/Systems/Cce/Test_ReadBoundaryDataH5.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_ReadBoundaryDataH5.cpp
@@ -435,7 +435,7 @@ void test_data_manager_with_dummy_buffer_updater(
       [&expected_boundary_box, &interpolated_boundary_box,
        &angular_derivative_approx](auto tag_v) {
         using tag = typename decltype(tag_v)::type;
-        INFO(tag::name());
+        INFO(db::tag_name<tag>());
         const auto& test_lhs = db::get<tag>(expected_boundary_box);
         const auto& test_rhs = db::get<tag>(interpolated_boundary_box);
         CHECK_ITERABLE_CUSTOM_APPROX(test_lhs, test_rhs,
@@ -508,7 +508,7 @@ void test_spec_worldtube_buffer_updater(
     &expected_coefficients_buffers, &coefficients_buffers_from_file
   ](auto tag_v) noexcept {
     using tag = typename decltype(tag_v)::type;
-    INFO(tag::name());
+    INFO(db::tag_name<tag>());
     const auto& test_lhs = get<tag>(expected_coefficients_buffers);
     const auto& test_rhs = get<tag>(coefficients_buffers_from_file);
     CHECK_ITERABLE_APPROX(test_lhs, test_rhs);
@@ -680,8 +680,7 @@ void test_reduced_spec_worldtube_buffer_updater(
       [&expected_coefficients_buffers, &coefficients_buffers_from_file,
        &modal_approx](auto tag_v) {
         using tag = typename decltype(tag_v)::type;
-
-        INFO(tag::name());
+        INFO(db::tag_name<tag>());
         const auto& test_lhs = get<tag>(expected_coefficients_buffers);
         const auto& test_rhs = get<tag>(coefficients_buffers_from_file);
         CHECK_ITERABLE_CUSTOM_APPROX(test_lhs, test_rhs, modal_approx);

--- a/tests/Unit/Evolution/Systems/Cce/Test_SwshDerivatives.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_SwshDerivatives.cpp
@@ -36,7 +36,6 @@ namespace {
 template <int Spin>
 struct TestSpinWeightedScalar : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, Spin>>;
-  static std::string name() noexcept { return "TestSpinWeightedScalar"; }
 };
 
 // note: J must be omitted from this due to the need for the Precomputation step

--- a/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace {
 struct SomeTag {
@@ -17,30 +18,81 @@ struct SomeTag {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Tags", "[Unit][Cce]") {
-  CHECK(db::tag_name<Cce::Tags::Dy<SomeTag>>() == "Dy(SomeTag)");
-  CHECK(db::tag_name<Cce::Tags::Du<SomeTag>>() == "Du(SomeTag)");
-  CHECK(db::tag_name<Cce::Tags::Dr<SomeTag>>() == "Dr(SomeTag)");
-  CHECK(db::tag_name<Cce::Tags::Integrand<SomeTag>>() == "Integrand(SomeTag)");
-  CHECK(db::tag_name<Cce::Tags::BoundaryValue<SomeTag>>() ==
-        "BoundaryValue(SomeTag)");
-  CHECK(db::tag_name<Cce::Tags::PoleOfIntegrand<SomeTag>>() ==
-        "PoleOfIntegrand(SomeTag)");
-  CHECK(db::tag_name<Cce::Tags::LinearFactor<SomeTag>>() ==
-        "LinearFactor(SomeTag)");
-  CHECK(db::tag_name<Cce::Tags::LinearFactorForConjugate<SomeTag>>() ==
-        "LinearFactorForConjugate(SomeTag)");
+  TestHelpers::db::test_simple_tag<Cce::Tags::BondiBeta>("BondiBeta");
+  TestHelpers::db::test_simple_tag<Cce::Tags::BondiH>("H");
+  TestHelpers::db::test_simple_tag<Cce::Tags::BondiJ>("J");
+  TestHelpers::db::test_simple_tag<Cce::Tags::BondiJbar>("Jbar");
+  TestHelpers::db::test_simple_tag<Cce::Tags::BondiK>("K");
+  TestHelpers::db::test_simple_tag<Cce::Tags::BondiQ>("Q");
+  TestHelpers::db::test_simple_tag<Cce::Tags::BondiQbar>("Qbar");
+  TestHelpers::db::test_simple_tag<Cce::Tags::BondiU>("U");
+  TestHelpers::db::test_simple_tag<Cce::Tags::BondiUAtScri>("BondiUAtScri");
+  TestHelpers::db::test_simple_tag<Cce::Tags::BondiUbar>("Ubar");
+  TestHelpers::db::test_simple_tag<Cce::Tags::BondiW>("W");
+  TestHelpers::db::test_simple_tag<Cce::Tags::GaugeC>("GaugeC");
+  TestHelpers::db::test_simple_tag<Cce::Tags::GaugeD>("GaugeD");
+  TestHelpers::db::test_simple_tag<Cce::Tags::GaugeOmega>("GaugeOmega");
+  TestHelpers::db::test_simple_tag<Cce::Tags::News>("News");
+  TestHelpers::db::test_simple_tag<Cce::Tags::CauchyAngularCoords>(
+      "CauchyAngularCoords");
+  TestHelpers::db::test_simple_tag<Cce::Tags::CauchyCartesianCoords>(
+      "CauchyCartesianCoords");
+  TestHelpers::db::test_simple_tag<Cce::Tags::InertialRetardedTime>(
+      "InertialRetardedTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::ComplexInertialRetardedTime>(
+      "ComplexInertialRetardedTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::OneMinusY>("OneMinusY");
+  TestHelpers::db::test_simple_tag<Cce::Tags::DuR>("DuR");
+  TestHelpers::db::test_simple_tag<Cce::Tags::DuRDividedByR>("DuRDividedByR");
+  TestHelpers::db::test_simple_tag<Cce::Tags::EthRDividedByR>("EthRDividedByR");
+  TestHelpers::db::test_simple_tag<Cce::Tags::EthEthRDividedByR>(
+      "EthEthRDividedByR");
+  TestHelpers::db::test_simple_tag<Cce::Tags::EthEthbarRDividedByR>(
+      "EthEthbarRDividedByR");
+  TestHelpers::db::test_simple_tag<Cce::Tags::Exp2Beta>("Exp2Beta");
+  TestHelpers::db::test_simple_tag<Cce::Tags::JbarQMinus2EthBeta>(
+      "JbarQMinus2EthBeta");
+  TestHelpers::db::test_simple_tag<Cce::Tags::BondiR>("R");
+  TestHelpers::db::test_simple_tag<Cce::Tags::H5WorldtubeBoundaryDataManager>(
+      "H5WorldtubeBoundaryDataManager");
 
-  CHECK(db::tag_name<Cce::Tags::H5WorldtubeBoundaryDataManager>() ==
-        "H5WorldtubeBoundaryDataManager");
   auto box =
       db::create<db::AddSimpleTags<Cce::Tags::H5WorldtubeBoundaryDataManager>>(
           Cce::WorldtubeDataManager{});
   CHECK(db::get<Cce::Tags::H5WorldtubeBoundaryDataManager>(box).get_l_max() ==
         0);
 
-  CHECK(db::tag_name<Cce::Tags::TimeIntegral<SomeTag>>() ==
-        "TimeIntegral(SomeTag)");
-  CHECK(db::tag_name<Cce::Tags::ScriPlus<SomeTag>>() == "ScriPlus(SomeTag)");
-  CHECK(db::tag_name<Cce::Tags::ScriPlusFactor<SomeTag>>() ==
-        "ScriPlusFactor(SomeTag)");
+  TestHelpers::db::test_simple_tag<Cce::Tags::Psi0>("Psi0");
+  TestHelpers::db::test_simple_tag<Cce::Tags::Psi1>("Psi1");
+  TestHelpers::db::test_simple_tag<Cce::Tags::Psi2>("Psi2");
+  TestHelpers::db::test_simple_tag<Cce::Tags::Psi3>("Psi3");
+  TestHelpers::db::test_simple_tag<Cce::Tags::Psi4>("Psi4");
+  TestHelpers::db::test_simple_tag<Cce::Tags::Strain>("Strain");
+  TestHelpers::db::test_simple_tag<Cce::Tags::EndTime>("EndTime");
+
+  TestHelpers::db::test_prefix_tag<Cce::Tags::Dy<SomeTag>>("Dy(SomeTag)");
+  TestHelpers::db::test_prefix_tag<Cce::Tags::Du<SomeTag>>("Du(SomeTag)");
+  TestHelpers::db::test_prefix_tag<Cce::Tags::Dr<SomeTag>>("Dr(SomeTag)");
+  TestHelpers::db::test_prefix_tag<Cce::Tags::Integrand<SomeTag>>(
+      "Integrand(SomeTag)");
+  TestHelpers::db::test_prefix_tag<Cce::Tags::BoundaryValue<SomeTag>>(
+      "BoundaryValue(SomeTag)");
+  TestHelpers::db::test_prefix_tag<
+      Cce::Tags::EvolutionGaugeBoundaryValue<SomeTag>>(
+      "EvolutionGaugeBoundaryValue(SomeTag)");
+  TestHelpers::db::test_prefix_tag<Cce::Tags::PoleOfIntegrand<SomeTag>>(
+      "PoleOfIntegrand(SomeTag)");
+  TestHelpers::db::test_prefix_tag<Cce::Tags::RegularIntegrand<SomeTag>>(
+      "RegularIntegrand(SomeTag)");
+  TestHelpers::db::test_prefix_tag<Cce::Tags::LinearFactor<SomeTag>>(
+      "LinearFactor(SomeTag)");
+  TestHelpers::db::test_prefix_tag<
+      Cce::Tags::LinearFactorForConjugate<SomeTag>>(
+      "LinearFactorForConjugate(SomeTag)");
+  TestHelpers::db::test_prefix_tag<Cce::Tags::TimeIntegral<SomeTag>>(
+      "TimeIntegral(SomeTag)");
+  TestHelpers::db::test_prefix_tag<Cce::Tags::ScriPlus<SomeTag>>(
+      "ScriPlus(SomeTag)");
+  TestHelpers::db::test_prefix_tag<Cce::Tags::ScriPlusFactor<SomeTag>>(
+      "ScriPlusFactor(SomeTag)");
 }

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   TestHelpers.cpp
   Test_Characteristics.cpp
   Test_DuDt.cpp
+  Test_Tags.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Characteristics.cpp
@@ -15,6 +15,7 @@
 #include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 
@@ -111,6 +112,16 @@ void test_evolved_from_characteristic_fields() noexcept {
 
 template <size_t SpatialDim>
 void test_characteristics_compute_tags() noexcept {
+  TestHelpers::db::test_compute_tag<
+      CurvedScalarWave::CharacteristicSpeedsCompute<SpatialDim>>(
+      "CharacteristicSpeeds");
+  TestHelpers::db::test_compute_tag<
+      CurvedScalarWave::CharacteristicFieldsCompute<SpatialDim>>(
+      "CharacteristicFields");
+  TestHelpers::db::test_compute_tag<
+      CurvedScalarWave::EvolvedFieldsFromCharacteristicFieldsCompute<
+          SpatialDim>>("EvolvedFieldsFromCharacteristicFields");
+
   const DataVector used_for_size(5);
 
   MAKE_GENERATOR(generator);

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Constraints.cpp
@@ -14,6 +14,7 @@
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -78,6 +79,12 @@ void test_constraint_compute_items(const DataVector& used_for_size) noexcept {
         CurvedScalarWave::one_index_constraint(d_psi, phi));
   CHECK(db::get<CurvedScalarWave::Tags::TwoIndexConstraint<SpatialDim>>(box) ==
         CurvedScalarWave::two_index_constraint(d_phi));
+  TestHelpers::db::test_compute_tag<
+      CurvedScalarWave::Tags::OneIndexConstraintCompute<SpatialDim>>(
+      "OneIndexConstraint");
+  TestHelpers::db::test_compute_tag<
+      CurvedScalarWave::Tags::TwoIndexConstraintCompute<SpatialDim>>(
+      "TwoIndexConstraint");
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Tags.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Tags",
+                  "[Unit][Evolution]") {
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Psi>("Psi");
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Pi>("Pi");
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Phi<3>>("Phi");
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Tags::ConstraintGamma1>(
+      "ConstraintGamma1");
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Tags::ConstraintGamma2>(
+      "ConstraintGamma2");
+  TestHelpers::db::test_simple_tag<
+      CurvedScalarWave::Tags::OneIndexConstraint<3>>("OneIndexConstraint");
+  TestHelpers::db::test_simple_tag<
+      CurvedScalarWave::Tags::TwoIndexConstraint<3>>("TwoIndexConstraint");
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Tags::VPsi>("VPsi");
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Tags::VZero<3>>("VZero");
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Tags::VPlus>("VPlus");
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Tags::VMinus>("VMinus");
+  TestHelpers::db::test_simple_tag<
+      CurvedScalarWave::Tags::CharacteristicSpeeds<3>>("CharacteristicSpeeds");
+  TestHelpers::db::test_simple_tag<
+      CurvedScalarWave::Tags::CharacteristicFields<3>>("CharacteristicFields");
+  TestHelpers::db::test_simple_tag<
+      CurvedScalarWave::Tags::EvolvedFieldsFromCharacteristicFields<3>>(
+      "EvolvedFieldsFromCharacteristicFields");
+}

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -39,6 +39,7 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -2931,11 +2932,12 @@ void test_damped_harmonic_compute_tags(const size_t grid_size_each_dimension,
   // Check that compute items work correctly in the DataBox
   //
   // First, check that the names are correct
-  CHECK(
-      GeneralizedHarmonic::DampedHarmonicHCompute<3, Frame::Inertial>::name() ==
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::DampedHarmonicHCompute<3, Frame::Inertial>>(
       "GaugeH");
-  CHECK(GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<
-            3, Frame::Inertial>::name() == "SpacetimeDerivGaugeH");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<
+          3, Frame::Inertial>>("SpacetimeDerivGaugeH");
 
   const auto box = db::create<
       db::AddSimpleTags<

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -33,6 +33,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 
@@ -59,6 +60,9 @@ Scalar<DataVector> speed_with_index(
 
 template <size_t Dim, typename Frame>
 void test_characteristic_speeds() noexcept {
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::CharacteristicSpeedsCompute<Dim, Frame>>(
+      "CharacteristicSpeeds");
   const DataVector used_for_size(5);
   pypp::check_with_random_values<1>(speed_with_index<0, Dim, Frame>,
                                     "TestFunctions", "char_speed_upsi",
@@ -162,6 +166,9 @@ typename Tag::type field_with_tag(
 
 template <size_t Dim, typename Frame>
 void test_characteristic_fields() noexcept {
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::CharacteristicFieldsCompute<Dim, Frame>>(
+      "CharacteristicFields");
   const DataVector used_for_size(20);
   // UPsi
   pypp::check_with_random_values<1>(
@@ -343,6 +350,10 @@ typename Tag::type evol_field_with_tag(
 
 template <size_t Dim, typename Frame>
 void test_evolved_from_characteristic_fields() noexcept {
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::EvolvedFieldsFromCharacteristicFieldsCompute<Dim,
+                                                                        Frame>>(
+      "EvolvedFieldsFromCharacteristicFields");
   const DataVector used_for_size(20);
   // Psi
   pypp::check_with_random_values<1>(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -39,6 +39,7 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 
@@ -676,28 +677,42 @@ void test_constraint_compute_items(
     const std::array<double, 3>& lower_bound,
     const std::array<double, 3>& upper_bound) noexcept {
   // Check that compute items are named correctly
-  CHECK(GeneralizedHarmonic::Tags::ConstraintGamma0Compute<
-            3, Frame::Inertial>::name() == "ConstraintGamma0");
-  CHECK(GeneralizedHarmonic::Tags::ConstraintGamma1Compute<
-            3, Frame::Inertial>::name() == "ConstraintGamma1");
-  CHECK(GeneralizedHarmonic::Tags::ConstraintGamma2Compute<
-            3, Frame::Inertial>::name() == "ConstraintGamma2");
-  CHECK(GeneralizedHarmonic::Tags::GaugeHImplicitFrom3p1QuantitiesCompute<
-            3, Frame::Inertial>::name() == "GaugeH");
-  CHECK(GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<
-            3, Frame::Inertial>::name() == "SpacetimeDerivGaugeH");
-  CHECK(GeneralizedHarmonic::Tags::GaugeConstraintCompute<
-            3, Frame::Inertial>::name() == "GaugeConstraint");
-  CHECK(GeneralizedHarmonic::Tags::FConstraintCompute<
-            3, Frame::Inertial>::name() == "FConstraint");
-  CHECK(GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<
-            3, Frame::Inertial>::name() == "TwoIndexConstraint");
-  CHECK(GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<
-            3, Frame::Inertial>::name() == "ThreeIndexConstraint");
-  CHECK(GeneralizedHarmonic::Tags::FourIndexConstraintCompute<
-            3, Frame::Inertial>::name() == "FourIndexConstraint");
-  CHECK(GeneralizedHarmonic::Tags::ConstraintEnergyCompute<
-            3, Frame::Inertial>::name() == "ConstraintEnergy");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::ConstraintGamma0Compute<3, Frame::Inertial>>(
+      "ConstraintGamma0");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::ConstraintGamma1Compute<3, Frame::Inertial>>(
+      "ConstraintGamma1");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::ConstraintGamma2Compute<3, Frame::Inertial>>(
+      "ConstraintGamma2");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::GaugeHImplicitFrom3p1QuantitiesCompute<
+          3, Frame::Inertial>>("GaugeH");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<3,
+                                                             Frame::Inertial>>(
+      "SpacetimeDerivGaugeH");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::GaugeConstraintCompute<3, Frame::Inertial>>(
+      "GaugeConstraint");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::FConstraintCompute<3, Frame::Inertial>>(
+      "FConstraint");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<3, Frame::Inertial>>(
+      "TwoIndexConstraint");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<3,
+                                                             Frame::Inertial>>(
+      "ThreeIndexConstraint");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::FourIndexConstraintCompute<3,
+                                                            Frame::Inertial>>(
+      "FourIndexConstraint");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::ConstraintEnergyCompute<3, Frame::Inertial>>(
+      "ConstraintEnergy");
 
   // Check vs. time-independent analytic solution
   // Set up grid

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Tags.cpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace {
 struct ArbitraryFrame;
@@ -14,61 +15,70 @@ struct ArbitraryFrame;
 
 template <size_t Dim, typename Frame>
 void test_simple_tags() {
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::Pi<Dim, Frame>>() == "Pi");
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::Phi<Dim, Frame>>() == "Phi");
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::ConstraintGamma0>() ==
-        "ConstraintGamma0");
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::ConstraintGamma1>() ==
-        "ConstraintGamma1");
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::ConstraintGamma2>() ==
-        "ConstraintGamma2");
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::GaugeH<Dim, Frame>>() ==
-        "GaugeH");
-  CHECK(db::tag_name<
-            GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<Dim, Frame>>() ==
-        "SpacetimeDerivGaugeH");
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, Frame>>() ==
-        "InitialGaugeH");
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::UPsi<Dim, Frame>>() == "UPsi");
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::UZero<Dim, Frame>>() ==
-        "UZero");
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::UPlus<Dim, Frame>>() ==
-        "UPlus");
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::UMinus<Dim, Frame>>() ==
-        "UMinus");
-  CHECK(db::tag_name<
-            GeneralizedHarmonic::Tags::CharacteristicSpeeds<Dim, Frame>>() ==
-        "CharacteristicSpeeds");
-  CHECK(db::tag_name<
-            GeneralizedHarmonic::Tags::CharacteristicFields<Dim, Frame>>() ==
-        "CharacteristicFields");
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::
-                         EvolvedFieldsFromCharacteristicFields<Dim, Frame>>() ==
-        "EvolvedFieldsFromCharacteristicFields");
-  CHECK(
-      db::tag_name<GeneralizedHarmonic::Tags::GaugeConstraint<Dim, Frame>>() ==
+  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::Pi<Dim, Frame>>(
+      "Pi");
+  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::Phi<Dim, Frame>>(
+      "Phi");
+  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::ConstraintGamma0>(
+      "ConstraintGamma0");
+  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::ConstraintGamma1>(
+      "ConstraintGamma1");
+  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::ConstraintGamma2>(
+      "ConstraintGamma2");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::GaugeH<Dim, Frame>>("GaugeH");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<Dim, Frame>>(
+      "SpacetimeDerivGaugeH");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::InitialGaugeH<Dim, Frame>>("InitialGaugeH");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<Dim, Frame>>(
+      "SpacetimeDerivInitialGaugeH");
+  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::UPsi<Dim, Frame>>(
+      "UPsi");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::UZero<Dim, Frame>>("UZero");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::UPlus<Dim, Frame>>("UPlus");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::UMinus<Dim, Frame>>("UMinus");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::CharacteristicSpeeds<Dim, Frame>>(
+      "CharacteristicSpeeds");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::CharacteristicFields<Dim, Frame>>(
+      "CharacteristicFields");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::EvolvedFieldsFromCharacteristicFields<Dim,
+                                                                       Frame>>(
+      "EvolvedFieldsFromCharacteristicFields");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::GaugeConstraint<Dim, Frame>>(
       "GaugeConstraint");
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::FConstraint<Dim, Frame>>() ==
-        "FConstraint");
-  CHECK(db::tag_name<
-            GeneralizedHarmonic::Tags::TwoIndexConstraint<Dim, Frame>>() ==
-        "TwoIndexConstraint");
-  CHECK(db::tag_name<
-            GeneralizedHarmonic::Tags::ThreeIndexConstraint<Dim, Frame>>() ==
-        "ThreeIndexConstraint");
-  CHECK(db::tag_name<
-            GeneralizedHarmonic::Tags::FourIndexConstraint<Dim, Frame>>() ==
-        "FourIndexConstraint");
-  CHECK(
-      db::tag_name<GeneralizedHarmonic::Tags::ConstraintEnergy<Dim, Frame>>() ==
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::FConstraint<Dim, Frame>>("FConstraint");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::TwoIndexConstraint<Dim, Frame>>(
+      "TwoIndexConstraint");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::ThreeIndexConstraint<Dim, Frame>>(
+      "ThreeIndexConstraint");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::FourIndexConstraint<Dim, Frame>>(
+      "FourIndexConstraint");
+
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::ConstraintEnergy<Dim, Frame>>(
       "ConstraintEnergy");
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::GaugeHRollOnStartTime>() ==
-        "GaugeHRollOnStartTime");
-  CHECK(db::tag_name<GeneralizedHarmonic::Tags::GaugeHRollOnTimeWindow>() ==
-        "GaugeHRollOnTimeWindow");
-  CHECK(
-      db::tag_name<
-          GeneralizedHarmonic::Tags::GaugeHSpatialWeightDecayWidth<Frame>>() ==
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::GaugeHRollOnStartTime>(
+      "GaugeHRollOnStartTime");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::GaugeHRollOnTimeWindow>(
+      "GaugeHRollOnTimeWindow");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::GaugeHSpatialWeightDecayWidth<Frame>>(
       "GaugeHSpatialWeightDecayWidth");
 }
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Characteristics.cpp
@@ -15,6 +15,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/PointwiseFunctions/Hydro/TestHelpers.hpp"
 #include "tests/Unit/Pypp/Pypp.hpp"
@@ -103,6 +104,10 @@ void test_with_normal_along_coordinate_axes(
   }
 }
 
+struct SomeEosType {
+  static constexpr size_t thermodynamic_dim = 3;
+};
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Characteristics",
@@ -115,4 +120,8 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Characteristics",
   // Test with aligned normals to check the code works
   // with vector components being 0.
   test_with_normal_along_coordinate_axes(dv);
+
+  TestHelpers::db::test_compute_tag<
+      grmhd::ValenciaDivClean::Tags::CharacteristicSpeedsCompute<SomeEosType>>(
+      "CharacteristicSpeeds");
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_ValenciaDivClean.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_ValenciaDivClean.cpp
@@ -7,18 +7,24 @@
 
 #include "DataStructures/Tensor/IndexType.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.ValenciaDivClean.Tags",
                   "[Unit][GrMhd]") {
-  CHECK(grmhd::ValenciaDivClean::Tags::TildeD::name() == "TildeD");
-  CHECK(grmhd::ValenciaDivClean::Tags::TildeTau::name() == "TildeTau");
-  CHECK(grmhd::ValenciaDivClean::Tags::TildeS<Frame::Inertial>::name() ==
-        "TildeS");
-  CHECK(grmhd::ValenciaDivClean::Tags::TildeS<Frame::Grid>::name() ==
-        "Grid_TildeS");
-  CHECK(grmhd::ValenciaDivClean::Tags::TildeB<Frame::Inertial>::name() ==
-        "TildeB");
-  CHECK(grmhd::ValenciaDivClean::Tags::TildeB<Frame::Grid>::name() ==
-        "Grid_TildeB");
-  CHECK(grmhd::ValenciaDivClean::Tags::TildePhi::name() == "TildePhi");
+  TestHelpers::db::test_simple_tag<
+      grmhd::ValenciaDivClean::Tags::CharacteristicSpeeds>(
+      "CharacteristicSpeeds");
+  TestHelpers::db::test_simple_tag<grmhd::ValenciaDivClean::Tags::TildeD>(
+      "TildeD");
+  TestHelpers::db::test_simple_tag<grmhd::ValenciaDivClean::Tags::TildeTau>(
+      "TildeTau");
+  TestHelpers::db::test_simple_tag<
+      grmhd::ValenciaDivClean::Tags::TildeS<Frame::Grid>>("Grid_TildeS");
+  TestHelpers::db::test_simple_tag<
+      grmhd::ValenciaDivClean::Tags::TildeB<Frame::Grid>>("Grid_TildeB");
+  TestHelpers::db::test_simple_tag<grmhd::ValenciaDivClean::Tags::TildePhi>(
+      "TildePhi");
+  TestHelpers::db::test_simple_tag<
+      grmhd::ValenciaDivClean::Tags::ConstraintDampingParameter>(
+      "ConstraintDampingParameter");
 }

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Characteristics.cpp
@@ -22,6 +22,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Overloader.hpp"
 #include "Utilities/StdHelpers.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/Pypp.hpp"
@@ -35,6 +36,9 @@ namespace {
 
 template <size_t Dim>
 void test_characteristic_speeds(const DataVector& used_for_size) noexcept {
+  TestHelpers::db::test_compute_tag<
+      NewtonianEuler::Tags::CharacteristicSpeedsCompute<Dim>>(
+      "CharacteristicSpeeds");
   pypp::check_with_random_values<3>(
       static_cast<std::array<DataVector, Dim + 2> (*)(
           const tnsr::I<DataVector, Dim>&, const Scalar<DataVector>&,

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_SoundSpeedSquared.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_SoundSpeedSquared.cpp
@@ -16,6 +16,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/Tags.hpp"  // IWYU pragma: keep
 #include "Utilities/Gsl.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 #include "tests/Utilities/MakeWithRandomValues.hpp"
 
@@ -32,10 +33,11 @@ void test_compute_item_in_databox(
     const Scalar<DataType>& mass_density,
     const Scalar<DataType>& specific_internal_energy,
     const EquationOfStateType& equation_of_state) noexcept {
-  CHECK(NewtonianEuler::Tags::SoundSpeedSquaredCompute<DataType>::name() ==
-        "SoundSpeedSquared");
-  CHECK(NewtonianEuler::Tags::SoundSpeedCompute<DataType>::name() ==
-        "SoundSpeed");
+  TestHelpers::db::test_compute_tag<
+      NewtonianEuler::Tags::SoundSpeedSquaredCompute<DataType>>(
+      "SoundSpeedSquared");
+  TestHelpers::db::test_compute_tag<
+      NewtonianEuler::Tags::SoundSpeedCompute<DataType>>("SoundSpeed");
   const auto box = db::create<
       db::AddSimpleTags<NewtonianEuler::Tags::MassDensity<DataType>,
                         NewtonianEuler::Tags::SpecificInternalEnergy<DataType>,

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Sources.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Sources.cpp
@@ -21,24 +21,20 @@ namespace {
 
 struct FirstArg : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "FirstArg"; }
 };
 
 template <size_t Dim>
 struct SecondArg : db::SimpleTag {
   using type = tnsr::I<DataVector, Dim>;
-  static std::string name() noexcept { return "SecondArg"; }
 };
 
 struct ThirdArg : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "ThirdArg"; }
 };
 
 template <size_t Dim>
 struct FourthArg : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim>;
-  static std::string name() noexcept { return "FourthArg"; }
 };
 
 // Some source term where all three conservative quantities are sourced.

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Tags.cpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/Tensor/IndexType.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 class DataVector;
 struct SomeSourceType {};
@@ -18,30 +19,33 @@ struct SomeInitialDataType {
 namespace {
 template <size_t Dim>
 void test_tags() noexcept {
-  CHECK(NewtonianEuler::Tags::CharacteristicSpeeds<Dim>::name() ==
-        "CharacteristicSpeeds");
-  CHECK(NewtonianEuler::Tags::MassDensity<DataVector>::name() == "MassDensity");
-  CHECK(NewtonianEuler::Tags::MomentumDensity<DataVector, Dim,
-                                              Frame::Inertial>::name() ==
-        "MomentumDensity");
-  CHECK(NewtonianEuler::Tags::MomentumDensity<DataVector, Dim,
-                                              Frame::Grid>::name() ==
-        "Grid_MomentumDensity");
-  CHECK(NewtonianEuler::Tags::EnergyDensity<DataVector>::name() ==
-        "EnergyDensity");
-  CHECK(NewtonianEuler::Tags::Velocity<DataVector, Dim,
-                                       Frame::Inertial>::name() == "Velocity");
-  CHECK(
-      NewtonianEuler::Tags::Velocity<DataVector, Dim, Frame::Logical>::name() ==
+  TestHelpers::db::test_simple_tag<
+      NewtonianEuler::Tags::CharacteristicSpeeds<Dim>>("CharacteristicSpeeds");
+  TestHelpers::db::test_simple_tag<
+      NewtonianEuler::Tags::MassDensityCons<DataVector>>("MassDensityCons");
+  TestHelpers::db::test_simple_tag<
+      NewtonianEuler::Tags::MassDensity<DataVector>>("MassDensity");
+  TestHelpers::db::test_simple_tag<
+      NewtonianEuler::Tags::MomentumDensity<DataVector, Dim, Frame::Grid>>(
+      "Grid_MomentumDensity");
+  TestHelpers::db::test_simple_tag<
+      NewtonianEuler::Tags::EnergyDensity<DataVector>>("EnergyDensity");
+  TestHelpers::db::test_simple_tag<
+      NewtonianEuler::Tags::Velocity<DataVector, Dim, Frame::Logical>>(
       "Logical_Velocity");
-  CHECK(NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>::name() ==
-        "SpecificInternalEnergy");
-  CHECK(NewtonianEuler::Tags::Pressure<DataVector>::name() == "Pressure");
-  CHECK(NewtonianEuler::Tags::SoundSpeed<DataVector>::name() == "SoundSpeed");
-  CHECK(NewtonianEuler::Tags::SoundSpeedSquared<DataVector>::name() ==
-        "SoundSpeedSquared");
-  CHECK(NewtonianEuler::Tags::SourceTerm<SomeInitialDataType>::name() ==
-        "SourceTerm");
+  TestHelpers::db::test_simple_tag<
+      NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>>(
+      "SpecificInternalEnergy");
+  TestHelpers::db::test_simple_tag<NewtonianEuler::Tags::Pressure<DataVector>>(
+      "Pressure");
+  TestHelpers::db::test_simple_tag<
+      NewtonianEuler::Tags::SoundSpeed<DataVector>>("SoundSpeed");
+  TestHelpers::db::test_simple_tag<
+      NewtonianEuler::Tags::SoundSpeedSquared<DataVector>>("SoundSpeedSquared");
+  TestHelpers::db::test_base_tag<NewtonianEuler::Tags::SourceTermBase>(
+      "SourceTermBase");
+  TestHelpers::db::test_simple_tag<
+      NewtonianEuler::Tags::SourceTerm<SomeInitialDataType>>("SourceTerm");
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Tags.cpp
@@ -6,8 +6,10 @@
 #include <string>
 
 #include "DataStructures/Tensor/IndexType.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/RadiationTransport/M1Grey/Characteristics.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp"
 #include "Evolution/Systems/RadiationTransport/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 /// Test tags used in M1Grey code
 SPECTRE_TEST_CASE("Evolution.Systems.RadiationTransport.M1Grey.Tags",
@@ -22,10 +24,36 @@ SPECTRE_TEST_CASE("Evolution.Systems.RadiationTransport.M1Grey.Tags",
   CHECK(neutrinos::get_name(nux) == "HeavyLeptonNeutrinos3");
 
   // (2) Tags for evolved variables
-  CHECK(RadiationTransport::M1Grey::Tags::TildeE<
-            Frame::Inertial, neutrinos::ElectronNeutrinos<1> >::name() ==
-        "TildeE_ElectronNeutrinos1");
-  CHECK(RadiationTransport::M1Grey::Tags::TildeS<
-            Frame::Grid, neutrinos::ElectronAntiNeutrinos<2> >::name() ==
-        "Grid_TildeS_ElectronAntiNeutrinos2");
+  TestHelpers::db::test_simple_tag<RadiationTransport::M1Grey::Tags::TildeE<
+      Frame::Grid, neutrinos::ElectronNeutrinos<1>>>(
+      "Grid_TildeE_ElectronNeutrinos1");
+  TestHelpers::db::test_simple_tag<RadiationTransport::M1Grey::Tags::TildeS<
+      Frame::Grid, neutrinos::ElectronAntiNeutrinos<2>>>(
+      "Grid_TildeS_ElectronAntiNeutrinos2");
+  TestHelpers::db::test_simple_tag<RadiationTransport::M1Grey::Tags::TildeP<
+      Frame::Grid, neutrinos::ElectronAntiNeutrinos<2>>>(
+      "Grid_TildeP_ElectronAntiNeutrinos2");
+  TestHelpers::db::test_simple_tag<
+      RadiationTransport::M1Grey::Tags::TildeSVector<Frame::Grid>>(
+      "Grid_TildeSVector");
+  TestHelpers::db::test_simple_tag<
+      RadiationTransport::M1Grey::Tags::ClosureFactor<
+          neutrinos::ElectronNeutrinos<1>>>("ClosureFactor_ElectronNeutrinos1");
+  TestHelpers::db::test_simple_tag<
+      RadiationTransport::M1Grey::Tags::TildeJ<
+          neutrinos::ElectronNeutrinos<1>>>("TildeJ_ElectronNeutrinos1");
+  TestHelpers::db::test_simple_tag<
+      RadiationTransport::M1Grey::Tags::TildeHNormal<
+          neutrinos::ElectronNeutrinos<1>>>("TildeHNormal_ElectronNeutrinos1");
+  TestHelpers::db::test_simple_tag<
+      RadiationTransport::M1Grey::Tags::TildeHSpatial<
+          Frame::Grid, neutrinos::ElectronNeutrinos<1>>>(
+      "Grid_TildeHSpatial_ElectronNeutrinos1");
+  TestHelpers::db::test_simple_tag<
+      RadiationTransport::M1Grey::Tags::CharacteristicSpeeds>(
+      "CharacteristicSpeeds");
+  TestHelpers::db::test_compute_tag<
+      RadiationTransport::M1Grey::Tags::CharacteristicSpeedsCompute>(
+      "CharacteristicSpeeds");
+
 }

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Characteristics.cpp
@@ -23,6 +23,7 @@
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/StdHelpers.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/PointwiseFunctions/Hydro/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
@@ -43,8 +44,9 @@ void test_compute_item_in_databox(
     const Scalar<DataVector>& spatial_velocity_squared,
     const Scalar<DataVector>& sound_speed_squared,
     const tnsr::i<DataVector, Dim>& normal) noexcept {
-  CHECK(RelativisticEuler::Valencia::Tags::CharacteristicSpeedsCompute<
-            Dim>::name() == "CharacteristicSpeeds");
+  TestHelpers::db::test_compute_tag<
+      RelativisticEuler::Valencia::Tags::CharacteristicSpeedsCompute<Dim>>(
+      "CharacteristicSpeeds");
   const auto box = db::create<
       db::AddSimpleTags<
           gr::Tags::Lapse<>, gr::Tags::Shift<Dim>, gr::Tags::SpatialMetric<Dim>,

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Tags.cpp
@@ -7,14 +7,17 @@
 
 #include "DataStructures/Tensor/IndexType.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.Tags", "[Unit][Evolution]") {
-  CHECK(RelativisticEuler::Valencia::Tags::CharacteristicSpeeds<3>::name() ==
-        "CharacteristicSpeeds");
-  CHECK(RelativisticEuler::Valencia::Tags::TildeD::name() == "TildeD");
-  CHECK(RelativisticEuler::Valencia::Tags::TildeTau::name() == "TildeTau");
-  CHECK(RelativisticEuler::Valencia::Tags::TildeS<3, Frame::Inertial>::name() ==
-        "TildeS");
-  CHECK(RelativisticEuler::Valencia::Tags::TildeS<3, Frame::Logical>::name() ==
-        "Logical_TildeS");
+  TestHelpers::db::test_simple_tag<
+      RelativisticEuler::Valencia::Tags::CharacteristicSpeeds<3>>(
+      "CharacteristicSpeeds");
+  TestHelpers::db::test_simple_tag<RelativisticEuler::Valencia::Tags::TildeD>(
+      "TildeD");
+  TestHelpers::db::test_simple_tag<RelativisticEuler::Valencia::Tags::TildeTau>(
+      "TildeTau");
+  TestHelpers::db::test_simple_tag<
+      RelativisticEuler::Valencia::Tags::TildeS<3, Frame::Logical>>(
+      "Logical_TildeS");
 }

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
@@ -31,6 +31,7 @@
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 
@@ -48,6 +49,8 @@ Scalar<DataVector> speed_with_index(
 
 template <size_t Dim>
 void test_characteristic_speeds() noexcept {
+  TestHelpers::db::test_compute_tag<
+      ScalarWave::CharacteristicSpeedsCompute<Dim>>("CharacteristicSpeeds");
   const DataVector used_for_size(5);
   pypp::check_with_random_values<1>(speed_with_index<0, Dim>, "Characteristics",
                                     "char_speed_vpsi", {{{-10.0, 10.0}}},
@@ -115,6 +118,8 @@ typename Tag::type field_with_tag(
 
 template <size_t Dim>
 void test_characteristic_fields() noexcept {
+  TestHelpers::db::test_compute_tag<
+      ScalarWave::CharacteristicFieldsCompute<Dim>>("CharacteristicFields");
   const DataVector used_for_size(5);
   // VPsi
   pypp::check_with_random_values<1>(field_with_tag<ScalarWave::Tags::VPsi, Dim>,
@@ -222,6 +227,9 @@ typename Tag::type evol_field_with_tag(
 
 template <size_t Dim>
 void test_evolved_from_characteristic_fields() noexcept {
+  TestHelpers::db::test_compute_tag<
+      ScalarWave::EvolvedFieldsFromCharacteristicFieldsCompute<Dim>>(
+      "EvolvedFieldsFromCharacteristicFields");
   const DataVector used_for_size(5);
   // Psi
   pypp::check_with_random_values<1>(evol_field_with_tag<ScalarWave::Psi, Dim>,
@@ -328,6 +336,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Characteristics",
                   "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/ScalarWave/"};
+
+  TestHelpers::db::test_compute_tag<ScalarWave::Tags::ConstraintGamma2Compute>(
+      "ConstraintGamma2");
 
   test_characteristic_speeds<1>();
   test_characteristic_speeds<2>();

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Constraints.cpp
@@ -38,6 +38,7 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 
@@ -52,6 +53,9 @@ void test_one_index_constraint_random(
           const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&)>(
           &ScalarWave::one_index_constraint<SpatialDim>),
       "Constraints", "one_index_constraint", {{{-10.0, 10.0}}}, used_for_size);
+  TestHelpers::db::test_compute_tag<
+      ScalarWave::Tags::OneIndexConstraintCompute<SpatialDim>>(
+      "OneIndexConstraint");
 }
 
 // Test the return-by-value two-index constraint function using random values
@@ -64,6 +68,9 @@ void test_two_index_constraint_random(
           &ScalarWave::two_index_constraint<SpatialDim>),
       "Constraints", "two_index_constraint", {{{-10.0, 10.0}}}, used_for_size,
       1.0e-12);
+  TestHelpers::db::test_compute_tag<
+      ScalarWave::Tags::TwoIndexConstraintCompute<SpatialDim>>(
+      "TwoIndexConstraint");
 }
 
 template <typename Solution>

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Tags.cpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Tags",
+                  "[Unit][Evolution]") {
+  TestHelpers::db::test_simple_tag<ScalarWave::Psi>("Psi");
+  TestHelpers::db::test_simple_tag<ScalarWave::Pi>("Pi");
+  TestHelpers::db::test_simple_tag<ScalarWave::Phi<3>>("Phi");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::ConstraintGamma2>(
+      "ConstraintGamma2");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::OneIndexConstraint<3>>(
+      "OneIndexConstraint");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::TwoIndexConstraint<3>>(
+      "TwoIndexConstraint");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::VPsi>("VPsi");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::VZero<3>>("VZero");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::VPlus>("VPlus");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::VMinus>("VMinus");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::CharacteristicSpeeds<3>>(
+      "CharacteristicSpeeds");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::CharacteristicFields<3>>(
+      "CharacteristicFields");
+  TestHelpers::db::test_simple_tag<
+      ScalarWave::Tags::EvolvedFieldsFromCharacteristicFields<3>>(
+      "EvolvedFieldsFromCharacteristicFields");
+}

--- a/tests/Unit/Evolution/Test_ComputeTags.cpp
+++ b/tests/Unit/Evolution/Test_ComputeTags.cpp
@@ -15,6 +15,7 @@
 #include "Evolution/ComputeTags.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace {
 
@@ -49,8 +50,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.ComputeTags", "[Unit][Evolution]") {
   const DataVector expected{2., 4., 6., 8.};
   CHECK_ITERABLE_APPROX(get(get<::Tags::Analytic<FieldTag>>(box)), expected);
 
-  CHECK(
-      db::tag_name<evolution::Tags::AnalyticCompute<1, AnalyticSolutionTag,
-                                                    tmpl::list<FieldTag>>>() ==
+  TestHelpers::db::test_compute_tag<evolution::Tags::AnalyticCompute<
+      1, AnalyticSolutionTag, tmpl::list<FieldTag>>>(
       "Analytic(Variables(Analytic(FieldTag)))");
 }

--- a/tests/Unit/IO/Observers/Test_Tags.cpp
+++ b/tests/Unit/IO/Observers/Test_Tags.cpp
@@ -7,24 +7,31 @@
 
 #include "IO/Observer/Tags.hpp"
 #include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace observers {
 namespace Tags {
 SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
-  CHECK(NumberOfEvents::name() == "NumberOfEvents");
-  CHECK(ReductionArrayComponentIds::name() == "ReductionArrayComponentIds");
-  CHECK(VolumeArrayComponentIds::name() == "VolumeArrayComponentIds");
-  CHECK(TensorData::name() == "TensorData");
-  CHECK(VolumeObserversRegistered::name() == "VolumeObserversRegistered");
-  CHECK(VolumeObserversContributed::name() == "VolumeObserversContributed");
-  CHECK(H5FileLock::name() == "H5FileLock");
-  CHECK(ReductionData<double>::name() == "ReductionData");
-  CHECK(ReductionDataNames<double>::name() == "ReductionDataNames");
-  CHECK(ReductionObserversContributed::name() ==
-        "ReductionObserversContributed");
-  CHECK(ReductionObserversRegistered::name() == "ReductionObserversRegistered");
-  CHECK(ReductionObserversRegisteredNodes::name() ==
-        "ReductionObserversRegisteredNodes");
+  TestHelpers::db::test_simple_tag<NumberOfEvents>("NumberOfEvents");
+  TestHelpers::db::test_simple_tag<ReductionArrayComponentIds>(
+      "ReductionArrayComponentIds");
+  TestHelpers::db::test_simple_tag<VolumeArrayComponentIds>(
+      "VolumeArrayComponentIds");
+  TestHelpers::db::test_simple_tag<TensorData>("TensorData");
+  TestHelpers::db::test_simple_tag<VolumeObserversRegistered>(
+      "VolumeObserversRegistered");
+  TestHelpers::db::test_simple_tag<VolumeObserversContributed>(
+      "VolumeObserversContributed");
+  TestHelpers::db::test_simple_tag<H5FileLock>("H5FileLock");
+  TestHelpers::db::test_simple_tag<ReductionData<double>>("ReductionData");
+  TestHelpers::db::test_simple_tag<ReductionDataNames<double>>(
+      "ReductionDataNames");
+  TestHelpers::db::test_simple_tag<ReductionObserversContributed>(
+      "ReductionObserversContributed");
+  TestHelpers::db::test_simple_tag<ReductionObserversRegistered>(
+      "ReductionObserversRegistered");
+  TestHelpers::db::test_simple_tag<ReductionObserversRegisteredNodes>(
+      "ReductionObserversRegisteredNodes");
   static_assert(
       cpp17::is_same_v<typename ReductionData<double, int, char>::names_tag,
                        ReductionDataNames<double, int, char>>,

--- a/tests/Unit/Informer/Test_Verbosity.cpp
+++ b/tests/Unit/Informer/Test_Verbosity.cpp
@@ -10,6 +10,7 @@
 #include "Options/ParseOptions.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace {
 
@@ -37,6 +38,7 @@ void test_ostream() noexcept {
 SPECTRE_TEST_CASE("Unit.Informer.Verbosity", "[Informer][Unit]") {
   test_construct_from_options();
   test_ostream();
+  TestHelpers::db::test_simple_tag<Tags::Verbosity>("Verbosity");
 }
 
 // [[OutputRegex, Failed to convert "Braggadocious" to Verbosity]]

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
@@ -51,7 +51,6 @@ class er;
 
 namespace {
 struct Var : db::SimpleTag {
-  static std::string name() noexcept { return "Var"; }
   using type = Scalar<DataVector>;
 };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyFluxes.cpp
@@ -54,21 +54,18 @@ class er;
 
 namespace {
 struct TemporalId : db::SimpleTag {
-  static std::string name() noexcept { return "TemporalId"; }
   using type = size_t;
   template <typename Tag>
   using step_prefix = Tags::dt<Tag>;
 };
 
 struct Var : db::SimpleTag {
-  static std::string name() noexcept { return "Var"; }
   using type = Scalar<DataVector>;
 };
 
 class NumericalFlux {
  public:
   struct ExtraData : db::SimpleTag {
-    static std::string name() noexcept { return "ExtraData"; }
     using type = tnsr::I<DataVector, 1>;
   };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -51,17 +51,14 @@
 
 namespace {
 struct Var : db::SimpleTag {
-  static std::string name() noexcept { return "Var"; }
   using type = Scalar<DataVector>;
 };
 
 struct Var2 : db::SimpleTag {
-  static std::string name() noexcept { return "Var2"; }
   using type = tnsr::ii<DataVector, 2>;
 };
 
 struct OtherArg : db::SimpleTag {
-  static std::string name() noexcept { return "OtherArg"; }
   using type = double;
 };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -69,17 +69,14 @@
 
 namespace {
 struct TemporalId : db::SimpleTag {
-  static std::string name() noexcept { return "TemporalId"; }
   using type = int;
 };
 
 struct Var : db::SimpleTag {
-  static std::string name() noexcept { return "Var"; }
   using type = Scalar<DataVector>;
 };
 
 struct OtherData : db::SimpleTag {
-  static std::string name() noexcept { return "OtherData"; }
   using type = Scalar<DataVector>;
 };
 
@@ -87,7 +84,6 @@ template <size_t Dim>
 class NumericalFlux {
  public:
   struct ExtraData : db::SimpleTag {
-    static std::string name() noexcept { return "ExtraTag"; }
     using type = tnsr::I<DataVector, 1>;
   };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -61,17 +61,14 @@
 
 namespace {
 struct TemporalId : db::SimpleTag {
-  static std::string name() noexcept { return "TemporalId"; }
   using type = int;
 };
 
 struct Var : db::SimpleTag {
-  static std::string name() noexcept { return "Var"; }
   using type = Scalar<DataVector>;
 };
 
 struct OtherData : db::SimpleTag {
-  static std::string name() noexcept { return "OtherData"; }
   using type = Scalar<DataVector>;
 };
 
@@ -79,7 +76,6 @@ template <size_t Dim>
 class NumericalFlux {
  public:
   struct ExtraData : db::SimpleTag {
-    static std::string name() noexcept { return "ExtraTag"; }
     using type = tnsr::I<DataVector, 1>;
   };
 
@@ -148,7 +144,6 @@ using mortar_sizes_tag = Tags::Mortars<Tags::MortarSize<Dim - 1>, Dim>;
 struct DataRecorder;
 
 struct DataRecorderTag : db::SimpleTag {
-  static std::string name() { return "DataRecorderTag"; }
   using type = DataRecorder;
 };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -65,24 +65,20 @@ constexpr size_t Dim = 2;
 using TemporalId = Tags::TimeStepId;
 
 struct Var : db::SimpleTag {
-  static std::string name() noexcept { return "Var"; }
   using type = Scalar<DataVector>;
 };
 
 struct PrimitiveVar : db::SimpleTag {
-  static std::string name() noexcept { return "PrimitiveVar"; }
   using type = Scalar<DataVector>;
 };
 
 struct OtherData : db::SimpleTag {
-  static std::string name() noexcept { return "OtherData"; }
   using type = Scalar<DataVector>;
 };
 
 class NumericalFlux {
  public:
   struct ExtraData : db::SimpleTag {
-    static std::string name() noexcept { return "ExtraTag"; }
     using type = tnsr::I<DataVector, 1>;
   };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp
@@ -30,31 +30,26 @@ namespace NumericalFluxes {
 namespace Tags {
 struct Variable1 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "Variable1"; }
 };
 
 template <size_t Dim>
 struct Variable2 : db::SimpleTag {
   using type = tnsr::I<DataVector, Dim>;
-  static std::string name() noexcept { return "Variable2"; }
 };
 
 template <size_t Dim>
 struct Variable3 : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim>;
-  static std::string name() noexcept { return "Variable3"; }
 };
 
 template <size_t Dim>
 struct Variable4 : db::SimpleTag {
   using type = tnsr::Ij<DataVector, Dim>;
-  static std::string name() noexcept { return "Variable4"; }
 };
 
 template <size_t Dim>
 struct CharacteristicSpeeds : db::SimpleTag {
   using type = std::array<DataVector, (Dim + 1) * (Dim + 1)>;
-  static std::string name() noexcept { return "CharacteristicSpeeds"; }
 };
 
 }  // namespace Tags

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_NormalDotFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_NormalDotFlux.cpp
@@ -57,13 +57,11 @@ void test_with_random_values(
 }
 
 struct Var1 : db::SimpleTag {
-  static std::string name() noexcept { return "Var1"; }
   using type = Scalar<DataVector>;
 };
 
 template <size_t Dim, typename Frame>
 struct Var2 : db::SimpleTag {
-  static std::string name() noexcept { return "Var2"; }
   using type = tnsr::i<DataVector, Dim, Frame>;
 };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_Tags.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_Tags.cpp
@@ -7,14 +7,22 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace {
+struct SomeType {};
+
 struct SomeTag : db::SimpleTag {
   using type = int;
-  static std::string name() noexcept { return "SomeTag"; }
 };
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DG.Tags", "[Unit][NumericalAlgorithms]") {
-  CHECK(db::tag_name<::Tags::Mortars<SomeTag, 3>>() == "Mortars(SomeTag)");
+  TestHelpers::db::test_simple_tag<
+      Tags::SimpleMortarData<SomeType, SomeType, SomeType>>("SimpleMortarData");
+  TestHelpers::db::test_prefix_tag<Tags::Mortars<SomeTag, 3>>(
+      "Mortars(SomeTag)");
+  TestHelpers::db::test_simple_tag<Tags::MortarSize<2>>("MortarSize");
+  TestHelpers::db::test_simple_tag<Tags::NumericalFlux<SomeType>>(
+      "NumericalFlux");
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -25,6 +25,7 @@ set(LIBRARY_SOURCES
   Test_ParallelInterpolator.cpp
   Test_RegularGridInterpolant.cpp
   Test_SpanInterpolators.cpp
+  Test_Tags.cpp
   )
 
 add_test_library(

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -89,10 +89,6 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Initialize",
           component, ::Tags::Variables<typename metavars::InterpolationTargetA::
                                            vars_to_interpolate_to_target>>(
           runner, 0) == test_vars);
-
-  CHECK(::intrp::Tags::IndicesOfFilledInterpPoints::name() ==
-        "IndicesOfFilledInterpPoints");
-  CHECK(::intrp::Tags::TemporalIds<metavars>::name() == "TemporalIds");
 }
 
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
@@ -78,11 +78,5 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Initialize",
   CHECK(holder.infos.empty());
   // Check that 'holders' has only one tag.
   CHECK(holders.size() == 1);
-
-  // check tag names
-  CHECK(::intrp::Tags::VolumeVarsInfo<metavars>::name() == "VolumeVarsInfo");
-  CHECK(::intrp::Tags::InterpolatedVarsHolders<metavars>::name() ==
-        "InterpolatedVarsHolders");
-  CHECK(::intrp::Tags::NumberOfElements::name() == "NumberOfElements");
 }
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -57,7 +57,6 @@ namespace {
 namespace Tags {
 struct Lapse : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "Lapse"; }
 };
 }  // namespace Tags
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -143,17 +143,16 @@ struct MockComputeTargetPoints {
 // Simple DataBoxItems to test.
 namespace Tags {
 struct Square : db::SimpleTag {
-  static std::string name() noexcept { return "Square"; }
   using type = Scalar<DataVector>;
 };
 struct SquareComputeItem : Square, db::ComputeTag {
-  static std::string name() noexcept { return "Square"; }
   static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
     auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
     get<>(result) = square(get<>(x));
     return result;
   }
   using argument_tags = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using base = Square;
 };
 }  // namespace Tags
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -91,17 +91,16 @@ namespace {
 // Simple DataBoxItems for test.
 namespace Tags {
 struct Square : db::SimpleTag {
-  static std::string name() noexcept { return "Square"; }
   using type = Scalar<DataVector>;
 };
 struct SquareComputeItem : Square, db::ComputeTag {
-  static std::string name() noexcept { return "Square"; }
   static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
     auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
     get<>(result) = square(get<>(x));
     return result;
   }
   using argument_tags = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using base = Square;
 };
 }  // namespace Tags
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -76,7 +76,6 @@ namespace TestTags {
 template <size_t Dim>
 struct Vector : db::SimpleTag {
   using type = tnsr::I<DataVector, Dim>;
-  static std::string name() noexcept { return "Vector"; }
   static auto fill_values(const MathFunctions::TensorProduct<Dim>& f,
                           const tnsr::I<DataVector, Dim>& x) noexcept {
     auto result = make_with_value<tnsr::I<DataVector, Dim>>(x, 0.);
@@ -91,7 +90,6 @@ struct Vector : db::SimpleTag {
 template <size_t Dim>
 struct SymmetricTensor : db::SimpleTag {
   using type = tnsr::ii<DataVector, Dim>;
-  static std::string name() noexcept { return "SymmetricTensor"; }
   static auto fill_values(const MathFunctions::TensorProduct<Dim>& f,
                           const tnsr::I<DataVector, Dim>& x) noexcept {
     auto result = make_with_value<tnsr::ii<DataVector, Dim>>(x, 0.);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -84,34 +84,31 @@ namespace {
 // Simple DataBoxItems for test.
 namespace Tags {
 struct TestSolution : db::SimpleTag {
-  static std::string name() noexcept { return "TestSolution"; }
   using type = Scalar<DataVector>;
 };
 struct Square : db::SimpleTag {
-  static std::string name() noexcept { return "Square"; }
   using type = Scalar<DataVector>;
 };
-struct SquareComputeItem : Square, db::ComputeTag {
-  static std::string name() noexcept { return "Square"; }
+struct SquareCompute : Square, db::ComputeTag {
   static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
     auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
     get(result) = square(get(x));
     return result;
   }
   using argument_tags = tmpl::list<TestSolution>;
+  using base = Square;
 };
 struct Negate : db::SimpleTag {
-  static std::string name() noexcept { return "Negate"; }
   using type = Scalar<DataVector>;
 };
-struct NegateComputeItem : Negate, db::ComputeTag {
-  static std::string name() noexcept { return "Negate"; }
+struct NegateCompute : Negate, db::ComputeTag {
   static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
     auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
     get(result) = -get(x);
     return result;
   }
   using argument_tags = tmpl::list<Square>;
+  using base = Negate;
 };
 }  // namespace Tags
 
@@ -204,7 +201,7 @@ struct MockMetavariables {
         tmpl::list<Tags::TestSolution,
                    gr::Tags::SpatialMetric<3, Frame::Inertial>>;
     using compute_items_on_target = tmpl::list<
-        Tags::SquareComputeItem,
+        Tags::SquareCompute,
         StrahlkorperGr::Tags::AreaElement<Frame::Inertial>,
         StrahlkorperGr::Tags::SurfaceIntegral<Tags::Square, ::Frame::Inertial>>;
     using compute_target_points =
@@ -221,7 +218,7 @@ struct MockMetavariables {
         tmpl::list<Tags::TestSolution,
                    gr::Tags::SpatialMetric<3, Frame::Inertial>>;
     using compute_items_on_target = tmpl::list<
-        Tags::SquareComputeItem, Tags::NegateComputeItem,
+        Tags::SquareCompute, Tags::NegateCompute,
         StrahlkorperGr::Tags::AreaElement<Frame::Inertial>,
         StrahlkorperGr::Tags::SurfaceIntegral<Tags::Square, Frame::Inertial>,
         StrahlkorperGr::Tags::SurfaceIntegral<Tags::Negate, Frame::Inertial>>;
@@ -241,7 +238,7 @@ struct MockMetavariables {
         tmpl::list<Tags::TestSolution,
                    gr::Tags::SpatialMetric<3, Frame::Inertial>>;
     using compute_items_on_target = tmpl::list<
-        Tags::SquareComputeItem, Tags::NegateComputeItem,
+        Tags::SquareCompute, Tags::NegateCompute,
         StrahlkorperGr::Tags::AreaElement<Frame::Inertial>,
         StrahlkorperGr::Tags::SurfaceIntegral<Tags::Negate, ::Frame::Inertial>>;
     using compute_target_points =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -446,11 +446,11 @@ SPECTRE_TEST_CASE(
   // minus sign for "Negate".
   const std::vector<double> expected_integral_c{-5.0625 * 2432.0 * M_PI / 3.0};
   const std::vector<std::string> expected_legend_a{"Time",
-                                                   "SurfaceIntegralSquare"};
+                                                   "SurfaceIntegral(Square)"};
   const std::vector<std::string> expected_legend_b{
-      "Time", "SurfaceIntegralSquare", "SurfaceIntegralNegate"};
+      "Time", "SurfaceIntegral(Square)", "SurfaceIntegral(Negate)"};
   const std::vector<std::string> expected_legend_c{"Time",
-                                                   "SurfaceIntegralNegate"};
+                                                   "SurfaceIntegral(Negate)"};
 
   // Check that the H5 file was written correctly.
   const auto file = h5::H5File<h5::AccessType::ReadOnly>(h5_file_name);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -71,34 +71,31 @@ namespace {
 // Simple DataBoxItems for test.
 namespace Tags {
 struct TestSolution : db::SimpleTag {
-  static std::string name() noexcept { return "TestSolution"; }
   using type = Scalar<DataVector>;
 };
 struct Square : db::SimpleTag {
-  static std::string name() noexcept { return "Square"; }
   using type = Scalar<DataVector>;
 };
-struct SquareComputeItem : Square, db::ComputeTag {
-  static std::string name() noexcept { return "Square"; }
+struct SquareCompute : Square, db::ComputeTag {
   static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
     auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
     get(result) = square(get(x));
     return result;
   }
   using argument_tags = tmpl::list<TestSolution>;
+  using base = Square;
 };
 struct Negate : db::SimpleTag {
-  static std::string name() noexcept { return "Negate"; }
   using type = Scalar<DataVector>;
 };
-struct NegateComputeItem : Negate, db::ComputeTag {
-  static std::string name() noexcept { return "Negate"; }
+struct NegateCompute : Negate, db::ComputeTag {
   static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
     auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
     get(result) = -get(x);
     return result;
   }
   using argument_tags = tmpl::list<Square>;
+  using base = Negate;
 };
 }  // namespace Tags
 
@@ -214,7 +211,7 @@ struct mock_interpolator {
 
 struct MockMetavariables {
   struct InterpolationTargetA {
-    using compute_items_on_source = tmpl::list<Tags::SquareComputeItem>;
+    using compute_items_on_source = tmpl::list<Tags::SquareCompute>;
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
@@ -223,9 +220,9 @@ struct MockMetavariables {
         TestFunction<InterpolationTargetA, Tags::Square>;
   };
   struct InterpolationTargetB {
-    using compute_items_on_source = tmpl::list<Tags::SquareComputeItem>;
+    using compute_items_on_source = tmpl::list<Tags::SquareCompute>;
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
-    using compute_items_on_target = tmpl::list<Tags::NegateComputeItem>;
+    using compute_items_on_target = tmpl::list<Tags::NegateCompute>;
     using compute_target_points =
         intrp::Actions::LineSegment<InterpolationTargetB, 3>;
     using post_interpolation_callback =
@@ -234,7 +231,7 @@ struct MockMetavariables {
   struct InterpolationTargetC {
     using compute_items_on_source = tmpl::list<>;
     using vars_to_interpolate_to_target = tmpl::list<Tags::TestSolution>;
-    using compute_items_on_target = tmpl::list<Tags::SquareComputeItem>;
+    using compute_items_on_target = tmpl::list<Tags::SquareCompute>;
     using compute_target_points =
         intrp::Actions::KerrHorizon<InterpolationTargetC, ::Frame::Inertial>;
     using post_interpolation_callback = TestKerrHorizonIntegral;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
@@ -74,7 +74,6 @@ namespace TestTags {
 
 struct ScalarTag : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "Scalar"; }
   template <size_t Dim>
   static auto fill_values(const MathFunctions::TensorProduct<Dim>& f,
                           const tnsr::I<DataVector, Dim>& x) noexcept {
@@ -85,7 +84,6 @@ struct ScalarTag : db::SimpleTag {
 template <size_t Dim>
 struct Vector : db::SimpleTag {
   using type = tnsr::I<DataVector, Dim>;
-  static std::string name() noexcept { return "Vector"; }
   static auto fill_values(const MathFunctions::TensorProduct<Dim>& f,
                           const tnsr::I<DataVector, Dim>& x) noexcept {
     auto result = make_with_value<tnsr::I<DataVector, Dim>>(x, 0.);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_Tags.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_Tags.cpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+struct SomeType {};
+struct SomeTag {
+  using type = SomeType;
+};
+struct Metavars {
+  using temporal_id = SomeTag;
+  static constexpr size_t volume_dim = 3;
+  using interpolation_target_tags = tmpl::list<>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Interpolation.Tags", "[Unit][NumericalAlgorithms]") {
+  TestHelpers::db::test_simple_tag<intrp::Tags::IndicesOfFilledInterpPoints>(
+      "IndicesOfFilledInterpPoints");
+  TestHelpers::db::test_simple_tag<intrp::Tags::IndicesOfInvalidInterpPoints>(
+      "IndicesOfInvalidInterpPoints");
+  TestHelpers::db::test_simple_tag<intrp::Tags::TemporalIds<Metavars>>(
+      "TemporalIds");
+  TestHelpers::db::test_simple_tag<intrp::Tags::CompletedTemporalIds<Metavars>>(
+      "CompletedTemporalIds");
+  TestHelpers::db::test_simple_tag<intrp::Tags::VolumeVarsInfo<Metavars>>(
+      "VolumeVarsInfo");
+  TestHelpers::db::test_simple_tag<
+      intrp::Tags::InterpolatedVarsHolders<Metavars>>(
+      "InterpolatedVarsHolders");
+  TestHelpers::db::test_simple_tag<intrp::Tags::NumberOfElements>(
+      "NumberOfElements");
+}

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
@@ -36,13 +36,11 @@
 namespace {
 namespace Tags {
 struct ScalarVar : db::SimpleTag {
-  static std::string name() noexcept { return "Scalar"; }
   using type = Scalar<DataVector>;
 };
 
 template <size_t Dim>
 struct VectorVar : db::SimpleTag {
-  static std::string name() noexcept { return "Vector"; }
   using type = tnsr::I<DataVector, Dim>;
 };
 }  // namespace Tags

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Tags.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Tags.cpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include "NumericalAlgorithms/LinearOperators/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+struct SomeType {};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.LinearOperators.Tags", "[Unit][NumericalAlgorithms]") {
+  TestHelpers::db::test_simple_tag<Filters::Tags::Filter<SomeType>>("Filter");
+}

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshDerivatives.cpp
@@ -36,7 +36,6 @@ namespace {
 
 template <size_t Index, int Spin>
 struct TestTag : db::SimpleTag {
-  static std::string name() noexcept { return "TestTag"; }
   using type = Scalar<SpinWeighted<ComplexDataVector, Spin>>;
 };
 

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTags.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTags.cpp
@@ -12,6 +12,7 @@
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 // IWYU pragma: no_forward_declare SpinWeighted
 // IWYU pragma: no_forward_declare Tensor
@@ -27,22 +28,18 @@ namespace Tags {
 namespace {
 
 struct UnweightedTestTag : db::SimpleTag {
-  static std::string name() noexcept { return "UnweightedTestTag"; }
   using type = Scalar<ComplexDataVector>;
 };
 
 struct SpinMinus1TestTag : db::SimpleTag {
-  static std::string name() noexcept { return "SpinMinus1TestTag"; }
   using type = Scalar<SpinWeighted<ComplexDataVector, -1>>;
 };
 
 struct AnotherSpinMinus1TestTag : db::SimpleTag {
-  static std::string name() noexcept { return "AnotherSpinMinus1TestTag"; }
   using type = Scalar<SpinWeighted<ComplexDataVector, -1>>;
 };
 
 struct Spin2TestTag : db::SimpleTag {
-  static std::string name() noexcept { return "Spin2TestTag"; }
   using type = Scalar<SpinWeighted<ComplexDataVector, 2>>;
 };
 
@@ -101,22 +98,27 @@ static_assert(cpp17::is_same_v<
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.Tags",
                   "[Unit][NumericalAlgorithms]") {
-  CHECK(Derivative<SpinMinus1TestTag, Eth>::name() == "Eth(SpinMinus1TestTag)");
-  CHECK(Derivative<SpinMinus1TestTag, EthEth>::name() ==
-        "EthEth(SpinMinus1TestTag)");
-  CHECK(Derivative<SpinMinus1TestTag, EthEthbar>::name() ==
-        "EthEthbar(SpinMinus1TestTag)");
-  CHECK(Derivative<SpinMinus1TestTag, Ethbar>::name() ==
-        "Ethbar(SpinMinus1TestTag)");
-  CHECK(Derivative<SpinMinus1TestTag, EthbarEth>::name() ==
-        "EthbarEth(SpinMinus1TestTag)");
-  CHECK(Derivative<SpinMinus1TestTag, EthbarEthbar>::name() ==
-        "EthbarEthbar(SpinMinus1TestTag)");
-  CHECK(Derivative<SpinMinus1TestTag, NoDerivative>::name() ==
-        "NoDerivative(SpinMinus1TestTag)");
-  CHECK(SwshTransform<Spin2TestTag>::name() == "SwshTransform(Spin2TestTag)");
-  CHECK(SwshInterpolator<Spin2TestTag>::name() ==
-        "SwshInterpolator(Spin2TestTag)");
+  TestHelpers::db::test_prefix_tag<Derivative<SpinMinus1TestTag, Eth>>(
+      "Eth(SpinMinus1TestTag)");
+  TestHelpers::db::test_prefix_tag<Derivative<SpinMinus1TestTag, EthEth>>(
+      "EthEth(SpinMinus1TestTag)");
+  TestHelpers::db::test_prefix_tag<Derivative<SpinMinus1TestTag, EthEthbar>>(
+      "EthEthbar(SpinMinus1TestTag)");
+  TestHelpers::db::test_prefix_tag<Derivative<SpinMinus1TestTag, Ethbar>>(
+      "Ethbar(SpinMinus1TestTag)");
+  TestHelpers::db::test_prefix_tag<Derivative<SpinMinus1TestTag, EthbarEth>>(
+      "EthbarEth(SpinMinus1TestTag)");
+  TestHelpers::db::test_prefix_tag<Derivative<SpinMinus1TestTag, EthbarEthbar>>(
+      "EthbarEthbar(SpinMinus1TestTag)");
+  TestHelpers::db::test_prefix_tag<Derivative<SpinMinus1TestTag, NoDerivative>>(
+      "NoDerivative(SpinMinus1TestTag)");
+  TestHelpers::db::test_prefix_tag<SwshTransform<Spin2TestTag>>(
+      "SwshTransform(Spin2TestTag)");
+  TestHelpers::db::test_prefix_tag<SwshInterpolator<Spin2TestTag>>(
+      "SwshInterpolator(Spin2TestTag)");
+  TestHelpers::db::test_simple_tag<LMax>("LMax");
+  TestHelpers::db::test_simple_tag<NumberOfRadialPoints>(
+      "NumberOfRadialPoints");
 }
 }  // namespace
 }  // namespace Tags

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransform.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransform.cpp
@@ -37,7 +37,6 @@ namespace {
 // for storing a computed spin-weighted value during the transform test
 template <size_t index, int Spin>
 struct TestTag : db::SimpleTag {
-  static std::string name() noexcept { return "TestTag"; }
   using type = Scalar<SpinWeighted<ComplexDataVector, Spin>>;
 };
 

--- a/tests/Unit/Parallel/Test_ConstGlobalCacheDataBox.cpp
+++ b/tests/Unit/Parallel/Test_ConstGlobalCacheDataBox.cpp
@@ -16,6 +16,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace Parallel {
 namespace Tags {
@@ -78,9 +79,14 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCacheDataBox", "[Unit][Parallel]") {
   CHECK(&Parallel::get<Tags::UniquePtrIntegerList>(cache2) ==
         &db::get<Tags::UniquePtrIntegerList>(box));
 
-  CHECK(Tags::FromConstGlobalCache<Tags::IntegerList>::name() ==
-        "FromConstGlobalCache(IntegerList)");
-  CHECK(Tags::FromConstGlobalCache<Tags::UniquePtrIntegerList>::name() ==
-        "FromConstGlobalCache(UniquePtrIntegerList)");
+  TestHelpers::db::test_base_tag<Tags::ConstGlobalCache>("ConstGlobalCache");
+  TestHelpers::db::test_simple_tag<Tags::ConstGlobalCacheImpl<Metavars>>(
+      "ConstGlobalCache");
+  TestHelpers::db::test_compute_tag<
+      Tags::FromConstGlobalCache<Tags::IntegerList>>(
+      "FromConstGlobalCache(IntegerList)");
+  TestHelpers::db::test_compute_tag<
+      Tags::FromConstGlobalCache<Tags::UniquePtrIntegerList>>(
+      "FromConstGlobalCache(UniquePtrIntegerList)");
 }
 }  // namespace Parallel

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_Tags.cpp
@@ -14,6 +14,8 @@ struct DummyType {};
 
 SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.EventsAndTriggers.Tags",
                   "[Unit][ParallelAlgorithms]") {
+  TestHelpers::db::test_base_tag<Tags::EventsAndTriggersBase>(
+      "EventsAndTriggersBase");
   TestHelpers::db::test_simple_tag<
       Tags::EventsAndTriggers<DummyType, DummyType>>("EventsAndTriggers");
 }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Test_Tags.cpp
@@ -29,32 +29,38 @@ using initial_residual_magnitude_tag =
 
 SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Tags",
                   "[Unit][ParallelAlgorithms][LinearSolver]") {
-  CHECK(LinearSolver::Tags::Operand<Tag>::name() == "LinearOperand(Tag)");
-  CHECK(LinearSolver::Tags::OperatorAppliedTo<Tag>::name() ==
-        "LinearOperatorAppliedTo(Tag)");
+  TestHelpers::db::test_prefix_tag<LinearSolver::Tags::Operand<Tag>>(
+      "LinearOperand(Tag)");
+  TestHelpers::db::test_prefix_tag<LinearSolver::Tags::OperatorAppliedTo<Tag>>(
+      "LinearOperatorAppliedTo(Tag)");
   TestHelpers::db::test_simple_tag<LinearSolver::Tags::IterationId>(
       "LinearIterationId");
   TestHelpers::db::test_simple_tag<LinearSolver::Tags::HasConverged>(
       "LinearSolverHasConverged");
-  CHECK(LinearSolver::Tags::Residual<Tag>::name() == "LinearResidual(Tag)");
-  CHECK(LinearSolver::Tags::Initial<Tag>::name() == "Initial(Tag)");
-  CHECK(LinearSolver::Tags::MagnitudeSquare<Tag>::name() ==
-        "LinearMagnitudeSquare(Tag)");
-  CHECK(LinearSolver::Tags::Magnitude<Tag>::name() == "LinearMagnitude(Tag)");
-  CHECK(LinearSolver::Tags::Orthogonalization<Tag>::name() ==
-        "LinearOrthogonalization(Tag)");
-  CHECK(LinearSolver::Tags::OrthogonalizationHistory<Tag>::name() ==
-        "LinearOrthogonalizationHistory(Tag)");
-  CHECK(LinearSolver::Tags::KrylovSubspaceBasis<Tag>::name() ==
-        "KrylovSubspaceBasis(Tag)");
+  TestHelpers::db::test_prefix_tag<LinearSolver::Tags::Residual<Tag>>(
+      "LinearResidual(Tag)");
+  TestHelpers::db::test_prefix_tag<LinearSolver::Tags::Initial<Tag>>(
+      "Initial(Tag)");
+  TestHelpers::db::test_prefix_tag<LinearSolver::Tags::MagnitudeSquare<Tag>>(
+      "LinearMagnitudeSquare(Tag)");
+  TestHelpers::db::test_prefix_tag<LinearSolver::Tags::Magnitude<Tag>>(
+      "LinearMagnitude(Tag)");
+  TestHelpers::db::test_prefix_tag<LinearSolver::Tags::Orthogonalization<Tag>>(
+      "LinearOrthogonalization(Tag)");
+  TestHelpers::db::test_prefix_tag<
+      LinearSolver::Tags::OrthogonalizationHistory<Tag>>(
+      "LinearOrthogonalizationHistory(Tag)");
+  TestHelpers::db::test_prefix_tag<
+      LinearSolver::Tags::KrylovSubspaceBasis<Tag>>("KrylovSubspaceBasis(Tag)");
   TestHelpers::db::test_simple_tag<LinearSolver::Tags::ConvergenceCriteria>(
       "ConvergenceCriteria");
   TestHelpers::db::test_simple_tag<LinearSolver::Tags::Verbosity>("Verbosity");
 
   {
     INFO("HasConvergedCompute");
-    CHECK(LinearSolver::Tags::HasConvergedCompute<Tag>::name() ==
-          "LinearSolverHasConverged");
+    TestHelpers::db::test_compute_tag<
+        LinearSolver::Tags::HasConvergedCompute<Tag>>(
+        "LinearSolverHasConverged");
     const auto box = db::create<
         db::AddSimpleTags<LinearSolver::Tags::ConvergenceCriteria,
                           LinearSolver::Tags::IterationId,
@@ -85,12 +91,17 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Tags",
 
   {
     INFO("MagnitudeCompute");
-    CHECK(LinearSolver::Tags::MagnitudeCompute<magnitude_square_tag>::name() ==
-          "LinearMagnitude(Tag)");
+    TestHelpers::db::test_compute_tag<
+        LinearSolver::Tags::MagnitudeCompute<magnitude_square_tag>>(
+        "LinearMagnitude(Tag)");
     const auto box =
         db::create<db::AddSimpleTags<magnitude_square_tag>,
                    db::AddComputeTags<LinearSolver::Tags::MagnitudeCompute<
                        magnitude_square_tag>>>(4.);
     CHECK(db::get<magnitude_tag>(box) == approx(2.));
   }
+
+  TestHelpers::db::test_compute_tag<
+      Tags::NextCompute<LinearSolver::Tags::IterationId>>(
+      "Next(LinearIterationId)");
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CMakeLists.txt
@@ -1,4 +1,17 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(LIBRARY "Test_AnalyticData")
+
+set(LIBRARY_SOURCES
+  Test_Tags.cpp
+  )
+
 add_subdirectory(GrMhd)
+
+add_test_library(
+  ${LIBRARY}
+  "PointwiseFunctions/AnalyticData"
+  "${LIBRARY_SOURCES}"
+  ""
+  )

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Test_Tags.cpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+struct DummyType {};
+struct DummyTag : db::SimpleTag {
+  using type = DummyType;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.AnalyticData.Tags", "[Unit][PointwiseFunctions]") {
+  TestHelpers::db::test_base_tag<Tags::AnalyticSolutionOrData>(
+      "AnalyticSolutionOrData");
+  TestHelpers::db::test_base_tag<Tags::AnalyticDataBase>("AnalyticDataBase");
+  TestHelpers::db::test_simple_tag<Tags::AnalyticData<DummyType>>(
+      "AnalyticData");
+}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(LIBRARY "Test_AnalyticSolutions")
+
+set(LIBRARY_SOURCES
+  Test_Tags.cpp
+  )
+
 add_subdirectory(Burgers)
 add_subdirectory(Elasticity)
 add_subdirectory(GeneralRelativity)
@@ -11,3 +17,10 @@ add_subdirectory(RadiationTransport)
 add_subdirectory(RelativisticEuler)
 add_subdirectory(WaveEquation)
 add_subdirectory(Xcts)
+
+add_test_library(
+  ${LIBRARY}
+  "PointwiseFunctions/AnalyticSolutions"
+  "${LIBRARY_SOURCES}"
+  ""
+  )

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Test_Tags.cpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+struct DummyType {};
+struct DummyTag : db::SimpleTag {
+  using type = DummyType;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.AnalyticSolutions.Tags", "[Unit][PointwiseFunctions]") {
+  TestHelpers::db::test_base_tag<Tags::AnalyticSolutionBase>(
+      "AnalyticSolutionBase");
+  TestHelpers::db::test_simple_tag<Tags::AnalyticSolution<DummyType>>(
+      "AnalyticSolution");
+  TestHelpers::db::test_base_tag<Tags::BoundaryConditionBase>(
+      "BoundaryConditionBase");
+  TestHelpers::db::test_simple_tag<Tags::BoundaryCondition<DummyType>>(
+      "BoundaryCondition");
+}

--- a/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/Test_Tags.cpp
@@ -6,12 +6,16 @@
 #include <string>
 
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace {
 struct SomeConstitutiveRelation;
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Elasticity.Tags", "[Unit][Elasticity]") {
-  CHECK(Elasticity::Tags::ConstitutiveRelation<
-            SomeConstitutiveRelation>::name() == "Material");
+  TestHelpers::db::test_base_tag<Elasticity::Tags::ConstitutiveRelationBase>(
+      "ConstitutiveRelationBase");
+  TestHelpers::db::test_simple_tag<
+      Elasticity::Tags::ConstitutiveRelation<SomeConstitutiveRelation>>(
+      "Material");
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
@@ -20,6 +20,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -65,42 +66,34 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Christoffel",
 
   // Check that compute items work correctly in the DataBox
   // First, check that the names are correct
-  CHECK(gr::Tags::SpatialChristoffelFirstKind<3, Frame::Inertial,
-                                              DataVector>::name() ==
-        "SpatialChristoffelFirstKind");
-  CHECK(gr::Tags::TraceSpatialChristoffelFirstKind<3, Frame::Inertial,
-                                                   DataVector>::name() ==
-        "TraceSpatialChristoffelFirstKind");
-  CHECK(gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial,
-                                               DataVector>::name() ==
-        "SpatialChristoffelSecondKind");
-  CHECK(gr::Tags::TraceSpatialChristoffelSecondKind<3, Frame::Inertial,
-                                                    DataVector>::name() ==
-        "TraceSpatialChristoffelSecondKind");
-
-  CHECK(gr::Tags::SpatialChristoffelFirstKindCompute<3, Frame::Inertial,
-                                                     DataVector>::name() ==
-        "SpatialChristoffelFirstKind");
-  CHECK(gr::Tags::TraceSpatialChristoffelFirstKindCompute<3, Frame::Inertial,
-                                                          DataVector>::name() ==
-        "TraceSpatialChristoffelFirstKind");
-  CHECK(gr::Tags::SpatialChristoffelSecondKindCompute<3, Frame::Inertial,
-                                                      DataVector>::name() ==
-        "SpatialChristoffelSecondKind");
-  CHECK(
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::SpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                   DataVector>>(
+      "SpatialChristoffelFirstKind");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::TraceSpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                        DataVector>>(
+      "TraceSpatialChristoffelFirstKind");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::SpatialChristoffelSecondKindCompute<3, Frame::Inertial,
+                                                    DataVector>>(
+      "SpatialChristoffelSecondKind");
+  TestHelpers::db::test_compute_tag<
       gr::Tags::TraceSpatialChristoffelSecondKindCompute<3, Frame::Inertial,
-                                                         DataVector>::name() ==
+                                                         DataVector>>(
       "TraceSpatialChristoffelSecondKind");
-  CHECK(gr::Tags::SpacetimeChristoffelFirstKindCompute<3, Frame::Inertial,
-                                                       DataVector>::name() ==
-        "SpacetimeChristoffelFirstKind");
-  CHECK(
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::SpacetimeChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                     DataVector>>(
+      "SpacetimeChristoffelFirstKind");
+  TestHelpers::db::test_compute_tag<
       gr::Tags::TraceSpacetimeChristoffelFirstKindCompute<3, Frame::Inertial,
-                                                          DataVector>::name() ==
+                                                          DataVector>>(
       "TraceSpacetimeChristoffelFirstKind");
-  CHECK(gr::Tags::SpacetimeChristoffelSecondKindCompute<3, Frame::Inertial,
-                                                        DataVector>::name() ==
-        "SpacetimeChristoffelSecondKind");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::SpacetimeChristoffelSecondKindCompute<3, Frame::Inertial,
+                                                      DataVector>>(
+      "SpacetimeChristoffelSecondKind");
 
   // Check that the compute items return correct values
   const DataVector used_for_size{3., 4., 5.};

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -37,6 +37,7 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -619,28 +620,34 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
 
   // Check that compute items work correctly in the DataBox
   // First, check that the names are correct
-  CHECK(GeneralizedHarmonic::Tags::TimeDerivSpatialMetricCompute<
-            3, Frame::Inertial>::name() == "dt(SpatialMetric)");
-  CHECK(GeneralizedHarmonic::Tags::TimeDerivLapseCompute<
-            3, Frame::Inertial>::name() == "dt(Lapse)");
-  CHECK(GeneralizedHarmonic::Tags::TimeDerivShiftCompute<
-            3, Frame::Inertial>::name() == "dt(Shift)");
-  CHECK(GeneralizedHarmonic::Tags::DerivSpatialMetricCompute<
-            3, Frame::Inertial>::name() == "deriv(SpatialMetric)");
-  CHECK(GeneralizedHarmonic::Tags::DerivLapseCompute<3,
-                                                     Frame::Inertial>::name() ==
-        "deriv(Lapse)");
-  CHECK(GeneralizedHarmonic::Tags::DerivShiftCompute<3,
-                                                     Frame::Inertial>::name() ==
-        "deriv(Shift)");
-  CHECK(GeneralizedHarmonic::Tags::PhiCompute<3, Frame::Inertial>::name() ==
-        "Phi");
-  CHECK(GeneralizedHarmonic::Tags::PiCompute<3, Frame::Inertial>::name() ==
-        "Pi");
-  CHECK(GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<
-            3, Frame::Inertial>::name() == "ExtrinsicCurvature");
-  CHECK(GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
-            3, Frame::Inertial>::name() == "TraceExtrinsicCurvature");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::TimeDerivSpatialMetricCompute<
+          3, Frame::Inertial>>("dt(SpatialMetric)");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::TimeDerivLapseCompute<3, Frame::Inertial>>(
+      "dt(Lapse)");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::TimeDerivShiftCompute<3, Frame::Inertial>>(
+      "dt(Shift)");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::DerivSpatialMetricCompute<3, Frame::Inertial>>(
+      "deriv(SpatialMetric)");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::DerivLapseCompute<3, Frame::Inertial>>(
+      "deriv(Lapse)");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::DerivShiftCompute<3, Frame::Inertial>>(
+      "deriv(Shift)");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::PhiCompute<3, Frame::Inertial>>("Phi");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::PiCompute<3, Frame::Inertial>>("Pi");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<3, Frame::Inertial>>(
+      "ExtrinsicCurvature");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
+          3, Frame::Inertial>>("TraceExtrinsicCurvature");
 
   // Check that the compute items return the correct values
   MAKE_GENERATOR(generator);

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -20,6 +20,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -176,35 +177,37 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
 
   // Check that compute items work correctly in the DataBox
   // First, check that the names are correct
-  CHECK(gr::Tags::SpacetimeNormalOneFormCompute<3, Frame::Inertial,
-                                                DataVector>::name() ==
-        "SpacetimeNormalOneForm");
-  CHECK(gr::Tags::SpacetimeNormalVectorCompute<3, Frame::Inertial,
-                                               DataVector>::name() ==
-        "SpacetimeNormalVector");
-  CHECK(gr::Tags::SpacetimeMetricCompute<3, Frame::Inertial,
-                                         DataVector>::name() ==
-        "SpacetimeMetric");
-  CHECK(gr::Tags::InverseSpacetimeMetricCompute<3, Frame::Inertial,
-                                                DataVector>::name() ==
-        "InverseSpacetimeMetric");
-  CHECK(
-      gr::Tags::SpatialMetricCompute<3, Frame::Inertial, DataVector>::name() ==
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::SpacetimeNormalOneFormCompute<3, Frame::Inertial, DataVector>>(
+      "SpacetimeNormalOneForm");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::SpacetimeNormalVectorCompute<3, Frame::Inertial, DataVector>>(
+      "SpacetimeNormalVector");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::SpacetimeMetricCompute<3, Frame::Inertial, DataVector>>(
+      "SpacetimeMetric");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::InverseSpacetimeMetricCompute<3, Frame::Inertial, DataVector>>(
+      "InverseSpacetimeMetric");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::SpatialMetricCompute<3, Frame::Inertial, DataVector>>(
       "SpatialMetric");
-  CHECK(gr::Tags::ShiftCompute<3, Frame::Inertial, DataVector>::name() ==
-        "Shift");
-  CHECK(gr::Tags::LapseCompute<3, Frame::Inertial, DataVector>::name() ==
-        "Lapse");
-  CHECK(gr::Tags::SqrtDetSpatialMetricCompute<3, Frame::Inertial,
-                                              DataVector>::name() ==
-        "SqrtDetSpatialMetric");
-  CHECK(gr::Tags::DetAndInverseSpatialMetricCompute<3, Frame::Inertial,
-                                                    DataVector>::name() ==
-        "Variables(DetSpatialMetric,InverseSpatialMetric)");
-  CHECK(gr::Tags::DerivativesOfSpacetimeMetricCompute<
-            3, Frame::Inertial>::name() == "DerivativesOfSpacetimeMetric");
-  CHECK(gr::Tags::DerivSpacetimeMetricCompute<3, Frame::Inertial>::name() ==
-        "DerivSpacetimeMetric");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::ShiftCompute<3, Frame::Inertial, DataVector>>("Shift");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::LapseCompute<3, Frame::Inertial, DataVector>>("Lapse");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::SqrtDetSpatialMetricCompute<3, Frame::Inertial, DataVector>>(
+      "SqrtDetSpatialMetric");
+  TestHelpers::db::test_compute_tag<gr::Tags::DetAndInverseSpatialMetricCompute<
+      3, Frame::Inertial, DataVector>>(
+      "Variables(DetSpatialMetric,InverseSpatialMetric)");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::DerivativesOfSpacetimeMetricCompute<3, Frame::Inertial>>(
+      "DerivativesOfSpacetimeMetric");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::DerivSpacetimeMetricCompute<3, Frame::Inertial>>(
+      "DerivSpacetimeMetric");
 
   // Second, put the compute items into a data box and check that they
   // put the correct results

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
@@ -8,6 +8,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 
@@ -33,4 +34,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Ricci.",
 
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_ricci, (1, 2, 3),
                                     (IndexType::Spatial, IndexType::Spacetime));
+
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::RicciTensorCompute<3, Frame::Inertial, DataVector>>(
+      "RicciTensor");
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
@@ -5,8 +5,8 @@
 
 #include <string>
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace {
 struct ArbitraryFrame;
@@ -15,52 +15,63 @@ struct ArbitraryType;
 
 template <size_t Dim, typename Frame, typename Type>
 void test_simple_tags() {
-  CHECK(db::tag_name<gr::Tags::SpacetimeMetric<Dim, Frame, Type>>() ==
-        "SpacetimeMetric");
-  CHECK(db::tag_name<gr::Tags::InverseSpacetimeMetric<Dim, Frame, Type>>() ==
-        "InverseSpacetimeMetric");
-  CHECK(db::tag_name<gr::Tags::InverseSpatialMetric<Dim, Frame, Type>>() ==
-        "InverseSpatialMetric");
-  CHECK(db::tag_name<gr::Tags::DetSpatialMetric<Type>>() == "DetSpatialMetric");
-  CHECK(db::tag_name<gr::Tags::SqrtDetSpatialMetric<Type>>() ==
-        "SqrtDetSpatialMetric");
-  CHECK(db::tag_name<gr::Tags::Shift<Dim, Frame, Type>>() == "Shift");
-  CHECK(db::tag_name<gr::Tags::Lapse<Type>>() == "Lapse");
-  CHECK(db::tag_name<gr::Tags::DerivSpacetimeMetric<Dim, Frame, Type>>() ==
-        "DerivSpacetimeMetric");
-  CHECK(db::tag_name<
-            gr::Tags::DerivativesOfSpacetimeMetric<Dim, Frame, Type>>() ==
-        "DerivativesOfSpacetimeMetric");
-  CHECK(db::tag_name<
-            gr::Tags::SpacetimeChristoffelFirstKind<Dim, Frame, Type>>() ==
-        "SpacetimeChristoffelFirstKind");
-  CHECK(db::tag_name<
-            gr::Tags::SpacetimeChristoffelSecondKind<Dim, Frame, Type>>() ==
-        "SpacetimeChristoffelSecondKind");
-  CHECK(
-      db::tag_name<gr::Tags::SpatialChristoffelFirstKind<Dim, Frame, Type>>() ==
+  TestHelpers::db::test_simple_tag<gr::Tags::SpacetimeMetric<Dim, Frame, Type>>(
+      "SpacetimeMetric");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::InverseSpacetimeMetric<Dim, Frame, Type>>(
+      "InverseSpacetimeMetric");
+  TestHelpers::db::test_simple_tag<gr::Tags::SpatialMetric<Dim, Frame, Type>>(
+      "SpatialMetric");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::InverseSpatialMetric<Dim, Frame, Type>>("InverseSpatialMetric");
+  TestHelpers::db::test_simple_tag<gr::Tags::DetSpatialMetric<Type>>(
+      "DetSpatialMetric");
+  TestHelpers::db::test_simple_tag<gr::Tags::SqrtDetSpatialMetric<Type>>(
+      "SqrtDetSpatialMetric");
+  TestHelpers::db::test_simple_tag<gr::Tags::Shift<Dim, Frame, Type>>("Shift");
+  TestHelpers::db::test_simple_tag<gr::Tags::Lapse<Type>>("Lapse");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::DerivSpacetimeMetric<Dim, Frame, Type>>("DerivSpacetimeMetric");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::DerivativesOfSpacetimeMetric<Dim, Frame, Type>>(
+      "DerivativesOfSpacetimeMetric");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::SpacetimeChristoffelFirstKind<Dim, Frame, Type>>(
+      "SpacetimeChristoffelFirstKind");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::SpacetimeChristoffelSecondKind<Dim, Frame, Type>>(
+      "SpacetimeChristoffelSecondKind");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::SpatialChristoffelFirstKind<Dim, Frame, Type>>(
       "SpatialChristoffelFirstKind");
-  CHECK(db::tag_name<
-            gr::Tags::SpatialChristoffelSecondKind<Dim, Frame, Type>>() ==
-        "SpatialChristoffelSecondKind");
-  CHECK(db::tag_name<gr::Tags::SpacetimeNormalOneForm<Dim, Frame, Type>>() ==
-        "SpacetimeNormalOneForm");
-  CHECK(db::tag_name<gr::Tags::SpacetimeNormalVector<Dim, Frame, Type>>() ==
-        "SpacetimeNormalVector");
-  CHECK(db::tag_name<
-            gr::Tags::TraceSpacetimeChristoffelFirstKind<Dim, Frame, Type>>() ==
-        "TraceSpacetimeChristoffelFirstKind");
-  CHECK(db::tag_name<
-            gr::Tags::TraceSpatialChristoffelFirstKind<Dim, Frame, Type>>() ==
-        "TraceSpatialChristoffelFirstKind");
-  CHECK(db::tag_name<
-            gr::Tags::TraceSpatialChristoffelSecondKind<Dim, Frame, Type>>() ==
-        "TraceSpatialChristoffelSecondKind");
-  CHECK(db::tag_name<gr::Tags::ExtrinsicCurvature<Dim, Frame, Type>>() ==
-        "ExtrinsicCurvature");
-  CHECK(db::tag_name<gr::Tags::TraceExtrinsicCurvature<Type>>() ==
-        "TraceExtrinsicCurvature");
-  CHECK(db::tag_name<gr::Tags::EnergyDensity<Type>>() == "EnergyDensity");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::SpatialChristoffelSecondKind<Dim, Frame, Type>>(
+      "SpatialChristoffelSecondKind");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::SpacetimeNormalOneForm<Dim, Frame, Type>>(
+      "SpacetimeNormalOneForm");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::SpacetimeNormalVector<Dim, Frame, Type>>(
+      "SpacetimeNormalVector");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::TraceSpacetimeChristoffelFirstKind<Dim, Frame, Type>>(
+      "TraceSpacetimeChristoffelFirstKind");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::TraceSpatialChristoffelFirstKind<Dim, Frame, Type>>(
+      "TraceSpatialChristoffelFirstKind");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::TraceSpatialChristoffelSecondKind<Dim, Frame, Type>>(
+      "TraceSpatialChristoffelSecondKind");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::ExtrinsicCurvature<Dim, Frame, Type>>("ExtrinsicCurvature");
+  TestHelpers::db::test_simple_tag<gr::Tags::TraceExtrinsicCurvature<Type>>(
+      "TraceExtrinsicCurvature");
+  TestHelpers::db::test_simple_tag<gr::Tags::RicciTensor<Dim, Frame, Type>>(
+      "RicciTensor");
+  TestHelpers::db::test_simple_tag<gr::Tags::EnergyDensity<Type>>(
+      "EnergyDensity");
+  TestHelpers::db::test_simple_tag<gr::Tags::WeylElectric<Dim, Frame, Type>>(
+      "WeylElectric");
 }
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Tags",

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylElectric.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylElectric.cpp
@@ -8,6 +8,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 
@@ -36,4 +37,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.WeylElectric",
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
 
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_weyl_electric, (1, 2, 3));
+
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::WeylElectricCompute<3, Frame::Inertial, DataVector>>(
+      "WeylElectric");
 }

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_LorentzFactor.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_LorentzFactor.cpp
@@ -13,6 +13,7 @@
 #include "PointwiseFunctions/Hydro/LorentzFactor.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 
@@ -49,8 +50,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.LorentzFactor",
   test_lorentz_factor<3, Frame::Grid>(0.0);
 
   // Check compute item works correctly in DataBox
-  CHECK(Tags::LorentzFactorCompute<DataVector, 2, Frame::Inertial>::name() ==
-        "LorentzFactor");
+  TestHelpers::db::test_compute_tag<
+      Tags::LorentzFactorCompute<DataVector, 2, Frame::Inertial>>(
+      "LorentzFactor");
   tnsr::i<DataVector, 2> velocity_one_form{
       {{DataVector{5, 0.2}, DataVector{5, 0.3}}}};
   tnsr::I<DataVector, 2> velocity{{{DataVector{5, 0.25}, DataVector{5, 0.35}}}};

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_MassFlux.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_MassFlux.cpp
@@ -13,6 +13,7 @@
 #include "PointwiseFunctions/Hydro/MassFlux.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 
@@ -46,8 +47,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.MassFlux",
   test_mass_flux<3, Frame::Grid>(0.0);
 
   // Check compute item works correctly in DataBox
-  CHECK(Tags::MassFluxCompute<DataVector, 2, Frame::Inertial>::name() ==
-        "MassFlux");
+  TestHelpers::db::test_compute_tag<
+      Tags::MassFluxCompute<DataVector, 2, Frame::Inertial>>("MassFlux");
   Scalar<DataVector> rho{{{DataVector{5, 1.0}}}};
   tnsr::I<DataVector, 3> velocity{
       {{DataVector{5, 0.25}, DataVector{5, 0.1}, DataVector{5, 0.35}}}};

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_SoundSpeedSquared.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_SoundSpeedSquared.cpp
@@ -14,6 +14,7 @@
 #include "PointwiseFunctions/Hydro/SoundSpeedSquared.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/Gsl.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/PointwiseFunctions/Hydro/TestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
@@ -25,8 +26,8 @@ void test_compute_item_in_databox(
     const Scalar<DataType>& specific_internal_energy,
     const Scalar<DataType>& specific_enthalpy,
     const EquationOfStateType& equation_of_state) noexcept {
-  CHECK(hydro::Tags::SoundSpeedSquaredCompute<DataType>::name() ==
-        "SoundSpeedSquared");
+  TestHelpers::db::test_compute_tag<
+      hydro::Tags::SoundSpeedSquaredCompute<DataType>>("SoundSpeedSquared");
   const auto box = db::create<
       db::AddSimpleTags<hydro::Tags::RestMassDensity<DataType>,
                         hydro::Tags::SpecificInternalEnergy<DataType>,

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_SpecificEnthalpy.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_SpecificEnthalpy.cpp
@@ -12,6 +12,7 @@
 #include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 
@@ -37,8 +38,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.SpecificEnthalpy",
   test_relativistic_specific_enthalpy(DataVector(5));
 
   // Check compute item works correctly in DataBox
-  CHECK(Tags::SpecificEnthalpyCompute<DataVector>::name() ==
-        "SpecificEnthalpy");
+  TestHelpers::db::test_compute_tag<Tags::SpecificEnthalpyCompute<DataVector>>(
+      "SpecificEnthalpy");
   Scalar<DataVector> rest_mass_density{{{DataVector{5, 0.2}}}};
   Scalar<DataVector> specific_internal_energy{{{DataVector{5, 0.23}}}};
   Scalar<DataVector> pressure{{{DataVector{5, 0.234}}}};

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
@@ -7,69 +7,73 @@
 
 #include "DataStructures/Tensor/IndexType.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 class DataVector;
 template <bool IsRelativistic>
 class IdealFluid;
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.Tags", "[Unit][Hydro]") {
-  CHECK(hydro::Tags::AlfvenSpeedSquared<DataVector>::name() ==
-        "AlfvenSpeedSquared");
-  CHECK(hydro::Tags::ComovingMagneticField<DataVector, 3,
-                                           Frame::Inertial>::name() ==
-        "ComovingMagneticField");
-  CHECK(hydro::Tags::ComovingMagneticField<DataVector, 3,
-                                           Frame::Logical>::name() ==
-        "Logical_ComovingMagneticField");
-  CHECK(hydro::Tags::ComovingMagneticFieldSquared<DataVector>::name() ==
-        "ComovingMagneticFieldSquared");
-  CHECK(hydro::Tags::DivergenceCleaningField<DataVector>::name() ==
-        "DivergenceCleaningField");
-  CHECK(hydro::Tags::EquationOfState<IdealFluid<true>>::name() ==
-        "EquationOfState");
-  CHECK(hydro::Tags::LorentzFactor<DataVector>::name() == "LorentzFactor");
-  CHECK(hydro::Tags::LorentzFactorSquared<DataVector>::name() ==
-        "LorentzFactorSquared");
-  CHECK(hydro::Tags::MagneticField<DataVector, 3, Frame::Inertial>::name() ==
-        "MagneticField");
-  CHECK(hydro::Tags::MagneticField<DataVector, 3, Frame::Distorted>::name() ==
-        "Distorted_MagneticField");
-  CHECK(hydro::Tags::MagneticFieldDotSpatialVelocity<DataVector>::name() ==
-        "MagneticFieldDotSpatialVelocity");
-  CHECK(hydro::Tags::MagneticFieldOneForm<DataVector, 3,
-                                          Frame::Inertial>::name() ==
-        "MagneticFieldOneForm");
-  CHECK(hydro::Tags::MagneticFieldSquared<DataVector>::name() ==
-        "MagneticFieldSquared");
-  CHECK(hydro::Tags::MagneticPressure<DataVector>::name() ==
-        "MagneticPressure");
-  CHECK(hydro::Tags::Pressure<DataVector>::name() == "Pressure");
-  CHECK(hydro::Tags::RestMassDensity<DataVector>::name() == "RestMassDensity");
-  CHECK(hydro::Tags::SoundSpeedSquared<DataVector>::name() ==
-        "SoundSpeedSquared");
+  TestHelpers::db::test_simple_tag<hydro::Tags::AlfvenSpeedSquared<DataVector>>(
+      "AlfvenSpeedSquared");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::ComovingMagneticField<DataVector, 3, Frame::Logical>>(
+      "Logical_ComovingMagneticField");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::ComovingMagneticFieldSquared<DataVector>>(
+      "ComovingMagneticFieldSquared");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::DivergenceCleaningField<DataVector>>(
+      "DivergenceCleaningField");
+  TestHelpers::db::test_base_tag<hydro::Tags::EquationOfStateBase>(
+      "EquationOfStateBase");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::EquationOfState<IdealFluid<true>>>("EquationOfState");
+  TestHelpers::db::test_simple_tag<hydro::Tags::LorentzFactor<DataVector>>(
+      "LorentzFactor");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::LorentzFactorSquared<DataVector>>("LorentzFactorSquared");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::MagneticField<DataVector, 3, Frame::Distorted>>(
+      "Distorted_MagneticField");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::MagneticFieldDotSpatialVelocity<DataVector>>(
+      "MagneticFieldDotSpatialVelocity");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::MagneticFieldOneForm<DataVector, 3, Frame::Logical>>(
+      "Logical_MagneticFieldOneForm");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::MagneticFieldSquared<DataVector>>("MagneticFieldSquared");
+  TestHelpers::db::test_simple_tag<hydro::Tags::MagneticPressure<DataVector>>(
+      "MagneticPressure");
+  TestHelpers::db::test_simple_tag<hydro::Tags::Pressure<DataVector>>(
+      "Pressure");
+  TestHelpers::db::test_simple_tag<hydro::Tags::RestMassDensity<DataVector>>(
+      "RestMassDensity");
+  TestHelpers::db::test_simple_tag<hydro::Tags::SoundSpeedSquared<DataVector>>(
+      "SoundSpeedSquared");
   /// [prefix_example]
-  CHECK(hydro::Tags::SpatialVelocity<DataVector, 3, Frame::Inertial>::name() ==
-        "SpatialVelocity");
-  CHECK(hydro::Tags::SpatialVelocity<DataVector, 3, Frame::Grid>::name() ==
-        "Grid_SpatialVelocity");
-  CHECK(hydro::Tags::SpatialVelocityOneForm<DataVector, 3,
-                                            Frame::Inertial>::name() ==
-        "SpatialVelocityOneForm");
-  CHECK(hydro::Tags::SpatialVelocityOneForm<DataVector, 3,
-                                            Frame::Logical>::name() ==
-        "Logical_SpatialVelocityOneForm");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::SpatialVelocity<DataVector, 3, Frame::Grid>>(
+      "Grid_SpatialVelocity");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::SpatialVelocityOneForm<DataVector, 3, Frame::Logical>>(
+      "Logical_SpatialVelocityOneForm");
   /// [prefix_example]
-  CHECK(hydro::Tags::SpatialVelocitySquared<double>::name() ==
-        "SpatialVelocitySquared");
-  CHECK(hydro::Tags::SpatialVelocitySquared<DataVector>::name() ==
-        "SpatialVelocitySquared");
-  CHECK(hydro::Tags::SpecificEnthalpy<double>::name() == "SpecificEnthalpy");
-  CHECK(hydro::Tags::SpecificEnthalpy<DataVector>::name() ==
-        "SpecificEnthalpy");
-  CHECK(hydro::Tags::SpecificInternalEnergy<double>::name() ==
-        "SpecificInternalEnergy");
-  CHECK(hydro::Tags::SpecificInternalEnergy<DataVector>::name() ==
-        "SpecificInternalEnergy");
-  CHECK(hydro::Tags::MassFlux<DataVector, 3, Frame::Inertial>::name() ==
-        "MassFlux");
+  TestHelpers::db::test_simple_tag<hydro::Tags::SpatialVelocitySquared<double>>(
+      "SpatialVelocitySquared");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::SpatialVelocitySquared<DataVector>>(
+      "SpatialVelocitySquared");
+  TestHelpers::db::test_simple_tag<hydro::Tags::SpecificEnthalpy<double>>(
+      "SpecificEnthalpy");
+  TestHelpers::db::test_simple_tag<hydro::Tags::SpecificEnthalpy<DataVector>>(
+      "SpecificEnthalpy");
+  TestHelpers::db::test_simple_tag<hydro::Tags::SpecificInternalEnergy<double>>(
+      "SpecificInternalEnergy");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::SpecificInternalEnergy<DataVector>>(
+      "SpecificInternalEnergy");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::MassFlux<DataVector, 3, Frame::Logical>>("Logical_MassFlux");
 }

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <tuple>
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Variables.hpp"
 #include "ErrorHandling/Assert.hpp"
 #include "ErrorHandling/Error.hpp"
@@ -443,7 +444,7 @@ struct check_variables_approx<Variables<TagList>> {
                     Approx& appx = approx) {  // NOLINT
     tmpl::for_each<TagList>([&a, &b, &appx](auto x) {
       using Tag = typename decltype(x)::type;
-      INFO(Tag::name());
+      INFO(db::tag_name<Tag>());
       const auto& a_val = extract_value_for_variables_comparison<Tag>(
           a, is_any_spin_weighted<typename Tag::type::type>{});
       const auto& b_val = extract_value_for_variables_comparison<Tag>(

--- a/tests/Unit/Time/Test_Tags.cpp
+++ b/tests/Unit/Time/Test_Tags.cpp
@@ -5,14 +5,24 @@
 
 #include <string>
 
+#include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Tags.hpp"
 #include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace {
 struct DummyType {};
+struct DummyTag : db::SimpleTag {
+  using type = DummyType;
+};
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.Tags", "[Unit][Time]") {
+  TestHelpers::db::test_base_tag<Tags::HistoryEvolvedVariables<>>(
+      "HistoryEvolvedVariables");
+  TestHelpers::db::test_base_tag<Tags::TimeStepper<>>("TimeStepper");
+  TestHelpers::db::test_compute_tag<Tags::SubstepTimeCompute>("SubstepTime");
+  TestHelpers::db::test_prefix_tag<SelfStart::Tags::InitialValue<DummyTag>>(
+      "InitialValue(DummyTag)");
   TestHelpers::db::test_simple_tag<Tags::TimeStepId>("TimeStepId");
   TestHelpers::db::test_simple_tag<Tags::TimeStep>("TimeStep");
   TestHelpers::db::test_simple_tag<Tags::SubstepTime>("SubstepTime");


### PR DESCRIPTION
## Proposed changes

Adds helper functions to test base, compute, and prefix tags.
Use them in testing tags in the Time directory.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration
