### PR TITLE
Test domain tags names, factor InverseJacobian into simple and compute tags

### DIFF
--- a/src/Domain/InterfaceComputeTags.hpp
+++ b/src/Domain/InterfaceComputeTags.hpp
@@ -123,7 +123,8 @@ struct InterfaceCompute : Interface<DirectionsTag, Tag>,
   // tags; Both Interface<Dirs, Tag> and Interface<Dirs, Tag::base> will have a
   // name function and so cannot be disambiguated.
   static std::string name() noexcept {
-    return "Interface<" + DirectionsTag::name() + ", " + Tag::name() + ">";
+    return "Interface<" + db::tag_name<DirectionsTag>() + ", " +
+           db::tag_name<Tag>() + ">";
   };
   using tag = Tag;
   using forwarded_argument_tags =

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -156,13 +156,36 @@ struct MappedCoordinates
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
+/// \brief The inverse Jacobian from the source frame to the target frame.
+///
+/// Specifically, \f$\partial x^{\bar{i}} / \partial x^i\f$, where \f$\bar{i}\f$
+/// denotes the source frame and \f$i\f$ denotes the target frame.
+template <size_t Dim, typename SourceFrame, typename TargetFrame>
+struct InverseJacobian : db::SimpleTag {
+  static std::string name() noexcept {
+    return "InverseJacobian(" + get_output(SourceFrame{}) + "," +
+           get_output(TargetFrame{}) + ")";
+  }
+  using type = ::InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
 /// Computes the inverse Jacobian of the map held by `MapTag` at the coordinates
 /// held by `SourceCoordsTag`. The coordinates must be in the source frame of
 /// the map.
 template <typename MapTag, typename SourceCoordsTag>
-struct InverseJacobian : db::ComputeTag, db::PrefixTag {
+struct InverseJacobianCompute
+    : InverseJacobian<db::const_item_type<MapTag>::dim,
+                      typename db::const_item_type<MapTag>::source_frame,
+                      typename db::const_item_type<MapTag>::target_frame>,
+      db::ComputeTag,
+      db::PrefixTag {
+  using base =
+      InverseJacobian<db::const_item_type<MapTag>::dim,
+                      typename db::const_item_type<MapTag>::source_frame,
+                      typename db::const_item_type<MapTag>::target_frame>;
   using tag = MapTag;
-  static std::string name() noexcept { return "InverseJacobian"; }
   static constexpr auto function(
       const db::const_item_type<MapTag>& element_map,
       const db::const_item_type<SourceCoordsTag>& source_coords) noexcept {

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -54,7 +54,6 @@ namespace Tags {
 /// The ::Domain.
 template <size_t VolumeDim>
 struct Domain : db::SimpleTag {
-  static std::string name() noexcept { return "Domain"; }
   using type = ::Domain<VolumeDim>;
   using option_tags = tmpl::list<::OptionTags::DomainCreator<VolumeDim>>;
 
@@ -72,7 +71,6 @@ struct Domain : db::SimpleTag {
 /// the initial computational domain
 template <size_t Dim>
 struct InitialExtents : db::SimpleTag {
-  static std::string name() noexcept { return "InitialExtents"; }
   using type = std::vector<std::array<size_t, Dim>>;
   using option_tags = tmpl::list<::OptionTags::DomainCreator<Dim>>;
 
@@ -89,7 +87,6 @@ struct InitialExtents : db::SimpleTag {
 /// the initial computational domain
 template <size_t Dim>
 struct InitialRefinementLevels : db::SimpleTag {
-  static std::string name() noexcept { return "InitialRefinementLevels"; }
   using type = std::vector<std::array<size_t, Dim>>;
   using option_tags = tmpl::list<::OptionTags::DomainCreator<Dim>>;
 
@@ -105,7 +102,6 @@ struct InitialRefinementLevels : db::SimpleTag {
 /// The ::Element associated with the DataBox
 template <size_t VolumeDim>
 struct Element : db::SimpleTag {
-  static std::string name() noexcept { return "Element"; }
   using type = ::Element<VolumeDim>;
 };
 
@@ -116,7 +112,6 @@ struct Element : db::SimpleTag {
 /// the mesh on the face of the element.
 template <size_t VolumeDim>
 struct Mesh : db::SimpleTag {
-  static std::string name() noexcept { return "Mesh"; }
   using type = ::Mesh<VolumeDim>;
 };
 
@@ -125,15 +120,12 @@ struct Mesh : db::SimpleTag {
 /// The coordinate map from logical to grid coordinate
 template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
 struct ElementMap : db::SimpleTag {
-  static std::string name() noexcept { return "ElementMap"; }
   using type = ::ElementMap<VolumeDim, Frame>;
 };
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// The coordinates in a given frame.
-///
-/// \snippet Test_CoordinatesTag.cpp coordinates_name
 template <size_t Dim, typename Frame>
 struct Coordinates : db::SimpleTag {
   static std::string name() noexcept {

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -120,6 +120,9 @@ struct Mesh : db::SimpleTag {
 /// The coordinate map from logical to grid coordinate
 template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
 struct ElementMap : db::SimpleTag {
+  static std::string name() noexcept {
+    return "ElementMap(" + get_output(Frame{}) + ")";
+  }
   using type = ::ElementMap<VolumeDim, Frame>;
 };
 

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -179,13 +179,11 @@ struct InverseJacobianCompute
     : InverseJacobian<db::const_item_type<MapTag>::dim,
                       typename db::const_item_type<MapTag>::source_frame,
                       typename db::const_item_type<MapTag>::target_frame>,
-      db::ComputeTag,
-      db::PrefixTag {
+      db::ComputeTag {
   using base =
       InverseJacobian<db::const_item_type<MapTag>::dim,
                       typename db::const_item_type<MapTag>::source_frame,
                       typename db::const_item_type<MapTag>::target_frame>;
-  using tag = MapTag;
   static constexpr auto function(
       const db::const_item_type<MapTag>& element_map,
       const db::const_item_type<SourceCoordsTag>& source_coords) noexcept {

--- a/src/Elliptic/Actions/InitializeSystem.hpp
+++ b/src/Elliptic/Actions/InitializeSystem.hpp
@@ -89,9 +89,8 @@ struct InitializeSystem {
                            linear_operand_tag>;
     using fluxes_tag = db::add_tag_prefix<::Tags::Flux, linear_operand_tag,
                                           tmpl::size_t<Dim>, Frame::Inertial>;
-    using inv_jacobian_tag =
-        ::Tags::InverseJacobian<::Tags::ElementMap<Dim>,
-                                ::Tags::Coordinates<Dim, Frame::Logical>>;
+    using inv_jacobian_tag = ::Tags::InverseJacobianCompute<
+        ::Tags::ElementMap<Dim>, ::Tags::Coordinates<Dim, Frame::Logical>>;
 
     using fluxes_compute_tag = elliptic::Tags::FirstOrderFluxesCompute<system>;
     using sources_compute_tag =

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -195,8 +195,7 @@ struct TimeStepperHistory {
   struct ComputeTags {
     using type = db::AddComputeTags<::Tags::DerivCompute<
         variables_tag,
-        ::Tags::InverseJacobian<::Tags::ElementMap<dim>,
-                                ::Tags::Coordinates<dim, Frame::Logical>>,
+        ::Tags::InverseJacobian<dim, Frame::Logical, Frame::Inertial>,
         typename System::gradients_tags>>;
   };
 
@@ -205,8 +204,7 @@ struct TimeStepperHistory {
     using type = db::AddComputeTags<::Tags::DivCompute<
         db::add_tag_prefix<::Tags::Flux, variables_tag, tmpl::size_t<dim>,
                            Frame::Inertial>,
-        ::Tags::InverseJacobian<::Tags::ElementMap<dim>,
-                                ::Tags::Coordinates<dim, Frame::Logical>>>>;
+        ::Tags::InverseJacobian<dim, Frame::Logical, Frame::Inertial>>>;
   };
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -179,9 +179,8 @@ struct InitializeGauge {
 
     get<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>>(
         initial_gauge_h_vars) = initial_gauge_h;
-    const auto& inverse_jacobian = db::get<
-        ::Tags::InverseJacobian<::Tags::ElementMap<Dim, frame>,
-                                ::Tags::Coordinates<Dim, Frame::Logical>>>(box);
+    const auto& inverse_jacobian =
+        db::get<::Tags::InverseJacobian<Dim, Frame::Logical, frame>>(box);
     auto d_initial_gauge_source =
         get<::Tags::deriv<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>,
                           tmpl::size_t<Dim>, frame>>(

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
@@ -53,7 +53,7 @@ namespace Actions {
  *   - `Tags::ElementMap<Dim, Frame::Inertial>`
  *   - `Tags::Coordinates<Dim, Frame::Logical>`
  *   - `Tags::Coordinates<Dim, Frame::Inertial>`
- *   - `Tags::InverseJacobian<
+ *   - `Tags::InverseJacobianCompute<
  *   Tags::ElementMap<Dim>, Tags::Coordinates<Dim, Frame::Logical>>`
  *   - `Tags::MinimumGridSpacing<Dim, Frame::Inertial>>`
  * - Removes: nothing
@@ -80,8 +80,8 @@ struct InitializeDomain {
         ::Tags::LogicalCoordinates<Dim>,
         ::Tags::MappedCoordinates<::Tags::ElementMap<Dim>,
                                   ::Tags::Coordinates<Dim, Frame::Logical>>,
-        ::Tags::InverseJacobian<::Tags::ElementMap<Dim>,
-                                ::Tags::Coordinates<Dim, Frame::Logical>>,
+        ::Tags::InverseJacobianCompute<
+            ::Tags::ElementMap<Dim>, ::Tags::Coordinates<Dim, Frame::Logical>>,
         ::Tags::MinimumGridSpacing<Dim, Frame::Inertial>>>;
 
     const auto& initial_extents = db::get<::Tags::InitialExtents<Dim>>(box);

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -36,6 +36,7 @@ set(LIBRARY_SOURCES
   Test_SegmentId.cpp
   Test_Side.cpp
   Test_SizeOfElement.cpp
+  Test_Tags.cpp
   )
 
 add_subdirectory(Amr)

--- a/tests/Unit/Domain/Test_CoordinatesTag.cpp
+++ b/tests/Unit/Domain/Test_CoordinatesTag.cpp
@@ -41,12 +41,6 @@ void test_coordinates_compute_item(const Mesh<Dim>& mesh, T map) noexcept {
       (db::get<Tags::Coordinates<Dim, Frame::Grid>>(box)),
       (make_coordinate_map<Frame::Logical, Frame::Grid>(map)(
           db::get<Tags::Coordinates<Dim, Frame::Logical>>(box))));
-
-  /// [coordinates_name]
-  CHECK(Tags::Coordinates<Dim, Frame::Logical>::name() == "LogicalCoordinates");
-  CHECK(Tags::Coordinates<Dim, Frame::Inertial>::name() ==
-        "InertialCoordinates");
-  /// [coordinates_name]
 }
 }  // namespace
 

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -36,7 +36,6 @@ namespace domain {
 namespace {
 void test_1d_domains() {
   {
-    CHECK(Tags::Domain<1>::name() == "Domain");
     PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial,
                                          CoordinateMaps::Affine>));
 
@@ -190,7 +189,6 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear1D1", "[Domain][Unit]") {
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear2D", "[Domain][Unit]") {
-  CHECK(Tags::Domain<2>::name() == "Domain");
   const OrientationMap<2> half_turn{std::array<Direction<2>, 2>{
       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}};
   const OrientationMap<2> quarter_turn_cw{std::array<Direction<2>, 2>{
@@ -234,7 +232,6 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear2D", "[Domain][Unit]") {
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear3D", "[Domain][Unit]") {
-  CHECK(Tags::Domain<3>::name() == "Domain");
   const OrientationMap<3> aligned{};
   const OrientationMap<3> quarter_turn_cw_xi{std::array<Direction<3>, 3>{
       {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),

--- a/tests/Unit/Domain/Test_Element.cpp
+++ b/tests/Unit/Domain/Test_Element.cpp
@@ -57,8 +57,6 @@ void check_element_work(const typename Element<VolumeDim>::Neighbors_t&
         "\n");
 
   test_serialization(element);
-
-  CHECK(Tags::Element<VolumeDim>::name() == "Element");
 }
 
 void check_element_1d() {

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -118,8 +118,6 @@ void test_element_map<1>() {
   test_element_impl(true, element_id, affine_map, first_map,
                     Affine{2.0, 8.0, 2.0, -1.0}, logical_point_double,
                     logical_point_dv);
-
-  CHECK(Tags::ElementMap<1>::name() == "ElementMap");
 }
 
 template <>
@@ -153,8 +151,6 @@ void test_element_map<2>() {
                   {Direction<2>::lower_eta(), Direction<2>::lower_xi()}}},
               false),
       logical_point_double, logical_point_dv);
-
-  CHECK(Tags::ElementMap<2>::name() == "ElementMap");
 }
 
 template <>
@@ -187,8 +183,6 @@ void test_element_map<3>() {
       true, element_id, affine_map, first_map,
       CoordinateMaps::Wedge3D{3.0, 7.0, OrientationMap<3>{}, 0.8, 0.9, true},
       logical_point_double, logical_point_dv);
-
-  CHECK(Tags::ElementMap<3>::name() == "ElementMap");
 }
 }  // namespace
 

--- a/tests/Unit/Domain/Test_Mesh.cpp
+++ b/tests/Unit/Domain/Test_Mesh.cpp
@@ -239,13 +239,6 @@ void test_serialization() noexcept {
               {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
                 Spectral::Quadrature::GaussLobatto}}});
 }
-
-void test_tags() noexcept {
-  INFO("Tags");
-  CHECK(Tags::Mesh<1>::name() == "Mesh");
-  CHECK(Tags::Mesh<2>::name() == "Mesh");
-  CHECK(Tags::Mesh<3>::name() == "Mesh");
-}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Mesh", "[Domain][Unit]") {
@@ -253,7 +246,6 @@ SPECTRE_TEST_CASE("Unit.Domain.Mesh", "[Domain][Unit]") {
   test_explicit_choices_per_dimension();
   test_equality();
   test_serialization();
-  test_tags();
 }
 
 // [[OutputRegex, Tried to slice through non-existing dimension]]

--- a/tests/Unit/Domain/Test_Tags.cpp
+++ b/tests/Unit/Domain/Test_Tags.cpp
@@ -18,7 +18,10 @@ void test() noexcept {
       "InitialRefinementLevels");
   TestHelpers::db::test_simple_tag<Tags::Element<Dim>>("Element");
   TestHelpers::db::test_simple_tag<Tags::Mesh<Dim>>("Mesh");
-  TestHelpers::db::test_simple_tag<Tags::ElementMap<Dim>>("ElementMap");
+  TestHelpers::db::test_simple_tag<Tags::ElementMap<Dim>>(
+      "ElementMap(Inertial)");
+  TestHelpers::db::test_simple_tag<Tags::ElementMap<Dim, Frame::Grid>>(
+      "ElementMap(Grid)");
   TestHelpers::db::test_simple_tag<Tags::Coordinates<Dim, Frame::Grid>>(
       "GridCoordinates");
   TestHelpers::db::test_simple_tag<Tags::Coordinates<Dim, Frame::Logical>>(

--- a/tests/Unit/Domain/Test_Tags.cpp
+++ b/tests/Unit/Domain/Test_Tags.cpp
@@ -28,6 +28,12 @@ void test() noexcept {
       "LogicalCoordinates");
   TestHelpers::db::test_simple_tag<Tags::Coordinates<Dim, Frame::Inertial>>(
       "InertialCoordinates");
+  TestHelpers::db::test_simple_tag<
+      Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>>(
+      "InverseJacobian(Logical,Inertial)");
+  CHECK(db::tag_name<Tags::InverseJacobianCompute<
+            Tags::ElementMap<Dim>, Tags::Coordinates<Dim, Frame::Logical>>>() ==
+        "InverseJacobian(Logical,Inertial)");
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Tags", "[Unit][Domain]") {

--- a/tests/Unit/Domain/Test_Tags.cpp
+++ b/tests/Unit/Domain/Test_Tags.cpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+template <size_t Dim>
+void test() noexcept {
+  TestHelpers::db::test_simple_tag<Tags::Domain<Dim>>("Domain");
+  TestHelpers::db::test_simple_tag<Tags::InitialExtents<Dim>>("InitialExtents");
+  TestHelpers::db::test_simple_tag<Tags::InitialRefinementLevels<Dim>>(
+      "InitialRefinementLevels");
+  TestHelpers::db::test_simple_tag<Tags::Element<Dim>>("Element");
+  TestHelpers::db::test_simple_tag<Tags::Mesh<Dim>>("Mesh");
+  TestHelpers::db::test_simple_tag<Tags::ElementMap<Dim>>("ElementMap");
+  TestHelpers::db::test_simple_tag<Tags::Coordinates<Dim, Frame::Grid>>(
+      "GridCoordinates");
+  TestHelpers::db::test_simple_tag<Tags::Coordinates<Dim, Frame::Logical>>(
+      "LogicalCoordinates");
+  TestHelpers::db::test_simple_tag<Tags::Coordinates<Dim, Frame::Inertial>>(
+      "InertialCoordinates");
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.Tags", "[Unit][Domain]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}
+}  // namespace

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
@@ -56,8 +56,8 @@ template <size_t Dim>
 using div_fluxes_tag = db::add_tag_prefix<::Tags::div, fluxes_tag<Dim>>;
 template <size_t Dim>
 using inv_jacobian_tag =
-    Tags::InverseJacobian<::Tags::ElementMap<Dim>,
-                          ::Tags::Coordinates<Dim, Frame::Logical>>;
+    Tags::InverseJacobianCompute<::Tags::ElementMap<Dim>,
+                                 ::Tags::Coordinates<Dim, Frame::Logical>>;
 
 template <size_t Dim>
 struct Fluxes {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -212,7 +212,7 @@ void test_divergence_compute_item(
   const auto coordinate_map = make_affine_map<Dim>();
   using map_tag = MapTag<std::decay_t<decltype(coordinate_map)>>;
   using inv_jac_tag =
-      Tags::InverseJacobian<map_tag, Tags::LogicalCoordinates<Dim>>;
+      Tags::InverseJacobianCompute<map_tag, Tags::LogicalCoordinates<Dim>>;
   using flux_tags = two_fluxes<Dim, Frame>;
   using flux_tag = Tags::Variables<flux_tags>;
   using div_tags = db::wrap_tags_in<Tags::div, flux_tags>;

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -494,7 +494,7 @@ void test_partial_derivatives_compute_item(
   using vars_tags = tmpl::list<Var1<Dim>, Var2>;
   using map_tag = MapTag<std::decay_t<decltype(map)>>;
   using inv_jac_tag =
-      Tags::InverseJacobian<map_tag, Tags::LogicalCoordinates<Dim>>;
+      Tags::InverseJacobianCompute<map_tag, Tags::LogicalCoordinates<Dim>>;
   using deriv_tag = Tags::DerivCompute<Tags::Variables<vars_tags>, inv_jac_tag>;
   using prefixed_variables_tag =
       db::add_tag_prefix<SomePrefix, Tags::Variables<vars_tags>>;

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
@@ -76,8 +76,7 @@ void check_compute_items(
   CHECK(tag_is_retrievable(::Tags::Coordinates<Dim, Frame::Logical>{}));
   CHECK(tag_is_retrievable(::Tags::Coordinates<Dim, Frame::Inertial>{}));
   CHECK(tag_is_retrievable(
-      ::Tags::InverseJacobian<::Tags::ElementMap<Dim>,
-                              ::Tags::Coordinates<Dim, Frame::Logical>>{}));
+      ::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>{}));
   CHECK(tag_is_retrievable(::Tags::MinimumGridSpacing<Dim, Frame::Inertial>{}));
 }
 
@@ -139,10 +138,9 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     const auto& inertial_coords =
         get_tag(Tags::Coordinates<1, Frame::Inertial>{});
     CHECK(inertial_coords == element_map(logical_coords));
-    CHECK(get_tag(
-              Tags::InverseJacobian<Tags::ElementMap<1>,
-                                    Tags::Coordinates<1, Frame::Logical>>{}) ==
-          element_map.inv_jacobian(logical_coords));
+    CHECK(
+        get_tag(Tags::InverseJacobian<1, Frame::Logical, Frame::Inertial>{}) ==
+        element_map.inv_jacobian(logical_coords));
   }
   {
     INFO("2D");
@@ -207,10 +205,9 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     const auto& inertial_coords =
         get_tag(Tags::Coordinates<2, Frame::Inertial>{});
     CHECK(inertial_coords == element_map(logical_coords));
-    CHECK(get_tag(
-              Tags::InverseJacobian<Tags::ElementMap<2>,
-                                    Tags::Coordinates<2, Frame::Logical>>{}) ==
-          element_map.inv_jacobian(logical_coords));
+    CHECK(
+        get_tag(Tags::InverseJacobian<2, Frame::Logical, Frame::Inertial>{}) ==
+        element_map.inv_jacobian(logical_coords));
   }
   {
     INFO("3D");
@@ -288,9 +285,8 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     const auto& inertial_coords =
         get_tag(Tags::Coordinates<3, Frame::Inertial>{});
     CHECK(inertial_coords == element_map(logical_coords));
-    CHECK(get_tag(
-              Tags::InverseJacobian<Tags::ElementMap<3>,
-                                    Tags::Coordinates<3, Frame::Logical>>{}) ==
-          element_map.inv_jacobian(logical_coords));
+    CHECK(
+        get_tag(Tags::InverseJacobian<3, Frame::Logical, Frame::Inertial>{}) ==
+        element_map.inv_jacobian(logical_coords));
   }
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -73,8 +73,8 @@ struct Component {
       Tags::Mortars<Tags::Mesh<0>, 1>, Tags::Mortars<Tags::MortarSize<0>, 1>>;
 
   using inverse_jacobian =
-      Tags::InverseJacobian<Tags::ElementMap<1>,
-                            Tags::Coordinates<1, Frame::Logical>>;
+      Tags::InverseJacobianCompute<Tags::ElementMap<1>,
+                                   Tags::Coordinates<1, Frame::Logical>>;
 
   template <typename Tag>
   using interface_compute_tag =


### PR DESCRIPTION
## Proposed changes

- Test domain tags name functions
- Include target frame in element map tag
- Have the `InverseJacobian` tag be a simple tag and add a compute tag.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
