### PR TITLE
Make metavariables to create_from_options optional

### DIFF
--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -49,7 +49,7 @@ struct Domain : db::SimpleTag {
   using type = ::Domain<VolumeDim>;
   using option_tags = tmpl::list<domain::OptionTags::DomainCreator<VolumeDim>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static ::Domain<VolumeDim> create_from_options(
       const std::unique_ptr<::DomainCreator<VolumeDim>>&
           domain_creator) noexcept {
@@ -66,7 +66,7 @@ struct InitialExtents : db::SimpleTag {
   using type = std::vector<std::array<size_t, Dim>>;
   using option_tags = tmpl::list<domain::OptionTags::DomainCreator<Dim>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static std::vector<std::array<size_t, Dim>> create_from_options(
       const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) noexcept {
     return domain_creator->initial_extents();
@@ -82,7 +82,7 @@ struct InitialRefinementLevels : db::SimpleTag {
   using type = std::vector<std::array<size_t, Dim>>;
   using option_tags = tmpl::list<domain::OptionTags::DomainCreator<Dim>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static std::vector<std::array<size_t, Dim>> create_from_options(
       const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) noexcept {
     return domain_creator->initial_refinement_levels();

--- a/src/Elliptic/Tags.hpp
+++ b/src/Elliptic/Tags.hpp
@@ -31,7 +31,7 @@ struct FluxesComputer : db::SimpleTag {
   }
   using option_tags = tmpl::list<>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static FluxesComputerType create_from_options() {
     return FluxesComputerType{};
   }

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp
@@ -41,7 +41,7 @@ struct Limiter : db::SimpleTag {
   using type = LimiterType;
   using option_tags = tmpl::list<::OptionTags::Limiter<LimiterType>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static LimiterType create_from_options(const LimiterType& limiter) noexcept {
     return limiter;
   }

--- a/src/Evolution/Initialization/Tags.hpp
+++ b/src/Evolution/Initialization/Tags.hpp
@@ -19,7 +19,7 @@ struct InitialTime : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::InitialTime>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static double create_from_options(const double initial_time) noexcept {
     return initial_time;
   }
@@ -29,7 +29,7 @@ struct InitialTimeDelta : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::InitialTimeStep>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static double create_from_options(const double initial_time_step) noexcept {
     return initial_time_step;
   }
@@ -40,7 +40,7 @@ struct InitialSlabSize : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::InitialSlabSize>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static double create_from_options(const double initial_slab_size) noexcept {
     return initial_slab_size;
   }
@@ -51,7 +51,7 @@ struct InitialSlabSize<false> : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::InitialTimeStep>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static double create_from_options(const double initial_time_step) noexcept {
     return std::abs(initial_time_step);
   }

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -141,6 +141,7 @@ struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
       tmpl::list<OptionTags::LMax, OptionTags::BoundaryDataFilename,
                  OptionTags::H5LookaheadTimes, OptionTags::H5Interpolator>;
 
+  static constexpr bool pass_metavariables = false;
   static WorldtubeDataManager create_from_options(
       const size_t l_max, const std::string& filename,
       const size_t number_of_lookahead_times,
@@ -155,6 +156,7 @@ struct ScriInterpolationOrder : db::SimpleTag {
   using type = size_t;
   using option_tags = tmpl::list<OptionTags::ScriInterpolationOrder>;
 
+  static constexpr bool pass_metavariables = false;
   static size_t create_from_options(
       const size_t scri_plus_interpolation_order) noexcept {
     return scri_plus_interpolation_order;
@@ -165,6 +167,7 @@ struct TargetStepSize : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::TargetStepSize>;
 
+  static constexpr bool pass_metavariables = false;
   static double create_from_options(const double target_step_size) noexcept {
     return target_step_size;
   }
@@ -174,6 +177,7 @@ struct ScriOutputDensity : db::SimpleTag {
   using type = size_t;
   using option_tags = tmpl::list<OptionTags::ScriOutputDensity>;
 
+  static constexpr bool pass_metavariables = false;
   static size_t create_from_options(const size_t scri_output_density) noexcept {
     return scri_output_density;
   }
@@ -185,6 +189,7 @@ struct LMax : db::SimpleTag, Spectral::Swsh::Tags::LMaxBase {
   using type = size_t;
   using option_tags = tmpl::list<OptionTags::LMax>;
 
+  static constexpr bool pass_metavariables = false;
   static size_t create_from_options(const size_t l_max) noexcept {
     return l_max;
   }
@@ -195,6 +200,7 @@ struct NumberOfRadialPoints : db::SimpleTag,
   using type = size_t;
   using option_tags = tmpl::list<OptionTags::NumberOfRadialPoints>;
 
+  static constexpr bool pass_metavariables = false;
   static size_t create_from_options(
       const size_t number_of_radial_points) noexcept {
     return number_of_radial_points;
@@ -214,6 +220,7 @@ struct FilterLMax : db::SimpleTag {
   using type = size_t;
   using option_tags = tmpl::list<OptionTags::FilterLMax>;
 
+  static constexpr bool pass_metavariables = false;
   static size_t create_from_options(const size_t filter_l_max) noexcept {
     return filter_l_max;
   }
@@ -223,6 +230,7 @@ struct RadialFilterAlpha : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::RadialFilterAlpha>;
 
+  static constexpr bool pass_metavariables = false;
   static double create_from_options(const double radial_filter_alpha) noexcept {
     return radial_filter_alpha;
   }
@@ -232,6 +240,7 @@ struct RadialFilterHalfPower : db::SimpleTag {
   using type = size_t;
   using option_tags = tmpl::list<OptionTags::RadialFilterHalfPower>;
 
+  static constexpr bool pass_metavariables = false;
   static size_t create_from_options(
       const size_t radial_filter_half_power) noexcept {
     return radial_filter_half_power;
@@ -243,6 +252,7 @@ struct StartTime : db::SimpleTag {
   using option_tags =
       tmpl::list<OptionTags::StartTime, OptionTags::BoundaryDataFilename>;
 
+  static constexpr bool pass_metavariables = false;
   static double create_from_options(double start_time,
                                     const std::string& filename) noexcept {
     if (start_time == -std::numeric_limits<double>::infinity()) {
@@ -259,6 +269,7 @@ struct EndTime : db::SimpleTag {
   using option_tags =
       tmpl::list<OptionTags::EndTime, OptionTags::BoundaryDataFilename>;
 
+  static constexpr bool pass_metavariables = false;
   static double create_from_options(double end_time,
                                     const std::string& filename) {
     if (end_time == std::numeric_limits<double>::infinity()) {

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -63,7 +63,7 @@ struct GaugeHRollOnStartTime : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::GaugeHRollOnStart>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static double create_from_options(
       const double gauge_roll_on_start_time) noexcept {
     return gauge_roll_on_start_time;
@@ -82,7 +82,7 @@ struct GaugeHRollOnTimeWindow : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::GaugeHRollOnWindow>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static double create_from_options(
       const double gauge_roll_on_window) noexcept {
     return gauge_roll_on_window;
@@ -106,7 +106,7 @@ struct GaugeHSpatialWeightDecayWidth : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::GaugeHSpatialDecayWidth<Frame>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static double create_from_options(
       const double gauge_spatial_decay_width) noexcept {
     return gauge_spatial_decay_width;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
@@ -83,7 +83,7 @@ struct ConstraintDampingParameter : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::DampingParameter>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static double create_from_options(
       const double constraint_damping_parameter) noexcept {
     return constraint_damping_parameter;

--- a/src/Evolution/Systems/NewtonianEuler/Tags.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Tags.hpp
@@ -95,7 +95,7 @@ struct SourceTerm : SourceTermBase, db::SimpleTag {
                           ::OptionTags::AnalyticSolution<InitialDataType>,
                           ::OptionTags::AnalyticData<InitialDataType>>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static type create_from_options(
       const InitialDataType& initial_data) noexcept {
     return initial_data.source_term();

--- a/src/Evolution/VariableFixing/Tags.hpp
+++ b/src/Evolution/VariableFixing/Tags.hpp
@@ -45,7 +45,7 @@ struct VariableFixer : db::SimpleTag {
   using option_tags =
       tmpl::list<::OptionTags::VariableFixer<VariableFixerType>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static VariableFixerType create_from_options(
       const VariableFixerType& variable_fixer) noexcept {
     return variable_fixer;

--- a/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
+++ b/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
@@ -32,7 +32,7 @@ struct Name : db::SimpleTag {
   using type = std::string;
   using option_tags = tmpl::list<OptionTags::Name>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static std::string create_from_options(const std::string& name) noexcept {
     return name;
   }

--- a/src/IO/Importers/Tags.hpp
+++ b/src/IO/Importers/Tags.hpp
@@ -88,7 +88,7 @@ struct FileName : db::SimpleTag {
   using type = std::string;
   using option_tags = tmpl::list<OptionTags::FileName<ImporterOptionsGroup>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& file_name) noexcept {
     return file_name;
   }
@@ -107,7 +107,7 @@ struct Subgroup : db::SimpleTag {
   using type = std::string;
   using option_tags = tmpl::list<OptionTags::Subgroup<ImporterOptionsGroup>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& subgroup) noexcept {
     return subgroup;
   }
@@ -125,7 +125,7 @@ struct ObservationValue : db::SimpleTag {
   using option_tags =
       tmpl::list<OptionTags::ObservationValue<ImporterOptionsGroup>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& observation_value) noexcept {
     return observation_value;
   }

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -153,7 +153,7 @@ struct VolumeFileName : db::SimpleTag {
   using type = std::string;
   using option_tags = tmpl::list<::observers::OptionTags::VolumeFileName>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static std::string create_from_options(
       const std::string& volume_file_name) noexcept {
     return volume_file_name;
@@ -164,7 +164,7 @@ struct ReductionFileName : db::SimpleTag {
   using type = std::string;
   using option_tags = tmpl::list<::observers::OptionTags::ReductionFileName>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static std::string create_from_options(
       const std::string& reduction_file_name) noexcept {
     return reduction_file_name;

--- a/src/Informer/Tags.hpp
+++ b/src/Informer/Tags.hpp
@@ -28,7 +28,7 @@ struct Verbosity : db::SimpleTag {
   using type = ::Verbosity;
   using option_tags = tmpl::list<OptionTags::Verbosity>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static ::Verbosity create_from_options(
       const ::Verbosity& verbosity) noexcept {
     return verbosity;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -85,7 +85,7 @@ struct NumericalFlux : db::SimpleTag {
   using option_tags =
       tmpl::list<::OptionTags::NumericalFlux<NumericalFluxType>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static NumericalFluxType create_from_options(
       const NumericalFluxType& numerical_flux) noexcept {
     return numerical_flux;

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -112,7 +112,7 @@ struct ApparentHorizon : db::SimpleTag {
   using option_tags =
       tmpl::list<OptionTags::ApparentHorizon<InterpolationTargetTag, Frame>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& option) noexcept {
     return option;
   }

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
@@ -107,7 +107,7 @@ struct KerrHorizon : db::SimpleTag {
   using option_tags =
       tmpl::list<OptionTags::KerrHorizon<InterpolationTargetTag>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& option) noexcept {
     return option;
   }

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
@@ -108,7 +108,7 @@ struct LineSegment : db::SimpleTag {
   using option_tags =
       tmpl::list<OptionTags::LineSegment<InterpolationTargetTag, VolumeDim>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& option) noexcept {
     return option;
   }

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -176,7 +176,7 @@ struct WedgeSectionTorus : db::SimpleTag {
   using option_tags =
       tmpl::list<OptionTags::WedgeSectionTorus<InterpolationTargetTag>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& option) noexcept {
     return option;
   }

--- a/src/NumericalAlgorithms/LinearOperators/Tags.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Tags.hpp
@@ -5,6 +5,7 @@
 
 #include <string>
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "Options/Options.hpp"
 
 namespace OptionTags {
@@ -42,7 +43,7 @@ struct Filter : db::SimpleTag {
   using type = FilterType;
   using option_tags = tmpl::list<::OptionTags::Filter<FilterType>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static FilterType create_from_options(const FilterType& filter) noexcept {
     return filter;
   }

--- a/src/Parallel/CreateFromOptions.hpp
+++ b/src/Parallel/CreateFromOptions.hpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace Parallel {
+namespace detail {
+template <typename Metavariables, typename Tag, typename... OptionTags,
+          typename... OptionTagsForTag,
+          Requires<Tag::pass_metavariables> = nullptr>
+typename Tag::type create_initialization_item_from_options(
+    const tuples::TaggedTuple<OptionTags...>& options,
+    tmpl::list<OptionTagsForTag...> /*meta*/) noexcept {
+  return Tag::template create_from_options<Metavariables>(
+      tuples::get<OptionTagsForTag>(options)...);
+}
+
+template <typename Metavariables, typename Tag, typename... OptionTags,
+          typename... OptionTagsForTag,
+          Requires<not Tag::pass_metavariables> = nullptr>
+typename Tag::type create_initialization_item_from_options(
+    const tuples::TaggedTuple<OptionTags...>& options,
+    tmpl::list<OptionTagsForTag...> /*meta*/) noexcept {
+  return Tag::create_from_options(tuples::get<OptionTagsForTag>(options)...);
+}
+}  // namespace detail
+
+/// \ingroup ParallelGroup
+/// \brief Given a list of tags and a tagged tuple containing items
+/// created from input options, return a tagged tuple of items constructed
+/// by calls to create_from_options for each tag in the list.
+template <typename Metavariables, typename... Tags, typename... OptionTags>
+tuples::TaggedTuple<Tags...> create_from_options(
+    const tuples::TaggedTuple<OptionTags...>& options,
+    tmpl::list<Tags...> /*meta*/) noexcept {
+  return {detail::create_initialization_item_from_options<Metavariables, Tags>(
+      options, typename Tags::option_tags{})...};
+}
+}  // namespace Parallel

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -18,6 +18,7 @@
 #include "Parallel/AlgorithmMetafunctions.hpp"
 #include "Parallel/CharmRegistration.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/CreateFromOptions.hpp"
 #include "Parallel/Exit.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/Printf.hpp"

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -165,29 +165,6 @@ using get_option_tags = tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
     InitializationTagsList,
     detail::get_option_tags_from_initialization_tag<tmpl::_1>>>>;
 
-namespace detail {
-template <typename Metavariables, typename Tag, typename... OptionTags,
-          typename... OptionTagsForTag>
-typename Tag::type create_initialization_item_from_options(
-    const tuples::TaggedTuple<OptionTags...>& options,
-    tmpl::list<OptionTagsForTag...> /*meta*/) noexcept {
-  return Tag::template create_from_options<Metavariables>(
-      tuples::get<OptionTagsForTag>(options)...);
-}
-}  // namespace detail
-
-/// \ingroup ParallelGroup
-/// \brief Given a list of tags and a tagged tuple containing items
-/// created from input options, return a tagged tuple of items constructed
-/// by calls to create_from_options for each tag in the list.
-template <typename Metavariables, typename... Tags, typename... OptionTags>
-tuples::TaggedTuple<Tags...> create_from_options(
-    const tuples::TaggedTuple<OptionTags...>& options,
-    tmpl::list<Tags...> /*meta*/) noexcept {
-  return {detail::create_initialization_item_from_options<Metavariables, Tags>(
-      options, typename Tags::option_tags{})...};
-}
-
 /// \cond
 namespace Algorithms {
 struct Singleton;

--- a/src/ParallelAlgorithms/EventsAndTriggers/Tags.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Tags.hpp
@@ -51,7 +51,7 @@ struct EventsAndTriggers : EventsAndTriggersBase, db::SimpleTag {
   using option_tags = tmpl::list<
       ::OptionTags::EventsAndTriggers<EventRegistrars, TriggerRegistrars>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& events_and_triggers) noexcept {
     return deserialize<type>(serialize<type>(events_and_triggers).data());
   }

--- a/src/ParallelAlgorithms/LinearSolver/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Tags.hpp
@@ -296,7 +296,7 @@ struct ConvergenceCriteria : db::SimpleTag {
   using type = Convergence::Criteria;
   using option_tags = tmpl::list<LinearSolver::OptionTags::ConvergenceCriteria>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static Convergence::Criteria create_from_options(
       const Convergence::Criteria& convergence_criteria) noexcept {
     return convergence_criteria;
@@ -307,7 +307,7 @@ struct Verbosity : db::SimpleTag {
   using type = ::Verbosity;
   using option_tags = tmpl::list<LinearSolver::OptionTags::Verbosity>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static ::Verbosity create_from_options(
       const ::Verbosity& verbosity) noexcept {
     return verbosity;

--- a/src/PointwiseFunctions/AnalyticData/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Tags.hpp
@@ -42,7 +42,7 @@ struct AnalyticData : AnalyticDataBase, db::SimpleTag {
   using type = DataType;
   using option_tags = tmpl::list<::OptionTags::AnalyticData<DataType>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static DataType create_from_options(
       const DataType& analytic_solution) noexcept {
     return deserialize<type>(serialize<type>(analytic_solution).data());

--- a/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
@@ -52,7 +52,7 @@ struct AnalyticSolution : AnalyticSolutionBase, db::SimpleTag {
   using type = SolutionType;
   using option_tags = tmpl::list<::OptionTags::AnalyticSolution<SolutionType>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static SolutionType create_from_options(
       const SolutionType& analytic_solution) noexcept {
     return deserialize<type>(serialize<type>(analytic_solution).data());
@@ -66,7 +66,7 @@ struct BoundaryCondition : BoundaryConditionBase, db::SimpleTag {
   using option_tags =
       tmpl::list<::OptionTags::BoundaryCondition<BoundaryConditionType>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static BoundaryConditionType create_from_options(
       const BoundaryConditionType& boundary_condition) noexcept {
     return boundary_condition;

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -185,7 +185,7 @@ struct TimeStepper : TimeStepper<>, db::SimpleTag {
   using type = std::unique_ptr<StepperType>;
   using option_tags = tmpl::list<::OptionTags::TimeStepper<StepperType>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static std::unique_ptr<StepperType> create_from_options(
       const std::unique_ptr<StepperType>& time_stepper) noexcept {
     return deserialize<type>(serialize<type>(time_stepper).data());
@@ -201,7 +201,7 @@ struct StepChoosers : db::SimpleTag {
   using type = std::vector<std::unique_ptr<::StepChooser<Registrars>>>;
   using option_tags = tmpl::list<::OptionTags::StepChoosers<Registrars>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& step_choosers) noexcept {
     return deserialize<type>(serialize<type>(step_choosers).data());
   }
@@ -214,7 +214,7 @@ struct StepController : db::SimpleTag {
   using type = std::unique_ptr<::StepController>;
   using option_tags = tmpl::list<::OptionTags::StepController>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static std::unique_ptr<::StepController> create_from_options(
       const std::unique_ptr<::StepController>& step_controller) noexcept {
     return deserialize<type>(serialize<type>(step_controller).data());

--- a/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
+++ b/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Options/ParseOptions.hpp"
+#include "Parallel/CreateFromOptions.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"  // IWYU pragma: keep
 #include "Utilities/NoSuchType.hpp"
 #include "Utilities/TMPL.hpp"
@@ -268,7 +269,7 @@ struct Yards {
   using option_tags = tmpl::list<OptionTags::Yards>;
   using type = double;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static double create_from_options(const double yards) noexcept {
     return yards;
   }
@@ -277,7 +278,7 @@ struct Feet {
   using option_tags = tmpl::list<OptionTags::Yards>;
   using type = double;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static double create_from_options(const double yards) noexcept {
     return 3.0 * yards;
   }
@@ -286,7 +287,7 @@ struct Sides {
   using option_tags = tmpl::list<OptionTags::Yards, OptionTags::Dim>;
   using type = std::vector<double>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static std::vector<double> create_from_options(const double yards,
                                                  const size_t dim) noexcept {
     return std::vector<double>(dim, yards);
@@ -296,6 +297,7 @@ struct FullGreeting {
   using option_tags = tmpl::list<OptionTags::Greeting, OptionTags::Name>;
   using type = std::string;
 
+  static constexpr bool pass_metavariables = true;
   template <typename Metavariables, typename... Tags>
   static std::string create_from_options(const std::string& greeting,
                                          const std::string& name) noexcept {

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -60,7 +60,7 @@ struct NumberOfElements : db::SimpleTag {
   using type = int;
   using option_tags = tmpl::list<OptionTags::NumberOfElements>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static int create_from_options(const size_t number_of_elements) noexcept {
     return number_of_elements;
   }
@@ -95,7 +95,7 @@ struct LinearOperator : db::SimpleTag {
   using type = std::vector<DenseMatrix<double, blaze::columnMajor>>;
   using option_tags = tmpl::list<OptionTags::LinearOperator>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static std::vector<DenseMatrix<double, blaze::columnMajor>>
   create_from_options(
       const std::vector<DenseMatrix<double, blaze::columnMajor>>&
@@ -108,7 +108,7 @@ struct Source : db::SimpleTag {
   using type = std::vector<DenseVector<double>>;
   using option_tags = tmpl::list<OptionTags::Source>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static std::vector<DenseVector<double>> create_from_options(
       const std::vector<DenseVector<double>>& source) noexcept {
     return source;
@@ -119,7 +119,7 @@ struct ExpectedResult : db::SimpleTag {
   using type = std::vector<DenseVector<double>>;
   using option_tags = tmpl::list<OptionTags::ExpectedResult>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static std::vector<DenseVector<double>> create_from_options(
       const std::vector<DenseVector<double>>& expected_result) noexcept {
     return expected_result;

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -62,7 +62,7 @@ struct LinearOperator : db::SimpleTag {
   using type = DenseMatrix<double>;
   using option_tags = tmpl::list<OptionTags::LinearOperator>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static DenseMatrix<double> create_from_options(
       const DenseMatrix<double>& linear_operator) noexcept {
     return linear_operator;
@@ -73,7 +73,7 @@ struct Source : db::SimpleTag {
   using type = DenseVector<double>;
   using option_tags = tmpl::list<OptionTags::Source>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static DenseVector<double> create_from_options(
       const DenseVector<double>& source) noexcept {
     return source;
@@ -84,7 +84,7 @@ struct InitialGuess : db::SimpleTag {
   using type = DenseVector<double>;
   using option_tags = tmpl::list<OptionTags::InitialGuess>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static DenseVector<double> create_from_options(
       const DenseVector<double>& initial_guess) noexcept {
     return initial_guess;
@@ -95,7 +95,7 @@ struct ExpectedResult : db::SimpleTag {
   using type = DenseVector<double>;
   using option_tags = tmpl::list<OptionTags::ExpectedResult>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static DenseVector<double> create_from_options(
       const DenseVector<double>& expected_result) noexcept {
     return expected_result;


### PR DESCRIPTION
## Proposed changes

Previously the `create_from_options` function always took `Metavariables` as an explicit template parameter, which meant we needed more includes in header files than necessary. Making that optional means we can have cpp files instead of doing everything in header files.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
