### PR TITLE
(Hopefully) fix clang-tidy failures on GitHub Actions

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -103,6 +103,8 @@ jobs:
           -D CMAKE_Fortran_COMPILER=gfortran-8
           -D CHARM_ROOT=/work/charm/multicore-linux64-clang
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -D OVERRIDE_ARCH=x86-64
+          -D USE_CCACHE=OFF
           -D DEBUG_SYMBOLS=OFF
           -D BUILD_PYTHON_BINDINGS=ON
           $GITHUB_WORKSPACE


### PR DESCRIPTION

## Proposed changes

Do not use native arch or ccache when running clang-tidy on GitHub Actions

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
