### PR TITLE
Add most of the tags needed for moving meshes

### DIFF
--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -34,6 +34,7 @@ set(LIBRARY_SOURCES
   Side.cpp
   SizeOfElement.cpp
   Tags.cpp
+  TagsTimeDependent.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Domain/CoordinateMaps/Tags.hpp
+++ b/src/Domain/CoordinateMaps/Tags.hpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Utilities/GetOutput.hpp"
+
+/// \cond
+namespace domain {
+template <typename SourceFrame, typename TargetFrame, size_t Dim>
+class CoordinateMapBase;
+}  // namespace domain
+/// \endcond
+
+namespace domain {
+namespace CoordinateMaps {
+/// \ingroup ComputationalDomainGroup
+/// \brief %Tags for the coordinate maps.
+namespace Tags {
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// The coordinate map from source to target coordinates
+template <size_t VolumeDim, typename SourceFrame, typename TargetFrame>
+struct CoordinateMap : db::SimpleTag {
+static constexpr size_t dim = VolumeDim;
+  using target_frame = TargetFrame;
+  using source_frame = Frame::Logical;
+
+  static std::string name() noexcept {
+    return "CoordinateMap(" + get_output(SourceFrame{}) + "," +
+           get_output(TargetFrame{}) + ")";
+  }
+  using type = std::unique_ptr<
+      domain::CoordinateMapBase<SourceFrame, TargetFrame, VolumeDim>>;
+};
+}  // namespace Tags
+}  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/src/Domain/FunctionsOfTime/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   PiecewisePolynomial.cpp
   RegisterDerivedWithCharm.cpp
   SettleToConstant.cpp
+  Tags.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Domain/FunctionsOfTime/Tags.cpp
+++ b/src/Domain/FunctionsOfTime/Tags.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/FunctionsOfTime/Tags.hpp"
+
+#include <memory>
+
+#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/Domain.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace domain {
+namespace Tags {
+template <size_t Dim>
+auto InitialFunctionsOfTime<Dim>::create_from_options(
+    const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) noexcept
+    -> type {
+  return domain_creator->functions_of_time();
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                            \
+  template auto InitialFunctionsOfTime<DIM(data)>::create_from_options( \
+      const std::unique_ptr<::DomainCreator<DIM(data)>>&                \
+          domain_creator) noexcept->type;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+}  // namespace Tags
+}  // namespace domain

--- a/src/Domain/FunctionsOfTime/Tags.hpp
+++ b/src/Domain/FunctionsOfTime/Tags.hpp
@@ -9,11 +9,15 @@
 #include <unordered_map>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/OptionTags.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class DomainCreator;
+/// \endcond
 
 namespace domain {
 namespace Tags {
@@ -24,11 +28,9 @@ struct InitialFunctionsOfTime : db::SimpleTag {
       std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
   using option_tags = tmpl::list<domain::OptionTags::DomainCreator<Dim>>;
 
-  template <typename Metavariables>
+  static constexpr bool pass_metavariables = false;
   static type create_from_options(
-      const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) noexcept {
-    return domain_creator->functions_of_time();
-  }
+      const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) noexcept;
 };
 
 /// The functions of time

--- a/src/Domain/TagsTimeDependent.cpp
+++ b/src/Domain/TagsTimeDependent.cpp
@@ -1,0 +1,128 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/TagsTimeDependent.hpp"
+
+#include <memory>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Domain.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain {
+namespace Tags {
+template <size_t Dim>
+void InertialFromGridCoordinatesCompute<Dim>::function(
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+        target_coords,
+    const tnsr::I<DataVector, Dim, Frame::Grid>& source_coords,
+    const boost::optional<std::tuple<
+        tnsr::I<DataVector, Dim, Frame::Inertial>,
+        ::InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+        ::Jacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+        tnsr::I<DataVector, Dim, Frame::Inertial>>>&
+        grid_to_inertial_quantities) noexcept {
+  if (not grid_to_inertial_quantities) {
+    // We use a const_cast to point the data into the existing allocation
+    // inside `source_coords` to avoid copying. This is safe because the output
+    // of a compute tag is immutable.
+    for (size_t i = 0; i < Dim; ++i) {
+      target_coords->get(i).set_data_ref(
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+          &const_cast<DataVector&>(source_coords.get(i)));
+    }
+  } else {
+    // We use a const_cast to point the data into the existing allocation
+    // inside `grid_to_inertial_quantities` to avoid copying. This is
+    // effectively unpacking the tuple. This is safe because the output
+    // of a compute tag is immutable.
+    for (size_t i = 0; i < Dim; ++i) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+      target_coords->get(i).set_data_ref(&const_cast<DataVector&>(
+          std::get<0>(*grid_to_inertial_quantities).get(i)));
+    }
+  }
+}
+
+template <size_t Dim>
+void ElementToInertialInverseJacobian<Dim>::function(
+    const gsl::not_null<
+        ::InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>*>
+        inv_jac_logical_to_inertial,
+    const ::InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Grid>&
+        inv_jac_logical_to_grid,
+    const boost::optional<std::tuple<
+        tnsr::I<DataVector, Dim, Frame::Inertial>,
+        ::InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+        ::Jacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+        tnsr::I<DataVector, Dim, Frame::Inertial>>>&
+        grid_to_inertial_quantities) noexcept {
+  if (not grid_to_inertial_quantities) {
+    // We use a const_cast to point the data into the existing allocation
+    // inside `inv_jac_logical_to_grid` to avoid copying. This is safe because
+    // the output of a compute tag is immutable.
+    for (size_t i = 0; i < inv_jac_logical_to_inertial->size(); ++i) {
+      inv_jac_logical_to_inertial->operator[](i).set_data_ref(
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+          &const_cast<DataVector&>(inv_jac_logical_to_grid[i]));
+    }
+  } else {
+    const auto& inv_jac_grid_to_inertial =
+        std::get<1>(*grid_to_inertial_quantities);
+    for (size_t logical_i = 0; logical_i < Dim; ++logical_i) {
+      for (size_t inertial_i = 0; inertial_i < Dim; ++inertial_i) {
+        inv_jac_logical_to_inertial->get(logical_i, inertial_i) =
+            inv_jac_logical_to_grid.get(logical_i, 0) *
+            inv_jac_grid_to_inertial.get(0, inertial_i);
+        for (size_t grid_i = 1; grid_i < Dim; ++grid_i) {
+          inv_jac_logical_to_inertial->get(logical_i, inertial_i) +=
+              inv_jac_logical_to_grid.get(logical_i, grid_i) *
+              inv_jac_grid_to_inertial.get(grid_i, inertial_i);
+        }
+      }
+    }
+  }
+}
+
+template <size_t Dim>
+void InertialMeshVelocityCompute<Dim>::function(
+    const gsl::not_null<return_type*> mesh_velocity,
+    const boost::optional<std::tuple<
+        tnsr::I<DataVector, Dim, Frame::Inertial>,
+        ::InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+        ::Jacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+        tnsr::I<DataVector, Dim, Frame::Inertial>>>&
+        grid_to_inertial_quantities) noexcept {
+  if (not grid_to_inertial_quantities) {
+    *mesh_velocity = boost::none;
+  } else {
+    if (not*mesh_velocity) {
+      *mesh_velocity = typename return_type::value_type{};
+    }
+    // We use a const_cast to point the data into the existing allocation
+    // inside `grid_to_inertial_quantities` to avoid copying. This is
+    // effectively unpacking the tuple. This is safe because the output
+    // of a compute tag is immutable.
+    for (size_t i = 0; i < Dim; ++i) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+      mesh_velocity->get().operator[](i).set_data_ref(&const_cast<DataVector&>(
+          std::get<3>(*grid_to_inertial_quantities).get(i)));
+    }
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                     \
+  template struct InertialFromGridCoordinatesCompute<DIM(data)>; \
+  template struct ElementToInertialInverseJacobian<DIM(data)>;   \
+  template struct InertialMeshVelocityCompute<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+}  // namespace Tags
+}  // namespace domain

--- a/src/Domain/TagsTimeDependent.hpp
+++ b/src/Domain/TagsTimeDependent.hpp
@@ -1,0 +1,164 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // For Tags::Normalized
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain {
+/// \ingroup ComputationalDomainGroup
+/// \brief %Tags for the domain.
+namespace Tags {
+/// The Inertial coordinates, the inverse Jacobian from the Grid to the Inertial
+/// frame, the Jacobian from the Grid to the Inertial frame, and the Inertial
+/// mesh velocity.
+///
+/// The type is a `boost::optional`, which, when is not valid, signals that the
+/// mesh is not moving. Thus,
+/// `static_cast<bool>(coordinates_velocity_and_jacobian)` can be used to check
+/// if the mesh is moving.
+template <size_t Dim>
+struct CoordinatesMeshVelocityAndJacobians : db::SimpleTag {
+  using type = boost::optional<std::tuple<
+      tnsr::I<DataVector, Dim, Frame::Inertial>,
+      ::InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+      ::Jacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+      tnsr::I<DataVector, Dim, Frame::Inertial>>>;
+};
+
+/// Computes the Inertial coordinates, the inverse Jacobian from the Grid to the
+/// Inertial frame, the Jacobian from the Grid to the Inertial frame, and the
+/// Inertial mesh velocity.
+template <typename MapTagGridToInertial>
+struct CoordinatesMeshVelocityAndJacobiansCompute
+    : CoordinatesMeshVelocityAndJacobians<MapTagGridToInertial::dim>,
+      db::ComputeTag {
+  static constexpr size_t dim = MapTagGridToInertial::dim;
+  using base = CoordinatesMeshVelocityAndJacobians<dim>;
+
+  using return_type = typename base::type;
+
+  static void function(
+      const gsl::not_null<return_type*> result,
+      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, dim>&
+          grid_to_inertial_map,
+      const tnsr::I<DataVector, dim, Frame::Grid>& source_coords,
+      const double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) noexcept {
+    // Use identity to signal time-independent
+    if (not grid_to_inertial_map.is_identity()) {
+      *result = grid_to_inertial_map.coords_frame_velocity_jacobians(
+          source_coords, time, functions_of_time);
+    } else {
+      *result = boost::none;
+    }
+  }
+
+  using argument_tags =
+      tmpl::list<MapTagGridToInertial, Tags::Coordinates<dim, Frame::Grid>,
+                 ::Tags::Time, Tags::FunctionsOfTime>;
+};
+
+/// Computes the Inertial coordinates from
+/// `CoordinatesVelocityAndJacobians`
+template <size_t Dim>
+struct InertialFromGridCoordinatesCompute
+    : Tags::Coordinates<Dim, Frame::Inertial>,
+      db::ComputeTag {
+  using base = Tags::Coordinates<Dim, Frame::Inertial>;
+  using return_type = typename base::type;
+
+  static void function(
+      gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> target_coords,
+      const tnsr::I<DataVector, Dim, Frame::Grid>& source_coords,
+      const boost::optional<std::tuple<
+          tnsr::I<DataVector, Dim, Frame::Inertial>,
+          ::InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+          ::Jacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+          tnsr::I<DataVector, Dim, Frame::Inertial>>>&
+          grid_to_inertial_quantities) noexcept;
+
+  using argument_tags = tmpl::list<Tags::Coordinates<Dim, Frame::Grid>,
+                                   CoordinatesMeshVelocityAndJacobians<Dim>>;
+};
+
+/// Computes the Logical to Inertial inverse Jacobian from
+/// `CoordinatesVelocityAndJacobians`
+template <size_t Dim>
+struct ElementToInertialInverseJacobian
+    : Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>,
+      db::ComputeTag {
+  using base = Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>;
+  using return_type = typename base::type;
+
+  static void function(
+      gsl::not_null<
+          ::InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>*>
+          inv_jac_logical_to_inertial,
+      const ::InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Grid>&
+          inv_jac_logical_to_grid,
+      const boost::optional<std::tuple<
+          tnsr::I<DataVector, Dim, Frame::Inertial>,
+          ::InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+          ::Jacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+          tnsr::I<DataVector, Dim, Frame::Inertial>>>&
+          grid_to_inertial_quantities) noexcept;
+
+  using argument_tags =
+      tmpl::list<Tags::InverseJacobian<Dim, Frame::Logical, Frame::Grid>,
+                 CoordinatesMeshVelocityAndJacobians<Dim>>;
+};
+
+/// The mesh velocity
+///
+/// The type is a `boost::optional`, which when it is not set indicates that the
+/// mesh is not moving.
+template <size_t Dim, typename Frame = ::Frame::Inertial>
+struct MeshVelocity : db::SimpleTag {
+  using type = boost::optional<tnsr::I<DataVector, Dim, Frame>>;
+};
+
+/// Computes the Inertial mesh velocity from `CoordinatesVelocityAndJacobians`
+///
+/// The type is a `boost::optional`, which when it is not set indicates that the
+/// mesh is not moving.
+template <size_t Dim>
+struct InertialMeshVelocityCompute : MeshVelocity<Dim, Frame::Inertial>,
+                                     db::ComputeTag {
+  using base = MeshVelocity<Dim, Frame::Inertial>;
+  using return_type = typename base::type;
+
+  static void function(
+      gsl::not_null<return_type*> mesh_velocity,
+      const boost::optional<std::tuple<
+          tnsr::I<DataVector, Dim, Frame::Inertial>,
+          ::InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+          ::Jacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+          tnsr::I<DataVector, Dim, Frame::Inertial>>>&
+          grid_to_inertial_quantities) noexcept;
+
+  using argument_tags = tmpl::list<CoordinatesMeshVelocityAndJacobians<Dim>>;
+};
+}  // namespace Tags
+}  // namespace domain

--- a/src/Informer/CMakeLists.txt
+++ b/src/Informer/CMakeLists.txt
@@ -4,18 +4,18 @@
 set(LIBRARY Informer)
 
 set(LIBRARY_SOURCES
-    Informer.cpp
-    Verbosity.cpp
-    ${CMAKE_BINARY_DIR}/Informer/InfoAtCompile.cpp
-    )
+  Informer.cpp
+  Verbosity.cpp
+  ${CMAKE_BINARY_DIR}/Informer/InfoAtCompile.cpp
+  )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
-    ErrorHandling
-    Options
+  ErrorHandling
+  Options
   )
 
 add_subdirectory(Python)

