### PR TITLE
Move Domain tags into domain namespace

### DIFF
--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -61,6 +61,7 @@ tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
     const Direction<VolumeDim>& direction) noexcept;
 // @}
 
+namespace domain {
 namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
@@ -127,3 +128,4 @@ struct InterfaceCompute<Tags::BoundaryDirectionsExterior<VolumeDim>,
                                    Tags::ElementMap<VolumeDim, Frame>>;
 };
 }  // namespace Tags
+}  // namespace domain

--- a/src/Domain/InterfaceComputeTags.hpp
+++ b/src/Domain/InterfaceComputeTags.hpp
@@ -17,6 +17,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace domain {
 namespace Tags {
 
 namespace Interface_detail {
@@ -238,17 +239,18 @@ struct BoundaryCoordinates : db::ComputeTag,
 };
 
 }  // namespace Tags
+}  // namespace domain
 
 namespace db {
 template <typename TagList, typename DirectionsTag, typename VariablesTag>
 struct Subitems<
-    TagList, Tags::InterfaceCompute<DirectionsTag, VariablesTag>,
+    TagList, domain::Tags::InterfaceCompute<DirectionsTag, VariablesTag>,
     Requires<tt::is_a_v<Variables, const_item_type<VariablesTag, TagList>>>>
     : detail::InterfaceSubitemsImpl<TagList, DirectionsTag, VariablesTag> {};
 
 template <typename TagList, typename DirectionsTag, typename VariablesTag>
 struct Subitems<
-    TagList, Tags::Slice<DirectionsTag, VariablesTag>,
+    TagList, domain::Tags::Slice<DirectionsTag, VariablesTag>,
     Requires<tt::is_a_v<Variables, const_item_type<VariablesTag, TagList>>>>
     : detail::InterfaceSubitemsImpl<TagList, DirectionsTag, VariablesTag> {};
 }  // namespace db

--- a/src/Domain/InterfaceHelpers.hpp
+++ b/src/Domain/InterfaceHelpers.hpp
@@ -34,7 +34,7 @@ namespace InterfaceHelpers_detail {
 template <typename Tag, typename DirectionsTag, typename VolumeTags>
 struct make_interface_tag_impl {
   using type = tmpl::conditional_t<tmpl::list_contains_v<VolumeTags, Tag>, Tag,
-                                   ::Tags::Interface<DirectionsTag, Tag>>;
+                                   domain::Tags::Interface<DirectionsTag, Tag>>;
 };
 
 // Retrieve the `argument_tags` from the `InterfaceInvokable` and wrap them in

--- a/src/Domain/LogicalCoordinates.hpp
+++ b/src/Domain/LogicalCoordinates.hpp
@@ -13,12 +13,14 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+namespace domain {
 namespace Tags {
 template<size_t Dim>
 struct Mesh;
 template <size_t, typename>
 struct Coordinates;  // IWYU pragma: keep
 }  // namespace Tags
+}  // namespace domain
 template <size_t Dim>
 class Mesh;
 class DataVector;
@@ -56,6 +58,7 @@ tnsr::I<DataVector, VolumeDim, Frame::Logical> interface_logical_coordinates(
     const Mesh<VolumeDim - 1>& mesh,
     const Direction<VolumeDim>& direction) noexcept;
 
+namespace domain {
 namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
@@ -67,3 +70,4 @@ struct LogicalCoordinates : Coordinates<VolumeDim, Frame::Logical>,
   static constexpr auto function = logical_coordinates<VolumeDim>;
 };
 }  // namespace Tags
+}  // namespace domain

--- a/src/Domain/MinimumGridSpacing.hpp
+++ b/src/Domain/MinimumGridSpacing.hpp
@@ -26,6 +26,7 @@ double minimum_grid_spacing(
     const Index<Dim>& extents,
     const tnsr::I<DataVector, Dim, Frame>& coords) noexcept;
 
+namespace domain {
 namespace Tags {
 /// \ingroup ComputationalDomainGroup
 /// \ingroup DataBoxTagsGroup
@@ -41,3 +42,4 @@ struct MinimumGridSpacing : db::ComputeTag {
   using argument_tags = tmpl::list<Mesh<Dim>, Coordinates<Dim, Frame>>;
 };
 }  // namespace Tags
+}  // namespace domain

--- a/src/Domain/OptionTags.hpp
+++ b/src/Domain/OptionTags.hpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "Options/Options.hpp"
+
+/// \cond
+template <size_t Dim>
+class DomainCreator;
+/// \endcond
+
+namespace OptionTags {
+/// \ingroup OptionTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// The input file tag for the DomainCreator to use
+template <size_t Dim>
+struct DomainCreator {
+  using type = std::unique_ptr<::DomainCreator<Dim>>;
+  static constexpr OptionString help = {"The domain to create initially"};
+};
+}  // namespace OptionTags

--- a/src/Domain/OptionTags.hpp
+++ b/src/Domain/OptionTags.hpp
@@ -13,6 +13,7 @@ template <size_t Dim>
 class DomainCreator;
 /// \endcond
 
+namespace domain {
 namespace OptionTags {
 /// \ingroup OptionTagsGroup
 /// \ingroup ComputationalDomainGroup
@@ -23,3 +24,4 @@ struct DomainCreator {
   static constexpr OptionString help = {"The domain to create initially"};
 };
 }  // namespace OptionTags
+}  // namespace domain

--- a/src/Domain/SizeOfElement.hpp
+++ b/src/Domain/SizeOfElement.hpp
@@ -14,10 +14,12 @@
 /// \cond
 template <size_t VolumeDim, typename Frame>
 class ElementMap;
