### PR TITLE
CCE executable

### DIFF
--- a/src/DataStructures/SpinWeighted.hpp
+++ b/src/DataStructures/SpinWeighted.hpp
@@ -99,6 +99,9 @@ struct SpinWeighted<T, Spin, false> {
 
  size_t size() const noexcept { return data_.size(); }
 
+  /// Serialization for Charm++
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
  private:
   T data_;
 };
@@ -202,10 +205,23 @@ struct SpinWeighted<T, Spin, true> {
 
   size_t size() const noexcept { return data_.size(); }
 
+  /// Serialization for Charm++
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
  private:
   T data_;
 };
 // @}
+
+template <typename T, int Spin>
+void SpinWeighted<T, Spin, true>::pup(PUP::er& p) noexcept {
+  p | data_;
+}
+
+template <typename T, int Spin>
+void SpinWeighted<T, Spin, false>::pup(PUP::er& p) noexcept {
+  p | data_;
+}
 
 // @{
 /// \ingroup TypeTraitsGroup

--- a/src/Evolution/Systems/Cce/Actions/CalculateScriInputs.hpp
+++ b/src/Evolution/Systems/Cce/Actions/CalculateScriInputs.hpp
@@ -1,0 +1,95 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/Cce/PreSwshDerivatives.hpp"
+#include "Evolution/Systems/Cce/SwshDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce {
+namespace Actions {
+
+/*!
+ * \ingroup Actions
+ * \brief Calculates the Bondi quantities that are required for any of the
+ * `CalculateScriPlusValue` mutators.
+ *
+ * \details Internally dispatches to the `PreSwshDerivatives` and
+ * `Spectral::Swsh::AngularDerivatives` utilities to perform the radial and
+ * angular differentiation that is required to prepare all of the Bondi
+ * quantities needed for evaluating the scri+ values. This relies on the
+ * typelists `Cce::all_pre_swsh_derivative_tags_for_scri`,
+ * `Cce::all_boundary_pre_swsh_derivative_tags_for_scri`,
+ * `Cce::all_swsh_derivative_tags_for_scri`, and
+ * `Cce::all_boundary_swsh_derivative_tags_for_scri` to determine which
+ * calculations to perform.
+ */
+struct CalculateScriInputs {
+  using const_global_cache_tags =
+      tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTags>&&> apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    tmpl::for_each<
+        tmpl::append<all_pre_swsh_derivative_tags_for_scri,
+                     all_boundary_pre_swsh_derivative_tags_for_scri>>([&box](
+        auto pre_swsh_derivative_tag_v) noexcept {
+      using pre_swsh_derivative_tag =
+          typename decltype(pre_swsh_derivative_tag_v)::type;
+      db::mutate_apply<PreSwshDerivatives<pre_swsh_derivative_tag>>(
+          make_not_null(&box));
+    });
+
+    db::mutate_apply<
+        Spectral::Swsh::AngularDerivatives<all_swsh_derivative_tags_for_scri>>(
+        make_not_null(&box));
+    boundary_derivative_impl(box, db::get<Tags::LMax>(box),
+                             all_boundary_swsh_derivative_tags_for_scri{});
+
+    tmpl::for_each<all_swsh_derivative_tags_for_scri>([&box](
+        auto derivative_tag_v) noexcept {
+      using derivative_tag = typename decltype(derivative_tag_v)::type;
+      ::Cce::detail::apply_swsh_jacobian_helper<derivative_tag>(
+          make_not_null(&box), typename ApplySwshJacobianInplace<
+                                   derivative_tag>::on_demand_argument_tags{});
+    });
+    return {std::move(box)};
+  }
+
+  template <typename DbTags, typename... TagPack>
+  static void boundary_derivative_impl(
+      db::DataBox<DbTags>& box, const size_t l_max,
+      tmpl::list<TagPack...> /*meta*/) noexcept {
+    db::mutate<TagPack...>(
+        make_not_null(&box),
+        [&l_max](const gsl::not_null<db::item_type<TagPack>*>... derivatives,
+                 const db::item_type<
+                     typename TagPack::derivative_of>&... arguments) noexcept {
+          Spectral::Swsh::angular_derivatives<
+              tmpl::list<typename TagPack::derivative_kind...>>(
+              l_max, 1, make_not_null(&get(*derivatives))...,
+              get(arguments)...);
+        },
+        db::get<typename TagPack::derivative_of>(box)...);
+  }
+};
+}  // namespace Actions
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/Actions/InitializeFirstHypersurface.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeFirstHypersurface.hpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/Systems/Cce/InitializeCce.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/Cce/ScriPlusValues.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce {
+namespace Actions {
+
+/*!
+ * \ingroup Actions
+ * \brief Given initial boundary data for \f$J\f$ and \f$\partial_r J\f$,
+ * computes the initial hypersurface quantities \f$J\f$ and gauge values.
+ *
+ * \details This action is to be called after boundary data has been received,
+ * but before the time-stepping evolution loop. So, it should be either late in
+ * an initialization phase or early (before a `Actions::Goto` loop or similar)
+ * in the `Evolve` phase.
+ *
+ * Internally, this dispatches to
+ * `Metavariables::cce_hypersufrace_initialization`, which designates a
+ * hypersurface initial data generator, `InitializeGauge`,
+ * and `InitializeScriPlusValue<Tags::InertialRetardedTime>` to perform the
+ * computations. Refer to the documentation for those mutators for mathematical
+ * details.
+ */
+struct InitializeFirstHypersurface {
+  using const_global_cache_tags =
+      tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTags>&&> apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate_apply<typename Metavariables::cce_hypersurface_initialization>(
+        make_not_null(&box));
+    db::mutate_apply<InitializeGauge>(make_not_null(&box));
+    db::mutate_apply<InitializeScriPlusValue<Tags::InertialRetardedTime>>(
+        make_not_null(&box));
+    return {std::move(box)};
+  }
+};
+}  // namespace Actions
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/Actions/RequestBoundaryData.hpp
+++ b/src/Evolution/Systems/Cce/Actions/RequestBoundaryData.hpp
@@ -92,10 +92,14 @@ struct RequestNextBoundaryData {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    Parallel::simple_action<
-        Actions::BoundaryComputeAndSendToEvolution<EvolutionComponent>>(
-        Parallel::get_parallel_component<WorldtubeBoundaryComponent>(cache),
-        db::get<::Tags::Next<::Tags::TimeStepId>>(box));
+    // only request the data if the next step is not after the end time.
+    if (db::get<::Tags::Next<::Tags::TimeStepId>>(box).substep_time().value() <
+        db::get<Tags::EndTime>(box)) {
+      Parallel::simple_action<
+          Actions::BoundaryComputeAndSendToEvolution<EvolutionComponent>>(
+          Parallel::get_parallel_component<WorldtubeBoundaryComponent>(cache),
+          db::get<::Tags::Next<::Tags::TimeStepId>>(box));
+    }
     return std::forward_as_tuple(std::move(box));
   }
 };

