### PR TITLE
Inbox tags improvements

### DIFF
--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -392,11 +392,19 @@ a `tmpl::list`. The `inbox_tags` must have two member type aliases, a
 which is the type of the data to be stored in the `inboxes`. The types are
 typically a `std::unordered_map<temporal_id, DATA>`. In the discussed scenario
 of waiting for neighboring elements to send their data the `DATA` type would be
-a `std::unordered_map<TheElementIndex, DataSent>`. Having `DATA` be a
-`std::unordered_multiset` is currently also supported. Here is an example of a
-receive tag:
+a `std::unordered_map<TheElementIndex, DataSent>`. Inbox tags must also specify
+a `static void insert_into_inbox()` function. For example,
 
 \snippet Test_AlgorithmParallel.cpp int_receive_tag
+
+For common types of `DATA`, such as a `map`, a data structure with an `insert`
+function, a data structure with a `push_back` function, or copy/move assignment
+that is used to insert the received data, inserters are available in
+`Parallel::InboxInserters`. For example, there is
+`Parallel::InboxInserters::Map` for `map` data structures. The inbox tag can
+inherit publicly off the inserters to gain the required insertion capabilities:
+
+\snippet Test_AlgorithmCore.cpp int receive tag insert
 
 The `inbox_tags` type alias for the action is:
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp
@@ -16,6 +16,7 @@
 #include "Domain/Tags.hpp"
 #include "ErrorHandling/Assert.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/InboxInserters.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -25,7 +26,8 @@ namespace Tags {
 /// \ingroup LimitersGroup
 /// \brief The inbox tag for limiter communication.
 template <typename Metavariables>
