### PR TITLE
Clarify that enthalpy in Hydro dir is relativistic

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -174,7 +174,7 @@ void PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
             .specific_internal_energy_from_density_and_pressure(
                 *rest_mass_density, *pressure);
       })(equation_of_state);
-  *specific_enthalpy = hydro::specific_enthalpy(
+  *specific_enthalpy = hydro::relativistic_specific_enthalpy(
       *rest_mass_density, *specific_internal_energy, *pressure);
 }
 }  // namespace ValenciaDivClean

--- a/src/PointwiseFunctions/Hydro/SpecificEnthalpy.cpp
+++ b/src/PointwiseFunctions/Hydro/SpecificEnthalpy.cpp
@@ -10,7 +10,7 @@
 /// \cond
 namespace hydro {
 template <typename DataType>
-Scalar<DataType> specific_enthalpy(
+Scalar<DataType> relativistic_specific_enthalpy(
     const Scalar<DataType>& rest_mass_density,
     const Scalar<DataType>& specific_internal_energy,
     const Scalar<DataType>& pressure) noexcept {
@@ -20,10 +20,10 @@ Scalar<DataType> specific_enthalpy(
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                               \
-  template Scalar<DTYPE(data)> specific_enthalpy(          \
-      const Scalar<DTYPE(data)>& rest_mass_density,        \
-      const Scalar<DTYPE(data)>& specific_internal_energy, \
+#define INSTANTIATE(_, data)                                   \
+  template Scalar<DTYPE(data)> relativistic_specific_enthalpy( \
+      const Scalar<DTYPE(data)>& rest_mass_density,            \
+      const Scalar<DTYPE(data)>& specific_internal_energy,     \
       const Scalar<DTYPE(data)>& pressure) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))

--- a/src/PointwiseFunctions/Hydro/SpecificEnthalpy.hpp
+++ b/src/PointwiseFunctions/Hydro/SpecificEnthalpy.hpp
@@ -17,18 +17,18 @@ namespace hydro {
  * is the pressure, and \f$\rho\f$ is the rest mass density.
  */
 template <typename DataType>
-Scalar<DataType> specific_enthalpy(
+Scalar<DataType> relativistic_specific_enthalpy(
     const Scalar<DataType>& rest_mass_density,
     const Scalar<DataType>& specific_internal_energy,
     const Scalar<DataType>& pressure) noexcept;
 
 namespace Tags {
-/// Compute item for specific enthalpy \f$h\f$.
+/// Compute item for the relativistic specific enthalpy \f$h\f$.
 ///
 /// Can be retrieved using `hydro::Tags::SpecificEnthalpy`
 template <typename DataType>
 struct SpecificEnthalpyCompute : SpecificEnthalpy<DataType>, db::ComputeTag {
-  static constexpr auto function = &specific_enthalpy<DataType>;
+  static constexpr auto function = &relativistic_specific_enthalpy<DataType>;
   using argument_tags =
       tmpl::list<RestMassDensity<DataType>, SpecificInternalEnergy<DataType>,
                  Pressure<DataType>>;

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -178,7 +178,7 @@ struct SpatialVelocitySquared : db::SimpleTag {
   static std::string name() noexcept { return "SpatialVelocitySquared"; }
 };
 
-/// The specific enthalpy \f$h\f$.
+/// The relativistic specific enthalpy \f$h\f$.
 template <typename DataType>
 struct SpecificEnthalpy : db::SimpleTag {
   using type = Scalar<DataType>;

--- a/tests/Unit/PointwiseFunctions/Hydro/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/TestFunctions.py
@@ -27,7 +27,8 @@ def mass_flux(rest_mass_density, spatial_velocity,
 # Functions for testing SpecificEnthalpy.cpp
 
 
-def specific_enthalpy(rest_mass_density, specific_internal_energy, pressure):
+def relativistic_specific_enthalpy(rest_mass_density, specific_internal_energy,
+                                   pressure):
     return pressure / rest_mass_density + 1.0 + specific_internal_energy
 
 

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_SpecificEnthalpy.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_SpecificEnthalpy.cpp
@@ -18,10 +18,11 @@
 namespace {
 
 template <typename DataType>
-void test_specific_enthalpy(const DataType& used_for_size) noexcept {
-  pypp::check_with_random_values<1>(&hydro::specific_enthalpy<DataType>,
-                                    "TestFunctions", "specific_enthalpy",
-                                    {{{0.01, 1.0}}}, used_for_size);
+void test_relativistic_specific_enthalpy(
+    const DataType& used_for_size) noexcept {
+  pypp::check_with_random_values<1>(
+      &hydro::relativistic_specific_enthalpy<DataType>, "TestFunctions",
+      "relativistic_specific_enthalpy", {{{0.01, 1.0}}}, used_for_size);
 }
 }  // namespace
 
@@ -31,8 +32,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.SpecificEnthalpy",
   pypp::SetupLocalPythonEnvironment local_python_env{
       "PointwiseFunctions/Hydro"};
 
-  test_specific_enthalpy(std::numeric_limits<double>::signaling_NaN());
-  test_specific_enthalpy(DataVector(5));
+  test_relativistic_specific_enthalpy(
+      std::numeric_limits<double>::signaling_NaN());
+  test_relativistic_specific_enthalpy(DataVector(5));
 
   // Check compute item works correctly in DataBox
   CHECK(Tags::SpecificEnthalpyCompute<DataVector>::name() ==
@@ -47,8 +49,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.SpecificEnthalpy",
                                    Tags::Pressure<DataVector>>,
                  db::AddComputeTags<Tags::SpecificEnthalpyCompute<DataVector>>>(
           rest_mass_density, specific_internal_energy, pressure);
-  CHECK(
-      db::get<Tags::SpecificEnthalpy<DataVector>>(box) ==
-      specific_enthalpy(rest_mass_density, specific_internal_energy, pressure));
+  CHECK(db::get<Tags::SpecificEnthalpy<DataVector>>(box) ==
+        relativistic_specific_enthalpy(rest_mass_density,
+                                       specific_internal_energy, pressure));
 }
 }  // namespace hydro


### PR DESCRIPTION
## Proposed changes

The enthalpy provided in `PointwiseFunctions/Hydro` is the relativistic enthalpy (with the +1).

This commit clarifies this by
- renaming the free function `specific_enthalpy` -> `relativistic_specific_enthalpy`
- clarifying some documentation strings

The Tag itself is not modified in this commit, but could be if that is the consensus.


### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

