### PR TITLE
Generalize push_back/front for CoordinateMap, add get_clone to FunctionsOfTime

### DIFF
--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -344,6 +344,18 @@ class CoordinateMap
       CoordinateMap<LocalSourceFrame, LocalTargetFrame, LocalMaps...>&& old_map,
       NewMap new_map, std::index_sequence<Is...> /*meta*/) noexcept;
 
+  template <typename... NewMaps, typename LocalSourceFrame,
+            typename LocalTargetFrame, typename... LocalMaps, size_t... Is,
+            size_t... Js>
+  friend CoordinateMap<LocalSourceFrame, LocalTargetFrame, LocalMaps...,
+                       NewMaps...>
+  // NOLINTNEXTLINE(readability-redundant-declaration,-warnings-as-errors)
+  push_back_impl(
+      CoordinateMap<LocalSourceFrame, LocalTargetFrame, LocalMaps...>&& old_map,
+      CoordinateMap<LocalSourceFrame, LocalTargetFrame, NewMaps...> new_map,
+      std::index_sequence<Is...> /*meta*/,
+      std::index_sequence<Js...> /*meta*/) noexcept;
+
   template <typename NewMap, typename LocalSourceFrame,
             typename LocalTargetFrame, typename... LocalMaps, size_t... Is>
   friend CoordinateMap<LocalSourceFrame, LocalTargetFrame, NewMap, LocalMaps...>

--- a/src/Domain/CoordinateMaps/CoordinateMap.tpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.tpp
@@ -374,6 +374,18 @@ CoordinateMap<SourceFrame, TargetFrame, Maps..., NewMap> push_back_impl(
       std::move(std::get<Is>(old_map.maps_))..., std::move(new_map)};
 }
 
+template <typename... NewMaps, typename SourceFrame, typename TargetFrame,
+          typename... Maps, size_t... Is, size_t... Js>
+CoordinateMap<SourceFrame, TargetFrame, Maps..., NewMaps...> push_back_impl(
+    CoordinateMap<SourceFrame, TargetFrame, Maps...>&& old_map,
+    CoordinateMap<SourceFrame, TargetFrame, NewMaps...> new_map,
+    std::index_sequence<Is...> /*meta*/,
+    std::index_sequence<Js...> /*meta*/) noexcept {
+  return CoordinateMap<SourceFrame, TargetFrame, Maps..., NewMaps...>{
+      std::move(std::get<Is>(old_map.maps_))...,
+      std::move(std::get<Js>(new_map.maps_))...};
+}
+
 template <typename NewMap, typename SourceFrame, typename TargetFrame,
           typename... Maps, size_t... Is>
 CoordinateMap<SourceFrame, TargetFrame, NewMap, Maps...> push_front_impl(
@@ -393,12 +405,32 @@ CoordinateMap<SourceFrame, TargetFrame, Maps..., NewMap> push_back(
 }
 
 template <typename SourceFrame, typename TargetFrame, typename... Maps,
+          typename... NewMaps>
+CoordinateMap<SourceFrame, TargetFrame, Maps..., NewMaps...> push_back(
+    CoordinateMap<SourceFrame, TargetFrame, Maps...> old_map,
+    CoordinateMap<SourceFrame, TargetFrame, NewMaps...> new_map) noexcept {
+  return push_back_impl(std::move(old_map), std::move(new_map),
+                        std::make_index_sequence<sizeof...(Maps)>{},
+                        std::make_index_sequence<sizeof...(NewMaps)>{});
+}
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps,
           typename NewMap>
 CoordinateMap<SourceFrame, TargetFrame, NewMap, Maps...> push_front(
     CoordinateMap<SourceFrame, TargetFrame, Maps...> old_map,
     NewMap new_map) noexcept {
   return push_front_impl(std::move(old_map), std::move(new_map),
                          std::make_index_sequence<sizeof...(Maps)>{});
+}
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps,
+          typename... NewMaps>
+CoordinateMap<SourceFrame, TargetFrame, NewMaps..., Maps...> push_front(
+    CoordinateMap<SourceFrame, TargetFrame, Maps...> old_map,
+    CoordinateMap<SourceFrame, TargetFrame, NewMaps...> new_map) noexcept {
+  return push_back_impl(std::move(new_map), std::move(old_map),
+                        std::make_index_sequence<sizeof...(NewMaps)>{},
+                        std::make_index_sequence<sizeof...(Maps)>{});
 }
 }  // namespace domain
 /// \endcond

