### PR TITLE
Fix use of uninitialized variable in Lane Emden source term

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.hpp"
 #include "Utilities/Gsl.hpp"
@@ -29,9 +30,8 @@ void LaneEmdenGravitationalField::apply(
   for (size_t i = 0; i < 3; ++i) {
     source_momentum_density->get(i) =
         get(mass_density_cons) * gravitational_field.get(i);
-    get(*source_energy_density) +=
-        momentum_density.get(i) * gravitational_field.get(i);
   }
+  *source_energy_density = dot_product(momentum_density, gravitational_field);
 }
 
 }  // Namespace Sources


### PR DESCRIPTION
## Proposed changes

Fixes a bug where a value was `+=`'d to an uninitialized DataVector. The value is now assigned using `=` (and computed more cleanly).

This line of code was added during review of PR #1938, but only after this was merged did I realize that variable may be used when uninitialized, potentially leading to FPE (signaling NaN) in evolutions.

But: why is this not caught by the test — am I using Pypp incorrectly? or does Pypp initialize the variable (edit: to 0) before calling the test function?

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
