### PR TITLE
Allow interpolation to be asynchronous

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp
@@ -41,13 +41,19 @@ struct AddTemporalIdsToInterpolationTarget {
                     Parallel::ConstGlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,
                     std::vector<TemporalId>&& temporal_ids) noexcept {
-    const bool begin_interpolation =
+    const bool temporal_id_added_for_the_first_time =
         db::get<Tags::TemporalIds<TemporalId>>(box).empty();
+
+    // Some of the temporal_ids may not be new;
+    // i.e. AddTemporalIdsToInterpolationTarget may have already been
+    // called for them.  So keep track of the new ones.
+    std::vector<TemporalId> new_temporal_ids{};
 
     db::mutate_apply<tmpl::list<Tags::TemporalIds<TemporalId>>,
                      tmpl::list<Tags::CompletedTemporalIds<TemporalId>>>(
-        [&temporal_ids](const gsl::not_null<std::deque<TemporalId>*> ids,
-                        const std::deque<TemporalId>& completed_ids) noexcept {
+        [&temporal_ids, &new_temporal_ids ](
+            const gsl::not_null<std::deque<TemporalId>*> ids,
+            const std::deque<TemporalId>& completed_ids) noexcept {
           // We allow this Action to be called multiple times with the
           // same temporal_ids (e.g. from each node of a NodeGroup
           // ParallelComponent such as Interpolator). If multiple calls
@@ -66,23 +72,37 @@ struct AddTemporalIdsToInterpolationTarget {
                     completed_ids.end() and
                 std::find(ids->begin(), ids->end(), id) == ids->end()) {
               ids->push_back(id);
+              new_temporal_ids.push_back(id);
             }
           }
         },
         make_not_null(&box));
 
-    // Begin interpolation if it is not already in progress
-    // (i.e. waiting for data), and if there are temporal_ids to
-    // interpolate.  If there's an interpolation in progress, then a
-    // later interpolation will be started as soon as the earlier one
-    // finishes.
     const auto& ids = db::get<Tags::TemporalIds<TemporalId>>(box);
-    if (begin_interpolation and not ids.empty()) {
+    if (InterpolationTargetTag::compute_target_points::is_sequential::value) {
+      // InterpolationTarget is sequential.
+      // Begin a single interpolation if one is not already in progress
+      // (i.e. waiting for data), and if there are temporal_ids to
+      // interpolate.  If there's an interpolation in progress, then a
+      // later interpolation will be started as soon as the earlier one
+      // finishes (in InterpolationTargetReceiveVars).
+      if (temporal_id_added_for_the_first_time and not ids.empty()) {
+        auto& my_proxy =
+            Parallel::get_parallel_component<ParallelComponent>(cache);
+        Parallel::simple_action<
+            typename InterpolationTargetTag::compute_target_points>(
+            my_proxy, ids.front());
+      }
+    } else {
+      // InterpolationTarget is not sequential. So begin interpolation
+      // on every new temporal_id that has just been added.
       auto& my_proxy =
           Parallel::get_parallel_component<ParallelComponent>(cache);
-      Parallel::simple_action<
-          typename InterpolationTargetTag::compute_target_points>(my_proxy,
-                                                                  ids.front());
+      for (const auto& id : new_temporal_ids) {
+        Parallel::simple_action<
+            typename InterpolationTargetTag::compute_target_points>(my_proxy,
+                                                                    id);
+      }
     }
   }
 };

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -28,7 +28,7 @@ class DataBox;
 }  // namespace db
 namespace intrp {
 namespace Tags {
-template <typename Metavariables>
+template <typename TemporalId>
 struct TemporalIds;
 }  // namespace Tags
 }  // namespace intrp
@@ -181,15 +181,15 @@ struct ApparentHorizon {
         std::move(box), options.initial_guess, options.fast_flow,
         options.verbosity);
   }
