### PR TITLE
Start to add Pybindings for Domain and DomainCreators

### DIFF
--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -136,11 +136,17 @@ function(SPECTRE_PYTHON_ADD_MODULE MODULE_NAME)
   if("${INIT_FILE_CONTENTS}" STREQUAL "")
     set(INIT_FILE_OUTPUT "${SPECTRE_PYTHON_MODULE_IMPORT}\n__all__ = []\n")
   else("${INIT_FILE_CONTENTS}" STREQUAL "")
-    string(REGEX REPLACE
-      "from[^\n]+"
-      "${SPECTRE_PYTHON_MODULE_IMPORT}"
-      INIT_FILE_OUTPUT
-      ${INIT_FILE_CONTENTS})
+    string(FIND ${INIT_FILE_CONTENTS} "from" FOUND_FROM_STATEMENT)
+    if (${FOUND_FROM_STATEMENT} EQUAL -1)
+      set(INIT_FILE_OUTPUT
+        "${SPECTRE_PYTHON_MODULE_IMPORT}\n${INIT_FILE_CONTENTS}")
+    else()
+      string(REGEX REPLACE
+        "from[^\n]+"
+        "${SPECTRE_PYTHON_MODULE_IMPORT}"
+        INIT_FILE_OUTPUT
+        ${INIT_FILE_CONTENTS})
+    endif()
   endif("${INIT_FILE_CONTENTS}" STREQUAL "")
 
   # configure the source files into the build directory and make sure
@@ -185,13 +191,14 @@ function(SPECTRE_PYTHON_ADD_MODULE MODULE_NAME)
   foreach(CURRENT_PYTHON_MODULE in ${WRITTEN_PYTHON_ALL_WITHOUT_EXTENSIONS})
     string(FIND "${ARG_PYTHON_FILES}" "${CURRENT_PYTHON_MODULE}.py"
       PYTHON_MODULE_EXISTS)
-    if(${PYTHON_MODULE_EXISTS} EQUAL -1)
+    if(${PYTHON_MODULE_EXISTS} EQUAL -1
+         AND NOT EXISTS "${MODULE_LOCATION}/${CURRENT_PYTHON_MODULE}")
       string(REPLACE "\"${CURRENT_PYTHON_MODULE}\""
         ""
         INIT_FILE_OUTPUT ${INIT_FILE_OUTPUT})
       string(REPLACE ", ," "," INIT_FILE_OUTPUT ${INIT_FILE_OUTPUT})
       file(REMOVE "${MODULE_LOCATION}/${CURRENT_PYTHON_MODULE}.py")
-    endif(${PYTHON_MODULE_EXISTS} EQUAL -1)
+    endif()
   endforeach(CURRENT_PYTHON_MODULE in ${MATCHED})
 
   # Write the __init__.py file for the module

--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(Amr)
 add_subdirectory(CoordinateMaps)
 add_subdirectory(Creators)
 add_subdirectory(FunctionsOfTime)
+add_subdirectory(Python)
 
 set(LIBRARY Domain)
 

--- a/src/Domain/Creators/CMakeLists.txt
+++ b/src/Domain/Creators/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Python)
 add_subdirectory(TimeDependence)
 
 set(LIBRARY DomainCreators)

