### PR TITLE
Remove DataType template from NewtonianEuler evolved variable tags

### DIFF
--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -126,10 +126,10 @@ struct EvolutionMetavars {
       Tags::NumericalFlux<dg::NumericalFluxes::Hll<system>>;
 
   using limiter = Tags::Limiter<Limiters::Minmod<
-      Dim, tmpl::list<NewtonianEuler::Tags::MassDensityCons<DataVector>,
-                      NewtonianEuler::Tags::MomentumDensity<DataVector, Dim,
-                                                            Frame::Inertial>,
-                      NewtonianEuler::Tags::EnergyDensity<DataVector>>>>;
+      Dim,
+      tmpl::list<NewtonianEuler::Tags::MassDensityCons,
+                 NewtonianEuler::Tags::MomentumDensity<Dim, Frame::Inertial>,
+                 NewtonianEuler::Tags::EnergyDensity>>>;
 
   using step_choosers_common =
       tmpl::list<StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial>,

--- a/src/Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp
@@ -44,9 +44,9 @@ namespace NewtonianEuler {
  */
 template <size_t Dim>
 struct ConservativeFromPrimitive {
-  using return_tags = tmpl::list<Tags::MassDensityCons<DataVector>,
-                                 Tags::MomentumDensity<DataVector, Dim>,
-                                 Tags::EnergyDensity<DataVector>>;
+  using return_tags =
+      tmpl::list<Tags::MassDensityCons, Tags::MomentumDensity<Dim>,
+                 Tags::EnergyDensity>;
 
   using argument_tags =
       tmpl::list<Tags::MassDensity<DataVector>, Tags::Velocity<DataVector, Dim>,

--- a/src/Evolution/Systems/NewtonianEuler/Fluxes.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Fluxes.hpp
@@ -53,17 +53,14 @@ namespace NewtonianEuler {
  */
 template <size_t Dim>
 struct ComputeFluxes {
-  using return_tags =
-      tmpl::list<::Tags::Flux<Tags::MassDensityCons<DataVector>,
-                              tmpl::size_t<Dim>, Frame::Inertial>,
-                 ::Tags::Flux<Tags::MomentumDensity<DataVector, Dim>,
-                              tmpl::size_t<Dim>, Frame::Inertial>,
-                 ::Tags::Flux<Tags::EnergyDensity<DataVector>,
-                              tmpl::size_t<Dim>, Frame::Inertial>>;
+  using return_tags = tmpl::list<
+      ::Tags::Flux<Tags::MassDensityCons, tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::Flux<Tags::MomentumDensity<Dim>, tmpl::size_t<Dim>,
+                   Frame::Inertial>,
+      ::Tags::Flux<Tags::EnergyDensity, tmpl::size_t<Dim>, Frame::Inertial>>;
 
   using argument_tags =
-      tmpl::list<Tags::MomentumDensity<DataVector, Dim>,
-                 Tags::EnergyDensity<DataVector>,
+      tmpl::list<Tags::MomentumDensity<Dim>, Tags::EnergyDensity,
                  Tags::Velocity<DataVector, Dim>, Tags::Pressure<DataVector>>;
 
   static void apply(

--- a/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.cpp
@@ -39,16 +39,15 @@ void Hllc<Dim, Frame>::package_data(
     const db::const_item_type<char_speeds_tag>& characteristic_speeds,
     const tnsr::i<DataVector, Dim, Frame>& interface_unit_normal) const
     noexcept {
-  get<::Tags::NormalDotFlux<Tags::MassDensityCons<DataVector>>>(
-      *packaged_data) = normal_dot_flux_mass_density;
-  get<::Tags::NormalDotFlux<Tags::MomentumDensity<DataVector, Dim, Frame>>>(
+  get<::Tags::NormalDotFlux<Tags::MassDensityCons>>(*packaged_data) =
+      normal_dot_flux_mass_density;
+  get<::Tags::NormalDotFlux<Tags::MomentumDensity<Dim, Frame>>>(
       *packaged_data) = normal_dot_flux_momentum_density;
-  get<::Tags::NormalDotFlux<Tags::EnergyDensity<DataVector>>>(*packaged_data) =
+  get<::Tags::NormalDotFlux<Tags::EnergyDensity>>(*packaged_data) =
       normal_dot_flux_energy_density;
-  get<Tags::MassDensityCons<DataVector>>(*packaged_data) = mass_density;
-  get<Tags::MomentumDensity<DataVector, Dim, Frame>>(*packaged_data) =
-      momentum_density;
-  get<Tags::EnergyDensity<DataVector>>(*packaged_data) = energy_density;
+  get<Tags::MassDensityCons>(*packaged_data) = mass_density;
+  get<Tags::MomentumDensity<Dim, Frame>>(*packaged_data) = momentum_density;
+  get<Tags::EnergyDensity>(*packaged_data) = energy_density;
   get<Tags::Pressure<DataVector>>(*packaged_data) = pressure;
   get<::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>>(
       *packaged_data) = interface_unit_normal;

--- a/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.hpp
@@ -141,23 +141,21 @@ struct Hllc {
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 
   using package_tags = tmpl::list<
-      ::Tags::NormalDotFlux<Tags::MassDensityCons<DataVector>>,
-      ::Tags::NormalDotFlux<Tags::MomentumDensity<DataVector, Dim, Frame>>,
-      ::Tags::NormalDotFlux<Tags::EnergyDensity<DataVector>>,
-      Tags::MassDensityCons<DataVector>,
-      Tags::MomentumDensity<DataVector, Dim, Frame>,
-      Tags::EnergyDensity<DataVector>, Tags::Pressure<DataVector>,
+      ::Tags::NormalDotFlux<Tags::MassDensityCons>,
+      ::Tags::NormalDotFlux<Tags::MomentumDensity<Dim, Frame>>,
+      ::Tags::NormalDotFlux<Tags::EnergyDensity>, Tags::MassDensityCons,
+      Tags::MomentumDensity<Dim, Frame>, Tags::EnergyDensity,
+      Tags::Pressure<DataVector>,
       ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>,
       NormalVelocity, LargestIngoingSpeed, LargestOutgoingSpeed>;
 
   using argument_tags = tmpl::list<
-      ::Tags::NormalDotFlux<Tags::MassDensityCons<DataVector>>,
-      ::Tags::NormalDotFlux<Tags::MomentumDensity<DataVector, Dim, Frame>>,
-      ::Tags::NormalDotFlux<Tags::EnergyDensity<DataVector>>,
-      Tags::MassDensityCons<DataVector>,
-      Tags::MomentumDensity<DataVector, Dim, Frame>,
-      Tags::EnergyDensity<DataVector>, Tags::Velocity<DataVector, Dim, Frame>,
-      Tags::Pressure<DataVector>, char_speeds_tag,
+      ::Tags::NormalDotFlux<Tags::MassDensityCons>,
+      ::Tags::NormalDotFlux<Tags::MomentumDensity<Dim, Frame>>,
+      ::Tags::NormalDotFlux<Tags::EnergyDensity>, Tags::MassDensityCons,
+      Tags::MomentumDensity<Dim, Frame>, Tags::EnergyDensity,
+      Tags::Velocity<DataVector, Dim, Frame>, Tags::Pressure<DataVector>,
+      char_speeds_tag,
       ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
 
   void package_data(

--- a/src/Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp
@@ -57,9 +57,9 @@ struct PrimitiveFromConservative {
                  Tags::SpecificInternalEnergy<DataVector>,
                  Tags::Pressure<DataVector>>;
 
-  using argument_tags = tmpl::list<
-      Tags::MassDensityCons<DataVector>, Tags::MomentumDensity<DataVector, Dim>,
-      Tags::EnergyDensity<DataVector>, hydro::Tags::EquationOfStateBase>;
+  using argument_tags =
+      tmpl::list<Tags::MassDensityCons, Tags::MomentumDensity<Dim>,
+                 Tags::EnergyDensity, hydro::Tags::EquationOfStateBase>;
 
   static void apply(
       gsl::not_null<Scalar<DataVector>*> mass_density,

--- a/src/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.hpp
@@ -78,11 +78,11 @@ struct LaneEmdenGravitationalField {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 
-  using sourced_variables = tmpl::list<Tags::MomentumDensity<DataVector, 3>,
-                                       Tags::EnergyDensity<DataVector>>;
+  using sourced_variables =
+      tmpl::list<Tags::MomentumDensity<3>, Tags::EnergyDensity>;
 
   using argument_tags = tmpl::list<
-      Tags::MassDensityCons<DataVector>, Tags::MomentumDensity<DataVector, 3>,
+      Tags::MassDensityCons, Tags::MomentumDensity<3>,
       ::Tags::AnalyticSolution<NewtonianEuler::Solutions::LaneEmdenStar>,
       ::Tags::Coordinates<3, Frame::Inertial>>;
 

--- a/src/Evolution/Systems/NewtonianEuler/Sources/UniformAcceleration.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/UniformAcceleration.hpp
@@ -66,11 +66,11 @@ struct UniformAcceleration {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& /*p*/) noexcept;  // NOLINT
 
-  using sourced_variables = tmpl::list<Tags::MomentumDensity<DataVector, Dim>,
-                                       Tags::EnergyDensity<DataVector>>;
+  using sourced_variables =
+      tmpl::list<Tags::MomentumDensity<Dim>, Tags::EnergyDensity>;
 
-  using argument_tags = tmpl::list<Tags::MassDensityCons<DataVector>,
-                                   Tags::MomentumDensity<DataVector, Dim>>;
+  using argument_tags =
+      tmpl::list<Tags::MassDensityCons, Tags::MomentumDensity<Dim>>;
 
   void apply(gsl::not_null<tnsr::I<DataVector, Dim>*> source_momentum_density,
              gsl::not_null<Scalar<DataVector>*> source_energy_density,

--- a/src/Evolution/Systems/NewtonianEuler/Sources/VortexPerturbation.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/VortexPerturbation.hpp
@@ -79,12 +79,11 @@ struct VortexPerturbation {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 
-  using sourced_variables =
-      tmpl::conditional_t<Dim == 3,
-                          tmpl::list<Tags::MassDensityCons<DataVector>,
-                                     Tags::MomentumDensity<DataVector, Dim>,
-                                     Tags::EnergyDensity<DataVector>>,
-                          tmpl::list<>>;
+  using sourced_variables = tmpl::conditional_t<
+      Dim == 3,
+      tmpl::list<Tags::MassDensityCons, Tags::MomentumDensity<Dim>,
+                 Tags::EnergyDensity>,
+      tmpl::list<>>;
 
   using argument_tags = tmpl::conditional_t<
       Dim == 3,

--- a/src/Evolution/Systems/NewtonianEuler/System.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/System.hpp
@@ -42,10 +42,8 @@ struct System {
       Tags::MassDensity<DataVector>, Tags::Velocity<DataVector, Dim>,
       Tags::SpecificInternalEnergy<DataVector>, Tags::Pressure<DataVector>>>;
 
-  using variables_tag =
-      ::Tags::Variables<tmpl::list<Tags::MassDensityCons<DataVector>,
-                                   Tags::MomentumDensity<DataVector, Dim>,
-                                   Tags::EnergyDensity<DataVector>>>;
+  using variables_tag = ::Tags::Variables<tmpl::list<
+      Tags::MassDensityCons, Tags::MomentumDensity<Dim>, Tags::EnergyDensity>>;
 
   template <typename Tag>
   using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;

--- a/src/Evolution/Systems/NewtonianEuler/Tags.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Tags.hpp
@@ -13,6 +13,10 @@
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 
+/// \cond
+class DataVector;
+/// \endcond
+
 namespace NewtonianEuler {
 /// %Tags for the conservative formulation of the Newtonian Euler system
 namespace Tags {
@@ -30,24 +34,22 @@ struct MassDensity : db::SimpleTag {
 };
 
 /// The mass density of the fluid (as a conservative variable).
-template <typename DataType>
 struct MassDensityCons : db::SimpleTag {
-  using type = Scalar<DataType>;
+  using type = Scalar<DataVector>;
 };
 
 /// The momentum density of the fluid.
-template <typename DataType, size_t Dim, typename Fr>
+template <size_t Dim, typename Fr>
 struct MomentumDensity : db::SimpleTag {
-  using type = tnsr::I<DataType, Dim, Fr>;
+  using type = tnsr::I<DataVector, Dim, Fr>;
   static std::string name() noexcept {
     return Frame::prefix<Fr>() + "MomentumDensity";
   }
 };
 
 /// The energy density of the fluid.
-template <typename DataType>
 struct EnergyDensity : db::SimpleTag {
-  using type = Scalar<DataType>;
+  using type = Scalar<DataVector>;
 };
 
 /// The macroscopic or flow velocity of the fluid.

--- a/src/Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp
@@ -14,11 +14,9 @@ template <size_t Dim>
 struct CharacteristicSpeeds;
 template <typename DataType>
 struct MassDensity;
-template <typename DataType>
 struct MassDensityCons;
-template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+template <size_t Dim, typename Fr = Frame::Inertial>
 struct MomentumDensity;
-template <typename DataType>
 struct EnergyDensity;
 template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
 struct Velocity;

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Sources.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Sources.cpp
@@ -42,9 +42,9 @@ template <size_t Dim>
 struct SomeSourceType {
   static constexpr size_t volume_dim = Dim;
   using sourced_variables =
-      tmpl::list<NewtonianEuler::Tags::MassDensityCons<DataVector>,
-                 NewtonianEuler::Tags::MomentumDensity<DataVector, Dim>,
-                 NewtonianEuler::Tags::EnergyDensity<DataVector>>;
+      tmpl::list<NewtonianEuler::Tags::MassDensityCons,
+                 NewtonianEuler::Tags::MomentumDensity<Dim>,
+                 NewtonianEuler::Tags::EnergyDensity>;
 
   using argument_tags =
       tmpl::list<FirstArg, SecondArg<Dim>, ThirdArg, FourthArg<Dim>>;
@@ -73,8 +73,8 @@ template <size_t Dim>
 struct SomeOtherSourceType {
   static constexpr size_t volume_dim = Dim;
   using sourced_variables =
-      tmpl::list<NewtonianEuler::Tags::MomentumDensity<DataVector, Dim>,
-                 NewtonianEuler::Tags::EnergyDensity<DataVector>>;
+      tmpl::list<NewtonianEuler::Tags::MomentumDensity<Dim>,
+                 NewtonianEuler::Tags::EnergyDensity>;
 
   using argument_tags =
       tmpl::list<FirstArg, SecondArg<Dim>, ThirdArg, FourthArg<Dim>>;

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Tags.cpp
@@ -6,11 +6,11 @@
 #include <cstddef>
 #include <string>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"
 #include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 
-class DataVector;
 struct SomeSourceType {};
 struct SomeInitialDataType {
   using source_term_type = SomeSourceType;
@@ -21,15 +21,15 @@ template <size_t Dim>
 void test_tags() noexcept {
   TestHelpers::db::test_simple_tag<
       NewtonianEuler::Tags::CharacteristicSpeeds<Dim>>("CharacteristicSpeeds");
-  TestHelpers::db::test_simple_tag<
-      NewtonianEuler::Tags::MassDensityCons<DataVector>>("MassDensityCons");
+  TestHelpers::db::test_simple_tag<NewtonianEuler::Tags::MassDensityCons>(
+      "MassDensityCons");
   TestHelpers::db::test_simple_tag<
       NewtonianEuler::Tags::MassDensity<DataVector>>("MassDensity");
   TestHelpers::db::test_simple_tag<
-      NewtonianEuler::Tags::MomentumDensity<DataVector, Dim, Frame::Grid>>(
+      NewtonianEuler::Tags::MomentumDensity<Dim, Frame::Grid>>(
       "Grid_MomentumDensity");
-  TestHelpers::db::test_simple_tag<
-      NewtonianEuler::Tags::EnergyDensity<DataVector>>("EnergyDensity");
+  TestHelpers::db::test_simple_tag<NewtonianEuler::Tags::EnergyDensity>(
+      "EnergyDensity");
   TestHelpers::db::test_simple_tag<
       NewtonianEuler::Tags::Velocity<DataVector, Dim, Frame::Logical>>(
       "Logical_Velocity");


### PR DESCRIPTION
## Proposed changes

This improves consistency with our other evolution systems, which do not template the evolved variable tags on data type.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
