### PR TITLE
Auto register maps from domain creators

### DIFF
--- a/src/Domain/CoordinateMaps/MapInstantiationMacros.hpp
+++ b/src/Domain/CoordinateMaps/MapInstantiationMacros.hpp
@@ -1,0 +1,261 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/optional.hpp>
+#include <boost/preprocessor/punctuation/comma_if.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/tuple/elem.hpp>
+#include <boost/preprocessor/tuple/enum.hpp>
+#include <boost/preprocessor/tuple/size.hpp>
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+#define INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS(data) \
+  BOOST_PP_TUPLE_ENUM(BOOST_PP_TUPLE_ELEM(0, data))
+#define INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data)                     \
+  BOOST_PP_TUPLE_ELEM(BOOST_PP_TUPLE_SIZE(BOOST_PP_TUPLE_ELEM(0, data)), 0, \
+                      BOOST_PP_TUPLE_ELEM(0, data))::dim
+#define INSTANTIATE_COORD_MAP_DETAILINSERT_SIZE(z, n, _) BOOST_PP_COMMA_IF(n) n
+
+#define INSTANTIATE_COORD_MAP_DETAIL_GET_FILLED_INDEX_SEQUENCE(data) \
+  BOOST_PP_REPEAT(BOOST_PP_TUPLE_SIZE(BOOST_PP_TUPLE_ELEM(0, data)), \
+                  INSTANTIATE_COORD_MAP_DETAILINSERT_SIZE, _)
+
+#define INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data) \
+  BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE_COORD_MAP_DETAIL_DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+/*!
+ * \ingroup ComputationalDomainGroup
+ * \brief Generate instantiations of member functions of the `CoordinateMap`
+ * class template.
+ *
+ * Called as follows:
+ *
+ * \code
+ *  using Affine2d =
+ *      domain::CoordinateMaps::ProductOf2Maps<domain::CoordinateMaps::Affine,
+ *                                             domain::CoordinateMaps::Affine>;
+ *  using Affine3d =
+ *      domain::CoordinateMaps::ProductOf3Maps<domain::CoordinateMaps::Affine,
+ *                                             domain::CoordinateMaps::Affine,
+ *                                             domain::CoordinateMaps::Affine>;
+ *
+ *  GENERATE_INSTANTIATIONS(INSTANTIATE_MAPS_SIMPLE_FUNCTIONS,
+ *                          ((Affine2d), (Affine3d)),
+ *                          (Frame::Grid, Frame::Inertial))
+ * \endcode
+ *
+ * The first tuple passed to `GENERATE_INSTANTIATIONS` has a bunch of tuples in
+ * it that is the list of maps being composed. The reason for defining the type
+ * aliases `Affine2d` and `Affine3d` is that otherwise the number of maps being
+ * composed is calculated incorrectly. The second tuple passed to
+ * `GENERATE_INSTANTIATIONS` contains the frames to instantiate for, typically
+ * `Frame::Grid` and `Frame::Inertial`.
+ *
+ * Instantiates:
+ * - `get_to_grid_frame_impl`
+ * - `inverse_impl`
+ * - `class CoordinateMap`
+ */
+#define INSTANTIATE_MAPS_SIMPLE_FUNCTIONS(_, data)                         \
+  template std::unique_ptr<domain::CoordinateMapBase<                      \
+      Frame::Logical, Frame::Grid,                                         \
+      INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data)>>                    \
+      domain::CoordinateMap<Frame::Logical,                                \
+                            INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data),  \
+                            INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS(data)>:: \
+          get_to_grid_frame_impl(                                          \
+              std::integer_sequence<                                       \
+                  unsigned long,                                           \
+                  INSTANTIATE_COORD_MAP_DETAIL_GET_FILLED_INDEX_SEQUENCE(  \
+                      data)>) const noexcept;                              \
+  template boost::optional<                                                \
+      tnsr::I<double, INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data),     \
+              Frame::Logical>>                                             \
+  domain::CoordinateMap<Frame::Logical,                                    \
+                        INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data),      \
+                        INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS(data)>::     \
+      inverse_impl(                                                        \
+          tnsr::I<double, INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data), \
+                  INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data)>&&,         \
+          double,                                                          \
+          const std::unordered_map<                                        \
+              std::string,                                                 \
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&,  \
+          std::index_sequence<                                             \
+              INSTANTIATE_COORD_MAP_DETAIL_GET_FILLED_INDEX_SEQUENCE(      \
+                  data)> /*meta*/) const noexcept;                         \
+  template class domain::CoordinateMap<                                    \
+      Frame::Logical, INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data),        \
+      INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS(data)>;
+
+/*!
+ * \ingroup ComputationalDomainGroup
+ * \brief Generate instantiations of member functions of the `CoordinateMap`
+ * class template.
+ *
+ * Called as follows:
+ *
+ * \code
+ *  using Affine2d =
+ *      domain::CoordinateMaps::ProductOf2Maps<domain::CoordinateMaps::Affine,
+ *                                             domain::CoordinateMaps::Affine>;
+ *  using Affine3d =
+ *      domain::CoordinateMaps::ProductOf3Maps<domain::CoordinateMaps::Affine,
+ *                                             domain::CoordinateMaps::Affine,
+ *                                             domain::CoordinateMaps::Affine>;
+ *
+ *  GENERATE_INSTANTIATIONS(INSTANTIATE_MAPS_DATA_TYPE_FUNCTIONS,
+ *                          ((Affine2d), (Affine3d)),
+ *                          (Frame::Grid, Frame::Inertial),
+ *                          (double, DataVector))
+ * \endcode
+ *
+ * The first tuple passed to `GENERATE_INSTANTIATIONS` has a bunch of tuples in
+ * it that is the list of maps being composed. The reason for defining the type
+ * aliases `Affine2d` and `Affine3d` is that otherwise the number of maps being
+ * composed is calculated incorrectly. The second tuple passed to
+ * `GENERATE_INSTANTIATIONS` contains the frames to instantiate for, typically
+ * `Frame::Grid` and `Frame::Inertial`. The last tuple is the data types for
+ * which to instantiate the functions, usually `double` and `DataVector`.
+ *
+ * Instantiates:
+ * - `call_impl`
+ * - `inv_jacobian_impl`
+ * - `jacobian_impl`
+ * - `coords_frame_velocity_jacobians_impl`
+ */
+#define INSTANTIATE_MAPS_DATA_TYPE_FUNCTIONS(_, data)                         \
+  template tnsr::I<INSTANTIATE_COORD_MAP_DETAIL_DTYPE(data),                  \
+                   INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data),           \
+                   INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data)>              \
+  domain::CoordinateMap<Frame::Logical,                                       \
+                        INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data),         \
+                        INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS(data)>::        \
+      call_impl(                                                              \
+          tnsr::I<INSTANTIATE_COORD_MAP_DETAIL_DTYPE(data),                   \
+                  INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data),            \
+                  Frame::Logical>&&,                                          \
+          double,                                                             \
+          const std::unordered_map<                                           \
+              std::string,                                                    \
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&,     \
+          std::integer_sequence<                                              \
+              unsigned long,                                                  \
+              INSTANTIATE_COORD_MAP_DETAIL_GET_FILLED_INDEX_SEQUENCE(data)>)  \
+          const;                                                              \
+  template InverseJacobian<INSTANTIATE_COORD_MAP_DETAIL_DTYPE(data),          \
+                           INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data),   \
+                           Frame::Logical,                                    \
+                           INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data)>      \
+  domain::CoordinateMap<Frame::Logical,                                       \
+                        INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data),         \
+                        INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS(data)>::        \
+      inv_jacobian_impl(                                                      \
+          tnsr::I<INSTANTIATE_COORD_MAP_DETAIL_DTYPE(data),                   \
+                  INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data),            \
+                  Frame::Logical>&&,                                          \
+          double,                                                             \
+          const std::unordered_map<                                           \
+              std::string,                                                    \
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&)     \
+          const;                                                              \
+  template Jacobian<INSTANTIATE_COORD_MAP_DETAIL_DTYPE(data),                 \
+                    INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data),          \
+                    Frame::Logical,                                           \
+                    INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data)>             \
+  domain::CoordinateMap<Frame::Logical,                                       \
+                        INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data),         \
+                        INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS(data)>::        \
+      jacobian_impl(                                                          \
+          tnsr::I<INSTANTIATE_COORD_MAP_DETAIL_DTYPE(data),                   \
+                  INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data),            \
+                  Frame::Logical>&&,                                          \
+          double,                                                             \
+          const std::unordered_map<                                           \
+              std::string,                                                    \
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&)     \
+          const;                                                              \
+  template std::tuple<                                                        \
+      tnsr::I<INSTANTIATE_COORD_MAP_DETAIL_DTYPE(data),                       \
+              INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data),                \
+              INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data)>,                  \
+      InverseJacobian<INSTANTIATE_COORD_MAP_DETAIL_DTYPE(data),               \
+                      INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data),        \
+                      Frame::Logical,                                         \
+                      INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data)>,          \
+      Jacobian<INSTANTIATE_COORD_MAP_DETAIL_DTYPE(data),                      \
+               INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data),               \
+               Frame::Logical, INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data)>, \
+      tnsr::I<INSTANTIATE_COORD_MAP_DETAIL_DTYPE(data),                       \
+              INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data),                \
+              INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data)>>                  \
+  domain::CoordinateMap<Frame::Logical,                                       \
+                        INSTANTIATE_COORD_MAP_DETAIL_GET_FRAME(data),         \
+                        INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS(data)>::        \
+      coords_frame_velocity_jacobians_impl(                                   \
+          tnsr::I<INSTANTIATE_COORD_MAP_DETAIL_DTYPE(data),                   \
+                  INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data),            \
+                  Frame::Logical>,                                            \
+          double,                                                             \
+          const std::unordered_map<                                           \
+              std::string,                                                    \
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&)     \
+          const;
+
+/*!
+ * \ingroup ComputationalDomainGroup
+ * \brief Generate instantiations of member functions of the `CoordinateMap`
+ * class template.
+ *
+ * Called as follows:
+ *
+ * \code
+ *  using Affine2d =
+ *      domain::CoordinateMaps::ProductOf2Maps<domain::CoordinateMaps::Affine,
+ *                                             domain::CoordinateMaps::Affine>;
+ *  using Affine3d =
+ *      domain::CoordinateMaps::ProductOf3Maps<domain::CoordinateMaps::Affine,
+ *                                             domain::CoordinateMaps::Affine,
+ *                                             domain::CoordinateMaps::Affine>;
+ *
+ *  INSTANTIATE_MAPS_FUNCTIONS(((Affine2d), (Affine3d)),
+ *                             (Frame::Grid, Frame::Inertial),
+ *                             (double, DataVector))
+ * \endcode
+ *
+ * The first tuple passed to `GENERATE_INSTANTIATIONS` has a bunch of tuples in
+ * it that is the list of maps being composed. The reason for defining the type
+ * aliases `Affine2d` and `Affine3d` is that otherwise the number of maps being
+ * composed is calculated incorrectly. The second tuple passed to
+ * `GENERATE_INSTANTIATIONS` contains the frames to instantiate for, typically
+ * `Frame::Grid` and `Frame::Inertial`.
+ *
+ * Instantiates:
+ * - `get_to_grid_frame_impl`
+ * - `inverse_impl`
+ * - `class CoordinateMap`
+ * - `call_impl`
+ * - `inv_jacobian_impl`
+ * - `jacobian_impl`
+ * - `coords_frame_velocity_jacobians_impl`
+ */
+#define INSTANTIATE_MAPS_FUNCTIONS(MAPS_TUPLE, FRAMES_TUPLE, TYPES_TUPLE)   \
+  GENERATE_INSTANTIATIONS(INSTANTIATE_MAPS_SIMPLE_FUNCTIONS, MAPS_TUPLE,    \
+                          FRAMES_TUPLE)                                     \
+  GENERATE_INSTANTIATIONS(INSTANTIATE_MAPS_DATA_TYPE_FUNCTIONS, MAPS_TUPLE, \
+                          FRAMES_TUPLE, TYPES_TUPLE)