--- a/src/Options/CMakeLists.txt
+++ b/src/Options/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(${LIBRARY} INTERFACE)
 target_link_libraries(
   ${LIBRARY}
   INTERFACE
-    ErrorHandling
-    YamlCpp
+  ErrorHandling
+  YamlCpp
+  Utilities
   )

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -59,6 +59,9 @@ add_spectre_executable(
 target_link_libraries(
   ${executable}
   ${SPECTRE_TESTS_LIBRARIES}
+  ErrorHandling
+  Informer
+  Utilities
   ${SPECTRE_LIBRARIES}
   )
 

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -37,6 +37,7 @@ set(LIBRARY_SOURCES
   Test_Side.cpp
   Test_SizeOfElement.cpp
   Test_Tags.cpp
+  Test_TagsTimeDependent.cpp
   )
 
 add_subdirectory(Amr)

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBRARY_SOURCES
   Test_Rotation.cpp
   Test_RotationTimeDep.cpp
   Test_SpecialMobius.cpp
+  Test_Tags.cpp
   Test_TimeDependentHelpers.cpp
   Test_Translation.cpp
   Test_Wedge2D.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_Tags.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Tags.cpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace domain {
+namespace {
+template <size_t Dim>
+void test() noexcept {
+  TestHelpers::db::test_simple_tag<
+      CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Logical, Frame::Grid>>(
+      "CoordinateMap(Logical,Grid)");
+  TestHelpers::db::test_simple_tag<
+      CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid, Frame::Inertial>>(
+      "CoordinateMap(Grid,Inertial)");
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Tags", "[Unit][Domain]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}
+}  // namespace
+}  // namespace domain

--- a/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_FunctionsOfTime")
 set(LIBRARY_SOURCES
   Test_PiecewisePolynomial.cpp
   Test_SettleToConstant.cpp
+  Test_Tags.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Domain/FunctionsOfTime/Test_Tags.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_Tags.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace domain {
+
+namespace {
+template <size_t Dim>
+void test() {
+  TestHelpers::db::test_simple_tag<Tags::InitialFunctionsOfTime<Dim>>(
+      "InitialFunctionsOfTime");
+  TestHelpers::db::test_simple_tag<Tags::FunctionsOfTime>("FunctionsOfTime");
+  static_assert(
+      cpp17::is_same_v<db::item_type<Tags::FunctionsOfTime>,
+                       db::item_type<Tags::InitialFunctionsOfTime<Dim>>>,
+      "FunctionsOfTime and InitialFunctionsOfTime tags must have the same "
+      "types");
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.Tags",
+                  "[Domain][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}
+}  // namespace
+}  // namespace domain

--- a/tests/Unit/Domain/Test_TagsTimeDependent.cpp
+++ b/tests/Unit/Domain/Test_TagsTimeDependent.cpp
@@ -1,0 +1,337 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.hpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.tpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/CoordinateMaps/Translation.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace {
+template <size_t Dim>
+void test_tags() noexcept {
+  TestHelpers::db::test_simple_tag<domain::Tags::InitialFunctionsOfTime<Dim>>(
+      "InitialFunctionsOfTime");
+  TestHelpers::db::test_simple_tag<domain::Tags::FunctionsOfTime>(
+      "FunctionsOfTime");
+  TestHelpers::db::test_simple_tag<
+      domain::Tags::CoordinatesMeshVelocityAndJacobians<Dim>>(
+      "CoordinatesMeshVelocityAndJacobians");
+  TestHelpers::db::test_compute_tag<
+      domain::Tags::CoordinatesMeshVelocityAndJacobiansCompute<
+          domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                      Frame::Inertial>>>(
+      "CoordinatesMeshVelocityAndJacobians");
+  TestHelpers::db::test_compute_tag<
+      domain::Tags::InertialFromGridCoordinatesCompute<Dim>>(
+      "InertialCoordinates");
+  TestHelpers::db::test_simple_tag<domain::Tags::MeshVelocity<Dim>>(
+      "MeshVelocity");
+  TestHelpers::db::test_compute_tag<
+      domain::Tags::InertialMeshVelocityCompute<Dim>>("MeshVelocity");
+}
+
+using TranslationMap = domain::CoordMapsTimeDependent::Translation;
+using TranslationMap2d =
+    domain::CoordMapsTimeDependent::ProductOf2Maps<TranslationMap,
+                                                   TranslationMap>;
+using TranslationMap3d = domain::CoordMapsTimeDependent::ProductOf3Maps<
+    TranslationMap, TranslationMap, TranslationMap>;
+
+using AffineMap = domain::CoordinateMaps::Affine;
+using AffineMap2d =
+    domain::CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
+using AffineMap3d =
+    domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+
+template <size_t MeshDim>
+using ConcreteMap = tmpl::conditional_t<
+    MeshDim == 1,
+    domain::CoordinateMap<Frame::Grid, Frame::Inertial, TranslationMap,
+                          AffineMap>,
+    tmpl::conditional_t<MeshDim == 2,
+                        domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                                              TranslationMap2d, AffineMap2d>,
+                        domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                                              TranslationMap3d, AffineMap3d>>>;
+
+template <size_t MeshDim>
+ConcreteMap<MeshDim> create_coord_map(
+    const std::array<std::string, 3>& f_of_t_names);
+
+template <>
+ConcreteMap<1> create_coord_map<1>(
+    const std::array<std::string, 3>& f_of_t_names) {
+  return ConcreteMap<1>{TranslationMap{f_of_t_names[0]},
+                        AffineMap{-1.0, 1.0, 2.0, 7.2}};
+}
+
+template <>
+ConcreteMap<2> create_coord_map<2>(
+    const std::array<std::string, 3>& f_of_t_names) {
+  return ConcreteMap<2>{
+      {TranslationMap{f_of_t_names[0]}, TranslationMap{f_of_t_names[1]}},
+      {AffineMap{-1.0, 1.0, -2.0, 2.2}, AffineMap{-1.0, 1.0, 2.0, 7.2}}};
+}
+
+template <>
+ConcreteMap<3> create_coord_map<3>(
+    const std::array<std::string, 3>& f_of_t_names) {
+  return ConcreteMap<3>{
+      {TranslationMap{f_of_t_names[0]}, TranslationMap{f_of_t_names[1]},
+       TranslationMap{f_of_t_names[2]}},
+      {AffineMap{-1.0, 1.0, -2.0, 2.2}, AffineMap{-1.0, 1.0, 2.0, 7.2},
+       AffineMap{-1.0, 1.0, 1.0, 3.5}}};
+}
+
+template <size_t Dim, bool IsTimeDependent>
+void test() noexcept {
+  using simple_tags = db::AddSimpleTags<
+      Tags::Time, domain::Tags::Coordinates<Dim, Frame::Grid>,
+      domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Grid>,
+      domain::Tags::FunctionsOfTime,
+      domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                  Frame::Inertial>>;
+  using compute_tags = db::AddComputeTags<
+      domain::Tags::CoordinatesMeshVelocityAndJacobiansCompute<
+          domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                      Frame::Inertial>>,
+      domain::Tags::InertialFromGridCoordinatesCompute<Dim>,
+      domain::Tags::ElementToInertialInverseJacobian<Dim>,
+      domain::Tags::InertialMeshVelocityCompute<Dim>>;
+
+  MAKE_GENERATOR(gen);
+  const std::array<double, 3> velocity{{1.2, 0.2, -8.9}};
+  const double initial_time = 0.0;
+  const std::array<std::string, 3> functions_of_time_names{
+      {"TranslationX", "TranslationY", "TranslationZ"}};
+
+  UniformCustomDistribution<double> dist(-10.0, 10.0);
+
+  const size_t num_pts = Dim * 5;
+
+  tnsr::I<DataVector, Dim, Frame::Grid> grid_coords{num_pts};
+  fill_with_random_values(make_not_null(&grid_coords), make_not_null(&gen),
+                          make_not_null(&dist));
+  InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Grid>
+      element_to_grid_inverse_jacobian{num_pts};
+  fill_with_random_values(make_not_null(&element_to_grid_inverse_jacobian),
+                          make_not_null(&gen), make_not_null(&dist));
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  functions_of_time[functions_of_time_names[0]] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time,
+          std::array<DataVector, 3>{{{0.0}, {velocity[0]}, {0.0}}});
+  functions_of_time[functions_of_time_names[1]] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time,
+          std::array<DataVector, 3>{{{0.0}, {velocity[1]}, {0.0}}});
+  functions_of_time[functions_of_time_names[2]] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time,
+          std::array<DataVector, 3>{{{0.0}, {velocity[2]}, {0.0}}});
+
+  using MapPtr = std::unique_ptr<
+      domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, Dim>>;
+  const MapPtr grid_to_inertial_map =
+      IsTimeDependent ? MapPtr{std::make_unique<ConcreteMap<Dim>>(
+                            create_coord_map<Dim>(functions_of_time_names))}
+                      : MapPtr{std::make_unique<domain::CoordinateMap<
+                            Frame::Grid, Frame::Inertial,
+                            domain::CoordinateMaps::Identity<Dim>>>()};
+
+  const double time = 3.0;
+  auto box = db::create<simple_tags, compute_tags>(
+      time, grid_coords, element_to_grid_inverse_jacobian,
+      std::move(functions_of_time), grid_to_inertial_map->get_clone());
+
+  const auto check_helper = [&box, &element_to_grid_inverse_jacobian,
+                             &grid_coords, &grid_to_inertial_map,
+                             num_pts](const double expected_time) noexcept {
+    if (IsTimeDependent) {
+      const tnsr::I<DataVector, Dim, Frame::Inertial> expected_coords =
+          (*grid_to_inertial_map)(grid_coords, expected_time,
+                                  db::get<domain::Tags::FunctionsOfTime>(box));
+
+      const InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>
+          expected_inv_jacobian_grid_to_inertial =
+              grid_to_inertial_map->inv_jacobian(
+                  grid_coords, expected_time,
+                  db::get<domain::Tags::FunctionsOfTime>(box));
+
+      InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
+          expected_inv_jacobian{num_pts};
+
+      for (size_t logical_i = 0; logical_i < Dim; ++logical_i) {
+        for (size_t inertial_i = 0; inertial_i < Dim; ++inertial_i) {
+          expected_inv_jacobian.get(logical_i, inertial_i) =
+              element_to_grid_inverse_jacobian.get(logical_i, 0) *
+              expected_inv_jacobian_grid_to_inertial.get(0, inertial_i);
+          for (size_t grid_i = 1; grid_i < Dim; ++grid_i) {
+            expected_inv_jacobian.get(logical_i, inertial_i) +=
+                element_to_grid_inverse_jacobian.get(logical_i, grid_i) *
+                expected_inv_jacobian_grid_to_inertial.get(grid_i, inertial_i);
+          }
+        }
+      }
+
+      REQUIRE(static_cast<bool>(
+          db::get<domain::Tags::CoordinatesMeshVelocityAndJacobians<Dim>>(
+              box)));
+
+      for (size_t i = 0; i < Dim; ++i) {
+        // Check that the `const_cast`s and set_data_ref inside the compute tag
+        // functions worked correctly
+        CHECK(db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box)
+                  .get(i)
+                  .data() ==
+              std::get<0>(
+                  *db::get<
+                      domain::Tags::CoordinatesMeshVelocityAndJacobians<Dim>>(
+                      box))
+                  .get(i)
+                  .data());
+      }
+      CHECK_ITERABLE_APPROX(
+          (db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box)),
+          expected_coords);
+
+      for (size_t i = 0;
+           i < db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical,
+                                                     Frame::Inertial>>(box)
+                   .size();
+           ++i) {
+        CHECK(
+            db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical,
+                                                  Frame::Inertial>>(box)[i]
+                .data() !=
+            std::get<1>(*db::get<
+                        domain::Tags::CoordinatesMeshVelocityAndJacobians<Dim>>(
+                box))[i]
+                .data());
+      }
+      CHECK_ITERABLE_APPROX(
+          (db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical,
+                                                 Frame::Inertial>>(box)),
+          expected_inv_jacobian);
+
+      const auto expected_coords_mesh_velocity_jacobians =
+          grid_to_inertial_map->coords_frame_velocity_jacobians(
+              db::get<domain::Tags::Coordinates<Dim, Frame::Grid>>(box),
+              db::get<::Tags::Time>(box),
+              db::get<domain::Tags::FunctionsOfTime>(box));
+
+      for (size_t i = 0; i < Dim; ++i) {
+        // Check that the `const_cast`s and set_data_ref inside the compute tag
+        // functions worked correctly
+        CHECK(db::get<domain::Tags::MeshVelocity<Dim>>(box)->get(i).data() ==
+              std::get<3>(
+                  *db::get<
+                      domain::Tags::CoordinatesMeshVelocityAndJacobians<Dim>>(
+                      box))
+                  .get(i)
+                  .data());
+      }
+      CHECK_ITERABLE_APPROX(
+          db::get<domain::Tags::MeshVelocity<Dim>>(box).get(),
+          std::get<3>(expected_coords_mesh_velocity_jacobians));
+    } else {
+      tnsr::I<DataVector, Dim, Frame::Inertial> expected_coords{num_pts};
+      for (size_t i = 0; i < Dim; ++i) {
+        expected_coords[i] = grid_coords[i];
+      }
+
+      InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
+          expected_inv_jacobian{num_pts};
+      // The Grid->Inertial Jacobian is currently just the identity
+      for (size_t i = 0; i < expected_inv_jacobian.size(); ++i) {
+        expected_inv_jacobian[i] = element_to_grid_inverse_jacobian[i];
+      }
+
+      for (size_t i = 0; i < Dim; ++i) {
+        // Check that the `const_cast`s and set_data_ref inside the compute tag
+        // functions worked correctly
+        CHECK(db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box)
+                  .get(i)
+                  .data() ==
+              db::get<domain::Tags::Coordinates<Dim, Frame::Grid>>(box)
+                  .get(i)
+                  .data());
+      }
+      CHECK_ITERABLE_APPROX(
+          (db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box)),
+          expected_coords);
+
+      for (size_t i = 0;
+           i < db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical,
+                                                     Frame::Inertial>>(box)
+                   .size();
+           ++i) {
+        // Check that the `const_cast`s and set_data_ref inside the compute tag
+        // functions worked correctly
+        CHECK(db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical,
+                                                    Frame::Inertial>>(box)[i]
+                  .data() ==
+              db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical,
+                                                    Frame::Grid>>(box)[i]
+                  .data());
+      }
+      CHECK_ITERABLE_APPROX(
+          (db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical,
+                                                 Frame::Inertial>>(box)),
+          expected_inv_jacobian);
+
+      CHECK_FALSE(db::get<domain::Tags::MeshVelocity<Dim>>(box));
+    }
+  };
+  check_helper(3.0);
+
+  db::mutate<Tags::Time>(make_not_null(&box),
+                         [](const gsl::not_null<double*> local_time) noexcept {
+                           *local_time = 4.5;
+                         });
+  check_helper(4.5);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.TagsTimeDependent", "[Unit][Actions]") {
+  test_tags<1>();
+  test_tags<2>();
+  test_tags<3>();
+
+  test<1, true>();
+  test<2, true>();
+  test<3, true>();
+
+  test<1, false>();
+  test<2, false>();
+  test<3, false>();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

- Add `domain::CoordinateMaps::Tags::CoordinateMap`
- Add test for `FunctionsOfTime` tags that were accidentally merged at some point.
- Add tags for moving mesh:
  * ~`CoordinatesVelocityAndJacobian`~ `CoordinatesMeshVelocityAndJacobian` these are cheapest to compute all together
  * `InertialCoordinates` computes only from Grid to Inertial
  * `ElementToInertialInverseJacobian` computes the logical to inertial inverse jacobian
  * ~`FrameVelocity`~ `MeshVelocity`

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
