### PR TITLE
Add star solution in Newtonian gravity

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -158,6 +158,12 @@
       SLACcitation   = "%%CITATION = ARXIV:1904.04831;%%"
 }
 
+@book{Chandrasekhar1939,
+  author = "Chandrasekhar, Subrahmanyan",
+  title  = "An introduction to the study of stellar structure",
+  year   = "1939"
+}
+
 @book{Cockburn1999,
   author     = "Cockburn, Bernardo",
   editor     = "Barth, Timothy J. and Deconinck, Herman",
@@ -673,6 +679,14 @@
   year      = "2013",
   month     = "sep",
   url       = "{http://adsabs.harvard.edu/abs/2013rehy.book.....R}",
+}
+
+@book{Shapiro1983,
+  author = "Shapiro, Stuart L. and Teukolsky, Saul A.",
+  title  = "Black holes, white dwarfs, and neutron stars:
+            the physics of compact objects",
+  year   = "1983",
+  url     = {https://ui.adsabs.harvard.edu/abs/1983bhwd.book.....S},
 }
 
 @article{Stamm2010,

--- a/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
@@ -50,3 +50,13 @@ endfunction(add_isentropic_vortex_executable)
 
 add_isentropic_vortex_executable(2)
 add_isentropic_vortex_executable(3)
+
+function(add_lane_emden_executable)
+  add_newtonian_euler_executable(
+    LaneEmdenStar
+    3
+    NewtonianEuler::Solutions::LaneEmdenStar
+    )
+endfunction(add_lane_emden_executable)
+
+add_lane_emden_executable()

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -54,6 +54,7 @@
 #include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEulerFwd.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEulerFwd.hpp
@@ -9,6 +9,7 @@ namespace NewtonianEuler {
 namespace Solutions {
 template <size_t Dim>
 class IsentropicVortex;
+class LaneEmdenStar;
 template <size_t Dim>
 class RiemannProblem;
 }  // namespace Solutions

--- a/src/Evolution/Systems/NewtonianEuler/Sources/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY NewtonianEulerSources)
 
 set(LIBRARY_SOURCES
+  LaneEmdenGravitationalField.cpp
   UniformAcceleration.cpp
   VortexPerturbation.cpp
   )

--- a/src/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.cpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.hpp"
+#include "Utilities/Gsl.hpp"
+
+// IWYU pragma: no_include <array>
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace NewtonianEuler {
+namespace Sources {
+
+void LaneEmdenGravitationalField::apply(
+    const gsl::not_null<tnsr::I<DataVector, 3>*> source_momentum_density,
+    const gsl::not_null<Scalar<DataVector>*> source_energy_density,
+    const Scalar<DataVector>& mass_density_cons,
+    const tnsr::I<DataVector, 3>& momentum_density,
+    const NewtonianEuler::Solutions::LaneEmdenStar& star,
+    const tnsr::I<DataVector, 3>& x) noexcept {
+  const auto gravitational_field = star.gravitational_field(x);
+  get(*source_energy_density) = 0.0;
+  for (size_t i = 0; i < 3; ++i) {
+    source_momentum_density->get(i) =
+        get(mass_density_cons) * gravitational_field.get(i);
+    get(*source_energy_density) +=
+        momentum_density.get(i) * gravitational_field.get(i);
+  }
+}
+
+}  // Namespace Sources
+}  // namespace NewtonianEuler

--- a/src/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.hpp
@@ -1,0 +1,99 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+
+namespace NewtonianEuler {
+namespace Solutions {
+struct LaneEmdenStar;
+}  // namespace Solutions
+}  // namespace NewtonianEuler
+
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+template <typename SolutionType>
+struct AnalyticSolution;
+}  // namespace Tags
+
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+// IWYU pragma: no_include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace NewtonianEuler {
+namespace Sources {
+
+/*!
+ * \brief Source giving the acceleration due to gravity in the spherical,
+ * Newtonian Lane-Emden star solution.
+ *
+ * The gravitational field \f$g^i\f$ enters the NewtonianEuler system as source
+ * terms for the conserved momentum and energy:
+ *
+ * \f{align*}
+ * \partial_t S^i + \partial_j F^{j}(S^i) &= S(S^i) = \rho g^i
+ * \partial_t e + \partial_j F^{j}(e) &= S(e) = S_i g^i,
+ * \f}
+ *
+ * where \f$S^i\f$ is the conserved momentum density, \f$e\f$ is the conserved
+ * energy, \f$F^{j}(u)\f$ is the flux of the conserved quantity \f$u\f$, and
+ * \f$\rho\f$ is the fluid mass density.
+ *
+ * \note This source is specialized to the Lane-Emden solution because it
+ * queries a LaneEmdenStar analytic solution for the gravitational field that
+ * generates the fluid acceleration. This source does *not* integrate the fluid
+ * density to compute a self-consistent gravitational field (i.e., as if one
+ * were solving a coupled Euler + Poisson system).
+ */
+struct LaneEmdenGravitationalField {
+  LaneEmdenGravitationalField() noexcept = default;
+  LaneEmdenGravitationalField(const LaneEmdenGravitationalField& /*rhs*/) =
+      default;
+  LaneEmdenGravitationalField& operator=(
+      const LaneEmdenGravitationalField& /*rhs*/) = default;
+  LaneEmdenGravitationalField(LaneEmdenGravitationalField&& /*rhs*/) noexcept =
+      default;
+  LaneEmdenGravitationalField& operator=(
+      LaneEmdenGravitationalField&& /*rhs*/) noexcept = default;
+  ~LaneEmdenGravitationalField() = default;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+
+  using sourced_variables = tmpl::list<Tags::MomentumDensity<DataVector, 3>,
+                                       Tags::EnergyDensity<DataVector>>;
+
+  using argument_tags = tmpl::list<
+      Tags::MassDensityCons<DataVector>, Tags::MomentumDensity<DataVector, 3>,
+      ::Tags::AnalyticSolution<NewtonianEuler::Solutions::LaneEmdenStar>,
+      ::Tags::Coordinates<3, Frame::Inertial>>;
+
+  static void apply(
+      gsl::not_null<tnsr::I<DataVector, 3>*> source_momentum_density,
+      gsl::not_null<Scalar<DataVector>*> source_energy_density,
+      const Scalar<DataVector>& mass_density_cons,
+      const tnsr::I<DataVector, 3>& momentum_density,
+      const NewtonianEuler::Solutions::LaneEmdenStar& star,
+      const tnsr::I<DataVector, 3>& x) noexcept;
+};
+
+}  // namespace Sources
+}  // namespace NewtonianEuler

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY NewtonianEulerSolutions)
 
 set(LIBRARY_SOURCES
   IsentropicVortex.cpp
+  LaneEmdenStar.cpp
   RiemannProblem.cpp
   )
 

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.cpp
@@ -1,0 +1,132 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.hpp"
+
+#include <cmath>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"                  // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"          // IWYU pragma: keep
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace NewtonianEuler {
+namespace Solutions {
+
+LaneEmdenStar::LaneEmdenStar(const double central_mass_density,
+                             const double polytropic_constant) noexcept
+    : central_mass_density_(central_mass_density),
+      polytropic_constant_(polytropic_constant),
+      equation_of_state_{polytropic_constant_, 2.0} {
+  ASSERT(central_mass_density > 0.0,
+         "central_mass_density = " << central_mass_density);
+  ASSERT(polytropic_constant > 0.0,
+         "polytropic_constant = " << polytropic_constant);
+}
+
+void LaneEmdenStar::pup(PUP::er& p) noexcept {
+  p | central_mass_density_;
+  p | polytropic_constant_;
+  p | equation_of_state_;
+}
+
+template <typename DataType>
+Scalar<DataType> LaneEmdenStar::precompute_mass_density(
+    const tnsr::I<DataType, 3>& x) const noexcept {
+  // Compute alpha for polytrope n==1, units G==1
+  const double alpha = sqrt(0.5 * polytropic_constant_ / M_PI);
+  const double outer_radius = alpha * M_PI;
+  // Add tiny offset to avoid divisons by zero
+  const DataType radius = get(magnitude(x)) + 1.e-30 * outer_radius;
+
+  Scalar<DataType> mass_density(get_size(radius));
+  for (size_t s = 0; s < get_size(radius); ++s) {
+    if (get_element(radius, s) < outer_radius) {
+      const double xi = get_element(radius, s) / alpha;
+      get_element(get(mass_density), s) = central_mass_density_ * sin(xi) / xi;
+    } else {
+      get_element(get(mass_density), s) = 0.0;
+    }
+  }
+  return mass_density;
+}
+
+template <typename DataType>
+tuples::TaggedTuple<Tags::MassDensity<DataType>> LaneEmdenStar::variables(
+    tmpl::list<Tags::MassDensity<DataType>> /*meta*/,
+    const Scalar<DataType>& mass_density) const noexcept {
+  return mass_density;
+}
+
+template <typename DataType>
+tuples::TaggedTuple<Tags::Velocity<DataType, 3, Frame::Inertial>>
+LaneEmdenStar::variables(
+    tmpl::list<Tags::Velocity<DataType, 3, Frame::Inertial>> /*meta*/,
+    const Scalar<DataType>& mass_density) const noexcept {
+  return make_with_value<tnsr::I<DataType, 3>>(get(mass_density), 0.0);
+}
+
+template <typename DataType>
+tuples::TaggedTuple<Tags::Pressure<DataType>> LaneEmdenStar::variables(
+    tmpl::list<Tags::Pressure<DataType>> /*meta*/,
+    const Scalar<DataType>& mass_density) const noexcept {
+  return equation_of_state_.pressure_from_density(mass_density);
+}
+
+template <typename DataType>
+tuples::TaggedTuple<Tags::SpecificInternalEnergy<DataType>>
+LaneEmdenStar::variables(
+    tmpl::list<Tags::SpecificInternalEnergy<DataType>> /*meta*/,
+    const Scalar<DataType>& mass_density) const noexcept {
+  return equation_of_state_.specific_internal_energy_from_density(mass_density);
+}
+
+bool operator==(const LaneEmdenStar& lhs, const LaneEmdenStar& rhs) noexcept {
+  // There is no comparison operator for the EoS, but should be okay as
+  // the `polytropic_constant`s are compared.
+  return lhs.central_mass_density_ == rhs.central_mass_density_ and
+         lhs.polytropic_constant_ == rhs.polytropic_constant_;
+}
+
+bool operator!=(const LaneEmdenStar& lhs, const LaneEmdenStar& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template Scalar<DTYPE(data)> LaneEmdenStar::precompute_mass_density(       \
+      const tnsr::I<DTYPE(data), 3>& x) const noexcept;                      \
+  template tuples::TaggedTuple<Tags::MassDensity<DTYPE(data)>>               \
+  LaneEmdenStar::variables(                                                  \
+      tmpl::list<Tags::MassDensity<DTYPE(data)>> /*meta*/,                   \
+      const Scalar<DTYPE(data)>& mass_density) const noexcept;               \
+  template tuples::TaggedTuple<                                              \
+      Tags::Velocity<DTYPE(data), 3, Frame::Inertial>>                       \
+      LaneEmdenStar::variables(                                              \
+          tmpl::list<                                                        \
+              Tags::Velocity<DTYPE(data), 3, Frame::Inertial>> /*meta*/,     \
+          const Scalar<DTYPE(data)>& mass_density) const noexcept;           \
+  template tuples::TaggedTuple<Tags::Pressure<DTYPE(data)>>                  \
+  LaneEmdenStar::variables(tmpl::list<Tags::Pressure<DTYPE(data)>> /*meta*/, \
+                           const Scalar<DTYPE(data)>& mass_density)          \
+      const noexcept;                                                        \
+  template tuples::TaggedTuple<Tags::SpecificInternalEnergy<DTYPE(data)>>    \
+  LaneEmdenStar::variables(                                                  \
+      tmpl::list<Tags::SpecificInternalEnergy<DTYPE(data)>> /*meta*/,        \
+      const Scalar<DTYPE(data)>& mass_density) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE
+
+}  // namespace Solutions
+}  // namespace NewtonianEuler

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.hpp
@@ -1,0 +1,140 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <limits>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/NewtonianEuler/Sources/NoSource.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PUP {
+class er;  // IWYU pragma: keep
+}  // namespace PUP
+/// \endcond
+
+// IWYU pragma: no_include <pup.h>
+
+namespace NewtonianEuler {
+namespace Solutions {
+
+/*!
+ * \brief A static spherically symmetric star in Newtonian gravity
+ *
+ * The solution for a static, spherically-symmetric star in 3 dimensions, found
+ * by solving the Lane-Emden equation \cite Chandrasekhar1939
+ * \cite Shapiro1983 .
+ * The Lane-Emden equation has closed-form solutions for certain equations of
+ * state; this class implements the solution for a polytropic fluid with
+ * polytropic exponent \f$\Gamma=2\f$ (i.e., with polytropic index \f$n=1\f$).
+ * The solution is returned in units where \f$G=1\f$, with \f$G\f$ the
+ * gravitational constant.
+ *
+ * The radius and mass of the star are determined by the polytropic constant
+ * \f$\kappa\f$ and central density \f$\rho_c\f$.
+ * The radius is \f$R = \pi \alpha\f$,
+ * and the mass is \f$M = 4 \pi^2 \alpha^3 \rho_c\f$,
+ * where \f$\alpha = \sqrt{\kappa / (2 \pi)}\f$ and \f$G=1\f$.
+ */
+class LaneEmdenStar : public MarkAsAnalyticSolution {
+ public:
+  using equation_of_state_type = EquationsOfState::PolytropicFluid<false>;
+  using source_term_type = Sources::NoSource;
+
+  /// The central mass density of the star.
+  struct CentralMassDensity {
+    using type = double;
+    static constexpr OptionString help = {
+        "The central mass density of the star."};
+    static type lower_bound() noexcept { return 0.; }
+  };
+
+  /// The polytropic constant of the polytropic fluid.
+  struct PolytropicConstant {
+    using type = double;
+    static constexpr OptionString help = {
+        "The polytropic constant of the fluid."};
+    static type lower_bound() noexcept { return 0.; }
+  };
+
+  using options = tmpl::list<CentralMassDensity, PolytropicConstant>;
+
+  static constexpr OptionString help = {
+      "A static, spherically-symmetric star in Newtonian gravity, found by\n"
+      "solving the Lane-Emden equations, with a given central density and\n"
+      "polytropic fluid. The fluid has polytropic index 1, but the polytropic\n"
+      "constant is specifiable"};
+
+  LaneEmdenStar() = default;
+  LaneEmdenStar(const LaneEmdenStar& /*rhs*/) = delete;
+  LaneEmdenStar& operator=(const LaneEmdenStar& /*rhs*/) = delete;
+  LaneEmdenStar(LaneEmdenStar&& /*rhs*/) noexcept = default;
+  LaneEmdenStar& operator=(LaneEmdenStar&& /*rhs*/) noexcept = default;
+  ~LaneEmdenStar() = default;
+
+  LaneEmdenStar(double central_mass_density,
+                double polytropic_constant) noexcept;
+
+  /// Retrieve a collection of variables at `(x, t)`
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, 3>& x,
+                                         const double /*t*/,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
+    const auto mass_density = precompute_mass_density(x);
+    return {tuples::get<Tags>(variables(tmpl::list<Tags>{}, mass_density))...};
+  }
+
+  const EquationsOfState::PolytropicFluid<false>& equation_of_state() const
+      noexcept {
+    return equation_of_state_;
+  }
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& /*p*/) noexcept;  // NOLINT
+
+ private:
+  template <typename DataType>
+  Scalar<DataType> precompute_mass_density(const tnsr::I<DataType, 3>& x) const
+      noexcept;
+
+  template <typename DataType>
+  tuples::TaggedTuple<Tags::MassDensity<DataType>> variables(
+      tmpl::list<Tags::MassDensity<DataType>> /*meta*/,
+      const Scalar<DataType>& mass_density) const noexcept;
+
+  template <typename DataType>
+  tuples::TaggedTuple<Tags::Velocity<DataType, 3>> variables(
+      tmpl::list<Tags::Velocity<DataType, 3>> /*meta*/,
+      const Scalar<DataType>& mass_density) const noexcept;
+
+  template <typename DataType>
+  tuples::TaggedTuple<Tags::Pressure<DataType>> variables(
+      tmpl::list<Tags::Pressure<DataType>> /*meta*/,
+      const Scalar<DataType>& mass_density) const noexcept;
+
+  template <typename DataType>
+  tuples::TaggedTuple<Tags::SpecificInternalEnergy<DataType>> variables(
+      tmpl::list<Tags::SpecificInternalEnergy<DataType>> /*meta*/,
+      const Scalar<DataType>& mass_density) const noexcept;
+
+  friend bool operator==(const LaneEmdenStar& lhs,
+                         const LaneEmdenStar& rhs) noexcept;
+
+  double central_mass_density_ = std::numeric_limits<double>::signaling_NaN();
+  double polytropic_constant_ = std::numeric_limits<double>::signaling_NaN();
+  EquationsOfState::PolytropicFluid<false> equation_of_state_{};
+};
+
+bool operator!=(const LaneEmdenStar& lhs, const LaneEmdenStar& rhs) noexcept;
+
+}  // namespace Solutions
+}  // namespace NewtonianEuler

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.hpp
@@ -6,7 +6,7 @@
 #include <limits>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Evolution/Systems/NewtonianEuler/Sources/NoSource.hpp"
