### PR TITLE
Observe Volume Integrals

### DIFF
--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -437,10 +437,12 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   }
   //@}
 
+  ///@{
   /// \brief Suffix to append to the tensor name that indicates the component
   ///
   /// The suffix is empty for scalars, otherwise it is an underscore followed by
-  /// the `Tensor::component_name` of the `tensor_index`. Use `axis_labels` to
+  /// the `Tensor::component_name` of either the `tensor_index` or the canonical
+  /// tensor index obtained from the `storage_index`. Use `axis_labels` to
   /// overwrite the default labels for each component (see
   /// `Tensor::component_name`).
   ///
@@ -456,6 +458,14 @@ class Tensor<X, Symm, IndexList<Indices...>> {
           make_array<rank()>(std::string(""))) noexcept {
     return rank() == 0 ? "" : "_" + component_name(tensor_index, axis_labels);
   }
+
+  static std::string component_suffix(
+      const size_t storage_index,
+      const std::array<std::string, rank()>& axis_labels =
+          make_array<rank()>(std::string(""))) noexcept {
+    return component_suffix(get_tensor_index(storage_index), axis_labels);
+  }
+  ///@}
 
   /// Copy tensor data into an `std::vector<X>` along with the
   /// component names into a `std::vector<std::string>`

--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -105,15 +105,6 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
       "All AnalyticSolutionTensors must be listed in Tensors.");
   using coordinates_tag = domain::Tags::Coordinates<VolumeDim, Frame::Inertial>;
 
-  template <typename T>
-  static std::string component_suffix(const T& tensor,
-                                      size_t component_index) noexcept {
-    return tensor.rank() == 0
-               ? ""
-               : "_" + tensor.component_name(
-                           tensor.get_tensor_index(component_index));
-  }
-
  public:
   /// \cond
   explicit ObserveFields(CkMigrateMessage* /*unused*/) noexcept {}
@@ -207,7 +198,7 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
       if (variables_to_observe_.count(db::tag_name<tensor_tag>()) == 1) {
         for (size_t i = 0; i < tensor.size(); ++i) {
           components.emplace_back(element_name + db::tag_name<tensor_tag>() +
-                                      component_suffix(tensor, i),
+                                      tensor.component_suffix(i),
                                   tensor[i]);
         }
       }
@@ -228,7 +219,7 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
           DataVector error = tensor[i] - analytic_tensor[i];
           components.emplace_back(element_name + "Error(" +
                                       db::tag_name<tensor_tag>() + ")" +
-                                      component_suffix(tensor, i),
+                                      tensor.component_suffix(i),
                                   std::move(error));
         }
       }

