### PR TITLE
Have reduction observer write data from doubles and/or std vectors

### DIFF
--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -30,6 +30,7 @@
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Numeric.hpp"
+#include "Utilities/Overloader.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
 #include "tests/Unit/IO/Observers/ObserverHelpers.hpp"
@@ -83,73 +84,161 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.ReductionObserver", "[Unit][Observers]") {
   ActionTesting::set_phase(make_not_null(&runner),
                            metavariables::Phase::Testing);
 
-  const std::string h5_file_name = output_file_prefix + ".h5";
-  if (file_system::check_if_file_exists(h5_file_name)) {
-    file_system::rm(h5_file_name, true);
-  }
+  const auto make_fake_reduction_data = make_overloader(
+      [](const observers::ArrayComponentId& id, const double time,
+         const helpers::reduction_data_from_doubles& /*meta*/) noexcept {
+        const auto hashed_id =
+            static_cast<double>(std::hash<observers::ArrayComponentId>{}(id));
+        constexpr size_t number_of_grid_points = 4;
+        const double error0 = 1.0e-10 * hashed_id + time;
+        const double error1 = 1.0e-12 * hashed_id + 2.0 * time;
+        return helpers::reduction_data_from_doubles{time, number_of_grid_points,
+                                                    error0, error1};
+      },
+      [](const observers::ArrayComponentId& id, const double time,
+         const helpers::reduction_data_from_vector& /*meta*/) noexcept {
+        const auto hashed_id =
+            static_cast<double>(std::hash<observers::ArrayComponentId>{}(id));
+        constexpr size_t number_of_grid_points = 4;
+        const std::vector<double> data{1.0e-10 * hashed_id + time,
+                                       1.0e-12 * hashed_id + 2.0 * time,
+                                       1.0e-11 * hashed_id + 3.0 * time};
+        return helpers::reduction_data_from_vector{time, number_of_grid_points,
+                                                   data};
+      },
+      [](const observers::ArrayComponentId& id, const double time,
+         const helpers::reduction_data_from_ds_and_vs& /*meta*/) noexcept {
+        const auto hashed_id =
+            static_cast<double>(std::hash<observers::ArrayComponentId>{}(id));
+        constexpr size_t number_of_grid_points = 4;
+        const double error0 = 1.0e-10 * hashed_id + time;
+        const double error1 = 1.0e-12 * hashed_id + 2.0 * time;
+        const std::vector<double> vector1{1.0e-10 * hashed_id + 3.0 * time,
+                                          1.0e-12 * hashed_id + 4.0 * time};
+        const std::vector<double> vector2{1.0e-11 * hashed_id + 5.0 * time,
+                                          1.0e-13 * hashed_id + 6.0 * time};
+        return helpers::reduction_data_from_ds_and_vs{
+            time, number_of_grid_points, error0, vector1, vector2, error1};
+      });
 
