### PR TITLE
Refactor conservative dudt

### DIFF
--- a/src/Evolution/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/Actions/ComputeTimeDerivative.hpp
@@ -42,7 +42,6 @@ namespace Actions {
  *   - `temporal_id::step_prefix`
  * - System:
  *   - `variables_tag`
- *   - `compute_time_derivative`
  * - DataBox:
  *   - db::add_tag_prefix<step_prefix, variables_tag>
  *   - All elements in `compute_time_derivative::argument_tags`
@@ -51,6 +50,7 @@ namespace Actions {
  * - Modifies:
  *   - `db::add_tag_prefix<step_prefix, variables_tag>`
  */
+template <typename TimeDerivativeComputer>
 struct ComputeTimeDerivative {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -63,7 +63,6 @@ struct ComputeTimeDerivative {
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {  // NOLINT const
     using system = typename Metavariables::system;
-    using computer = typename system::compute_time_derivative;
     // Notes:
     // - dt_variables is not zeroed and the operator cannot assume this.
     // - We retrieve the `step_prefix` from the `Metavariables` (as opposed to
@@ -73,8 +72,8 @@ struct ComputeTimeDerivative {
     db::mutate_apply<db::split_tag<db::add_tag_prefix<
                          Metavariables::temporal_id::template step_prefix,
                          typename system::variables_tag>>,
-                     typename computer::argument_tags>(computer{},
-                                                       make_not_null(&box));
+                     typename TimeDerivativeComputer::argument_tags>(
+        TimeDerivativeComputer{}, make_not_null(&box));
     return std::forward_as_tuple(std::move(box));
   }
 };

--- a/src/Evolution/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/Actions/ComputeTimeDerivative.hpp
@@ -48,7 +48,7 @@ namespace Actions {
  *
  * DataBox changes:
  * - Modifies:
- *   - `db::add_tag_prefix<step_prefix, variables_tag>`
+ *   - `TimeDerivativeComputer::return_tags<step_prefix>`
  */
 template <typename TimeDerivativeComputer>
 struct ComputeTimeDerivative {
@@ -62,16 +62,14 @@ struct ComputeTimeDerivative {
       const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {  // NOLINT const
-    using system = typename Metavariables::system;
     // Notes:
     // - dt_variables is not zeroed and the operator cannot assume this.
     // - We retrieve the `step_prefix` from the `Metavariables` (as opposed to
     // hard-coding `Tags::dt`) to retain consistency with other actions that do
     // the same (for instance `dg::Actions::ApplyFluxes` that is not specific to
     // evolution systems)
-    db::mutate_apply<db::split_tag<db::add_tag_prefix<
-                         Metavariables::temporal_id::template step_prefix,
-                         typename system::variables_tag>>,
+    db::mutate_apply<typename TimeDerivativeComputer::template return_tags<
+                         Metavariables::temporal_id::template step_prefix>,
                      typename TimeDerivativeComputer::argument_tags>(
         TimeDerivativeComputer{}, make_not_null(&box));
     return std::forward_as_tuple(std::move(box));

--- a/src/Evolution/Conservative/ConservativeDuDt.hpp
+++ b/src/Evolution/Conservative/ConservativeDuDt.hpp
@@ -59,6 +59,10 @@ struct ConservativeDuDt {
   static constexpr size_t volume_dim = System::volume_dim;
   using frame = Frame::Inertial;
 
+  template <template <class> class StepPrefix>
+  using return_tags = db::split_tag<
+      db::add_tag_prefix<StepPrefix, typename System::variables_tag>>;
+
   using argument_tags = tmpl::append<
       db::split_tag<db::add_tag_prefix<
           Tags::div,

--- a/src/Evolution/Conservative/ConservativeDuDt.hpp
+++ b/src/Evolution/Conservative/ConservativeDuDt.hpp
@@ -17,6 +17,8 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace evolution {
+namespace dg {
 /// \ingroup ConservativeGroup
 /// \brief Calculate \f$\partial u/\partial t\f$ for a conservative system.
 ///
@@ -39,9 +41,9 @@ struct ConservativeDuDt {
       domain::Tags::Mesh<volume_dim>,
       domain::Tags::InverseJacobian<volume_dim, Frame::Logical,
                                     Frame::Inertial>,
-      db::add_tag_prefix<Tags::Flux, typename System::variables_tag,
+      db::add_tag_prefix<::Tags::Flux, typename System::variables_tag,
                          tmpl::size_t<volume_dim>, frame>,
-      db::add_tag_prefix<Tags::Source, typename System::variables_tag>>;
+      db::add_tag_prefix<::Tags::Source, typename System::variables_tag>>;
 
   template <template <class> class StepPrefix, typename... VarsTags, size_t Dim>
   static void apply(
@@ -50,12 +52,12 @@ struct ConservativeDuDt {
       const Mesh<Dim> mesh,
       const InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
           inverse_jacobian,
-      const Variables<tmpl::list<
-          Tags::Flux<VarsTags, tmpl::size_t<Dim>, Frame::Inertial>...>>& fluxes,
-      const Variables<tmpl::list<Tags::Source<VarsTags>...>>&
+      const Variables<tmpl::list<::Tags::Flux<VarsTags, tmpl::size_t<Dim>,
+                                              Frame::Inertial>...>>& fluxes,
+      const Variables<tmpl::list<::Tags::Source<VarsTags>...>>&
           sources) noexcept {
-    const Variables<tmpl::list<
-        Tags::div<Tags::Flux<VarsTags, tmpl::size_t<Dim>, Frame::Inertial>>...>>
+    const Variables<tmpl::list<::Tags::div<
+        ::Tags::Flux<VarsTags, tmpl::size_t<Dim>, Frame::Inertial>>...>>
         div_fluxes = divergence(fluxes, mesh, inverse_jacobian);
 
     ASSERT(dt_vars->size() == div_fluxes.size(),
@@ -68,7 +70,7 @@ struct ConservativeDuDt {
     tmpl::for_each<typename System::sourced_variables>(
         [&dt_vars, &sources](auto tag_v) noexcept {
           using tag = typename decltype(tag_v)::type;
-          const auto& source = get<Tags::Source<tag>>(sources);
+          const auto& source = get<::Tags::Source<tag>>(sources);
           auto& dt_var = get<StepPrefix<tag>>(*dt_vars);
           ASSERT(source.size() == dt_var.size(),
                  "The source and the time derivative variable must have the "
@@ -80,3 +82,5 @@ struct ConservativeDuDt {
         });
   }
 };
+}  // namespace dg
+}  // namespace evolution

--- a/src/Evolution/Conservative/ConservativeDuDt.hpp
+++ b/src/Evolution/Conservative/ConservativeDuDt.hpp
@@ -9,6 +9,10 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -24,54 +28,55 @@
 /// `System::sourced_variables` type list.
 template <typename System>
 struct ConservativeDuDt {
- private:
-  template <typename TensorTagList, typename SourcedTagList>
-  struct apply_helper;
-
-  template <typename... TensorTags, typename... SourcedTags>
-  struct apply_helper<tmpl::list<TensorTags...>, tmpl::list<SourcedTags...>> {
-    static void function(
-        const gsl::not_null<db::item_type<TensorTags>*>... dt_u,
-        const db::const_item_type<TensorTags>&... div_flux,
-        const db::const_item_type<SourcedTags>&... sources) noexcept {
-      const auto negate = [](const auto a, const auto& b) noexcept {
-        for (size_t i = 0; i < a->size(); ++i) {
-          (*a)[i] = -b[i];
-        }
-        return nullptr;
-      };
-      expand_pack(negate(dt_u, div_flux)...);
-      const auto add = [](const auto a, const auto& b) noexcept {
-        for (size_t i = 0; i < a->size(); ++i) {
-          (*a)[i] += b[i];
-        }
-        return nullptr;
-      };
-      (void)add;
-      expand_pack(add(
-          get<tmpl::index_of<tmpl::list<TensorTags...>, SourcedTags>::value>(
-              std::forward_as_tuple(dt_u...)),
-          sources)...);
-    }
-  };
-
- public:
   static constexpr size_t volume_dim = System::volume_dim;
   using frame = Frame::Inertial;
 
   template <template <class> class StepPrefix>
-  using return_tags = db::split_tag<
+  using return_tags = tmpl::list<
       db::add_tag_prefix<StepPrefix, typename System::variables_tag>>;
 
-  using argument_tags = tmpl::append<
-      db::split_tag<db::add_tag_prefix<
-          Tags::div,
-          db::add_tag_prefix<Tags::Flux, typename System::variables_tag,
-                             tmpl::size_t<volume_dim>, frame>>>,
-      tmpl::transform<typename System::sourced_variables,
-                      tmpl::bind<Tags::Source, tmpl::_1>>>;
+  using argument_tags = tmpl::list<
+      domain::Tags::Mesh<volume_dim>,
+      domain::Tags::InverseJacobian<volume_dim, Frame::Logical,
+                                    Frame::Inertial>,
+      db::add_tag_prefix<Tags::Flux, typename System::variables_tag,
+                         tmpl::size_t<volume_dim>, frame>,
+      db::add_tag_prefix<Tags::Source, typename System::variables_tag>>;
 
-  static constexpr auto apply =
-      apply_helper<db::split_tag<typename System::variables_tag>,
-                   typename System::sourced_variables>::function;
+  template <template <class> class StepPrefix, typename... VarsTags, size_t Dim>
+  static void apply(
+      const gsl::not_null<Variables<tmpl::list<StepPrefix<VarsTags>...>>*>
+          dt_vars,
+      const Mesh<Dim> mesh,
+      const InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
+          inverse_jacobian,
+      const Variables<tmpl::list<
+          Tags::Flux<VarsTags, tmpl::size_t<Dim>, Frame::Inertial>...>>& fluxes,
+      const Variables<tmpl::list<Tags::Source<VarsTags>...>>&
+          sources) noexcept {
+    const Variables<tmpl::list<
+        Tags::div<Tags::Flux<VarsTags, tmpl::size_t<Dim>, Frame::Inertial>>...>>
+        div_fluxes = divergence(fluxes, mesh, inverse_jacobian);
+
+    ASSERT(dt_vars->size() == div_fluxes.size(),
+           "The time derivative and the flux divergence have different sizes. "
+           "Time derivative: "
+               << dt_vars->size() << " div fluxes: " << div_fluxes.size() << " "
+               << dt_vars->number_of_grid_points() << " "
+               << div_fluxes.number_of_grid_points());
+    *dt_vars = -div_fluxes;
+    tmpl::for_each<typename System::sourced_variables>(
+        [&dt_vars, &sources](auto tag_v) noexcept {
+          using tag = typename decltype(tag_v)::type;
+          const auto& source = get<Tags::Source<tag>>(sources);
+          auto& dt_var = get<StepPrefix<tag>>(*dt_vars);
+          ASSERT(source.size() == dt_var.size(),
+                 "The source and the time derivative variable must have the "
+                 "same number of independent components. Time derivative: "
+                     << dt_var.size() << " source: " << source.size());
+          for (size_t i = 0; i < source.size(); ++i) {
+            dt_var[i] += source[i];
+          }
+        });
+  }
 };

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -11,6 +11,7 @@
 #include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep
 #include "Evolution/Actions/ComputeVolumeFluxes.hpp"    // IWYU pragma: keep
 #include "Evolution/ComputeTags.hpp"
+#include "Evolution/Conservative/ConservativeDuDt.hpp"
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp"
@@ -48,15 +49,15 @@
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
-#include "Time/Actions/AdvanceTime.hpp"            // IWYU pragma: keep
-#include "Time/Actions/ChangeSlabSize.hpp"         // IWYU pragma: keep
-#include "Time/Actions/ChangeStepSize.hpp"         // IWYU pragma: keep
-#include "Time/Actions/RecordTimeStepperData.hpp"  // IWYU pragma: keep
-#include "Time/Actions/SelfStartActions.hpp"       // IWYU pragma: keep
-#include "Time/Actions/UpdateU.hpp"                // IWYU pragma: keep
-#include "Time/StepChoosers/Cfl.hpp"               // IWYU pragma: keep
-#include "Time/StepChoosers/Constant.hpp"          // IWYU pragma: keep
-#include "Time/StepChoosers/Increase.hpp"          // IWYU pragma: keep
+#include "Time/Actions/AdvanceTime.hpp"                // IWYU pragma: keep
+#include "Time/Actions/ChangeSlabSize.hpp"             // IWYU pragma: keep
+#include "Time/Actions/ChangeStepSize.hpp"             // IWYU pragma: keep
+#include "Time/Actions/RecordTimeStepperData.hpp"      // IWYU pragma: keep
+#include "Time/Actions/SelfStartActions.hpp"           // IWYU pragma: keep
+#include "Time/Actions/UpdateU.hpp"                    // IWYU pragma: keep
+#include "Time/StepChoosers/Cfl.hpp"                   // IWYU pragma: keep
+#include "Time/StepChoosers/Constant.hpp"              // IWYU pragma: keep
+#include "Time/StepChoosers/Increase.hpp"              // IWYU pragma: keep
 #include "Time/StepChoosers/PreventRapidIncrease.hpp"  // IWYU pragma: keep
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepChoosers/StepToTimes.hpp"
@@ -135,7 +136,7 @@ struct EvolutionMetavars {
   using step_actions = tmpl::flatten<tmpl::list<
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
-      Actions::ComputeTimeDerivative,
+      Actions::ComputeTimeDerivative<ConservativeDuDt<Burgers::System>>,
       dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -136,7 +136,8 @@ struct EvolutionMetavars {
   using step_actions = tmpl::flatten<tmpl::list<
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
-      Actions::ComputeTimeDerivative<ConservativeDuDt<Burgers::System>>,
+      Actions::ComputeTimeDerivative<
+          evolution::dg::ConservativeDuDt<Burgers::System>>,
       dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -225,7 +225,8 @@ struct EvolutionMetavars {
       dg::Actions::ComputeNonconservativeBoundaryFluxes<
           domain::Tags::InternalDirections<volume_dim>>,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
-      Actions::ComputeTimeDerivative,
+      Actions::ComputeTimeDerivative<
+          GeneralizedHarmonic::ComputeDuDt<volume_dim>>,
       dg::Actions::ComputeNonconservativeBoundaryFluxes<
           domain::Tags::BoundaryDirectionsInterior<volume_dim>>,
       dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -184,7 +184,7 @@ struct EvolutionMetavars {
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       Actions::ComputeVolumeSources,
-      Actions::ComputeTimeDerivative<ConservativeDuDt<system>>,
+      Actions::ComputeTimeDerivative<evolution::dg::ConservativeDuDt<system>>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -12,6 +12,7 @@
 #include "Evolution/Actions/ComputeVolumeFluxes.hpp"
 #include "Evolution/Actions/ComputeVolumeSources.hpp"
 #include "Evolution/ComputeTags.hpp"
+#include "Evolution/Conservative/ConservativeDuDt.hpp"
 #include "Evolution/Conservative/UpdateConservatives.hpp"
 #include "Evolution/Conservative/UpdatePrimitives.hpp"
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
@@ -182,7 +183,8 @@ struct EvolutionMetavars {
   using step_actions = tmpl::flatten<tmpl::list<
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
-      Actions::ComputeVolumeSources, Actions::ComputeTimeDerivative,
+      Actions::ComputeVolumeSources,
+      Actions::ComputeTimeDerivative<ConservativeDuDt<system>>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -13,6 +13,7 @@
 #include "Evolution/Actions/ComputeVolumeFluxes.hpp"
 #include "Evolution/Actions/ComputeVolumeSources.hpp"
 #include "Evolution/ComputeTags.hpp"
+#include "Evolution/Conservative/ConservativeDuDt.hpp"
 #include "Evolution/Conservative/UpdateConservatives.hpp"
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp"
@@ -176,7 +177,7 @@ struct EvolutionMetavars {
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<has_source_terms, Actions::ComputeVolumeSources,
                           tmpl::list<>>,
-      Actions::ComputeTimeDerivative,
+      Actions::ComputeTimeDerivative<ConservativeDuDt<system>>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -177,7 +177,7 @@ struct EvolutionMetavars {
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<has_source_terms, Actions::ComputeVolumeSources,
                           tmpl::list<>>,
-      Actions::ComputeTimeDerivative<ConservativeDuDt<system>>,
+      Actions::ComputeTimeDerivative<evolution::dg::ConservativeDuDt<system>>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
@@ -12,6 +12,7 @@
 #include "Evolution/Actions/ComputeVolumeFluxes.hpp"
 #include "Evolution/Actions/ComputeVolumeSources.hpp"
 #include "Evolution/ComputeTags.hpp"
+#include "Evolution/Conservative/ConservativeDuDt.hpp"
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp"
@@ -158,7 +159,8 @@ struct EvolutionMetavars {
   using step_actions = tmpl::flatten<tmpl::list<
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
-      Actions::ComputeVolumeSources, Actions::ComputeTimeDerivative,
+      Actions::ComputeVolumeSources,
+      Actions::ComputeTimeDerivative<ConservativeDuDt<system>>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
@@ -160,7 +160,7 @@ struct EvolutionMetavars {
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       Actions::ComputeVolumeSources,
-      Actions::ComputeTimeDerivative<ConservativeDuDt<system>>,
+      Actions::ComputeTimeDerivative<evolution::dg::ConservativeDuDt<system>>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -173,7 +173,7 @@ struct EvolutionMetavars {
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       Actions::ComputeVolumeSources,
-      Actions::ComputeTimeDerivative<ConservativeDuDt<system>>,
+      Actions::ComputeTimeDerivative<evolution::dg::ConservativeDuDt<system>>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -13,6 +13,7 @@
 #include "Evolution/Actions/ComputeVolumeFluxes.hpp"
 #include "Evolution/Actions/ComputeVolumeSources.hpp"
 #include "Evolution/ComputeTags.hpp"
+#include "Evolution/Conservative/ConservativeDuDt.hpp"
 #include "Evolution/Conservative/UpdateConservatives.hpp"
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp"
@@ -171,7 +172,8 @@ struct EvolutionMetavars {
   using step_actions = tmpl::flatten<tmpl::list<
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
-      Actions::ComputeVolumeSources, Actions::ComputeTimeDerivative,
+      Actions::ComputeVolumeSources,
+      Actions::ComputeTimeDerivative<ConservativeDuDt<system>>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -149,7 +149,7 @@ struct EvolutionMetavars {
       dg::Actions::ComputeNonconservativeBoundaryFluxes<
           domain::Tags::InternalDirections<Dim>>,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
-      Actions::ComputeTimeDerivative,
+      Actions::ComputeTimeDerivative<ScalarWave::ComputeDuDt<Dim>>,
       dg::Actions::ComputeNonconservativeBoundaryFluxes<
           domain::Tags::BoundaryDirectionsInterior<Dim>>,
       dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -201,10 +201,7 @@ struct TimeStepperHistory {
 
   template <typename System>
   struct ComputeTags<System, true> {
-    using type = db::AddComputeTags<::Tags::DivVariablesCompute<
-        db::add_tag_prefix<::Tags::Flux, variables_tag, tmpl::size_t<dim>,
-                           Frame::Inertial>,
-        domain::Tags::InverseJacobian<dim, Frame::Logical, Frame::Inertial>>>;
+    using type = db::AddComputeTags<>;
   };
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,

--- a/src/Evolution/Systems/Burgers/System.hpp
+++ b/src/Evolution/Systems/Burgers/System.hpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Evolution/Conservative/ConservativeDuDt.hpp"
 #include "Evolution/Systems/Burgers/Characteristics.hpp"
 #include "Evolution/Systems/Burgers/Fluxes.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"  // IWYU pragma: keep
@@ -28,7 +27,6 @@ struct System {
   using variables_tag = ::Tags::Variables<tmpl::list<Tags::U>>;
   using sourced_variables = tmpl::list<>;
 
-  using compute_time_derivative = ConservativeDuDt<System>;
   using volume_fluxes = Fluxes;
   using compute_largest_characteristic_speed =
       ComputeLargestCharacteristicSpeed;

--- a/src/Evolution/Systems/CurvedScalarWave/System.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/System.hpp
@@ -28,7 +28,5 @@ struct System {
 
   using variables_tag = ::Tags::Variables<tmpl::list<Pi, Phi<Dim>, Psi>>;
   using gradients_tags = tmpl::list<Pi, Phi<Dim>, Psi>;
-
-  using compute_time_derivative = ComputeDuDt<Dim>;
 };
 }  // namespace CurvedScalarWave

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -55,6 +55,13 @@ namespace GeneralizedHarmonic {
 template <size_t Dim>
 struct ComputeDuDt {
  public:
+  template <template <class> class StepPrefix>
+  using return_tags = tmpl::list<
+      db::add_tag_prefix<StepPrefix, gr::Tags::SpacetimeMetric<
+                                         Dim, Frame::Inertial, DataVector>>,
+      db::add_tag_prefix<StepPrefix, Tags::Pi<Dim>>,
+      db::add_tag_prefix<StepPrefix, Tags::Phi<Dim>>>;
+
   using argument_tags = tmpl::list<
       gr::Tags::SpacetimeMetric<Dim>, Tags::Pi<Dim>, Tags::Phi<Dim>,
       ::Tags::deriv<gr::Tags::SpacetimeMetric<Dim>, tmpl::size_t<Dim>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
@@ -37,7 +37,6 @@ struct System {
                  Tags::Pi<Dim, Frame::Inertial>,
                  Tags::Phi<Dim, Frame::Inertial>>;
 
-  using compute_time_derivative = ComputeDuDt<Dim>;
   using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;
   using char_speeds_tag = CharacteristicSpeedsCompute<Dim, Frame::Inertial>;
   using compute_largest_characteristic_speed =

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Evolution/Conservative/ConservativeDuDt.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
@@ -74,8 +73,6 @@ struct System {
   using volume_fluxes = ComputeFluxes;
 
   using volume_sources = ComputeSources;
-
-  using compute_time_derivative = ConservativeDuDt<System>;
 
   // skip TildeD as its source is zero.
   using sourced_variables = tmpl::list<Tags::TildeTau, Tags::TildeS<>,

--- a/src/Evolution/Systems/NewtonianEuler/System.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/System.hpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Evolution/Conservative/ConservativeDuDt.hpp"
 #include "Evolution/Systems/NewtonianEuler/Characteristics.hpp"
 #include "Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp"
 #include "Evolution/Systems/NewtonianEuler/Fluxes.hpp"
@@ -59,8 +58,6 @@ struct System {
   using volume_fluxes = ComputeFluxes<Dim>;
 
   using volume_sources = ComputeSources<InitialDataType>;
-
-  using compute_time_derivative = ConservativeDuDt<System>;
 
   using sourced_variables =
       typename InitialDataType::source_term_type::sourced_variables;

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/System.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/System.hpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Evolution/Conservative/ConservativeDuDt.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/Characteristics.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/Fluxes.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/Sources.hpp"
@@ -83,8 +82,6 @@ struct System<tmpl::list<NeutrinoSpecies...>> {
   using volume_fluxes = ComputeFluxes<NeutrinoSpecies...>;
 
   using volume_sources = ComputeSources<NeutrinoSpecies...>;
-
-  using compute_time_derivative = ConservativeDuDt<System>;
 
   using sourced_variables =
       tmpl::list<Tags::TildeE<Frame::Inertial, NeutrinoSpecies>...,

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/System.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/System.hpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Evolution/Conservative/ConservativeDuDt.hpp"
 #include "Evolution/Systems/RelativisticEuler/Valencia/Characteristics.hpp"
 #include "Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp"
 #include "Evolution/Systems/RelativisticEuler/Valencia/Fluxes.hpp"
@@ -65,8 +64,6 @@ struct System {
   using volume_fluxes = ComputeFluxes<Dim>;
 
   using volume_sources = ComputeSources<Dim>;
-
-  using compute_time_derivative = ConservativeDuDt<System>;
 
   // source for TildeD is zero.
   using sourced_variables = tmpl::list<Tags::TildeTau, Tags::TildeS<Dim>>;

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -63,6 +63,11 @@ namespace ScalarWave {
  */
 template <size_t Dim>
 struct ComputeDuDt {
+  template <template <class> class StepPrefix>
+  using return_tags = tmpl::list<db::add_tag_prefix<StepPrefix, Pi>,
+                                 db::add_tag_prefix<StepPrefix, Phi<Dim>>,
+                                 db::add_tag_prefix<StepPrefix, Psi>>;
+
   using argument_tags =
       tmpl::list<Pi, ::Tags::deriv<Pi, tmpl::size_t<Dim>, Frame::Inertial>,
                  ::Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -47,7 +47,6 @@ struct System {
   // Typelist of which subset of the variables to take the gradient of.
   using gradients_tags = tmpl::list<Pi, Phi<Dim>>;
 
-  using compute_time_derivative = ComputeDuDt<Dim>;
   using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;
   using compute_largest_characteristic_speed =
       ComputeLargestCharacteristicSpeed;

--- a/tests/Unit/Evolution/Actions/Test_ComputeTimeDerivative.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeTimeDerivative.cpp
@@ -32,6 +32,8 @@ struct var_tag : db::SimpleTag {
 };
 
 struct ComputeDuDt {
+  template <template <class> class StepPrefix>
+  using return_tags = db::split_tag<db::add_tag_prefix<StepPrefix, var_tag>>;
   using argument_tags = tmpl::list<var_tag>;
   static void apply(const gsl::not_null<int*> dt_var, const int& var) {
     *dt_var = var * 2;

--- a/tests/Unit/Evolution/Actions/Test_ComputeTimeDerivative.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeTimeDerivative.cpp
@@ -40,7 +40,6 @@ struct ComputeDuDt {
 
 struct System {
   using variables_tag = var_tag;
-  using compute_time_derivative = ComputeDuDt;
 };
 
 using ElementIndexType = ElementIndex<2>;
@@ -56,9 +55,9 @@ struct component {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing,
-                             tmpl::list<Actions::ComputeTimeDerivative>>>;
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<Actions::ComputeTimeDerivative<ComputeDuDt>>>>;
 };
 
 struct Metavariables {

--- a/tests/Unit/Evolution/Conservative/Test_ConservativeDuDt.cpp
+++ b/tests/Unit/Evolution/Conservative/Test_ConservativeDuDt.cpp
@@ -12,8 +12,18 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
 #include "Evolution/Conservative/ConservativeDuDt.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.tpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "PointwiseFunctions/MathFunctions/PowX.hpp"
+#include "PointwiseFunctions/MathFunctions/TensorProduct.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
@@ -22,86 +32,274 @@
 // IWYU pragma: no_forward_declare Tags::div
 
 namespace {
-using frame = Frame::Inertial;
-constexpr size_t volume_dim = 2;
-
 struct Var1 : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
+template <size_t Dim>
 struct Var2 : db::SimpleTag {
-  using type = tnsr::i<DataVector, volume_dim, frame>;
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
 };
 
-template <typename SourcedVariables>
+template <typename Tag>
+struct Functions;
+
+template <size_t Dim>
+struct Functions<Tags::Flux<Var1, tmpl::size_t<Dim>, Frame::Inertial>> {
+  static auto flux(
+      const MathFunctions::TensorProduct<Dim>& f,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x) noexcept {
+    auto result =
+        make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(x, 0.);
+    const auto f_of_x = f(x);
+    for (size_t d = 0; d < Dim; ++d) {
+      result.get(d) = (d + 0.5) * get(f_of_x);
+    }
+    return result;
+  }
+  static auto divergence_of_flux(
+      const MathFunctions::TensorProduct<Dim>& f,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x) noexcept {
+    auto result = make_with_value<Scalar<DataVector>>(x, 0.);
+    const auto df = f.first_derivatives(x);
+    for (size_t d = 0; d < Dim; ++d) {
+      get(result) += (d + 0.5) * df.get(d);
+    }
+    return result;
+  }
+};
+
+template <size_t Dim>
+struct Functions<Tags::Flux<Var2<Dim>, tmpl::size_t<Dim>, Frame::Inertial>> {
+  static auto flux(
+      const MathFunctions::TensorProduct<Dim>& f,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x) noexcept {
+    auto result =
+        make_with_value<tnsr::Ij<DataVector, Dim, Frame::Inertial>>(x, 0.);
+    const auto f_of_x = f(x);
+    for (size_t d = 0; d < Dim; ++d) {
+      for (size_t j = 0; j < Dim; ++j) {
+        result.get(d, j) = (d + 0.5) * (j + 0.25) * get(f_of_x);
+      }
+    }
+    return result;
+  }
+  static auto divergence_of_flux(
+      const MathFunctions::TensorProduct<Dim>& f,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x) noexcept {
+    auto result =
+        make_with_value<tnsr::i<DataVector, Dim, Frame::Inertial>>(x, 0.);
+    const auto df = f.first_derivatives(x);
+    for (size_t j = 0; j < Dim; ++j) {
+      for (size_t d = 0; d < Dim; ++d) {
+        result.get(j) += (d + 0.5) * (j + 0.25) * df.get(d);
+      }
+    }
+    return result;
+  }
+};
+
+template <typename SourcedVariables, size_t Dim>
 struct System {
-  using variables_tag = Tags::Variables<tmpl::list<Var1, Var2>>;
+  using variables_tag = Tags::Variables<tmpl::list<Var1, Var2<Dim>>>;
   using sourced_variables = SourcedVariables;
-  static constexpr size_t volume_dim = ::volume_dim;
+  static constexpr size_t volume_dim = Dim;
 };
 
-template <typename Var>
-using divergence_flux =
-    Tags::div<Tags::Flux<Var, tmpl::size_t<volume_dim>, frame>>;
-
-using divergence_tags =
-    tmpl::list<divergence_flux<Var1>, divergence_flux<Var2>>;
+template <typename SourcedVariables, size_t Dim>
+using expected_argument_tags = tmpl::list<
+    domain::Tags::Mesh<Dim>,
+    domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>,
+    db::add_tag_prefix<Tags::Flux,
+                       typename System<SourcedVariables, Dim>::variables_tag,
+                       tmpl::size_t<Dim>, Frame::Inertial>,
+    db::add_tag_prefix<Tags::Source,
+                       typename System<SourcedVariables, Dim>::variables_tag>>;
 
 static_assert(
-    cpp17::is_same_v<ConservativeDuDt<System<tmpl::list<>>>::argument_tags,
-                     divergence_tags>,
+    cpp17::is_same_v<ConservativeDuDt<System<tmpl::list<>, 1>>::argument_tags,
+                     expected_argument_tags<tmpl::list<>, 1>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
-    cpp17::is_same_v<ConservativeDuDt<System<tmpl::list<Var1>>>::argument_tags,
-                     tmpl::push_back<divergence_tags, Tags::Source<Var1>>>,
+    cpp17::is_same_v<ConservativeDuDt<System<tmpl::list<>, 2>>::argument_tags,
+                     expected_argument_tags<tmpl::list<>, 2>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
-    cpp17::is_same_v<ConservativeDuDt<System<tmpl::list<Var2>>>::argument_tags,
-                     tmpl::push_back<divergence_tags, Tags::Source<Var2>>>,
+    cpp17::is_same_v<ConservativeDuDt<System<tmpl::list<>, 3>>::argument_tags,
+                     expected_argument_tags<tmpl::list<>, 3>>,
+    "Failed testing ConservativeDuDt::argument_tags");
+static_assert(cpp17::is_same_v<
+                  ConservativeDuDt<System<tmpl::list<Var1>, 1>>::argument_tags,
+                  expected_argument_tags<tmpl::list<Var1>, 1>>,
+              "Failed testing ConservativeDuDt::argument_tags");
+static_assert(cpp17::is_same_v<
+                  ConservativeDuDt<System<tmpl::list<Var1>, 2>>::argument_tags,
+                  expected_argument_tags<tmpl::list<Var1>, 2>>,
+              "Failed testing ConservativeDuDt::argument_tags");
+static_assert(cpp17::is_same_v<
+                  ConservativeDuDt<System<tmpl::list<Var1>, 3>>::argument_tags,
+                  expected_argument_tags<tmpl::list<Var1>, 3>>,
+              "Failed testing ConservativeDuDt::argument_tags");
+static_assert(
+    cpp17::is_same_v<
+        ConservativeDuDt<System<tmpl::list<Var2<1>>, 1>>::argument_tags,
+        expected_argument_tags<tmpl::list<Var2<1>>, 1>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
     cpp17::is_same_v<
-        ConservativeDuDt<System<tmpl::list<Var1, Var2>>>::argument_tags,
-        tmpl::push_back<divergence_tags, Tags::Source<Var1>,
-                        Tags::Source<Var2>>>,
+        ConservativeDuDt<System<tmpl::list<Var2<2>>, 2>>::argument_tags,
+        expected_argument_tags<tmpl::list<Var2<2>>, 2>>,
     "Failed testing ConservativeDuDt::argument_tags");
+static_assert(
+    cpp17::is_same_v<
+        ConservativeDuDt<System<tmpl::list<Var2<3>>, 3>>::argument_tags,
+        expected_argument_tags<tmpl::list<Var2<3>>, 3>>,
+    "Failed testing ConservativeDuDt::argument_tags");
+static_assert(
+    cpp17::is_same_v<
+        ConservativeDuDt<System<tmpl::list<Var1, Var2<1>>, 1>>::argument_tags,
+        expected_argument_tags<tmpl::list<Var1, Var2<1>>, 1>>,
+    "Failed testing ConservativeDuDt::argument_tags");
+static_assert(
+    cpp17::is_same_v<
+        ConservativeDuDt<System<tmpl::list<Var1, Var2<2>>, 2>>::argument_tags,
+        expected_argument_tags<tmpl::list<Var1, Var2<2>>, 2>>,
+    "Failed testing ConservativeDuDt::argument_tags");
+static_assert(
+    cpp17::is_same_v<
+        ConservativeDuDt<System<tmpl::list<Var1, Var2<3>>, 3>>::argument_tags,
+        expected_argument_tags<tmpl::list<Var1, Var2<3>>, 3>>,
+    "Failed testing ConservativeDuDt::argument_tags");
+
+using Affine = domain::CoordinateMaps::Affine;
+using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+
+template <size_t VolumeDim>
+auto make_affine_map() noexcept;
+
+template <>
+auto make_affine_map<1>() noexcept {
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine{-1.0, 1.0, -0.3, 0.7});
+}
+
+template <>
+auto make_affine_map<2>() noexcept {
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine2D{Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55}});
+}
+
+template <>
+auto make_affine_map<3>() noexcept {
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine3D{Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55},
+               Affine{-1.0, 1.0, 2.3, 2.8}});
+}
+
+template <size_t Dim>
+void test(
+    const Mesh<Dim>& mesh,
+    std::array<std::unique_ptr<MathFunction<1>>, Dim> functions) noexcept {
+  using flux_tags = tmpl::list<
+      db::add_tag_prefix<Tags::Flux, Var1, tmpl::size_t<Dim>, Frame::Inertial>,
+      db::add_tag_prefix<Tags::Flux, Var2<Dim>, tmpl::size_t<Dim>,
+                         Frame::Inertial>>;
+  using Flux1 = tmpl::at_c<flux_tags, 0>;
+  using Flux2 = tmpl::at_c<flux_tags, 1>;
+
+  const auto coord_map = make_affine_map<Dim>();
+  const auto logical_coords = logical_coordinates(mesh);
+  const auto inertial_coords = coord_map(logical_coords);
+  const auto inverse_jacobian = coord_map.inv_jacobian(logical_coords);
+
+  Variables<tmpl::list<Tags::dt<Var1>, Tags::dt<Var2<Dim>>>> dt_vars(
+      mesh.number_of_grid_points());
+  Variables<flux_tags> fluxes(mesh.number_of_grid_points());
+  Variables<tmpl::list<Tags::Source<Var1>, Tags::Source<Var2<Dim>>>> sources(
+      mesh.number_of_grid_points());
+  Variables<db::wrap_tags_in<Tags::div, flux_tags>> expected_div_fluxes(
+      mesh.number_of_grid_points());
+
+  MathFunctions::TensorProduct<Dim> f(1.0, std::move(functions));
+
+  tmpl::for_each<flux_tags>(
+      [&inertial_coords, &f, &fluxes, &expected_div_fluxes](auto tag) noexcept {
+        using FluxTag = tmpl::type_from<decltype(tag)>;
+        get<FluxTag>(fluxes) = Functions<FluxTag>::flux(f, inertial_coords);
+        using DivFluxTag = Tags::div<FluxTag>;
+        get<DivFluxTag>(expected_div_fluxes) =
+            Functions<FluxTag>::divergence_of_flux(f, inertial_coords);
+      });
+
+  ConservativeDuDt<System<tmpl::list<>, Dim>>::apply(
+      make_not_null(&dt_vars), mesh, inverse_jacobian, fluxes, sources);
+  CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
+        -get(get<Tags::div<Flux1>>(expected_div_fluxes)));
+  for (size_t i = 0; i < Dim; ++i) {
+    CHECK(get<Tags::dt<Var2<Dim>>>(dt_vars).get(i) ==
+          -get<Tags::div<Flux2>>(expected_div_fluxes).get(i));
+  }
+
+  // Test with Tags::Source<Var1>
+  get(get<Tags::Source<Var1>>(sources)) = 0.9 * get<0>(inertial_coords);
+
+  ConservativeDuDt<System<tmpl::list<Var1>, Dim>>::apply(
+      make_not_null(&dt_vars), mesh, inverse_jacobian, fluxes, sources);
+  CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
+        -get(get<Tags::div<Flux1>>(expected_div_fluxes)) +
+            get(get<Tags::Source<Var1>>(sources)));
+  for (size_t i = 0; i < Dim; ++i) {
+    CHECK(get<Tags::dt<Var2<Dim>>>(dt_vars).get(i) ==
+          -get<Tags::div<Flux2>>(expected_div_fluxes).get(i));
+  }
+
+  // Test with Tags::Source<Var2>
+  for (size_t i = 0; i < Dim; ++i) {
+    get<Tags::Source<Var2<Dim>>>(sources).get(i) =
+        0.9 * (i + 1.0) * inertial_coords.get(i);
+  }
+
+  ConservativeDuDt<System<tmpl::list<Var2<Dim>>, Dim>>::apply(
+      make_not_null(&dt_vars), mesh, inverse_jacobian, fluxes, sources);
+  CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
+        -get(get<Tags::div<Flux1>>(expected_div_fluxes)));
+  for (size_t i = 0; i < Dim; ++i) {
+    CHECK(get<Tags::dt<Var2<Dim>>>(dt_vars).get(i) ==
+          -get<Tags::div<Flux2>>(expected_div_fluxes).get(i) +
+              get<Tags::Source<Var2<Dim>>>(sources).get(i));
+  }
+
+  // Test with both sources
+  ConservativeDuDt<System<tmpl::list<Var1, Var2<Dim>>, Dim>>::apply(
+      make_not_null(&dt_vars), mesh, inverse_jacobian, fluxes, sources);
+  CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
+        -get(get<Tags::div<Flux1>>(expected_div_fluxes)) +
+            get(get<Tags::Source<Var1>>(sources)));
+  for (size_t i = 0; i < Dim; ++i) {
+    CHECK(get<Tags::dt<Var2<Dim>>>(dt_vars).get(i) ==
+          -get<Tags::div<Flux2>>(expected_div_fluxes).get(i) +
+              get<Tags::Source<Var2<Dim>>>(sources).get(i));
+  }
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.ConservativeDuDt", "[Unit][Evolution]") {
   constexpr size_t num_points = 5;
 
-  const Scalar<DataVector> divflux_var1{{{{1., 2., 3., 4., 5.}}}};
-  const tnsr::i<DataVector, volume_dim, frame> divflux_var2{
-      {{{11., 12., 13., 14., 15.}, {21., 22., 23., 24., 25.}}}};
+  const Mesh<1> mesh_1d{num_points, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  test(mesh_1d, {{std::make_unique<MathFunctions::PowX>(num_points - 1)}});
 
-  const Scalar<DataVector> source_var1{{{{5., 4., 3., 2., 1.}}}};
-  const tnsr::i<DataVector, volume_dim, frame> source_var2{
-      {{{15., 14., 13., 12., 11.}, {25., 24., 23., 22., 21.}}}};
+  const Mesh<2> mesh_2d{num_points, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  test(mesh_2d, {{std::make_unique<MathFunctions::PowX>(num_points - 1),
+                  std::make_unique<MathFunctions::PowX>(num_points - 1)}});
 
-  Scalar<DataVector> dt_var1(num_points);
-  tnsr::i<DataVector, volume_dim, frame> dt_var2(num_points);
-
-  ConservativeDuDt<System<tmpl::list<>>>::apply(
-      &dt_var1, &dt_var2, divflux_var1, divflux_var2);
-  CHECK(get(dt_var1) == -get(divflux_var1));
-  CHECK(get<0>(dt_var2) == -get<0>(divflux_var2));
-  CHECK(get<1>(dt_var2) == -get<1>(divflux_var2));
-
-  ConservativeDuDt<System<tmpl::list<Var1>>>::apply(
-      &dt_var1, &dt_var2, divflux_var1, divflux_var2, source_var1);
-  CHECK(get(dt_var1) == get(source_var1) - get(divflux_var1));
-  CHECK(get<0>(dt_var2) == -get<0>(divflux_var2));
-  CHECK(get<1>(dt_var2) == -get<1>(divflux_var2));
-
-  ConservativeDuDt<System<tmpl::list<Var2>>>::apply(
-      &dt_var1, &dt_var2, divflux_var1, divflux_var2, source_var2);
-  CHECK(get(dt_var1) == -get(divflux_var1));
-  CHECK(get<0>(dt_var2) == get<0>(source_var2) - get<0>(divflux_var2));
-  CHECK(get<1>(dt_var2) == get<1>(source_var2) - get<1>(divflux_var2));
-
-  ConservativeDuDt<System<tmpl::list<Var1, Var2>>>::apply(
-      &dt_var1, &dt_var2, divflux_var1, divflux_var2, source_var1, source_var2);
-  CHECK(get(dt_var1) == get(source_var1) - get(divflux_var1));
-  CHECK(get<0>(dt_var2) == get<0>(source_var2) - get<0>(divflux_var2));
-  CHECK(get<1>(dt_var2) == get<1>(source_var2) - get<1>(divflux_var2));
+  const Mesh<3> mesh_3d{num_points, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  test(mesh_3d, {{std::make_unique<MathFunctions::PowX>(num_points - 1),
+                  std::make_unique<MathFunctions::PowX>(num_points - 1),
+                  std::make_unique<MathFunctions::PowX>(num_points - 1)}});
 }

--- a/tests/Unit/Evolution/Conservative/Test_ConservativeDuDt.cpp
+++ b/tests/Unit/Evolution/Conservative/Test_ConservativeDuDt.cpp
@@ -117,58 +117,61 @@ using expected_argument_tags = tmpl::list<
                        typename System<SourcedVariables, Dim>::variables_tag>>;
 
 static_assert(
-    cpp17::is_same_v<ConservativeDuDt<System<tmpl::list<>, 1>>::argument_tags,
-                     expected_argument_tags<tmpl::list<>, 1>>,
+    cpp17::is_same_v<
+        evolution::dg::ConservativeDuDt<System<tmpl::list<>, 1>>::argument_tags,
+        expected_argument_tags<tmpl::list<>, 1>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
-    cpp17::is_same_v<ConservativeDuDt<System<tmpl::list<>, 2>>::argument_tags,
-                     expected_argument_tags<tmpl::list<>, 2>>,
+    cpp17::is_same_v<
+        evolution::dg::ConservativeDuDt<System<tmpl::list<>, 2>>::argument_tags,
+        expected_argument_tags<tmpl::list<>, 2>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
-    cpp17::is_same_v<ConservativeDuDt<System<tmpl::list<>, 3>>::argument_tags,
-                     expected_argument_tags<tmpl::list<>, 3>>,
+    cpp17::is_same_v<
+        evolution::dg::ConservativeDuDt<System<tmpl::list<>, 3>>::argument_tags,
+        expected_argument_tags<tmpl::list<>, 3>>,
     "Failed testing ConservativeDuDt::argument_tags");
-static_assert(cpp17::is_same_v<
-                  ConservativeDuDt<System<tmpl::list<Var1>, 1>>::argument_tags,
-                  expected_argument_tags<tmpl::list<Var1>, 1>>,
+static_assert(cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                                   System<tmpl::list<Var1>, 1>>::argument_tags,
+                               expected_argument_tags<tmpl::list<Var1>, 1>>,
               "Failed testing ConservativeDuDt::argument_tags");
-static_assert(cpp17::is_same_v<
-                  ConservativeDuDt<System<tmpl::list<Var1>, 2>>::argument_tags,
-                  expected_argument_tags<tmpl::list<Var1>, 2>>,
+static_assert(cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                                   System<tmpl::list<Var1>, 2>>::argument_tags,
+                               expected_argument_tags<tmpl::list<Var1>, 2>>,
               "Failed testing ConservativeDuDt::argument_tags");
-static_assert(cpp17::is_same_v<
-                  ConservativeDuDt<System<tmpl::list<Var1>, 3>>::argument_tags,
-                  expected_argument_tags<tmpl::list<Var1>, 3>>,
+static_assert(cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                                   System<tmpl::list<Var1>, 3>>::argument_tags,
+                               expected_argument_tags<tmpl::list<Var1>, 3>>,
               "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
-    cpp17::is_same_v<
-        ConservativeDuDt<System<tmpl::list<Var2<1>>, 1>>::argument_tags,
-        expected_argument_tags<tmpl::list<Var2<1>>, 1>>,
+    cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                         System<tmpl::list<Var2<1>>, 1>>::argument_tags,
+                     expected_argument_tags<tmpl::list<Var2<1>>, 1>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
-    cpp17::is_same_v<
-        ConservativeDuDt<System<tmpl::list<Var2<2>>, 2>>::argument_tags,
-        expected_argument_tags<tmpl::list<Var2<2>>, 2>>,
+    cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                         System<tmpl::list<Var2<2>>, 2>>::argument_tags,
+                     expected_argument_tags<tmpl::list<Var2<2>>, 2>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
-    cpp17::is_same_v<
-        ConservativeDuDt<System<tmpl::list<Var2<3>>, 3>>::argument_tags,
-        expected_argument_tags<tmpl::list<Var2<3>>, 3>>,
+    cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                         System<tmpl::list<Var2<3>>, 3>>::argument_tags,
+                     expected_argument_tags<tmpl::list<Var2<3>>, 3>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
-    cpp17::is_same_v<
-        ConservativeDuDt<System<tmpl::list<Var1, Var2<1>>, 1>>::argument_tags,
-        expected_argument_tags<tmpl::list<Var1, Var2<1>>, 1>>,
+    cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                         System<tmpl::list<Var1, Var2<1>>, 1>>::argument_tags,
+                     expected_argument_tags<tmpl::list<Var1, Var2<1>>, 1>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
-    cpp17::is_same_v<
-        ConservativeDuDt<System<tmpl::list<Var1, Var2<2>>, 2>>::argument_tags,
-        expected_argument_tags<tmpl::list<Var1, Var2<2>>, 2>>,
+    cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                         System<tmpl::list<Var1, Var2<2>>, 2>>::argument_tags,
+                     expected_argument_tags<tmpl::list<Var1, Var2<2>>, 2>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
-    cpp17::is_same_v<
-        ConservativeDuDt<System<tmpl::list<Var1, Var2<3>>, 3>>::argument_tags,
-        expected_argument_tags<tmpl::list<Var1, Var2<3>>, 3>>,
+    cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                         System<tmpl::list<Var1, Var2<3>>, 3>>::argument_tags,
+                     expected_argument_tags<tmpl::list<Var1, Var2<3>>, 3>>,
     "Failed testing ConservativeDuDt::argument_tags");
 
 using Affine = domain::CoordinateMaps::Affine;
@@ -232,7 +235,7 @@ void test(
             Functions<FluxTag>::divergence_of_flux(f, inertial_coords);
       });
 
-  ConservativeDuDt<System<tmpl::list<>, Dim>>::apply(
+  evolution::dg::ConservativeDuDt<System<tmpl::list<>, Dim>>::apply(
       make_not_null(&dt_vars), mesh, inverse_jacobian, fluxes, sources);
   CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
         -get(get<Tags::div<Flux1>>(expected_div_fluxes)));
@@ -244,7 +247,7 @@ void test(
   // Test with Tags::Source<Var1>
   get(get<Tags::Source<Var1>>(sources)) = 0.9 * get<0>(inertial_coords);
 
-  ConservativeDuDt<System<tmpl::list<Var1>, Dim>>::apply(
+  evolution::dg::ConservativeDuDt<System<tmpl::list<Var1>, Dim>>::apply(
       make_not_null(&dt_vars), mesh, inverse_jacobian, fluxes, sources);
   CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
         -get(get<Tags::div<Flux1>>(expected_div_fluxes)) +
@@ -260,7 +263,7 @@ void test(
         0.9 * (i + 1.0) * inertial_coords.get(i);
   }
 
-  ConservativeDuDt<System<tmpl::list<Var2<Dim>>, Dim>>::apply(
+  evolution::dg::ConservativeDuDt<System<tmpl::list<Var2<Dim>>, Dim>>::apply(
       make_not_null(&dt_vars), mesh, inverse_jacobian, fluxes, sources);
   CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
         -get(get<Tags::div<Flux1>>(expected_div_fluxes)));
@@ -271,8 +274,8 @@ void test(
   }
 
   // Test with both sources
-  ConservativeDuDt<System<tmpl::list<Var1, Var2<Dim>>, Dim>>::apply(
-      make_not_null(&dt_vars), mesh, inverse_jacobian, fluxes, sources);
+  evolution::dg::ConservativeDuDt<System<tmpl::list<Var1, Var2<Dim>>, Dim>>::
+      apply(make_not_null(&dt_vars), mesh, inverse_jacobian, fluxes, sources);
   CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
         -get(get<Tags::div<Flux1>>(expected_div_fluxes)) +
             get(get<Tags::Source<Var1>>(sources)));

--- a/tests/Unit/Evolution/Systems/Burgers/Test_Fluxes.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Test_Fluxes.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
+#include "Evolution/Conservative/ConservativeDuDt.hpp"
 #include "Evolution/Systems/Burgers/Fluxes.hpp"
 #include "Evolution/Systems/Burgers/System.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"
@@ -57,7 +58,7 @@ SPECTRE_TEST_CASE("Unit.Burgers.Fluxes", "[Unit][Burgers]") {
   Burgers::Fluxes::apply(&get<flux_tag>(flux), get<Burgers::Tags::U>(vars));
   const auto div_flux = divergence(flux, mesh, identity);
   auto dudt = make_with_value<Scalar<DataVector>>(coords, 0.);
-  Burgers::System::compute_time_derivative::apply(
-      &dudt, get<Tags::div<flux_tag>>(div_flux));
+  ConservativeDuDt<Burgers::System>::apply(&dudt,
+                                           get<Tags::div<flux_tag>>(div_flux));
   CHECK_ITERABLE_APPROX(dudt, dudt_expected);
 }

--- a/tests/Unit/Evolution/Systems/Burgers/Test_Fluxes.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Test_Fluxes.cpp
@@ -40,6 +40,9 @@ SPECTRE_TEST_CASE("Unit.Burgers.Fluxes", "[Unit][Burgers]") {
                                                                        1.);
 
   Variables<tmpl::list<Burgers::Tags::U>> vars(num_points);
+  Variables<tmpl::list<Tags::dt<Burgers::Tags::U>>> dt_vars(num_points);
+  const Variables<tmpl::list<Tags::Source<Burgers::Tags::U>>> sources(
+      num_points);
   // Arbitrary polynomial whose square is exactly representable.
   get(get<Burgers::Tags::U>(vars)) =
       pow<num_points / 2 - 1>(coords) + pow<num_points / 4>(coords) + 5.;
@@ -57,8 +60,8 @@ SPECTRE_TEST_CASE("Unit.Burgers.Fluxes", "[Unit][Burgers]") {
   Variables<tmpl::list<flux_tag>> flux(num_points);
   Burgers::Fluxes::apply(&get<flux_tag>(flux), get<Burgers::Tags::U>(vars));
   const auto div_flux = divergence(flux, mesh, identity);
-  auto dudt = make_with_value<Scalar<DataVector>>(coords, 0.);
-  ConservativeDuDt<Burgers::System>::apply(&dudt,
-                                           get<Tags::div<flux_tag>>(div_flux));
-  CHECK_ITERABLE_APPROX(dudt, dudt_expected);
+  ConservativeDuDt<Burgers::System>::apply(make_not_null(&dt_vars), mesh,
+                                           identity, flux, sources);
+  CHECK_ITERABLE_APPROX(get<Tags::dt<Burgers::Tags::U>>(dt_vars),
+                        dudt_expected);
 }

--- a/tests/Unit/Evolution/Systems/Burgers/Test_Fluxes.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Test_Fluxes.cpp
@@ -60,8 +60,8 @@ SPECTRE_TEST_CASE("Unit.Burgers.Fluxes", "[Unit][Burgers]") {
   Variables<tmpl::list<flux_tag>> flux(num_points);
   Burgers::Fluxes::apply(&get<flux_tag>(flux), get<Burgers::Tags::U>(vars));
   const auto div_flux = divergence(flux, mesh, identity);
-  ConservativeDuDt<Burgers::System>::apply(make_not_null(&dt_vars), mesh,
-                                           identity, flux, sources);
+  evolution::dg::ConservativeDuDt<Burgers::System>::apply(
+      make_not_null(&dt_vars), mesh, identity, flux, sources);
   CHECK_ITERABLE_APPROX(get<Tags::dt<Burgers::Tags::U>>(dt_vars),
                         dudt_expected);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -111,7 +111,7 @@ struct Component {
           tmpl::list<dg::Actions::ComputeNonconservativeBoundaryFluxes<
                          domain::Tags::InternalDirections<1>>,
                      dg::Actions::SendDataForFluxes<Metavariables>,
-                     Actions::ComputeTimeDerivative,
+                     Actions::ComputeTimeDerivative<ScalarWave::ComputeDuDt<1>>,
                      dg::Actions::ReceiveDataForFluxes<Metavariables>,
                      dg::Actions::ApplyFluxes>>>;
 };

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -61,7 +61,7 @@ struct SystemBase {
   static constexpr bool has_primitive_and_conservative_vars = HasPrimitives;
   using variables_tag = Var;
 
-  using compute_time_derivative = struct {
+  using ComputeTimeDerivative = struct {
     using argument_tags =
         tmpl::list<tmpl::conditional_t<has_primitive_and_conservative_vars,
                                        PrimitiveVar, Var>>;
@@ -131,7 +131,8 @@ struct Component {
   static constexpr bool has_primitives = Metavariables::has_primitives;
 
   using step_actions =
-      tmpl::list<Actions::ComputeTimeDerivative,
+      tmpl::list<Actions::ComputeTimeDerivative<
+                     typename metavariables::system::ComputeTimeDerivative>,
                  Actions::RecordTimeStepperData<>,
                  tmpl::conditional_t<
                      has_primitives,

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -62,6 +62,9 @@ struct SystemBase {
   using variables_tag = Var;
 
   using ComputeTimeDerivative = struct {
+    template <template <class> class StepPrefix>
+    using return_tags = tmpl::list<db::add_tag_prefix<StepPrefix, Var>>;
+
     using argument_tags =
         tmpl::list<tmpl::conditional_t<has_primitive_and_conservative_vars,
                                        PrimitiveVar, Var>>;


### PR DESCRIPTION
## Proposed changes

- Template `ComputeTimeDerivative` on computation struct
- Use a `return_tags` type alias in `ComputeTimeDerivative`
- `ConservativeDuDt` takes `Variables` and computes divergence of flux internally
- Move `ConservativeDuDt` to `evolution::dg` namespace

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
