### PR TITLE
Fix STL streaming bug in ObserveFields

### DIFF
--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -34,6 +34,7 @@
 #include "Utilities/Literals.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/Numeric.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -147,6 +148,7 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
                          const OptionContext& context = {})
       : variables_to_observe_(variables_to_observe.begin(),
                               variables_to_observe.end()) {
+    using ::operator<<;
     const std::unordered_set<std::string> valid_tensors{
         db::tag_name<Tensors>()...};
     for (const auto& name : variables_to_observe_) {


### PR DESCRIPTION
## Proposed changes

- In `ObserveFields.hpp` STL containers are streamed without including `StdHelpers.hpp` and without bringing the global `operator<<` into scope, which causes compilation failure as soon as a stream operator is added to the namespace.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