--- a/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
@@ -1,0 +1,184 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Tags.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Reduction.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace dg {
+namespace Events {
+template <size_t VolumeDim, typename ObservationValueTag, typename Tensors,
+          typename EventRegistrars>
+class ObserveVolumeIntegrals;
+
+namespace Registrars {
+template <size_t VolumeDim, typename ObservationValueTag, typename Tensors>
+// Presence of size_t template argument requires to define this struct
+// instead of using Registration::Registrar alias.
+struct ObserveVolumeIntegrals {
+  template <typename RegistrarList>
+  using f = Events::ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
+                                           Tensors, RegistrarList>;
+};
+}  // namespace Registrars
+
+template <size_t VolumeDim, typename ObservationValueTag, typename Tensors,
+          typename EventRegistrars =
+              tmpl::list<Registrars::ObserveVolumeIntegrals<
+                  VolumeDim, ObservationValueTag, Tensors>>>
+class ObserveVolumeIntegrals;
+
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief %Observe the volume integrals of the tensors over the domain.
+ *
+ * Writes reduction quantities:
+ * - `ObservationValueTag`
+ * - `Volume` = volume of the domain
+ * - `VolumeIntegral(*)` = volume integral of the tensor
+ *
+ * \warning Currently, only one reduction observation event can be
+ * triggered at a given observation value.  Causing multiple events to run at
+ * once will produce unpredictable results.
+ */
+template <size_t VolumeDim, typename ObservationValueTag, typename... Tensors,
+          typename EventRegistrars>
+class ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
+                             tmpl::list<Tensors...>, EventRegistrars>
+    : public Event<EventRegistrars> {
+ private:
+  using VolumeIntegralDatum =
+      Parallel::ReductionDatum<std::vector<double>, funcl::VectorPlus>;
+
+  using ReductionData = tmpl::wrap<
+      tmpl::list<Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+                 Parallel::ReductionDatum<double, funcl::Plus<>>,
+                 VolumeIntegralDatum>,
+      Parallel::ReductionData>;
+
+ public:
+  /// \cond
+  explicit ObserveVolumeIntegrals(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ObserveVolumeIntegrals);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::list<>;
+  static constexpr OptionString help =
+      "Observe the volume integrals of the tensors over the domain.\n"
+      "\n"
+      "Writes reduction quantities:\n"
+      " * ObservationValueTag\n"
+      " * Volume = volume of the domain\n"
+      " * VolumeIntegral(*) = volume integral of the tensor\n"
+      "\n"
+      "Warning: Currently, only one reduction observation event can be\n"
+      "triggered at a given observation value.  Causing multiple events to\n"
+      "run at once will produce unpredictable results.";
+
+  ObserveVolumeIntegrals() = default;
+
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
+
+  using argument_tags =
+      tmpl::list<ObservationValueTag, domain::Tags::Mesh<VolumeDim>,
+                 domain::Tags::ElementMap<VolumeDim, Frame::Inertial>,
+                 domain::Tags::Coordinates<VolumeDim, Frame::Logical>,
+                 Tensors...>;
+
+  template <typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
+  void operator()(
+      const db::const_item_type<ObservationValueTag>& observation_value,
+      const Mesh<VolumeDim>& mesh,
+      const ElementMap<VolumeDim, Frame::Inertial>& element_map,
+      const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coordinates,
+      const db::const_item_type<Tensors>&... tensors,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/,
+      const ParallelComponent* const /*meta*/) const noexcept {
+    // Determinant of Jacobian is needed because integral is performed in
+    // logical coords. Currently not initialized in the Metavariables
+    // as of PR #2048 (https://github.com/sxs-collaboration/spectre/pull/2048)
+    const DataVector det_jacobian =
+        get(determinant(element_map.jacobian(logical_coordinates)));
+    const double local_volume = definite_integral(det_jacobian, mesh);
+
+    std::vector<double> local_volume_integrals{};
+    std::vector<std::string> reduction_names = {
+        db::tag_name<ObservationValueTag>(), "Volume"};
+    const auto record_integrals =
+        [&local_volume_integrals, &reduction_names, &det_jacobian, &mesh ](
+            const auto tensor_tag_v, const auto& tensor) noexcept {
+      using tensor_tag = tmpl::type_from<decltype(tensor_tag_v)>;
+      for (size_t i = 0; i < tensor.size(); ++i) {
+        reduction_names.push_back("VolumeIntegral(" +
+                                  db::tag_name<tensor_tag>() +
+                                  tensor.component_suffix(i) + ")");
+        local_volume_integrals.push_back(
+            definite_integral(det_jacobian * tensor[i], mesh));
+      }
+      return 0;
+    };
+    EXPAND_PACK_LEFT_TO_RIGHT(
+        record_integrals(tmpl::type_<Tensors>{}, tensors));
+
+    // Send data to reduction observer
+    auto& local_observer =
+        *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+             cache)
+             .ckLocalBranch();
+    Parallel::simple_action<observers::Actions::ContributeReductionData>(
+        local_observer,
+        observers::ObservationId(
+            observation_value,
+            typename Metavariables::element_observation_type{}),
+        std::string{"/volume_integrals"}, reduction_names,
+        ReductionData{static_cast<double>(observation_value), local_volume,
+                      local_volume_integrals});
+  }
+};
+
+/// \cond
+template <size_t VolumeDim, typename ObservationValueTag, typename... Tensors,
+          typename EventRegistrars>
+PUP::able::PUP_ID ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
+                                         tmpl::list<Tensors...>,
+                                         EventRegistrars>::my_PUP_ID =
+    0;  // NOLINT
+/// \endcond
+}  // namespace Events
+}  // namespace dg

