### PR TITLE
Make Cce test filenames unique

### DIFF
--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -38,7 +38,7 @@ SPECTRE_TEST_CASE(
   ActionTesting::MockRuntimeSystem<metavariables> runner{{l_max}};
 
   const size_t buffer_size = 8;
-  const std::string filename = "test_CceR0100.h5";
+  const std::string filename = "InitializeWorldtubeBoundaryTest_CceR0100.h5";
 
   // create the test file, because on initialization the manager will need to
   // get basic data out of the file

--- a/tests/Unit/Evolution/Systems/Cce/Test_ReadBoundaryDataH5.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_ReadBoundaryDataH5.cpp
@@ -471,7 +471,7 @@ void test_spec_worldtube_buffer_updater(
       (buffer_size + 2 * interpolator_length) * square(l_max + 1)};
   Variables<detail::cce_input_tags> expected_coefficients_buffers{
       (buffer_size + 2 * interpolator_length) * square(l_max + 1)};
-  const std::string filename = "test_CceR0100.h5";
+  const std::string filename = "BoundaryDataH5Test_CceR0100.h5";
   TestHelpers::write_test_file(solution, filename, target_time,
                                extraction_radius, frequency, amplitude, l_max);
 
@@ -561,7 +561,7 @@ void test_reduced_spec_worldtube_buffer_updater(
           db::item_type<boundary_variables_tag>{number_of_angular_points});
 
   // write times to file for several steps before and after the target time
-  const std::string filename = "test_CceR0100.h5";
+  const std::string filename = "BoundaryDataH5Test_CceR0100.h5";
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);
   }


### PR DESCRIPTION
## Proposed changes
fix #1949

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
