### PR TITLE
Add time dependence Interval, Rectangle, and Brick domain creators

### DIFF
--- a/src/Domain/Creators/CMakeLists.txt
+++ b/src/Domain/Creators/CMakeLists.txt
@@ -28,5 +28,6 @@ target_link_libraries(
   INTERFACE CoordinateMaps
   INTERFACE DataStructures
   INTERFACE Domain
+  INTERFACE DomainTimeDependence
   INTERFACE ErrorHandling
   )

--- a/src/Domain/Creators/DomainCreator.hpp
+++ b/src/Domain/Creators/DomainCreator.hpp
@@ -19,6 +19,10 @@ class Block;
 namespace domain {
 template <typename, typename, size_t>
 class CoordinateMapBase;
+
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
 }  // namespace domain
 template <size_t>
 class Domain;
@@ -98,6 +102,13 @@ class DomainCreator {
   /// Obtain the initial refinement levels of the blocks.
   virtual std::vector<std::array<size_t, VolumeDim>> initial_refinement_levels()
       const noexcept = 0;
+
+  /// Retrieve the functions of time used for moving meshes.
+  virtual std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+  functions_of_time() const noexcept {
+    return {};
+  }
 };
 
 #include "Domain/Creators/AlignedLattice.hpp"

--- a/src/Domain/Creators/DomainCreator.hpp
+++ b/src/Domain/Creators/DomainCreator.hpp
@@ -104,9 +104,8 @@ class DomainCreator {
       const noexcept = 0;
 
   /// Retrieve the functions of time used for moving meshes.
-  virtual std::unordered_map<
-      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-  functions_of_time() const noexcept {
+  virtual auto functions_of_time() const noexcept -> std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> {
     return {};
   }
 };

--- a/src/Domain/Creators/Interval.cpp
+++ b/src/Domain/Creators/Interval.cpp
@@ -4,6 +4,7 @@
 #include "Domain/Creators/Interval.hpp"
 
 #include <array>
+#include <memory>
 #include <vector>
 
 #include "Domain/Block.hpp"          // IWYU pragma: keep
@@ -12,6 +13,8 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/Creators/TimeDependence/None.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 
@@ -24,28 +27,45 @@ struct Logical;
 
 namespace domain {
 namespace creators {
-Interval::Interval(typename LowerBound::type lower_x,
-                   typename UpperBound::type upper_x,
-                   typename IsPeriodicIn::type is_periodic_in_x,
-                   typename InitialRefinement::type initial_refinement_level_x,
-                   typename InitialGridPoints::type
-                       initial_number_of_grid_points_in_x) noexcept
+Interval::Interval(
+    typename LowerBound::type lower_x, typename UpperBound::type upper_x,
+    typename IsPeriodicIn::type is_periodic_in_x,
+    typename InitialRefinement::type initial_refinement_level_x,
+    typename InitialGridPoints::type initial_number_of_grid_points_in_x,
+    std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
+        time_dependence) noexcept
     // clang-tidy: trivially copyable
-    : lower_x_(std::move(lower_x)),                          // NOLINT
-      upper_x_(std::move(upper_x)),                          // NOLINT
-      is_periodic_in_x_(std::move(is_periodic_in_x)),        // NOLINT
-      initial_refinement_level_x_(                           // NOLINT
-          std::move(initial_refinement_level_x)),            // NOLINT
-      initial_number_of_grid_points_in_x_(                   // NOLINT
-          std::move(initial_number_of_grid_points_in_x)) {}  // NOLINT
+    : lower_x_(std::move(lower_x)),                        // NOLINT
+      upper_x_(std::move(upper_x)),                        // NOLINT
+      is_periodic_in_x_(std::move(is_periodic_in_x)),      // NOLINT
+      initial_refinement_level_x_(                         // NOLINT
+          std::move(initial_refinement_level_x)),          // NOLINT
+      initial_number_of_grid_points_in_x_(                 // NOLINT
+          std::move(initial_number_of_grid_points_in_x)),  // NOLINT
+      time_dependence_(std::move(time_dependence)) {
+  if (time_dependence_ == nullptr) {
+    time_dependence_ =
+        std::make_unique<domain::creators::time_dependence::None<1>>();
+  }
+}
 
 Domain<1> Interval::create_domain() const noexcept {
-  return Domain<1>{
+  Domain<1> domain{
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           CoordinateMaps::Affine{-1., 1., lower_x_[0], upper_x_[0]}),
       std::vector<std::array<size_t, 2>>{{{1, 2}}},
       is_periodic_in_x_[0] ? std::vector<PairOfFaces>{{{1}, {2}}}
                            : std::vector<PairOfFaces>{}};
+  if (not time_dependence_->is_none()) {
+    domain.inject_time_dependent_map_for_block(
+        0, std::move(time_dependence_->block_maps(1)[0]));
+  }
+  return domain;
+}
+
+std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
+Interval::TimeDependence::default_value() noexcept {
+  return std::make_unique<domain::creators::time_dependence::None<1>>();
 }
 
 std::vector<std::array<size_t, 1>> Interval::initial_extents() const noexcept {
@@ -55,6 +75,16 @@ std::vector<std::array<size_t, 1>> Interval::initial_extents() const noexcept {
 std::vector<std::array<size_t, 1>> Interval::initial_refinement_levels() const
     noexcept {
   return {{{initial_refinement_level_x_}}};
+}
+
+std::unordered_map<std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+Interval::functions_of_time() const noexcept {
+  if (time_dependence_->is_none()) {
+    return {};
+  } else {
+    return time_dependence_->functions_of_time();
+  }
 }
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/Interval.hpp
+++ b/src/Domain/Creators/Interval.hpp
@@ -8,9 +8,11 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
 #include <vector>
 
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -59,17 +61,26 @@ class Interval : public DomainCreator<1> {
     static constexpr OptionString help = {
         "Initial number of grid points in [x]."};
   };
+  struct TimeDependence {
+    using type =
+        std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>;
+    static constexpr OptionString help = {
+        "The time dependence of the moving mesh domain."};
+    static type default_value() noexcept;
+  };
 
-  using options = tmpl::list<LowerBound, UpperBound, IsPeriodicIn,
-                             InitialRefinement, InitialGridPoints>;
+  using options =
+      tmpl::list<LowerBound, UpperBound, IsPeriodicIn, InitialRefinement,
+                 InitialGridPoints, TimeDependence>;
 
   static constexpr OptionString help = {"Creates a 1D interval."};
 
   Interval(typename LowerBound::type lower_x, typename UpperBound::type upper_x,
            typename IsPeriodicIn::type is_periodic_in_x,
            typename InitialRefinement::type initial_refinement_level_x,
-           typename InitialGridPoints::type
-               initial_number_of_grid_points_in_x) noexcept;
+           typename InitialGridPoints::type initial_number_of_grid_points_in_x,
+           std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
+               time_dependence = nullptr) noexcept;
 
   Interval() = default;
   Interval(const Interval&) = delete;
@@ -85,12 +96,18 @@ class Interval : public DomainCreator<1> {
   std::vector<std::array<size_t, 1>> initial_refinement_levels() const
       noexcept override;
 
+  auto functions_of_time() const noexcept -> std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
+
  private:
   typename LowerBound::type lower_x_{};
   typename UpperBound::type upper_x_{};
   typename IsPeriodicIn::type is_periodic_in_x_{};
   typename InitialRefinement::type initial_refinement_level_x_{};
   typename InitialGridPoints::type initial_number_of_grid_points_in_x_{};
+  std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
+      time_dependence_;
 };
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/Rectangle.cpp
+++ b/src/Domain/Creators/Rectangle.cpp
@@ -4,6 +4,7 @@
 #include "Domain/Creators/Rectangle.hpp"
 
 #include <array>
+#include <memory>
 #include <vector>
 
 #include "Domain/Block.hpp"          // IWYU pragma: keep
@@ -14,6 +15,8 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/Creators/TimeDependence/None.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 
@@ -31,15 +34,22 @@ Rectangle::Rectangle(
     typename IsPeriodicIn::type is_periodic_in_xy,
     typename InitialRefinement::type initial_refinement_level_xy,
     typename InitialGridPoints::type initial_number_of_grid_points_in_xy,
-    const OptionContext& /*context*/) noexcept
+    std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
+        time_dependence) noexcept
     // clang-tidy: trivially copyable
-    : lower_xy_(std::move(lower_xy)),                         // NOLINT
-      upper_xy_(std::move(upper_xy)),                         // NOLINT
-      is_periodic_in_xy_(std::move(is_periodic_in_xy)),       // NOLINT
-      initial_refinement_level_xy_(                           // NOLINT
-          std::move(initial_refinement_level_xy)),            // NOLINT
-      initial_number_of_grid_points_in_xy_(                   // NOLINT
-          std::move(initial_number_of_grid_points_in_xy)) {}  // NOLINT
+    : lower_xy_(std::move(lower_xy)),                       // NOLINT
+      upper_xy_(std::move(upper_xy)),                       // NOLINT
+      is_periodic_in_xy_(std::move(is_periodic_in_xy)),     // NOLINT
+      initial_refinement_level_xy_(                         // NOLINT
+          std::move(initial_refinement_level_xy)),          // NOLINT
+      initial_number_of_grid_points_in_xy_(                 // NOLINT
+          std::move(initial_number_of_grid_points_in_xy)),  // NOLINT
+      time_dependence_(std::move(time_dependence)) {
+  if (time_dependence_ == nullptr) {
+    time_dependence_ =
+        std::make_unique<domain::creators::time_dependence::None<2>>();
+  }
+}
 
 Domain<2> Rectangle::create_domain() const noexcept {
   using Affine = CoordinateMaps::Affine;
@@ -52,11 +62,22 @@ Domain<2> Rectangle::create_domain() const noexcept {
     identifications.push_back({{0, 1}, {2, 3}});
   }
 
-  return Domain<2>{
+  Domain<2> domain{
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Affine2D{Affine{-1., 1., lower_xy_[0], upper_xy_[0]},
                    Affine{-1., 1., lower_xy_[1], upper_xy_[1]}}),
       std::vector<std::array<size_t, 4>>{{{0, 1, 2, 3}}}, identifications};
+
+  if (not time_dependence_->is_none()) {
+    domain.inject_time_dependent_map_for_block(
+        0, std::move(time_dependence_->block_maps(1)[0]));
+  }
+  return domain;
+}
+
+std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
+Rectangle::TimeDependence::default_value() noexcept {
+  return std::make_unique<domain::creators::time_dependence::None<2>>();
 }
 
 std::vector<std::array<size_t, 2>> Rectangle::initial_extents() const noexcept {
@@ -66,6 +87,16 @@ std::vector<std::array<size_t, 2>> Rectangle::initial_extents() const noexcept {
 std::vector<std::array<size_t, 2>> Rectangle::initial_refinement_levels() const
     noexcept {
   return {initial_refinement_level_xy_};
+}
+
+std::unordered_map<std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+Rectangle::functions_of_time() const noexcept {
+  if (time_dependence_->is_none()) {
+    return {};
+  } else {
+    return time_dependence_->functions_of_time();
+  }
 }
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/Rectangle.hpp
+++ b/src/Domain/Creators/Rectangle.hpp
@@ -8,9 +8,11 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
 #include <vector>
 
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -67,8 +69,17 @@ class Rectangle : public DomainCreator<2> {
     static constexpr OptionString help = {
         "Initial number of grid points in [x,y]."};
   };
-  using options = tmpl::list<LowerBound, UpperBound, IsPeriodicIn,
-                             InitialRefinement, InitialGridPoints>;
+  struct TimeDependence {
+    using type =
+        std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>;
+    static constexpr OptionString help = {
+        "The time dependence of the moving mesh domain."};
+    static type default_value() noexcept;
+  };
+
+  using options =
+      tmpl::list<LowerBound, UpperBound, IsPeriodicIn, InitialRefinement,
+                 InitialGridPoints, TimeDependence>;
 
   static constexpr OptionString help{"Creates a 2D rectangle."};
 
@@ -77,7 +88,8 @@ class Rectangle : public DomainCreator<2> {
       typename IsPeriodicIn::type is_periodic_in_xy,
       typename InitialRefinement::type initial_refinement_level_xy,
       typename InitialGridPoints::type initial_number_of_grid_points_in_xy,
-      const OptionContext& context = {}) noexcept;
+      std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
+          time_dependence = nullptr) noexcept;
 
   Rectangle() = default;
   Rectangle(const Rectangle&) = delete;
@@ -93,12 +105,18 @@ class Rectangle : public DomainCreator<2> {
   std::vector<std::array<size_t, 2>> initial_refinement_levels() const
       noexcept override;
 
+  auto functions_of_time() const noexcept -> std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
+
  private:
   typename LowerBound::type lower_xy_{};
   typename UpperBound::type upper_xy_{};
   typename IsPeriodicIn::type is_periodic_in_xy_{};
   typename InitialRefinement::type initial_refinement_level_xy_{};
   typename InitialGridPoints::type initial_number_of_grid_points_in_xy_{};
+  std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
+      time_dependence_;
 };
 }  // namespace creators
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/TestHelpers.hpp
+++ b/tests/Unit/Domain/Creators/TestHelpers.hpp
@@ -1,0 +1,51 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/Tuple.hpp"
+
+namespace TestHelpers {
+namespace domain {
+namespace creators {
+template <typename Creator, typename... ExpectedFunctionsOfTime>
+void test_functions_of_time(
+    const Creator& creator,
+    const std::tuple<std::pair<std::string, ExpectedFunctionsOfTime>...>&
+        expected_functions_of_time) {
+  const std::unordered_map<
+      std::string, std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>&
+      functions_of_time = creator.functions_of_time();
+  REQUIRE(functions_of_time.size() == sizeof...(ExpectedFunctionsOfTime));
+
+  tuple_fold(
+      expected_functions_of_time,
+      [&functions_of_time](const auto& name_and_function_of_time) noexcept {
+        const std::string& name = name_and_function_of_time.first;
+        const auto& function_of_time = name_and_function_of_time.second;
+        using FunctionOfTimeType = std::decay_t<decltype(function_of_time)>;
+        const bool in_functions_of_time =
+            functions_of_time.find(name) != functions_of_time.end();
+        CHECK(in_functions_of_time);
+        if (in_functions_of_time) {
+          const auto* function_from_creator =
+              dynamic_cast<const FunctionOfTimeType*>(
+                  functions_of_time.at(name).get());
+          REQUIRE(function_from_creator != nullptr);
+          CHECK(*function_from_creator == function_of_time);
+        }
+      });
+}
+}  // namespace creators
+}  // namespace domain
+}  // namespace TestHelpers


### PR DESCRIPTION
## Proposed changes

- Add function to retrieve functions of time from a domain creator
- Add time dependence to Interval, Rectangle, and Brick domain creators

Only the following commits are new:
1. Add functions_of_time function to DomainCreator
2. Add time dependence to Interval domain creator
3. Add time dependence to Rectangle domain creator
4. Add time dependence to Brick domain creator

Dependent on:
- [x] #2030 
- [x] #2031 
- [x] #2032 

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