+#include "Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.hpp"
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
@@ -47,7 +47,7 @@ namespace Solutions {
 class LaneEmdenStar : public MarkAsAnalyticSolution {
  public:
   using equation_of_state_type = EquationsOfState::PolytropicFluid<false>;
-  using source_term_type = Sources::NoSource;
+  using source_term_type = Sources::LaneEmdenGravitationalField;
 
   /// The central mass density of the star.
   struct CentralMassDensity {
@@ -93,9 +93,22 @@ class LaneEmdenStar : public MarkAsAnalyticSolution {
     return {tuples::get<Tags>(variables(tmpl::list<Tags>{}, mass_density))...};
   }
 
+  /// \brief Compute the gravitational field for the corresponding source term,
+  /// LaneEmdenGravitationalField.
+  ///
+  /// The result is the vector-field giving the acceleration due to gravity
+  /// that is felt by a test particle.
+  template <typename DataType>
+  tnsr::I<DataType, 3> gravitational_field(const tnsr::I<DataType, 3>& x) const
+      noexcept;
+
   const EquationsOfState::PolytropicFluid<false>& equation_of_state() const
       noexcept {
     return equation_of_state_;
+  }
+
+  const Sources::LaneEmdenGravitationalField& source_term() const noexcept {
+    return source_term_;
   }
 
   // clang-tidy: no runtime references
@@ -132,6 +145,7 @@ class LaneEmdenStar : public MarkAsAnalyticSolution {
   double central_mass_density_ = std::numeric_limits<double>::signaling_NaN();
   double polytropic_constant_ = std::numeric_limits<double>::signaling_NaN();
   EquationsOfState::PolytropicFluid<false> equation_of_state_{};
+  Sources::LaneEmdenGravitationalField source_term_{};
 };
 
 bool operator!=(const LaneEmdenStar& lhs, const LaneEmdenStar& rhs) noexcept;

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Sources/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Sources/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_NewtonianEulerSources")
 
 set(LIBRARY_SOURCES
+  Test_LaneEmdenGravitationalField.cpp
   Test_UniformAcceleration.cpp
   Test_VortexPerturbation.cpp
   )

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.py
@@ -1,0 +1,19 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+from PointwiseFunctions.AnalyticSolutions.NewtonianEuler.LaneEmdenStar \
+    import (mass_density, gravitational_field)
+
+
+def source_momentum_density(mass_density, momentum_density, x,
+                            central_mass_density, polytropic_constant):
+    g = gravitational_field(x, central_mass_density, polytropic_constant)
+    return mass_density * g
+
+
+def source_energy_density(mass_density, momentum_density, x,
+                          central_mass_density, polytropic_constant):
+    g = gravitational_field(x, central_mass_density, polytropic_constant)
+    return np.dot(momentum_density, g)

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Sources/Test_LaneEmdenGravitationalField.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Sources/Test_LaneEmdenGravitationalField.cpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+// Need this proxy in order for pypp to evaluate function whose arguments
+// include a variable of type `NewtonianEuler::Solutions::LaneEmdenStar`
+struct LaneEmdenGravitationalFieldProxy
+    : NewtonianEuler::Sources::LaneEmdenGravitationalField {
+  using NewtonianEuler::Sources::LaneEmdenGravitationalField::
+      LaneEmdenGravitationalField;
+  LaneEmdenGravitationalFieldProxy(const double central_mass_density,
+                                   const double polytropic_index)
+      : star_(central_mass_density, polytropic_index) {}
+
+  void apply_helper(
+      const gsl::not_null<tnsr::I<DataVector, 3>*> source_momentum_density,
+      const gsl::not_null<Scalar<DataVector>*> source_energy_density,
+      const Scalar<DataVector>& mass_density_cons,
+      const tnsr::I<DataVector, 3>& momentum_density,
+      const tnsr::I<DataVector, 3>& x) const noexcept {
+    this->apply(source_momentum_density, source_energy_density,
+                mass_density_cons, momentum_density, star_, x);
+  }
+
+ private:
+  NewtonianEuler::Solutions::LaneEmdenStar star_{};
+};
+
+void test_sources() noexcept {
+  // Nothing special about these values, we just want them to be non-unity and
+  // to be different from each other:
+  const double central_mass_density = 0.7;
+  const double polytropic_constant = 2.0;
+  LaneEmdenGravitationalFieldProxy source_proxy(central_mass_density,
+                                                polytropic_constant);
+  pypp::check_with_random_values<3>(
+      &LaneEmdenGravitationalFieldProxy::apply_helper, source_proxy,
+      "Evolution.Systems.NewtonianEuler.Sources.LaneEmdenGravitationalField",
+      {"source_momentum_density", "source_energy_density"},
+      {{{0.0, 3.0},
+        {-1.0, 1.0},
+        // with polytropic_constant == 2, star has outer radius ~ 1.77
+        {-2.0, 2.0}}},
+      std::make_tuple(central_mass_density, polytropic_constant),
+      DataVector(5));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.NewtonianEuler.Sources.LaneEmdenGravitationalField",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+
+  test_sources();
+}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_NewtonianEulerSolutions")
 
 set(LIBRARY_SOURCES
   Test_IsentropicVortex.cpp
+  Test_LaneEmdenStar.cpp
   Test_RiemannProblem.cpp
   )
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.py
@@ -1,0 +1,29 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def mass_density(x, t, central_mass_density, polytropic_constant):
+    alpha = np.sqrt(0.5 * polytropic_constant / np.pi)
+    outer_radius = alpha * np.pi
+    radius = np.sqrt(np.sum(x**2)) + 1.e-30 * outer_radius
+    if (radius < outer_radius):
+        xi = radius / alpha
+        return central_mass_density * np.sin(xi) / xi
+    else:
+        return 0.0
+
+
+def velocity(x, t, central_mass_density, polytropic_constant):
+    return np.zeros(3)
+
+
+def specific_internal_energy(x, t, central_mass_density, polytropic_constant):
+    rho = mass_density(x, t, central_mass_density, polytropic_constant)
+    return polytropic_constant * rho
+
+
+def pressure(x, t, central_mass_density, polytropic_constant):
+    rho = mass_density(x, t, central_mass_density, polytropic_constant)
+    return polytropic_constant * rho**2

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.py
@@ -4,6 +4,20 @@
 import numpy as np
 
 
+def gravitational_field(x, central_mass_density, polytropic_constant):
+    alpha = np.sqrt(0.5 * polytropic_constant / np.pi)
+    outer_radius = alpha * np.pi
+    mass_scale = 4.0 * np.pi * alpha**3 * central_mass_density
+    radius = np.sqrt(np.sum(x**2)) + 1.e-30 * outer_radius
+    if (radius < outer_radius):
+        xi = radius / alpha
+        enclosed_mass = mass_scale * (np.sin(xi) - xi * np.cos(xi))
+        return - x * enclosed_mass / radius**3
+    else:
+        total_mass = mass_scale * np.pi
+        return - x * total_mass / radius**3
+
+
 def mass_density(x, t, central_mass_density, polytropic_constant):
     alpha = np.sqrt(0.5 * polytropic_constant / np.pi)
     outer_radius = alpha * np.pi

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_LaneEmdenStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_LaneEmdenStar.cpp
@@ -1,0 +1,109 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+
+void test_construction_and_serialization() {
+  const double central_mass_density = 0.7;
+  const double polytropic_constant = 2.0;
+  NewtonianEuler::Solutions::LaneEmdenStar star(central_mass_density,
+                                                polytropic_constant);
+
+  const std::string input =
+      MakeString{} << "  CentralMassDensity: " << central_mass_density
+                   << "\n  PolytropicConstant: " << polytropic_constant;
+  const auto star_from_options =
+      TestHelpers::test_creation<NewtonianEuler::Solutions::LaneEmdenStar>(
+          input);
+
+  CHECK(star_from_options == star);
+
+  NewtonianEuler::Solutions::LaneEmdenStar star_to_move(central_mass_density,
+                                                        polytropic_constant);
+  test_move_semantics(std::move(star_to_move), star);  //  NOLINT
+
+  test_serialization(star);
+}
+
+struct LaneEmdenStarProxy : NewtonianEuler::Solutions::LaneEmdenStar {
+  using NewtonianEuler::Solutions::LaneEmdenStar::LaneEmdenStar;
+
+  template <typename DataType>
+  using variables_tags =
+      tmpl::list<NewtonianEuler::Tags::MassDensity<DataType>,
+                 NewtonianEuler::Tags::Velocity<DataType, 3, Frame::Inertial>,
+                 NewtonianEuler::Tags::SpecificInternalEnergy<DataType>,
+                 NewtonianEuler::Tags::Pressure<DataType>>;
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<variables_tags<DataType>>
+  primitive_variables(const tnsr::I<DataType, 3, Frame::Inertial>& x,
+                      double t) const noexcept {
+    return this->variables(x, t, variables_tags<DataType>{});
+  }
+};
+
+template <typename DataType>
+void test_solution(const DataType& used_for_size,
+                   const double central_mass_density,
+                   const double polytropic_constant) noexcept {
+  const LaneEmdenStarProxy star(central_mass_density, polytropic_constant);
+  pypp::check_with_random_values<
+      1, typename LaneEmdenStarProxy::template variables_tags<DataType>>(
+      &LaneEmdenStarProxy::template primitive_variables<DataType>, star,
+      "LaneEmdenStar",
+      {"mass_density", "velocity", "specific_internal_energy", "pressure"},
+      // with polytropic_constant == 2, star has outer radius ~ 1.77
+      {{{-2.0, 2.0}}},
+      std::make_tuple(central_mass_density, polytropic_constant),
+      used_for_size);
+
+  const auto star_sd = serialize_and_deserialize(star);
+  pypp::check_with_random_values<
+      1, typename LaneEmdenStarProxy::template variables_tags<DataType>>(
+      &LaneEmdenStarProxy::template primitive_variables<DataType>, star_sd,
+      "LaneEmdenStar",
+      {"mass_density", "velocity", "specific_internal_energy", "pressure"},
+      // with polytropic_constant == 2, star has outer radius ~ 1.77
+      {{{-2.0, 2.0}}},
+      std::make_tuple(central_mass_density, polytropic_constant),
+      used_for_size);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.LaneEmdenStar",
+    "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/NewtonianEuler"};
+
+  test_construction_and_serialization();
+
+  // Nothing special about these values, we just want them to be non-unity and
+  // to be different from each other:
+  const double central_mass_density = 0.7;
+  const double polytropic_constant = 2.0;
+  test_solution(std::numeric_limits<double>::signaling_NaN(),
+                central_mass_density, polytropic_constant);
+  test_solution(DataVector(5), central_mass_density, polytropic_constant);
+}


### PR DESCRIPTION
## Proposed changes

Adds a solution to the Lane-Emden equation, describing a static spherical star in Newtonian Gravity in 3D.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
