### PR TITLE
Add a solution to the semidiscretized DG scalar wave

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY WaveEquation)
 set(LIBRARY_SOURCES
   PlaneWave.cpp
   RegularSphericalWave.cpp
+  SemidiscretizedDg.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.cpp
@@ -1,0 +1,161 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.hpp"
+
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <pup.h>
+#include <utility>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace ScalarWave {
+namespace Solutions {
+SemidiscretizedDg::SemidiscretizedDg(
+    const int harmonic, const std::array<double, 4>& amplitudes) noexcept
+    : harmonic_(harmonic), amplitudes_(amplitudes) {}
+
+namespace {
+struct Mode {
+  std::complex<double> frequency;
+  ComplexDataVector pi_coefficients{2};
+  ComplexDataVector phi_coefficients{2};
+};
+
+std::array<Mode, 4> get_modes(const tnsr::I<DataVector, 1>& x,
+                              const int harmonic) noexcept {
+  using namespace std::complex_literals;
+
+  if (get<0>(x).size() != 2) {
+    ERROR("SemidiscretizedDg solution only supports linear elements.");
+  }
+
+  const double element_length = get<0>(x)[1] - get<0>(x)[0];
+  // Phase change across an element
+  const double element_phase = harmonic * element_length;
+
+  std::array<Mode, 4> result;
+  {
+    std::complex<double> one_plus_i_omega =
+        sqrt(2.0 * exp(1.0i * element_phase) - 1.0);
+    {
+      Mode& mode = result[0];
+      // Same as
+      //   mode.frequency = 1.0i * (1.0 - one_plus_i_omega) / element_length
+      // but better behaved as one_plus_i_omega -> 1
+      mode.frequency = 4.0 * sin(element_phase) /
+                       ((1.0 + exp(-1.0i * element_phase)) *
+                        (1.0 + one_plus_i_omega) * element_length);
+      mode.pi_coefficients[0] = sqrt(1.0 / one_plus_i_omega);
+      mode.pi_coefficients[1] = 1.0 / mode.pi_coefficients[0];
+      mode.phi_coefficients = -mode.pi_coefficients;
+    }
+    {
+      Mode& mode = result[1];
+      mode.frequency = 1.0i * (1.0 + one_plus_i_omega) / element_length;
+      mode.pi_coefficients[0] = sqrt(1.0 / one_plus_i_omega);
+      mode.pi_coefficients[1] = -1.0 / mode.pi_coefficients[0];
+      mode.phi_coefficients = -mode.pi_coefficients;
+    }
+  }
+  {
+    std::complex<double> one_plus_i_omega =
+        sqrt(2.0 * exp(-1.0i * element_phase) - 1.0);
+    {
+      Mode& mode = result[2];
+      // Same as
+      //   mode.frequency = 1.0i * (1.0 - one_plus_i_omega) / element_length
+      // but better behaved as one_plus_i_omega -> 1
+      mode.frequency = -4.0 * sin(element_phase) /
+                       ((1.0 + exp(1.0i * element_phase)) *
+                        (1.0 + one_plus_i_omega) * element_length);
+      mode.pi_coefficients[0] = sqrt(one_plus_i_omega);
+      mode.pi_coefficients[1] = 1.0 / mode.pi_coefficients[0];
+      mode.phi_coefficients = mode.pi_coefficients;
+    }
+    {
+      Mode& mode = result[3];
+      mode.frequency = 1.0i * (1.0 + one_plus_i_omega) / element_length;
+      mode.pi_coefficients[0] = sqrt(one_plus_i_omega);
+      mode.pi_coefficients[1] = -1.0 / mode.pi_coefficients[0];
+      mode.phi_coefficients = mode.pi_coefficients;
+    }
+  }
+  return result;
+}
+}  // namespace
+
+tuples::TaggedTuple<ScalarWave::Pi> SemidiscretizedDg::variables(
+    const tnsr::I<DataVector, 1>& x, double t,
+    tmpl::list<ScalarWave::Pi> /*meta*/) const noexcept {
+  using namespace std::complex_literals;
+
+  const auto modes = get_modes(x, harmonic_);
+  const double spatial_phase = harmonic_ * get<0>(x)[0];
+  DataVector pi{0.0, 0.0};
+  for (size_t i = 0; i < 4; ++i) {
+    const auto& mode = gsl::at(modes, i);
+    pi += gsl::at(amplitudes_, i) *
+          real(exp(1.0i * (spatial_phase + mode.frequency * t)) *
+               mode.pi_coefficients);
+  }
+  return {Scalar<DataVector>(std::move(pi))};
+}
+
+tuples::TaggedTuple<ScalarWave::Phi<1>> SemidiscretizedDg::variables(
+    const tnsr::I<DataVector, 1>& x, double t,
+    tmpl::list<ScalarWave::Phi<1>> /*meta*/) const noexcept {
+  using namespace std::complex_literals;
+
+  const auto modes = get_modes(x, harmonic_);
+  const double spatial_phase = harmonic_ * get<0>(x)[0];
+  DataVector phi{0.0, 0.0};
+  for (size_t i = 0; i < 4; ++i) {
+    const auto& mode = gsl::at(modes, i);
+    phi += gsl::at(amplitudes_, i) *
+           real(exp(1.0i * (spatial_phase + mode.frequency * t)) *
+                mode.phi_coefficients);
+  }
+  return {tnsr::i<DataVector, 1>{{{std::move(phi)}}}};
+}
+
+tuples::TaggedTuple<ScalarWave::Psi> SemidiscretizedDg::variables(
+    const tnsr::I<DataVector, 1>& x, double t,
+    tmpl::list<ScalarWave::Psi> /*meta*/) const noexcept {
+  using namespace std::complex_literals;
+
+  // There are two more modes that are just constant offsets of Psi,
+  // but they are boring so we ignore them.
+  const auto modes = get_modes(x, harmonic_);
+  const double spatial_phase = harmonic_ * get<0>(x)[0];
+  DataVector psi{0.0, 0.0};
+  for (size_t i = 0; i < 4; ++i) {
+    const auto& mode = gsl::at(modes, i);
+    if (mode.frequency == 0.0) {
+      psi -= gsl::at(amplitudes_, i) *
+             real(t * exp(1.0i * spatial_phase) * mode.pi_coefficients);
+    } else {
+      psi -= gsl::at(amplitudes_, i) *
+             real(exp(1.0i * (spatial_phase + mode.frequency * t)) /
+                  (1.0i * mode.frequency) * mode.pi_coefficients);
+    }
+  }
+  return {Scalar<DataVector>(std::move(psi))};
+}
+
+void SemidiscretizedDg::pup(PUP::er& p) noexcept {
+  p | harmonic_;
+  p | amplitudes_;
+}
+}  // namespace Solutions
+}  // namespace ScalarWave

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.hpp
@@ -1,0 +1,99 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"  // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+class DataVector;
+// IWYU pragma: no_forward_declare Tensor
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace ScalarWave {
+namespace Solutions {
+/*!
+ * \brief An exact solution to the semidiscretized DG ScalarWave
+ * system with an upwind flux
+ *
+ * This solution takes into account the spatial discretization error,
+ * and so should show convergence in time integration accuracy to
+ * roundoff at any resolution.
+ *
+ * \warning This is not really a pointwise function, as the solution
+ * depends on the spatial discretization.  It will only work on a
+ * periodic domain of length \f$2 \pi\f$ (or an integer multiple) with
+ * equally sized linear elements.
+ */
+class SemidiscretizedDg : public MarkAsAnalyticSolution {
+ public:
+  using tags = tmpl::list<ScalarWave::Pi, ScalarWave::Phi<1>, ScalarWave::Psi>;
+
+  struct Harmonic {
+    using type = int;
+    static constexpr OptionString help =
+        "Number of wave periods across the domain";
+  };
+
+  struct Amplitudes {
+    using type = std::array<double, 4>;
+    static constexpr OptionString help =
+        "Amplitudes of the independent modes of the harmonic";
+  };
+
+  using options = tmpl::list<Harmonic, Amplitudes>;
+
+  static constexpr OptionString help =
+      "A solution of the semidiscretized DG system on linear elements\n"
+      "with spatial period 2 pi.";
+
+  SemidiscretizedDg(int harmonic,
+                    const std::array<double, 4>& amplitudes) noexcept;
+
+  SemidiscretizedDg() = default;
+
+  /// Retrieve the evolution variables at time `t` and spatial coordinates `x`
+  template <typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataVector, 1>& x,
+                                         double t,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
+    static_assert(
+        tmpl2::flat_all_v<tmpl::list_contains_v<tags, Tags>...>,
+        "At least one of the requested tags is not supported. The requested "
+        "tags are listed as template parameters of the `variables` function.");
+    return {get<Tags>(variables(x, t, tmpl::list<Tags>{}))...};
+  }
+
+  /// \cond
+  tuples::TaggedTuple<ScalarWave::Pi> variables(
+      const tnsr::I<DataVector, 1>& x, double t,
+      tmpl::list<ScalarWave::Pi> /*meta*/) const noexcept;
+
+  tuples::TaggedTuple<ScalarWave::Phi<1>> variables(
+      const tnsr::I<DataVector, 1>& x, double t,
+      tmpl::list<ScalarWave::Phi<1>> /*meta*/) const noexcept;
+
+  tuples::TaggedTuple<ScalarWave::Psi> variables(
+      const tnsr::I<DataVector, 1>& x, double t,
+      tmpl::list<ScalarWave::Psi> /*meta*/) const noexcept;
+  /// \endcond
+
+  void pup(PUP::er& p) noexcept;  // NOLINT(google-runtime-references)
+
+ private:
+  int harmonic_;
+  std::array<double, 4> amplitudes_;
+};
+}  // namespace Solutions
+}  // namespace ScalarWave

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY "Test_WaveEquation")
 set(LIBRARY_SOURCES
   Test_PlaneWave.cpp
   Test_RegularSphericalWave.cpp
+  Test_SemidiscretizedDg.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -1,0 +1,268 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <pup.h>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/ScalarWave/Equations.hpp"
+#include "Evolution/Systems/ScalarWave/System.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndex<1>;
+  using const_global_cache_tags = tmpl::list<>;
+
+  using variables_tag = typename metavariables::system::variables_tag;
+  using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
+  using normal_dot_fluxes_tag =
+      Tags::Interface<Tags::InternalDirections<1>,
+                      typename flux_comm_types::normal_dot_fluxes_tag>;
+  using mortar_data_tag = typename flux_comm_types::simple_mortar_data_tag;
+
+  using simple_tags = db::AddSimpleTags<
+      Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::Mesh<1>,
+      Tags::Element<1>, Tags::ElementMap<1>, variables_tag,
+      db::add_tag_prefix<Tags::dt, variables_tag>, normal_dot_fluxes_tag,
+      mortar_data_tag, Tags::Mortars<Tags::Next<Tags::TimeStepId>, 1>,
+      Tags::Mortars<Tags::Mesh<0>, 1>, Tags::Mortars<Tags::MortarSize<0>, 1>>;
+
+  using inverse_jacobian =
+      Tags::InverseJacobian<Tags::ElementMap<1>,
+                            Tags::Coordinates<1, Frame::Logical>>;
+
+  template <typename Tag>
+  using interface_compute_tag =
+      Tags::InterfaceCompute<Tags::InternalDirections<1>, Tag>;
+
+  using compute_tags = db::AddComputeTags<
+      Tags::LogicalCoordinates<1>,
+      Tags::MappedCoordinates<Tags::ElementMap<1>,
+                              Tags::Coordinates<1, Frame::Logical>>,
+      inverse_jacobian,
+      Tags::DerivCompute<variables_tag, inverse_jacobian,
+                         typename metavariables::system::gradients_tags>,
+      Tags::InternalDirections<1>,
+      Tags::Slice<Tags::InternalDirections<1>,
+                  typename metavariables::system::variables_tag>,
+      interface_compute_tag<Tags::Direction<1>>,
+      interface_compute_tag<Tags::InterfaceMesh<1>>,
+      interface_compute_tag<Tags::UnnormalizedFaceNormalCompute<1>>,
+      interface_compute_tag<
+          Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<1>>>,
+      interface_compute_tag<
+          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<1>>>>;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<
+              ActionTesting::InitializeDataBox<simple_tags, compute_tags>>>,
+
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<dg::Actions::ComputeNonconservativeBoundaryFluxes<
+                         Tags::InternalDirections<1>>,
+                     dg::Actions::SendDataForFluxes<Metavariables>,
+                     Actions::ComputeTimeDerivative,
+                     dg::Actions::ReceiveDataForFluxes<Metavariables>,
+                     dg::Actions::ApplyFluxes>>>;
+};
+
+struct Metavariables {
+  using system = ScalarWave::System<1>;
+  using component_list = tmpl::list<Component<Metavariables>>;
+  using temporal_id = Tags::TimeStepId;
+  using normal_dot_numerical_flux =
+      Tags::NumericalFlux<ScalarWave::UpwindFlux<1>>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+using system = Metavariables::system;
+using EvolvedVariables = db::item_type<system::variables_tag>;
+
+std::pair<tnsr::I<DataVector, 1>, EvolvedVariables> evaluate_rhs(
+    const double time,
+    const ScalarWave::Solutions::SemidiscretizedDg& solution) noexcept {
+  using component = Component<Metavariables>;
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      {ScalarWave::UpwindFlux<1>{}}};
+
+  const Slab slab(time, time + 1.0);
+  const TimeStepId current_time(true, 0, slab.start());
+  const TimeStepId next_time(true, 0, slab.end());
+  const Mesh<1> mesh{2, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+
+  PUPable_reg(
+      SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                                       domain::CoordinateMaps::Affine>));
+  const auto block_map =
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::Affine(-1.0, 1.0, 0.0, 2.0 * M_PI));
+
+  const auto emplace_element =
+      [&block_map, &current_time, &mesh, &next_time, &runner, &solution, &time](
+          const ElementId<1>& id,
+          const std::vector<std::pair<Direction<1>, ElementId<1>>>&
+              mortars) noexcept {
+        Element<1>::Neighbors_t neighbors;
+        for (const auto& mortar_id : mortars) {
+          neighbors.insert({mortar_id.first, {{mortar_id.second}, {}}});
+        }
+        const Element<1> element(id, std::move(neighbors));
+
+        auto map = ElementMap<1, Frame::Inertial>(id, block_map->get_clone());
+
+        db::item_type<system::variables_tag> variables(2);
+        db::item_type<db::add_tag_prefix<Tags::dt, system::variables_tag>>
+            dt_variables(2);
+
+        db::item_type<component::normal_dot_fluxes_tag> normal_dot_fluxes;
+        db::item_type<typename component::mortar_data_tag> mortar_history{};
+        db::item_type<Tags::Mortars<Tags::Next<Tags::TimeStepId>, 1>>
+            mortar_next_temporal_ids{};
+        db::item_type<Tags::Mortars<Tags::Mesh<0>, 1>> mortar_meshes{};
+        db::item_type<Tags::Mortars<Tags::MortarSize<0>, 1>> mortar_sizes{};
+        for (const auto& mortar_id : mortars) {
+          normal_dot_fluxes[mortar_id.first].initialize(1, 0.0);
+          mortar_history.insert({mortar_id, {}});
+          mortar_next_temporal_ids.insert({mortar_id, current_time});
+          mortar_meshes.insert({mortar_id, mesh.slice_away(0)});
+          mortar_sizes.insert({mortar_id, {}});
+        }
+
+        ActionTesting::emplace_component_and_initialize<component>(
+            &runner, id,
+            {current_time, next_time, mesh, element, std::move(map),
+             std::move(variables), std::move(dt_variables),
+             std::move(normal_dot_fluxes), std::move(mortar_history),
+             std::move(mortar_next_temporal_ids), std::move(mortar_meshes),
+             std::move(mortar_sizes)});
+
+        auto& box = ActionTesting::get_databox<
+            component,
+            tmpl::append<component::simple_tags, component::compute_tags>>(
+            make_not_null(&runner), id);
+        db::mutate<system::variables_tag>(
+            make_not_null(&box),
+            [&solution, &time](
+                const gsl::not_null<EvolvedVariables*> vars,
+                const db::const_item_type<
+                    Tags::Coordinates<1, Frame::Inertial>>& coords) noexcept {
+              vars->assign_subset(solution.variables(
+                  coords, time, system::variables_tag::tags_list{}));
+            },
+            db::get<Tags::Coordinates<1, Frame::Inertial>>(box));
+      };
+
+  const ElementId<1> self_id(0, {{{4, 1}}});
+  const ElementId<1> left_id(0, {{{4, 0}}});
+  const ElementId<1> right_id(0, {{{4, 2}}});
+
+  emplace_element(self_id, {{Direction<1>::lower_xi(), left_id},
+                            {Direction<1>::upper_xi(), right_id}});
+  emplace_element(left_id, {{Direction<1>::upper_xi(), self_id}});
+  emplace_element(right_id, {{Direction<1>::lower_xi(), self_id}});
+  runner.set_phase(Metavariables::Phase::Testing);
+
+  // The neighbors only have to get as far as sending data
+  for (size_t i = 0; i < 2; ++i) {
+    runner.next_action<component>(left_id);
+    runner.next_action<component>(right_id);
+  }
+
+  for (size_t i = 0; i < 5; ++i) {
+    runner.next_action<component>(self_id);
+  }
+
+  return {
+      ActionTesting::get_databox_tag<component,
+                                     Tags::Coordinates<1, Frame::Inertial>>(
+          runner, self_id),
+      db::const_item_type<system::variables_tag>(
+          ActionTesting::get_databox_tag<
+              component, db::add_tag_prefix<Tags::dt, system::variables_tag>>(
+              runner, self_id))};
+}
+
+void check_solution(
+    const ScalarWave::Solutions::SemidiscretizedDg& solution) noexcept {
+  const double time = 1.23;
+
+  const auto coords_and_deriv_from_system = evaluate_rhs(time, solution);
+  const auto& coords = coords_and_deriv_from_system.first;
+  const auto& deriv_from_system = coords_and_deriv_from_system.second;
+  const auto numerical_deriv = numerical_derivative(
+      [&coords, &solution](const std::array<double, 1>& t) noexcept {
+        EvolvedVariables result(2);
+        result.assign_subset(solution.variables(
+            coords, t[0], system::variables_tag::tags_list{}));
+        return result;
+      },
+      std::array<double, 1>{{time}}, 0, 1e-3);
+
+  CHECK_VARIABLES_CUSTOM_APPROX(numerical_deriv, deriv_from_system,
+                                approx.epsilon(1.0e-12));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.WaveEquation.SemidiscretizedDg",
+    "[Unit][PointwiseFunctions]") {
+  // We use 16 elements, so there are 16 independent harmonics.
+  for (int harmonic = 0; harmonic < 16; ++harmonic) {
+    check_solution({harmonic, {{1.2, 2.3, 3.4, 4.5}}});
+  }
+
+  check_solution(
+      TestHelpers::test_creation<ScalarWave::Solutions::SemidiscretizedDg>(
+          "Harmonic: 1\n"
+          "Amplitudes: [1.2, 2.3, 3.4, 4.5]"));
+}

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -251,9 +251,10 @@ void check_cmp(const T& less, const U& greater) {
  * \requires direction be between 0 and VolumeDim
  */
 template <typename Invocable, size_t VolumeDim>
-std::array<double, VolumeDim> numerical_derivative(
-    const Invocable& map, const std::array<double, VolumeDim>& x,
-    const size_t direction, const double delta) {
+std::result_of_t<const Invocable&(const std::array<double, VolumeDim>&)>
+numerical_derivative(const Invocable& map,
+                     const std::array<double, VolumeDim>& x,
+                     const size_t direction, const double delta) noexcept {
   ASSERT(0 <= direction and direction < VolumeDim,
          "Trying to take derivative along axis " << direction);
 

--- a/tests/Unit/Test_TestHelpers.cpp
+++ b/tests/Unit/Test_TestHelpers.cpp
@@ -134,6 +134,19 @@ SPECTRE_TEST_CASE("Unit.TestHelpers.Derivative", "[Unit]") {
             approx(gsl::at(dfunc(x), i)));
     }
   }
+  {  // Non-array return type
+    const std::array<double, 1> x{{1.2}};
+    const double delta = 1.e-2;
+
+    const auto func = [](const std::array<double, 1>& y) {
+      return sin(y[0]);
+    };
+    const auto dfunc = [](const std::array<double, 1>& y) {
+      return cos(y[0]);
+    };
+
+    CHECK(numerical_derivative(func, x, 0, delta) == approx(dfunc(x)));
+  }
 }
 
 SPECTRE_TEST_CASE("Unit.TestHelpers.MAKE_GENERATOR", "[Unit]") {


### PR DESCRIPTION
This is not a super-efficient implementation, but since it's only for testing in 1D, and then only useful for initial data and error observations, I think that's OK.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