--- a/src/Utilities/Functional.hpp
+++ b/src/Utilities/Functional.hpp
@@ -308,6 +308,24 @@ struct Square : Functional<C::arity> {
   }
 };
 
+/// Function for adding two `std::vector`s of `double` component-wise
+struct VectorPlus {
+  std::vector<double> operator()(const std::vector<double>& lhs,
+                                 const std::vector<double>& rhs) const
+      noexcept {
+    ASSERT(lhs.size() == rhs.size(),
+           "Vector sizes in `funcl::VectorPlus` operator do not match. First "
+           "argument size: "
+               << lhs.size() << ". Second argument size: " << rhs.size()
+               << ".");
+    std::vector<double> result(lhs.size());
+    for (size_t i = 0; i < lhs.size(); ++i) {
+      result[i] = lhs[i] + rhs[i];
+    }
+    return result;
+  }
+};
+
 #undef MAKE_BINARY_FUNCTIONAL
 #undef MAKE_BINARY_INPLACE_OPERATOR
 #undef MAKE_BINARY_OPERATOR

--- a/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
@@ -433,6 +433,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.ComponentNames",
   CHECK(tensor_5.component_suffix(std::array<size_t, 3>{{0, 2, 1}},
                                   make_array<3>(std::string("abcd"))) ==
         "_acb");
+  CHECK(scalar.component_suffix(0).empty());
+  CHECK(tensor_2.component_suffix(3) == "_tyx");
+  CHECK(tensor_3.component_suffix(12) == "_xzy");
 }
 
 // [[OutputRegex, Tensor dim\[0\] must be 1,2,3, or 4 for default axis_labels]]

--- a/tests/Unit/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/IO/Observers/ObserverHelpers.hpp
@@ -13,6 +13,7 @@
 #include "IO/Observer/Tags.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
+#include "Utilities/Functional.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
 
@@ -99,34 +100,18 @@ using reduction_data_from_doubles = Parallel::ReductionData<
     Parallel::ReductionDatum<size_t, funcl::Plus<>>, l2_error_datum,
     l2_error_datum>;
 
-struct VectorPlus {
-  std::vector<double> operator()(const std::vector<double>& lhs,
-                                 const std::vector<double>& rhs) const
-      noexcept {
-    ASSERT(lhs.size() == rhs.size(),
-           "Vector sizes in `VectorPlus` operator do not match. First argument "
-           "size: "
-               << lhs.size() << ". Second argument size: " << rhs.size()
-               << ".");
-    std::vector<double> result(lhs.size());
-    for (size_t i = 0; i < lhs.size(); ++i) {
-      result[i] = lhs[i] + rhs[i];
-    }
-    return result;
-  }
-};
-
 using reduction_data_from_vector = Parallel::ReductionData<
     Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
     Parallel::ReductionDatum<size_t, funcl::Plus<>>,
-    Parallel::ReductionDatum<std::vector<double>, VectorPlus>>;
+    Parallel::ReductionDatum<std::vector<double>, funcl::VectorPlus>>;
 
 // Nothing special about the order. We just want doubles and std::vector's.
 using reduction_data_from_ds_and_vs = Parallel::ReductionData<
     Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
     Parallel::ReductionDatum<size_t, funcl::Plus<>>, l2_error_datum,
