### PR TITLE
Rename TVBM -> TVB in Minmod code

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
@@ -28,7 +28,7 @@ bool minmod_limited_slopes(
     const gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
     const gsl::not_null<DataVector*> u_lin_buffer,
     const gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
-    const Limiters::MinmodType minmod_type, const double tvbm_constant,
+    const Limiters::MinmodType minmod_type, const double tvb_constant,
     const DataVector& u, const Element<VolumeDim>& element,
     const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
@@ -37,10 +37,10 @@ bool minmod_limited_slopes(
     const std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,
                                gsl::span<std::pair<size_t, size_t>>>,
                      VolumeDim>& volume_and_slice_indices) noexcept {
-  const double tvbm_scale = [&tvbm_constant, &element_size ]() noexcept {
+  const double tvb_scale = [&tvb_constant, &element_size ]() noexcept {
     const double max_h =
         *std::max_element(element_size.begin(), element_size.end());
-    return tvbm_constant * square(max_h);
+    return tvb_constant * square(max_h);
   }
   ();
 
@@ -65,7 +65,7 @@ bool minmod_limited_slopes(
   // limiting solutions that appear smooth:
   if (minmod_type == Limiters::MinmodType::LambdaPiN) {
     const bool u_needs_limiting = troubled_cell_indicator(
-        boundary_buffer, tvbm_constant, u, element, mesh, element_size,
+        boundary_buffer, tvb_constant, u, element, mesh, element_size,
         effective_neighbor_means, effective_neighbor_sizes,
         volume_and_slice_indices);
 
@@ -108,7 +108,7 @@ bool minmod_limited_slopes(
 
     const MinmodResult result =
         tvb_corrected_minmod(local_slope, max_slope_factor * upper_slope,
-                             max_slope_factor * lower_slope, tvbm_scale);
+                             max_slope_factor * lower_slope, tvb_scale);
     gsl::at(*u_limited_slopes, d) = result.value;
     if (result.activated) {
       slopes_need_reducing = true;

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
@@ -107,8 +107,8 @@ bool minmod_limited_slopes(
     const double lower_slope = 0.5 * difference_to_neighbor(d, Side::Lower);
 
     const MinmodResult result =
-        minmod_tvbm(local_slope, max_slope_factor * upper_slope,
-                    max_slope_factor * lower_slope, tvbm_scale);
+        tvb_corrected_minmod(local_slope, max_slope_factor * upper_slope,
+                             max_slope_factor * lower_slope, tvbm_scale);
     gsl::at(*u_limited_slopes, d) = result.value;
     if (result.activated) {
       slopes_need_reducing = true;

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
@@ -120,11 +120,11 @@ bool minmod_limited_slopes(
 /// original (higher-order) data in the case that the slopes are acceptable.
 ///
 /// For all three types of minmod limiter the "total variation bound in the
-/// means" (TVBM) correction is implemented, enabling the limiter to avoid
+/// means" (TVB) correction is implemented, enabling the limiter to avoid
 /// limiting away smooth extrema in the solution that would otherwise look like
 /// spurious oscillations. The limiter will not reduce the slope (but may still
 /// linearize) on elements where the slope is less than \f$m h^2\f$, where
-/// \f$m\f$ is the TVBM constant and \f$h\f$ is the size of the DG element.
+/// \f$m\f$ is the TVB constant and \f$h\f$ is the size of the DG element.
 ///
 /// The limiter acts in the `Frame::Logical` coordinates, because in these
 /// coordinates it is straightforward to formulate the algorithm. This means the
@@ -161,14 +161,14 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
     using type = MinmodType;
     static constexpr OptionString help = {"Type of minmod"};
   };
-  /// \brief The TVBM constant
+  /// \brief The TVB constant
   ///
   /// See `Limiters::Minmod` documentation for details.
   struct TvbConstant {
     using type = double;
     static type default_value() noexcept { return 0.0; }
     static type lower_bound() noexcept { return 0.0; }
-    static constexpr OptionString help = {"TVBM constant 'm'"};
+    static constexpr OptionString help = {"TVB constant 'm'"};
   };
   /// \brief Turn the limiter off
   ///
@@ -184,14 +184,14 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
   static constexpr OptionString help = {
       "A minmod-based slope limiter.\n"
       "The different types of minmod are more or less aggressive in trying\n"
-      "to reduce slopes. The TVBM correction allows the limiter to ignore\n"
+      "to reduce slopes. The TVB correction allows the limiter to ignore\n"
       "'small' slopes, and helps to avoid limiting of smooth extrema in the\n"
       "solution.\n"};
 
   /// \brief Constuct a Minmod slope limiter
   ///
   /// \param minmod_type The type of Minmod slope limiter.
-  /// \param tvb_constant The value of the TVBM constant (default: 0).
+  /// \param tvb_constant The value of the TVB constant (default: 0).
   /// \param disable_for_debugging Switch to turn the limiter off (default:
   //         false).
   explicit Minmod(MinmodType minmod_type, double tvb_constant = 0.0,

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
@@ -164,7 +164,7 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
   /// \brief The TVBM constant
   ///
   /// See `Limiters::Minmod` documentation for details.
-  struct TvbmConstant {
+  struct TvbConstant {
     using type = double;
     static type default_value() noexcept { return 0.0; }
     static type lower_bound() noexcept { return 0.0; }
@@ -180,7 +180,7 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
     static type default_value() noexcept { return false; }
     static constexpr OptionString help = {"Disable the limiter"};
   };
-  using options = tmpl::list<Type, TvbmConstant, DisableForDebugging>;
+  using options = tmpl::list<Type, TvbConstant, DisableForDebugging>;
   static constexpr OptionString help = {
       "A minmod-based slope limiter.\n"
       "The different types of minmod are more or less aggressive in trying\n"

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
@@ -77,7 +77,7 @@ bool minmod_limited_slopes(
     gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
     gsl::not_null<DataVector*> u_lin_buffer,
     gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
-    Limiters::MinmodType minmod_type, double tvbm_constant, const DataVector& u,
+    Limiters::MinmodType minmod_type, double tvb_constant, const DataVector& u,
     const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
@@ -191,10 +191,10 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
   /// \brief Constuct a Minmod slope limiter
   ///
   /// \param minmod_type The type of Minmod slope limiter.
-  /// \param tvbm_constant The value of the TVBM constant (default: 0).
+  /// \param tvb_constant The value of the TVBM constant (default: 0).
   /// \param disable_for_debugging Switch to turn the limiter off (default:
   //         false).
-  explicit Minmod(MinmodType minmod_type, double tvbm_constant = 0.0,
+  explicit Minmod(MinmodType minmod_type, double tvb_constant = 0.0,
                   bool disable_for_debugging = false) noexcept;
 
   Minmod() noexcept = default;
@@ -296,7 +296,7 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
                          const Minmod<LocalDim, LocalTagList>& rhs) noexcept;
 
   MinmodType minmod_type_;
-  double tvbm_constant_;
+  double tvb_constant_;
   bool disable_for_debugging_;
 };
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
@@ -119,12 +119,16 @@ bool minmod_limited_slopes(
 /// \f$\Lambda\Pi^1\f$ in the case that the slopes must be reduced, but is the
 /// original (higher-order) data in the case that the slopes are acceptable.
 ///
-/// For all three types of minmod limiter the "total variation bound in the
-/// means" (TVB) correction is implemented, enabling the limiter to avoid
-/// limiting away smooth extrema in the solution that would otherwise look like
-/// spurious oscillations. The limiter will not reduce the slope (but may still
+/// For all three types of minmod limiter, the algorithm can be relaxed from
+/// TVD (total variation diminishing) in the means to TVB (total variation
+/// bound) in the means. This may avoid limiting away smooth extrema in the
+/// solution that would otherwise look like spurious oscillations. When this
+/// correction is enabled, the limiter will not reduce the slope (but may still
 /// linearize) on elements where the slope is less than \f$m h^2\f$, where
 /// \f$m\f$ is the TVB constant and \f$h\f$ is the size of the DG element.
+/// Note the "in the means" qualifier: the limiter controls the oscillation
+/// between the mean solution values across neighboring cells, but may not
+/// control oscillations within the cells.
 ///
 /// The limiter acts in the `Frame::Logical` coordinates, because in these
 /// coordinates it is straightforward to formulate the algorithm. This means the

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
@@ -110,7 +110,7 @@ Minmod<VolumeDim, tmpl::list<Tags...>>::Minmod(
     : minmod_type_(minmod_type),
       tvb_constant_(tvb_constant),
       disable_for_debugging_(disable_for_debugging) {
-  ASSERT(tvb_constant >= 0.0, "The TVBM constant must be non-negative.");
+  ASSERT(tvb_constant >= 0.0, "The TVB constant must be non-negative.");
 }
 
 template <size_t VolumeDim, typename... Tags>

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
@@ -45,7 +45,7 @@ bool limit_one_tensor(
     const gsl::not_null<db::item_type<Tag>*> tensor,
     const gsl::not_null<DataVector*> u_lin_buffer,
     const gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
-    const Limiters::MinmodType minmod_type, const double tvbm_constant,
+    const Limiters::MinmodType minmod_type, const double tvb_constant,
     const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
     const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
     const std::array<double, VolumeDim>& element_size,
@@ -85,7 +85,7 @@ bool limit_one_tensor(
     std::array<double, VolumeDim> u_limited_slopes{};
     const bool reduce_slopes = minmod_limited_slopes(
         make_not_null(&u_mean), make_not_null(&u_limited_slopes), u_lin_buffer,
-        boundary_buffer, minmod_type, tvbm_constant, u, element, mesh,
+        boundary_buffer, minmod_type, tvb_constant, u, element, mesh,
         element_size, effective_neighbor_means, effective_neighbor_sizes,
         volume_and_slice_indices);
 
@@ -105,18 +105,18 @@ bool limit_one_tensor(
 
 template <size_t VolumeDim, typename... Tags>
 Minmod<VolumeDim, tmpl::list<Tags...>>::Minmod(
-    const MinmodType minmod_type, const double tvbm_constant,
+    const MinmodType minmod_type, const double tvb_constant,
     const bool disable_for_debugging) noexcept
     : minmod_type_(minmod_type),
-      tvbm_constant_(tvbm_constant),
+      tvb_constant_(tvb_constant),
       disable_for_debugging_(disable_for_debugging) {
-  ASSERT(tvbm_constant >= 0.0, "The TVBM constant must be non-negative.");
+  ASSERT(tvb_constant >= 0.0, "The TVBM constant must be non-negative.");
 }
 
 template <size_t VolumeDim, typename... Tags>
 void Minmod<VolumeDim, tmpl::list<Tags...>>::pup(PUP::er& p) noexcept {
   p | minmod_type_;
-  p | tvbm_constant_;
+  p | tvb_constant_;
   p | disable_for_debugging_;
 }
 
@@ -185,7 +185,7 @@ bool Minmod<VolumeDim, tmpl::list<Tags...>>::operator()(
     limiter_activated =
         Minmod_detail::limit_one_tensor<VolumeDim, decltype(tag)>(
             tensor, &u_lin_buffer, &boundary_buffer, minmod_type_,
-            tvbm_constant_, element, mesh, logical_coords, element_size,
+            tvb_constant_, element, mesh, logical_coords, element_size,
             neighbor_data, volume_and_slice_indices) or
         limiter_activated;
     return '0';
@@ -198,7 +198,7 @@ template <size_t LocalDim, typename LocalTagList>
 bool operator==(const Minmod<LocalDim, LocalTagList>& lhs,
                 const Minmod<LocalDim, LocalTagList>& rhs) noexcept {
   return lhs.minmod_type_ == rhs.minmod_type_ and
-         lhs.tvbm_constant_ == rhs.tvbm_constant_ and
+         lhs.tvb_constant_ == rhs.tvb_constant_ and
          lhs.disable_for_debugging_ == rhs.disable_for_debugging_;
 }
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
@@ -21,8 +21,8 @@ namespace Minmod_detail {
 
 MinmodResult tvb_corrected_minmod(const double a, const double b,
                                   const double c,
-                                  const double tvbm_scale) noexcept {
-  if (fabs(a) <= tvbm_scale) {
+                                  const double tvb_scale) noexcept {
+  if (fabs(a) <= tvb_scale) {
     return {a, false};
   }
   if ((std::signbit(a) == std::signbit(b)) and

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
@@ -19,8 +19,9 @@
 namespace Limiters {
 namespace Minmod_detail {
 
-MinmodResult minmod_tvbm(const double a, const double b, const double c,
-                         const double tvbm_scale) noexcept {
+MinmodResult tvb_corrected_minmod(const double a, const double b,
+                                  const double c,
+                                  const double tvbm_scale) noexcept {
   if (fabs(a) <= tvbm_scale) {
     return {a, false};
   }

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
@@ -40,7 +40,7 @@ struct MinmodResult {
   const bool activated;
 };
 
-// The TVBM-corrected minmod function, see e.g. Cockburn reference Eq. 2.26.
+// The TVB-corrected minmod function, see e.g. Cockburn reference Eq. 2.26.
 MinmodResult tvb_corrected_minmod(double a, double b, double c,
                                   double tvb_scale) noexcept;
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
@@ -42,7 +42,7 @@ struct MinmodResult {
 
 // The TVBM-corrected minmod function, see e.g. Cockburn reference Eq. 2.26.
 MinmodResult tvb_corrected_minmod(double a, double b, double c,
-                                  double tvbm_scale) noexcept;
+                                  double tvb_scale) noexcept;
 
 // Allocate the buffer `boundary_buffer` to the correct sizes expected by
 // `troubled_cell_indicator` for its arguments

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
@@ -34,15 +34,15 @@ struct hash;
 namespace Limiters {
 namespace Minmod_detail {
 
-// Encodes the return status of the minmod_tvbm function.
+// Encodes the return status of the tvb_corrected_minmod function.
 struct MinmodResult {
   const double value;
   const bool activated;
 };
 
 // The TVBM-corrected minmod function, see e.g. Cockburn reference Eq. 2.26.
-MinmodResult minmod_tvbm(double a, double b, double c,
-                         double tvbm_scale) noexcept;
+MinmodResult tvb_corrected_minmod(double a, double b, double c,
+                                  double tvbm_scale) noexcept;
 
 // Allocate the buffer `boundary_buffer` to the correct sizes expected by
 // `troubled_cell_indicator` for its arguments

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
@@ -57,12 +57,15 @@ bool troubled_cell_indicator(
     const double diff_upper = difference_to_neighbor(d, Side::Upper);
 
     // Results from SpECTRE paper (https://arxiv.org/abs/1609.00098) used
-    // minmod_tvbm(..., 0.0), rather than minmod_tvbm(..., tvbm_scale)
+    // tvb_corrected_minmod(..., 0.0), rather than
+    // tvb_corrected_minmod(..., tvbm_scale)
     const bool activated_lower =
-        minmod_tvbm(u_mean - u_lower, diff_lower, diff_upper, tvbm_scale)
+        tvb_corrected_minmod(u_mean - u_lower, diff_lower, diff_upper,
+                             tvbm_scale)
             .activated;
     const bool activated_upper =
-        minmod_tvbm(u_upper - u_mean, diff_lower, diff_upper, tvbm_scale)
+        tvb_corrected_minmod(u_upper - u_mean, diff_lower, diff_upper,
+                             tvbm_scale)
             .activated;
     if (activated_lower or activated_upper) {
       return true;

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
@@ -21,7 +21,7 @@ namespace Minmod_detail {
 template <size_t VolumeDim>
 bool troubled_cell_indicator(
     const gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
-    const double tvbm_constant, const DataVector& u,
+    const double tvb_constant, const DataVector& u,
     const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
@@ -29,10 +29,10 @@ bool troubled_cell_indicator(
     const std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,
                                gsl::span<std::pair<size_t, size_t>>>,
                      VolumeDim>& volume_and_slice_indices) noexcept {
-  const double tvbm_scale = [&tvbm_constant, &element_size ]() noexcept {
+  const double tvb_scale = [&tvb_constant, &element_size ]() noexcept {
     const double max_h =
         *std::max_element(element_size.begin(), element_size.end());
-    return tvbm_constant * square(max_h);
+    return tvb_constant * square(max_h);
   }
   ();
   const double u_mean = mean_value(u, mesh);
@@ -58,14 +58,14 @@ bool troubled_cell_indicator(
 
     // Results from SpECTRE paper (https://arxiv.org/abs/1609.00098) used
     // tvb_corrected_minmod(..., 0.0), rather than
-    // tvb_corrected_minmod(..., tvbm_scale)
+    // tvb_corrected_minmod(..., tvb_scale)
     const bool activated_lower =
         tvb_corrected_minmod(u_mean - u_lower, diff_lower, diff_upper,
-                             tvbm_scale)
+                             tvb_scale)
             .activated;
     const bool activated_upper =
         tvb_corrected_minmod(u_upper - u_mean, diff_lower, diff_upper,
-                             tvbm_scale)
+                             tvb_scale)
             .activated;
     if (activated_lower or activated_upper) {
       return true;

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
@@ -41,8 +41,8 @@ namespace Minmod_detail {
 template <size_t VolumeDim>
 bool troubled_cell_indicator(
     gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
-    double tvbm_constant, const DataVector& u,
-    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
+    double tvb_constant, const DataVector& u, const Element<VolumeDim>& element,
+    const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
     const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
@@ -66,7 +66,7 @@ bool troubled_cell_indicator(
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
         neighbor_data,
-    const double tvbm_constant, const Element<VolumeDim>& element,
+    const double tvb_constant, const Element<VolumeDim>& element,
     const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size) noexcept {
   // Optimization: allocate a single buffer to avoid multiple allocations
@@ -105,7 +105,7 @@ bool troubled_cell_indicator(
 
       const DataVector& u = tensor[tensor_storage_index];
       const bool component_needs_limiting = troubled_cell_indicator(
-          make_not_null(&boundary_buffer), tvbm_constant, u, element, mesh,
+          make_not_null(&boundary_buffer), tvb_constant, u, element, mesh,
           element_size, effective_neighbor_means, effective_neighbor_sizes,
           volume_and_slice_indices);
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -291,10 +291,10 @@ bool Weno<VolumeDim, tmpl::list<Tags...>>::operator()(
 
   // Troubled-cell detection for WENO flags the element for limiting if any
   // component of any tensor needs limiting.
-  const double minmod_tci_tvbm_constant = 0.0;
+  const double minmod_tci_tvb_constant = 0.0;
   const bool cell_is_troubled =
       Minmod_detail::troubled_cell_indicator<VolumeDim, PackagedData, Tags...>(
-          (*tensors)..., neighbor_data, minmod_tci_tvbm_constant, element, mesh,
+          (*tensors)..., neighbor_data, minmod_tci_tvb_constant, element, mesh,
           element_size);
 
   if (not cell_is_troubled) {

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -38,7 +38,7 @@ EvolutionSystem:
 Limiter:
   Minmod:
     Type: Muscl
-    TvbmConstant: 0
+    TvbConstant: 0
 
 VariableFixing:
   FixConservatives:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -51,7 +51,7 @@ Limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
     # Recommended value from minmod papers:
-    TvbmConstant: 50.0
+    TvbConstant: 50.0
 
 VariableFixing:
   FixConservatives:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -38,7 +38,7 @@ Limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
     # Recommended value from minmod papers:
-    TvbmConstant: 50.0
+    TvbConstant: 50.0
 
 EventsAndTriggers:
   # ? EveryNSlabs:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -38,7 +38,7 @@ Limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
     # Recommended value from minmod papers:
-    TvbmConstant: 50.0
+    TvbConstant: 50.0
 
 EventsAndTriggers:
   # ? EveryNSlabs:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -38,7 +38,7 @@ Limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
     # Recommended value from minmod papers:
-    TvbmConstant: 50.0
+    TvbConstant: 50.0
 
 EventsAndTriggers:
   # ? EveryNSlabs:

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -35,7 +35,7 @@ Limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
     # Recommended value from minmod papers:
-    TvbmConstant: 50.0
+    TvbConstant: 50.0
 
 EventsAndTriggers:
   ? EveryNSlabs:

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
@@ -35,7 +35,7 @@ Limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
     # Recommended value from minmod papers:
-    TvbmConstant: 50.0
+    TvbConstant: 50.0
 
 VariableFixing:
   FixConservatives:

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
@@ -35,7 +35,7 @@ Limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
     # Recommended value from minmod papers:
-    TvbmConstant: 100.0
+    TvbConstant: 100.0
 
 VariableFixing:
   FixConservatives:

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
@@ -35,7 +35,7 @@ Limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
     # Recommended value from minmod papers:
-    TvbmConstant: 100.0
+    TvbConstant: 100.0
 
 VariableFixing:
   FixConservatives:

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
@@ -188,7 +188,7 @@ template <size_t VolumeDim>
 bool wrap_minmod_limited_slopes(
     const gsl::not_null<double*> u_mean,
     const gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
-    const Limiters::MinmodType& minmod_type, const double tvbm_constant,
+    const Limiters::MinmodType& minmod_type, const double tvb_constant,
     const DataVector& u, const Element<VolumeDim>& element,
     const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
@@ -209,7 +209,7 @@ bool wrap_minmod_limited_slopes(
 
   return Limiters::Minmod_detail::minmod_limited_slopes(
       u_mean, u_limited_slopes, make_not_null(&u_lin_buffer),
-      make_not_null(&boundary_buffer), minmod_type, tvbm_constant, u, element,
+      make_not_null(&boundary_buffer), minmod_type, tvb_constant, u, element,
       mesh, element_size, effective_neighbor_means, effective_neighbor_sizes,
       volume_and_slice_indices);
 }
@@ -245,7 +245,7 @@ auto make_six_neighbors(const std::array<double, 6>& values) noexcept {
 // mean and reduced slopes.
 template <size_t VolumeDim>
 void test_minmod_activates(
-    const Limiters::MinmodType& minmod_type, const double tvbm_constant,
+    const Limiters::MinmodType& minmod_type, const double tvb_constant,
     const DataVector& input, const Element<VolumeDim>& element,
     const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
@@ -256,7 +256,7 @@ void test_minmod_activates(
   std::array<double, VolumeDim> u_limited_slopes{};
   const bool reduce_slopes = wrap_minmod_limited_slopes(
       make_not_null(&u_mean), make_not_null(&u_limited_slopes), minmod_type,
-      tvbm_constant, input, element, mesh, element_size,
+      tvb_constant, input, element, mesh, element_size,
       effective_neighbor_means, effective_neighbor_sizes);
   CHECK(reduce_slopes);
   CHECK(u_mean == approx(mean_value(input, mesh)));
@@ -266,7 +266,7 @@ void test_minmod_activates(
 // Test that TCI does not detect a cell that is not troubled.
 template <size_t VolumeDim>
 void test_minmod_does_not_activate(
-    const Limiters::MinmodType& minmod_type, const double tvbm_constant,
+    const Limiters::MinmodType& minmod_type, const double tvb_constant,
     const DataVector& input, const Element<VolumeDim>& element,
     const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
@@ -277,7 +277,7 @@ void test_minmod_does_not_activate(
   std::array<double, VolumeDim> u_limited_slopes{};
   const bool reduce_slopes = wrap_minmod_limited_slopes(
       make_not_null(&u_mean), make_not_null(&u_limited_slopes), minmod_type,
-      tvbm_constant, input, element, mesh, element_size,
+      tvb_constant, input, element, mesh, element_size,
       effective_neighbor_means, effective_neighbor_sizes);
   CHECK_FALSE(reduce_slopes);
   if (minmod_type != Limiters::MinmodType::LambdaPiN) {
@@ -292,28 +292,28 @@ void test_minmod_slopes_on_linear_function(
   INFO("Testing linear function...");
   CAPTURE(number_of_grid_points);
   CAPTURE(get_output(minmod_type));
-  const double tvbm_constant = 0.0;
+  const double tvb_constant = 0.0;
   const auto element = TestHelpers::Limiters::make_element<1>();
   const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   const auto element_size = make_array<1>(2.0);
 
   const auto test_activates =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
+      [&minmod_type, &tvb_constant, &element, &mesh, &element_size ](
           const DataVector& local_input, const double left, const double right,
           const double expected_slope) noexcept {
     const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_activates(minmod_type, tvbm_constant, local_input, element,
-                          mesh, element_size, make_two_neighbors(left, right),
+    test_minmod_activates(minmod_type, tvb_constant, local_input, element, mesh,
+                          element_size, make_two_neighbors(left, right),
                           make_two_neighbors(2.0, 2.0), expected_slopes);
   };
   const auto test_does_not_activate =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
+      [&minmod_type, &tvb_constant, &element, &mesh, &element_size ](
           const DataVector& local_input, const double left, const double right,
           const double original_slope) noexcept {
     const auto original_slopes = make_array<1>(original_slope);
     test_minmod_does_not_activate(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        minmod_type, tvb_constant, local_input, element, mesh, element_size,
         make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
         original_slopes);
   };
@@ -384,28 +384,28 @@ void test_minmod_slopes_on_quadratic_function(
   INFO("Testing quadratic function...");
   CAPTURE(number_of_grid_points);
   CAPTURE(get_output(minmod_type));
-  const double tvbm_constant = 0.0;
+  const double tvb_constant = 0.0;
   const auto element = TestHelpers::Limiters::make_element<1>();
   const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   const auto element_size = make_array<1>(2.0);
 
   const auto test_activates =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
+      [&minmod_type, &tvb_constant, &element, &mesh, &element_size ](
           const DataVector& local_input, const double left, const double right,
           const double expected_slope) noexcept {
     const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_activates(minmod_type, tvbm_constant, local_input, element,
-                          mesh, element_size, make_two_neighbors(left, right),
+    test_minmod_activates(minmod_type, tvb_constant, local_input, element, mesh,
+                          element_size, make_two_neighbors(left, right),
                           make_two_neighbors(2.0, 2.0), expected_slopes);
   };
   const auto test_does_not_activate =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
+      [&minmod_type, &tvb_constant, &element, &mesh, &element_size ](
           const DataVector& local_input, const double left, const double right,
           const double original_slope) noexcept {
     const auto original_slopes = make_array<1>(original_slope);
     test_minmod_does_not_activate(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        minmod_type, tvb_constant, local_input, element, mesh, element_size,
         make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
         original_slopes);
   };
@@ -441,7 +441,7 @@ void test_minmod_slopes_on_quadratic_function(
   test_activates(input, 14.0, 2.3, 0.0);
 }
 
-void test_minmod_slopes_with_tvbm_correction(
+void test_minmod_slopes_with_tvb_correction(
     const size_t number_of_grid_points,
     const Limiters::MinmodType& minmod_type) noexcept {
   INFO("Testing TVBM correction...");
@@ -453,30 +453,30 @@ void test_minmod_slopes_with_tvbm_correction(
   const auto element_size = make_array<1>(2.0);
 
   const auto test_activates = [&minmod_type, &element, &mesh, &element_size ](
-      const double tvbm_constant, const DataVector& local_input,
+      const double tvb_constant, const DataVector& local_input,
       const double left, const double right,
       const double expected_slope) noexcept {
     const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_activates(minmod_type, tvbm_constant, local_input, element,
-                          mesh, element_size, make_two_neighbors(left, right),
+    test_minmod_activates(minmod_type, tvb_constant, local_input, element, mesh,
+                          element_size, make_two_neighbors(left, right),
                           make_two_neighbors(2.0, 2.0), expected_slopes);
   };
   const auto test_does_not_activate =
       [&minmod_type, &element, &mesh, &
-       element_size ](const double tvbm_constant, const DataVector& local_input,
+       element_size ](const double tvb_constant, const DataVector& local_input,
                       const double left, const double right,
                       const double original_slope) noexcept {
     const auto original_slopes = make_array<1>(original_slope);
     test_minmod_does_not_activate(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        minmod_type, tvb_constant, local_input, element, mesh, element_size,
         make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
         original_slopes);
   };
 
   // Slopes will be compared to m * h^2, where here h = 2
-  const double tvbm_m0 = 0.0;
-  const double tvbm_m1 = 1.0;
-  const double tvbm_m2 = 2.0;
+  const double tvb_m0 = 0.0;
+  const double tvb_m1 = 1.0;
+  const double tvb_m2 = 2.0;
 
   const auto input = [&mesh]() noexcept {
     const auto coords = logical_coordinates(mesh);
@@ -490,14 +490,14 @@ void test_minmod_slopes_with_tvbm_correction(
   const double left = (minmod_type == Limiters::MinmodType::Muscl) ? 8.4 : 15.0;
   const double right =
       (minmod_type == Limiters::MinmodType::Muscl) ? 34.8 : 30.0;
-  test_activates(tvbm_m0, input, left, right, 6.6);
-  test_activates(tvbm_m1, input, left, right, 6.6);
-  test_does_not_activate(tvbm_m2, input, left, right, 7.2);
+  test_activates(tvb_m0, input, left, right, 6.6);
+  test_activates(tvb_m1, input, left, right, 6.6);
+  test_does_not_activate(tvb_m2, input, left, right, 7.2);
 }
 
 // Here we test the coupling of the LambdaPiN troubled cell detector with the
 // TVBM constant value.
-void test_lambda_pin_troubled_cell_tvbm_correction(
+void test_lambda_pin_troubled_cell_tvb_correction(
     const size_t number_of_grid_points) noexcept {
   INFO("Testing LambdaPiN-TVBM correction...");
   CAPTURE(number_of_grid_points);
@@ -508,24 +508,24 @@ void test_lambda_pin_troubled_cell_tvbm_correction(
   const auto element_size = make_array<1>(2.0);
 
   const auto test_activates = [&element, &mesh, &element_size ](
-      const double tvbm_constant, const DataVector& local_input,
+      const double tvb_constant, const DataVector& local_input,
       const double left, const double right,
       const double expected_slope) noexcept {
     const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_activates(Limiters::MinmodType::LambdaPiN, tvbm_constant,
+    test_minmod_activates(Limiters::MinmodType::LambdaPiN, tvb_constant,
                           local_input, element, mesh, element_size,
                           make_two_neighbors(left, right),
                           make_two_neighbors(2.0, 2.0), expected_slopes);
   };
   const auto test_does_not_activate = [&element, &mesh, &element_size ](
-      const double tvbm_constant, const DataVector& local_input,
+      const double tvb_constant, const DataVector& local_input,
       const double left, const double right) noexcept {
     // Because in this test the limiter is LambdaPiN, no slopes are returned,
     // and no comparison is made. So set these to NaN
     const auto original_slopes =
         make_array<1>(std::numeric_limits<double>::signaling_NaN());
     test_minmod_does_not_activate(
-        Limiters::MinmodType::LambdaPiN, tvbm_constant, local_input, element,
+        Limiters::MinmodType::LambdaPiN, tvb_constant, local_input, element,
         mesh, element_size, make_two_neighbors(left, right),
         make_two_neighbors(2.0, 2.0), original_slopes);
   };
@@ -572,7 +572,7 @@ void test_minmod_slopes_at_boundary(
   INFO("Testing limiter at boundary...");
   CAPTURE(number_of_grid_points);
   CAPTURE(get_output(minmod_type));
-  const double tvbm_constant = 0.0;
+  const double tvb_constant = 0.0;
   const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   const auto element_size = make_array<1>(2.0);
@@ -590,7 +590,7 @@ void test_minmod_slopes_at_boundary(
       TestHelpers::Limiters::make_element<1>({{Direction<1>::lower_xi()}});
   for (const double neighbor : {-1.3, 3.6, 4.8, 13.2}) {
     test_minmod_activates(
-        minmod_type, tvbm_constant, input, element_at_lower_xi_boundary, mesh,
+        minmod_type, tvb_constant, input, element_at_lower_xi_boundary, mesh,
         element_size, {{std::make_pair(Direction<1>::upper_xi(), neighbor)}},
         {{std::make_pair(Direction<1>::upper_xi(), element_size[0])}},
         make_array<1>(0.0));
@@ -601,7 +601,7 @@ void test_minmod_slopes_at_boundary(
       TestHelpers::Limiters::make_element<1>({{Direction<1>::upper_xi()}});
   for (const double neighbor : {-1.3, 3.6, 4.8, 13.2}) {
     test_minmod_activates(
-        minmod_type, tvbm_constant, input, element_at_upper_xi_boundary, mesh,
+        minmod_type, tvb_constant, input, element_at_upper_xi_boundary, mesh,
         element_size, {{std::make_pair(Direction<1>::lower_xi(), neighbor)}},
         {{std::make_pair(Direction<1>::lower_xi(), element_size[0])}},
         make_array<1>(0.0));
@@ -614,7 +614,7 @@ void test_minmod_slopes_with_different_size_neighbor(
   INFO("Testing limiter with neighboring elements of different size...");
   CAPTURE(number_of_grid_points);
   CAPTURE(get_output(minmod_type));
-  const double tvbm_constant = 0.0;
+  const double tvb_constant = 0.0;
   const auto element = TestHelpers::Limiters::make_element<1>();
   const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
@@ -622,24 +622,24 @@ void test_minmod_slopes_with_different_size_neighbor(
   const auto element_size = make_array<1>(dx);
 
   const auto test_activates =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
+      [&minmod_type, &tvb_constant, &element, &mesh, &element_size ](
           const DataVector& local_input, const double left, const double right,
           const double left_size, const double right_size,
           const double expected_slope) noexcept {
     const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_activates(minmod_type, tvbm_constant, local_input, element,
-                          mesh, element_size, make_two_neighbors(left, right),
+    test_minmod_activates(minmod_type, tvb_constant, local_input, element, mesh,
+                          element_size, make_two_neighbors(left, right),
                           make_two_neighbors(left_size, right_size),
                           expected_slopes);
   };
   const auto test_does_not_activate =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &element_size ](
+      [&minmod_type, &tvb_constant, &element, &mesh, &element_size ](
           const DataVector& local_input, const double left, const double right,
           const double left_size, const double right_size,
           const double original_slope) noexcept {
     const auto original_slopes = make_array<1>(original_slope);
     test_minmod_does_not_activate(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        minmod_type, tvb_constant, local_input, element, mesh, element_size,
         make_two_neighbors(left, right),
         make_two_neighbors(left_size, right_size), original_slopes);
   };
@@ -693,7 +693,7 @@ void test_minmod_limited_slopes_1d() noexcept {
         Limiters::MinmodType::Muscl}) {
     for (const auto num_grid_points : std::array<size_t, 2>{{2, 4}}) {
       test_minmod_slopes_on_linear_function(num_grid_points, minmod_type);
-      test_minmod_slopes_with_tvbm_correction(num_grid_points, minmod_type);
+      test_minmod_slopes_with_tvb_correction(num_grid_points, minmod_type);
       test_minmod_slopes_at_boundary(num_grid_points, minmod_type);
       test_minmod_slopes_with_different_size_neighbor(num_grid_points,
                                                       minmod_type);
@@ -703,36 +703,36 @@ void test_minmod_limited_slopes_1d() noexcept {
     test_minmod_slopes_on_quadratic_function(4, minmod_type);
   }
   // This test only makes sense with LambdaPiN and more than 2 grid points
-  test_lambda_pin_troubled_cell_tvbm_correction(4);
+  test_lambda_pin_troubled_cell_tvb_correction(4);
 }
 
 // In 2D, test that the slopes are correctly reduced dimension-by-dimension.
 void test_minmod_limited_slopes_2d() noexcept {
   INFO("Testing Minmod minmod_limited_slopes in 2D");
   const auto minmod_type = Limiters::MinmodType::LambdaPi1;
-  const double tvbm_constant = 0.0;
+  const double tvb_constant = 0.0;
   const auto element = TestHelpers::Limiters::make_element<2>();
   const Mesh<2> mesh(3, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   const auto element_size = make_array<2>(2.0);
 
   const auto test_activates =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &
+      [&minmod_type, &tvb_constant, &element, &mesh, &
        element_size ](const DataVector& local_input,
                       const std::array<double, 4>& neighbor_means,
                       const std::array<double, 2>& expected_slopes) noexcept {
-    test_minmod_activates(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
-        make_four_neighbors(neighbor_means),
-        make_four_neighbors(make_array<4>(2.0)), expected_slopes);
+    test_minmod_activates(minmod_type, tvb_constant, local_input, element, mesh,
+                          element_size, make_four_neighbors(neighbor_means),
+                          make_four_neighbors(make_array<4>(2.0)),
+                          expected_slopes);
   };
   const auto test_does_not_activate =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &
+      [&minmod_type, &tvb_constant, &element, &mesh, &
        element_size ](const DataVector& local_input,
                       const std::array<double, 4>& neighbor_means,
                       const std::array<double, 2>& original_slopes) noexcept {
     test_minmod_does_not_activate(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        minmod_type, tvb_constant, local_input, element, mesh, element_size,
         make_four_neighbors(neighbor_means),
         make_four_neighbors(make_array<4>(2.0)), original_slopes);
   };
@@ -765,29 +765,29 @@ void test_minmod_limited_slopes_2d() noexcept {
 void test_minmod_limited_slopes_3d() noexcept {
   INFO("Testing Minmod minmod_limited_slopes in 3D");
   const auto minmod_type = Limiters::MinmodType::LambdaPi1;
-  const double tvbm_constant = 0.0;
+  const double tvb_constant = 0.0;
   const auto element = TestHelpers::Limiters::make_element<3>();
   const Mesh<3> mesh(3, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   const auto element_size = make_array<3>(2.0);
 
   const auto test_activates =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &
+      [&minmod_type, &tvb_constant, &element, &mesh, &
        element_size ](const DataVector& local_input,
                       const std::array<double, 6>& neighbor_means,
                       const std::array<double, 3>& expected_slopes) noexcept {
-    test_minmod_activates(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
-        make_six_neighbors(neighbor_means),
-        make_six_neighbors(make_array<6>(2.0)), expected_slopes);
+    test_minmod_activates(minmod_type, tvb_constant, local_input, element, mesh,
+                          element_size, make_six_neighbors(neighbor_means),
+                          make_six_neighbors(make_array<6>(2.0)),
+                          expected_slopes);
   };
   const auto test_does_not_activate =
-      [&minmod_type, &tvbm_constant, &element, &mesh, &
+      [&minmod_type, &tvb_constant, &element, &mesh, &
        element_size ](const DataVector& local_input,
                       const std::array<double, 6>& neighbor_means,
                       const std::array<double, 3>& original_slopes) noexcept {
     test_minmod_does_not_activate(
-        minmod_type, tvbm_constant, local_input, element, mesh, element_size,
+        minmod_type, tvb_constant, local_input, element, mesh, element_size,
         make_six_neighbors(neighbor_means),
         make_six_neighbors(make_array<6>(2.0)), original_slopes);
   };

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
@@ -80,7 +80,7 @@ void test_minmod_option_parsing() noexcept {
       TestHelpers::test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
           "Type: Muscl");
 
-  // Test default TVBM value, operator==, and operator!=
+  // Test default TVB value, operator==, and operator!=
   CHECK(lambda_pi1_default == lambda_pi1_m0);
   CHECK(lambda_pi1_default != lambda_pi1_m1);
   CHECK(lambda_pi1_default != muscl_default);
@@ -444,7 +444,7 @@ void test_minmod_slopes_on_quadratic_function(
 void test_minmod_slopes_with_tvb_correction(
     const size_t number_of_grid_points,
     const Limiters::MinmodType& minmod_type) noexcept {
-  INFO("Testing TVBM correction...");
+  INFO("Testing TVB correction...");
   CAPTURE(number_of_grid_points);
   CAPTURE(get_output(minmod_type));
   const auto element = TestHelpers::Limiters::make_element<1>();
@@ -484,8 +484,8 @@ void test_minmod_slopes_with_tvb_correction(
   }
   ();
 
-  // The TVBM constant sets a threshold slope, below which the solution will not
-  // be limited. We test this by increasing the TVBM constant until the limiter
+  // The TVB constant sets a threshold slope, below which the solution will not
+  // be limited. We test this by increasing the TVB constant until the limiter
   // stops activating / stops changing the solution.
   const double left = (minmod_type == Limiters::MinmodType::Muscl) ? 8.4 : 15.0;
   const double right =
@@ -496,10 +496,10 @@ void test_minmod_slopes_with_tvb_correction(
 }
 
 // Here we test the coupling of the LambdaPiN troubled cell detector with the
-// TVBM constant value.
+// TVB constant value.
 void test_lambda_pin_troubled_cell_tvb_correction(
     const size_t number_of_grid_points) noexcept {
-  INFO("Testing LambdaPiN-TVBM correction...");
+  INFO("Testing LambdaPiN-TVB correction...");
   CAPTURE(number_of_grid_points);
   const auto element = TestHelpers::Limiters::make_element<1>();
   const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
@@ -548,18 +548,18 @@ void test_lambda_pin_troubled_cell_tvb_correction(
   test_activates(m0, input, 0.02, 10.0, 4.98);
   test_activates(m0, input, 0.0, 9.99, 4.99);
 
-  // However, with a non-zero TVBM constant, LambdaPiN should additionally avoid
-  // limiting when max(edge - mean) < TVBM correction.
-  // We test first a case where the TVBM correction is too small to affect
+  // However, with a non-zero TVB constant, LambdaPiN should additionally avoid
+  // limiting when max(edge - mean) < TVB correction.
+  // We test first a case where the TVB correction is too small to affect
   // the limiter action,
   test_does_not_activate(m1, input, 0.0, 10.0);
   test_does_not_activate(m1, input, -0.3, 10.2);
   test_activates(m1, input, 0.02, 10.0, 4.98);
   test_activates(m1, input, 0.0, 9.99, 4.99);
 
-  // And a case where the TVBM correction enables LambdaPiN to avoid limiting
+  // And a case where the TVB correction enables LambdaPiN to avoid limiting
   // (Note that the slope here is still too large to avoid limiting through
-  // the normal TVBM tolerance.)
+  // the normal TVB tolerance.)
   test_does_not_activate(m2, input, 0.0, 10.0);
   test_does_not_activate(m2, input, -0.3, 10.2);
   test_does_not_activate(m2, input, 0.02, 10.0);
@@ -684,7 +684,7 @@ void test_minmod_slopes_with_different_size_neighbor(
                          1.2 * muscl_slope_factor);
 }
 
-// In 1D, test combinations of MinmodType, TVBM constant, polynomial order, etc.
+// In 1D, test combinations of MinmodType, TVB constant, polynomial order, etc.
 // Check that each combination reduces the slopes as expected.
 void test_minmod_limited_slopes_1d() noexcept {
   INFO("Testing Minmod minmod_limited_slopes in 1D");

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
@@ -71,11 +71,11 @@ void test_minmod_option_parsing() noexcept {
   const auto lambda_pi1_m0 =
       TestHelpers::test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
           "Type: LambdaPi1\n"
-          "TvbmConstant: 0.0");
+          "TvbConstant: 0.0");
   const auto lambda_pi1_m1 =
       TestHelpers::test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
           "Type: LambdaPi1\n"
-          "TvbmConstant: 1.0");
+          "TvbConstant: 1.0");
   const auto muscl_default =
       TestHelpers::test_creation<Limiters::Minmod<1, tmpl::list<ScalarTag>>>(
           "Type: Muscl");

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodTci.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodTci.cpp
@@ -141,7 +141,7 @@ void test_tci_on_linear_function(const size_t number_of_grid_points) noexcept {
   test_tci(true, input, 1.7, 1.85, 0.0);
   test_tci(true, input, 1.45, 1.5, 0.0);
 
-  // Test TVBM can avoid the triggers
+  // Test TVB can avoid the triggers
   test_tci(true, input, 1.45, 1.75, 0.19);
   test_tci(true, input, 1.7, 1.85, 0.19);
   test_tci(true, input, 1.45, 1.5, 0.19);
@@ -186,7 +186,7 @@ void test_tci_on_quadratic_function(
   test_tci(true, input, 1.15, 1.75, 0.0);
   test_tci(true, input, 1.25, 1.75, 0.0);
 
-  // Test TVBM can avoid the trigger
+  // Test TVB can avoid the trigger
   test_tci(true, input, 1.25, 1.85, 0.11);
   test_tci(true, input, 1.25, 1.85, 0.29);
   test_tci(false, input, 1.25, 1.85, 0.31);
@@ -201,14 +201,14 @@ void test_tci_on_quadratic_function(
   ();
 
   // Because left-to-mean and mean-to-right slopes have different signs,
-  // any TCI call with TVBM=0 should trigger
+  // any TCI call with TVB=0 should trigger
   test_tci(true, input2, 1.7, 1.9, 0.0);
   test_tci(true, input2, 1.7, 1.3, 0.0);
   test_tci(true, input2, 1.3, 1.7, 0.0);
   test_tci(true, input2, 1.1, 1.9, 0.0);
 
   // Conversely, because left-to-mean and mean-to-right slopes have different
-  // signs, calls with TVBM>0 give results that depend on neighbor means
+  // signs, calls with TVB>0 give results that depend on neighbor means
   test_tci(true, input2, 1.7, 1.3, 0.11);
   test_tci(true, input2, 1.7, 1.3, 0.29);
   test_tci(false, input2, 1.7, 1.3, 0.31);
@@ -308,7 +308,7 @@ void test_tci_with_different_size_neighbor(
   test_tci(false, input, 1.1 - eps, 3.2 + eps, smaller, dx);
 }
 
-// In 1D, test combinations of TVBM constant, polynomial order, etc.
+// In 1D, test combinations of TVB constant, polynomial order, etc.
 // Check that each combination has the expected TCI behavior.
 void test_minmod_tci_1d() noexcept {
   INFO("Testing MinmodTci in 1D");


### PR DESCRIPTION
## Proposed changes

Rename TVBM to TVB in Minmod code. This better matches use in literature.

(The limiter is strictly "total variation bound in the means", where the "TVB" part is similar to use in FVM codes, and the "in the means" part refers to how this generalizes to DG (i.e., not well))

The first few commits are pure renaming. The last commit improves documentation.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

