### PR TITLE
Add numerical flux protocol and first-order DG boundary flux

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryData.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryData.hpp
@@ -5,9 +5,13 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/NumericalFluxHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace dg {
@@ -41,5 +45,35 @@ struct BoundaryDataImpl {
  */
 template <typename NumericalFluxType>
 using BoundaryData = typename detail::BoundaryDataImpl<NumericalFluxType>::type;
+
+/*!
+ * \brief Package the data on element boundaries that's needed for the (strong)
+ * first-order boundary scheme.
+ *
+ * This function currently packages the data required by the `NumericalFluxType`
+ * plus all "normal-dot-fluxes", which are needed for the strong first-order
+ * boundary scheme (see `dg::FirstOrderScheme::BoundaryData`). Note that for
+ * the weak formulation the normal-dot-fluxes need not be included explicitly,
+ * but the `NumericalFluxType` may require a subset of them.
+ */
+template <
+    size_t FaceDim, typename NumericalFluxType, typename... NumericalFluxArgs,
+    Requires<tt::conforms_to_v<NumericalFluxType, protocols::NumericalFlux>> =
+        nullptr>
+auto package_boundary_data(
+    const NumericalFluxType& numerical_flux_computer,
+    const Mesh<FaceDim>& face_mesh,
+    const Variables<db::wrap_tags_in<
+        ::Tags::NormalDotFlux, typename NumericalFluxType::variables_tags>>&
+        normal_dot_fluxes,
+    const NumericalFluxArgs&... args) noexcept {
+  BoundaryData<NumericalFluxType> boundary_data{
+      face_mesh.number_of_grid_points()};
+  boundary_data.field_data.assign_subset(normal_dot_fluxes);
+  dg::NumericalFluxes::package_data(make_not_null(&boundary_data),
+                                    numerical_flux_computer, args...);
+  return boundary_data;
+}
+
 }  // namespace FirstOrderScheme
 }  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryData.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryData.hpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace dg {
+namespace FirstOrderScheme {
+
+namespace detail {
+template <typename NumericalFluxType>
+struct BoundaryDataImpl {
+  static_assert(tt::conforms_to_v<NumericalFluxType, protocols::NumericalFlux>,
+                "The 'NumericalFluxType' must conform to the "
+                "'dg::protocols::NumericalFlux'.");
+  using type = dg::SimpleBoundaryData<
+      tmpl::remove_duplicates<tmpl::append<
+          db::wrap_tags_in<::Tags::NormalDotFlux,
+                           typename NumericalFluxType::variables_tags>,
+          typename NumericalFluxType::package_field_tags>>,
+      typename NumericalFluxType::package_extra_tags>;
+};
+}  // namespace detail
+
+/*!
+ * \brief The data on element boundaries that's needed for the (strong)
+ * first-order boundary scheme
+ *
+ * The boundary data includes the `NumericalFluxType`'s packaged data plus all
+ * "normal-dot-fluxes" so the strong boundary scheme can compute the difference
+ * between the normal-dot-numerical-fluxes and the normal-dot-fluxes
+ * (see `dg::FirstOrder`). For the weak formulation the normal-dot-fluxes
+ * need not be included explicitly, but the `NumericalFluxType` may require
+ * a subset of them.
+ */
+template <typename NumericalFluxType>
+using BoundaryData = typename detail::BoundaryDataImpl<NumericalFluxType>::type;
+}  // namespace FirstOrderScheme
+}  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryFlux.hpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryData.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/NumericalFluxHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace dg {
+/// Functionality related to the first-order DG scheme.
+namespace FirstOrderScheme {
+
+/*!
+ * \brief Compute the boundary flux contribution and lift it to the volume.
+ *
+ * This computes the numerical flux minus the flux dotted into the interface
+ * normal, projects the result to the face mesh if necessary, and then lifts it
+ * to the volume (still presented only on the face mesh as all other points are
+ * zero).
+ *
+ * Projection must happen after the numerical flux calculation so that the
+ * elements on either side of the mortar calculate the same result.  Projection
+ * must happen before flux lifting because we want the factor of the magnitude
+ * of the unit normal added during the lift to cancel the Jacobian factor in
+ * integrals to preserve conservation; this only happens if the two operations
+ * are done on the same grid.
+ */
+template <size_t FaceDim, typename NumericalFluxType,
+          Requires<tt::conforms_to_v<NumericalFluxType,
+                                     dg::protocols::NumericalFlux>> = nullptr>
+Variables<typename NumericalFluxType::variables_tags> boundary_flux(
+    const BoundaryData<NumericalFluxType>& local_boundary_data,
+    const BoundaryData<NumericalFluxType>& remote_boundary_data,
+    const NumericalFluxType& numerical_flux_computer,
+    const Scalar<DataVector>& magnitude_of_face_normal,
+    const size_t extent_perpendicular_to_boundary,
+    const Mesh<FaceDim>& face_mesh, const Mesh<FaceDim>& mortar_mesh,
+    const MortarSize<FaceDim>& mortar_size) noexcept {
+  using variables_tags = typename NumericalFluxType::variables_tags;
+
+  // Compute the Tags::NormalDotNumericalFlux from local and remote data
+  Variables<db::wrap_tags_in<::Tags::NormalDotNumericalFlux, variables_tags>>
+      normal_dot_numerical_fluxes{mortar_mesh.number_of_grid_points()};
+  dg::NumericalFluxes::normal_dot_numerical_fluxes(
+      make_not_null(&normal_dot_numerical_fluxes), numerical_flux_computer,
+      local_boundary_data, remote_boundary_data);
+
+  // Subtract the local Tags::NormalDotFlux
+  tmpl::for_each<variables_tags>([&normal_dot_numerical_fluxes,
+                                  &local_boundary_data](
+                                     const auto tag_v) noexcept {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    auto& numerical_flux =
+        get<::Tags::NormalDotNumericalFlux<tag>>(normal_dot_numerical_fluxes);
+    const auto& local_flux =
+        get<::Tags::NormalDotFlux<tag>>(local_boundary_data.field_data);
+    for (size_t i = 0; i < numerical_flux.size(); ++i) {
+      numerical_flux[i] -= local_flux[i];
+    }
+  });
+
+  // Project from the mortar back to the face if needed
+  auto projected_fluxes =
+      needs_projection(face_mesh, mortar_mesh, mortar_size)
+          ? project_from_mortar(normal_dot_numerical_fluxes, face_mesh,
+                                mortar_mesh, mortar_size)
+          : std::move(normal_dot_numerical_fluxes);
+
+  // Lift flux to the volume. We still only need to provide it on the face
+  // because it is zero everywhere else.
+  return lift_flux(std::move(projected_fluxes),
+                   extent_perpendicular_to_boundary, magnitude_of_face_normal);
+}
+
+}  // namespace FirstOrderScheme
+}  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
@@ -63,6 +63,18 @@ MortarSize<Dim - 1> mortar_size(
     size_t dimension, const OrientationMap<Dim>& orientation) noexcept;
 
 /// \ingroup DiscontinuousGalerkinGroup
