### PR TITLE
Add NewtonianEuler HLLC flux

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -741,6 +741,19 @@
   publisher  = "Princeton University Press",
 }
 
+@article{Toro1994,
+  author         = "Toro, E. F. and Spruce, M. and Speares, W.",
+  title          = "{Restoration of the Contact Surface in the HLL–Riemann
+                     Solver}",
+  journal        = "Shock Waves",
+  volume         = "4",
+  year           = "1994",
+  number         = "1",
+  pages          = "25--34",
+  doi            = "10.1007/BF01414629",
+  url            = "https://doi.org/10.1007/BF01414629"
+}
+
 @book{Toro2009,
   author     = "Toro, E. F.",
   title      = "Riemann Solvers and Numerical Methods for Fluid Dynamics",

--- a/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBS_TO_LINK
   LinearOperators
   MathFunctions
   NewtonianEuler
+  NewtonianEulerNumericalFluxes
   NewtonianEulerSolutions
   NewtonianEulerSources
   Time

--- a/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/CMakeLists.txt
@@ -1,14 +1,10 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY NewtonianEuler)
+set(LIBRARY NewtonianEulerNumericalFluxes)
 
 set(LIBRARY_SOURCES
-  Characteristics.cpp
-  ConservativeFromPrimitive.cpp
-  Fluxes.cpp
-  PrimitiveFromConservative.cpp
-  SoundSpeedSquared.cpp
+  Hllc.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
@@ -17,8 +13,4 @@ target_link_libraries(
   ${LIBRARY}
   INTERFACE DataStructures
   INTERFACE ErrorHandling
-  INTERFACE Hydro
   )
-
-add_subdirectory(NumericalFluxes)
-add_subdirectory(Sources)

--- a/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.cpp
@@ -1,0 +1,217 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Evolution/Systems/NewtonianEuler/Characteristics.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+/// \cond
+namespace NewtonianEuler {
+namespace NumericalFluxes {
+
+template <size_t Dim, typename Frame>
+void Hllc<Dim, Frame>::package_data(
+    const gsl::not_null<Variables<package_tags>*> packaged_data,
+    const Scalar<DataVector>& normal_dot_flux_mass_density,
+    const tnsr::I<DataVector, Dim, Frame>& normal_dot_flux_momentum_density,
+    const Scalar<DataVector>& normal_dot_flux_energy_density,
+    const Scalar<DataVector>& mass_density,
+    const tnsr::I<DataVector, Dim, Frame>& momentum_density,
+    const Scalar<DataVector>& energy_density,
+    const tnsr::I<DataVector, Dim, Frame>& velocity,
+    const Scalar<DataVector>& pressure,
+    const db::const_item_type<char_speeds_tag>& characteristic_speeds,
+    const tnsr::i<DataVector, Dim, Frame>& interface_unit_normal) const
+    noexcept {
+  get<::Tags::NormalDotFlux<Tags::MassDensityCons<DataVector>>>(
+      *packaged_data) = normal_dot_flux_mass_density;
+  get<::Tags::NormalDotFlux<Tags::MomentumDensity<DataVector, Dim, Frame>>>(
+      *packaged_data) = normal_dot_flux_momentum_density;
+  get<::Tags::NormalDotFlux<Tags::EnergyDensity<DataVector>>>(*packaged_data) =
+      normal_dot_flux_energy_density;
+  get<Tags::MassDensityCons<DataVector>>(*packaged_data) = mass_density;
+  get<Tags::MomentumDensity<DataVector, Dim, Frame>>(*packaged_data) =
+      momentum_density;
+  get<Tags::EnergyDensity<DataVector>>(*packaged_data) = energy_density;
+  get<Tags::Pressure<DataVector>>(*packaged_data) = pressure;
+  get<::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>>(
+      *packaged_data) = interface_unit_normal;
+  get<NormalVelocity>(*packaged_data) =
+      dot_product(interface_unit_normal, velocity);
+
+  // When packaging interior data, FirstSpeedEstimate and SecondSpeedEstimate
+  // will hold the min and max char speeds, respectively. On the other hand,
+  // when packaging exterior data, the characteristic speeds will be computed
+  // along *minus* the exterior normal, so FirstSpeedEstimate will hold *minus*
+  // the max speed, while SecondSpeedEstimate will store *minus* the min speed.
+  get<FirstSpeedEstimate>(*packaged_data) = make_with_value<Scalar<DataVector>>(
+      characteristic_speeds[0], std::numeric_limits<double>::signaling_NaN());
+  get<SecondSpeedEstimate>(*packaged_data) =
+      make_with_value<Scalar<DataVector>>(
+          characteristic_speeds[0],
+          std::numeric_limits<double>::signaling_NaN());
+  for (size_t s = 0; s < characteristic_speeds[0].size(); ++s) {
+    get(get<FirstSpeedEstimate>(*packaged_data))[s] = (*std::min_element(
+        characteristic_speeds.begin(), characteristic_speeds.end(),
+        [&s](const DataVector& a, const DataVector& b) noexcept {
+          return a[s] < b[s];
+        }))[s];
+    get(get<SecondSpeedEstimate>(*packaged_data))[s] = (*std::max_element(
+        characteristic_speeds.begin(), characteristic_speeds.end(),
+        [&s](const DataVector& a, const DataVector& b) noexcept {
+          return a[s] < b[s];
+        }))[s];
+  }
+}
+
+template <size_t Dim, typename Frame>
+void Hllc<Dim, Frame>::operator()(
+    const gsl::not_null<Scalar<DataVector>*>
+        normal_dot_numerical_flux_mass_density,
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame>*>
+        normal_dot_numerical_flux_momentum_density,
+    const gsl::not_null<Scalar<DataVector>*>
+        normal_dot_numerical_flux_energy_density,
+    const Scalar<DataVector>& normal_dot_flux_mass_density_int,
+    const tnsr::I<DataVector, Dim, Frame>& normal_dot_flux_momentum_density_int,
+    const Scalar<DataVector>& normal_dot_flux_energy_density_int,
+    const Scalar<DataVector>& mass_density_int,
+    const tnsr::I<DataVector, Dim, Frame>& momentum_density_int,
+    const Scalar<DataVector>& energy_density_int,
+    const Scalar<DataVector>& pressure_int,
+    const tnsr::i<DataVector, Dim, Frame>& interface_unit_normal,
+    const Scalar<DataVector>& normal_velocity_int,
+    const Scalar<DataVector>& min_signal_speed_int,
+    const Scalar<DataVector>& max_signal_speed_int,
+    const Scalar<DataVector>& minus_normal_dot_flux_mass_density_ext,
+    const tnsr::I<DataVector, Dim, Frame>&
+        minus_normal_dot_flux_momentum_density_ext,
+    const Scalar<DataVector>& minus_normal_dot_flux_energy_density_ext,
+    const Scalar<DataVector>& mass_density_ext,
+    const tnsr::I<DataVector, Dim, Frame>& momentum_density_ext,
+    const Scalar<DataVector>& energy_density_ext,
+    const Scalar<DataVector>& pressure_ext,
+    const tnsr::i<DataVector, Dim, Frame>& minus_interface_unit_normal,
+    const Scalar<DataVector>& minus_normal_velocity_ext,
+    // names are inverted w.r.t interior data. See package_data()
+    const Scalar<DataVector>& minus_max_signal_speed_ext,
+    const Scalar<DataVector>& minus_min_signal_speed_ext) const noexcept {
+  DataVector min_signal_speed = make_with_value<DataVector>(
+      min_signal_speed_int, std::numeric_limits<double>::signaling_NaN());
+  DataVector max_signal_speed = make_with_value<DataVector>(
+      max_signal_speed_int, std::numeric_limits<double>::signaling_NaN());
+  for (size_t s = 0; s < min_signal_speed.size(); ++s) {
+    min_signal_speed[s] = std::min({get(min_signal_speed_int)[s],
+                                    -get(minus_min_signal_speed_ext)[s], 0.0});
+    max_signal_speed[s] = std::max({get(max_signal_speed_int)[s],
+                                    -get(minus_max_signal_speed_ext)[s], 0.0});
+  }
+  const DataVector signal_speed_star =
+      (get(pressure_int) +
+       get(normal_dot_flux_mass_density_int) *
+           (get(normal_velocity_int) - min_signal_speed) -
+       get(pressure_ext) -
+       get(minus_normal_dot_flux_mass_density_ext) *
+           (get(minus_normal_velocity_ext) + max_signal_speed)) /
+      (get(normal_dot_flux_mass_density_int) -
+       min_signal_speed * get(mass_density_int) +
+       get(minus_normal_dot_flux_mass_density_ext) +
+       max_signal_speed * get(mass_density_ext));
+
+  for (size_t s = 0; s < min_signal_speed.size(); ++s) {
+    const double s_min = min_signal_speed[s];
+    const double s_max = max_signal_speed[s];
+    const double s_star = signal_speed_star[s];
+    ASSERT((s_min <= s_star) and (s_star <= s_max),
+           "Signal speeds in HLLC Riemann solver not consistent: "
+               << "s_min = " << s_min << ", c_* = " << s_star
+               << ", s_max = " << s_max);
+
+    const auto pressure_star = [&s_star](
+        const double mass_density, const double pressure,
+        const double normal_velocity, const double signal_speed) noexcept {
+      return pressure + mass_density * (normal_velocity - signal_speed) *
+                            (normal_velocity - s_star);
+    };
+    const auto numerical_flux_star = [&s_star](
+        const double n_dot_f, const double u, const double d_star,
+        const double p_star, const double signal_speed) noexcept {
+      return (s_star * (n_dot_f - signal_speed * u) -
+              signal_speed * p_star * d_star) /
+             (s_star - signal_speed);
+    };
+
+    if (s_star > 0.0) {
+      const double pressure_star_int =
+          pressure_star(get(mass_density_int)[s], get(pressure_int)[s],
+                        get(normal_velocity_int)[s], s_min);
+
+      get(*normal_dot_numerical_flux_mass_density)[s] = numerical_flux_star(
+          get(normal_dot_flux_mass_density_int)[s], get(mass_density_int)[s],
+          0.0, pressure_star_int, s_min);
+
+      get(*normal_dot_numerical_flux_energy_density)[s] = numerical_flux_star(
+          get(normal_dot_flux_energy_density_int)[s],
+          get(energy_density_int)[s], s_star, pressure_star_int, s_min);
+
+      for (size_t i = 0; i < Dim; ++i) {
+        normal_dot_numerical_flux_momentum_density->get(i)[s] =
+            numerical_flux_star(normal_dot_flux_momentum_density_int.get(i)[s],
+                                momentum_density_int.get(i)[s],
+                                interface_unit_normal.get(i)[s],
+                                pressure_star_int, s_min);
+      }
+    } else {
+      const double pressure_star_ext =
+          pressure_star(get(mass_density_ext)[s], get(pressure_ext)[s],
+                        -1.0 * get(minus_normal_velocity_ext)[s], s_max);
+
+      get(*normal_dot_numerical_flux_mass_density)[s] = numerical_flux_star(
+          -1.0 * get(minus_normal_dot_flux_mass_density_ext)[s],
+          get(mass_density_ext)[s], 0.0, pressure_star_ext, s_max);
+
+      get(*normal_dot_numerical_flux_energy_density)[s] = numerical_flux_star(
+          -1.0 * get(minus_normal_dot_flux_energy_density_ext)[s],
+          get(energy_density_ext)[s], s_star, pressure_star_ext, s_max);
+
+      for (size_t i = 0; i < Dim; ++i) {
+        normal_dot_numerical_flux_momentum_density->get(i)[s] =
+            numerical_flux_star(
+                -1.0 * minus_normal_dot_flux_momentum_density_ext.get(i)[s],
+                momentum_density_ext.get(i)[s],
+                -1.0 * minus_interface_unit_normal.get(i)[s], pressure_star_ext,
+                s_max);
+      }
+    }
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data) template struct Hllc<DIM(data), FRAME(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial))
+
+#undef DIM
+#undef FRAME
+#undef INSTANTIATE
+}  // namespace NumericalFluxes
+}  // namespace NewtonianEuler
+/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.hpp
@@ -1,0 +1,214 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/NewtonianEuler/Characteristics.hpp"
+#include "Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+
+namespace Tags {
+template <typename>
+struct NormalDotFlux;
+template <typename>
+struct Normalized;
+}  // namespace Tags
+
+class DataVector;
+template <typename>
+class Variables;
+/// \endcond
+
+namespace NewtonianEuler {
+namespace NumericalFluxes {
+
+/*!
+ * \brief Compute the HLLC numerical flux
+ *
+ * Class implementing the HLLC flux for the Newtonian Euler equations,
+ * originally introduced by E. F. Toro, M. Spruce and W. Speares \cite Toro1994.
+ * Let \f$F^k = [F^k(\rho), F^k(S^i), F^k(e)]^T\f$ be the fluxes of
+ * the conservative quantities \f$U = [\rho, S^i, e]^T\f$
+ * (see NewtonianEuler::ComputeFluxes). Denoting \f$v_n = n_k v^k\f$ and
+ * \f$F = n_kF^k\f$, where \f$v^k\f$ is the velocity and
+ * \f$n_k\f$ is the interface unit normal, the HLLC flux is
+ *
+ * \f{align*}
+ * G_\text{HLLC} =
+ * \begin{cases}
+ * F_\text{int}, & S_\text{min} > 0, \\
+ * G_{*\text{int}}, & S_\text{min} \leq 0\quad\text{and}\quad S_* > 0, \\
+ * G_{*\text{ext}}, & S_* \leq 0\quad\text{and}\quad S_\text{max} > 0, \\
+ * F_\text{ext}, & S_\text{max} \leq 0,
+ * \end{cases}
+ * \f}
+ *
+ * where
+ *
+ * \f{align*}
+ * G_{*\text{int}} &= \frac{S_*\left(F_\text{int}
+ * - S_\text{min}U_\text{int}\right)
+ * - S_\text{min} p_{*\text{int}}D_*}{S_* - S_\text{min}},\\
+ * G_{*\text{ext}} &= \frac{S_*\left(F_\text{ext}
+ * - S_\text{max}U_\text{ext}\right)
+ * - S_\text{max} p_{*\text{ext}}D_*}{S_* - S_\text{max}},
+ * \f}
+ *
+ * with
+ *
+ * \f{align*}
+ * p_{*\text{int}} &\equiv p_\text{int} + \rho_\text{int}
+ * \left[(v_n)_\text{int} - S_\text{min}\right]
+ * \left[(v_n)_\text{int} - S_*\right], \\
+ * p_{*\text{ext}} &\equiv p_\text{ext} + \rho_\text{ext}
+ * \left[(v_n)_\text{ext} - S_\text{max}\right]
+ * \left[(v_n)_\text{ext} - S_*\right], \\
+ * S_* &\equiv \frac{p_\text{int} + F(\rho)_\text{int}\left[(v_n)_\text{int}
+ * - S_\text{min}\right] - p_\text{ext}
+ * - F(\rho)_\text{ext}\left[(v_n)_\text{ext} -
+ * S_\text{max}\right]}{F(\rho)_\text{int} - \rho_\text{int}S_\text{min}
+ * - F(\rho)_\text{ext} + \rho_\text{ext}S_\text{max}},\\
+ * D_* &\equiv \left[\begin{array}{c}
+ * 0\\ n^i\\ S_*
+ * \end{array}\right],
+ * \f}
+ *
+ * and \f$S_\text{min}\f$ and \f$S_\text{max}\f$ are estimates of the minimum
+ * and maximum signal speeds bounding the interior-moving and exterior-moving
+ * wavespeeds that arise when solving the Riemann problem. One requires
+ * \f$S_\text{min} \leq S_* \leq S_\text{max}\f$. As estimates, we use
+ *
+ * \f{align*}
+ * S_\text{min} &=
+ * \text{min}\left(\{\lambda_\text{int}\},\{\lambda_\text{ext}\}, 0\right)\\
+ * S_\text{max} &=
+ * \text{max}\left(\{\lambda_\text{int}\},\{\lambda_\text{ext}\}, 0\right),
+ * \f}
+ *
+ * where \f$\{\lambda\}\f$ is the set of all the characteristic speeds along a
+ * given normal. This way, the definition of \f$G_\text{HLLC}\f$ simplifies to
+ *
+ * \f{align*}
+ * G_\text{HLLC} =
+ * \begin{cases}
+ * \dfrac{S_*\left(F_\text{int} - S_\text{min}U_\text{int}\right)
+ * - S_\text{min} p_{*\text{int}}D_*}{S_* - S_\text{min}}, & S_* > 0, \\
+ * \dfrac{S_*\left(F_\text{ext} - S_\text{max}U_\text{ext}\right)
+ * - S_\text{max} p_{*\text{ext}}D_*}{S_* - S_\text{max}}, & S_* \leq 0. \\
+ * \end{cases}
+ * \f}
+ *
+ * \warning The HLLC flux implemented here does not incorporate any cure for
+ * the Carbuncle phenomenon or other shock instabilities reported in the
+ * literature. Prefer using another numerical flux in more than 1-d.
+ */
+template <size_t Dim, typename Frame>
+struct Hllc {
+  using char_speeds_tag = Tags::CharacteristicSpeedsCompute<Dim>;
+
+  /// Estimate for one of the signal speeds
+  struct FirstSpeedEstimate : db::SimpleTag {
+    using type = Scalar<DataVector>;
+    static std::string name() noexcept { return "FirstSpeedEstimate"; }
+  };
+
+  /// Estimate for the other signal speed
+  struct SecondSpeedEstimate : db::SimpleTag {
+    using type = Scalar<DataVector>;
+    static std::string name() noexcept { return "SecondSpeedEstimate"; }
+  };
+
+  /// The normal component of the velocity
+  struct NormalVelocity : db::SimpleTag {
+    using type = Scalar<DataVector>;
+    static std::string name() noexcept { return "NormalVelocity"; }
+  };
+
+  using options = tmpl::list<>;
+  static constexpr OptionString help = {
+      "Compute the HLLC flux for the Newtonian Euler system."};
+
+  // clang-tidy: non-const reference
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+
+  using package_tags = tmpl::list<
+      ::Tags::NormalDotFlux<Tags::MassDensityCons<DataVector>>,
+      ::Tags::NormalDotFlux<Tags::MomentumDensity<DataVector, Dim, Frame>>,
+      ::Tags::NormalDotFlux<Tags::EnergyDensity<DataVector>>,
+      Tags::MassDensityCons<DataVector>,
+      Tags::MomentumDensity<DataVector, Dim, Frame>,
+      Tags::EnergyDensity<DataVector>, Tags::Pressure<DataVector>,
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>,
+      NormalVelocity, FirstSpeedEstimate, SecondSpeedEstimate>;
+
+  using argument_tags = tmpl::list<
+      ::Tags::NormalDotFlux<Tags::MassDensityCons<DataVector>>,
+      ::Tags::NormalDotFlux<Tags::MomentumDensity<DataVector, Dim, Frame>>,
+      ::Tags::NormalDotFlux<Tags::EnergyDensity<DataVector>>,
+      Tags::MassDensityCons<DataVector>,
+      Tags::MomentumDensity<DataVector, Dim, Frame>,
+      Tags::EnergyDensity<DataVector>, Tags::Velocity<DataVector, Dim, Frame>,
+      Tags::Pressure<DataVector>, char_speeds_tag,
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
+
+  void package_data(
+      gsl::not_null<Variables<package_tags>*> packaged_data,
+      const Scalar<DataVector>& normal_dot_flux_mass_density,
+      const tnsr::I<DataVector, Dim, Frame>& normal_dot_flux_momentum_density,
+      const Scalar<DataVector>& normal_dot_flux_energy_density,
+      const Scalar<DataVector>& mass_density,
+      const tnsr::I<DataVector, Dim, Frame>& momentum_density,
+      const Scalar<DataVector>& energy_density,
+      const tnsr::I<DataVector, Dim, Frame>& velocity,
+      const Scalar<DataVector>& pressure,
+      const db::const_item_type<char_speeds_tag>& characteristic_speeds,
+      const tnsr::i<DataVector, Dim, Frame>& interface_unit_normal) const
+      noexcept;
+
+  void operator()(
+      gsl::not_null<Scalar<DataVector>*> normal_dot_numerical_flux_mass_density,
+      gsl::not_null<tnsr::I<DataVector, Dim, Frame>*>
+          normal_dot_numerical_flux_momentum_density,
+      gsl::not_null<Scalar<DataVector>*>
+          normal_dot_numerical_flux_energy_density,
+      const Scalar<DataVector>& normal_dot_flux_mass_density_int,
+      const tnsr::I<DataVector, Dim, Frame>&
+          normal_dot_flux_momentum_density_int,
+      const Scalar<DataVector>& normal_dot_flux_energy_density_int,
+      const Scalar<DataVector>& mass_density_int,
+      const tnsr::I<DataVector, Dim, Frame>& momentum_density_int,
+      const Scalar<DataVector>& energy_density_int,
+      const Scalar<DataVector>& pressure_int,
+      const tnsr::i<DataVector, Dim, Frame>& interface_unit_normal,
+      const Scalar<DataVector>& normal_velocity_int,
+      const Scalar<DataVector>& min_signal_speed_int,
+      const Scalar<DataVector>& max_signal_speed_int,
+      const Scalar<DataVector>& minus_normal_dot_flux_mass_density_ext,
+      const tnsr::I<DataVector, Dim, Frame>&
+          minus_normal_dot_flux_momentum_density_ext,
+      const Scalar<DataVector>& minus_normal_dot_flux_energy_density_ext,
+      const Scalar<DataVector>& mass_density_ext,
+      const tnsr::I<DataVector, Dim, Frame>& momentum_density_ext,
+      const Scalar<DataVector>& energy_density_ext,
+      const Scalar<DataVector>& pressure_ext,
+      const tnsr::i<DataVector, Dim, Frame>& minus_interface_unit_normal,
+      const Scalar<DataVector>& minus_normal_velocity_ext,
+      // names are inverted w.r.t interior data. See package_data()
+      const Scalar<DataVector>& minus_max_signal_speed_ext,
+      const Scalar<DataVector>& minus_min_signal_speed_ext) const noexcept;
+};
+
+}  // namespace NumericalFluxes
+}  // namespace NewtonianEuler

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
+add_subdirectory(NumericalFluxes)
 add_subdirectory(Sources)
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/NumericalFluxes/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/NumericalFluxes/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_NewtonianEulerNumericalFluxes")
+
+set(LIBRARY_SOURCES
+  Test_Hllc.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Evolution/Systems/NewtonianEuler/NumericalFluxes"
+  "${LIBRARY_SOURCES}"
+  "NewtonianEulerNumericalFluxes"
+  )

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.py
@@ -1,0 +1,146 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+from Evolution.Systems.NewtonianEuler.TestFunctions import characteristic_speeds
+
+
+def sound_speed(mass_density, pressure):
+    return np.sqrt(1.3333333333333333 * pressure / mass_density)
+
+
+def signal_speed_star(mass_density_int, pressure_int, n_dot_f_mass_density_int,
+                      normal_velocity_int, signal_speed_int,
+                      mass_density_ext, pressure_ext, n_dot_f_mass_density_ext,
+                      normal_velocity_ext, signal_speed_ext):
+    return ((pressure_int + n_dot_f_mass_density_int *
+             (normal_velocity_int - signal_speed_int) -
+             pressure_ext - n_dot_f_mass_density_ext *
+             (normal_velocity_ext - signal_speed_ext)) /
+            (n_dot_f_mass_density_int - signal_speed_int * mass_density_int -
+             n_dot_f_mass_density_ext + signal_speed_ext * mass_density_ext))
+
+
+def pressure_star(mass_density, pressure, normal_velocity, signal_speed,
+                  signal_speed_star):
+    return (pressure + mass_density * (normal_velocity - signal_speed) *
+            (normal_velocity - signal_speed_star))
+
+
+def flux_star(n_dot_f, u, signal_speed, d, signal_speed_star, p_star):
+    return (signal_speed_star * (n_dot_f - signal_speed * u) -
+            signal_speed * p_star * d) / (signal_speed_star - signal_speed)
+
+
+def apply_flux(n_dot_f_int, u_int, vector_d_int, mass_density_int,
+               momentum_density_int, velocity_int, pressure_int,
+               sound_speed_int, n_dot_f_mass_density_int, normal_int,
+               n_dot_f_ext, u_ext, vector_d_ext, mass_density_ext,
+               momentum_density_ext, velocity_ext, pressure_ext,
+               sound_speed_ext, n_dot_f_mass_density_ext, normal_ext):
+    normal_velocity_int = np.dot(velocity_int, normal_int)
+    normal_velocity_ext = np.dot(velocity_ext, normal_ext)
+    all_char_speeds = (characteristic_speeds(velocity_int, sound_speed_int,
+                                             normal_int) +
+                       characteristic_speeds(velocity_ext, sound_speed_ext,
+                                             normal_ext))
+    c_min = min(all_char_speeds)
+    c_max = max(all_char_speeds)
+    c_star = signal_speed_star(mass_density_int, pressure_int,
+                               n_dot_f_mass_density_int, normal_velocity_int,
+                               c_min, mass_density_ext, pressure_ext,
+                               n_dot_f_mass_density_ext, normal_velocity_ext,
+                               c_max)
+    if (c_min >= 0.0):
+        return n_dot_f_int
+    elif (c_max <= 0.0):
+        return n_dot_f_ext
+    elif (c_min < 0.0 and c_star >= 0.0):
+        return flux_star(n_dot_f_int, u_int, c_min, vector_d_int, c_star,
+                         pressure_star(mass_density_int, pressure_int,
+                                       normal_velocity_int, c_min, c_star))
+    elif(c_star < 0.0 and c_max > 0.0):
+        return flux_star(n_dot_f_ext, u_ext, c_max, vector_d_ext, c_star,
+                         pressure_star(mass_density_ext, pressure_ext,
+                                       normal_velocity_ext, c_max, c_star))
+    else:
+        raise Error("Signal speeds not valid.")
+
+
+def n_dot_num_f_mass_density(mass_density_int, momentum_density_int,
+                             energy_density_int, pressure_int, mass_density_ext,
+                             momentum_density_ext, energy_density_ext,
+                             pressure_ext, interface_normal):
+    velocity_int = momentum_density_int / mass_density_int
+    normal_velocity_int = np.dot(velocity_int, interface_normal)
+    velocity_ext = momentum_density_ext / mass_density_ext
+    normal_velocity_ext = np.dot(velocity_ext, interface_normal)
+    return apply_flux(mass_density_int * normal_velocity_int, mass_density_int,
+                      0.0, mass_density_int, momentum_density_int, velocity_int,
+                      pressure_int, sound_speed(mass_density_int, pressure_int),
+                      mass_density_int * normal_velocity_int, interface_normal,
+                      mass_density_ext * normal_velocity_ext, mass_density_ext,
+                      0.0, mass_density_ext, momentum_density_ext, velocity_ext,
+                      pressure_ext, sound_speed(mass_density_ext, pressure_ext),
+                      mass_density_ext * normal_velocity_ext, interface_normal)
+
+
+def n_dot_num_f_momentum_density(mass_density_int, momentum_density_int,
+                                 energy_density_int, pressure_int,
+                                 mass_density_ext, momentum_density_ext,
+                                 energy_density_ext, pressure_ext,
+                                 interface_normal):
+    velocity_int = momentum_density_int / mass_density_int
+    normal_velocity_int = np.dot(velocity_int, interface_normal)
+    velocity_ext = momentum_density_ext / mass_density_ext
+    normal_velocity_ext = np.dot(velocity_ext, interface_normal)
+    return apply_flux(momentum_density_int * normal_velocity_int +
+                      pressure_int * interface_normal, momentum_density_int,
+                      interface_normal, mass_density_int, momentum_density_int,
+                      velocity_int, pressure_int,
+                      sound_speed(mass_density_int, pressure_int),
+                      mass_density_int * normal_velocity_int, interface_normal,
+                      momentum_density_ext * normal_velocity_ext +
+                      pressure_ext * interface_normal, momentum_density_ext,
+                      interface_normal, mass_density_ext, momentum_density_ext,
+                      velocity_ext, pressure_ext,
+                      sound_speed(mass_density_ext, pressure_ext),
+                      mass_density_ext * normal_velocity_ext, interface_normal)
+
+
+def n_dot_num_f_energy_density(mass_density_int, momentum_density_int,
+                               energy_density_int, pressure_int,
+                               mass_density_ext, momentum_density_ext,
+                               energy_density_ext, pressure_ext,
+                               interface_normal):
+    velocity_int = momentum_density_int / mass_density_int
+    sound_speed_int = sound_speed(mass_density_int, pressure_int)
+    normal_velocity_int = np.dot(velocity_int, interface_normal)
+    velocity_ext = momentum_density_ext / mass_density_ext
+    sound_speed_ext = sound_speed(mass_density_ext, pressure_ext)
+    normal_velocity_ext = np.dot(velocity_ext, interface_normal)
+    all_char_speeds = (characteristic_speeds(velocity_int, sound_speed_int,
+                                             interface_normal) +
+                       characteristic_speeds(velocity_ext, sound_speed_ext,
+                                             interface_normal))
+    c_min = min(all_char_speeds)
+    c_max = max(all_char_speeds)
+    c_star = signal_speed_star(mass_density_int, pressure_int,
+                               mass_density_int * normal_velocity_int,
+                               normal_velocity_int, c_min,
+                               mass_density_ext, pressure_ext,
+                               mass_density_ext * normal_velocity_ext,
+                               normal_velocity_ext, c_max)
+    return apply_flux((energy_density_int + pressure_int) * normal_velocity_int,
+                      energy_density_int, c_star, mass_density_int,
+                      momentum_density_int, velocity_int, pressure_int,
+                      sound_speed_int, mass_density_int * normal_velocity_int,
+                      interface_normal,
+                      (energy_density_ext + pressure_ext) * normal_velocity_ext,
+                      energy_density_ext, c_star, mass_density_ext,
+                      momentum_density_ext, velocity_ext, pressure_ext,
+                      sound_speed_ext, mass_density_ext * normal_velocity_ext,
+                      interface_normal)
+
+

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/NumericalFluxes/Test_Hllc.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/NumericalFluxes/Test_Hllc.cpp
@@ -1,0 +1,217 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/NewtonianEuler/Characteristics.hpp"
+#include "Evolution/Systems/NewtonianEuler/Fluxes.hpp"
+#include "Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+namespace {
+
+// This test will check the correct implementation of the numerical flux,
+// as well as the interface expected to be used by the flux communication code.
+// Note: for these checks, the interface normal does not require be normalized.
+template <size_t Dim, typename Frame>
+void apply_hllc(
+    const gsl::not_null<Scalar<DataVector>*> n_dot_num_f_mass_density,
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame>*>
+        n_dot_num_f_momentum_density,
+    const gsl::not_null<Scalar<DataVector>*> n_dot_num_f_energy_density,
+    const Scalar<DataVector>& mass_density_int,
+    const tnsr::I<DataVector, Dim, Frame>& momentum_density_int,
+    const Scalar<DataVector>& energy_density_int,
+    const Scalar<DataVector>& pressure_int,
+    const Scalar<DataVector>& mass_density_ext,
+    const tnsr::I<DataVector, Dim, Frame>& momentum_density_ext,
+    const Scalar<DataVector>& energy_density_ext,
+    const Scalar<DataVector>& pressure_ext,
+    const tnsr::i<DataVector, Dim, Frame>& interface_normal) noexcept {
+  const size_t number_of_points = get(mass_density_int).size();
+
+  // make consistent velocity from conservatives
+  tnsr::I<DataVector, Dim, Frame> velocity_int(number_of_points);
+  tnsr::I<DataVector, Dim, Frame> velocity_ext(number_of_points);
+  for (size_t i = 0; i < Dim; ++i) {
+    velocity_int.get(i) = momentum_density_int.get(i) / get(mass_density_int);
+    velocity_ext.get(i) = momentum_density_ext.get(i) / get(mass_density_ext);
+  }
+
+  // make consistent volume fluxes from primitives and conservatives
+  tnsr::I<DataVector, Dim, Frame> flux_mass_density_int(number_of_points);
+  tnsr::IJ<DataVector, Dim, Frame> flux_momentum_density_int(number_of_points);
+  tnsr::I<DataVector, Dim, Frame> flux_energy_density_int(number_of_points);
+  NewtonianEuler::ComputeFluxes<Dim>::apply(
+      make_not_null(&flux_mass_density_int),
+      make_not_null(&flux_momentum_density_int),
+      make_not_null(&flux_energy_density_int), momentum_density_int,
+      energy_density_int, velocity_int, pressure_int);
+
+  tnsr::I<DataVector, Dim, Frame> flux_mass_density_ext(number_of_points);
+  tnsr::IJ<DataVector, Dim, Frame> flux_momentum_density_ext(number_of_points);
+  tnsr::I<DataVector, Dim, Frame> flux_energy_density_ext(number_of_points);
+  NewtonianEuler::ComputeFluxes<Dim>::apply(
+      make_not_null(&flux_mass_density_ext),
+      make_not_null(&flux_momentum_density_ext),
+      make_not_null(&flux_energy_density_ext), momentum_density_ext,
+      energy_density_ext, velocity_ext, pressure_ext);
+
+  // Given the general interface required by the (generic) evolution code,
+  // the computation of the numerical flux will work for a general case where
+  // the exterior interface normal does not equal minus the interior one. Here,
+  // we test n_ext = n_int as it is the only case expected to be used.
+  tnsr::i<DataVector, Dim, Frame> minus_interface_normal = interface_normal;
+  for (size_t i = 0; i < Dim; ++i) {
+    minus_interface_normal.get(i) *= -1.0;
+  }
+
+  // In an actual run, a generic action will perform the computation of the
+  // normal fluxes. For simplicity, here we compute them manually.
+  const Scalar<DataVector> n_dot_f_mass_density_int =
+      dot_product(flux_mass_density_int, interface_normal);
+  const Scalar<DataVector> n_dot_f_energy_density_int =
+      dot_product(flux_energy_density_int, interface_normal);
+  tnsr::I<DataVector, Dim, Frame> n_dot_f_momentum_density_int(
+      number_of_points);
+  tnsr::I<DataVector, Dim, Frame> minus_n_dot_f_momentum_density_ext(
+      number_of_points);
+  for (size_t i = 0; i < Dim; ++i) {
+    n_dot_f_momentum_density_int.get(i) = 0.0;
+    minus_n_dot_f_momentum_density_ext.get(i) = 0.0;
+    for (size_t j = 0; j < Dim; ++j) {
+      n_dot_f_momentum_density_int.get(i) +=
+          flux_momentum_density_int.get(i, j) * interface_normal.get(j);
+      minus_n_dot_f_momentum_density_ext.get(i) +=
+          flux_momentum_density_ext.get(i, j) * minus_interface_normal.get(j);
+    }
+  }
+
+  // make consistent sound speed for representative EoS (ideal gas)
+  const double adiabatic_index = 1.3333333333333333;
+  const Scalar<DataVector> sound_speed_int{
+      sqrt(adiabatic_index * get(pressure_int) / get(mass_density_int))};
+  const Scalar<DataVector> sound_speed_ext{
+      sqrt(adiabatic_index * get(pressure_ext) / get(mass_density_ext))};
+
+  using hllc_flux = NewtonianEuler::NumericalFluxes::Hllc<Dim, Frame>;
+  using packaged_data_tag = typename hllc_flux::package_tags;
+  Variables<packaged_data_tag> packaged_data_int(number_of_points);
+  Variables<packaged_data_tag> packaged_data_ext(number_of_points);
+
+  // Package interior data
+  hllc_flux{}.package_data(
+      make_not_null(&packaged_data_int), n_dot_f_mass_density_int,
+      n_dot_f_momentum_density_int, n_dot_f_energy_density_int,
+      mass_density_int, momentum_density_int, energy_density_int, velocity_int,
+      pressure_int,
+      NewtonianEuler::characteristic_speeds(velocity_int, sound_speed_int,
+                                            interface_normal),
+      interface_normal);
+
+  // First, let exterior data equal interior data in order to test consistency.
+  // We need to use minus interface normal to package exterior data, though.
+  tnsr::I<DataVector, Dim, Frame> minus_n_dot_f_momentum_density_int(
+      number_of_points);
+  for (size_t i = 0; i < Dim; ++i) {
+    minus_n_dot_f_momentum_density_int.get(i) =
+        -n_dot_f_momentum_density_int.get(i);
+  }
+  hllc_flux{}.package_data(
+      make_not_null(&packaged_data_ext),
+      dot_product(flux_mass_density_int, minus_interface_normal),
+      minus_n_dot_f_momentum_density_int,
+      dot_product(flux_energy_density_int, minus_interface_normal),
+      mass_density_int, momentum_density_int, energy_density_int, velocity_int,
+      pressure_int,
+      NewtonianEuler::characteristic_speeds(velocity_int, sound_speed_int,
+                                            minus_interface_normal),
+      minus_interface_normal);
+
+  // Test consistency: F_num(U, U) = F(U)
+  TestHelpers::NumericalFluxes::apply_numerical_flux(
+      hllc_flux{}, packaged_data_int, packaged_data_ext,
+      n_dot_num_f_mass_density, n_dot_num_f_momentum_density,
+      n_dot_num_f_energy_density);
+  CHECK(*n_dot_num_f_mass_density == n_dot_f_mass_density_int);
+  CHECK(*n_dot_num_f_momentum_density == n_dot_f_momentum_density_int);
+  CHECK(*n_dot_num_f_energy_density == n_dot_f_energy_density_int);
+
+  // Now package different exterior data.
+  hllc_flux{}.package_data(
+      make_not_null(&packaged_data_ext),
+      dot_product(flux_mass_density_ext, minus_interface_normal),
+      minus_n_dot_f_momentum_density_ext,
+      dot_product(flux_energy_density_ext, minus_interface_normal),
+      mass_density_ext, momentum_density_ext, energy_density_ext, velocity_ext,
+      pressure_ext,
+      NewtonianEuler::characteristic_speeds(velocity_ext, sound_speed_ext,
+                                            minus_interface_normal),
+      minus_interface_normal);
+
+  // These numerical fluxes will be compared with those obtained with pypp.
+  TestHelpers::NumericalFluxes::apply_numerical_flux(
+      hllc_flux{}, packaged_data_int, packaged_data_ext,
+      n_dot_num_f_mass_density, n_dot_num_f_momentum_density,
+      n_dot_num_f_energy_density);
+
+  // Before exiting, check that flux is conservative by swapping int/ext data
+  Scalar<DataVector> minus_n_dot_num_f_mass_density(number_of_points);
+  tnsr::I<DataVector, Dim, Frame> minus_n_dot_num_f_momentum_density(
+      number_of_points);
+  Scalar<DataVector> minus_n_dot_num_f_energy_density(number_of_points);
+  TestHelpers::NumericalFluxes::apply_numerical_flux(
+      hllc_flux{}, packaged_data_ext, packaged_data_int,
+      make_not_null(&minus_n_dot_num_f_mass_density),
+      make_not_null(&minus_n_dot_num_f_momentum_density),
+      make_not_null(&minus_n_dot_num_f_energy_density));
+  CHECK(get(*n_dot_num_f_mass_density) == -get(minus_n_dot_num_f_mass_density));
+  CHECK(get(*n_dot_num_f_energy_density) ==
+        -get(minus_n_dot_num_f_energy_density));
+  for (size_t i = 0; i < Dim; ++i) {
+    CHECK(n_dot_num_f_momentum_density->get(i) ==
+          -minus_n_dot_num_f_momentum_density.get(i));
+  }
+}
+
+template <size_t Dim, typename Frame>
+void test_flux(const DataVector& used_for_size) noexcept {
+  pypp::check_with_random_values<9>(
+      &apply_hllc<Dim, Frame>,
+      "Evolution.Systems.NewtonianEuler.NumericalFluxes.Hllc",
+      {"n_dot_num_f_mass_density", "n_dot_num_f_momentum_density",
+       "n_dot_num_f_energy_density"},
+      {{{0.0, 3.0},
+        {-4.0, 4.0},
+        {0.0, 3.0},
+        {0.0, 2.0},
+        {0.0, 3.0},
+        {-4.0, 4.0},
+        {0.0, 3.0},
+        {0.0, 2.0},
+        {-0.5, 0.5}}},
+      used_for_size);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.NumericalFluxes.Hllc",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+
+  GENERATE_UNINITIALIZED_DATAVECTOR;
+  CHECK_FOR_DATAVECTORS(test_flux, (1, 2, 3), (Frame::Inertial));
+}

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/NumericalFluxes/__init__.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/NumericalFluxes/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.


### PR DESCRIPTION
## Proposed changes

This flux is expected to be actively used in turbulence simulations so I'm opening a PR for it after rescuing it from an old local branch. 

Edit: relativistic HLLC should work with a similar interface, so any suggestions for improvements on design would be appreciated.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
