### PR TITLE
Allow registering all classes in a typelist with charm, register functions of time with charm

### DIFF
--- a/src/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/src/Domain/FunctionsOfTime/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY FunctionsOfTime)
 
 set(LIBRARY_SOURCES
   PiecewisePolynomial.cpp
+  RegisterDerivedWithCharm.cpp
   SettleToConstant.cpp
   )
 
@@ -14,4 +15,5 @@ target_link_libraries(
   ${LIBRARY}
   INTERFACE DataStructures
   INTERFACE ErrorHandling
+  INTERFACE Utilities
   )

--- a/src/Domain/FunctionsOfTime/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/FunctionsOfTime/RegisterDerivedWithCharm.cpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <string>
+
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/SettleToConstant.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain {
+namespace FunctionsOfTime {
+void register_derived_with_charm() noexcept {
+  using to_register = tmpl::list<FunctionsOfTime::PiecewisePolynomial<2>,
+                                 FunctionsOfTime::PiecewisePolynomial<3>,
+                                 FunctionsOfTime::PiecewisePolynomial<4>,
+                                 FunctionsOfTime::SettleToConstant>;
+  Parallel::register_classes_in_list<to_register>();
+}
+}  // namespace FunctionsOfTime
+}  // namespace domain

--- a/src/Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp
+++ b/src/Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,10 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace domain {
+namespace FunctionsOfTime {
+void register_derived_with_charm() noexcept;
+}  // namespace FunctionsOfTime
+}  // namespace domain

--- a/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -105,8 +106,7 @@ void test_within_roundoff(
 
 SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
                   "[Domain][Unit]") {
-  PUPable_reg(FunctionsOfTime::PiecewisePolynomial<2>);
-  PUPable_reg(FunctionsOfTime::PiecewisePolynomial<3>);
+  FunctionsOfTime::register_derived_with_charm();
 
   {
     INFO("Core test");

--- a/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstant.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstant.cpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Domain/FunctionsOfTime/SettleToConstant.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -53,7 +54,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.SettleToConstant",
                   "[Domain][Unit]") {
   using SettleToConstant = domain::FunctionsOfTime::SettleToConstant;
 
-  PUPable_reg(SettleToConstant);
+  domain::FunctionsOfTime::register_derived_with_charm();
 
   const double match_time = 10.0;
   const double decay_time = 5.0;


### PR DESCRIPTION
## Proposed changes

- Previously we could only easily register creatable classes from base classes. This makes the impl function that previously did the looping over the typelist public so we can register everything in a typelist.
- Register functions of time with Charm++ so they can be serialized.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
