### PR TITLE
Remove mean_value from size_of_element

### DIFF
--- a/src/Domain/ElementMap.hpp
+++ b/src/Domain/ElementMap.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/ElementId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -16,12 +17,6 @@
 namespace PUP {
 class er;
 }  // namespace PUP
-/// \cond
-namespace domain {
-template <typename SourceFrame, typename TargetFrame, size_t Dim>
-class CoordinateMapBase;
-}  // namespace domain
-/// \endcond
 
 /*!
  * \ingroup ComputationalDomainGroup

--- a/src/Domain/SizeOfElement.cpp
+++ b/src/Domain/SizeOfElement.cpp
@@ -3,37 +3,35 @@
 
 #include "Domain/SizeOfElement.hpp"
 
-#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
-#include "DataStructures/Tensor/TypeAliases.hpp"
-#include "Domain/Mesh.hpp"  // IWYU pragma: keep
+#include "Domain/ElementMap.hpp"  // IWYU pragma: keep
 #include "Domain/Side.hpp"
-#include "ErrorHandling/Assert.hpp"
-#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
-#include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/StdArrayHelpers.hpp"  // IWYU pragma: keep
 
 template <size_t VolumeDim>
 std::array<double, VolumeDim> size_of_element(
-    const Mesh<VolumeDim>& mesh,
-    const tnsr::I<DataVector, VolumeDim>& inertial_coords) noexcept {
-  ASSERT(mesh.quadrature() ==
-             make_array<VolumeDim>(Spectral::Quadrature::GaussLobatto),
-         "Implementation assumes that grid points extend to the faces of the\n"
-         "element, but not sure if this is true for quadrature: "
-             << mesh.quadrature());
+    const ElementMap<VolumeDim, Frame::Inertial>& element_map) noexcept {
   auto result = make_array<VolumeDim>(0.0);
-  // inertial-coord vector between lower face center and upper face center
-  auto center_to_center = make_array<VolumeDim>(0.0);
   for (size_t logical_dim = 0; logical_dim < VolumeDim; ++logical_dim) {
+    const auto face_center =
+        [&logical_dim, &element_map ](const Side& side) noexcept {
+      tnsr::I<double, VolumeDim, Frame::Logical> logical_center{{{0.0}}};
+      logical_center.get(logical_dim) = (side == Side::Lower ? -1.0 : 1.0);
+      const tnsr::I<double, VolumeDim, Frame::Inertial> inertial_center =
+          element_map(logical_center);
+      return inertial_center;
+    };
+    const auto lower_center = face_center(Side::Lower);
+    const auto upper_center = face_center(Side::Upper);
+
+    // inertial-coord distance from lower face center to upper face center
+    auto center_to_center = make_array<VolumeDim>(0.0);
     for (size_t inertial_dim = 0; inertial_dim < VolumeDim; ++inertial_dim) {
-      const double center_upper = mean_value_on_boundary(
-          inertial_coords.get(inertial_dim), mesh, logical_dim, Side::Upper);
-      const double center_lower = mean_value_on_boundary(
-          inertial_coords.get(inertial_dim), mesh, logical_dim, Side::Lower);
-      center_to_center.at(inertial_dim) = center_upper - center_lower;
+      center_to_center.at(inertial_dim) =
+          upper_center.get(inertial_dim) - lower_center.get(inertial_dim);
     }
+
     result.at(logical_dim) = magnitude(center_to_center);
   }
   return result;
@@ -44,8 +42,7 @@ std::array<double, VolumeDim> size_of_element(
 
 #define INSTANTIATION(r, data)                                \
   template std::array<double, GET_DIM(data)> size_of_element( \
-      const Mesh<GET_DIM(data)>&,                             \
-      const tnsr::I<DataVector, GET_DIM(data)>&) noexcept;
+      const ElementMap<GET_DIM(data), Frame::Inertial>&) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Domain/SizeOfElement.hpp
+++ b/src/Domain/SizeOfElement.hpp
@@ -8,18 +8,15 @@
 #include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
-template <size_t VolumeDim>
-class Mesh;
+template <size_t VolumeDim, typename Frame>
+class ElementMap;
 namespace Tags {
 template <size_t Dim, typename Frame>
-struct Coordinates;
-template <size_t VolumeDim>
-struct Mesh;
+struct ElementMap;
 }  // namespace Tags
 /// \endcond
 
@@ -28,11 +25,10 @@ struct Mesh;
  * \brief Compute the inertial-coordinate size of an element along each of its
  * logical directions.
  *
- * For each logical direction, compute the mean position (in inertial
- * coordinates) of the element's lower and upper faces in that direction.
- * This is done by simply averaging the coordinates of the face grid points.
- * The size of the element along this logical direction is then the distance
- * between the mean positions of the lower and upper faces.
+ * For each logical direction, compute the distance (in inertial coordinates)
+ * between the element's lower and upper faces in that logical direction.
+ * The distance is measured between centers of the faces, with the centers
+ * defined in the logical coordinates.
  * Note that for curved elements, this is an approximate measurement of size.
  *
  * \details
@@ -41,8 +37,7 @@ struct Mesh;
  */
 template <size_t VolumeDim>
 std::array<double, VolumeDim> size_of_element(
-    const Mesh<VolumeDim>& mesh,
-    const tnsr::I<DataVector, VolumeDim>& inertial_coords) noexcept;
+    const ElementMap<VolumeDim, Frame::Inertial>& element_map) noexcept;
 
 namespace Tags {
 /// \ingroup DataBoxTagsGroup
@@ -53,8 +48,7 @@ template <size_t VolumeDim>
 struct SizeOfElement : db::ComputeTag {
   static std::string name() noexcept { return "SizeOfElement"; }
   using argument_tags =
-      tmpl::list<Tags::Mesh<VolumeDim>,
-                 Tags::Coordinates<VolumeDim, Frame::Inertial>>;
+      tmpl::list<Tags::ElementMap<VolumeDim, Frame::Inertial>>;
   static constexpr auto function = size_of_element<VolumeDim>;
 };
 }  // namespace Tags

