### PR TITLE
Add dg::Formulation enum

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -4,8 +4,9 @@
 set(LIBRARY DiscontinuousGalerkin)
 
 set(LIBRARY_SOURCES
-    MortarHelpers.cpp
-    )
+  Formulation.cpp
+  MortarHelpers.cpp
+  )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Formulation.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Formulation.cpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+
+#include <ostream>
+
+#include "ErrorHandling/Error.hpp"
+
+namespace dg {
+std::ostream& operator<<(std::ostream& os, const Formulation t) noexcept {
+  switch (t) {
+    case Formulation::StrongInertial:
+      return os << "StrongInertial";
+    case Formulation::WeakInertial:
+      return os << "WeakInertial";
+    default:
+      ERROR("Unknown DG formulation.");
+  }
+}
+}  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <iosfwd>
+
+namespace dg {
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief The DG formulation to use
+ *
+ * - The `StrongInertial` formulation is also known as the integrate then
+ *   transform formulation. The "Inertial" part of the name refers to the fact
+ *   that the integration is done over the physical/inertial coordinates, while
+ *   the "strong" part refers to the fact that the boundary correction terms are
+ *   zero if the solution is continuous at the interfaces.
+ *   See \cite Teukolsky2015ega for an overview.
+ * - The `WeakInertial` formulation is also known as the integrate then
+ *   transform formulation. The "Inertial" part of the name refers to the fact
+ *   that the integration is done over the physical/inertial coordinates, while
+ *   the "weak" part refers to the fact that the boundary correction terms are
+ *   non-zero even if the solution is continuous at the interfaces.
+ *   See \cite Teukolsky2015ega for an overview.
+ */
+enum class Formulation { StrongInertial, WeakInertial };
+
+std::ostream& operator<<(std::ostream& os, Formulation t) noexcept;
+}  // namespace dg

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_NumericalDiscontinuousGalerkin")
 
 set(LIBRARY_SOURCES
+  Test_Formulation.cpp
   Test_LiftFlux.cpp
   Test_MortarHelpers.cpp
   Test_NormalDotFlux.cpp

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_Formulation.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_Formulation.cpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Utilities/GetOutput.hpp"
+
+SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Formulation",
+                  "[Unit][NumericalAlgorithms]") {
+  CHECK(get_output(dg::Formulation::StrongInertial) == "StrongInertial");
+  CHECK(get_output(dg::Formulation::WeakInertial) == "WeakInertial");
+}


### PR DESCRIPTION
## Proposed changes

- Add an enum that allows us to choose which DG formulation to use

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
