### PR TITLE
Prevent spurious FPE due to clang optimizer

### DIFF
--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -45,4 +45,5 @@ target_link_libraries(
   INTERFACE FunctionsOfTime
   INTERFACE LinearOperators
   INTERFACE Spectral
+  INTERFACE Utilities
   )

--- a/src/Domain/ElementMap.cpp
+++ b/src/Domain/ElementMap.cpp
@@ -7,6 +7,7 @@
 #include "Domain/Side.hpp"
 #include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/OptimizerHacks.hpp"
 
 /// \cond
 template <size_t Dim, typename TargetFrame>
@@ -28,6 +29,9 @@ ElementMap<Dim, TargetFrame>::ElementMap(
       map_offset_{[](const ElementId<Dim>& id) {
         std::array<double, Dim> result{};
         for (size_t d = 0; d < Dim; ++d) {
+          // The clang optimizer appears to generate code to execute
+          // this loop extra times and then throw away the results.
+          VARIABLE_CAUSES_CLANG_FPE(d);
           gsl::at(result, d) =
               0.5 * (gsl::at(id.segment_ids(), d).endpoint(Side::Upper) +
                      gsl::at(id.segment_ids(), d).endpoint(Side::Lower));

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY Utilities)
 set(LIBRARY_SOURCES
   FileSystem.cpp
   Formaline.cpp
+  OptimizerHacks.cpp
   PrettyType.cpp
   Rational.cpp
   )

--- a/src/Utilities/OptimizerHacks.cpp
+++ b/src/Utilities/OptimizerHacks.cpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Utilities/OptimizerHacks.hpp"
+
+namespace optimizer_hacks {
+void indicate_value_can_be_changed(void* /*variable*/) noexcept {}
+}  // namespace optimizer_hacks

--- a/src/Utilities/OptimizerHacks.hpp
+++ b/src/Utilities/OptimizerHacks.hpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/// \ingroup PeoGroup
+/// Workarounds for optimizer bugs
+namespace optimizer_hacks {
+/// \ingroup PeoGroup
+/// Produce a situation where the value of `*variable` could have been
+/// changed without the optimizer's knowledge, without actually
+/// changing the variable.
+void indicate_value_can_be_changed(void* variable) noexcept;
+}  // namespace optimizer_hacks
+
+#ifdef __clang__
+#define VARIABLE_CAUSES_CLANG_FPE(var) \
+  ::optimizer_hacks::indicate_value_can_be_changed(&(var))
+#else  /* __clang__ */
+/// \ingroup PeoGroup
+/// Clang's optimizer has a known bug that sometimes produces spurious
+/// FPEs.  This indicates that the variable `var` can trigger that bug
+/// and prevents some optimizations.  (See [the LLVM bug
+/// report](https://llvm.org/bugs/show_bug.cgi?id=18673), which is
+/// effectively WONTFIX.)
+#define VARIABLE_CAUSES_CLANG_FPE(var) ((void)(var))
+#endif  /* __clang__ */


### PR DESCRIPTION
This failure appeared after an upgrade from clang 7 to 9.

After a number of failed attempts to trick the optimizer with inline assembly, I went with just passing a variable related to the problem to a function defined in another compilation unit, which should prevent the optimizer from making assumptions about that variable.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