-    Parallel::ReductionDatum<std::vector<double>, VectorPlus>,
-    Parallel::ReductionDatum<std::vector<double>, VectorPlus>, l2_error_datum>;
+    Parallel::ReductionDatum<std::vector<double>, funcl::VectorPlus>,
+    Parallel::ReductionDatum<std::vector<double>, funcl::VectorPlus>,
+    l2_error_datum>;
 
 template <observers::TypeOfObservation TypeOfObservation>
 struct Metavariables {

--- a/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_ParallelAlgorithmsEvents")
 set(LIBRARY_SOURCES
   Test_ObserveErrorNorms.cpp
   Test_ObserveFields.cpp
+  Test_ObserveVolumeIntegrals.cpp
   )
 
 add_test_library(

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -1,0 +1,290 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Creators/Brick.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/Interval.hpp"
+#include "Domain/Creators/Rectangle.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+namespace observers {
+namespace Actions {
+struct ContributeReductionData;
+}  // namespace Actions
+}  // namespace observers
+
+namespace {
+
+struct ObservationTimeTag : db::SimpleTag {
+  using type = double;
+};
+
+struct MockContributeReductionData {
+  struct Results {
+    observers::ObservationId observation_id;
+    std::string subfile_name;
+    std::vector<std::string> reduction_names{};
+    double time;
+    double volume;
+    std::vector<double> volume_integrals{};
+  };
+  static Results results;
+
+  template <typename ParallelComponent, typename... DbTags,
+            typename Metavariables, typename ArrayIndex, typename... Ts>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+                    Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const observers::ObservationId& observation_id,
+                    const std::string& subfile_name,
+                    const std::vector<std::string>& reduction_names,
+                    Parallel::ReductionData<Ts...>&& reduction_data) noexcept {
+    results.observation_id = observation_id;
+    results.subfile_name = subfile_name;
+    results.reduction_names = reduction_names;
+    results.time = std::get<0>(reduction_data.data());
+    results.volume = std::get<1>(reduction_data.data());
+    results.volume_integrals = std::get<2>(reduction_data.data());
+  }
+};
+
+MockContributeReductionData::Results MockContributeReductionData::results{};
+
+template <typename Metavariables>
+struct ElementComponent {
+  using component_being_mocked = void;
+
+  using metavariables = Metavariables;
+  using array_index = int;
+  using chare_type = ActionTesting::MockArrayChare;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+template <typename Metavariables>
+struct MockObserverComponent {
+  using component_being_mocked = observers::Observer<Metavariables>;
+  using replace_these_simple_actions =
+      tmpl::list<observers::Actions::ContributeReductionData>;
+  using with_these_simple_actions = tmpl::list<MockContributeReductionData>;
+
+  using metavariables = Metavariables;
+  using array_index = int;
+  using chare_type = ActionTesting::MockArrayChare;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<ElementComponent<Metavariables>,
+                                    MockObserverComponent<Metavariables>>;
+  using const_global_cache_tags = tmpl::list<>;  //  unused
+  enum class Phase { Initialization, Testing, Exit };
+
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+};
+
+struct ScalarVar : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t SpatialDim>
+struct VectorVar : db::SimpleTag {
+  using type = tnsr::I<DataVector, SpatialDim>;
+};
+
+template <size_t SpatialDim>
+struct TensorVar : db::SimpleTag {
+  using type = tnsr::Ij<DataVector, SpatialDim>;
+};
+
+template <size_t SpatialDim>
+using variables_for_test =
+    tmpl::list<ScalarVar, VectorVar<SpatialDim>, TensorVar<SpatialDim>>;
+
+template <size_t SpatialDim>
+std::unique_ptr<DomainCreator<SpatialDim>> domain_creator() noexcept;
+
+template <>
+std::unique_ptr<DomainCreator<1>> domain_creator() noexcept {
+  return std::make_unique<domain::creators::Interval>(
+      domain::creators::Interval({{-0.5}}, {{0.5}}, {{false}}, {{0}}, {{4}}));
+}
+
+template <>
+std::unique_ptr<DomainCreator<2>> domain_creator() noexcept {
+  return std::make_unique<domain::creators::Rectangle>(
+      domain::creators::Rectangle({{-0.5, -0.5}}, {{0.5, 0.5}},
+                                  {{false, false}}, {{0, 0}}, {{4, 4}}));
+}
+
+template <>
+std::unique_ptr<DomainCreator<3>> domain_creator() noexcept {
+  return std::make_unique<domain::creators::Brick>(domain::creators::Brick(
+      {{-0.5, -0.5, -0.5}}, {{0.5, 0.5, 0.5}}, {{false, false, false}},
+      {{0, 0, 0}}, {{4, 4, 4}}));
+}
+
+template <size_t VolumeDim, typename ObserveEvent>
+void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
+  using metavariables = Metavariables;
+  using element_component = ElementComponent<metavariables>;
+  using observer_component = MockObserverComponent<metavariables>;
+
+  const typename element_component::array_index array_index(0);
+  const ElementId<VolumeDim> element_id{array_index};
+
+  // ObserveVolumeIntegrals requires some domain items in the DataBox.
+  // Any domain, mesh and basis should be fine--we'll just check received data
+  const auto creator = domain_creator<VolumeDim>();
+  const auto domain = creator->create_domain();
+  const auto& block = domain.blocks()[element_id.block_id()];
+
+  ElementMap<VolumeDim, Frame::Inertial> map{
+      element_id, block.stationary_map().get_clone()};
+  Mesh<VolumeDim> mesh{creator->initial_extents()[0],
+                       Spectral::Basis::Chebyshev,
+                       Spectral::Quadrature::GaussLobatto};
+  auto logical_coords = logical_coordinates(mesh);
+
+  // Any data held by tensors to integrate should be fine
+  MAKE_GENERATOR(gen);
+  using value_type = DataVector::value_type;
+  UniformCustomDistribution<tt::get_fundamental_type_t<value_type>> dist{-10.0,
+                                                                         10.0};
+  Variables<variables_for_test<VolumeDim>> vars(mesh.number_of_grid_points());
+  fill_with_random_values(make_not_null(&vars), make_not_null(&gen),
+                          make_not_null(&dist));
+
+  // Compute expected data for checks
+  size_t num_tensor_components = 0;
+  const DataVector det_jacobian =
+      get(determinant(map.jacobian(logical_coords)));
+  const double expected_volume = definite_integral(det_jacobian, mesh);
+  std::vector<double> expected_volume_integrals{};
+  std::vector<std::string> expected_reduction_names = {
+      db::tag_name<ObservationTimeTag>(), "Volume"};
+  tmpl::for_each<typename std::decay_t<decltype(vars)>::tags_list>([
+    &num_tensor_components, &vars, &expected_volume_integrals,
+    &expected_reduction_names, &det_jacobian, &mesh
+  ](auto tag) noexcept {
+    using tensor_tag = tmpl::type_from<decltype(tag)>;
+    const auto tensor = get<tensor_tag>(vars);
+    for (size_t i = 0; i < tensor.size(); ++i) {
+      expected_reduction_names.push_back("VolumeIntegral(" +
+                                         db::tag_name<tensor_tag>() +
+                                         tensor.component_suffix(i) + ")");
+      expected_volume_integrals.push_back(
+          definite_integral(det_jacobian * tensor[i], mesh));
+      ++num_tensor_components;
+    }
+  });
+
+  const double observation_time = 2.0;
+  const auto box = db::create<
+      db::AddSimpleTags<ObservationTimeTag, domain::Tags::Mesh<VolumeDim>,
+                        domain::Tags::ElementMap<VolumeDim, Frame::Inertial>,
+                        domain::Tags::Coordinates<VolumeDim, Frame::Logical>,
+                        Tags::Variables<typename decltype(vars)::tags_list>>>(
+      observation_time, mesh, std::move(map), logical_coords, vars);
+
+  ActionTesting::MockRuntimeSystem<metavariables> runner{{}};
+  ActionTesting::emplace_component<element_component>(make_not_null(&runner),
+                                                      0);
+  ActionTesting::emplace_component<observer_component>(&runner, 0);
+
+  observe->run(box, runner.cache(), array_index,
+               std::add_pointer_t<element_component>{});
+
+  // Process the data
+  runner.invoke_queued_simple_action<observer_component>(0);
+  CHECK(runner.is_simple_action_queue_empty<observer_component>(0));
+
+  const auto& results = MockContributeReductionData::results;
+  CHECK(results.observation_id.value() == observation_time);
+  CHECK(results.subfile_name == "/volume_integrals");
+  CHECK(results.reduction_names == expected_reduction_names);
+  CHECK(results.time == observation_time);
+  CHECK(results.volume == expected_volume);
+  CHECK(results.volume_integrals.size() == num_tensor_components);
+  CHECK(results.volume_integrals == expected_volume_integrals);
+}
+}  // namespace
+
+template <size_t VolumeDim>
+void test_observe_system() noexcept {
+  using vars_for_test = variables_for_test<VolumeDim>;
+
+  {
+    INFO("Testing observation for Dim = " << VolumeDim);
+    test_observe<VolumeDim>(
+        std::make_unique<dg::Events::ObserveVolumeIntegrals<
+            VolumeDim, ObservationTimeTag, vars_for_test>>());
+  }
+  {
+    INFO("Testing create/serialize for Dim = " << VolumeDim);
+    using EventType =
+        Event<tmpl::list<dg::Events::Registrars::ObserveVolumeIntegrals<
+            VolumeDim, ObservationTimeTag, vars_for_test>>>;
+    Parallel::register_derived_classes_with_charm<EventType>();
+    const auto factory_event =
+        TestHelpers::test_factory_creation<EventType>("ObserveVolumeIntegrals");
+    auto serialized_event = serialize_and_deserialize(factory_event);
+    test_observe<VolumeDim>(std::move(serialized_event));
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveVolumeIntegrals",
+                  "[Unit][Evolution]") {
+  test_observe_system<1>();
+  test_observe_system<2>();
+  test_observe_system<3>();
+}

--- a/tests/Unit/Utilities/Test_Functional.cpp
+++ b/tests/Unit/Utilities/Test_Functional.cpp
@@ -449,6 +449,12 @@ void test_real_functions(const gsl::not_null<Gen*> gen) noexcept {
   });
 }
 
