### PR TITLE
Add time dependence to Block and Domain classes

### DIFF
--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -3,8 +3,10 @@
 
 #include "Domain/Block.hpp"
 
+#include <ios>
 #include <pup.h>  // IWYU pragma: keep
 
+#include "ErrorHandling/Assert.hpp"
 #include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
 #include "Utilities/GenerateInstantiations.hpp"
 
@@ -16,10 +18,12 @@ struct Logical;
 template <size_t VolumeDim>
 Block<VolumeDim>::Block(
     std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, Frame::Inertial,
-                                              VolumeDim>>&& map,
+                                              VolumeDim>>&& stationary_map,
     const size_t id,
     DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors) noexcept
-    : map_(std::move(map)), id_(id), neighbors_(std::move(neighbors)) {
+    : stationary_map_(std::move(stationary_map)),
+      id_(id),
+      neighbors_(std::move(neighbors)) {
   // Loop over Directions to search which Directions were not set to neighbors_,
   // set these Directions to external_boundaries_.
   for (const auto& direction : Direction<VolumeDim>::all_directions()) {
@@ -30,8 +34,53 @@ Block<VolumeDim>::Block(
 }
 
 template <size_t VolumeDim>
+const domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>&
+Block<VolumeDim>::stationary_map() const noexcept {
+  ASSERT(stationary_map_ != nullptr,
+         "The stationary map is set to nullptr and so cannot be retrieved. "
+         "This is because the domain is time-dependent and so there are two "
+         "maps: the Logical to Grid map and the Grid to Inertial map.");
+  return *stationary_map_;
+}
+
+template <size_t VolumeDim>
+const domain::CoordinateMapBase<Frame::Logical, Frame::Grid, VolumeDim>&
+Block<VolumeDim>::moving_mesh_logical_to_grid_map() const noexcept {
+  ASSERT(moving_mesh_grid_map_ != nullptr,
+         "The moving mesh Logical to Grid map is set to nullptr and so cannot "
+         "be retrieved. This is because the domain is time-independent and so "
+         "only the stationary map exists.");
+  return *moving_mesh_grid_map_;
+}
+
+template <size_t VolumeDim>
+const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>&
+Block<VolumeDim>::moving_mesh_grid_to_inertial_map() const noexcept {
+  ASSERT(moving_mesh_inertial_map_ != nullptr,
+         "The moving mesh Grid to Inertial map is set to nullptr and so cannot "
+         "be retrieved. This is because the domain is time-independent and so "
+         "only the stationary map exists.");
+  return *moving_mesh_inertial_map_;
+}
+
+template <size_t VolumeDim>
+void Block<VolumeDim>::inject_time_dependent_map(
+    std::unique_ptr<
+        domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>>
+        moving_mesh_inertial_map) noexcept {
+  ASSERT(stationary_map_ != nullptr,
+         "Cannot inject time-dependent map into a block that already has a "
+         "time-dependent map.");
+  moving_mesh_inertial_map_ = std::move(moving_mesh_inertial_map);
+  moving_mesh_grid_map_ = stationary_map_->get_to_grid_frame();
+  stationary_map_ = nullptr;
+}
+
+template <size_t VolumeDim>
 void Block<VolumeDim>::pup(PUP::er& p) noexcept {
-  p | map_;
+  p | stationary_map_;
+  p | moving_mesh_grid_map_;
+  p | moving_mesh_inertial_map_;
   p | id_;
   p | neighbors_;
   p | external_boundaries_;
@@ -43,6 +92,7 @@ std::ostream& operator<<(std::ostream& os,
   os << "Block " << block.id() << ":\n";
   os << "Neighbors: " << block.neighbors() << '\n';
   os << "External boundaries: " << block.external_boundaries() << '\n';
+  os << "Is time dependent: " << std::boolalpha << block.is_time_dependent();
   return os;
 }
 
@@ -51,7 +101,13 @@ bool operator==(const Block<VolumeDim>& lhs,
                 const Block<VolumeDim>& rhs) noexcept {
   return lhs.id() == rhs.id() and lhs.neighbors() == rhs.neighbors() and
          lhs.external_boundaries() == rhs.external_boundaries() and
-         lhs.coordinate_map() == rhs.coordinate_map();
+         lhs.is_time_dependent() == rhs.is_time_dependent() and
+         (lhs.is_time_dependent()
+              ? (lhs.moving_mesh_logical_to_grid_map() ==
+                     rhs.moving_mesh_logical_to_grid_map() and
+                 lhs.moving_mesh_grid_to_inertial_map() ==
+                     rhs.moving_mesh_grid_to_inertial_map())
+              : lhs.stationary_map() == rhs.stationary_map());
 }
 
 template <size_t VolumeDim>

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -46,6 +46,20 @@ Domain<VolumeDim>::Domain(
 }
 
 template <size_t VolumeDim>
+void Domain<VolumeDim>::inject_time_dependent_map_for_block(
+    const size_t block_id,
+    std::unique_ptr<
+        domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>>
+        moving_mesh_inertial_map) noexcept {
+  ASSERT(block_id < blocks_.size(),
+         "The block id " << block_id
+                         << " larger than the total number of blocks, "
+                         << blocks_.size());
+  blocks_[block_id].inject_time_dependent_map(
+      std::move(moving_mesh_inertial_map));
+}
+
+template <size_t VolumeDim>
 bool operator==(const Domain<VolumeDim>& lhs,
                 const Domain<VolumeDim>& rhs) noexcept {
   return lhs.blocks() == rhs.blocks();

--- a/src/Domain/Domain.hpp
+++ b/src/Domain/Domain.hpp
@@ -70,6 +70,12 @@ class Domain {
   Domain<VolumeDim>& operator=(const Domain<VolumeDim>&) = delete;
   Domain<VolumeDim>& operator=(Domain<VolumeDim>&&) = default;
 
+  void inject_time_dependent_map_for_block(
+      size_t block_id,
+      std::unique_ptr<
+          domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>>
+          moving_mesh_inertial_map) noexcept;
+
   const std::vector<Block<VolumeDim>>& blocks() const noexcept {
     return blocks_;
   }

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
@@ -96,8 +96,14 @@ struct InitializeDomain {
         initial_extents, element_id);
     Element<Dim> element =
         domain::Initialization::create_initial_element(element_id, my_block);
+    if (my_block.is_time_dependent()) {
+      ERROR(
+          "The version of the InitializeDomain action being used is for "
+          "elliptic systems which do not have any time-dependence but the "
+          "domain creator has set up the domain to have time-dependence.");
+    }
     ElementMap<Dim, Frame::Inertial> element_map{
-        element_id, my_block.coordinate_map().get_clone()};
+        element_id, my_block.stationary_map().get_clone()};
 
     return std::make_tuple(
         ::Initialization::merge_into_databox<InitializeDomain, simple_tags,

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -305,7 +305,7 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
                    Spectral::Basis::Legendre,
                    Spectral::Quadrature::GaussLobatto};
     ElementMap<3, Frame::Inertial> map{element_id,
-                                       block.coordinate_map().get_clone()};
+                                       block.stationary_map().get_clone()};
     const auto inertial_coords = map(logical_coordinates(mesh));
 
     // Compute psi, pi, phi for KerrSchild.

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -499,8 +499,13 @@ void test_radial_block_layers(const double inner_radius,
       if (element_id.segment_ids()[0] == SegmentId{refinement_level, 0} and
           element_id.segment_ids()[1] == SegmentId{refinement_level, 0}) {
         element_count++;
+        if (block.is_time_dependent()) {
+          ERROR(
+              "Only stationary maps are supported in the Shell domain creator "
+              "test");
+        }
         const auto map = ElementMap<3, Frame::Inertial>{
-            element_id, block.coordinate_map().get_clone()};
+            element_id, block.stationary_map().get_clone()};
         const tnsr::I<double, 3, Frame::Logical> logical_point(
             std::array<double, 3>{{0.0, 0.0, 1.0}});
         CHECK(magnitude(map(logical_point)).get() ==

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -296,16 +296,64 @@ double physical_separation(const Block<VolumeDim>& block1,
 }  // namespace
 }  // namespace domain
 
-template <size_t VolumeDim>
+namespace {
+template <size_t Dim>
+void dispatch_check_if_maps_are_equal(
+    const Block<Dim>& block,
+    const domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, Dim>&
+        expected_map,
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) noexcept {
+  check_if_maps_are_equal(expected_map, block.stationary_map(), time,
+                          functions_of_time);
+}
+
+template <size_t Dim>
+void dispatch_check_if_maps_are_equal(
+    const Block<Dim>& block,
+    const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, Dim>&
+        expected_map,
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) noexcept {
+  check_if_maps_are_equal(expected_map,
+                          block.moving_mesh_grid_to_inertial_map(), time,
+                          functions_of_time);
+}
+
+template <size_t Dim>
+void dispatch_check_if_maps_are_equal(
+    const Block<Dim>& block,
+    const domain::CoordinateMapBase<Frame::Logical, Frame::Grid, Dim>&
+        expected_map,
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) noexcept {
+  check_if_maps_are_equal(expected_map, block.moving_mesh_logical_to_grid_map(),
+                          time, functions_of_time);
+}
+}  // namespace
+
+template <size_t VolumeDim, typename TargetFrameGridOrInertial>
 void test_domain_construction(
     const Domain<VolumeDim>& domain,
     const std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,
+    const std::vector<std::unique_ptr<domain::CoordinateMapBase<
+        Frame::Logical, TargetFrameGridOrInertial, VolumeDim>>>& expected_maps,
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
     const std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>>&
-        expected_maps) noexcept {
+        domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>>>&
+        expected_grid_to_inertial_maps) noexcept {
   const auto& blocks = domain.blocks();
   CHECK(blocks.size() == expected_external_boundaries.size());
   CHECK(blocks.size() == expected_block_neighbors.size());
@@ -315,7 +363,17 @@ void test_domain_construction(
     CHECK(block.id() == i);
     CHECK(block.neighbors() == expected_block_neighbors[i]);
     CHECK(block.external_boundaries() == expected_external_boundaries[i]);
-    check_if_maps_are_equal(*expected_maps[i], block.stationary_map());
+    dispatch_check_if_maps_are_equal(block, *expected_maps[i], time,
+                                     functions_of_time);
+    if (std::is_same<TargetFrameGridOrInertial, Frame::Grid>::value) {
+      if (expected_grid_to_inertial_maps.size() != blocks.size()) {
+        ERROR("Need at least one grid to inertial map for each block ("
+              << blocks.size() << " blocks in total) but received "
+              << expected_grid_to_inertial_maps.size() << " instead.");
+      }
+      dispatch_check_if_maps_are_equal(
+          block, *expected_grid_to_inertial_maps[i], time, functions_of_time);
+    }
   }
   domain::creators::register_derived_with_charm();
   test_serialization(domain);
@@ -394,26 +452,44 @@ tnsr::i<DataType, SpatialDim> unit_basis_form(
 /// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
+#define INSTANTIATE(_, data)                                 \
+  template boost::rational<size_t> fraction_of_block_volume( \
+      const ElementId<DIM(data)>& element_id) noexcept;      \
+  template void test_initial_domain(                         \
+      const Domain<DIM(data)>& domain,                       \
+      const std::vector<std::array<size_t, DIM(data)>>&      \
+          initial_refinement_levels) noexcept;               \
+  template void test_physical_separation(                    \
+      const std::vector<Block<DIM(data)>>& blocks) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+
+#define GET_FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
 #define INSTANTIATE(_, data)                                                \
-  template boost::rational<size_t> fraction_of_block_volume(                \
-      const ElementId<DIM(data)>& element_id) noexcept;                     \
-  template void test_domain_construction<DIM(data)>(                        \
+  template void test_domain_construction<DIM(data), GET_FRAME(data)>(       \
       const Domain<DIM(data)>& domain,                                      \
       const std::vector<DirectionMap<DIM(data), BlockNeighbor<DIM(data)>>>& \
           expected_block_neighbors,                                         \
       const std::vector<std::unordered_set<Direction<DIM(data)>>>&          \
           expected_external_boundaries,                                     \
       const std::vector<std::unique_ptr<domain::CoordinateMapBase<          \
-          Frame::Logical, Frame::Inertial, DIM(data)>>>&                    \
-          expected_maps) noexcept;                                          \
-  template void test_initial_domain(                                        \
-      const Domain<DIM(data)>& domain,                                      \
-      const std::vector<std::array<size_t, DIM(data)>>&                     \
-          initial_refinement_levels) noexcept;                              \
-  template void test_physical_separation(                                   \
-      const std::vector<Block<DIM(data)>>& blocks) noexcept;
+          Frame::Logical, GET_FRAME(data), DIM(data)>>>& expected_maps,     \
+      const double time,                                                    \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time,                                                \
+      const std::vector<std::unique_ptr<domain::CoordinateMapBase<          \
+          Frame::Grid, Frame::Inertial, DIM(data)>>>&                       \
+          expected_logical_to_grid_maps) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial))
+
+#undef INSTANTIATE
+#undef GET_FRAME
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -430,6 +506,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_BASIS_VECTOR, (1, 2, 3),
 
 #undef DIM
 #undef DTYPE
-#undef INSTANTIATE
 #undef INSTANTIATE_BASIS_VECTOR
 /// \endcond

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -6,7 +6,9 @@
 #include <array>
 #include <boost/rational.hpp>
 #include <cstddef>
+#include <limits>
 #include <memory>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -20,6 +22,9 @@ class BlockNeighbor;
 namespace domain {
 template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase;
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
 }  // namespace domain
 class DataVector;
 template <size_t VolumeDim>
@@ -33,16 +38,22 @@ class ElementId;
 /// \endcond
 
 // Test that the Blocks in the Domain are constructed correctly.
-template <size_t VolumeDim>
+template <size_t VolumeDim, typename TargetFrameGridOrInertial>
 void test_domain_construction(
     const Domain<VolumeDim>& domain,
     const std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,
+    const std::vector<std::unique_ptr<domain::CoordinateMapBase<
+        Frame::Logical, TargetFrameGridOrInertial, VolumeDim>>>& expected_maps,
+    double time = std::numeric_limits<double>::quiet_NaN(),
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time = {},
     const std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>>&
-        expected_maps) noexcept;
+        domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>>>&
+        expected_grid_to_inertial_maps = {}) noexcept;
 
 // Test that two neighboring Blocks abut each other.
 template <size_t VolumeDim>

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <pup.h>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -17,8 +18,12 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.hpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.tpp"
+#include "Domain/CoordinateMaps/Translation.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/DirectionMap.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -26,43 +31,130 @@
 namespace domain {
 namespace {
 template <size_t Dim>
-void test_block() {
+void test_block_time_independent() {
   PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial,
                                        CoordinateMaps::Identity<Dim>>));
 
   using coordinate_map = CoordinateMap<Frame::Logical, Frame::Inertial,
                                        CoordinateMaps::Identity<Dim>>;
   const coordinate_map identity_map{CoordinateMaps::Identity<Dim>{}};
-  Block<Dim> block(identity_map.get_clone(), 7, {});
+  Block<Dim> original_block(identity_map.get_clone(), 7, {});
+  CHECK_FALSE(original_block.is_time_dependent());
 
-  // Test external boundaries:
-  CHECK((block.external_boundaries().size()) == 2 * Dim);
+  const auto check_block = [](const Block<Dim>& block) {
+    // Test external boundaries:
+    CHECK((block.external_boundaries().size()) == 2 * Dim);
 
-  // Test neighbors:
-  CHECK((block.neighbors().size()) == 0);
+    // Test neighbors:
+    CHECK((block.neighbors().size()) == 0);
 
-  // Test id:
-  CHECK((block.id()) == 7);
+    // Test id:
+    CHECK((block.id()) == 7);
 
-  // Test that the block's coordinate_map is Identity:
-  const auto& map = block.coordinate_map();
-  const tnsr::I<double, Dim, Frame::Logical> xi(1.0);
-  const tnsr::I<double, Dim, Frame::Inertial> x(1.0);
-  CHECK(map(xi) == x);
-  CHECK(map.inverse(x).get() == xi);
+    // Test that the block's coordinate_map is Identity:
+    const auto& map = block.stationary_map();
+    const tnsr::I<double, Dim, Frame::Logical> xi(1.0);
+    const tnsr::I<double, Dim, Frame::Inertial> x(1.0);
+    CHECK(map(xi) == x);
+    CHECK(map.inverse(x).get() == xi);
+  };
+
+  check_block(original_block);
+  check_block(serialize_and_deserialize(original_block));
 
   // Test PUP
-  test_serialization(block);
+  test_serialization(original_block);
 
   // Test move semantics:
   const Block<Dim> block_copy(identity_map.get_clone(), 7, {});
-  test_move_semantics(std::move(block), block_copy);
+  test_move_semantics(std::move(original_block), block_copy);
+}
+
+template <size_t Dim>
+void test_block_time_dependent() {
+  using Translation = domain::CoordMapsTimeDependent::Translation;
+  using TranslationDimD = tmpl::conditional_t<
+      Dim == 1,
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial, Translation>,
+      tmpl::conditional_t<
+          Dim == 2,
+          domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                                domain::CoordMapsTimeDependent::ProductOf2Maps<
+                                    Translation, Translation>>,
+          domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                                domain::CoordMapsTimeDependent::ProductOf3Maps<
+                                    Translation, Translation, Translation>>>>;
+  using logical_to_grid_coordinate_map =
+      CoordinateMap<Frame::Logical, Frame::Inertial,
+                    CoordinateMaps::Identity<Dim>>;
+  using grid_to_inertial_coordinate_map = TranslationDimD;
+  PUPable_reg(logical_to_grid_coordinate_map);
+  PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Grid,
+                                       CoordinateMaps::Identity<Dim>>));
+  PUPable_reg(grid_to_inertial_coordinate_map);
+  const logical_to_grid_coordinate_map identity_map{
+      CoordinateMaps::Identity<Dim>{}};
+  const grid_to_inertial_coordinate_map translation_map{TranslationDimD{}};
+  Block<Dim> original_block(identity_map.get_clone(), 7, {});
+  CHECK_FALSE(original_block.is_time_dependent());
+  original_block.inject_time_dependent_map(translation_map.get_clone());
+  CHECK(original_block.is_time_dependent());
+
+  const auto check_block = [](const Block<Dim>& block) {
+    const double time = 2.0;
+
+    std::unordered_map<std::string,
+                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+        functions_of_time{};
+
+    functions_of_time["trans"] =
+        std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
+            0.0, std::array<DataVector, 3>{{{0.0}, {1.0}, {0.0}}});
+
+    // Test external boundaries:
+    CHECK((block.external_boundaries().size()) == 2 * Dim);
+
+    // Test neighbors:
+    CHECK((block.neighbors().size()) == 0);
+
+    // Test id:
+    CHECK((block.id()) == 7);
+
+    // Test that the block's coordinate_map is Identity:
+    const auto& grid_to_inertial_map = block.moving_mesh_grid_to_inertial_map();
+    const auto& logical_to_grid_map = block.moving_mesh_logical_to_grid_map();
+    const tnsr::I<double, Dim, Frame::Logical> xi(1.0);
+    const tnsr::I<double, Dim, Frame::Inertial> x(1.0 + time);
+    CHECK(grid_to_inertial_map(logical_to_grid_map(xi), time,
+                               functions_of_time) == x);
+    CHECK(
+        logical_to_grid_map
+            .inverse(
+                grid_to_inertial_map.inverse(x, time, functions_of_time).get())
+            .get() == xi);
+  };
+
+  check_block(original_block);
+  check_block(serialize_and_deserialize(original_block));
+
+  // Test PUP
+  test_serialization(original_block);
+
+  // Test move semantics:
+  Block<Dim> block_copy(identity_map.get_clone(), 7, {});
+  block_copy.inject_time_dependent_map(translation_map.get_clone());
+  test_move_semantics(std::move(original_block), block_copy);
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
-  test_block<1>();
-  test_block<2>();
+  test_block_time_independent<1>();
+  test_block_time_independent<2>();
+  test_block_time_independent<3>();
+
+  test_block_time_dependent<1>();
+  test_block_time_dependent<2>();
+  test_block_time_dependent<3>();
 
   // Create DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>
 
@@ -96,7 +188,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
         "Neighbors: "
         "([+0,Id = 1; orientation = (+0, +1)],"
         "[-1,Id = 2; orientation = (-0, +1)])\n"
-        "External boundaries: (+1,-0)\n");
+        "External boundaries: (+1,-0)\n"
+        "Is time dependent: false");
 
   // Test comparison:
   const Block<2> neighborless_block(identity_map.get_clone(), 7, {});

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -1518,7 +1518,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.SetCartesianPeriodicBoundaries1",
     INFO(i);
     CHECK(domain.blocks()[i].external_boundaries() ==
           expected_external_boundaries[i]);
-    CHECK(domain.blocks()[i].coordinate_map() == *expected_coordinate_maps[i]);
+    CHECK(domain.blocks()[i].stationary_map() == *expected_coordinate_maps[i]);
   }
 }
 
