### PR TITLE
Fix problem with not handling paths with R

### DIFF
--- a/src/Evolution/Systems/Cce/ReadBoundaryDataH5.cpp
+++ b/src/Evolution/Systems/Cce/ReadBoundaryDataH5.cpp
@@ -88,10 +88,10 @@ SpecWorldtubeH5BufferUpdater::SpecWorldtubeH5BufferUpdater(
       not cce_data_file_.exists<h5::Version>("/VersionHist");
 
   // We assume that the filename has the extraction radius encoded as an
-  // integer between the first occurrence of 'R' and the first occurrence of
+  // integer between the last occurrence of 'R' and the last occurrence of
   // '.'. This is the format provided by SpEC.
-  const size_t r_pos = cce_data_filename.find('R');
-  const size_t dot_pos = cce_data_filename.find('.');
+  const size_t r_pos = cce_data_filename.find_last_of('R');
+  const size_t dot_pos = cce_data_filename.find_last_of('.');
   const std::string text_radius =
       cce_data_filename.substr(r_pos + 1, dot_pos - r_pos - 1);
   try {
@@ -100,7 +100,8 @@ SpecWorldtubeH5BufferUpdater::SpecWorldtubeH5BufferUpdater(
     ERROR(
         "The CCE filename must encode the extraction radius as an integer "
         "between the first instance of 'R' and the first instance of '.' (SpEC "
-        "CCE filename format).");
+        "CCE filename format). Provided filename : "
+        << cce_data_filename);
   }
   const auto& lapse_data = cce_data_file_.get<h5::Dat>("/Lapse");
   const auto data_table_dimensions = lapse_data.get_dimensions();
@@ -269,10 +270,10 @@ ReducedSpecWorldtubeH5BufferUpdater::ReducedSpecWorldtubeH5BufferUpdater(
       dataset_names_) = "DuRDividedByR";
 
   // We assume that the filename has the extraction radius encoded as an
-  // integer between the first occurrence of 'R' and the first occurrence of
+  // integer between the last occurrence of 'R' and the last occurrence of
   // '.'. This is the format provided by SpEC.
-  const size_t r_pos = cce_data_filename.find('R');
-  const size_t dot_pos = cce_data_filename.find('.');
+  const size_t r_pos = cce_data_filename.find_last_of('R');
+  const size_t dot_pos = cce_data_filename.find_last_of('.');
   const std::string text_radius =
       cce_data_filename.substr(r_pos + 1, dot_pos - r_pos - 1);
   try {
@@ -281,7 +282,8 @@ ReducedSpecWorldtubeH5BufferUpdater::ReducedSpecWorldtubeH5BufferUpdater(
     ERROR(
         "The CCE filename must encode the extraction radius as an integer "
         "between the first instance of 'R' and the first instance of '.' (SpEC "
-        "CCE filename format).");
+        "CCE filename format). Provided filename : "
+        << cce_data_filename);
   }
 
   const auto& lapse_data = cce_data_file_.get<h5::Dat>("/Lapse");


### PR DESCRIPTION
## Proposed changes

The find in the read boundary data utility currently searches for the extraction radius between the first 'R' and the first '.', but that causes problems with complete paths. Instead, this PR changes it to the last instance of each of those characters, which should fail only when the Cce file is a non-standard name.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
