### PR TITLE
GRMHD fix conservatives catch exception, fix bug in prim from con error message

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.cpp
@@ -184,15 +184,33 @@ void FixConservatives::operator()(
       const auto f_of_lorentz_factor = FunctionOfLorentzFactor{
           b_squared_over_d, tau_over_d, normalized_s_dot_b};
       const double upper_bound_of_lorentz_factor = 1.0 + tau_over_d;
-      const double lorentz_factor =
-          (equal_within_roundoff(lower_bound_of_lorentz_factor,
-                                 upper_bound_of_lorentz_factor)
-               ? lower_bound_of_lorentz_factor
-               :
-               // NOLINTNEXTLINE(clang-analyzer-core)
-               RootFinder::toms748(
-                   f_of_lorentz_factor, lower_bound_of_lorentz_factor,
-                   upper_bound_of_lorentz_factor, 1.e-14, 1.e-14, 50));
+
+      double lorentz_factor;
+      try {
+        lorentz_factor =
+            (equal_within_roundoff(lower_bound_of_lorentz_factor,
+                                   upper_bound_of_lorentz_factor)
+                 ? lower_bound_of_lorentz_factor
+                 :
+                 // NOLINTNEXTLINE(clang-analyzer-core)
+                 RootFinder::toms748(
+                     f_of_lorentz_factor, lower_bound_of_lorentz_factor,
+                     upper_bound_of_lorentz_factor, 1.e-14, 1.e-14, 50));
+      } catch (std::exception& exception) {
+        ERROR(
+            "Failed to fix conserved variables because the root finder failed "
+            "to find the lorentz factor.\n"
+            "  Upper bound: "
+            << upper_bound_of_lorentz_factor
+            << "\n  Lower bound: " << lower_bound_of_lorentz_factor
+            << "\n  s_tilde_squared: " << s_tilde_squared
+            << "\n  d_tilde: " << d_tilde << "\n  sqrt_det_g: " << sqrt_det_g
+            << "\n  tau_tilde: " << tau_tilde
+            << "\n  b_tilde_squared: " << b_tilde_squared
+            << "\n  s_tilde_squared: " << s_tilde_squared << "\n"
+            << "The message of the exception thrown by the root finder is:\n"
+            << exception.what());
+      }
 
       const double upper_bound_for_s_tilde_squared =
           square(lorentz_factor + b_squared_over_d) *

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -148,11 +148,12 @@ void PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
             << s << ".\n"
             << std::setprecision(std::numeric_limits<double>::digits10 + 1)
             << "total_energy_density = " << total_energy_density[s] << "\n"
-            << "momentum_density_squared = " << momentum_density_squared[s]
+            << "momentum_density_squared = " << get(momentum_density_squared)[s]
             << "\n"
             << "momentum_density_dot_magnetic_field = "
-            << momentum_density_dot_magnetic_field[s] << "\n"
-            << "magnetic_field_squared = " << magnetic_field_squared[s] << "\n"
+            << get(momentum_density_dot_magnetic_field)[s] << "\n"
+            << "magnetic_field_squared = " << get(magnetic_field_squared)[s]
+            << "\n"
             << "rest_mass_density_times_lorentz_factor = "
             << rest_mass_density_times_lorentz_factor[s] << "\n"
             << "previous_rest_mass_density = " << get(*rest_mass_density)[s]


### PR DESCRIPTION
## Proposed changes

- The root finder in fixing the conservative variables can throw an exception, which was previously uncaught and made it terrible to debug.
- The `ERROR` in PrimitivesFromeConservatives can get out-of-bounds values of the tensor components, which causes segfaults while printing the error message.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
