### PR TITLE
Make GH evolve GaugeWave instead of KerrSchild

### DIFF
--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave.yaml
@@ -5,8 +5,8 @@
 # Check: parse;execute
 # Timeout: 8
 # ExpectedOutput:
-#   GhKerrSchildReductionData.h5
-#   GhKerrSchildVolumeData0.h5
+#   GhGaugeWaveReductionData.h5
+#   GhGaugeWaveVolumeData0.h5
 
 Evolution:
   InitialTime: 0.0
@@ -16,21 +16,17 @@ Evolution:
       Order: 1
 
 DomainCreator:
-    Shell:
-      InnerRadius: 1.9
-      OuterRadius: 2.3
-      InitialRefinement: 0
-      InitialGridPoints: [5, 5]
-      UseEquiangularMap: true
-      AspectRatio: 1.0
-      UseLogarithmicMap: true
-      RadialBlockLayers: 1
+  Brick:
+    LowerBound: [-2.0, -2.0, -2.0]
+    UpperBound: [2.0, 2.0, 2.0]
+    InitialRefinement: [0, 0, 0]
+    InitialGridPoints: [5, 5, 5]
+    IsPeriodicIn: [true, true, true]
 
 AnalyticSolution:
-  KerrSchild:
-    Mass: 1.0
-    Spin: [0.0, 0.0, 0.0]
-    Center: [0.0, 0.0, 0.0]
+  GaugeWave:
+    Amplitude: 0.01
+    Wavelength: 1.0
 
 EvolutionSystem:
   GeneralizedHarmonic:
@@ -54,21 +50,8 @@ EventsAndTriggers:
   ? EveryNSlabs:
       N: 5
       Offset: 2
-  : - Interpolate
-  ? SpecifiedSlabs:
-      Slabs: [3]
   : - Completion
 
 Observers:
-  VolumeFileName: "GhKerrSchildVolumeData"
-  ReductionFileName: "GhKerrSchildReductionData"
-
-ApparentHorizons:
-  Horizon:
-    InitialGuess:
-      Lmax: 4
-      Radius: 2.2
-      Center: [0.0, 0.0, 0.0]
-    FastFlow:
-      Flow: Fast
-    Verbosity: Verbose
+  VolumeFileName: "GhGaugeWaveVolumeData"
+  ReductionFileName: "GhGaugeWaveReductionData"


### PR DESCRIPTION
## Proposed changes

This PR is intended for code sharing, not to be merged. It evolves a gauge wave instead of KerrSchild with the GeneralizedHarmonic executable.

Note: to actually get an accurate evolution, increase resolution and use a better time stepper in the `GaugeWave.yaml` input file. The example here uses simple settings so that the automated test doesn't time out.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
