### PR TITLE
Factor out some test helpers in hydro

### DIFF
--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -9,6 +9,7 @@
 #include <unordered_map>
 
 #include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "Domain/Block.hpp"                  // IWYU pragma: keep
 #include "Domain/BlockNeighbor.hpp"          // IWYU pragma: keep
@@ -362,6 +363,20 @@ tnsr::i<DataType, SpatialDim> euclidean_basis_vector(
   return basis_vector;
 }
 
+template <typename DataType, size_t SpatialDim>
+tnsr::i<DataType, SpatialDim> unit_basis_form(
+    const Direction<SpatialDim>& direction,
+    const tnsr::II<DataType, SpatialDim>& inv_spatial_metric) noexcept {
+  auto basis_form =
+      euclidean_basis_vector(direction, get<0, 0>(inv_spatial_metric));
+  const DataType inv_norm =
+      1.0 / get(magnitude(basis_form, inv_spatial_metric));
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    basis_form.get(i) *= inv_norm;
+  }
+  return basis_form;
+}
+
 /// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
@@ -391,7 +406,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #define INSTANTIATE_BASIS_VECTOR(_, data)                          \
   template tnsr::i<DTYPE(data), DIM(data)> euclidean_basis_vector( \
       const Direction<DIM(data)>& direction,                       \
-      const DTYPE(data) & used_for_size) noexcept;
+      const DTYPE(data) & used_for_size) noexcept;                 \
+  template tnsr::i<DTYPE(data), DIM(data)> unit_basis_form(        \
+      const Direction<DIM(data)>& direction,                       \
+      const tnsr::II<DTYPE(data), DIM(data)>& inv_spatial_metric) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_BASIS_VECTOR, (1, 2, 3),
                         (double, DataVector))

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -69,3 +69,8 @@ template <typename DataType, size_t SpatialDim>
 tnsr::i<DataType, SpatialDim> euclidean_basis_vector(
     const Direction<SpatialDim>& direction,
     const DataType& used_for_size) noexcept;
+
+template <typename DataType, size_t SpatialDim>
+tnsr::i<DataType, SpatialDim> unit_basis_form(
+    const Direction<SpatialDim>& direction,
+    const tnsr::II<DataType, SpatialDim>& inv_spatial_metric) noexcept;

--- a/tests/Unit/Domain/Test_DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainTestHelpers.cpp
@@ -6,18 +6,38 @@
 #include <algorithm>
 #include <cstddef>
 #include <limits>
