### PR TITLE
Fix rendering of ABN docs

### DIFF
--- a/docs/config/MathJax.js
+++ b/docs/config/MathJax.js
@@ -1,14 +1,14 @@
 window.MathJax = {
     tex: {
         tags: "ams",
-        packages: ['base', 'ams', 'bbox', 'color', 'physics']
+        packages: ['base', 'ams', 'bbox', 'color', 'physics', 'newcommand']
     },
     options: {
         ignoreHtmlClass: 'tex2jax_ignore',
         processHtmlClass: 'tex2jax_process'
     },
     loader: {
-        load: ['[tex]/bbox', '[tex]/color', '[tex]/physics']
+        load: ['[tex]/bbox', '[tex]/color', '[tex]/physics', '[tex]/newcommand']
     }
 };
 


### PR DESCRIPTION
This was presumably broken by the upgrade to MathJax 3.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
