### PR TITLE
Document singularity out of memory issue

### DIFF
--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -179,8 +179,20 @@ To use Singularity you must:
    Singularity instructions on setting up additional [bind
    points](http://singularity.lbl.gov/docs-mount). Once inside the WORKDIR,
    clone SpECTRE into `WORKDIR/SPECTRE_ROOT`.
-3. Run `singularity build spectre.img
+3. Run `sudo singularity build spectre.img
    docker://sxscollaboration/spectrebuildenv:latest`.
+
+   If you get the error message that `makesquashfs` did not have enough space to
+   create the image you need to set a different `SINGULARITY_TMPDIR`. This can
+   be done by running: `sudo SINGULARITY_TMPDIR=/path/to/new/tmp singularity
+   build spectre.img docker://sxscollaboration/spectrebuildenv:latest`. Normally
+   `SINGULARITY_TMPDIR` is `/tmp`, but building the image will temporarily need
+   almost 8GB of space.
+
+   You can control where Singularity stores the downloaded image files from
+   DockerHub by specifying the `SINGULARITY_CACHEDIR` environment variable. The
+   default is `$HOME/.singularity/`. Note that `$HOME` is `/root` when running
+   using `sudo`.
 4. To start the container run `singularity shell spectre.img` and you
    will be dropped into a bash shell.
 5. Run `cd SPECTRE_HOME && mkdir build && cd build` to set up a build


### PR DESCRIPTION
## Proposed changes

Singularity uses /tmp to build an image. With the SpECTRE image being quite
large at this point it requires almost 8GB of space in /tmp, which isn't always
available. This is fixed by specifying a new TMP dir using the TMPDIR
environment variable

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
