### PR TITLE
Add a CMake flag that can disable Formaline

### DIFF
--- a/cmake/SetupBuildInfo.cmake
+++ b/cmake/SetupBuildInfo.cmake
@@ -14,13 +14,23 @@ configure_file(
   ${CMAKE_BINARY_DIR}/Informer/InfoAtCompile.cpp
   )
 
+option(USE_FORMALINE
+  "Use Formaline to encode the source tree into executables and output files."
+  ON)
+
 # APPLE instead of ${APPLE} is intentional
-if (NOT APPLE)
+if (APPLE)
+  set(USE_FORMALINE OFF)
+endif (APPLE)
+
+if (USE_FORMALINE)
   configure_file(
     ${CMAKE_SOURCE_DIR}/tools/Formaline.sh
     ${CMAKE_BINARY_DIR}/tmp/Formaline.sh
     @ONLY
     )
+else()
+  file(REMOVE ${CMAKE_BINARY_DIR}/tmp/Formaline.sh)
 endif()
 
 configure_file(

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -17,3 +17,10 @@ target_link_libraries(
   ${LIBRARY}
   INTERFACE ErrorHandling
   )
+
+if (NOT USE_FORMALINE)
+  set_source_files_properties(
+    Formaline.cpp
+    PROPERTIES
+    COMPILE_DEFINITIONS SPECTRE_NO_FORMALINE)
+endif (NOT USE_FORMALINE)

--- a/src/Utilities/Formaline.cpp
+++ b/src/Utilities/Formaline.cpp
@@ -26,7 +26,7 @@ void write_to_file(const std::string& filename_without_extension) noexcept {
   std::fclose(outfile);
 }
 
-#ifdef __APPLE__
+#ifdef SPECTRE_NO_FORMALINE
 std::vector<char> get_archive() noexcept {
   return {'N', 'o', 't', ' ', 's', 'u', 'p', 'p', 'o', 'r', 't', 'e', 'd'};
 }


### PR DESCRIPTION
## Proposed changes

In some cases and on some systems (such as macOS) Formaline either doesn't work
and so it is good to be able to easily disable it.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