+/// Determine whether data on an element face needs to be projected to a mortar.
+/// If no projection is necessary the data may be used on the mortar as-is.
+template <size_t Dim>
+bool needs_projection(const Mesh<Dim>& face_mesh, const Mesh<Dim>& mortar_mesh,
+                      const MortarSize<Dim>& mortar_size) noexcept {
+  return mortar_mesh != face_mesh or
+      alg::any_of(mortar_size, [](const Spectral::MortarSize& size) noexcept {
+        return size != Spectral::MortarSize::Full;
+      });
+}
+
+/// \ingroup DiscontinuousGalerkinGroup
 /// Project variables from a face to a mortar.
 template <typename Tags, size_t Dim>
 Variables<Tags> project_to_mortar(const Variables<Tags>& vars,

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/NumericalFluxHelpers.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/NumericalFluxHelpers.hpp
@@ -1,0 +1,103 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace dg {
+namespace NumericalFluxes {
+
+namespace detail {
+template <typename NumericalFluxType, typename... AllFieldTags,
+          typename... AllExtraTags, typename... Args,
+          typename... PackageFieldTags, typename... PackageExtraTags>
+void package_data_impl(
+    const gsl::not_null<dg::SimpleBoundaryData<tmpl::list<AllFieldTags...>,
+                                               tmpl::list<AllExtraTags...>>*>
+        packaged_data,
+    const NumericalFluxType& numerical_flux_computer,
+    tmpl::list<PackageFieldTags...> /*meta*/,
+    tmpl::list<PackageExtraTags...> /*meta*/, const Args&... args) noexcept {
+  numerical_flux_computer.package_data(
+      make_not_null(&get<PackageFieldTags>(packaged_data->field_data))...,
+      make_not_null(&get<PackageExtraTags>(packaged_data->extra_data))...,
+      args...);
+}
+
+template <typename NumericalFluxType, typename... AllFieldTags,
+          typename... AllExtraTags, typename... NormalDotNumericalFluxTypes,
+          typename... PackageFieldTags, typename... PackageExtraTags>
+void normal_dot_numerical_fluxes_impl(
+    const NumericalFluxType& numerical_flux_computer,
+    const dg::SimpleBoundaryData<tmpl::list<AllFieldTags...>,
+                                 tmpl::list<AllExtraTags...>>&
+        packaged_data_int,
+    const dg::SimpleBoundaryData<tmpl::list<AllFieldTags...>,
+                                 tmpl::list<AllExtraTags...>>&
+        packaged_data_ext,
+    tmpl::list<PackageFieldTags...> /*meta*/,
+    tmpl::list<PackageExtraTags...> /*meta*/,
+    // Taking output arguments last in this detail implementation so the
+    // `NormalDotNumericalFluxTypes` can be inferred
+    const gsl::not_null<
+        NormalDotNumericalFluxTypes*>... n_dot_num_fluxes) noexcept {
+  numerical_flux_computer(
+      n_dot_num_fluxes...,
+      get<PackageFieldTags>(packaged_data_int.field_data)...,
+      get<PackageExtraTags>(packaged_data_int.extra_data)...,
+      get<PackageFieldTags>(packaged_data_ext.field_data)...,
+      get<PackageExtraTags>(packaged_data_ext.extra_data)...);
+}
+}  // namespace detail
+
+// @{
+/// Helper function to unpack arguments when invoking the numerical flux
+template <typename NumericalFluxType, typename... AllFieldTags,
+          typename... AllExtraTags, typename... Args>
+void package_data(
+    const gsl::not_null<dg::SimpleBoundaryData<tmpl::list<AllFieldTags...>,
+                                               tmpl::list<AllExtraTags...>>*>
+        packaged_data,
+    const NumericalFluxType& numerical_flux_computer,
+    const Args&... args) noexcept {
+  static_assert(
+      tt::conforms_to_v<NumericalFluxType, protocols::NumericalFlux>,
+      "The 'NumericalFluxType' must conform to 'dg::protocol::NumericalFlux'.");
+  detail::package_data_impl(packaged_data, numerical_flux_computer,
+                            typename NumericalFluxType::package_field_tags{},
+                            typename NumericalFluxType::package_extra_tags{},
+                            args...);
+}
+
+template <typename NumericalFluxType, typename... AllFieldTags,
+          typename... AllExtraTags, typename... NormalDotNumericalFluxTags>
+void normal_dot_numerical_fluxes(
+    const gsl::not_null<Variables<tmpl::list<NormalDotNumericalFluxTags...>>*>
+        n_dot_num_fluxes,
+    const NumericalFluxType& numerical_flux_computer,
+    const dg::SimpleBoundaryData<tmpl::list<AllFieldTags...>,
+                                 tmpl::list<AllExtraTags...>>&
+        packaged_data_int,
+    const dg::SimpleBoundaryData<tmpl::list<AllFieldTags...>,
+                                 tmpl::list<AllExtraTags...>>&
+        packaged_data_ext) noexcept {
+  static_assert(
+      tt::conforms_to_v<NumericalFluxType, protocols::NumericalFlux>,
+      "The 'NumericalFluxType' must conform to 'dg::protocol::NumericalFlux'.");
+  detail::normal_dot_numerical_fluxes_impl(
+      numerical_flux_computer, packaged_data_int, packaged_data_ext,
+      typename NumericalFluxType::package_field_tags{},
+      typename NumericalFluxType::package_extra_tags{},
+      make_not_null(&get<NormalDotNumericalFluxTags>(*n_dot_num_fluxes))...);
+}
+// @}
+
+}  // namespace NumericalFluxes
+}  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp
@@ -1,0 +1,140 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace dg {
+/// \ref protocols related to Discontinuous Galerkin functionality
+namespace protocols {
+
+namespace detail {
+CREATE_HAS_TYPE_ALIAS(variables_tags)
+CREATE_HAS_TYPE_ALIAS_V(variables_tags)
+CREATE_HAS_TYPE_ALIAS(argument_tags)
+CREATE_HAS_TYPE_ALIAS_V(argument_tags)
+CREATE_HAS_TYPE_ALIAS(package_field_tags)
+CREATE_HAS_TYPE_ALIAS_V(package_field_tags)
+CREATE_HAS_TYPE_ALIAS(package_extra_tags)
+CREATE_HAS_TYPE_ALIAS_V(package_extra_tags)
+CREATE_IS_CALLABLE(package_data)
+
+template <typename NumericalFluxType, typename ArgumentTags,
+          typename PackageFieldTags, typename PackageExtraTags>
+struct IsPackageDataCallableImpl;
+
+template <typename NumericalFluxType, typename... ArgumentTags,
+          typename... PackageFieldTags, typename... PackageExtraTags>
+struct IsPackageDataCallableImpl<NumericalFluxType, tmpl::list<ArgumentTags...>,
+                                 tmpl::list<PackageFieldTags...>,
+                                 tmpl::list<PackageExtraTags...>>
+    : is_package_data_callable_r_t<
+          void, NumericalFluxType,
+          gsl::not_null<db::item_type<PackageFieldTags>*>...,
+          gsl::not_null<db::item_type<PackageExtraTags>*>...,
+          db::const_item_type<ArgumentTags>...> {};
+
+template <typename NumericalFluxType>
+struct IsPackageDataCallable
+    : IsPackageDataCallableImpl<
+          NumericalFluxType, typename NumericalFluxType::argument_tags,
+          typename NumericalFluxType::package_field_tags,
+          typename NumericalFluxType::package_extra_tags> {};
+
+template <typename NumericalFluxType, typename VariablesTags,
+          typename PackageFieldTags, typename PackageExtraTags>
+struct IsNumericalFluxCallableImpl;
+
+template <typename NumericalFluxType, typename... VariablesTags,
+          typename... PackageFieldTags, typename... PackageExtraTags>
+struct IsNumericalFluxCallableImpl<
+    NumericalFluxType, tmpl::list<VariablesTags...>,
+    tmpl::list<PackageFieldTags...>, tmpl::list<PackageExtraTags...>>
+    : tt::is_callable_t<NumericalFluxType,
+                        gsl::not_null<db::item_type<VariablesTags>*>...,
+                        db::const_item_type<PackageFieldTags>...,
+                        db::const_item_type<PackageExtraTags>...,
+                        db::const_item_type<PackageFieldTags>...,
+                        db::const_item_type<PackageExtraTags>...> {};
+
+template <typename NumericalFluxType>
+struct IsNumericalFluxCallable
+    : IsNumericalFluxCallableImpl<
+          NumericalFluxType, typename NumericalFluxType::variables_tags,
+          typename NumericalFluxType::package_field_tags,
+          typename NumericalFluxType::package_extra_tags> {};
+}  // namespace detail
+
+/*!
+ * \ingroup ProtocolsGroup
+ * \brief Defines the interface for DG numerical fluxes
+ *
+ * This protocol defines the interface that a class must conform to so that it
+ * can be used as a numerical flux in DG boundary schemes. Essentially, the
+ * class must be able to compute the quantity \f$G\f$ that appears, for example,
+ * in the strong first-order DG boundary scheme
+ * \f$G_\alpha(n_i^\mathrm{int}, u_\alpha^\mathrm{int}, n_i^\mathrm{ext},
+ * u_\alpha^\mathrm{ext}) - n_i^\mathrm{int} F^{i,\mathrm{int}}_\alpha\f$
+ * where \f$u_\alpha\f$ are the system variables and \f$F^i_\alpha\f$ their
+ * corresponding fluxes. See also Eq. (2.20) in \cite Teukolsky2015ega where the
+ * quantity \f$G\f$ is denoted \f$n_i F^{i*}\f$, which is why we occasionally
+ * refer to it as the "normal-dot-numerical-fluxes".
+ *
+ * Requires the `ConformingType` has these type aliases:
+ * - `variables_tags`: A typelist of DataBox tags that the class computes
+ * numerical fluxes for.
+ * - `argument_tags`: A typelist of DataBox tags that will be retrieved on
+ * interfaces and passed to the `package_data` function (see below). The
+ * `ConformingType` may also have a `volume_tags` typelist that specifies the
+ * subset of `argument_tags` that should be retrieved from the volume instead
+ * of the interface.
+ * - `package_field_tags`: A typelist of DataBox tags with `Tensor` types that
+ * the `package_data` function will compute from the `argument_tags`. These
+ * quantities will be made available on both sides of a mortar and passed to
+ * the call operator to compute the numerical flux.
+ * - `package_extra_tags`: Additional non-tensor tags that will be made
+ * available on both sides of a mortar, e.g. geometric quantities.
+ *
+ * Requires the `ConformingType` has these member functions:
+ * - `package_data`: Takes the types of the `package_field_tags` and the
+ * `package_extra_tags` by `gsl::not_null` pointer, followed by the types of the
+ * `argument_tags`.
+ * - `operator()`: Takes the types of the `variables_tags` by `gsl::not_null`
+ * pointer, followed by the types of the `package_field_tags` and the
+ * `package_extra_tags` from the interior side of the mortar and from the
+ * exterior side. Note that the data from the exterior side was computed
+ * entirely with data from the neighboring element, including its interface
+ * normal which is (at least when it's independent of the system variables)
+ * opposite to the interior element's interface normal. Therefore, make sure to
+ * take into account the sign flip for quantities that include the interface
+ * normal.
+ *
+ * Here's an example for a simple "central" numerical flux
+ * \f$G_\alpha(n_i^\mathrm{int}, u_\alpha^\mathrm{int}, n_i^\mathrm{ext},
+ * u_\alpha^\mathrm{ext}) = \frac{1}{2}\left(n_i^\mathrm{int}
+ * F^{i,\mathrm{int}}_\alpha - n_i^\mathrm{ext} F^{i,\mathrm{ext}}_\alpha
+ * \right)\f$:
+ *
+ * \snippet DiscontinuousGalerkin/Test_Protocols.cpp numerical_flux_example
+ *
+ * Note that this numerical flux reduces to the interface average
+ * \f$G_\alpha=\frac{n^\mathrm{int}_i}{2}\left(F^{i,\mathrm{int}}_\alpha +
+ * F^{i,\mathrm{ext}}_\alpha\right)\f$ for the case where the interface normal
+ * is independent of the system variables and therefore \f$n_i^\mathrm{ext} =
+ * -n_i^\mathrm{int}\f$.
+ */
+template <typename ConformingType>
+using NumericalFlux = std::conditional_t<
+    tmpl2::flat_all_v<detail::has_variables_tags_v<ConformingType>,
+                      detail::has_argument_tags_v<ConformingType>,
+                      detail::has_package_field_tags_v<ConformingType>,
+                      detail::has_package_extra_tags_v<ConformingType>>,
+    cpp17::conjunction<detail::IsPackageDataCallable<ConformingType>,
+                       detail::IsNumericalFluxCallable<ConformingType>>,
+    std::false_type>;
+
+}  // namespace protocols
+}  // namespace dg

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+add_subdirectory(FirstOrder)

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryFlux.py
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryFlux.py
@@ -1,0 +1,12 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+
+def boundary_flux(field_int, field_ext):
+    # We are working with a simple "central" numerical flux
+    numerical_flux = 0.5 * (field_int + field_ext)
+    # Eq. 2.20 in https://arxiv.org/pdf/1510.01190.pdf
+    surface_term = numerical_flux - field_int
+    # Eq. 3.19 in https://arxiv.org/pdf/1510.01190.pdf
+    # (The LGL quadrature weight for 5 points at the boundary is 1/10)
+    return -surface_term * 10.

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_FirstOrderDgScheme")
+
+set(LIBRARY_SOURCES
+  Test_BoundaryFlux.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder"
+  "${LIBRARY_SOURCES}"
+  "DataStructures;DiscontinuousGalerkin;Domain;ErrorHandling;Utilities"
+  )

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_FirstOrderDgScheme")
 
 set(LIBRARY_SOURCES
+  Test_BoundaryData.cpp
   Test_BoundaryFlux.cpp
   )
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_BoundaryData.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_BoundaryData.cpp
@@ -1,0 +1,71 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryData.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+struct SomeField : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct ExtraDataTag : db::SimpleTag {
+  using type = int;
+};
+
+struct NumericalFlux : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  using variables_tags = tmpl::list<SomeField>;
+  using argument_tags = tmpl::list<SomeField, ExtraDataTag>;
+  using volume_tags = tmpl::list<ExtraDataTag>;
+  using package_field_tags = tmpl::list<SomeField>;
+  using package_extra_tags = tmpl::list<ExtraDataTag>;
+  static void package_data(
+      const gsl::not_null<Scalar<DataVector>*> packaged_field,
+      const gsl::not_null<int*> packaged_extra_data,
+      const Scalar<DataVector>& field, const int& extra_data) noexcept {
+    *packaged_field = field;
+    *packaged_extra_data = extra_data;
+  }
+  void operator()(const gsl::not_null<Scalar<DataVector>*> numerical_flux,
+                  const Scalar<DataVector>& field_int,
+                  const int& extra_data_int,
+                  const Scalar<DataVector>& field_ext,
+                  const int& extra_data_ext) const noexcept {
+    CHECK(extra_data_int == extra_data_ext);
+    // A simple central flux
+    get(*numerical_flux) = 0.5 * (get(field_int) + get(field_ext));
+  }
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DG.FirstOrderScheme.BoundaryData",
+                  "[Unit][NumericalAlgorithms]") {
+  const Scalar<DataVector> field{{{{1., 2., 3.}}}};
+  const int extra_data = 1;
+  Variables<tmpl::list<::Tags::NormalDotFlux<SomeField>>> normal_dot_fluxes{3};
+  get<::Tags::NormalDotFlux<SomeField>>(normal_dot_fluxes) =
+      Scalar<DataVector>{{{{4., 5., 6.}}}};
+  const auto packaged_data = dg::FirstOrderScheme::package_boundary_data(
+      NumericalFlux{},
+      Mesh<1>{3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto},
+      normal_dot_fluxes, field, extra_data);
+  CHECK(get<SomeField>(packaged_data.field_data) == field);
+  CHECK(get<ExtraDataTag>(packaged_data.extra_data) == extra_data);
+  CHECK(get<::Tags::NormalDotFlux<SomeField>>(packaged_data.field_data) ==
+        get<::Tags::NormalDotFlux<SomeField>>(normal_dot_fluxes));
+}

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_BoundaryFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_BoundaryFlux.cpp
@@ -1,0 +1,256 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/SliceIterator.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
+#include "Domain/InterfaceHelpers.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryData.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryFlux.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "tests/Unit/ProtocolTestHelpers.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace {
+
+struct SomeField : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct ExtraDataTag : db::SimpleTag {
+  using type = int;
+};
+
+struct NumericalFlux : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  using variables_tags = tmpl::list<SomeField>;
+  using argument_tags = tmpl::list<SomeField, ExtraDataTag>;
+  using volume_tags = tmpl::list<ExtraDataTag>;
+  using package_field_tags = tmpl::list<SomeField>;
+  using package_extra_tags = tmpl::list<ExtraDataTag>;
+  static void package_data(
+      const gsl::not_null<Scalar<DataVector>*> packaged_field,
+      const gsl::not_null<int*> packaged_extra_data,
+      const Scalar<DataVector>& field, const int& extra_data) noexcept {
+    *packaged_field = field;
+    *packaged_extra_data = extra_data;
+  }
+  void operator()(const gsl::not_null<Scalar<DataVector>*> numerical_flux,
+                  const Scalar<DataVector>& field_int,
+                  const int& extra_data_int,
+                  const Scalar<DataVector>& field_ext,
+                  const int& extra_data_ext) const noexcept {
+    CHECK(extra_data_int == extra_data_ext);
+    // A simple central flux
+    get(*numerical_flux) = 0.5 * (get(field_int) + get(field_ext));
+  }
+};
+
+static_assert(
+    test_protocol_conformance<NumericalFlux, dg::protocols::NumericalFlux>,
+    "Failed testing protocol conformance");
+
+// A flux used in earlier versions of this test (see history of
+// tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp),
+// included here to make sure it didn't break
+struct RefinementTestsNumericalFlux
+    : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  DataVector answer;
+  explicit RefinementTestsNumericalFlux(DataVector local_answer) noexcept
+      : answer{std::move(local_answer)} {};
+
+  using variables_tags = tmpl::list<SomeField>;
+  using argument_tags = tmpl::list<SomeField>;
+  using package_field_tags = tmpl::list<SomeField>;
+  using package_extra_tags = tmpl::list<>;
+  void package_data(const gsl::not_null<Scalar<DataVector>*> packaged_field,
+                    const Scalar<DataVector>& field) const noexcept {
+    *packaged_field = field;
+  }
+  void operator()(const gsl::not_null<Scalar<DataVector>*> numerical_flux,
+                  const Scalar<DataVector>& local_var,
+                  const Scalar<DataVector>& remote_var) const noexcept {
+    CHECK(get(local_var) == DataVector{1., 2., 3.});
+    CHECK(get(remote_var) == DataVector{6., 5., 4.});
+    get(*numerical_flux) = answer;
+  }
+};
+
+static_assert(test_protocol_conformance<RefinementTestsNumericalFlux,
+                                        dg::protocols::NumericalFlux>,
+              "Failed testing protocol conformance");
+
+// Helper function to compare a simple setup to the Python implementation
+template <size_t Dim, size_t NumPointsPerDim, typename NumericalFluxType>
+Scalar<DataVector> simple_boundary_flux(
+    const Scalar<DataVector>& field_int,
+    const Scalar<DataVector>& field_ext) noexcept {
+  constexpr size_t num_points_per_dim = NumPointsPerDim;
+  CAPTURE(num_points_per_dim);
+  using BoundaryData = dg::FirstOrderScheme::BoundaryData<NumericalFluxType>;
+  // Setup a mortar
+  const Mesh<Dim - 1> mortar_mesh{num_points_per_dim, Spectral::Basis::Legendre,
+                                  Spectral::Quadrature::GaussLobatto};
+  const size_t mortar_num_points = mortar_mesh.number_of_grid_points();
+  dg::MortarSize<Dim - 1> mortar_size{};
+  mortar_size.fill(Spectral::MortarSize::Full);
+  // Make sure the input fields are of the correct size
+  ASSERT(get(field_int).size() == mortar_num_points &&
+             get(field_ext).size() == mortar_num_points,
+         "The input fields have "
+             << get(field_int).size() << " points but should have "
+             << mortar_num_points
+             << "points since they represent data on the boundary.");
+  // Construct data on either side of the mortar
+  const auto make_boundary_data =
+      [&mortar_num_points](const Scalar<DataVector>& field,
+                           const Direction<Dim>& direction) noexcept {
+        BoundaryData boundary_data{mortar_num_points};
+        get<SomeField>(boundary_data.field_data) = field;
+        get(get<::Tags::NormalDotFlux<SomeField>>(boundary_data.field_data)) =
+            direction.sign() * get(field);
+        get<ExtraDataTag>(boundary_data.extra_data) = 1;
+        return boundary_data;
+      };
+  return get<SomeField>(dg::FirstOrderScheme::boundary_flux(
+      make_boundary_data(field_int, Direction<Dim>::upper_xi()),
+      make_boundary_data(field_ext, Direction<Dim>::lower_xi()),
+      NumericalFluxType{}, Scalar<DataVector>{mortar_num_points, 1.},
+      num_points_per_dim, mortar_mesh, mortar_mesh, mortar_size));
+}
+
+template <size_t Dim>
+void test_simple_boundary_flux() noexcept {
+  CAPTURE(Dim);
+  {
+    INFO("Compare to Python implementation");
+    constexpr size_t num_points_per_dim = 5;
+    const DataVector used_for_size_on_face{pow<Dim - 1>(num_points_per_dim)};
+    pypp::check_with_random_values<1>(
+        &simple_boundary_flux<Dim, num_points_per_dim, NumericalFlux>,
+        "BoundaryFlux", "boundary_flux", {{{-1., 1.}}},
+        used_for_size_on_face);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DG.FirstOrderScheme.BoundaryFlux",
+                  "[Unit][NumericalAlgorithms]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/"
+      "FirstOrder/");
+  test_simple_boundary_flux<1>();
+  test_simple_boundary_flux<2>();
+  test_simple_boundary_flux<3>();
+
+  {
+    // This test was carried over from Test_MortarHelpers.cpp
+    INFO("p-refinement");
+    static constexpr size_t Dim = 2;
+    const RefinementTestsNumericalFlux numerical_flux{{0., 3., 0.}};
+    using BoundaryData =
+        dg::FirstOrderScheme::BoundaryData<RefinementTestsNumericalFlux>;
+    const Mesh<Dim> mesh{{{4, 2}},
+                         Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+    // Setup a mortar
+    const dg::MortarId<Dim> mortar_id{Direction<Dim>::upper_xi(),
+                                      ElementId<Dim>{1}};
+    const size_t slice_dim = mortar_id.first.dimension();
+    const auto face_mesh = mesh.slice_away(slice_dim);
+    const size_t face_num_points = face_mesh.number_of_grid_points();
+    // The face has 2 grid points, but we make a mortar mesh with 3 grid points,
+    // so this test includes a projection from a p-refined mortar mesh.
+    const Mesh<Dim - 1> mortar_mesh{3, Spectral::Basis::Legendre,
+                                    Spectral::Quadrature::GaussLobatto};
+    const size_t mortar_num_points = mortar_mesh.number_of_grid_points();
+    const size_t perpendicular_extent = mesh.extents(slice_dim);
+    const dg::MortarSize<Dim - 1> mortar_size{{Spectral::MortarSize::Full}};
+    // Construct boundary data
+    const Scalar<DataVector> magnitude_of_face_normal{2., 5.};
+    BoundaryData interior_data{mortar_num_points};
+    get(get<SomeField>(interior_data.field_data)) = DataVector{1., 2., 3.};
+    get(get<Tags::NormalDotFlux<SomeField>>(interior_data.field_data)) =
+        DataVector{-3., 0., 3.};
+    BoundaryData exterior_data{mortar_num_points};
+    get(get<SomeField>(exterior_data.field_data)) = DataVector{6., 5., 4.};
+    // Apply boundary scheme
+    const auto boundary_flux = dg::FirstOrderScheme::boundary_flux(
+        interior_data, exterior_data, numerical_flux, magnitude_of_face_normal,
+        perpendicular_extent, face_mesh, mortar_mesh, mortar_size);
+    // Projected F* - F = {5., -1.}
+    Variables<tmpl::list<::Tags::NormalDotFlux<SomeField>>> fstar_minus_f{
+        face_num_points};
+    get(get<::Tags::NormalDotFlux<SomeField>>(fstar_minus_f)) =
+        DataVector{5., -1.};
+    const auto expected = dg::lift_flux(fstar_minus_f, perpendicular_extent,
+                                        magnitude_of_face_normal);
+    CHECK_VARIABLES_APPROX(boundary_flux, expected);
+  }
+  {
+    // This test was carried over from Test_MortarHelpers.cpp
+    INFO("h-refinement");
+    constexpr size_t Dim = 2;
+    using BoundaryData =
+        dg::FirstOrderScheme::BoundaryData<RefinementTestsNumericalFlux>;
+    const Mesh<Dim> mesh{{{4, 3}},
+                         Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+    const auto compute_contribution = [&mesh](
+                                          const dg::MortarId<Dim>& mortar_id,
+                                          const dg::MortarSize<Dim - 1>&
+                                              mortar_size,
+                                          const DataVector&
+                                              numerical_flux) noexcept {
+      const auto mortar_mesh = mesh.slice_away(mortar_id.first.dimension());
+      const size_t mortar_num_points = mortar_mesh.number_of_grid_points();
+
+      // These are all arbitrary
+      const DataVector local_flux{-1., 5., 7.};
+      const Scalar<DataVector> magnitude_of_face_normal{{{{2., 5., 7.}}}};
+
+      BoundaryData interior_data{mortar_num_points};
+      get(get<Tags::NormalDotFlux<SomeField>>(interior_data.field_data)) =
+          local_flux;
+      get<SomeField>(interior_data.field_data) =
+          Scalar<DataVector>{mortar_num_points, 0.};
+      interior_data = interior_data.project_to_mortar(mortar_mesh, mortar_mesh,
+                                                      mortar_size);
+      get(get<SomeField>(interior_data.field_data)) = DataVector{1., 2., 3.};
+
+      BoundaryData exterior_data{mortar_num_points};
+      get(get<SomeField>(exterior_data.field_data)) = DataVector{6., 5., 4.};
+
+      return dg::FirstOrderScheme::boundary_flux(
+          interior_data, exterior_data,
+          RefinementTestsNumericalFlux{numerical_flux},
+          magnitude_of_face_normal, mesh.extents(mortar_id.first.dimension()),
+          mortar_mesh, mortar_mesh, mortar_size);
+    };
+    const auto unrefined_result =
+        compute_contribution({Direction<Dim>::upper_xi(), ElementId<Dim>{0}},
+                             {{Spectral::MortarSize::Full}}, {1., 4., 9.});
+    const decltype(unrefined_result) refined_result =
+        compute_contribution({Direction<Dim>::upper_xi(), ElementId<Dim>{0}},
+                             {{Spectral::MortarSize::LowerHalf}},
+                             {1., 9. / 4., 4.}) +
+        compute_contribution({Direction<Dim>::upper_xi(), ElementId<Dim>{1}},
+                             {{Spectral::MortarSize::UpperHalf}},
+                             {4., 25. / 4., 9.});
+    CHECK_VARIABLES_APPROX(unrefined_result, refined_result);
+  }
+}

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_LiftFlux.cpp
   Test_MortarHelpers.cpp
   Test_NormalDotFlux.cpp
+  Test_Protocols.cpp
   Test_SimpleBoundaryData.cpp
   Test_SimpleMortarData.cpp
   Test_Tags.cpp

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(BoundarySchemes)
+
 set(LIBRARY "Test_NumericalDiscontinuousGalerkin")
 
 set(LIBRARY_SOURCES

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp
@@ -181,6 +181,59 @@ SPECTRE_TEST_CASE("Unit.DG.MortarHelpers.projections",
   const auto all_mortar_sizes = {MortarSize::Full, MortarSize::LowerHalf,
                                  MortarSize::UpperHalf};
 
+  {
+    INFO("needs_projection");
+    CHECK_FALSE(
+        dg::needs_projection(Mesh<0>{}, Mesh<0>{}, dg::MortarSize<0>{}));
+    CHECK_FALSE(
+        dg::needs_projection(Mesh<1>{3, Spectral::Basis::Legendre,
+                                     Spectral::Quadrature::GaussLobatto},
+                             Mesh<1>{3, Spectral::Basis::Legendre,
+                                     Spectral::Quadrature::GaussLobatto},
+                             dg::MortarSize<1>{{MortarSize::Full}}));
+    CHECK_FALSE(dg::needs_projection(
+        Mesh<2>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto},
+        Mesh<2>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto},
+        dg::MortarSize<2>{{MortarSize::Full, MortarSize::Full}}));
+    CHECK_FALSE(dg::needs_projection(
+        Mesh<3>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto},
+        Mesh<3>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto},
+        dg::MortarSize<3>{
+            {MortarSize::Full, MortarSize::Full, MortarSize::Full}}));
+    CHECK(dg::needs_projection(Mesh<1>{3, Spectral::Basis::Legendre,
+                                       Spectral::Quadrature::GaussLobatto},
+                               Mesh<1>{4, Spectral::Basis::Legendre,
+                                       Spectral::Quadrature::GaussLobatto},
+                               dg::MortarSize<1>{{MortarSize::Full}}));
+    CHECK(dg::needs_projection(
+        Mesh<1>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto},
+        Mesh<1>{3, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss},
+        dg::MortarSize<1>{{MortarSize::Full}}));
+    CHECK(dg::needs_projection(Mesh<1>{3, Spectral::Basis::Legendre,
+                                       Spectral::Quadrature::GaussLobatto},
+                               Mesh<1>{3, Spectral::Basis::Legendre,
+                                       Spectral::Quadrature::GaussLobatto},
+                               dg::MortarSize<1>{{MortarSize::LowerHalf}}));
+    CHECK(dg::needs_projection(
+        Mesh<2>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto},
+        Mesh<2>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto},
+        dg::MortarSize<2>{{MortarSize::Full, MortarSize::LowerHalf}}));
+    CHECK(dg::needs_projection(
+        Mesh<3>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto},
+        Mesh<3>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto},
+        dg::MortarSize<3>{
+            {MortarSize::Full, MortarSize::Full, MortarSize::UpperHalf}}));
+  }
+
   // Check 0D
   {
     Variables<tmpl::list<Var>> vars(1);

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_Protocols.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_Protocols.cpp
@@ -1,0 +1,171 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ProtocolTestHelpers.hpp"
+
+namespace {
+
+struct FieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct ExtraTag : db::SimpleTag {
+  using type = int;
+};
+
+struct ValidNumericalFlux : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  using variables_tags = tmpl::list<FieldTag>;
+  using argument_tags = tmpl::list<FieldTag>;
+  using package_field_tags = tmpl::list<FieldTag>;
+  using package_extra_tags = tmpl::list<ExtraTag>;
+  void package_data(gsl::not_null<Scalar<DataVector>*> packaged_field,
+                    gsl::not_null<int*> packaged_int,
+                    const Scalar<DataVector>& field) const noexcept;
+  void operator()(gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
+                  const Scalar<DataVector>& field_interior,
+                  const int& int_interior,
+                  const Scalar<DataVector>& field_exterior,
+                  const int& int_exterior) const noexcept;
+};
+
+struct NumericalFluxMissingVarsTags
+    : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  using argument_tags = tmpl::list<>;
+  using package_field_tags = tmpl::list<>;
+  using package_extra_tags = tmpl::list<>;
+};
+struct NumericalFluxMissingArgumentTags
+    : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  using variables_tags = tmpl::list<>;
+  using package_field_tags = tmpl::list<>;
+  using package_extra_tags = tmpl::list<>;
+};
+struct NumericalFluxMissingPackageFieldTags
+    : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  using variables_tags = tmpl::list<>;
+  using argument_tags = tmpl::list<>;
+  using package_extra_tags = tmpl::list<>;
+};
+struct NumericalFluxMissingPackageExtraTags
+    : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  using variables_tags = tmpl::list<>;
+  using argument_tags = tmpl::list<>;
+  using package_field_tags = tmpl::list<>;
+};
+struct NumericalFluxMissingPackageData
+    : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  using variables_tags = tmpl::list<>;
+  using argument_tags = tmpl::list<>;
+  using package_field_tags = tmpl::list<>;
+  using package_extra_tags = tmpl::list<>;
+  void operator()(gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
+                  const Scalar<DataVector>& field_interior,
+                  const int& int_interior,
+                  const Scalar<DataVector>& field_exterior,
+                  const int& int_exterior) const noexcept;
+};
+struct NumericalFluxInvalidPackageData
+    : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  using variables_tags = tmpl::list<FieldTag>;
+  using argument_tags = tmpl::list<FieldTag>;
+  using package_field_tags = tmpl::list<FieldTag>;
+  using package_extra_tags = tmpl::list<ExtraTag>;
+  void package_data(gsl::not_null<Scalar<DataVector>*> packaged_field,
+                    const Scalar<DataVector>& field) const noexcept;
+  void operator()(gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
+                  const Scalar<DataVector>& field_interior,
+                  const int& int_interior,
+                  const Scalar<DataVector>& field_exterior,
+                  const int& int_exterior) const noexcept;
+};
+struct NumericalFluxMissingCallOperator
+    : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  using variables_tags = tmpl::list<FieldTag>;
+  using argument_tags = tmpl::list<FieldTag>;
+  using package_field_tags = tmpl::list<FieldTag>;
+  using package_extra_tags = tmpl::list<ExtraTag>;
+  void package_data(gsl::not_null<Scalar<DataVector>*> packaged_field,
+                    gsl::not_null<int*> packaged_int,
+                    const Scalar<DataVector>& field) const noexcept;
+};
+struct NumericalFluxInvalidCallOperator
+    : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  using variables_tags = tmpl::list<FieldTag>;
+  using argument_tags = tmpl::list<FieldTag>;
+  using package_field_tags = tmpl::list<FieldTag>;
+  using package_extra_tags = tmpl::list<ExtraTag>;
+  void package_data(gsl::not_null<Scalar<DataVector>*> packaged_field,
+                    gsl::not_null<int*> packaged_int,
+                    const Scalar<DataVector>& field) const noexcept;
+  void operator()(const Scalar<DataVector>& field_interior,
+                  const Scalar<DataVector>& field_exterior) const noexcept;
+};
+
+static_assert(dg::protocols::NumericalFlux<ValidNumericalFlux>::value,
+              "Failed testing protocol");
+static_assert(
+    not dg::protocols::NumericalFlux<NumericalFluxMissingVarsTags>::value,
+    "Failed testing protocol");
+static_assert(
+    not dg::protocols::NumericalFlux<NumericalFluxMissingArgumentTags>::value,
+    "Failed testing protocol");
+static_assert(not dg::protocols::NumericalFlux<
+                  NumericalFluxMissingPackageFieldTags>::value,
+              "Failed testing protocol");
+static_assert(not dg::protocols::NumericalFlux<
+                  NumericalFluxMissingPackageExtraTags>::value,
+              "Failed testing protocol");
+static_assert(
+    not dg::protocols::NumericalFlux<NumericalFluxMissingPackageData>::value,
+    "Failed testing protocol");
+static_assert(
+    not dg::protocols::NumericalFlux<NumericalFluxInvalidPackageData>::value,
+    "Failed testing protocol");
+static_assert(
+    not dg::protocols::NumericalFlux<NumericalFluxMissingCallOperator>::value,
+    "Failed testing protocol");
+static_assert(
+    not dg::protocols::NumericalFlux<NumericalFluxInvalidCallOperator>::value,
+    "Failed testing protocol");
+
+static_assert(
+    test_protocol_conformance<ValidNumericalFlux, dg::protocols::NumericalFlux>,
+    "Failed testing protocol conformance");
+
+// [numerical_flux_example]
+struct CentralFlux : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  using variables_tags = tmpl::list<FieldTag>;
+  using argument_tags = tmpl::list<::Tags::NormalDotFlux<FieldTag>>;
+  using package_field_tags = tmpl::list<::Tags::NormalDotFlux<FieldTag>>;
+  using package_extra_tags = tmpl::list<>;
+  void package_data(
+      const gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux,
+      const Scalar<DataVector>& normal_dot_flux) const noexcept {
+    *packaged_normal_dot_flux = normal_dot_flux;
+  }
+  void operator()(const gsl::not_null<Scalar<DataVector>*> numerical_flux,
+                  const Scalar<DataVector>& normal_dot_flux_interior,
+                  const Scalar<DataVector>& normal_dot_flux_exterior) const
+      noexcept {
+    // The minus sign appears because the `normal_dot_flux_exterior` was
+    // computed with the interface normal from the neighboring element
+    get(*numerical_flux) =
+        0.5 * (get(normal_dot_flux_interior) - get(normal_dot_flux_exterior));
+  }
+};
+// [numerical_flux_example]
+
+static_assert(
+    test_protocol_conformance<CentralFlux, dg::protocols::NumericalFlux>,
+    "Failed testing protocol conformance");
+
+}  // namespace


### PR DESCRIPTION
## Proposed changes

This is the next step towards #1725. The PR adds a protocol that defines and documents the interface for numerical fluxes and uses this interface to implement the equation for the strong first-order boundary flux. This implementation will eventually replace the `compute_boundary_flux_contribution` function in `MortarHelpers.hpp` that is built on top of the old `FluxCommTypes` infrastructure.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
