### PR TITLE
Add 2D time-dependent rotation map

### DIFF
--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
     Frustum.cpp
     Identity.cpp
     Rotation.cpp
+    RotationTimeDep.cpp
     SpecialMobius.cpp
     Translation.cpp
     Wedge2D.cpp

--- a/src/Domain/CoordinateMaps/RotationTimeDep.cpp
+++ b/src/Domain/CoordinateMaps/RotationTimeDep.cpp
@@ -1,0 +1,196 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/RotationTimeDep.hpp"
+
+#include <cmath>
+#include <ostream>
+#include <pup.h>
+#include <pup_stl.h>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace {
+Matrix rotation_matrix(
+    const std::string& f_of_t_name, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) noexcept {
+  ASSERT(functions_of_time.count(f_of_t_name) == 1,
+         "The function of time '" << f_of_t_name
+                                  << "' is not one of the known functions of "
+                                     "time. The known functions of time are: "
+                                  << keys_of(functions_of_time));
+  const double rotation_angle =
+      functions_of_time.at(f_of_t_name)->func(time)[0][0];
+  const Matrix rot_matrix{{cos(rotation_angle), -sin(rotation_angle)},
+                          {sin(rotation_angle), cos(rotation_angle)}};
+  return rot_matrix;
+}
+}  // namespace
+
+namespace domain {
+namespace CoordMapsTimeDependent {
+
+Rotation<2>::Rotation(std::string function_of_time_name) noexcept
+    : f_of_t_name_(std::move(function_of_time_name)) {}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 2> Rotation<2>::operator()(
+    const std::array<T, 2>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  const Matrix& rot_matrix =
+      rotation_matrix(f_of_t_name_, time, functions_of_time);
+  return {{source_coords[0] * rot_matrix(0, 0) +
+               source_coords[1] * rot_matrix(0, 1),
+           source_coords[0] * rot_matrix(1, 0) +
+               source_coords[1] * rot_matrix(1, 1)}};
+}
+
+boost::optional<std::array<double, 2>> Rotation<2>::inverse(
+    const std::array<double, 2>& target_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  const Matrix& rot_matrix =
+      rotation_matrix(f_of_t_name_, time, functions_of_time);
+  // The inverse map uses the inverse rotation matrix, which is just the
+  // transpose of the rotation matrix
+  return {{{target_coords[0] * rot_matrix(0, 0) +
+                target_coords[1] * rot_matrix(1, 0),
+            target_coords[0] * rot_matrix(0, 1) +
+                target_coords[1] * rot_matrix(1, 1)}}};
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 2> Rotation<2>::frame_velocity(
+    const std::array<T, 2>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  // The mapped coordinates (x,y) are related to the unmapped
+  // coordinates (\xi, \eta) by
+  //   x = \cos(\alpha) \xi - \sin(\alpha) \eta
+  //   y = \sin(\alpha) \xi + \cos(\alpha) \eta
+  //
+  // The frame velocity is
+  //   dx/dt = (-\sin(\alpha) \xi - \cos(\alpha)\eta) * d\alpha/dt
+  //   dy/dt = (\cos(\alpha) \xi -\sin(\alpha) \eta) * d\alpha/dt
+  const Matrix& rot_matrix =
+      rotation_matrix(f_of_t_name_, time, functions_of_time);
+  const double rotation_angular_velocity =
+      functions_of_time.at(f_of_t_name_)->func_and_deriv(time)[1][0];
+  return {{(source_coords[0] * rot_matrix(0, 1) -
+            source_coords[1] * rot_matrix(0, 0)) *
+               rotation_angular_velocity,
+           (source_coords[0] * rot_matrix(0, 0) +
+            source_coords[1] * rot_matrix(0, 1)) *
+               rotation_angular_velocity}};
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> Rotation<2>::jacobian(
+    const std::array<T, 2>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  const Matrix& rot_matrix =
+      rotation_matrix(f_of_t_name_, time, functions_of_time);
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> jacobian_matrix{
+      make_with_value<tt::remove_cvref_wrap_t<T>>(
+          dereference_wrapper(source_coords[0]), rot_matrix(0, 0))};
+  // rot_matrix(0, 0) == rot_matrix(1, 1), so only set off-diagonal terms
+  get<1, 0>(jacobian_matrix) = rot_matrix(1, 0);
+  get<0, 1>(jacobian_matrix) = rot_matrix(0, 1);
+  return jacobian_matrix;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame>
+Rotation<2>::inv_jacobian(
+    const std::array<T, 2>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  const Matrix& rot_matrix =
+      rotation_matrix(f_of_t_name_, time, functions_of_time);
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> inv_jacobian_matrix{
+      make_with_value<tt::remove_cvref_wrap_t<T>>(
+          dereference_wrapper(source_coords[0]), rot_matrix(0, 0))};
+  // The inverse jacobian is just the inverse rotation matrix, which is the
+  // transpose of the rotation matrix.
+  // Also, rot_matrix(0, 0) == rot_matrix(1, 1), so only set off-diagonal terms
+  get<1, 0>(inv_jacobian_matrix) = rot_matrix(0, 1);
+  get<0, 1>(inv_jacobian_matrix) = rot_matrix(1, 0);
+  return inv_jacobian_matrix;
+}
+
+void Rotation<2>::pup(PUP::er& p) noexcept { p | f_of_t_name_; }
+
+bool operator==(const Rotation<2>& lhs, const Rotation<2>& rhs) noexcept {
+  return lhs.f_of_t_name_ == rhs.f_of_t_name_;
+}
+
+bool operator!=(const Rotation<2>& lhs, const Rotation<2>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>      \
+  Rotation<DIM(data)>::operator()(                                          \
+      const std::array<DTYPE(data), DIM(data)>& source_coords, double time, \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time) const noexcept;                                \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>      \
+  Rotation<DIM(data)>::frame_velocity(                                      \
+      const std::array<DTYPE(data), DIM(data)>& source_coords,              \
+      const double time,                                                    \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time) const noexcept;                                \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),        \
+                    Frame::NoFrame>                                         \
+  Rotation<DIM(data)>::jacobian(                                            \
+      const std::array<DTYPE(data), DIM(data)>& source_coords, double time, \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time) const noexcept;                                \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),        \
+                    Frame::NoFrame>                                         \
+  Rotation<DIM(data)>::inv_jacobian(                                        \
+      const std::array<DTYPE(data), DIM(data)>& source_coords, double time, \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2),
+                        (double, DataVector,
+                         std::reference_wrapper<const double>,
+                         std::reference_wrapper<const DataVector>))
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond
+
+}  // namespace CoordMapsTimeDependent
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/RotationTimeDep.hpp
+++ b/src/Domain/CoordinateMaps/RotationTimeDep.hpp
@@ -1,0 +1,115 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+namespace domain {
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
+}  // namespace domain
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain {
+namespace CoordMapsTimeDependent {
+
+/// \cond HIDDEN_SYMBOLS
+template <size_t Dim>
+class Rotation;
+/// \endcond
+
+/*!
+ * \ingroup CoordMapsTimeDependentGroup
+ * \brief Time-dependent spatial rotation in two dimensions.
+ *
+ * Let \f$(R,\Phi)\f$ be the polar coordinates associated with
+ * \f$(\xi,\eta)\f$, where \f$\xi\f$ and \f$\eta\f$ are the unmapped
+ * coordiantes. Let \f$(r,\phi)\f$ be the polar coordinates associated with
+ * \f$(x,y)\f$, where \f$x\f$ and \f$y\f$ are the mapped coordinates.
+ * This map applies the spatial rotation \f$\phi = \Phi + \alpha(t)\f$.
+ *
+ * The formula for the mapping is:
+ *\f{eqnarray*}
+  x &=& \xi \cos \alpha(t) - \eta \sin \alpha(t), \\
+  y &=& \xi \sin \alpha(t) + \eta \cos \alpha(t).
+  \f}
+ *
+ * \note Currently, only a rotation in two-dimensional space is implemented
+ * here. In the future, this class should be extended to also support
+ * three-dimensional rotations using quaternions.
+ */
+template <>
+class Rotation<2> {
+ public:
+  static constexpr size_t dim = 2;
+
+  explicit Rotation(std::string function_of_time_name) noexcept;
+  Rotation() = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 2> operator()(
+      const std::array<T, 2>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  boost::optional<std::array<double, 2>> inverse(
+      const std::array<double, 2>& target_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 2> frame_velocity(
+      const std::array<T, 2>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> jacobian(
+      const std::array<T, 2>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 2>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  bool is_identity() const noexcept { return false; }
+
+ private:
+  friend bool operator==(const Rotation<2>& lhs,
+                         const Rotation<2>& rhs) noexcept;
+  std::string f_of_t_name_;
+};
+
+bool operator!=(const Rotation<2>& lhs, const Rotation<2>& rhs) noexcept;
+
+}  // namespace CoordMapsTimeDependent
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
   Test_ProductMaps.cpp
   Test_ProductMapsTimeDep.cpp
   Test_Rotation.cpp
+  Test_RotationTimeDep.cpp
   Test_SpecialMobius.cpp
   Test_TimeDependentHelpers.cpp
   Test_Translation.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_RotationTimeDep.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_RotationTimeDep.cpp
@@ -1,0 +1,144 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <boost/optional.hpp>
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/RotationTimeDep.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+class DataVector;
+namespace domain {
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
+}  // namespace domain
+
+namespace {
+std::array<double, 2> expected_mapped_point(
+    const std::array<double, 2> initial_unmapped_point,
+    const double time) noexcept {
+  const double rotation_angle = square(time);
+  return {{initial_unmapped_point[0] * cos(rotation_angle) -
+               initial_unmapped_point[1] * sin(rotation_angle),
+           initial_unmapped_point[0] * sin(rotation_angle) +
+               initial_unmapped_point[1] * cos(rotation_angle)}};
+}
+
+std::array<double, 2> expected_frame_velocity(
+    const std::array<double, 2> initial_unmapped_point,
+    const double time) noexcept {
+  const double rotation_angle = square(time);
+  const double angular_velocity = 2.0 * time;
+  return {
+      {initial_unmapped_point[0] * -sin(rotation_angle) * angular_velocity -
+           initial_unmapped_point[1] * cos(rotation_angle) * angular_velocity,
+       initial_unmapped_point[0] * cos(rotation_angle) * angular_velocity +
+           initial_unmapped_point[1] * -sin(rotation_angle) *
+               angular_velocity}};
+}
+}  // namespace
+
+namespace domain {
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.RotationTimeDep",
+                  "[Domain][Unit]") {
+  double t{-1.0};
+  const double dt{0.6};
+  const double final_time{4.0};
+  constexpr size_t deriv_order{3};
+  constexpr size_t spatial_dim{2};
+
+  using Polynomial = domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
+  using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
+
+  const std::string f_of_t_name{"rotation_angle"};
+  const std::array<DataVector, deriv_order + 1> init_func{
+      {{1.0}, {-2.0}, {2.0}, {0.0}}};
+  std::unordered_map<std::string, FoftPtr> f_of_t_list{};
+  f_of_t_list[f_of_t_name] = std::make_unique<Polynomial>(t, init_func);
+
+  const CoordMapsTimeDependent::Rotation<spatial_dim> rotation_map{f_of_t_name};
+  const auto rotation_map_deserialized =
+      serialize_and_deserialize(rotation_map);
+
+  const std::array<double, 2> initial_unmapped_point{{3.2, 4.5}};
+
+  while (t < final_time) {
+    const std::array<double, 2> expected{
+        expected_mapped_point(initial_unmapped_point, t)};
+    CHECK_ITERABLE_APPROX(rotation_map(initial_unmapped_point, t, f_of_t_list),
+                          expected);
+    CHECK_ITERABLE_APPROX(rotation_map.inverse(expected, t, f_of_t_list).get(),
+                          initial_unmapped_point);
+    CHECK_ITERABLE_APPROX(
+        rotation_map.frame_velocity(initial_unmapped_point, t, f_of_t_list),
+        expected_frame_velocity(initial_unmapped_point, t));
+
+    CHECK_ITERABLE_APPROX(
+        rotation_map_deserialized(initial_unmapped_point, t, f_of_t_list),
+        expected);
+    CHECK_ITERABLE_APPROX(
+        rotation_map_deserialized.inverse(expected, t, f_of_t_list).get(),
+        initial_unmapped_point);
+    CHECK_ITERABLE_APPROX(rotation_map_deserialized.frame_velocity(
+                              initial_unmapped_point, t, f_of_t_list),
+                          expected_frame_velocity(initial_unmapped_point, t));
+
+    const auto jac{
+        rotation_map.jacobian(initial_unmapped_point, t, f_of_t_list)};
+    const auto inv_jac{
+        rotation_map.inv_jacobian(initial_unmapped_point, t, f_of_t_list)};
+    const double cos_t_squared{cos(square(t))};
+    const double sin_t_squared{sin(square(t))};
+
+    CHECK(get<0, 0>(jac) == approx(cos_t_squared));
+    CHECK(get<0, 1>(jac) == approx(-sin_t_squared));
+    CHECK(get<1, 0>(jac) == approx(sin_t_squared));
+    CHECK(get<1, 1>(jac) == approx(cos_t_squared));
+
+    CHECK(get<0, 0>(inv_jac) == approx(cos_t_squared));
+    CHECK(get<0, 1>(inv_jac) == approx(sin_t_squared));
+    CHECK(get<1, 0>(inv_jac) == approx(-sin_t_squared));
+    CHECK(get<1, 1>(inv_jac) == approx(cos_t_squared));
+
+    const auto jac_deserialized{rotation_map_deserialized.jacobian(
+        initial_unmapped_point, t, f_of_t_list)};
+    const auto inv_jac_deserialized{rotation_map_deserialized.inv_jacobian(
+        initial_unmapped_point, t, f_of_t_list)};
+    CHECK(get<0, 0>(jac_deserialized) == approx(cos_t_squared));
+    CHECK(get<0, 1>(jac_deserialized) == approx(-sin_t_squared));
+    CHECK(get<1, 0>(jac_deserialized) == approx(sin_t_squared));
+    CHECK(get<1, 1>(jac_deserialized) == approx(cos_t_squared));
+
+    CHECK(get<0, 0>(inv_jac_deserialized) == approx(cos_t_squared));
+    CHECK(get<0, 1>(inv_jac_deserialized) == approx(sin_t_squared));
+    CHECK(get<1, 0>(inv_jac_deserialized) == approx(-sin_t_squared));
+    CHECK(get<1, 1>(inv_jac_deserialized) == approx(cos_t_squared));
+
+    t += dt;
+  }
+
+  // Check inequivalence operator
+  CHECK_FALSE(rotation_map != rotation_map);
+  CHECK_FALSE(rotation_map_deserialized != rotation_map_deserialized);
+
+  // Check serialization
+  CHECK(rotation_map == rotation_map_deserialized);
+  CHECK_FALSE(rotation_map != rotation_map_deserialized);
+
+  test_coordinate_map_argument_types(rotation_map, initial_unmapped_point, t,
+                                     f_of_t_list);
+  CHECK(not CoordMapsTimeDependent::Rotation<spatial_dim>{}.is_identity());
+}
+}  // namespace domain


### PR DESCRIPTION
## Proposed changes

This PR creates a new CoordinateMap that implements a 2D time-dependent rotation. 

Currently, spectre has static 2D and 3D (Euler-angle) rotation maps. This PR adds a 2D time-dependent rotation map. A 3D time-dependent rotation map using quaternions will be added in the future, but not in this PR.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