--- a/src/Domain/Creators/Python/Bindings.cpp
+++ b/src/Domain/Creators/Python/Bindings.cpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace domain {
+namespace creators {
+
+namespace py_bindings {
+void bind_cylinder(py::module& m);  // NOLINT
+void bind_domain_creator(py::module& m);  // NOLINT
+}  // namespace py_bindings
+
+PYBIND11_MODULE(_PyDomainCreators, m) {  // NOLINT
+  py_bindings::bind_domain_creator(m);
+  py_bindings::bind_cylinder(m);
+}
+
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/Python/CMakeLists.txt
+++ b/src/Domain/Creators/Python/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PyDomainCreators")
+
+spectre_python_add_module(
+  Creators
+  LIBRARY_NAME ${LIBRARY}
+  MODULE_PATH "Domain"
+  SOURCES
+  Bindings.cpp
+  Cylinder.cpp
+  DomainCreator.cpp
+  )
+
+spectre_python_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DomainCreators
+  )

--- a/src/Domain/Creators/Python/Cylinder.cpp
+++ b/src/Domain/Creators/Python/Cylinder.cpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+#include "Domain/Creators/Cylinder.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+
+namespace py = pybind11;
+
+namespace domain {
+namespace creators {
+namespace py_bindings {
+void bind_cylinder(py::module& m) {  // NOLINT
+  py::class_<Cylinder, DomainCreator<3>>(m, "Cylinder")
+      .def(py::init<double, double, double, double, bool, size_t,
+                    std::array<size_t, 3>, bool>(),
+           py::arg("inner_radius"), py::arg("outer_radius"),
+           py::arg("lower_bound"), py::arg("upper_bound"),
+           py::arg("is_periodic_in_z"), py::arg("initial_refinement"),
+           py::arg("initial_number_of_grid_points"),
+           py::arg("use_equiangular_map"));
+}
+}  // namespace py_bindings
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/Python/DomainCreator.cpp
+++ b/src/Domain/Creators/Python/DomainCreator.cpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <pybind11/pybind11.h>
+#include <string>
+
+#include "Domain/Creators/DomainCreator.hpp"
+
+namespace py = pybind11;
+
+namespace domain {
+namespace creators {
+namespace py_bindings {
+void bind_domain_creator(py::module& m) {  // NOLINT
+  py::class_<DomainCreator<1>>(m, "DomainCreator1D");  // NOLINT
+  py::class_<DomainCreator<2>>(m, "DomainCreator2D");  // NOLINT
+  py::class_<DomainCreator<3>>(m, "DomainCreator3D");  // NOLINT
+}
+}  // namespace py_bindings
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Python/Bindings.cpp
+++ b/src/Domain/Python/Bindings.cpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace domain {
+
+namespace py_bindings {
+void bind_segment_id(py::module& m);  // NOLINT
+void bind_element_id(py::module& m);  // NOLINT
+}  // namespace py_bindings
+
+PYBIND11_MODULE(_PyDomain, m) {  // NOLINT
+  py_bindings::bind_segment_id(m);
+  py_bindings::bind_element_id(m);
+}
+
+}  // namespace domain

--- a/src/Domain/Python/CMakeLists.txt
+++ b/src/Domain/Python/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PyDomain")
+
+spectre_python_add_module(
+  Domain
+  LIBRARY_NAME ${LIBRARY}
+  SOURCES
+  Bindings.cpp
+  ElementId.cpp
+  SegmentId.cpp
+  )
+
+spectre_python_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Domain
+  )

--- a/src/Domain/Python/ElementId.cpp
+++ b/src/Domain/Python/ElementId.cpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <cstddef>
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+#include "Domain/ElementId.hpp"
+#include "Domain/SegmentId.hpp"
+#include "Utilities/GetOutput.hpp"
+
+namespace py = pybind11;
+
+namespace domain {
+namespace py_bindings {
+
+namespace detail {
+template <size_t Dim>
+void bind_element_id_impl(py::module& m) {  // NOLINT
+  // These bindings don't cover the full public interface yet. More bindings
+  // can be added as needed.
+  py::class_<ElementId<Dim>>(m, ("ElementId" + get_output(Dim) + "D").c_str())
+      .def(py::init<size_t>(), py::arg("block_id"))
+      .def(py::init<size_t, std::array<SegmentId, Dim>>(), py::arg("block_id"),
+           py::arg("segment_ids"))
+      .def_property("block_id", &ElementId<Dim>::block_id, nullptr)
+      .def_property("segment_ids", &ElementId<Dim>::segment_ids, nullptr)
+      .def_static("external_boundary_id", &ElementId<Dim>::external_boundary_id)
+      .def("__repr__",
+           [](const ElementId<Dim>& element_id) {
+             return get_output(element_id);
+           })
+      // NOLINTNEXTLINE(misc-redundant-expression)
+      .def(py::self == py::self)
+      // NOLINTNEXTLINE(misc-redundant-expression)
+      .def(py::self != py::self);
+}
+}  // namespace detail
+
+void bind_element_id(py::module& m) {  // NOLINT
+  detail::bind_element_id_impl<1>(m);
+  detail::bind_element_id_impl<2>(m);
+  detail::bind_element_id_impl<3>(m);
+}
+
+}  // namespace py_bindings
+}  // namespace domain

--- a/src/Domain/Python/SegmentId.cpp
+++ b/src/Domain/Python/SegmentId.cpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <cstddef>
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+#include "Domain/SegmentId.hpp"
+#include "Utilities/GetOutput.hpp"
+
+namespace py = pybind11;
+
+namespace domain {
+namespace py_bindings {
+
+void bind_segment_id(py::module& m) {  // NOLINT
+  // These bindings don't cover the full public interface yet. More bindings
+  // can be added as needed.
+  py::class_<SegmentId>(m, "SegmentId")
+      .def(py::init<size_t, size_t>(), py::arg("refinement_level"),
+           py::arg("index"))
+      .def_property("refinement_level", &SegmentId::refinement_level, nullptr)
+      .def_property("index", &SegmentId::index, nullptr)
+      .def("__repr__",
+           [](const SegmentId& segment_id) { return get_output(segment_id); })
+      // NOLINTNEXTLINE(misc-redundant-expression)
+      .def(py::self == py::self)
+      // NOLINTNEXTLINE(misc-redundant-expression)
+      .def(py::self != py::self);
+}
+
+}  // namespace py_bindings
+}  // namespace domain

--- a/src/PythonBindings/CharmCompatibility.cpp
+++ b/src/PythonBindings/CharmCompatibility.cpp
@@ -84,12 +84,15 @@ std::string get_paths() noexcept { return "Not supported in python."; }
 // Destructor will be called in Python, but doesn't need to do anything
 PUP::able::~able() = default;
 
-// gcc suggests to mark these functions `noreturn`, but they are declared in
-// pup.h
-#if defined(__GNUC__) && !defined(__clang__)
+// gcc and clang suggest to mark these functions `noreturn`, but they are
+// declared in pup.h
 #pragma GCC diagnostic push
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wsuggest-attribute=noreturn"
 #endif  // defined(__GNUC__) && !defined(__clang__)
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Wmissing-noreturn"
+#endif  // __clang__
 
 void PUP::able::pup(PUP::er& /*p*/) {
   throw std::runtime_error{
@@ -110,8 +113,12 @@ PUP::able* PUP::able::clone() const {
       "Charm++ and is not intended to be called."};
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+void pup_bytes(pup_er /*p*/, void* /*ptr*/, size_t /*nBytes*/) {
+  throw std::runtime_error{
+      "The function 'pup_bytes' is provided for compatibility with "
+      "Charm++ and is not intended to be called."};
+}
+
 #pragma GCC diagnostic pop
-#endif  // defined(__GNUC__) && !defined(__clang__)
 
 /// \endcond

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(FunctionsOfTime)
+add_subdirectory(Python)
 
 set(LIBRARY "Test_Domain")
 

--- a/tests/Unit/Domain/Creators/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Python)
 add_subdirectory(TimeDependence)
 
 set(LIBRARY "Test_DomainCreators")

--- a/tests/Unit/Domain/Creators/Python/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/Python/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_add_python_bindings_test(
+  "Unit.Domain.Creators.Python.Cylinder"
+  Test_Cylinder.py
+  "Unit;Domain")

--- a/tests/Unit/Domain/Creators/Python/Test_Cylinder.py
+++ b/tests/Unit/Domain/Creators/Python/Test_Cylinder.py
@@ -1,0 +1,22 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.Domain.Creators import Cylinder, DomainCreator3D
+import unittest
+
+
+class TestCylinder(unittest.TestCase):
+    def test_construction(self):
+        cylinder = Cylinder(inner_radius=1.,
+                            outer_radius=2.,
+                            lower_bound=0.,
+                            upper_bound=1.,
+                            is_periodic_in_z=False,
+                            initial_refinement=1,
+                            initial_number_of_grid_points=[3, 4, 5],
+                            use_equiangular_map=False)
+        self.assertIsInstance(cylinder, DomainCreator3D)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/Unit/Domain/Python/CMakeLists.txt
+++ b/tests/Unit/Domain/Python/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_add_python_bindings_test(
+  "Unit.Domain.Python.ElementId"
+  Test_ElementId.py
+  "Unit;Domain")
+spectre_add_python_bindings_test(
+  "Unit.Domain.Python.SegmentId"
+  Test_SegmentId.py
+  "Unit;Domain")

--- a/tests/Unit/Domain/Python/Test_ElementId.py
+++ b/tests/Unit/Domain/Python/Test_ElementId.py
@@ -1,0 +1,41 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.Domain import ElementId1D, ElementId2D, ElementId3D, SegmentId
+import unittest
+
+
+class TestElementId(unittest.TestCase):
+    def test_construction(self):
+        element_id = ElementId1D(block_id=1)
+        self.assertEqual(element_id.block_id, 1)
+        self.assertEqual(element_id.segment_ids, [SegmentId(0, 0)])
+        element_id = ElementId1D(block_id=1, segment_ids=[SegmentId(1, 0)])
+        self.assertEqual(element_id.block_id, 1)
+        self.assertEqual(element_id.segment_ids, [SegmentId(1, 0)])
+
+    def test_repr(self):
+        self.assertEqual(repr(ElementId1D(0)), "[B0,(L0I0)]")
+        self.assertEqual(
+            repr(ElementId2D(
+                2, [SegmentId(0, 0), SegmentId(1, 0)])), "[B2,(L0I0,L1I0)]")
+        self.assertEqual(
+            repr(
+                ElementId3D(
+                    1, [SegmentId(1, 0),
+                        SegmentId(0, 0),
+                        SegmentId(1, 1)])), "[B1,(L1I0,L0I0,L1I1)]")
+
+    def test_equality(self):
+        self.assertEqual(ElementId1D(0, [SegmentId(1, 0)]),
+                         ElementId1D(0, [SegmentId(1, 0)]))
+        self.assertNotEqual(ElementId1D(0, [SegmentId(1, 0)]),
+                            ElementId1D(0, [SegmentId(1, 1)]))
+
+    def test_external_boundary_id(self):
+        self.assertEqual(ElementId1D.external_boundary_id(),
+                         ElementId1D.external_boundary_id())
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/Unit/Domain/Python/Test_SegmentId.py
+++ b/tests/Unit/Domain/Python/Test_SegmentId.py
@@ -1,0 +1,24 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.Domain import SegmentId
+import unittest
+
+
+class TestSegmentId(unittest.TestCase):
+    def test_construction(self):
+        segment_id = SegmentId(refinement_level=1, index=0)
+        self.assertEqual(segment_id.refinement_level, 1)
+        self.assertEqual(segment_id.index, 0)
+
+    def test_repr(self):
+        self.assertEqual(repr(SegmentId(1, 0)), "L1I0")
+
+    def test_equality(self):
+        self.assertEqual(SegmentId(1, 0), SegmentId(1, 0))
+        self.assertNotEqual(SegmentId(1, 0), SegmentId(1, 1))
+        self.assertNotEqual(SegmentId(2, 0), SegmentId(1, 0))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Adding Pybindings for domain, spectral etc will be useful for testing things in Python. This PR adds a few bindings to establish the structure of the modules. People who would like to use other classes can add them fairly easily, and I will also continue to add more bindings when I need them.

Depends on:
- [x] #2052

TODO:
- [x] Add a test

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
