### PR TITLE
Import numeric initial data in GeneralizedHarmonic executable

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -14,11 +14,96 @@
 #include "Domain/InitialElementIds.hpp"
 #include "Domain/OptionTags.hpp"
 #include "Domain/Tags.hpp"
+#include "Evolution/Protocols.hpp"
+#include "Evolution/Tags.hpp"
+#include "IO/Importers/VolumeDataReader.hpp"
+#include "IO/Importers/VolumeDataReaderActions.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Info.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "ParallelAlgorithms/Actions/SetData.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+
+/*!
+ * \brief Don't try to import initial data from a data file
+ *
+ * \see `DgElementArray`
+ */
+struct ImportNoInitialData {};
+
+/*!
+ * \brief Import numeric initial data in the `ImportPhase`
+ *
+ * Requires the `InitialData` conforms to
+ * `evolution::protocols::NumericInitialData`. The `InitialData::import_fields`
+ * will be imported in the `ImportPhase` from the data file that is specified by
+ * the options in the `evolution::OptionTags::NumericInitialData` group.
+ *
+ * \see `DgElementArray`
+ */
+template <typename PhaseType, PhaseType ImportPhase, typename InitialData>
+struct ImportNumericInitialData {
+  static_assert(
+      tt::conforms_to_v<InitialData, evolution::protocols::NumericInitialData>);
+};
+
+namespace DgElementArray_detail {
+
+template <typename DgElementArray, typename InitialData,
+          typename ImportFields = typename InitialData::import_fields>
+using read_element_data_action = importers::ThreadedActions::ReadVolumeData<
+    evolution::OptionTags::NumericInitialData, ImportFields,
+    ::Actions::SetData<ImportFields>, DgElementArray>;
+
+template <typename DgElementArray, typename ImportInitialData>
+struct import_numeric_data_cache_tags {
+  using type = tmpl::list<>;
+};
+
+template <typename DgElementArray, typename PhaseType, PhaseType ImportPhase,
+          typename InitialData>
+struct import_numeric_data_cache_tags<
+    DgElementArray,
+    ImportNumericInitialData<PhaseType, ImportPhase, InitialData>> {
+  using type =
+      typename read_element_data_action<DgElementArray,
+                                        InitialData>::const_global_cache_tags;
+};
+
+template <typename DgElementArray, typename ImportInitialData>
+struct try_import_data {
+  template <typename Metavariables>
+  static void apply(const typename Metavariables::Phase /*next_phase*/,
+                    Parallel::CProxy_ConstGlobalCache<
+                        Metavariables>& /*global_cache*/) noexcept {}
+};
+
+template <typename DgElementArray, typename PhaseType, PhaseType ImportPhase,
+          typename InitialData>
+struct try_import_data<
+    DgElementArray,
+    ImportNumericInitialData<PhaseType, ImportPhase, InitialData>> {
+  template <typename Metavariables>
+  static void apply(
+      const typename Metavariables::Phase next_phase,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
+    static_assert(
+        std::is_same_v<PhaseType, typename Metavariables::Phase>,
+        "Make sure the 'ImportNumericInitialData' type uses a 'Phase' "
+        "that is defined in the Metavariables.");
+    if (next_phase == ImportPhase) {
+      auto& local_cache = *(global_cache.ckLocalBranch());
+      Parallel::threaded_action<
+          read_element_data_action<DgElementArray, InitialData>>(
+          Parallel::get_parallel_component<
+              importers::VolumeDataReader<Metavariables>>(local_cache));
+    }
+  }
+};
+
+}  // namespace DgElementArray_detail
 
 /*!
  * \brief The parallel component responsible for managing the DG elements that
@@ -27,8 +112,13 @@
  * This parallel component will perform the actions specified by the
  * `PhaseDepActionList`.
  *
+ * This component also supports loading initial for its elements from a file.
+ * To do so, set the `ImportInitialData` template parameter to
+ * `ImportNumericInitialData`. See the documentation of the
+ * `ImportNumericInitialData` for details.
  */
