### PR TITLE
Add divergence overload for a `tnsr::I`

### DIFF
--- a/src/Elliptic/Actions/InitializeSystem.hpp
+++ b/src/Elliptic/Actions/InitializeSystem.hpp
@@ -103,9 +103,9 @@ struct InitializeSystem {
         db::AddSimpleTags<fields_tag, linear_operator_applied_to_fields_tag,
                           fixed_sources_tag, linear_operand_tag,
                           linear_operator_applied_to_operand_tag>;
-    using compute_tags =
-        db::AddComputeTags<fluxes_compute_tag, sources_compute_tag,
-                           ::Tags::DivCompute<fluxes_tag, inv_jacobian_tag>>;
+    using compute_tags = db::AddComputeTags<
+        fluxes_compute_tag, sources_compute_tag,
+        ::Tags::DivVariablesCompute<fluxes_tag, inv_jacobian_tag>>;
 
     const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
     const size_t num_grid_points = mesh.number_of_grid_points();

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -201,7 +201,7 @@ struct TimeStepperHistory {
 
   template <typename System>
   struct ComputeTags<System, true> {
-    using type = db::AddComputeTags<::Tags::DivCompute<
+    using type = db::AddComputeTags<::Tags::DivVariablesCompute<
         db::add_tag_prefix<::Tags::Flux, variables_tag, tmpl::size_t<dim>,
                            Frame::Inertial>,
         domain::Tags::InverseJacobian<dim, Frame::Logical, Frame::Inertial>>>;

--- a/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   ApplyMatrices.cpp
   CoefficientTransforms.cpp
   DefiniteIntegral.cpp
+  Divergence.cpp
   ExponentialFilter.cpp
   IndefiniteIntegral.cpp
   Linearize.cpp

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.cpp
@@ -1,0 +1,64 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <size_t Dim, typename DerivativeFrame>
+struct VectorTag {
+  using type = tnsr::I<DataVector, Dim, DerivativeFrame>;
+};
+}  // namespace
+
+template <size_t Dim, typename DerivativeFrame>
+Scalar<DataVector> divergence(
+    const tnsr::I<DataVector, Dim, DerivativeFrame>& input,
+    const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
+        inverse_jacobian) noexcept {
+  // We have to copy into a Variables because we don't currently have partial
+  // derivative functions for anything other than Variables.
+  using VectorTag = VectorTag<Dim, DerivativeFrame>;
+  Variables<tmpl::list<VectorTag>> vars{get<0>(input).size()};
+  get<VectorTag>(vars) = input;
+  const auto logical_derivs =
+      logical_partial_derivatives<tmpl::list<VectorTag>>(vars, mesh);
+
+  Scalar<DataVector> div_input{get<0>(input).size(), 0.0};
+  for (size_t logical_i = 0; logical_i < Dim; ++logical_i) {
+    for (size_t deriv_i = 0; deriv_i < Dim; ++deriv_i) {
+      get(div_input) +=
+          inverse_jacobian.get(logical_i, deriv_i) *
+          get<VectorTag>(gsl::at(logical_derivs, logical_i)).get(deriv_i);
+    }
+  }
+
+  return div_input;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                       \
+  template Scalar<DataVector> divergence(                          \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& input,    \
+      const Mesh<DIM(data)>& mesh,                                 \
+      const InverseJacobian<DataVector, DIM(data), Frame::Logical, \
+                            FRAME(data)>& inverse_jacobian) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef FRAME
+#undef INSTANTIATE

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -39,7 +39,7 @@ namespace Tags {
 /// Prefix indicating the divergence of a Tensor or that a Variables
 /// contains divergences of Tensors.
 ///
-/// \see Tags::DivVariablesCompute
+/// \see Tags::DivVectorCompute Tags::DivVariablesCompute
 template <typename Tag, typename = std::nullptr_t>
 struct div;
 
@@ -76,15 +76,39 @@ auto divergence(
         inverse_jacobian) noexcept
     -> Variables<db::wrap_tags_in<Tags::div, FluxTags>>;
 
+/// \ingroup NumericalAlgorithmsGroup
+/// \brief Compute the divergence of the vector `input`
+template <size_t Dim, typename DerivativeFrame>
+Scalar<DataVector> divergence(
+    const tnsr::I<DataVector, Dim, DerivativeFrame>& input,
+    const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
+        inverse_jacobian) noexcept;
+
 namespace Tags {
-/// \ingroup DataBoxTagsGroup
-/// \brief Compute the divergence of a Variables
-///
-/// Computes the divergence of the Tensors in the Variables
-/// represented by `Tag` in the frame mapped to by
-/// `InverseJacobianTag`.  The map must map from the logical frame.
-///
-/// This tag inherits from `db::add_prefix_tag<Tags::div, Tag>`.
+/*!
+ * \ingroup DataBoxTagsGroup
+ * \brief Compute the divergence of a Variables
+ *
+ * Computes the divergence of the every Tensor in the Variables represented by
+ * `Tag`. The first index of each Tensor must be an upper spatial index, i.e.,
+ * the first index must have type
+ * `TensorIndexType<Dim, UpLo::Up, Frame::TargetFrame, IndexType::Spatial>`.
+ * The divergence is computed in the frame `TargetFrame`, and
+ * `InverseJacobianTag` must be associated with a map from `Frame::Logical` to
+ * `Frame::TargetFrame`.
+ *
+ * Note that each tensor may have additional tensor indices - in this case the
+ * divergence is computed for each additional index. For instance, a tensor
+ * \f$F^i_{ab}\f$ has divergence
+ * \f$Div_{ab} = \partial_i F^i_{ab}\f$. This is to accommodate evolution
+ * equations where the evolved variables \f$u_\alpha\f$ are higher-rank tensors
+ * and thus their fluxes can be written as \f$F^i_\alpha\f$. A simple example
+ * would be the fluid velocity in hydro systems, where we would write the flux
+ * as \f$F^{ij}\f$.
+ *
+ * This tag inherits from `db::add_tag_prefix<Tags::div, Tag>`.
+ */
 template <typename Tag, typename InverseJacobianTag>
 struct DivVariablesCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
  private:
@@ -99,6 +123,27 @@ struct DivVariablesCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
   static constexpr auto function =
       divergence<typename db::const_item_type<Tag>::tags_list, dim,
                  typename tmpl::back<inv_jac_indices>::Frame>;
+  using argument_tags =
+      tmpl::list<Tag, domain::Tags::Mesh<dim>, InverseJacobianTag>;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \brief Compute the divergence of a `tnsr::I` (vector)
+///
+/// This tag inherits from `db::add_tag_prefix<Tags::div, Tag>`.
+template <typename Tag, typename InverseJacobianTag>
+struct DivVectorCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
+ private:
+  using inv_jac_indices =
+      typename db::const_item_type<InverseJacobianTag>::index_list;
+  static constexpr auto dim = tmpl::back<inv_jac_indices>::dim;
+  static_assert(cpp17::is_same_v<typename tmpl::front<inv_jac_indices>::Frame,
+                                 Frame::Logical>,
+                "Must map from the logical frame.");
+
+ public:
+  static constexpr auto function =
+      divergence<dim, typename tmpl::back<inv_jac_indices>::Frame>;
   using argument_tags =
       tmpl::list<Tag, domain::Tags::Mesh<dim>, InverseJacobianTag>;
 };

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -39,7 +39,7 @@ namespace Tags {
 /// Prefix indicating the divergence of a Tensor or that a Variables
 /// contains divergences of Tensors.
 ///
-/// \see Tags::DivCompute
+/// \see Tags::DivVariablesCompute
 template <typename Tag, typename = std::nullptr_t>
 struct div;
 
@@ -86,7 +86,7 @@ namespace Tags {
 ///
 /// This tag inherits from `db::add_prefix_tag<Tags::div, Tag>`.
 template <typename Tag, typename InverseJacobianTag>
-struct DivCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
+struct DivVariablesCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
  private:
   using inv_jac_indices =
       typename db::const_item_type<InverseJacobianTag>::index_list;

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
@@ -92,10 +92,11 @@ struct ElementArray {
               ActionTesting::InitializeDataBox<
                   tmpl::list<domain::Tags::InitialExtents<Dim>, vars_tag<Dim>>>,
               dg::Actions::InitializeDomain<Dim>,
-              Initialization::Actions::AddComputeTags<tmpl::list<
-                  elliptic::Tags::FirstOrderFluxesCompute<
-                      typename metavariables::system>,
-                  ::Tags::DivCompute<fluxes_tag<Dim>, inv_jacobian_tag<Dim>>>>,
+              Initialization::Actions::AddComputeTags<
+                  tmpl::list<elliptic::Tags::FirstOrderFluxesCompute<
+                                 typename metavariables::system>,
+                             ::Tags::DivVariablesCompute<
+                                 fluxes_tag<Dim>, inv_jacobian_tag<Dim>>>>,
               dg::Actions::InitializeInterfaces<
                   typename Metavariables::system,
                   dg::Initialization::slice_tags_to_face<vars_tag<Dim>>,

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -122,7 +122,7 @@ template <size_t Dim, typename Frame>
 using two_fluxes = tmpl::list<Flux1<Dim, Frame>, Flux2<Dim, Frame>>;
 
 template <size_t Dim, typename Frame = Frame::Inertial>
-void test_divergence(
+void test_divergence_impl(
     const Mesh<Dim>& mesh,
     std::array<std::unique_ptr<MathFunction<1>>, Dim> functions) noexcept {
   const auto coordinate_map = make_affine_map<Dim>();
@@ -153,10 +153,8 @@ void test_divergence(
           approx(expected_div_fluxes.data()[n]).epsilon(1.e-11));  // NOLINT
   }
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Divergence",
-                  "[NumericalAlgorithms][LinearOperators][Unit]") {
+void test_divergence() noexcept {
   using TensorTag = Flux1<1, Frame::Inertial>;
   using VariablesTag = Tags::Variables<tmpl::list<TensorTag>>;
   TestHelpers::db::test_prefix_tag<Tags::div<TensorTag>>("div(Flux1)");
@@ -180,24 +178,23 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Divergence",
   for (size_t a = 0; a < 5; ++a) {
     std::array<std::unique_ptr<MathFunction<1>>, 1> functions_1d{
         {std::make_unique<MathFunctions::PowX>(a)}};
-    test_divergence(mesh_1d, std::move(functions_1d));
+    test_divergence_impl(mesh_1d, std::move(functions_1d));
     for (size_t b = 0; b < 4; ++b) {
       std::array<std::unique_ptr<MathFunction<1>>, 2> functions_2d{
           {std::make_unique<MathFunctions::PowX>(a),
            std::make_unique<MathFunctions::PowX>(b)}};
-      test_divergence(mesh_2d, std::move(functions_2d));
+      test_divergence_impl(mesh_2d, std::move(functions_2d));
       for (size_t c = 0; c < 3; ++c) {
         std::array<std::unique_ptr<MathFunction<1>>, 3> functions_3d{
             {std::make_unique<MathFunctions::PowX>(a),
              std::make_unique<MathFunctions::PowX>(b),
              std::make_unique<MathFunctions::PowX>(c)}};
-        test_divergence(mesh_3d, std::move(functions_3d));
+        test_divergence_impl(mesh_3d, std::move(functions_3d));
       }
     }
   }
 }
 
-namespace {
 template <class MapType>
 struct MapTag : db::SimpleTag {
   static constexpr size_t dim = MapType::dim;
@@ -208,7 +205,7 @@ struct MapTag : db::SimpleTag {
 };
 
 template <size_t Dim, typename Frame = Frame::Inertial>
-void test_divergence_compute_item(
+void test_divergence_compute_item_impl(
     const Mesh<Dim>& mesh,
     std::array<std::unique_ptr<MathFunction<1>>, Dim> functions) noexcept {
   const auto coordinate_map = make_affine_map<Dim>();
@@ -256,10 +253,8 @@ void test_divergence_compute_item(
           approx(expected_div_fluxes.data()[n]).epsilon(1.e-11));  // NOLINT
   }
 }
-} // namespace
 
-SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Divergence.ComputeItem",
-                  "[NumericalAlgorithms][LinearOperators][Unit]") {
+void test_divergence_compute() noexcept {
   const size_t n0 =
       Spectral::maximum_number_of_points<Spectral::Basis::Legendre> / 2;
   const size_t n1 =
@@ -277,19 +272,26 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Divergence.ComputeItem",
   for (size_t a = 0; a < 5; ++a) {
     std::array<std::unique_ptr<MathFunction<1>>, 1> functions_1d{
         {std::make_unique<MathFunctions::PowX>(a)}};
-    test_divergence_compute_item(mesh_1d, std::move(functions_1d));
+    test_divergence_compute_item_impl(mesh_1d, std::move(functions_1d));
     for (size_t b = 0; b < 4; ++b) {
       std::array<std::unique_ptr<MathFunction<1>>, 2> functions_2d{
           {std::make_unique<MathFunctions::PowX>(a),
            std::make_unique<MathFunctions::PowX>(b)}};
-      test_divergence_compute_item(mesh_2d, std::move(functions_2d));
+      test_divergence_compute_item_impl(mesh_2d, std::move(functions_2d));
       for (size_t c = 0; c < 3; ++c) {
         std::array<std::unique_ptr<MathFunction<1>>, 3> functions_3d{
             {std::make_unique<MathFunctions::PowX>(a),
              std::make_unique<MathFunctions::PowX>(b),
              std::make_unique<MathFunctions::PowX>(c)}};
-        test_divergence_compute_item(mesh_3d, std::move(functions_3d));
+        test_divergence_compute_item_impl(mesh_3d, std::move(functions_3d));
       }
     }
   }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Divergence",
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
+  test_divergence();
+  test_divergence_compute();
 }

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -218,7 +218,8 @@ void test_divergence_compute_item(
   using flux_tags = two_fluxes<Dim, Frame>;
   using flux_tag = Tags::Variables<flux_tags>;
   using div_tags = db::wrap_tags_in<Tags::div, flux_tags>;
-  TestHelpers::db::test_compute_tag<Tags::DivCompute<flux_tag, inv_jac_tag>>(
+  TestHelpers::db::test_compute_tag<
+      Tags::DivVariablesCompute<flux_tag, inv_jac_tag>>(
       "div(Variables(div(Flux1),div(Flux2)))");
 
   const size_t num_grid_points = mesh.number_of_grid_points();
@@ -240,7 +241,7 @@ void test_divergence_compute_item(
   auto box = db::create<
       db::AddSimpleTags<domain::Tags::Mesh<Dim>, flux_tag, map_tag>,
       db::AddComputeTags<domain::Tags::LogicalCoordinates<Dim>, inv_jac_tag,
-                         Tags::DivCompute<flux_tag, inv_jac_tag>>>(
+                         Tags::DivVariablesCompute<flux_tag, inv_jac_tag>>>(
       mesh, fluxes, coordinate_map);
 
   const auto& div_fluxes =


### PR DESCRIPTION
## Proposed changes

- Rename `DivCompute` to `DivVariablesCompute`
- Combine test cases for `Test_Divergence`
- Add divergence overload for a `tnsr::I`

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
