### PR TITLE
Add function to compute orthonormal oneforms

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -4,13 +4,14 @@
 set(LIBRARY DataStructures)
 
 set(LIBRARY_SOURCES
-    Index.cpp
-    IndexIterator.cpp
-    LeviCivitaIterator.cpp
-    SliceIterator.cpp
-    StripeIterator.cpp
-    Tensor/TensorData.cpp
-    )
+  Index.cpp
+  IndexIterator.cpp
+  LeviCivitaIterator.cpp
+  SliceIterator.cpp
+  StripeIterator.cpp
+  Tensor/EagerMath/OrthonormalOneform.cpp
+  Tensor/TensorData.cpp
+  )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 

--- a/src/DataStructures/Tensor/EagerMath/OrthonormalOneform.cpp
+++ b/src/DataStructures/Tensor/EagerMath/OrthonormalOneform.cpp
@@ -1,0 +1,126 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/Tensor/EagerMath/OrthonormalOneform.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/CrossProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+template <typename DataType, size_t VolumeDim, typename Frame>
+void orthonormal_oneform(
+    const gsl::not_null<tnsr::i<DataType, VolumeDim, Frame>*> orthonormal_form,
+    const tnsr::i<DataType, VolumeDim, Frame>& unit_form,
+    const tnsr::II<DataType, VolumeDim, Frame>& inv_spatial_metric) noexcept {
+  *orthonormal_form = unit_form;
+  const size_t number_of_points = get_size(get<0>(unit_form));
+  for (size_t s = 0; s < number_of_points; ++s) {
+    size_t min_index = 0;
+    for (size_t i = 1; i < VolumeDim; ++i) {
+      if (std::abs(get_element(unit_form.get(i), s)) <
+          std::abs(get_element(unit_form.get(min_index), s))) {
+        min_index = i;
+      }
+    }
+
+    double proj = 0.0;
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      proj += (get_element(inv_spatial_metric.get(min_index, i), s) *
+               get_element(unit_form.get(i), s));
+    }
+    const double inv_magnitude =
+        1.0 /
+        sqrt(get_element(inv_spatial_metric.get(min_index, min_index), s) -
+             square(proj));
+
+    proj *= -inv_magnitude;
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      get_element(orthonormal_form->get(i), s) *= proj;
+      if (i == min_index) {
+        get_element(orthonormal_form->get(i), s) += inv_magnitude;
+      }
+    }
+  }
+}
+
+template <typename DataType, size_t VolumeDim, typename Frame>
+tnsr::i<DataType, VolumeDim, Frame> orthonormal_oneform(
+    const tnsr::i<DataType, VolumeDim, Frame>& unit_form,
+    const tnsr::II<DataType, VolumeDim, Frame>& inv_spatial_metric) noexcept {
+  tnsr::i<DataType, VolumeDim, Frame> orthonormal_form{};
+  orthonormal_oneform(make_not_null(&orthonormal_form), unit_form,
+                      inv_spatial_metric);
+  return orthonormal_form;
+}
+
+template <typename DataType, typename Frame>
+void orthonormal_oneform(
+    gsl::not_null<tnsr::i<DataType, 3, Frame>*> orthonormal_form,
+    const tnsr::i<DataType, 3, Frame>& first_unit_form,
+    const tnsr::i<DataType, 3, Frame>& second_unit_form,
+    const tnsr::ii<DataType, 3, Frame>& spatial_metric,
+    const Scalar<DataType>& det_spatial_metric) noexcept {
+  *orthonormal_form = cross_product(first_unit_form, second_unit_form,
+                                    spatial_metric, det_spatial_metric);
+}
+
+template <typename DataType, typename Frame>
+tnsr::i<DataType, 3, Frame> orthonormal_oneform(
+    const tnsr::i<DataType, 3, Frame>& first_unit_form,
+    const tnsr::i<DataType, 3, Frame>& second_unit_form,
+    const tnsr::ii<DataType, 3, Frame>& spatial_metric,
+    const Scalar<DataType>& det_spatial_metric) noexcept {
+  tnsr::i<DataType, 3, Frame> orthonormal_form{};
+  orthonormal_oneform(make_not_null(&orthonormal_form), first_unit_form,
+                      second_unit_form, spatial_metric, det_spatial_metric);
+  return orthonormal_form;
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE_FIRST_FORM(_, data)                                      \
+  template void orthonormal_oneform(                                         \
+      const gsl::not_null<tnsr::i<DTYPE(data), DIM(data), FRAME(data)>*>     \
+          orthonormal_form,                                                  \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& unit_form,         \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          inv_spatial_metric) noexcept;                                      \
+  template tnsr::i<DTYPE(data), DIM(data), FRAME(data)> orthonormal_oneform( \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& unit_form,         \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          inv_spatial_metric) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_FIRST_FORM, (double, DataVector),
+                        (Frame::Inertial), (2, 3))
+
+#define INSTANTIATE_SECOND_FORM(_, data)                             \
+  template void orthonormal_oneform(                                 \
+      const gsl::not_null<tnsr::i<DTYPE(data), 3, FRAME(data)>*>     \
+          orthonormal_form,                                          \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& first_unit_form,   \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& second_unit_form,  \
+      const tnsr::ii<DTYPE(data), 3, FRAME(data)>& spatial_metric,   \
+      const Scalar<DTYPE(data)>& det_spatial_metric) noexcept;       \
+  template tnsr::i<DTYPE(data), 3, FRAME(data)> orthonormal_oneform( \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& first_unit_form,   \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& second_unit_form,  \
+      const tnsr::ii<DTYPE(data), 3, FRAME(data)>& spatial_metric,   \
+      const Scalar<DTYPE(data)>& det_spatial_metric) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_SECOND_FORM, (double, DataVector),
+                        (Frame::Inertial))
+
+#undef INSTANTIATE_SECOND_FORM
+#undef INSTANTIATE_FIRST_FORM
+#undef DIM
+#undef FRAME
+#undef DTYPE
+/// \endcond

