### PR TITLE
Fix docs issue with '\boldsymbol'

### DIFF
--- a/docs/config/MathJax.js
+++ b/docs/config/MathJax.js
@@ -1,14 +1,16 @@
 window.MathJax = {
     tex: {
         tags: "ams",
-        packages: ['base', 'ams', 'bbox', 'color', 'physics', 'newcommand']
+        packages: ['base', 'ams', 'bbox', 'color', 'physics', 'newcommand',
+            'boldsymbol']
     },
     options: {
         ignoreHtmlClass: 'tex2jax_ignore',
         processHtmlClass: 'tex2jax_process'
     },
     loader: {
-        load: ['[tex]/bbox', '[tex]/color', '[tex]/physics', '[tex]/newcommand']
+        load: ['[tex]/bbox', '[tex]/color', '[tex]/physics', '[tex]/newcommand',
+            '[tex]/boldsymbol']
     }
 };
 


### PR DESCRIPTION
## Proposed changes

Here's and example where the issue appears: https://spectre-code.org/group__NumericalAlgorithmsGroup.html#ga4c7f843ef5929ec34ac18a31494df054

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