+#include <random>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Direction.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
 
 namespace {
 
+template <typename DataType, size_t SpatialDim>
+tnsr::II<DataType, SpatialDim> random_inv_spatial_metric(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept {
+  std::uniform_real_distribution<> distribution(-0.05, 0.05);
+  auto inv_spatial_metric =
+      make_with_random_values<tnsr::II<DataType, SpatialDim>>(
+          generator, make_not_null(&distribution), used_for_size);
+  for (size_t d = 0; d < SpatialDim; ++d) {
+    inv_spatial_metric.get(d, d) += 1.0;
+  }
+  return inv_spatial_metric;
+}
+
 template <size_t SpatialDim, typename DataType>
-void test_euclidean_basis_vectors(const DataType& used_for_size) noexcept {
+void test_euclidean_basis_vector(const DataType& used_for_size) noexcept {
   for (const auto& direction : Direction<SpatialDim>::all_directions()) {
     auto expected =
         make_with_value<tnsr::i<DataType, SpatialDim>>(used_for_size, 0.0);
@@ -29,16 +49,29 @@ void test_euclidean_basis_vectors(const DataType& used_for_size) noexcept {
   }
 }
 
+template <size_t SpatialDim, typename DataType>
+void test_unit_basis_form(const DataType& used_for_size) noexcept {
+  MAKE_GENERATOR(generator);
+  const auto inv_spatial_metric =
+      random_inv_spatial_metric<DataType, SpatialDim>(make_not_null(&generator),
+                                                      used_for_size);
+  for (const auto& direction : Direction<SpatialDim>::all_directions()) {
+    const auto basis_form = unit_basis_form(direction, inv_spatial_metric);
+    auto expected = euclidean_basis_vector(direction, used_for_size);
+    const DataType norm = get(magnitude(expected, inv_spatial_metric));
+    for (size_t d = 0; d < SpatialDim; ++d) {
+      expected.get(d) /= norm;
+    }
+    CHECK_ITERABLE_APPROX(basis_form, expected);
+    CHECK_ITERABLE_APPROX(get(magnitude(expected, inv_spatial_metric)),
+                          make_with_value<DataType>(used_for_size, 1.0));
+  }
+}
+
 }  //  namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.TestHelpers.BasisVector", "[Unit][Domain]") {
-  const double d(std::numeric_limits<double>::signaling_NaN());
-  test_euclidean_basis_vectors<1>(d);
-  test_euclidean_basis_vectors<2>(d);
-  test_euclidean_basis_vectors<3>(d);
-
-  const DataVector dv(5);
-  test_euclidean_basis_vectors<1>(dv);
-  test_euclidean_basis_vectors<2>(dv);
-  test_euclidean_basis_vectors<3>(dv);
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_euclidean_basis_vector, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_unit_basis_form, (1, 2, 3));
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Characteristics.cpp
@@ -4,23 +4,22 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
-#include <random>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Direction.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/LorentzFactor.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
+#include "tests/Unit/PointwiseFunctions/Hydro/TestHelpers.hpp"
 #include "tests/Unit/Pypp/Pypp.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Unit/TestHelpers.hpp"
-#include "tests/Utilities/MakeWithRandomValues.hpp"
 
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 // IWYU pragma: no_forward_declare Tensor
@@ -47,34 +46,28 @@ void test_characteristic_speeds(const DataVector& /*used_for_size*/) noexcept {
 void test_with_normal_along_coordinate_axes(
     const DataVector& used_for_size) noexcept {
   MAKE_GENERATOR(generator);
-  std::uniform_real_distribution<> distribution(0.0, 1.0);
-  std::uniform_real_distribution<> small_distribution(0.0, 0.1);
-
-  const auto nn_generator = make_not_null(&generator);
-  const auto nn_distribution = make_not_null(&distribution);
-
-  const auto rest_mass_density = make_with_random_values<Scalar<DataVector>>(
-      nn_generator, nn_distribution, used_for_size);
+  namespace helper = hydro::TestHelpers;
+  const auto nn_gen = make_not_null(&generator);
+  const auto rest_mass_density = helper::random_density(nn_gen, used_for_size);
   EquationsOfState::PolytropicFluid<true> eos(0.001, 4.0 / 3.0);
   const auto specific_internal_energy =
       eos.specific_internal_energy_from_density(rest_mass_density);
   const auto specific_enthalpy =
       eos.specific_enthalpy_from_density(rest_mass_density);
 
-  const auto lapse = make_with_random_values<Scalar<DataVector>>(
-      nn_generator, nn_distribution, used_for_size);
-  const auto shift = make_with_random_values<tnsr::I<DataVector, 3>>(
-      nn_generator, nn_distribution, used_for_size);
-  const auto spatial_velocity = make_with_random_values<tnsr::I<DataVector, 3>>(
-      nn_generator, make_not_null(&small_distribution), used_for_size);
-  const auto spatial_metric = make_with_random_values<tnsr::ii<DataVector, 3>>(
-      nn_generator, nn_distribution, used_for_size);
+  const auto lapse = helper::random_lapse(nn_gen, used_for_size);
+  const auto shift = helper::random_shift<3>(nn_gen, used_for_size);
+  const auto spatial_metric =
+      helper::random_spatial_metric<3>(nn_gen, used_for_size);
+  const auto lorentz_factor =
+      helper::random_lorentz_factor(nn_gen, used_for_size);
+  const auto spatial_velocity =
+      helper::random_velocity(nn_gen, lorentz_factor, spatial_metric);
   const auto spatial_velocity_squared =
       dot_product(spatial_velocity, spatial_velocity, spatial_metric);
-  const auto lorentz_factor = hydro::lorentz_factor(spatial_velocity_squared);
 
-  const auto magnetic_field = make_with_random_values<tnsr::I<DataVector, 3>>(
-      nn_generator, nn_distribution, used_for_size);
+  const auto magnetic_field = helper::random_magnetic_field(
+      nn_gen, eos.pressure_from_density(rest_mass_density), spatial_metric);
   const auto magnetic_field_squared =
       dot_product(magnetic_field, magnetic_field, spatial_metric);
   const auto magnetic_field_dot_spatial_velocity =
@@ -93,20 +86,20 @@ void test_with_normal_along_coordinate_axes(
       get(specific_enthalpy)};
 
   for (const auto& direction : Direction<3>::all_directions()) {
-    const auto normal = euclidean_basis_vector(direction, used_for_size);
+    const auto normal = unit_basis_form(
+        direction, determinant_and_inverse(spatial_metric).second);
 
     const auto& eos_base =
         static_cast<const EquationsOfState::EquationOfState<true, 1>&>(eos);
-    const auto computed = grmhd::ValenciaDivClean::characteristic_speeds(
-        rest_mass_density, specific_internal_energy, specific_enthalpy,
-        spatial_velocity, lorentz_factor, magnetic_field, lapse, shift,
-        spatial_metric, normal, eos_base);
-
-    const auto expected = pypp::call<std::array<DataVector, 9>>(
-        "TestFunctions", "characteristic_speeds", lapse, shift,
-        spatial_velocity, spatial_velocity_squared, sound_speed_squared,
-        alfven_speed_squared, normal);
-    CHECK_ITERABLE_APPROX(computed, expected);
+    CHECK_ITERABLE_APPROX(
+        grmhd::ValenciaDivClean::characteristic_speeds(
+            rest_mass_density, specific_internal_energy, specific_enthalpy,
+            spatial_velocity, lorentz_factor, magnetic_field, lapse, shift,
+            spatial_metric, normal, eos_base),
+        (pypp::call<std::array<DataVector, 9>>(
+            "TestFunctions", "characteristic_speeds", lapse, shift,
+            spatial_velocity, spatial_velocity_squared, sound_speed_squared,
+            alfven_speed_squared, normal)));
   }
 }
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <limits>
 #include <random>
-#include <utility>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
@@ -15,14 +14,13 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
-#include "Utilities/ConstantExpressions.hpp"
+#include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Overloader.hpp"
 #include "Utilities/TMPL.hpp"
+#include "tests/Unit/PointwiseFunctions/Hydro/TestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
-#include "tests/Utilities/MakeWithRandomValues.hpp"
-#include "tests/Utilities/RandomUnitNormal.hpp"
 
 // IWYU pragma: no_include <array>
 
@@ -40,108 +38,6 @@ class PalenzuelaEtAl;
 
 namespace {
 
-Scalar<DataVector> random_density(const gsl::not_null<std::mt19937*> generator,
-                                  const DataVector& used_for_size) noexcept {
-  // 1 g/cm^3 = 1.62e-18 in geometric units
-  constexpr double minimum_density = 1.0e-5;
-  constexpr double maximum_density = 1.0e-3;
-  std::uniform_real_distribution<> distribution(log(minimum_density),
-                                                log(maximum_density));
-  return Scalar<DataVector>{exp(make_with_random_values<DataVector>(
-      generator, make_not_null(&distribution), used_for_size))};
-}
-
-Scalar<DataVector> random_lorentz_factor(
-    const gsl::not_null<std::mt19937*> generator,
-    const DataVector& used_for_size) noexcept {
-  std::uniform_real_distribution<> distribution(-10.0, 3.0);
-  return Scalar<DataVector>{
-      1.0 + exp(make_with_random_values<DataVector>(
-                generator, make_not_null(&distribution), used_for_size))};
-}
-
-tnsr::I<DataVector, 3> random_velocity(
-    const gsl::not_null<std::mt19937*> generator,
-    const Scalar<DataVector>& lorentz_factor,
-    const tnsr::ii<DataVector, 3>& spatial_metric) noexcept {
-  tnsr::I<DataVector, 3> spatial_velocity =
-      random_unit_normal(generator, spatial_metric);
-  const DataVector v = sqrt(1.0 - 1.0 / square(get(lorentz_factor)));
-  get<0>(spatial_velocity) *= v;
-  get<1>(spatial_velocity) *= v;
-  get<2>(spatial_velocity) *= v;
-  return spatial_velocity;
-}
-
-tnsr::I<DataVector, 3> random_magnetic_field(
-    const gsl::not_null<std::mt19937*> generator,
-    const Scalar<DataVector>& pressure,
-    const tnsr::ii<DataVector, 3>& spatial_metric) noexcept {
-  tnsr::I<DataVector, 3> magnetic_field =
-      random_unit_normal(generator, spatial_metric);
-  std::uniform_real_distribution<> distribution(-8.0, 14.0);
-  const size_t number_of_points = get(pressure).size();
-  for (size_t s = 0; s < number_of_points; ++s) {
-    // magnitude of B set to vary ratio of magnetic pressure to fluid pressure
-    const double B = sqrt(get(pressure)[s] * exp(distribution(*generator)));
-    get<0>(magnetic_field)[s] *= B;
-    get<1>(magnetic_field)[s] *= B;
-    get<2>(magnetic_field)[s] *= B;
-  }
-  return magnetic_field;
-}
-
-// temperature in MeV
-Scalar<DataVector> random_temperature(
-    const gsl::not_null<std::mt19937*> generator,
-    const DataVector& used_for_size) noexcept {
-  constexpr double minimum_temperature = 1.0;
-  constexpr double maximum_temperature = 50.0;
-  std::uniform_real_distribution<> distribution(log(minimum_temperature),
-                                                log(maximum_temperature));
-  return Scalar<DataVector>{exp(make_with_random_values<DataVector>(
-      generator, make_not_null(&distribution), used_for_size))};
-}
-
-// assumes gamma = 4/3 ideal fluid
-Scalar<DataVector> random_specific_internal_energy(
-    const gsl::not_null<std::mt19937*> generator,
-    const DataVector& used_for_size) noexcept {
-  // assumes Ideal gas with gamma = 4/3
-  // For ideal fluid T = (m/k_b)(gamma - 1) epsilon
-  // where m = atomic mass unit, k_b = Boltzmann constant
-  return Scalar<DataVector>{3.21e-3 *
-                            get(random_temperature(generator, used_for_size))};
-}
-
-Scalar<DataVector> random_divergence_cleaning_field(
-    const gsl::not_null<std::mt19937*> generator,
-    const DataVector& used_for_size) noexcept {
-  std::uniform_real_distribution<> distribution(-10.0, 10.0);
-  return make_with_random_values<Scalar<DataVector>>(
-      generator, make_not_null(&distribution), used_for_size);
-}
-
-tnsr::ii<DataVector, 3> random_spatial_metric(
-    const gsl::not_null<std::mt19937*> generator,
-    const DataVector& used_for_size) noexcept {
-  std::uniform_real_distribution<> distribution(-0.05, 0.05);
-  auto spatial_metric = make_with_random_values<tnsr::ii<DataVector, 3>>(
-      generator, make_not_null(&distribution), used_for_size);
-  for (size_t d = 0; d < 3; ++d) {
-    spatial_metric.get(d, d) += 1.0;
-  }
-  return spatial_metric;
-}
-
-Scalar<DataVector> specific_enthalpy(
-    const Scalar<DataVector>& rest_mass_density,
-    const Scalar<DataVector>& specific_internal_energy,
-    const Scalar<DataVector>& pressure) noexcept {
-  return Scalar<DataVector>{1.0 + get(specific_internal_energy) +
-                            get(pressure) / get(rest_mass_density)};
-}
-
 template <typename OrderedListOfPrimitiveRecoverySchemes,
           size_t ThermodynamicDim>
 void test_primitive_from_conservative_random(
@@ -151,12 +47,13 @@ void test_primitive_from_conservative_random(
     const DataVector& used_for_size) noexcept {
   // generate random primitives with interesting astrophysical values
   const auto expected_rest_mass_density =
-      random_density(generator, used_for_size);
+      hydro::TestHelpers::random_density(generator, used_for_size);
   const auto expected_lorentz_factor =
-      random_lorentz_factor(generator, used_for_size);
-  const auto spatial_metric = random_spatial_metric(generator, used_for_size);
-  const auto expected_spatial_velocity =
-      random_velocity(generator, expected_lorentz_factor, spatial_metric);
+      hydro::TestHelpers::random_lorentz_factor(generator, used_for_size);
+  const auto spatial_metric =
+      hydro::TestHelpers::random_spatial_metric<3>(generator, used_for_size);
+  const auto expected_spatial_velocity = hydro::TestHelpers::random_velocity(
+      generator, expected_lorentz_factor, spatial_metric);
   const auto expected_specific_internal_energy = make_overloader(
       [&expected_rest_mass_density](
           const EquationsOfState::EquationOfState<true, 1>&
@@ -168,7 +65,8 @@ void test_primitive_from_conservative_random(
        &used_for_size ](const EquationsOfState::EquationOfState<true, 2>&
                         /*the_equation_of_state*/) noexcept {
         // note this call assumes an ideal fluid
-        return random_specific_internal_energy(generator, used_for_size);
+        return hydro::TestHelpers::random_specific_internal_energy(
+            generator, used_for_size);
       })(equation_of_state);
   const auto expected_pressure = make_overloader(
       [&expected_rest_mass_density](
@@ -184,13 +82,15 @@ void test_primitive_from_conservative_random(
             expected_rest_mass_density, expected_specific_internal_energy);
       })(equation_of_state);
 
-  const auto expected_specific_enthalpy =
-      specific_enthalpy(expected_rest_mass_density,
-                        expected_specific_internal_energy, expected_pressure);
+  const auto expected_specific_enthalpy = hydro::relativistic_specific_enthalpy(
+      expected_rest_mass_density, expected_specific_internal_energy,
+      expected_pressure);
   const auto expected_magnetic_field =
-      random_magnetic_field(generator, expected_pressure, spatial_metric);
+      hydro::TestHelpers::random_magnetic_field(generator, expected_pressure,
+                                                spatial_metric);
   const auto expected_divergence_cleaning_field =
-      random_divergence_cleaning_field(generator, used_for_size);
+      hydro::TestHelpers::random_divergence_cleaning_field(generator,
+                                                           used_for_size);
 
   const auto det_and_inv = determinant_and_inverse(spatial_metric);
   const auto& inv_spatial_metric = det_and_inv.second;

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Characteristics.cpp
@@ -6,10 +6,10 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
-#include <random>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -18,16 +18,18 @@
 #include "Domain/FaceNormal.hpp"
 #include "Evolution/Systems/RelativisticEuler/Valencia/Characteristics.hpp"
 #include "Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
+#include "tests/Unit/PointwiseFunctions/Hydro/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/Pypp.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Unit/TestHelpers.hpp"
-#include "tests/Utilities/MakeWithRandomValues.hpp"
+#include "tests/Utilities/RandomUnitNormal.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
 
@@ -62,53 +64,30 @@ void test_compute_item_in_databox(
 
 template <size_t Dim>
 void test_characteristic_speeds(const DataVector& used_for_size) noexcept {
-  //  Arbitrary random numbers can produce a negative radicand in Lambda^\pm.
-  //  This bound helps to prevent that situation.
-  const double max_value = 1.0 / sqrt(Dim);
-  std::array<DataVector, Dim + 2> (*f)(
-      const Scalar<DataVector>& lapse, const tnsr::I<DataVector, Dim>& shift,
-      const tnsr::I<DataVector, Dim>& spatial_velocity,
-      const Scalar<DataVector>& spatial_velocity_squared,
-      const Scalar<DataVector>& sound_speed_squared,
-      const tnsr::i<DataVector, Dim>& normal) =
-      &RelativisticEuler::Valencia::characteristic_speeds<Dim>;
-  pypp::check_with_random_values<6>(f, "TestFunctions", "characteristic_speeds",
-                                    {{{0.0, 1.0},
-                                      {-1.0, 1.0},
-                                      {-max_value, max_value},
-                                      {0.0, 1.0},
-                                      {0.0, 1.0},
-                                      {-max_value, max_value}}},
-                                    used_for_size);
-}
-
-template <size_t Dim>
-void test_with_normal_along_coordinate_axes(
-    const DataVector& used_for_size) noexcept {
   MAKE_GENERATOR(generator);
-  std::uniform_real_distribution<> distribution(0.0, 0.3);
-
-  const auto nn_generator = make_not_null(&generator);
-  const auto nn_distribution = make_not_null(&distribution);
-
-  const auto lapse = make_with_random_values<Scalar<DataVector>>(
-      nn_generator, nn_distribution, used_for_size);
-  const auto shift = make_with_random_values<tnsr::I<DataVector, Dim>>(
-      nn_generator, nn_distribution, used_for_size);
+  namespace helper = hydro::TestHelpers;
+  const auto nn_gen = make_not_null(&generator);
+  const auto lapse = helper::random_lapse(nn_gen, used_for_size);
+  const auto shift = helper::random_shift<Dim>(nn_gen, used_for_size);
   const auto spatial_metric =
-      make_with_random_values<tnsr::ii<DataVector, Dim>>(
-          nn_generator, nn_distribution, used_for_size);
-  const auto spatial_velocity =
-      make_with_random_values<tnsr::I<DataVector, Dim>>(
-          nn_generator, nn_distribution, used_for_size);
+      helper::random_spatial_metric<Dim>(nn_gen, used_for_size);
+  const auto spatial_velocity = helper::random_velocity(
+      nn_gen, helper::random_lorentz_factor(nn_gen, used_for_size),
+      spatial_metric);
   const auto spatial_velocity_squared =
       dot_product(spatial_velocity, spatial_velocity, spatial_metric);
-  const auto sound_speed_squared = make_with_random_values<Scalar<DataVector>>(
-      nn_generator, nn_distribution, used_for_size);
+  EquationsOfState::PolytropicFluid<true> eos(0.001, 4.0 / 3.0);
+  const auto rest_mass_density = helper::random_density(nn_gen, used_for_size);
+  const Scalar<DataVector> sound_speed_squared{
+      (get(eos.chi_from_density(rest_mass_density)) +
+       get(eos.kappa_times_p_over_rho_squared_from_density(
+           rest_mass_density))) /
+      get(eos.specific_enthalpy_from_density(rest_mass_density))};
 
+  // test with normal along coordinate axes
   for (const auto& direction : Direction<Dim>::all_directions()) {
-    const auto normal = euclidean_basis_vector(direction, used_for_size);
-
+    const auto normal = unit_basis_form(
+        direction, determinant_and_inverse(spatial_metric).second);
     CHECK_ITERABLE_APPROX(
         RelativisticEuler::Valencia::characteristic_speeds(
             lapse, shift, spatial_velocity, spatial_velocity_squared,
@@ -119,12 +98,20 @@ void test_with_normal_along_coordinate_axes(
             normal)));
   }
 
-  // test compute item with random normal vector
-  test_compute_item_in_databox(
-      lapse, shift, spatial_metric, spatial_velocity, spatial_velocity_squared,
-      sound_speed_squared,
-      make_with_random_values<tnsr::i<DataVector, Dim>>(
-          nn_generator, nn_distribution, used_for_size));
+  // test with random normal
+  const auto random_normal = raise_or_lower_index(
+      random_unit_normal(nn_gen, spatial_metric), spatial_metric);
+  CHECK_ITERABLE_APPROX(
+      RelativisticEuler::Valencia::characteristic_speeds(
+          lapse, shift, spatial_velocity, spatial_velocity_squared,
+          sound_speed_squared, random_normal),
+      (pypp::call<std::array<DataVector, Dim + 2>>(
+          "TestFunctions", "characteristic_speeds", lapse, shift,
+          spatial_velocity, spatial_velocity_squared, sound_speed_squared,
+          random_normal)));
+  test_compute_item_in_databox(lapse, shift, spatial_metric, spatial_velocity,
+                               spatial_velocity_squared, sound_speed_squared,
+                               random_normal);
 }
 
 }  // namespace
@@ -135,8 +122,5 @@ SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.Characteristics",
       "Evolution/Systems/RelativisticEuler/Valencia"};
 
   GENERATE_UNINITIALIZED_DATAVECTOR;
-  CHECK_FOR_DATAVECTORS(test_characteristic_speeds, (1, 2, 3))
-  // Test with aligned normals to check the code works
-  // with vector components being 0.
-  CHECK_FOR_DATAVECTORS(test_with_normal_along_coordinate_axes, (1, 2, 3))
+  CHECK_FOR_DATAVECTORS(test_characteristic_speeds, (1, 2, 3));
 }

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
@@ -16,94 +16,16 @@
 #include "Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
-#include "Utilities/ConstantExpressions.hpp"
+#include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Overloader.hpp"
+#include "tests/Unit/PointwiseFunctions/Hydro/TestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
-#include "tests/Utilities/MakeWithRandomValues.hpp"
-#include "tests/Utilities/RandomUnitNormal.hpp"
 
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 
 namespace {
-
-Scalar<DataVector> random_density(const gsl::not_null<std::mt19937*> generator,
-                                  const DataVector& used_for_size) noexcept {
-  // 1 g/cm^3 = 1.62e-18 in geometric units
-  constexpr double minimum_density = 1.0e-5;
-  constexpr double maximum_density = 1.0e-3;
-  std::uniform_real_distribution<> distribution(log(minimum_density),
-                                                log(maximum_density));
-  return Scalar<DataVector>{exp(make_with_random_values<DataVector>(
-      generator, make_not_null(&distribution), used_for_size))};
-}
-
-Scalar<DataVector> random_lorentz_factor(
-    const gsl::not_null<std::mt19937*> generator,
-    const DataVector& used_for_size) noexcept {
-  std::uniform_real_distribution<> distribution(-10.0, 3.0);
-  return Scalar<DataVector>{
-      1.0 + exp(make_with_random_values<DataVector>(
-                generator, make_not_null(&distribution), used_for_size))};
-}
-
-template <size_t Dim>
-tnsr::I<DataVector, Dim> random_velocity(
-    const gsl::not_null<std::mt19937*> generator,
-    const Scalar<DataVector>& lorentz_factor,
-    const tnsr::ii<DataVector, Dim>& spatial_metric) noexcept {
-  tnsr::I<DataVector, Dim> spatial_velocity =
-      random_unit_normal(generator, spatial_metric);
-  const DataVector v = sqrt(1.0 - 1.0 / square(get(lorentz_factor)));
-  for (size_t d = 0; d < Dim; ++d) {
-    spatial_velocity.get(d) *= v;
-  }
-  return spatial_velocity;
-}
-
-// temperature in MeV
-Scalar<DataVector> random_temperature(
-    const gsl::not_null<std::mt19937*> generator,
-    const DataVector& used_for_size) noexcept {
-  constexpr double minimum_temperature = 1.0;
-  constexpr double maximum_temperature = 50.0;
-  std::uniform_real_distribution<> distribution(log(minimum_temperature),
-                                                log(maximum_temperature));
-  return Scalar<DataVector>{exp(make_with_random_values<DataVector>(
-      generator, make_not_null(&distribution), used_for_size))};
-}
-
-Scalar<DataVector> random_specific_internal_energy(
-    const gsl::not_null<std::mt19937*> generator,
-    const DataVector& used_for_size) noexcept {
-  // assumes Ideal gas with gamma = 4/3
-  // For ideal fluid T = (m/k_b)(gamma - 1) epsilon
-  // where m = atomic mass unit, k_b = Boltzmann constant
-  return Scalar<DataVector>{3.21e-3 *
-                            get(random_temperature(generator, used_for_size))};
-}
-
-Scalar<DataVector> specific_enthalpy(
-    const Scalar<DataVector>& rest_mass_density,
-    const Scalar<DataVector>& specific_internal_energy,
-    const Scalar<DataVector>& pressure) noexcept {
-  return Scalar<DataVector>{1.0 + get(specific_internal_energy) +
-                            get(pressure) / get(rest_mass_density)};
-}
-
-template <size_t Dim>
-tnsr::ii<DataVector, Dim> random_spatial_metric(
-    const gsl::not_null<std::mt19937*> generator,
-    const DataVector& used_for_size) noexcept {
-  std::uniform_real_distribution<> distribution(-0.05, 0.05);
-  auto spatial_metric = make_with_random_values<tnsr::ii<DataVector, Dim>>(
-      generator, make_not_null(&distribution), used_for_size);
-  for (size_t d = 0; d < Dim; ++d) {
-    spatial_metric.get(d, d) += 1.0;
-  }
-  return spatial_metric;
-}
 
 template <size_t Dim, size_t ThermodynamicDim>
 void test_primitive_from_conservative(
@@ -112,13 +34,13 @@ void test_primitive_from_conservative(
         equation_of_state,
     const DataVector& used_for_size) noexcept {
   const auto expected_rest_mass_density =
-      random_density(generator, used_for_size);
+      hydro::TestHelpers::random_density(generator, used_for_size);
   const auto expected_lorentz_factor =
-      random_lorentz_factor(generator, used_for_size);
+      hydro::TestHelpers::random_lorentz_factor(generator, used_for_size);
   const auto spatial_metric =
-      random_spatial_metric<Dim>(generator, used_for_size);
-  const auto expected_spatial_velocity =
-      random_velocity(generator, expected_lorentz_factor, spatial_metric);
+      hydro::TestHelpers::random_spatial_metric<Dim>(generator, used_for_size);
+  const auto expected_spatial_velocity = hydro::TestHelpers::random_velocity(
+      generator, expected_lorentz_factor, spatial_metric);
   const auto expected_specific_internal_energy = make_overloader(
       [&expected_rest_mass_density](
           const EquationsOfState::EquationOfState<true, 1>&
@@ -130,7 +52,8 @@ void test_primitive_from_conservative(
        &used_for_size ](const EquationsOfState::EquationOfState<true, 2>&
                         /*the_equation_of_state*/) noexcept {
         // note this call assumes an ideal fluid
-        return random_specific_internal_energy(generator, used_for_size);
+        return hydro::TestHelpers::random_specific_internal_energy(
+            generator, used_for_size);
       })(equation_of_state);
   const auto expected_pressure = make_overloader(
       [&expected_rest_mass_density](
@@ -146,9 +69,9 @@ void test_primitive_from_conservative(
             expected_rest_mass_density, expected_specific_internal_energy);
       })(equation_of_state);
 
-  const auto expected_specific_enthalpy =
-      specific_enthalpy(expected_rest_mass_density,
-                        expected_specific_internal_energy, expected_pressure);
+  const auto expected_specific_enthalpy = hydro::relativistic_specific_enthalpy(
+      expected_rest_mass_density, expected_specific_internal_energy,
+      expected_pressure);
 
   const auto det_and_inv = determinant_and_inverse(spatial_metric);
   const auto& inv_spatial_metric = det_and_inv.second;

--- a/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -6,11 +6,13 @@ add_subdirectory(EquationsOfState)
 set(LIBRARY "Test_Hydro")
 
 set(LIBRARY_SOURCES
+  TestHelpers.cpp
   Test_LorentzFactor.cpp
   Test_MassFlux.cpp
   Test_SoundSpeedSquared.cpp
   Test_SpecificEnthalpy.cpp
   Test_Tags.cpp
+  Test_TestHelpers.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/Hydro/TestHelpers.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/TestHelpers.cpp
@@ -1,0 +1,199 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/PointwiseFunctions/Hydro/TestHelpers.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+#include "tests/Utilities/RandomUnitNormal.hpp"
+
+/// \cond
+namespace hydro {
+namespace TestHelpers {
+template <typename DataType>
+Scalar<DataType> random_density(const gsl::not_null<std::mt19937*> generator,
+                                const DataType& used_for_size) noexcept {
+  // 1 g/cm^3 = 1.62e-18 in geometric units
+  // Most tests will work fine for any positive density, the exception being
+  // tests for primitive inversions in GR hydro and MHD, for which the tolerance
+  // would have to be loosened in order to allow for smaller densities.
+  constexpr double minimum_density = 1.0e-5;
+  constexpr double maximum_density = 1.0e-3;
+  std::uniform_real_distribution<> distribution(log(minimum_density),
+                                                log(maximum_density));
+  return Scalar<DataType>{exp(make_with_random_values<DataType>(
+      generator, make_not_null(&distribution), used_for_size))};
+}
+
+template <typename DataType>
+Scalar<DataType> random_lorentz_factor(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept {
+  std::uniform_real_distribution<> distribution(-10.0, 3.0);
+  return Scalar<DataType>{
+      1.0 + exp(make_with_random_values<DataType>(
+                generator, make_not_null(&distribution), used_for_size))};
+}
+
+template <typename DataType, size_t Dim>
+tnsr::I<DataType, Dim> random_velocity(
+    const gsl::not_null<std::mt19937*> generator,
+    const Scalar<DataType>& lorentz_factor,
+    const tnsr::ii<DataType, Dim>& spatial_metric) noexcept {
+  tnsr::I<DataType, Dim> spatial_velocity =
+      random_unit_normal(generator, spatial_metric);
+  const DataType v = sqrt(1.0 - 1.0 / square(get(lorentz_factor)));
+  for (size_t d = 0; d < Dim; ++d) {
+    spatial_velocity.get(d) *= v;
+  }
+  return spatial_velocity;
+}
+
+// temperature in MeV
+template <typename DataType>
+Scalar<DataType> random_temperature(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept {
+  constexpr double minimum_temperature = 1.0;
+  constexpr double maximum_temperature = 50.0;
+  std::uniform_real_distribution<> distribution(log(minimum_temperature),
+                                                log(maximum_temperature));
+  return Scalar<DataType>{exp(make_with_random_values<DataType>(
+      generator, make_not_null(&distribution), used_for_size))};
+}
+
+template <typename DataType>
+Scalar<DataType> random_specific_internal_energy(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept {
+  // assumes Ideal gas with gamma = 4/3
+  // For ideal fluid T = (m/k_b)(gamma - 1) epsilon
+  // where m = atomic mass unit, k_b = Boltzmann constant
+  // m/k_b ~ 933MeV in geometrized units so k_b/[m*(gamma - 1)] ~ 3.21e-3 MeV^-1
+  return Scalar<DataType>{3.21e-3 *
+                          get(random_temperature(generator, used_for_size))};
+}
+
+template <typename DataType>
+tnsr::I<DataType, 3> random_magnetic_field(
+    const gsl::not_null<std::mt19937*> generator,
+    const Scalar<DataType>& pressure,
+    const tnsr::ii<DataType, 3>& spatial_metric) noexcept {
+  tnsr::I<DataType, 3> magnetic_field =
+      random_unit_normal(generator, spatial_metric);
+  std::uniform_real_distribution<> distribution(-8.0, 14.0);
+  const size_t number_of_points = get_size(get(pressure));
+  for (size_t s = 0; s < number_of_points; ++s) {
+    // magnitude of B set to vary ratio of magnetic pressure to fluid pressure
+    const double B =
+        sqrt(get_element(get(pressure), s) * exp(distribution(*generator)));
+    get_element(get<0>(magnetic_field), s) *= B;
+    get_element(get<1>(magnetic_field), s) *= B;
+    get_element(get<2>(magnetic_field), s) *= B;
+  }
+  return magnetic_field;
+}
+
+template <typename DataType>
+Scalar<DataType> random_divergence_cleaning_field(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept {
+  std::uniform_real_distribution<> distribution(-10.0, 10.0);
+  return make_with_random_values<Scalar<DataType>>(
+      generator, make_not_null(&distribution), used_for_size);
+}
+
+template <typename DataType>
+Scalar<DataType> random_lapse(const gsl::not_null<std::mt19937*> generator,
+                              const DataType& used_for_size) noexcept {
+  std::uniform_real_distribution<> distribution(0.0, 3.0);
+  return make_with_random_values<Scalar<DataType>>(
+      generator, make_not_null(&distribution), used_for_size);
+}
+
+template <size_t Dim, typename DataType>
+tnsr::I<DataType, Dim> random_shift(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+  return make_with_random_values<tnsr::I<DataType, Dim>>(
+      generator, make_not_null(&distribution), used_for_size);
+}
+
+template <size_t Dim, typename DataType>
+tnsr::ii<DataType, Dim> random_spatial_metric(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept {
+  std::uniform_real_distribution<> distribution(-0.05, 0.05);
+  auto spatial_metric = make_with_random_values<tnsr::ii<DataType, Dim>>(
+      generator, make_not_null(&distribution), used_for_size);
+  for (size_t d = 0; d < Dim; ++d) {
+    spatial_metric.get(d, d) += 1.0;
+  }
+  return spatial_metric;
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE_SCALARS(_, data)                             \
+  template Scalar<DTYPE(data)> random_density(                   \
+      const gsl::not_null<std::mt19937*> generator,              \
+      const DTYPE(data) & used_for_size) noexcept;               \
+  template Scalar<DTYPE(data)> random_lorentz_factor(            \
+      const gsl::not_null<std::mt19937*> generator,              \
+      const DTYPE(data) & used_for_size) noexcept;               \
+  template Scalar<DTYPE(data)> random_temperature(               \
+      const gsl::not_null<std::mt19937*> generator,              \
+      const DTYPE(data) & used_for_size) noexcept;               \
+  template Scalar<DTYPE(data)> random_specific_internal_energy(  \
+      const gsl::not_null<std::mt19937*> generator,              \
+      const DTYPE(data) & used_for_size) noexcept;               \
+  template Scalar<DTYPE(data)> random_divergence_cleaning_field( \
+      const gsl::not_null<std::mt19937*> generator,              \
+      const DTYPE(data) & used_for_size) noexcept;               \
+  template Scalar<DTYPE(data)> random_lapse(                     \
+      const gsl::not_null<std::mt19937*> generator,              \
+      const DTYPE(data) & used_for_size) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_SCALARS, (double, DataVector))
+
+#define INSTANTIATE_TENSORS(_, data)                                    \
+  template tnsr::I<DTYPE(data), DIM(data)> random_velocity(             \
+      const gsl::not_null<std::mt19937*> generator,                     \
+      const Scalar<DTYPE(data)>& lorentz_factor,                        \
+      const tnsr::ii<DTYPE(data), DIM(data)>& spatial_metric) noexcept; \
+  template tnsr::I<DTYPE(data), DIM(data)> random_shift(                \
+      const gsl::not_null<std::mt19937*> generator,                     \
+      const DTYPE(data) & used_for_size) noexcept;                      \
+  template tnsr::ii<DTYPE(data), DIM(data)> random_spatial_metric(      \
+      const gsl::not_null<std::mt19937*> generator,                     \
+      const DTYPE(data) & used_for_size) noexcept;
+
+template tnsr::I<double, 3> random_magnetic_field(
+    const gsl::not_null<std::mt19937*> generator,
+    const Scalar<double>& pressure,
+    const tnsr::ii<double, 3>& spatial_metric) noexcept;
+template tnsr::I<DataVector, 3> random_magnetic_field(
+    const gsl::not_null<std::mt19937*> generator,
+    const Scalar<DataVector>& pressure,
+    const tnsr::ii<DataVector, 3>& spatial_metric) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_TENSORS, (double, DataVector), (1, 2, 3))
+
+#undef INSTANTIATE_SCALARS
+#undef INSTANTIATE_VECTORS
+#undef DIM
+#undef DTYPE
+}  // namespace TestHelpers
+}  // namespace hydro
+/// \endcond

--- a/tests/Unit/PointwiseFunctions/Hydro/TestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/TestHelpers.hpp
@@ -1,0 +1,69 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <random>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace hydro {
+/// \ingroup TestingFrameworkGroup
+/// \brief Make random hydro variables which correct physical behavior,
+/// e.g. Lorentz factor will be greater or equal than one.
+namespace TestHelpers {
+template <typename DataType>
+Scalar<DataType> random_density(gsl::not_null<std::mt19937*> generator,
+                                const DataType& used_for_size) noexcept;
+
+template <typename DataType>
+Scalar<DataType> random_lorentz_factor(gsl::not_null<std::mt19937*> generator,
+                                       const DataType& used_for_size) noexcept;
+
+template <typename DataType, size_t Dim>
+tnsr::I<DataType, Dim> random_velocity(
+    gsl::not_null<std::mt19937*> generator,
+    const Scalar<DataType>& lorentz_factor,
+    const tnsr::ii<DataType, Dim>& spatial_metric) noexcept;
+
+template <typename DataType>
+Scalar<DataType> random_temperature(gsl::not_null<std::mt19937*> generator,
+                                    const DataType& used_for_size) noexcept;
+
+template <typename DataType>
+Scalar<DataType> random_specific_internal_energy(
+    gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept;
+
+template <typename DataType>
+tnsr::I<DataType, 3> random_magnetic_field(
+    gsl::not_null<std::mt19937*> generator, const Scalar<DataType>& pressure,
+    const tnsr::ii<DataType, 3>& spatial_metric) noexcept;
+
+template <typename DataType>
+Scalar<DataType> random_divergence_cleaning_field(
+    gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept;
+
+// 3+1 GR variables are used in some tests, so we include them for convenience
+template <typename DataType>
+Scalar<DataType> random_lapse(gsl::not_null<std::mt19937*> generator,
+                              const DataType& used_for_size) noexcept;
+
+template <size_t Dim, typename DataType>
+tnsr::I<DataType, Dim> random_shift(gsl::not_null<std::mt19937*> generator,
+                                    const DataType& used_for_size) noexcept;
+
+template <size_t Dim, typename DataType>
+tnsr::ii<DataType, Dim> random_spatial_metric(
+    gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept;
+}  // namespace TestHelpers
+}  // namespace hydro

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_SoundSpeedSquared.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_SoundSpeedSquared.cpp
@@ -4,7 +4,6 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <limits>
-#include <random>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -15,8 +14,8 @@
 #include "PointwiseFunctions/Hydro/SoundSpeedSquared.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/Gsl.hpp"
+#include "tests/Unit/PointwiseFunctions/Hydro/TestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
-#include "tests/Utilities/MakeWithRandomValues.hpp"
 
 namespace {
 
@@ -47,12 +46,9 @@ void test_compute_item_in_databox(
 template <typename DataType>
 void test_sound_speed_squared(const DataType& used_for_size) noexcept {
   MAKE_GENERATOR(generator);
-  std::uniform_real_distribution<> distribution(0.0, 1.0);
-  const auto nn_generator = make_not_null(&generator);
-  const auto nn_distribution = make_not_null(&distribution);
 
-  const auto rest_mass_density = make_with_random_values<Scalar<DataType>>(
-      nn_generator, nn_distribution, used_for_size);
+  const auto rest_mass_density = hydro::TestHelpers::random_density(
+      make_not_null(&generator), used_for_size);
   Scalar<DataType> specific_internal_energy{};
   Scalar<DataType> specific_enthalpy{};
 
@@ -73,8 +69,9 @@ void test_sound_speed_squared(const DataType& used_for_size) noexcept {
 
   // check with representative equation of state of two independent variables
   const EquationsOfState::IdealFluid<true> eos_2d(5.0 / 3.0);
-  specific_internal_energy = make_with_random_values<Scalar<DataType>>(
-      nn_generator, nn_distribution, used_for_size);
+  specific_internal_energy =
+      hydro::TestHelpers::random_specific_internal_energy(
+          make_not_null(&generator), used_for_size);
   specific_enthalpy = eos_2d.specific_enthalpy_from_density_and_energy(
       rest_mass_density, specific_internal_energy);
   CHECK(Scalar<DataType>{

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_TestHelpers.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_TestHelpers.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/PointwiseFunctions/Hydro/TestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+template <size_t Dim, typename DataType>
+void test_spatial_velocity(const gsl::not_null<std::mt19937*> generator,
+                           const DataType& used_for_size) noexcept {
+  const auto metric =
+      hydro::TestHelpers::random_spatial_metric<Dim>(generator, used_for_size);
+  const auto lorentz_factor =
+      hydro::TestHelpers::random_lorentz_factor(generator, used_for_size);
+  const auto spatial_velocity =
+      hydro::TestHelpers::random_velocity(generator, lorentz_factor, metric);
+  CHECK_ITERABLE_APPROX(
+      get(dot_product(spatial_velocity, spatial_velocity, metric)),
+      1.0 - 1.0 / square(get(lorentz_factor)));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.TestHelpers",
+                  "[Unit][Hydro]") {
+  MAKE_GENERATOR(generator);
+  const double d = std::numeric_limits<double>::signaling_NaN();
+  test_spatial_velocity<1>(&generator, d);
+  test_spatial_velocity<2>(&generator, d);
+  test_spatial_velocity<3>(&generator, d);
+  const DataVector dv(5);
+  test_spatial_velocity<1>(&generator, dv);
+  test_spatial_velocity<2>(&generator, dv);
+  test_spatial_velocity<3>(&generator, dv);
+}


### PR DESCRIPTION
## Proposed changes

Several tests in hydro systems require random fields with physical meaning, e.g. the Lorentz factor must be greater or equal than one, and must be consistent with a spatial velocity. Rather than having a bunch of different calls to make_with_random_values with fine-tuned distributions for each variables, this PR factors out some duplicated functions that can be reused in other tests across hydro systems and pointwise functions.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
