### PR TITLE
Init function vs times from file

### DIFF
--- a/src/IO/Importers/ReadSpecThirdOrderPiecewisePolynomial.hpp
+++ b/src/IO/Importers/ReadSpecThirdOrderPiecewisePolynomial.hpp
@@ -1,0 +1,202 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/Importers/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace importers {
+namespace Actions {
+/// \brief Import SpEC `FunctionOfTime` data from an H5 file.
+///
+/// Uses:
+///  - DataBox:
+///    - `importers::Tags::FunctionOfTimeFile`
+///    - `importers::Tags::FunctionOfTimeNameMap`
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - `::domain::Tags::FunctionsOfTime`
+///
+/// Columns in the file to be read must have the following form:
+///   - 0 = time
+///   - 1 = time of last update
+///   - 2 = number of components
+///   - 3 = maximum derivative order
+///   - 4 = version
+///   - 5 = function
+///   - 6 = d/dt (function)
+///   - 7 = d^2/dt^2 (function)
+///   - 8 = d^3/dt^3 (function)
+///
+/// If the function has more than one component, columns 5-8 give
+/// the first component and its derivatives, columns 9-12 give the second
+/// component and its derivatives, etc.
+///
+struct ReadSpecThirdOrderPiecewisePolynomial {
+  template <
+      typename DbTagsList, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      Requires<db::tag_is_retrievable_v<importers::Tags::FunctionOfTimeFile,
+                                        db::DataBox<DbTagsList>> and
+               db::tag_is_retrievable_v<importers::Tags::FunctionOfTimeNameMap,
+                                        db::DataBox<DbTagsList>> and
+               db::tag_is_retrievable_v<::domain::Tags::FunctionsOfTime,
+                                        db::DataBox<DbTagsList>>> = nullptr>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    const std::string& file_name{
+        db::get<importers::Tags::FunctionOfTimeFile>(box)};
+
+    // Get the map of SpEC -> SpECTRE FunctionofTime names
+    const std::map<std::string, std::string>& dataset_name_map{
+        db::get<importers::Tags::FunctionOfTimeNameMap>(box)};
+
+    // Currently, only support order 3 piecewise polynomials.
+    // This could be generalized later, but the SpEC functions of time
+    // that we will read in with this action will always be 3rd-order
+    // piecewise polynomials
+    constexpr size_t max_deriv{3};
+
+    std::unordered_map<std::string,
+                       domain::FunctionsOfTime::PiecewisePolynomial<max_deriv>>
+        spec_functions_of_time;
+
+    std::unique_ptr<h5::H5File<h5::AccessType::ReadOnly>> file =
+        std::make_unique<h5::H5File<h5::AccessType::ReadOnly>>(file_name);
+    for (const auto& spec_and_spectre_names : dataset_name_map) {
+      const std::string& spec_name = std::get<0>(spec_and_spectre_names);
+      const std::string& spectre_name = std::get<1>(spec_and_spectre_names);
+      // clang-tidy: use auto when initializing with a template cast to avoid
+      // duplicating the type name
+      const h5::Dat& dat_file = file->get<h5::Dat>("/" + spec_name);  // NOLINT
+      const Matrix& dat_data = dat_file.get_data();
+
+      // Check that the data in the file uses deriv order 3
+      // Column 3 of the file contains the derivative order
+      const size_t dat_max_deriv = dat_data(0, 3);
+      if (dat_max_deriv != max_deriv) {
+        file.reset();
+        ERROR("Deriv order in " << file_name << " should be " << max_deriv
+                                << ", not " << dat_max_deriv);
+      }
+
+      // Get the initial time ('time of last update') from the file
+      // and the values of the function and its derivatives at that time
+      const double start_time = dat_data(0, 1);
+
+      // Currently, assume the same number of components are used
+      // at each time. This could be generalized if needed
+      const size_t number_of_components = dat_data(0, 2);
+
+      std::array<DataVector, max_deriv + 1> initial_coefficients;
+      for (size_t deriv_order = 0; deriv_order < max_deriv + 1; ++deriv_order) {
+        gsl::at(initial_coefficients, deriv_order) =
+            DataVector(number_of_components);
+        for (size_t component = 0; component < number_of_components;
+             ++component) {
+          gsl::at(initial_coefficients, deriv_order)[component] =
+              dat_data(0, 5 + (max_deriv + 1) * component + deriv_order);
+        }
+      }
+      spec_functions_of_time[spectre_name] =
+          domain::FunctionsOfTime::PiecewisePolynomial<3>(start_time,
+                                                          initial_coefficients);
+
+      // Loop over the remaining times, updating the function of time
+      DataVector highest_derivative(number_of_components);
+      double time_last_updated = start_time;
+      for (size_t row = 1; row < dat_data.rows(); ++row) {
+        // If time of last update has changed, then update the FunctionOfTime
+        // The time of last update is stored in column 1 in the dat file
+        if (dat_data(row, 1) > time_last_updated) {
+          time_last_updated = dat_data(row, 1);
+          for (size_t a = 0; a < number_of_components; ++a) {
+            highest_derivative[a] =
+                dat_data(row, 4 + (max_deriv + 1) * a + max_deriv);
+          }
+          spec_functions_of_time[spectre_name].update(time_last_updated,
+                                                      highest_derivative);
+        } else {
+          file.reset();
+          ERROR("Non-monotonic time found in FunctionOfTime data. "
+                << "Time " << dat_data(row, 1) << " follows time "
+                << time_last_updated << " while reading " << spectre_name
+                << "\n");
+        }
+      }
+    }
+
+    // Mutate ::domain::Tags::FunctionsOfTime, adding the imported
+    // FunctionsOfTime to it
+    db::mutate<::domain::Tags::FunctionsOfTime>(
+        make_not_null(&box),
+        [&dataset_name_map, &spec_functions_of_time,
+         &file](const gsl::not_null<std::unordered_map<
+                    std::string,
+                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
+                    functions_of_time) {
+          for (auto spec_and_spectre_names : dataset_name_map) {
+            const std::string& spectre_name =
+                std::get<1>(spec_and_spectre_names);
+
+            // The FunctionsOfTime we are mutating must already have
+            // an element with key==spectre_name; this action only
+            // mutates the value associated with that key
+            if ((*functions_of_time).count(spectre_name) == 0) {
+              file.reset();
+              ERROR("Trying to import data for key "
+                    << spectre_name
+                    << "in FunctionsOfTime, but FunctionsOfTime does not "
+                       "contain that key.\n");
+            }
+            auto* piecewise_polynomial = dynamic_cast<
+                domain::FunctionsOfTime::PiecewisePolynomial<max_deriv>*>(
+                (*functions_of_time)[spectre_name].get());
+            if (piecewise_polynomial == nullptr) {
+              file.reset();
+              ERROR(
+                  "The function of time with name spectre_name is not a "
+                  "PiecewisePolynomial<"
+                  << max_deriv
+                  << "> and so cannot be set using "
+                     "ReadSpecThirdOrderPiecewisePolynomial\n");
+            }
+            *piecewise_polynomial = spec_functions_of_time[spectre_name];
+          }
+        });
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions
+}  // namespace importers

--- a/src/IO/Importers/Tags.hpp
+++ b/src/IO/Importers/Tags.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <map>
 #include <string>
 
 #include "DataStructures/DataBox/Tag.hpp"
@@ -72,6 +73,34 @@ struct ObservationValue {
   using group = ImporterOptionsGroup;
 };
 
+/*!
+ * \ingroup OptionGroupsGroup
+ * \brief Groups options for reading in FunctionOfTime data from SpEC
+ */
+struct SpecFuncOfTimeReader {
+  static constexpr OptionString help{
+      "Options for importing FunctionOfTimes from SpEC"};
+};
+
+/*!
+ * \brief Path to an H5 file containing SpEC FunctionOfTime data
+ */
+struct FunctionOfTimeFile {
+  using type = std::string;
+  static constexpr OptionString help{
+      "Path to an H5 file containing SpEC FunctionOfTime data"};
+  using group = SpecFuncOfTimeReader;
+};
+
+/*!
+ * \brief Pairs of strings mapping SpEC FunctionOfTime names to SpECTRE names
+ */
+struct FunctionOfTimeNameMap {
+  using type = std::map<std::string, std::string>;
+  static constexpr OptionString help{
+      "String pairs mapping spec names to spectre names"};
+  using group = SpecFuncOfTimeReader;
+};
 }  // namespace OptionTags
 
 /// The \ref DataBoxGroup tags associated with the data importer
@@ -140,6 +169,43 @@ struct ObservationValue : db::SimpleTag {
  */
 struct RegisteredElements : db::SimpleTag {
   using type = std::unordered_map<observers::ArrayComponentId, std::string>;
+};
+
+/*!
+ * \brief Path to an H5 file containing SpEC `FunctionOfTime` data to read.
+ */
+struct FunctionOfTimeFile : db::SimpleTag {
+  static std::string name() noexcept { return "FunctionOfTimeFile"; }
+  using type = std::string;
+  using option_tags = tmpl::list<::importers::OptionTags::FunctionOfTimeFile>;
+  static constexpr bool pass_metavariables = false;
+  template <typename Metavariables>
+  static std::string create_from_options(
+      const std::string& function_of_time_file) noexcept {
+    return function_of_time_file;
+  }
+};
+
+/*!
+ * \brief Pairs of strings mapping SpEC -> SpECTRE FunctionOfTime names
+ *
+ * \details The first string in each pair is the name of a Dat file inside
+ * an H5 file that contains SpEC FunctionOfTime data.
+ * The second string in each pair is the SpECTRE name of the FunctionOfTime,
+ * which will be the key used to index the `FunctionOfTime` in a
+ * `std::unordered_map` after reading it.
+ */
+struct FunctionOfTimeNameMap : db::SimpleTag {
+  static std::string name() noexcept { return "FunctionOfTimeNameMap"; }
+  using type = std::map<std::string, std::string>;
+  using option_tags =
+      tmpl::list<::importers::OptionTags::FunctionOfTimeNameMap>;
+  static constexpr bool pass_metavariables = false;
+  template <typename Metavariables>
+  static std::map<std::string, std::string> create_from_options(
+      const std::map<std::string, std::string>& dataset_names) noexcept {
+    return dataset_names;
+  }
 };
 
 }  // namespace Tags

--- a/tests/Unit/IO/Importers/CMakeLists.txt
+++ b/tests/Unit/IO/Importers/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_DataImporter")
 
 set(LIBRARY_SOURCES
+  Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
   Test_Tags.cpp
   Test_VolumeDataReaderActions.cpp
   )

--- a/tests/Unit/IO/Importers/Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
+++ b/tests/Unit/IO/Importers/Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
@@ -1,0 +1,256 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/Importers/ReadSpecThirdOrderPiecewisePolynomial.hpp"
+#include "IO/Importers/Tags.hpp"
+#include "Informer/InfoFromBuild.hpp"
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <typename Metavariables>
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using simple_tags = tmpl::list<importers::Tags::FunctionOfTimeFile,
+                                 importers::Tags::FunctionOfTimeNameMap,
+                                 ::domain::Tags::FunctionsOfTime>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<
+              importers::Actions::ReadSpecThirdOrderPiecewisePolynomial>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<component<Metavariables>>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+void test_options() noexcept {
+  CHECK(db::tag_name<importers::Tags::FunctionOfTimeFile>() ==
+        "FunctionOfTimeFile");
+  CHECK(db::tag_name<importers::Tags::FunctionOfTimeNameMap>() ==
+        "FunctionOfTimeNameMap");
+
+  const std::string option_string{
+      "SpecFuncOfTimeReader:\n"
+      "  FunctionOfTimeFile: TestFile.h5\n"
+      "  FunctionOfTimeNameMap: {Set1: Name1, Set2: Name2}"};
+  using option_tags = tmpl::list<importers::OptionTags::FunctionOfTimeFile,
+                                 importers::OptionTags::FunctionOfTimeNameMap>;
+  Options<option_tags> options{""};
+  options.parse(option_string);
+  CHECK(options.get<importers::OptionTags::FunctionOfTimeFile>() ==
+        "TestFile.h5");
+  const auto& set_names =
+      options.get<importers::OptionTags::FunctionOfTimeNameMap>();
+  const std::map<std::string, std::string> expected_set_names{
+      {"Set1", "Name1"}, {"Set2", "Name2"}};
+  CHECK(set_names == expected_set_names);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomial",
+                  "[Unit][Evolution][Actions]") {
+  domain::FunctionsOfTime::register_derived_with_charm();
+
+  test_options();
+
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+
+  const size_t self_id{1};
+
+  // Create a temporary file with test data to read in
+  // First, check if the file exists, and delete it if so
+  const std::string test_filename{"TestSpecFuncOfTimeData.h5"};
+  constexpr uint32_t version_number = 4;
+  if (file_system::check_if_file_exists(test_filename)) {
+    file_system::rm(test_filename, true);
+  }
+
+  h5::H5File<h5::AccessType::ReadWrite> test_file(test_filename);
+
+  const std::array<double, 2> expected_times{{0.0, 0.00599999974179903}};
+  const std::array<std::string, 2> expected_names{
+      {"ExpansionFactor", "RotationAngle"}};
+
+  const std::vector<std::vector<double>> test_expansion{
+      {5.9999997417990300e-03, 0.0, 1.0, 3.0, 1.0, 1.0, -1.4268296756999999e-06,
+       0.0, 0.0},
+      {5.9999997417990300e-03, 5.9999997417990300e-03, 1.0, 3.0, 1.0,
+       9.9999999143902230e-01, -1.4268296756999999e-06, 0.0,
+       -3.5943676411727592e-05}};
+  const std::vector<std::string> expansion_legend{
+      "Time", "TLastUpdate", "Nc",  "DerivOrder", "Version",
+      "a",    "da",          "d2a", "d3a"};
+  auto& expansion_file = test_file.insert<h5::Dat>(
+      "/" + expected_names[0], expansion_legend, version_number);
+  expansion_file.append(test_expansion);
+
+  const std::vector<std::vector<double>> test_rotation{
+      {5.9999997417990300e-03, 0.0, 1.0, 3.0, 1.0, 0.0, 1.3472907726000001e-02,
+       0.0, 0.0},
+      {5.9999997417990300e-03, 5.9999997417990300e-03, 1.0, 3.0, 1.0,
+       8.0837442877282155e-05, 1.3472907726000001e-02, 0.0,
+       1.4799266358888008e-04}};
+  const std::vector<std::string> rotation_legend{
+      "Time", "TLastUpdate", "Nc",    "DerivOrder", "Version",
+      "Phi",  "dPhi",        "d2Phi", "d3Phi"};
+  auto& rotation_file = test_file.insert<h5::Dat>(
+      "/" + expected_names[1], rotation_legend, version_number);
+  rotation_file.append(test_rotation);
+
+  MockRuntimeSystem runner{{}};
+  std::unordered_map<std::string,
+                     std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
+      initial_functions_of_time{};
+
+  const std::array<DataVector, 4> initial_coefficients{
+      {{0.0}, {0.0}, {0.0}, {0.0}}};
+  initial_functions_of_time["ExpansionFactor"] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+          0.0, initial_coefficients);
+  initial_functions_of_time["RotationAngle"] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+          0.0, initial_coefficients);
+
+  ActionTesting::emplace_component_and_initialize<component<Metavariables>>(
+      &runner, self_id,
+      {std::string{test_filename},
+       std::map<std::string, std::string>{
+           {"ExpansionFactor", "ExpansionFactor"},
+           {"RotationAngle", "RotationAngle"}},
+       std::move(initial_functions_of_time)});
+
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Metavariables::Phase::Testing);
+  ActionTesting::next_action<component<Metavariables>>(make_not_null(&runner),
+                                                       self_id);
+
+  const auto& functions_of_time =
+      ActionTesting::get_databox_tag<component<Metavariables>,
+                                     domain::Tags::FunctionsOfTime>(runner,
+                                                                    self_id);
+
+  // Check that the FunctionOfTime and its derivatives have the expected
+  // values
+  const std::array<std::array<double, 3>, 2> expected_expansion{
+      {{{test_expansion[0][5], test_expansion[0][6], test_expansion[0][7]}},
+       {{test_expansion[1][5], test_expansion[1][6], test_expansion[1][7]}}}};
+  const std::array<std::array<double, 3>, 2> expected_rotation{
+      {{{test_rotation[0][5], test_rotation[0][6], test_rotation[0][7]}},
+       {{test_rotation[1][5], test_rotation[1][6], test_rotation[1][7]}}}};
+  std::unordered_map<std::string, std::array<std::array<double, 3>, 2>>
+      expected_functions;
+  expected_functions[expected_names[0]] = expected_expansion;
+  expected_functions[expected_names[1]] = expected_rotation;
+
+  REQUIRE(functions_of_time.size() == expected_names.size());
+
+  for (const auto& function_of_time : functions_of_time) {
+    const auto& f = function_of_time.second;
+    const auto& name = function_of_time.first;
+    // Check if the name is one of the expected names
+    CHECK(std::find(expected_names.begin(), expected_names.end(), name) !=
+          expected_names.end());
+
+    for (size_t i = 0; i < 2; ++i) {
+      const auto time = gsl::at(expected_times, i);
+      const auto f_and_derivs = f->func_and_2_derivs(time);
+      for (size_t j = 0; j < 3; ++j) {
+        CHECK(gsl::at(gsl::at(expected_functions[name], i), j) ==
+              approx(gsl::at(f_and_derivs, j)[0]));
+      }
+    }
+  }
+
+  // Delete the temporary file created for this test
+  file_system::rm(test_filename, true);
+}
+
+// [[OutputRegex, Non-monotonic time found]]
+SPECTRE_TEST_CASE(
+    "Unit.IO.ReadSpecThirdOrderPiecewisePolynomialNonmonotonic",
+    "[Unit][Evolution][Actions]") {
+  ERROR_TEST();
+  domain::FunctionsOfTime::register_derived_with_charm();
+
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+
+  const size_t self_id{1};
+
+  // Create a temporary file with test data to read in
+  // First, check if the file exists, and delete it if so
+  const std::string test_filename{"TestSpecFuncOfTimeDataNonmonotonic.h5"};
+  constexpr uint32_t version_number = 4;
+  if (file_system::check_if_file_exists(test_filename)) {
+    file_system::rm(test_filename, true);
+  }
+
+  h5::H5File<h5::AccessType::ReadWrite> test_file(test_filename);
+
+  const std::vector<std::vector<double>> test_rotation{
+      {0.0, 0.0, 1.0, 3.0, 1.0, 0.0, 1.3472907726000001e-02, 0.0, 0.0},
+      {-1.0, -1.0, 1.0, 3.0, 1.0, 8.0837442877282155e-05,
+       1.3472907726000001e-02, 0.0, 1.4799266358888008e-04}};
+  const std::vector<std::string> rotation_legend{
+      "Time", "TLastUpdate", "Nc",    "DerivOrder", "Version",
+      "Phi",  "dPhi",        "d2Phi", "d3Phi"};
+  auto& rotation_file = test_file.insert<h5::Dat>(
+      "/RotationAngle", rotation_legend, version_number);
+  rotation_file.append(test_rotation);
+
+  MockRuntimeSystem runner{{}};
+  std::unordered_map<std::string,
+                     std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
+      initial_functions_of_time{};
+
+  const std::array<DataVector, 4> initial_coefficients{
+      {{0.0}, {0.0}, {0.0}, {0.0}}};
+  initial_functions_of_time["RotationAngle"] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+          0.0, initial_coefficients);
+
+  ActionTesting::emplace_component_and_initialize<component<Metavariables>>(
+      &runner, self_id,
+      {std::string{test_filename},
+       std::map<std::string, std::string>{
+           {"RotationAngle", "RotationAngle"}},
+       std::move(initial_functions_of_time)});
+
+  runner.set_phase(Metavariables::Phase::Testing);
+  runner.next_action<component<Metavariables>>(self_id);
+}


### PR DESCRIPTION
## Proposed changes

This PR adds code to read in FunctionOfTime data from an H5 Dat file. This is a step toward evolving BBHs using FunctionOfTime data from a corresponding spec simulation.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
