### PR TITLE
Refactor MinmodTci

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
@@ -52,16 +52,16 @@ bool minmod_limited_slopes(
     &u_mean, &element, &element_size, &effective_neighbor_means, &
     effective_neighbor_sizes
   ](const size_t dim, const Side& side) noexcept {
-    return effective_difference_to_neighbor(
-        *u_mean, element, element_size, effective_neighbor_means,
-        effective_neighbor_sizes, dim, side);
+    return effective_difference_to_neighbor(*u_mean, element, element_size, dim,
+                                            side, effective_neighbor_means,
+                                            effective_neighbor_sizes);
   };
 
   // The LambdaPiN limiter calls a simple troubled-cell indicator to avoid
   // limiting solutions that appear smooth:
   if (minmod_type == Limiters::MinmodType::LambdaPiN) {
     const bool u_needs_limiting = Tci::tvb_minmod_indicator(
-        buffer, tvb_constant, u, element, mesh, element_size,
+        buffer, tvb_constant, u, mesh, element, element_size,
         effective_neighbor_means, effective_neighbor_sizes);
 
     if (not u_needs_limiting) {

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
@@ -64,7 +64,7 @@ bool minmod_limited_slopes(
   // The LambdaPiN limiter calls a simple troubled-cell indicator to avoid
   // limiting solutions that appear smooth:
   if (minmod_type == Limiters::MinmodType::LambdaPiN) {
-    const bool u_needs_limiting = Tci::troubled_cell_indicator(
+    const bool u_needs_limiting = Tci::tvb_minmod_indicator(
         boundary_buffer, tvb_constant, u, element, mesh, element_size,
         effective_neighbor_means, effective_neighbor_sizes,
         volume_and_slice_indices);

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
@@ -64,7 +64,7 @@ bool minmod_limited_slopes(
   // The LambdaPiN limiter calls a simple troubled-cell indicator to avoid
   // limiting solutions that appear smooth:
   if (minmod_type == Limiters::MinmodType::LambdaPiN) {
-    const bool u_needs_limiting = troubled_cell_indicator(
+    const bool u_needs_limiting = Tci::troubled_cell_indicator(
         boundary_buffer, tvb_constant, u, element, mesh, element_size,
         effective_neighbor_means, effective_neighbor_sizes,
         volume_and_slice_indices);

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
@@ -23,13 +23,13 @@ namespace Minmod_detail {
 
 template <size_t VolumeDim>
 bool minmod_limited_slopes(
-    const gsl::not_null<double*> u_mean,
-    const gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
     const gsl::not_null<DataVector*> u_lin_buffer,
     const gsl::not_null<BufferWrapper<VolumeDim>*> buffer,
+    const gsl::not_null<double*> u_mean,
+    const gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
     const Limiters::MinmodType minmod_type, const double tvb_constant,
-    const DataVector& u, const Element<VolumeDim>& element,
-    const Mesh<VolumeDim>& mesh,
+    const DataVector& u, const Mesh<VolumeDim>& mesh,
+    const Element<VolumeDim>& element,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
     const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept {
@@ -131,12 +131,12 @@ bool minmod_limited_slopes(
 
 #define INSTANTIATE(_, data)                                       \
   template bool minmod_limited_slopes<DIM(data)>(                  \
-      const gsl::not_null<double*>,                                \
-      const gsl::not_null<std::array<double, DIM(data)>*>,         \
       const gsl::not_null<DataVector*>,                            \
       const gsl::not_null<BufferWrapper<DIM(data)>*>,              \
+      const gsl::not_null<double*>,                                \
+      const gsl::not_null<std::array<double, DIM(data)>*>,         \
       const Limiters::MinmodType, const double, const DataVector&, \
-      const Element<DIM(data)>&, const Mesh<DIM(data)>&,           \
+      const Mesh<DIM(data)>&, const Element<DIM(data)>&,           \
       const std::array<double, DIM(data)>&,                        \
       const DirectionMap<DIM(data), double>&,                      \
       const DirectionMap<DIM(data), double>&) noexcept;

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
@@ -80,12 +80,12 @@ namespace Minmod_detail {
 // testing.
 template <size_t VolumeDim>
 bool minmod_limited_slopes(
-    gsl::not_null<double*> u_mean,
-    gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
     gsl::not_null<DataVector*> u_lin_buffer,
     gsl::not_null<BufferWrapper<VolumeDim>*> buffer,
+    gsl::not_null<double*> u_mean,
+    gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
     Limiters::MinmodType minmod_type, double tvb_constant, const DataVector& u,
-    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
+    const Mesh<VolumeDim>& mesh, const Element<VolumeDim>& element,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
     const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept;
@@ -259,8 +259,8 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
 
   using limit_tags = tmpl::list<Tags...>;
   using limit_argument_tags =
-      tmpl::list<domain::Tags::Element<VolumeDim>,
-                 domain::Tags::Mesh<VolumeDim>,
+      tmpl::list<domain::Tags::Mesh<VolumeDim>,
+                 domain::Tags::Element<VolumeDim>,
                  domain::Tags::Coordinates<VolumeDim, Frame::Logical>,
                  domain::Tags::SizeOfElement<VolumeDim>>;
 
@@ -291,7 +291,7 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
   ///   test cases with very clean initial data.
   bool operator()(
       const gsl::not_null<std::add_pointer_t<db::item_type<Tags>>>... tensors,
-      const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
+      const Mesh<VolumeDim>& mesh, const Element<VolumeDim>& element,
       const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
       const std::array<double, VolumeDim>& element_size,
       const std::unordered_map<

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
@@ -47,6 +47,11 @@ class er;
 namespace Limiters {
 template <size_t VolumeDim, typename TagsToLimit>
 class Minmod;
+
+namespace Minmod_detail {
+template <size_t VolumeDim>
+class BufferWrapper;
+}  // namespace Minmod_detail
 }  // namespace Limiters
 
 namespace domain {
@@ -78,15 +83,12 @@ bool minmod_limited_slopes(
     gsl::not_null<double*> u_mean,
     gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
     gsl::not_null<DataVector*> u_lin_buffer,
-    gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
+    gsl::not_null<BufferWrapper<VolumeDim>*> buffer,
     Limiters::MinmodType minmod_type, double tvb_constant, const DataVector& u,
     const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
-    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
-    const std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,
-                               gsl::span<std::pair<size_t, size_t>>>,
-                     VolumeDim>& volume_and_slice_indices) noexcept;
+    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept;
 }  // namespace Minmod_detail
 
 /// \ingroup LimitersGroup

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
@@ -73,7 +73,7 @@ bool limit_one_tensor(
     // all different neighbors in that direction. This produces one effective
     // neighbor per direction.
     const auto effective_neighbor_means =
-        compute_effective_neighbor_means<Tag>(element, i, neighbor_data);
+        compute_effective_neighbor_means<Tag>(i, element, neighbor_data);
 
     DataVector& u = (*tensor)[i];
     double u_mean;

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
@@ -70,10 +70,10 @@ BufferWrapper<VolumeDim>::BufferWrapper(const Mesh<VolumeDim>& mesh) noexcept
 template <size_t VolumeDim>
 double effective_difference_to_neighbor(
     const double u_mean, const Element<VolumeDim>& element,
-    const std::array<double, VolumeDim>& element_size,
+    const std::array<double, VolumeDim>& element_size, const size_t dim,
+    const Side& side,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
-    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
-    const size_t dim, const Side& side) noexcept {
+    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept {
   const auto& externals = element.external_boundaries();
   const auto dir = Direction<VolumeDim>(dim, side);
   const bool has_neighbors = (externals.find(dir) == externals.end());
@@ -96,8 +96,8 @@ double effective_difference_to_neighbor(
   template class Minmod_detail::BufferWrapper<DIM(data)>;                      \
   template double effective_difference_to_neighbor<DIM(data)>(                 \
       double, const Element<DIM(data)>&, const std::array<double, DIM(data)>&, \
-      const DirectionMap<DIM(data), double>&,                                  \
-      const DirectionMap<DIM(data), double>&, size_t, const Side&) noexcept;
+      size_t, const Side&, const DirectionMap<DIM(data), double>&,             \
+      const DirectionMap<DIM(data), double>&) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
@@ -113,7 +113,7 @@ DirectionMap<VolumeDim, double> compute_effective_neighbor_sizes(
 // specifying the tensor to work with.
 template <typename Tag, size_t VolumeDim, typename PackagedData>
 DirectionMap<VolumeDim, double> compute_effective_neighbor_means(
-    const Element<VolumeDim>& element, const size_t tensor_storage_index,
+    const size_t tensor_storage_index, const Element<VolumeDim>& element,
     const std::unordered_map<
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
@@ -155,10 +155,10 @@ DirectionMap<VolumeDim, double> compute_effective_neighbor_means(
 template <size_t VolumeDim>
 double effective_difference_to_neighbor(
     double u_mean, const Element<VolumeDim>& element,
-    const std::array<double, VolumeDim>& element_size,
+    const std::array<double, VolumeDim>& element_size, size_t dim,
+    const Side& side,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
-    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes, size_t dim,
-    const Side& side) noexcept;
+    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept;
 
 }  // namespace Minmod_detail
 }  // namespace Limiters

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
@@ -19,7 +19,7 @@ namespace Limiters {
 namespace Tci {
 
 template <size_t VolumeDim>
-bool troubled_cell_indicator(
+bool tvb_minmod_indicator(
     const gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
     const double tvb_constant, const DataVector& u,
     const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
@@ -78,7 +78,7 @@ bool troubled_cell_indicator(
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                 \
-  template bool troubled_cell_indicator<DIM(data)>(                          \
+  template bool tvb_minmod_indicator<DIM(data)>(                             \
       const gsl::not_null<std::array<DataVector, DIM(data)>*>, const double, \
       const DataVector&, const Element<DIM(data)>&, const Mesh<DIM(data)>&,  \
       const std::array<double, DIM(data)>&,                                  \

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
@@ -20,8 +20,8 @@ namespace Tci {
 template <size_t VolumeDim>
 bool tvb_minmod_indicator(
     const gsl::not_null<Minmod_detail::BufferWrapper<VolumeDim>*> buffer,
-    const double tvb_constant, const DataVector& u,
-    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
+    const double tvb_constant, const DataVector& u, const Mesh<VolumeDim>& mesh,
+    const Element<VolumeDim>& element,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
     const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept {
@@ -38,8 +38,8 @@ bool tvb_minmod_indicator(
     effective_neighbor_sizes
   ](const size_t dim, const Side& side) noexcept {
     return Minmod_detail::effective_difference_to_neighbor(
-        u_mean, element, element_size, effective_neighbor_means,
-        effective_neighbor_sizes, dim, side);
+        u_mean, element, element_size, dim, side, effective_neighbor_means,
+        effective_neighbor_sizes);
   };
 
   for (size_t d = 0; d < VolumeDim; ++d) {
@@ -77,12 +77,12 @@ bool tvb_minmod_indicator(
 // Explicit instantiations
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                         \
-  template bool tvb_minmod_indicator<DIM(data)>(                     \
-      const gsl::not_null<Minmod_detail::BufferWrapper<DIM(data)>*>, \
-      const double, const DataVector&, const Element<DIM(data)>&,    \
-      const Mesh<DIM(data)>&, const std::array<double, DIM(data)>&,  \
-      const DirectionMap<DIM(data), double>&,                        \
+#define INSTANTIATE(_, data)                                           \
+  template bool tvb_minmod_indicator<DIM(data)>(                       \
+      const gsl::not_null<Minmod_detail::BufferWrapper<DIM(data)>*>,   \
+      const double, const DataVector&, const Mesh<DIM(data)>&,         \
+      const Element<DIM(data)>&, const std::array<double, DIM(data)>&, \
+      const DirectionMap<DIM(data), double>&,                          \
       const DirectionMap<DIM(data), double>&) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
@@ -16,7 +16,7 @@
 #include "Utilities/Gsl.hpp"
 
 namespace Limiters {
-namespace Minmod_detail {
+namespace Tci {
 
 template <size_t VolumeDim>
 bool troubled_cell_indicator(
@@ -41,7 +41,7 @@ bool troubled_cell_indicator(
     &u_mean, &element, &element_size, &effective_neighbor_means, &
     effective_neighbor_sizes
   ](const size_t dim, const Side& side) noexcept {
-    return effective_difference_to_neighbor(
+    return Minmod_detail::effective_difference_to_neighbor(
         u_mean, element, element_size, effective_neighbor_means,
         effective_neighbor_sizes, dim, side);
   };
@@ -60,12 +60,12 @@ bool troubled_cell_indicator(
     // tvb_corrected_minmod(..., 0.0), rather than
     // tvb_corrected_minmod(..., tvb_scale)
     const bool activated_lower =
-        tvb_corrected_minmod(u_mean - u_lower, diff_lower, diff_upper,
-                             tvb_scale)
+        Minmod_detail::tvb_corrected_minmod(u_mean - u_lower, diff_lower,
+                                            diff_upper, tvb_scale)
             .activated;
     const bool activated_upper =
-        tvb_corrected_minmod(u_upper - u_mean, diff_lower, diff_upper,
-                             tvb_scale)
+        Minmod_detail::tvb_corrected_minmod(u_upper - u_mean, diff_lower,
+                                            diff_upper, tvb_scale)
             .activated;
     if (activated_lower or activated_upper) {
       return true;
@@ -93,5 +93,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 #undef INSTANTIATE
 
-}  // namespace Minmod_detail
+}  // namespace Tci
 }  // namespace Limiters

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
@@ -5,12 +5,10 @@
 
 #include <array>
 #include <cstdlib>
-#include <memory>
 #include <unordered_map>
 #include <utility>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "DataStructures/SliceIterator.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -40,21 +38,15 @@ namespace Tci {
 // Implements the TVB troubled-cell indicator from Cockburn1999.
 template <size_t VolumeDim>
 bool tvb_minmod_indicator(
-    gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
+    gsl::not_null<Minmod_detail::BufferWrapper<VolumeDim>*> buffer,
     double tvb_constant, const DataVector& u, const Element<VolumeDim>& element,
     const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
-    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
-    const std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,
-                               gsl::span<std::pair<size_t, size_t>>>,
-                     VolumeDim>& volume_and_slice_indices) noexcept;
+    const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept;
 
 // Implements the TVB troubled-cell indicator from Cockburn1999 for several
-// tensors.
-//
-// Internally loops over all tensors and tensor components, calling the above
-// function for each case. Returns true if any component needs limiting.
+// tensors. Returns true if any component of any tensor needs limiting.
 //
 // Expects type `PackagedData` to contain, as in Limiters::Minmod:
 // - a variable `means` that is a `TaggedTuple<Tags::Mean<Tags>...>`
@@ -69,19 +61,7 @@ bool tvb_minmod_indicator(
     const double tvb_constant, const Element<VolumeDim>& element,
     const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size) noexcept {
-  // Optimization: allocate a single buffer to avoid multiple allocations
-  std::unique_ptr<double[], decltype(&free)> contiguous_buffer(nullptr, &free);
-  std::array<DataVector, VolumeDim> boundary_buffer{};
-  Minmod_detail::allocate_buffers(make_not_null(&contiguous_buffer),
-                                  make_not_null(&boundary_buffer), mesh);
-
-  // Optimization: precompute the slice indices since this is (surprisingly)
-  // expensive
-  const auto volume_and_slice_buffer_and_indices =
-      volume_and_slice_indices(mesh.extents());
-  const auto& volume_and_slice_indices =
-      volume_and_slice_buffer_and_indices.second;
-
+  Minmod_detail::BufferWrapper<VolumeDim> buffer(mesh);
   const auto effective_neighbor_sizes =
       Minmod_detail::compute_effective_neighbor_sizes(element, neighbor_data);
 
@@ -105,9 +85,8 @@ bool tvb_minmod_indicator(
 
       const DataVector& u = tensor[tensor_storage_index];
       const bool component_needs_limiting = tvb_minmod_indicator(
-          make_not_null(&boundary_buffer), tvb_constant, u, element, mesh,
-          element_size, effective_neighbor_means, effective_neighbor_sizes,
-          volume_and_slice_indices);
+          make_not_null(&buffer), tvb_constant, u, element, mesh, element_size,
+          effective_neighbor_means, effective_neighbor_sizes);
 
       if (component_needs_limiting) {
         some_component_needs_limiting = true;

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
@@ -39,8 +39,8 @@ namespace Tci {
 template <size_t VolumeDim>
 bool tvb_minmod_indicator(
     gsl::not_null<Minmod_detail::BufferWrapper<VolumeDim>*> buffer,
-    double tvb_constant, const DataVector& u, const Element<VolumeDim>& element,
-    const Mesh<VolumeDim>& mesh,
+    double tvb_constant, const DataVector& u, const Mesh<VolumeDim>& mesh,
+    const Element<VolumeDim>& element,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
     const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept;
@@ -53,14 +53,13 @@ bool tvb_minmod_indicator(
 // - a variable `element_size` that is a `std::array<double, VolumeDim>`
 template <size_t VolumeDim, typename PackagedData, typename... Tags>
 bool tvb_minmod_indicator(
-    const db::const_item_type<Tags>&... tensors,
+    const double tvb_constant, const db::const_item_type<Tags>&... tensors,
+    const Mesh<VolumeDim>& mesh, const Element<VolumeDim>& element,
+    const std::array<double, VolumeDim>& element_size,
     const std::unordered_map<
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
-        neighbor_data,
-    const double tvb_constant, const Element<VolumeDim>& element,
-    const Mesh<VolumeDim>& mesh,
-    const std::array<double, VolumeDim>& element_size) noexcept {
+        neighbor_data) noexcept {
   Minmod_detail::BufferWrapper<VolumeDim> buffer(mesh);
   const auto effective_neighbor_sizes =
       Minmod_detail::compute_effective_neighbor_sizes(element, neighbor_data);
@@ -81,11 +80,11 @@ bool tvb_minmod_indicator(
          ++tensor_storage_index) {
       const auto effective_neighbor_means =
           Minmod_detail::compute_effective_neighbor_means<decltype(tag)>(
-              element, tensor_storage_index, neighbor_data);
+              tensor_storage_index, element, neighbor_data);
 
       const DataVector& u = tensor[tensor_storage_index];
       const bool component_needs_limiting = tvb_minmod_indicator(
-          make_not_null(&buffer), tvb_constant, u, element, mesh, element_size,
+          make_not_null(&buffer), tvb_constant, u, mesh, element, element_size,
           effective_neighbor_means, effective_neighbor_sizes);
 
       if (component_needs_limiting) {

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
@@ -35,7 +35,7 @@ struct hash;
 /// \endcond
 
 namespace Limiters {
-namespace Minmod_detail {
+namespace Tci {
 
 // Implements the TVB troubled-cell indicator from Cockburn1999.
 template <size_t VolumeDim>
@@ -83,7 +83,7 @@ bool troubled_cell_indicator(
       volume_and_slice_buffer_and_indices.second;
 
   const auto effective_neighbor_sizes =
-      compute_effective_neighbor_sizes(element, neighbor_data);
+      Minmod_detail::compute_effective_neighbor_sizes(element, neighbor_data);
 
   // Ideally, as soon as one component is found that needs limiting, then we
   // would exit the TCI early with return value `true`. But there is no natural
@@ -100,7 +100,7 @@ bool troubled_cell_indicator(
     for (size_t tensor_storage_index = 0; tensor_storage_index < tensor.size();
          ++tensor_storage_index) {
       const auto effective_neighbor_means =
-          compute_effective_neighbor_means<decltype(tag)>(
+          Minmod_detail::compute_effective_neighbor_means<decltype(tag)>(
               element, tensor_storage_index, neighbor_data);
 
       const DataVector& u = tensor[tensor_storage_index];
@@ -121,5 +121,5 @@ bool troubled_cell_indicator(
   return some_component_needs_limiting;
 }
 
-}  // namespace Minmod_detail
+}  // namespace Tci
 }  // namespace Limiters

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
@@ -39,7 +39,7 @@ namespace Tci {
 
 // Implements the TVB troubled-cell indicator from Cockburn1999.
 template <size_t VolumeDim>
-bool troubled_cell_indicator(
+bool tvb_minmod_indicator(
     gsl::not_null<std::array<DataVector, VolumeDim>*> boundary_buffer,
     double tvb_constant, const DataVector& u, const Element<VolumeDim>& element,
     const Mesh<VolumeDim>& mesh,
@@ -60,7 +60,7 @@ bool troubled_cell_indicator(
 // - a variable `means` that is a `TaggedTuple<Tags::Mean<Tags>...>`
 // - a variable `element_size` that is a `std::array<double, VolumeDim>`
 template <size_t VolumeDim, typename PackagedData, typename... Tags>
-bool troubled_cell_indicator(
+bool tvb_minmod_indicator(
     const db::const_item_type<Tags>&... tensors,
     const std::unordered_map<
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
@@ -104,7 +104,7 @@ bool troubled_cell_indicator(
               element, tensor_storage_index, neighbor_data);
 
       const DataVector& u = tensor[tensor_storage_index];
-      const bool component_needs_limiting = troubled_cell_indicator(
+      const bool component_needs_limiting = tvb_minmod_indicator(
           make_not_null(&boundary_buffer), tvb_constant, u, element, mesh,
           element_size, effective_neighbor_means, effective_neighbor_sizes,
           volume_and_slice_indices);

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Tci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Tci.hpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace Limiters {
+
+/// \ingroup LimitersGroup
+/// \brief Troubled Cell Indicators that identify when limiting is needed
+namespace Tci {}
+
+}  // namespace Limiters

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -293,10 +293,10 @@ bool Weno<VolumeDim, tmpl::list<Tags...>>::operator()(
 
   // Troubled-cell detection for WENO flags the element for limiting if any
   // component of any tensor needs limiting.
-  const double minmod_tci_tvb_constant = 0.0;
+  const double tci_tvb_constant = 0.0;
   const bool cell_is_troubled =
-      Tci::troubled_cell_indicator<VolumeDim, PackagedData, Tags...>(
-          (*tensors)..., neighbor_data, minmod_tci_tvb_constant, element, mesh,
+      Tci::tvb_minmod_indicator<VolumeDim, PackagedData, Tags...>(
+          (*tensors)..., neighbor_data, tci_tvb_constant, element, mesh,
           element_size);
 
   if (not cell_is_troubled) {

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -296,8 +296,8 @@ bool Weno<VolumeDim, tmpl::list<Tags...>>::operator()(
   const double tci_tvb_constant = 0.0;
   const bool cell_is_troubled =
       Tci::tvb_minmod_indicator<VolumeDim, PackagedData, Tags...>(
-          (*tensors)..., neighbor_data, tci_tvb_constant, element, mesh,
-          element_size);
+          tci_tvb_constant, (*tensors)..., mesh, element, element_size,
+          neighbor_data);
 
   if (not cell_is_troubled) {
     // No limiting is needed

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -295,7 +295,7 @@ bool Weno<VolumeDim, tmpl::list<Tags...>>::operator()(
   // component of any tensor needs limiting.
   const double minmod_tci_tvb_constant = 0.0;
   const bool cell_is_troubled =
-      Minmod_detail::troubled_cell_indicator<VolumeDim, PackagedData, Tags...>(
+      Tci::troubled_cell_indicator<VolumeDim, PackagedData, Tags...>(
           (*tensors)..., neighbor_data, minmod_tci_tvb_constant, element, mesh,
           element_size);
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
@@ -189,16 +189,16 @@ bool wrap_minmod_limited_slopes(
     const gsl::not_null<double*> u_mean,
     const gsl::not_null<std::array<double, VolumeDim>*> u_limited_slopes,
     const Limiters::MinmodType& minmod_type, const double tvb_constant,
-    const DataVector& u, const Element<VolumeDim>& element,
-    const Mesh<VolumeDim>& mesh,
+    const DataVector& u, const Mesh<VolumeDim>& mesh,
+    const Element<VolumeDim>& element,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
     const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept {
   DataVector u_lin_buffer(mesh.number_of_grid_points());
   Limiters::Minmod_detail::BufferWrapper<VolumeDim> buffer(mesh);
   return Limiters::Minmod_detail::minmod_limited_slopes(
-      u_mean, u_limited_slopes, make_not_null(&u_lin_buffer),
-      make_not_null(&buffer), minmod_type, tvb_constant, u, element, mesh,
+      make_not_null(&u_lin_buffer), make_not_null(&buffer), u_mean,
+      u_limited_slopes, minmod_type, tvb_constant, u, mesh, element,
       element_size, effective_neighbor_means, effective_neighbor_sizes);
 }
 
@@ -234,8 +234,8 @@ auto make_six_neighbors(const std::array<double, 6>& values) noexcept {
 template <size_t VolumeDim>
 void test_minmod_activates(
     const Limiters::MinmodType& minmod_type, const double tvb_constant,
-    const DataVector& input, const Element<VolumeDim>& element,
-    const Mesh<VolumeDim>& mesh,
+    const DataVector& input, const Mesh<VolumeDim>& mesh,
+    const Element<VolumeDim>& element,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
     const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
@@ -244,7 +244,7 @@ void test_minmod_activates(
   std::array<double, VolumeDim> u_limited_slopes{};
   const bool reduce_slopes = wrap_minmod_limited_slopes(
       make_not_null(&u_mean), make_not_null(&u_limited_slopes), minmod_type,
-      tvb_constant, input, element, mesh, element_size,
+      tvb_constant, input, mesh, element, element_size,
       effective_neighbor_means, effective_neighbor_sizes);
   CHECK(reduce_slopes);
   CHECK(u_mean == approx(mean_value(input, mesh)));
@@ -255,8 +255,8 @@ void test_minmod_activates(
 template <size_t VolumeDim>
 void test_minmod_does_not_activate(
     const Limiters::MinmodType& minmod_type, const double tvb_constant,
-    const DataVector& input, const Element<VolumeDim>& element,
-    const Mesh<VolumeDim>& mesh,
+    const DataVector& input, const Mesh<VolumeDim>& mesh,
+    const Element<VolumeDim>& element,
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
     const DirectionMap<VolumeDim, double>& effective_neighbor_sizes,
@@ -265,7 +265,7 @@ void test_minmod_does_not_activate(
   std::array<double, VolumeDim> u_limited_slopes{};
   const bool reduce_slopes = wrap_minmod_limited_slopes(
       make_not_null(&u_mean), make_not_null(&u_limited_slopes), minmod_type,
-      tvb_constant, input, element, mesh, element_size,
+      tvb_constant, input, mesh, element, element_size,
       effective_neighbor_means, effective_neighbor_sizes);
   CHECK_FALSE(reduce_slopes);
   if (minmod_type != Limiters::MinmodType::LambdaPiN) {
@@ -281,27 +281,27 @@ void test_minmod_slopes_on_linear_function(
   CAPTURE(number_of_grid_points);
   CAPTURE(get_output(minmod_type));
   const double tvb_constant = 0.0;
-  const auto element = TestHelpers::Limiters::make_element<1>();
   const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
+  const auto element = TestHelpers::Limiters::make_element<1>();
   const auto element_size = make_array<1>(2.0);
 
   const auto test_activates =
-      [&minmod_type, &tvb_constant, &element, &mesh, &element_size ](
+      [&minmod_type, &tvb_constant, &mesh, &element, &element_size ](
           const DataVector& local_input, const double left, const double right,
           const double expected_slope) noexcept {
     const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_activates(minmod_type, tvb_constant, local_input, element, mesh,
+    test_minmod_activates(minmod_type, tvb_constant, local_input, mesh, element,
                           element_size, make_two_neighbors(left, right),
                           make_two_neighbors(2.0, 2.0), expected_slopes);
   };
   const auto test_does_not_activate =
-      [&minmod_type, &tvb_constant, &element, &mesh, &element_size ](
+      [&minmod_type, &tvb_constant, &mesh, &element, &element_size ](
           const DataVector& local_input, const double left, const double right,
           const double original_slope) noexcept {
     const auto original_slopes = make_array<1>(original_slope);
     test_minmod_does_not_activate(
-        minmod_type, tvb_constant, local_input, element, mesh, element_size,
+        minmod_type, tvb_constant, local_input, mesh, element, element_size,
         make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
         original_slopes);
   };
@@ -373,27 +373,27 @@ void test_minmod_slopes_on_quadratic_function(
   CAPTURE(number_of_grid_points);
   CAPTURE(get_output(minmod_type));
   const double tvb_constant = 0.0;
-  const auto element = TestHelpers::Limiters::make_element<1>();
   const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
+  const auto element = TestHelpers::Limiters::make_element<1>();
   const auto element_size = make_array<1>(2.0);
 
   const auto test_activates =
-      [&minmod_type, &tvb_constant, &element, &mesh, &element_size ](
+      [&minmod_type, &tvb_constant, &mesh, &element, &element_size ](
           const DataVector& local_input, const double left, const double right,
           const double expected_slope) noexcept {
     const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_activates(minmod_type, tvb_constant, local_input, element, mesh,
+    test_minmod_activates(minmod_type, tvb_constant, local_input, mesh, element,
                           element_size, make_two_neighbors(left, right),
                           make_two_neighbors(2.0, 2.0), expected_slopes);
   };
   const auto test_does_not_activate =
-      [&minmod_type, &tvb_constant, &element, &mesh, &element_size ](
+      [&minmod_type, &tvb_constant, &mesh, &element, &element_size ](
           const DataVector& local_input, const double left, const double right,
           const double original_slope) noexcept {
     const auto original_slopes = make_array<1>(original_slope);
     test_minmod_does_not_activate(
-        minmod_type, tvb_constant, local_input, element, mesh, element_size,
+        minmod_type, tvb_constant, local_input, mesh, element, element_size,
         make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
         original_slopes);
   };
@@ -435,28 +435,28 @@ void test_minmod_slopes_with_tvb_correction(
   INFO("Testing TVB correction...");
   CAPTURE(number_of_grid_points);
   CAPTURE(get_output(minmod_type));
-  const auto element = TestHelpers::Limiters::make_element<1>();
   const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
+  const auto element = TestHelpers::Limiters::make_element<1>();
   const auto element_size = make_array<1>(2.0);
 
-  const auto test_activates = [&minmod_type, &element, &mesh, &element_size ](
+  const auto test_activates = [&minmod_type, &mesh, &element, &element_size ](
       const double tvb_constant, const DataVector& local_input,
       const double left, const double right,
       const double expected_slope) noexcept {
     const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_activates(minmod_type, tvb_constant, local_input, element, mesh,
+    test_minmod_activates(minmod_type, tvb_constant, local_input, mesh, element,
                           element_size, make_two_neighbors(left, right),
                           make_two_neighbors(2.0, 2.0), expected_slopes);
   };
   const auto test_does_not_activate =
-      [&minmod_type, &element, &mesh, &
+      [&minmod_type, &mesh, &element, &
        element_size ](const double tvb_constant, const DataVector& local_input,
                       const double left, const double right,
                       const double original_slope) noexcept {
     const auto original_slopes = make_array<1>(original_slope);
     test_minmod_does_not_activate(
-        minmod_type, tvb_constant, local_input, element, mesh, element_size,
+        minmod_type, tvb_constant, local_input, mesh, element, element_size,
         make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
         original_slopes);
   };
@@ -489,23 +489,23 @@ void test_lambda_pin_troubled_cell_tvb_correction(
     const size_t number_of_grid_points) noexcept {
   INFO("Testing LambdaPiN-TVB correction...");
   CAPTURE(number_of_grid_points);
-  const auto element = TestHelpers::Limiters::make_element<1>();
   const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
+  const auto element = TestHelpers::Limiters::make_element<1>();
   const auto logical_coords = logical_coordinates(mesh);
   const auto element_size = make_array<1>(2.0);
 
-  const auto test_activates = [&element, &mesh, &element_size ](
+  const auto test_activates = [&mesh, &element, &element_size ](
       const double tvb_constant, const DataVector& local_input,
       const double left, const double right,
       const double expected_slope) noexcept {
     const auto expected_slopes = make_array<1>(expected_slope);
     test_minmod_activates(Limiters::MinmodType::LambdaPiN, tvb_constant,
-                          local_input, element, mesh, element_size,
+                          local_input, mesh, element, element_size,
                           make_two_neighbors(left, right),
                           make_two_neighbors(2.0, 2.0), expected_slopes);
   };
-  const auto test_does_not_activate = [&element, &mesh, &element_size ](
+  const auto test_does_not_activate = [&mesh, &element, &element_size ](
       const double tvb_constant, const DataVector& local_input,
       const double left, const double right) noexcept {
     // Because in this test the limiter is LambdaPiN, no slopes are returned,
@@ -513,8 +513,8 @@ void test_lambda_pin_troubled_cell_tvb_correction(
     const auto original_slopes =
         make_array<1>(std::numeric_limits<double>::signaling_NaN());
     test_minmod_does_not_activate(
-        Limiters::MinmodType::LambdaPiN, tvb_constant, local_input, element,
-        mesh, element_size, make_two_neighbors(left, right),
+        Limiters::MinmodType::LambdaPiN, tvb_constant, local_input, mesh,
+        element, element_size, make_two_neighbors(left, right),
         make_two_neighbors(2.0, 2.0), original_slopes);
   };
 
@@ -578,7 +578,7 @@ void test_minmod_slopes_at_boundary(
       TestHelpers::Limiters::make_element<1>({{Direction<1>::lower_xi()}});
   for (const double neighbor : {-1.3, 3.6, 4.8, 13.2}) {
     test_minmod_activates(
-        minmod_type, tvb_constant, input, element_at_lower_xi_boundary, mesh,
+        minmod_type, tvb_constant, input, mesh, element_at_lower_xi_boundary,
         element_size, {{std::make_pair(Direction<1>::upper_xi(), neighbor)}},
         {{std::make_pair(Direction<1>::upper_xi(), element_size[0])}},
         make_array<1>(0.0));
@@ -589,7 +589,7 @@ void test_minmod_slopes_at_boundary(
       TestHelpers::Limiters::make_element<1>({{Direction<1>::upper_xi()}});
   for (const double neighbor : {-1.3, 3.6, 4.8, 13.2}) {
     test_minmod_activates(
-        minmod_type, tvb_constant, input, element_at_upper_xi_boundary, mesh,
+        minmod_type, tvb_constant, input, mesh, element_at_upper_xi_boundary,
         element_size, {{std::make_pair(Direction<1>::lower_xi(), neighbor)}},
         {{std::make_pair(Direction<1>::lower_xi(), element_size[0])}},
         make_array<1>(0.0));
@@ -603,31 +603,31 @@ void test_minmod_slopes_with_different_size_neighbor(
   CAPTURE(number_of_grid_points);
   CAPTURE(get_output(minmod_type));
   const double tvb_constant = 0.0;
-  const auto element = TestHelpers::Limiters::make_element<1>();
   const Mesh<1> mesh(number_of_grid_points, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
+  const auto element = TestHelpers::Limiters::make_element<1>();
   const double dx = 1.0;
   const auto element_size = make_array<1>(dx);
 
   const auto test_activates =
-      [&minmod_type, &tvb_constant, &element, &mesh, &element_size ](
+      [&minmod_type, &tvb_constant, &mesh, &element, &element_size ](
           const DataVector& local_input, const double left, const double right,
           const double left_size, const double right_size,
           const double expected_slope) noexcept {
     const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_activates(minmod_type, tvb_constant, local_input, element, mesh,
+    test_minmod_activates(minmod_type, tvb_constant, local_input, mesh, element,
                           element_size, make_two_neighbors(left, right),
                           make_two_neighbors(left_size, right_size),
                           expected_slopes);
   };
   const auto test_does_not_activate =
-      [&minmod_type, &tvb_constant, &element, &mesh, &element_size ](
+      [&minmod_type, &tvb_constant, &mesh, &element, &element_size ](
           const DataVector& local_input, const double left, const double right,
           const double left_size, const double right_size,
           const double original_slope) noexcept {
     const auto original_slopes = make_array<1>(original_slope);
     test_minmod_does_not_activate(
-        minmod_type, tvb_constant, local_input, element, mesh, element_size,
+        minmod_type, tvb_constant, local_input, mesh, element, element_size,
         make_two_neighbors(left, right),
         make_two_neighbors(left_size, right_size), original_slopes);
   };
@@ -699,28 +699,28 @@ void test_minmod_limited_slopes_2d() noexcept {
   INFO("Testing Minmod minmod_limited_slopes in 2D");
   const auto minmod_type = Limiters::MinmodType::LambdaPi1;
   const double tvb_constant = 0.0;
-  const auto element = TestHelpers::Limiters::make_element<2>();
   const Mesh<2> mesh(3, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
+  const auto element = TestHelpers::Limiters::make_element<2>();
   const auto element_size = make_array<2>(2.0);
 
   const auto test_activates =
-      [&minmod_type, &tvb_constant, &element, &mesh, &
+      [&minmod_type, &tvb_constant, &mesh, &element, &
        element_size ](const DataVector& local_input,
                       const std::array<double, 4>& neighbor_means,
                       const std::array<double, 2>& expected_slopes) noexcept {
-    test_minmod_activates(minmod_type, tvb_constant, local_input, element, mesh,
+    test_minmod_activates(minmod_type, tvb_constant, local_input, mesh, element,
                           element_size, make_four_neighbors(neighbor_means),
                           make_four_neighbors(make_array<4>(2.0)),
                           expected_slopes);
   };
   const auto test_does_not_activate =
-      [&minmod_type, &tvb_constant, &element, &mesh, &
+      [&minmod_type, &tvb_constant, &mesh, &element, &
        element_size ](const DataVector& local_input,
                       const std::array<double, 4>& neighbor_means,
                       const std::array<double, 2>& original_slopes) noexcept {
     test_minmod_does_not_activate(
-        minmod_type, tvb_constant, local_input, element, mesh, element_size,
+        minmod_type, tvb_constant, local_input, mesh, element, element_size,
         make_four_neighbors(neighbor_means),
         make_four_neighbors(make_array<4>(2.0)), original_slopes);
   };
@@ -754,28 +754,28 @@ void test_minmod_limited_slopes_3d() noexcept {
   INFO("Testing Minmod minmod_limited_slopes in 3D");
   const auto minmod_type = Limiters::MinmodType::LambdaPi1;
   const double tvb_constant = 0.0;
-  const auto element = TestHelpers::Limiters::make_element<3>();
   const Mesh<3> mesh(3, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
+  const auto element = TestHelpers::Limiters::make_element<3>();
   const auto element_size = make_array<3>(2.0);
 
   const auto test_activates =
-      [&minmod_type, &tvb_constant, &element, &mesh, &
+      [&minmod_type, &tvb_constant, &mesh, &element, &
        element_size ](const DataVector& local_input,
                       const std::array<double, 6>& neighbor_means,
                       const std::array<double, 3>& expected_slopes) noexcept {
-    test_minmod_activates(minmod_type, tvb_constant, local_input, element, mesh,
+    test_minmod_activates(minmod_type, tvb_constant, local_input, mesh, element,
                           element_size, make_six_neighbors(neighbor_means),
                           make_six_neighbors(make_array<6>(2.0)),
                           expected_slopes);
   };
   const auto test_does_not_activate =
-      [&minmod_type, &tvb_constant, &element, &mesh, &
+      [&minmod_type, &tvb_constant, &mesh, &element, &
        element_size ](const DataVector& local_input,
                       const std::array<double, 6>& neighbor_means,
                       const std::array<double, 3>& original_slopes) noexcept {
     test_minmod_does_not_activate(
-        minmod_type, tvb_constant, local_input, element, mesh, element_size,
+        minmod_type, tvb_constant, local_input, mesh, element, element_size,
         make_six_neighbors(neighbor_means),
         make_six_neighbors(make_array<6>(2.0)), original_slopes);
   };
@@ -816,6 +816,9 @@ template <size_t VolumeDim>
 void test_limiter_work(
     const Scalar<DataVector>& input_scalar,
     const tnsr::I<DataVector, VolumeDim>& input_vector,
+    const Mesh<VolumeDim>& mesh,
+    const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
+    const std::array<double, VolumeDim>& element_size,
     const std::unordered_map<
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
         typename Limiters::Minmod<
@@ -823,9 +826,6 @@ void test_limiter_work(
             tmpl::list<ScalarTag, VectorTag<VolumeDim>>>::PackagedData,
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
         neighbor_data,
-    const Mesh<VolumeDim>& mesh,
-    const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
-    const std::array<double, VolumeDim>& element_size,
     const std::array<double, VolumeDim>& target_scalar_slope,
     const std::array<std::array<double, VolumeDim>, VolumeDim>&
         target_vector_slope) noexcept {
@@ -848,7 +848,7 @@ void test_limiter_work(
       minmod(Limiters::MinmodType::LambdaPi1);
   const bool limiter_activated =
       minmod(make_not_null(&scalar_to_limit), make_not_null(&vector_to_limit),
-             element, mesh, logical_coords, element_size, neighbor_data);
+             mesh, element, logical_coords, element_size, neighbor_data);
 
   CHECK(limiter_activated);
 
@@ -928,8 +928,8 @@ void test_minmod_limiter_1d() noexcept {
   get<Tags::Mean<VectorTag<1>>>(neighbor_data[dir_keys[1]].means) =
       tnsr::I<double, 1>(mean + 2.0 * true_slope[0]);
 
-  test_limiter_work(input_scalar, input_vector, neighbor_data, mesh,
-                    logical_coords, element_size, target_scalar_slope,
+  test_limiter_work(input_scalar, input_vector, mesh, logical_coords,
+                    element_size, neighbor_data, target_scalar_slope,
                     target_vector_slope);
 }
 
@@ -1018,8 +1018,8 @@ void test_minmod_limiter_2d() noexcept {
   get<Tags::Mean<VectorTag<2>>>(neighbor_data[dir_keys[3]].means) =
       neighbor_vector_func(1, 1);
 
-  test_limiter_work(input_scalar, input_vector, neighbor_data, mesh,
-                    logical_coords, element_size, target_scalar_slope,
+  test_limiter_work(input_scalar, input_vector, mesh, logical_coords,
+                    element_size, neighbor_data, target_scalar_slope,
                     target_vector_slope);
 }
 
@@ -1134,8 +1134,8 @@ void test_minmod_limiter_3d() noexcept {
   get<Tags::Mean<VectorTag<3>>>(neighbor_data[dir_keys[5]].means) =
       neighbor_vector_func(2, 1);
 
-  test_limiter_work(input_scalar, input_vector, neighbor_data, mesh,
-                    logical_coords, element_size, target_scalar_slope,
+  test_limiter_work(input_scalar, input_vector, mesh, logical_coords,
+                    element_size, neighbor_data, target_scalar_slope,
                     target_vector_slope);
 }
 
@@ -1144,8 +1144,8 @@ void test_minmod_limiter_3d() noexcept {
 template <size_t VolumeDim>
 void test_limiter_activates_work(
     const Limiters::Minmod<VolumeDim, tmpl::list<ScalarTag>>& minmod,
-    const ScalarTag::type& input, const Element<VolumeDim>& element,
-    const Mesh<VolumeDim>& mesh,
+    const ScalarTag::type& input, const Mesh<VolumeDim>& mesh,
+    const Element<VolumeDim>& element,
     const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
     const std::array<double, VolumeDim>& element_size,
     const std::unordered_map<
@@ -1157,7 +1157,7 @@ void test_limiter_activates_work(
     const double expected_slope) noexcept {
   auto input_to_limit = input;
   const bool limiter_activated =
-      minmod(make_not_null(&input_to_limit), element, mesh, logical_coords,
+      minmod(make_not_null(&input_to_limit), mesh, element, logical_coords,
              element_size, neighbor_data);
   CHECK(limiter_activated);
   const ScalarTag::type expected_output = [&logical_coords, &mesh ](
@@ -1220,7 +1220,7 @@ void test_minmod_limiter_two_lower_xi_neighbors() noexcept {
   const auto neighbor_data_two_means =
       make_neighbors(mean - 1.1, mean - 1.0, mean + 1.4, dx, dx);
   // Effective neighbor mean (1.1 + 1.0) / 2.0 => 1.05
-  test_limiter_activates_work(minmod, input, element, mesh, logical_coords,
+  test_limiter_activates_work(minmod, input, mesh, element, logical_coords,
                               element_size, neighbor_data_two_means, 1.05);
 
   // Make two left neighbors with different means and sizes
@@ -1229,7 +1229,7 @@ void test_minmod_limiter_two_lower_xi_neighbors() noexcept {
   // Effective neighbor mean (1.1 + 1.0) / 2.0 => 1.05
   // Average neighbor size (1.0 + 0.5) / 2.0 => 0.75
   // Effective distance (0.75 + 1.0) / 2.0 => 0.875
-  test_limiter_activates_work(minmod, input, element, mesh, logical_coords,
+  test_limiter_activates_work(minmod, input, mesh, element, logical_coords,
                               element_size, neighbor_data_two_sizes,
                               1.05 / 0.875);
 }
@@ -1294,7 +1294,7 @@ void test_minmod_limiter_four_upper_xi_neighbors() noexcept {
       make_neighbors(mean - 1.4, mean + 1.0, mean + 1.1, mean - 0.2, mean + 1.8,
                      dx, dx, dx, dx);
   // Effective neighbor mean (1.0 + 1.1 - 0.2 + 1.8) / 4.0 => 0.925
-  test_limiter_activates_work(minmod, input, element, mesh, logical_coords,
+  test_limiter_activates_work(minmod, input, mesh, element, logical_coords,
                               element_size, neighbor_data_two_means, 0.925);
 
   // Make four right neighbors with different means and sizes
@@ -1304,7 +1304,7 @@ void test_minmod_limiter_four_upper_xi_neighbors() noexcept {
   // Effective neighbor mean (1.0 + 1.1 - 0.2 + 1.8) / 4.0 => 0.925
   // Average neighbor size (1.0 + 0.5 + 0.5 + 0.5) / 4.0 => 0.625
   // Effective distance (0.625 + 1.0) / 2.0 => 0.8125
-  test_limiter_activates_work(minmod, input, element, mesh, logical_coords,
+  test_limiter_activates_work(minmod, input, mesh, element, logical_coords,
                               element_size, neighbor_data_two_sizes,
                               0.925 / 0.8125);
 }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodTci.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodTci.cpp
@@ -55,7 +55,7 @@ bool wrap_allocations_and_tci(
   const auto& volume_and_slice_indices =
       volume_and_slice_buffer_and_indices.second;
 
-  return Limiters::Minmod_detail::troubled_cell_indicator(
+  return Limiters::Tci::troubled_cell_indicator(
       make_not_null(&boundary_buffer), tvb_constant, u, element, mesh,
       element_size, effective_neighbor_means, effective_neighbor_sizes,
       volume_and_slice_indices);
@@ -503,8 +503,8 @@ void test_minmod_tci_several_tensors() noexcept {
   get<2>(get<::Tags::Mean<VectorTag<3>>>(lower_zeta_neighbor.means)) = 3.1;
   get<2>(get<::Tags::Mean<VectorTag<3>>>(upper_zeta_neighbor.means)) = 0.5;
   const bool trigger_base_case =
-      Limiters::Minmod_detail::troubled_cell_indicator<3, TestPackagedData,
-                                                       ScalarTag, VectorTag<3>>(
+      Limiters::Tci::troubled_cell_indicator<3, TestPackagedData, ScalarTag,
+                                             VectorTag<3>>(
           local_scalar, local_vector, neighbor_data, tvb_constant, element,
           mesh, element_size);
   CHECK_FALSE(trigger_base_case);
@@ -512,8 +512,8 @@ void test_minmod_tci_several_tensors() noexcept {
   // Case where the scalar triggers limiting
   get(get<::Tags::Mean<ScalarTag>>(upper_xi_neighbor.means)) = 2.0;
   const bool trigger_scalar =
-      Limiters::Minmod_detail::troubled_cell_indicator<3, TestPackagedData,
-                                                       ScalarTag, VectorTag<3>>(
+      Limiters::Tci::troubled_cell_indicator<3, TestPackagedData, ScalarTag,
+                                             VectorTag<3>>(
           local_scalar, local_vector, neighbor_data, tvb_constant, element,
           mesh, element_size);
   CHECK(trigger_scalar);
@@ -522,8 +522,8 @@ void test_minmod_tci_several_tensors() noexcept {
   get(get<::Tags::Mean<ScalarTag>>(upper_xi_neighbor.means)) = 3.3;
   get<0>(get<::Tags::Mean<VectorTag<3>>>(lower_zeta_neighbor.means)) = -0.1;
   const bool trigger_vector_x =
-      Limiters::Minmod_detail::troubled_cell_indicator<3, TestPackagedData,
-                                                       ScalarTag, VectorTag<3>>(
+      Limiters::Tci::troubled_cell_indicator<3, TestPackagedData, ScalarTag,
+                                             VectorTag<3>>(
           local_scalar, local_vector, neighbor_data, tvb_constant, element,
           mesh, element_size);
   CHECK(trigger_vector_x);
@@ -532,8 +532,8 @@ void test_minmod_tci_several_tensors() noexcept {
   get<0>(get<::Tags::Mean<VectorTag<3>>>(lower_zeta_neighbor.means)) = -1.8;
   get<1>(get<::Tags::Mean<VectorTag<3>>>(upper_eta_neighbor.means)) = -0.2;
   const bool trigger_vector_y =
-      Limiters::Minmod_detail::troubled_cell_indicator<3, TestPackagedData,
-                                                       ScalarTag, VectorTag<3>>(
+      Limiters::Tci::troubled_cell_indicator<3, TestPackagedData, ScalarTag,
+                                             VectorTag<3>>(
           local_scalar, local_vector, neighbor_data, tvb_constant, element,
           mesh, element_size);
   CHECK(trigger_vector_y);
@@ -542,8 +542,8 @@ void test_minmod_tci_several_tensors() noexcept {
   get<1>(get<::Tags::Mean<VectorTag<3>>>(upper_eta_neighbor.means)) = 0.1;
   get<2>(get<::Tags::Mean<VectorTag<3>>>(lower_xi_neighbor.means)) = 1.9;
   const bool trigger_vector_z =
-      Limiters::Minmod_detail::troubled_cell_indicator<3, TestPackagedData,
-                                                       ScalarTag, VectorTag<3>>(
+      Limiters::Tci::troubled_cell_indicator<3, TestPackagedData, ScalarTag,
+                                             VectorTag<3>>(
           local_scalar, local_vector, neighbor_data, tvb_constant, element,
           mesh, element_size);
   CHECK(trigger_vector_z);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodTci.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodTci.cpp
@@ -55,7 +55,7 @@ bool wrap_allocations_and_tci(
   const auto& volume_and_slice_indices =
       volume_and_slice_buffer_and_indices.second;
 
-  return Limiters::Tci::troubled_cell_indicator(
+  return Limiters::Tci::tvb_minmod_indicator(
       make_not_null(&boundary_buffer), tvb_constant, u, element, mesh,
       element_size, effective_neighbor_means, effective_neighbor_sizes,
       volume_and_slice_indices);
@@ -310,7 +310,7 @@ void test_tci_with_different_size_neighbor(
 
 // In 1D, test combinations of TVB constant, polynomial order, etc.
 // Check that each combination has the expected TCI behavior.
-void test_minmod_tci_1d() noexcept {
+void test_tvb_minmod_tci_1d() noexcept {
   INFO("Testing MinmodTci in 1D");
   for (const auto num_grid_points : std::array<size_t, 2>{{2, 4}}) {
     test_tci_on_linear_function(num_grid_points);
@@ -324,7 +324,7 @@ void test_minmod_tci_1d() noexcept {
 
 // In 2D, test that the dimension-by-dimension application of the TCI works as
 // expected.
-void test_minmod_tci_2d() noexcept {
+void test_tvb_minmod_tci_2d() noexcept {
   INFO("Testing MinmodTci in 2D");
   const double tvb_constant = 0.0;
   const auto element = TestHelpers::Limiters::make_element<2>();
@@ -366,7 +366,7 @@ void test_minmod_tci_2d() noexcept {
 
 // In 3D, test that the dimension-by-dimension application of the TCI works as
 // expected.
-void test_minmod_tci_3d() noexcept {
+void test_tvb_minmod_tci_3d() noexcept {
   INFO("Testing MinmodTci in 3D");
   const double tvb_constant = 0.0;
   const auto element = TestHelpers::Limiters::make_element<3>();
@@ -423,7 +423,7 @@ struct VectorTag : db::SimpleTag {
   static std::string name() noexcept { return "Vector"; }
 };
 
-void test_minmod_tci_several_tensors() noexcept {
+void test_tvb_minmod_tci_several_tensors() noexcept {
   INFO("Testing MinmodTci action on several tensors");
   // Test that TCI returns true if just one component needs limiting, which
   // we do by limiting a scalar and vector in 3D
@@ -503,8 +503,8 @@ void test_minmod_tci_several_tensors() noexcept {
   get<2>(get<::Tags::Mean<VectorTag<3>>>(lower_zeta_neighbor.means)) = 3.1;
   get<2>(get<::Tags::Mean<VectorTag<3>>>(upper_zeta_neighbor.means)) = 0.5;
   const bool trigger_base_case =
-      Limiters::Tci::troubled_cell_indicator<3, TestPackagedData, ScalarTag,
-                                             VectorTag<3>>(
+      Limiters::Tci::tvb_minmod_indicator<3, TestPackagedData, ScalarTag,
+                                          VectorTag<3>>(
           local_scalar, local_vector, neighbor_data, tvb_constant, element,
           mesh, element_size);
   CHECK_FALSE(trigger_base_case);
@@ -512,8 +512,8 @@ void test_minmod_tci_several_tensors() noexcept {
   // Case where the scalar triggers limiting
   get(get<::Tags::Mean<ScalarTag>>(upper_xi_neighbor.means)) = 2.0;
   const bool trigger_scalar =
-      Limiters::Tci::troubled_cell_indicator<3, TestPackagedData, ScalarTag,
-                                             VectorTag<3>>(
+      Limiters::Tci::tvb_minmod_indicator<3, TestPackagedData, ScalarTag,
+                                          VectorTag<3>>(
           local_scalar, local_vector, neighbor_data, tvb_constant, element,
           mesh, element_size);
   CHECK(trigger_scalar);
@@ -522,8 +522,8 @@ void test_minmod_tci_several_tensors() noexcept {
   get(get<::Tags::Mean<ScalarTag>>(upper_xi_neighbor.means)) = 3.3;
   get<0>(get<::Tags::Mean<VectorTag<3>>>(lower_zeta_neighbor.means)) = -0.1;
   const bool trigger_vector_x =
-      Limiters::Tci::troubled_cell_indicator<3, TestPackagedData, ScalarTag,
-                                             VectorTag<3>>(
+      Limiters::Tci::tvb_minmod_indicator<3, TestPackagedData, ScalarTag,
+                                          VectorTag<3>>(
           local_scalar, local_vector, neighbor_data, tvb_constant, element,
           mesh, element_size);
   CHECK(trigger_vector_x);
@@ -532,8 +532,8 @@ void test_minmod_tci_several_tensors() noexcept {
   get<0>(get<::Tags::Mean<VectorTag<3>>>(lower_zeta_neighbor.means)) = -1.8;
   get<1>(get<::Tags::Mean<VectorTag<3>>>(upper_eta_neighbor.means)) = -0.2;
   const bool trigger_vector_y =
-      Limiters::Tci::troubled_cell_indicator<3, TestPackagedData, ScalarTag,
-                                             VectorTag<3>>(
+      Limiters::Tci::tvb_minmod_indicator<3, TestPackagedData, ScalarTag,
+                                          VectorTag<3>>(
           local_scalar, local_vector, neighbor_data, tvb_constant, element,
           mesh, element_size);
   CHECK(trigger_vector_y);
@@ -542,8 +542,8 @@ void test_minmod_tci_several_tensors() noexcept {
   get<1>(get<::Tags::Mean<VectorTag<3>>>(upper_eta_neighbor.means)) = 0.1;
   get<2>(get<::Tags::Mean<VectorTag<3>>>(lower_xi_neighbor.means)) = 1.9;
   const bool trigger_vector_z =
-      Limiters::Tci::troubled_cell_indicator<3, TestPackagedData, ScalarTag,
-                                             VectorTag<3>>(
+      Limiters::Tci::tvb_minmod_indicator<3, TestPackagedData, ScalarTag,
+                                          VectorTag<3>>(
           local_scalar, local_vector, neighbor_data, tvb_constant, element,
           mesh, element_size);
   CHECK(trigger_vector_z);
@@ -552,9 +552,9 @@ void test_minmod_tci_several_tensors() noexcept {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.MinmodTci", "[Limiters][Unit]") {
-  test_minmod_tci_1d();
-  test_minmod_tci_2d();
-  test_minmod_tci_3d();
+  test_tvb_minmod_tci_1d();
+  test_tvb_minmod_tci_2d();
+  test_tvb_minmod_tci_3d();
 
-  test_minmod_tci_several_tensors();
+  test_tvb_minmod_tci_several_tensors();
 }


### PR DESCRIPTION
## Proposed changes

This is the first in a series of PRs that will reorganize parts of the limiter code. The main goal of the overall refactor is to provide a more flexible interface for limiting.

- Adds a TCI namespace
- Adds a helper class to handle the multiple buffers and precomputations for Minmod
- Renames a function and reorders function arguments

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
