### PR TITLE
Split elliptic homogeneous boundary conditions into free function

### DIFF
--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
@@ -40,7 +40,6 @@
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
-#include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -78,7 +77,7 @@ struct ScalarField : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
-using field_tag = LinearSolver::Tags::Operand<ScalarField>;
+using field_tag = ScalarField;
 using vars_tag = Tags::Variables<tmpl::list<field_tag>>;
 
 struct OtherData : db::SimpleTag {
@@ -123,7 +122,7 @@ struct NumericalFluxTag {
 struct System {
   static constexpr const size_t volume_dim = Dim;
   using variables_tag = vars_tag;
-  using primal_fields = tmpl::list<ScalarField>;
+  using primal_variables = tmpl::list<ScalarField>;
 
   template <typename Tag>
   using magnitude_tag = Tags::EuclideanMagnitude<Tag>;


### PR DESCRIPTION
## Proposed changes

Part of a series of PRs that decouple the DG functionality from the DataBox and Actions. Needed for preconditioning.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
