### PR TITLE
Fix Newtonian Euler characteristics to allow 1d EOS's

### DIFF
--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -349,16 +349,15 @@ void test_initial_domain(const Domain<VolumeDim>& domain,
   domain::test_refinement_levels_of_neighbors<0>(elements);
 }
 
-template <size_t SpatialDim>
-tnsr::i<DataVector, SpatialDim, Frame::Inertial> euclidean_basis_vector(
+template <typename DataType, size_t SpatialDim>
+tnsr::i<DataType, SpatialDim> euclidean_basis_vector(
     const Direction<SpatialDim>& direction,
-    const DataVector& used_for_size) noexcept {
+    const DataType& used_for_size) noexcept {
   auto basis_vector =
-      make_with_value<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
-          used_for_size, 0.0);
+      make_with_value<tnsr::i<DataType, SpatialDim>>(used_for_size, 0.0);
 
   basis_vector.get(direction.axis()) =
-      make_with_value<DataVector>(used_for_size, direction.sign());
+      make_with_value<DataType>(used_for_size, direction.sign());
 
   return basis_vector;
 }
@@ -383,13 +382,22 @@ tnsr::i<DataVector, SpatialDim, Frame::Inertial> euclidean_basis_vector(
       const std::vector<std::array<size_t, DIM(data)>>&                     \
           initial_refinement_levels) noexcept;                              \
   template void test_physical_separation(                                   \
-      const std::vector<Block<DIM(data)>>& blocks) noexcept;                \
-  template tnsr::i<DataVector, DIM(data), Frame::Inertial>                  \
-  euclidean_basis_vector(const Direction<DIM(data)>& direction,             \
-                         const DataVector& used_for_size) noexcept;
+      const std::vector<Block<DIM(data)>>& blocks) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE_BASIS_VECTOR(_, data)                          \
+  template tnsr::i<DTYPE(data), DIM(data)> euclidean_basis_vector( \
+      const Direction<DIM(data)>& direction,                       \
+      const DTYPE(data) & used_for_size) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_BASIS_VECTOR, (1, 2, 3),
+                        (double, DataVector))
+
 #undef DIM
+#undef DTYPE
 #undef INSTANTIATE
+#undef INSTANTIATE_BASIS_VECTOR
 /// \endcond

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -65,7 +65,7 @@ void test_initial_domain(const Domain<VolumeDim>& domain,
 
 // Euclidean basis vector along the given `Direction` and in the given
 // `Frame::Inertial` frame.
-template <size_t SpatialDim>
-tnsr::i<DataVector, SpatialDim, Frame::Inertial> euclidean_basis_vector(
+template <typename DataType, size_t SpatialDim>
+tnsr::i<DataType, SpatialDim> euclidean_basis_vector(
     const Direction<SpatialDim>& direction,
-    const DataVector& used_for_size) noexcept;
+    const DataType& used_for_size) noexcept;

--- a/tests/Unit/Domain/Test_DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainTestHelpers.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <limits>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -15,26 +16,28 @@
 
 namespace {
 
-template <size_t SpatialDim>
-void test_euclidean_basis_vectors(const DataVector& used_for_size) noexcept {
+template <size_t SpatialDim, typename DataType>
+void test_euclidean_basis_vectors(const DataType& used_for_size) noexcept {
   for (const auto& direction : Direction<SpatialDim>::all_directions()) {
     auto expected =
-        make_with_value<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
-            used_for_size, 0.0);
+        make_with_value<tnsr::i<DataType, SpatialDim>>(used_for_size, 0.0);
     expected.get(direction.axis()) =
-        make_with_value<DataVector>(used_for_size, direction.sign());
+        make_with_value<DataType>(used_for_size, direction.sign());
 
-    CHECK_ITERABLE_APPROX(
-        (euclidean_basis_vector<SpatialDim>(direction, used_for_size)),
-        std::move(expected));
+    CHECK_ITERABLE_APPROX((euclidean_basis_vector(direction, used_for_size)),
+                          std::move(expected));
   }
 }
 
 }  //  namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.TestHelpers.BasisVector", "[Unit][Domain]") {
-  const DataVector dv(5);
+  const double d(std::numeric_limits<double>::signaling_NaN());
+  test_euclidean_basis_vectors<1>(d);
+  test_euclidean_basis_vectors<2>(d);
+  test_euclidean_basis_vectors<3>(d);
 
+  const DataVector dv(5);
   test_euclidean_basis_vectors<1>(dv);
   test_euclidean_basis_vectors<2>(dv);
   test_euclidean_basis_vectors<3>(dv);

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Characteristics.cpp
@@ -321,6 +321,17 @@ void test_right_and_left_eigenvectors() noexcept {
   const EquationsOfState::PolytropicFluid<false> polytropic_eos{100., 2.};
   test_left_and_right_eigenvectors_impl(
       density, velocity, specific_internal_energy, unit_normal, polytropic_eos);
+
+  // Test also in cases where unit normal is aligned to coordinate axes
+  for (const auto& direction : Direction<Dim>::all_directions()) {
+    const auto aligned = euclidean_basis_vector(direction, used_for_size);
+
+    test_left_and_right_eigenvectors_impl(
+        density, velocity, specific_internal_energy, aligned, ideal_gas_eos);
+
+    test_left_and_right_eigenvectors_impl(
+        density, velocity, specific_internal_energy, aligned, polytropic_eos);
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
## Proposed changes

The quantity `kappa_over_density` goes to zero for these equations of state. This commit changes the normalization of some of the eigenvectors that enter the characteristic transformation matrices to avoid dividing by this quantity.

The left and right eigenvector matrices only change to adjust the normalizations. The test changes more because I now check the matrices with both a Polytropic and an IdealFluid equation of state.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

