### PR TITLE
Clean up some hydro stuff in PointwiseFunctions

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.cpp
@@ -6,11 +6,9 @@
 #include <cmath>
 #include <pup.h>
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -52,14 +50,11 @@ void BondiHoyleAccretion::pup(PUP::er& p) noexcept {
 }
 
 template <typename DataType>
-typename hydro::Tags::SpatialVelocity<DataType, 3, Frame::NoFrame>::type
-BondiHoyleAccretion::spatial_velocity(const DataType& r_squared,
-                                      const DataType& cos_theta,
-                                      const DataType& sin_theta) const
-    noexcept {
-  auto result = make_with_value<
-      typename hydro::Tags::SpatialVelocity<DataType, 3, Frame::NoFrame>::type>(
-      r_squared, 0.0);
+tnsr::I<DataType, 3, Frame::NoFrame> BondiHoyleAccretion::spatial_velocity(
+    const DataType& r_squared, const DataType& cos_theta,
+    const DataType& sin_theta) const noexcept {
+  auto result =
+      make_with_value<tnsr::I<DataType, 3, Frame::NoFrame>>(r_squared, 0.0);
 
   const DataType sigma = r_squared + square(bh_spin_a_) * square(cos_theta);
   get<0>(result) = flow_speed_ * cos_theta /
@@ -71,10 +66,9 @@ BondiHoyleAccretion::spatial_velocity(const DataType& r_squared,
 }
 
 template <typename DataType>
-typename hydro::Tags::MagneticField<DataType, 3, Frame::NoFrame>::type
-BondiHoyleAccretion::magnetic_field(const DataType& r_squared,
-                                    const DataType& cos_theta,
-                                    const DataType& sin_theta) const noexcept {
+tnsr::I<DataType, 3, Frame::NoFrame> BondiHoyleAccretion::magnetic_field(
+    const DataType& r_squared, const DataType& cos_theta,
+    const DataType& sin_theta) const noexcept {
   const double a_squared = bh_spin_a_ * bh_spin_a_;
   const DataType cos_theta_squared = square(cos_theta);
   const DataType two_m_r = 2.0 * bh_mass_ * sqrt(r_squared);
@@ -85,9 +79,8 @@ BondiHoyleAccretion::magnetic_field(const DataType& r_squared,
   const DataType prefactor =
       magnetic_field_strength_ / sqrt(sigma * (sigma + two_m_r));
 
-  auto result = make_with_value<
-      typename hydro::Tags::MagneticField<DataType, 3, Frame::NoFrame>::type>(
-      r_squared, 0.0);
+  auto result =
+      make_with_value<tnsr::I<DataType, 3, Frame::NoFrame>>(r_squared, 0.0);
 
   // Redefine sigma to save an allocation.
   sigma = 1.0 / square(sigma);
@@ -113,18 +106,16 @@ BondiHoyleAccretion::magnetic_field(const DataType& r_squared,
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>
 BondiHoyleAccretion::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const
     noexcept {
-  return {
-      make_with_value<db::item_type<hydro::Tags::RestMassDensity<DataType>>>(
-          x, rest_mass_density_)};
+  return {make_with_value<Scalar<DataType>>(x, rest_mass_density_)};
 }
 
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>
 BondiHoyleAccretion::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/) const
     noexcept {
   const DataType r_squared = get(kerr_schild_coords_.r_coord_squared(x));
@@ -138,7 +129,7 @@ BondiHoyleAccretion::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>
 BondiHoyleAccretion::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
     noexcept {
   return equation_of_state_.specific_internal_energy_from_density(
@@ -149,7 +140,7 @@ BondiHoyleAccretion::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>
 BondiHoyleAccretion::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const noexcept {
   return equation_of_state_.pressure_from_density(
       get<hydro::Tags::RestMassDensity<DataType>>(
@@ -159,7 +150,7 @@ BondiHoyleAccretion::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>
 BondiHoyleAccretion::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
     noexcept {
   const DataType r_squared = get(kerr_schild_coords_.r_coord_squared(x));
@@ -173,26 +164,25 @@ BondiHoyleAccretion::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>
 BondiHoyleAccretion::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const
     noexcept {
-  return {make_with_value<
-      db::item_type<hydro::Tags::DivergenceCleaningField<DataType>>>(x, 0.0)};
+  return {make_with_value<Scalar<DataType>>(x, 0.0)};
 }
 
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>
 BondiHoyleAccretion::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const noexcept {
-  return {make_with_value<db::item_type<hydro::Tags::LorentzFactor<DataType>>>(
+  return {make_with_value<Scalar<DataType>>(
       x, 1.0 / sqrt(1.0 - square(flow_speed_)))};
 }
 
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>
 BondiHoyleAccretion::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
     noexcept {
   return equation_of_state_.specific_enthalpy_from_density(
@@ -222,10 +212,10 @@ bool operator!=(const BondiHoyleAccretion& lhs,
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define TAG(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE_SCALARS(_, data)                         \
-  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>>     \
-      BondiHoyleAccretion::variables(                        \
-          const tnsr::I<DTYPE(data), 3, Frame::Inertial>& x, \
+#define INSTANTIATE_SCALARS(_, data)                     \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>> \
+      BondiHoyleAccretion::variables(                    \
+          const tnsr::I<DTYPE(data), 3>& x,              \
           tmpl::list<TAG(data) < DTYPE(data)>> /*meta*/) const noexcept;
 
 GENERATE_INSTANTIATIONS(
@@ -234,12 +224,11 @@ GENERATE_INSTANTIATIONS(
      hydro::Tags::Pressure, hydro::Tags::DivergenceCleaningField,
      hydro::Tags::LorentzFactor, hydro::Tags::SpecificEnthalpy))
 
-#define INSTANTIATE_VECTORS(_, data)                                         \
-  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>>                  \
-      BondiHoyleAccretion::variables(                                        \
-          const tnsr::I<DTYPE(data), 3, Frame::Inertial>& x,                 \
-          tmpl::list<TAG(data) < DTYPE(data), 3, Frame::Inertial>> /*meta*/) \
-          const noexcept;
+#define INSTANTIATE_VECTORS(_, data)                        \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>> \
+      BondiHoyleAccretion::variables(                       \
+          const tnsr::I<DTYPE(data), 3>& x,                 \
+          tmpl::list<TAG(data) < DTYPE(data), 3>> /*meta*/) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
                         (hydro::Tags::SpatialVelocity,

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
@@ -10,9 +10,8 @@
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/GeneralRelativity/KerrSchildCoords.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -142,12 +141,11 @@ class BondiHoyleAccretion : public MarkAsAnalyticData {
       default;
   ~BondiHoyleAccretion() = default;
 
-  BondiHoyleAccretion(BhMass::type bh_mass, BhDimlessSpin::type bh_dimless_spin,
-                      RestMassDensity::type rest_mass_density,
-                      FlowSpeed::type flow_speed,
-                      MagFieldStrength::type magnetic_field_strength,
-                      PolytropicConstant::type polytropic_constant,
-                      PolytropicExponent::type polytropic_exponent) noexcept;
+  BondiHoyleAccretion(double bh_mass, double bh_dimless_spin,
+                      double rest_mass_density, double flow_speed,
+                      double magnetic_field_strength,
+                      double polytropic_constant,
+                      double polytropic_exponent) noexcept;
 
   // @{
   /// Retrieve hydro variable at `x`
@@ -171,17 +169,15 @@ class BondiHoyleAccretion : public MarkAsAnalyticData {
 
   template <typename DataType>
   auto variables(const tnsr::I<DataType, 3>& x,
-                 tmpl::list<hydro::Tags::SpatialVelocity<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>;
+                 tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/)
+      const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>;
 
   template <typename DataType>
-  auto variables(const tnsr::I<DataType, 3>& x,
-                 tmpl::list<hydro::Tags::MagneticField<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>;
 
   template <typename DataType>
   auto variables(
@@ -205,9 +201,9 @@ class BondiHoyleAccretion : public MarkAsAnalyticData {
 
   /// Retrieve a collection of hydro variables at `x`
   template <typename DataType, typename... Tags>
-  tuples::TaggedTuple<Tags...> variables(
-      const tnsr::I<DataType, 3, Frame::Inertial>& x,
-      tmpl::list<Tags...> /*meta*/) const noexcept {
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, 3>& x,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
     static_assert(sizeof...(Tags) > 1,
                   "The generic template will recurse infinitely if only one "
                   "tag is being retrieved.");
@@ -239,26 +235,23 @@ class BondiHoyleAccretion : public MarkAsAnalyticData {
 
   // compute the spatial velocity in spherical Kerr-Schild coordinates
   template <typename DataType>
-  typename hydro::Tags::SpatialVelocity<DataType, 3, Frame::NoFrame>::type
-  spatial_velocity(const DataType& r_squared, const DataType& cos_theta,
-                   const DataType& sin_theta) const noexcept;
+  tnsr::I<DataType, 3, Frame::NoFrame> spatial_velocity(
+      const DataType& r_squared, const DataType& cos_theta,
+      const DataType& sin_theta) const noexcept;
   // compute the magnetic field in spherical Kerr-Schild coordinates
   template <typename DataType>
-  typename hydro::Tags::MagneticField<DataType, 3, Frame::NoFrame>::type
-  magnetic_field(const DataType& r_squared, const DataType& cos_theta,
-                 const DataType& sin_theta) const noexcept;
+  tnsr::I<DataType, 3, Frame::NoFrame> magnetic_field(
+      const DataType& r_squared, const DataType& cos_theta,
+      const DataType& sin_theta) const noexcept;
 
-  BhMass::type bh_mass_ = std::numeric_limits<double>::signaling_NaN();
-  BhDimlessSpin::type bh_spin_a_ = std::numeric_limits<double>::signaling_NaN();
-  RestMassDensity::type rest_mass_density_ =
+  double bh_mass_ = std::numeric_limits<double>::signaling_NaN();
+  double bh_spin_a_ = std::numeric_limits<double>::signaling_NaN();
+  double rest_mass_density_ = std::numeric_limits<double>::signaling_NaN();
+  double flow_speed_ = std::numeric_limits<double>::signaling_NaN();
+  double magnetic_field_strength_ =
       std::numeric_limits<double>::signaling_NaN();
-  FlowSpeed::type flow_speed_ = std::numeric_limits<double>::signaling_NaN();
-  MagFieldStrength::type magnetic_field_strength_ =
-      std::numeric_limits<double>::signaling_NaN();
-  PolytropicConstant::type polytropic_constant_ =
-      std::numeric_limits<double>::signaling_NaN();
-  PolytropicExponent::type polytropic_exponent_ =
-      std::numeric_limits<double>::signaling_NaN();
+  double polytropic_constant_ = std::numeric_limits<double>::signaling_NaN();
+  double polytropic_exponent_ = std::numeric_limits<double>::signaling_NaN();
   EquationsOfState::PolytropicFluid<true> equation_of_state_{};
   gr::Solutions::KerrSchild background_spacetime_{};
   gr::KerrSchildCoords kerr_schild_coords_{};

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.cpp
@@ -7,9 +7,10 @@
 #include <ostream>
 #include <pup.h>
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "Parallel/PupStlCpp11.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/ConstantExpressions.hpp"  // IWYU pragma: keep
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
@@ -18,10 +19,11 @@
 
 namespace {
 template <typename DataType>
-Scalar<DataType> compute_piecewise(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double& inner_radius,
-    const double& outer_radius, const double& inner_value,
-    const double& outer_value) noexcept {
+Scalar<DataType> compute_piecewise(const tnsr::I<DataType, 3>& x,
+                                   const double& inner_radius,
+                                   const double& outer_radius,
+                                   const double& inner_value,
+                                   const double& outer_value) noexcept {
   const DataType cylindrical_radius =
       sqrt(square(get<0>(x)) + square(get<1>(x)));
   auto piecewise_scalar = make_with_value<Scalar<DataType>>(x, 0.0);
@@ -53,13 +55,11 @@ namespace grmhd {
 namespace AnalyticData {
 
 CylindricalBlastWave::CylindricalBlastWave(
-    const InnerRadius::type inner_radius, const OuterRadius::type outer_radius,
-    const InnerDensity::type inner_density,
-    const OuterDensity::type outer_density,
-    const InnerPressure::type inner_pressure,
-    const OuterPressure::type outer_pressure,
-    const MagneticField::type magnetic_field,
-    const AdiabaticIndex::type adiabatic_index, const OptionContext& context)
+    const double inner_radius, const double outer_radius,
+    const double inner_density, const double outer_density,
+    const double inner_pressure, const double outer_pressure,
+    const std::array<double, 3> magnetic_field, const double adiabatic_index,
+    const OptionContext& context)
     : inner_radius_(inner_radius),
       outer_radius_(outer_radius),
       inner_density_(inner_density),
@@ -93,7 +93,7 @@ void CylindricalBlastWave::pup(PUP::er& p) noexcept {
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>
 CylindricalBlastWave::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const
     noexcept {
   return compute_piecewise(x, inner_radius_, outer_radius_, inner_density_,
@@ -103,17 +103,16 @@ CylindricalBlastWave::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>
 CylindricalBlastWave::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/) const
     noexcept {
-  return {make_with_value<db::item_type<
-      hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>>(x, 0.0)};
+  return {make_with_value<tnsr::I<DataType, 3>>(x, 0.0)};
 }
 
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>
 CylindricalBlastWave::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
     noexcept {
   return equation_of_state_.specific_internal_energy_from_density_and_pressure(
@@ -126,7 +125,7 @@ CylindricalBlastWave::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>
 CylindricalBlastWave::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const noexcept {
   return compute_piecewise(x, inner_radius_, outer_radius_, inner_pressure_,
                            outer_pressure_);
@@ -136,12 +135,10 @@ CylindricalBlastWave::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>
 CylindricalBlastWave::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
     noexcept {
-  auto magnetic_field =
-      make_with_value<typename hydro::Tags::MagneticField<DataType, 3>::type>(
-          get<0>(x), 0.0);
+  auto magnetic_field = make_with_value<tnsr::I<DataType, 3>>(get<0>(x), 0.0);
   get<0>(magnetic_field) = gsl::at(magnetic_field_, 0);
   get<1>(magnetic_field) = gsl::at(magnetic_field_, 1);
   get<2>(magnetic_field) = gsl::at(magnetic_field_, 2);
@@ -151,26 +148,24 @@ CylindricalBlastWave::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>
 CylindricalBlastWave::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const
     noexcept {
-  return {make_with_value<
-      db::item_type<hydro::Tags::DivergenceCleaningField<DataType>>>(x, 0.0)};
+  return {make_with_value<Scalar<DataType>>(x, 0.0)};
 }
 
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>
 CylindricalBlastWave::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const noexcept {
-  return {make_with_value<
-      db::item_type<hydro::Tags::LorentzFactor<DataType>>>(x, 1.0)};
+  return {make_with_value<Scalar<DataType>>(x, 1.0)};
 }
 
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>
 CylindricalBlastWave::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
     noexcept {
   return equation_of_state_.specific_enthalpy_from_density_and_energy(
@@ -200,10 +195,10 @@ bool operator!=(const CylindricalBlastWave& lhs,
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define TAG(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE_SCALARS(_, data)                         \
-  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>>     \
-      CylindricalBlastWave::variables(                       \
-          const tnsr::I<DTYPE(data), 3, Frame::Inertial>& x, \
+#define INSTANTIATE_SCALARS(_, data)                     \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>> \
+      CylindricalBlastWave::variables(                   \
+          const tnsr::I<DTYPE(data), 3>& x,              \
           tmpl::list<TAG(data) < DTYPE(data)>> /*meta*/) const noexcept;
 
 GENERATE_INSTANTIATIONS(
@@ -212,12 +207,11 @@ GENERATE_INSTANTIATIONS(
      hydro::Tags::Pressure, hydro::Tags::DivergenceCleaningField,
      hydro::Tags::LorentzFactor, hydro::Tags::SpecificEnthalpy))
 
-#define INSTANTIATE_VECTORS(_, data)                                         \
-  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>>                  \
-      CylindricalBlastWave::variables(                                       \
-          const tnsr::I<DTYPE(data), 3, Frame::Inertial>& x,                 \
-          tmpl::list<TAG(data) < DTYPE(data), 3, Frame::Inertial>> /*meta*/) \
-          const noexcept;
+#define INSTANTIATE_VECTORS(_, data)                        \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>> \
+      CylindricalBlastWave::variables(                      \
+          const tnsr::I<DTYPE(data), 3>& x,                 \
+          tmpl::list<TAG(data) < DTYPE(data), 3>> /*meta*/) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
                         (hydro::Tags::SpatialVelocity,

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.hpp
@@ -10,10 +10,8 @@
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/Tags.hpp"
-#include "Utilities/MakeArray.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -130,12 +128,12 @@ class CylindricalBlastWave : public MarkAsAnalyticData {
       default;
   ~CylindricalBlastWave() = default;
 
-  CylindricalBlastWave(
-      InnerRadius::type inner_radius, OuterRadius::type outer_radius,
-      InnerDensity::type inner_density, OuterDensity::type outer_density,
-      InnerPressure::type inner_pressure, OuterPressure::type outer_pressure,
-      MagneticField::type magnetic_field, AdiabaticIndex::type adiabatic_index,
-      const OptionContext& context = {});
+  CylindricalBlastWave(double inner_radius, double outer_radius,
+                       double inner_density, double outer_density,
+                       double inner_pressure, double outer_pressure,
+                       std::array<double, 3> magnetic_field,
+                       double adiabatic_index,
+                       const OptionContext& context = {});
 
   explicit CylindricalBlastWave(CkMigrateMessage* /*unused*/) noexcept {}
 
@@ -161,17 +159,15 @@ class CylindricalBlastWave : public MarkAsAnalyticData {
 
   template <typename DataType>
   auto variables(const tnsr::I<DataType, 3>& x,
-                 tmpl::list<hydro::Tags::SpatialVelocity<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>;
+                 tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/)
+      const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>;
 
   template <typename DataType>
-  auto variables(const tnsr::I<DataType, 3>& x,
-                 tmpl::list<hydro::Tags::MagneticField<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>;
 
   template <typename DataType>
   auto variables(
@@ -195,9 +191,9 @@ class CylindricalBlastWave : public MarkAsAnalyticData {
 
   /// Retrieve a collection of hydrodynamic variables at position x
   template <typename DataType, typename... Tags>
-  tuples::TaggedTuple<Tags...> variables(
-      const tnsr::I<DataType, 3, Frame::Inertial>& x,
-      tmpl::list<Tags...> /*meta*/) const noexcept {
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, 3>& x,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
     static_assert(sizeof...(Tags) > 1,
                   "The generic template will recurse infinitely if only one "
                   "tag is being retrieved.");
@@ -220,24 +216,17 @@ class CylindricalBlastWave : public MarkAsAnalyticData {
   void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
 
  private:
-  InnerRadius::type inner_radius_ =
-      std::numeric_limits<double>::signaling_NaN();
-  OuterRadius::type outer_radius_ =
-      std::numeric_limits<double>::signaling_NaN();
-  InnerDensity::type inner_density_ =
-      std::numeric_limits<double>::signaling_NaN();
-  OuterDensity::type outer_density_ =
-      std::numeric_limits<double>::signaling_NaN();
-  InnerPressure::type inner_pressure_ =
-      std::numeric_limits<double>::signaling_NaN();
-  OuterPressure::type outer_pressure_ =
-      std::numeric_limits<double>::signaling_NaN();
-  MagneticField::type magnetic_field_ =
-      std::array<double, 3>{{std::numeric_limits<double>::signaling_NaN(),
-                             std::numeric_limits<double>::signaling_NaN(),
-                             std::numeric_limits<double>::signaling_NaN()}};
-  AdiabaticIndex::type adiabatic_index_ =
-      std::numeric_limits<double>::signaling_NaN();
+  double inner_radius_ = std::numeric_limits<double>::signaling_NaN();
+  double outer_radius_ = std::numeric_limits<double>::signaling_NaN();
+  double inner_density_ = std::numeric_limits<double>::signaling_NaN();
+  double outer_density_ = std::numeric_limits<double>::signaling_NaN();
+  double inner_pressure_ = std::numeric_limits<double>::signaling_NaN();
+  double outer_pressure_ = std::numeric_limits<double>::signaling_NaN();
+  std::array<double, 3> magnetic_field_{
+      {std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN()}};
+  double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();
   EquationsOfState::IdealFluid<true> equation_of_state_{};
   gr::Solutions::Minkowski<3> background_spacetime_{};
 

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.cpp
@@ -10,8 +10,10 @@
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Parallel/PupStlCpp11.hpp"
 #include "PointwiseFunctions/Hydro/LorentzFactor.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/ConstantExpressions.hpp"  // IWYU pragma: keep
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -67,7 +69,7 @@ void MagneticFieldLoop::pup(PUP::er& p) noexcept {
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>
 MagneticFieldLoop::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const
     noexcept {
   return {make_with_value<Scalar<DataType>>(x, rest_mass_density_)};
@@ -76,10 +78,10 @@ MagneticFieldLoop::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>
 MagneticFieldLoop::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/) const
     noexcept {
-  auto result = make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(x, 0.0);
+  auto result = make_with_value<tnsr::I<DataType, 3>>(x, 0.0);
   get<0>(result) = advection_velocity_[0];
   get<1>(result) = advection_velocity_[1];
   get<2>(result) = advection_velocity_[2];
@@ -89,7 +91,7 @@ MagneticFieldLoop::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>
 MagneticFieldLoop::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
     noexcept {
   return equation_of_state_.specific_internal_energy_from_density_and_pressure(
@@ -102,7 +104,7 @@ MagneticFieldLoop::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>
 MagneticFieldLoop::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const noexcept {
   return {make_with_value<Scalar<DataType>>(x, pressure_)};
 }
@@ -110,10 +112,10 @@ MagneticFieldLoop::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>
 MagneticFieldLoop::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
     noexcept {
-  auto result = make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(x, 0.0);
+  auto result = make_with_value<tnsr::I<DataType, 3>>(x, 0.0);
   const DataType cylindrical_radius =
       sqrt(square(get<0>(x)) + square(get<1>(x)));
   for (size_t s = 0; s < get_size(cylindrical_radius); ++s) {
@@ -141,7 +143,7 @@ MagneticFieldLoop::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>
 MagneticFieldLoop::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const
     noexcept {
   return {make_with_value<Scalar<DataType>>(x, 0.0)};
@@ -150,7 +152,7 @@ MagneticFieldLoop::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>
 MagneticFieldLoop::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const noexcept {
   using velocity_tag = hydro::Tags::SpatialVelocity<DataType, 3>;
   const auto velocity =
@@ -161,7 +163,7 @@ MagneticFieldLoop::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>
 MagneticFieldLoop::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
     noexcept {
   return equation_of_state_.specific_enthalpy_from_density_and_energy(
@@ -193,10 +195,10 @@ bool operator!=(const MagneticFieldLoop& lhs,
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define TAG(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE_SCALARS(_, data)                         \
-  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>>     \
-      MagneticFieldLoop::variables(                          \
-          const tnsr::I<DTYPE(data), 3, Frame::Inertial>& x, \
+#define INSTANTIATE_SCALARS(_, data)                     \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>> \
+      MagneticFieldLoop::variables(                      \
+          const tnsr::I<DTYPE(data), 3>& x,              \
           tmpl::list<TAG(data) < DTYPE(data)>> /*meta*/) const noexcept;
 
 GENERATE_INSTANTIATIONS(
@@ -205,12 +207,11 @@ GENERATE_INSTANTIATIONS(
      hydro::Tags::Pressure, hydro::Tags::DivergenceCleaningField,
      hydro::Tags::LorentzFactor, hydro::Tags::SpecificEnthalpy))
 
-#define INSTANTIATE_VECTORS(_, data)                                         \
-  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>>                  \
-      MagneticFieldLoop::variables(                                          \
-          const tnsr::I<DTYPE(data), 3, Frame::Inertial>& x,                 \
-          tmpl::list<TAG(data) < DTYPE(data), 3, Frame::Inertial>> /*meta*/) \
-          const noexcept;
+#define INSTANTIATE_VECTORS(_, data)                        \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>> \
+      MagneticFieldLoop::variables(                         \
+          const tnsr::I<DTYPE(data), 3>& x,                 \
+          tmpl::list<TAG(data) < DTYPE(data), 3>> /*meta*/) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
                         (hydro::Tags::SpatialVelocity,

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp
@@ -10,10 +10,8 @@
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/Tags.hpp"
-#include "Utilities/MakeArray.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -160,17 +158,15 @@ class MagneticFieldLoop : public MarkAsAnalyticData {
 
   template <typename DataType>
   auto variables(const tnsr::I<DataType, 3>& x,
-                 tmpl::list<hydro::Tags::SpatialVelocity<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>;
+                 tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/)
+      const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>;
 
   template <typename DataType>
-  auto variables(const tnsr::I<DataType, 3>& x,
-                 tmpl::list<hydro::Tags::MagneticField<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>;
 
   template <typename DataType>
   auto variables(
@@ -194,9 +190,9 @@ class MagneticFieldLoop : public MarkAsAnalyticData {
 
   /// Retrieve a collection of hydrodynamic variables at position x
   template <typename DataType, typename... Tags>
-  tuples::TaggedTuple<Tags...> variables(
-      const tnsr::I<DataType, 3, Frame::Inertial>& x,
-      tmpl::list<Tags...> /*meta*/) const noexcept {
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, 3>& x,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
     static_assert(sizeof...(Tags) > 1,
                   "The generic template will recurse infinitely if only one "
                   "tag is being retrieved.");
@@ -222,8 +218,10 @@ class MagneticFieldLoop : public MarkAsAnalyticData {
   double pressure_ = std::numeric_limits<double>::signaling_NaN();
   double rest_mass_density_ = std::numeric_limits<double>::signaling_NaN();
   double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();
-  std::array<double, 3> advection_velocity_ =
-      make_array<3>(std::numeric_limits<double>::signaling_NaN());
+  std::array<double, 3> advection_velocity_{
+      {std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN()}};
   double magnetic_field_magnitude_ =
       std::numeric_limits<double>::signaling_NaN();
   double inner_radius_ = std::numeric_limits<double>::signaling_NaN();

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp
@@ -10,10 +10,8 @@
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/Tags.hpp"
-#include "Utilities/MakeArray.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -148,17 +146,15 @@ class MagneticRotor : public MarkAsAnalyticData {
 
   template <typename DataType>
   auto variables(const tnsr::I<DataType, 3>& x,
-                 tmpl::list<hydro::Tags::SpatialVelocity<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>;
+                 tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/)
+      const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>;
 
   template <typename DataType>
-  auto variables(const tnsr::I<DataType, 3>& x,
-                 tmpl::list<hydro::Tags::MagneticField<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>;
 
   template <typename DataType>
   auto variables(
@@ -182,9 +178,9 @@ class MagneticRotor : public MarkAsAnalyticData {
 
   /// Retrieve a collection of hydrodynamic variables at position x
   template <typename DataType, typename... Tags>
-  tuples::TaggedTuple<Tags...> variables(
-      const tnsr::I<DataType, 3, Frame::Inertial>& x,
-      tmpl::list<Tags...> /*meta*/) const noexcept {
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, 3>& x,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
     static_assert(sizeof...(Tags) > 1,
                   "The generic template will recurse infinitely if only one "
                   "tag is being retrieved.");
@@ -212,10 +208,10 @@ class MagneticRotor : public MarkAsAnalyticData {
   double background_density_ = std::numeric_limits<double>::signaling_NaN();
   double pressure_ = std::numeric_limits<double>::signaling_NaN();
   double angular_velocity_ = std::numeric_limits<double>::signaling_NaN();
-  std::array<double, 3> magnetic_field_ =
-      std::array<double, 3>{{std::numeric_limits<double>::signaling_NaN(),
-                             std::numeric_limits<double>::signaling_NaN(),
-                             std::numeric_limits<double>::signaling_NaN()}};
+  std::array<double, 3> magnetic_field_{
+      {std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN()}};
   double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();
   EquationsOfState::IdealFluid<true> equation_of_state_{};
   gr::Solutions::Minkowski<3> background_spacetime_{};

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
@@ -12,7 +12,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp"
 #include "PointwiseFunctions/GeneralRelativity/KerrSchildCoords.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -178,18 +178,15 @@ class MagnetizedFmDisk
 
  private:
   template <typename DataType, bool NeedSpacetime>
-  auto variables(
-      const tnsr::I<DataType, 3>& x,
-      tmpl::list<
-          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>> /*meta*/,
-      const IntermediateVariables<DataType, NeedSpacetime>& vars,
-      size_t index) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/,
+                 const IntermediateVariables<DataType, NeedSpacetime>& vars,
+                 size_t index) const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>;
 
   template <typename DataType>
-  tnsr::I<DataType, 3, Frame::Inertial> unnormalized_magnetic_field(
-      const tnsr::I<DataType, 3, Frame::Inertial>& x) const noexcept;
+  tnsr::I<DataType, 3> unnormalized_magnetic_field(
+      const tnsr::I<DataType, 3>& x) const noexcept;
 
   friend bool operator==(const MagnetizedFmDisk& lhs,
                          const MagnetizedFmDisk& rhs) noexcept;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.cpp
@@ -6,10 +6,11 @@
 #include <cmath>
 #include <pup.h>
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/Hydro/LorentzFactor.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
@@ -22,29 +23,27 @@ OrszagTangVortex::OrszagTangVortex() = default;
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>
 OrszagTangVortex::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const
     noexcept {
-  return {
-      make_with_value<db::item_type<hydro::Tags::RestMassDensity<DataType>>>(
-          x, 25. / (36. * M_PI))};
+  return {make_with_value<Scalar<DataType>>(x, 25. / (36. * M_PI))};
 }
 
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>
 OrszagTangVortex::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/) const
     noexcept {
-  return {tnsr::I<DataType, 3>{{{-0.5 * sin(2. * M_PI * get<1>(x)),
-                                 0.5 * sin(2. * M_PI * get<0>(x)),
-                                 make_with_value<DataType>(x, 0.)}}}};
+  return {tnsr::I<DataType, 3>{
+      {{-0.5 * sin(2. * M_PI * get<1>(x)), 0.5 * sin(2. * M_PI * get<0>(x)),
+        make_with_value<DataType>(x, 0.)}}}};
 }
 
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>
 OrszagTangVortex::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
     noexcept {
   using density_tag = hydro::Tags::RestMassDensity<DataType>;
@@ -57,16 +56,15 @@ OrszagTangVortex::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>
 OrszagTangVortex::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const noexcept {
-  return {make_with_value<db::item_type<hydro::Tags::Pressure<DataType>>>(
-      x, 5. / (12. * M_PI))};
+  return {make_with_value<Scalar<DataType>>(x, 5. / (12. * M_PI))};
 }
 
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>
 OrszagTangVortex::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
     noexcept {
   return {
@@ -78,17 +76,16 @@ OrszagTangVortex::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>
 OrszagTangVortex::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const
     noexcept {
-  return {make_with_value<
-      db::item_type<hydro::Tags::DivergenceCleaningField<DataType>>>(x, 0.)};
+  return {make_with_value<Scalar<DataType>>(x, 0.)};
 }
 
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>
 OrszagTangVortex::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const noexcept {
   using velocity_tag = hydro::Tags::SpatialVelocity<DataType, 3>;
   const auto velocity =
@@ -99,7 +96,7 @@ OrszagTangVortex::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>
 OrszagTangVortex::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
     noexcept {
   using density_tag = hydro::Tags::RestMassDensity<DataType>;
@@ -126,10 +123,10 @@ bool operator!=(const OrszagTangVortex& lhs,
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define TAG(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE_SCALARS(_, data)                         \
-  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>>     \
-      OrszagTangVortex::variables(                           \
-          const tnsr::I<DTYPE(data), 3, Frame::Inertial>& x, \
+#define INSTANTIATE_SCALARS(_, data)                     \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>> \
+      OrszagTangVortex::variables(                       \
+          const tnsr::I<DTYPE(data), 3>& x,              \
           tmpl::list<TAG(data) < DTYPE(data)>> /*meta*/) const noexcept;
 
 GENERATE_INSTANTIATIONS(
@@ -138,12 +135,11 @@ GENERATE_INSTANTIATIONS(
      hydro::Tags::Pressure, hydro::Tags::DivergenceCleaningField,
      hydro::Tags::LorentzFactor, hydro::Tags::SpecificEnthalpy))
 
-#define INSTANTIATE_VECTORS(_, data)                                         \
-  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>>                  \
-      OrszagTangVortex::variables(                                           \
-          const tnsr::I<DTYPE(data), 3, Frame::Inertial>& x,                 \
-          tmpl::list<TAG(data) < DTYPE(data), 3, Frame::Inertial>> /*meta*/) \
-          const noexcept;
+#define INSTANTIATE_VECTORS(_, data)                        \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>> \
+      OrszagTangVortex::variables(                          \
+          const tnsr::I<DTYPE(data), 3>& x,                 \
+          tmpl::list<TAG(data) < DTYPE(data), 3>> /*meta*/) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
                         (hydro::Tags::SpatialVelocity,

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp
@@ -8,7 +8,7 @@
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -89,17 +89,15 @@ class OrszagTangVortex : public MarkAsAnalyticData {
 
   template <typename DataType>
   auto variables(const tnsr::I<DataType, 3>& x,
-                 tmpl::list<hydro::Tags::SpatialVelocity<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>;
+                 tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/)
+      const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>;
 
   template <typename DataType>
-  auto variables(const tnsr::I<DataType, 3>& x,
-                 tmpl::list<hydro::Tags::MagneticField<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>;
 
   template <typename DataType>
   auto variables(
@@ -123,9 +121,9 @@ class OrszagTangVortex : public MarkAsAnalyticData {
 
   /// Retrieve a collection of hydro variables at `x`
   template <typename DataType, typename... Tags>
-  tuples::TaggedTuple<Tags...> variables(
-      const tnsr::I<DataType, 3, Frame::Inertial>& x,
-      tmpl::list<Tags...> /*meta*/) const noexcept {
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, 3>& x,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
     static_assert(sizeof...(Tags) > 1,
                   "The generic template will recurse infinitely if only one "
                   "tag is being retrieved.");

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
@@ -11,9 +11,8 @@
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
-#include "PointwiseFunctions/Hydro/Tags.hpp"  // IWYU pragma: keep
-#include "Utilities/MakeArray.hpp"            // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -151,11 +150,10 @@ class AlfvenWave : public MarkAsAnalyticSolution {
   AlfvenWave& operator=(AlfvenWave&& /*rhs*/) noexcept = default;
   ~AlfvenWave() = default;
 
-  AlfvenWave(WaveNumber::type wavenumber, Pressure::type pressure,
-             RestMassDensity::type rest_mass_density,
-             AdiabaticIndex::type adiabatic_index,
-             BackgroundMagneticField::type background_magnetic_field,
-             WaveMagneticField::type wave_magnetic_field) noexcept;
+  AlfvenWave(double wavenumber, double pressure, double rest_mass_density,
+             double adiabatic_index,
+             std::array<double, 3> background_magnetic_field,
+             std::array<double, 3> wave_magnetic_field) noexcept;
 
   // @{
   /// Retrieve hydro variable at `(x, t)`
@@ -179,17 +177,15 @@ class AlfvenWave : public MarkAsAnalyticSolution {
 
   template <typename DataType>
   auto variables(const tnsr::I<DataType, 3>& x, double /*t*/,
-                 tmpl::list<hydro::Tags::SpatialVelocity<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>;
+                 tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/)
+      const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>;
 
   template <typename DataType>
-  auto variables(const tnsr::I<DataType, 3>& x, double /*t*/,
-                 tmpl::list<hydro::Tags::MagneticField<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+  auto variables(
+      const tnsr::I<DataType, 3>& x, double /*t*/,
+      tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>;
 
   template <typename DataType>
   auto variables(
@@ -244,23 +240,22 @@ class AlfvenWave : public MarkAsAnalyticSolution {
   template <typename DataType>
   DataType k_dot_x_minus_vt(const tnsr::I<DataType, 3>& x, double t) const
       noexcept;
-  WaveNumber::type wavenumber_ = std::numeric_limits<double>::signaling_NaN();
-  Pressure::type pressure_ = std::numeric_limits<double>::signaling_NaN();
-  RestMassDensity::type rest_mass_density_ =
-      std::numeric_limits<double>::signaling_NaN();
-  AdiabaticIndex::type adiabatic_index_ =
-      std::numeric_limits<double>::signaling_NaN();
-  BackgroundMagneticField::type background_magnetic_field_{
-      {std::numeric_limits<double>::signaling_NaN()}};
-  WaveMagneticField::type wave_magnetic_field_{
-      {std::numeric_limits<double>::signaling_NaN()}};
+  double wavenumber_ = std::numeric_limits<double>::signaling_NaN();
+  double pressure_ = std::numeric_limits<double>::signaling_NaN();
+  double rest_mass_density_ = std::numeric_limits<double>::signaling_NaN();
+  double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();
+  std::array<double, 3> background_magnetic_field_{
+      {std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN()}};
+  std::array<double, 3> wave_magnetic_field_{
+      {std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN()}};
   EquationsOfState::IdealFluid<true> equation_of_state_{};
-  tnsr::I<double, 3, Frame::Inertial>
-      initial_unit_vector_along_background_magnetic_field_{};
-  tnsr::I<double, 3, Frame::Inertial>
-      initial_unit_vector_along_wave_magnetic_field_{};
-  tnsr::I<double, 3, Frame::Inertial>
-      initial_unit_vector_along_wave_electric_field_{};
+  tnsr::I<double, 3> initial_unit_vector_along_background_magnetic_field_{};
+  tnsr::I<double, 3> initial_unit_vector_along_wave_magnetic_field_{};
+  tnsr::I<double, 3> initial_unit_vector_along_wave_electric_field_{};
   double magnitude_B0_ = std::numeric_limits<double>::signaling_NaN();
   double magnitude_B1_ = std::numeric_limits<double>::signaling_NaN();
   double magnitude_E_ = std::numeric_limits<double>::signaling_NaN();

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
@@ -7,8 +7,12 @@
 #include <cmath>
 #include <cstddef>
 
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -17,11 +21,10 @@
 namespace grmhd {
 namespace Solutions {
 
-BondiMichel::BondiMichel(
-    const Mass::type mass, const SonicRadius::type sonic_radius,
-    const SonicDensity::type sonic_density,
-    const PolytropicExponent::type polytropic_exponent,
-    const MagFieldStrength::type mag_field_strength) noexcept
+BondiMichel::BondiMichel(const double mass, const double sonic_radius,
+                         const double sonic_density,
+                         const double polytropic_exponent,
+                         const double mag_field_strength) noexcept
     : mass_(mass),
       sonic_radius_(sonic_radius),
       sonic_density_(sonic_density),
@@ -243,11 +246,11 @@ BondiMichel::variables(
 }
 
 template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>
+tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>
 BondiMichel::variables(
     const tnsr::I<DataType, 3>& x,
     tmpl::list<
-        hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>> /*meta*/,
+        hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/,
     const IntermediateVars<DataType>& vars) const noexcept {
   auto result = make_with_value<tnsr::I<DataType, 3>>(x, 0.0);
   // Rezzola and Zanotti (2013) Eq. 11.79
@@ -279,11 +282,11 @@ BondiMichel::variables(
 }
 
 template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>
+tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>
 BondiMichel::variables(
     const tnsr::I<DataType, 3>& x,
     tmpl::list<
-        hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>> /*meta*/,
+        hydro::Tags::MagneticField<DataType, 3>> /*meta*/,
     const IntermediateVars<DataType>& vars) const noexcept {
   auto result = make_with_value<tnsr::I<DataType, 3>>(x, 0.0);
   const DataType mag_field_strength_factor =
@@ -347,19 +350,15 @@ bool operator!=(const BondiMichel& lhs, const BondiMichel& rhs) noexcept {
       const tnsr::I<DTYPE(data), 3>& x,                                       \
       tmpl::list<hydro::Tags::LorentzFactor<DTYPE(data)>> /*meta*/,           \
       const BondiMichel::IntermediateVars<DTYPE(data)>& vars) const noexcept; \
-  template tuples::TaggedTuple<                                               \
-      hydro::Tags::SpatialVelocity<DTYPE(data), 3, Frame::Inertial>>          \
+  template tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DTYPE(data), 3>>  \
   BondiMichel::variables(                                                     \
       const tnsr::I<DTYPE(data), 3>& x,                                       \
-      tmpl::list<hydro::Tags::SpatialVelocity<DTYPE(data), 3,                 \
-                                              Frame::Inertial>> /*meta*/,     \
+      tmpl::list<hydro::Tags::SpatialVelocity<DTYPE(data), 3>> /*meta*/,      \
       const BondiMichel::IntermediateVars<DTYPE(data)>& vars) const noexcept; \
-  template tuples::TaggedTuple<                                               \
-      hydro::Tags::MagneticField<DTYPE(data), 3, Frame::Inertial>>            \
+  template tuples::TaggedTuple<hydro::Tags::MagneticField<DTYPE(data), 3>>    \
   BondiMichel::variables(                                                     \
       const tnsr::I<DTYPE(data), 3>& x,                                       \
-      tmpl::list<hydro::Tags::MagneticField<DTYPE(data), 3,                   \
-                                            Frame::Inertial>> /*meta*/,       \
+      tmpl::list<hydro::Tags::MagneticField<DTYPE(data), 3>> /*meta*/,        \
       const BondiMichel::IntermediateVars<DTYPE(data)>& vars) const noexcept; \
   template tuples::TaggedTuple<                                               \
       hydro::Tags::DivergenceCleaningField<DTYPE(data)>>                      \

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
@@ -6,16 +6,12 @@
 #include <limits>
 #include <pup.h>
 
-#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
-#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
-#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -225,10 +221,8 @@ class BondiMichel : public MarkAsAnalyticSolution {
   BondiMichel& operator=(BondiMichel&& /*rhs*/) noexcept = default;
   ~BondiMichel() = default;
 
-  BondiMichel(Mass::type mass, SonicRadius::type sonic_radius,
-              SonicDensity::type sonic_density,
-              PolytropicExponent::type polytropic_exponent,
-              MagFieldStrength::type mag_field_strength) noexcept;
+  BondiMichel(double mass, double sonic_radius, double sonic_density,
+              double polytropic_exponent, double mag_field_strength) noexcept;
 
   /// Retrieve a collection of  hydro variables at `(x, t)`
   template <typename DataType, typename... Tags>
@@ -301,22 +295,16 @@ class BondiMichel : public MarkAsAnalyticSolution {
       -> tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>;
 
   template <typename DataType>
-  auto variables(
-      const tnsr::I<DataType, 3>& x,
-      tmpl::list<
-          hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>> /*meta*/,
-      const IntermediateVars<DataType>& vars) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>;
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/,
+                 const IntermediateVars<DataType>& vars) const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>;
 
   template <typename DataType>
-  auto variables(
-      const tnsr::I<DataType, 3>& x,
-      tmpl::list<
-          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>> /*meta*/,
-      const IntermediateVars<DataType>& vars) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/,
+                 const IntermediateVars<DataType>& vars) const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>;
 
   template <typename DataType>
   auto variables(
@@ -373,15 +361,11 @@ class BondiMichel : public MarkAsAnalyticSolution {
         kerr_schild_soln{};
   };
 
-  Mass::type mass_ = std::numeric_limits<double>::signaling_NaN();
-  SonicRadius::type sonic_radius_ =
-      std::numeric_limits<double>::signaling_NaN();
-  SonicDensity::type sonic_density_ =
-      std::numeric_limits<double>::signaling_NaN();
-  PolytropicExponent::type polytropic_exponent_ =
-      std::numeric_limits<double>::signaling_NaN();
-  MagFieldStrength::type mag_field_strength_ =
-      std::numeric_limits<double>::signaling_NaN();
+  double mass_ = std::numeric_limits<double>::signaling_NaN();
+  double sonic_radius_ = std::numeric_limits<double>::signaling_NaN();
+  double sonic_density_ = std::numeric_limits<double>::signaling_NaN();
+  double polytropic_exponent_ = std::numeric_limits<double>::signaling_NaN();
+  double mag_field_strength_ = std::numeric_limits<double>::signaling_NaN();
   double sonic_fluid_speed_squared_ =
       std::numeric_limits<double>::signaling_NaN();
   double sonic_sound_speed_squared_ =

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.cpp
@@ -5,11 +5,12 @@
 
 #include <pup.h>
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "Parallel/PupStlCpp11.hpp"
 #include "PointwiseFunctions/Hydro/LorentzFactor.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Math.hpp"  // IWYU pragma: keep
@@ -18,20 +19,21 @@
 
 namespace {
 template <typename DataType>
-Scalar<DataType> compute_piecewise(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double shock_position,
-    const double left_value, const double right_value) noexcept {
+Scalar<DataType> compute_piecewise(const tnsr::I<DataType, 3>& x,
+                                   const double shock_position,
+                                   const double left_value,
+                                   const double right_value) noexcept {
   return Scalar<DataType>(left_value -
                           (left_value - right_value) *
                               step_function(get<0>(x) - shock_position));
 }
 
 template <typename DataType>
-tnsr::I<DataType, 3, Frame::Inertial> compute_piecewise_vector(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double shock_position,
+tnsr::I<DataType, 3> compute_piecewise_vector(
+    const tnsr::I<DataType, 3>& x, const double shock_position,
     const std::array<double, 3>& left_value,
     const std::array<double, 3>& right_value) noexcept {
-  return tnsr::I<DataType, 3, Frame::Inertial>{
+  return tnsr::I<DataType, 3>{
       {{left_value[0] - (left_value[0] - right_value[0]) *
                             step_function(get<0>(x) - shock_position),
         left_value[1] - (left_value[1] - right_value[1]) *
@@ -46,15 +48,14 @@ namespace grmhd {
 namespace Solutions {
 
 KomissarovShock::KomissarovShock(
-    AdiabaticIndex::type adiabatic_index,
-    LeftRestMassDensity::type left_rest_mass_density,
-    RightRestMassDensity::type right_rest_mass_density,
-    LeftPressure::type left_pressure, RightPressure::type right_pressure,
-    LeftSpatialVelocity::type left_spatial_velocity,
-    RightSpatialVelocity::type right_spatial_velocity,
-    LeftMagneticField::type left_magnetic_field,
-    RightMagneticField::type right_magnetic_field,
-    ShockSpeed::type shock_speed) noexcept
+    const double adiabatic_index, const double left_rest_mass_density,
+    const double right_rest_mass_density, const double left_pressure,
+    const double right_pressure,
+    const std::array<double, 3> left_spatial_velocity,
+    const std::array<double, 3> right_spatial_velocity,
+    const std::array<double, 3> left_magnetic_field,
+    const std::array<double, 3> right_magnetic_field,
+    const double shock_speed) noexcept
     : equation_of_state_(adiabatic_index),
       adiabatic_index_(adiabatic_index),
       left_rest_mass_density_(left_rest_mass_density),
@@ -85,7 +86,7 @@ void KomissarovShock::pup(PUP::er& p) noexcept {
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>
 KomissarovShock::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t,
+    const tnsr::I<DataType, 3>& x, const double t,
     tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const
     noexcept {
   return compute_piecewise(x, t * shock_speed_, left_rest_mass_density_,
@@ -95,7 +96,7 @@ KomissarovShock::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>
 KomissarovShock::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t,
+    const tnsr::I<DataType, 3>& x, const double t,
     tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/) const
     noexcept {
   return compute_piecewise_vector(x, t * shock_speed_, left_spatial_velocity_,
@@ -105,7 +106,7 @@ KomissarovShock::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>
 KomissarovShock::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t,
+    const tnsr::I<DataType, 3>& x, const double t,
     tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
     noexcept {
   return equation_of_state_.specific_internal_energy_from_density_and_pressure(
@@ -117,7 +118,7 @@ KomissarovShock::variables(
 
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::Pressure<DataType>> KomissarovShock::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t,
+    const tnsr::I<DataType, 3>& x, const double t,
     tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const noexcept {
   return compute_piecewise(x, t * shock_speed_, left_pressure_,
                            right_pressure_);
@@ -127,7 +128,7 @@ tuples::TaggedTuple<hydro::Tags::Pressure<DataType>> KomissarovShock::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>
 KomissarovShock::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t,
+    const tnsr::I<DataType, 3>& x, const double t,
     tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
     noexcept {
   return compute_piecewise_vector(x, t * shock_speed_, left_magnetic_field_,
@@ -137,17 +138,16 @@ KomissarovShock::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>
 KomissarovShock::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double /*t*/,
+    const tnsr::I<DataType, 3>& x, const double /*t*/,
     tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const
     noexcept {
-  return {make_with_value<
-      db::item_type<hydro::Tags::DivergenceCleaningField<DataType>>>(x, 0.0)};
+  return {make_with_value<Scalar<DataType>>(x, 0.0)};
 }
 
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>
 KomissarovShock::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t,
+    const tnsr::I<DataType, 3>& x, const double t,
     tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const noexcept {
   const auto spatial_velocity = get<hydro::Tags::SpatialVelocity<DataType, 3>>(
       variables(x, t, tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>>{}));
@@ -158,7 +158,7 @@ KomissarovShock::variables(
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>
 KomissarovShock::variables(
-    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t,
+    const tnsr::I<DataType, 3>& x, const double t,
     tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
     noexcept {
   return equation_of_state_.specific_enthalpy_from_density_and_energy(
@@ -190,11 +190,11 @@ bool operator!=(const KomissarovShock& lhs,
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define TAG(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE_SCALARS(_, data)                               \
-  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>>           \
-      KomissarovShock::variables(                                  \
-          const tnsr::I<DTYPE(data), 3, Frame::Inertial>&, double, \
-          tmpl::list<TAG(data) < DTYPE(data)>>) const noexcept;
+#define INSTANTIATE_SCALARS(_, data)                                     \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>>                 \
+      KomissarovShock::variables(const tnsr::I<DTYPE(data), 3>&, double, \
+                                 tmpl::list<TAG(data) < DTYPE(data)>>)   \
+          const noexcept;
 
 GENERATE_INSTANTIATIONS(
     INSTANTIATE_SCALARS, (double, DataVector),
@@ -202,11 +202,10 @@ GENERATE_INSTANTIATIONS(
      hydro::Tags::Pressure, hydro::Tags::DivergenceCleaningField,
      hydro::Tags::LorentzFactor, hydro::Tags::SpecificEnthalpy))
 
-#define INSTANTIATE_VECTORS(_, data)                                \
-  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>>         \
-      KomissarovShock::variables(                                   \
-          const tnsr::I<DTYPE(data), 3, Frame::Inertial>&, double,  \
-          tmpl::list<TAG(data) < DTYPE(data), 3, Frame::Inertial>>) \
+#define INSTANTIATE_VECTORS(_, data)                                      \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>>               \
+      KomissarovShock::variables(const tnsr::I<DTYPE(data), 3>&, double,  \
+                                 tmpl::list<TAG(data) < DTYPE(data), 3>>) \
           const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp
@@ -11,9 +11,8 @@
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -122,16 +121,14 @@ class KomissarovShock : public MarkAsAnalyticSolution {
   KomissarovShock& operator=(KomissarovShock&& /*rhs*/) noexcept = default;
   ~KomissarovShock() = default;
 
-  KomissarovShock(AdiabaticIndex::type adiabatic_index,
-                  LeftRestMassDensity::type left_rest_mass_density,
-                  RightRestMassDensity::type right_rest_mass_density,
-                  LeftPressure::type left_pressure,
-                  RightPressure::type right_pressure,
-                  LeftSpatialVelocity::type left_spatial_velocity,
-                  RightSpatialVelocity::type right_spatial_velocity,
-                  LeftMagneticField::type left_magnetic_field,
-                  RightMagneticField::type right_magnetic_field,
-                  ShockSpeed::type shock_speed) noexcept;
+  KomissarovShock(double adiabatic_index, double left_rest_mass_density,
+                  double right_rest_mass_density, double left_pressure,
+                  double right_pressure,
+                  std::array<double, 3> left_spatial_velocity,
+                  std::array<double, 3> right_spatial_velocity,
+                  std::array<double, 3> left_magnetic_field,
+                  std::array<double, 3> right_magnetic_field,
+                  double shock_speed) noexcept;
 
   explicit KomissarovShock(CkMigrateMessage* /*unused*/) noexcept {}
 
@@ -157,17 +154,15 @@ class KomissarovShock : public MarkAsAnalyticSolution {
 
   template <typename DataType>
   auto variables(const tnsr::I<DataType, 3>& x, double t,
-                 tmpl::list<hydro::Tags::SpatialVelocity<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>;
+                 tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/)
+      const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>;
 
   template <typename DataType>
-  auto variables(const tnsr::I<DataType, 3>& x, double t,
-                 tmpl::list<hydro::Tags::MagneticField<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+  auto variables(
+      const tnsr::I<DataType, 3>& x, double t,
+      tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>;
 
   template <typename DataType>
   auto variables(
@@ -191,9 +186,10 @@ class KomissarovShock : public MarkAsAnalyticSolution {
 
   /// Retrieve a collection of hydrodynamic variables at position x
   template <typename DataType, typename... Tags>
-  tuples::TaggedTuple<Tags...> variables(
-      const tnsr::I<DataType, 3, Frame::Inertial>& x, double t,
-      tmpl::list<Tags...> /*meta*/) const noexcept {
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, 3>& x,
+                                         double t,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
     static_assert(sizeof...(Tags) > 1,
                   "The generic template will recurse infinitely if only one "
                   "tag is being retrieved.");
@@ -218,33 +214,29 @@ class KomissarovShock : public MarkAsAnalyticSolution {
   EquationsOfState::IdealFluid<true> equation_of_state_{};
   gr::Solutions::Minkowski<3> background_spacetime_{};
 
-  AdiabaticIndex::type adiabatic_index_ =
+  double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();
+  double left_rest_mass_density_ = std::numeric_limits<double>::signaling_NaN();
+  double right_rest_mass_density_ =
       std::numeric_limits<double>::signaling_NaN();
-  LeftRestMassDensity::type left_rest_mass_density_ =
-      std::numeric_limits<double>::signaling_NaN();
-  RightRestMassDensity::type right_rest_mass_density_ =
-      std::numeric_limits<double>::signaling_NaN();
-  LeftPressure::type left_pressure_ =
-      std::numeric_limits<double>::signaling_NaN();
-  RightPressure::type right_pressure_ =
-      std::numeric_limits<double>::signaling_NaN();
-  LeftSpatialVelocity::type left_spatial_velocity_ =
-      std::array<double, 3>{{std::numeric_limits<double>::signaling_NaN(),
-                             std::numeric_limits<double>::signaling_NaN(),
-                             std::numeric_limits<double>::signaling_NaN()}};
-  RightSpatialVelocity::type right_spatial_velocity_ =
-      std::array<double, 3>{{std::numeric_limits<double>::signaling_NaN(),
-                             std::numeric_limits<double>::signaling_NaN(),
-                             std::numeric_limits<double>::signaling_NaN()}};
-  LeftMagneticField::type left_magnetic_field_ =
-      std::array<double, 3>{{std::numeric_limits<double>::signaling_NaN(),
-                             std::numeric_limits<double>::signaling_NaN(),
-                             std::numeric_limits<double>::signaling_NaN()}};
-  RightMagneticField::type right_magnetic_field_ =
-      std::array<double, 3>{{std::numeric_limits<double>::signaling_NaN(),
-                             std::numeric_limits<double>::signaling_NaN(),
-                             std::numeric_limits<double>::signaling_NaN()}};
-  ShockSpeed::type shock_speed_ = std::numeric_limits<double>::signaling_NaN();
+  double left_pressure_ = std::numeric_limits<double>::signaling_NaN();
+  double right_pressure_ = std::numeric_limits<double>::signaling_NaN();
+  std::array<double, 3> left_spatial_velocity_{
+      {std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN()}};
+  std::array<double, 3> right_spatial_velocity_{
+      {std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN()}};
+  std::array<double, 3> left_magnetic_field_{
+      {std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN()}};
+  std::array<double, 3> right_magnetic_field_{
+      {std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN()}};
+  double shock_speed_ = std::numeric_limits<double>::signaling_NaN();
 
   friend bool operator==(const KomissarovShock& lhs,
                          const KomissarovShock& rhs) noexcept;

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <array>
-#include <limits>
 #include <pup.h>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -12,9 +11,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
-#include "PointwiseFunctions/Hydro/Tags.hpp"  // IWYU pragma: keep
-#include "Utilities/MakeArray.hpp"            // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -56,9 +53,9 @@ class SmoothFlow : virtual public MarkAsAnalyticSolution,
   SmoothFlow& operator=(SmoothFlow&& /*rhs*/) noexcept = default;
   ~SmoothFlow() = default;
 
-  SmoothFlow(MeanVelocity::type mean_velocity, WaveVector::type wavevector,
-             Pressure::type pressure, AdiabaticIndex::type adiabatic_index,
-             PerturbationSize::type perturbation_size) noexcept;
+  SmoothFlow(std::array<double, 3> mean_velocity,
+             std::array<double, 3> wavevector, double pressure,
+             double adiabatic_index, double perturbation_size) noexcept;
 
   using smooth_flow::equation_of_state;
   using smooth_flow::equation_of_state_type;
@@ -69,11 +66,10 @@ class SmoothFlow : virtual public MarkAsAnalyticSolution,
   // @{
   /// Retrieve hydro variable at `(x, t)`
   template <typename DataType>
-  auto variables(const tnsr::I<DataType, 3>& x, double /*t*/,
-                 tmpl::list<hydro::Tags::MagneticField<
-                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+  auto variables(
+      const tnsr::I<DataType, 3>& x, double /*t*/,
+      tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>;
 
   template <typename DataType>
   auto variables(

--- a/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.hpp
@@ -12,8 +12,7 @@
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
-#include "PointwiseFunctions/Hydro/Tags.hpp"  // IWYU pragma: keep
-#include "Utilities/MakeArray.hpp"            // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -65,8 +64,8 @@ class ConstantM1 : public MarkAsAnalyticSolution {
   ConstantM1& operator=(ConstantM1&& /*rhs*/) noexcept = default;
   ~ConstantM1() = default;
 
-  ConstantM1(MeanVelocity::type mean_velocity,
-             ComovingEnergyDensity::type comoving_energy_density) noexcept;
+  ConstantM1(std::array<double, 3> mean_velocity,
+             double comoving_energy_density) noexcept;
 
   explicit ConstantM1(CkMigrateMessage* /*unused*/) noexcept {}
 
@@ -94,11 +93,11 @@ class ConstantM1 : public MarkAsAnalyticSolution {
       tmpl::list<hydro::Tags::LorentzFactor<DataVector>> /*meta*/) const
       noexcept -> tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataVector>>;
 
-  auto variables(const tnsr::I<DataVector, 3>& x, double t,
-                 tmpl::list<hydro::Tags::SpatialVelocity<
-                     DataVector, 3, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::SpatialVelocity<DataVector, 3, Frame::Inertial>>;
+  auto variables(
+      const tnsr::I<DataVector, 3>& x, double t,
+      tmpl::list<hydro::Tags::SpatialVelocity<DataVector, 3>> /*meta*/) const
+      noexcept
+      -> tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataVector, 3>>;
   // @}
 
   /// Retrieve a collection of hydro and/or M1 variables at `(x, t)`
@@ -126,9 +125,11 @@ class ConstantM1 : public MarkAsAnalyticSolution {
  private:
   friend bool operator==(const ConstantM1& lhs, const ConstantM1& rhs) noexcept;
 
-  MeanVelocity::type mean_velocity_ =
-      make_array<3>(std::numeric_limits<double>::signaling_NaN());
-  ComovingEnergyDensity::type comoving_energy_density_ =
+  std::array<double, 3> mean_velocity_{
+      {std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN()}};
+  double comoving_energy_density_ =
       std::numeric_limits<double>::signaling_NaN();
   gr::Solutions::Minkowski<3> background_spacetime_{};
 };

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
@@ -8,15 +8,12 @@
 #include <cstddef>
 #include <pup.h>
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -275,16 +272,13 @@ FishboneMoncriefDisk::variables(
 }
 
 template <typename DataType, bool NeedSpacetime>
-tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>
+tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>
 FishboneMoncriefDisk::variables(
     const tnsr::I<DataType, 3>& x,
-    tmpl::list<
-        hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>> /*meta*/,
+    tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/,
     const IntermediateVariables<DataType, NeedSpacetime>& /*vars*/,
     const size_t /*index*/) const noexcept {
-  return {make_with_value<
-      db::item_type<hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>>(
-      x, 0.0)};
+  return {make_with_value<tnsr::I<DataType, 3>>(x, 0.0)};
 }
 
 template <typename DataType, bool NeedSpacetime>
@@ -294,8 +288,7 @@ FishboneMoncriefDisk::variables(
     tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/,
     const IntermediateVariables<DataType, NeedSpacetime>& /*vars*/,
     const size_t /*index*/) const noexcept {
-  return {make_with_value<
-      db::item_type<hydro::Tags::DivergenceCleaningField<DataType>>>(x, 0.0)};
+  return {make_with_value<Scalar<DataType>>(x, 0.0)};
 }
 
 template <typename DataType, bool NeedSpacetime, typename Func>
@@ -373,8 +366,7 @@ bool operator!=(const FishboneMoncriefDisk& lhs,
       const FishboneMoncriefDisk::IntermediateVariables<                      \
           DTYPE(data), NEED_SPACETIME(data)>& vars,                           \
       const size_t) const noexcept;                                           \
-  template tuples::TaggedTuple<                                               \
-      hydro::Tags::MagneticField<DTYPE(data), 3, Frame::Inertial>>            \
+  template tuples::TaggedTuple<hydro::Tags::MagneticField<DTYPE(data), 3>>    \
   FishboneMoncriefDisk::variables(                                            \
       const tnsr::I<DTYPE(data), 3>& x,                                       \
       tmpl::list<hydro::Tags::MagneticField<DTYPE(data), 3,                   \

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -6,14 +6,12 @@
 #include <cstddef>
 #include <limits>
 
-#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -350,14 +348,11 @@ class FishboneMoncriefDisk : public MarkAsAnalyticSolution {
       -> tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>;
 
   template <typename DataType, bool NeedSpacetime>
-  auto variables(
-      const tnsr::I<DataType, 3>& x,
-      tmpl::list<
-          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>> /*meta*/,
-      const IntermediateVariables<DataType, NeedSpacetime>& vars,
-      size_t index) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/,
+                 const IntermediateVariables<DataType, NeedSpacetime>& vars,
+                 size_t index) const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>;
 
   template <typename DataType, bool NeedSpacetime>
   auto variables(

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp
@@ -11,8 +11,8 @@
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
-#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -130,11 +130,11 @@ class SmoothFlow : virtual public MarkAsAnalyticSolution {
       noexcept -> tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>;
 
   template <typename DataType>
-  auto variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
-                 tmpl::list<hydro::Tags::SpatialVelocity<
-                     DataType, Dim, Frame::Inertial>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<
-          hydro::Tags::SpatialVelocity<DataType, Dim, Frame::Inertial>>;
+  auto variables(
+      const tnsr::I<DataType, Dim>& x, double /*t*/,
+      tmpl::list<hydro::Tags::SpatialVelocity<DataType, Dim>> /*meta*/) const
+      noexcept
+      -> tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, Dim>>;
 
   template <typename DataType>
   auto variables(

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
@@ -7,7 +7,9 @@
 
 #include "DataStructures/DataVector.hpp"                  // IWYU pragma: keep
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -94,22 +96,20 @@ TovStar<RadialSolution>::variables(
 
 template <typename RadialSolution>
 template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>
+tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>
 TovStar<RadialSolution>::variables(
     const tnsr::I<DataType, 3>& x,
-    tmpl::list<
-        hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>> /*meta*/,
+    tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/,
     const RadialVariables<DataType>& /*radial_vars*/) const noexcept {
   return make_with_value<tnsr::I<DataType, 3>>(x, 0.0);
 }
 
 template <typename RadialSolution>
 template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>
+tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>
 TovStar<RadialSolution>::variables(
     const tnsr::I<DataType, 3>& x,
-    tmpl::list<
-        hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>> /*meta*/,
+    tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/,
     const RadialVariables<DataType>& /*radial_vars*/) const noexcept {
   return make_with_value<tnsr::I<DataType, 3>>(x, 0.0);
 }
@@ -329,19 +329,15 @@ bool operator!=(const TovStar<RadialSolution>& lhs,
       const tnsr::I<DTYPE(data), 3>& x,                                        \
       tmpl::list<hydro::Tags::LorentzFactor<DTYPE(data)>> /*meta*/,            \
       const RadialVariables<DTYPE(data)>& radial_vars) const noexcept;         \
-  template tuples::TaggedTuple<                                                \
-      hydro::Tags::SpatialVelocity<DTYPE(data), 3, Frame::Inertial>>           \
+  template tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DTYPE(data), 3>>   \
   TovStar<STYPE(data)>::variables(                                             \
       const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<hydro::Tags::SpatialVelocity<DTYPE(data), 3,                  \
-                                              Frame::Inertial>> /*meta*/,      \
+      tmpl::list<hydro::Tags::SpatialVelocity<DTYPE(data), 3>> /*meta*/,       \
       const RadialVariables<DTYPE(data)>& radial_vars) const noexcept;         \
-  template tuples::TaggedTuple<                                                \
-      hydro::Tags::MagneticField<DTYPE(data), 3, Frame::Inertial>>             \
+  template tuples::TaggedTuple<hydro::Tags::MagneticField<DTYPE(data), 3>>     \
   TovStar<STYPE(data)>::variables(                                             \
       const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<hydro::Tags::MagneticField<DTYPE(data), 3,                    \
-                                            Frame::Inertial>> /*meta*/,        \
+      tmpl::list<hydro::Tags::MagneticField<DTYPE(data), 3>> /*meta*/,         \
       const RadialVariables<DTYPE(data)>& radial_vars) const noexcept;         \
   template tuples::TaggedTuple<                                                \
       hydro::Tags::DivergenceCleaningField<DTYPE(data)>>                       \

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
@@ -8,13 +8,11 @@
 #include <limits>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"

--- a/src/PointwiseFunctions/Hydro/LorentzFactor.cpp
+++ b/src/PointwiseFunctions/Hydro/LorentzFactor.cpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "PointwiseFunctions/Hydro/Tags.hpp"  // IWYU pragma: keep
 #include "Utilities/GenerateInstantiations.hpp"
 
 /// \cond

--- a/src/PointwiseFunctions/Hydro/LorentzFactor.hpp
+++ b/src/PointwiseFunctions/Hydro/LorentzFactor.hpp
@@ -7,7 +7,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "PointwiseFunctions/Hydro/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 
 namespace hydro {

--- a/src/PointwiseFunctions/Hydro/SoundSpeedSquared.cpp
+++ b/src/PointwiseFunctions/Hydro/SoundSpeedSquared.cpp
@@ -5,11 +5,9 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
-#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Overloader.hpp"
 

--- a/src/PointwiseFunctions/Hydro/SoundSpeedSquared.hpp
+++ b/src/PointwiseFunctions/Hydro/SoundSpeedSquared.hpp
@@ -7,12 +7,14 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+namespace EquationsOfState {
 template <bool IsRelativistic, size_t ThermodynamicDim>
 class EquationOfState;
+}  // namespace EquationsOfState
 /// \endcond
 
 namespace hydro {

--- a/src/PointwiseFunctions/Hydro/SpecificEnthalpy.hpp
+++ b/src/PointwiseFunctions/Hydro/SpecificEnthalpy.hpp
@@ -5,7 +5,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace hydro {

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -7,9 +7,8 @@
 #include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 
 /// \ingroup EvolutionSystemsGroup
@@ -200,16 +199,4 @@ struct MassFlux : db::SimpleTag {
   }
 };
 }  // namespace Tags
-
-/// The tags for the primitive variables for GRMHD.
-template <typename DataType>
-using grmhd_tags =
-    tmpl::list<hydro::Tags::RestMassDensity<DataType>,
-               hydro::Tags::SpecificInternalEnergy<DataType>,
-               hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>,
-               hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>,
-               hydro::Tags::DivergenceCleaningField<DataType>,
-               hydro::Tags::LorentzFactor<DataType>,
-               hydro::Tags::Pressure<DataType>,
-               hydro::Tags::SpecificEnthalpy<DataType>>;
 }  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
@@ -5,9 +5,13 @@
 
 #include <cstddef>
 
-#include "DataStructures/Tensor/IndexType.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+
 class DataVector;
 
 namespace hydro {
@@ -26,8 +30,6 @@ template <typename EquationOfStateType>
 struct EquationOfState;
 template <typename DataType>
 struct LorentzFactor;
-template <typename DataType, size_t Dim, typename Fr>
-struct LorentzFactorCompute;
 template <typename DataType>
 struct LorentzFactorSquared;
 template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
@@ -40,6 +42,8 @@ template <typename DataType>
 struct MagneticFieldSquared;
 template <typename DataType>
 struct MagneticPressure;
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct MassFlux;
 template <typename DataType>
 struct Pressure;
 template <typename DataType>
@@ -55,11 +59,19 @@ struct SpatialVelocitySquared;
 template <typename DataType>
 struct SpecificEnthalpy;
 template <typename DataType>
-struct SpecificEnthalpyCompute;
-template <typename DataType>
 struct SpecificInternalEnergy;
-template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
-struct MassFlux;
 }  // namespace Tags
-}  // namespace hydro
 /// \endcond
+
+/// The tags for the primitive variables for GRMHD.
+template <typename DataType>
+using grmhd_tags =
+    tmpl::list<hydro::Tags::RestMassDensity<DataType>,
+               hydro::Tags::SpecificInternalEnergy<DataType>,
+               hydro::Tags::SpatialVelocity<DataType, 3>,
+               hydro::Tags::MagneticField<DataType, 3>,
+               hydro::Tags::DivergenceCleaningField<DataType>,
+               hydro::Tags::LorentzFactor<DataType>,
+               hydro::Tags::Pressure<DataType>,
+               hydro::Tags::SpecificEnthalpy<DataType>>;
+}  // namespace hydro


### PR DESCRIPTION
## Proposed changes

Use known types instead of type aliases.
Clean up includes.
Use default frame of hydro tags.


<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