@@ -1552,7 +1552,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.SetCartesianPeriodicBoundaries2",
     INFO(i);
     CHECK(domain.blocks()[i].external_boundaries() ==
           expected_external_boundaries[i]);
-    CHECK(domain.blocks()[i].coordinate_map() == *expected_coordinate_maps[i]);
+    CHECK(domain.blocks()[i].stationary_map() == *expected_coordinate_maps[i]);
   }
 }
 
@@ -1606,7 +1606,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.SetCartesianPeriodicBoundaries3",
     INFO(i);
     CHECK(domain.blocks()[i].external_boundaries() ==
           expected_external_boundaries[i]);
-    CHECK(domain.blocks()[i].coordinate_map() == *expected_coordinate_maps[i]);
+    CHECK(domain.blocks()[i].stationary_map() == *expected_coordinate_maps[i]);
     CHECK(domain.blocks()[i].neighbors() == expected_block_neighbors[i]);
   }
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -310,8 +310,11 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceiveVolumeData",
     ::Mesh<3> mesh{domain_creator.initial_extents()[element_id.block_id()],
                    Spectral::Basis::Legendre,
                    Spectral::Quadrature::GaussLobatto};
+    if (block.is_time_dependent()) {
+      ERROR("The block must be time-independent");
+    }
     ElementMap<3, Frame::Inertial> map{element_id,
-                                       block.coordinate_map().get_clone()};
+                                       block.stationary_map().get_clone()};
     const auto inertial_coords = map(logical_coordinates(mesh));
     db::item_type<
         ::Tags::Variables<typename metavars::interpolator_source_vars>>

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -380,8 +380,11 @@ SPECTRE_TEST_CASE(
     ::Mesh<3> mesh{domain_creator.initial_extents()[element_id.block_id()],
                    Spectral::Basis::Legendre,
                    Spectral::Quadrature::GaussLobatto};
+    if (block.is_time_dependent()) {
+      ERROR("The block must be time-independent");
+    }
     ElementMap<3, Frame::Inertial> map{element_id,
-                                       block.coordinate_map().get_clone()};
+                                       block.stationary_map().get_clone()};
     const auto inertial_coords = map(logical_coordinates(mesh));
     db::item_type<
         ::Tags::Variables<typename metavars::interpolator_source_vars>>

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -338,8 +338,11 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
     ::Mesh<3> mesh{domain_creator.initial_extents()[element_id.block_id()],
                    Spectral::Basis::Legendre,
                    Spectral::Quadrature::GaussLobatto};