--- a/src/DataStructures/Tensor/EagerMath/OrthonormalOneform.hpp
+++ b/src/DataStructures/Tensor/EagerMath/OrthonormalOneform.hpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+// @{
+/*!
+ * \ingroup TensorGroup
+ *
+ * \brief Compute a spatial one-form orthonormal to the given unit form
+ *
+ * Given a unit spatial one-form \f$s_i\f$, compute a new form \f$t_i\f$
+ * which is orthonormal to \f$s_i\f$, in the sense that
+ * \f$\gamma^{ij}s_i t_j = 0\f$, for the given inverse spatial metric
+ * \f$\gamma^{ij}\f$. The normalization of \f$t_i\f$ is such that
+ * \f$\gamma^{ij}t_it_j = 1\f$.
+ *
+ * \details The new form is obtained via Gram-Schmidt process, starting
+ * from a form whose components are \f$t_i = \delta_i^I\f$, where \f$I\f$ is
+ * the index of the component of \f$s_i\f$ with the smallest absolute value.
+ */
+template <typename DataType, size_t VolumeDim, typename Frame>
+void orthonormal_oneform(
+    gsl::not_null<tnsr::i<DataType, VolumeDim, Frame>*> orthonormal_form,
+    const tnsr::i<DataType, VolumeDim, Frame>& unit_form,
+    const tnsr::II<DataType, VolumeDim, Frame>& inv_spatial_metric) noexcept;
+
+template <typename DataType, size_t VolumeDim, typename Frame>
+tnsr::i<DataType, VolumeDim, Frame> orthonormal_oneform(
+    const tnsr::i<DataType, VolumeDim, Frame>& unit_form,
+    const tnsr::II<DataType, VolumeDim, Frame>& inv_spatial_metric) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup TensorGroup
+ *
+ * \brief Compute a spatial one-form orthonormal to two given unit forms.
+ *
+ * Given a unit spatial one-form \f$s_i\f$ and another form \f$t_i\f$ that is
+ * orthonormal to \f$s_i\f$, compute a new form \f$u_i\f$ which is orthonormal
+ * to both \f$s_i\f$ and \f$t_i\f$, in the sense that
+ * \f$\gamma^{ij}s_i u_j = \gamma^{ij}t_i u_j = 0\f$, for the given
+ * inverse spatial metric \f$\gamma^{ij}\f$. The normalization of \f$u_i\f$
+ * is such that \f$\gamma^{ij}u_iu_j = 1\f$.
+ *
+ * \details The new form is obtained by taking the covariant cross product
+ * of \f$s_i\f$ and \f$ t_i\f$, for which the spatial metric as well as
+ * its determinant must be provided.
+ */
+template <typename DataType, typename Frame>
+void orthonormal_oneform(
+    gsl::not_null<tnsr::i<DataType, 3, Frame>*> orthonormal_form,
+    const tnsr::i<DataType, 3, Frame>& first_unit_form,
+    const tnsr::i<DataType, 3, Frame>& second_unit_form,
+    const tnsr::ii<DataType, 3, Frame>& spatial_metric,
+    const Scalar<DataType>& det_spatial_metric) noexcept;
+
+template <typename DataType, typename Frame>
+tnsr::i<DataType, 3, Frame> orthonormal_oneform(
+    const tnsr::i<DataType, 3, Frame>& first_unit_form,
+    const tnsr::i<DataType, 3, Frame>& second_unit_form,
+    const tnsr::ii<DataType, 3, Frame>& spatial_metric,
+    const Scalar<DataType>& det_spatial_metric) noexcept;
+// @}

