### PR TITLE
Remove unused variables from CCE tests

### DIFF
--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_BoundaryCommunication.cpp
@@ -193,7 +193,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.BoundaryCommunication",
   // create the test file, because on initialization the manager will need
   // to get basic data out of the file
   const size_t buffer_size = 5;
-  const size_t scri_plus_interpolation_order = 3;
 
   runner.set_phase(test_metavariables::Phase::Initialization);
   ActionTesting::emplace_component<evolution_component>(&runner, 0,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -174,7 +174,6 @@ SPECTRE_TEST_CASE(
   // to get basic data out of the file
   const double start_time = target_time;
   const double target_step_size = 0.01 * value_dist(gen);
-  const size_t scri_interpolation_order = 3;
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{
       {l_max, number_of_radial_points,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -174,7 +174,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
   const double end_time = std::numeric_limits<double>::quiet_NaN();
   const double target_step_size = 0.01 * value_dist(gen);
   const size_t buffer_size = 5;
-  const size_t scri_plus_interpolation_order = 3;
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       {l_max, number_of_radial_points,
        std::make_unique<::TimeSteppers::RungeKutta3>(), start_time,


### PR DESCRIPTION
## Proposed changes

In one of the recent refactors of the tests some variables became unused. This removes them.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
