### PR TITLE
Print unique ptr default options

### DIFF
--- a/src/Options/Factory.hpp
+++ b/src/Options/Factory.hpp
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <string>
 #include <utility>
+#include <yaml-cpp/yaml.h>
 
 #include "ErrorHandling/Assert.hpp"
 #include "Options/Options.hpp"

--- a/tests/Unit/Options/Test_Factory.cpp
+++ b/tests/Unit/Options/Test_Factory.cpp
@@ -25,6 +25,7 @@ struct TestWithMetavars;
 struct OptionType {
   using type = std::unique_ptr<OptionTest>;
   static constexpr OptionString help = {"The type of OptionTest"};
+  static std::unique_ptr<OptionTest> default_value() noexcept;
 };
 
 class OptionTest {
@@ -77,6 +78,10 @@ class TestWithArg : public OptionTest {
  private:
   std::string arg_;
 };
+
+std::unique_ptr<OptionTest> OptionType::default_value() noexcept {
+  return std::make_unique<Test2>();
+}
 
 struct Vector {
   using type = std::vector<std::unique_ptr<OptionTest>>;
@@ -203,7 +208,8 @@ void test_factory_format() {
   // I don't want to rely on that, so just check that the type is at
   // the end of the line, which should ensure it is not in a template
   // parameter or something.
-  CHECK(opts.help().find("OptionTest\n") != std::string::npos);
+  CHECK(opts.help().find("OptionTest [default=Test2]\n") != std::string::npos);
+  CHECK(opts.help().find("OptionTest [default=Test1]\n") == std::string::npos);
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

- Allow having a default value for a `unique_ptr<Derived>`

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
