### PR TITLE
is_identity for CoordMap, refactor coordinate map functions

### DIFF
--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -62,6 +62,12 @@ class CoordinateMapBase : public PUP::able {
   /// Returns `true` if the map is the identity
   virtual bool is_identity() const noexcept = 0;
 
+  /// Returns `true` if the inverse Jacobian depends on time.
+  virtual bool inv_jacobian_is_time_dependent() const noexcept = 0;
+
+  /// Returns `true` if the Jacobian depends on time.
+  virtual bool jacobian_is_time_dependent() const noexcept = 0;
+
   // @{
   /// Apply the `Maps` to the point(s) `source_point`
   virtual tnsr::I<double, Dim, TargetFrame> operator()(
@@ -218,6 +224,12 @@ class CoordinateMap
 
   /// Returns `true` if the map is the identity
   bool is_identity() const noexcept override;
+
+  /// Returns `true` if the inverse Jacobian depends on time.
+  bool inv_jacobian_is_time_dependent() const noexcept override;
+
+  /// Returns `true` if the Jacobian depends on time.
+  bool jacobian_is_time_dependent() const noexcept override;
 
   // @{
   /// Apply the `Maps...` to the point(s) `source_point`

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -59,6 +59,9 @@ class CoordinateMapBase : public PUP::able {
   virtual std::unique_ptr<CoordinateMapBase<SourceFrame, TargetFrame, Dim>>
   get_clone() const = 0;
 
+  /// Returns `true` if the map is the identity
+  virtual bool is_identity() const noexcept = 0;
+
   // @{
   /// Apply the `Maps` to the point(s) `source_point`
   virtual tnsr::I<double, Dim, TargetFrame> operator()(
@@ -212,6 +215,9 @@ class CoordinateMap
       const override {
     return std::make_unique<CoordinateMap>(*this);
   }
+
+  /// Returns `true` if the map is the identity
+  bool is_identity() const noexcept override;
 
   // @{
   /// Apply the `Maps...` to the point(s) `source_point`

--- a/src/Domain/CoordinateMaps/CoordinateMap.tpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.tpp
@@ -64,6 +64,19 @@ bool CoordinateMap<SourceFrame, TargetFrame, Maps...>::is_identity() const
 }
 
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
+bool CoordinateMap<SourceFrame, TargetFrame,
+                   Maps...>::inv_jacobian_is_time_dependent() const noexcept {
+  return tmpl2::flat_any_v<
+      domain::is_jacobian_time_dependent_t<Maps, double>::value...>;
+}
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+bool CoordinateMap<SourceFrame, TargetFrame,
+                   Maps...>::jacobian_is_time_dependent() const noexcept {
+  return inv_jacobian_is_time_dependent();
+}
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
 template <typename T, size_t... Is>
 tnsr::I<T, CoordinateMap<SourceFrame, TargetFrame, Maps...>::dim, TargetFrame>
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::call_impl(

--- a/src/Domain/CoordinateMaps/ProductMapsTimeDep.tpp
+++ b/src/Domain/CoordinateMaps/ProductMapsTimeDep.tpp
@@ -380,7 +380,7 @@ ProductOf3Maps<Map1, Map2, Map3>::jacobian(
           {source_coords[1]}},
       time, functions_of_time,
       domain::is_jacobian_time_dependent_t<
-          Map1, std::reference_wrapper<const UnwrappedT>>{}
+          Map2, std::reference_wrapper<const UnwrappedT>>{}
 
       ));
   get<2, 2>(jacobian_matrix) = get<0, 0>(CoordinateMap_detail::apply_jacobian(
@@ -389,7 +389,7 @@ ProductOf3Maps<Map1, Map2, Map3>::jacobian(
           {source_coords[2]}},
       time, functions_of_time,
       domain::is_jacobian_time_dependent_t<
-          Map1, std::reference_wrapper<const UnwrappedT>>{}));
+          Map3, std::reference_wrapper<const UnwrappedT>>{}));
   return jacobian_matrix;
 }
 template <typename Map1, typename Map2, typename Map3>

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -130,6 +130,9 @@ void test_single_coordinate_map() {
     CHECK(inv_jac.get(0, 0) == expected_inv_jac.get(0, 0));
   }
 
+  CHECK_FALSE(affine1d.is_identity());
+  CHECK_FALSE(affine1d_base->is_identity());
+
   using rotate2d = CoordinateMaps::Rotation<2>;
 
   const auto first_rotated2d = rotate2d{M_PI_4};