-  template <typename ParallelComponent, typename DbTags, typename Metavariables,
-            typename ArrayIndex,
-            Requires<tmpl::list_contains_v<
-                DbTags, Tags::TemporalIds<Metavariables>>> = nullptr>
-  static void apply(
-      db::DataBox<DbTags>& box,
-      Parallel::ConstGlobalCache<Metavariables>& cache,
-      const ArrayIndex& /*array_index*/,
-      const typename Metavariables::temporal_id::type& temporal_id) noexcept {
+  template <
+      typename ParallelComponent, typename DbTags, typename Metavariables,
+      typename ArrayIndex, typename TemporalId,
+      Requires<tmpl::list_contains_v<DbTags, Tags::TemporalIds<TemporalId>>> =
+          nullptr>
+  static void apply(db::DataBox<DbTags>& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const TemporalId& temporal_id) noexcept {
     const auto& fast_flow = db::get<::ah::Tags::FastFlow>(box);
     const auto& strahlkorper =
         db::get<StrahlkorperTags::Strahlkorper<Frame>>(box);

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -162,6 +162,7 @@ struct ApparentHorizon {
       tmpl::append<StrahlkorperTags::items_tags<Frame>,
                    tmpl::list<::ah::Tags::FastFlow, ::Tags::Verbosity>,
                    StrahlkorperTags::compute_items_tags<Frame>>;
+  using is_sequential = std::true_type;
   template <typename DbTags, typename Metavariables>
   static auto initialize(
       db::DataBox<DbTags>&& box,

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
@@ -29,7 +29,7 @@ class DataBox;
 }  // namespace db
 namespace intrp {
 namespace Tags {
-template <typename Metavariables>
+template <typename TemporalId>
 struct TemporalIds;
 }  // namespace Tags
 }  // namespace intrp
@@ -174,15 +174,15 @@ struct KerrHorizon {
         db::AddComputeTags<StrahlkorperTags::compute_items_tags<Frame>>>(
         std::move(box), std::move(strahlkorper));
   }
-  template <typename ParallelComponent, typename DbTags, typename Metavariables,
-            typename ArrayIndex,
-            Requires<tmpl::list_contains_v<
-                DbTags, Tags::TemporalIds<Metavariables>>> = nullptr>
-  static void apply(
-      db::DataBox<DbTags>& box,
-      Parallel::ConstGlobalCache<Metavariables>& cache,
-      const ArrayIndex& /*array_index*/,
-      const typename Metavariables::temporal_id::type& temporal_id) noexcept {
+  template <
+      typename ParallelComponent, typename DbTags, typename Metavariables,
+      typename ArrayIndex, typename TemporalId,
+      Requires<tmpl::list_contains_v<DbTags, Tags::TemporalIds<TemporalId>>> =
+          nullptr>
+  static void apply(db::DataBox<DbTags>& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const TemporalId& temporal_id) noexcept {
     // In the future, when we add support for multiple Frames,
     // the code that transforms coordinates from the Strahlkorper Frame
     // to Frame::Inertial will go here.  That transformation

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
@@ -152,6 +152,7 @@ struct KerrHorizon {
   using initialization_tags =
       tmpl::append<StrahlkorperTags::items_tags<Frame>,
                    StrahlkorperTags::compute_items_tags<Frame>>;
+  using is_sequential = std::false_type;
   template <typename DbTags, typename Metavariables>
   static auto initialize(
       db::DataBox<DbTags>&& box,

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
@@ -139,6 +139,7 @@ template <typename InterpolationTargetTag, size_t VolumeDim>
 struct LineSegment {
   using const_global_cache_tags =
       tmpl::list<Tags::LineSegment<InterpolationTargetTag, VolumeDim>>;
+  using is_sequential = std::false_type;
   template <
       typename ParallelComponent, typename DbTags, typename Metavariables,
       typename ArrayIndex, typename TemporalId,

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
@@ -27,7 +27,7 @@ class DataBox;
 }  // namespace db
 namespace intrp {
 namespace Tags {
-template <typename Metavariables>
+template <typename TemporalId>
 struct TemporalIds;
 }  // namespace Tags
 }  // namespace intrp
@@ -139,15 +139,15 @@ template <typename InterpolationTargetTag, size_t VolumeDim>
 struct LineSegment {
   using const_global_cache_tags =
       tmpl::list<Tags::LineSegment<InterpolationTargetTag, VolumeDim>>;
-  template <typename ParallelComponent, typename DbTags, typename Metavariables,
-            typename ArrayIndex,
-            Requires<tmpl::list_contains_v<
-                DbTags, Tags::TemporalIds<Metavariables>>> = nullptr>
-  static void apply(
-      db::DataBox<DbTags>& box,
-      Parallel::ConstGlobalCache<Metavariables>& cache,
-      const ArrayIndex& /*array_index*/,
-      const typename Metavariables::temporal_id::type& temporal_id) noexcept {
+  template <
+      typename ParallelComponent, typename DbTags, typename Metavariables,
+      typename ArrayIndex, typename TemporalId,
+      Requires<tmpl::list_contains_v<DbTags, Tags::TemporalIds<TemporalId>>> =
+          nullptr>
+  static void apply(db::DataBox<DbTags>& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const TemporalId& temporal_id) noexcept {
     const auto& options =
         Parallel::get<Tags::LineSegment<InterpolationTargetTag, VolumeDim>>(
             cache);

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
@@ -173,8 +173,8 @@ void callback_and_cleanup(
         // completed_ids forever, but we probably don't want it to get too
         // large, so we limit its size.  We assume that
         // asynchronous calls to AddTemporalIdsToInterpolationTarget do not span
-        // more than 10 temporal_ids.
-        if (completed_ids->size() > 10) {
+        // more than 1000 temporal_ids.
+        if (completed_ids->size() > 1000) {
           completed_ids->pop_front();
         }
       });

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
@@ -209,15 +209,17 @@ void callback_and_cleanup(
   Parallel::simple_action<Actions::CleanUpInterpolator<InterpolationTargetTag>>(
       interpolator_proxy, temporal_id);
 
-  // If there are further temporal_ids, begin interpolation for
-  // the next one.
-  const auto& temporal_ids = db::get<Tags::TemporalIds<TemporalId>>(*box);
-  if (not temporal_ids.empty()) {
-    auto& my_proxy = Parallel::get_parallel_component<
-        InterpolationTarget<Metavariables, InterpolationTargetTag>>(*cache);
-    Parallel::simple_action<
-        typename InterpolationTargetTag::compute_target_points>(
-        my_proxy, temporal_ids.front());
+  // If we have a sequential target, and there are further
+  // temporal_ids, begin interpolation for the next one.
+  if (InterpolationTargetTag::compute_target_points::is_sequential::value) {
+    const auto& temporal_ids = db::get<Tags::TemporalIds<TemporalId>>(*box);
+    if (not temporal_ids.empty()) {
+      auto& my_proxy = Parallel::get_parallel_component<
+          InterpolationTarget<Metavariables, InterpolationTargetTag>>(*cache);
+      Parallel::simple_action<
+          typename InterpolationTargetTag::compute_target_points>(
+          my_proxy, temporal_ids.front());
+    }
   }
 }
 

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -207,6 +207,7 @@ template <typename InterpolationTargetTag>
 struct WedgeSectionTorus {
   using const_global_cache_tags =
       tmpl::list<Tags::WedgeSectionTorus<InterpolationTargetTag>>;
+  using is_sequential = std::false_type;
   template <
       typename ParallelComponent, typename DbTags, typename Metavariables,
       typename ArrayIndex, typename TemporalId,

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -26,7 +26,7 @@ class DataBox;
 }  // namespace db
 namespace intrp {
 namespace Tags {
-template <typename Metavariables>
+template <typename TemporalId>
 struct TemporalIds;
 }  // namespace Tags
 }  // namespace intrp
@@ -207,15 +207,15 @@ template <typename InterpolationTargetTag>
 struct WedgeSectionTorus {
   using const_global_cache_tags =
       tmpl::list<Tags::WedgeSectionTorus<InterpolationTargetTag>>;
-  template <typename ParallelComponent, typename DbTags, typename Metavariables,
-            typename ArrayIndex,
-            Requires<tmpl::list_contains_v<
-                DbTags, Tags::TemporalIds<Metavariables>>> = nullptr>
-  static void apply(
-      db::DataBox<DbTags>& box,
-      Parallel::ConstGlobalCache<Metavariables>& cache,
-      const ArrayIndex& /*array_index*/,
-      const typename Metavariables::temporal_id::type& temporal_id) noexcept {
+  template <
+      typename ParallelComponent, typename DbTags, typename Metavariables,
+      typename ArrayIndex, typename TemporalId,
+      Requires<tmpl::list_contains_v<DbTags, Tags::TemporalIds<TemporalId>>> =
+          nullptr>
+  static void apply(db::DataBox<DbTags>& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const TemporalId& temporal_id) noexcept {
     const auto& options =
         Parallel::get<Tags::WedgeSectionTorus<InterpolationTargetTag>>(cache);
 

--- a/src/NumericalAlgorithms/Interpolation/Tags.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Tags.hpp
@@ -41,8 +41,9 @@ struct InterpolationTargets {
 namespace Tags {
 
 /// Keeps track of which points have been filled with interpolated data.
+template <typename TemporalId>
 struct IndicesOfFilledInterpPoints : db::SimpleTag {
-  using type = std::unordered_set<size_t>;
+  using type = std::unordered_map<TemporalId, std::unordered_set<size_t>>;
 };
 
 /// Keeps track of points that cannot be filled with interpolated data.
@@ -51,22 +52,32 @@ struct IndicesOfFilledInterpPoints : db::SimpleTag {
 /// In most cases the correct action is to throw an error, but in other
 /// cases one might wish to fill these points with a default value or
 /// take some other action.
+template <typename TemporalId>
 struct IndicesOfInvalidInterpPoints : db::SimpleTag {
-  using type = std::unordered_set<size_t>;
+  using type = std::unordered_map<TemporalId, std::unordered_set<size_t>>;
 };
 
 /// `temporal_id`s on which to interpolate.
-template <typename Metavariables>
+template <typename TemporalId>
 struct TemporalIds : db::SimpleTag {
-  using type = std::deque<typename Metavariables::temporal_id::type>;
+  using type = std::deque<TemporalId>;
 };
 
 /// `temporal_id`s that we have already interpolated onto.
 ///  This is used to prevent problems with multiple late calls to
 ///  AddTemporalIdsToInterpolationTarget.
-template <typename Metavariables>
+template <typename TemporalId>
 struct CompletedTemporalIds : db::SimpleTag {
-  using type = std::deque<typename Metavariables::temporal_id::type>;
+  using type = std::deque<TemporalId>;
+};
+
+/// Holds interpolated variables on an InterpolationTarget.
+template <typename InterpolationTargetTag, typename TemporalId>
+struct InterpolatedVars : db::SimpleTag {
+  using type = std::unordered_map<
+      TemporalId,
+      Variables<
+          typename InterpolationTargetTag::vars_to_interpolate_to_target>>;
 };
 
 /// Volume variables at all `temporal_id`s for all local `Element`s.

--- a/src/NumericalAlgorithms/Interpolation/TryToInterpolate.hpp
+++ b/src/NumericalAlgorithms/Interpolation/TryToInterpolate.hpp
@@ -154,7 +154,7 @@ void try_to_interpolate(
           InterpolationTarget<Metavariables, InterpolationTargetTag>>(*cache);
       Parallel::simple_action<
           Actions::InterpolationTargetReceiveVars<InterpolationTargetTag>>(
-          receiver_proxy, info.vars, info.global_offsets);
+          receiver_proxy, info.vars, info.global_offsets, temporal_id);
     }
 
     // Clear interpolated data, since we don't need it anymore.

--- a/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -47,8 +47,9 @@ class DataBox;
 }  // namespace db
 namespace intrp {
 namespace Tags {
+template <typename TemporalId>
 struct IndicesOfFilledInterpPoints;
-template <typename Metavariables>
+template <typename TemporalId>
 struct InterpolatedVarsHolders;
 struct NumberOfElements;
 }  // namespace Tags
@@ -143,6 +144,7 @@ void test_interpolation_target(
     typename InterpolationTargetOptionTag::type options,
     const BlockCoordHolder& expected_block_coord_holders) noexcept {
   using metavars = MetaVariables;
+  using temporal_id_type = typename metavars::temporal_id::type;
   using target_component =
       mock_interpolation_target<metavars,
                                 typename metavars::InterpolationTargetA>;
@@ -171,7 +173,8 @@ void test_interpolation_target(
 
   // This should not have changed.
   CHECK(ActionTesting::get_databox_tag<
-            target_component, ::intrp::Tags::IndicesOfFilledInterpPoints>(
+            target_component,
+            ::intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(
             runner, 0)
             .empty());
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -63,7 +63,9 @@ struct mock_interpolation_target {
                              Metavariables::Phase::Testing, tmpl::list<>>>;
 };
 
+template <typename IsSequential>
 struct MockComputeTargetPoints {
+  using is_sequential = IsSequential;
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
             typename ArrayIndex, typename TemporalId,
             Requires<tmpl::list_contains_v<
@@ -72,8 +74,6 @@ struct MockComputeTargetPoints {
                     Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     const TemporalId& temporal_id) noexcept {
-    Slab slab(0.0, 1.0);
-    CHECK(temporal_id == TimeStepId(true, 0, Time(slab, 0)));
     // Put something in IndicesOfFilledInterpPts so we can check later whether
     // this function was called.  This isn't the usual usage of
     // IndicesOfFilledInterpPoints.
@@ -88,12 +88,13 @@ struct MockComputeTargetPoints {
   }
 };
 
+template <typename IsSequential>
 struct MockMetavariables {
   struct InterpolationTargetA {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_target = tmpl::list<>;
-    using compute_target_points = MockComputeTargetPoints;
+    using compute_target_points = MockComputeTargetPoints<IsSequential>;
   };
   using temporal_id = ::Tags::TimeStepId;
 
@@ -102,12 +103,13 @@ struct MockMetavariables {
   enum class Phase { Initialization, Testing, Exit };
 };
 
-SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.AddTemporalIds",
-                  "[Unit]") {
-  using metavars = MockMetavariables;
+template <typename IsSequential>
+void test_add_temporal_ids() {
+  using metavars = MockMetavariables<IsSequential>;
   using temporal_id_type = typename metavars::temporal_id::type;
   using target_component =
-      mock_interpolation_target<metavars, metavars::InterpolationTargetA>;
+      mock_interpolation_target<metavars,
+                                typename metavars::InterpolationTargetA>;
 
   const auto domain_creator =
       domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
@@ -128,9 +130,10 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.AddTemporalIds",
       TimeStepId(true, 0, Time(slab, 0)),
       TimeStepId(true, 0, Time(slab, Rational(1, 3)))};
 
-  runner.simple_action<target_component,
-                       ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
-                           metavars::InterpolationTargetA>>(0, temporal_ids);
+  runner.template simple_action<
+      target_component, ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
+                            typename metavars::InterpolationTargetA>>(
+      0, temporal_ids);
 
   CHECK(ActionTesting::get_databox_tag<
             target_component, ::intrp::Tags::TemporalIds<temporal_id_type>>(
@@ -138,16 +141,24 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.AddTemporalIds",
         std::deque<TimeStepId>(temporal_ids.begin(), temporal_ids.end()));
 
   // Add the same temporal_ids again, which should do nothing...
-  runner.simple_action<target_component,
-                       ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
-                           metavars::InterpolationTargetA>>(0, temporal_ids);
+  runner.template simple_action<
+      target_component, ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
+                            typename metavars::InterpolationTargetA>>(
+      0, temporal_ids);
   // ...and check that it indeed did nothing.
   CHECK(ActionTesting::get_databox_tag<
             target_component, ::intrp::Tags::TemporalIds<temporal_id_type>>(
             runner, 0) ==
         std::deque<TimeStepId>(temporal_ids.begin(), temporal_ids.end()));
 
-  runner.invoke_queued_simple_action<target_component>(0);
+  if (IsSequential::value) {
+    // Only one simple action should be queued, for the first temporal_id.
+    runner.template invoke_queued_simple_action<target_component>(0);
+  } else {
+    // Two simple actions should be queued, one for each temporal_id.
+    runner.template invoke_queued_simple_action<target_component>(0);
+    runner.template invoke_queued_simple_action<target_component>(0);
+  }
 
   // Check that MockComputeTargetPoints was called.
   CHECK(ActionTesting::get_databox_tag<
@@ -156,16 +167,48 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.AddTemporalIds",
             runner, 0)
             .at(temporal_ids[0])
             .size() == 1);
+  if (not IsSequential::value) {
+    // MockComputeTargetPoints should have been called twice
+    CHECK(ActionTesting::get_databox_tag<
+              target_component,
+              ::intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(
+              runner, 0)
+              .at(temporal_ids[1])
+              .size() == 1);
+  }
 
-  // Call again; it should not call MockComputeTargetPoints this time.
+  // Call again.
+  // If sequential, it should not call MockComputeTargetPoints this time.
+  // Otherwise it should call MockComputeTargetPoints twice.
   const std::vector<TimeStepId> temporal_ids_2 = {
       TimeStepId(true, 0, Time(slab, Rational(2, 3))),
       TimeStepId(true, 0, Time(slab, Rational(3, 3)))};
-  runner.simple_action<target_component,
-                       ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
-                           metavars::InterpolationTargetA>>(0, temporal_ids_2);
+  runner.template simple_action<
+      target_component, ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
+                            typename metavars::InterpolationTargetA>>(
+      0, temporal_ids_2);
 
-  // Check that MockComputeTargetPoints was not called.
-  CHECK(runner.is_simple_action_queue_empty<target_component>(0));
+  if (not IsSequential::value) {
+    // For non-sequential, there should be two queued_simple_actions,
+    // each of which will call MockComputeTargetPoints for one of the
+    // new temporal_ids.
+    for (size_t i = 0; i < 2; ++i) {
+      runner.template invoke_queued_simple_action<target_component>(0);
+      CHECK(ActionTesting::get_databox_tag<
+                target_component,
+                ::intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(
+                runner, 0)
+                .at(temporal_ids_2[i])
+                .size() == 1);
+    }
+  }
+
+  // Check that there are no queued simple actions.
+  CHECK(runner.template is_simple_action_queue_empty<target_component>(0));
+}
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.AddTemporalIds",
+                  "[Unit]") {
+  test_add_temporal_ids<std::true_type>();
+  test_add_temporal_ids<std::false_type>();
 }
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -58,6 +58,7 @@ struct Metavariables {
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Initialize",
                   "[Unit]") {
   using metavars = Metavariables;
+  using temporal_id_type = typename metavars::temporal_id::type;
   using component =
       mock_interpolation_target<metavars,
                                 typename metavars::InterpolationTargetA>;
@@ -74,23 +75,22 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Initialize",
                            Metavariables::Phase::Testing);
 
   CHECK(ActionTesting::get_databox_tag<
-            component, ::intrp::Tags::IndicesOfFilledInterpPoints>(runner, 0)
-            .empty());
-  CHECK(ActionTesting::get_databox_tag<component,
-                                       ::intrp::Tags::TemporalIds<metavars>>(
+            component,
+            ::intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(
             runner, 0)
+            .empty());
+  CHECK(ActionTesting::get_databox_tag<
+            component, ::intrp::Tags::TemporalIds<temporal_id_type>>(runner, 0)
             .empty());
 
   CHECK(Parallel::get<domain::Tags::Domain<3>>(runner.cache()) ==
         domain_creator.create_domain());
 
-  const auto test_vars = db::item_type<
-      ::Tags::Variables<tmpl::list<gr::Tags::Lapse<DataVector>>>>{};
-  CHECK(
-      ActionTesting::get_databox_tag<
-          component, ::Tags::Variables<typename metavars::InterpolationTargetA::
-                                           vars_to_interpolate_to_target>>(
-          runner, 0) == test_vars);
+  CHECK(ActionTesting::get_databox_tag<
+            component, ::intrp::Tags::InterpolatedVars<
+                           metavars::InterpolationTargetA, temporal_id_type>>(
+            runner, 0)
+            .empty());
 }
 
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_Tags.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_Tags.cpp
@@ -19,13 +19,21 @@ struct Metavars {
   static constexpr size_t volume_dim = 3;
   using interpolation_target_tags = tmpl::list<>;
 };
+struct InterpolationTargetTag {
+  using vars_to_interpolate_to_target = tmpl::list<>;
+};
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Interpolation.Tags", "[Unit][NumericalAlgorithms]") {
-  TestHelpers::db::test_simple_tag<intrp::Tags::IndicesOfFilledInterpPoints>(
+  TestHelpers::db::test_simple_tag<
+      intrp::Tags::IndicesOfFilledInterpPoints<Metavars>>(
       "IndicesOfFilledInterpPoints");
-  TestHelpers::db::test_simple_tag<intrp::Tags::IndicesOfInvalidInterpPoints>(
+  TestHelpers::db::test_simple_tag<
+      intrp::Tags::IndicesOfInvalidInterpPoints<Metavars>>(
       "IndicesOfInvalidInterpPoints");
+  TestHelpers::db::test_simple_tag<
+      intrp::Tags::InterpolatedVars<InterpolationTargetTag, Metavars>>(
+      "InterpolatedVars");
   TestHelpers::db::test_simple_tag<intrp::Tags::TemporalIds<Metavars>>(
       "TemporalIds");
   TestHelpers::db::test_simple_tag<intrp::Tags::CompletedTemporalIds<Metavars>>(


### PR DESCRIPTION
## Proposed changes

The interpolator receives volume data asynchronously from DgElementArray elements at various time steps.  Before this PR, the interpolator did no work at time `t_0` until it had finished all its work at all times `t < t_0`.  This is correct behavior for AH finding, in which the interpolation points (i.e. the initial guess for the horizon) at time `t_0` are unknown until the horizon is found at all prior times.  However, for many applications (e.g. CCE), the interpolation points are known ahead of time, so interpolation work can be done at multiple time steps simultaneously.

This PR introduces a new type alias `using is_sequential = ` that appears inside the `apply` function of each `InterpolationTarget`.  If `is_sequential::value` is true, then the previous (sequential) behavior
is unchanged. If `is_sequential::value` is false, then interpolations are processed immediately, regardless of the temporal_id, when volume data is received. 

Before this PR, each `InterpolationTarget` stored interpolated data at only one set of interpolation points. Now, each `InterpolationTarget` holds this same data at multiple temporal_ids simultaneously. The commit that makes this change is the largest.

This PR fixes a bug in which sequential interpolation slowed down the interpolator to the point that evolutions would run out of memory, because too much memory was used storing volume data at times that had not yet been interpolated.

### Types of changes:

- [x] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
