### PR TITLE
Don't use hdf5 module on wheeler.

### DIFF
--- a/support/Environments/wheeler_clang.sh
+++ b/support/Environments/wheeler_clang.sh
@@ -14,7 +14,6 @@ spectre_unload_modules() {
     module unload brigand/master
     module unload catch/2.1.2
     module unload gsl/2.1
-    module unload hdf5/1.8.17
     module unload libsharp/1.0.0
     module unload libxsmm/1.8.1
     module unload openblas/0.2.18
@@ -37,7 +36,6 @@ spectre_load_modules() {
     module load brigand/master
     module load catch/2.1.2
     module load gsl/2.1
-    module load hdf5/1.8.17
     module load libsharp/1.0.0
     module load libxsmm/1.8.1
     module load openblas/0.2.18

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -14,7 +14,6 @@ spectre_unload_modules() {
     module unload brigand/master
     module unload catch/2.1.2
     module unload gsl/2.1
-    module unload hdf5/1.8.17
     module unload libsharp/1.0.0
     module unload libxsmm/1.8.1
     module unload openblas/0.2.18
@@ -37,7 +36,6 @@ spectre_load_modules() {
     module load brigand/master
     module load catch/2.1.2
     module load gsl/2.1
-    module load hdf5/1.8.17
     module load libsharp/1.0.0
     module load libxsmm/1.8.1
     module load openblas/0.2.18


### PR DESCRIPTION
The python/anaconda2-4.1.1 module also loads hdf5,
so it is not necessary to load an extra hdf5 module.

On the contrary, if you do load an hdf5 module and it is a
different version than anaconda's, you will get runtime errors.
The latter problem was noticed when the anaconda2-4.1.1 module was
changed but the hdf5 module was not.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