--- a/src/Domain/CoordinateMaps/Translation.cpp
+++ b/src/Domain/CoordinateMaps/Translation.cpp
@@ -3,6 +3,7 @@
 
 #include "Domain/CoordinateMaps/Translation.hpp"
 
+#include <ostream>
 #include <pup.h>
 #include <pup_stl.h>
 #include <utility>
@@ -10,9 +11,11 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Identity.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "ErrorHandling/Assert.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/StdHelpers.hpp"
 
 namespace domain {
 namespace CoordMapsTimeDependent {
@@ -26,6 +29,11 @@ std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::operator()(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         map_list) const noexcept {
+  ASSERT(map_list.count(f_of_t_name_) == 1,
+         "The function of time '" << f_of_t_name_
+                                  << "' is not one of the known functions of "
+                                     "time. The known functions of time are: "
+                                  << keys_of(map_list));
   return {{source_coords[0] + map_list.at(f_of_t_name_)->func(time)[0][0]}};
 }
 
@@ -34,6 +42,11 @@ boost::optional<std::array<double, 1>> Translation::inverse(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         map_list) const noexcept {
+  ASSERT(map_list.count(f_of_t_name_) == 1,
+         "The function of time '" << f_of_t_name_
+                                  << "' is not one of the known functions of "
+                                     "time. The known functions of time are: "
+                                  << keys_of(map_list));
   return {{{target_coords[0] - map_list.at(f_of_t_name_)->func(time)[0][0]}}};
 }
 
@@ -43,6 +56,11 @@ std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::frame_velocity(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         map_list) const noexcept {
+  ASSERT(map_list.count(f_of_t_name_) == 1,
+         "The function of time '" << f_of_t_name_
+                                  << "' is not one of the known functions of "
+                                     "time. The known functions of time are: "
+                                  << keys_of(map_list));
   return {{make_with_value<tt::remove_cvref_wrap_t<T>>(
       dereference_wrapper(source_coords[0]),
       map_list.at(f_of_t_name_)->func_and_deriv(time)[1][0])}};

--- a/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <memory>
 #include <pup.h>
 #include <vector>
 
@@ -21,9 +22,12 @@ class FunctionOfTime : public PUP::able {
   FunctionOfTime() = default;
   FunctionOfTime(FunctionOfTime&&) noexcept = default;
   FunctionOfTime& operator=(FunctionOfTime&&) noexcept = default;
-  FunctionOfTime(const FunctionOfTime&) = delete;
-  FunctionOfTime& operator=(const FunctionOfTime&) = delete;
+  FunctionOfTime(const FunctionOfTime&) = default;
+  FunctionOfTime& operator=(const FunctionOfTime&) = default;
   ~FunctionOfTime() override = default;
+
+  virtual auto get_clone() const noexcept
+      -> std::unique_ptr<FunctionOfTime> = 0;
 
   virtual std::array<double, 2> time_bounds() const noexcept = 0;
 

--- a/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
@@ -12,10 +12,10 @@
 
 namespace domain {
 /// \ingroup ComputationalDomainGroup
-/// Contains functions of time to support the dual frame system.
+/// \brief Contains functions of time to support the dual frame system.
 namespace FunctionsOfTime {
 /// \ingroup ComputationalDomainGroup
-/// Base class for FunctionsOfTime
+/// \brief Base class for FunctionsOfTime
 class FunctionOfTime : public PUP::able {
  public:
   FunctionOfTime() = default;

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <memory>
 #include <ostream>
 #include <utility>  // IWYU pragma: keep
 
@@ -22,6 +23,12 @@ template <size_t MaxDeriv>
 PiecewisePolynomial<MaxDeriv>::PiecewisePolynomial(
     const double t, value_type initial_func_and_derivs) noexcept
     : deriv_info_at_update_times_{{t, std::move(initial_func_and_derivs)}} {}
+
+template <size_t MaxDeriv>
+std::unique_ptr<FunctionOfTime> PiecewisePolynomial<MaxDeriv>::get_clone() const
+    noexcept {
+  return std::make_unique<PiecewisePolynomial>(*this);
+}
 
 template <size_t MaxDeriv>
 template <size_t MaxDerivReturned>

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
@@ -16,7 +16,7 @@
 namespace domain {
 namespace FunctionsOfTime {
 /// \ingroup ComputationalDomainGroup
-/// A function that has a piecewise-constant `MaxDeriv`th derivative.
+/// \brief A function that has a piecewise-constant `MaxDeriv`th derivative.
 template <size_t MaxDeriv>
 class PiecewisePolynomial : public FunctionOfTime {
  public:

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <limits>
+#include <memory>
 #include <pup.h>
 #include <vector>
 
@@ -28,10 +29,12 @@ class PiecewisePolynomial : public FunctionOfTime {
   ~PiecewisePolynomial() override = default;
   PiecewisePolynomial(PiecewisePolynomial&&) noexcept = default;
   PiecewisePolynomial& operator=(PiecewisePolynomial&&) noexcept = default;
-  PiecewisePolynomial(const PiecewisePolynomial&) = delete;
-  PiecewisePolynomial& operator=(const PiecewisePolynomial&) = delete;
+  PiecewisePolynomial(const PiecewisePolynomial&) = default;
+  PiecewisePolynomial& operator=(const PiecewisePolynomial&) = default;
 
   explicit PiecewisePolynomial(CkMigrateMessage* /*unused*/) {}
+
+  auto get_clone() const noexcept -> std::unique_ptr<FunctionOfTime> override;
 
   // NOLINTNEXTLINE(google-runtime-references)
   WRAPPED_PUPable_decl_template(PiecewisePolynomial<MaxDeriv>);

--- a/src/Domain/FunctionsOfTime/SettleToConstant.cpp
+++ b/src/Domain/FunctionsOfTime/SettleToConstant.cpp
@@ -4,6 +4,7 @@
 #include "Domain/FunctionsOfTime/SettleToConstant.hpp"
 
 #include <cmath>
+#include <memory>
 
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
@@ -24,6 +25,10 @@ SettleToConstant::SettleToConstant(
       -initial_func_and_derivs[1] - initial_func_and_derivs[2] * decay_time;
   coef_b_ = (coef_c_ - initial_func_and_derivs[1]) * decay_time;
   coef_a_ = initial_func_and_derivs[0] - coef_b_;
+}
+
+std::unique_ptr<FunctionOfTime> SettleToConstant::get_clone() const noexcept {
+  return std::make_unique<SettleToConstant>(*this);
 }
 
 template <size_t MaxDerivReturned>

--- a/src/Domain/FunctionsOfTime/SettleToConstant.hpp
+++ b/src/Domain/FunctionsOfTime/SettleToConstant.hpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <limits>
+#include <memory>
 #include <pup.h>
 
 #include "DataStructures/DataVector.hpp"
@@ -35,13 +36,15 @@ class SettleToConstant : public FunctionOfTime {
   ~SettleToConstant() override = default;
   SettleToConstant(SettleToConstant&&) noexcept = default;
   SettleToConstant& operator=(SettleToConstant&&) noexcept = default;
-  SettleToConstant(const SettleToConstant&) = delete;
-  SettleToConstant& operator=(const SettleToConstant&) = delete;
+  SettleToConstant(const SettleToConstant&) = default;
+  SettleToConstant& operator=(const SettleToConstant&) = default;
 
   // NOLINTNEXTLINE(google-runtime-references)
   WRAPPED_PUPable_decl_template(SettleToConstant);
 
   explicit SettleToConstant(CkMigrateMessage* /*unused*/) {}
+
+  auto get_clone() const noexcept -> std::unique_ptr<FunctionOfTime> override;
 
   /// Returns the function at an arbitrary time `t`.
   std::array<DataVector, 1> func(const double t) const noexcept override {

--- a/src/Domain/FunctionsOfTime/SettleToConstant.hpp
+++ b/src/Domain/FunctionsOfTime/SettleToConstant.hpp
@@ -15,6 +15,9 @@
 namespace domain {
 namespace FunctionsOfTime {
 /// \ingroup ControlSystemGroup
+/// \brief Given an initial function of time, transitions the map to a
+/// constant-in-time value.
+///
 /// Given an initial function \f$f(t)\f$ and its first two derivatives
 /// at the matching time \f$t_0\f$, the constant coefficients \f$A,B,C\f$
 /// are computed such that the resulting function of time

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -1032,6 +1032,9 @@ void test_push_back() {
         push_front(second_coord_map, first_map);
     CHECK(composed_map == composed_push_back_map);
     CHECK(composed_map == composed_push_front_map);
+
+    CHECK(composed_map == push_back(first_coord_map, second_coord_map));
+    CHECK(composed_map == push_front(second_coord_map, first_coord_map));
   };
 
   // Test 1d

--- a/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
@@ -126,6 +126,8 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
               t, init_func);
       std::unique_ptr<FunctionsOfTime::FunctionOfTime> f_of_t2 =
           serialize_and_deserialize(f_of_t);
+      std::unique_ptr<FunctionsOfTime::FunctionOfTime> f_of_t3 =
+          f_of_t->get_clone();
 
       test(make_not_null(f_of_t.get()),
            make_not_null(
@@ -136,6 +138,11 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
            make_not_null(
                dynamic_cast<FunctionsOfTime::PiecewisePolynomial<deriv_order>*>(
                    f_of_t2.get())),
+           t, dt, final_time);
+      test(make_not_null(f_of_t3.get()),
+           make_not_null(
+               dynamic_cast<FunctionsOfTime::PiecewisePolynomial<deriv_order>*>(
+                   f_of_t3.get())),
            t, dt, final_time);
     }
   }
@@ -167,6 +174,8 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
               t, init_func);
       std::unique_ptr<FunctionsOfTime::FunctionOfTime> f_of_t2 =
           serialize_and_deserialize(f_of_t);
+      std::unique_ptr<FunctionsOfTime::FunctionOfTime> f_of_t3 =
+          f_of_t->get_clone();
 
       test_non_const_deriv(
           make_not_null(f_of_t.get()),
@@ -179,6 +188,12 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
           make_not_null(
               dynamic_cast<FunctionsOfTime::PiecewisePolynomial<deriv_order>*>(
                   f_of_t2.get())),
+          t, dt, final_time);
+      test_non_const_deriv(
+          make_not_null(f_of_t3.get()),
+          make_not_null(
+              dynamic_cast<FunctionsOfTime::PiecewisePolynomial<deriv_order>*>(
+                  f_of_t3.get())),
           t, dt, final_time);
     }
   }

--- a/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstant.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstant.cpp
@@ -76,4 +76,8 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.SettleToConstant",
   const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t2 =
       serialize_and_deserialize(f_of_t);
   test(f_of_t2, match_time, f_t0, dtf_t0, d2tf_t0, A);
+
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t3 =
+      f_of_t->get_clone();
+  test(f_of_t3, match_time, f_t0, dtf_t0, d2tf_t0, A);
 }


### PR DESCRIPTION
## Proposed changes

- Minor cleanups in the FunctionsOfTime dox
- Generalize push_back and push_front to work on CoordinateMap classes instead of just individual coordinate maps.
- Add a get_clone function to FunctionsOfTime so that we are able to "copy" them.
- Add an `ASSERT` to the `TranslationMap` when the function of time cannot be found by name.

### Types of changes:

- [x] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