--- a/src/Domain/Creators/AlignedLattice.hpp
+++ b/src/Domain/Creators/AlignedLattice.hpp
@@ -15,6 +15,21 @@
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace domain {
+namespace CoordinateMaps {
+class Affine;
+template <typename Map1, typename Map2>
+class ProductOf2Maps;
+template <typename Map1, typename Map2, typename Map3>
+class ProductOf3Maps;
+}  // namespace CoordinateMaps
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+/// \endcond
+
 namespace domain {
 namespace creators {
 
@@ -31,6 +46,18 @@ namespace creators {
 template <size_t VolumeDim>
 class AlignedLattice : public DomainCreator<VolumeDim> {
  public:
+  using maps_list = tmpl::list<
+      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                            CoordinateMaps::Affine>,
+      domain::CoordinateMap<
+          Frame::Logical, Frame::Inertial,
+          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                         CoordinateMaps::Affine>>,
+      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                            CoordinateMaps::ProductOf3Maps<
+                                CoordinateMaps::Affine, CoordinateMaps::Affine,
+                                CoordinateMaps::Affine>>>;
+
   struct BlockBounds {
     using type = std::array<std::vector<double>, VolumeDim>;
     static constexpr OptionString help = {

--- a/src/Domain/Creators/Brick.hpp
+++ b/src/Domain/Creators/Brick.hpp
@@ -16,12 +16,31 @@
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace domain {
+namespace CoordinateMaps {
+class Affine;
+template <typename Map1, typename Map2, typename Map3>
+class ProductOf3Maps;
+}  // namespace CoordinateMaps
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+/// \endcond
+
 namespace domain {
 namespace creators {
 
 /// Create a 3D Domain consisting of a single Block.
 class Brick : public DomainCreator<3> {
  public:
+  using maps_list = tmpl::list<
+      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                            CoordinateMaps::ProductOf3Maps<
+                                CoordinateMaps::Affine, CoordinateMaps::Affine,
+                                CoordinateMaps::Affine>>>;
+
   struct LowerBound {
     using type = std::array<double, 3>;
     static constexpr OptionString help = {

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -12,6 +12,23 @@
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace domain {
+namespace CoordinateMaps {
+class Affine;
+class Equiangular;
+template <typename Map1, typename Map2>
+class ProductOf2Maps;
+template <typename Map1, typename Map2, typename Map3>
+class ProductOf3Maps;
+class Wedge2D;
+}  // namespace CoordinateMaps
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+/// \endcond
+
 namespace domain {
 namespace creators {
 /// Create a 3D Domain in the shape of a cylinder where the cross-section
@@ -20,6 +37,21 @@ namespace creators {
 /// \image html Cylinder.png "The Cylinder Domain."
 class Cylinder : public DomainCreator<3> {
  public:
+  using maps_list = tmpl::list<
+      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                            CoordinateMaps::ProductOf3Maps<
+                                CoordinateMaps::Affine, CoordinateMaps::Affine,
+                                CoordinateMaps::Affine>>,
+      domain::CoordinateMap<
+          Frame::Logical, Frame::Inertial,
+          CoordinateMaps::ProductOf3Maps<CoordinateMaps::Equiangular,
+                                         CoordinateMaps::Equiangular,
+                                         CoordinateMaps::Affine>>,
+      domain::CoordinateMap<
+          Frame::Logical, Frame::Inertial,
+          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge2D,
+                                         CoordinateMaps::Affine>>>;
+
   struct InnerRadius {
     using type = double;
     static constexpr OptionString help = {

--- a/src/Domain/Creators/Disk.hpp
+++ b/src/Domain/Creators/Disk.hpp
@@ -12,12 +12,39 @@
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace domain {
+namespace CoordinateMaps {
+class Affine;
+class Equiangular;
+template <typename Map1, typename Map2>
+class ProductOf2Maps;
+class Wedge2D;
+}  // namespace CoordinateMaps
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+/// \endcond
+
 namespace domain {
 namespace creators {
 /// Create a 2D Domain in the shape of a disk from a square surrounded by four
 /// wedges.
 class Disk : public DomainCreator<2> {
  public:
+  using maps_list =
+      tmpl::list<domain::CoordinateMap<
+                     Frame::Logical, Frame::Inertial,
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                                    CoordinateMaps::Affine>>,
+                 domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                                       CoordinateMaps::ProductOf2Maps<
+                                           CoordinateMaps::Equiangular,
+                                           CoordinateMaps::Equiangular>>,
+                 domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                                       CoordinateMaps::Wedge2D>>;
+
   struct InnerRadius {
     using type = double;
     static constexpr OptionString help = {

--- a/src/Domain/Creators/FrustalCloak.hpp
+++ b/src/Domain/Creators/FrustalCloak.hpp
@@ -15,12 +15,27 @@
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace domain {
+namespace CoordinateMaps {
+class Frustum;
+}  // namespace CoordinateMaps
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+/// \endcond
+
 namespace domain {
 namespace creators {
 /// Create a 3D cubical domain with two equal-sized abutting excised cubes in
 /// the center. This is done by combining ten frusta.
 class FrustalCloak : public DomainCreator<3> {
  public:
+  using maps_list =
+      tmpl::list<domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                                       domain::CoordinateMaps::Frustum>>;
+
   struct InitialRefinement {
     using type = size_t;
     static constexpr OptionString help = {

--- a/src/Domain/Creators/Interval.hpp
+++ b/src/Domain/Creators/Interval.hpp
@@ -16,11 +16,26 @@
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace domain {
+namespace CoordinateMaps {
+class Affine;
+}  // namespace CoordinateMaps
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+/// \endcond
+
 namespace domain {
 namespace creators {
 /// Create a 1D Domain consisting of a single Block.
 class Interval : public DomainCreator<1> {
  public:
+  using maps_list =
+      tmpl::list<domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                                       CoordinateMaps::Affine>>;
+
   struct LowerBound {
     using type = std::array<double, 1>;
     static constexpr OptionString help = {"Sequence of [x] for lower bounds."};

--- a/src/Domain/Creators/Rectangle.hpp
+++ b/src/Domain/Creators/Rectangle.hpp
@@ -16,11 +16,29 @@
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace domain {
+namespace CoordinateMaps {
+class Affine;
+template <typename Map1, typename Map2>
+class ProductOf2Maps;
+}  // namespace CoordinateMaps
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+/// \endcond
+
 namespace domain {
 namespace creators {
 /// Create a 2D Domain consisting of a single Block.
 class Rectangle : public DomainCreator<2> {
  public:
+  using maps_list = tmpl::list<domain::CoordinateMap<
+      Frame::Logical, Frame::Inertial,
+      CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                     CoordinateMaps::Affine>>>;
+
   struct LowerBound {
     using type = std::array<double, 2>;
     static constexpr OptionString help = {

--- a/src/Domain/Creators/RotatedBricks.hpp
+++ b/src/Domain/Creators/RotatedBricks.hpp
@@ -13,6 +13,21 @@
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace domain {
+namespace CoordinateMaps {
+class Affine;
+template <size_t VolumeDim>
+class DiscreteRotation;
+template <typename Map1, typename Map2, typename Map3>
+class ProductOf3Maps;
+}  // namespace CoordinateMaps
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+/// \endcond
+
 namespace domain {
 namespace creators {
 /// Create a 3D Domain consisting of eight rotated Blocks.
@@ -72,6 +87,17 @@ namespace creators {
 /// unaligned blocks.
 class RotatedBricks : public DomainCreator<3> {
  public:
+  using maps_list = tmpl::list<
+      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                            CoordinateMaps::ProductOf3Maps<
+                                CoordinateMaps::Affine, CoordinateMaps::Affine,
+                                CoordinateMaps::Affine>>,
+      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                            CoordinateMaps::DiscreteRotation<3>,
+                            CoordinateMaps::ProductOf3Maps<
+                                CoordinateMaps::Affine, CoordinateMaps::Affine,
+                                CoordinateMaps::Affine>>>;
+
   struct LowerBound {
     using type = std::array<double, 3>;
     static constexpr OptionString help = {

--- a/src/Domain/Creators/RotatedIntervals.hpp
+++ b/src/Domain/Creators/RotatedIntervals.hpp
@@ -16,6 +16,19 @@
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace domain {
+namespace CoordinateMaps {
+class Affine;
+template <size_t VolumeDim>
+class DiscreteRotation;
+}  // namespace CoordinateMaps
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+/// \endcond
+
 namespace domain {
 namespace creators {
 /// Create a 1D Domain consisting of two rotated Blocks.
@@ -24,6 +37,10 @@ namespace creators {
 /// This is useful for testing code that deals with unaligned blocks.
 class RotatedIntervals : public DomainCreator<1> {
  public:
+  using maps_list = tmpl::list<domain::CoordinateMap<
+      Frame::Logical, Frame::Inertial,
+      domain::CoordinateMaps::DiscreteRotation<1>, CoordinateMaps::Affine>>;
+
   struct LowerBound {
     using type = std::array<double, 1>;
     static constexpr OptionString help = {

--- a/src/Domain/Creators/RotatedRectangles.hpp
+++ b/src/Domain/Creators/RotatedRectangles.hpp
@@ -13,6 +13,21 @@
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace domain {
+namespace CoordinateMaps {
+class Affine;
+template <size_t VolumeDim>
+class DiscreteRotation;
+template <typename Map1, typename Map2>
+class ProductOf2Maps;
+}  // namespace CoordinateMaps
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+/// \endcond
+
 namespace domain {
 namespace creators {
 /// Create a 2D Domain consisting of four rotated Blocks.
@@ -32,6 +47,16 @@ namespace creators {
 /// unaligned blocks.
 class RotatedRectangles : public DomainCreator<2> {
  public:
+  using maps_list = tmpl::list<
+      domain::CoordinateMap<
+          Frame::Logical, Frame::Inertial,
+          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                         CoordinateMaps::Affine>>,
+      domain::CoordinateMap<
+          Frame::Logical, Frame::Inertial, CoordinateMaps::DiscreteRotation<2>,
+          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                         CoordinateMaps::Affine>>>;
+
   struct LowerBound {
     using type = std::array<double, 2>;
     static constexpr OptionString help = {

--- a/src/Domain/Creators/Shell.cpp
+++ b/src/Domain/Creators/Shell.cpp
@@ -6,9 +6,8 @@
 #include <memory>
 #include <utility>
 
-#include "Domain/Block.hpp"                         // IWYU pragma: keep
-#include "Domain/BlockNeighbor.hpp"                 // IWYU pragma: keep
-#include "Domain/CoordinateMaps/CoordinateMap.hpp"  // IWYU pragma: keep
+#include "Domain/Block.hpp"                   // IWYU pragma: keep
+#include "Domain/BlockNeighbor.hpp"           // IWYU pragma: keep
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"

--- a/src/Domain/Creators/Shell.hpp
+++ b/src/Domain/Creators/Shell.hpp
@@ -13,6 +13,23 @@
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace domain {
+namespace CoordinateMaps {
+class Affine;
+class EquatorialCompression;
+template <size_t VolumeDim>
+class Identity;
+template <typename Map1, typename Map2>
+class ProductOf2Maps;
+class Wedge3D;
+}  // namespace CoordinateMaps
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+/// \endcond
+
 namespace domain {
 namespace creators {
 /*!
@@ -21,9 +38,14 @@ namespace creators {
  *
  * \image html WedgeOrientations.png "The orientation of each wedge in Shell."
  */
-
 class Shell : public DomainCreator<3> {
  public:
+  using maps_list = tmpl::list<domain::CoordinateMap<
+      Frame::Logical, Frame::Inertial, CoordinateMaps::Wedge3D,
+      CoordinateMaps::EquatorialCompression,
+      CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                     CoordinateMaps::Identity<2>>>>;
+
   struct InnerRadius {
     using type = double;
     static constexpr OptionString help = {"Inner radius of the Shell."};

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -18,6 +18,26 @@
 
 // IWYU pragma: no_include "DataStructures/Tensor/Tensor.hpp" // Not needed
 
+/// \cond
+namespace domain {
+namespace CoordinateMaps {
+class Affine;
+class EquatorialCompression;
+class Equiangular;
+template <size_t VolumeDim>
+class Identity;
+template <typename Map1, typename Map2>
+class ProductOf2Maps;
+template <typename Map1, typename Map2, typename Map3>
+class ProductOf3Maps;
+class Wedge3D;
+}  // namespace CoordinateMaps
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+/// \endcond
+
 namespace domain {
 namespace creators {
 /// Create a 3D Domain in the shape of a sphere consisting of six wedges
@@ -25,6 +45,22 @@ namespace creators {
 /// this Domain, see the documentation for Shell.
 class Sphere : public DomainCreator<3> {
  public:
+  using maps_list = tmpl::list<
+      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                            CoordinateMaps::ProductOf3Maps<
+                                CoordinateMaps::Affine, CoordinateMaps::Affine,
+                                CoordinateMaps::Affine>>,
+      domain::CoordinateMap<
+          Frame::Logical, Frame::Inertial,
+          CoordinateMaps::ProductOf3Maps<CoordinateMaps::Equiangular,
+                                         CoordinateMaps::Equiangular,
+                                         CoordinateMaps::Equiangular>>,
+      domain::CoordinateMap<
+          Frame::Logical, Frame::Inertial, CoordinateMaps::Wedge3D,
+          CoordinateMaps::EquatorialCompression,
+          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                         CoordinateMaps::Identity<2>>>>;
+
   struct InnerRadius {
     using type = double;
     static constexpr OptionString help = {

--- a/src/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/src/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY DomainTimeDependence)
 set(LIBRARY_SOURCES
   CubicScale.cpp
   None.cpp
+  RegisterDerivedWithCharm.cpp
   UniformTranslation.cpp
   )
 

--- a/src/Domain/Creators/TimeDependence/CubicScale.hpp
+++ b/src/Domain/Creators/TimeDependence/CubicScale.hpp
@@ -22,6 +22,9 @@ namespace domain {
 namespace FunctionsOfTime {
 class FunctionOfTime;
 }  // namespace FunctionsOfTime
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
 }  // namespace domain
 
 namespace Frame {
@@ -44,6 +47,9 @@ class CubicScale final : public TimeDependence<MeshDim> {
   using CubicScaleMap = domain::CoordMapsTimeDependent::CubicScale<MeshDim>;
 
  public:
+  using maps_list =
+      tmpl::list<CoordinateMap<Frame::Grid, Frame::Inertial, CubicScaleMap>>;
+
   static constexpr size_t mesh_dim = MeshDim;
 
   /// \brief The initial time of the functions of time.

--- a/src/Domain/Creators/TimeDependence/None.hpp
+++ b/src/Domain/Creators/TimeDependence/None.hpp
@@ -39,6 +39,7 @@ namespace time_dependence {
 template <size_t MeshDim>
 class None final : public TimeDependence<MeshDim> {
  public:
+  using maps_list = tmpl::list<>;
   using options = tmpl::list<>;
 
   static constexpr OptionString help = {"No time dependence in the in grid."};

--- a/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.cpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "Domain/CoordinateMaps/CubicScale.hpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.hpp"
+#include "Domain/CoordinateMaps/Translation.hpp"
+#include "Domain/Creators/TimeDependence/CubicScale.hpp"
+#include "Domain/Creators/TimeDependence/None.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Domain/Creators/TimeDependence/UniformTranslation.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+namespace {
+template <typename TimeDep>
+struct get_maps {
+  using type = typename TimeDep::maps_list;
+};
+
+template <size_t Dim>
+void register_maps_with_charm() noexcept {
+  using maps_to_register = tmpl::remove_duplicates<tmpl::flatten<
+      tmpl::transform<typename TimeDependence<Dim>::creatable_classes,
+                      get_maps<tmpl::_1>>>>;
+
+  Parallel::register_classes_in_list<maps_to_register>();
+}
+}  // namespace
+
+void register_derived_with_charm() noexcept {
+  register_maps_with_charm<1>();
+  register_maps_with_charm<2>();
+  register_maps_with_charm<3>();
+}
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp
+++ b/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+void register_derived_with_charm() noexcept;
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/TimeDependence/UniformTranslation.hpp
+++ b/src/Domain/Creators/TimeDependence/UniformTranslation.hpp
@@ -29,6 +29,9 @@ class ProductOf3Maps;
 template <typename Map1, typename Map2>
 class ProductOf2Maps;
 }  // namespace CoordMapsTimeDependent
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
 }  // namespace domain
 
 namespace Frame {
@@ -57,6 +60,15 @@ class UniformTranslation final : public TimeDependence<MeshDim> {
   using Translation = domain::CoordMapsTimeDependent::Translation;
 
  public:
+  using maps_list = tmpl::list<
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial, Translation>,
+      domain::CoordinateMap<
+          Frame::Grid, Frame::Inertial,
+          CoordMapsTimeDependent::ProductOf2Maps<Translation, Translation>>,
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                            CoordMapsTimeDependent::ProductOf3Maps<
+                                Translation, Translation, Translation>>>;
+
   static constexpr size_t mesh_dim = MeshDim;
 
   /// \brief The initial time of the functions of time.

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -22,6 +22,7 @@
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/MapInstantiationMacros.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
@@ -1157,6 +1158,38 @@ frustum_coordinate_maps(const double length_inner_cube,
                         const double projective_scale_factor) noexcept;
 // Explicit instantiations
 /// \cond
+using Affine2d =
+    domain::CoordinateMaps::ProductOf2Maps<domain::CoordinateMaps::Affine,
+                                           domain::CoordinateMaps::Affine>;
+using Affine3d =
+    domain::CoordinateMaps::ProductOf3Maps<domain::CoordinateMaps::Affine,
+                                           domain::CoordinateMaps::Affine,
+                                           domain::CoordinateMaps::Affine>;
+using Equiangular3d =
+    domain::CoordinateMaps::ProductOf3Maps<domain::CoordinateMaps::Equiangular,
+                                           domain::CoordinateMaps::Equiangular,
+                                           domain::CoordinateMaps::Equiangular>;
+using AffineIdentity =
+    domain::CoordinateMaps::ProductOf2Maps<domain::CoordinateMaps::Affine,
+                                           domain::CoordinateMaps::Identity<2>>;
+
+template class domain::CoordinateMaps::ProductOf2Maps<
+    domain::CoordinateMaps::Affine, domain::CoordinateMaps::Affine>;
+template class domain::CoordinateMaps::ProductOf3Maps<
+    domain::CoordinateMaps::Affine, domain::CoordinateMaps::Affine,
+    domain::CoordinateMaps::Affine>;
+template class domain::CoordinateMaps::ProductOf3Maps<
+    domain::CoordinateMaps::Equiangular, domain::CoordinateMaps::Equiangular,
+    domain::CoordinateMaps::Equiangular>;
+template class domain::CoordinateMaps::ProductOf2Maps<
+    domain::CoordinateMaps::Affine, domain::CoordinateMaps::Identity<2>>;
+
+INSTANTIATE_MAPS_FUNCTIONS(((Affine2d), (Affine3d), (Equiangular3d),
+                            (domain::CoordinateMaps::Wedge3D,
+                             domain::CoordinateMaps::EquatorialCompression,
+                             AffineIdentity)),
+                           (Frame::Grid, Frame::Inertial), (double, DataVector))
+
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 

--- a/tests/Unit/Domain/Creators/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/CMakeLists.txt
@@ -24,5 +24,5 @@ add_test_library(
   ${LIBRARY}
   "Domain/Creators"
   "${LIBRARY_SOURCES}"
-  "DomainCreators;Test_Domain"
+  "DomainCreators;Domain;Test_Domain"
   )

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -6,11 +6,16 @@
 #include <cstddef>
 #include <memory>
 
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Creators/AlignedLattice.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 
 // IWYU pragma: no_include <vector>
 
@@ -25,6 +30,10 @@ void test_aligned_blocks(
     const creators::AlignedLattice<VolumeDim>& aligned_blocks) noexcept {
   const auto domain = aligned_blocks.create_domain();
   test_initial_domain(domain, aligned_blocks.initial_refinement_levels());
+
+  Parallel::register_classes_in_list<
+      typename creators::AlignedLattice<VolumeDim>::maps_list>();
+  test_serialization(domain);
 }
 }  // namespace
 

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -8,7 +8,9 @@
 
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/AlignedLattice.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -26,6 +26,7 @@
 #include "Domain/Domain.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Parallel/PupStlCpp11.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
@@ -58,6 +59,9 @@ void test_brick_construction(
                    Affine{-1., 1., lower_bound[2], upper_bound[2]}})));
 
   test_initial_domain(domain, brick.initial_refinement_levels());
+
+  Parallel::register_classes_in_list<typename creators::Brick::maps_list>();
+  test_serialization(domain);
 }
 
 void test_brick() {

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -27,9 +27,11 @@
 #include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/OrientationMap.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 
 namespace domain {
 namespace {
@@ -188,6 +190,9 @@ void test_cylinder_construction(
                            expected_external_boundaries, coord_maps);
 
   test_initial_domain(domain, cylinder.initial_refinement_levels());
+
+  Parallel::register_classes_in_list<typename creators::Cylinder::maps_list>();
+  test_serialization(domain);
 }
 
 void test_cylinder_boundaries_equiangular() {

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -27,9 +27,11 @@
 #include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/OrientationMap.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 
 namespace domain {
 namespace {
@@ -126,6 +128,9 @@ void test_disk_construction(
                            expected_external_boundaries, coord_maps);
 
   test_initial_domain(domain, disk.initial_refinement_levels());
+
+  Parallel::register_classes_in_list<typename creators::Disk::maps_list>();
+  test_serialization(domain);
 }
 
 void test_disk_boundaries_equiangular() {

--- a/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
+++ b/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
@@ -24,10 +24,23 @@ void test_frustal_cloak_construction(
   test_initial_domain(domain, frustal_cloak.initial_refinement_levels());
   test_physical_separation(frustal_cloak.create_domain().blocks());
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.FrustalCloak.Connectivity",
-                  "[Domain][Unit]") {
+void test_factory() {
+  const auto frustal_cloak =
+      TestHelpers::test_factory_creation<DomainCreator<3>>(
+          "FrustalCloak:\n"
+          "  InitialRefinement: 3\n"
+          "  InitialGridPoints: [2,3]\n"
+          "  UseEquiangularMap: true\n"
+          "  ProjectionFactor: 0.3\n"
+          "  LengthInnerCube: 15.5\n"
+          "  LengthOuterCube: 42.4\n"
+          "  OriginPreimage: [0.2,0.3,-0.1]");
+  test_frustal_cloak_construction(
+      dynamic_cast<const domain::creators::FrustalCloak&>(*frustal_cloak));
+}
+
+void test_connectivity() {
   const size_t refinement = 1;
   const std::array<size_t, 2> grid_points = {{6, 5}};
   const double projective_scale_factor = 0.3;
@@ -45,18 +58,10 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.FrustalCloak.Connectivity",
   }
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.FrustalCloak.Factory",
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.FrustalCloak",
                   "[Domain][Unit]") {
-  const auto frustal_cloak =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "FrustalCloak:\n"
-          "  InitialRefinement: 3\n"
-          "  InitialGridPoints: [2,3]\n"
-          "  UseEquiangularMap: true\n"
-          "  ProjectionFactor: 0.3\n"
-          "  LengthInnerCube: 15.5\n"
-          "  LengthOuterCube: 42.4\n"
-          "  OriginPreimage: [0.2,0.3,-0.1]");
-  test_frustal_cloak_construction(
-      dynamic_cast<const domain::creators::FrustalCloak&>(*frustal_cloak));
+  test_factory();
+  test_connectivity();
 }

--- a/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
+++ b/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
@@ -11,6 +11,8 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
 #include "Domain/Block.hpp"                       // IWYU pragma: keep
 #include "Domain/BlockNeighbor.hpp"               // IWYU pragma: keep
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/FrustalCloak.hpp"

--- a/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
+++ b/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
@@ -11,11 +11,14 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
 #include "Domain/Block.hpp"                       // IWYU pragma: keep
 #include "Domain/BlockNeighbor.hpp"               // IWYU pragma: keep
+#include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/FrustalCloak.hpp"
 #include "Domain/Domain.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 
 namespace {
 void test_frustal_cloak_construction(
@@ -23,6 +26,10 @@ void test_frustal_cloak_construction(
   const auto domain = frustal_cloak.create_domain();
   test_initial_domain(domain, frustal_cloak.initial_refinement_levels());
   test_physical_separation(frustal_cloak.create_domain().blocks());
+
+  Parallel::register_classes_in_list<
+      typename domain::creators::FrustalCloak::maps_list>();
+  test_serialization(domain);
 }
 
 void test_factory() {

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -24,6 +24,7 @@
 #include "Domain/Domain.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Parallel/PupStlCpp11.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
@@ -51,6 +52,10 @@ void test_interval_construction(
       make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           CoordinateMaps::Affine{-1., 1., lower_bound[0], upper_bound[0]})));
   test_initial_domain(domain, interval.initial_refinement_levels());
+
+  Parallel::register_classes_in_list<
+      typename domain::creators::Interval::maps_list>();
+  test_serialization(domain);
 }
 
 void test_interval() {
@@ -80,20 +85,6 @@ void test_interval() {
           {{Direction<1>::lower_xi(), {0, aligned_orientation}},
            {Direction<1>::upper_xi(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<1>>>{{}});
-
-  // Test serialization of the map
-  creators::register_derived_with_charm();
-
-  const auto base_map =
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::Affine{-1., 1., lower_bound[0], upper_bound[0]});
-  const auto base_map_deserialized = serialize_and_deserialize(base_map);
-  using MapType = const CoordinateMap<Frame::Logical, Frame::Inertial,
-                                      CoordinateMaps::Affine>*;
-  REQUIRE(dynamic_cast<MapType>(base_map.get()) != nullptr);
-  const auto coord_map = make_coordinate_map<Frame::Logical, Frame::Inertial>(
-      CoordinateMaps::Affine{-1., 1., lower_bound[0], upper_bound[0]});
-  CHECK(*dynamic_cast<MapType>(base_map.get()) == coord_map);
 }
 
 void test_interval_factory() {

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -26,6 +26,7 @@
 #include "Domain/Domain.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Parallel/PupStlCpp11.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
@@ -56,6 +57,10 @@ void test_rectangle_construction(
           Affine2D{Affine{-1., 1., lower_bound[0], upper_bound[0]},
                    Affine{-1., 1., lower_bound[1], upper_bound[1]}})));
   test_initial_domain(domain, rectangle.initial_refinement_levels());
+
+  Parallel::register_classes_in_list<
+      typename domain::creators::Rectangle::maps_list>();
+  test_serialization(domain);
 }
 
 void test_rectangle() {
@@ -114,22 +119,6 @@ void test_rectangle() {
            {Direction<2>::lower_eta(), {0, aligned_orientation}},
            {Direction<2>::upper_eta(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<2>>>{{}});
-
-  // Test serialization of the map
-  creators::register_derived_with_charm();
-
-  const auto base_map =
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          Affine2D{Affine{-1., 1., lower_bound[0], upper_bound[0]},
-                   Affine{-1., 1., lower_bound[1], upper_bound[1]}});
-  const auto base_map_deserialized = serialize_and_deserialize(base_map);
-  using MapType =
-      const CoordinateMap<Frame::Logical, Frame::Inertial, Affine2D>*;
-  REQUIRE(dynamic_cast<MapType>(base_map.get()) != nullptr);
-  const auto coord_map = make_coordinate_map<Frame::Logical, Frame::Inertial>(
-      Affine2D{Affine{-1., 1., lower_bound[0], upper_bound[0]},
-               Affine{-1., 1., lower_bound[1], upper_bound[1]}});
-  CHECK(*dynamic_cast<MapType>(base_map.get()) == coord_map);
 }
 
 void test_rectangle_factory() {

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -24,8 +24,10 @@
 #include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/OrientationMap.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 
 namespace domain {
 namespace {
@@ -108,6 +110,10 @@ void test_rotated_bricks_construction(
   test_domain_construction(domain, expected_block_neighbors,
                            expected_external_boundaries, coord_maps);
   test_initial_domain(domain, rotated_bricks.initial_refinement_levels());
+
+  Parallel::register_classes_in_list<
+      typename domain::creators::RotatedBricks::maps_list>();
+  test_serialization(domain);
 }
 
 void test_rotated_bricks() {

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -23,9 +23,11 @@
 #include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/OrientationMap.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 
 namespace domain {
 namespace {
@@ -58,6 +60,10 @@ void test_rotated_intervals_construction(
                   std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}}},
               CoordinateMaps::Affine{-1., 1., midpoint[0], upper_bound[0]})));
   test_initial_domain(domain, rotated_intervals.initial_refinement_levels());
+
+  Parallel::register_classes_in_list<
+      typename domain::creators::RotatedIntervals::maps_list>();
+  test_serialization(domain);
 }
 
 void test_rotated_intervals() {

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -24,8 +24,10 @@
 #include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/OrientationMap.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 
 namespace domain {
 namespace {
@@ -80,6 +82,10 @@ void test_rotated_rectangles_construction(
   test_domain_construction(domain, expected_block_neighbors,
                            expected_external_boundaries, coord_maps);
   test_initial_domain(domain, rotated_rectangles.initial_refinement_levels());
+
+  Parallel::register_classes_in_list<
+      typename domain::creators::RotatedRectangles::maps_list>();
+  test_serialization(domain);
 }
 
 void test_rotated_rectangles() {

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -25,6 +25,7 @@
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/CreateInitialElement.hpp"
 #include "Domain/Creators/DomainCreator.hpp"

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -19,9 +19,12 @@
 #include "Domain/BlockId.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/BlockNeighbor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/CreateInitialElement.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
@@ -35,6 +38,7 @@
 #include "Domain/InitialElementIds.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Domain/SegmentId.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -42,6 +46,7 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 
 // IWYU pragma: no_forward_declare BlockNeighbor
 
@@ -253,6 +258,10 @@ void test_shell_construction(
   }
 
   test_initial_domain(domain, shell.initial_refinement_levels());
+
+  Parallel::register_classes_in_list<
+      typename domain::creators::Shell::maps_list>();
+  test_serialization(domain);
 }
 
 void test_shell_boundaries() {

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -17,7 +17,9 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
@@ -27,9 +29,11 @@
 #include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/OrientationMap.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 
 namespace domain {
 namespace {
@@ -189,6 +193,10 @@ void test_sphere_construction(
   test_domain_construction(domain, expected_block_neighbors,
                            expected_external_boundaries, coord_maps);
   test_initial_domain(domain, sphere.initial_refinement_levels());
+
+  Parallel::register_classes_in_list<
+      typename domain::creators::Sphere::maps_list>();
+  test_serialization(domain);
 }
 
 void test_sphere_boundaries_equiangular() {


### PR DESCRIPTION
## Proposed changes

- Have domain creators specify which maps they will use
- Use the maps info from the domain creators to automatically register the appropriate maps with Charm++ for serialization.

Depends on:
- [x] #2027

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