--- a/tests/Unit/DataStructures/Tensor/EagerMath/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_DotProduct.cpp
   Test_Magnitude.cpp
   Test_Norms.cpp
+  Test_OrthonormalOneform.cpp
   )
 
 add_test_library(

--- a/tests/Unit/DataStructures/Tensor/EagerMath/Test_OrthonormalOneform.cpp
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/Test_OrthonormalOneform.cpp
@@ -1,0 +1,145 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/EagerMath/OrthonormalOneform.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Direction.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/Domain/DomainTestHelpers.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+#include "tests/Utilities/RandomUnitNormal.hpp"
+
+namespace {
+
+template <typename DataType, size_t Dim, typename Frame>
+tnsr::ii<DataType, Dim, Frame> random_spatial_metric(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept {
+  std::uniform_real_distribution<> distribution(-0.05, 0.05);
+  auto spatial_metric = make_with_random_values<tnsr::ii<DataType, Dim, Frame>>(
+      generator, make_not_null(&distribution), used_for_size);
+  for (size_t d = 0; d < Dim; ++d) {
+    spatial_metric.get(d, d) += 1.0;
+  }
+  return spatial_metric;
+}
+
+template <size_t Dim>
+struct TestOrthonormalForms {
+  template <typename DataType, typename Frame>
+  void operator()(
+      const tnsr::i<DataType, Dim, Frame>& unit_form,
+      const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
+      const tnsr::II<DataType, Dim, Frame>& inv_spatial_metric) const noexcept;
+};
+
+template <>
+struct TestOrthonormalForms<2> {
+  template <typename DataType, typename Frame>
+  void operator()(const tnsr::i<DataType, 2, Frame>& unit_form,
+                  const tnsr::ii<DataType, 2, Frame>& /*spatial_metric*/,
+                  const tnsr::II<DataType, 2, Frame>& inv_spatial_metric) const
+      noexcept {
+    const auto orthonormal_form =
+        orthonormal_oneform(unit_form, inv_spatial_metric);
+
+    const auto zero = make_with_value<Scalar<DataType>>(unit_form, 0.0);
+    const auto one = make_with_value<Scalar<DataType>>(unit_form, 1.0);
+    CHECK_ITERABLE_APPROX(dot_product(unit_form, unit_form, inv_spatial_metric),
+                          one);
+    CHECK_ITERABLE_APPROX(
+        dot_product(orthonormal_form, orthonormal_form, inv_spatial_metric),
+        one);
+    CHECK_ITERABLE_APPROX(
+        dot_product(unit_form, orthonormal_form, inv_spatial_metric), zero);
+  }
+};
+
+template <>
+struct TestOrthonormalForms<3> {
+  template <typename DataType, typename Frame>
+  void operator()(const tnsr::i<DataType, 3, Frame>& unit_form,
+                  const tnsr::ii<DataType, 3, Frame>& spatial_metric,
+                  const tnsr::II<DataType, 3, Frame>& inv_spatial_metric) const
+      noexcept {
+    const auto first_orthonormal_form =
+        orthonormal_oneform(unit_form, inv_spatial_metric);
+    const auto second_orthonormal_form =
+        orthonormal_oneform(unit_form, first_orthonormal_form, spatial_metric,
+                            determinant(spatial_metric));
+
+    const auto zero = make_with_value<Scalar<DataType>>(unit_form, 0.0);
+    const auto one = make_with_value<Scalar<DataType>>(unit_form, 1.0);
+    CHECK_ITERABLE_APPROX(dot_product(unit_form, unit_form, inv_spatial_metric),
+                          one);
+    CHECK_ITERABLE_APPROX(
+        dot_product(first_orthonormal_form, first_orthonormal_form,
+                    inv_spatial_metric),
+        one);
+    CHECK_ITERABLE_APPROX(
+        dot_product(second_orthonormal_form, second_orthonormal_form,
+                    inv_spatial_metric),
+        one);
+    CHECK_ITERABLE_APPROX(
+        dot_product(unit_form, first_orthonormal_form, inv_spatial_metric),
+        zero);
+    CHECK_ITERABLE_APPROX(
+        dot_product(unit_form, second_orthonormal_form, inv_spatial_metric),
+        zero);
+    CHECK_ITERABLE_APPROX(
+        dot_product(first_orthonormal_form, second_orthonormal_form,
+                    inv_spatial_metric),
+        zero);
+  }
+};
+
+template <size_t Dim, typename Frame, typename DataType>
+void check_orthonormal_forms(const DataType& used_for_size) noexcept {
+  MAKE_GENERATOR(generator);
+  const TestOrthonormalForms<Dim> test;
+
+  const auto spatial_metric =
+      random_spatial_metric<DataType, Dim, Frame>(&generator, used_for_size);
+  const auto inv_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto unit_vector = random_unit_normal(&generator, spatial_metric);
+  const auto unit_form = raise_or_lower_index(unit_vector, spatial_metric);
+
+  // test for random unit form
+  test(unit_form, spatial_metric, inv_spatial_metric);
+
+  // test for unit form along coordinate axes
+  for (const auto& direction : Direction<Dim>::all_directions()) {
+    auto basis_form = euclidean_basis_vector(direction, used_for_size);
+    const DataType inv_norm =
+        1.0 / get(magnitude(basis_form, inv_spatial_metric));
+    for (size_t i = 0; i < Dim; ++i) {
+      basis_form.get(i) *= inv_norm;
+    }
+    test(basis_form, spatial_metric, inv_spatial_metric);
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.OrthonormalOneform",
+                  "[Unit][DataStructures]") {
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(check_orthonormal_forms, (2, 3),
+                                    (Frame::Inertial))
+}


### PR DESCRIPTION
## Proposed changes

The characteristic decomposition of Valencia requires constructing an orthonormal basis starting from the normal along which the decomposition is performed. This PR adds functions to compute such "tangent" vectors, given the normal and the spatial metric, so they can be reused in other hydro systems.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
