### PR TITLE
Add unary plus and minus to Variables

### DIFF
--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -395,6 +395,15 @@ class Variables<tmpl::list<Tags...>> {
     return lhs.variable_data_ / rhs;
   }
 
+  friend SPECTRE_ALWAYS_INLINE decltype(auto) operator-(
+      const Variables& lhs) noexcept {
+    return -lhs.variable_data_;
+  }
+  friend SPECTRE_ALWAYS_INLINE decltype(auto) operator+(
+      const Variables& lhs) noexcept {
+    return lhs.variable_data_;
+  }
+
  private:
   //{@
   /*!

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -798,61 +798,79 @@ void test_variables_from_tagged_tuple() noexcept {
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
-  SECTION("Test Variables construction, access, and assignment") {
+  {
+    INFO("Test Variables construction, access, and assignment");
     test_variables_construction_and_access<ComplexDataVector>();
     test_variables_construction_and_access<ComplexModalVector>();
     test_variables_construction_and_access<DataVector>();
     test_variables_construction_and_access<ModalVector>();
   }
-  SECTION("Test Variables move operations") {
+
+  {
+    INFO("Test Variables move operations");
     test_variables_move<ComplexDataVector>();
     test_variables_move<ComplexModalVector>();
     test_variables_move<DataVector>();
     test_variables_move<ModalVector>();
   }
-  SECTION("Test Variables arithmetic operations") {
+
+  {
+    INFO("Test Variables arithmetic operations");
     test_variables_math<DataVector>();
     test_variables_math<ComplexDataVector>();
     // tests for ModalVector and ComplexModalVector omitted due to limited
     // arithmetic operation support for ModalVectors
   }
-  SECTION("Test Prefix Variables move and copy semantics") {
+
+  {
+    INFO("Test Prefix Variables move and copy semantics");
     test_variables_prefix_semantics<ComplexDataVector>();
     test_variables_prefix_semantics<ComplexModalVector>();
     test_variables_prefix_semantics<DataVector>();
     test_variables_prefix_semantics<ModalVector>();
   }
-  SECTION("Test Prefix Variables arithmetic operations") {
+
+  {
+    INFO("Test Prefix Variables arithmetic operations");
     test_variables_prefix_math<ComplexDataVector>();
     test_variables_prefix_math<ComplexModalVector>();
     test_variables_prefix_math<DataVector>();
     test_variables_prefix_math<ModalVector>();
   }
-  SECTION("Test Variables serialization") {
+
+  {
+    INFO("Test Variables serialization");
     test_variables_serialization<ComplexDataVector>();
     test_variables_serialization<ComplexModalVector>();
     test_variables_serialization<DataVector>();
     test_variables_serialization<ModalVector>();
   }
-  SECTION("Test Variables assign subset") {
+
+  {
+    INFO("Test Variables assign subset");
     test_variables_assign_subset<ComplexDataVector>();
     test_variables_assign_subset<ComplexModalVector>();
     test_variables_assign_subset<DataVector>();
     test_variables_assign_subset<ModalVector>();
   }
-  SECTION("Test Variables extract subset") {
+
+  {
+    INFO("Test Variables extract subset");
     test_variables_extract_subset<ComplexDataVector>();
     test_variables_extract_subset<ComplexModalVector>();
     test_variables_extract_subset<DataVector>();
     test_variables_extract_subset<ModalVector>();
   }
-  SECTION("Test variables_from_tagged_tuple") {
+
+  {
+    INFO("Test variables_from_tagged_tuple");
     // The commented functions require a fix to issue #1420.
     // test_variables_from_tagged_tuple<ComplexDataVector>();
     // test_variables_from_tagged_tuple<ComplexModalVector>();
     test_variables_from_tagged_tuple<DataVector>();
     // test_variables_from_tagged_tuple<ModalVector>();
   }
+
   TestHelpers::db::test_simple_tag<Tags::TempScalar<1>>("TempTensor1");
 }
 }  // namespace

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -301,6 +301,10 @@ void test_variables_math() noexcept {
   CHECK_VARIABLES_APPROX(expected, vars - vars + vars);  // NOLINT
   expected = TestVariablesType{num_points, value_in_variables};
   CHECK_VARIABLES_APPROX(expected, vars + vars - vars);
+  expected = TestVariablesType{num_points, -value_in_variables};
+  CHECK_VARIABLES_APPROX(expected, -vars);
+  expected = TestVariablesType{num_points, value_in_variables};
+  CHECK_VARIABLES_APPROX(expected, +vars);
 
   // Test math_assignment operators +=, -=, *=, /= with values
   TestVariablesType test_assignment(vars * rand_vals[0]);
@@ -525,6 +529,10 @@ void test_variables_prefix_math() noexcept {
   expected =
       Prefix3VariablesType{number_of_grid_points, 1.0 * value_in_variables};
   CHECK_VARIABLES_APPROX(expected, prefix_vars0 + prefix_vars1 - prefix_vars2);
+  expected = Prefix3VariablesType{number_of_grid_points, -value_in_variables};
+  CHECK_VARIABLES_APPROX(expected, -prefix_vars0);
+  expected = Prefix3VariablesType{number_of_grid_points, value_in_variables};
+  CHECK_VARIABLES_APPROX(expected, +prefix_vars0);
 
   // Test assignment arithmetic operators +=, -=, *=, /= with values
   Prefix0VariablesType test_assignment(prefix_vars0 * 1.0);


### PR DESCRIPTION
## Proposed changes

Add unary plus and minus to Variables. This is useful e.g. when setting `dudt = - div_flux`

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