+    if (block.is_time_dependent()) {
+      ERROR("The block must be time-independent");
+    }
     ElementMap<3, Frame::Inertial> map{element_id,
-                                       block.coordinate_map().get_clone()};
+                                       block.stationary_map().get_clone()};
     const auto inertial_coords = map(logical_coordinates(mesh));
     db::item_type<
         ::Tags::Variables<typename metavars::interpolator_source_vars>>

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/VerifyGrMhdSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/VerifyGrMhdSolution.hpp
@@ -124,7 +124,10 @@ void verify_grmhd_solution(const Solution& solution, const Block<3>& block,
                 "Solution was not derived from AnalyticSolution");
   // Set up coordinates
   const auto x_logical = logical_coordinates(mesh);
-  const auto x = block.coordinate_map()(x_logical);
+  if (block.is_time_dependent()) {
+    ERROR("The block must be time-independent");
+  }
+  const auto x = block.stationary_map()(x_logical);
 
   // Evaluate analytic solution
   using solution_tags = tmpl::list<
@@ -235,8 +238,11 @@ void verify_grmhd_solution(const Solution& solution, const Block<3>& block,
       inv_spatial_metric, pressure, spatial_velocity, lorentz_factor,
       magnetic_field);
 
+  if (block.is_time_dependent()) {
+    ERROR("The block must be time-independent");
+  }
   const auto div_of_fluxes = divergence<flux_tags, 3, Frame::Inertial>(
-      fluxes, mesh, block.coordinate_map().inv_jacobian(x_logical));
+      fluxes, mesh, block.stationary_map().inv_jacobian(x_logical));
 
   const auto& div_flux_tilde_d =
       get<Tags::div<Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeD,


### PR DESCRIPTION
## Proposed changes

- Add a function to inject time dependent maps into a Block
- Add function to inject time dependent maps into the Blocks held by a Domain

Depends:
- [x] #2018

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
