### PR TITLE
Support any coordinates in GenerateXdmf

### DIFF
--- a/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
+++ b/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
@@ -20,10 +20,11 @@ class TestGenerateXdmf(unittest.TestCase):
                       output_filename=output_filename,
                       start_time=0.,
                       stop_time=1.,
-                      stride=1)
+                      stride=1,
+                      coordinates='InertialCoordinates')
 
         # The script is quite opaque right now, so we only test that we can run
-        # it and it produces output without raising and error. To test more
+        # it and it produces output without raising an error. To test more
         # details, we should refactor the script into smaller units.
         self.assertTrue(os.path.isfile(output_filename + '.xmf'))
         os.remove(output_filename + '.xmf')


### PR DESCRIPTION
## Proposed changes

Allows the user to select the coordinates used for visualization in `GenerateXdmf.py`. Also helps with #1776.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
