### PR TITLE
Add DataVector interface to RegularGrid interpolator

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.cpp
@@ -50,6 +50,21 @@ void RegularGrid<Dim>::pup(PUP::er& p) noexcept {
 }
 
 template <size_t Dim>
+void RegularGrid<Dim>::interpolate(const gsl::not_null<DataVector*> result,
+                                   const DataVector& input) const noexcept {
+  result->destructive_resize(number_of_target_points_);
+  apply_matrices(result, interpolation_matrices_, input, source_extents_);
+}
+
+template <size_t Dim>
+DataVector RegularGrid<Dim>::interpolate(const DataVector& input) const
+    noexcept {
+  DataVector result(number_of_target_points_);
+  interpolate(make_not_null(&result), input);
+  return result;
+}
+
+template <size_t Dim>
 const std::array<Matrix, Dim>& RegularGrid<Dim>::interpolation_matrices() const
     noexcept {
   return interpolation_matrices_;

--- a/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp
+++ b/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp
@@ -27,7 +27,7 @@ class er;
 namespace intrp {
 
 /// \ingroup NumericalAlgorithmsGroup
-/// \brief Interpolate a Variables from a Mesh onto a regular grid of points.
+/// \brief Interpolate data from a Mesh onto a regular grid of points.
 ///
 /// The target points must lie on a tensor-product grid that is aligned with the
 /// source Mesh. In any direction where the source and target points share an
@@ -64,14 +64,26 @@ class RegularGrid {
   // clang-tidy: no runtime references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
-  /// \brief Interpolate Variables onto new mesh.
   //@{
+  /// \brief Interpolate a Variables onto the target points.
   template <typename TagsList>
   void interpolate(gsl::not_null<Variables<TagsList>*> result,
                    const Variables<TagsList>& vars) const noexcept;
   template <typename TagsList>
   Variables<TagsList> interpolate(const Variables<TagsList>& vars) const
       noexcept;
+  //@}
+
+  //@{
+  /// \brief Interpolate a DataVector onto the target points.
+  ///
+  /// \note When interpolating multiple tensors, the Variables interface is more
+  /// efficient. However, this DataVector interface is useful for applications
+  /// where only some components of a Tensor or Variables need to be
+  /// interpolated.
+  void interpolate(gsl::not_null<DataVector*> result,
+                   const DataVector& input) const noexcept;
+  DataVector interpolate(const DataVector& input) const noexcept;
   //@}
 
   /// \brief Return the internally-stored matrices that interpolate from the

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
@@ -17,7 +17,7 @@
 #include "DataStructures/Variables.hpp"         // IWYU pragma: keep
 #include "DataStructures/VariablesHelpers.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/Affine.hpp"
-#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
@@ -150,6 +150,11 @@ void test_regular_interpolation(const Mesh<Dim>& source_mesh,
       using Tag = tmpl::type_from<decltype(tag)>;
       CHECK_ITERABLE_APPROX(get<Tag>(result), get<Tag>(expected_result));
     });
+
+    const DataVector result_dv = regular_grid_interpolant.interpolate(
+        get(get<TestTags::ScalarTag>(source_vars)));
+    CHECK_ITERABLE_APPROX(result_dv,
+                          get(get<TestTags::ScalarTag>(expected_result)));
   }
 }
 
@@ -235,6 +240,11 @@ void test_regular_interpolation_override(
       using Tag = tmpl::type_from<decltype(tag)>;
       CHECK_ITERABLE_APPROX(get<Tag>(result), get<Tag>(expected_result));
     });
+
+    const DataVector result_dv = regular_grid_interpolant.interpolate(
+        get(get<TestTags::ScalarTag>(source_vars)));
+    CHECK_ITERABLE_APPROX(result_dv,
+                          get(get<TestTags::ScalarTag>(expected_result)));
   }
 }
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
@@ -72,10 +72,10 @@ auto make_affine_map<3>() noexcept {
 
 namespace TestTags {
 
-template <size_t Dim>
 struct ScalarTag : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() noexcept { return "Scalar"; }
+  template <size_t Dim>
   static auto fill_values(const MathFunctions::TensorProduct<Dim>& f,
                           const tnsr::I<DataVector, Dim>& x) noexcept {
     return Scalar<DataVector>{{{get(f(x))}}};
@@ -110,7 +110,7 @@ void test_regular_interpolation(const Mesh<Dim>& source_mesh,
   const auto target_coords = map(logical_coordinates(target_mesh));
 
   // Set up variables
-  using tags = tmpl::list<TestTags::ScalarTag<Dim>, TestTags::Vector<Dim>>;
+  using tags = tmpl::list<TestTags::ScalarTag, TestTags::Vector<Dim>>;
   Variables<tags> source_vars(source_mesh.number_of_grid_points());
   Variables<tags> expected_result(target_mesh.number_of_grid_points());
 
@@ -195,7 +195,7 @@ void test_regular_interpolation_override(
     const auto target_coords = map(target_logical_coords);
 
     // Set up variables
-    using tags = tmpl::list<TestTags::ScalarTag<Dim>, TestTags::Vector<Dim>>;
+    using tags = tmpl::list<TestTags::ScalarTag, TestTags::Vector<Dim>>;
     Variables<tags> source_vars(source_mesh.number_of_grid_points());
     Variables<tags> expected_result(get<0>(target_coords).size());
 


### PR DESCRIPTION
## Proposed changes

When interpolating multiple tensors, the original Variables interface is more efficient. However, the new DataVector interface is useful for applications (such as limiting) where only some components of a Tensor or Variables need to be interpolated.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