--- a/tests/Unit/Domain/Test_SizeOfElement.cpp
+++ b/tests/Unit/Domain/Test_SizeOfElement.cpp
@@ -9,7 +9,6 @@
 #include <pup.h>
 
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -19,82 +18,86 @@
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
 #include "Domain/Direction.hpp"
-#include "Domain/LogicalCoordinates.hpp"
-#include "Domain/Mesh.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementMap.hpp"
 #include "Domain/OrientationMap.hpp"
+#include "Domain/SegmentId.hpp"
 #include "Domain/SizeOfElement.hpp"
 #include "Domain/Tags.hpp"
-#include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace {
-tnsr::I<DataVector, 2> make_inertial_coords_2d(const Mesh<2>& mesh) noexcept {
-  using Affine = domain::CoordinateMaps::Affine;
-  using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-  const auto map = domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
-      Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
-      domain::CoordinateMaps::DiscreteRotation<2>(
-          OrientationMap<2>{std::array<Direction<2>, 2>{
-              {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
-  return map(logical_coordinates(mesh));
-}
-}  // namespace
-
 SPECTRE_TEST_CASE("Unit.Domain.SizeOfElement", "[Domain][Unit]") {
   SECTION("1D") {
-    const auto mesh = Mesh<1>(4, Spectral::Basis::Legendre,
-                              Spectral::Quadrature::GaussLobatto);
-    const auto coords = [&mesh]() {
-      const auto map =
-          domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
-              domain::CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.2));
-      return map(logical_coordinates(mesh));
-    }();
-    const auto size = size_of_element(mesh, coords);
-    const auto size_expected = make_array<1>(0.9);
+    auto map =
+        domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            domain::CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.2));
+    const ElementId<1> element_id(
+        0, std::array<SegmentId, 1>({{SegmentId(2, 3)}}));
+    const ElementMap<1, Frame::Inertial> element_map(element_id,
+                                                     std::move(map));
+    const auto size = size_of_element(element_map);
+    // for this affine map, expected size = width of block / number of elements
+    const auto size_expected = make_array<1>(0.225);
     CHECK_ITERABLE_APPROX(size, size_expected);
   }
 
   SECTION("2D") {
-    const auto mesh = Mesh<2>({{4, 5}}, Spectral::Basis::Legendre,
-                              Spectral::Quadrature::GaussLobatto);
-    const auto coords = make_inertial_coords_2d(mesh);
-    const auto size = size_of_element(mesh, coords);
-    const auto size_expected = make_array(0.1, 1.7);
+    using Affine = domain::CoordinateMaps::Affine;
+    using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+    auto map =
+        domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
+            domain::CoordinateMaps::DiscreteRotation<2>(
+                OrientationMap<2>{std::array<Direction<2>, 2>{
+                    {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
+    const ElementId<2> element_id(
+        0, std::array<SegmentId, 2>({{SegmentId(1, 1), SegmentId(2, 0)}}));
+    const ElementMap<2, Frame::Inertial> element_map(element_id,
+                                                     std::move(map));
+    const auto size = size_of_element(element_map);
+    const auto size_expected = make_array(0.05, 0.425);
     CHECK_ITERABLE_APPROX(size, size_expected);
   }
 
   SECTION("3D") {
-    const auto mesh = Mesh<3>({{4, 5, 6}}, Spectral::Basis::Legendre,
-                              Spectral::Quadrature::GaussLobatto);
-    const auto coords = [&mesh]() {
-      using Affine = domain::CoordinateMaps::Affine;
-      using Affine3D =
-          domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
-      const auto map =
-          domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
-              Affine3D{Affine(-1.0, 1.0, 0.3, 0.4),
-                       Affine(-1.0, 1.0, -0.5, 1.2),
-                       Affine(-1.0, 1.0, 12.0, 12.5)},
-              domain::CoordinateMaps::Rotation<3>(0.7, 2.3, -0.4));
-      return map(logical_coordinates(mesh));
-    }();
-    const auto size = size_of_element(mesh, coords);
-    const auto size_expected = make_array(0.1, 1.7, 0.5);
+    using Affine = domain::CoordinateMaps::Affine;
+    using Affine3D =
+        domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+    auto map =
+        domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            Affine3D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2),
+                     Affine(-1.0, 1.0, 12.0, 12.5)},
+            domain::CoordinateMaps::Rotation<3>(0.7, 2.3, -0.4));
+    const ElementId<3> element_id(
+        0, std::array<SegmentId, 3>(
+               {{SegmentId(3, 5), SegmentId(1, 0), SegmentId(2, 3)}}));
+    const ElementMap<3, Frame::Inertial> element_map(element_id,
+                                                     std::move(map));
+    const auto size = size_of_element(element_map);
+    const auto size_expected = make_array(0.0125, 0.85, 0.125);
     CHECK_ITERABLE_APPROX(size, size_expected);
   }
 
   SECTION("ComputeTag") {
-    auto mesh = Mesh<2>({{4, 5}}, Spectral::Basis::Legendre,
-                        Spectral::Quadrature::GaussLobatto);
-    auto coords = make_inertial_coords_2d(mesh);
-    const auto box = db::create<
-        db::AddSimpleTags<Tags::Mesh<2>, Tags::Coordinates<2, Frame::Inertial>>,
-        db::AddComputeTags<Tags::SizeOfElement<2>>>(mesh, std::move(coords));
+    using Affine = domain::CoordinateMaps::Affine;
+    using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+    auto map =
+        domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
+            domain::CoordinateMaps::DiscreteRotation<2>(
+                OrientationMap<2>{std::array<Direction<2>, 2>{
+                    {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
+    const ElementId<2> element_id(
+        0, std::array<SegmentId, 2>({{SegmentId(1, 1), SegmentId(2, 0)}}));
+    ElementMap<2, Frame::Inertial> element_map(element_id, std::move(map));
+    const auto box =
+        db::create<db::AddSimpleTags<Tags::ElementMap<2, Frame::Inertial>>,
+                   db::AddComputeTags<Tags::SizeOfElement<2>>>(
+            std::move(element_map));
 
     const auto size_compute_item = db::get<Tags::SizeOfElement<2>>(box);
-    const auto size_expected = make_array(0.1, 1.7);
+    const auto size_expected = make_array(0.05, 0.425);
     CHECK_ITERABLE_APPROX(size_compute_item, size_expected);
   }
 }


### PR DESCRIPTION
## Proposed changes

As a first step toward resolving #1675, removes `mean_value` from `size_of_element`.

I've opted to compute the size of the element in a slightly different way. Both the old and the new algorithms compute the distance between the centers of pairs of opposing faces. The old algorithm was computing the face center by averaging the face's inertial coordinates. The new algorithm instead maps the logical-coordinate face center to the inertial coordinates. I favored this approach because it avoids making assumptions about the quadrature of the mesh (i.e. also works for Gauss points).


### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
