### PR TITLE
Add time dependences for domain creators

### DIFF
--- a/src/Domain/Creators/CMakeLists.txt
+++ b/src/Domain/Creators/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(TimeDependence)
+
 set(LIBRARY DomainCreators)
 
 set(LIBRARY_SOURCES

--- a/src/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/src/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY DomainTimeDependence)
 
 set(LIBRARY_SOURCES
+  None.cpp
   UniformTranslation.cpp
   )
 

--- a/src/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/src/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY DomainTimeDependence)
+
+set(LIBRARY_SOURCES
+  UniformTranslation.cpp
+  )
+
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE CoordinateMaps
+  INTERFACE DataStructures
+  INTERFACE Domain
+  INTERFACE ErrorHandling
+  INTERFACE FunctionsOfTime
+  INTERFACE Utilities
+  )

--- a/src/Domain/Creators/TimeDependence/Composition.hpp
+++ b/src/Domain/Creators/TimeDependence/Composition.hpp
@@ -1,0 +1,124 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Creators/TimeDependence/GenerateCoordinateMap.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+/*!
+ * \brief A tag used by the `Composition` class to generate a TimeDependence
+ * that is a composition of existing `TimeDependences`.
+ *
+ * The first template parameter is the existing TimeDependence while the
+ * `Suffix` parameter can be used by a composition that contains multiple of the
+ * same TimeDependence. This could occur for example when adding a rotation
+ * TimeDependence before and after a Translation since the two rotations would
+ * be rotating about a different center.
+ */
+template <typename TimeDep, size_t Suffix = std::numeric_limits<size_t>::max()>
+struct TimeDependenceCompositionTag {
+  static constexpr size_t mesh_dim = TimeDep::mesh_dim;
+  static std::string name() noexcept {
+    return pretty_type::short_name<TimeDep>() +
+           (Suffix == std::numeric_limits<size_t>::max()
+                ? std::string{}
+                : std::to_string(Suffix));
+  }
+  using type = std::unique_ptr<TimeDependence<TimeDep::mesh_dim>>;
+  static constexpr OptionString help = {"One of the maps in the composition."};
+  using time_dependence = TimeDep;
+};
+
+/*!
+ * \brief A TimeDependence that is a composition of various other
+ * TimeDependences.
+ *
+ * To create a new Composition TimeDependence you must create an explicit
+ * instantiation of the `Composition<Tags...>` TimeDependence in a `.cpp` file.
+ * You must add the `Composition` to the `creatable_classes` list of
+ * `TimeDependence` in order for the new Composition to be factory creatable.
+ *
+ * The tags in the template parameters must be `TimeDependenceCompositionTag`s.
+ * See the documentation of the `TimeDependenceCompositionTag` class for details
+ * on the tags.
+ */
+template <typename TimeDependenceCompTag0, typename... TimeDependenceCompTags>
+class Composition final
+    : public TimeDependence<TimeDependenceCompTag0::mesh_dim> {
+ private:
+  using CoordMap = detail::generate_coordinate_map_t<tmpl::flatten<
+      tmpl::list<typename TimeDependenceCompTag0::time_dependence::
+                     MapForComposition::maps_list,
+                 typename TimeDependenceCompTags::time_dependence::
+                     MapForComposition::maps_list...>>>;
+
+ public:
+  static constexpr size_t mesh_dim = TimeDependenceCompTag0::mesh_dim;
+
+  static_assert(
+      tmpl::all<
+          tmpl::integral_list<size_t, TimeDependenceCompTags::mesh_dim...>,
+          std::is_same<tmpl::integral_constant<size_t, mesh_dim>,
+                       tmpl::_1>>::value,
+      "All TimeDependences passed to Composition must be of the same "
+      "dimensionality.");
+
+  using options = tmpl::list<TimeDependenceCompTag0, TimeDependenceCompTags...>;
+
+  Composition() = default;
+  ~Composition() override = default;
+  Composition(const Composition&) = default;
+  Composition& operator=(const Composition&) = default;
+  Composition( Composition&&) = default;
+  Composition& operator=(Composition&&) = default;
+
+  explicit Composition(
+      tmpl::type_from<TimeDependenceCompTag0> first_time_dep,
+      tmpl::type_from<TimeDependenceCompTags>... rest_time_dep) noexcept;
+
+  /// Constructor for copying the composition time dependence. Internally
+  /// performs all the copying necessary to deal with the functions of time.
+  Composition(CoordMap coord_map,
+              const std::unordered_map<
+                  std::string,
+                  std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                  functions_of_time) noexcept;
+
+  auto get_clone() const noexcept
+      -> std::unique_ptr<TimeDependence<mesh_dim>> override;
+
+  auto block_maps(size_t number_of_blocks) const noexcept
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Grid, Frame::Inertial, mesh_dim>>> override;
+
+  auto functions_of_time() const noexcept -> std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
+
+ private:
+  CoordMap coord_map_;
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time_;
+};
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/TimeDependence/Composition.tpp
+++ b/src/Domain/Creators/TimeDependence/Composition.tpp
@@ -1,0 +1,140 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Domain/Creators/TimeDependence/Composition.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/CloneUniquePtrs.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+namespace detail {
+template <typename... MapsSoFar>
+auto combine_coord_maps(
+    CoordinateMap<Frame::Grid, Frame::Inertial, MapsSoFar...>
+        coord_map_so_far) noexcept {
+  return coord_map_so_far;
+}
+
+template <typename... MapsSoFar, typename... NextMaps, typename... RestMaps>
+auto combine_coord_maps(
+    CoordinateMap<Frame::Grid, Frame::Inertial, MapsSoFar...> coord_map_so_far,
+    CoordinateMap<Frame::Grid, Frame::Inertial, NextMaps...> next_map,
+    RestMaps... rest_maps) noexcept {
+  return combine_coord_maps(
+      domain::push_back(std::move(coord_map_so_far), std::move(next_map)),
+      std::move(rest_maps)...);
+}
+
+template <typename... Ts>
+std::unordered_map<std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+combine_functions_of_time(const std::vector<std::string>& time_dep_names,
+                          Ts... functions_of_time_pack) noexcept {
+  static_assert(sizeof...(Ts) > 0,
+                "Must have at least one set of function of times to combine. "
+                "We must have one "
+                "entry per TimeDependence being composed.");
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  size_t counter_into_dep_names = 0;
+
+  const auto insert_into_map = [&counter_into_dep_names, &functions_of_time,
+                                &time_dep_names](
+                                   std::unordered_map<
+                                       std::string,
+                                       std::unique_ptr<domain::FunctionsOfTime::
+                                                           FunctionOfTime>>&&
+                                       functions_of_time_single_map) noexcept {
+    for (auto& name_and_func : functions_of_time_single_map) {
+      if (UNLIKELY(functions_of_time.count(name_and_func.first) != 0)) {
+        ERROR("Inserting already known function '"
+              << name_and_func.first
+              << "' into composed functions of time. You must change the name "
+                 "of one the functions of time being composed. This is done as "
+                 "an option to the time dependence in the input file. The "
+                 "corresponding time dependence with the duplicate name is '"
+              << time_dep_names[counter_into_dep_names] << "'.");
+      }
+      functions_of_time.insert(std::move(name_and_func));
+    }
+    ++counter_into_dep_names;
+  };
+  (void)insert_into_map;  // Silence compiler warnings
+  EXPAND_PACK_LEFT_TO_RIGHT(insert_into_map(std::move(functions_of_time_pack)));
+  return functions_of_time;
+}
+}  // namespace detail
+
+template <typename TimeDependenceCompTag0, typename... TimeDependenceCompTags>
+Composition<TimeDependenceCompTag0, TimeDependenceCompTags...>::Composition(
+    tmpl::type_from<TimeDependenceCompTag0> first_time_dep,
+    tmpl::type_from<TimeDependenceCompTags>... rest_time_dep) noexcept
+    : coord_map_(detail::combine_coord_maps(
+          dynamic_cast<typename TimeDependenceCompTag0::time_dependence&>(
+              *first_time_dep)
+              .map_for_composition(),
+          dynamic_cast<typename TimeDependenceCompTags::time_dependence&>(
+              *rest_time_dep)
+              .map_for_composition()...)),
+      functions_of_time_(detail::combine_functions_of_time(
+          {db::tag_name<TimeDependenceCompTag0>(),
+           db::tag_name<TimeDependenceCompTags>()...},
+          std::move(first_time_dep->functions_of_time()),
+          std::move(rest_time_dep->functions_of_time())...)) {}
+
+template <typename TimeDependenceCompTag0, typename... TimeDependenceCompTags>
+Composition<TimeDependenceCompTag0, TimeDependenceCompTags...>::Composition(
+    CoordMap coord_map,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) noexcept
+    : coord_map_(std::move(coord_map)) {
+  functions_of_time_ = clone_unique_ptrs(functions_of_time);
+}
+
+template <typename TimeDependenceCompTag0, typename... TimeDependenceCompTags>
+auto Composition<TimeDependenceCompTag0, TimeDependenceCompTags...>::get_clone()
+    const noexcept -> std::unique_ptr<TimeDependence<mesh_dim>> {
+  return std::make_unique<Composition>(coord_map_, functions_of_time_);
+}
+
+template <typename TimeDependenceCompTag0, typename... TimeDependenceCompTags>
+auto Composition<TimeDependenceCompTag0, TimeDependenceCompTags...>::block_maps(
+    const size_t number_of_blocks) const noexcept
+    -> std::vector<std::unique_ptr<
+        domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, mesh_dim>>> {
+  std::vector<std::unique_ptr<
+      domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, mesh_dim>>>
+      result{number_of_blocks};
+  result[0] = std::make_unique<CoordMap>(coord_map_);
+  for (size_t i = 1; i < number_of_blocks; ++i) {
+    result[i] = result[0]->get_clone();
+  }
+  return result;
+}
+
+template <typename TimeDependenceCompTag0, typename... TimeDependenceCompTags>
+auto Composition<TimeDependenceCompTag0,
+                 TimeDependenceCompTags...>::functions_of_time() const noexcept
+    -> std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> {
+  return clone_unique_ptrs(functions_of_time_);
+}
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/TimeDependence/GenerateCoordinateMap.hpp
+++ b/src/Domain/Creators/TimeDependence/GenerateCoordinateMap.hpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain {
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+namespace Frame {
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+namespace detail {
+template <typename MapsList>
+struct generate_coordinate_map;
+
+template <typename... Maps>
+struct generate_coordinate_map<tmpl::list<Maps...>> {
+  using type = domain::CoordinateMap<Frame::Grid, Frame::Inertial, Maps...>;
+};
+
+template <typename MapsList>
+using generate_coordinate_map_t =
+    typename generate_coordinate_map<MapsList>::type;
+}  // namespace detail
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/TimeDependence/None.cpp
+++ b/src/Domain/Creators/TimeDependence/None.cpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependence/None.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+template <size_t MeshDim>
+std::unique_ptr<TimeDependence<MeshDim>> None<MeshDim>::get_clone() const
+    noexcept {
+  return std::make_unique<None>(*this);
+}
+
+template <size_t MeshDim>
+[[noreturn]] std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, MeshDim>>>
+None<MeshDim>::block_maps(const size_t /*number_of_blocks*/) const noexcept {
+  ERROR(
+      "The 'block_maps' function of the 'None' TimeDependence should never be "
+      "called because 'None' is only used as a place holder class to mark that "
+      "the mesh is time-independent.");
+}
+
+template <size_t MeshDim>
+[[noreturn]] std::unordered_map<
+    std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+None<MeshDim>::functions_of_time() const noexcept {
+  ERROR(
+      "The 'functions_of_time' function of the 'None' TimeDependence should "
+      "never be  called because 'None' is only used as a place holder class to "
+      "mark that the mesh is time-independent.");
+}
+
+template <size_t Dim>
+bool operator==(const None<Dim>& /*lhs*/, const None<Dim>& /*rhs*/) noexcept {
+  return true;
+}
+
+template <size_t Dim>
+bool operator!=(const None<Dim>& lhs, const None<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+/// \cond
+
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                          \
+  template class None<GET_DIM(data)>;                                   \
+  template bool operator==<GET_DIM(data)>(                              \
+      const None<GET_DIM(data)>&, const None<GET_DIM(data)>&) noexcept; \
+  template bool operator!=<GET_DIM(data)>(                              \
+      const None<GET_DIM(data)>&, const None<GET_DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef GET_DIM
+#undef INSTANTIATION
+/// \endcond
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/TimeDependence/None.hpp
+++ b/src/Domain/Creators/TimeDependence/None.hpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain {
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
+}  // namespace domain
+
+namespace Frame {
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+/// \brief Make the mesh time independent so that it isn't moving.
+///
+/// \warning Calling the `block_maps` and `functions_of_time` functions causes
+/// an error because the `None` class should be detected separately and
+/// optimizations applied so that the coordinates, Jacobians, etc. are not
+/// recomputed.
+template <size_t MeshDim>
+class None final : public TimeDependence<MeshDim> {
+ public:
+  using options = tmpl::list<>;
+
+  static constexpr OptionString help = {"No time dependence in the in grid."};
+
+  None() = default;
+  ~None() override = default;
+  None(const None&) = default;
+  None(None&&) noexcept = default;
+  None& operator=(const None&) = default;
+  None& operator=(None&&) noexcept = default;
+
+  auto get_clone() const noexcept
+      -> std::unique_ptr<TimeDependence<MeshDim>> override;
+
+  [[noreturn]] auto block_maps(size_t number_of_blocks) const noexcept
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Grid, Frame::Inertial, MeshDim>>> override;
+
+  [[noreturn]] auto functions_of_time() const noexcept -> std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
+};
+
+template <size_t Dim>
+bool operator==(const None<Dim>& lhs, const None<Dim>& rhs) noexcept;
+
+template <size_t Dim>
+bool operator!=(const None<Dim>& lhs, const None<Dim>& rhs) noexcept;
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/TimeDependence/TimeDependence.hpp
+++ b/src/Domain/Creators/TimeDependence/TimeDependence.hpp
@@ -1,0 +1,81 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain {
+template <typename SourceFrame, typename TargetFrame, size_t Dim>
+class CoordinateMapBase;
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
+}  // namespace domain
+namespace Frame {
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+template <size_t MeshDim>
+class UniformTranslation;
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain
+/// \endcond
+
+namespace domain {
+namespace creators {
+/// \ingroup ComputationalDomainGroup
+/// \brief Classes and functions for adding time dependence to a domain.
+namespace time_dependence {
+/// \brief The abstract base class off of which specific classes for adding
+/// time dependence into a domain creator must inherit off of.
+///
+/// The simplest examples of a `TimeDependence` are `None` and
+/// `UniformTranslation`. The `None` class is treated in a special manner to
+/// communicate to the code that the domain is time-independent.
+template <size_t MeshDim>
+struct TimeDependence {
+  using creatable_classes = tmpl::list<UniformTranslation<MeshDim>>;
+
+  TimeDependence() = default;
+  virtual ~TimeDependence() = 0;
+  TimeDependence(const TimeDependence&) = default;
+  TimeDependence& operator=(const TimeDependence&) = default;
+  TimeDependence(TimeDependence&&) = default;
+  TimeDependence& operator=(TimeDependence&&) = default;
+
+  /// Returns a `std::unique_ptr` pointing to a copy of the `TimeDependence`.
+  virtual auto get_clone() const noexcept
+      -> std::unique_ptr<TimeDependence> = 0;
+
+  /// Returns the coordinate maps from the `Frame::Grid` to the
+  /// `Frame::Inertial` frame for each block.
+  virtual auto block_maps(size_t number_of_blocks) const noexcept
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Grid, Frame::Inertial, MeshDim>>> = 0;
+
+  /// Returns the functions of time for the domain.
+  virtual auto functions_of_time() const noexcept -> std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> = 0;
+};
+
+template <size_t MeshDim>
+TimeDependence<MeshDim>::~TimeDependence() = default;
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain
+
+#include "Domain/Creators/TimeDependence/UniformTranslation.hpp"

--- a/src/Domain/Creators/TimeDependence/TimeDependence.hpp
+++ b/src/Domain/Creators/TimeDependence/TimeDependence.hpp
@@ -28,6 +28,8 @@ namespace domain {
 namespace creators {
 namespace time_dependence {
 template <size_t MeshDim>
+class None;
+template <size_t MeshDim>
 class UniformTranslation;
 }  // namespace time_dependence
 }  // namespace creators
@@ -47,7 +49,8 @@ namespace time_dependence {
 /// communicate to the code that the domain is time-independent.
 template <size_t MeshDim>
 struct TimeDependence {
-  using creatable_classes = tmpl::list<UniformTranslation<MeshDim>>;
+  using creatable_classes =
+      tmpl::list<None<MeshDim>, UniformTranslation<MeshDim>>;
 
   TimeDependence() = default;
   virtual ~TimeDependence() = 0;
@@ -78,4 +81,5 @@ TimeDependence<MeshDim>::~TimeDependence() = default;
 }  // namespace creators
 }  // namespace domain
 
+#include "Domain/Creators/TimeDependence/None.hpp"
 #include "Domain/Creators/TimeDependence/UniformTranslation.hpp"

--- a/src/Domain/Creators/TimeDependence/TimeDependence.hpp
+++ b/src/Domain/Creators/TimeDependence/TimeDependence.hpp
@@ -73,6 +73,11 @@ struct TimeDependence {
   virtual auto functions_of_time() const noexcept -> std::unordered_map<
       std::string,
       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> = 0;
+
+  /// Returns `true` if the instance is `None`, meaning no time dependence.
+  bool is_none() const noexcept {
+    return dynamic_cast<const None<MeshDim>*>(this) != nullptr;
+  }
 };
 
 template <size_t MeshDim>

--- a/src/Domain/Creators/TimeDependence/UniformTranslation.cpp
+++ b/src/Domain/Creators/TimeDependence/UniformTranslation.cpp
@@ -1,0 +1,173 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependence/UniformTranslation.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.hpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.tpp"
+#include "Domain/CoordinateMaps/Translation.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+namespace {
+std::array<std::string, 3> default_function_names_impl() noexcept {
+  return {{"TranslationX", "TranslationY", "TranslationZ"}};
+}
+}  // namespace
+
+template <size_t MeshDim>
+UniformTranslation<MeshDim>::UniformTranslation(
+    const double initial_time, const std::array<double, MeshDim>& velocity,
+    std::array<std::string, MeshDim> functions_of_time_names) noexcept
+    : initial_time_(initial_time),
+      velocity_(velocity),
+      functions_of_time_names_(std::move(functions_of_time_names)) {}
+
+template <size_t MeshDim>
+std::unique_ptr<TimeDependence<MeshDim>>
+UniformTranslation<MeshDim>::get_clone() const noexcept {
+  return std::make_unique<UniformTranslation>(initial_time_, velocity_,
+                                              functions_of_time_names_);
+}
+
+template <size_t MeshDim>
+std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, MeshDim>>>
+UniformTranslation<MeshDim>::block_maps(const size_t number_of_blocks) const
+    noexcept {
+  ASSERT(number_of_blocks > 0, "Must have at least one block to create.");
+  std::vector<std::unique_ptr<
+      domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, MeshDim>>>
+      result{number_of_blocks};
+  result[0] = std::make_unique<MapForComposition>(map_for_composition());
+  for (size_t i = 1; i < number_of_blocks; ++i) {
+    result[i] = result[0]->get_clone();
+  }
+  return result;
+}
+
+template <size_t MeshDim>
+std::unordered_map<std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+UniformTranslation<MeshDim>::functions_of_time() const noexcept {
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      result{};
+  // We use a `PiecewisePolynomial` with 2 derivs since some transformations
+  // between different frames for moving meshes can require Hessians.
+  result[functions_of_time_names_[0]] =
+      std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time_,
+          std::array<DataVector, 3>{{{0.0}, {velocity_[0]}, {0.0}}});
+  if (MeshDim > 1) {
+    result[gsl::at(functions_of_time_names_, 1)] =
+        std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
+            initial_time_,
+            std::array<DataVector, 3>{{{0.0}, {gsl::at(velocity_, 1)}, {0.0}}});
+  }
+  if (MeshDim > 2) {
+    result[gsl::at(functions_of_time_names_, 2)] =
+        std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
+            initial_time_,
+            std::array<DataVector, 3>{{{0.0}, {gsl::at(velocity_, 2)}, {0.0}}});
+  }
+  return result;
+}
+
+/// \cond
+template <>
+auto UniformTranslation<1>::map_for_composition() const noexcept
+    -> MapForComposition {
+  return MapForComposition{
+      domain::CoordMapsTimeDependent::Translation{functions_of_time_names_[0]}};
+}
+
+template <>
+auto UniformTranslation<2>::map_for_composition() const noexcept
+    -> MapForComposition {
+  using ProductMap =
+      domain::CoordMapsTimeDependent::ProductOf2Maps<Translation, Translation>;
+  return MapForComposition{
+      ProductMap{Translation{functions_of_time_names_[0]},
+                 Translation{functions_of_time_names_[1]}}};
+}
+
+template <>
+auto UniformTranslation<3>::map_for_composition() const noexcept
+    -> MapForComposition {
+  using ProductMap =
+      domain::CoordMapsTimeDependent::ProductOf3Maps<Translation, Translation,
+                                                     Translation>;
+  return MapForComposition{
+      ProductMap{Translation{functions_of_time_names_[0]},
+                 Translation{functions_of_time_names_[1]},
+                 Translation{functions_of_time_names_[2]}}};
+}
+
+template <>
+std::array<std::string, 1>
+UniformTranslation<1>::default_function_names() noexcept {
+  return {{default_function_names_impl()[0]}};
+}
+
+template <>
+std::array<std::string, 2>
+UniformTranslation<2>::default_function_names() noexcept {
+  return {{default_function_names_impl()[0], default_function_names_impl()[1]}};
+}
+
+template <>
+std::array<std::string, 3>
+UniformTranslation<3>::default_function_names() noexcept {
+  return default_function_names_impl();
+}
+
+template <size_t Dim>
+bool operator==(const UniformTranslation<Dim>& lhs,
+                const UniformTranslation<Dim>& rhs) noexcept {
+  return lhs.initial_time_ == rhs.initial_time_ and
+         lhs.velocity_ == rhs.velocity_ and
+         lhs.functions_of_time_names_ == rhs.functions_of_time_names_;
+}
+
+template <size_t Dim>
+bool operator!=(const UniformTranslation<Dim>& lhs,
+                const UniformTranslation<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                            \
+  template class UniformTranslation<GET_DIM(data)>;                       \
+  template bool operator==                                                \
+      <GET_DIM(data)>(const UniformTranslation<GET_DIM(data)>&,           \
+                      const UniformTranslation<GET_DIM(data)>&) noexcept; \
+  template bool operator!=                                                \
+      <GET_DIM(data)>(const UniformTranslation<GET_DIM(data)>&,           \
+                      const UniformTranslation<GET_DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef GET_DIM
+#undef INSTANTIATION
+/// \endcond
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/TimeDependence/UniformTranslation.hpp
+++ b/src/Domain/Creators/TimeDependence/UniformTranslation.hpp
@@ -1,0 +1,148 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Translation.hpp"
+#include "Domain/Creators/TimeDependence/GenerateCoordinateMap.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain {
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
+namespace CoordMapsTimeDependent {
+template <typename Map1, typename Map2, typename Map3>
+class ProductOf3Maps;
+template <typename Map1, typename Map2>
+class ProductOf2Maps;
+}  // namespace CoordMapsTimeDependent
+}  // namespace domain
+
+namespace Frame {
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+/*!
+ * \brief A uniform translation in the \f$x-, y-\f$ and \f$z-\f$direction.
+ *
+ * The coordinates are adjusted according to:
+ *
+ * \f{align}{
+ * x^i \to x^i + f^i(t)
+ * \f}
+ *
+ * where \f$f^i(t)\f$ are the functions of time.
+ */
+template <size_t MeshDim>
+class UniformTranslation final : public TimeDependence<MeshDim> {
+ private:
+  using Translation = domain::CoordMapsTimeDependent::Translation;
+
+ public:
+  static constexpr size_t mesh_dim = MeshDim;
+
+  /// \brief The initial time of the functions of time.
+  struct InitialTime {
+    using type = double;
+    static constexpr OptionString help = {
+        "The initial time of the functions of time"};
+  };
+  /// \brief The \f$x\f$-, \f$y\f$-, and \f$z\f$-velocity.
+  struct Velocity {
+    using type = std::array<double, MeshDim>;
+    static constexpr OptionString help = {"The velocity of the map."};
+  };
+  /// \brief The names of the functions of times to be added to the added to the
+  /// DataBox.
+  ///
+  /// The defaults are `"TranslationX", "TranslationY", "TranslationZ"`.
+  struct FunctionOfTimeNames {
+    using type = std::array<std::string, MeshDim>;
+    static constexpr OptionString help = {"Names of the functions of time."};
+    static type default_value() noexcept {
+      return UniformTranslation::default_function_names();
+    }
+  };
+
+  using MapForComposition =
+      detail::generate_coordinate_map_t<tmpl::list<tmpl::conditional_t<
+          MeshDim == 1, Translation,
+          tmpl::conditional_t<MeshDim == 2,
+                              domain::CoordMapsTimeDependent::ProductOf2Maps<
+                                  Translation, Translation>,
+                              domain::CoordMapsTimeDependent::ProductOf3Maps<
+                                  Translation, Translation, Translation>>>>>;
+
+  using options = tmpl::list<InitialTime, Velocity, FunctionOfTimeNames>;
+
+  static constexpr OptionString help = {
+      "A spatially uniform translation initialized with a constant velocity."};
+
+  UniformTranslation() = default;
+  ~UniformTranslation() override = default;
+  UniformTranslation(const UniformTranslation&) = delete;
+  UniformTranslation(UniformTranslation&&) noexcept = default;
+  UniformTranslation& operator=(const UniformTranslation&) = delete;
+  UniformTranslation& operator=(UniformTranslation&&) noexcept = default;
+
+  UniformTranslation(double initial_time,
+                     const std::array<double, MeshDim>& velocity,
+                     std::array<std::string, MeshDim> functions_of_time_names =
+                         default_function_names()) noexcept;
+
+  auto get_clone() const noexcept
+      -> std::unique_ptr<TimeDependence<MeshDim>> override;
+
+  auto block_maps(size_t number_of_blocks) const noexcept
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Grid, Frame::Inertial, MeshDim>>> override;
+
+  auto functions_of_time() const noexcept -> std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
+
+  /// Returns the map for each block to be used in a composition of
+  /// `TimeDependence`s.
+  MapForComposition map_for_composition() const noexcept;
+
+ private:
+  static std::array<std::string, MeshDim> default_function_names() noexcept;
+
+  template <size_t LocalDim>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const UniformTranslation<LocalDim>& lhs,
+                         const UniformTranslation<LocalDim>& rhs) noexcept;
+
+  double initial_time_{std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, MeshDim> velocity_{};
+  std::array<std::string, MeshDim> functions_of_time_names_{};
+};
+
+template <size_t Dim>
+bool operator==(const UniformTranslation<Dim>& lhs,
+                const UniformTranslation<Dim>& rhs) noexcept;
+
+template <size_t Dim>
+bool operator!=(const UniformTranslation<Dim>& lhs,
+                const UniformTranslation<Dim>& rhs) noexcept;
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain

--- a/src/Utilities/CloneUniquePtrs.hpp
+++ b/src/Utilities/CloneUniquePtrs.hpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+/// \ingroup UtilitiesGroup
+/// \brief Given a map of `std::unique_ptr` returns a copy of the map by
+/// invoking `get_clone()` on each element of the input map.
+template <typename KeyType, typename T>
+std::unordered_map<KeyType, std::unique_ptr<T>> clone_unique_ptrs(
+    const std::unordered_map<KeyType, std::unique_ptr<T>>& map) noexcept {
+  std::unordered_map<KeyType, std::unique_ptr<T>> result{};
+  for (const auto& kv : map) {
+    result[kv.first] = kv.second->get_clone();
+  }
+  return result;
+}
+
+/// \ingroup UtilitiesGroup
+/// \brief Given a vector of `std::unique_ptr` returns a copy of the vector by
+/// invoking `get_clone()` on each element of the input vector.
+template <typename T>
+std::vector<std::unique_ptr<T>> clone_unique_ptrs(
+    const std::vector<std::unique_ptr<T>>& vector) noexcept {
+  std::vector<std::unique_ptr<T>> result{vector.size()};
+  for (size_t i = 0; i < vector.size(); ++i) {
+    result[i] = vector[i]->get_clone();
+  }
+  return result;
+}

--- a/tests/Unit/Domain/Creators/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(TimeDependence)
+
 set(LIBRARY "Test_DomainCreators")
 
 set(LIBRARY_SOURCES

--- a/tests/Unit/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_DomainTimeDependence")
 
 set(LIBRARY_SOURCES
   Test_Composition.cpp
+  Test_None.cpp
   Test_UniformTranslation.cpp
   )
 

--- a/tests/Unit/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_DomainTimeDependence")
 
 set(LIBRARY_SOURCES
+  Test_Composition.cpp
   Test_UniformTranslation.cpp
   )
 

--- a/tests/Unit/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_DomainTimeDependence")
+
+set(LIBRARY_SOURCES
+  Test_UniformTranslation.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Domain/Creators/TimeDependence"
+  "${LIBRARY_SOURCES}"
+  "DomainTimeDependence;TestUtilities;Test_Domain"
+  )

--- a/tests/Unit/Domain/Creators/TimeDependence/TestHelpers.hpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/TestHelpers.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <random>
+
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+/*!
+ * \brief Generates random coordinates of double and DataVector types.
+ *
+ * Creates:
+ * - `std::uniform_real_distribution<double>` named `dist` on interval
+ *   `LOWER_BOUND` and `UPPER_BOUND`
+ * - `grid_coords_dv` of type `tnsr::I<DataVector, DIM, Frame::Grid>`
+ * - `grid_coords_double` of type `tnsr::I<double, DIMN, Frame::Grid>`
+ * - `inertial_coords_dv` of type `tnsr::I<DataVector, DIM, Frame::Inertial>`
+ * - `inertial_coords_double` of type `tnsr::I<double, DIMN, Frame::Inertial>`
+ *
+ * The argument `GENERATOR` must be a `gsl::not_null` to a random number
+ * generator. Typically the generator would be created using the
+ * `MAKE_GENERATOR` macro.
+ */
+#define TIME_DEPENDENCE_GENERATE_COORDS(GENERATOR, DIM, LOWER_BOUND,      \
+                                        UPPER_BOUND)                      \
+  std::uniform_real_distribution<double> dist{LOWER_BOUND, UPPER_BOUND};  \
+  const auto grid_coords_dv =                                             \
+      make_with_random_values<tnsr::I<DataVector, DIM, Frame::Grid>>(     \
+          GENERATOR, make_not_null(&dist), DataVector{5});                \
+  const auto grid_coords_double =                                         \
+      make_with_random_values<tnsr::I<double, DIM, Frame::Grid>>(         \
+          GENERATOR, make_not_null(&dist));                               \
+  const auto inertial_coords_dv =                                         \
+      make_with_random_values<tnsr::I<DataVector, DIM, Frame::Inertial>>( \
+          GENERATOR, make_not_null(&dist), DataVector{5});                \
+  const auto inertial_coords_double =                                     \
+      make_with_random_values<tnsr::I<double, DIM, Frame::Inertial>>(     \
+          GENERATOR, make_not_null(&dist))

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_Composition.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_Composition.cpp
@@ -1,0 +1,238 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <random>
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.hpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.tpp"
+#include "Domain/CoordinateMaps/Translation.hpp"
+#include "Domain/Creators/TimeDependence/Composition.hpp"
+#include "Domain/Creators/TimeDependence/Composition.tpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Domain/Creators/TimeDependence/UniformTranslation.hpp"
+#include "tests/Unit/Domain/Creators/TimeDependence/TestHelpers.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+
+namespace {
+using Translation = domain::CoordMapsTimeDependent::Translation;
+
+template <typename T0, size_t MeshDim>
+void test_impl(
+    const gsl::not_null<T0> gen, const double initial_time,
+    const std::unique_ptr<
+        domain::creators::time_dependence::TimeDependence<MeshDim>>& time_dep,
+    const std::unique_ptr<
+        domain::creators::time_dependence::TimeDependence<MeshDim>>&
+        expected_time_dep,
+    const std::vector<std::string>& expected_f_of_t_names) noexcept {
+  // Test coordinate maps
+  UniformCustomDistribution<size_t> dist_size_t{1, 10};
+  const size_t num_blocks = dist_size_t(*gen);
+  CAPTURE(num_blocks);
+
+  const auto functions_of_time = time_dep->functions_of_time();
+  REQUIRE(functions_of_time.size() == expected_f_of_t_names.size());
+  for (const auto& f_of_t_name : expected_f_of_t_names) {
+    CHECK(functions_of_time.count(f_of_t_name) == 1);
+  }
+
+  const auto functions_of_time_for_expected =
+      expected_time_dep->functions_of_time();
+
+  // For a random point at a random time check that the values agree. This is to
+  // check that the internals were assigned the correct function of times.
+  TIME_DEPENDENCE_GENERATE_COORDS(gen, MeshDim, -1.0, 1.0);
+
+  const auto block_maps = time_dep->block_maps(num_blocks);
+  const auto expected_block_maps = expected_time_dep->block_maps(num_blocks);
+  REQUIRE(block_maps.size() == expected_block_maps.size());
+
+  for (size_t i = 0; i < block_maps.size(); ++i) {
+    const double time_offset = dist(*gen) + 1.2;
+    CHECK_ITERABLE_APPROX(
+        expected_block_maps[i]->operator()(grid_coords_dv,
+                                           initial_time + time_offset,
+                                           functions_of_time_for_expected),
+        block_maps[i]->operator()(grid_coords_dv, initial_time + time_offset,
+                                  functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_maps[i]->operator()(grid_coords_double,
+                                           initial_time + time_offset,
+                                           functions_of_time_for_expected),
+        block_maps[i]->operator()(
+            grid_coords_double, initial_time + time_offset, functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_maps[i]
+            ->inverse(inertial_coords_double, initial_time + time_offset,
+                      functions_of_time_for_expected)
+            .value(),
+        block_maps[i]
+            ->inverse(inertial_coords_double, initial_time + time_offset,
+                      functions_of_time)
+            .value());
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_maps[i]->inv_jacobian(grid_coords_dv,
+                                             initial_time + time_offset,
+                                             functions_of_time_for_expected),
+        block_maps[i]->inv_jacobian(grid_coords_dv, initial_time + time_offset,
+                                    functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_maps[i]->inv_jacobian(grid_coords_double,
+                                             initial_time + time_offset,
+                                             functions_of_time_for_expected),
+        block_maps[i]->inv_jacobian(
+            grid_coords_double, initial_time + time_offset, functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_maps[i]->jacobian(grid_coords_dv,
+                                         initial_time + time_offset,
+                                         functions_of_time_for_expected),
+        block_maps[i]->jacobian(grid_coords_dv, initial_time + time_offset,
+                                functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_maps[i]->jacobian(grid_coords_double,
+                                         initial_time + time_offset,
+                                         functions_of_time_for_expected),
+        block_maps[i]->jacobian(grid_coords_double, initial_time + time_offset,
+                                functions_of_time));
+  }
+}
+
+template <typename T>
+void test_composition_1d(const gsl::not_null<T> gen,
+                         const double initial_time) noexcept {
+  using Composition1d =
+      Composition<TimeDependenceCompositionTag<UniformTranslation<1>>,
+                  TimeDependenceCompositionTag<UniformTranslation<1>, 1>>;
+
+  const std::array<double, 1> velocity0{{2.4}};
+  const std::array<double, 1> velocity1{{-1.4}};
+  const std::array<std::string, 1> f_of_t_names0{{"TranslationInX0"}};
+  const std::array<std::string, 1> f_of_t_names1{{"TranslationInX1"}};
+
+  std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
+      time_dep0 = std::make_unique<UniformTranslation<1>>(
+          initial_time, velocity0, f_of_t_names0);
+  std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
+      time_dep1 = std::make_unique<UniformTranslation<1>>(
+          initial_time, velocity1, f_of_t_names1);
+
+  const std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
+      expected_time_dep = std::make_unique<UniformTranslation<1>>(
+          initial_time, velocity0 + velocity1,
+          std::array<std::string, 1>{{"TranslationX"}});
+
+  const std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
+      time_dep = std::make_unique<Composition1d>(std::move(time_dep0),
+                                                 std::move(time_dep1));
+
+  test_impl(gen, initial_time, time_dep, expected_time_dep,
+            {f_of_t_names0[0], f_of_t_names1[0]});
+
+  test_impl(gen, initial_time, time_dep->get_clone(), expected_time_dep,
+            {f_of_t_names0[0], f_of_t_names1[0]});
+}
+
+template <typename T>
+void test_composition_2d(const gsl::not_null<T> gen,
+                         const double initial_time) noexcept {
+  using Composition2d =
+      Composition<TimeDependenceCompositionTag<UniformTranslation<2>>,
+                  TimeDependenceCompositionTag<UniformTranslation<2>, 1>>;
+
+  const std::array<double, 2> velocity0{{2.4, -7.3}};
+  const std::array<double, 2> velocity1{{-1.4, 3.2}};
+  const std::array<std::string, 2> f_of_t_names0{
+      {"TranslationInX0", "TranslationInY0"}};
+  const std::array<std::string, 2> f_of_t_names1{
+      {"TranslationInX1", "TranslationInY1"}};
+
+  std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
+      time_dep0 = std::make_unique<UniformTranslation<2>>(
+          initial_time, velocity0, f_of_t_names0);
+  std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
+      time_dep1 = std::make_unique<UniformTranslation<2>>(
+          initial_time, velocity1, f_of_t_names1);
+
+  const std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
+      expected_time_dep = std::make_unique<UniformTranslation<2>>(
+          initial_time, velocity0 + velocity1,
+          std::array<std::string, 2>{{"TranslationX", "TranslationY"}});
+
+  const std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
+      time_dep = std::make_unique<Composition2d>(std::move(time_dep0),
+                                                 std::move(time_dep1));
+
+  test_impl(
+      gen, initial_time, time_dep, expected_time_dep,
+      {f_of_t_names0[0], f_of_t_names1[0], f_of_t_names0[1], f_of_t_names1[1]});
+
+  test_impl(
+      gen, initial_time, time_dep->get_clone(), expected_time_dep,
+      {f_of_t_names0[0], f_of_t_names1[0], f_of_t_names0[1], f_of_t_names1[1]});
+}
+
+template <typename T>
+void test_composition_3d(const gsl::not_null<T> gen,
+                         const double initial_time) noexcept {
+  using Composition3d =
+      Composition<TimeDependenceCompositionTag<UniformTranslation<3>>,
+                  TimeDependenceCompositionTag<UniformTranslation<3>, 1>>;
+
+  const std::array<double, 3> velocity0{{2.4, -7.3, 5.7}};
+  const std::array<double, 3> velocity1{{-1.4, 3.2, -1.9}};
+  const std::array<std::string, 3> f_of_t_names0{
+      {"TranslationInX0", "TranslationInY0", "TranslationInZ0"}};
+  const std::array<std::string, 3> f_of_t_names1{
+      {"TranslationInX1", "TranslationInY1", "TranslationInZ1"}};
+
+  std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+      time_dep0 = std::make_unique<UniformTranslation<3>>(
+          initial_time, velocity0, f_of_t_names0);
+  std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+      time_dep1 = std::make_unique<UniformTranslation<3>>(
+          initial_time, velocity1, f_of_t_names1);
+
+  const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+      expected_time_dep = std::make_unique<UniformTranslation<3>>(
+          initial_time, velocity0 + velocity1,
+          std::array<std::string, 3>{
+              {"TranslationX", "TranslationY", "TranslationZ"}});
+
+  const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+      time_dep = std::make_unique<Composition3d>(std::move(time_dep0),
+                                                 std::move(time_dep1));
+
+  test_impl(gen, initial_time, time_dep, expected_time_dep,
+            {f_of_t_names0[0], f_of_t_names1[0], f_of_t_names0[1],
+             f_of_t_names1[1], f_of_t_names0[2], f_of_t_names1[2]});
+
+  test_impl(gen, initial_time, time_dep->get_clone(), expected_time_dep,
+            {f_of_t_names0[0], f_of_t_names1[0], f_of_t_names0[1],
+             f_of_t_names1[1], f_of_t_names0[2], f_of_t_names1[2]});
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.Composition",
+                  "[Domain][Unit]") {
+  MAKE_GENERATOR(gen);
+  const double initial_time = 1.3;
+  test_composition_1d(make_not_null(&gen), initial_time);
+  test_composition_2d(make_not_null(&gen), initial_time);
+  test_composition_3d(make_not_null(&gen), initial_time);
+}
+}  // namespace
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_Composition.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_Composition.cpp
@@ -40,6 +40,8 @@ void test_impl(
   const size_t num_blocks = dist_size_t(*gen);
   CAPTURE(num_blocks);
 
+  CHECK_FALSE(time_dep->is_none());
+
   const auto functions_of_time = time_dep->functions_of_time();
   REQUIRE(functions_of_time.size() == expected_f_of_t_names.size());
   for (const auto& f_of_t_name : expected_f_of_t_names) {

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_None.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_None.cpp
@@ -1,0 +1,107 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "Domain/Creators/TimeDependence/None.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+
+namespace {
+
+template <size_t MeshDim>
+void test() noexcept {
+  const std::unique_ptr<TimeDependence<MeshDim>> time_dep =
+      std::make_unique<None<MeshDim>>();
+  CHECK(time_dep != nullptr);
+
+  const std::unique_ptr<TimeDependence<MeshDim>> time_dep_clone =
+      time_dep->get_clone();
+  CHECK(time_dep_clone != nullptr);
+
+  const std::unique_ptr<TimeDependence<MeshDim>> time_dep_factory =
+      TestHelpers::test_factory_creation<TimeDependence<MeshDim>>("None\n");
+  CHECK(time_dep_factory != nullptr);
+
+  CHECK(None<MeshDim>{} == None<MeshDim>{});
+  CHECK_FALSE(None<MeshDim>{} != None<MeshDim>{});
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.None",
+                  "[Domain][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}
+
+template <size_t MeshDim>
+void test_error_block_maps() noexcept {
+  const std::unique_ptr<TimeDependence<MeshDim>> time_dep =
+      std::make_unique<None<MeshDim>>();
+  (void)time_dep->block_maps(5);
+}
+
+template <size_t MeshDim>
+void test_error_functions_of_time() noexcept {
+  const std::unique_ptr<TimeDependence<MeshDim>> time_dep =
+      std::make_unique<None<MeshDim>>();
+  (void)time_dep->functions_of_time();
+}
+
+// [[OutputRegex, The 'block_maps' function of the 'None']]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.Creators.TimeDependence.None.ErrorBlockMaps",
+    "[Domain][Unit]") {
+  ERROR_TEST();
+
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> dist_size_t{1, 3};
+  const size_t mesh_dim = dist_size_t(gen);
+
+  if (mesh_dim == 1) {
+    test_error_block_maps<1>();
+  } else if (mesh_dim == 2) {
+    test_error_block_maps<2>();
+  } else if (mesh_dim == 3) {
+    test_error_block_maps<3>();
+  }
+  ERROR("Bad MeshDim in test: " << mesh_dim);
+}
+
+// [[OutputRegex, The 'functions_of_time' function of the 'None']]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.Creators.TimeDependence.None.ErrorFunctionsOfTime",
+    "[Domain][Unit]") {
+  ERROR_TEST();
+  MAKE_GENERATOR(gen);
+
+  UniformCustomDistribution<size_t> dist_size_t{1, 3};
+  const size_t mesh_dim = dist_size_t(gen);
+
+  if (mesh_dim == 1) {
+    test_error_functions_of_time<1>();
+  } else if (mesh_dim == 2) {
+    test_error_functions_of_time<2>();
+  } else if (mesh_dim == 3) {
+    test_error_functions_of_time<3>();
+  }
+  ERROR("Bad MeshDim in test: " << mesh_dim);
+}
+
+}  // namespace
+
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_None.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_None.cpp
@@ -26,6 +26,7 @@ void test() noexcept {
   const std::unique_ptr<TimeDependence<MeshDim>> time_dep =
       std::make_unique<None<MeshDim>>();
   CHECK(time_dep != nullptr);
+  CHECK(time_dep->is_none());
 
   const std::unique_ptr<TimeDependence<MeshDim>> time_dep_clone =
       time_dep->get_clone();

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_UniformTranslation.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_UniformTranslation.cpp
@@ -1,0 +1,346 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.hpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.tpp"
+#include "Domain/CoordinateMaps/Translation.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Domain/Creators/TimeDependence/UniformTranslation.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/Domain/Creators/TimeDependence/TestHelpers.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+
+namespace {
+using Translation = domain::CoordMapsTimeDependent::Translation;
+
+template <size_t MeshDim>
+using ConcreteMap = tmpl::conditional_t<
+    MeshDim == 1,
+    domain::CoordinateMap<Frame::Grid, Frame::Inertial, Translation>,
+    tmpl::conditional_t<
+        MeshDim == 2,
+        domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                              domain::CoordMapsTimeDependent::ProductOf2Maps<
+                                  Translation, Translation>>,
+        domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                              domain::CoordMapsTimeDependent::ProductOf3Maps<
+                                  Translation, Translation, Translation>>>>;
+
+template <size_t MeshDim>
+ConcreteMap<MeshDim> create_coord_map(
+    const std::array<std::string, MeshDim>& f_of_t_names);
+
+template <>
+ConcreteMap<1> create_coord_map(
+    const std::array<std::string, 1>& f_of_t_names) {
+  return ConcreteMap<1>{Translation{f_of_t_names[0]}};
+}
+
+template <>
+ConcreteMap<2> create_coord_map(
+    const std::array<std::string, 2>& f_of_t_names) {
+  return ConcreteMap<2>{
+      {Translation{f_of_t_names[0]}, Translation{f_of_t_names[1]}}};
+}
+
+template <>
+ConcreteMap<3> create_coord_map(
+    const std::array<std::string, 3>& f_of_t_names) {
+  return ConcreteMap<3>{{Translation{f_of_t_names[0]},
+                         Translation{f_of_t_names[1]},
+                         Translation{f_of_t_names[2]}}};
+}
+
+template <size_t MeshDim>
+void test(const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr,
+          const double initial_time,
+          const std::array<std::string, MeshDim>& f_of_t_names) noexcept {
+  MAKE_GENERATOR(gen);
+  CAPTURE(initial_time);
+  CAPTURE(f_of_t_names);
+
+  // We downcast to the expected derived class to make sure that factory
+  // creation worked correctly. In order to maximize code reuse this check is
+  // done here as opposed to separately elsewhere.
+  const auto* const time_dep = dynamic_cast<const UniformTranslation<MeshDim>*>(
+      time_dep_unique_ptr.get());
+  REQUIRE(time_dep != nullptr);
+
+  // Test coordinate maps
+  UniformCustomDistribution<size_t> dist_size_t{1, 10};
+  const size_t num_blocks = dist_size_t(gen);
+  CAPTURE(num_blocks);
+
+  const auto expected_block_map = create_coord_map(f_of_t_names);
+
+  const auto block_maps = time_dep_unique_ptr->block_maps(num_blocks);
+  for (const auto& block_map_unique_ptr : block_maps) {
+    const auto* const block_map =
+        dynamic_cast<const ConcreteMap<MeshDim>*>(block_map_unique_ptr.get());
+    REQUIRE(block_map != nullptr);
+    CHECK(*block_map == expected_block_map);
+  }
+
+  // Test functions of time
+  const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
+  REQUIRE(functions_of_time.size() == f_of_t_names.size());
+  for (const auto& f_of_t_name : f_of_t_names) {
+    CHECK(functions_of_time.count(f_of_t_name) == 1);
+  }
+
+  // Test map for composition
+  CHECK(time_dep->map_for_composition() == expected_block_map);
+
+  // For a random point at a random time check that the values agree. This is to
+  // check that the internals were assigned the correct function of times.
+  TIME_DEPENDENCE_GENERATE_COORDS(make_not_null(&gen), MeshDim, -1.0, 1.0);
+
+  for (const auto& block_map : block_maps) {
+    // We've checked equivalence above
+    // (CHECK(*black_map == expected_block_map);), but have sometimes been
+    // burned by incorrect operator== implementations so we check that the
+    // mappings behave as expected.
+    const double time_offset = dist(gen) + 1.2;
+    CHECK_ITERABLE_APPROX(
+        expected_block_map(grid_coords_dv, initial_time + time_offset,
+                           functions_of_time),
+        (*block_map)(grid_coords_dv, initial_time + time_offset,
+                     functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map(grid_coords_double, initial_time + time_offset,
+                           functions_of_time),
+        (*block_map)(grid_coords_double, initial_time + time_offset,
+                     functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        *expected_block_map.inverse(inertial_coords_double,
+                                    initial_time + time_offset,
+                                    functions_of_time),
+        *block_map->inverse(inertial_coords_double, initial_time + time_offset,
+                            functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.inv_jacobian(
+            grid_coords_dv, initial_time + time_offset, functions_of_time),
+        block_map->inv_jacobian(grid_coords_dv, initial_time + time_offset,
+                                functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.inv_jacobian(
+            grid_coords_double, initial_time + time_offset, functions_of_time),
+        block_map->inv_jacobian(grid_coords_double, initial_time + time_offset,
+                                functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.jacobian(grid_coords_dv, initial_time + time_offset,
+                                    functions_of_time),
+        block_map->jacobian(grid_coords_dv, initial_time + time_offset,
+                            functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.jacobian(
+            grid_coords_double, initial_time + time_offset, functions_of_time),
+        block_map->jacobian(grid_coords_double, initial_time + time_offset,
+                            functions_of_time));
+  }
+}
+
+void test_equivalence() noexcept {
+  {
+    UniformTranslation<1> ut0{1.0, {{2.0}}, {{"TranslationX"}}};
+    UniformTranslation<1> ut1{1.2, {{2.0}}, {{"TranslationX"}}};
+    UniformTranslation<1> ut2{1.0, {{3.0}}, {{"TranslationX"}}};
+    UniformTranslation<1> ut3{1.0, {{2.0}}, {{"TranslationY"}}};
+    CHECK(ut0 == ut0);
+    CHECK_FALSE(ut0 != ut0);
+    CHECK(ut0 != ut1);
+    CHECK_FALSE(ut0 == ut1);
+    CHECK(ut0 != ut2);
+    CHECK_FALSE(ut0 == ut2);
+    CHECK(ut0 != ut3);
+    CHECK_FALSE(ut0 == ut3);
+  }
+  {
+    UniformTranslation<3> ut0{
+        1.0, {{2.0, 4.0}}, {{"TranslationX", "TranslationY"}}};
+    UniformTranslation<3> ut1{
+        1.2, {{2.0, 4.0}}, {{"TranslationX", "TranslationY"}}};
+    UniformTranslation<3> ut2{
+        1.0, {{3.0, 4.0}}, {{"TranslationX", "TranslationY"}}};
+    UniformTranslation<3> ut3{
+        1.0, {{2.0, 5.0}}, {{"TranslationX", "TranslationY"}}};
+    UniformTranslation<3> ut4{
+        1.0, {{2.0, 4.0}}, {{"TranslationZ", "TranslationY"}}};
+    UniformTranslation<3> ut5{
+        1.0, {{2.0, 4.0}}, {{"TranslationX", "TranslationZ"}}};
+    CHECK(ut0 == ut0);
+    CHECK_FALSE(ut0 != ut0);
+    CHECK(ut0 != ut1);
+    CHECK_FALSE(ut0 == ut1);
+    CHECK(ut0 != ut2);
+    CHECK_FALSE(ut0 == ut2);
+    CHECK(ut0 != ut3);
+    CHECK_FALSE(ut0 == ut3);
+    CHECK(ut0 != ut4);
+    CHECK_FALSE(ut0 == ut4);
+    CHECK(ut0 != ut5);
+    CHECK_FALSE(ut0 == ut5);
+  }
+  {
+    UniformTranslation<3> ut0{
+        1.0,
+        {{2.0, 4.0, 6.0}},
+        {{"TranslationX", "TranslationY", "TranslationZ"}}};
+    UniformTranslation<3> ut1{
+        1.2,
+        {{2.0, 4.0, 6.0}},
+        {{"TranslationX", "TranslationY", "TranslationZ"}}};
+    UniformTranslation<3> ut2{
+        1.0,
+        {{3.0, 4.0, 6.0}},
+        {{"TranslationX", "TranslationY", "TranslationZ"}}};
+    UniformTranslation<3> ut3{
+        1.0,
+        {{2.0, 5.0, 6.0}},
+        {{"TranslationX", "TranslationY", "TranslationZ"}}};
+    UniformTranslation<3> ut4{
+        1.0,
+        {{2.0, 4.0, 7.0}},
+        {{"TranslationX", "TranslationY", "TranslationZ"}}};
+    UniformTranslation<3> ut5{
+        1.0,
+        {{2.0, 4.0, 6.0}},
+        {{"TranslationW", "TranslationY", "TranslationZ"}}};
+    UniformTranslation<3> ut6{
+        1.0,
+        {{2.0, 4.0, 6.0}},
+        {{"TranslationX", "TranslationW", "TranslationZ"}}};
+    UniformTranslation<3> ut7{
+        1.0,
+        {{2.0, 4.0, 6.0}},
+        {{"TranslationX", "TranslationY", "TranslationW"}}};
+    CHECK(ut0 == ut0);
+    CHECK_FALSE(ut0 != ut0);
+    CHECK(ut0 != ut1);
+    CHECK_FALSE(ut0 == ut1);
+    CHECK(ut0 != ut2);
+    CHECK_FALSE(ut0 == ut2);
+    CHECK(ut0 != ut3);
+    CHECK_FALSE(ut0 == ut3);
+    CHECK(ut0 != ut4);
+    CHECK_FALSE(ut0 == ut4);
+    CHECK(ut0 != ut5);
+    CHECK_FALSE(ut0 == ut5);
+    CHECK(ut0 != ut6);
+    CHECK_FALSE(ut0 == ut6);
+    CHECK(ut0 != ut7);
+    CHECK_FALSE(ut0 == ut7);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.UniformTranslation",
+                  "[Domain][Unit]") {
+  const double initial_time = 1.3;
+
+  {
+    // 1d
+    const std::array<double, 1> velocity{{2.4}};
+    const std::array<std::string, 1> f_of_t_names{{"TranslationInX"}};
+    const std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
+        time_dep = std::make_unique<UniformTranslation<1>>(
+            initial_time, velocity, f_of_t_names);
+    test(time_dep, initial_time, f_of_t_names);
+    test(time_dep->get_clone(), initial_time, f_of_t_names);
+
+    test(TestHelpers::test_factory_creation<TimeDependence<1>>(
+             "UniformTranslation:\n"
+             "  InitialTime: 1.3\n"
+             "  Velocity: [2.4]\n"
+             "  FunctionOfTimeNames: [TranslationInX]\n"),
+         initial_time, f_of_t_names);
+
+    test(TestHelpers::test_factory_creation<TimeDependence<1>>(
+             "UniformTranslation:\n"
+             "  InitialTime: 1.3\n"
+             "  Velocity: [2.4]\n"),
+         initial_time, {{"TranslationX"}});
+  }
+
+  {
+    // 2d
+    const std::array<double, 2> velocity{{2.4, 3.1}};
+    const std::array<std::string, 2> f_of_t_names{
+        {"TranslationInX", "TranslationInY"}};
+    const std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
+        time_dep = std::make_unique<UniformTranslation<2>>(
+            initial_time, velocity, f_of_t_names);
+    test(time_dep, initial_time, f_of_t_names);
+    test(time_dep->get_clone(), initial_time, f_of_t_names);
+
+    test(TestHelpers::test_factory_creation<TimeDependence<2>>(
+             "UniformTranslation:\n"
+             "  InitialTime: 1.3\n"
+             "  Velocity: [2.4, 3.1]\n"
+             "  FunctionOfTimeNames: [TranslationInX, TranslationInY]\n"),
+         initial_time, f_of_t_names);
+
+    test(TestHelpers::test_factory_creation<TimeDependence<2>>(
+             "UniformTranslation:\n"
+             "  InitialTime: 1.3\n"
+             "  Velocity: [2.4, 3.1]\n"),
+         initial_time, {{"TranslationX", "TranslationY"}});
+  }
+
+  {
+    // 3d
+    const std::array<double, 3> velocity{{2.4, 3.1, -1.2}};
+    const std::array<std::string, 3> f_of_t_names{
+        {"TranslationInX", "TranslationInY", "TranslationInZ"}};
+    const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+        time_dep = std::make_unique<UniformTranslation<3>>(
+            initial_time, velocity, f_of_t_names);
+    test(time_dep, initial_time, f_of_t_names);
+    test(time_dep->get_clone(), initial_time, f_of_t_names);
+
+    test(TestHelpers::test_factory_creation<TimeDependence<3>>(
+             "UniformTranslation:\n"
+             "  InitialTime: 1.3\n"
+             "  Velocity: [2.4, 3.1, -1.2]\n"
+             "  FunctionOfTimeNames: [TranslationInX, TranslationInY, "
+             "TranslationInZ]\n"),
+         initial_time, f_of_t_names);
+
+    test(TestHelpers::test_factory_creation<TimeDependence<3>>(
+             "UniformTranslation:\n"
+             "  InitialTime: 1.3\n"
+             "  Velocity: [2.4, 3.1, -1.2]\n"),
+         initial_time, {{"TranslationX", "TranslationY", "TranslationZ"}});
+  }
+
+  test_equivalence();
+}
+}  // namespace
+
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_UniformTranslation.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_UniformTranslation.cpp
@@ -81,6 +81,8 @@ void test(const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr,
   CAPTURE(initial_time);
   CAPTURE(f_of_t_names);
 
+  CHECK_FALSE(time_dep_unique_ptr->is_none());
+
   // We downcast to the expected derived class to make sure that factory
   // creation worked correctly. In order to maximize code reuse this check is
   // done here as opposed to separately elsewhere.

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_Blas.cpp
   Test_BoostHelpers.cpp
   Test_CachedFunction.cpp
+  Test_CloneUniquePtrs.cpp
   Test_ConstantExpressions.cpp
   Test_ContainerHelpers.cpp
   Test_DereferenceWrapper.cpp

--- a/tests/Unit/Utilities/Test_CloneUniquePtrs.cpp
+++ b/tests/Unit/Utilities/Test_CloneUniquePtrs.cpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <memory>
+#include <unordered_map>
+
+#include "Utilities/CloneUniquePtrs.hpp"
+
+namespace {
+struct NonCopyableValue {
+  explicit constexpr NonCopyableValue(const int value_in) : value(value_in) {}
+  constexpr NonCopyableValue(const NonCopyableValue&) = delete;
+  constexpr NonCopyableValue& operator=(const NonCopyableValue&) = delete;
+  constexpr NonCopyableValue(NonCopyableValue&&) = default;
+  NonCopyableValue& operator=(NonCopyableValue&&) = default;
+  ~NonCopyableValue() = default;
+
+  std::unique_ptr<NonCopyableValue> get_clone() {
+    return std::make_unique<NonCopyableValue>(value);
+  }
+
+  int value;
+};
+
+void test_unordered_map() {
+  using Map = std::unordered_map<int, std::unique_ptr<NonCopyableValue>>;
+  const auto check_cloning = [](const Map& map) noexcept {
+    const auto map_copy = clone_unique_ptrs(map);
+    REQUIRE(map.size() == map_copy.size());
+    for (const auto& kv : map) {
+      CHECK(map_copy.at(kv.first)->value == kv.second->value);
+    }
+  };
+  check_cloning({});
+
+  Map t0{};
+  t0[10] = std::make_unique<NonCopyableValue>(150);
+  check_cloning(t0);
+
+  Map t1{};
+  t1[10] = std::make_unique<NonCopyableValue>(150);
+  t1[32] = std::make_unique<NonCopyableValue>(1);
+  check_cloning(t1);
+
+  Map t2{};
+  t2[10] = std::make_unique<NonCopyableValue>(150);
+  t2[32] = std::make_unique<NonCopyableValue>(1);
+  t2[-1] = std::make_unique<NonCopyableValue>(100);
+  check_cloning(t2);
+}
+
+void test_vector() {
+  using Vector = std::vector<std::unique_ptr<NonCopyableValue>>;
+  const auto check_cloning = [](const Vector& vector) noexcept {
+    const auto vector_copy = clone_unique_ptrs(vector);
+    REQUIRE(vector.size() == vector_copy.size());
+    for (size_t i = 0; i < vector.size(); ++i) {
+      CHECK(vector_copy[i]->value == vector[i]->value);
+    }
+  };
+
+  check_cloning({});
+
+  Vector t0{1};
+  t0[0] = std::make_unique<NonCopyableValue>(10);
+  check_cloning(t0);
+
+  Vector t1{2};
+  t1[0] = std::make_unique<NonCopyableValue>(10);
+  t1[1] = std::make_unique<NonCopyableValue>(100);
+  check_cloning(t1);
+
+  Vector t2{3};
+  t2[0] = std::make_unique<NonCopyableValue>(10);
+  t2[1] = std::make_unique<NonCopyableValue>(100);
+  t2[2] = std::make_unique<NonCopyableValue>(200);
+  check_cloning(t2);
+}
+
+SPECTRE_TEST_CASE("Unit.Utilities.CloneUniquePtrs", "[Unit][Utilities]") {
+  test_unordered_map();
+  test_vector();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Adds what I'm calling `TimeDependence`s for the domain creators.

- `TimeDependence` base class so the specific time dependence can be specified at runtime
- Individual domain creators choose the type of time dependence they want. E.g. a BBH domain probably will have very few to no options for what time dependences are used to generate the moving maps.
- Time dependences are used to retrieve the new maps for individual blocks. Later I will add `inject` functions to the `Block` class that allows adding the time dependence there.
- Add None, UniformTranslation, and Composition time dependences.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