+namespace domain {
 namespace Tags {
 template <size_t Dim, typename Frame>
 struct ElementMap;
 }  // namespace Tags
+}  // namespace domain
 /// \endcond
 
 /*!
@@ -39,6 +41,7 @@ template <size_t VolumeDim>
 std::array<double, VolumeDim> size_of_element(
     const ElementMap<VolumeDim, Frame::Inertial>& element_map) noexcept;
 
+namespace domain {
 namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
@@ -52,3 +55,4 @@ struct SizeOfElement : db::ComputeTag {
   static constexpr auto function = size_of_element<VolumeDim>;
 };
 }  // namespace Tags
+}  // namespace domain

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -23,8 +23,8 @@
 #include "Domain/Element.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/Mesh.hpp"
+#include "Domain/OptionTags.hpp"
 #include "Domain/Side.hpp"
-#include "Options/Options.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/NoSuchType.hpp"
@@ -36,17 +36,6 @@
 /// \cond
 class DataVector;
 /// \endcond
-
-namespace OptionTags {
-/// \ingroup OptionTagsGroup
-/// \ingroup ComputationalDomainGroup
-/// The input file tag for the DomainCreator to use
-template <size_t Dim>
-struct DomainCreator {
-  using type = std::unique_ptr<::DomainCreator<Dim>>;
-  static constexpr OptionString help = {"The domain to create initially"};
-};
-}  // namespace OptionTags
 
 namespace Tags {
 /// \ingroup DataBoxTagsGroup

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -37,6 +37,9 @@
 class DataVector;
 /// \endcond
 
+namespace domain {
+/// \ingroup ComputationalDomainGroup
+/// \brief %Tags for the domain.
 namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
@@ -307,6 +310,7 @@ struct Direction : db::SimpleTag {
 };
 
 }  // namespace Tags
+}  // namespace domain
 
 namespace db {
 namespace detail {
@@ -314,9 +318,9 @@ template <typename TagList, typename DirectionsTag, typename VariablesTag>
 struct InterfaceSubitemsImpl {
   using type = tmpl::transform<
       typename const_item_type<VariablesTag>::tags_list,
-      tmpl::bind<Tags::Interface, tmpl::pin<DirectionsTag>, tmpl::_1>>;
+      tmpl::bind<domain::Tags::Interface, tmpl::pin<DirectionsTag>, tmpl::_1>>;
 
-  using tag = Tags::Interface<DirectionsTag, VariablesTag>;
+  using tag = domain::Tags::Interface<DirectionsTag, VariablesTag>;
 
   template <typename Subtag>
   static void create_item(
@@ -368,9 +372,8 @@ struct InterfaceSubitemsImpl {
 
 template <typename TagList, typename DirectionsTag, typename VariablesTag>
 struct Subitems<
-    TagList, Tags::Interface<DirectionsTag, VariablesTag>,
+    TagList, domain::Tags::Interface<DirectionsTag, VariablesTag>,
     Requires<tt::is_a_v<Variables, item_type<VariablesTag, TagList>>>>
-    : detail::InterfaceSubitemsImpl<TagList, DirectionsTag, VariablesTag> {
-};
+    : detail::InterfaceSubitemsImpl<TagList, DirectionsTag, VariablesTag> {};
 
 }  // namespace db

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -44,7 +44,7 @@ namespace Tags {
 template <size_t VolumeDim>
 struct Domain : db::SimpleTag {
   using type = ::Domain<VolumeDim>;
-  using option_tags = tmpl::list<::OptionTags::DomainCreator<VolumeDim>>;
+  using option_tags = tmpl::list<domain::OptionTags::DomainCreator<VolumeDim>>;
 
   template <typename Metavariables>
   static ::Domain<VolumeDim> create_from_options(
@@ -61,7 +61,7 @@ struct Domain : db::SimpleTag {
 template <size_t Dim>
 struct InitialExtents : db::SimpleTag {
   using type = std::vector<std::array<size_t, Dim>>;
-  using option_tags = tmpl::list<::OptionTags::DomainCreator<Dim>>;
+  using option_tags = tmpl::list<domain::OptionTags::DomainCreator<Dim>>;
 
   template <typename Metavariables>
   static std::vector<std::array<size_t, Dim>> create_from_options(
@@ -77,7 +77,7 @@ struct InitialExtents : db::SimpleTag {
 template <size_t Dim>
 struct InitialRefinementLevels : db::SimpleTag {
   using type = std::vector<std::array<size_t, Dim>>;
-  using option_tags = tmpl::list<::OptionTags::DomainCreator<Dim>>;
+  using option_tags = tmpl::list<domain::OptionTags::DomainCreator<Dim>>;
 
   template <typename Metavariables>
   static std::vector<std::array<size_t, Dim>> create_from_options(

--- a/src/Elliptic/Actions/InitializeAnalyticSolution.hpp
+++ b/src/Elliptic/Actions/InitializeAnalyticSolution.hpp
@@ -56,7 +56,7 @@ struct InitializeAnalyticSolution {
                            ::Tags::Variables<AnalyticSolutionFields>>;
 
     const auto& inertial_coords =
-        get<::Tags::Coordinates<Dim, Frame::Inertial>>(box);
+        get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box);
     db::item_type<analytic_fields_tag> analytic_fields{
         variables_from_tagged_tuple(get<AnalyticSolutionTag>(cache).variables(
             inertial_coords, AnalyticSolutionFields{}))};

--- a/src/Elliptic/Actions/InitializeSystem.hpp
+++ b/src/Elliptic/Actions/InitializeSystem.hpp
@@ -9,8 +9,10 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
 #include "Elliptic/FirstOrderComputeTags.hpp"
 #include "Elliptic/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
@@ -89,8 +91,9 @@ struct InitializeSystem {
                            linear_operand_tag>;
     using fluxes_tag = db::add_tag_prefix<::Tags::Flux, linear_operand_tag,
                                           tmpl::size_t<Dim>, Frame::Inertial>;
-    using inv_jacobian_tag = ::Tags::InverseJacobianCompute<
-        ::Tags::ElementMap<Dim>, ::Tags::Coordinates<Dim, Frame::Logical>>;
+    using inv_jacobian_tag = domain::Tags::InverseJacobianCompute<
+        domain::Tags::ElementMap<Dim>,
+        domain::Tags::Coordinates<Dim, Frame::Logical>>;
 
     using fluxes_compute_tag = elliptic::Tags::FirstOrderFluxesCompute<system>;
     using sources_compute_tag =
@@ -104,10 +107,10 @@ struct InitializeSystem {
         db::AddComputeTags<fluxes_compute_tag, sources_compute_tag,
                            ::Tags::DivCompute<fluxes_tag, inv_jacobian_tag>>;
 
-    const auto& mesh = db::get<::Tags::Mesh<Dim>>(box);
+    const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
     const size_t num_grid_points = mesh.number_of_grid_points();
     const auto& inertial_coords =
-        get<::Tags::Coordinates<Dim, Frame::Inertial>>(box);
+        get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box);
 
     // Set initial data to zero. Non-zero initial data would require us to also
     // compute the linear operator applied to the the initial data.

--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -41,10 +41,10 @@ struct DgElementArray {
   using phase_dependent_action_list = PhaseDepActionList;
   using array_index = ElementIndex<volume_dim>;
 
-  using const_global_cache_tags = tmpl::list<::Tags::Domain<volume_dim>>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<volume_dim>>;
 
   using array_allocation_tags =
-      tmpl::list<::Tags::InitialRefinementLevels<volume_dim>>;
+      tmpl::list<domain::Tags::InitialRefinementLevels<volume_dim>>;
 
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>,
@@ -72,9 +72,11 @@ void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
   auto& local_cache = *(global_cache.ckLocalBranch());
   auto& dg_element_array =
       Parallel::get_parallel_component<DgElementArray>(local_cache);
-  const auto& domain = Parallel::get<::Tags::Domain<volume_dim>>(local_cache);
+  const auto& domain =
+      Parallel::get<domain::Tags::Domain<volume_dim>>(local_cache);
   const auto& initial_refinement_levels =
-      get<::Tags::InitialRefinementLevels<volume_dim>>(initialization_items);
+      get<domain::Tags::InitialRefinementLevels<volume_dim>>(
+          initialization_items);
   for (const auto& block : domain.blocks()) {
     const auto initial_ref_levs = initial_refinement_levels[block.id()];
     const std::vector<ElementId<volume_dim>> element_ids =

--- a/src/Elliptic/DiscontinuousGalerkin/ImposeInhomogeneousBoundaryConditionsOnSource.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/ImposeInhomogeneousBoundaryConditionsOnSource.hpp
@@ -115,28 +115,28 @@ struct ImposeInhomogeneousBoundaryConditionsOnSource<
 
     db::mutate<fixed_sources_tag>(
         make_not_null(&box),
-        [
-          &analytic_solution, &normal_dot_numerical_flux_computer
-        ](const gsl::not_null<db::item_type<fixed_sources_tag>*> fixed_sources,
-          const Mesh<volume_dim>& mesh,
-          const db::const_item_type<::Tags::BoundaryDirectionsInterior<
-              volume_dim>>& boundary_directions,
-          const db::const_item_type<::Tags::Interface<
-              ::Tags::BoundaryDirectionsExterior<volume_dim>,
-              ::Tags::Coordinates<volume_dim, Frame::Inertial>>>&
-              boundary_coordinates,
-          const db::const_item_type<fluxes_computer_tag>& fluxes_computer,
-          const db::const_item_type<
-              ::Tags::Interface<::Tags::BoundaryDirectionsExterior<volume_dim>,
-                                FluxesArgs>>&... fluxes_args,
-          const db::const_item_type<::Tags::Interface<
-              ::Tags::BoundaryDirectionsInterior<volume_dim>,
-              ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<volume_dim>>>>&
-              normalized_face_normals,
-          const db::const_item_type<::Tags::Interface<
-              ::Tags::BoundaryDirectionsInterior<volume_dim>,
-              ::Tags::Magnitude<::Tags::UnnormalizedFaceNormal<volume_dim>>>>&
-              magnitude_of_face_normals) noexcept {
+        [&analytic_solution, &normal_dot_numerical_flux_computer](
+            const gsl::not_null<db::item_type<fixed_sources_tag>*>
+                fixed_sources,
+            const Mesh<volume_dim>& mesh,
+            const db::const_item_type<domain::Tags::BoundaryDirectionsInterior<
+                volume_dim>>& boundary_directions,
+            const db::const_item_type<domain ::Tags::Interface<
+                domain::Tags::BoundaryDirectionsExterior<volume_dim>,
+                domain::Tags::Coordinates<volume_dim, Frame::Inertial>>>&
+                boundary_coordinates,
+            const db::const_item_type<fluxes_computer_tag>& fluxes_computer,
+            const db::const_item_type<domain::Tags::Interface<
+                domain::Tags::BoundaryDirectionsExterior<volume_dim>,
+                FluxesArgs>>&... fluxes_args,
+            const db::const_item_type<domain::Tags::Interface<
+                domain::Tags::BoundaryDirectionsInterior<volume_dim>,
+                ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<
+                    volume_dim>>>>& normalized_face_normals,
+            const db::const_item_type<domain::Tags::Interface<
+                domain::Tags::BoundaryDirectionsInterior<volume_dim>,
+                ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<
+                    volume_dim>>>>& magnitude_of_face_normals) noexcept {
           // Impose Dirichlet boundary conditions as contributions to the source
           for (const auto& direction : boundary_directions) {
             const size_t dimension = direction.dimension();
@@ -170,22 +170,23 @@ struct ImposeInhomogeneousBoundaryConditionsOnSource<
                               index_to_slice_at(mesh.extents(), direction));
           }
         },
-        get<::Tags::Mesh<volume_dim>>(box),
-        get<::Tags::BoundaryDirectionsInterior<volume_dim>>(box),
-        get<::Tags::Interface<
-            ::Tags::BoundaryDirectionsExterior<volume_dim>,
-            ::Tags::Coordinates<volume_dim, Frame::Inertial>>>(box),
+        get<domain::Tags::Mesh<volume_dim>>(box),
+        get<domain::Tags::BoundaryDirectionsInterior<volume_dim>>(box),
+        get<domain::Tags::Interface<
+            domain::Tags::BoundaryDirectionsExterior<volume_dim>,
+            domain::Tags::Coordinates<volume_dim, Frame::Inertial>>>(box),
         get<fluxes_computer_tag>(box),
-        get<::Tags::Interface<::Tags::BoundaryDirectionsExterior<volume_dim>,
-                              FluxesArgs>>(box)...,
-        get<::Tags::Interface<
-            ::Tags::BoundaryDirectionsInterior<volume_dim>,
-            ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<volume_dim>>>>(
-            box),
-        get<::Tags::Interface<
-            ::Tags::BoundaryDirectionsInterior<volume_dim>,
-            ::Tags::Magnitude<::Tags::UnnormalizedFaceNormal<volume_dim>>>>(
-            box));
+        get<domain::Tags::Interface<
+            domain::Tags::BoundaryDirectionsExterior<volume_dim>, FluxesArgs>>(
+            box)...,
+        get<domain::Tags::Interface<
+            domain::Tags::BoundaryDirectionsInterior<volume_dim>,
+            ::Tags::Normalized<
+                domain::Tags::UnnormalizedFaceNormal<volume_dim>>>>(box),
+        get<domain::Tags::Interface<
+            domain::Tags::BoundaryDirectionsInterior<volume_dim>,
+            ::Tags::Magnitude<
+                domain::Tags::UnnormalizedFaceNormal<volume_dim>>>>(box));
 
     return {std::move(box)};
   }

--- a/src/Elliptic/DiscontinuousGalerkin/InitializeFluxes.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/InitializeFluxes.hpp
@@ -53,11 +53,11 @@ struct InitializeFluxes {
 
   template <typename Directions>
   using face_tags =
-      tmpl::list<::Tags::Slice<Directions, fluxes_tag>,
-                 ::Tags::Slice<Directions, div_fluxes_tag>,
+      tmpl::list<domain::Tags::Slice<Directions, fluxes_tag>,
+                 domain::Tags::Slice<Directions, div_fluxes_tag>,
                  // For the strong first-order DG scheme we also need the
                  // interface normal dotted into the fluxes
-                 ::Tags::InterfaceCompute<
+                 domain::Tags::InterfaceCompute<
                      Directions, ::Tags::NormalDotFluxCompute<
                                      vars_tag, volume_dim, Frame::Inertial>>>;
 
@@ -68,13 +68,14 @@ struct InitializeFluxes {
       // data that is being set there to impose boundary conditions. Then, we
       // compute their normal-dot-fluxes. The flux divergences are sliced from
       // the volume.
-      ::Tags::InterfaceCompute<::Tags::BoundaryDirectionsExterior<volume_dim>,
-                               fluxes_compute_tag>,
-      ::Tags::InterfaceCompute<
-          ::Tags::BoundaryDirectionsExterior<volume_dim>,
+      domain::Tags::InterfaceCompute<
+          domain::Tags::BoundaryDirectionsExterior<volume_dim>,
+          fluxes_compute_tag>,
+      domain::Tags::InterfaceCompute<
+          domain::Tags::BoundaryDirectionsExterior<volume_dim>,
           ::Tags::NormalDotFluxCompute<vars_tag, volume_dim, Frame::Inertial>>,
-      ::Tags::Slice<::Tags::BoundaryDirectionsExterior<volume_dim>,
-                    div_fluxes_tag>>;
+      domain::Tags::Slice<domain::Tags::BoundaryDirectionsExterior<volume_dim>,
+                          div_fluxes_tag>>;
 
  public:
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
@@ -85,10 +86,10 @@ struct InitializeFluxes {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using compute_tags = tmpl::flatten<
-        tmpl::list<face_tags<::Tags::InternalDirections<volume_dim>>,
-                   face_tags<::Tags::BoundaryDirectionsInterior<volume_dim>>,
-                   exterior_tags>>;
+    using compute_tags = tmpl::flatten<tmpl::list<
+        face_tags<domain::Tags::InternalDirections<volume_dim>>,
+        face_tags<domain::Tags::BoundaryDirectionsInterior<volume_dim>>,
+        exterior_tags>>;
     return std::make_tuple(
         ::Initialization::merge_into_databox<InitializeFluxes,
                                              db::AddSimpleTags<>, compute_tags>(

--- a/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp
@@ -194,7 +194,7 @@ struct FirstOrderInternalPenalty<Dim, FluxesComputerTag,
                  ::Tags::div<::Tags::Flux<AuxiliaryFieldTags, tmpl::size_t<Dim>,
                                           Frame::Inertial>>...,
                  fluxes_computer_tag, FluxesArgs...,
-                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
+                 ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
   using volume_tags = tmpl::list<fluxes_computer_tag>;
 
   // This is the data needed to compute the numerical flux.

--- a/src/Evolution/ComputeTags.hpp
+++ b/src/Evolution/ComputeTags.hpp
@@ -25,8 +25,8 @@ struct AnalyticCompute
   using base = db::add_tag_prefix<::Tags::Analytic,
                                   ::Tags::Variables<AnalyticFieldsTagList>>;
   using argument_tags =
-      tmpl::list<AnalyticSolutionTag, ::Tags::Coordinates<Dim, Frame::Inertial>,
-                 ::Tags::Time>;
+      tmpl::list<AnalyticSolutionTag,
+                 domain::Tags::Coordinates<Dim, Frame::Inertial>, ::Tags::Time>;
   static db::const_item_type<base> function(
       const db::const_item_type<AnalyticSolutionTag>&
           analytic_solution_computer,

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -36,10 +36,10 @@ struct DgElementArray {
   using phase_dependent_action_list = PhaseDepActionList;
   using array_index = ElementIndex<volume_dim>;
 
-  using const_global_cache_tags = tmpl::list<::Tags::Domain<volume_dim>>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<volume_dim>>;
 
   using array_allocation_tags =
-      tmpl::list<::Tags::InitialRefinementLevels<volume_dim>>;
+      tmpl::list<domain::Tags::InitialRefinementLevels<volume_dim>>;
 
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>,
@@ -67,9 +67,11 @@ void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
   auto& local_cache = *(global_cache.ckLocalBranch());
   auto& dg_element_array =
       Parallel::get_parallel_component<DgElementArray>(local_cache);
-  const auto& domain = Parallel::get<::Tags::Domain<volume_dim>>(local_cache);
+  const auto& domain =
+      Parallel::get<domain::Tags::Domain<volume_dim>>(local_cache);
   const auto& initial_refinement_levels =
-      get<::Tags::InitialRefinementLevels<volume_dim>>(initialization_items);
+      get<domain::Tags::InitialRefinementLevels<volume_dim>>(
+          initialization_items);
   for (const auto& block : domain.blocks()) {
     const auto initial_ref_levs = initial_refinement_levels[block.id()];
     const std::vector<ElementId<volume_dim>> element_ids =

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
@@ -499,7 +499,8 @@ class Krivodonova<VolumeDim, tmpl::list<Tags...>> {
     }
   };
 
-  using package_argument_tags = tmpl::list<Tags..., ::Tags::Mesh<VolumeDim>>;
+  using package_argument_tags =
+      tmpl::list<Tags..., domain::Tags::Mesh<VolumeDim>>;
 
   /// \brief Package data for sending to neighbor elements.
   void package_data(gsl::not_null<PackagedData*> packaged_data,
@@ -509,8 +510,8 @@ class Krivodonova<VolumeDim, tmpl::list<Tags...>> {
       noexcept;
 
   using limit_tags = tmpl::list<Tags...>;
-  using limit_argument_tags =
-      tmpl::list<::Tags::Element<VolumeDim>, ::Tags::Mesh<VolumeDim>>;
+  using limit_argument_tags = tmpl::list<domain::Tags::Element<VolumeDim>,
+                                         domain::Tags::Mesh<VolumeDim>>;
 
   bool operator()(
       const gsl::not_null<std::add_pointer_t<db::item_type<Tags>>>... tensors,

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp
@@ -109,7 +109,7 @@ struct Limit {
       const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/) noexcept {
     constexpr size_t volume_dim = Metavariables::system::volume_dim;
-    const auto& element = db::get<::Tags::Element<volume_dim>>(box);
+    const auto& element = db::get<domain::Tags::Element<volume_dim>>(box);
     const auto num_expected = element.neighbors().size();
     // Edge case where we do not receive any data
     if (UNLIKELY(num_expected == 0)) {
@@ -174,7 +174,7 @@ struct SendData {
 
     auto& receiver_proxy =
         Parallel::get_parallel_component<ParallelComponent>(cache);
-    const auto& element = db::get<::Tags::Element<volume_dim>>(box);
+    const auto& element = db::get<domain::Tags::Element<volume_dim>>(box);
     const auto& temporal_id = db::get<typename Metavariables::temporal_id>(box);
     const auto& limiter = get<typename Metavariables::limiter>(cache);
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
@@ -49,6 +49,7 @@ template <size_t VolumeDim, typename TagsToLimit>
 class Minmod;
 }  // namespace Limiters
 
+namespace domain {
 namespace Tags {
 template <size_t Dim, typename Frame>
 struct Coordinates;
@@ -59,6 +60,7 @@ struct Mesh;
 template <size_t VolumeDim>
 struct SizeOfElement;
 }  // namespace Tags
+}  // namespace domain
 /// \endcond
 
 namespace Limiters {
@@ -229,8 +231,9 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
     }
   };
 
-  using package_argument_tags = tmpl::list<Tags..., ::Tags::Mesh<VolumeDim>,
-                                           ::Tags::SizeOfElement<VolumeDim>>;
+  using package_argument_tags =
+      tmpl::list<Tags..., domain::Tags::Mesh<VolumeDim>,
+                 domain::Tags::SizeOfElement<VolumeDim>>;
 
   /// \brief Package data for sending to neighbor elements.
   ///
@@ -254,9 +257,10 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
 
   using limit_tags = tmpl::list<Tags...>;
   using limit_argument_tags =
-      tmpl::list<::Tags::Element<VolumeDim>, ::Tags::Mesh<VolumeDim>,
-                 ::Tags::Coordinates<VolumeDim, Frame::Logical>,
-                 ::Tags::SizeOfElement<VolumeDim>>;
+      tmpl::list<domain::Tags::Element<VolumeDim>,
+                 domain::Tags::Mesh<VolumeDim>,
+                 domain::Tags::Coordinates<VolumeDim, Frame::Logical>,
+                 domain::Tags::SizeOfElement<VolumeDim>>;
 
   /// \brief Limits the solution on the element.
   ///

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -157,8 +157,9 @@ class Weno<VolumeDim, tmpl::list<Tags...>> {
     }
   };
 
-  using package_argument_tags = tmpl::list<Tags..., ::Tags::Mesh<VolumeDim>,
-                                           ::Tags::SizeOfElement<VolumeDim>>;
+  using package_argument_tags =
+      tmpl::list<Tags..., domain::Tags::Mesh<VolumeDim>,
+                 domain::Tags::SizeOfElement<VolumeDim>>;
 
   /// \brief Package data for sending to neighbor elements
   void package_data(gsl::not_null<PackagedData*> packaged_data,
@@ -170,8 +171,9 @@ class Weno<VolumeDim, tmpl::list<Tags...>> {
 
   using limit_tags = tmpl::list<Tags...>;
   using limit_argument_tags =
-      tmpl::list<::Tags::Element<VolumeDim>, ::Tags::Mesh<VolumeDim>,
-                 ::Tags::SizeOfElement<VolumeDim>>;
+      tmpl::list<domain::Tags::Element<VolumeDim>,
+                 domain::Tags::Mesh<VolumeDim>,
+                 domain::Tags::SizeOfElement<VolumeDim>>;
 
   /// \brief Limit the solution on the element
   bool operator()(

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -222,11 +222,11 @@ struct EvolutionMetavars {
 
   using step_actions = tmpl::flatten<tmpl::list<
       dg::Actions::ComputeNonconservativeBoundaryFluxes<
-          Tags::InternalDirections<volume_dim>>,
+          domain::Tags::InternalDirections<volume_dim>>,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       Actions::ComputeTimeDerivative,
       dg::Actions::ComputeNonconservativeBoundaryFluxes<
-          Tags::BoundaryDirectionsInterior<volume_dim>>,
+          domain::Tags::BoundaryDirectionsInterior<volume_dim>>,
       dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       dg::Actions::ApplyFluxes, Actions::RecordTimeStepperData<>,
@@ -262,7 +262,7 @@ struct EvolutionMetavars {
               gr::Tags::Shift<volume_dim, frame, DataVector>,
               gr::Tags::Lapse<DataVector>>,
           dg::Initialization::face_compute_tags<
-              ::Tags::BoundaryCoordinates<volume_dim, frame>,
+              domain::Tags::BoundaryCoordinates<volume_dim, frame>,
               GeneralizedHarmonic::Tags::ConstraintGamma0Compute<volume_dim,
                                                                  frame>,
               GeneralizedHarmonic::Tags::ConstraintGamma1Compute<volume_dim,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -147,11 +147,11 @@ struct EvolutionMetavars {
 
   using step_actions = tmpl::flatten<tmpl::list<
       dg::Actions::ComputeNonconservativeBoundaryFluxes<
-          Tags::InternalDirections<Dim>>,
+          domain::Tags::InternalDirections<Dim>>,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       Actions::ComputeTimeDerivative,
       dg::Actions::ComputeNonconservativeBoundaryFluxes<
-          Tags::BoundaryDirectionsInterior<Dim>>,
+          domain::Tags::BoundaryDirectionsInterior<Dim>>,
       dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,

--- a/src/Evolution/Initialization/ConservativeSystem.hpp
+++ b/src/Evolution/Initialization/ConservativeSystem.hpp
@@ -28,13 +28,18 @@ namespace Tags {
 struct InitialTime;
 }  // namespace Tags
 }  // namespace Initialization
+
 namespace Tags {
 struct AnalyticSolutionOrData;
+}  // namespace Tags
+namespace domain {
+namespace Tags {
 template <size_t VolumeDim, typename Frame>
 struct Coordinates;
 template <size_t VolumeDim>
 struct Mesh;
 }  // namespace Tags
+}  // namespace domain
 // IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
 
@@ -83,7 +88,7 @@ struct ConservativeSystem {
     using compute_tags = db::AddComputeTags<>;
 
     const size_t num_grid_points =
-        db::get<::Tags::Mesh<dim>>(box).number_of_grid_points();
+        db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points();
     typename variables_tag::type vars(num_grid_points);
     typename fluxes_tag::type fluxes(num_grid_points);
     typename sources_tag::type sources(num_grid_points);
@@ -132,10 +137,10 @@ struct ConservativeSystem {
     using PrimitiveVars = typename primitives_tag::type;
 
     const size_t num_grid_points =
-        db::get<::Tags::Mesh<dim>>(box).number_of_grid_points();
+        db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points();
 
     const auto& inertial_coords =
-        db::get<::Tags::Coordinates<dim, Frame::Inertial>>(box);
+        db::get<domain::Tags::Coordinates<dim, Frame::Inertial>>(box);
 
     // Set initial data from analytic solution
     const auto& solution_or_data =
@@ -165,7 +170,7 @@ struct ConservativeSystem {
 
     const double initial_time = db::get<Initialization::Tags::InitialTime>(box);
     const auto& inertial_coords =
-        db::get<::Tags::Coordinates<dim, Frame::Inertial>>(box);
+        db::get<domain::Tags::Coordinates<dim, Frame::Inertial>>(box);
 
     // Set initial data from analytic solution
     using Vars = typename variables_tag::type;

--- a/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
+++ b/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
@@ -67,15 +67,18 @@ struct DiscontinuousGalerkin {
   using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
 
   template <typename Tag>
-  using interface_tag = ::Tags::Interface<::Tags::InternalDirections<dim>, Tag>;
+  using interface_tag =
+      domain::Tags::Interface<domain::Tags::InternalDirections<dim>, Tag>;
 
   template <typename Tag>
   using interior_boundary_tag =
-      ::Tags::Interface<::Tags::BoundaryDirectionsInterior<dim>, Tag>;
+      domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<dim>,
+                              Tag>;
 
   template <typename Tag>
   using external_boundary_tag =
-      ::Tags::Interface<::Tags::BoundaryDirectionsExterior<dim>, Tag>;
+      domain::Tags::Interface<domain::Tags::BoundaryDirectionsExterior<dim>,
+                              Tag>;
 
   template <typename LocalSystem, bool IsInFluxConservativeForm =
                                       LocalSystem::is_in_flux_conservative_form>
@@ -89,16 +92,16 @@ struct DiscontinuousGalerkin {
     template <typename TagsList>
     static auto initialize(db::DataBox<TagsList>&& box) noexcept {
       const auto& internal_directions =
-          db::get<::Tags::InternalDirections<dim>>(box);
+          db::get<domain::Tags::InternalDirections<dim>>(box);
 
       const auto& boundary_directions =
-          db::get<::Tags::BoundaryDirectionsInterior<dim>>(box);
+          db::get<domain::Tags::BoundaryDirectionsInterior<dim>>(box);
 
       typename interface_tag<typename flux_comm_types::normal_dot_fluxes_tag>::
           type normal_dot_fluxes_interface{};
       for (const auto& direction : internal_directions) {
         const auto& interface_num_points =
-            db::get<interface_tag<::Tags::Mesh<dim - 1>>>(box)
+            db::get<interface_tag<domain::Tags::Mesh<dim - 1>>>(box)
                 .at(direction)
                 .number_of_grid_points();
         normal_dot_fluxes_interface[direction].initialize(interface_num_points,
@@ -111,7 +114,7 @@ struct DiscontinuousGalerkin {
           normal_dot_fluxes_boundary_interior{};
       for (const auto& direction : boundary_directions) {
         const auto& boundary_num_points =
-            db::get<interior_boundary_tag<::Tags::Mesh<dim - 1>>>(box)
+            db::get<interior_boundary_tag<domain::Tags::Mesh<dim - 1>>>(box)
                 .at(direction)
                 .number_of_grid_points();
         normal_dot_fluxes_boundary_exterior[direction].initialize(
@@ -134,37 +137,41 @@ struct DiscontinuousGalerkin {
 
     template <typename Tag>
     using interface_compute_tag =
-        ::Tags::InterfaceCompute<::Tags::InternalDirections<dim>, Tag>;
+        domain::Tags::InterfaceCompute<domain::Tags::InternalDirections<dim>,
+                                       Tag>;
 
     template <typename Tag>
-    using boundary_interior_compute_tag =
-        ::Tags::InterfaceCompute<::Tags::BoundaryDirectionsInterior<dim>, Tag>;
+    using boundary_interior_compute_tag = domain::Tags::InterfaceCompute<
+        domain::Tags::BoundaryDirectionsInterior<dim>, Tag>;
 
     template <typename Tag>
-    using boundary_exterior_compute_tag =
-        ::Tags::InterfaceCompute<::Tags::BoundaryDirectionsExterior<dim>, Tag>;
+    using boundary_exterior_compute_tag = domain::Tags::InterfaceCompute<
+        domain::Tags::BoundaryDirectionsExterior<dim>, Tag>;
 
     using char_speed_tag = typename LocalSystem::char_speeds_tag;
 
     using compute_tags = db::AddComputeTags<
-        ::Tags::Slice<::Tags::InternalDirections<dim>,
-                      db::add_tag_prefix<::Tags::Flux,
-                                         typename LocalSystem::variables_tag,
-                                         tmpl::size_t<dim>, Frame::Inertial>>,
+        domain::Tags::Slice<
+            domain::Tags::InternalDirections<dim>,
+            db::add_tag_prefix<::Tags::Flux,
+                               typename LocalSystem::variables_tag,
+                               tmpl::size_t<dim>, Frame::Inertial>>,
         interface_compute_tag<::Tags::NormalDotFluxCompute<
             typename LocalSystem::variables_tag, dim, Frame::Inertial>>,
         interface_compute_tag<char_speed_tag>,
-        ::Tags::Slice<::Tags::BoundaryDirectionsInterior<dim>,
-                      db::add_tag_prefix<::Tags::Flux,
-                                         typename LocalSystem::variables_tag,
-                                         tmpl::size_t<dim>, Frame::Inertial>>,
+        domain::Tags::Slice<
+            domain::Tags::BoundaryDirectionsInterior<dim>,
+            db::add_tag_prefix<::Tags::Flux,
+                               typename LocalSystem::variables_tag,
+                               tmpl::size_t<dim>, Frame::Inertial>>,
         boundary_interior_compute_tag<::Tags::NormalDotFluxCompute<
             typename LocalSystem::variables_tag, dim, Frame::Inertial>>,
         boundary_interior_compute_tag<char_speed_tag>,
-        ::Tags::Slice<::Tags::BoundaryDirectionsExterior<dim>,
-                      db::add_tag_prefix<::Tags::Flux,
-                                         typename LocalSystem::variables_tag,
-                                         tmpl::size_t<dim>, Frame::Inertial>>,
+        domain::Tags::Slice<
+            domain::Tags::BoundaryDirectionsExterior<dim>,
+            db::add_tag_prefix<::Tags::Flux,
+                               typename LocalSystem::variables_tag,
+                               tmpl::size_t<dim>, Frame::Inertial>>,
         boundary_exterior_compute_tag<::Tags::NormalDotFluxCompute<
             typename LocalSystem::variables_tag, dim, Frame::Inertial>>,
         boundary_exterior_compute_tag<char_speed_tag>>;
@@ -178,7 +185,7 @@ struct DiscontinuousGalerkin {
   };
 
   using initialization_tags =
-      tmpl::list<::Tags::InitialExtents<Metavariables::volume_dim>>;
+      tmpl::list<domain::Tags::InitialExtents<Metavariables::volume_dim>>;
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent>

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -195,7 +195,7 @@ struct TimeStepperHistory {
   struct ComputeTags {
     using type = db::AddComputeTags<::Tags::DerivCompute<
         variables_tag,
-        ::Tags::InverseJacobian<dim, Frame::Logical, Frame::Inertial>,
+        domain::Tags::InverseJacobian<dim, Frame::Logical, Frame::Inertial>,
         typename System::gradients_tags>>;
   };
 
@@ -204,14 +204,14 @@ struct TimeStepperHistory {
     using type = db::AddComputeTags<::Tags::DivCompute<
         db::add_tag_prefix<::Tags::Flux, variables_tag, tmpl::size_t<dim>,
                            Frame::Inertial>,
-        ::Tags::InverseJacobian<dim, Frame::Logical, Frame::Inertial>>>;
+        domain::Tags::InverseJacobian<dim, Frame::Logical, Frame::Inertial>>>;
   };
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent,
             Requires<tmpl::list_contains_v<
                          typename db::DataBox<DbTagsList>::simple_item_tags,
-                         ::Tags::Mesh<dim>> and
+                         domain::Tags::Mesh<dim>> and
 
                      tmpl::list_contains_v<
                          typename db::DataBox<DbTagsList>::simple_item_tags,
@@ -224,7 +224,7 @@ struct TimeStepperHistory {
     using DtVars = typename dt_variables_tag::type;
 
     const size_t num_grid_points =
-        db::get<::Tags::Mesh<dim>>(box).number_of_grid_points();
+        db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points();
 
     // Will be overwritten before use
     DtVars dt_vars{num_grid_points};
@@ -245,7 +245,7 @@ struct TimeStepperHistory {
             typename ActionList, typename ParallelComponent,
             Requires<not(tmpl::list_contains_v<
                              typename db::DataBox<DbTagsList>::simple_item_tags,
-                             ::Tags::Mesh<dim>> and
+                             domain::Tags::Mesh<dim>> and
 
                          tmpl::list_contains_v<
                              typename db::DataBox<DbTagsList>::simple_item_tags,

--- a/src/Evolution/Initialization/GrTagsForHydro.hpp
+++ b/src/Evolution/Initialization/GrTagsForHydro.hpp
@@ -25,11 +25,15 @@ struct InitialTime;
 }  // namespace Initialization
 namespace Tags {
 struct AnalyticSolutionOrData;
+}  // namespace Tags
+namespace domain {
+namespace Tags {
 template <size_t Dim, typename Frame>
 struct Coordinates;
 template <size_t VolumeDim>
 struct Mesh;
 }  // namespace Tags
+}  // namespace domain
 // IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
 
@@ -70,9 +74,9 @@ struct GrTagsForHydro {
     using GrVars = typename gr_tag::type;
 
     const size_t num_grid_points =
-        db::get<::Tags::Mesh<dim>>(box).number_of_grid_points();
+        db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points();
     const auto& inertial_coords =
-        db::get<::Tags::Coordinates<dim, Frame::Inertial>>(box);
+        db::get<domain::Tags::Coordinates<dim, Frame::Inertial>>(box);
 
     // Set initial data from analytic solution
     GrVars gr_vars{num_grid_points};

--- a/src/Evolution/Initialization/Limiter.hpp
+++ b/src/Evolution/Initialization/Limiter.hpp
@@ -34,7 +34,7 @@ namespace Actions {
 template <size_t Dim>
 struct Minmod {
   using simple_tags = db::AddSimpleTags<>;
-  using compute_tags = tmpl::list<::Tags::SizeOfElement<Dim>>;
+  using compute_tags = tmpl::list<domain::Tags::SizeOfElement<Dim>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,

--- a/src/Evolution/Initialization/NonconservativeSystem.hpp
+++ b/src/Evolution/Initialization/NonconservativeSystem.hpp
@@ -25,11 +25,15 @@ struct InitialTime;
 }  // namespace Initialization
 namespace Tags {
 struct AnalyticSolutionOrData;
+}  // namespace Tags
+namespace domain {
+namespace Tags {
 template <size_t VolumeDim, typename Frame>
 struct Coordinates;
 template <size_t VolumeDim>
 struct Mesh;
 }  // namespace Tags
+}  // namespace domain
 // IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
 
@@ -70,10 +74,10 @@ struct NonconservativeSystem {
     using Vars = typename variables_tag::type;
 
     const size_t num_grid_points =
-        db::get<::Tags::Mesh<dim>>(box).number_of_grid_points();
+        db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points();
     const double initial_time = db::get<Initialization::Tags::InitialTime>(box);
     const auto& inertial_coords =
-        db::get<::Tags::Coordinates<dim, Frame::Inertial>>(box);
+        db::get<domain::Tags::Coordinates<dim, Frame::Inertial>>(box);
 
     // Set initial data from analytic solution
     Vars vars{num_grid_points};

--- a/src/Evolution/Systems/Burgers/Characteristics.hpp
+++ b/src/Evolution/Systems/Burgers/Characteristics.hpp
@@ -28,7 +28,8 @@ namespace Tags {
 struct CharacteristicSpeedsCompute : db::ComputeTag {
   static std::string name() noexcept { return "CharacteristicSpeeds"; }
 
-  using argument_tags = tmpl::list<Tags::U, ::Tags::UnnormalizedFaceNormal<1>>;
+  using argument_tags =
+      tmpl::list<Tags::U, domain::Tags::UnnormalizedFaceNormal<1>>;
 
   using return_type = std::array<DataVector, 1>;
   static void function(gsl::not_null<return_type*> result,

--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
@@ -67,7 +67,7 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<SpatialDim>,
   using argument_tags = tmpl::list<
       Tags::ConstraintGamma1, gr::Tags::Lapse<DataVector>,
       gr::Tags::Shift<SpatialDim, Frame::Inertial, DataVector>,
-      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<SpatialDim>>>;
+      ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<SpatialDim>>>;
 
   static constexpr void function(
       gsl::not_null<return_type*> result, const Scalar<DataVector>& gamma_1,
@@ -164,7 +164,7 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<SpatialDim>,
       Tags::ConstraintGamma2,
       gr::Tags::InverseSpatialMetric<SpatialDim, Frame::Inertial, DataVector>,
       Psi, Pi, Phi<SpatialDim>,
-      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<SpatialDim>>>;
+      ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<SpatialDim>>>;
 
   static constexpr void function(
       gsl::not_null<return_type*> result, const Scalar<DataVector>& gamma_2,
@@ -214,7 +214,7 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
   using argument_tags = tmpl::list<
       Tags::ConstraintGamma2, Tags::VPsi, Tags::VZero<SpatialDim>, Tags::VPlus,
       Tags::VMinus,
-      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<SpatialDim>>>;
+      ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<SpatialDim>>>;
 
   static constexpr void function(
       gsl::not_null<return_type*> result, const Scalar<DataVector>& gamma_2,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -80,7 +80,7 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim, Frame>,
   using argument_tags = tmpl::list<
       Tags::ConstraintGamma1, gr::Tags::Lapse<DataVector>,
       gr::Tags::Shift<Dim, Frame, DataVector>,
-      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
+      ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
 
   static typename Tags::CharacteristicSpeeds<Dim, Frame>::type function(
       const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
@@ -168,7 +168,7 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim, Frame>,
       gr::Tags::InverseSpatialMetric<Dim, Frame, DataVector>,
       gr::Tags::SpacetimeMetric<Dim, Frame, DataVector>, Tags::Pi<Dim, Frame>,
       Tags::Phi<Dim, Frame>,
-      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
+      ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
 
   static typename Tags::CharacteristicFields<Dim, Frame>::type function(
       const Scalar<DataVector>& gamma_2,
@@ -221,7 +221,7 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
   using argument_tags = tmpl::list<
       Tags::ConstraintGamma2, Tags::UPsi<Dim, Frame>, Tags::UZero<Dim, Frame>,
       Tags::UPlus<Dim, Frame>, Tags::UMinus<Dim, Frame>,
-      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
+      ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
 
   static typename Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>::type
   function(

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
@@ -425,7 +425,8 @@ void UpwindFlux<Dim>::package_data(
       *packaged_data) = inverse_spatial_metric;
   get<Tags::ConstraintGamma1>(*packaged_data) = gamma1;
   get<Tags::ConstraintGamma2>(*packaged_data) = gamma2;
-  get<::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>(
+  get<::Tags::Normalized<
+      domain::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>(
       *packaged_data) = interface_unit_normal;
 }
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -127,7 +127,8 @@ struct ComputeNormalDotFluxes {
       gr::Tags::SpacetimeMetric<Dim>, Tags::Pi<Dim>, Tags::Phi<Dim>,
       Tags::ConstraintGamma1, Tags::ConstraintGamma2, gr::Tags::Lapse<>,
       gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>,
-      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>;
+      ::Tags::Normalized<
+          domain::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>;
 
   static void apply(
       gsl::not_null<tnsr::aa<DataVector, Dim>*>
@@ -220,7 +221,8 @@ struct UpwindFlux {
       gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
       gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
       Tags::ConstraintGamma1, Tags::ConstraintGamma2,
-      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>;
+      ::Tags::Normalized<
+          domain::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>;
 
   // These tags on the interface of the element are passed to
   // `package_data` to provide the data needed to compute the numerical fluxes.
@@ -231,7 +233,8 @@ struct UpwindFlux {
       gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
       gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
       Tags::ConstraintGamma1, Tags::ConstraintGamma2,
-      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>;
+      ::Tags::Normalized<
+          domain::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>;
 
   // pseudo-interface: used internally by Algorithm infrastructure, not
   // user-level code

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -132,7 +132,7 @@ struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
       ::gr::Tags::SqrtDetSpatialMetric<DataVector>,
       ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>, ::Tags::Time,
       Tags::GaugeHRollOnStartTime, Tags::GaugeHRollOnTimeWindow,
-      ::Tags::Coordinates<SpatialDim, Frame>,
+      domain::Tags::Coordinates<SpatialDim, Frame>,
       Tags::GaugeHSpatialWeightDecayWidth<Frame>>;
 
   static constexpr db::const_item_type<Tags::GaugeH<SpatialDim, Frame>>
@@ -280,7 +280,7 @@ struct SpacetimeDerivDampedHarmonicHCompute
       ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>,
       Tags::Pi<SpatialDim, Frame>, Tags::Phi<SpatialDim, Frame>, ::Tags::Time,
       Tags::GaugeHRollOnStartTime, Tags::GaugeHRollOnTimeWindow,
-      ::Tags::Coordinates<SpatialDim, Frame>,
+      domain::Tags::Coordinates<SpatialDim, Frame>,
       Tags::GaugeHSpatialWeightDecayWidth<Frame>>;
 
   static constexpr db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -138,7 +138,7 @@ struct InitializeGauge {
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
     // compute initial-gauge related quantities
-    const auto& mesh = db::get<::Tags::Mesh<Dim>>(box);
+    const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
     const size_t num_grid_points = mesh.number_of_grid_points();
     const auto& lapse = get<gr::Tags::Lapse<DataVector>>(box);
     const auto& dt_lapse = get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(box);
@@ -180,7 +180,7 @@ struct InitializeGauge {
     get<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>>(
         initial_gauge_h_vars) = initial_gauge_h;
     const auto& inverse_jacobian =
-        db::get<::Tags::InverseJacobian<Dim, Frame::Logical, frame>>(box);
+        db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical, frame>>(box);
     auto d_initial_gauge_source =
         get<::Tags::deriv<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>,
                           tmpl::size_t<Dim>, frame>>(

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
@@ -139,7 +139,7 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds,
                  hydro::Tags::LorentzFactor<DataVector>,
                  hydro::Tags::MagneticField<DataVector, 3>, gr::Tags::Lapse<>,
                  gr::Tags::Shift<3>, gr::Tags::SpatialMetric<3>,
-                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<3>>,
+                 ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<3>>,
                  hydro::Tags::EquationOfState<EquationOfStateType>>;
 
   using volume_tags =

--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
@@ -121,7 +121,7 @@ struct CharacteristicSpeedsCompute : CharacteristicSpeeds<Dim>, db::ComputeTag {
   using base =  CharacteristicSpeeds<Dim>;
   using argument_tags =
       tmpl::list<Velocity<DataVector, Dim>, SoundSpeed<DataVector>,
-                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
+                 ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
 
   using return_type = std::array<DataVector, Dim + 2>;
 

--- a/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.cpp
@@ -50,7 +50,7 @@ void Hllc<Dim, Frame>::package_data(
       momentum_density;
   get<Tags::EnergyDensity<DataVector>>(*packaged_data) = energy_density;
   get<Tags::Pressure<DataVector>>(*packaged_data) = pressure;
-  get<::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>>(
+  get<::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>>(
       *packaged_data) = interface_unit_normal;
   get<NormalVelocity>(*packaged_data) =
       dot_product(interface_unit_normal, velocity);

--- a/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.hpp
@@ -150,7 +150,7 @@ struct Hllc {
       Tags::MassDensityCons<DataVector>,
       Tags::MomentumDensity<DataVector, Dim, Frame>,
       Tags::EnergyDensity<DataVector>, Tags::Pressure<DataVector>,
-      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>,
+      ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>,
       NormalVelocity, FirstSpeedEstimate, SecondSpeedEstimate>;
 
   using argument_tags = tmpl::list<
@@ -161,7 +161,7 @@ struct Hllc {
       Tags::MomentumDensity<DataVector, Dim, Frame>,
       Tags::EnergyDensity<DataVector>, Tags::Velocity<DataVector, Dim, Frame>,
       Tags::Pressure<DataVector>, char_speeds_tag,
-      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
+      ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
 
   void package_data(
       gsl::not_null<Variables<package_tags>*> packaged_data,

--- a/src/Evolution/Systems/NewtonianEuler/Sources/VortexPerturbation.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/VortexPerturbation.hpp
@@ -90,7 +90,7 @@ struct VortexPerturbation {
       Dim == 3,
       tmpl::list<::Tags::AnalyticSolution<
                      NewtonianEuler::Solutions::IsentropicVortex<Dim>>,
-                 ::Tags::Coordinates<3, Frame::Inertial>, ::Tags::Time>,
+                 domain::Tags::Coordinates<3, Frame::Inertial>, ::Tags::Time>,
       tmpl::list<>>;
 
   // Overload required for 2d simulations, where no variable is sourced.

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Initialize.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Initialize.hpp
@@ -25,11 +25,15 @@ struct InitialTime;
 }  // namespace Initialization
 namespace Tags {
 struct AnalyticSolutionOrData;
+}  // namespace Tags
+namespace domain {
+namespace Tags {
 template <size_t Dim, typename Frame>
 struct Coordinates;
 template <size_t VolumeDim>
 struct Mesh;
 }  // namespace Tags
+}  // namespace domain
 // IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
 
@@ -64,9 +68,9 @@ struct InitializeM1Tags {
     static constexpr size_t dim = system::volume_dim;
     const double initial_time = db::get<Initialization::Tags::InitialTime>(box);
     const size_t num_grid_points =
-        db::get<::Tags::Mesh<dim>>(box).number_of_grid_points();
+        db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points();
     const auto& inertial_coords =
-        db::get<::Tags::Coordinates<dim, Frame::Inertial>>(box);
+        db::get<domain::Tags::Coordinates<dim, Frame::Inertial>>(box);
 
     db::mutate<evolved_variables_tag>(make_not_null(&box), [
       &cache, initial_time, &inertial_coords

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Characteristics.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Characteristics.hpp
@@ -85,7 +85,7 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim>,
                  gr::Tags::SpatialMetric<Dim>,
                  hydro::Tags::SpatialVelocity<DataVector, Dim>,
                  hydro::Tags::SoundSpeedSquared<DataVector>,
-                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
+                 ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
 
   using volume_tags = tmpl::list<>;
 

--- a/src/Evolution/Systems/ScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/ScalarWave/Characteristics.hpp
@@ -79,7 +79,7 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim>,
   using base = Tags::CharacteristicSpeeds<Dim>;
   using type = typename base::type;
   using argument_tags =
-      tmpl::list<::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
+      tmpl::list<::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
 
   static typename Tags::CharacteristicSpeeds<Dim>::type function(
       const tnsr::i<DataVector, Dim, Frame::Inertial>&
@@ -164,7 +164,7 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim>,
   using type = typename base::type;
   using argument_tags =
       tmpl::list<Tags::ConstraintGamma2, Psi, Pi, Phi<Dim>,
-                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
+                 ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
 
   static typename Tags::CharacteristicFields<Dim>::type function(
       const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,
@@ -212,7 +212,7 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
   using argument_tags =
       tmpl::list<Tags::ConstraintGamma2, Tags::VPsi, Tags::VZero<Dim>,
                  Tags::VPlus, Tags::VMinus,
-                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
+                 ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
 
   static typename Tags::EvolvedFieldsFromCharacteristicFields<Dim>::type
   function(const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -87,7 +87,7 @@ template <size_t Dim>
 struct ComputeNormalDotFluxes {
   using argument_tags =
       tmpl::list<Pi, Phi<Dim>,
-                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
+                 ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
   static void apply(gsl::not_null<Scalar<DataVector>*> pi_normal_dot_flux,
                     gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
                         phi_normal_dot_flux,
@@ -155,7 +155,7 @@ struct PenaltyFlux {
   using argument_tags =
       tmpl::list<::Tags::NormalDotFlux<Pi>, ::Tags::NormalDotFlux<Phi<Dim>>,
                  Tags::VPlus, Tags::VMinus,
-                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
+                 ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
 
   // pseudo-interface: used internally by Algorithm infrastructure, not
   // user-level code
@@ -247,7 +247,7 @@ struct UpwindFlux {
   // `package_data` to provide the data needed to compute the numerical fluxes.
   using argument_tags =
       tmpl::list<::Tags::NormalDotFlux<Pi>, ::Tags::NormalDotFlux<Phi<Dim>>, Pi,
-                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>;
+                 ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
 
   // pseudo-interface: used internally by Algorithm infrastructure, not
   // user-level code

--- a/src/Evolution/VariableFixing/RadiallyFallingFloor.hpp
+++ b/src/Evolution/VariableFixing/RadiallyFallingFloor.hpp
@@ -18,10 +18,12 @@ namespace PUP {
 class er;
 }  // namespace PUP
 class DataVector;
+namespace domain {
 namespace Tags {
 template <size_t Dim, typename Frame>
 struct Coordinates;
 }  // namespace Tags
+}  // namespace domain
 namespace hydro {
 namespace Tags {
 template <typename DataType>
@@ -119,7 +121,8 @@ class RadiallyFallingFloor {
 
   using return_tags = tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
                                  hydro::Tags::Pressure<DataVector>>;
-  using argument_tags = tmpl::list<::Tags::Coordinates<Dim, Frame::Inertial>>;
+  using argument_tags =
+      tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>>;
 
   void operator()(gsl::not_null<Scalar<DataVector>*> density,
                   gsl::not_null<Scalar<DataVector>*> pressure,

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -50,16 +50,17 @@ struct ExportCoordinates {
   template <
       typename DbTagsList, typename... InboxTags, typename Metavariables,
       typename ArrayIndex, typename ActionList, typename ParallelComponent,
-      Requires<tmpl::list_contains_v<DbTagsList, Tags::Mesh<Dim>>> = nullptr>
+      Requires<tmpl::list_contains_v<DbTagsList, domain::Tags::Mesh<Dim>>> =
+          nullptr>
   static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
       db::DataBox<DbTagsList>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
       const Parallel::ConstGlobalCache<Metavariables>& cache,
       const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    const auto& mesh = get<Tags::Mesh<Dim>>(box);
+    const auto& mesh = get<domain::Tags::Mesh<Dim>>(box);
     const auto& inertial_coordinates =
-        db::get<::Tags::Coordinates<Dim, Frame::Inertial>>(box);
+        db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box);
     const std::string element_name = MakeString{} << ElementId<Dim>(array_index)
                                                   << '/';
     // Collect volume data

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp
@@ -80,9 +80,9 @@ struct ApplyBoundaryFluxesLocalTimeStepping {
         [&cache](
             const gsl::not_null<db::item_type<variables_tag>*> vars,
             const gsl::not_null<db::item_type<mortar_data_tag>*> mortar_data,
-            const db::const_item_type<Tags::Mesh<volume_dim>>& mesh,
-            const db::const_item_type<Tags::Mortars<Tags::Mesh<volume_dim - 1>,
-                                                    volume_dim>>& mortar_meshes,
+            const db::const_item_type<domain::Tags::Mesh<volume_dim>>& mesh,
+            const db::const_item_type<Tags::Mortars<
+                domain::Tags::Mesh<volume_dim - 1>, volume_dim>>& mortar_meshes,
             const db::const_item_type<Tags::Mortars<
                 Tags::MortarSize<volume_dim - 1>, volume_dim>>& mortar_sizes,
             const db::const_item_type<Tags::TimeStep>& time_step,
@@ -129,8 +129,9 @@ struct ApplyBoundaryFluxesLocalTimeStepping {
             }
           }();
         },
-        db::get<Tags::Mesh<volume_dim>>(box),
-        db::get<Tags::Mortars<Tags::Mesh<volume_dim - 1>, volume_dim>>(box),
+        db::get<domain::Tags::Mesh<volume_dim>>(box),
+        db::get<Tags::Mortars<domain::Tags::Mesh<volume_dim - 1>, volume_dim>>(
+            box),
         db::get<Tags::Mortars<Tags::MortarSize<volume_dim - 1>, volume_dim>>(
             box),
         db::get<Tags::TimeStep>(box), db::get<Tags::TimeStepper<>>(box));

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp
@@ -22,10 +22,12 @@ namespace Parallel {
 template <typename Metavariables>
 class ConstGlobalCache;
 }  // namespace Parallel
+namespace domain {
 namespace Tags {
 template <size_t VolumeDim>
 struct Mesh;
 }  // namespace Tags
+}  // namespace domain
 // IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
 
@@ -88,9 +90,9 @@ struct ApplyFluxes {
         [&cache](
             const gsl::not_null<db::item_type<dt_variables_tag>*> dt_vars,
             const gsl::not_null<db::item_type<mortar_data_tag>*> mortar_data,
-            const db::const_item_type<Tags::Mesh<volume_dim>>& mesh,
-            const db::const_item_type<Tags::Mortars<Tags::Mesh<volume_dim - 1>,
-                                                    volume_dim>>& mortar_meshes,
+            const db::const_item_type<domain::Tags::Mesh<volume_dim>>& mesh,
+            const db::const_item_type<Tags::Mortars<
+                domain::Tags::Mesh<volume_dim - 1>, volume_dim>>& mortar_meshes,
             const db::const_item_type<
                 Tags::Mortars<Tags::MortarSize<volume_dim - 1>, volume_dim>>&
                 mortar_sizes) noexcept {
@@ -117,8 +119,9 @@ struct ApplyFluxes {
                               index_to_slice_at(mesh.extents(), direction));
           }
         },
-        db::get<Tags::Mesh<volume_dim>>(box),
-        db::get<Tags::Mortars<Tags::Mesh<volume_dim - 1>, volume_dim>>(box),
+        db::get<domain::Tags::Mesh<volume_dim>>(box),
+        db::get<Tags::Mortars<domain::Tags::Mesh<volume_dim - 1>, volume_dim>>(
+            box),
         db::get<Tags::Mortars<Tags::MortarSize<volume_dim - 1>, volume_dim>>(
             box));
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp
@@ -66,15 +66,14 @@ struct ComputeNonconservativeBoundaryFluxes {
     using system = typename Metavariables::system;
     using variables_tag = typename system::variables_tag;
 
-    using interface_normal_dot_fluxes_tag =
-        Tags::Interface<DirectionsTag,
-                        db::add_tag_prefix<Tags::NormalDotFlux, variables_tag>>;
+    using interface_normal_dot_fluxes_tag = domain::Tags::Interface<
+        DirectionsTag, db::add_tag_prefix<Tags::NormalDotFlux, variables_tag>>;
 
     db::mutate_apply<
         tmpl::list<interface_normal_dot_fluxes_tag>,
         tmpl::push_front<tmpl::transform<typename Metavariables::system::
                                              normal_dot_fluxes::argument_tags,
-                                         tmpl::bind<Tags::Interface,
+                                         tmpl::bind<domain::Tags::Interface,
                                                     DirectionsTag, tmpl::_1>>,
                          DirectionsTag>>(
         [](const gsl::not_null<db::item_type<interface_normal_dot_fluxes_tag>*>

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/InterfaceActionHelpers.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/InterfaceActionHelpers.hpp
@@ -29,7 +29,7 @@ DirectionMap<VolumeDim, PackagedData> compute_packaged_data(
     const DirectionsTag /*meta*/, const Metavariables /*meta*/) noexcept {
   return interface_apply<
       DirectionsTag,
-      tmpl::flatten<tmpl::list<::Tags::Mesh<VolumeDim - 1>,
+      tmpl::flatten<tmpl::list<domain::Tags::Mesh<VolumeDim - 1>,
                                typename NumericalFlux::argument_tags>>,
       get_volume_tags<NumericalFlux>>(
       [&normal_dot_numerical_flux_computer](
@@ -52,14 +52,15 @@ DirectionMap<VolumeDim, LocalData> compute_local_mortar_data(
     const NumericalFlux& normal_dot_numerical_flux_computer,
     const DirectionsTag /*meta*/, const Metavariables /*meta*/) noexcept {
   using normal_dot_fluxes_tag =
-      Tags::Interface<DirectionsTag,
-                      typename FluxCommTypes::normal_dot_fluxes_tag>;
+      domain::Tags::Interface<DirectionsTag,
+                              typename FluxCommTypes::normal_dot_fluxes_tag>;
 
   const auto& face_meshes =
-      db::get<Tags::Interface<DirectionsTag, Tags::Mesh<VolumeDim - 1>>>(box);
-  const auto& magnitude_of_face_normals = db::get<Tags::Interface<
-      DirectionsTag, Tags::Magnitude<Tags::UnnormalizedFaceNormal<VolumeDim>>>>(
-      box);
+      db::get<domain::Tags::Interface<DirectionsTag,
+                                      domain::Tags::Mesh<VolumeDim - 1>>>(box);
+  const auto& magnitude_of_face_normals = db::get<domain::Tags::Interface<
+      DirectionsTag,
+      Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<VolumeDim>>>>(box);
   const auto& normal_dot_fluxes = db::get<normal_dot_fluxes_tag>(box);
 
   const auto packaged_data =

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
@@ -78,7 +78,7 @@ struct FluxCommunicationTypes {
   /// The DataBox tag for the data stored on the mortars for global
   /// stepping.
   using simple_mortar_data_tag =
-      BasedMortars<Tags::VariablesBoundaryData,
+      BasedMortars<domain::Tags::VariablesBoundaryData,
                    Tags::SimpleMortarData<
                        db::const_item_type<typename Metavariables::temporal_id>,
                        LocalData, PackagedData>,
@@ -87,7 +87,7 @@ struct FluxCommunicationTypes {
   /// The DataBox tag for the data stored on the mortars for local
   /// stepping.
   using local_time_stepping_mortar_data_tag =
-      BasedMortars<Tags::VariablesBoundaryData,
+      BasedMortars<domain::Tags::VariablesBoundaryData,
                    Tags::BoundaryHistory<
                        LocalData, PackagedData,
                        db::const_item_type<typename system::variables_tag>>,

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp
@@ -81,7 +81,7 @@ struct NormalDotFluxCompute : db::add_tag_prefix<NormalDotFlux, Tag>,
  private:
   using flux_tag = db::add_tag_prefix<Flux, Tag, tmpl::size_t<VolumeDim>, Fr>;
   using normal_tag =
-      Tags::Normalized<Tags::UnnormalizedFaceNormal<VolumeDim, Fr>>;
+      Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<VolumeDim, Fr>>;
 
  public:
   static auto function(const db::const_item_type<flux_tag>& flux,

--- a/src/NumericalAlgorithms/Interpolation/Interpolate.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Interpolate.hpp
@@ -20,8 +20,14 @@
 class TimeStepId;
 namespace Tags {
 struct TimeStepId;
+}  // namespace Tags
+namespace domain {
+namespace Tags {
 template <size_t VolumeDim>
 struct Mesh;
+}  // namespace Tags
+}  // namespace domain
+namespace Tags {
 template <typename TagsList>
 struct Variables;
 }  // namespace Tags
@@ -71,7 +77,7 @@ class Interpolate<VolumeDim, tmpl::list<Tensors...>, EventRegistrars>
   Interpolate() = default;
 
   using argument_tags =
-      tmpl::list<::Tags::TimeStepId, ::Tags::Mesh<VolumeDim>, Tensors...>;
+      tmpl::list<::Tags::TimeStepId, domain::Tags::Mesh<VolumeDim>, Tensors...>;
 
   template <typename Metavariables, typename ParallelComponent>
   void operator()(const TimeStepId& time_id, const Mesh<VolumeDim>& mesh,

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -131,7 +131,7 @@ namespace Actions {
 ///
 /// Uses:
 /// - DataBox:
-///   - `::Tags::Domain<3>`
+///   - `domain::Tags::Domain<3>`
 ///   - `::ah::Tags::FastFlow`
 ///   - `StrahlkorperTags::CartesianCoords<Frame>`
 ///   - `::Tags::Variables<typename

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
@@ -131,7 +131,7 @@ namespace Actions {
 ///
 /// Uses:
 /// - DataBox:
-///   - `::Tags::Domain<3>`
+///   - `domain::Tags::Domain<3>`
 ///   - `::Tags::Variables<typename
 ///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
 ///

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
@@ -121,7 +121,7 @@ namespace Actions {
 ///
 /// Uses:
 /// - DataBox:
-///   - `::Tags::Domain<3>`
+///   - `domain::Tags::Domain<3>`
 ///   - `::Tags::Variables<typename
 ///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
 ///

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -189,7 +189,7 @@ namespace Actions {
 ///
 /// Uses:
 /// - DataBox:
-///   - `::Tags::Domain<3>`
+///   - `domain::Tags::Domain<3>`
 ///   - `::Tags::Variables<typename
 ///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
 ///

--- a/src/NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp
@@ -42,7 +42,7 @@ void send_points_to_interpolator(
     db::DataBox<DbTags>& box, Parallel::ConstGlobalCache<Metavariables>& cache,
     const tnsr::I<DataVector, VolumeDim, Frame>& target_points,
     const typename Metavariables::temporal_id::type& temporal_id) noexcept {
-  const auto& domain = db::get<::Tags::Domain<VolumeDim>>(box);
+  const auto& domain = db::get<domain::Tags::Domain<VolumeDim>>(box);
   auto coords = block_logical_coordinates(domain, target_points);
 
   db::mutate<

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -22,11 +22,15 @@ class Mesh;
 template <typename TagsList>
 class Variables;
 
+namespace domain {
 namespace Tags {
 template <size_t Dim>
 struct Mesh;
+}  // namespace Tags
+}  // namespace domain
 /// \endcond
 
+namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating the divergence
 ///
@@ -93,6 +97,7 @@ struct DivCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
   static constexpr auto function =
       divergence<typename db::const_item_type<Tag>::tags_list, dim,
                  typename tmpl::back<inv_jac_indices>::Frame>;
-  using argument_tags = tmpl::list<Tag, Tags::Mesh<dim>, InverseJacobianTag>;
+  using argument_tags =
+      tmpl::list<Tag, domain::Tags::Mesh<dim>, InverseJacobianTag>;
 };
 }  // namespace Tags

--- a/src/NumericalAlgorithms/LinearOperators/FilterAction.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/FilterAction.hpp
@@ -99,7 +99,7 @@ class Filter<FilterType, tmpl::list<TagsToFilter...>> {
     if (UNLIKELY(filter_helper.disable_for_debugging())) {
       return {std::move(box)};
     }
-    const Mesh<volume_dim> mesh = db::get<::Tags::Mesh<volume_dim>>(box);
+    const Mesh<volume_dim> mesh = db::get<domain::Tags::Mesh<volume_dim>>(box);
     const Matrix empty{};
     auto filter = make_array<volume_dim>(std::cref(empty));
     for (size_t d = 0; d < volume_dim; d++) {

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -21,13 +21,19 @@ class DataVector;
 template <size_t Dim>
 class Mesh;
 
+namespace domain {
 namespace Tags {
 template <size_t Dim>
 struct Mesh;
+}  // namespace Tags
+}  // namespace domain
+namespace Tags {
 template <class TagList>
 struct Variables;
+}  // namespace Tags
 /// \endcond
 
+namespace Tags {
 /*!
  * \ingroup DataBoxTagsGroup
  * \brief Prefix indicating spatial derivatives
@@ -215,7 +221,7 @@ struct DerivCompute
                           typename db::const_item_type<VariablesTag>::tags_list,
                           Dim, deriv_frame>;
   using argument_tags =
-      tmpl::list<VariablesTag, Tags::Mesh<Dim>, InverseJacobianTag>;
+      tmpl::list<VariablesTag, domain::Tags::Mesh<Dim>, InverseJacobianTag>;
 };
 
 }  // namespace Tags

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
@@ -61,11 +61,11 @@ namespace Actions {
  */
 template <size_t Dim>
 struct InitializeDomain {
-  using initialization_tags = tmpl::list<::Tags::InitialExtents<Dim>>;
+  using initialization_tags = tmpl::list<domain::Tags::InitialExtents<Dim>>;
 
   template <typename DataBox, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent,
-            Requires<db::tag_is_retrievable_v<::Tags::InitialExtents<Dim>,
+            Requires<db::tag_is_retrievable_v<domain::Tags::InitialExtents<Dim>,
                                               DataBox>> = nullptr>
   static auto apply(DataBox& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
@@ -74,18 +74,21 @@ struct InitializeDomain {
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
     using simple_tags =
-        db::AddSimpleTags<::Tags::Mesh<Dim>, ::Tags::Element<Dim>,
-                          ::Tags::ElementMap<Dim>>;
+        db::AddSimpleTags<domain::Tags::Mesh<Dim>, domain::Tags::Element<Dim>,
+                          domain::Tags::ElementMap<Dim>>;
     using compute_tags = tmpl::append<db::AddComputeTags<
-        ::Tags::LogicalCoordinates<Dim>,
-        ::Tags::MappedCoordinates<::Tags::ElementMap<Dim>,
-                                  ::Tags::Coordinates<Dim, Frame::Logical>>,
-        ::Tags::InverseJacobianCompute<
-            ::Tags::ElementMap<Dim>, ::Tags::Coordinates<Dim, Frame::Logical>>,
-        ::Tags::MinimumGridSpacing<Dim, Frame::Inertial>>>;
+        domain::Tags::LogicalCoordinates<Dim>,
+        domain ::Tags::MappedCoordinates<
+            domain::Tags::ElementMap<Dim>,
+            domain ::Tags::Coordinates<Dim, Frame::Logical>>,
+        domain ::Tags::InverseJacobianCompute<
+            domain ::Tags::ElementMap<Dim>,
+            domain::Tags::Coordinates<Dim, Frame::Logical>>,
+        domain::Tags::MinimumGridSpacing<Dim, Frame::Inertial>>>;
 
-    const auto& initial_extents = db::get<::Tags::InitialExtents<Dim>>(box);
-    const auto& domain = db::get<::Tags::Domain<Dim>>(box);
+    const auto& initial_extents =
+        db::get<domain::Tags::InitialExtents<Dim>>(box);
+    const auto& domain = db::get<domain::Tags::Domain<Dim>>(box);
 
     const ElementId<Dim> element_id{array_index};
     const auto& my_block = domain.blocks()[element_id.block_id()];
@@ -106,8 +109,8 @@ struct InitializeDomain {
   template <typename DataBox, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent,
-            Requires<not db::tag_is_retrievable_v<::Tags::InitialExtents<Dim>,
-                                                  DataBox>> = nullptr>
+            Requires<not db::tag_is_retrievable_v<
+                domain::Tags::InitialExtents<Dim>, DataBox>> = nullptr>
   static std::tuple<DataBox&&> apply(
       DataBox& /*box*/, const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
       const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,

--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -101,7 +101,7 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
                                 tmpl::list<Tensors...>>,
           tmpl::list<>>,
       "All AnalyticSolutionTensors must be listed in Tensors.");
-  using coordinates_tag = ::Tags::Coordinates<VolumeDim, Frame::Inertial>;
+  using coordinates_tag = domain::Tags::Coordinates<VolumeDim, Frame::Inertial>;
 
   template <typename T>
   static std::string component_suffix(const T& tensor,
@@ -163,10 +163,11 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
     variables_to_observe_.insert(coordinates_tag::name());
   }
 
-  using argument_tags = tmpl::list<ObservationValueTag, ::Tags::Mesh<VolumeDim>,
-                                   coordinates_tag, AnalyticSolutionTensors...,
-                                   ::Tags::Analytic<AnalyticSolutionTensors>...,
-                                   NonSolutionTensors...>;
+  using argument_tags =
+      tmpl::list<ObservationValueTag, domain::Tags::Mesh<VolumeDim>,
+                 coordinates_tag, AnalyticSolutionTensors...,
+                 ::Tags::Analytic<AnalyticSolutionTensors>...,
+                 NonSolutionTensors...>;
 
   template <typename Metavariables, typename ParallelComponent>
   void operator()(

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -29,10 +29,12 @@ namespace gsl {
 template <class T>
 class not_null;
 }  // namespace gsl
+namespace domain {
 namespace Tags {
 template <size_t Dim, typename Frame>
 struct Coordinates;
 }  // namespace Tags
+}  // namespace domain
 class DataVector;
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
@@ -588,7 +590,7 @@ struct TimeDerivShiftCompute
  *        the generalized harmonic spatial derivative variable.
  *
  * \details See `deriv_spatial_metric()`. Can be retrieved using
- * `gr::Tags::SpatialMetric` wrapped in \ref deriv "Tags::deriv".
+ * `gr::Tags::SpatialMetric` wrapped in `::Tags::deriv`.
  */
 template <size_t SpatialDim, typename Frame>
 struct DerivSpatialMetricCompute
@@ -609,7 +611,7 @@ struct DerivSpatialMetricCompute
  * generalized harmonic variables and spacetime unit normal one-form.
  *
  * \details See `spatial_deriv_of_lapse()`. Can be retrieved using
- * `gr::Tags::Lapse` wrapped in \ref deriv "Tags::deriv".
+ * `gr::Tags::Lapse` wrapped in `::Tags::deriv`.
  */
 template <size_t SpatialDim, typename Frame>
 struct DerivLapseCompute : ::Tags::deriv<gr::Tags::Lapse<DataVector>,
@@ -632,7 +634,7 @@ struct DerivLapseCompute : ::Tags::deriv<gr::Tags::Lapse<DataVector>,
  *        generalized harmonic and geometric variables
  *
  * \details See `spatial_deriv_of_shift()`. Can be retrieved using
- * `gr::Tags::Shift` wrapped in \ref deriv "Tags::deriv".
+ * `gr::Tags::Shift` wrapped in `::Tags::deriv`.
  */
 template <size_t SpatialDim, typename Frame>
 struct DerivShiftCompute
@@ -763,7 +765,8 @@ struct TraceExtrinsicCurvatureCompute
  */
 template <size_t SpatialDim, typename Frame>
 struct ConstraintGamma0Compute : ConstraintGamma0, db::ComputeTag {
-  using argument_tags = tmpl::list<::Tags::Coordinates<SpatialDim, Frame>>;
+  using argument_tags =
+      tmpl::list<domain::Tags::Coordinates<SpatialDim, Frame>>;
   static auto function(
       const tnsr::I<DataVector, SpatialDim, Frame>& coords) noexcept {
     const DataVector r_squared = get(dot_product(coords, coords));
@@ -776,7 +779,8 @@ struct ConstraintGamma0Compute : ConstraintGamma0, db::ComputeTag {
 /// \copydoc ConstraintGamma0Compute
 template <size_t SpatialDim, typename Frame>
 struct ConstraintGamma1Compute : ConstraintGamma1, db::ComputeTag {
-  using argument_tags = tmpl::list<::Tags::Coordinates<SpatialDim, Frame>>;
+  using argument_tags =
+      tmpl::list<domain::Tags::Coordinates<SpatialDim, Frame>>;
   static constexpr auto function(
       const tnsr::I<DataVector, SpatialDim, Frame>& coords) noexcept {
     return make_with_value<type>(coords, -1.);
@@ -786,7 +790,8 @@ struct ConstraintGamma1Compute : ConstraintGamma1, db::ComputeTag {
 /// \copydoc ConstraintGamma0Compute
 template <size_t SpatialDim, typename Frame>
 struct ConstraintGamma2Compute : ConstraintGamma2, db::ComputeTag {
-  using argument_tags = tmpl::list<::Tags::Coordinates<SpatialDim, Frame>>;
+  using argument_tags =
+      tmpl::list<domain::Tags::Coordinates<SpatialDim, Frame>>;
   static auto function(
       const tnsr::I<DataVector, SpatialDim, Frame>& coords) noexcept {
     const DataVector r_squared = get(dot_product(coords, coords));

--- a/src/Time/StepChoosers/ByBlock.hpp
+++ b/src/Time/StepChoosers/ByBlock.hpp
@@ -22,10 +22,12 @@ namespace Parallel {
 template <typename Metavariables>
 class ConstGlobalCache;
 }  // namespace Parallel
+namespace domain {
 namespace Tags {
 template <size_t VolumeDim>
 struct Element;
 }  // namespace Tags
+}  // namespace domain
 /// \endcond
 
 namespace StepChoosers {
@@ -64,7 +66,7 @@ class ByBlock : public StepChooser<StepChooserRegistrars> {
   explicit ByBlock(std::vector<double> sizes) noexcept
       : sizes_(std::move(sizes)) {}
 
-  using argument_tags = tmpl::list<Tags::Element<Dim>>;
+  using argument_tags = tmpl::list<domain::Tags::Element<Dim>>;
 
   template <typename Metavariables>
   double operator()(

--- a/src/Time/StepChoosers/Cfl.hpp
+++ b/src/Time/StepChoosers/Cfl.hpp
@@ -20,10 +20,12 @@ namespace Parallel {
 template <typename Metavariables>
 class ConstGlobalCache;
 }  // namespace Parallel
+namespace domain {
 namespace Tags {
 template <size_t Dim, typename Frame>
 struct MinimumGridSpacing;
 }  // namespace Tags
+}  // namespace domain
 // IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
 
@@ -66,7 +68,7 @@ class Cfl : public StepChooser<StepChooserRegistrars> {
   explicit Cfl(const double safety_factor) noexcept
       : safety_factor_(safety_factor) {}
 
-  using argument_tags = tmpl::list<Tags::MinimumGridSpacing<Dim, Frame>,
+  using argument_tags = tmpl::list<domain::Tags::MinimumGridSpacing<Dim, Frame>,
                                    Tags::DataBox, Tags::TimeStepper<>>;
 
   template <typename Metavariables, typename DbTags>

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -216,7 +216,7 @@ struct MockMetavariables {
   using component_list =
       tmpl::list<mock_interpolation_target<MockMetavariables, AhA>,
                  mock_interpolator<MockMetavariables>>;
-  using const_global_cache_tags = tmpl::list<::Tags::Domain<3>>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<3>>;
 
   enum class Phase { Initialization, Registration, Testing, Exit };
 };
@@ -252,7 +252,7 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
       1.9, 2.9, 1, {{grid_points_each_dimension, grid_points_each_dimension}},
       false);
 
-  tuples::TaggedTuple<::Tags::Domain<3>,
+  tuples::TaggedTuple<domain::Tags::Domain<3>,
                       typename ::intrp::Tags::ApparentHorizon<
                           typename metavars::AhA, Frame::Inertial>>
       tuple_of_opts{std::move(domain_creator.create_domain()),

--- a/tests/Unit/Domain/Test_InterfaceHelpers.cpp
+++ b/tests/Unit/Domain/Test_InterfaceHelpers.cpp
@@ -11,6 +11,7 @@
 #include "Domain/Neighbors.hpp"
 #include "Domain/Tags.hpp"
 
+namespace domain {
 namespace {
 struct SomeNumber : db::SimpleTag {
   using type = double;
@@ -21,7 +22,6 @@ struct SomeVolumeArgument : VolumeArgumentBase, db::SimpleTag {
   using type = double;
   static std::string name() noexcept { return "SomeVolumeArgument"; }
 };
-}  // namespace
 
 template <size_t Dim, typename DirectionsTag>
 void test_interface_apply(
@@ -31,8 +31,8 @@ void test_interface_apply(
         expected_result_on_interfaces) {
   // Construct DataBox that holds the test data
   const auto box =
-      db::create<db::AddSimpleTags<::Tags::Element<Dim>,
-                                   ::Tags::Interface<DirectionsTag, SomeNumber>,
+      db::create<db::AddSimpleTags<Tags::Element<Dim>,
+                                   Tags::Interface<DirectionsTag, SomeNumber>,
                                    SomeVolumeArgument>,
                  db::AddComputeTags<DirectionsTag>>(element,
                                                     number_on_interfaces, 1.);
@@ -69,22 +69,22 @@ void test_interface_apply(
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.InterfaceHelpers", "[Unit][Domain]") {
-  test_interface_apply<1, ::Tags::InternalDirections<1>>(
+  test_interface_apply<1, Tags::InternalDirections<1>>(
       // Reference element has one internal direction:
       // [ X | ]-> xi
       {{0, {{{1, 0}}}}, {{Direction<1>::upper_xi(), {{{0, {{{1, 1}}}}}, {}}}}},
       {{Direction<1>::upper_xi(), 2.}}, {{Direction<1>::upper_xi(), 5.}});
-  test_interface_apply<1, ::Tags::InternalDirections<1>>(
+  test_interface_apply<1, Tags::InternalDirections<1>>(
       // Reference element has no internal directions:
       // [ X ]-> xi
       {{0, {{{0, 0}}}}, {}}, {}, {});
-  test_interface_apply<1, ::Tags::BoundaryDirectionsInterior<1>>(
+  test_interface_apply<1, Tags::BoundaryDirectionsInterior<1>>(
       // Reference element has two boundary directions:
       // [ X ]-> xi
       {{0, {{{0, 0}}}}, {}},
       {{Direction<1>::lower_xi(), 2.}, {Direction<1>::upper_xi(), 3.}},
       {{Direction<1>::lower_xi(), 5.}, {Direction<1>::upper_xi(), 7.}});
-  test_interface_apply<2, ::Tags::InternalDirections<2>>(
+  test_interface_apply<2, Tags::InternalDirections<2>>(
       // Reference element has one internal directions:
       // ^ eta
       // +-+-+
@@ -94,3 +94,5 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceHelpers", "[Unit][Domain]") {
        {{Direction<2>::upper_xi(), {{{0, {{{1, 1}, {0, 0}}}}}, {}}}}},
       {{Direction<2>::upper_xi(), 2.}}, {{Direction<2>::upper_xi(), 5.}});
 }
+}  // namespace
+}  // namespace domain

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -40,6 +40,7 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
+namespace domain {
 namespace {
 template <size_t N>
 struct NoCopy {
@@ -65,7 +66,7 @@ struct Double : db::SimpleTag {
 template <size_t N>
 struct NoCopy : db::SimpleTag {
   static std::string name() noexcept { return "NoCopy"; }
-  using type = ::NoCopy<N>;
+  using type = domain::NoCopy<N>;
 };
 
 template <typename Tag>
@@ -90,8 +91,8 @@ template <size_t VolumeDim>
 struct ComplexComputeItem : db::ComputeTag {
   static std::string name() noexcept { return "ComplexComputeItem"; }
   static constexpr auto function(const int i, const double d,
-                                 const ::NoCopy<1>& /*unused*/,
-                                 const ::NoCopy<2>& /*unused*/) noexcept {
+                                 const domain::NoCopy<1>& /*unused*/,
+                                 const domain::NoCopy<2>& /*unused*/) noexcept {
     return std::make_pair(i, d);
   }
   using argument_tags = tmpl::list<Int, Double, NoCopy<1>, NoCopy<2>>;
@@ -359,15 +360,15 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems.Subitems", "[Unit][Domain]") {
 
   auto box = db::create<
       db::AddSimpleTags<
-          Tags::Mesh<dim>, Tags::Variables<tmpl::list<Var<2>>>, Var<3>,
-          Tags::Interface<Dirs, Tags::Variables<tmpl::list<Var<0>>>>>,
-      db::AddComputeTags<Dirs, VarPlusFiveCompute<3>,
-                         Tags::InterfaceCompute<Dirs, Tags::Direction<dim>>,
-                         Tags::InterfaceCompute<Dirs, Tags::InterfaceMesh<dim>>,
-                         Tags::InterfaceCompute<Dirs, Compute<1>>,
-                         Tags::Slice<Dirs, Tags::Variables<tmpl::list<Var<2>>>>,
-                         Tags::Slice<Dirs, Var<3>>,
-                         Tags::Slice<Dirs, VarPlusFive<3>>>>(
+          Tags::Mesh<dim>, ::Tags::Variables<tmpl::list<Var<2>>>, Var<3>,
+          Tags::Interface<Dirs, ::Tags::Variables<tmpl::list<Var<0>>>>>,
+      db::AddComputeTags<
+          Dirs, VarPlusFiveCompute<3>,
+          Tags::InterfaceCompute<Dirs, Tags::Direction<dim>>,
+          Tags::InterfaceCompute<Dirs, Tags::InterfaceMesh<dim>>,
+          Tags::InterfaceCompute<Dirs, Compute<1>>,
+          Tags::Slice<Dirs, ::Tags::Variables<tmpl::list<Var<2>>>>,
+          Tags::Slice<Dirs, Var<3>>, Tags::Slice<Dirs, VarPlusFive<3>>>>(
       mesh, volume_var, volume_tensor,
       make_interface_variables<0>(boundary_vars_xi, boundary_vars_eta));
 
@@ -393,10 +394,10 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems.Subitems", "[Unit][Domain]") {
 }
 
 namespace {
-using simple_item_tag = Tags::Variables<tmpl::list<Var<0>>>;
+using simple_item_tag = ::Tags::Variables<tmpl::list<Var<0>>>;
 using compute_item_tag = Compute<1>;
 using sliced_compute_item_tag = Compute<2>;
-using sliced_simple_item_tag = Tags::Variables<tmpl::list<Var<3>>>;
+using sliced_simple_item_tag = ::Tags::Variables<tmpl::list<Var<3>>>;
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems.Slice", "[Unit][Domain]") {
@@ -518,3 +519,4 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems.BaseTags", "[Unit][Domain]") {
   CHECK(get<Tags::Interface<Dirs, SimpleBase>>(box) == interface(4, 5));
   CHECK(get<Tags::Interface<Dirs, ComputeBase>>(box) == interface(5.5, 6.5));
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Test_SizeOfElement.cpp
+++ b/tests/Unit/Domain/Test_SizeOfElement.cpp
@@ -91,12 +91,12 @@ SPECTRE_TEST_CASE("Unit.Domain.SizeOfElement", "[Domain][Unit]") {
     const ElementId<2> element_id(
         0, std::array<SegmentId, 2>({{SegmentId(1, 1), SegmentId(2, 0)}}));
     ElementMap<2, Frame::Inertial> element_map(element_id, std::move(map));
-    const auto box =
-        db::create<db::AddSimpleTags<Tags::ElementMap<2, Frame::Inertial>>,
-                   db::AddComputeTags<Tags::SizeOfElement<2>>>(
-            std::move(element_map));
+    const auto box = db::create<
+        db::AddSimpleTags<domain::Tags::ElementMap<2, Frame::Inertial>>,
+        db::AddComputeTags<domain::Tags::SizeOfElement<2>>>(
+        std::move(element_map));
 
-    const auto size_compute_item = db::get<Tags::SizeOfElement<2>>(box);
+    const auto size_compute_item = db::get<domain::Tags::SizeOfElement<2>>(box);
     const auto size_expected = make_array(0.05, 0.425);
     CHECK_ITERABLE_APPROX(size_compute_item, size_expected);
   }

--- a/tests/Unit/Domain/Test_Tags.cpp
+++ b/tests/Unit/Domain/Test_Tags.cpp
@@ -9,6 +9,7 @@
 #include "Domain/Tags.hpp"
 #include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 template <size_t Dim>
 void test() noexcept {
@@ -42,3 +43,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Tags", "[Unit][Domain]") {
   test<3>();
 }
 }  // namespace
+}  // namespace domain

--- a/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
@@ -54,7 +54,7 @@ struct ElementArray {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
-              tmpl::list<::Tags::Coordinates<Dim, Frame::Inertial>>>>>,
+              tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>>>>>,
 
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,

--- a/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
@@ -108,12 +108,12 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tags = tmpl::list<::Tags::Domain<Dim>>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<Dim>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
-                         tmpl::list<::Tags::InitialExtents<Dim>>>,
+                         tmpl::list<domain::Tags::InitialExtents<Dim>>>,
                      dg::Actions::InitializeDomain<Dim>>>,
 
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -203,7 +203,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
           Scalar<DataVector>{{{{4, 0.}}}});
     // Test the analytic source
     const auto& inertial_coords =
-        get_tag(Tags::Coordinates<1, Frame::Inertial>{});
+        get_tag(domain::Tags::Coordinates<1, Frame::Inertial>{});
     CHECK(get(get_tag(Tags::FixedSource<ScalarFieldTag>{})) ==
           // This check is against the source computed by the
           // analytic solution above
@@ -253,7 +253,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
           Scalar<DataVector>{{{{12, 0.}}}});
     // Test the analytic source
     const auto& inertial_coords =
-        get_tag(Tags::Coordinates<2, Frame::Inertial>{});
+        get_tag(domain::Tags::Coordinates<2, Frame::Inertial>{});
     CHECK(get(get_tag(Tags::FixedSource<ScalarFieldTag>{})) ==
           // This check is against the source computed by the
           // analytic solution above
@@ -307,7 +307,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
           Scalar<DataVector>{{{{24, 0.}}}});
     // Test the analytic source
     const auto& inertial_coords =
-        get_tag(Tags::Coordinates<3, Frame::Inertial>{});
+        get_tag(domain::Tags::Coordinates<3, Frame::Inertial>{});
     CHECK(get(get_tag(Tags::FixedSource<ScalarFieldTag>{})) ==
           // This check is against the source computed by the
           // analytic solution above

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
@@ -90,7 +90,7 @@ class NumericalFlux {
 
   using argument_tags =
       tmpl::list<Tags::NormalDotFlux<field_tag>, OtherData,
-                 Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>;
+                 Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
 
   using package_tags = tmpl::list<ExtraData, field_tag>;
 
@@ -125,24 +125,25 @@ struct System {
 };
 
 template <typename Tag>
-using interface_tag = Tags::Interface<Tags::InternalDirections<Dim>, Tag>;
+using interface_tag =
+    domain::Tags::Interface<domain::Tags::InternalDirections<Dim>, Tag>;
 template <typename Tag>
 using interface_compute_tag =
-    Tags::InterfaceCompute<Tags::InternalDirections<Dim>, Tag>;
+    domain::Tags::InterfaceCompute<domain::Tags::InternalDirections<Dim>, Tag>;
 
 template <typename Tag>
 using boundary_tag =
-    Tags::Interface<Tags::BoundaryDirectionsInterior<Dim>, Tag>;
+    domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<Dim>, Tag>;
 template <typename Tag>
-using boundary_compute_tag =
-    Tags::InterfaceCompute<Tags::BoundaryDirectionsInterior<Dim>, Tag>;
+using boundary_compute_tag = domain::Tags::InterfaceCompute<
+    domain::Tags::BoundaryDirectionsInterior<Dim>, Tag>;
 
 template <typename Tag>
 using exterior_boundary_tag =
-    Tags::Interface<Tags::BoundaryDirectionsExterior<Dim>, Tag>;
+    domain::Tags::Interface<domain::Tags::BoundaryDirectionsExterior<Dim>, Tag>;
 template <typename Tag>
-using exterior_boundary_compute_tag =
-    Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<Dim>, Tag>;
+using exterior_boundary_compute_tag = domain::Tags::InterfaceCompute<
+    domain::Tags::BoundaryDirectionsExterior<Dim>, Tag>;
 
 template <typename FluxCommTypes>
 using mortar_data_tag = typename FluxCommTypes::simple_mortar_data_tag;
@@ -172,7 +173,7 @@ using bdry_other_data_tag =
 using exterior_bdry_other_data_tag =
     exterior_boundary_tag<Tags::Variables<tmpl::list<OtherData>>>;
 using mortar_next_temporal_ids_tag = Tags::Mortars<Tags::Next<TemporalId>, Dim>;
-using mortar_meshes_tag = Tags::Mortars<Tags::Mesh<Dim - 1>, Dim>;
+using mortar_meshes_tag = Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>;
 using mortar_sizes_tag = Tags::Mortars<Tags::MortarSize<Dim - 1>, Dim>;
 
 template <typename Metavariables>
@@ -184,8 +185,8 @@ struct ElementArray {
 
   using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
   using simple_tags = db::AddSimpleTags<
-      TemporalId, Tags::Next<TemporalId>, Tags::Mesh<Dim>, Tags::Element<Dim>,
-      Tags::ElementMap<Dim>, bdry_vars_tag,
+      TemporalId, Tags::Next<TemporalId>, domain::Tags::Mesh<Dim>,
+      domain::Tags::Element<Dim>, domain::Tags::ElementMap<Dim>, bdry_vars_tag,
       bdry_normal_dot_fluxes_tag<flux_comm_types>, bdry_other_data_tag,
       exterior_bdry_normal_dot_fluxes_tag<flux_comm_types>,
       exterior_bdry_other_data_tag, exterior_bdry_vars_tag,
@@ -193,23 +194,24 @@ struct ElementArray {
       mortar_meshes_tag, mortar_sizes_tag>;
 
   using compute_tags = db::AddComputeTags<
-      Tags::BoundaryDirectionsInterior<Dim>,
-      boundary_compute_tag<Tags::Direction<Dim>>,
-      boundary_compute_tag<Tags::InterfaceMesh<Dim>>,
-      boundary_compute_tag<Tags::UnnormalizedFaceNormalCompute<Dim>>,
+      domain::Tags::BoundaryDirectionsInterior<Dim>,
+      boundary_compute_tag<domain::Tags::Direction<Dim>>,
+      boundary_compute_tag<domain::Tags::InterfaceMesh<Dim>>,
+      boundary_compute_tag<domain::Tags::UnnormalizedFaceNormalCompute<Dim>>,
       boundary_compute_tag<
-          Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
+          Tags::EuclideanMagnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>>,
       boundary_compute_tag<
-          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>,
-      Tags::BoundaryDirectionsExterior<Dim>,
-      exterior_boundary_compute_tag<Tags::Direction<Dim>>,
-      exterior_boundary_compute_tag<Tags::InterfaceMesh<Dim>>,
-      exterior_boundary_compute_tag<Tags::BoundaryCoordinates<Dim>>,
-      exterior_boundary_compute_tag<Tags::UnnormalizedFaceNormalCompute<Dim>>,
+          Tags::NormalizedCompute<domain::Tags::UnnormalizedFaceNormal<Dim>>>,
+      domain::Tags::BoundaryDirectionsExterior<Dim>,
+      exterior_boundary_compute_tag<domain::Tags::Direction<Dim>>,
+      exterior_boundary_compute_tag<domain::Tags::InterfaceMesh<Dim>>,
+      exterior_boundary_compute_tag<domain::Tags::BoundaryCoordinates<Dim>>,
       exterior_boundary_compute_tag<
-          Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
+          domain::Tags::UnnormalizedFaceNormalCompute<Dim>>,
       exterior_boundary_compute_tag<
-          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>>;
+          Tags::EuclideanMagnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>>,
+      exterior_boundary_compute_tag<
+          Tags::NormalizedCompute<domain::Tags::UnnormalizedFaceNormal<Dim>>>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
@@ -107,18 +107,19 @@ struct ElementArray {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<
-                         ::Tags::Domain<Dim>, ::Tags::InitialExtents<Dim>,
-                         db::add_tag_prefix<
-                             ::Tags::FixedSource,
-                             typename Metavariables::system::fields_tag>>>,
-                     dg::Actions::InitializeDomain<Dim>,
-                     dg::Actions::InitializeInterfaces<
-                         typename Metavariables::system,
-                         dg::Initialization::slice_tags_to_face<>,
-                         dg::Initialization::slice_tags_to_exterior<>,
-                         dg::Initialization::face_compute_tags<>,
-                         dg::Initialization::exterior_compute_tags<>, false>>>,
+          tmpl::list<
+              ActionTesting::InitializeDataBox<tmpl::list<
+                  domain::Tags::Domain<Dim>, domain::Tags::InitialExtents<Dim>,
+                  db::add_tag_prefix<
+                      ::Tags::FixedSource,
+                      typename Metavariables::system::fields_tag>>>,
+              dg::Actions::InitializeDomain<Dim>,
+              dg::Actions::InitializeInterfaces<
+                  typename Metavariables::system,
+                  dg::Initialization::slice_tags_to_face<>,
+                  dg::Initialization::slice_tags_to_exterior<>,
+                  dg::Initialization::face_compute_tags<>,
+                  dg::Initialization::exterior_compute_tags<>, false>>>,
 
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
@@ -53,9 +53,9 @@ using fluxes_tag = db::add_tag_prefix<::Tags::Flux, vars_tag<Dim>,
 template <size_t Dim>
 using div_fluxes_tag = db::add_tag_prefix<::Tags::div, fluxes_tag<Dim>>;
 template <size_t Dim>
-using inv_jacobian_tag =
-    Tags::InverseJacobianCompute<::Tags::ElementMap<Dim>,
-                                 ::Tags::Coordinates<Dim, Frame::Logical>>;
+using inv_jacobian_tag = domain::Tags::InverseJacobianCompute<
+    domain::Tags::ElementMap<Dim>,
+    domain::Tags::Coordinates<Dim, Frame::Logical>>;
 
 template <size_t Dim>
 struct Fluxes {
@@ -83,13 +83,13 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tags = tmpl::list<::Tags::Domain<Dim>>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<Dim>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<
               ActionTesting::InitializeDataBox<
-                  tmpl::list<::Tags::InitialExtents<Dim>, vars_tag<Dim>>>,
+                  tmpl::list<domain::Tags::InitialExtents<Dim>, vars_tag<Dim>>>,
               dg::Actions::InitializeDomain<Dim>,
               Initialization::Actions::AddComputeTags<tmpl::list<
                   elliptic::Tags::FirstOrderFluxesCompute<

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
@@ -68,7 +68,7 @@ class DummyLimiterForTest {
     double mean_;
     Mesh<2> mesh_;
   };
-  using package_argument_tags = tmpl::list<Var, Tags::Mesh<2>>;
+  using package_argument_tags = tmpl::list<Var, domain::Tags::Mesh<2>>;
   void package_data(const gsl::not_null<PackagedData*> packaged_data,
                     const Scalar<DataVector>& var, const Mesh<2>& mesh,
                     const OrientationMap<2>& orientation_map) const noexcept {
@@ -77,7 +77,8 @@ class DummyLimiterForTest {
   }
 
   using limit_tags = tmpl::list<Var>;
-  using limit_argument_tags = tmpl::list<Tags::Mesh<2>, Tags::Element<2>>;
+  using limit_argument_tags =
+      tmpl::list<domain::Tags::Mesh<2>, domain::Tags::Element<2>>;
   void operator()(const gsl::not_null<db::item_type<Var>*> var,
                   const Mesh<2>& /*mesh*/, const Element<2>& /*element*/,
                   const std::unordered_map<
@@ -105,9 +106,9 @@ struct component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
   using const_global_cache_tags = tmpl::list<LimiterTag>;
-  using simple_tags =
-      db::AddSimpleTags<TemporalId, Tags::Mesh<Dim>, Tags::Element<Dim>,
-                        Tags::ElementMap<Dim>, Var>;
+  using simple_tags = db::AddSimpleTags<TemporalId, domain::Tags::Mesh<Dim>,
+                                        domain::Tags::Element<Dim>,
+                                        domain::Tags::ElementMap<Dim>, Var>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
@@ -67,11 +67,12 @@ struct component {
   using array_index = ElementIndex<Dim>;
   using const_global_cache_tags = tmpl::list<LimiterTag>;
   using simple_tags =
-      db::AddSimpleTags<TemporalId, Tags::Mesh<Dim>, Tags::Element<Dim>,
-                        Tags::ElementMap<Dim>,
-                        Tags::Coordinates<Dim, Frame::Logical>,
-                        Tags::Coordinates<Dim, Frame::Inertial>, Var>;
-  using compute_tags = db::AddComputeTags<Tags::SizeOfElement<Dim>>;
+      db::AddSimpleTags<TemporalId, domain::Tags::Mesh<Dim>,
+                        domain::Tags::Element<Dim>,
+                        domain::Tags::ElementMap<Dim>,
+                        domain::Tags::Coordinates<Dim, Frame::Logical>,
+                        domain::Tags::Coordinates<Dim, Frame::Inertial>, Var>;
+  using compute_tags = db::AddComputeTags<domain::Tags::SizeOfElement<Dim>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,

--- a/tests/Unit/Evolution/Systems/Burgers/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Test_Characteristics.cpp
@@ -18,14 +18,16 @@ SPECTRE_TEST_CASE("Unit.Burgers.Characteristics", "[Unit][Burgers]") {
       "CharacteristicSpeeds");
   {
     const auto box = db::create<
-        db::AddSimpleTags<Burgers::Tags::U, Tags::UnnormalizedFaceNormal<1>>,
+        db::AddSimpleTags<Burgers::Tags::U,
+                          domain::Tags::UnnormalizedFaceNormal<1>>,
         db::AddComputeTags<Burgers::Tags::CharacteristicSpeedsCompute>>(
         Scalar<DataVector>{{{{4.0}}}}, tnsr::i<DataVector, 1>{{{{1.0}}}});
     CHECK(db::get<Burgers::Tags::CharacteristicSpeedsCompute>(box)[0] == 4.0);
   }
   {
     const auto box = db::create<
-        db::AddSimpleTags<Burgers::Tags::U, Tags::UnnormalizedFaceNormal<1>>,
+        db::AddSimpleTags<Burgers::Tags::U,
+                          domain::Tags::UnnormalizedFaceNormal<1>>,
         db::AddComputeTags<Burgers::Tags::CharacteristicSpeedsCompute>>(
         Scalar<DataVector>{{{{4.0}}}}, tnsr::i<DataVector, 1>{{{{-1.0}}}});
     CHECK(db::get<Burgers::Tags::CharacteristicSpeedsCompute>(box)[0] == -4.0);

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Characteristics.cpp
@@ -164,7 +164,7 @@ void test_characteristics_compute_tags() noexcept {
                                          DataVector>,
           CurvedScalarWave::Psi, CurvedScalarWave::Pi,
           CurvedScalarWave::Phi<SpatialDim>,
-          ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<SpatialDim>>>,
+          ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<SpatialDim>>>,
       db::AddComputeTags<
           CurvedScalarWave::CharacteristicSpeedsCompute<SpatialDim>,
           CurvedScalarWave::CharacteristicFieldsCompute<SpatialDim>>>(
@@ -197,7 +197,7 @@ void test_characteristics_compute_tags() noexcept {
           CurvedScalarWave::Tags::VPsi,
           CurvedScalarWave::Tags::VZero<SpatialDim>,
           CurvedScalarWave::Tags::VPlus, CurvedScalarWave::Tags::VMinus,
-          ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<SpatialDim>>>,
+          ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<SpatialDim>>>,
       db::AddComputeTags<
           CurvedScalarWave::EvolvedFieldsFromCharacteristicFieldsCompute<
               SpatialDim>>>(gamma_2, u_psi, u_zero, u_plus, u_minus, normal);

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -2952,7 +2952,7 @@ void test_damped_harmonic_compute_tags(const size_t grid_size_each_dimension,
           gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>,
           GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
           GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>, ::Tags::Time,
-          ::Tags::Coordinates<3, Frame::Inertial>,
+          domain::Tags::Coordinates<3, Frame::Inertial>,
           GeneralizedHarmonic::Tags::GaugeHRollOnStartTime,
           GeneralizedHarmonic::Tags::GaugeHRollOnTimeWindow,
           GeneralizedHarmonic::Tags::GaugeHSpatialWeightDecayWidth<

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -830,7 +830,7 @@ void test_constraint_compute_items(
   // Insert into databox
   const auto box = db::create<
       db::AddSimpleTags<
-          ::Tags::Coordinates<3, Frame::Inertial>,
+          domain::Tags::Coordinates<3, Frame::Inertial>,
           gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
           gr::Tags::Lapse<DataVector>,
           gr::Tags::Shift<3, Frame::Inertial, DataVector>,

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Actions.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Actions.cpp
@@ -35,7 +35,7 @@ struct mock_component {
       typename Metavariables::neutrino_species>;
   using simple_tags = db::AddSimpleTags<tmpl::flatten<
       tmpl::list<typename Closure::return_tags, typename Closure::argument_tags,
-                 Tags::Coordinates<3, Frame::Inertial>>>>;
+                 domain::Tags::Coordinates<3, Frame::Inertial>>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Characteristics.cpp
@@ -52,7 +52,7 @@ void test_compute_item_in_databox(
           gr::Tags::Lapse<>, gr::Tags::Shift<Dim>, gr::Tags::SpatialMetric<Dim>,
           hydro::Tags::SpatialVelocity<DataVector, Dim>,
           hydro::Tags::SoundSpeedSquared<DataVector>,
-          ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>,
+          ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>,
       db::AddComputeTags<
           RelativisticEuler::Valencia::Tags::CharacteristicSpeedsCompute<Dim>>>(
       lapse, shift, spatial_metric, spatial_velocity, sound_speed_squared,

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Constraints.cpp
@@ -156,8 +156,8 @@ void test_constraints_and_compute_tags_analytic(
   // (2.) Test that compute tags return expected values
   const auto box = db::create<
       db::AddSimpleTags<
-          ::Tags::Coordinates<spatial_dim, Frame::Inertial>, ScalarWave::Psi,
-          ScalarWave::Phi<spatial_dim>, ScalarWave::Pi,
+          domain::Tags::Coordinates<spatial_dim, Frame::Inertial>,
+          ScalarWave::Psi, ScalarWave::Phi<spatial_dim>, ScalarWave::Pi,
           ::Tags::deriv<ScalarWave::Psi, tmpl::size_t<spatial_dim>,
                         Frame::Inertial>,
           ::Tags::deriv<ScalarWave::Phi<spatial_dim>, tmpl::size_t<spatial_dim>,

--- a/tests/Unit/Evolution/Test_ComputeTags.cpp
+++ b/tests/Unit/Evolution/Test_ComputeTags.cpp
@@ -41,12 +41,12 @@ struct AnalyticSolutionTag : db::SimpleTag {
 SPECTRE_TEST_CASE("Unit.Evolution.ComputeTags", "[Unit][Evolution]") {
   tnsr::I<DataVector, 1, Frame::Inertial> inertial_coords{{{{1., 2., 3., 4.}}}};
   const double current_time = 2.;
-  const auto box =
-      db::create<db::AddSimpleTags<::Tags::Coordinates<1, Frame::Inertial>,
-                                   AnalyticSolutionTag, Tags::Time>,
-                 db::AddComputeTags<evolution::Tags::AnalyticCompute<
-                     1, AnalyticSolutionTag, tmpl::list<FieldTag>>>>(
-          std::move(inertial_coords), AnalyticSolution{}, current_time);
+  const auto box = db::create<
+      db::AddSimpleTags<domain::Tags::Coordinates<1, Frame::Inertial>,
+                        AnalyticSolutionTag, Tags::Time>,
+      db::AddComputeTags<evolution::Tags::AnalyticCompute<
+          1, AnalyticSolutionTag, tmpl::list<FieldTag>>>>(
+      std::move(inertial_coords), AnalyticSolution{}, current_time);
   const DataVector expected{2., 4., 6., 8.};
   CHECK_ITERABLE_APPROX(get(get<::Tags::Analytic<FieldTag>>(box)), expected);
 

--- a/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
@@ -33,7 +33,7 @@ struct mock_component {
   using array_index = size_t;
   using simple_tags = tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
                                  hydro::Tags::Pressure<DataVector>,
-                                 ::Tags::Coordinates<3, Frame::Inertial>>;
+                                 domain::Tags::Coordinates<3, Frame::Inertial>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
@@ -85,12 +85,12 @@ struct Component {
   using array_index = ElementIndex<2>;
   using const_global_cache_tags =
       tmpl::list<Tags::TimeStepper<LtsTimeStepper>, NumericalFluxTag>;
-  using simple_tags =
-      db::AddSimpleTags<Tags::Mesh<2>, Tags::Mortars<Tags::Mesh<1>, 2>,
-                        Tags::Mortars<Tags::MortarSize<1>, 2>, Tags::TimeStep,
-                        System::variables_tag,
-                        typename dg::FluxCommunicationTypes<Metavariables>::
-                            local_time_stepping_mortar_data_tag>;
+  using simple_tags = db::AddSimpleTags<
+      domain::Tags::Mesh<2>, Tags::Mortars<domain::Tags::Mesh<1>, 2>,
+      Tags::Mortars<Tags::MortarSize<1>, 2>, Tags::TimeStep,
+      System::variables_tag,
+      typename dg::FluxCommunicationTypes<
+          Metavariables>::local_time_stepping_mortar_data_tag>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -128,7 +128,7 @@ SPECTRE_TEST_CASE("Unit.DG.Actions.ApplyBoundaryFluxesLocalTimeStepping",
   const auto fast_mortar = std::make_pair(Direction<2>::upper_xi(),
                                           ElementId<2>(1, {{{0, 0}, {1, 1}}}));
 
-  typename Tags::Mortars<Tags::Mesh<1>, 2>::type mortar_meshes{
+  typename Tags::Mortars<domain::Tags::Mesh<1>, 2>::type mortar_meshes{
       {slow_mortar, mesh.slice_away(face_dimension)},
       {fast_mortar, mesh.slice_away(face_dimension)}};
   typename Tags::Mortars<Tags::MortarSize<1>, 2>::type mortar_sizes{

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -71,7 +71,7 @@ struct System {
   struct normal_dot_fluxes {
     using argument_tags =
         tmpl::list<Var, OtherArg, Var2,
-                   Tags::Normalized<Tags::UnnormalizedFaceNormal<2>>>;
+                   Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<2>>>;
     static void apply(
         const gsl::not_null<Scalar<DataVector>*> var_normal_dot_flux,
         const gsl::not_null<tnsr::ii<DataVector, 2>*> var2_normal_dot_flux,
@@ -91,10 +91,11 @@ struct System {
 };
 
 template <typename Tag>
-using interface_tag = Tags::Interface<Tags::InternalDirections<2>, Tag>;
+using interface_tag =
+    domain::Tags::Interface<domain::Tags::InternalDirections<2>, Tag>;
 template <typename Tag>
 using interface_compute_tag =
-    Tags::InterfaceCompute<Tags::InternalDirections<2>, Tag>;
+    domain::Tags::InterfaceCompute<domain::Tags::InternalDirections<2>, Tag>;
 
 using n_dot_f_tag = interface_tag<Tags::NormalDotFlux<Tags::Variables<
     tmpl::list<Tags::NormalDotFlux<Var>, Tags::NormalDotFlux<Var2>>>>>;
@@ -107,17 +108,19 @@ struct component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<2>;
   using simple_tags =
-      db::AddSimpleTags<Tags::Element<2>, Tags::Mesh<2>, Tags::ElementMap<2>,
+      db::AddSimpleTags<domain::Tags::Element<2>, domain::Tags::Mesh<2>,
+                        domain::Tags::ElementMap<2>,
                         interface_tag<Tags::Variables<tmpl::list<Var, Var2>>>,
                         interface_tag<OtherArg>, n_dot_f_tag>;
   using compute_tags = db::AddComputeTags<
-      Tags::InternalDirections<2>, interface_compute_tag<Tags::Direction<2>>,
-      interface_compute_tag<Tags::InterfaceMesh<2>>,
-      interface_compute_tag<Tags::UnnormalizedFaceNormalCompute<2>>,
+      domain::Tags::InternalDirections<2>,
+      interface_compute_tag<domain::Tags::Direction<2>>,
+      interface_compute_tag<domain::Tags::InterfaceMesh<2>>,
+      interface_compute_tag<domain::Tags::UnnormalizedFaceNormalCompute<2>>,
       interface_compute_tag<
-          Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<2>>>,
+          Tags::EuclideanMagnitude<domain::Tags::UnnormalizedFaceNormal<2>>>,
       interface_compute_tag<
-          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<2>>>>;
+          Tags::NormalizedCompute<domain::Tags::UnnormalizedFaceNormal<2>>>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -127,7 +130,7 @@ struct component {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
           tmpl::list<dg::Actions::ComputeNonconservativeBoundaryFluxes<
-              Tags::InternalDirections<2>>>>>;
+              domain::Tags::InternalDirections<2>>>>>;
 };
 
 struct Metavariables {
@@ -203,9 +206,9 @@ SPECTRE_TEST_CASE("Unit.DG.Actions.ComputeNonconservativeBoundaryFluxes",
 
   auto box = run_action(element, vars, other_arg);
 
-  const auto& unit_face_normal =
-      db::get<interface_tag<Tags::Normalized<Tags::UnnormalizedFaceNormal<2>>>>(
-          box);
+  const auto& unit_face_normal = db::get<
+      interface_tag<Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<2>>>>(
+      box);
   const auto& n_dot_f = db::get<n_dot_f_tag>(box);
 
   std::unordered_map<Direction<2>,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -93,7 +93,7 @@ class NumericalFlux {
   // things.
   using argument_tags =
       tmpl::list<Tags::NormalDotFlux<Var>, OtherData,
-                 Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>;
+                 Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
   void package_data(const gsl::not_null<Variables<package_tags>*> packaged_data,
                     const Scalar<DataVector>& var_flux,
                     const Scalar<DataVector>& other_data,
@@ -126,10 +126,11 @@ struct System {
 };
 
 template <size_t Dim, typename Tag>
-using interface_tag = Tags::Interface<Tags::InternalDirections<Dim>, Tag>;
+using interface_tag =
+    domain::Tags::Interface<domain::Tags::InternalDirections<Dim>, Tag>;
 template <size_t Dim, typename Tag>
 using interface_compute_tag =
-    Tags::InterfaceCompute<Tags::InternalDirections<Dim>, Tag>;
+    domain::Tags::InterfaceCompute<domain::Tags::InternalDirections<Dim>, Tag>;
 
 template <typename FluxCommTypes>
 using mortar_data_tag = typename FluxCommTypes::simple_mortar_data_tag;
@@ -150,7 +151,7 @@ using other_data_tag =
 template <size_t Dim>
 using mortar_next_temporal_ids_tag = Tags::Mortars<Tags::Next<TemporalId>, Dim>;
 template <size_t Dim>
-using mortar_meshes_tag = Tags::Mortars<Tags::Mesh<Dim - 1>, Dim>;
+using mortar_meshes_tag = Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>;
 template <size_t Dim>
 using mortar_sizes_tag = Tags::Mortars<Tags::MortarSize<Dim - 1>, Dim>;
 
@@ -162,23 +163,25 @@ struct component {
   using const_global_cache_tags = tmpl::list<NumericalFluxTag<Dim>>;
   using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
 
-  using simple_tags =
-      db::AddSimpleTags<TemporalId, Tags::Next<TemporalId>, Tags::Mesh<Dim>,
-                        Tags::Element<Dim>, Tags::ElementMap<Dim>,
-                        normal_dot_fluxes_tag<Dim, flux_comm_types>,
-                        other_data_tag<Dim>, mortar_data_tag<flux_comm_types>,
-                        mortar_next_temporal_ids_tag<Dim>,
-                        mortar_meshes_tag<Dim>, mortar_sizes_tag<Dim>>;
+  using simple_tags = db::AddSimpleTags<
+      TemporalId, Tags::Next<TemporalId>, domain::Tags::Mesh<Dim>,
+      domain::Tags::Element<Dim>, domain::Tags::ElementMap<Dim>,
+      normal_dot_fluxes_tag<Dim, flux_comm_types>, other_data_tag<Dim>,
+      mortar_data_tag<flux_comm_types>, mortar_next_temporal_ids_tag<Dim>,
+      mortar_meshes_tag<Dim>, mortar_sizes_tag<Dim>>;
 
   using compute_tags = db::AddComputeTags<
-      Tags::InternalDirections<Dim>,
-      interface_compute_tag<Dim, Tags::Direction<Dim>>,
-      interface_compute_tag<Dim, Tags::InterfaceMesh<Dim>>,
-      interface_compute_tag<Dim, Tags::UnnormalizedFaceNormalCompute<Dim>>,
+      domain::Tags::InternalDirections<Dim>,
+      interface_compute_tag<Dim, domain::Tags::Direction<Dim>>,
+      interface_compute_tag<Dim, domain::Tags::InterfaceMesh<Dim>>,
+      interface_compute_tag<Dim,
+                            domain::Tags::UnnormalizedFaceNormalCompute<Dim>>,
       interface_compute_tag<
-          Dim, Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
+          Dim,
+          Tags::EuclideanMagnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>>,
       interface_compute_tag<
-          Dim, Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>>;
+          Dim,
+          Tags::NormalizedCompute<domain::Tags::UnnormalizedFaceNormal<Dim>>>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -85,7 +85,7 @@ class NumericalFlux {
   // things.
   using argument_tags =
       tmpl::list<Tags::NormalDotFlux<Var>, OtherData,
-                 Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>;
+                 Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
   void package_data(const gsl::not_null<Variables<package_tags>*> packaged_data,
                     const Scalar<DataVector>& var_flux,
                     const Scalar<DataVector>& other_data,
@@ -118,10 +118,11 @@ struct System {
 };
 
 template <size_t Dim, typename Tag>
-using interface_tag = Tags::Interface<Tags::InternalDirections<Dim>, Tag>;
+using interface_tag =
+    domain::Tags::Interface<domain::Tags::InternalDirections<Dim>, Tag>;
 template <size_t Dim, typename Tag>
 using interface_compute_tag =
-    Tags::InterfaceCompute<Tags::InternalDirections<Dim>, Tag>;
+    domain::Tags::InterfaceCompute<domain::Tags::InternalDirections<Dim>, Tag>;
 
 template <typename FluxCommTypes>
 using LocalData = typename FluxCommTypes::LocalData;
@@ -137,7 +138,7 @@ using other_data_tag =
 template <size_t Dim>
 using mortar_next_temporal_ids_tag = Tags::Mortars<Tags::Next<TemporalId>, Dim>;
 template <size_t Dim>
-using mortar_meshes_tag = Tags::Mortars<Tags::Mesh<Dim - 1>, Dim>;
+using mortar_meshes_tag = Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>;
 template <size_t Dim>
 using mortar_sizes_tag = Tags::Mortars<Tags::MortarSize<Dim - 1>, Dim>;
 
@@ -147,7 +148,7 @@ struct DataRecorderTag : db::SimpleTag {
   using type = DataRecorder;
 };
 
-struct MortarRecorderTag : Tags::VariablesBoundaryData,
+struct MortarRecorderTag : domain::Tags::VariablesBoundaryData,
                            Tags::Mortars<DataRecorderTag, 2> {};
 
 template <size_t Dim, typename MV>
@@ -159,20 +160,24 @@ struct lts_component {
   using flux_comm_types = dg::FluxCommunicationTypes<MV>;
 
   using simple_tags = db::AddSimpleTags<
-      TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>, Tags::Element<2>,
-      Tags::ElementMap<2>, normal_dot_fluxes_tag<2, flux_comm_types>,
-      other_data_tag<2>, mortar_meshes_tag<2>, mortar_sizes_tag<2>,
-      MortarRecorderTag, mortar_next_temporal_ids_tag<2>>;
+      TemporalId, Tags::Next<TemporalId>, domain::Tags::Mesh<2>,
+      domain::Tags::Element<2>, domain::Tags::ElementMap<2>,
+      normal_dot_fluxes_tag<2, flux_comm_types>, other_data_tag<2>,
+      mortar_meshes_tag<2>, mortar_sizes_tag<2>, MortarRecorderTag,
+      mortar_next_temporal_ids_tag<2>>;
 
   using compute_tags = db::AddComputeTags<
-      Tags::InternalDirections<Dim>,
-      interface_compute_tag<Dim, Tags::Direction<Dim>>,
-      interface_compute_tag<Dim, Tags::InterfaceMesh<Dim>>,
-      interface_compute_tag<Dim, Tags::UnnormalizedFaceNormalCompute<Dim>>,
+      domain::Tags::InternalDirections<Dim>,
+      interface_compute_tag<Dim, domain::Tags::Direction<Dim>>,
+      interface_compute_tag<Dim, domain::Tags::InterfaceMesh<Dim>>,
+      interface_compute_tag<Dim,
+                            domain::Tags::UnnormalizedFaceNormalCompute<Dim>>,
       interface_compute_tag<
-          Dim, Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
+          Dim,
+          Tags::EuclideanMagnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>>,
       interface_compute_tag<
-          Dim, Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>>;
+          Dim,
+          Tags::NormalizedCompute<domain::Tags::UnnormalizedFaceNormal<Dim>>>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename MV::Phase, MV::Phase::Initialization,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -86,7 +86,7 @@ class NumericalFlux {
 
   using argument_tags =
       tmpl::list<Tags::NormalDotFlux<Var>, OtherData,
-                 Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>;
+                 Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
   void package_data(const gsl::not_null<Variables<package_tags>*> packaged_data,
                     const Scalar<DataVector>& var_flux,
                     const Scalar<DataVector>& other_data,
@@ -154,17 +154,17 @@ struct System {
 
 template <typename Tag>
 using boundary_tag =
-    Tags::Interface<Tags::BoundaryDirectionsInterior<Dim>, Tag>;
+    domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<Dim>, Tag>;
 template <typename Tag>
-using boundary_compute_tag =
-    Tags::InterfaceCompute<Tags::BoundaryDirectionsInterior<Dim>, Tag>;
+using boundary_compute_tag = domain::Tags::InterfaceCompute<
+    domain::Tags::BoundaryDirectionsInterior<Dim>, Tag>;
 
 template <typename Tag>
 using external_boundary_tag =
-    Tags::Interface<Tags::BoundaryDirectionsExterior<Dim>, Tag>;
+    domain::Tags::Interface<domain::Tags::BoundaryDirectionsExterior<Dim>, Tag>;
 template <typename Tag>
-using external_boundary_compute_tag =
-    Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<Dim>, Tag>;
+using external_boundary_compute_tag = domain::Tags::InterfaceCompute<
+    domain::Tags::BoundaryDirectionsExterior<Dim>, Tag>;
 
 template <typename FluxCommTypes>
 using mortar_data_tag = typename FluxCommTypes::simple_mortar_data_tag;
@@ -198,30 +198,32 @@ struct component {
   using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
 
   using simple_tags = db::AddSimpleTags<
-      TemporalId, Tags::Time, Tags::Mesh<Dim>, Tags::Element<Dim>,
-      Tags::ElementMap<Dim>, bdry_normal_dot_fluxes_tag<flux_comm_types>,
-      bdry_other_data_tag, external_bdry_normal_dot_fluxes_tag<flux_comm_types>,
+      TemporalId, Tags::Time, domain::Tags::Mesh<Dim>,
+      domain::Tags::Element<Dim>, domain::Tags::ElementMap<Dim>,
+      bdry_normal_dot_fluxes_tag<flux_comm_types>, bdry_other_data_tag,
+      external_bdry_normal_dot_fluxes_tag<flux_comm_types>,
       external_bdry_other_data_tag, external_bdry_vars_tag,
       mortar_data_tag<flux_comm_types>>;
 
   using compute_tags = db::AddComputeTags<
-      Tags::BoundaryDirectionsInterior<Dim>,
-      boundary_compute_tag<Tags::Direction<Dim>>,
-      boundary_compute_tag<Tags::InterfaceMesh<Dim>>,
-      boundary_compute_tag<Tags::UnnormalizedFaceNormalCompute<Dim>>,
+      domain::Tags::BoundaryDirectionsInterior<Dim>,
+      boundary_compute_tag<domain::Tags::Direction<Dim>>,
+      boundary_compute_tag<domain::Tags::InterfaceMesh<Dim>>,
+      boundary_compute_tag<domain::Tags::UnnormalizedFaceNormalCompute<Dim>>,
       boundary_compute_tag<
-          Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
+          Tags::EuclideanMagnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>>,
       boundary_compute_tag<
-          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>,
-      Tags::BoundaryDirectionsExterior<Dim>,
-      external_boundary_compute_tag<Tags::Direction<Dim>>,
-      external_boundary_compute_tag<Tags::InterfaceMesh<Dim>>,
-      external_boundary_compute_tag<Tags::BoundaryCoordinates<Dim>>,
-      external_boundary_compute_tag<Tags::UnnormalizedFaceNormalCompute<Dim>>,
+          Tags::NormalizedCompute<domain::Tags::UnnormalizedFaceNormal<Dim>>>,
+      domain::Tags::BoundaryDirectionsExterior<Dim>,
+      external_boundary_compute_tag<domain::Tags::Direction<Dim>>,
+      external_boundary_compute_tag<domain::Tags::InterfaceMesh<Dim>>,
+      external_boundary_compute_tag<domain::Tags::BoundaryCoordinates<Dim>>,
       external_boundary_compute_tag<
-          Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
+          domain::Tags::UnnormalizedFaceNormalCompute<Dim>>,
       external_boundary_compute_tag<
-          Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim>>>>;
+          Tags::EuclideanMagnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>>,
+      external_boundary_compute_tag<
+          Tags::NormalizedCompute<domain::Tags::UnnormalizedFaceNormal<Dim>>>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_NormalDotFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_NormalDotFlux.cpp
@@ -184,11 +184,11 @@ void check_compute_item() {
 
   // Doing this through a DataBox would require a full element to be
   // set up.
-  using magnitude_normal_tag =
-      Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim, Frame>>;
+  using magnitude_normal_tag = Tags::EuclideanMagnitude<
+      domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>;
   const auto magnitude_normal = magnitude_normal_tag::function(normal);
   using normalized_normal_tag =
-      Tags::NormalizedCompute<Tags::UnnormalizedFaceNormal<Dim, Frame>>;
+      Tags::NormalizedCompute<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>;
   const auto normalized_normal =
       normalized_normal_tag::function(normal, magnitude_normal);
   using compute_n_dot_f =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -69,7 +69,7 @@ struct mock_interpolation_target {
   using const_global_cache_tags = tmpl::flatten<tmpl::append<
       Parallel::get_const_global_cache_tags_from_actions<tmpl::list<
           typename Metavariables::InterpolationTargetA::compute_target_points>>,
-      tmpl::list<::Tags::Domain<Metavariables::volume_dim>>>>;
+      tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -149,7 +149,7 @@ void test_interpolation_target(
   using interp_component = mock_interpolator<metavars>;
 
   tuples::TaggedTuple<InterpolationTargetOptionTag,
-                      ::Tags::Domain<MetaVariables::volume_dim>>
+                      domain::Tags::Domain<MetaVariables::volume_dim>>
       tuple_of_opts{std::move(options),
                     std::move(domain_creator.create_domain())};
   ActionTesting::MockRuntimeSystem<metavars> runner{std::move(tuple_of_opts)};

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -52,7 +52,7 @@ struct mock_interpolation_target {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tags = tmpl::list<::Tags::Domain<3>>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<3>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -35,7 +35,7 @@ struct mock_interpolation_target {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tags = tmpl::list<::Tags::Domain<3>>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<3>>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<intrp::Actions::InitializeInterpolationTarget<
@@ -79,7 +79,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Initialize",
             runner, 0)
             .empty());
 
-  CHECK(Parallel::get<::Tags::Domain<3>>(runner.cache()) ==
+  CHECK(Parallel::get<domain::Tags::Domain<3>>(runner.cache()) ==
         domain_creator.create_domain());
 
   const auto test_vars = db::item_type<

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -162,7 +162,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
   std::iota(vars.data(), vars.data() + vars.size(), 1.0);
 
   const auto box = db::create<db::AddSimpleTags<
-      metavars::temporal_id, ::Tags::Mesh<metavars::volume_dim>,
+      metavars::temporal_id, domain::Tags::Mesh<metavars::volume_dim>,
       ::Tags::Variables<typename decltype(vars)::tags_list>>>(
       TimeStepId(true, 0, Slab(0., observation_time).end()), mesh, vars);
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -77,7 +77,7 @@ struct mock_interpolation_target {
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
   using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<Metavariables::volume_dim>>;
+      tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>;
   using simple_tags =
       db::get_items<typename intrp::Actions::InitializeInterpolationTarget<
           Metavariables, InterpolationTargetTag>::return_tag_list>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -110,7 +110,7 @@ struct mock_interpolation_target {
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
   using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<Metavariables::volume_dim>>;
+      tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -182,7 +182,7 @@ struct mock_interpolation_target {
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
   using const_global_cache_tags =
-      tmpl::list<::Tags::Domain<Metavariables::volume_dim>>;
+      tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -162,7 +162,7 @@ struct MockInterpolationTarget {
       Parallel::get_const_global_cache_tags_from_actions<tmpl::list<
           typename InterpolationTargetTag::compute_target_points,
           typename InterpolationTargetTag::post_interpolation_callback>>,
-      tmpl::list<::Tags::Domain<Metavariables::volume_dim>>>>;
+      tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -299,7 +299,7 @@ SPECTRE_TEST_CASE(
       domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
   tuples::TaggedTuple<observers::Tags::ReductionFileName,
                       ::intrp::Tags::KerrHorizon<metavars::SurfaceA>,
-                      ::Tags::Domain<3>,
+                      domain::Tags::Domain<3>,
                       ::intrp::Tags::KerrHorizon<metavars::SurfaceB>,
                       ::intrp::Tags::KerrHorizon<metavars::SurfaceC>>
       tuple_of_opts{h5_file_prefix, kerr_horizon_opts_A,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -177,7 +177,7 @@ struct mock_interpolation_target {
   using const_global_cache_tags = tmpl::flatten<tmpl::append<
       Parallel::get_const_global_cache_tags_from_actions<
           tmpl::list<typename InterpolationTargetTag::compute_target_points>>,
-      tmpl::list<::Tags::Domain<Metavariables::volume_dim>>>>;
+      tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -275,7 +275,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
       domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
   tuples::TaggedTuple<
       intrp::Tags::LineSegment<metavars::InterpolationTargetA, 3>,
-      ::Tags::Domain<3>,
+      domain::Tags::Domain<3>,
       intrp::Tags::LineSegment<metavars::InterpolationTargetB, 3>,
       intrp::Tags::KerrHorizon<metavars::InterpolationTargetC>>
       tuple_of_opts(std::move(line_segment_opts_A),

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -208,8 +208,8 @@ void test_divergence_compute_item(
     std::array<std::unique_ptr<MathFunction<1>>, Dim> functions) noexcept {
   const auto coordinate_map = make_affine_map<Dim>();
   using map_tag = MapTag<std::decay_t<decltype(coordinate_map)>>;
-  using inv_jac_tag =
-      Tags::InverseJacobianCompute<map_tag, Tags::LogicalCoordinates<Dim>>;
+  using inv_jac_tag = domain::Tags::InverseJacobianCompute<
+      map_tag, domain::Tags::LogicalCoordinates<Dim>>;
   using flux_tags = two_fluxes<Dim, Frame>;
   using flux_tag = Tags::Variables<flux_tags>;
   using div_tags = db::wrap_tags_in<Tags::div, flux_tags>;
@@ -232,11 +232,11 @@ void test_divergence_compute_item(
     get<DivFluxTag>(expected_div_fluxes) = FluxTag::divergence_of_flux(f, x);
   });
 
-  auto box =
-      db::create<db::AddSimpleTags<Tags::Mesh<Dim>, flux_tag, map_tag>,
-                 db::AddComputeTags<Tags::LogicalCoordinates<Dim>, inv_jac_tag,
-                                    Tags::DivCompute<flux_tag, inv_jac_tag>>>(
-          mesh, fluxes, coordinate_map);
+  auto box = db::create<
+      db::AddSimpleTags<domain::Tags::Mesh<Dim>, flux_tag, map_tag>,
+      db::AddComputeTags<domain::Tags::LogicalCoordinates<Dim>, inv_jac_tag,
+                         Tags::DivCompute<flux_tag, inv_jac_tag>>>(
+      mesh, fluxes, coordinate_map);
 
   const auto& div_fluxes =
       db::get<Tags::div<Tags::Variables<div_tags>>>(box);

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
@@ -60,7 +60,7 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
   using simple_tags =
-      db::AddSimpleTags<::Tags::Mesh<dim>,
+      db::AddSimpleTags<domain::Tags::Mesh<dim>,
                         typename metavariables::system::variables_tag>;
 
   using phase_dependent_action_list = tmpl::list<

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -491,8 +491,8 @@ void test_partial_derivatives_compute_item(
     const std::array<size_t, Dim> extents_array, const T& map) noexcept {
   using vars_tags = tmpl::list<Var1<Dim>, Var2>;
   using map_tag = MapTag<std::decay_t<decltype(map)>>;
-  using inv_jac_tag =
-      Tags::InverseJacobianCompute<map_tag, Tags::LogicalCoordinates<Dim>>;
+  using inv_jac_tag = domain::Tags::InverseJacobianCompute<
+      map_tag, domain::Tags::LogicalCoordinates<Dim>>;
   using deriv_tag = Tags::DerivCompute<Tags::Variables<vars_tags>, inv_jac_tag>;
   using prefixed_variables_tag =
       db::add_tag_prefix<SomePrefix, Tags::Variables<vars_tags>>;
@@ -528,12 +528,12 @@ void test_partial_derivatives_compute_item(
         get<DerivativeTag>(expected_du) = Tag::df(array_to_functions, x);
       });
 
-  auto box =
-      db::create<db::AddSimpleTags<Tags::Mesh<Dim>, Tags::Variables<vars_tags>,
-                                   prefixed_variables_tag, map_tag>,
-                 db::AddComputeTags<Tags::LogicalCoordinates<Dim>, inv_jac_tag,
-                                    deriv_tag, deriv_prefixed_tag>>(
-          mesh, u, prefixed_vars, map);
+  auto box = db::create<
+      db::AddSimpleTags<domain::Tags::Mesh<Dim>, Tags::Variables<vars_tags>,
+                        prefixed_variables_tag, map_tag>,
+      db::AddComputeTags<domain::Tags::LogicalCoordinates<Dim>, inv_jac_tag,
+                         deriv_tag, deriv_prefixed_tag>>(mesh, u, prefixed_vars,
+                                                         map);
 
   const auto& du = db::get<deriv_tag>(box);
 

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
@@ -37,12 +37,12 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tags = tmpl::list<::Tags::Domain<Dim>>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<Dim>>;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
-                             tmpl::list<ActionTesting::InitializeDataBox<
-                                 tmpl::list<::Tags::InitialExtents<Dim>>>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<
+              tmpl::list<domain::Tags::InitialExtents<Dim>>>>>,
 
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
@@ -73,11 +73,12 @@ void check_compute_items(
     return ActionTesting::tag_is_retrievable<
         ElementArray<Dim, Metavariables<Dim>>, tag>(runner, element_id);
   };
-  CHECK(tag_is_retrievable(::Tags::Coordinates<Dim, Frame::Logical>{}));
-  CHECK(tag_is_retrievable(::Tags::Coordinates<Dim, Frame::Inertial>{}));
+  CHECK(tag_is_retrievable(domain::Tags::Coordinates<Dim, Frame::Logical>{}));
+  CHECK(tag_is_retrievable(domain::Tags::Coordinates<Dim, Frame::Inertial>{}));
   CHECK(tag_is_retrievable(
-      ::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>{}));
-  CHECK(tag_is_retrievable(::Tags::MinimumGridSpacing<Dim, Frame::Inertial>{}));
+      domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>{}));
+  CHECK(tag_is_retrievable(
+      domain::Tags::MinimumGridSpacing<Dim, Frame::Inertial>{}));
 }
 
 }  // namespace
@@ -112,16 +113,16 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
 
     check_compute_items(runner, element_id);
 
-    CHECK(get_tag(Tags::Mesh<1>{}) ==
+    CHECK(get_tag(domain::Tags::Mesh<1>{}) ==
           Mesh<1>{4, Spectral::Basis::Legendre,
                   Spectral::Quadrature::GaussLobatto});
-    CHECK(get_tag(Tags::Element<1>{}) ==
+    CHECK(get_tag(domain::Tags::Element<1>{}) ==
           Element<1>{element_id,
                      {{Direction<1>::lower_xi(),
                        {{{ElementId<1>{0, {{SegmentId{2, 0}}}}}}, {}}},
                       {Direction<1>::upper_xi(),
                        {{{ElementId<1>{0, {{SegmentId{2, 2}}}}}}, {}}}}});
-    const auto& element_map = get_tag(Tags::ElementMap<1>{});
+    const auto& element_map = get_tag(domain::Tags::ElementMap<1>{});
     const tnsr::I<DataVector, 1, Frame::Logical> logical_coords_for_element_map{
         {{{-1., -0.5, 0., 0.1, 1.}}}};
     const auto inertial_coords_from_element_map =
@@ -131,16 +132,16 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     CHECK_ITERABLE_APPROX(get<0>(inertial_coords_from_element_map),
                           get<0>(expected_inertial_coords));
     const auto& logical_coords =
-        get_tag(Tags::Coordinates<1, Frame::Logical>{});
+        get_tag(domain::Tags::Coordinates<1, Frame::Logical>{});
     CHECK(get<0>(logical_coords) ==
           Spectral::collocation_points<Spectral::Basis::Legendre,
                                        Spectral::Quadrature::GaussLobatto>(4));
     const auto& inertial_coords =
-        get_tag(Tags::Coordinates<1, Frame::Inertial>{});
+        get_tag(domain::Tags::Coordinates<1, Frame::Inertial>{});
     CHECK(inertial_coords == element_map(logical_coords));
-    CHECK(
-        get_tag(Tags::InverseJacobian<1, Frame::Logical, Frame::Inertial>{}) ==
-        element_map.inv_jacobian(logical_coords));
+    CHECK(get_tag(domain::Tags::InverseJacobian<1, Frame::Logical,
+                                                Frame::Inertial>{}) ==
+          element_map.inv_jacobian(logical_coords));
   }
   {
     INFO("2D");
@@ -176,12 +177,12 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
 
     check_compute_items(runner, element_id);
 
-    CHECK(get_tag(Tags::Mesh<2>{}) ==
+    CHECK(get_tag(domain::Tags::Mesh<2>{}) ==
           Mesh<2>{{{4, 3}},
                   Spectral::Basis::Legendre,
                   Spectral::Quadrature::GaussLobatto});
     CHECK(
-        get_tag(Tags::Element<2>{}) ==
+        get_tag(domain::Tags::Element<2>{}) ==
         Element<2>{
             element_id,
             {{Direction<2>::lower_xi(),
@@ -189,7 +190,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
              {Direction<2>::upper_xi(),
               {{{ElementId<2>{0, {{SegmentId{2, 2}, SegmentId{0, 0}}}}}},
                {}}}}});
-    const auto& element_map = get_tag(Tags::ElementMap<2>{});
+    const auto& element_map = get_tag(domain::Tags::ElementMap<2>{});
     const tnsr::I<DataVector, 2, Frame::Logical> logical_coords_for_element_map{
         {{{-1., -0.5, 0., 0.1, 1.}, {-1., -0.5, 0., 0.1, 1.}}}};
     const auto inertial_coords_from_element_map =
@@ -201,13 +202,13 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     CHECK_ITERABLE_APPROX(get<1>(inertial_coords_from_element_map),
                           get<1>(expected_inertial_coords));
     const auto& logical_coords =
-        get_tag(Tags::Coordinates<2, Frame::Logical>{});
+        get_tag(domain::Tags::Coordinates<2, Frame::Logical>{});
     const auto& inertial_coords =
-        get_tag(Tags::Coordinates<2, Frame::Inertial>{});
+        get_tag(domain::Tags::Coordinates<2, Frame::Inertial>{});
     CHECK(inertial_coords == element_map(logical_coords));
-    CHECK(
-        get_tag(Tags::InverseJacobian<2, Frame::Logical, Frame::Inertial>{}) ==
-        element_map.inv_jacobian(logical_coords));
+    CHECK(get_tag(domain::Tags::InverseJacobian<2, Frame::Logical,
+                                                Frame::Inertial>{}) ==
+          element_map.inv_jacobian(logical_coords));
   }
   {
     INFO("3D");
@@ -243,12 +244,12 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
 
     check_compute_items(runner, element_id);
 
-    CHECK(get_tag(Tags::Mesh<3>{}) ==
+    CHECK(get_tag(domain::Tags::Mesh<3>{}) ==
           Mesh<3>{{{4, 3, 2}},
                   Spectral::Basis::Legendre,
                   Spectral::Quadrature::GaussLobatto});
     CHECK(
-        get_tag(Tags::Element<3>{}) ==
+        get_tag(domain::Tags::Element<3>{}) ==
         Element<3>{
             element_id,
             {{Direction<3>::lower_xi(),
@@ -263,7 +264,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
               {{{ElementId<3>{
                    0, {{SegmentId{2, 1}, SegmentId{0, 0}, SegmentId{1, 0}}}}}},
                {}}}}});
-    const auto& element_map = get_tag(Tags::ElementMap<3>{});
+    const auto& element_map = get_tag(domain::Tags::ElementMap<3>{});
     const tnsr::I<DataVector, 3, Frame::Logical> logical_coords_for_element_map{
         {{{-1., -0.5, 0., 0.1, 1.},
           {-1., -0.5, 0., 0.1, 1.},
@@ -281,12 +282,12 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     CHECK_ITERABLE_APPROX(get<2>(inertial_coords_from_element_map),
                           get<2>(expected_inertial_coords));
     const auto& logical_coords =
-        get_tag(Tags::Coordinates<3, Frame::Logical>{});
+        get_tag(domain::Tags::Coordinates<3, Frame::Logical>{});
     const auto& inertial_coords =
-        get_tag(Tags::Coordinates<3, Frame::Inertial>{});
+        get_tag(domain::Tags::Coordinates<3, Frame::Inertial>{});
     CHECK(inertial_coords == element_map(logical_coords));
-    CHECK(
-        get_tag(Tags::InverseJacobian<3, Frame::Logical, Frame::Inertial>{}) ==
-        element_map.inv_jacobian(logical_coords));
+    CHECK(get_tag(domain::Tags::InverseJacobian<3, Frame::Logical,
+                                                Frame::Inertial>{}) ==
+          element_map.inv_jacobian(logical_coords));
   }
 }

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
@@ -63,13 +63,13 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tags = tmpl::list<::Tags::Domain<Dim>>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<Dim>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<
               ActionTesting::InitializeDataBox<tmpl::list<
-                  ::Tags::InitialExtents<Dim>, vars_tag, other_vars_tag>>,
+                  domain::Tags::InitialExtents<Dim>, vars_tag, other_vars_tag>>,
               dg::Actions::InitializeDomain<Dim>>>,
 
       Parallel::PhaseActions<
@@ -101,39 +101,42 @@ void check_compute_items(
     return ActionTesting::tag_is_retrievable<
         ElementArray<Dim, Metavariables<Dim>>, tag>(runner, element_id);
   };
-  CHECK(tag_is_retrievable(::Tags::InternalDirections<Dim>{}));
-  CHECK(tag_is_retrievable(::Tags::BoundaryDirectionsInterior<Dim>{}));
-  CHECK(tag_is_retrievable(::Tags::BoundaryDirectionsExterior<Dim>{}));
+  CHECK(tag_is_retrievable(domain::Tags::InternalDirections<Dim>{}));
+  CHECK(tag_is_retrievable(domain::Tags::BoundaryDirectionsInterior<Dim>{}));
+  CHECK(tag_is_retrievable(domain::Tags::BoundaryDirectionsExterior<Dim>{}));
+  CHECK(tag_is_retrievable(domain::Tags::Interface<
+                           domain::Tags::BoundaryDirectionsExterior<Dim>,
+                           domain::Tags::Coordinates<Dim, Frame::Inertial>>{}));
   CHECK(tag_is_retrievable(
-      ::Tags::Interface<::Tags::BoundaryDirectionsExterior<Dim>,
-                        ::Tags::Coordinates<Dim, Frame::Inertial>>{}));
+      domain::Tags::Interface<domain::Tags::InternalDirections<Dim>,
+                              vars_tag>{}));
   CHECK(tag_is_retrievable(
-      ::Tags::Interface<::Tags::InternalDirections<Dim>, vars_tag>{}));
+      domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<Dim>,
+                              vars_tag>{}));
   CHECK(tag_is_retrievable(
-      ::Tags::Interface<::Tags::BoundaryDirectionsInterior<Dim>, vars_tag>{}));
+      domain::Tags::Interface<domain::Tags::BoundaryDirectionsExterior<Dim>,
+                              other_vars_tag>{}));
   CHECK(tag_is_retrievable(
-      ::Tags::Interface<::Tags::BoundaryDirectionsExterior<Dim>,
-                        other_vars_tag>{}));
-  CHECK(tag_is_retrievable(::Tags::Interface<::Tags::InternalDirections<Dim>,
-                                             SomeComputeTag<vars_tag>>{}));
+      domain::Tags::Interface<domain::Tags::InternalDirections<Dim>,
+                              SomeComputeTag<vars_tag>>{}));
   CHECK(tag_is_retrievable(
-      ::Tags::Interface<::Tags::BoundaryDirectionsInterior<Dim>,
-                        SomeComputeTag<vars_tag>>{}));
+      domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<Dim>,
+                              SomeComputeTag<vars_tag>>{}));
   CHECK(tag_is_retrievable(
-      ::Tags::Interface<::Tags::BoundaryDirectionsExterior<Dim>,
-                        SomeComputeTag<other_vars_tag>>{}));
+      domain::Tags::Interface<domain::Tags::BoundaryDirectionsExterior<Dim>,
+                              SomeComputeTag<other_vars_tag>>{}));
   CHECK(tag_is_retrievable(
-      ::Tags::Interface<
-          ::Tags::InternalDirections<Dim>,
-          ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>{}));
+      domain::Tags::Interface<
+          domain::Tags::InternalDirections<Dim>,
+          ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>{}));
   CHECK(tag_is_retrievable(
-      ::Tags::Interface<
-          ::Tags::BoundaryDirectionsInterior<Dim>,
-          ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>{}));
+      domain::Tags::Interface<
+          domain::Tags::BoundaryDirectionsInterior<Dim>,
+          ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>{}));
   CHECK(tag_is_retrievable(
-      ::Tags::Interface<
-          ::Tags::BoundaryDirectionsExterior<Dim>,
-          ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim>>>{}));
+      domain::Tags::Interface<
+          domain::Tags::BoundaryDirectionsExterior<Dim>,
+          ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>{}));
 }
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
@@ -53,27 +53,29 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tags = tmpl::list<::Tags::Domain<Dim>>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<Dim>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<
               ActionTesting::InitializeDataBox<tmpl::list<
-                  ::Tags::InitialExtents<Dim>, ::Tags::Next<TemporalId>>>,
+                  domain::Tags::InitialExtents<Dim>, ::Tags::Next<TemporalId>>>,
               dg::Actions::InitializeDomain<Dim>,
-              Initialization::Actions::AddComputeTags<tmpl::list<
-                  ::Tags::InternalDirections<Dim>,
-                  ::Tags::BoundaryDirectionsInterior<Dim>,
-                  ::Tags::InterfaceCompute<::Tags::InternalDirections<Dim>,
-                                           ::Tags::Direction<Dim>>,
-                  ::Tags::InterfaceCompute<
-                      ::Tags::BoundaryDirectionsInterior<Dim>,
-                      ::Tags::Direction<Dim>>,
-                  ::Tags::InterfaceCompute<::Tags::InternalDirections<Dim>,
-                                           ::Tags::InterfaceMesh<Dim>>,
-                  ::Tags::InterfaceCompute<
-                      ::Tags::BoundaryDirectionsInterior<Dim>,
-                      ::Tags::InterfaceMesh<Dim>>>>>>,
+              Initialization::Actions::AddComputeTags<
+                  tmpl::list<domain::Tags::InternalDirections<Dim>,
+                             domain::Tags::BoundaryDirectionsInterior<Dim>,
+                             domain::Tags::InterfaceCompute<
+                                 domain::Tags::InternalDirections<Dim>,
+                                 domain::Tags::Direction<Dim>>,
+                             domain::Tags::InterfaceCompute<
+                                 domain::Tags::BoundaryDirectionsInterior<Dim>,
+                                 domain::Tags::Direction<Dim>>,
+                             domain::Tags::InterfaceCompute<
+                                 domain::Tags::InternalDirections<Dim>,
+                                 domain::Tags::InterfaceMesh<Dim>>,
+                             domain::Tags::InterfaceCompute<
+                                 domain::Tags::BoundaryDirectionsInterior<Dim>,
+                                 domain::Tags::InterfaceMesh<Dim>>>>>>,
 
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
@@ -153,13 +155,14 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeMortars", "[Unit][Actions]") {
     const auto& mortar_next_temporal_ids =
         get_tag(Tags::Mortars<Tags::Next<TemporalId>, 1>{});
     CHECK(mortar_next_temporal_ids.at(interface_mortar_id) == 0);
-    const auto& mortar_meshes = get_tag(Tags::Mortars<Tags::Mesh<0>, 1>{});
+    const auto& mortar_meshes =
+        get_tag(Tags::Mortars<domain::Tags::Mesh<0>, 1>{});
     CHECK(mortar_meshes.at(boundary_mortar_id) == Mesh<0>());
     CHECK(mortar_meshes.at(interface_mortar_id) == Mesh<0>());
     const auto& mortar_sizes = get_tag(Tags::Mortars<Tags::MortarSize<0>, 1>{});
     CHECK(mortar_sizes.at(boundary_mortar_id).empty());
     CHECK(mortar_sizes.at(interface_mortar_id).empty());
-    const auto& mortar_data = get_tag(Tags::VariablesBoundaryData{});
+    const auto& mortar_data = get_tag(domain::Tags::VariablesBoundaryData{});
     // Just make sure this exists, it is not expected to hold any data
     mortar_data.at(boundary_mortar_id);
     mortar_data.at(interface_mortar_id);
@@ -218,7 +221,8 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeMortars", "[Unit][Actions]") {
         get_tag(Tags::Mortars<Tags::Next<TemporalId>, 2>{});
     CHECK(mortar_next_temporal_ids.at(interface_mortar_id_east) == 0);
     CHECK(mortar_next_temporal_ids.at(interface_mortar_id_south) == 0);
-    const auto& mortar_meshes = get_tag(Tags::Mortars<Tags::Mesh<1>, 2>{});
+    const auto& mortar_meshes =
+        get_tag(Tags::Mortars<domain::Tags::Mesh<1>, 2>{});
     CHECK(mortar_meshes.at(boundary_mortar_id_west) ==
           Mesh<1>(2, Spectral::Basis::Legendre,
                   Spectral::Quadrature::GaussLobatto));
@@ -238,7 +242,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeMortars", "[Unit][Actions]") {
     CHECK(mortar_sizes.at(boundary_mortar_id_north) == expected_mortar_sizes);
     CHECK(mortar_sizes.at(interface_mortar_id_east) == expected_mortar_sizes);
     CHECK(mortar_sizes.at(interface_mortar_id_south) == expected_mortar_sizes);
-    const auto& mortar_data = get_tag(Tags::VariablesBoundaryData{});
+    const auto& mortar_data = get_tag(domain::Tags::VariablesBoundaryData{});
     // Just make sure this exists, it is not expected to hold any data
     mortar_data.at(boundary_mortar_id_west);
     mortar_data.at(boundary_mortar_id_north);
@@ -301,7 +305,8 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeMortars", "[Unit][Actions]") {
     CHECK(mortar_next_temporal_ids.at(interface_mortar_id_right) == 0);
     CHECK(mortar_next_temporal_ids.at(interface_mortar_id_front) == 0);
     CHECK(mortar_next_temporal_ids.at(interface_mortar_id_top) == 0);
-    const auto& mortar_meshes = get_tag(Tags::Mortars<Tags::Mesh<2>, 3>{});
+    const auto& mortar_meshes =
+        get_tag(Tags::Mortars<domain::Tags::Mesh<2>, 3>{});
     CHECK(mortar_meshes.at(boundary_mortar_id_left) ==
           Mesh<2>({{3, 4}}, Spectral::Basis::Legendre,
                   Spectral::Quadrature::GaussLobatto));
@@ -329,7 +334,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeMortars", "[Unit][Actions]") {
     CHECK(mortar_sizes.at(interface_mortar_id_right) == expected_mortar_sizes);
     CHECK(mortar_sizes.at(interface_mortar_id_front) == expected_mortar_sizes);
     CHECK(mortar_sizes.at(interface_mortar_id_top) == expected_mortar_sizes);
-    const auto& mortar_data = get_tag(Tags::VariablesBoundaryData{});
+    const auto& mortar_data = get_tag(domain::Tags::VariablesBoundaryData{});
     // Just make sure this exists, it is not expected to hold any data
     mortar_data.at(boundary_mortar_id_left);
     mortar_data.at(boundary_mortar_id_back);

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
@@ -220,7 +220,8 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   using metavariables = Metavariables<System>;
   using element_component = ElementComponent<metavariables>;
   using observer_component = MockObserverComponent<metavariables>;
-  using coordinates_tag = Tags::Coordinates<volume_dim, Frame::Inertial>;
+  using coordinates_tag =
+      domain::Tags::Coordinates<volume_dim, Frame::Inertial>;
 
   const typename element_component::array_index array_index(0);
   const size_t num_points = 5;

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -286,7 +286,8 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   constexpr size_t volume_dim = System::volume_dim;
   using element_component = ElementComponent<metavariables>;
   using observer_component = MockObserverComponent<metavariables>;
-  using coordinates_tag = Tags::Coordinates<volume_dim, Frame::Inertial>;
+  using coordinates_tag =
+      domain::Tags::Coordinates<volume_dim, Frame::Inertial>;
 
   const ElementId<volume_dim> element_id(2);
   const typename element_component::array_index array_index(element_id);
@@ -322,7 +323,7 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   ActionTesting::emplace_component<observer_component>(&runner, 0);
 
   const auto box = db::create<db::AddSimpleTags<
-      ObservationTimeTag, Tags::Mesh<volume_dim>,
+      ObservationTimeTag, domain::Tags::Mesh<volume_dim>,
       Tags::Variables<typename decltype(vars)::tags_list>,
       db::add_tag_prefix<Tags::Analytic, Tags::Variables<solution_variables>>>>(
       observation_time, mesh, vars, solutions);

--- a/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
@@ -47,7 +47,8 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ByBlock", "[Unit][Time]") {
   for (size_t block = 0; block < 3; ++block) {
     const Element<volume_dim> element(ElementId<volume_dim>(block), {});
     const auto box =
-        db::create<db::AddSimpleTags<Tags::Element<volume_dim>>>(element);
+        db::create<db::AddSimpleTags<domain::Tags::Element<volume_dim>>>(
+            element);
     const double expected = 0.5 * (block + 5);
 
     CHECK(by_block(element, current_step, cache) == expected);

--- a/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
@@ -58,16 +58,18 @@ double get_suggestion(const size_t stepper_order, const double safety_factor,
                       const DataVector& coordinates) noexcept {
   const Parallel::ConstGlobalCache<Metavariables> cache{{}};
   const auto box = db::create<
-      db::AddSimpleTags<CharacteristicSpeed, Tags::Coordinates<dim, frame>,
-                        Tags::Mesh<dim>, Tags::TimeStepper<TimeStepper>>,
-      db::AddComputeTags<Tags::MinimumGridSpacing<dim, frame>>>(
+      db::AddSimpleTags<
+          CharacteristicSpeed, domain::Tags::Coordinates<dim, frame>,
+          domain::Tags::Mesh<dim>, Tags::TimeStepper<TimeStepper>>,
+      db::AddComputeTags<domain::Tags::MinimumGridSpacing<dim, frame>>>(
       characteristic_speed, tnsr::I<DataVector, dim, frame>{{{coordinates}}},
       Mesh<dim>(coordinates.size(), Spectral::Basis::Legendre,
                 Spectral::Quadrature::GaussLobatto),
       db::item_type<Tags::TimeStepper<TimeStepper>>{
           std::make_unique<TimeSteppers::AdamsBashforthN>(stepper_order)});
 
-  const double grid_spacing = get<Tags::MinimumGridSpacing<dim, frame>>(box);
+  const double grid_spacing =
+      get<domain::Tags::MinimumGridSpacing<dim, frame>>(box);
   const auto& time_stepper = get<Tags::TimeStepper<TimeStepper>>(box);
 
   const Cfl cfl{safety_factor};


### PR DESCRIPTION
## Proposed changes

- Move the tags in `Domain/Tags.hpp` (and some others in `Domain`) into the `domain` namespace
- Factor out the domain option tags into an `OptionTags.hpp` file
- Move domain option tags into `domain::OptionTags`

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