@@ -186,6 +189,9 @@ void test_single_coordinate_map() {
       }
     }
   }
+
+  CHECK_FALSE(rotated2d.is_identity());
+  CHECK_FALSE(rotated2d_base->is_identity());
 
   using rotate3d = CoordinateMaps::Rotation<3>;
 
@@ -245,6 +251,9 @@ void test_single_coordinate_map() {
       }
     }
   }
+
+  CHECK_FALSE(rotated3d.is_identity());
+  CHECK_FALSE(rotated3d_base->is_identity());
 }
 
 void test_coordinate_map_with_affine_map() {
@@ -788,7 +797,15 @@ void test_coordinate_maps_are_identity() {
               CoordinateMaps::Affine{-1.0, 1.0, -1.0, 1.0}},
           CoordinateMaps::Rotation<3>{0.0, 0.0, 0.0},
           CoordinateMaps::SpecialMobius{0.0});
+  const std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>
+      giant_identity_map_base =
+          std::make_unique<std::decay_t<decltype(giant_identity_map)>>(
+              giant_identity_map);
   test_serialization(giant_identity_map);
+
+  CHECK(giant_identity_map.is_identity());
+  CHECK(giant_identity_map_base->is_identity());
+
 
   const auto wedge = make_coordinate_map<Frame::Logical, Frame::Inertial>(
       CoordinateMaps::Wedge3D(0.2, 4.0, OrientationMap<3>{}, 0.0, 1.0, true));
@@ -812,6 +829,9 @@ void test_coordinate_maps_are_identity() {
               CoordinateMaps::Affine{-1.0, 1.0, -1.0, 1.0}},
           CoordinateMaps::Rotation<3>{0.0, 0.0, 0.0},
           CoordinateMaps::SpecialMobius{0.0});
+
+  CHECK_FALSE(wedge.is_identity());
+  CHECK_FALSE(wedge_composed_with_giant_identity.is_identity());
 
   for (size_t i = 1; i < 11; ++i) {
     const auto source_point = tnsr::I<double, 3, Frame::Logical>{

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -102,8 +102,9 @@ void test_single_coordinate_map() {
       {{{0.1}}, {{-8.2}}, {{5.7}}, {{2.9}}}};
 
   for (const auto& coord : coords1d) {
-    CHECK((make_array<double, 1>((*affine1d_base)(
-              tnsr::I<double, 1, Frame::Logical>{{{coord[0]}}}))) ==
+    const tnsr::I<double, 1, Frame::Logical> source_points{{{coord[0]}}};
+
+    CHECK((make_array<double, 1>((*affine1d_base)(source_points))) ==
           first_affine1d(coord));
     CHECK((make_array<double, 1>(
               affine1d_base
@@ -116,20 +117,16 @@ void test_single_coordinate_map() {
               affine1d.inverse(tnsr::I<double, 1, Frame::Grid>{{{coord[0]}}})
                   .get())) == first_affine1d.inverse(coord).get());
 
-    const auto jac =
-        affine1d.jacobian(tnsr::I<double, 1, Frame::Logical>{{{coord[0]}}});
+    const auto jac = affine1d.jacobian(source_points);
     const auto expected_jac = first_affine1d.jacobian(coord);
-    CHECK(affine1d_base
-              ->jacobian(tnsr::I<double, 1, Frame::Logical>{{{coord[0]}}})
-              .get(0, 0) == expected_jac.get(0, 0));
+    CHECK(affine1d_base->jacobian(source_points).get(0, 0) ==
+          expected_jac.get(0, 0));
     CHECK(jac.get(0, 0) == expected_jac.get(0, 0));
 
-    const auto inv_jac =
-        affine1d.inv_jacobian(tnsr::I<double, 1, Frame::Logical>{{{coord[0]}}});
+    const auto inv_jac = affine1d.inv_jacobian(source_points);
     const auto expected_inv_jac = first_affine1d.inv_jacobian(coord);
-    CHECK(affine1d_base
-              ->inv_jacobian(tnsr::I<double, 1, Frame::Logical>{{{coord[0]}}})
-              .get(0, 0) == expected_inv_jac.get(0, 0));
+    CHECK(affine1d_base->inv_jacobian(source_points).get(0, 0) ==
+          expected_inv_jac.get(0, 0));
     CHECK(inv_jac.get(0, 0) == expected_inv_jac.get(0, 0));
   }
 
@@ -156,8 +153,10 @@ void test_single_coordinate_map() {
       {{{0.1, 2.8}}, {{-8.2, 2.8}}, {{5.7, -4.9}}, {{2.9, 3.4}}}};
 
   for (const auto& coord : coords2d) {
-    CHECK((make_array<double, 2>((*rotated2d_base)(
-              tnsr::I<double, 2, Frame::Logical>{{{coord[0], coord[1]}}}))) ==
+    const tnsr::I<double, 2, Frame::Logical> source_points{
+        {{coord[0], coord[1]}}};
+
+    CHECK((make_array<double, 2>((*rotated2d_base)(source_points))) ==
           first_rotated2d(coord));
     CHECK((make_array<double, 2>(rotated2d_base
                                      ->inverse(tnsr::I<double, 2, Frame::Grid>{
@@ -165,18 +164,16 @@ void test_single_coordinate_map() {
                                      .get())) ==
           first_rotated2d.inverse(coord).get());
 
-    CHECK((make_array<double, 2>(rotated2d(tnsr::I<double, 2, Frame::Logical>{
-              {{coord[0], coord[1]}}}))) == first_rotated2d(coord));
+    CHECK((make_array<double, 2>(rotated2d(source_points))) ==
+          first_rotated2d(coord));
     CHECK((make_array<double, 2>(rotated2d
                                      .inverse(tnsr::I<double, 2, Frame::Grid>{
                                          {{coord[0], coord[1]}}})
                                      .get())) ==
           first_rotated2d.inverse(coord).get());
 
-    const auto jac = rotated2d.jacobian(
-        tnsr::I<double, 2, Frame::Logical>{{{coord[0], coord[1]}}});
-    const auto jac2 = rotated2d_base->jacobian(
-        tnsr::I<double, 2, Frame::Logical>{{{coord[0], coord[1]}}});
+    const auto jac = rotated2d.jacobian(source_points);
+    const auto jac2 = rotated2d_base->jacobian(source_points);
     const auto expected_jac = first_rotated2d.jacobian(coord);
     for (size_t j = 0; j < 2; ++j) {
       for (size_t k = 0; k < 2; ++k) {
@@ -185,10 +182,8 @@ void test_single_coordinate_map() {
       }
     }
 
-    const auto inv_jac = rotated2d.inv_jacobian(
-        tnsr::I<double, 2, Frame::Logical>{{{coord[0], coord[1]}}});
-    const auto inv_jac2 = rotated2d_base->inv_jacobian(
-        tnsr::I<double, 2, Frame::Logical>{{{coord[0], coord[1]}}});
+    const auto inv_jac = rotated2d.inv_jacobian(source_points);
+    const auto inv_jac2 = rotated2d_base->inv_jacobian(source_points);
     const auto expected_inv_jac = first_rotated2d.inv_jacobian(coord);
     for (size_t j = 0; j < 2; ++j) {
       for (size_t k = 0; k < 2; ++k) {
@@ -223,27 +218,26 @@ void test_single_coordinate_map() {
                                                  {{2.9, 3.4, -7.8}}}};
 
   for (const auto& coord : coords3d) {
-    CHECK((make_array<double, 3>((
-              *rotated3d_base)(tnsr::I<double, 3, Frame::Logical>{
-              {{coord[0], coord[1], coord[2]}}}))) == first_rotated3d(coord));
+    const tnsr::I<double, 3, Frame::Logical> source_points{
+        {{coord[0], coord[1], coord[2]}}};
+    CHECK((make_array<double, 3>((*rotated3d_base)(source_points))) ==
+          first_rotated3d(coord));
     CHECK((make_array<double, 3>(rotated3d_base
                                      ->inverse(tnsr::I<double, 3, Frame::Grid>{
                                          {{coord[0], coord[1], coord[2]}}})
                                      .get())) ==
           first_rotated3d.inverse(coord).get());
 
-    CHECK((make_array<double, 3>(rotated3d(tnsr::I<double, 3, Frame::Logical>{
-              {{coord[0], coord[1], coord[2]}}}))) == first_rotated3d(coord));
+    CHECK((make_array<double, 3>(rotated3d(source_points))) ==
+          first_rotated3d(coord));
     CHECK((make_array<double, 3>(rotated3d
                                      .inverse(tnsr::I<double, 3, Frame::Grid>{
                                          {{coord[0], coord[1], coord[2]}}})
                                      .get())) ==
           first_rotated3d.inverse(coord).get());
 
-    const auto jac = rotated3d.jacobian(
-        tnsr::I<double, 3, Frame::Logical>{{{coord[0], coord[1], coord[2]}}});
-    const auto jac2 = rotated3d_base->jacobian(
-        tnsr::I<double, 3, Frame::Logical>{{{coord[0], coord[1], coord[2]}}});
+    const auto jac = rotated3d.jacobian(source_points);
+    const auto jac2 = rotated3d_base->jacobian(source_points);
     const auto expected_jac = first_rotated3d.jacobian(coord);
     for (size_t j = 0; j < 3; ++j) {
       for (size_t k = 0; k < 3; ++k) {
@@ -252,10 +246,8 @@ void test_single_coordinate_map() {
       }
     }
 
-    const auto inv_jac = rotated3d.inv_jacobian(
-        tnsr::I<double, 3, Frame::Logical>{{{coord[0], coord[1], coord[2]}}});
-    const auto inv_jac2 = rotated3d_base->inv_jacobian(
-        tnsr::I<double, 3, Frame::Logical>{{{coord[0], coord[1], coord[2]}}});
+    const auto inv_jac = rotated3d.inv_jacobian(source_points);
+    const auto inv_jac2 = rotated3d_base->inv_jacobian(source_points);
     const auto expected_inv_jac = first_rotated3d.inv_jacobian(coord);
     for (size_t j = 0; j < 3; ++j) {
       for (size_t k = 0; k < 3; ++k) {
@@ -287,18 +279,15 @@ void test_coordinate_map_with_affine_map() {
   const auto map = make_coordinate_map<Frame::Logical, Frame::Grid>(
       affine_map{-1.0, 1.0, 0.0, 2.3}, affine_map{0.0, 2.3, -0.5, 0.5});
   for (size_t i = 1; i < number_of_points_checked + 1; ++i) {
+    const tnsr::I<double, 1, Frame::Logical> source_points{2.0 / i + -1.0};
     CHECK((tnsr::I<double, 1, Frame::Grid>(1.0 / i + -0.5))[0] ==
-          approx(map(tnsr::I<double, 1, Frame::Logical>{2.0 / i + -1.0})[0]));
+          approx(map(source_points)[0]));
     CHECK((tnsr::I<double, 1, Frame::Logical>(2.0 / i + -1.0))[0] ==
           approx(map.inverse(tnsr::I<double, 1, Frame::Grid>{1.0 / i + -0.5})
                      .get()[0]));
 
-    CHECK(approx(map.inv_jacobian(
-                        tnsr::I<double, 1, Frame::Logical>{2.0 / i + -1.0})
-                     .get(0, 0)) == 2.0);
-    CHECK(
-        approx(map.jacobian(tnsr::I<double, 1, Frame::Logical>{2.0 / i + -1.0})
-                   .get(0, 0)) == 0.5);
+    CHECK(approx(map.inv_jacobian(source_points).get(0, 0)) == 2.0);
+    CHECK(approx(map.jacobian(source_points).get(0, 0)) == 0.5);
   }
 
   // Test 2D
@@ -308,8 +297,9 @@ void test_coordinate_map_with_affine_map() {
       affine_map_2d{affine_map{0.0, 2.0, 2.0, 6.0},
                     affine_map{-0.5, 0.5, 0.0, 8.0}});
   for (size_t i = 1; i < number_of_points_checked + 1; ++i) {
-    const auto mapped_point = prod_map2d(
-        tnsr::I<double, 2, Frame::Logical>{{{-1.0 + 2.0 / i, 0.0 + 2.0 / i}}});
+    const tnsr::I<double, 2, Frame::Logical> source_points{
+        {{-1.0 + 2.0 / i, 0.0 + 2.0 / i}}};
+    const auto mapped_point = prod_map2d(source_points);
     const auto expected_mapped_point =
         tnsr::I<double, 2, Frame::Grid>{{{4.0 / i + 2.0, 8.0 / i + 0.0}}};
     CHECK(get<0>(expected_mapped_point) == approx(get<0>(mapped_point)));
@@ -326,15 +316,13 @@ void test_coordinate_map_with_affine_map() {
     CHECK(get<1>(expected_inv_mapped_point) ==
           approx(get<1>(inv_mapped_point)));
 
-    const auto inv_jac = prod_map2d.inv_jacobian(
-        tnsr::I<double, 2, Frame::Logical>{{{-1.0 + 2.0 / i, 0.0 + 2.0 / i}}});
+    const auto inv_jac = prod_map2d.inv_jacobian(source_points);
     CHECK(0.5 == approx(get<0, 0>(inv_jac)));
     CHECK(0.0 == approx(get<1, 0>(inv_jac)));
     CHECK(0.0 == approx(get<0, 1>(inv_jac)));
     CHECK(0.25 == approx(get<1, 1>(inv_jac)));
 
-    const auto jac = prod_map2d.jacobian(
-        tnsr::I<double, 2, Frame::Logical>{{{-1.0 + 2.0 / i, 0.0 + 2.0 / i}}});
+    const auto jac = prod_map2d.jacobian(source_points);
     CHECK(2.0 == approx(get<0, 0>(jac)));
     CHECK(0.0 == approx(get<1, 0>(jac)));
     CHECK(0.0 == approx(get<0, 1>(jac)));
@@ -351,8 +339,9 @@ void test_coordinate_map_with_affine_map() {
                     affine_map{-7.0, 7.0, 3.0, 23.0}});
 
   for (size_t i = 1; i < number_of_points_checked + 1; ++i) {
-    const auto mapped_point = prod_map3d(tnsr::I<double, 3, Frame::Logical>{
-        {{-1.0 + 2.0 / i, 0.0 + 2.0 / i, 5.0 + 2.0 / i}}});
+    const tnsr::I<double, 3, Frame::Logical> source_points{
+        {{-1.0 + 2.0 / i, 0.0 + 2.0 / i, 5.0 + 2.0 / i}}};
+    const auto mapped_point = prod_map3d(source_points);
     const auto expected_mapped_point = tnsr::I<double, 3, Frame::Grid>{
         {{4.0 / i + 2.0, 8.0 / i + 0.0, 3.0 + 20.0 / i}}};
     CHECK(get<0>(expected_mapped_point) == approx(get<0>(mapped_point)));
@@ -373,9 +362,7 @@ void test_coordinate_map_with_affine_map() {
     CHECK(get<2>(expected_inv_mapped_point) ==
           approx(get<2>(inv_mapped_point)));
 
-    const auto inv_jac =
-        prod_map3d.inv_jacobian(tnsr::I<double, 3, Frame::Logical>{
-            {{-1.0 + 2.0 / i, 0.0 + 2.0 / i, 5.0 + 2.0 / i}}});
+    const auto inv_jac = prod_map3d.inv_jacobian(source_points);
     CHECK(0.5 == approx(get<0, 0>(inv_jac)));
     CHECK(0.0 == approx(get<1, 0>(inv_jac)));
     CHECK(0.0 == approx(get<0, 1>(inv_jac)));
@@ -386,8 +373,7 @@ void test_coordinate_map_with_affine_map() {
     CHECK(0.0 == approx(get<2, 1>(inv_jac)));
     CHECK(0.1 == approx(get<2, 2>(inv_jac)));
 
-    const auto jac = prod_map3d.jacobian(tnsr::I<double, 3, Frame::Logical>{
-        {{-1.0 + 2.0 / i, 0.0 + 2.0 / i, 5.0 + 2.0 / i}}});
+    const auto jac = prod_map3d.jacobian(source_points);
     CHECK(2.0 == approx(get<0, 0>(jac)));
     CHECK(0.0 == approx(get<1, 0>(jac)));
     CHECK(0.0 == approx(get<0, 1>(jac)));
@@ -420,8 +406,10 @@ void test_coordinate_map_with_rotation_map() {
   for (size_t i = 0; i < coords2d.size(); ++i) {
     INFO(i);
     const auto coord = gsl::at(coords2d, i);
-    CHECK((make_array<double, 2>(double_rotated2d(
-              tnsr::I<double, 2, Frame::Logical>{{{coord[0], coord[1]}}}))) ==
+    const tnsr::I<double, 2, Frame::Logical> source_points{
+        {{coord[0], coord[1]}}};
+
+    CHECK((make_array<double, 2>(double_rotated2d(source_points))) ==
           second_rotated2d(first_rotated2d(coord)));
     CHECK((make_array<double, 2>(double_rotated2d
                                      .inverse(tnsr::I<double, 2, Frame::Grid>{
@@ -429,14 +417,12 @@ void test_coordinate_map_with_rotation_map() {
                                      .get())) ==
           first_rotated2d.inverse(second_rotated2d.inverse(coord).get()).get());
 
-    const auto jac = double_rotated2d.jacobian(
-        tnsr::I<double, 2, Frame::Logical>{{{coord[0], coord[1]}}});
+    const auto jac = double_rotated2d.jacobian(source_points);
     const auto expected_jac = compose_jacobians(
         first_rotated2d, second_rotated2d, gsl::at(coords2d, i));
     CHECK_ITERABLE_APPROX(jac, expected_jac);
 
-    const auto inv_jac = double_rotated2d.inv_jacobian(
-        tnsr::I<double, 2, Frame::Logical>{{{coord[0], coord[1]}}});
+    const auto inv_jac = double_rotated2d.inv_jacobian(source_points);
     const auto expected_inv_jac = compose_inv_jacobians(
         first_rotated2d, second_rotated2d, gsl::at(coords2d, i));
     CHECK_ITERABLE_APPROX(inv_jac, expected_inv_jac);
@@ -457,9 +443,10 @@ void test_coordinate_map_with_rotation_map() {
   for (size_t i = 0; i < coords3d.size(); ++i) {
     INFO(i);
     const auto coord = gsl::at(coords3d, i);
-    CHECK((make_array<double, 3>(
-              double_rotated3d(tnsr::I<double, 3, Frame::Logical>{
-                  {{coord[0], coord[1], coord[2]}}}))) ==
+    const tnsr::I<double, 3, Frame::Logical> source_points{
+        {{coord[0], coord[1], coord[2]}}};
+
+    CHECK((make_array<double, 3>(double_rotated3d(source_points))) ==
           second_rotated3d(first_rotated3d(coord)));
     CHECK((make_array<double, 3>(double_rotated3d
                                      .inverse(tnsr::I<double, 3, Frame::Grid>{
@@ -467,14 +454,12 @@ void test_coordinate_map_with_rotation_map() {
                                      .get())) ==
           first_rotated3d.inverse(second_rotated3d.inverse(coord).get()).get());
 
-    const auto jac = double_rotated3d.jacobian(
-        tnsr::I<double, 3, Frame::Logical>{{{coord[0], coord[1], coord[2]}}});
+    const auto jac = double_rotated3d.jacobian(source_points);
     const auto expected_jac = compose_jacobians(
         first_rotated3d, second_rotated3d, gsl::at(coords3d, i));
     CHECK_ITERABLE_APPROX(jac, expected_jac);
 
-    const auto inv_jac = double_rotated3d.inv_jacobian(
-        tnsr::I<double, 3, Frame::Logical>{{{coord[0], coord[1], coord[2]}}});
+    const auto inv_jac = double_rotated3d.inv_jacobian(source_points);
     const auto expected_inv_jac = compose_inv_jacobians(
         first_rotated3d, second_rotated3d, gsl::at(coords3d, i));
     CHECK_ITERABLE_APPROX(inv_jac, expected_inv_jac);
@@ -572,9 +557,9 @@ void test_coordinate_map_with_rotation_wedge() {
   using Rotate = CoordinateMaps::Rotation<2>;
   using Wedge2D = CoordinateMaps::Wedge2D;
 
-  const auto first_map = Rotate(2.);
+  const auto first_map = Rotate(2.0);
   const auto second_map =
-      Wedge2D(3., 7., 0.0, 1.0,
+      Wedge2D(3.0, 7.0, 0.0, 1.0,
               OrientationMap<2>{std::array<Direction<2>, 2>{
                   {Direction<2>::lower_eta(), Direction<2>::lower_xi()}}},
               false);

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
@@ -13,6 +13,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/Brick.hpp"

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
@@ -13,6 +13,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/Brick.hpp"


### PR DESCRIPTION
## Proposed changes

- Add function to `CoordinateMap` and the base class to check if the map is the identity
- Add a function to `CoordinateMap` and the base class to check if the Jacobian is time-independent
- Refactor Jacobian code so it can be reused more easily with the moving mesh changes that'll be needed. I also find that factoring the code makes it easier to reason about.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