--- a/src/Evolution/Systems/Cce/Actions/UpdateGauge.hpp
+++ b/src/Evolution/Systems/Cce/Actions/UpdateGauge.hpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce {
+namespace Actions {
+
+/*!
+ * \ingroup Actions
+ * \brief Updates all of the gauge quantities associated with the additional
+ * regularity-preserving gauge transformation on the boundaries for a new set of
+ * Cauchy coordinates.
+ *
+ * \details This action is to be called after `Tags::CauchyCartesianCoords` has
+ * been updated, typically via a time step of a set of coordinate evolution
+ * equations. It prepares the gauge quantities in the \ref DataBoxGroup for
+ * calls to the individual `GaugeAdjustedBoundaryValue` specializations.
+ *
+ * Internally, this dispatches to `GaugeUpdateAngularFromCartesian`,
+ * `GaugeUpdateJacobianFromCoordinates`, `GaugeUpdateInterpolator`, and
+ * `GaugeUpdateOmega` to perform the computations. Refer to the documentation
+ * for those mutators for mathematical details.
+ */
+struct UpdateGauge {
+  using const_global_cache_tags = tmpl::list<Tags::LMax>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTags>&&> apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate_apply<GaugeUpdateAngularFromCartesian<
+        Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords>>(
+        make_not_null(&box));
+    db::mutate_apply<GaugeUpdateJacobianFromCoordinates<
+        Tags::GaugeC, Tags::GaugeD, Tags::CauchyAngularCoords,
+        Tags::CauchyCartesianCoords>>(make_not_null(&box));
+    db::mutate_apply<GaugeUpdateInterpolator<Tags::CauchyAngularCoords>>(
+        make_not_null(&box));
+    db::mutate_apply<GaugeUpdateOmega>(make_not_null(&box));
+    return {std::move(box)};
+  }
+};
+}  // namespace Actions
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -5,13 +5,32 @@
 
 #include <type_traits>
 
+#include "Evolution/Systems/Cce/Actions/BoundaryComputeAndSendToEvolution.hpp"
+#include "Evolution/Systems/Cce/Actions/CalculateScriInputs.hpp"
+#include "Evolution/Systems/Cce/Actions/CharacteristicEvolutionBondiCalculations.hpp"
+#include "Evolution/Systems/Cce/Actions/FilterSwshVolumeQuantity.hpp"
 #include "Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionScri.hpp"
 #include "Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp"
 #include "Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionVariables.hpp"
