### PR TITLE
Add conversion of a CoordinateMapBase to go to Frame::Grid

### DIFF
--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -59,6 +59,15 @@ class CoordinateMapBase : public PUP::able {
   virtual std::unique_ptr<CoordinateMapBase<SourceFrame, TargetFrame, Dim>>
   get_clone() const = 0;
 
+  /// \brief Retrieve the same map but going from `SourceFrame` to
+  /// `Frame::Grid`.
+  ///
+  /// This functionality is needed when composing time-dependent maps with
+  /// time-independent maps, where the target frame of the time-independent map
+  /// is `Frame::Grid`.
+  virtual std::unique_ptr<CoordinateMapBase<SourceFrame, Frame::Grid, Dim>>
+  get_to_grid_frame() const = 0;
+
   /// Returns `true` if the map is the identity
   virtual bool is_identity() const noexcept = 0;
 
@@ -74,21 +83,21 @@ class CoordinateMapBase : public PUP::able {
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
       const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+      functions_of_time = std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
   virtual tnsr::I<DataVector, Dim, TargetFrame> operator()(
       tnsr::I<DataVector, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
       const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+      functions_of_time = std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
   // @}
 
@@ -102,11 +111,11 @@ class CoordinateMapBase : public PUP::able {
       tnsr::I<double, Dim, TargetFrame> target_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
       const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+      functions_of_time = std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
   // @}
 
@@ -117,22 +126,22 @@ class CoordinateMapBase : public PUP::able {
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
       const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+      functions_of_time = std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
   virtual InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>
   inv_jacobian(
       tnsr::I<DataVector, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
       const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+      functions_of_time = std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
   // @}
 
@@ -142,21 +151,21 @@ class CoordinateMapBase : public PUP::able {
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
       const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+      functions_of_time = std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
   virtual Jacobian<DataVector, Dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<DataVector, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
       const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+      functions_of_time = std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
   // @}
 
@@ -171,12 +180,12 @@ class CoordinateMapBase : public PUP::able {
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
       const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
-      noexcept = 0;
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+      functions_of_time = std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
+  noexcept = 0;
   virtual std::tuple<tnsr::I<DataVector, Dim, TargetFrame>,
                      InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>,
                      Jacobian<DataVector, Dim, SourceFrame, TargetFrame>,
@@ -185,12 +194,12 @@ class CoordinateMapBase : public PUP::able {
       tnsr::I<DataVector, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
       const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
-      noexcept = 0;
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+      functions_of_time = std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
+  noexcept = 0;
   // @}
 
  private:
@@ -254,6 +263,11 @@ class CoordinateMap
   std::unique_ptr<CoordinateMapBase<SourceFrame, TargetFrame, dim>> get_clone()
       const override {
     return std::make_unique<CoordinateMap>(*this);
+  }
+
+  std::unique_ptr<CoordinateMapBase<SourceFrame, Frame::Grid, dim>>
+  get_to_grid_frame() const override {
+    return get_to_grid_frame_impl(std::make_index_sequence<sizeof...(Maps)>{});
   }
 
   /// Returns `true` if the map is the identity
@@ -454,6 +468,11 @@ class CoordinateMap
   push_front_impl(
       CoordinateMap<LocalSourceFrame, LocalTargetFrame, LocalMaps...>&& old_map,
       NewMap new_map, std::index_sequence<Is...> /*meta*/) noexcept;
+
+  template <size_t... Is>
+  std::unique_ptr<CoordinateMapBase<SourceFrame, Frame::Grid, dim>>
+      get_to_grid_frame_impl(std::index_sequence<Is...> /*meta*/) const
+      noexcept;
 
   bool is_equal_to(const CoordinateMapBase<SourceFrame, TargetFrame, dim>&
                        other) const override {

--- a/src/Domain/CoordinateMaps/CoordinateMap.tpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.tpp
@@ -509,6 +509,15 @@ auto CoordinateMap<SourceFrame, TargetFrame, Maps...>::
 }
 
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
+template <size_t... Is>
+auto CoordinateMap<SourceFrame, TargetFrame, Maps...>::get_to_grid_frame_impl(
+    std::index_sequence<Is...> /*meta*/) const noexcept
+    -> std::unique_ptr<CoordinateMapBase<SourceFrame, Frame::Grid, dim>> {
+  return std::make_unique<CoordinateMap<SourceFrame, Frame::Grid, Maps...>>(
+      std::get<Is>(maps_)...);
+}
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
 bool operator!=(
     const CoordinateMap<SourceFrame, TargetFrame, Maps...>& lhs,
     const CoordinateMap<SourceFrame, TargetFrame, Maps...>& rhs) noexcept {


### PR DESCRIPTION
## Proposed changes

For injecting time dependence into the domain we need to be able to take a
coordinate map that goes from Frame::Logical to Frame::Inertial to a map that
goes from Frame::Logical to Frame::Grid.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
