### PR TITLE
Rename map_list, remove default function of time name from Translation map

### DIFF
--- a/src/Domain/CoordinateMaps/CubicScale.cpp
+++ b/src/Domain/CoordinateMaps/CubicScale.cpp
@@ -51,8 +51,8 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> CubicScale<Dim>::operator()(
     const std::array<T, Dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        map_list) const noexcept {
-  const double a_of_t = map_list.at(f_of_t_a_)->func(time)[0][0];
+        functions_of_time) const noexcept {
+  const double a_of_t = functions_of_time.at(f_of_t_a_)->func(time)[0][0];
 
   if (functions_of_time_equal_) {
     // optimization for linear radial scaling
@@ -63,7 +63,7 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> CubicScale<Dim>::operator()(
     return result;
   }
 
-  const double b_of_t = map_list.at(f_of_t_b_)->func(time)[0][0];
+  const double b_of_t = functions_of_time.at(f_of_t_b_)->func(time)[0][0];
 
   tt::remove_cvref_wrap_t<T> rho_squared =
       square(dereference_wrapper(source_coords[0]));
@@ -90,11 +90,11 @@ CubicScale<Dim>::inverse(
     const std::array<T, Dim>& target_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        map_list) const noexcept {
+        functions_of_time) const noexcept {
   if (functions_of_time_equal_) {
     // optimization for linear radial scaling
     const double one_over_a_of_t =
-        1.0 / map_list.at(f_of_t_a_)->func(time)[0][0];
+        1.0 / functions_of_time.at(f_of_t_a_)->func(time)[0][0];
 
     // Construct boost::optional to have a default value of an empty array.
     // Doing just result{} would construct a boost::optional that doesn't hold a
@@ -111,8 +111,8 @@ CubicScale<Dim>::inverse(
   // (b-a)/R^2*\rho^3 + a*\rho - r = 0,
   // where a and b are the FunctionsOfTime, R is the outer_boundary, and r is
   // the mapped/target coordinates radius.
-  const double a_of_t = map_list.at(f_of_t_a_)->func(time)[0][0];
-  const double b_of_t = map_list.at(f_of_t_b_)->func(time)[0][0];
+  const double a_of_t = functions_of_time.at(f_of_t_a_)->func(time)[0][0];
+  const double b_of_t = functions_of_time.at(f_of_t_b_)->func(time)[0][0];
 
   // these checks ensure that the function is monotonically increasing
   // and that there is one real root in the domain of \rho, [0,R]
@@ -194,8 +194,9 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> CubicScale<Dim>::frame_velocity(
     const std::array<T, Dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        map_list) const noexcept {
-  const double dt_a_of_t = map_list.at(f_of_t_a_)->func_and_deriv(time)[1][0];
+        functions_of_time) const noexcept {
+  const double dt_a_of_t =
+      functions_of_time.at(f_of_t_a_)->func_and_deriv(time)[1][0];
 
   if (functions_of_time_equal_) {
     // optimization for linear radial scaling
@@ -206,7 +207,8 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> CubicScale<Dim>::frame_velocity(
     return result;
   }
 
-  const double dt_b_of_t = map_list.at(f_of_t_b_)->func_and_deriv(time)[1][0];
+  const double dt_b_of_t =
+      functions_of_time.at(f_of_t_b_)->func_and_deriv(time)[1][0];
 
   tt::remove_cvref_wrap_t<T> rho_squared =
       square(dereference_wrapper(source_coords[0]));
@@ -233,8 +235,8 @@ CubicScale<Dim>::jacobian(
     const std::array<T, Dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        map_list) const noexcept {
-  const double a_of_t = map_list.at(f_of_t_a_)->func(time)[0][0];
+        functions_of_time) const noexcept {
+  const double a_of_t = functions_of_time.at(f_of_t_a_)->func(time)[0][0];
 
   if (functions_of_time_equal_) {
     // optimization for linear radial scaling
@@ -247,7 +249,7 @@ CubicScale<Dim>::jacobian(
     return jac;
   }
 
-  const double b_of_t = map_list.at(f_of_t_b_)->func(time)[0][0];
+  const double b_of_t = functions_of_time.at(f_of_t_b_)->func(time)[0][0];
 
   tt::remove_cvref_wrap_t<T> rho_squared =
       square(dereference_wrapper(source_coords[0]));
@@ -285,8 +287,8 @@ CubicScale<Dim>::inv_jacobian(
     const std::array<T, Dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        map_list) const noexcept {
-  const double a_of_t = map_list.at(f_of_t_a_)->func(time)[0][0];
+        functions_of_time) const noexcept {
+  const double a_of_t = functions_of_time.at(f_of_t_a_)->func(time)[0][0];
 
   if (functions_of_time_equal_) {
     // optimization for linear radial scaling
@@ -300,7 +302,7 @@ CubicScale<Dim>::inv_jacobian(
     return inv_jac;
   }
 
-  const double b_of_t = map_list.at(f_of_t_b_)->func(time)[0][0];
+  const double b_of_t = functions_of_time.at(f_of_t_b_)->func(time)[0][0];
 
   tt::remove_cvref_wrap_t<T> rho_squared =
       square(dereference_wrapper(source_coords[0]));
@@ -366,28 +368,28 @@ bool operator==(const CubicScale<Dim>& lhs,
 /// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                   \
-  template class CubicScale<DIM(data)>;                                        \
-  template boost::optional<                                                    \
-      std::array<tt::remove_cvref_wrap_t<double>, DIM(data)>>                  \
-  CubicScale<DIM(data)>::inverse(                                              \
-      const std::array<double, DIM(data)>& target_coords, const double time,   \
-      const std::unordered_map<                                                \
-          std::string,                                                         \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
-      const noexcept;                                                          \
-  template boost::optional<std::array<                                         \
-      tt::remove_cvref_wrap_t<std::reference_wrapper<const double>>,           \
-      DIM(data)>>                                                              \
-  CubicScale<DIM(data)>::inverse(                                              \
-      const std::array<std::reference_wrapper<const double>, DIM(data)>&       \
-          target_coords,                                                       \
-      const double time,                                                       \
-      const std::unordered_map<                                                \
-          std::string,                                                         \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
-      const noexcept;                                                          \
-  template bool operator==(const CubicScale<DIM(data)>&,                       \
+#define INSTANTIATE(_, data)                                                 \
+  template class CubicScale<DIM(data)>;                                      \
+  template boost::optional<                                                  \
+      std::array<tt::remove_cvref_wrap_t<double>, DIM(data)>>                \
+  CubicScale<DIM(data)>::inverse(                                            \
+      const std::array<double, DIM(data)>& target_coords, const double time, \
+      const std::unordered_map<                                              \
+          std::string,                                                       \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
+          functions_of_time) const noexcept;                                 \
+  template boost::optional<std::array<                                       \
+      tt::remove_cvref_wrap_t<std::reference_wrapper<const double>>,         \
+      DIM(data)>>                                                            \
+  CubicScale<DIM(data)>::inverse(                                            \
+      const std::array<std::reference_wrapper<const double>, DIM(data)>&     \
+          target_coords,                                                     \
+      const double time,                                                     \
+      const std::unordered_map<                                              \
+          std::string,                                                       \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
+          functions_of_time) const noexcept;                                 \
+  template bool operator==(const CubicScale<DIM(data)>&,                     \
                            const CubicScale<DIM(data)>&) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
@@ -396,41 +398,41 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE(_, data)                                                   \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
-  CubicScale<DIM(data)>::operator()(                                           \
-      const std::array<DTYPE(data), DIM(data)>& source_coords,                 \
-      const double time,                                                       \
-      const std::unordered_map<                                                \
-          std::string,                                                         \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
-      const noexcept;                                                          \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
-  CubicScale<DIM(data)>::frame_velocity(                                       \
-      const std::array<DTYPE(data), DIM(data)>& source_coords,                 \
-      const double time,                                                       \
-      const std::unordered_map<                                                \
-          std::string,                                                         \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
-      const noexcept;                                                          \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
-                    Frame::NoFrame>                                            \
-  CubicScale<DIM(data)>::jacobian(                                             \
-      const std::array<DTYPE(data), DIM(data)>& source_coords,                 \
-      const double time,                                                       \
-      const std::unordered_map<                                                \
-          std::string,                                                         \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
-      const noexcept;                                                          \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
-                    Frame::NoFrame>                                            \
-  CubicScale<DIM(data)>::inv_jacobian(                                         \
-      const std::array<DTYPE(data), DIM(data)>& source_coords,                 \
-      const double time,                                                       \
-      const std::unordered_map<                                                \
-          std::string,                                                         \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
-      const noexcept;
+#define INSTANTIATE(_, data)                                           \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)> \
+  CubicScale<DIM(data)>::operator()(                                   \
+      const std::array<DTYPE(data), DIM(data)>& source_coords,         \
+      const double time,                                               \
+      const std::unordered_map<                                        \
+          std::string,                                                 \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&   \
+          functions_of_time) const noexcept;                           \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)> \
+  CubicScale<DIM(data)>::frame_velocity(                               \
+      const std::array<DTYPE(data), DIM(data)>& source_coords,         \
+      const double time,                                               \
+      const std::unordered_map<                                        \
+          std::string,                                                 \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&   \
+          functions_of_time) const noexcept;                           \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),   \
+                    Frame::NoFrame>                                    \
+  CubicScale<DIM(data)>::jacobian(                                     \
+      const std::array<DTYPE(data), DIM(data)>& source_coords,         \
+      const double time,                                               \
+      const std::unordered_map<                                        \
+          std::string,                                                 \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&   \
+          functions_of_time) const noexcept;                           \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),   \
+                    Frame::NoFrame>                                    \
+  CubicScale<DIM(data)>::inv_jacobian(                                 \
+      const std::array<DTYPE(data), DIM(data)>& source_coords,         \
+      const double time,                                               \
+      const std::unordered_map<                                        \
+          std::string,                                                 \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&   \
+          functions_of_time) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
                         (double, DataVector,

--- a/src/Domain/CoordinateMaps/CubicScale.hpp
+++ b/src/Domain/CoordinateMaps/CubicScale.hpp
@@ -108,8 +108,8 @@ class CubicScale {
       const std::array<T, Dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
-      const noexcept;
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
 
   /// Returns boost::none if the point is outside the range of the map.
   template <typename T>
@@ -117,32 +117,32 @@ class CubicScale {
       const std::array<T, Dim>& target_coords, double time,
       const std::unordered_map<
           std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
-      const noexcept;
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
 
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, Dim> frame_velocity(
       const std::array<T, Dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
-      const noexcept;
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> inv_jacobian(
       const std::array<T, Dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
-      const noexcept;
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> jacobian(
       const std::array<T, Dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
-      const noexcept;
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/src/Domain/CoordinateMaps/Translation.cpp
+++ b/src/Domain/CoordinateMaps/Translation.cpp
@@ -28,26 +28,28 @@ std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::operator()(
     const std::array<T, 1>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        map_list) const noexcept {
-  ASSERT(map_list.count(f_of_t_name_) == 1,
+        functions_of_time) const noexcept {
+  ASSERT(functions_of_time.count(f_of_t_name_) == 1,
          "The function of time '" << f_of_t_name_
                                   << "' is not one of the known functions of "
                                      "time. The known functions of time are: "
-                                  << keys_of(map_list));
-  return {{source_coords[0] + map_list.at(f_of_t_name_)->func(time)[0][0]}};
+                                  << keys_of(functions_of_time));
+  return {{source_coords[0] +
+           functions_of_time.at(f_of_t_name_)->func(time)[0][0]}};
 }
 
 boost::optional<std::array<double, 1>> Translation::inverse(
     const std::array<double, 1>& target_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        map_list) const noexcept {
-  ASSERT(map_list.count(f_of_t_name_) == 1,
+        functions_of_time) const noexcept {
+  ASSERT(functions_of_time.count(f_of_t_name_) == 1,
          "The function of time '" << f_of_t_name_
                                   << "' is not one of the known functions of "
                                      "time. The known functions of time are: "
-                                  << keys_of(map_list));
-  return {{{target_coords[0] - map_list.at(f_of_t_name_)->func(time)[0][0]}}};
+                                  << keys_of(functions_of_time));
+  return {{{target_coords[0] -
+            functions_of_time.at(f_of_t_name_)->func(time)[0][0]}}};
 }
 
 template <typename T>
@@ -55,15 +57,15 @@ std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::frame_velocity(
     const std::array<T, 1>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        map_list) const noexcept {
-  ASSERT(map_list.count(f_of_t_name_) == 1,
+        functions_of_time) const noexcept {
+  ASSERT(functions_of_time.count(f_of_t_name_) == 1,
          "The function of time '" << f_of_t_name_
                                   << "' is not one of the known functions of "
                                      "time. The known functions of time are: "
-                                  << keys_of(map_list));
+                                  << keys_of(functions_of_time));
   return {{make_with_value<tt::remove_cvref_wrap_t<T>>(
       dereference_wrapper(source_coords[0]),
-      map_list.at(f_of_t_name_)->func_and_deriv(time)[1][0])}};
+      functions_of_time.at(f_of_t_name_)->func_and_deriv(time)[1][0])}};
 }
 
 template <typename T>
@@ -90,26 +92,26 @@ bool operator==(const CoordMapsTimeDependent::Translation& lhs,
 /// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                   \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                 \
-  Translation::operator()(                                                     \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
-      const std::unordered_map<                                                \
-          std::string,                                                         \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
-      const noexcept;                                                          \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                 \
-  Translation::frame_velocity(                                                 \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
-      const std::unordered_map<                                                \
-          std::string,                                                         \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list) \
-      const noexcept;                                                          \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>   \
-  Translation::jacobian(const std::array<DTYPE(data), 1>& source_coords)       \
-      const noexcept;                                                          \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>   \
-  Translation::inv_jacobian(const std::array<DTYPE(data), 1>& source_coords)   \
+#define INSTANTIATE(_, data)                                                 \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>               \
+  Translation::operator()(                                                   \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,    \
+      const std::unordered_map<                                              \
+          std::string,                                                       \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
+          functions_of_time) const noexcept;                                 \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>               \
+  Translation::frame_velocity(                                               \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,    \
+      const std::unordered_map<                                              \
+          std::string,                                                       \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
+          functions_of_time) const noexcept;                                 \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
+  Translation::jacobian(const std::array<DTYPE(data), 1>& source_coords)     \
+      const noexcept;                                                        \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
+  Translation::inv_jacobian(const std::array<DTYPE(data), 1>& source_coords) \
       const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,

--- a/src/Domain/CoordinateMaps/Translation.hpp
+++ b/src/Domain/CoordinateMaps/Translation.hpp
@@ -45,23 +45,23 @@ class Translation {
       const std::array<T, 1>& source_coords, double time,
       const std::unordered_map<
           std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
-      const noexcept;
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
 
   boost::optional<std::array<double, 1>> inverse(
       const std::array<double, 1>& target_coords, double time,
       const std::unordered_map<
           std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
-      const noexcept;
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
 
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 1> frame_velocity(
       const std::array<T, 1>& source_coords, double time,
       const std::unordered_map<
           std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
-      const noexcept;
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> inv_jacobian(

--- a/src/Domain/CoordinateMaps/Translation.hpp
+++ b/src/Domain/CoordinateMaps/Translation.hpp
@@ -80,7 +80,7 @@ class Translation {
   friend bool operator==(const Translation& lhs,
                          const Translation& rhs) noexcept;
 
-  std::string f_of_t_name_ = "trans";
+  std::string f_of_t_name_{};
 };
 
 inline bool operator!=(

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -1072,10 +1072,10 @@ void test_time_dependent_map() {
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time{};
-  functions_of_time["trans"] =
+  functions_of_time["Translation"] =
       std::make_unique<Polynomial>(initial_time, init_func);
 
-  const CoordMapsTimeDependent::Translation trans_map{};
+  const CoordMapsTimeDependent::Translation trans_map{"Translation"};
 
   // affine(x) = 1.5 * x + 5.5
   domain::CoordinateMaps::Affine affine_map{-1., 1., 4., 7.};
@@ -1194,7 +1194,7 @@ void test_time_dependent_map() {
           serialized_map.jacobian(tnsr_double_logical, final_time,
                                   functions_of_time));
     const auto velocity =
-        functions_of_time.at("trans")->func_and_deriv(final_time)[1];
+        functions_of_time.at("Translation")->func_and_deriv(final_time)[1];
     // The 1.5 factor comes from the Jacobian
     CHECK(std::get<3>(coords_jacs_velocity) ==
           tnsr::I<double, 1, Frame::Inertial>{1.5 *
@@ -1214,7 +1214,7 @@ void test_time_dependent_map() {
           serialized_map.jacobian(tnsr_datavector_logical, final_time,
                                   functions_of_time));
     const auto velocity =
-        functions_of_time.at("trans")->func_and_deriv(final_time)[1];
+        functions_of_time.at("Translation")->func_and_deriv(final_time)[1];
     // The 1.5 factor comes from the Jacobian
     CHECK(std::get<3>(coords_jacs_velocity) ==
           tnsr::I<DataVector, 1, Frame::Inertial>{

--- a/tests/Unit/Domain/CoordinateMaps/Test_TimeDependentHelpers.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_TimeDependentHelpers.cpp
@@ -33,8 +33,8 @@ struct TimeDepMap {
       const std::array<T, Dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
-      const noexcept;
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
 };
 template <size_t Dim>
 struct TimeIndepMap {
@@ -54,8 +54,8 @@ struct TimeDepJac {
       const std::array<T, Dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& map_list)
-      const noexcept;
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
 };
 template <size_t Dim>
 struct TimeIndepJac {


### PR DESCRIPTION
## Proposed changes

- Rename `map_list` argument to `functions_of_time`
- Remove default function of time name `trans` from `Translation` map.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
