### PR TITLE
Remove unused var in Test_WriteSimpleData, ignore docs/auto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ compile_commands.json
 *.blg
 *.out
 *.bak
+docs/auto
 
 # Python related files
 *.pyc

--- a/tests/Unit/IO/Observers/Test_WriteSimpleData.cpp
+++ b/tests/Unit/IO/Observers/Test_WriteSimpleData.cpp
@@ -49,8 +49,6 @@ struct test_metavariables {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.IO.Observers.WriteSimpleData", "[Unit][Observers]") {
-  constexpr observers::TypeOfObservation type_of_observation =
-      observers::TypeOfObservation::Volume;
   using obs_writer = helpers::observer_writer_component<test_metavariables>;
 
   tuples::TaggedTuple<observers::Tags::ReductionFileName,


### PR DESCRIPTION
## Proposed changes

- Add docs/auto to gitignore
- Remove unused variable from `Test_WriteSimpleData`

### Types of changes:

- [x] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