+void test_vector_plus() noexcept {
+  CHECK_ITERABLE_APPROX(VectorPlus{}(std::vector<double>{0.12, -20.87, 3.2},
+                                     std::vector<double>{-11.04, 7.5, 6.18}),
+                        (std::vector<double>{-10.92, -13.37, 9.38}));
+}
+
 SPECTRE_TEST_CASE("Unit.Utilities.Functional", "[Utilities][Unit]") {
   MAKE_GENERATOR(generator);
   test_generic_unaries(make_not_null(&generator));
@@ -457,6 +463,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.Functional", "[Utilities][Unit]") {
   test_functional_combinations(make_not_null(&generator));
   test_assert_equal();
   test_get_argument();
+  test_vector_plus();
 }
 
 // [[OutputRegex, Values are not equal in funcl::AssertEqual 7 and 8]]
@@ -468,6 +475,19 @@ SPECTRE_TEST_CASE("Unit.Utilities.Functional", "[Utilities][Unit]") {
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
+
+    // clang-format off
+// [[OutputRegex, Vector sizes in `funcl::VectorPlus` operator do not match.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Functional.VectorPlus",
+                               "[Unit][Utilities]") {
+  // clang-format on
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  VectorPlus{}(std::vector<double>{2.0}, std::vector<double>{0.4, -19.90});
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
 #undef MAKE_UNARY_TEST
 #undef MAKE_BINARY_TEST
 #undef MAKE_BINARY_OP_TEST


### PR DESCRIPTION
## Proposed changes

Adds event that observes volume integrals of the given tensors. The integrals will be performed component-wise for tensors of rank > 0. 

(Putting a PR in order to get feedback from people interested in having this in develop.)

### Types of changes:

- [ ] Bugfix
- [x ] New feature
- [ ] Refactor

### Component:

- [x ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

- This PR is in progress and depends on #2042 Please only check last commit. l'm currently adding some tests using the ATF.
- This action should be capable of integrating any field retrieved from the DataBox. In particular, it works with compute items, so new compute items can be added for new fields one wants to integrate.
- The action also integrates the physical volume itself: this is useful if one is interested in taking means or higher moments.
- It is not clear to me if higher moments (e.g. integrals of the square of a given field) should be handled here or elsewhere.
- This is to be compared with `ObserveErrorNorms`. Maybe in the future (or as part of this PR; I haven't thought about how to do it yet) both can be unified.

Feel free to suggest better ways to do anything here.