### PR TITLE
Add constraint damping to ScalarWave

### DIFF
--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -19,6 +19,7 @@
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/NonconservativeSystem.hpp"
 #include "Evolution/Systems/ScalarWave/Equations.hpp"  // IWYU pragma: keep // for UpwindFlux
+#include "Evolution/Systems/ScalarWave/Initialize.hpp"
 #include "Evolution/Systems/ScalarWave/System.hpp"
 #include "IO/Observer/Actions.hpp"            // IWYU pragma: keep
 #include "IO/Observer/Helpers.hpp"            // IWYU pragma: keep
@@ -197,11 +198,14 @@ struct EvolutionMetavars {
       evolution::dg::Initialization::Domain<system::volume_dim>,
       Initialization::Actions::NonconservativeSystem,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
+      ScalarWave::Actions::InitializeConstraints<volume_dim>,
       dg::Actions::InitializeInterfaces<
           system,
           dg::Initialization::slice_tags_to_face<
-              typename system::variables_tag>,
-          dg::Initialization::slice_tags_to_exterior<>,
+              typename system::variables_tag,
+              ScalarWave::Tags::ConstraintGamma2>,
+          dg::Initialization::slice_tags_to_exterior<
+              ScalarWave::Tags::ConstraintGamma2>,
           dg::Initialization::face_compute_tags<>,
           dg::Initialization::exterior_compute_tags<>, true, true>,
       Initialization::Actions::AddComputeTags<
@@ -234,8 +238,7 @@ struct EvolutionMetavars {
               Parallel::PhaseActions<
                   Phase, Phase::Evolve,
                   tmpl::list<
-                      Actions::RunEventsAndTriggers,
-                      Actions::ChangeSlabSize,
+                      Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,

--- a/src/Evolution/Systems/ScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/ScalarWave/Characteristics.hpp
@@ -26,16 +26,6 @@ struct Normalized;
 /// \endcond
 
 namespace ScalarWave {
-namespace Tags {
-struct ConstraintGamma2Compute : ConstraintGamma2, db::ComputeTag {
-  using argument_tags = tmpl::list<Psi>;
-  static auto function(const Scalar<DataVector>& psi) noexcept {
-    return make_with_value<type>(psi, 0.);
-  }
-  using base = ConstraintGamma2;
-};
-}  // namespace Tags
-
 // @{
 /*!
  * \ingroup ScalarWave

--- a/src/Evolution/Systems/ScalarWave/Constraints.hpp
+++ b/src/Evolution/Systems/ScalarWave/Constraints.hpp
@@ -61,6 +61,14 @@ void two_index_constraint(
 // @}
 
 namespace Tags {
+struct ConstraintGamma2Compute : ConstraintGamma2, db::ComputeTag {
+  using argument_tags = tmpl::list<Psi>;
+  static auto function(const Scalar<DataVector>& psi) noexcept {
+    return make_with_value<type>(psi, 0.);
+  }
+  using base = ConstraintGamma2;
+};
+
 /*!
  * \brief Compute item to get the one-index constraint for the scalar-wave
  * evolution system.

--- a/src/Evolution/Systems/ScalarWave/Initialize.hpp
+++ b/src/Evolution/Systems/ScalarWave/Initialize.hpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/EagerMath/Norms.hpp"
+#include "DataStructures/Variables.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Systems/ScalarWave/Constraints.hpp"
+#include "Evolution/Systems/ScalarWave/System.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+
+namespace ScalarWave {
+namespace Actions {
+/// \ingroup InitializationGroup
+/// \brief Initialize items related to constraints of the ScalarWave system
+///
+/// We add both constraints and the constraint damping parameter to the
+/// evolution databox.
+///
+/// DataBox changes:
+/// - Adds:
+///   * `ScalarWave::Tags::ConstraintGamma2`
+///   * `ScalarWave::Tags::OneIndexConstraint<Dim>`
+///   * `ScalarWave::Tags::TwoIndexConstraint<Dim>`
+///   * `::Tags::PointwiseL2Norm<ScalarWave::Tags::OneIndexConstraint<Dim>>`
+///   * `::Tags::PointwiseL2Norm<ScalarWave::Tags::TwoIndexConstraint<Dim>>`
+/// - Removes: nothing
+/// - Modifies: nothing
+///
+template <size_t Dim>
+struct InitializeConstraints {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using compute_tags =
+        db::AddComputeTags<ScalarWave::Tags::ConstraintGamma2Compute,
+                           ScalarWave::Tags::OneIndexConstraintCompute<Dim>,
+                           ScalarWave::Tags::TwoIndexConstraintCompute<Dim>,
+                           ::Tags::PointwiseL2NormCompute<
+                               ScalarWave::Tags::OneIndexConstraint<Dim>>,
+                           ::Tags::PointwiseL2NormCompute<
+                               ScalarWave::Tags::TwoIndexConstraint<Dim>>>;
+
+    return std::make_tuple(
+        Initialization::merge_into_databox<InitializeConstraints,
+                                           db::AddSimpleTags<>, compute_tags>(
+            std::move(box)));
+  }
+};
+}  // namespace Actions
+}  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -41,7 +41,7 @@ struct System {
 
   using variables_tag = ::Tags::Variables<tmpl::list<Pi, Phi<Dim>, Psi>>;
   // Typelist of which subset of the variables to take the gradient of.
-  using gradients_tags = tmpl::list<Pi, Phi<Dim>>;
+  using gradients_tags = tmpl::list<Pi, Phi<Dim>, Psi>;
 
   using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;
   using compute_largest_characteristic_speed =

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"

--- a/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
@@ -48,7 +48,7 @@ NumericalFlux:
 
 EventsAndTriggers:
   ? SpecifiedSlabs:
-      Slabs: [10]
+      Slabs: [5]
   : - Completion
   ? EveryNSlabs:
       N: 2

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
@@ -337,9 +337,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Characteristics",
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/ScalarWave/"};
 
-  TestHelpers::db::test_compute_tag<ScalarWave::Tags::ConstraintGamma2Compute>(
-      "ConstraintGamma2");
-
   test_characteristic_speeds<1>();
   test_characteristic_speeds<2>();
   test_characteristic_speeds<3>();

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Constraints.cpp
@@ -179,6 +179,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Constraints",
                   "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/ScalarWave/"};
+
+  TestHelpers::db::test_compute_tag<ScalarWave::Tags::ConstraintGamma2Compute>(
+      "ConstraintGamma2");
+
   {
     INFO("Testing constraints with randomized input");
     // Test the one-index constraint with random numbers

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -29,6 +29,7 @@
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/ScalarWave/Constraints.hpp"
 #include "Evolution/Systems/ScalarWave/Equations.hpp"
 #include "Evolution/Systems/ScalarWave/System.hpp"
 #include "Framework/ActionTesting.hpp"
@@ -100,6 +101,7 @@ struct Component {
       inverse_jacobian,
       Tags::DerivCompute<variables_tag, inverse_jacobian,
                          typename metavariables::system::gradients_tags>,
+      ScalarWave::Tags::ConstraintGamma2Compute,
       domain::Tags::InternalDirections<1>,
       domain::Tags::Slice<domain::Tags::InternalDirections<1>,
                           typename metavariables::system::variables_tag>,
@@ -109,7 +111,8 @@ struct Component {
       interface_compute_tag<
           Tags::EuclideanMagnitude<domain::Tags::UnnormalizedFaceNormal<1>>>,
       interface_compute_tag<
-          Tags::NormalizedCompute<domain::Tags::UnnormalizedFaceNormal<1>>>>;
+          Tags::NormalizedCompute<domain::Tags::UnnormalizedFaceNormal<1>>>,
+      interface_compute_tag<ScalarWave::Tags::ConstraintGamma2Compute>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<


### PR DESCRIPTION
## Proposed changes

Add constraint damping parameter to DuDt+UpwindFlux for the ScalarWave evolution system. Add constraints to the executable.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration