### PR TITLE
Generalize Cubic scale map to 2d and 3d

### DIFF
--- a/src/Domain/CoordinateMaps/CubicScale.cpp
+++ b/src/Domain/CoordinateMaps/CubicScale.cpp
@@ -5,9 +5,14 @@
 
 #include <array>
 #include <boost/none.hpp>
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <memory>
 #include <ostream>
 #include <pup.h>
 #include <pup_stl.h>
+#include <string>
+#include <unordered_map>
 #include <utility>
 
 #include "DataStructures/DataVector.hpp"
@@ -18,45 +23,99 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+#include "Utilities/TypeTraits.hpp"
 
 namespace domain {
 namespace CoordMapsTimeDependent {
 
-CubicScale::CubicScale(const double outer_boundary) noexcept
-    : outer_boundary_(outer_boundary) {
-  if (outer_boundary_ <= 0.0) {
-    ERROR("For invertability, we require outer_boundary to be positive.\n");
+template <size_t Dim>
+CubicScale<Dim>::CubicScale(const double outer_boundary,
+                            std::string function_of_time_name_a,
+                            std::string function_of_time_name_b) noexcept
+    : f_of_t_a_(std::move(function_of_time_name_a)),
+      f_of_t_b_(std::move(function_of_time_name_b)),
+      functions_of_time_equal_(f_of_t_a_ == f_of_t_b_) {
+  if (outer_boundary <= 0.0) {
+    ERROR("For invertability, we require outer_boundary to be positive, but is "
+          << outer_boundary);
   }
+  one_over_outer_boundary_ = 1.0 / outer_boundary;
 }
 
+template <size_t Dim>
 template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, 1> CubicScale::operator()(
-    const std::array<T, 1>& source_coords, const double time,
+std::array<tt::remove_cvref_wrap_t<T>, Dim> CubicScale<Dim>::operator()(
+    const std::array<T, Dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         map_list) const noexcept {
-  const auto a_of_t = map_list.at(f_of_t_a_)->func(time)[0][0];
-  const auto b_of_t = map_list.at(f_of_t_b_)->func(time)[0][0];
-  return {{source_coords[0] *
-           (a_of_t +
-            (b_of_t - a_of_t) * square(source_coords[0] / outer_boundary_))}};
+  const double a_of_t = map_list.at(f_of_t_a_)->func(time)[0][0];
+
+  if (functions_of_time_equal_) {
+    // optimization for linear radial scaling
+    std::array<tt::remove_cvref_wrap_t<T>, Dim> result{};
+    for (size_t i = 0; i < Dim; ++i) {
+      gsl::at(result, i) = a_of_t * gsl::at(source_coords, i);
+    }
+    return result;
+  }
+
+  const double b_of_t = map_list.at(f_of_t_b_)->func(time)[0][0];
+
+  tt::remove_cvref_wrap_t<T> rho_squared =
+      square(dereference_wrapper(source_coords[0]));
+  for (size_t i = 1; i < Dim; ++i) {
+    rho_squared += square(dereference_wrapper(gsl::at(source_coords, i)));
+  }
+  // Reuse rho^2 allocation
+  rho_squared = a_of_t + (b_of_t - a_of_t) * square(one_over_outer_boundary_) *
+                             rho_squared;
+
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> result{};
+  for (size_t i = 0; i < Dim - 1; ++i) {
+    gsl::at(result, i) = gsl::at(source_coords, i) * rho_squared;
+  }
+  rho_squared = source_coords[Dim - 1] * rho_squared;
+  result[Dim - 1] = std::move(rho_squared);
+  return result;
 }
 
+template <size_t Dim>
 template <typename T>
-boost::optional<std::array<tt::remove_cvref_wrap_t<T>, 1>> CubicScale::inverse(
-    const std::array<T, 1>& target_coords, const double time,
+boost::optional<std::array<tt::remove_cvref_wrap_t<T>, Dim>>
+CubicScale<Dim>::inverse(
+    const std::array<T, Dim>& target_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         map_list) const noexcept {
-  // the original coordinates are found by solving for the roots
-  // of (b-a)/X^2*\xi^3 + a*\xi - x = 0, where a and b are the FunctionsOfTime,
-  // X is the outer_boundary, and x represents the mapped coordinates
-  const auto a_of_t = map_list.at(f_of_t_a_)->func(time)[0][0];
-  const auto b_of_t = map_list.at(f_of_t_b_)->func(time)[0][0];
+  if (functions_of_time_equal_) {
+    // optimization for linear radial scaling
+    const double one_over_a_of_t =
+        1.0 / map_list.at(f_of_t_a_)->func(time)[0][0];
+
+    // Construct boost::optional to have a default value of an empty array.
+    // Doing just result{} would construct a boost::optional that doesn't hold a
+    // value and so *result would throw an exception.
+    boost::optional<std::array<tt::remove_cvref_wrap_t<T>, Dim>> result{
+        std::array<tt::remove_cvref_wrap_t<T>, Dim>{}};
+    for (size_t i = 0; i < Dim; ++i) {
+      gsl::at(*result, i) = one_over_a_of_t * gsl::at(target_coords, i);
+    }
+    return result;
+  }
+
+  // the source coordinates \xi^{\hat{i}} are found by solving for the roots of
+  // (b-a)/R^2*\rho^3 + a*\rho - r = 0,
+  // where a and b are the FunctionsOfTime, R is the outer_boundary, and r is
+  // the mapped/target coordinates radius.
+  const double a_of_t = map_list.at(f_of_t_a_)->func(time)[0][0];
+  const double b_of_t = map_list.at(f_of_t_b_)->func(time)[0][0];
 
   // these checks ensure that the function is monotonically increasing
-  // and that there is one real root in the domain of \xi, [0,X]
+  // and that there is one real root in the domain of \rho, [0,R]
   if (a_of_t <= 0.0) {
     ERROR("We require expansion_a > 0 for invertibility, however expansion_a = "
           << a_of_t << ".");
@@ -67,27 +126,44 @@ boost::optional<std::array<tt::remove_cvref_wrap_t<T>, 1>> CubicScale::inverse(
           << ".");
   }
 
-  // Make the coordinates dimensionless
-  const tt::remove_cvref_wrap_t<T> x_bar = target_coords[0] / outer_boundary_;
+  // To invert the map we work in the dimensionless radius,
+  // r / R_{outer_boundary}.
+  tt::remove_cvref_wrap_t<T> target_dimensionless_radius =
+      magnitude(target_coords) * one_over_outer_boundary_;
 
-  // Check if x_bar is outside of the range of the map
-  if (x_bar < 0.0 or x_bar > b_of_t) {
+  if (UNLIKELY(target_dimensionless_radius == 0.0)) {
+    return {make_array<Dim>(0.0)};
+  }
+
+  // Check if x_bar is outside of the range of the map.
+  // We need a slight buffer because computing (r/R) is not equal to (r * (1/R))
+  // at roundoff and thus to make sure we include the boundary we need to
+  // support epsilon above b(t).
+  if (UNLIKELY(target_dimensionless_radius >
+               b_of_t * (1.0 + 2.0 * std::numeric_limits<double>::epsilon()))) {
     return boost::none;
   }
 
-  // with the assumptions above:
-  // x_bar lies within the range [0,b]
-  // and \xi_bar = \xi/X is restricted to the domain [0,1]
   // For an initial guess, we provide a linearly approximated solution for
-  // \xi_bar, which is just x_bar/b.
-  const tt::remove_cvref_wrap_t<T> initial_guess = x_bar / b_of_t;
+  // q, which is just r / (R b).
+  const tt::remove_cvref_wrap_t<T> initial_guess =
+      target_dimensionless_radius / b_of_t;
   const double cubic_coef_a = (b_of_t - a_of_t);
 
+  // Solve the modified equation:
+  // q * ( (b-a) q^2 + a) - r / R = 0,
+  // where q = rho / R, and rho is the source radius
   const auto cubic_and_deriv =
-      [&cubic_coef_a, &a_of_t, &x_bar ](double x) noexcept {
-    return std::make_pair(x * (cubic_coef_a * square(x) + a_of_t) - x_bar,
-                          3.0 * cubic_coef_a * square(x) + a_of_t);
-  };
+      [&cubic_coef_a, &a_of_t, &target_dimensionless_radius](
+          const double source_dimensionless_radius) noexcept {
+        return std::make_pair(
+            source_dimensionless_radius *
+                    (cubic_coef_a * square(source_dimensionless_radius) +
+                     a_of_t) -
+                target_dimensionless_radius,
+
+            3.0 * cubic_coef_a * square(source_dimensionless_radius) + a_of_t);
+      };
 
   // The original implementation of this inverse function used a cubic
   // equation solver. However, given that the problem of finding the inverse
@@ -101,168 +177,266 @@ boost::optional<std::array<tt::remove_cvref_wrap_t<T>, 1>> CubicScale::inverse(
   // version, here we utilize the boost implementation, as it includes
   // additional checks for zero derivative, checks on bounds, and can implement
   // bisection if necessary.
-  return {
-      {{outer_boundary_ * RootFinder::newton_raphson(
-                              cubic_and_deriv, initial_guess, 0.0, 1.0, 14)}}};
+  const double scale_factor =
+      RootFinder::newton_raphson(cubic_and_deriv, initial_guess, 0.0, 1.0, 14) /
+      target_dimensionless_radius;
+
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> result{};
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(result, i) = scale_factor * gsl::at(target_coords, i);
+  }
+  return {std::move(result)};
 }
 
+template <size_t Dim>
 template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, 1> CubicScale::frame_velocity(
-    const std::array<T, 1>& source_coords, const double time,
+std::array<tt::remove_cvref_wrap_t<T>, Dim> CubicScale<Dim>::frame_velocity(
+    const std::array<T, Dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         map_list) const noexcept {
-  const auto dt_a_of_t = map_list.at(f_of_t_a_)->func_and_deriv(time)[1][0];
-  const auto dt_b_of_t = map_list.at(f_of_t_b_)->func_and_deriv(time)[1][0];
-  const auto frame_vel =
-      source_coords[0] *
-      (dt_a_of_t +
-       (dt_b_of_t - dt_a_of_t) * square(source_coords[0] / outer_boundary_));
+  const double dt_a_of_t = map_list.at(f_of_t_a_)->func_and_deriv(time)[1][0];
 
-  return {{frame_vel}};
+  if (functions_of_time_equal_) {
+    // optimization for linear radial scaling
+    std::array<tt::remove_cvref_wrap_t<T>, Dim> result{};
+    for (size_t i = 0; i < Dim; ++i) {
+      gsl::at(result, i) = dt_a_of_t * gsl::at(source_coords, i);
+    }
+    return result;
+  }
+
+  const double dt_b_of_t = map_list.at(f_of_t_b_)->func_and_deriv(time)[1][0];
+
+  tt::remove_cvref_wrap_t<T> rho_squared =
+      square(dereference_wrapper(source_coords[0]));
+  for (size_t i = 1; i < Dim; ++i) {
+    rho_squared += square(dereference_wrapper(gsl::at(source_coords, i)));
+  }
+  // Reuse rho^2 allocation
+  rho_squared = dt_a_of_t + (dt_b_of_t - dt_a_of_t) *
+                                square(one_over_outer_boundary_) * rho_squared;
+
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> result{};
+  for (size_t i = 0; i < Dim - 1; ++i) {
+    gsl::at(result, i) = gsl::at(source_coords, i) * rho_squared;
+  }
+  rho_squared = source_coords[Dim - 1] * rho_squared;
+  result[Dim - 1] = std::move(rho_squared);
+  return result;
 }
 
+template <size_t Dim>
 template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> CubicScale::jacobian(
-    const std::array<T, 1>& source_coords, const double time,
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>
+CubicScale<Dim>::jacobian(
+    const std::array<T, Dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         map_list) const noexcept {
-  const auto a_of_t = map_list.at(f_of_t_a_)->func(time)[0][0];
-  const auto b_of_t = map_list.at(f_of_t_b_)->func(time)[0][0];
-  auto jac{
-      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame>>(
-          dereference_wrapper(source_coords[0]), 0.0)};
+  const double a_of_t = map_list.at(f_of_t_a_)->func(time)[0][0];
 
-  get<0, 0>(jac) =
-      a_of_t +
-      3.0 * (b_of_t - a_of_t) * square(source_coords[0] / outer_boundary_);
+  if (functions_of_time_equal_) {
+    // optimization for linear radial scaling
+    auto jac{make_with_value<
+        tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>>(
+        dereference_wrapper(source_coords[0]), 0.0)};
+    for (size_t i = 0; i < Dim; ++i) {
+      jac.get(i, i) = a_of_t;
+    }
+    return jac;
+  }
+
+  const double b_of_t = map_list.at(f_of_t_b_)->func(time)[0][0];
+
+  tt::remove_cvref_wrap_t<T> rho_squared =
+      square(dereference_wrapper(source_coords[0]));
+  for (size_t i = 1; i < Dim; ++i) {
+    rho_squared += square(dereference_wrapper(gsl::at(source_coords, i)));
+  }
+  const double rho_squared_coeff =
+      (b_of_t - a_of_t) * square(one_over_outer_boundary_);
+  // Reuse rho^2 allocation
+  rho_squared = a_of_t + rho_squared_coeff * rho_squared;
+
+  const double coeff =
+      2.0 * (b_of_t - a_of_t) * square(one_over_outer_boundary_);
+
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> jac{};
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = 0; j < Dim; ++j) {
+      if (i == j) {
+        jac.get(i, j) = rho_squared + gsl::at(source_coords, i) *
+                                          gsl::at(source_coords, j) * coeff;
+      } else {
+        jac.get(i, j) =
+            gsl::at(source_coords, i) * gsl::at(source_coords, j) * coeff;
+      }
+    }
+  }
 
   return jac;
 }
 
+template <size_t Dim>
 template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame>
-CubicScale::inv_jacobian(
-    const std::array<T, 1>& source_coords, const double time,
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>
+CubicScale<Dim>::inv_jacobian(
+    const std::array<T, Dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         map_list) const noexcept {
-  const auto a_of_t = map_list.at(f_of_t_a_)->func(time)[0][0];
-  const auto b_of_t = map_list.at(f_of_t_b_)->func(time)[0][0];
-  auto inv_jac{
-      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame>>(
-          dereference_wrapper(source_coords[0]), 0.0)};
+  const double a_of_t = map_list.at(f_of_t_a_)->func(time)[0][0];
 
-  get<0, 0>(inv_jac) = 1.0 / (a_of_t +
-                              3.0 * (b_of_t - a_of_t) *
-                                  square(source_coords[0] / outer_boundary_));
+  if (functions_of_time_equal_) {
+    // optimization for linear radial scaling
+    auto inv_jac{make_with_value<
+        tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>>(
+        dereference_wrapper(source_coords[0]), 0.0)};
+    const double one_over_a = 1.0 / a_of_t;
+    for (size_t i = 0; i < Dim; ++i) {
+      inv_jac.get(i, i) = one_over_a;
+    }
+    return inv_jac;
+  }
+
+  const double b_of_t = map_list.at(f_of_t_b_)->func(time)[0][0];
+
+  tt::remove_cvref_wrap_t<T> rho_squared =
+      square(dereference_wrapper(source_coords[0]));
+  for (size_t i = 1; i < Dim; ++i) {
+    rho_squared += square(dereference_wrapper(gsl::at(source_coords, i)));
+  }
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> inv_jac{};
+  get<0, 0>(inv_jac) =
+      1.0 / (a_of_t + (b_of_t - a_of_t) * square(one_over_outer_boundary_) *
+                          rho_squared);
+  for (size_t i = 1; i < Dim; ++i) {
+    inv_jac.get(i, i) = get<0, 0>(inv_jac);
+  }
+
+  // Factor out `double` computations to ensure minimal DataVector operations
+  const double denom_constant_a = a_of_t / square(one_over_outer_boundary_);
+  const double denom_constant_b = 3.0 * (b_of_t - a_of_t);
+  const double numerator_constant = -2.0 * (b_of_t - a_of_t);
+  if (Dim == 1) {
+    get<0, 0>(inv_jac) *=
+        (1.0 + numerator_constant /
+                   (denom_constant_a + denom_constant_b * rho_squared) *
+                   square(source_coords[0]));
+  } else {
+    // Reuse rho^2 allocation
+    rho_squared = numerator_constant /
+                  (denom_constant_a + denom_constant_b * rho_squared) *
+                  get<0, 0>(inv_jac);
+
+    for (size_t i = 0; i < Dim; ++i) {
+      for (size_t j = 0; j < Dim; ++j) {
+        if (i == j) {
+          inv_jac.get(i, j) += rho_squared * gsl::at(source_coords, i) *
+                               gsl::at(source_coords, j);
+        } else {
+          inv_jac.get(i, j) = rho_squared * gsl::at(source_coords, i) *
+                              gsl::at(source_coords, j);
+        }
+      }
+    }
+  }
 
   return inv_jac;
 }
 
-template <typename T>
-tnsr::Iaa<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> CubicScale::hessian(
-    const std::array<T, 1>& source_coords, const double time,
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        map_list) const noexcept {
-  const auto a_of_t_and_derivs =
-      map_list.at(f_of_t_a_)->func_and_2_derivs(time);
-  const auto b_of_t_and_derivs =
-      map_list.at(f_of_t_b_)->func_and_2_derivs(time);
-
-  auto result{
-      make_with_value<tnsr::Iaa<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame>>(
-          dereference_wrapper(source_coords[0]), 0.0)};
-  // time-time
-  get<0, 0, 0>(result) = a_of_t_and_derivs[2][0] * source_coords[0] +
-                         (b_of_t_and_derivs[2][0] - a_of_t_and_derivs[2][0]) *
-                             cube(source_coords[0]) / square(outer_boundary_);
-  // time-space
-  get<0, 0, 1>(result) =
-      a_of_t_and_derivs[1][0] +
-      3.0 * (b_of_t_and_derivs[1][0] - a_of_t_and_derivs[1][0]) *
-          square(source_coords[0] / outer_boundary_);
-  // space-space
-  get<0, 1, 1>(result) = 6.0 *
-                         (b_of_t_and_derivs[0][0] - a_of_t_and_derivs[0][0]) *
-                         source_coords[0] / square(outer_boundary_);
-
-  return result;
-}
-
-void CubicScale::pup(PUP::er& p) noexcept {
+template <size_t Dim>
+void CubicScale<Dim>::pup(PUP::er& p) noexcept {
   p | f_of_t_a_;
   p | f_of_t_b_;
-  p | outer_boundary_;
+  p | one_over_outer_boundary_;
+  p | functions_of_time_equal_;
 }
 
-bool operator==(const CoordMapsTimeDependent::CubicScale& lhs,
-                const CoordMapsTimeDependent::CubicScale& rhs) noexcept {
+template <size_t Dim>
+bool operator==(const CubicScale<Dim>& lhs,
+                const CubicScale<Dim>& rhs) noexcept {
   return lhs.f_of_t_a_ == rhs.f_of_t_a_ and lhs.f_of_t_b_ == rhs.f_of_t_b_ and
-         lhs.outer_boundary_ == rhs.outer_boundary_;
+         lhs.one_over_outer_boundary_ == rhs.one_over_outer_boundary_ and
+         lhs.functions_of_time_equal_ == rhs.functions_of_time_equal_;
 }
 
 // Explicit instantiations
 /// \cond
-template boost::optional<std::array<tt::remove_cvref_wrap_t<double>, 1>>
-CubicScale::inverse(
-    const std::array<double, 1>& target_coords, const double time,
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        map_list) const noexcept;
-template boost::optional<std::array<
-    tt::remove_cvref_wrap_t<std::reference_wrapper<const double>>, 1>>
-CubicScale::inverse(
-    const std::array<std::reference_wrapper<const double>, 1>& target_coords,
-    const double time,
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        map_list) const noexcept;
-
-#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                   \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                 \
-  CubicScale::operator()(                                                      \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
+  template class CubicScale<DIM(data)>;                                        \
+  template boost::optional<                                                    \
+      std::array<tt::remove_cvref_wrap_t<double>, DIM(data)>>                  \
+  CubicScale<DIM(data)>::inverse(                                              \
+      const std::array<double, DIM(data)>& target_coords, const double time,   \
       const std::unordered_map<                                                \
           std::string,                                                         \
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
       const noexcept;                                                          \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                 \
-  CubicScale::frame_velocity(                                                  \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
+  template boost::optional<std::array<                                         \
+      tt::remove_cvref_wrap_t<std::reference_wrapper<const double>>,           \
+      DIM(data)>>                                                              \
+  CubicScale<DIM(data)>::inverse(                                              \
+      const std::array<std::reference_wrapper<const double>, DIM(data)>&       \
+          target_coords,                                                       \
+      const double time,                                                       \
       const std::unordered_map<                                                \
           std::string,                                                         \
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
       const noexcept;                                                          \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>   \
-  CubicScale::jacobian(                                                        \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
+  template bool operator==(const CubicScale<DIM(data)>&,                       \
+                           const CubicScale<DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
+  CubicScale<DIM(data)>::operator()(                                           \
+      const std::array<DTYPE(data), DIM(data)>& source_coords,                 \
+      const double time,                                                       \
       const std::unordered_map<                                                \
           std::string,                                                         \
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
       const noexcept;                                                          \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>   \
-  CubicScale::inv_jacobian(                                                    \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
+  CubicScale<DIM(data)>::frame_velocity(                                       \
+      const std::array<DTYPE(data), DIM(data)>& source_coords,                 \
+      const double time,                                                       \
       const std::unordered_map<                                                \
           std::string,                                                         \
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
       const noexcept;                                                          \
-  template tnsr::Iaa<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>  \
-  CubicScale::hessian(                                                         \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
+                    Frame::NoFrame>                                            \
+  CubicScale<DIM(data)>::jacobian(                                             \
+      const std::array<DTYPE(data), DIM(data)>& source_coords,                 \
+      const double time,                                                       \
+      const std::unordered_map<                                                \
+          std::string,                                                         \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
+      const noexcept;                                                          \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
+                    Frame::NoFrame>                                            \
+  CubicScale<DIM(data)>::inv_jacobian(                                         \
+      const std::array<DTYPE(data), DIM(data)>& source_coords,                 \
+      const double time,                                                       \
       const std::unordered_map<                                                \
           std::string,                                                         \
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
       const noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
-                                      std::reference_wrapper<const double>,
-                                      std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
+                        (double, DataVector,
+                         std::reference_wrapper<const double>,
+                         std::reference_wrapper<const DataVector>))
+#undef DIM
 #undef DTYPE
 #undef INSTANTIATE
 /// \endcond

--- a/src/Domain/CoordinateMaps/CubicScale.hpp
+++ b/src/Domain/CoordinateMaps/CubicScale.hpp
@@ -28,25 +28,84 @@ namespace domain {
 namespace CoordMapsTimeDependent {
 /*!
  * \ingroup CoordMapsTimeDependentGroup
- * \brief CubicScale map defined by \f$x = a(t)*\xi+(b(t)-a(t))\xi^3/X^2\f$,
- *  where \f$X\f$ is the outer boundary.
+ * \brief Maps the radius as \f$r(t) = a(t)\rho + \left(b(t) - a(t)\right)
+ * \frac{\rho^3} {R^2}\f$ where \f$\rho\f$ is the radius of the source
+ * coordinates.
  *
- * The map scales the coordinates \f$\xi\f$ near the center by a factor
- * \f$a(t)\f$, while the coordinates near the outer boundary \f$X\f$, are scaled
- * by a factor \f$b(t)\f$. Here \f$a(t)\f$ and \f$b(t)\f$ are FunctionsOfTime.
+ * The map scales the radius \f$\rho\f$ in the source coordinates
+ * \f$\xi^{\hat{i}}\f$ by a factor \f$a(t)\f$, while the coordinates near the
+ * outer boundary \f$R\f$, are scaled by a factor \f$b(t)\f$. Here \f$a(t)\f$
+ * and \f$b(t)\f$ are FunctionsOfTime. The target/mapped coordinates are denoted
+ * by \f$x^i\f$.
  *
- * Currently, only a 1-D implementation.
+ * The mapped coordinates are given by:
+ *
+ * \f{align}{
+ * x^i = \left[a + (b-a) \frac{\rho^2}{R^2}\right] \xi^{\hat{i}}
+ *       \delta^i_{\hat{i}},
+ * \f}
+ *
+ * where \f$\xi^{\hat{i}}\f$ are the source coordinates, \f$a\f$ and \f$b\f$ are
+ * functions of time, \f$\rho\f$ is the radius in the source coordinates, and
+ * \f$R\f$ is the outer boundary.
+ *
+ * The inverse map is computed by solving the cubic equation:
+ *
+ * \f{align}{
+ * (b-a)\frac{\rho^3}{R^2} + a \rho - r = 0,
+ * \f}
+ *
+ * which is done by defining \f$q=\rho/R\f$, and solving
+ *
+ * \f{align}{
+ * q \left[(b-a) q^2 + a\right] - \frac{r}{R} = 0.
+ * \f}
+ *
+ * The source coordinates are obtained using:
+ *
+ * \f{align}{
+ * \xi^{\hat{i}} = \frac{qR}{r} x^i(t) \delta^{\hat{i}}_i
+ * \f}
+ *
+ * The Jacobian is given by:
+ *
+ * \f{align}{
+ * \frac{\partial x^i}{\partial \xi^{\hat{i}}}=
+ *    \left[a + (b-a) \frac{\rho^2}{R^2}\right] \delta^i_{\hat{i}}
+ *    + \frac{2 (b-a)}{R^2} \xi^{\hat{j}} \delta^i_{\hat{j}} \xi^{\hat{k}}
+ *      \delta_{\hat{k}\hat{i}}
+ * \f}
+ *
+ * The inverse Jacobian is given by:
+ *
+ * \f{align}{
+ * \frac{\partial \xi^{\hat{i}}}{\partial x^i}=
+ * \frac{1}{\left[a + (b-a)\rho^2/R^2\right]}
+ *  \left[\delta^{\hat{i}}_i -
+ *        \frac{2 (b-a)}{\left[a R^2 + 3(b-a)\rho^2\right]}
+ *        \xi^{\hat{i}}\xi^{\hat{j}}\delta_{\hat{j}i}\right]
+ * \f}
+ *
+ * The mesh velocity \f$v_g^i\f$ is given by:
+ *
+ * \f{align}{
+ * v_g^i = \left[\frac{da}{dt} + \left(\frac{db}{dt}-\frac{da}{dt}\right)
+ *         \frac{\rho^2}{R^2}\right] \xi^{\hat{i}} \delta^i_{\hat{i}}.
+ * \f}
  */
+template <size_t Dim>
 class CubicScale {
  public:
-  static constexpr size_t dim = 1;
+  static constexpr size_t dim = Dim;
 
-  explicit CubicScale(double outer_boundary) noexcept;
+  explicit CubicScale(double outer_boundary,
+                      std::string function_of_time_name_a,
+                      std::string function_of_time_name_b) noexcept;
   CubicScale() = default;
 
   template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
-      const std::array<T, 1>& source_coords, double time,
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> operator()(
+      const std::array<T, Dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
@@ -54,40 +113,32 @@ class CubicScale {
 
   /// Returns boost::none if the point is outside the range of the map.
   template <typename T>
-  boost::optional<std::array<tt::remove_cvref_wrap_t<T>, 1>> inverse(
-      const std::array<T, 1>& target_coords, double time,
+  boost::optional<std::array<tt::remove_cvref_wrap_t<T>, Dim>> inverse(
+      const std::array<T, Dim>& target_coords, double time,
       const std::unordered_map<
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
       const noexcept;
 
   template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 1> frame_velocity(
-      const std::array<T, 1>& source_coords, double time,
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> frame_velocity(
+      const std::array<T, Dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
       const noexcept;
 
   template <typename T>
-  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> inv_jacobian(
-      const std::array<T, 1>& source_coords, double time,
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> inv_jacobian(
+      const std::array<T, Dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
       const noexcept;
 
   template <typename T>
-  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> jacobian(
-      const std::array<T, 1>& source_coords, double time,
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
-      const noexcept;
-
-  template <typename T>
-  tnsr::Iaa<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> hessian(
-      const std::array<T, 1>& source_coords, double time,
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> jacobian(
+      const std::array<T, Dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
@@ -99,15 +150,20 @@ class CubicScale {
   bool is_identity() const noexcept { return false; }
 
  private:
-  friend bool operator==(const CubicScale& lhs, const CubicScale& rhs) noexcept;
+  template <size_t LocalDim>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const CubicScale<LocalDim>& lhs,
+                         const CubicScale<LocalDim>& rhs) noexcept;
 
-  std::string f_of_t_a_ = "expansion_a";
-  std::string f_of_t_b_ = "expansion_b";
-  double outer_boundary_{std::numeric_limits<double>::signaling_NaN()};
+  std::string f_of_t_a_{};
+  std::string f_of_t_b_{};
+  double one_over_outer_boundary_{std::numeric_limits<double>::signaling_NaN()};
+  bool functions_of_time_equal_{false};
 };
 
-inline bool operator!=(const CoordMapsTimeDependent::CubicScale& lhs,
-                       const CoordMapsTimeDependent::CubicScale& rhs) noexcept {
+template <size_t Dim>
+bool operator!=(const CubicScale<Dim>& lhs,
+                const CubicScale<Dim>& rhs) noexcept {
   return not(lhs == rhs);
 }
 

--- a/src/Utilities/StdArrayHelpers.hpp
+++ b/src/Utilities/StdArrayHelpers.hpp
@@ -150,22 +150,18 @@ inline constexpr std::array<T, Dim + 1> prepend(const std::array<T, Dim>& a,
 /// abs(), sqrt(), and element-wise addition and multiplication.  In addition,
 /// each T in the array must have the same size.
 template <typename T>
-inline T magnitude(const std::array<T, 1>& a) noexcept {
+decltype(auto) magnitude(const std::array<T, 1>& a) noexcept {
+  using std::abs;
   return abs(a[0]);
 }
 
-template <>
-inline double magnitude(const std::array<double, 1>& a) noexcept {
-  return std::abs(a[0]);
-}
-
 template <typename T>
-inline T magnitude(const std::array<T, 2>& a) noexcept {
+decltype(auto) magnitude(const std::array<T, 2>& a) noexcept {
   return sqrt(a[0] * a[0] + a[1] * a[1]);
 }
 
 template <typename T>
-inline T magnitude(const std::array<T, 3>& a) noexcept {
+decltype(auto) magnitude(const std::array<T, 3>& a) noexcept {
   return sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2]);
 }
 //@}

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -1094,31 +1094,33 @@ void test_push_back() {
 
 void test_jacobian_is_time_dependent() noexcept {
   using affine_map = CoordinateMaps::Affine;
-  using cubic_scale_map = CoordMapsTimeDependent::CubicScale;
+  using cubic_scale_map = CoordMapsTimeDependent::CubicScale<1>;
   using map_2d =
       CoordMapsTimeDependent::ProductOf2Maps<affine_map, cubic_scale_map>;
   using map_3d = CoordMapsTimeDependent::ProductOf3Maps<affine_map, affine_map,
                                                         cubic_scale_map>;
 
-  const auto coord_map_1 =
-      make_coordinate_map<Frame::Logical, Frame::Grid>(cubic_scale_map(10.0));
+  const auto coord_map_1 = make_coordinate_map<Frame::Logical, Frame::Grid>(
+      cubic_scale_map(10.0, "ExpansionA", "ExpansionB"));
   const auto coord_map_1_base =
       make_coordinate_map_base<Frame::Logical, Frame::Grid>(
-          cubic_scale_map(10.0));
+          cubic_scale_map(10.0, "ExpansionA", "ExpansionB"));
 
   const auto coord_map_2 = make_coordinate_map<Frame::Logical, Frame::Grid>(
-      map_2d(affine_map(-1.0, 1.0, 2.0, 3.0), cubic_scale_map(10.0)));
+      map_2d(affine_map(-1.0, 1.0, 2.0, 3.0),
+             cubic_scale_map(10.0, "ExpansionA", "ExpansionB")));
   const auto coord_map_2_base =
       make_coordinate_map_base<Frame::Logical, Frame::Grid>(
-          map_2d(affine_map(-1.0, 1.0, 2.0, 3.0), cubic_scale_map(10.0)));
+          map_2d(affine_map(-1.0, 1.0, 2.0, 3.0),
+                 cubic_scale_map(10.0, "ExpansionA", "ExpansionB")));
 
   const auto coord_map_3 = make_coordinate_map<Frame::Logical, Frame::Grid>(
       map_3d(affine_map(-1.0, 1.0, 2.0, 3.0), affine_map(-1.0, 1.0, 2.0, 3.0),
-             cubic_scale_map(10.0)));
+             cubic_scale_map(10.0, "ExpansionA", "ExpansionB")));
   const auto coord_map_3_base =
-      make_coordinate_map_base<Frame::Logical, Frame::Grid>(
-          map_3d(affine_map(-1.0, 1.0, 2.0, 3.0),
-                 affine_map(-1.0, 1.0, 2.0, 3.0), cubic_scale_map(10.0)));
+      make_coordinate_map_base<Frame::Logical, Frame::Grid>(map_3d(
+          affine_map(-1.0, 1.0, 2.0, 3.0), affine_map(-1.0, 1.0, 2.0, 3.0),
+          cubic_scale_map(10.0, "ExpansionA", "ExpansionB")));
 
   CHECK(coord_map_1.inv_jacobian_is_time_dependent());
   CHECK(coord_map_1.jacobian_is_time_dependent());

--- a/tests/Unit/Domain/CoordinateMaps/Test_CubicScale.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CubicScale.cpp
@@ -43,7 +43,8 @@ void cubic_scale_non_invertible(const double a0, const double b0,
   const FoftPtr& expansion_a_base = f_of_t_list.at("expansion_a");
   const FoftPtr& expansion_b_base = f_of_t_list.at("expansion_b");
 
-  const CoordMapsTimeDependent::CubicScale scale_map(outer_boundary);
+  const CoordMapsTimeDependent::CubicScale<1> scale_map(
+      outer_boundary, "expansion_a", "expansion_b");
   const std::array<double, 1> point_xi{{19.2}};
 
   const std::array<double, 1> mapped_point{
@@ -54,138 +55,6 @@ void cubic_scale_non_invertible(const double a0, const double b0,
 
   // this call should fail.
   scale_map.inverse(mapped_point, t, f_of_t_list);
-}
-
-void test_map() {
-  INFO("Map");
-  static constexpr size_t deriv_order = 2;
-
-  const auto run_tests = [](const std::array<DataVector, deriv_order + 1>&
-                                init_func_a,
-                            const std::array<DataVector, deriv_order + 1>&
-                                init_func_b,
-                            const double outer_b, const double x0,
-                            const double final_time) {
-    double t = -0.5;
-    const double dt = 0.6;
-
-    using Polynomial =
-        domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
-    using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
-    std::unordered_map<std::string, FoftPtr> f_of_t_list{};
-    f_of_t_list["expansion_a"] = std::make_unique<Polynomial>(t, init_func_a);
-    f_of_t_list["expansion_b"] = std::make_unique<Polynomial>(t, init_func_b);
-
-    const FoftPtr& expansion_a_base = f_of_t_list.at("expansion_a");
-    const FoftPtr& expansion_b_base = f_of_t_list.at("expansion_b");
-
-    const double outer_boundary = outer_b;
-    const CoordMapsTimeDependent::CubicScale scale_map(outer_boundary);
-    const std::array<double, 1> point_xi{{x0}};
-
-    // test serialized/deserialized map
-    const auto scale_map_deserialized = serialize_and_deserialize(scale_map);
-
-    while (t < final_time) {
-      const double a = expansion_a_base->func_and_deriv(t)[0][0];
-      const double b = expansion_b_base->func_and_deriv(t)[0][0];
-
-      const std::array<double, 1> mapped_point{
-          {point_xi[0] * (a + (b - a) * square(point_xi[0] / outer_boundary))}};
-
-      CHECK_ITERABLE_APPROX(scale_map(point_xi, t, f_of_t_list), mapped_point);
-      CHECK_ITERABLE_APPROX(
-          scale_map.inverse(mapped_point, t, f_of_t_list).get(), point_xi);
-      CHECK_ITERABLE_APPROX(scale_map_deserialized(point_xi, t, f_of_t_list),
-                            mapped_point);
-      CHECK_ITERABLE_APPROX(
-          scale_map_deserialized.inverse(mapped_point, t, f_of_t_list).get(),
-          point_xi);
-
-      // Check that inverse map returns invalid for mapped point outside
-      // the outer boundary and inside the inner boundary.
-      const std::array<double, 1> bad_mapped_point_1{{1.1 * outer_boundary}};
-      const std::array<double, 1> bad_mapped_point_2{{-0.1 * outer_boundary}};
-      CHECK(not scale_map.inverse(bad_mapped_point_1, t, f_of_t_list));
-      CHECK(not scale_map.inverse(bad_mapped_point_2, t, f_of_t_list));
-
-      const double jacobian =
-          a + 3.0 * (b - a) * square(point_xi[0] / outer_boundary);
-      const double inv_jacobian =
-          1.0 / (a + 3.0 * (b - a) * square(point_xi[0] / outer_boundary));
-
-      CHECK(scale_map.jacobian(point_xi, t, f_of_t_list).get(0, 0) == jacobian);
-      CHECK(scale_map.inv_jacobian(point_xi, t, f_of_t_list).get(0, 0) ==
-            inv_jacobian);
-      CHECK(
-          scale_map_deserialized.jacobian(point_xi, t, f_of_t_list).get(0, 0) ==
-          jacobian);
-      CHECK(scale_map_deserialized.inv_jacobian(point_xi, t, f_of_t_list)
-                .get(0, 0) == inv_jacobian);
-
-      const double a_dot = expansion_a_base->func_and_deriv(t)[1][0];
-      const double b_dot = expansion_b_base->func_and_deriv(t)[1][0];
-      const std::array<double, 1> frame_vel =
-          point_xi *
-          (a_dot + (b_dot - a_dot) * square(point_xi[0] / outer_boundary));
-
-      CHECK_ITERABLE_APPROX(scale_map.frame_velocity(point_xi, t, f_of_t_list),
-                            frame_vel);
-      CHECK_ITERABLE_APPROX(
-          scale_map_deserialized.frame_velocity(point_xi, t, f_of_t_list),
-          frame_vel);
-
-      const double a_ddot = expansion_a_base->func_and_2_derivs(t)[2][0];
-      const double b_ddot = expansion_b_base->func_and_2_derivs(t)[2][0];
-      const double time_time =
-          a_ddot * point_xi[0] +
-          (b_ddot - a_ddot) * cube(point_xi[0]) / square(outer_boundary);
-      const double time_space =
-          a_dot + 3.0 * (b_dot - a_dot) * square(point_xi[0] / outer_boundary);
-      const double space_space =
-          6.0 * (b - a) * point_xi[0] / square(outer_boundary);
-
-      CHECK(approx(scale_map.hessian(point_xi, t, f_of_t_list).get(0, 0, 0)) ==
-            time_time);
-      CHECK(approx(scale_map.hessian(point_xi, t, f_of_t_list).get(0, 1, 0)) ==
-            time_space);
-      CHECK(approx(scale_map.hessian(point_xi, t, f_of_t_list).get(0, 0, 1)) ==
-            time_space);
-      CHECK(approx(scale_map.hessian(point_xi, t, f_of_t_list).get(0, 1, 1)) ==
-            space_space);
-
-      CHECK(approx(scale_map_deserialized.hessian(point_xi, t, f_of_t_list)
-                       .get(0, 0, 0)) == time_time);
-      CHECK(approx(scale_map_deserialized.hessian(point_xi, t, f_of_t_list)
-                       .get(0, 1, 0)) == time_space);
-      CHECK(approx(scale_map_deserialized.hessian(point_xi, t, f_of_t_list)
-                       .get(0, 0, 1)) == time_space);
-      CHECK(approx(scale_map_deserialized.hessian(point_xi, t, f_of_t_list)
-                       .get(0, 1, 1)) == space_space);
-
-      // Check inequivalence operator
-      CHECK_FALSE(scale_map != scale_map);
-      CHECK_FALSE(scale_map_deserialized != scale_map_deserialized);
-
-      // Check serialization
-      CHECK(scale_map == scale_map_deserialized);
-      CHECK_FALSE(scale_map != scale_map_deserialized);
-
-      test_coordinate_map_argument_types(scale_map, point_xi, t, f_of_t_list);
-
-      t += dt;
-    }
-  };
-
-  std::array<DataVector, deriv_order + 1> init_func_a1{
-      {{1.0}, {0.0007}, {-0.004}}};
-  std::array<DataVector, deriv_order + 1> init_func_b1{
-      {{1.0}, {-0.001}, {0.003}}};
-  run_tests(init_func_a1, init_func_b1, 20.0, 19.2, 4.0);
-  // test again with inputs that explicitly result in multiple roots
-  std::array<DataVector, deriv_order + 1> init_func_a2{{{1.0}, {0.0}, {0.0}}};
-  std::array<DataVector, deriv_order + 1> init_func_b2{{{0.99}, {0.0}, {0.0}}};
-  run_tests(init_func_a2, init_func_b2, 6.0, 5.0, 0.0);
 }
 
 void test_boundaries() {
@@ -213,7 +82,8 @@ void test_boundaries() {
     const FoftPtr& expansion_b_base = f_of_t_list.at("expansion_b");
 
     const double outer_boundary = 20.0;
-    const CoordMapsTimeDependent::CubicScale scale_map(outer_boundary);
+    const CoordMapsTimeDependent::CubicScale<1> scale_map(
+        outer_boundary, "expansion_a", "expansion_b");
     const std::array<double, 1> point_xi{{x0}};
 
     while (t < final_time) {
@@ -224,6 +94,8 @@ void test_boundaries() {
           {point_xi[0] * (a + (b - a) * square(point_xi[0] / outer_boundary))}};
 
       CHECK_ITERABLE_APPROX(scale_map(point_xi, t, f_of_t_list), mapped_point);
+      REQUIRE(
+          static_cast<bool>(scale_map.inverse(mapped_point, t, f_of_t_list)));
       CHECK_ITERABLE_APPROX(
           scale_map.inverse(mapped_point, t, f_of_t_list).get(), point_xi);
       t += dt;
@@ -234,13 +106,153 @@ void test_boundaries() {
   run_tests(0.0);
   run_tests(20.0);
 }
+
+template <size_t Dim>
+std::array<double, Dim> coords_single_root();
+
+template <>
+std::array<double, 1> coords_single_root() {
+  return {{19.2}};
+}
+
+template <>
+std::array<double, 2> coords_single_root() {
+  return {{19.2, 0.1}};
+}
+
+template <>
+std::array<double, 3> coords_single_root() {
+  return {{19.2, 0.1, -1.1}};
+}
+
+template <size_t Dim>
+std::array<double, Dim> coords_multi_root();
+
+template <>
+std::array<double, 1> coords_multi_root() {
+  return {{5.0}};
+}
+
+template <>
+std::array<double, 2> coords_multi_root() {
+  return {{5.0, 0.0}};
+}
+
+template <>
+std::array<double, 3> coords_multi_root() {
+  return {{5.0, 0.0, 0.0}};
+}
+
+template <size_t Dim>
+void test(const bool linear_expansion) {
+  INFO("Map");
+  CAPTURE(Dim);
+  CAPTURE(linear_expansion);
+  static constexpr size_t deriv_order = 2;
+
+  const auto run_tests = [linear_expansion](
+                             const std::array<DataVector, deriv_order + 1>&
+                                 init_func_a,
+                             const std::array<DataVector, deriv_order + 1>&
+                                 init_func_b,
+                             const double outer_boundary,
+                             const std::array<double, Dim> point_xi,
+                             const double final_time) {
+    const double initial_time = -0.5;
+    double t = -0.4;
+    const double dt = 0.6;
+
+    using Polynomial =
+        domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
+    using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
+    std::unordered_map<std::string, FoftPtr> f_of_t_list{};
+    f_of_t_list["expansion_a"] =
+        std::make_unique<Polynomial>(initial_time, init_func_a);
+    f_of_t_list["expansion_b"] =
+        std::make_unique<Polynomial>(initial_time, init_func_b);
+
+    const FoftPtr& expansion_a_base = f_of_t_list.at("expansion_a");
+    const FoftPtr& expansion_b_base = f_of_t_list.at("expansion_b");
+
+    const CoordMapsTimeDependent::CubicScale<Dim> scale_map(
+        outer_boundary, "expansion_a",
+        linear_expansion ? "expansion_a"s : "expansion_b"s);
+
+    // test serialized/deserialized map
+    const auto scale_map_deserialized = serialize_and_deserialize(scale_map);
+
+    while (t < final_time) {
+      const double a = expansion_a_base->func_and_deriv(t)[0][0];
+      const double b =
+          linear_expansion ? a : expansion_b_base->func_and_deriv(t)[0][0];
+
+      const double radius_squared = square(magnitude(point_xi));
+      const std::array<double, Dim> mapped_point =
+          point_xi * (a + (b - a) * radius_squared / square(outer_boundary));
+
+      CHECK_ITERABLE_APPROX(scale_map(point_xi, t, f_of_t_list), mapped_point);
+      CHECK_ITERABLE_APPROX(
+          scale_map.inverse(mapped_point, t, f_of_t_list).get(), point_xi);
+      CHECK_ITERABLE_APPROX(scale_map_deserialized(point_xi, t, f_of_t_list),
+                            mapped_point);
+      CHECK_ITERABLE_APPROX(
+          scale_map_deserialized.inverse(mapped_point, t, f_of_t_list).get(),
+          point_xi);
+
+      if (not linear_expansion) {
+        // Check that inverse map returns invalid for mapped point outside
+        // the outer boundary and inside the inner boundary.
+        for (size_t i = 0; i < Dim; ++i) {
+          std::array<double, Dim> bad_mapped_point = make_array<Dim>(1.1);
+          gsl::at(bad_mapped_point, i) *= outer_boundary;
+          CHECK(not scale_map.inverse(bad_mapped_point, t, f_of_t_list));
+        }
+      }
+
+      test_jacobian(scale_map, point_xi, t, f_of_t_list);
+      test_inv_jacobian(scale_map, point_xi, t, f_of_t_list);
+      test_frame_velocity(scale_map, point_xi, t, f_of_t_list);
+
+      test_jacobian(scale_map_deserialized, point_xi, t, f_of_t_list);
+      test_inv_jacobian(scale_map_deserialized, point_xi, t, f_of_t_list);
+      test_frame_velocity(scale_map_deserialized, point_xi, t, f_of_t_list);
+
+      // Check inequivalence operator
+      CHECK_FALSE(scale_map != scale_map);
+      CHECK_FALSE(scale_map_deserialized != scale_map_deserialized);
+
+      // Check serialization
+      CHECK(scale_map == scale_map_deserialized);
+      CHECK_FALSE(scale_map != scale_map_deserialized);
+
+      test_coordinate_map_argument_types(scale_map, point_xi, t, f_of_t_list);
+
+      t += dt;
+    }
+  };
+
+  std::array<DataVector, deriv_order + 1> init_func_a1{
+      {{1.0}, {0.0007}, {-0.004}}};
+  std::array<DataVector, deriv_order + 1> init_func_b1{
+      {{1.0}, {-0.001}, {0.003}}};
+  run_tests(init_func_a1, init_func_b1, 20.0, coords_single_root<Dim>(), 4.0);
+
+  // test again with inputs that explicitly result in multiple roots
+  std::array<DataVector, deriv_order + 1> init_func_a2{{{1.0}, {0.0}, {0.0}}};
+  std::array<DataVector, deriv_order + 1> init_func_b2{{{0.99}, {0.0}, {0.0}}};
+  run_tests(init_func_a2, init_func_b2, 6.0, coords_multi_root<Dim>(), 0.0);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.CubicScale",
                   "[Domain][Unit]") {
-  test_map();
+  for (const auto linear_expansion : {false, true}) {
+    test<1>(linear_expansion);
+    test<2>(linear_expansion);
+    test<3>(linear_expansion);
+  }
   test_boundaries();
-  CHECK(not CoordMapsTimeDependent::CubicScale{}.is_identity());
+  CHECK(not CoordMapsTimeDependent::CubicScale<1>{}.is_identity());
 }
 
 // [[OutputRegex, The map is invertible only if 0 < expansion_b <

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -253,7 +253,7 @@ void check_cmp(const T& less, const U& greater) {
  */
 template <typename Invocable, size_t VolumeDim>
 std::result_of_t<const Invocable&(const std::array<double, VolumeDim>&)>
-numerical_derivative(const Invocable& map,
+numerical_derivative(const Invocable& function,
                      const std::array<double, VolumeDim>& x,
                      const size_t direction, const double delta) noexcept {
   ASSERT(0 <= direction and direction < VolumeDim,
@@ -271,11 +271,12 @@ numerical_derivative(const Invocable& map,
   const std::array<double, VolumeDim> x_1behind = x - dx;
   const std::array<double, VolumeDim> x_2behind = x_1behind - dx;
   const std::array<double, VolumeDim> x_3behind = x_2behind - dx;
-  return (1.0 / (60.0 * delta)) * map(x_3ahead) +
-         (-3.0 / (20.0 * delta)) * map(x_2ahead) +
-         (0.75 / delta) * map(x_1ahead) + (-0.75 / delta) * map(x_1behind) +
-         (3.0 / (20.0 * delta)) * map(x_2behind) +
-         (-1.0 / (60.0 * delta)) * map(x_3behind);
+  return (1.0 / (60.0 * delta)) * function(x_3ahead) +
+         (-3.0 / (20.0 * delta)) * function(x_2ahead) +
+         (0.75 / delta) * function(x_1ahead) +
+         (-0.75 / delta) * function(x_1behind) +
+         (3.0 / (20.0 * delta)) * function(x_2behind) +
+         (-1.0 / (60.0 * delta)) * function(x_3behind);
 }
 
 struct NonCopyable {


### PR DESCRIPTION
## Proposed changes

- We need the cubic scale map to work in 2d and 3d for binaries, so this generalizes it
- Optimizations for linear radial scaling
- Add test helpers for time-dependent (inverse) Jacobians, and the frame velocity that use numerical derivatives.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
