### PR TITLE
Accept extra cmake args to spectre_run_cmake

### DIFF
--- a/support/Environments/bluewaters_gcc.sh
+++ b/support/Environments/bluewaters_gcc.sh
@@ -333,5 +333,6 @@ spectre_run_cmake() {
           -D ENABLE_WARNINGS=OFF \
           -D CMAKE_EXE_LINKER_FLAGS="-I$BOOST_ROOT/include" \
           -D USE_PCH=OFF \
+          "$@" \
           $SPECTRE_HOME
 }

--- a/support/Environments/compute_canada_gcc.sh
+++ b/support/Environments/compute_canada_gcc.sh
@@ -241,5 +241,6 @@ spectre_run_cmake() {
     spectre_load_modules
     cmake -D CHARM_ROOT=$CHARM_ROOT \
           -D CMAKE_BUILD_TYPE=Release \
+          "$@" \
           $SPECTRE_HOME
 }

--- a/support/Environments/minerva_gcc.sh
+++ b/support/Environments/minerva_gcc.sh
@@ -53,5 +53,5 @@ spectre_run_cmake() {
         return 1
     fi
     spectre_load_modules
-    cmake -D CMAKE_BUILD_TYPE=Release $SPECTRE_HOME
+    cmake -D CMAKE_BUILD_TYPE=Release "$@" $SPECTRE_HOME
 }

--- a/support/Environments/ocean_gcc.sh
+++ b/support/Environments/ocean_gcc.sh
@@ -69,5 +69,6 @@ spectre_run_cmake() {
     spectre_load_modules
     cmake -D CHARM_ROOT=$CHARM_ROOT \
           -D CMAKE_BUILD_TYPE=Release \
+          "$@" \
           $SPECTRE_HOME
 }

--- a/support/Environments/ocean_orca0_gcc.sh
+++ b/support/Environments/ocean_orca0_gcc.sh
@@ -66,5 +66,6 @@ spectre_run_cmake() {
     spectre_load_modules
     cmake -D CHARM_ROOT=$CHARM_ROOT \
           -D CMAKE_BUILD_TYPE=Release \
+          "$@" \
           $SPECTRE_HOME
 }

--- a/support/Environments/orca_gcc.sh
+++ b/support/Environments/orca_gcc.sh
@@ -59,5 +59,6 @@ spectre_run_cmake() {
           -D CMAKE_BUILD_TYPE=Release \
           -D CMAKE_Fortran_COMPILER=gfortran \
           -D PYTHON_EXECUTABLE=/share/apps/python/2.7.15/bin/python \
+          "$@" \
           $SPECTRE_HOME
 }

--- a/support/Environments/wheeler_clang.sh
+++ b/support/Environments/wheeler_clang.sh
@@ -65,5 +65,6 @@ spectre_run_cmake() {
           -D MEMORY_ALLOCATOR=SYSTEM \
           -D BUILD_PYTHON_BINDINGS=on \
           -D CMAKE_CXX_LINK_FLAGS=-lstdc++ \
+          "$@" \
           $SPECTRE_HOME
 }

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -62,5 +62,6 @@ spectre_run_cmake() {
           -D CMAKE_Fortran_COMPILER=gfortran \
           -D MEMORY_ALLOCATOR=SYSTEM \
           -D BUILD_PYTHON_BINDINGS=on \
+          "$@" \
           $SPECTRE_HOME
 }

--- a/support/Environments/zwicky_gcc.sh
+++ b/support/Environments/zwicky_gcc.sh
@@ -68,5 +68,6 @@ spectre_run_cmake() {
     cmake -D CHARM_ROOT=$CHARM_ROOT \
           -D CMAKE_BUILD_TYPE=Release \
           -D CMAKE_Fortran_COMPILER=gfortran \
+          "$@" \
           $SPECTRE_HOME
 }


### PR DESCRIPTION
This can be used, for example, to disable debug symbols by

spectre_run_cmake -DDEBUG_SYMBOLS=NO

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