+#include "Evolution/Systems/Cce/Actions/InitializeFirstHypersurface.hpp"
+#include "Evolution/Systems/Cce/Actions/InsertInterpolationScriData.hpp"
+#include "Evolution/Systems/Cce/Actions/RequestBoundaryData.hpp"
+#include "Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp"
+#include "Evolution/Systems/Cce/Actions/TimeManagement.hpp"
+#include "Evolution/Systems/Cce/Actions/UpdateGauge.hpp"
+#include "Evolution/Systems/Cce/LinearSolve.hpp"
+#include "Evolution/Systems/Cce/PreSwshDerivatives.hpp"
+#include "Evolution/Systems/Cce/PrecomputeCceDependencies.hpp"
+#include "Evolution/Systems/Cce/ScriPlusValues.hpp"
+#include "Evolution/Systems/Cce/SwshDerivatives.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
+#include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/RecordTimeStepperData.hpp"
+#include "Time/Actions/UpdateU.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
@@ -62,7 +81,10 @@ namespace Cce {
  * modal representation. (typically `Cce::all_transform_buffer_tags`).
  *  - `cce_angular_coordinate_tags`: A typelist of real-valued angular
  * coordinates that are not evolved.
- *  - `cce_scri_tags` - the tags of quantities to compute at scri+
+ *  - `cce_scri_tags`: the tags of quantities to compute at scri+
+ *  - `cce_hypersurface_initialization`: a mutator (for use with
+ * `::Actions::MutateApply`) that is used to compute the initial hypersurface
+ * data from the boundary data.
  */
 template <class Metavariables>
 struct CharacteristicEvolution {
@@ -73,20 +95,82 @@ struct CharacteristicEvolution {
       tmpl::list<Actions::InitializeCharacteristicEvolutionVariables,
                  Actions::InitializeCharacteristicEvolutionTime,
                  Actions::InitializeCharacteristicEvolutionScri,
+                 Actions::RequestBoundaryData<
+                     typename Metavariables::cce_boundary_component,
+                     CharacteristicEvolution<Metavariables>>,
+                 Actions::ReceiveWorldtubeData<Metavariables>,
+                 Actions::InitializeFirstHypersurface,
                  Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;
 
-  using extract_action_list = tmpl::list<::Actions::AdvanceTime>;
+  // the list of actions that occur for each of the hypersurface-integrated
+  // Bondi tags
+  template <typename BondiTag>
+  using hypersurface_computation = tmpl::list<
+      ::Actions::MutateApply<GaugeAdjustedBoundaryValue<BondiTag>>,
+      Actions::CalculateIntegrandInputsForTag<BondiTag>,
+      tmpl::transform<integrand_terms_to_compute_for_bondi_variable<BondiTag>,
+                      tmpl::bind<::Actions::MutateApply,
+                                 tmpl::bind<ComputeBondiIntegrand, tmpl::_1>>>,
+      ::Actions::MutateApply<
+          RadialIntegrateBondi<Tags::EvolutionGaugeBoundaryValue, BondiTag>>,
+      // Once we finish the U computation, we need to update all the quantities
+      // that depend on the time derivative of the gauge
+      tmpl::conditional_t<
+          cpp17::is_same_v<BondiTag, Tags::BondiU>,
+          tmpl::list<
+              ::Actions::MutateApply<GaugeUpdateTimeDerivatives>,
+              ::Actions::MutateApply<
+                  GaugeAdjustedBoundaryValue<Tags::DuRDividedByR>>,
+              ::Actions::MutateApply<PrecomputeCceDependencies<
+                  Tags::EvolutionGaugeBoundaryValue, Tags::DuRDividedByR>>>,
+          tmpl::list<>>>;
 
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
-                             initialize_action_list>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Evolve,
-                             extract_action_list>>;
+  using compute_scri_quantities_and_observe = tmpl::list<
+      ::Actions::MutateApply<
+          CalculateScriPlusValue<::Tags::dt<Tags::InertialRetardedTime>>>,
+      Actions::CalculateScriInputs,
+      tmpl::transform<typename metavariables::cce_scri_tags,
+                      tmpl::bind<::Actions::MutateApply,
+                                 tmpl::bind<CalculateScriPlusValue, tmpl::_1>>>,
+      tmpl::transform<
+          typename metavariables::scri_values_to_observe,
+          tmpl::bind<Actions::InsertInterpolationScriData, tmpl::_1>>,
+      Actions::ScriObserveInterpolated<
+          observers::ObserverWriter<Metavariables>>>;
+
+  using record_time_stepper_data_and_step =
+      tmpl::list<::Actions::RecordTimeStepperData<
+                     typename Metavariables::evolved_coordinates_variables_tag>,
+                 ::Actions::RecordTimeStepperData<::Tags::Variables<
+                     tmpl::list<typename Metavariables::evolved_swsh_tag>>>,
+                 ::Actions::UpdateU<
+                     typename Metavariables::evolved_coordinates_variables_tag>,
+                 ::Actions::UpdateU<::Tags::Variables<
+                     tmpl::list<typename Metavariables::evolved_swsh_tag>>>,
+                 ::Actions::AdvanceTime>;
+
+  using extract_action_list = tmpl::list<
+      Actions::RequestNextBoundaryData<
+          typename Metavariables::cce_boundary_component,
+          CharacteristicEvolution<Metavariables>>,
+      Actions::UpdateGauge, Actions::PrecomputeGlobalCceDependencies,
+      tmpl::transform<bondi_hypersurface_step_tags,
+                      tmpl::bind<hypersurface_computation, tmpl::_1>>,
+      Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
+      compute_scri_quantities_and_observe, record_time_stepper_data_and_step,
+      Actions::ExitIfEndTimeReached,
+      Actions::ReceiveWorldtubeData<Metavariables>>;
+
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        initialize_action_list>,
+                 Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Evolve,
+                                        extract_action_list>>;
 
   using const_global_cache_tag_list =
       Parallel::get_const_global_cache_tags_from_actions<
@@ -100,12 +184,9 @@ struct CharacteristicEvolution {
       const Parallel::CProxy_ConstGlobalCache<Metavariables>&
           global_cache) noexcept {
     auto& local_cache = *(global_cache.ckLocalBranch());
-    if (next_phase == Metavariables::Phase::RegisterWithObserver or
-        next_phase == Metavariables::Phase::Evolve) {
-      Parallel::get_parallel_component<CharacteristicEvolution<Metavariables>>(
-          local_cache)
-          .start_phase(next_phase);
-    }
+    Parallel::get_parallel_component<CharacteristicEvolution<Metavariables>>(
+        local_cache)
+        .start_phase(next_phase);
   }
 };
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/IntegrandInputSteps.hpp
+++ b/src/Evolution/Systems/Cce/IntegrandInputSteps.hpp
@@ -253,6 +253,35 @@ using second_swsh_derivative_tags_to_compute_for_t =
     typename single_swsh_derivative_tags_to_compute_for<Tag>::type;
 // @}
 
+/// Typelist of steps for `SwshDerivatives` mutations called on volume
+/// quantities needed for scri+ computations
+using all_swsh_derivative_tags_for_scri = tmpl::list<
+    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiU>,
+                                     Spectral::Swsh::Tags::Eth>,
+    Spectral::Swsh::Tags::Derivative<
+        Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                         Spectral::Swsh::Tags::EthEthbar>,
+        Spectral::Swsh::Tags::Ethbar>,
+    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::Du<Tags::BondiJ>>,
+                                     Spectral::Swsh::Tags::Ethbar>,
+    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::Dy<Tags::BondiU>>,
+                                     Spectral::Swsh::Tags::Ethbar>,
+    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiQ>,
+                                     Spectral::Swsh::Tags::Ethbar>,
+    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::Dy<Tags::BondiBeta>>,
+                                     Spectral::Swsh::Tags::Eth>>;
+
+/// Typelist of steps for `PreSwshDerivatives` mutations called on boundary
+/// (angular grid only) quantities needed for scri+ computations
+using all_boundary_pre_swsh_derivative_tags_for_scri =
+    tmpl::list<Tags::ComplexInertialRetardedTime>;
+
+/// Typelist of steps for `SwshDerivatives` mutations called on boundary
+/// (angular grid only) quantities needed for scri+ computations
+using all_boundary_swsh_derivative_tags_for_scri =
+    tmpl::list<Spectral::Swsh::Tags::Derivative<
+        Tags::ComplexInertialRetardedTime, Spectral::Swsh::Tags::EthEth>>;
+
 /*!
  * \brief A typelist for the set of tags computed by spin-weighted
  * differentiation using utilities from the `Swsh` namespace.
@@ -270,11 +299,13 @@ using second_swsh_derivative_tags_to_compute_for_t =
  * typelist `bondi_hypersurface_step_tags`.
  */
 using all_swsh_derivative_tags =
-    tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
-        bondi_hypersurface_step_tags,
-        tmpl::bind<tmpl::list,
-                   single_swsh_derivative_tags_to_compute_for<tmpl::_1>,
-                   second_swsh_derivative_tags_to_compute_for<tmpl::_1>>>>>;
+    tmpl::remove_duplicates<tmpl::flatten<tmpl::list<
+        tmpl::transform<
+            bondi_hypersurface_step_tags,
+            tmpl::bind<tmpl::list,
+                       single_swsh_derivative_tags_to_compute_for<tmpl::_1>,
+                       second_swsh_derivative_tags_to_compute_for<tmpl::_1>>>,
+        all_swsh_derivative_tags_for_scri>>>;
 
 /*!
  * \brief A typelist for the full set of coefficient buffers needed to process
@@ -307,10 +338,16 @@ struct additional_pre_swsh_derivative_tags_for {
 /// Typelist of steps for `PreSwshDerivatives` mutations needed for scri+
 /// computations
 using all_pre_swsh_derivative_tags_for_scri =
-    tmpl::list<Tags::Dy<Tags::Du<Tags::BondiJ>>,
+    tmpl::list<Tags::Du<Tags::BondiJ>, Tags::Dy<Tags::Du<Tags::BondiJ>>,
+               Tags::Dy<Tags::Dy<Tags::Du<Tags::BondiJ>>>,
                Tags::Dy<Tags::Dy<Tags::BondiW>>,
+               Tags::Dy<Tags::Dy<Tags::BondiQ>>,
+               Tags::Dy<Tags::Dy<Tags::BondiU>>,
                Tags::Dy<Tags::Dy<Tags::Dy<Tags::BondiJ>>>,
-               Tags::ComplexInertialRetardedTime>;
+               Tags::Dy<Tags::Dy<Tags::Dy<Tags::BondiU>>>,
+               Tags::Dy<Tags::Dy<Tags::Dy<Tags::BondiBeta>>>,
+               Tags::Dy<Spectral::Swsh::Tags::Derivative<
+                   Tags::BondiBeta, Spectral::Swsh::Tags::EthEthbar>>>;
 
 /*!
  * \brief A typelist for the full set of tags needed as direct or indirect
@@ -332,30 +369,5 @@ using all_pre_swsh_derivative_tags =
                 detail::additional_pre_swsh_derivative_tags_for<tmpl::_1>>>,
         all_pre_swsh_derivative_tags_for_scri>>>;
 
-/// Typelist of steps for `SwshDerivatives` mutations called on volume
-/// quantities needed for scri+ computations
-using all_swsh_derivative_tags_for_scri = tmpl::list<
-    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiU>,
-                                     Spectral::Swsh::Tags::Eth>,
-    Spectral::Swsh::Tags::Derivative<
-        Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
-                                         Spectral::Swsh::Tags::EthEthbar>,
-        Spectral::Swsh::Tags::Ethbar>,
-    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::Du<Tags::BondiJ>>,
-                                     Spectral::Swsh::Tags::Ethbar>,
-    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::Dy<Tags::BondiU>>,
-                                     Spectral::Swsh::Tags::Ethbar>,
-    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiQ>,
-                                     Spectral::Swsh::Tags::Ethbar>,
-    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiU>,
-                                     Spectral::Swsh::Tags::Eth>,
-    Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::Dy<Tags::BondiBeta>>,
-                                     Spectral::Swsh::Tags::Eth>>;
-
-/// Typelist of steps for `SwshDerivatives` mutations called on boundary
-/// (angular grid only) quantities needed for scri+ computations
-using all_boundary_swsh_derivative_tags_for_scri =
-    tmpl::list<Spectral::Swsh::Tags::Derivative<
-        Tags::ComplexInertialRetardedTime, Spectral::Swsh::Tags::EthEth>>;
 
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/LinearSolve.cpp
+++ b/src/Evolution/Systems/Cce/LinearSolve.cpp
@@ -147,8 +147,8 @@ void transpose_to_reals_then_imags_radial_stripes(
 }  // namespace detail
 
 // generic template applies to `Tags::BondiBeta` and `Tags::BondiU`
-template <typename Tag>
-void RadialIntegrateBondi<Tag>::apply(
+template <template <typename> class BoundaryPrefix, typename Tag>
+void RadialIntegrateBondi<BoundaryPrefix, Tag>::apply(
     const gsl::not_null<Scalar<
         SpinWeighted<ComplexDataVector, db::item_type<Tag>::type::spin>>*>
         integral_result,
@@ -172,7 +172,8 @@ void RadialIntegrateBondi<Tag>::apply(
   }
 }
 
-void RadialIntegrateBondi<Tags::BondiQ>::apply(
+template <template <typename> class BoundaryPrefix>
+void RadialIntegrateBondi<BoundaryPrefix, Tags::BondiQ>::apply(
     const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*>
         integral_result,
     const Scalar<SpinWeighted<ComplexDataVector, 1>>& pole_of_integrand,
@@ -187,7 +188,8 @@ void RadialIntegrateBondi<Tags::BondiQ>::apply(
       number_of_radial_points);
 }
 
-void RadialIntegrateBondi<Tags::BondiW>::apply(
+template <template <typename> class BoundaryPrefix>
+void RadialIntegrateBondi<BoundaryPrefix, Tags::BondiW>::apply(
     const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
         integral_result,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& pole_of_integrand,
@@ -202,7 +204,8 @@ void RadialIntegrateBondi<Tags::BondiW>::apply(
       number_of_radial_points);
 }
 
-void RadialIntegrateBondi<Tags::BondiH>::apply(
+template <template <typename> class BoundaryPrefix>
+void RadialIntegrateBondi<BoundaryPrefix, Tags::BondiH>::apply(
     const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
         integral_result,
     const Scalar<SpinWeighted<ComplexDataVector, 2>>& pole_of_integrand,
@@ -317,7 +320,20 @@ void RadialIntegrateBondi<Tags::BondiH>::apply(
                 2 * number_of_angular_points);
 }
 
-template struct RadialIntegrateBondi<Tags::BondiBeta>;
-template struct RadialIntegrateBondi<Tags::BondiU>;
+template struct RadialIntegrateBondi<Tags::BoundaryValue, Tags::BondiBeta>;
+template struct RadialIntegrateBondi<Tags::BoundaryValue, Tags::BondiQ>;
+template struct RadialIntegrateBondi<Tags::BoundaryValue, Tags::BondiU>;
+template struct RadialIntegrateBondi<Tags::BoundaryValue, Tags::BondiW>;
+template struct RadialIntegrateBondi<Tags::BoundaryValue, Tags::BondiH>;
+template struct RadialIntegrateBondi<Tags::EvolutionGaugeBoundaryValue,
+                                     Tags::BondiBeta>;
+template struct RadialIntegrateBondi<Tags::EvolutionGaugeBoundaryValue,
+                                     Tags::BondiQ>;
+template struct RadialIntegrateBondi<Tags::EvolutionGaugeBoundaryValue,
+                                     Tags::BondiU>;
+template struct RadialIntegrateBondi<Tags::EvolutionGaugeBoundaryValue,
+                                     Tags::BondiW>;
+template struct RadialIntegrateBondi<Tags::EvolutionGaugeBoundaryValue,
+                                     Tags::BondiH>;
 
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/LinearSolve.hpp
+++ b/src/Evolution/Systems/Cce/LinearSolve.hpp
@@ -96,7 +96,7 @@ void transpose_to_reals_then_imags_radial_stripes(
  * spectral matrix multiplications which are available for the other integrals.
  *
  * In each case, the boundary value at the world tube for the integration is
- * retrieved from `Tags::BoundaryValue<Tag>`.
+ * retrieved from `BoundaryPrefix<Tag>`.
  *
  * Additional type aliases `boundary_tags` and `integrand_tags` are provided for
  * template processing of the required input tags necessary for these functions.
@@ -105,9 +105,9 @@ void transpose_to_reals_then_imags_radial_stripes(
  * roles, and have different extents, it is better for tag management to give
  * separated lists for the dependencies.
  */
-template <typename Tag>
+template <template <typename> class BoundaryPrefix, typename Tag>
 struct RadialIntegrateBondi {
-  using boundary_tags = tmpl::list<Tags::BoundaryValue<Tag>>;
+  using boundary_tags = tmpl::list<BoundaryPrefix<Tag>>;
   using integrand_tags = tmpl::list<Tags::Integrand<Tag>>;
 
   using return_tags = tmpl::list<Tag>;
@@ -125,9 +125,9 @@ struct RadialIntegrateBondi {
       size_t l_max, size_t number_of_radial_points) noexcept;
 };
 
-template <>
-struct RadialIntegrateBondi<Tags::BondiQ> {
-  using boundary_tags = tmpl::list<Tags::BoundaryValue<Tags::BondiQ>>;
+template <template <typename> class BoundaryPrefix>
+struct RadialIntegrateBondi<BoundaryPrefix, Tags::BondiQ> {
+  using boundary_tags = tmpl::list<BoundaryPrefix<Tags::BondiQ>>;
   using integrand_tags = tmpl::list<Tags::PoleOfIntegrand<Tags::BondiQ>,
                                     Tags::RegularIntegrand<Tags::BondiQ>>;
   using integration_independent_tags = tmpl::list<Tags::OneMinusY>;
@@ -146,9 +146,9 @@ struct RadialIntegrateBondi<Tags::BondiQ> {
       size_t l_max, size_t number_of_radial_points) noexcept;
 };
 
-template <>
-struct RadialIntegrateBondi<Tags::BondiW> {
-  using boundary_tags = tmpl::list<Tags::BoundaryValue<Tags::BondiW>>;
+template <template <typename> class BoundaryPrefix>
+struct RadialIntegrateBondi<BoundaryPrefix, Tags::BondiW> {
+  using boundary_tags = tmpl::list<BoundaryPrefix<Tags::BondiW>>;
   using integrand_tags = tmpl::list<Tags::PoleOfIntegrand<Tags::BondiW>,
                                     Tags::RegularIntegrand<Tags::BondiW>>;
   using integration_independent_tags = tmpl::list<Tags::OneMinusY>;
@@ -167,9 +167,9 @@ struct RadialIntegrateBondi<Tags::BondiW> {
       size_t l_max, size_t number_of_radial_points) noexcept;
 };
 
-template <>
-struct RadialIntegrateBondi<Tags::BondiH> {
-  using boundary_tags = tmpl::list<Tags::BoundaryValue<Tags::BondiH>>;
+template <template <typename> class BoundaryPrefix>
+struct RadialIntegrateBondi<BoundaryPrefix, Tags::BondiH> {
+  using boundary_tags = tmpl::list<BoundaryPrefix<Tags::BondiH>>;
   using integrand_tags =
       tmpl::list<Tags::PoleOfIntegrand<Tags::BondiH>,
                  Tags::RegularIntegrand<Tags::BondiH>,

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -11,10 +11,6 @@
 #include "Options/Options.hpp"
 
 namespace Cce {
-/// \cond
-class Interpolator;
-/// \endcond
-
 namespace OptionTags {
 
 /// %Option group
@@ -109,7 +105,7 @@ struct H5LookaheadTimes {
 };
 
 struct H5Interpolator {
-  using type = std::unique_ptr<Interpolator>;
+  using type = std::unique_ptr<intrp::SpanInterpolator>;
   static constexpr OptionString help{
       "The interpolator for imported h5 worldtube data."};
   using group = Cce;
@@ -211,6 +207,7 @@ struct ObservationLMax : db::SimpleTag {
   using type = size_t;
   using option_tags = tmpl::list<OptionTags::ObservationLMax>;
 
+  static constexpr bool pass_metavariables = false;
   static size_t create_from_options(const size_t observation_l_max) noexcept {
     return observation_l_max;
   }
@@ -264,6 +261,13 @@ struct StartTime : db::SimpleTag {
   }
 };
 
+/// \brief Represents the final time of a bounded CCE evolution, determined
+/// either from option specification or from the file
+///
+/// \details If the option `OptionTags::EndTime` is set to
+/// `std::numeric_limits<double>::%infinity()`, this will find the end time from
+/// the provided H5 file. If `OptionTags::EndTime` takes any other value, it
+/// will be used directly as the end time for the CCE evolution instead.
 struct EndTime : db::SimpleTag {
   using type = double;
   using option_tags =

--- a/src/Evolution/Systems/Cce/PreSwshDerivatives.hpp
+++ b/src/Evolution/Systems/Cce/PreSwshDerivatives.hpp
@@ -252,7 +252,7 @@ struct PreSwshDerivatives<Tags::Exp2Beta> {
   using integrand_tags = tmpl::list<>;
 
   using return_tags = tmpl::list<Tags::Exp2Beta>;
-  using argument_tags = tmpl::append<tmpl::list<pre_swsh_derivative_tags>>;
+  using argument_tags = pre_swsh_derivative_tags;
   static void apply(
       const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
           exp_2_beta,
@@ -355,6 +355,29 @@ struct PreSwshDerivatives<Tags::Dy<Tags::BondiU>> {
       const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*> dy_u,
       const Scalar<SpinWeighted<ComplexDataVector, 1>>& integrand_u) noexcept {
     *dy_u = integrand_u;
+  }
+};
+
+/// \brief Compute \f$\partial_u J\f$ from \f$H\f$ and the Jacobian factors.
+template <>
+struct PreSwshDerivatives<Tags::Du<Tags::BondiJ>> {
+  using pre_swsh_derivative_tags = tmpl::list<Tags::Dy<Tags::BondiJ>>;
+  using swsh_derivative_tags = tmpl::list<>;
+  using integrand_tags = tmpl::list<Tags::BondiH>;
+  using integration_independent_tags =
+      tmpl::list<Tags::DuRDividedByR, Tags::OneMinusY>;
+
+  using return_tags = tmpl::list<Tags::Du<Tags::BondiJ>>;
+  using argument_tags = tmpl::append<pre_swsh_derivative_tags, integrand_tags,
+                                     integration_independent_tags>;
+  static void apply(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> du_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_bondi_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& bondi_h,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& du_r_divided_by_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y) noexcept {
+    get(*du_j) = get(bondi_h) -
+                 get(du_r_divided_by_r) * get(one_minus_y) * get(dy_bondi_j);
   }
 };
 

--- a/src/Utilities/VectorAlgebra.hpp
+++ b/src/Utilities/VectorAlgebra.hpp
@@ -51,9 +51,11 @@ ResultVectorType outer_product(const LhsVectorType& lhs,
 /// three-dimensional representation. The result would then be uniform in the
 /// slowest-varying direction of the three dimensional grid.
 template <typename VectorType>
-void fill_with_n_copies(const gsl::not_null<VectorType*> result,
-                        const VectorType& to_copy,
-                        const size_t times_to_copy) noexcept {
+void fill_with_n_copies(
+    // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
+    const gsl::not_null<VectorType*> result, const VectorType& to_copy,
+    // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
+    const size_t times_to_copy) noexcept {
   result->destructive_resize(to_copy.size() * times_to_copy);
   for (size_t i = 0; i < times_to_copy; ++i) {
     VectorType view{result->data() + i * to_copy.size(), to_copy.size()};

--- a/tests/Unit/DataStructures/Test_SpinWeighted.cpp
+++ b/tests/Unit/DataStructures/Test_SpinWeighted.cpp
@@ -92,6 +92,10 @@ void test_spinweights() {
   CHECK_ITERABLE_APPROX(exp_spin_weight_0.data(), exp(spin_weight_0.data()));
   CHECK_ITERABLE_APPROX(sqrt_spin_weight_0.data(), sqrt(spin_weight_0.data()));
 
+  const auto serialized_and_deserialized_copy =
+      serialize_and_deserialize(spin_weight_0);
+  CHECK(spin_weight_0 == serialized_and_deserialized_copy);
+
   const auto compatible_spin_weight_0 =
       make_with_random_values<SpinWeighted<CompatibleType, 0>>(
           make_not_null(&gen), make_not_null(&compatible_dist), size);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   Test_RequestBoundaryData.cpp
   Test_ScriObserveInterpolated.cpp
   Test_TimeManagement.cpp
+  Test_UpdateGauge.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_BoundaryCommunication.cpp
   Test_CalculateScriInputs.cpp
   Test_CharacteristicEvolutionBondiCalculations.cpp
+  Test_InitializeFirstHypersurface.cpp
   Test_InsertInterpolationScriData.cpp
   Test_FilterSwshVolumeQuantity.cpp
   Test_InitializeCharacteristicEvolution.cpp

--- a/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_Cce_Actions")
 
 set(LIBRARY_SOURCES
   Test_BoundaryCommunication.cpp
+  Test_CalculateScriInputs.cpp
   Test_CharacteristicEvolutionBondiCalculations.cpp
   Test_InsertInterpolationScriData.cpp
   Test_FilterSwshVolumeQuantity.cpp

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CalculateScriInputs.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CalculateScriInputs.cpp
@@ -1,0 +1,282 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <utility>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/Actions/CalculateScriInputs.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
+#include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/Cce/PreSwshDerivatives.hpp"
+#include "Evolution/Systems/Cce/PrecomputeCceDependencies.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "ParallelAlgorithms/Actions/MutateApply.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeSteppers/RungeKutta3.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/VectorAlgebra.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
+#include "tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Cce {
+
+namespace {
+// these will be generated in the test
+using all_pre_swsh_derivative_scri_input_tags = tmpl::list<
+    Tags::BondiH, Tags::DuRDividedByR, Tags::EthRDividedByR,
+    Tags::Dy<Tags::BondiJ>, Tags::Dy<Tags::BondiW>, Tags::Dy<Tags::BondiQ>,
+    Tags::Dy<Tags::BondiU>, Tags::Dy<Tags::Dy<Tags::BondiBeta>>,
+    Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                     Spectral::Swsh::Tags::EthEthbar>>;
+
+// these need to be computed via `PreSwshDerivatives` and
+// `PrecomputeCceDependencies`, but are not calculated in the action being
+// tested
+using extra_pre_swsh_derivative_scri_tags =
+    tmpl::list<Tags::Dy<Tags::Dy<Tags::BondiJ>>>;
+
+using extra_precomputation_scri_tags = tmpl::list<Tags::OneMinusY>;
+
+using all_real_boundary_scri_input_tags =
+    tmpl::list<Tags::InertialRetardedTime>;
+
+using transform_buffers_for_scri =
+    tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+        all_swsh_derivative_tags_for_scri,
+        tmpl::bind<Spectral::Swsh::coefficient_buffer_tags_for_derivative_tag,
+                   tmpl::_1>>>>;
+
+template <typename Metavariables>
+struct mock_characteristic_evolution {
+  using simple_tags = db::AddSimpleTags<
+      ::Tags::Variables<tmpl::append<all_swsh_derivative_tags_for_scri,
+                                     all_pre_swsh_derivative_tags_for_scri,
+                                     all_pre_swsh_derivative_scri_input_tags,
+                                     extra_pre_swsh_derivative_scri_tags,
+                                     extra_precomputation_scri_tags>>,
+      ::Tags::Variables<transform_buffers_for_scri>,
+      ::Tags::Variables<all_real_boundary_scri_input_tags>,
+      ::Tags::Variables<
+          tmpl::append<all_boundary_pre_swsh_derivative_tags_for_scri,
+                       all_boundary_swsh_derivative_tags_for_scri>>>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  // so that the precomputation mutator can be used in the tmpl::transform
+  template <typename Tag>
+  using local_precompute = PrecomputeCceDependencies<Tags::BoundaryValue, Tag>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Evolve,
+          tmpl::list<tmpl::transform<
+                         extra_pre_swsh_derivative_scri_tags,
+                         tmpl::bind<::Actions::MutateApply,
+                                    tmpl::bind<PreSwshDerivatives, tmpl::_1>>>,
+                     tmpl::transform<
+                         extra_precomputation_scri_tags,
+                         tmpl::bind<::Actions::MutateApply,
+                                    tmpl::bind<local_precompute, tmpl::_1>>>,
+                     Actions::CalculateScriInputs>>>;
+};
+
+struct metavariables {
+  using component_list =
+      tmpl::list<mock_characteristic_evolution<metavariables>>;
+  enum class Phase { Initialization, Evolve, Exit };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.CalculateScriInputs",
+                  "[Unit][Cce]") {
+  MAKE_GENERATOR(gen);
+  // limited l_max distribution because test depends on an analytic
+  // basis function with factorials.
+  UniformCustomDistribution<size_t> sdist{7, 10};
+  const size_t l_max = sdist(gen);
+  UniformCustomDistribution<double> coefficient_distribution{-2.0, 2.0};
+  const size_t number_of_radial_points = sdist(gen);
+  CAPTURE(l_max);
+  CAPTURE(number_of_radial_points);
+  using component = mock_characteristic_evolution<metavariables>;
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
+      tuples::tagged_tuple_from_typelist<
+          Parallel::get_const_global_cache_tags<metavariables>>{
+          l_max, number_of_radial_points}};
+  Variables<tmpl::append<
+      all_swsh_derivative_tags_for_scri, all_pre_swsh_derivative_tags_for_scri,
+      all_pre_swsh_derivative_scri_input_tags,
+      extra_pre_swsh_derivative_scri_tags, extra_precomputation_scri_tags>>
+      component_volume_variables{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
+          number_of_radial_points};
+  Variables<all_real_boundary_scri_input_tags> component_real_variables{
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  Variables<transform_buffers_for_scri> component_transform_variables{
+      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max) *
+      number_of_radial_points};
+  Variables<tmpl::append<all_boundary_pre_swsh_derivative_tags_for_scri,
+                         all_boundary_swsh_derivative_tags_for_scri>>
+      component_boundary_variables{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+
+  tmpl::for_each<all_pre_swsh_derivative_scri_input_tags>([
+    &component_volume_variables, &gen, &coefficient_distribution,
+    &number_of_radial_points, &l_max
+  ](auto tag_v) noexcept {
+    using tag = typename decltype(tag_v)::type;
+    SpinWeighted<ComplexModalVector, tag::type::type::spin> generated_modes{
+        number_of_radial_points *
+        Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+    Spectral::Swsh::TestHelpers::generate_swsh_modes<tag::type::type::spin>(
+        make_not_null(&generated_modes.data()), make_not_null(&gen),
+        make_not_null(&coefficient_distribution), number_of_radial_points,
+        l_max);
+    get(get<tag>(component_volume_variables)) =
+        Spectral::Swsh::inverse_swsh_transform(l_max, number_of_radial_points,
+                                               generated_modes);
+    // aggressive filter to make the uniformly generated random modes
+    // somewhat reasonable
+    Spectral::Swsh::filter_swsh_volume_quantity(
+        make_not_null(&get(get<tag>(component_volume_variables))), l_max,
+        l_max / 2, 32.0, 8);
+  });
+
+  tmpl::for_each<all_real_boundary_scri_input_tags>([
+    &component_real_variables, &gen, &coefficient_distribution, &l_max
+  ](auto tag_v) noexcept {
+    using tag = typename decltype(tag_v)::type;
+    SpinWeighted<ComplexModalVector, 0> generated_modes{
+        Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+    Spectral::Swsh::TestHelpers::generate_swsh_modes<0>(
+        make_not_null(&generated_modes.data()), make_not_null(&gen),
+        make_not_null(&coefficient_distribution), 1, l_max);
+    SpinWeighted<ComplexDataVector, 0> spin_weighted_buffer =
+        Spectral::Swsh::inverse_swsh_transform(l_max, 1, generated_modes);
+    // aggressive filter to make the uniformly generated random modes
+    // somewhat reasonable
+    Spectral::Swsh::filter_swsh_boundary_quantity(
+        make_not_null(&spin_weighted_buffer), l_max, l_max / 2);
+    get(get<tag>(component_real_variables)) = real(spin_weighted_buffer.data());
+  });
+
+  ActionTesting::emplace_component_and_initialize<component>(
+      &runner, 0,
+      {component_volume_variables, component_transform_variables,
+       component_real_variables, component_boundary_variables});
+  auto expected_box = db::create<
+      tmpl::append<component::simple_tags,
+                   db::AddSimpleTags<Tags::LMax, Tags::NumberOfRadialPoints>>>(
+      component_volume_variables, component_transform_variables,
+      component_real_variables, component_boundary_variables, l_max,
+      number_of_radial_points);
+  runner.set_phase(metavariables::Phase::Initialization);
+
+  // run the initialization to get the values into the databox
+  tmpl::for_each<extra_pre_swsh_derivative_scri_tags>([&expected_box](
+      auto tag_v) noexcept {
+    using tag = typename decltype(tag_v)::type;
+    db::mutate_apply<PreSwshDerivatives<tag>>(make_not_null(&expected_box));
+  });
+
+  tmpl::for_each<extra_precomputation_scri_tags>([&expected_box](
+      auto tag_v) noexcept {
+    using tag = typename decltype(tag_v)::type;
+    db::mutate_apply<PrecomputeCceDependencies<Tags::BoundaryValue, tag>>(
+        make_not_null(&expected_box));
+  });
+
+  runner.set_phase(metavariables::Phase::Evolve);
+  // this will execute all of the `MutateApply` actions for the `extra...`
+  // typelists
+  for (size_t i = 0;
+       i < tmpl::size<extra_pre_swsh_derivative_scri_tags>::value +
+               tmpl::size<extra_precomputation_scri_tags>::value + 1;
+       ++i) {
+    ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  }
+
+  // execute the desired box manipulations directly without calling the actions.
+  // The mutations themselves are tested in other unit tests.
+  tmpl::for_each<tmpl::append<all_pre_swsh_derivative_tags_for_scri,
+                              all_boundary_pre_swsh_derivative_tags_for_scri>>(
+      [&expected_box](auto pre_swsh_derivative_tag_v) noexcept {
+        using pre_swsh_derivative_tag =
+            typename decltype(pre_swsh_derivative_tag_v)::type;
+        db::mutate_apply<PreSwshDerivatives<pre_swsh_derivative_tag>>(
+            make_not_null(&expected_box));
+      });
+
+  db::mutate_apply<
+      Spectral::Swsh::AngularDerivatives<all_swsh_derivative_tags_for_scri>>(
+      make_not_null(&expected_box));
+  tmpl::for_each<all_boundary_swsh_derivative_tags_for_scri>([
+    &expected_box, &l_max
+  ](auto swsh_derivative_tag_v) noexcept {
+    using swsh_derivative_tag = typename decltype(swsh_derivative_tag_v)::type;
+    db::mutate<swsh_derivative_tag>(
+        make_not_null(&expected_box),
+        [&l_max](
+            const gsl::not_null<db::item_type<swsh_derivative_tag>*> derivative,
+            const db::item_type<typename swsh_derivative_tag::derivative_of>&
+                argument) noexcept {
+          Spectral::Swsh::angular_derivatives<
+              tmpl::list<typename swsh_derivative_tag::derivative_kind>>(
+              l_max, 1, make_not_null(&get(*derivative)), get(argument));
+        },
+        db::get<typename swsh_derivative_tag::derivative_of>(expected_box));
+  });
+
+  tmpl::for_each<all_swsh_derivative_tags_for_scri>([&expected_box](
+      auto derivative_tag_v) noexcept {
+    using derivative_tag = typename decltype(derivative_tag_v)::type;
+    detail::apply_swsh_jacobian_helper<derivative_tag>(
+        make_not_null(&expected_box),
+        typename ApplySwshJacobianInplace<
+            derivative_tag>::on_demand_argument_tags{});
+  });
+
+  Approx multiple_derivative_approx =
+      Approx::custom()
+          .epsilon(std::numeric_limits<double>::epsilon() * 1.0e4)
+          .scale(1.0);
+
+  tmpl::for_each<tmpl::append<all_swsh_derivative_tags_for_scri,
+                              all_pre_swsh_derivative_tags_for_scri,
+                              all_boundary_pre_swsh_derivative_tags_for_scri,
+                              all_boundary_swsh_derivative_tags_for_scri>>([
+    &expected_box, &runner, &multiple_derivative_approx
+  ](auto tag_v) noexcept {
+    using tag = typename decltype(tag_v)::type;
+    const auto& test_lhs =
+        ActionTesting::get_databox_tag<component, tag>(runner, 0);
+    const auto& test_rhs = db::get<tag>(expected_box);
+    CHECK_ITERABLE_CUSTOM_APPROX(test_lhs, test_rhs,
+                                 multiple_derivative_approx);
+  });
+}
+}  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
@@ -1,0 +1,153 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <utility>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/Actions/UpdateGauge.hpp"
+#include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
+#include "Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "ParallelAlgorithms/Actions/MutateApply.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Cce {
+
+namespace {
+
+using swsh_boundary_tags_to_generate =
+    tmpl::list<Tags::BoundaryValue<Tags::BondiJ>,
+               Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
+               Tags::BoundaryValue<Tags::BondiR>>;
+
+using real_boundary_tags_to_compute =
+    tmpl::list<Tags::CauchyCartesianCoords, Tags::CauchyAngularCoords,
+               Tags::InertialRetardedTime>;
+
+using swsh_boundary_tags_to_compute =
+    tmpl::list<Tags::GaugeC, Tags::GaugeD, Tags::GaugeOmega>;
+
+using swsh_volume_tags_to_compute = tmpl::list<Tags::BondiJ>;
+
+template <typename Metavariables>
+struct mock_characteristic_evolution {
+  using simple_tags = tmpl::push_back<db::AddSimpleTags<
+      ::Tags::Variables<real_boundary_tags_to_compute>,
+      ::Tags::Variables<tmpl::append<swsh_boundary_tags_to_generate,
+                                     swsh_boundary_tags_to_compute>>,
+      ::Tags::Variables<swsh_volume_tags_to_compute>>>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Testing,
+                             tmpl::list<Actions::InitializeFirstHypersurface>>>;
+};
+
+struct metavariables {
+  using component_list =
+      tmpl::list<mock_characteristic_evolution<metavariables>>;
+
+  using cce_hypersurface_initialization = InitializeJ<Tags::BoundaryValue>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.Cce.Actions.InitializeFirstHypersurface",
+    "[Unit][Cce]") {
+  MAKE_GENERATOR(gen);
+  // limited l_max distribution because test depends on an analytic
+  // basis function with factorials.
+  UniformCustomDistribution<size_t> sdist{7, 10};
+  const size_t l_max = sdist(gen);
+  const size_t number_of_radial_points = sdist(gen);
+  UniformCustomDistribution<double> coefficient_distribution{-2.0, 2.0};
+  CAPTURE(l_max);
+
+  using component = mock_characteristic_evolution<metavariables>;
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
+      {l_max, number_of_radial_points}};
+
+  Variables<real_boundary_tags_to_compute> real_variables{
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  Variables<tmpl::append<swsh_boundary_tags_to_generate,
+                         swsh_boundary_tags_to_compute>>
+      swsh_variables{Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  Variables<swsh_volume_tags_to_compute> swsh_volume_variables{
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
+      number_of_radial_points};
+
+  tmpl::for_each<swsh_boundary_tags_to_generate>([&swsh_variables, &gen,
+                                                  &coefficient_distribution,
+                                                  &l_max](auto tag_v) noexcept {
+    using tag = typename decltype(tag_v)::type;
+    SpinWeighted<ComplexModalVector, tag::type::type::spin> generated_modes{
+        Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+    Spectral::Swsh::TestHelpers::generate_swsh_modes<tag::type::type::spin>(
+        make_not_null(&generated_modes.data()), make_not_null(&gen),
+        make_not_null(&coefficient_distribution), 1, l_max);
+    Spectral::Swsh::inverse_swsh_transform(
+        l_max, 1, make_not_null(&get(get<tag>(swsh_variables))),
+        generated_modes);
+    // aggressive filter to make the uniformly generated random modes
+    // somewhat reasonable
+    Spectral::Swsh::filter_swsh_volume_quantity(
+        make_not_null(&get(get<tag>(swsh_variables))), l_max, l_max / 2, 32.0,
+        8);
+  });
+
+  ActionTesting::emplace_component_and_initialize<component>(
+      &runner, 0, {real_variables, swsh_variables, swsh_volume_variables});
+  auto expected_box = db::create<
+      tmpl::append<component::simple_tags,
+                   db::AddSimpleTags<Tags::LMax, Tags::NumberOfRadialPoints>>>(
+      std::move(real_variables), std::move(swsh_variables),
+      std::move(swsh_volume_variables), l_max, number_of_radial_points);
+
+  runner.set_phase(metavariables::Phase::Testing);
+  // apply the `InitializeFirstHypersurface` action
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+
+  // apply the corresponding mutators to the `expected_box`
+  db::mutate_apply<InitializeJ<Tags::BoundaryValue>>(
+      make_not_null(&expected_box));
+  db::mutate_apply<InitializeGauge>(make_not_null(&expected_box));
+  db::mutate_apply<InitializeScriPlusValue<Tags::InertialRetardedTime>>(
+      make_not_null(&expected_box));
+
+  tmpl::for_each<
+      tmpl::append<real_boundary_tags_to_compute, swsh_boundary_tags_to_compute,
+                   swsh_volume_tags_to_compute>>(
+      [&runner, &expected_box](auto tag_v) noexcept {
+        using tag = typename decltype(tag_v)::type;
+        const auto& test_lhs =
+            ActionTesting::get_databox_tag<component, tag>(runner, 0);
+        const auto& test_rhs = db::get<tag>(expected_box);
+        CHECK_ITERABLE_APPROX(test_lhs, test_rhs);
+      });
+}
+}  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -170,9 +170,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
   TestHelpers::write_test_file(solution, filename, target_time,
                                extraction_radius, frequency, amplitude, l_max);
 
-  const double start_time = value_dist(gen);
-  const double end_time = std::numeric_limits<double>::quiet_NaN();
+  const double start_time = target_time;
   const double target_step_size = 0.01 * value_dist(gen);
+  const double end_time = start_time + 10 * target_step_size;
   const size_t buffer_size = 5;
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       {l_max, number_of_radial_points,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_UpdateGauge.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_UpdateGauge.cpp
@@ -1,0 +1,173 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <utility>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/Actions/UpdateGauge.hpp"
+#include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
+#include "Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "ParallelAlgorithms/Actions/MutateApply.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Cce {
+
+namespace {
+using real_tags_to_generate = tmpl::list<Tags::CauchyCartesianCoords>;
+
+using real_tags_to_compute = tmpl::list<Tags::CauchyAngularCoords>;
+
+using swsh_tags_to_compute =
+    tmpl::list<Tags::GaugeC, Tags::GaugeD, Tags::GaugeOmega,
+               Spectral::Swsh::Tags::Derivative<Tags::GaugeOmega,
+                                                Spectral::Swsh::Tags::Eth>>;
+
+template <typename Metavariables>
+struct mock_characteristic_evolution {
+  using simple_tags = tmpl::push_back<
+      db::AddSimpleTags<::Tags::Variables<tmpl::append<
+                            real_tags_to_generate, real_tags_to_compute>>,
+                        ::Tags::Variables<swsh_tags_to_compute>>,
+      Spectral::Swsh::Tags::SwshInterpolator<Tags::CauchyAngularCoords>>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Evolve,
+                             tmpl::list<Actions::UpdateGauge>>>;
+};
+
+struct metavariables {
+  using component_list =
+      tmpl::list<mock_characteristic_evolution<metavariables>>;
+  enum class Phase { Initialization, Evolve, Exit };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.UpdateGauge",
+                  "[Unit][Cce]") {
+  MAKE_GENERATOR(gen);
+  // limited l_max distribution because test depends on an analytic
+  // basis function with factorials.
+  UniformCustomDistribution<size_t> sdist{7, 10};
+  const size_t l_max = sdist(gen);
+  UniformCustomDistribution<double> coefficient_distribution{-2.0, 2.0};
+  CAPTURE(l_max);
+
+  using component = mock_characteristic_evolution<metavariables>;
+  ActionTesting::MockRuntimeSystem<metavariables> runner{{l_max}};
+  Variables<tmpl::append<real_tags_to_generate, real_tags_to_compute>>
+      real_variables{Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  Variables<swsh_tags_to_compute> swsh_variables{
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+
+  tmpl::for_each<real_tags_to_generate>([&real_variables, &gen,
+                                         &coefficient_distribution,
+                                         &l_max](auto tag_v) noexcept {
+    using tag = typename decltype(tag_v)::type;
+    SpinWeighted<ComplexModalVector, 0> generated_modes{
+        Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+    SpinWeighted<ComplexDataVector, 0> generated_data{
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+    for (auto& tensor_component : get<tag>(real_variables)) {
+      Spectral::Swsh::TestHelpers::generate_swsh_modes<0>(
+          make_not_null(&generated_modes.data()), make_not_null(&gen),
+          make_not_null(&coefficient_distribution), 1, l_max);
+      Spectral::Swsh::inverse_swsh_transform(
+          l_max, 1, make_not_null(&generated_data), generated_modes);
+      // aggressive filter to make the uniformly generated random modes
+      // somewhat reasonable
+      Spectral::Swsh::filter_swsh_boundary_quantity(
+          make_not_null(&generated_data), l_max, l_max / 2);
+      tensor_component = real(generated_data.data());
+    }
+  });
+
+  ActionTesting::emplace_component_and_initialize<component>(
+      &runner, 0,
+      {real_variables, swsh_variables, Spectral::Swsh::SwshInterpolator{}});
+  auto expected_box = db::create<
+      tmpl::append<component::simple_tags, db::AddSimpleTags<Tags::LMax>>>(
+      std::move(real_variables), std::move(swsh_variables),
+      Spectral::Swsh::SwshInterpolator{}, l_max);
+
+  runner.set_phase(metavariables::Phase::Evolve);
+  // apply the `UpdateGauge` action
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+
+  // apply the corresponding mutators to the `expected_box`
+  db::mutate_apply<GaugeUpdateAngularFromCartesian<
+      Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords>>(
+      make_not_null(&expected_box));
+  db::mutate_apply<GaugeUpdateJacobianFromCoordinates<
+      Tags::GaugeC, Tags::GaugeD, Tags::CauchyAngularCoords,
+      Tags::CauchyCartesianCoords>>(make_not_null(&expected_box));
+  db::mutate_apply<GaugeUpdateInterpolator<Tags::CauchyAngularCoords>>(
+      make_not_null(&expected_box));
+  db::mutate_apply<GaugeUpdateOmega>(make_not_null(&expected_box));
+
+  tmpl::for_each<
+      tmpl::append<real_tags_to_compute, swsh_tags_to_compute>>(
+      [&runner, &expected_box](auto tag_v) noexcept {
+        using tag = typename decltype(tag_v)::type;
+        const auto& test_lhs =
+            ActionTesting::get_databox_tag<component, tag>(runner, 0);
+        const auto& test_rhs = db::get<tag>(expected_box);
+        CHECK_ITERABLE_APPROX(test_lhs, test_rhs);
+      });
+
+  // verify the interpolators are the same by interpolating a random set of
+  // modes.
+  SpinWeighted<ComplexModalVector, 2> generated_modes{
+      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+  Spectral::Swsh::TestHelpers::generate_swsh_modes<2>(
+      make_not_null(&generated_modes.data()), make_not_null(&gen),
+      make_not_null(&coefficient_distribution), 1, l_max);
+
+  const Spectral::Swsh::SwshInterpolator& computed_interpolator =
+      ActionTesting::get_databox_tag<
+          component,
+          Spectral::Swsh::Tags::SwshInterpolator<Tags::CauchyAngularCoords>>(
+          runner, 0);
+  const Spectral::Swsh::SwshInterpolator& expected_interpolator = db::get<
+      Spectral::Swsh::Tags::SwshInterpolator<Tags::CauchyAngularCoords>>(
+      expected_box);
+
+  SpinWeighted<ComplexDataVector, 2> interpolated_points_from_computed{
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  SpinWeighted<ComplexDataVector, 2> interpolated_points_from_expected{
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  computed_interpolator.interpolate(
+      make_not_null(&interpolated_points_from_computed),
+      Spectral::Swsh::libsharp_to_goldberg_modes(generated_modes, l_max));
+  expected_interpolator.interpolate(
+      make_not_null(&interpolated_points_from_expected),
+      Spectral::Swsh::libsharp_to_goldberg_modes(generated_modes, l_max));
+  CHECK_ITERABLE_APPROX(interpolated_points_from_computed,
+                        interpolated_points_from_expected);
+}
+}  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Test_LinearSolve.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_LinearSolve.cpp
@@ -113,9 +113,9 @@ auto create_box_for_bondi_integration(
       number_of_radial_grid_points *
       Spectral::Swsh::number_of_swsh_collocation_points(l_max);
 
-  using integration_tags = tmpl::flatten<
-      tmpl::list<BondiValueTag,
-                 typename RadialIntegrateBondi<BondiValueTag>::integrand_tags>>;
+  using integration_tags = tmpl::flatten<tmpl::list<
+      BondiValueTag, typename RadialIntegrateBondi<
+                         Tags::BoundaryValue, BondiValueTag>::integrand_tags>>;
   using integration_variables_tag = ::Tags::Variables<integration_tags>;
   using integration_modes_variables_tag =
       ::Tags::Variables<db::wrap_tags_in<TestHelpers::RadialPolyCoefficientsFor,
@@ -188,7 +188,8 @@ void test_regular_integration(const gsl::not_null<Generator*> gen,
   make_boundary_data<BondiValueTag>(make_not_null(&box),
                                     make_not_null(&expected), l_max);
 
-  db::mutate_apply<RadialIntegrateBondi<BondiValueTag>>(make_not_null(&box));
+  db::mutate_apply<RadialIntegrateBondi<Tags::BoundaryValue, BondiValueTag>>(
+      make_not_null(&box));
 
   Approx numerical_differentiation_approximation =
       Approx::custom()
@@ -278,7 +279,8 @@ void test_pole_integration(const gsl::not_null<Generator*> gen,
   db::mutate<Tags::OneMinusY>(make_not_null(&box),
                               TestHelpers::volume_one_minus_y, l_max);
 
-  db::mutate_apply<RadialIntegrateBondi<BondiValueTag>>(make_not_null(&box));
+  db::mutate_apply<RadialIntegrateBondi<Tags::BoundaryValue, BondiValueTag>>(
+      make_not_null(&box));
 
   Approx numerical_differentiation_approximation =
       Approx::custom()
@@ -458,7 +460,8 @@ void test_pole_integration_with_linear_operator(
   db::mutate<Tags::OneMinusY>(make_not_null(&box),
                               TestHelpers::volume_one_minus_y, l_max);
 
-  db::mutate_apply<RadialIntegrateBondi<BondiValueTag>>(make_not_null(&box));
+  db::mutate_apply<RadialIntegrateBondi<Tags::BoundaryValue, BondiValueTag>>(
+      make_not_null(&box));
 
   Approx numerical_differentiation_approximation =
       Approx::custom()
@@ -470,8 +473,7 @@ void test_pole_integration_with_linear_operator(
                                numerical_differentiation_approximation);
 }
 
-SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.LinearSolve",
-                  "[Unit][Cce]") {
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.LinearSolve", "[Unit][Cce]") {
   MAKE_GENERATOR(gen);
   UniformCustomDistribution<size_t> sdist{3, 6};
   const size_t l_max = sdist(gen);

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -86,7 +86,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
             "OptionTagsTestCceR0100.h5") == 5.4);
   CHECK(Cce::Tags::EndTime::create_from_options(
             2.2, "OptionTagsTestCceR0100.h5") == 2.2);
+
   CHECK(Cce::Tags::ObservationLMax::create_from_options(5_st) == 5_st);
+  CHECK(Cce::InitializationTags::TargetStepSize::create_from_options(0.2) ==
+        0.2);
 
   CHECK(Cce::InitializationTags::ScriInterpolationOrder::create_from_options(
             6_st) == 6_st);


### PR DESCRIPTION
## Proposed changes

Puts the previous CCE utilities all together into a working executable that extracts waves from input H5 worldtube data.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies
- [x] #1993 
- [x] #2009