-struct LimiterCommunicationTag {
+struct LimiterCommunicationTag : public Parallel::InboxInserters::Map<
+                                     LimiterCommunicationTag<Metavariables>> {
   static constexpr size_t volume_dim = Metavariables::system::volume_dim;
   using packaged_data_t = typename Metavariables::limiter::type::PackagedData;
   using temporal_id = db::const_item_type<typename Metavariables::temporal_id>;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
@@ -20,6 +20,7 @@
 #include "Domain/MaxNumberOfNeighbors.hpp"
 #include "Domain/Tags.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Parallel/InboxInserters.hpp"
 #include "Time/Tags.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 
@@ -93,7 +94,7 @@ struct FluxCommunicationTypes {
                    volume_dim>;
 
   /// The inbox tag for flux communication.
-  struct FluxesTag {
+  struct FluxesTag : public Parallel::InboxInserters::Map<FluxesTag> {
     using temporal_id =
         db::const_item_type<typename Metavariables::temporal_id>;
     using type = std::map<

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -325,24 +325,6 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>> {
         std::forward<Args>(std::get<Is>(args))...);
   }
 
-  // @{
-  /// Since it's not clear how or if it's possible at all to do SFINAE with
-  /// Charm's ci files, we use a forward to implementation, where the
-  /// implementation is a simple function call that we can use SFINAE with
-  template <typename ReceiveTag, typename ReceiveDataType,
-            Requires<tt::is_maplike_v<typename ReceiveTag::type::mapped_type>> =
-                nullptr>
-  void receive_data_impl(typename ReceiveTag::temporal_id& instance,
-                         ReceiveDataType&& t);
-
-  template <
-      typename ReceiveTag, typename ReceiveDataType,
-      Requires<tt::is_a_v<std::unordered_multiset,
-                          typename ReceiveTag::type::mapped_type>> = nullptr>
-  constexpr void receive_data_impl(typename ReceiveTag::temporal_id& instance,
-                                   ReceiveDataType&& t);
-  // @}
-
   size_t number_of_actions_in_phase(const PhaseType phase) const noexcept {
     size_t number_of_actions = 0;
     const auto helper = [&number_of_actions, phase](auto pdal_v) {
@@ -527,7 +509,9 @@ void AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
     if (enable_if_disabled) {
       set_terminate(false);
     }
-    receive_data_impl<ReceiveTag>(instance, std::forward<ReceiveDataType>(t));
+    ReceiveTag::insert_into_inbox(
+        make_not_null(&tuples::get<ReceiveTag>(inboxes_)), instance,
+        std::forward<ReceiveDataType>(t));
     unlock(&node_lock_);
   } catch (std::exception& e) {
     ERROR("Fatal error: Unexpected exception caught in receive_data: "
@@ -781,50 +765,5 @@ AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
   // This is a template for loop for Is
   EXPAND_PACK_LEFT_TO_RIGHT(helper(std::integral_constant<size_t, Is>{}));
   return take_next_action;
-}
-
-template <typename ParallelComponent, typename... PhaseDepActionListsPack>
-template <typename ReceiveTag, typename ReceiveDataType,
-          Requires<tt::is_maplike_v<typename ReceiveTag::type::mapped_type>>>
-void AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
-    receive_data_impl(typename ReceiveTag::temporal_id& instance,
-                      ReceiveDataType&& t) {
-  static_assert(
-      cpp17::is_same_v<
-          cpp20::remove_cvref_t<typename ReceiveDataType::first_type>,
-          typename ReceiveTag::type::mapped_type::key_type> and
-          cpp17::is_same_v<
-              cpp20::remove_cvref_t<typename ReceiveDataType::second_type>,
-              typename ReceiveTag::type::mapped_type::mapped_type>,
-      "The type of the data passed to receive_data for a tag that holds a map "
-      "must be a std::pair.");
-#ifdef SPECTRE_CHARM_RECEIVE_MAP_DATA_EVENT_ID
-  double start_time = Parallel::wall_time();
-#endif
-  auto& inbox = tuples::get<ReceiveTag>(inboxes_)[instance];
-  ASSERT(0 == inbox.count(t.first),
-         "Receiving data from the 'same' source twice. The message id is: "
-             << t.first);
-  if (not inbox.insert(std::forward<ReceiveDataType>(t)).second) {
-    ERROR("Failed to insert data to receive at instance '"
-          << instance << "' with tag '" << pretty_type::get_name<ReceiveTag>()
-          << "'.\n");
-  }
-#ifdef SPECTRE_CHARM_RECEIVE_MAP_DATA_EVENT_ID
-  traceUserBracketEvent(SPECTRE_CHARM_RECEIVE_MAP_DATA_EVENT_ID, start_time,
-                        Parallel::wall_time());
-#endif
-}
-
-template <typename ParallelComponent, typename... PhaseDepActionListsPack>
-template <typename ReceiveTag, typename ReceiveDataType,
-          Requires<tt::is_a_v<std::unordered_multiset,
-                              typename ReceiveTag::type::mapped_type>>>
-constexpr void
-AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
-    receive_data_impl(typename ReceiveTag::temporal_id& instance,
-                      ReceiveDataType&& t) {
-  tuples::get<ReceiveTag>(inboxes_)[instance].insert(
-      std::forward<ReceiveDataType>(t));
 }
 }  // namespace Parallel

--- a/src/Parallel/InboxInserters.hpp
+++ b/src/Parallel/InboxInserters.hpp
@@ -1,0 +1,122 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+
+namespace Parallel {
+/// \ingroup ParallelGroup
+/// \brief Structs that have `insert_into_inbox` methods for commonly used
+/// cases.
+///
+/// Inbox tags can inherit from the inserters to gain the `insert_into_inbox`
+/// static method used by the parallel infrastructure to store data in the
+/// inboxes. Collected in the `InboxInserters` namespace are implementations for
+/// the most common types of data sent that one may encounter.
+namespace InboxInserters {
+/*!
+ * \brief Inserter for inserting data that is received as the `value_type` (with
+ * non-const `key_type`) of a map data structure.
+ *
+ * An example would be a `std::unordered_map<int, int>`, where the first `int`
+ * is the "spatial" id of the parallel component array. The data type that is
+ * sent to the component would be a `std::pair<int, int>`, or more generally a
+ * `std::pair<key_type, mapped_type>`. The inbox tag would be:
+ *
+ * \snippet Test_InboxInserters.cpp map tag
+ */
+template <typename InboxTag>
+struct Map {
+  template <typename Inbox, typename TemporalId, typename ReceiveDataType>
+  static void insert_into_inbox(const gsl::not_null<Inbox*> inbox,
+                                const TemporalId& temporal_id,
+                                ReceiveDataType&& data) noexcept {
+    static_assert(std::is_same<std::decay_t<TemporalId>,
+                               typename InboxTag::temporal_id>::value,
+                  "The temporal_id of the inbox tag does not match the "
+                  "received temporal id.");
+    auto& current_inbox = (*inbox)[temporal_id];
+    ASSERT(0 == current_inbox.count(data.first),
+           "Receiving data from the 'same' source twice. The message id is: "
+               << data.first);
+    if (not current_inbox.insert(std::forward<ReceiveDataType>(data)).second) {
+      ERROR("Failed to insert data to receive at instance '"
+            << temporal_id << "' with tag '"
+            << pretty_type::get_name<InboxTag>() << "'.\n");
+    }
+  }
+};
+
+/*!
+ * \brief Inserter for inserting data that is received as the `value_type` of a
+ * data structure that has an `insert(value_type&&)` member function.
+ *
+ * Can be used for receiving data into data structures like
+ * `std::(unordered_)multiset`.
+ *
+ * \snippet Test_InboxInserters.cpp member insert tag
+ */
+template <typename InboxTag>
+struct MemberInsert {
+  template <typename Inbox, typename TemporalId, typename ReceiveDataType>
+  static void insert_into_inbox(const gsl::not_null<Inbox*> inbox,
+                                const TemporalId& temporal_id,
+                                ReceiveDataType&& data) noexcept {
+    static_assert(std::is_same<std::decay_t<TemporalId>,
+                               typename InboxTag::temporal_id>::value,
+                  "The temporal_id of the inbox tag does not match the "
+                  "received temporal id.");
+    (*inbox)[temporal_id].insert(std::forward<ReceiveDataType>(data));
+  }
+};
+
+/*!
+ * \brief Inserter for data that is inserted by copy/move.
+ *
+ * \snippet Test_InboxInserters.cpp value tag
+ */
+template <typename InboxTag>
+struct Value {
+  template <typename Inbox, typename TemporalId, typename ReceiveDataType>
+  static void insert_into_inbox(const gsl::not_null<Inbox*> inbox,
+                                const TemporalId& temporal_id,
+                                ReceiveDataType&& data) noexcept {
+    static_assert(std::is_same<std::decay_t<TemporalId>,
+                               typename InboxTag::temporal_id>::value,
+                  "The temporal_id of the inbox tag does not match the "
+                  "received temporal id.");
+    (*inbox)[temporal_id] = std::forward<ReceiveDataType>(data);
+  }
+};
+
+/*!
+ * \brief Inserter for inserting data that is received as the `value_type` of a
+ * data structure that has an `push_back(value_type&&)` member function.
+ *
+ * Can be used for receiving data into data structures like
+ * `std::vector`.
+ *
+ * \snippet Test_InboxInserters.cpp pushback tag
+ */
+template <typename InboxTag>
+struct Pushback {
+  template <typename Inbox, typename TemporalId, typename ReceiveDataType>
+  static void insert_into_inbox(const gsl::not_null<Inbox*> inbox,
+                                const TemporalId& temporal_id,
+                                ReceiveDataType&& data) noexcept {
+    static_assert(std::is_same<std::decay_t<TemporalId>,
+                               typename InboxTag::temporal_id>::value,
+                  "The temporal_id of the inbox tag does not match the "
+                  "received temporal id.");
+    (*inbox)[temporal_id].push_back(std::forward<ReceiveDataType>(data));
+  }
+};
+}  // namespace InboxInserters
+}  // namespace Parallel

--- a/src/Time/Actions/ChangeSlabSize.hpp
+++ b/src/Time/Actions/ChangeSlabSize.hpp
@@ -20,6 +20,7 @@
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/InboxInserters.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
@@ -47,7 +48,8 @@ struct Next;
 /// \endcond
 
 namespace ChangeSlabSize_detail {
-struct NewSlabSizeInbox {
+struct NewSlabSizeInbox
+    : public Parallel::InboxInserters::MemberInsert<NewSlabSizeInbox> {
   using temporal_id = int64_t;
   using type = std::map<temporal_id, std::unordered_multiset<double>>;
 };
@@ -57,7 +59,9 @@ struct NewSlabSizeInbox {
 // NewSlabSizeInbox, another message is sent here synchronously, so
 // the count here is the number of messages we expect in the
 // NewSlabSizeInbox.
-struct NumberOfExpectedMessagesInbox {
+struct NumberOfExpectedMessagesInbox
+    : public Parallel::InboxInserters::MemberInsert<
+          NumberOfExpectedMessagesInbox> {
   using temporal_id = int64_t;
   using NoData = std::tuple<>;
   using type = std::map<temporal_id,

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
@@ -260,7 +260,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.LimiterActions.Generic",
         const double expected_mean_data,
         const Mesh<2>& expected_mesh) noexcept {
       const auto received_package =
-          tuples::get<limiter_comm_tag>(runner.inboxes<my_component>()[self_id])
+          tuples::get<limiter_comm_tag>(
+              runner.inboxes<my_component>().at(self_id))
               .at(0)
               .at(std::make_pair(direction, id));
       CHECK(received_package.mean_ == approx(expected_mean_data));
@@ -291,8 +292,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.LimiterActions.Generic",
   // Check that data for this time (t=0) was deleted from the inbox after the
   // limiter call. Note that we only put in t=0 data, so the whole inbox should
   // be empty.
-  CHECK(tuples::get<limiter_comm_tag>(runner.inboxes<my_component>()[self_id])
-            .empty());
+  CHECK(
+      tuples::get<limiter_comm_tag>(runner.inboxes<my_component>().at(self_id))
+          .empty());
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.LimiterActions.NoNeighbors",
@@ -333,8 +335,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.LimiterActions.NoNeighbors",
 
   CHECK(runner.nonempty_inboxes<my_component, limiter_comm_tag>().empty());
   CHECK(runner.is_ready<my_component>(self_id));
-  CHECK(tuples::get<limiter_comm_tag>(runner.inboxes<my_component>()[self_id])
-            .empty());
+  CHECK(
+      tuples::get<limiter_comm_tag>(runner.inboxes<my_component>().at(self_id))
+          .empty());
 
   // Now we run the ApplyLimiter action, checking pre and post values.
   const auto& var_to_limit =

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -420,7 +420,7 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
           make_not_null(&runner), self_id);
 
   CHECK(tuples::get<fluxes_tag<flux_comm_types<2>>>(
-            runner.inboxes<my_component>()[self_id])
+            runner.inboxes<my_component>().at(self_id))
             .empty());
 
   for (const auto& mortar_id : neighbor_mortar_ids) {

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -125,6 +125,7 @@ set(LIBRARY "Test_Parallel")
 
 set(LIBRARY_SOURCES
   Test_ConstGlobalCacheDataBox.cpp
+  Test_InboxInserters.cpp
   Test_Parallel.cpp
   Test_ParallelComponentHelpers.cpp
   Test_PupStlCpp11.cpp

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -22,6 +22,7 @@
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/InboxInserters.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Main.hpp"
@@ -395,10 +396,13 @@ struct MutateComponent {
 //////////////////////////////////////////////////////////////////////
 
 namespace receive_data_test {
-struct IntReceiveTag {
+/// [int receive tag insert]
+struct IntReceiveTag
+    : public Parallel::InboxInserters::MemberInsert<IntReceiveTag> {
   using temporal_id = TestAlgorithmArrayInstance;
   using type = std::unordered_map<temporal_id, std::unordered_multiset<int>>;
 };
+/// [int receive tag insert]
 
 struct add_int0_from_receive {
   using inbox_tags = tmpl::list<IntReceiveTag>;

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -19,6 +19,7 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/InboxInserters.hpp"
 #include "Parallel/Info.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Invoke.hpp"
@@ -58,6 +59,13 @@ struct CountActionsCalled : db::SimpleTag {
 struct IntReceiveTag {
   using temporal_id = int;
   using type = std::unordered_map<temporal_id, std::unordered_multiset<int>>;
+
+  template <typename Inbox, typename ReceiveDataType>
+  static void insert_into_inbox(const gsl::not_null<Inbox*> inbox,
+                                const temporal_id& temporal_id_v,
+                                ReceiveDataType&& data) noexcept {
+    (*inbox)[temporal_id_v].insert(std::forward<ReceiveDataType>(data));
+  }
 };
 /// [int_receive_tag]
 }  // namespace Tags

--- a/tests/Unit/Parallel/Test_InboxInserters.cpp
+++ b/tests/Unit/Parallel/Test_InboxInserters.cpp
@@ -1,0 +1,395 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/InboxInserters.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+namespace Tags {
+struct MapCounter : db::SimpleTag {
+  using type = size_t;
+};
+
+struct MemberInsertCounter : db::SimpleTag {
+  using type = size_t;
+};
+
+struct ValueCounter : db::SimpleTag {
+  using type = size_t;
+};
+
+struct PushbackCounter : db::SimpleTag {
+  using type = size_t;
+};
+
+/// [map tag]
+struct MapTag : public Parallel::InboxInserters::Map<MapTag> {
+  using temporal_id = size_t;
+  using type = std::unordered_map<temporal_id, std::unordered_map<int, int>>;
+};
+/// [map tag]
+
+/// [member insert tag]
+struct MemberInsertTag
+    : public Parallel::InboxInserters::MemberInsert<MemberInsertTag> {
+  using temporal_id = size_t;
+  using type = std::unordered_map<temporal_id, std::unordered_multiset<int>>;
+};
+/// [member insert tag]
+
+/// [value tag]
+struct ValueTag : public Parallel::InboxInserters::Value<ValueTag> {
+  using temporal_id = size_t;
+  using type = std::unordered_map<temporal_id, int>;
+};
+/// [value tag]
+
+/// [pushback tag]
+struct PushbackTag : public Parallel::InboxInserters::Pushback<PushbackTag> {
+  using temporal_id = size_t;
+  using type = std::unordered_map<temporal_id, std::vector<int>>;
+};
+/// [pushback tag]
+}  // namespace Tags
+
+namespace Actions {
+struct SendMap {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    Parallel::receive_data<Tags::MapTag>(
+        Parallel::get_parallel_component<ParallelComponent>(cache)[0], 1_st,
+        std::make_pair(10, 23));
+    db::mutate<Tags::MapCounter>(make_not_null(&box), [
+    ](const gsl::not_null<size_t*> map_counter) noexcept { (*map_counter)++; });
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+
+struct ReceiveMap {
+  using inbox_tags = tmpl::list<Tags::MapTag>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<Tags::MapCounter>(make_not_null(&box), [
+    ](const gsl::not_null<size_t*> map_counter) noexcept { (*map_counter)++; });
+    return std::forward_as_tuple(std::move(box));
+  }
+
+  template <typename DbTags, typename Metavariables, typename... InboxTags,
+            typename ArrayIndex>
+  static bool is_ready(
+      const db::DataBox<DbTags>& /*box*/,
+      const tuples::TaggedTuple<InboxTags...>& inboxes,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/) noexcept {
+    return get<Tags::MapTag>(inboxes).at(1_st).size() == 1;
+  }
+};
+
+struct SendMemberInsert {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    Parallel::receive_data<Tags::MemberInsertTag>(
+        Parallel::get_parallel_component<ParallelComponent>(cache)[0], 1_st,
+        23);
+    db::mutate<Tags::MemberInsertCounter>(make_not_null(&box), [
+    ](const gsl::not_null<size_t*> member_insert_counter) noexcept {
+      (*member_insert_counter)++;
+    });
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+
+struct ReceiveMemberInsert {
+  using inbox_tags = tmpl::list<Tags::MemberInsertTag>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<Tags::MemberInsertCounter>(make_not_null(&box), [
+    ](const gsl::not_null<size_t*> member_insert_counter) noexcept {
+      (*member_insert_counter)++;
+    });
+    return std::forward_as_tuple(std::move(box));
+  }
+
+  template <typename DbTags, typename Metavariables, typename... InboxTags,
+            typename ArrayIndex>
+  static bool is_ready(
+      const db::DataBox<DbTags>& /*box*/,
+      const tuples::TaggedTuple<InboxTags...>& inboxes,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/) noexcept {
+    return get<Tags::MemberInsertTag>(inboxes).at(1_st).size() == 1;
+  }
+};
+
+struct SendValue {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    Parallel::receive_data<Tags::ValueTag>(
+        Parallel::get_parallel_component<ParallelComponent>(cache)[0], 1_st,
+        23);
+    db::mutate<Tags::ValueCounter>(make_not_null(&box), [
+    ](const gsl::not_null<size_t*> value_counter) noexcept {
+      (*value_counter)++;
+    });
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+
+struct ReceiveValue {
+  using inbox_tags = tmpl::list<Tags::ValueTag>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<Tags::ValueCounter>(make_not_null(&box), [
+    ](const gsl::not_null<size_t*> value_counter) noexcept {
+      (*value_counter)++;
+    });
+    return std::forward_as_tuple(std::move(box));
+  }
+
+  template <typename DbTags, typename Metavariables, typename... InboxTags,
+            typename ArrayIndex>
+  static bool is_ready(
+      const db::DataBox<DbTags>& /*box*/,
+      const tuples::TaggedTuple<InboxTags...>& inboxes,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/) noexcept {
+    return get<Tags::ValueTag>(inboxes).count(1_st) == 1;
+  }
+};
+
+struct SendPushback {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    Parallel::receive_data<Tags::PushbackTag>(
+        Parallel::get_parallel_component<ParallelComponent>(cache)[0], 1_st,
+        23);
+    db::mutate<Tags::PushbackCounter>(make_not_null(&box), [
+    ](const gsl::not_null<size_t*> pushback_counter) noexcept {
+      (*pushback_counter)++;
+    });
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+
+struct ReceivePushback {
+  using inbox_tags = tmpl::list<Tags::PushbackTag>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<Tags::PushbackCounter>(make_not_null(&box), [
+    ](const gsl::not_null<size_t*> pushback_counter) noexcept {
+      (*pushback_counter)++;
+    });
+    return std::forward_as_tuple(std::move(box));
+  }
+
+  template <typename DbTags, typename Metavariables, typename... InboxTags,
+            typename ArrayIndex>
+  static bool is_ready(
+      const db::DataBox<DbTags>& /*box*/,
+      const tuples::TaggedTuple<InboxTags...>& inboxes,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/) noexcept {
+    return get<Tags::PushbackTag>(inboxes).at(1_st).size() == 1;
+  }
+};
+}  // namespace Actions
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<
+              db::AddSimpleTags<Tags::MapCounter, Tags::MemberInsertCounter,
+                                Tags::ValueCounter, Tags::PushbackCounter>>>>,
+
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<Actions::SendMap, Actions::ReceiveMap,
+                     Actions::SendMemberInsert, Actions::ReceiveMemberInsert,
+                     Actions::SendValue, Actions::ReceiveValue,
+                     Actions::SendPushback, Actions::ReceivePushback>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<Component<Metavariables>>;
+
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+SPECTRE_TEST_CASE("Unit.Parallel.InboxInserters", "[Parallel][Unit]") {
+  using metavars = Metavariables;
+  using component = Component<metavars>;
+
+  ActionTesting::MockRuntimeSystem<metavars> runner{{}};
+  ActionTesting::emplace_component_and_initialize<component>(
+      &runner, 0, {0_st, 0_st, 0_st, 0_st});
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Metavariables::Phase::Testing);
+
+  // Check map insertion
+  CHECK(ActionTesting::is_ready<component>(runner, 0));
+  CHECK(ActionTesting::get_next_action_index<component>(runner, 0) == 0);
+  CHECK(ActionTesting::get_databox_tag<component, Tags::MapCounter>(runner,
+                                                                    0) == 0);
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  CHECK(ActionTesting::get_inbox_tag<component, Tags::MapTag>(runner, 0)
+            .at(1)
+            .size() == 1);
+  CHECK(
+      ActionTesting::get_inbox_tag<component, Tags::MapTag>(runner, 0).at(1).at(
+          10) == 23);
+  CHECK(ActionTesting::is_ready<component>(runner, 0));
+  CHECK(ActionTesting::get_next_action_index<component>(runner, 0) == 1);
+  CHECK(ActionTesting::get_databox_tag<component, Tags::MapCounter>(runner,
+                                                                    0) == 1);
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  CHECK(ActionTesting::get_databox_tag<component, Tags::MapCounter>(runner,
+                                                                    0) == 2);
+  ActionTesting::get_inbox_tag<component, Tags::MapTag>(make_not_null(&runner),
+                                                        0)
+      .clear();
+
+  // Check member insertion
+  CHECK(ActionTesting::is_ready<component>(runner, 0));
+  CHECK(ActionTesting::get_next_action_index<component>(runner, 0) == 2);
+  CHECK(ActionTesting::get_databox_tag<component, Tags::MemberInsertCounter>(
+            runner, 0) == 0);
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  CHECK(
+      ActionTesting::get_inbox_tag<component, Tags::MemberInsertTag>(runner, 0)
+          .at(1)
+          .size() == 1);
+  CHECK(
+      ActionTesting::get_inbox_tag<component, Tags::MemberInsertTag>(runner, 0)
+          .at(1)
+          .count(23) == 1);
+  CHECK(ActionTesting::is_ready<component>(runner, 0));
+  CHECK(ActionTesting::get_next_action_index<component>(runner, 0) == 3);
+  CHECK(ActionTesting::get_databox_tag<component, Tags::MemberInsertCounter>(
+            runner, 0) == 1);
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  CHECK(ActionTesting::get_databox_tag<component, Tags::MemberInsertCounter>(
+            runner, 0) == 2);
+  ActionTesting::get_inbox_tag<component, Tags::MemberInsertTag>(
+      make_not_null(&runner), 0)
+      .clear();
+
+  // Check value insertion
+  CHECK(ActionTesting::is_ready<component>(runner, 0));
+  CHECK(ActionTesting::get_next_action_index<component>(runner, 0) == 4);
+  CHECK(ActionTesting::get_databox_tag<component, Tags::ValueCounter>(runner,
+                                                                      0) == 0);
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  CHECK(ActionTesting::get_inbox_tag<component, Tags::ValueTag>(runner, 0).at(
+            1) == 23);
+  CHECK(ActionTesting::is_ready<component>(runner, 0));
+  CHECK(ActionTesting::get_next_action_index<component>(runner, 0) == 5);
+  CHECK(ActionTesting::get_databox_tag<component, Tags::ValueCounter>(runner,
+                                                                      0) == 1);
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  CHECK(ActionTesting::get_databox_tag<component, Tags::ValueCounter>(runner,
+                                                                      0) == 2);
+  ActionTesting::get_inbox_tag<component, Tags::ValueTag>(
+      make_not_null(&runner), 0)
+      .clear();
+
+  // Check pushback insertion
+  CHECK(ActionTesting::is_ready<component>(runner, 0));
+  CHECK(ActionTesting::get_next_action_index<component>(runner, 0) == 6);
+  CHECK(ActionTesting::get_databox_tag<component, Tags::PushbackCounter>(
+            runner, 0) == 0);
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  CHECK(ActionTesting::get_inbox_tag<component, Tags::PushbackTag>(runner, 0)
+            .at(1)
+            .size() == 1);
+  CHECK(
+      ActionTesting::get_inbox_tag<component, Tags::PushbackTag>(runner, 0).at(
+          1)[0] == 23);
+  CHECK(ActionTesting::is_ready<component>(runner, 0));
+  CHECK(ActionTesting::get_next_action_index<component>(runner, 0) == 7);
+  CHECK(ActionTesting::get_databox_tag<component, Tags::PushbackCounter>(
+            runner, 0) == 1);
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  CHECK(ActionTesting::get_databox_tag<component, Tags::PushbackCounter>(
+            runner, 0) == 2);
+  ActionTesting::get_inbox_tag<component, Tags::PushbackTag>(
+      make_not_null(&runner), 0)
+      .clear();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

- Add free function `ActionTesting::set_phase`
- Add free function `ActionTesting::get_inbox_tag`
- Change the way that `receive_data` and inbox tags store data into the inboxes. Instead of needing special implementations of `receive_data` for different types of data, each inbox tag must provide a `static void insert_into_inbox(inbox, temporal_id, data)` function. To avoid copy-pasting the same implementation into many places, `Parallel/InboxInserters.hpp` provides base classes that inbox tags can inherit from to obtain insertion functions for map-like data structures, multiset-like data structures (have an insert function used to insert the data), vector-like data structures with a `push_back` function, and value stored data.

A simpler design for the inbox tags and `receive_data` code came up during the review of #1972 

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