-  const auto make_fake_reduction_data = [](
-      const observers::ArrayComponentId& id, const double time) noexcept {
-    const auto hashed_id =
-        static_cast<double>(std::hash<observers::ArrayComponentId>{}(id));
-    constexpr size_t number_of_grid_points = 4;
-    const double error0 = 1.0e-10 * hashed_id + time;
-    const double error1 = 1.0e-12 * hashed_id + 2 * time;
-    return helpers::reduction_data{time, number_of_grid_points, error0, error1};
-  };
+  tmpl::for_each<tmpl::list<helpers::reduction_data_from_doubles,
+                            helpers::reduction_data_from_vector,
+                            helpers::reduction_data_from_ds_and_vs>>([
+    &element_ids, &make_fake_reduction_data, &runner, &output_file_prefix
+  ](auto reduction_data_v) noexcept {
+    using reduction_data = tmpl::type_from<decltype(reduction_data_v)>;
 
-  const double time = 3.;
-  const std::vector<std::string> legend{"Time", "NumberOfPoints", "Error0",
-                                        "Error1"};
-  // Test passing reduction data.
-  for (const auto& id : element_ids) {
-    const observers::ArrayComponentId array_id(
-        std::add_pointer_t<element_comp>{nullptr},
-        Parallel::ArrayIndex<ElementIndex<2>>{ElementIndex<2>{id}});
+    const double time = 3.0;
+    const auto legend = make_overloader(
+        [](const helpers::reduction_data_from_doubles& /*meta*/) noexcept {
+          return std::vector<std::string>{"Time", "NumberOfPoints", "Error0",
+                                          "Error1"};
+        },
+        [](const helpers::reduction_data_from_vector& /*meta*/) noexcept {
+          return std::vector<std::string>{"Time", "NumberOfPoints", "Vec0",
+                                          "Vec1", "Vec2"};
+        },
+        [](const helpers::reduction_data_from_ds_and_vs& /*meta*/) noexcept {
+          return std::vector<std::string>{"Time",  "NumberOfPoints", "Error0",
+                                          "Vec10", "Vec11",          "Vec20",
+                                          "Vec21", "Error1"};
+        })(reduction_data{});
+    const std::string h5_file_name = output_file_prefix + ".h5";
+    if (file_system::check_if_file_exists(h5_file_name)) {
+      file_system::rm(h5_file_name, true);
+    }
 
-    auto reduction_data_fakes =
-        make_fake_reduction_data(array_id, time);
-    runner.simple_action<obs_component,
-                         observers::Actions::ContributeReductionData>(
-        0,
-        observers::ObservationId{
-            time, typename TestObservers_detail::RegisterThisObsType<
-                      type_of_observation>::ElementObservationType{}},
-        "/element_data", legend, std::move(reduction_data_fakes));
-  }
-  // Invoke the threaded action 'WriteReductionData' to write reduction data to
-  // disk.
-  runner.invoke_queued_threaded_action<obs_writer>(0);
+    // Test passing reduction data.
+    for (const auto& id : element_ids) {
+      const observers::ArrayComponentId array_id(
+          std::add_pointer_t<element_comp>{nullptr},
+          Parallel::ArrayIndex<ElementIndex<2>>{ElementIndex<2>{id}});
 
-  REQUIRE(file_system::check_if_file_exists(h5_file_name));
-  // Check that the H5 file was written correctly.
-  {
-    const auto file = h5::H5File<h5::AccessType::ReadOnly>(h5_file_name);
-    const auto& dat_file = file.get<h5::Dat>("/element_data");
-    const Matrix written_data = dat_file.get_data();
-    const auto& written_legend = dat_file.get_legend();
-    CHECK(written_legend == legend);
-    const auto expected =
-        alg::accumulate(
-            element_ids, helpers::reduction_data(time, 0, 0.0, 0.0),
-            [
-              &time, &make_fake_reduction_data
-            ](helpers::reduction_data state, const ElementId<2>& id) noexcept {
-              const observers::ArrayComponentId array_id(
-                  std::add_pointer_t<element_comp>{nullptr},
-                  Parallel::ArrayIndex<ElementIndex<2>>{ElementIndex<2>{id}});
-              return state.combine(
-                  make_fake_reduction_data(array_id, time));
-            })
-            .finalize()
-            .data();
-    CHECK(std::get<0>(expected) == written_data(0, 0));
-    CHECK(std::get<1>(expected) == written_data(0, 1));
-    CHECK(std::get<2>(expected) == written_data(0, 2));
-    CHECK(std::get<3>(expected) == written_data(0, 3));
-  }
+      auto reduction_data_fakes =
+          make_fake_reduction_data(array_id, time, reduction_data{});
+      runner.simple_action<obs_component,
+                           observers::Actions::ContributeReductionData>(
+          0,
+          observers::ObservationId{
+              time, typename TestObservers_detail::RegisterThisObsType<
+                        type_of_observation>::ElementObservationType{}},
+          "/element_data", legend, std::move(reduction_data_fakes));
+    }
+    // Invoke the threaded action 'WriteReductionData' to write reduction data
+    // to disk.
+    runner.invoke_queued_threaded_action<obs_writer>(0);
 
-  if (file_system::check_if_file_exists(h5_file_name)) {
-    file_system::rm(h5_file_name, true);
-  }
+    REQUIRE(file_system::check_if_file_exists(h5_file_name));
+    // Check that the H5 file was written correctly.
+    {
+      const auto file = h5::H5File<h5::AccessType::ReadOnly>(h5_file_name);
+      const auto& dat_file = file.get<h5::Dat>("/element_data");
+      const Matrix written_data = dat_file.get_data();
+      const auto& written_legend = dat_file.get_legend();
+      CHECK(written_legend == legend);
+      const auto data = make_overloader(
+          [&time](
+              const helpers::reduction_data_from_doubles& /*meta*/) noexcept {
+            return helpers::reduction_data_from_doubles(time, 0, 0., 0.);
+          },
+          [&time](
+              const helpers::reduction_data_from_vector& /*meta*/) noexcept {
+            return helpers::reduction_data_from_vector(
+                time, 0, std::vector<double>{0., 0., 0.});
+          },
+          [&time](
+              const helpers::reduction_data_from_ds_and_vs& /*meta*/) noexcept {
+            return helpers::reduction_data_from_ds_and_vs(
+                time, 0, 0., std::vector<double>{0., 0.},
+                std::vector<double>{0., 0.}, 0.);
+          })(reduction_data{});
+      const auto expected =
+          alg::accumulate(
+              element_ids, data,
+              [&time, &make_fake_reduction_data ](
+                  reduction_data state, const ElementId<2>& id) noexcept {
+                const observers::ArrayComponentId array_id(
+                    std::add_pointer_t<element_comp>{nullptr},
+                    Parallel::ArrayIndex<ElementIndex<2>>{ElementIndex<2>{id}});
+                return state.combine(
+                    make_fake_reduction_data(array_id, time, reduction_data{}));
+              })
+              .finalize()
+              .data();
+      make_overloader(
+          [](const auto l_expected, const auto l_written_data,
+             const helpers::reduction_data_from_doubles& /*meta*/) noexcept {
+            CHECK(std::get<0>(l_expected) == l_written_data(0, 0));
+            CHECK(std::get<1>(l_expected) == l_written_data(0, 1));
+            CHECK(std::get<2>(l_expected) == l_written_data(0, 2));
+            CHECK(std::get<3>(l_expected) == l_written_data(0, 3));
+          },
+          [](const auto l_expected, const auto l_written_data,
+             const helpers::reduction_data_from_vector&
+             /*meta*/) noexcept {
+            CHECK(std::get<0>(l_expected) == l_written_data(0, 0));
+            CHECK(std::get<1>(l_expected) == l_written_data(0, 1));
+            for (size_t i = 0; i < std::get<2>(l_expected).size(); ++i) {
+              CHECK(std::get<2>(l_expected)[i] == l_written_data(0, i + 2));
+            }
+          },
+          [](const auto l_expected, const auto l_written_data,
+             const helpers::reduction_data_from_ds_and_vs&
+             /*meta*/) noexcept {
+            CHECK(std::get<0>(l_expected) == l_written_data(0, 0));
+            CHECK(std::get<1>(l_expected) == l_written_data(0, 1));
+            CHECK(std::get<2>(l_expected) == l_written_data(0, 2));
+            for (size_t i = 0; i < std::get<3>(l_expected).size(); ++i) {
+              CHECK(std::get<3>(l_expected)[i] == l_written_data(0, i + 3));
+            }
+            for (size_t i = 0; i < std::get<4>(l_expected).size(); ++i) {
+              CHECK(std::get<4>(l_expected)[i] == l_written_data(0, i + 5));
+            }
+            CHECK(std::get<5>(l_expected) == l_written_data(0, 7));
+          })(expected, written_data, reduction_data{});
+    }
+    if (file_system::check_if_file_exists(h5_file_name)) {
+      file_system::rm(h5_file_name, true);
+    }
+  });
 }

--- a/tests/Unit/IO/Observers/Test_WriteSimpleData.cpp
+++ b/tests/Unit/IO/Observers/Test_WriteSimpleData.cpp
@@ -41,8 +41,8 @@ struct test_metavariables {
   using component_list =
       tmpl::list<helpers::observer_writer_component<test_metavariables>>;
 
-  using observed_reduction_data_tags =
-      observers::make_reduction_data_tags<tmpl::list<helpers::reduction_data>>;
+  using observed_reduction_data_tags = observers::make_reduction_data_tags<
+      tmpl::list<helpers::reduction_data_from_doubles>>;
 
   enum class Phase { Initialization, Testing, Exit };
 };


### PR DESCRIPTION
## Proposed changes

This is needed for observing reductions of integrals/norms of tensors component-wise.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