-template <class Metavariables, class PhaseDepActionList>
+template <class Metavariables, class PhaseDepActionList,
+          class ImportInitialData = ImportNoInitialData>
 struct DgElementArray {
   static constexpr size_t volume_dim = Metavariables::volume_dim;
 
@@ -37,7 +127,10 @@ struct DgElementArray {
   using phase_dependent_action_list = PhaseDepActionList;
   using array_index = ElementId<volume_dim>;
 
-  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<volume_dim>>;
+  using const_global_cache_tags = tmpl::flatten<tmpl::list<
+      domain::Tags::Domain<volume_dim>,
+      tmpl::type_from<DgElementArray_detail::import_numeric_data_cache_tags<
+          DgElementArray, ImportInitialData>>>>;
 
   using array_allocation_tags =
       tmpl::list<domain::Tags::InitialRefinementLevels<volume_dim>>;
@@ -57,14 +150,19 @@ struct DgElementArray {
     auto& local_cache = *(global_cache.ckLocalBranch());
     Parallel::get_parallel_component<DgElementArray>(local_cache)
         .start_phase(next_phase);
+
+    DgElementArray_detail::try_import_data<
+        DgElementArray, ImportInitialData>::apply(next_phase, global_cache);
   }
 };
 
-template <class Metavariables, class PhaseDepActionList>
-void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
-    Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
-    const tuples::tagged_tuple_from_typelist<initialization_tags>&
-        initialization_items) noexcept {
+template <class Metavariables, class PhaseDepActionList,
+          class ImportInitialData>
+void DgElementArray<Metavariables, PhaseDepActionList, ImportInitialData>::
+    allocate_array(
+        Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+        const tuples::tagged_tuple_from_typelist<initialization_tags>&
+            initialization_items) noexcept {
   auto& local_cache = *(global_cache.ckLocalBranch());
   auto& dg_element_array =
       Parallel::get_parallel_component<DgElementArray>(local_cache);

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -42,3 +42,14 @@ target_link_libraries(
   PRIVATE
   GeneralRelativitySolutions
   )
+
+add_generalized_harmonic_executable(
+  KerrSchildNumericInitialData
+  evolution::NumericInitialData<GeneralizedHarmonic::System<3>>
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
+)
+target_link_libraries(
+  EvolveKerrSchildNumericInitialData
+  PRIVATE
+  GeneralRelativitySolutions
+  )

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -9,7 +9,6 @@ set(LIBS_TO_LINK
   DomainCreators
   Evolution
   GeneralRelativity
-  GeneralRelativitySolutions
   GeneralizedHarmonic
   GeneralizedHarmonicGaugeSourceFunctions
   IO
@@ -22,10 +21,24 @@ set(LIBS_TO_LINK
   Utilities
   )
 
-add_spectre_parallel_executable(
-  EvolveGeneralizedHarmonic
-  EvolveGeneralizedHarmonic
-  Evolution/Executables/GeneralizedHarmonic
-  EvolutionMetavars
-  "${LIBS_TO_LINK}"
+function(add_generalized_harmonic_executable
+  EXECUTABLE_NAME INITIAL_DATA BOUNDARY_CONDITIONS)
+  add_spectre_parallel_executable(
+    "Evolve${EXECUTABLE_NAME}"
+    EvolveGeneralizedHarmonic
+    Evolution/Executables/GeneralizedHarmonic
+    "EvolutionMetavars<${INITIAL_DATA}, ${BOUNDARY_CONDITIONS}>"
+    "${LIBS_TO_LINK}"
+    )
+endfunction(add_generalized_harmonic_executable)
+
+add_generalized_harmonic_executable(
+  KerrSchild
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
+)
+target_link_libraries(
+  EvolveKerrSchild
+  PRIVATE
+  GeneralRelativitySolutions
   )

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicFwd.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicFwd.hpp
@@ -5,4 +5,19 @@
 
 #include <cstddef>
 
+/// \cond
+namespace GeneralizedHarmonic {
+namespace Solutions {
+template <typename GrSolution>
+struct WrappedGr;
+}  // namespace Solutions
+}  // namespace GeneralizedHarmonic
+namespace gr {
+namespace Solutions {
+struct KerrSchild;
+}  // namespace Solutions
+}  // namespace gr
+
+template <typename InitialData, typename BoundaryConditions>
 struct EvolutionMetavars;
+/// \endcond

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicFwd.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicFwd.hpp
@@ -7,6 +7,8 @@
 
 /// \cond
 namespace GeneralizedHarmonic {
+template <size_t Dim>
+struct System;
 namespace Solutions {
 template <typename GrSolution>
 struct WrappedGr;
@@ -17,6 +19,10 @@ namespace Solutions {
 struct KerrSchild;
 }  // namespace Solutions
 }  // namespace gr
+namespace evolution {
+template <typename System>
+struct NumericInitialData;
+}  // namespace evolution
 
 template <typename InitialData, typename BoundaryConditions>
 struct EvolutionMetavars;

--- a/src/Evolution/NumericInitialData.hpp
+++ b/src/Evolution/NumericInitialData.hpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Protocols.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+
+namespace evolution {
+
+/*!
+ * \brief Provides compile-time information to import numeric initial data for
+ * the given `System` from a volume data file.
+ */
+template <typename System>
+struct NumericInitialData : tt::ConformsTo<protocols::NumericInitialData> {
+  using import_fields =
+      db::get_variables_tags_list<typename System::variables_tag>;
+};
+
+}  // namespace evolution

--- a/src/Evolution/Protocols.hpp
+++ b/src/Evolution/Protocols.hpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"
+
+namespace evolution {
+/// \ref protocols related to evolution systems
+namespace protocols {
+
+namespace detail {
+CREATE_HAS_TYPE_ALIAS(import_fields)
+}  // namespace detail
+
+/*!
+ * \ingroup ProtocolsGroup
+ * \brief Indicates the `ConformingType` provides compile-time information for
+ * importing numeric initial data for an evolution.
+ *
+ * Requires the `ConformingType` has these type aliases:
+ * - `import_fields`: The list of tags that should be imported from a volume
+ * data file
+ *
+ * Here's an example of a class that conforms to this protocol:
+ *
+ * \snippet Evolution/Test_Protocols.cpp conforming_type_example
+ */
+template <typename ConformingType>
+using NumericInitialData = detail::has_import_fields<ConformingType>;
+
+}  // namespace protocols
+}  // namespace evolution

--- a/src/Evolution/Tags.hpp
+++ b/src/Evolution/Tags.hpp
@@ -5,6 +5,7 @@
 
 #include <string>
 
+#include "IO/Importers/Tags.hpp"
 #include "Options/Options.hpp"
 
 namespace evolution {
@@ -30,6 +31,16 @@ struct Group {
 struct SystemGroup {
   static std::string name() noexcept { return "EvolutionSystem"; }
   static constexpr OptionString help{"The system of hyperbolic PDEs"};
+};
+
+/*!
+ * \ingroup OptionGroupsGroup
+ * \brief Holds option tags for importing numeric initial data for an evolution.
+ */
+struct NumericInitialData {
+  using group = importers::OptionTags::Group;
+  static constexpr OptionString help =
+      "Numeric initial data for all system variables";
 };
 
 }  // namespace OptionTags

--- a/src/Evolution/TypeTraits.hpp
+++ b/src/Evolution/TypeTraits.hpp
@@ -5,8 +5,10 @@
 
 #include <type_traits>
 
+#include "Evolution/Protocols.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 namespace evolution {
@@ -32,4 +34,16 @@ using is_analytic_solution =
 template <typename T>
 constexpr bool is_analytic_solution_v =
     std::is_convertible_v<T*, MarkAsAnalyticSolution*>;
+
+// @{
+/// Helper metafunction that checks if the class `T` is marked as numeric
+/// initial data.
+template <typename T>
+using is_numeric_initial_data =
+    tt::conforms_to<T, protocols::NumericInitialData>;
+
+template <typename T>
+constexpr bool is_numeric_initial_data_v =
+    tt::conforms_to_v<T, protocols::NumericInitialData>;
+// @}
 }  // namespace evolution

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
@@ -13,6 +13,7 @@
 #include "Domain/FaceNormal.hpp"
 #include "Domain/Tags.hpp"
 #include "ErrorHandling/Assert.hpp"
+#include "Evolution/TypeTraits.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
@@ -45,7 +46,6 @@ namespace Actions {
 /// Uses:
 /// - ConstGlobalCache:
 ///   - Metavariables::boundary_condition_tag
-///   - Metavariables::initial_data_tag
 /// - DataBox:
 ///   - Tags::Time
 ///   - External<Tags::BoundaryCoordinates<volume_dim>>,
@@ -107,8 +107,8 @@ struct ImposeDirichletBoundaryConditions {
 
     static_assert(
         system::is_in_flux_conservative_form or
-            std::is_same_v<typename Metavariables::initial_data_tag,
-                           typename Metavariables::boundary_condition_tag>,
+            evolution::is_analytic_solution_v<
+                typename Metavariables::boundary_condition_tag::type>,
         "Only analytic boundary conditions, or dirichlet boundary conditions "
         "for conservative systems are implemented");
 
@@ -165,8 +165,8 @@ struct ImposeDirichletBoundaryConditions {
     static_assert(
         system::is_in_flux_conservative_form and
             system::has_primitive_and_conservative_vars and
-            std::is_same_v<typename Metavariables::initial_data_tag,
-                           typename Metavariables::boundary_condition_tag>,
+            evolution::is_analytic_solution_v<
+                typename Metavariables::boundary_condition_tag::type>,
         "Only analytic boundary conditions, or dirichlet boundary conditions "
         "for conservative systems are implemented");
 

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Executable: EvolveGeneralizedHarmonic
+# Executable: EvolveKerrSchild
 # Check: parse;execute
 # Timeout: 8
 # ExpectedOutput:

--- a/tests/Unit/Evolution/CMakeLists.txt
+++ b/tests/Unit/Evolution/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY "Test_Evolution")
 
 set(LIBRARY_SOURCES
   Test_ComputeTags.cpp
+  Test_Protocols.cpp
   Test_TagsDomain.cpp
   Test_TypeTraits.cpp
   )

--- a/tests/Unit/Evolution/CMakeLists.txt
+++ b/tests/Unit/Evolution/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY "Test_Evolution")
 
 set(LIBRARY_SOURCES
   Test_ComputeTags.cpp
+  Test_NumericInitialData.cpp
   Test_Protocols.cpp
   Test_TagsDomain.cpp
   Test_TypeTraits.cpp

--- a/tests/Unit/Evolution/Test_NumericInitialData.cpp
+++ b/tests/Unit/Evolution/Test_NumericInitialData.cpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/NumericInitialData.hpp"
+#include "Evolution/Protocols.hpp"
+#include "Helpers/Utilities/ProtocolTestHelpers.hpp"
+
+namespace {
+
+struct FieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct SecondFieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct System {
+  using variables_tag = ::Tags::Variables<tmpl::list<FieldTag, SecondFieldTag>>;
+};
+
+// Test that the system's numeric initial data conforms to the protocol
+static_assert(
+    test_protocol_conformance<evolution::NumericInitialData<System>,
+                              evolution::protocols::NumericInitialData>,
+    "Failed testing protocol conformance");
+
+// Test that the `import_fields` extracted from the system are correct
+static_assert(std::is_same_v<
+                  typename evolution::NumericInitialData<System>::import_fields,
+                  tmpl::list<FieldTag, SecondFieldTag>>,
+              "Failed testing evolution::NumericInitialData");
+
+}  // namespace

--- a/tests/Unit/Evolution/Test_Protocols.cpp
+++ b/tests/Unit/Evolution/Test_Protocols.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Protocols.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+struct FieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+// [conforming_type_example]
+struct ValidNumericInitialData
+    : tt::ConformsTo<evolution::protocols::NumericInitialData> {
+  using import_fields = tmpl::list<FieldTag>;
+};
+// [conforming_type_example]
+struct InvalidNumericInitialData
+    : tt::ConformsTo<evolution::protocols::NumericInitialData> {};
+
+static_assert(
+    evolution::protocols::NumericInitialData<ValidNumericInitialData>::value,
+    "Failed testing protocol");
+static_assert(not evolution::protocols::NumericInitialData<
+                  InvalidNumericInitialData>::value,
+              "Failed testing protocol");
+
+}  // namespace

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -42,15 +42,15 @@ struct PrimitiveVar : db::SimpleTag {
 // Only analytic Dirichlet boundary conditions are supported right now,
 // so this is `MarkedAsAnalyticSolution`.
 struct BoundaryCondition : MarkAsAnalyticSolution {
-  tuples::TaggedTuple<Var> variables(const tnsr::I<DataVector, Dim>& /*x*/,
-                                     double /*t*/,
-                                     tmpl::list<Var> /*meta*/) const noexcept {
+  static tuples::TaggedTuple<Var> variables(
+      const tnsr::I<DataVector, Dim>& /*x*/, double /*t*/,
+      tmpl::list<Var> /*meta*/) noexcept {
     return tuples::TaggedTuple<Var>{Scalar<DataVector>{{{{30., 40., 50.}}}}};
   }
 
-  tuples::TaggedTuple<PrimitiveVar> variables(
+  static tuples::TaggedTuple<PrimitiveVar> variables(
       const tnsr::I<DataVector, Dim>& /*x*/, double /*t*/,
-      tmpl::list<PrimitiveVar> /*meta*/) const noexcept {
+      tmpl::list<PrimitiveVar> /*meta*/) noexcept {
     return tuples::TaggedTuple<PrimitiveVar>{
         Scalar<DataVector>{{{{15., 20., 25.}}}}};
   }

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -22,6 +22,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -38,7 +39,9 @@ struct PrimitiveVar : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
-struct BoundaryCondition {
+// Only analytic Dirichlet boundary conditions are supported right now,
+// so this is `MarkedAsAnalyticSolution`.
+struct BoundaryCondition : MarkAsAnalyticSolution {
   tuples::TaggedTuple<Var> variables(const tnsr::I<DataVector, Dim>& /*x*/,
                                      double /*t*/,
                                      tmpl::list<Var> /*meta*/) const noexcept {
@@ -111,7 +114,6 @@ struct Metavariables {
   using component_list = tmpl::list<component<Metavariables>>;
 
   using boundary_condition_tag = BoundaryConditionTag;
-  using initial_data_tag = boundary_condition_tag;
   enum class Phase { Initialization, Testing, Exit };
 };
 


### PR DESCRIPTION
## Proposed changes

Adds support for importing numeric initial data to the `evolution::DgElementArray` and the GeneralizedHarmonic executable. Other executables can follow this example to add numeric initial data as well.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
