### PR TITLE
Update to catch2 v2.11.1 in container

### DIFF
--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -107,7 +107,7 @@ RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.2.tar.gz -O bla
     && git clone https://github.com/edouarda/brigand.git \
     && mv brigand/include/brigand /usr/local/include \
     && rm -rf brigand \
-    && wget https://github.com/catchorg/Catch2/releases/download/v2.2.1/catch.hpp -O catch.hpp \
+    && wget https://github.com/catchorg/Catch2/releases/download/v2.11.1/catch.hpp -O catch.hpp \
     && mv catch.hpp /usr/local/include \
     && wget https://github.com/pybind/pybind11/archive/v2.4.3.tar.gz -O pybind11.tar.gz \
     && tar -xzf pybind11.tar.gz \


### PR DESCRIPTION
## Proposed changes

This should resolve the issue of unused variable warnings not showing up in CI.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
