### PR TITLE
Scri observation

### DIFF
--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -36,6 +36,7 @@ namespace Actions {
  *  - `Tags::TimeStepId`
  *  - `Tags::Next<Tags::TimeStepId>`
  *  - `Tags::TimeStep`
+ *  - `Tags::Time`
  *  -
  * ```
  * Tags::HistoryEvolvedVariables<
@@ -69,11 +70,12 @@ struct InitializeCharacteristicEvolutionTime {
                     const ParallelComponent* const /*meta*/) noexcept {
     using coordinate_variables_tag =
         typename Metavariables::evolved_coordinates_variables_tag;
+    using evolved_swsh_variables_tag =
+        ::Tags::Variables<tmpl::list<typename Metavariables::evolved_swsh_tag>>;
     using evolution_simple_tags = db::AddSimpleTags<
         ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep,
-        ::Tags::HistoryEvolvedVariables<coordinate_variables_tag>,
-        ::Tags::HistoryEvolvedVariables<::Tags::Variables<
-            tmpl::list<typename Metavariables::evolved_swsh_tag>>>>;
+        ::Tags::Time, ::Tags::HistoryEvolvedVariables<coordinate_variables_tag>,
+        ::Tags::HistoryEvolvedVariables<evolved_swsh_variables_tag>>;
     using evolution_compute_tags =
         db::AddComputeTags<::Tags::SubstepTimeCompute>;
 
@@ -93,8 +95,7 @@ struct InitializeCharacteristicEvolutionTime {
     db::item_type<::Tags::HistoryEvolvedVariables<coordinate_variables_tag>>
         coordinate_history;
 
-    db::item_type<::Tags::HistoryEvolvedVariables<::Tags::Variables<
-        tmpl::list<typename Metavariables::evolved_swsh_tag>>>>
+    db::item_type<::Tags::HistoryEvolvedVariables<evolved_swsh_variables_tag>>
         swsh_history;
     return std::make_tuple(
         Initialization::merge_into_databox<
@@ -102,7 +103,8 @@ struct InitializeCharacteristicEvolutionTime {
             evolution_compute_tags, Initialization::MergePolicy::Overwrite>(
             std::move(box), std::move(initial_time_id),  // NOLINT
             std::move(second_time_id), fixed_time_step,  // NOLINT
-            std::move(coordinate_history), std::move(swsh_history)));
+            initial_time_value, std::move(coordinate_history),
+            std::move(swsh_history)));
   }
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionVariables.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionVariables.hpp
@@ -95,8 +95,8 @@ struct InitializeCharacteristicEvolutionVariables {
         db::add_tag_prefix<::Tags::dt, coordinate_variables_tag>;
     using evolved_swsh_variables_tag =
         ::Tags::Variables<tmpl::list<typename Metavariables::evolved_swsh_tag>>;
-    using evolved_swsh_dt_variables_tag = ::Tags::Variables<
-        tmpl::list<typename Metavariables::evolved_swsh_dt_tag>>;
+    using evolved_swsh_dt_variables_tag =
+        db::add_tag_prefix<::Tags::dt, evolved_swsh_variables_tag>;
 
     const size_t l_max = db::get<Spectral::Swsh::Tags::LMaxBase>(box);
     const size_t number_of_radial_points =

--- a/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp
+++ b/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp
@@ -1,0 +1,139 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/Cce/ScriPlusInterpolationManager.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "IO/Observer/WriteSimpleData.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce {
+namespace detail {
+// Provide a nicer name for the output h5 files for some of the uglier
+// combinations we need
+template <typename Tag>
+struct ScriOutput {
+  static std::string name() noexcept { return db::tag_name<Tag>(); }
+};
+template <typename Tag>
+struct ScriOutput<Tags::ScriPlus<Tag>> {
+  static std::string name() noexcept {
+    return pretty_type::short_name<Tag>();
+  }
+};
+template <>
+struct ScriOutput<::Tags::Multiplies<
+  Tags::Du<Tags::TimeIntegral<Tags::ScriPlus<Tags::Psi4>>>,
+  Tags::ScriPlusFactor<Tags::Psi4>>> {
+  static std::string name() noexcept { return "Psi4"; }
+};
+}  // namespace detail
+
+namespace Actions {
+
+/*!
+ * \ingroup ActionsGroup
+ * \brief Checks the interpolation managers and if they are ready, performs the
+ * interpolation and sends the data to file via
+ * `observers::ThreadedActions::WriteSimpleData`.
+ *
+ * \details This uses the `ScriPlusInterpolationManager` to perform the
+ * interpolations of all requested scri quantities (determined by
+ * `scri_values_to_observe` in the metavariables), and write them to disk using
+ * `observers::threadedActions::WriteSimpleData`.
+ *
+ * \ref DataBoxGroup changes:
+ * - Adds: nothing
+ * - Removes: nothing
+ * - Modifies: `InterpolagionManager<ComplexDataVector, Tag>` for each `Tag` in
+ * `Metavariables::scri_values_to_observe`
+ */
+template <typename ObserverWriterComponent>
+struct ScriObserveInterpolated {
+  using const_global_cache_tags = tmpl::list<Tags::ObservationLMax>;
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTags>&&> apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const size_t observation_l_max = db::get<Tags::ObservationLMax>(box);
+    const size_t l_max = db::get<Tags::LMax>(box);
+    std::vector<double> data_to_write(2 * square(observation_l_max + 1) + 1);
+    std::vector<std::string> file_legend;
+    file_legend.reserve(2 * square(observation_l_max + 1) + 1);
+    file_legend.emplace_back("time");
+    for (int i = 0; i <= static_cast<int>(observation_l_max); ++i) {
+      for(int j = -i; j <= i; ++j) {
+        file_legend.push_back(MakeString{} << "Real Y_" << i << "," << j);
+        file_legend.push_back(MakeString{} << "Imag Y_" << i << "," << j);
+      }
+    }
+    auto observer_proxy =
+        Parallel::get_parallel_component<ObserverWriterComponent>(
+            cache)[static_cast<size_t>(Parallel::my_node())];
+    while (
+        db::get<Tags::InterpolationManager<
+            ComplexDataVector,
+            tmpl::front<typename Metavariables::scri_values_to_observe>>>(box)
+            .first_time_is_ready_to_interpolate()) {
+      tmpl::for_each<typename Metavariables::scri_values_to_observe>([
+        &box, &data_to_write, &observer_proxy, &file_legend, &observation_l_max,
+        &l_max
+      ](auto tag_v) noexcept {
+        using tag = typename decltype(tag_v)::type;
+        std::pair<double, ComplexDataVector> interpolation;
+        db::mutate<Tags::InterpolationManager<ComplexDataVector, tag>>(
+            make_not_null(&box),
+            [&interpolation](
+                const gsl::not_null<
+                    ScriPlusInterpolationManager<ComplexDataVector, tag>*>
+                    interpolation_manager) {
+              interpolation =
+                  interpolation_manager->interpolate_and_pop_first_time();
+            });
+        // swsh transform
+        const auto to_transform =
+            SpinWeighted<ComplexDataVector, tag::type::type::spin>{
+                interpolation.second};
+        const ComplexModalVector goldberg_modes =
+            Spectral::Swsh::libsharp_to_goldberg_modes(
+                Spectral::Swsh::swsh_transform(l_max, 1, to_transform), l_max)
+                .data();
+
+        data_to_write[0] = interpolation.first;
+        for(size_t i = 0; i < square(observation_l_max + 1); ++i) {
+          data_to_write[2 * i + 1] = real(goldberg_modes[i]);
+          data_to_write[2 * i + 2] = imag(goldberg_modes[i]);
+        }
+        Parallel::threaded_action<observers::ThreadedActions::WriteSimpleData>(
+            observer_proxy, file_legend, data_to_write,
+            "/" + ::Cce::detail::ScriOutput<tag>::name());
+      });
+    }
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -201,6 +201,15 @@ struct NumberOfRadialPoints : db::SimpleTag,
   }
 };
 
+struct ObservationLMax : db::SimpleTag {
+  using type = size_t;
+  using option_tags = tmpl::list<OptionTags::ObservationLMax>;
+
+  static size_t create_from_options(const size_t observation_l_max) noexcept {
+    return observation_l_max;
+  }
+};
+
 struct FilterLMax : db::SimpleTag {
   using type = size_t;
   using option_tags = tmpl::list<OptionTags::FilterLMax>;

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -28,6 +29,28 @@ struct BondiBeta : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;
 };
 
+/// Bondi parameter \f$J\f$
+struct BondiJ : db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, 2>>;
+  static std::string name() noexcept { return "J"; }
+};
+
+}  // namespace Tags
+}  // namespace Cce
+
+namespace Tags {
+/// \cond
+template <>
+struct dt<Cce::Tags::BondiJ> : db::PrefixTag, db::SimpleTag {
+  static std::string name() noexcept { return "H"; }
+  using type = Scalar<::SpinWeighted<ComplexDataVector, 2>>;
+  using tag = Cce::Tags::BondiJ;
+};
+/// \endcond
+}  // namespace Tags
+
+namespace Cce {
+namespace Tags {
 /// \brief Bondi parameter \f$H = \partial_u J\f$.
 /// \note The notation in the literature is not consistent regarding this
 /// quantity, or whether it is denoted by an \f$H\f$ at all. The SpECTRE CCE
@@ -35,16 +58,7 @@ struct BondiBeta : db::SimpleTag {
 /// derivative of \f$J\f$ at fixed compactified radius \f$y\f$ (to be contrasted
 /// with the physical Bondi radius, which is not directly used for numerical
 /// grids).
-struct BondiH : db::SimpleTag {
-  using type = Scalar<SpinWeighted<ComplexDataVector, 2>>;
-  static std::string name() noexcept { return "H"; }
-};
-
-/// Bondi parameter \f$J\f$
-struct BondiJ : db::SimpleTag {
-  using type = Scalar<SpinWeighted<ComplexDataVector, 2>>;
-  static std::string name() noexcept { return "J"; }
-};
+using BondiH = ::Tags::dt<BondiJ>;
 
 /// Bondi parameter \f$\bar{J}\f$
 struct BondiJbar : db::SimpleTag {

--- a/src/IO/Observer/WriteSimpleData.hpp
+++ b/src/IO/Observer/WriteSimpleData.hpp
@@ -1,0 +1,69 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/NodeLock.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace observers {
+namespace ThreadedActions {
+
+/*!
+ * \brief Append data to an h5::Dat subfile of `Tags::VolumeFileName`.
+ *
+ * \details This is a streamlined interface for getting data to the volume file
+ * associated with a node; it will simply write the `.dat` object
+ * `subfile_name`, giving it the `file_legend` if it does not yet exist,
+ * appending `data_row` to the end of the dat.
+ */
+struct WriteSimpleData {
+  template <
+      typename ParallelComponent, typename DbTagsList, typename Metavariables,
+      typename ArrayIndex,
+      Requires<tmpl::list_contains_v<DbTagsList, Tags::H5FileLock>> = nullptr>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const gsl::not_null<CmiNodeLock*> node_lock,
+                    const std::vector<std::string>& file_legend,
+                    const std::vector<double>& data_row,
+                    const std::string& subfile_name) noexcept {
+    Parallel::lock(node_lock);
+    CmiNodeLock file_lock;
+    db::mutate<Tags::H5FileLock>(
+        make_not_null(&box), [&file_lock](const gsl::not_null<CmiNodeLock*>
+                                              in_file_lock) noexcept {
+          file_lock = *in_file_lock;
+        });
+    Parallel::unlock(node_lock);
+
+    Parallel::lock(&file_lock);
+    // scoped to close file
+    {
+      const auto& file_prefix = Parallel::get<Tags::VolumeFileName>(cache);
+      h5::H5File<h5::AccessType::ReadWrite> h5file(
+          file_prefix + std::to_string(Parallel::my_node()) + ".h5", true);
+      const size_t version_number = 0;
+      auto& output_dataset =
+          h5file.try_insert<h5::Dat>(subfile_name, file_legend, version_number);
+      output_dataset.append(data_row);
+      h5file.close_current_object();
+    }
+    Parallel::unlock(&file_lock);
+  }
+};
+}  // namespace ThreadedActions
+}  // namespace observers

--- a/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_InitializeCharacteristicEvolution.cpp
   Test_InitializeWorldtubeBoundary.cpp
   Test_RequestBoundaryData.cpp
+  Test_ScriObserveInterpolated.cpp
   Test_TimeManagement.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -245,8 +245,8 @@ SPECTRE_TEST_CASE(
             number_of_radial_points);
 
   const auto& evolved_swsh_dt_variables = ActionTesting::get_databox_tag<
-      component, ::Tags::Variables<
-                     tmpl::list<typename metavariables::evolved_swsh_dt_tag>>>(
+      component, ::Tags::dt<::Tags::Variables<
+                     tmpl::list<typename metavariables::evolved_swsh_dt_tag>>>>(
       runner, 0);
   CHECK(evolved_swsh_dt_variables.number_of_grid_points() ==
         Spectral::Swsh::number_of_swsh_collocation_points(l_max) *

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -1,0 +1,314 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionScri.hpp"
+#include "Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp"
+#include "Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionVariables.hpp"
+#include "Evolution/Systems/Cce/Actions/InsertInterpolationScriData.hpp"
+#include "Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
+#include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
+#include "IO/Observer/Initialize.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeSteppers/RungeKutta3.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/Numeric.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Cce {
+namespace {
+
+template <typename Tag>
+struct SetBoundaryValues {
+  template <
+      typename ParallelComponent, typename... DbTags, typename Metavariables,
+      typename ArrayIndex,
+      Requires<tmpl::list_contains_v<tmpl::list<DbTags...>, Tag>> = nullptr>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    ComplexDataVector set_values) noexcept {
+    db::mutate<Tag>(
+        make_not_null(&box), [&set_values](
+                                 const gsl::not_null<db::item_type<Tag>*>
+                                     spin_weighted_scalar_quantity) noexcept {
+          get(*spin_weighted_scalar_quantity).data() = std::move(set_values);
+        });
+  }
+
+  template <
+      typename ParallelComponent, typename... DbTags, typename Metavariables,
+      typename ArrayIndex,
+      Requires<tmpl::list_contains_v<tmpl::list<DbTags...>, Tag>> = nullptr>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    DataVector set_values) noexcept {
+    db::mutate<Tag>(
+        make_not_null(&box), [&set_values](
+                                 const gsl::not_null<db::item_type<Tag>*>
+                                     scalar_quantity) noexcept {
+          get(*scalar_quantity) = std::move(set_values);
+        });
+  }
+};
+
+template <typename Metavariables>
+struct mock_observer {
+  using component_being_mocked = observers::ObserverWriter<Metavariables>;
+  using replace_these_simple_actions = tmpl::list<>;
+  using with_these_simple_actions = tmpl::list<>;
+
+  using const_global_cache_tags = tmpl::list<observers::Tags::VolumeFileName>;
+  using initialize_action_list =
+      tmpl::list<observers::Actions::InitializeWriter<Metavariables>>;
+  using initialization_tags =
+      Parallel::get_initialization_tags<initialize_action_list>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             initialize_action_list>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Evolve, tmpl::list<>>>;
+};
+
+template <typename Metavariables>
+struct mock_characteristic_evolution {
+  using component_being_mocked = CharacteristicEvolution<Metavariables>;
+  using replace_these_simple_actions = tmpl::list<>;
+  using with_these_simple_actions = tmpl::list<>;
+
+  using initialize_action_list =
+      tmpl::list<Actions::InitializeCharacteristicEvolutionVariables,
+                 Actions::InitializeCharacteristicEvolutionTime,
+                 Actions::InitializeCharacteristicEvolutionScri,
+                 Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+  using initialization_tags =
+      Parallel::get_initialization_tags<initialize_action_list>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             initialize_action_list>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Evolve,
+          tmpl::list<
+              Actions::InsertInterpolationScriData<Tags::News>,
+              Actions::ScriObserveInterpolated<mock_observer<Metavariables>>,
+              ::Actions::AdvanceTime>>>;
+};
+
+struct test_metavariables {
+  using evolved_swsh_tag = Tags::BondiJ;
+  using evolved_swsh_dt_tag = Tags::BondiH;
+  using evolved_coordinates_variables_tag = ::Tags::Variables<
+      tmpl::list<Tags::CauchyCartesianCoords, Tags::InertialRetardedTime>>;
+  using cce_boundary_communication_tags =
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>;
+  using cce_gauge_boundary_tags = tmpl::flatten<tmpl::list<
+      tmpl::transform<
+          tmpl::list<Tags::BondiR, Tags::DuRDividedByR, Tags::BondiJ,
+                     Tags::Dr<Tags::BondiJ>, Tags::BondiBeta, Tags::BondiQ,
+                     Tags::BondiU, Tags::BondiW, Tags::BondiH>,
+          tmpl::bind<Tags::EvolutionGaugeBoundaryValue, tmpl::_1>>,
+      Tags::BondiUAtScri, Tags::GaugeC, Tags::GaugeD, Tags::GaugeOmega,
+      Tags::Du<Tags::GaugeOmega>,
+      Spectral::Swsh::Tags::Derivative<Tags::GaugeOmega,
+                                       Spectral::Swsh::Tags::Eth>>>;
+
+  using cce_integrand_tags = tmpl::flatten<tmpl::transform<
+      bondi_hypersurface_step_tags,
+      tmpl::bind<integrand_terms_to_compute_for_bondi_variable, tmpl::_1>>>;
+  using cce_integration_independent_tags =
+      tmpl::append<pre_computation_tags, tmpl::list<Tags::DuRDividedByR>>;
+  using cce_temporary_equations_tags =
+      tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+          cce_integrand_tags, tmpl::bind<integrand_temporary_tags, tmpl::_1>>>>;
+  using cce_pre_swsh_derivatives_tags = all_pre_swsh_derivative_tags;
+  using cce_transform_buffer_tags = all_transform_buffer_tags;
+  using cce_swsh_derivative_tags = all_swsh_derivative_tags;
+  using cce_angular_coordinate_tags = tmpl::list<Tags::CauchyAngularCoords>;
+  using cce_scri_tags = tmpl::list<Cce::Tags::News>;
+
+  using scri_values_to_observe = tmpl::list<Cce::Tags::News>;
+
+  using observed_reduction_data_tags = tmpl::list<>;
+
+  using component_list =
+      tmpl::list<mock_characteristic_evolution<test_metavariables>,
+                 mock_observer<test_metavariables>>;
+  enum class Phase { Initialization, Evolve, Exit };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
+                  "[Unit][Cce]") {
+  using evolution_component = mock_characteristic_evolution<test_metavariables>;
+  using observation_component = mock_observer<test_metavariables>;
+
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<double> value_dist{0.1, 0.5};
+  UniformCustomDistribution<double> coefficient_distribution{-2.0, 2.0};
+
+  const size_t number_of_radial_points = 10;
+  const size_t l_max = 8;
+  const size_t observation_l_max = 4;
+  const size_t scri_output_density = 1;
+  const std::string filename = "ScriObserveInterpolatedTest_CceVolumeOutput";
+
+  const double start_time = 0.0;
+  const double end_time = 100.0;
+  const double target_step_size = 0.1;
+  const size_t scri_interpolation_size = 3;
+
+  ActionTesting::MockRuntimeSystem<test_metavariables> runner{
+      {filename, l_max, number_of_radial_points,
+       std::make_unique<::TimeSteppers::RungeKutta3>(), start_time, end_time,
+       scri_output_density, observation_l_max}};
+
+  runner.set_phase(test_metavariables::Phase::Initialization);
+  ActionTesting::emplace_component<evolution_component>(
+      &runner, 0, target_step_size, scri_interpolation_size);
+  if (file_system::check_if_file_exists(filename + "0.h5")) {
+    file_system::rm(filename + "0.h5", true);
+  }
+
+  ActionTesting::emplace_component<observation_component>(&runner, 0);
+
+  // the initialization actions
+  for (size_t i = 0; i < 4; ++i) {
+    ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
+  }
+  ActionTesting::next_action<observation_component>(make_not_null(&runner), 0);
+  runner.set_phase(test_metavariables::Phase::Evolve);
+
+  // generate data that will be well behaved for the interpolation and the
+  // decomposition to modes done in the observation routine
+  UniformCustomDistribution<double> time_dist{-0.01, 0.01};
+
+  const double linear_coefficient = value_dist(gen) * 0.1;
+  const double quadratic_coefficient = value_dist(gen) * 0.1;
+  const size_t vector_size =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  const size_t data_points = 30;
+
+  // random vector based on modes
+  // Generate data uniform in r with all angular modes
+  SpinWeighted<ComplexModalVector, -2> generated_modes;
+  generated_modes.data() = make_with_random_values<ComplexModalVector>(
+      make_not_null(&gen), make_not_null(&coefficient_distribution),
+      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max));
+  for (const auto& mode : Spectral::Swsh::cached_coefficients_metadata(l_max)) {
+    if (mode.l < 2) {
+      generated_modes.data()[mode.transform_of_real_part_offset] = 0.0;
+      generated_modes.data()[mode.transform_of_imag_part_offset] = 0.0;
+    }
+    if (mode.m == 0) {
+      generated_modes.data()[mode.transform_of_real_part_offset] =
+          real(generated_modes.data()[mode.transform_of_real_part_offset]);
+      generated_modes.data()[mode.transform_of_imag_part_offset] =
+          real(generated_modes.data()[mode.transform_of_imag_part_offset]);
+    }
+  }
+  const SpinWeighted<ComplexDataVector, -2> random_vector =
+      Spectral::Swsh::inverse_swsh_transform(l_max, 1, generated_modes);
+
+  for (size_t i = 0; i < 3 * data_points; ++i) {
+    // this will give random times that are nonetheless guaranteed to be
+    // monotonically increasing
+    const DataVector time_vector =
+        i * 0.1 / 3.0 +
+        make_with_random_values<DataVector>(
+            make_not_null(&gen), make_not_null(&time_dist), vector_size);
+    ActionTesting::simple_action<evolution_component,
+                                 SetBoundaryValues<Tags::InertialRetardedTime>>(
+        make_not_null(&runner), 0, time_vector);
+    ActionTesting::simple_action<evolution_component,
+                                 SetBoundaryValues<Tags::News>>(
+        make_not_null(&runner), 0,
+        random_vector.data() * (1.0 + linear_coefficient * (time_vector) +
+                                quadratic_coefficient * square(time_vector)));
+
+    // should put the data we just set into the interpolator
+    ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
+    // should process the interpolation and write to file
+    ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
+    ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
+    while (not ActionTesting::is_threaded_action_queue_empty<
+           observation_component>(runner, 0)) {
+      ActionTesting::invoke_queued_threaded_action<observation_component>(
+          make_not_null(&runner), 0);
+    }
+  }
+  const auto& interpolation_manager = ActionTesting::get_databox_tag<
+      evolution_component,
+      Tags::InterpolationManager<ComplexDataVector, Tags::News>>(runner, 0);
+  // we won't have dropped all of the volume data or gotten through all of the
+  // data, because the last few points will not be sufficiently centered on the
+  // interpolation stencil
+  CHECK(interpolation_manager.number_of_data_points() < 10);
+  CHECK(interpolation_manager.number_of_target_times() < 8);
+
+  // most of the interpolations should be written now, so we read in the file
+  // and check that they are as expected.
+
+  // scoped to close the file
+  {
+    h5::H5File<h5::AccessType::ReadOnly> read_file{filename + "0.h5"};
+    const auto& dataset = read_file.get<h5::Dat>("/News");
+    const Matrix data_matrix = dataset.get_data();
+    CHECK(data_matrix.rows() > 20);
+    const auto expected_goldberg_modes =
+        Spectral::Swsh::libsharp_to_goldberg_modes(generated_modes, l_max);
+
+    Approx interpolation_approx =
+        Approx::custom()
+            .epsilon(std::numeric_limits<double>::epsilon() * 1.0e4)
+            .scale(1.0);
+    // skip the first time because the extrapolation will make that value
+    // unreliable
+    for (size_t i = 1; i < data_matrix.rows(); ++i) {
+      for (size_t j = 0; j < square(observation_l_max + 1); ++j) {
+        CHECK(data_matrix(i, 2 * j + 1) ==
+              interpolation_approx(
+                  real(expected_goldberg_modes.data()[j] *
+                       (1.0 + linear_coefficient * data_matrix(i, 0) +
+                        quadratic_coefficient * square(data_matrix(i, 0))))));
+      }
+    }
+  }
+  if (file_system::check_if_file_exists(filename + "0.h5")) {
+    file_system::rm(filename + "0.h5", true);
+  }
+}
+}  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/BoundaryTestHelpers.hpp
+++ b/tests/Unit/Evolution/Systems/Cce/BoundaryTestHelpers.hpp
@@ -13,6 +13,7 @@
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
 #include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
 #include "Utilities/FileSystem.hpp"

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -86,15 +86,16 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
             "OptionTagsTestCceR0100.h5") == 5.4);
   CHECK(Cce::Tags::EndTime::create_from_options(
             2.2, "OptionTagsTestCceR0100.h5") == 2.2);
-
-  CHECK(Cce::InitializationTags::TargetStepSize::create_from_options(0.2) ==
-        0.2);
+  CHECK(Cce::Tags::ObservationLMax::create_from_options(5_st) == 5_st);
 
   CHECK(Cce::InitializationTags::ScriInterpolationOrder::create_from_options(
             6_st) == 6_st);
 
   CHECK(Cce::InitializationTags::ScriOutputDensity::create_from_options(4_st) ==
         4_st);
+
+  CHECK(Cce::InitializationTags::TargetStepSize::create_from_options(0.2) ==
+        0.2);
 
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   Observers/Test_ReductionObserver.cpp
   Observers/Test_TypeOfObservation.cpp
   Observers/Test_VolumeObserver.cpp
+  Observers/Test_WriteSimpleData.cpp
   Test_H5.cpp
   Test_StellarCollapseEos.cpp
   Test_VolumeData.cpp

--- a/tests/Unit/IO/Observers/Test_WriteSimpleData.cpp
+++ b/tests/Unit/IO/Observers/Test_WriteSimpleData.cpp
@@ -1,0 +1,100 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/Matrix.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/Initialize.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "IO/Observer/WriteSimpleData.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/IO/Observers/ObserverHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+// NOLINTNEXTLINE(google-build-using-namespace)
+namespace helpers = TestObservers_detail;
+
+namespace {
+
+struct test_metavariables {
+  using component_list =
+      tmpl::list<helpers::observer_writer_component<test_metavariables>>;
+
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<helpers::reduction_data>>;
+
+  enum class Phase { Initialization, Testing, Exit };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.IO.Observers.WriteSimpleData", "[Unit][Observers]") {
+  constexpr observers::TypeOfObservation type_of_observation =
+      observers::TypeOfObservation::Volume;
+  using obs_writer = helpers::observer_writer_component<test_metavariables>;
+
+  tuples::TaggedTuple<observers::Tags::ReductionFileName,
+                      observers::Tags::VolumeFileName>
+      cache_data{};
+  tuples::get<observers::Tags::VolumeFileName>(cache_data) =
+      "./Unit.IO.Observers.WriteSimpleData";
+  const auto& output_file_prefix =
+      tuples::get<observers::Tags::VolumeFileName>(cache_data);
+  ActionTesting::MockRuntimeSystem<test_metavariables> runner{cache_data};
+  ActionTesting::emplace_component<obs_writer>(&runner, 0);
+  ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
+
+  runner.set_phase(test_metavariables::Phase::Testing);
+
+  const std::string h5_file_name = output_file_prefix + "0.h5";
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<double> value_dist{1.0, 5.0};
+  const size_t vector_size = 10;
+  std::vector<double> data_row(vector_size);
+  fill_with_random_values(make_not_null(&data_row), make_not_null(&gen),
+                          make_not_null(&value_dist));
+  std::vector<std::string> legend(vector_size);
+  for (size_t i = 0; i < vector_size; ++i) {
+    legend[i] = std::to_string(i);
+  }
+  ActionTesting::threaded_action<obs_writer,
+                                 observers::ThreadedActions::WriteSimpleData>(
+      make_not_null(&runner), 0, legend, data_row, "/simple_data.dat");
+  // scoped to close the file
+  {
+    h5::H5File<h5::AccessType::ReadOnly> read_file{h5_file_name};
+    const auto& dataset = read_file.get<h5::Dat>("/simple_data");
+    const auto cols = alg::iota(std::vector<size_t>(vector_size), 0_st);
+    const Matrix data_matrix = dataset.get_data_subset(cols, 0, 1);
+    for (size_t i = 0; i < vector_size; ++i) {
+      CHECK(approx(data_matrix(0, i)) == data_row[i]);
+    }
+    if (file_system::check_if_file_exists(h5_file_name)) {
+      file_system::rm(h5_file_name, true);
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes

Adds the action to be executed by the evolution component to perform the interpolation at scri+ once it is available and write the result to disk.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies
- [x] #1993