### PR TITLE
Refactor WENO reconstruction interface

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   MinmodTci.cpp
   MinmodType.cpp
   WenoGridHelpers.cpp
+  WenoHelpers.cpp
   WenoOscillationIndicator.cpp
   WenoType.cpp
   )

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.cpp
@@ -1,0 +1,123 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp"
+
+#include <boost/functional/hash.hpp>  // IWYU pragma: keep
+#include <cstddef>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Variables.hpp"  // IWYU pragma: keep
+#include "Domain/Direction.hpp"          // IWYU pragma: keep
+#include "Domain/ElementId.hpp"          // IWYU pragma: keep
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp"
+#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+
+// Compute the unnormalized nonlinear WENO weights. This is a fairly standard
+// choice of weights; see e.g., Eq. 3.9 of Zhong2013 or Eq. 3.6 of Zhu2016.
+inline double unnormalized_nonlinear_weight(
+    const double linear_weight, const double oscillation_indicator) noexcept {
+  return linear_weight / square(1.e-6 + oscillation_indicator);
+}
+
+}  // namespace
+
+namespace Limiters {
+namespace Weno_detail {
+
+template <size_t VolumeDim>
+void reconstruct_from_weighted_sum(
+    const gsl::not_null<DataVector*> local_polynomial,
+    const Mesh<VolumeDim>& mesh, const double neighbor_linear_weight,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, DataVector,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_polynomials,
+    const DerivativeWeight derivative_weight) noexcept {
+#ifdef SPECTRE_DEBUG
+  // Check inputs match requirements
+  const double local_mean = mean_value(*local_polynomial, mesh);
+  for (const auto& kv : neighbor_polynomials) {
+    const auto& neighbor_polynomial = kv.second;
+    const double neighbor_mean = mean_value(neighbor_polynomial, mesh);
+    ASSERT(equal_within_roundoff(local_mean, neighbor_mean),
+           "Invalid inputs to Weno_detail::reconstruct_from_weighted_sum:\n"
+           "The neighbor polynomials should have the same mean as the local\n"
+           "polynomial.");
+  }
+#endif  // ifdef SPECTRE_DEBUG
+
+  // Store linear weights in `local_weights` and `neighbor_weights`
+  // These weights will have to be generalized for multiple neighbors per
+  // face for use with h-refinement and AMR.
+  double local_weight = 1.;
+  std::unordered_map<
+      std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, double,
+      boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>
+      neighbor_weights;
+  for (const auto& kv : neighbor_polynomials) {
+    local_weight -= neighbor_linear_weight;
+    neighbor_weights[kv.first] = neighbor_linear_weight;
+  }
+
+  // Update `local_weights` and `neighbor_weights` to hold the unnormalized
+  // nonlinear weights.
+  local_weight = unnormalized_nonlinear_weight(
+      local_weight,
+      oscillation_indicator(*local_polynomial, mesh, derivative_weight));
+  for (const auto& kv : neighbor_polynomials) {
+    const auto& key = kv.first;
+    const auto& neighbor_polynomial = kv.second;
+    neighbor_weights[key] = unnormalized_nonlinear_weight(
+        neighbor_weights[key],
+        oscillation_indicator(neighbor_polynomial, mesh, derivative_weight));
+  }
+
+  // Update `local_weights` and `neighbor_weights` to hold the normalized
+  // weights; these are the final weights of the WENO reconstruction.
+  double normalization = local_weight;
+  for (const auto& kv : neighbor_weights) {
+    normalization += kv.second;
+  }
+  local_weight /= normalization;
+  for (auto& kv : neighbor_weights) {
+    kv.second /= normalization;
+  }
+
+  // Perform reconstruction by combining the local and neighbor polynomials.
+  *local_polynomial *= local_weight;
+  for (const auto& kv : neighbor_polynomials) {
+    const auto& key = kv.first;
+    const auto& neighbor_polynomial = kv.second;
+    *local_polynomial += neighbor_weights.at(key) * neighbor_polynomial;
+  }
+}
+
+// Explicit instantiations
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template void reconstruct_from_weighted_sum(                                \
+      const gsl::not_null<DataVector*>, const Mesh<DIM(data)>&, const double, \
+      const std::unordered_map<                                               \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,  \
+          boost::hash<                                                        \
+              std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>&,       \
+      const DerivativeWeight) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+
+}  // namespace Weno_detail
+}  // namespace Limiters

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp
@@ -7,17 +7,10 @@
 #include <unordered_map>
 #include <utility>
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "DataStructures/Variables.hpp"  // IWYU pragma: keep
 #include "Domain/Direction.hpp"          // IWYU pragma: keep
 #include "Domain/ElementId.hpp"          // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp"
-#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
-#include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/Gsl.hpp"
-
-// IWYU pragma: no_forward_declare Variables
 
 /// \cond
 class DataVector;
@@ -33,98 +26,26 @@ struct hash;
 namespace Limiters {
 namespace Weno_detail {
 
-// Compute the unnormalized nonlinear WENO weights. This is a fairly standard
-// choice of weights; see e.g., Eq. 3.9 of Zhong2013 or Eq. 3.6 of Zhu2016.
-inline double unnormalized_nonlinear_weight(
-    const double linear_weight, const double oscillation_indicator) noexcept {
-  return linear_weight / square(1.e-6 + oscillation_indicator);
-}
-
-// Compute the WENO weighted reconstruction of several polynomials, see e.g.,
+// Compute the WENO weighted reconstruction of a DataVector, see e.g.,
 // Eq. 4.3 of Zhu2016. This is fairly standard, though different references can
-// differ in their choice of oscillation/smoothness indicator.
+// differ in their choice of oscillation/smoothness indicator. The
+// `DerivativeWeight` enum specifies the relative weight of each derivative
+// term when computing the oscillation indicator.
 //
-// The neighbor tensors corresponding to `local_tensor` (i.e., the tensor in
-// each `neighbor_vars` value that is identified by `Tag`), must have the same
-// mean as the local tensor. This is checked with an ASSERT.
-template <typename Tag, size_t VolumeDim, typename TagsList>
+// The reconstruction modifies the DataVector in `local_polynomial` by adding
+// to it a weighted combination of one or more neighbor contributions, passed
+// in as several DataVectors in `neighbor_polynommials`. Each neighbor
+// polynomial must have the same mean as the local polynomial; this is checked
+// with an ASSERT.
+template <size_t VolumeDim>
 void reconstruct_from_weighted_sum(
-    const gsl::not_null<db::item_type<Tag>*> local_tensor,
-    const Mesh<VolumeDim>& mesh, const double neighbor_linear_weight,
+    gsl::not_null<DataVector*> local_polynomial, const Mesh<VolumeDim>& mesh,
+    double neighbor_linear_weight,
     const std::unordered_map<
-        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
-        Variables<TagsList>,
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, DataVector,
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
-        neighbor_vars,
-    const DerivativeWeight derivative_weight) noexcept {
-  for (size_t tensor_storage_index = 0;
-       tensor_storage_index < local_tensor->size(); ++tensor_storage_index) {
-    auto& local_polynomial = (*local_tensor)[tensor_storage_index];
-
-#ifdef SPECTRE_DEBUG
-    // Check inputs match requirements
-    const double local_mean = mean_value(local_polynomial, mesh);
-    for (const auto& kv : neighbor_vars) {
-      const auto& neighbor_polynomial =
-          get<Tag>(kv.second)[tensor_storage_index];
-      const double neighbor_mean = mean_value(neighbor_polynomial, mesh);
-      ASSERT(equal_within_roundoff(local_mean, neighbor_mean),
-             "Invalid inputs to Weno_detail::reconstruct_from_weighted_sum:\n"
-             "The neighbor polynomials should have the same mean as the local\n"
-             "polynomial.");
-    }
-#endif  // ifdef SPECTRE_DEBUG
-
-    // Store linear weights in `local_weights` and `neighbor_weights`
-    // These weights will have to be generalized for multiple neighbors per
-    // face for use with h-refinement and AMR.
-    double local_weight = 1.;
-    std::unordered_map<
-        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, double,
-        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>
-        neighbor_weights;
-    for (const auto& kv : neighbor_vars) {
-      local_weight -= neighbor_linear_weight;
-      neighbor_weights[kv.first] = neighbor_linear_weight;
-    }
-
-    // Update `local_weights` and `neighbor_weights` to hold the unnormalized
-    // nonlinear weights.
-    local_weight = unnormalized_nonlinear_weight(
-        local_weight,
-        oscillation_indicator(local_polynomial, mesh, derivative_weight));
-    for (const auto& kv : neighbor_vars) {
-      const auto& key = kv.first;
-      const auto& neighbor_tensor_component =
-          get<Tag>(kv.second)[tensor_storage_index];
-      neighbor_weights[key] = unnormalized_nonlinear_weight(
-          neighbor_weights[key],
-          oscillation_indicator(neighbor_tensor_component, mesh,
-                                derivative_weight));
-    }
-
-    // Update `local_weights` and `neighbor_weights` to hold the normalized
-    // weights; these are the final weights of the WENO reconstruction.
-    double normalization = local_weight;
-    for (const auto& kv : neighbor_weights) {
-      normalization += kv.second;
-    }
-    local_weight /= normalization;
-    for (auto& kv : neighbor_weights) {
-      kv.second /= normalization;
-    }
-
-    // Perform reconstruction, by superposition of local and neighbor
-    // polynomials.
-    local_polynomial *= local_weight;
-    for (const auto& kv : neighbor_vars) {
-      const auto& key = kv.first;
-      const auto& neighbor_polynomial =
-          get<Tag>(kv.second)[tensor_storage_index];
-      local_polynomial += neighbor_weights.at(key) * neighbor_polynomial;
-    }
-  }
-}
+        neighbor_polynomials,
+    DerivativeWeight derivative_weight) noexcept;
 
 }  // namespace Weno_detail
 }  // namespace Limiters

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoHelpers.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoHelpers.cpp
@@ -5,15 +5,11 @@
 
 #include <array>
 #include <boost/functional/hash.hpp>
-#include <cstddef>
-#include <string>
 #include <unordered_map>
 #include <utility>
 
-#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "DataStructures/Variables.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/LogicalCoordinates.hpp"
@@ -24,22 +20,8 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/TMPL.hpp"
-
-// IWYU pragma: no_forward_declare Variables
 
 namespace {
-
-struct ScalarTag : db::SimpleTag {
-  using type = Scalar<DataVector>;
-  static std::string name() noexcept { return "Scalar"; }
-};
-
-template <size_t VolumeDim>
-struct VectorTag : db::SimpleTag {
-  using type = tnsr::I<DataVector, VolumeDim>;
-  static std::string name() noexcept { return "Vector"; }
-};
 
 void test_reconstruction_1d() noexcept {
   const double neighbor_linear_weight = 0.005;
@@ -54,45 +36,35 @@ void test_reconstruction_1d() noexcept {
                       coeffs[3] * cube(x) + coeffs[4] * pow<4>(x)};
   };
 
-  auto scalar =
-      ScalarTag::type{{{evaluate_polynomial({{1., 2., 0., 0.5, 0.1}})}}};
+  DataVector local_data = evaluate_polynomial({{1., 2., 0., 0.5, 0.1}});
   // WENO reconstruction should preserve the mean, so expected = initial
-  const double expected_scalar_mean = mean_value(get(scalar), mesh);
+  const double expected_local_mean = mean_value(local_data, mesh);
 
   const auto shift_data_to_local_mean =
-      [&mesh, &expected_scalar_mean ](const ScalarTag::type& data) noexcept {
-    auto result = data;
-    get(result) += expected_scalar_mean - mean_value(get(data), mesh);
-    return result;
+      [&mesh, &expected_local_mean ](const DataVector& neighbor_data) noexcept {
+    return neighbor_data + expected_local_mean -
+           mean_value(neighbor_data, mesh);
   };
 
-  std::unordered_map<std::pair<Direction<1>, ElementId<1>>,
-                     Variables<tmpl::list<ScalarTag>>,
+  std::unordered_map<std::pair<Direction<1>, ElementId<1>>, DataVector,
                      boost::hash<std::pair<Direction<1>, ElementId<1>>>>
-      neighbor_vars{};
-  auto& vars_lower_xi =
-      neighbor_vars[std::make_pair(Direction<1>::lower_xi(), ElementId<1>(1))];
-  auto& vars_upper_xi =
-      neighbor_vars[std::make_pair(Direction<1>::upper_xi(), ElementId<1>(2))];
-  vars_lower_xi.initialize(mesh.number_of_grid_points());
-  vars_upper_xi.initialize(mesh.number_of_grid_points());
-  get<ScalarTag>(vars_lower_xi) = shift_data_to_local_mean(
-      ScalarTag::type{{{evaluate_polynomial({{0., 1., 0., 1., 0.}})}}});
-  get<ScalarTag>(vars_upper_xi) = shift_data_to_local_mean(
-      ScalarTag::type{{{evaluate_polynomial({{0., 0., 1., 1., 2.}})}}});
-
-  Limiters::Weno_detail::reconstruct_from_weighted_sum<ScalarTag>(
-      make_not_null(&scalar), mesh, neighbor_linear_weight, neighbor_vars,
-      Limiters::Weno_detail::DerivativeWeight::Unity);
-
-  CHECK(mean_value(get(scalar), mesh) == approx(expected_scalar_mean));
+      neighbor_data{};
+  neighbor_data[std::make_pair(Direction<1>::lower_xi(), ElementId<1>(1))] =
+      shift_data_to_local_mean(evaluate_polynomial({{0., 1., 0., 1., 0.}}));
+  neighbor_data[std::make_pair(Direction<1>::upper_xi(), ElementId<1>(2))] =
+      shift_data_to_local_mean(evaluate_polynomial({{0., 0., 1., 1., 2.}}));
 
   // Expected result computed in Mathematica by computing oscillation indicator
   // as in oscillation_indicator tests, then WENO weights, then superposition.
-  auto expected_reconstructed_scalar = ScalarTag::type{{{evaluate_polynomial(
+  const DataVector expected_reconstructed_data = evaluate_polynomial(
       {{1.0000250662809542, 1.9987344134217362, 3.25819395292328e-7,
-        0.5006326303794342, 0.09987412556290375}})}}};
-  CHECK_ITERABLE_APPROX(scalar, expected_reconstructed_scalar);
+        0.5006326303794342, 0.09987412556290375}});
+
+  Limiters::Weno_detail::reconstruct_from_weighted_sum(
+      make_not_null(&local_data), mesh, neighbor_linear_weight, neighbor_data,
+      Limiters::Weno_detail::DerivativeWeight::Unity);
+  CHECK(mean_value(local_data, mesh) == approx(expected_local_mean));
+  CHECK_ITERABLE_APPROX(local_data, expected_reconstructed_data);
 }
 
 void test_reconstruction_2d() noexcept {
@@ -111,75 +83,45 @@ void test_reconstruction_2d() noexcept {
                           (coeffs[6] + coeffs[7] * x + coeffs[8] * square(x))};
   };
 
-  auto vector = VectorTag<2>::type{
-      {{evaluate_polynomial({{2., 1., 0., 1.5, 1., 0., 1., 0., 0.}}),
-        evaluate_polynomial({{0.5, 1., 0.5, 1.5, 2., 1., 1., 2., 3.}})}}};
+  DataVector local_data =
+      evaluate_polynomial({{2., 1., 0., 1.5, 1., 0., 1., 0., 0.}});
   // WENO reconstruction should preserve the mean, so expected = initial
-  const std::array<double, 2> expected_vector_means = {
-      {mean_value(get<0>(vector), mesh), mean_value(get<1>(vector), mesh)}};
+  const double expected_local_mean = mean_value(local_data, mesh);
 
-  const auto shift_data_to_local_mean = [&mesh, &expected_vector_means ](
-      const VectorTag<2>::type& data) noexcept {
-    auto result = data;
-    get<0>(result) += expected_vector_means[0] - mean_value(get<0>(data), mesh);
-    get<1>(result) += expected_vector_means[1] - mean_value(get<1>(data), mesh);
-    return result;
+  const auto shift_data_to_local_mean =
+      [&mesh, &expected_local_mean ](const DataVector& neighbor_data) noexcept {
+    return neighbor_data + expected_local_mean -
+           mean_value(neighbor_data, mesh);
   };
 
-  std::unordered_map<std::pair<Direction<2>, ElementId<2>>,
-                     Variables<tmpl::list<VectorTag<2>>>,
+  std::unordered_map<std::pair<Direction<2>, ElementId<2>>, DataVector,
                      boost::hash<std::pair<Direction<2>, ElementId<2>>>>
-      neighbor_vars{};
-  auto& vars_lower_xi =
-      neighbor_vars[std::make_pair(Direction<2>::lower_xi(), ElementId<2>(1))];
-  auto& vars_upper_xi =
-      neighbor_vars[std::make_pair(Direction<2>::upper_xi(), ElementId<2>(2))];
-  auto& vars_lower_eta =
-      neighbor_vars[std::make_pair(Direction<2>::lower_eta(), ElementId<2>(3))];
-  auto& vars_upper_eta =
-      neighbor_vars[std::make_pair(Direction<2>::upper_eta(), ElementId<2>(4))];
-  vars_lower_xi.initialize(mesh.number_of_grid_points());
-  vars_upper_xi.initialize(mesh.number_of_grid_points());
-  vars_lower_eta.initialize(mesh.number_of_grid_points());
-  vars_upper_eta.initialize(mesh.number_of_grid_points());
-  get<VectorTag<2>>(vars_lower_xi) =
-      shift_data_to_local_mean(VectorTag<2>::type{
-          {{evaluate_polynomial({{0., 1., 0., 0., 1., 1., 0., 0., 0}}),
-            evaluate_polynomial({{1., 0.1, 0., 0.1, 0., 0., 0., 0.}})}}});
-  get<VectorTag<2>>(vars_upper_xi) =
-      shift_data_to_local_mean(VectorTag<2>::type{
-          {{evaluate_polynomial({{0., 0., 1., 1., 2., 1., 0., 1., 1.}}),
-            evaluate_polynomial({{0., 1., 0., 1., 0., 0., 0., 0., 0.}})}}});
-  get<VectorTag<2>>(vars_lower_eta) =
-      shift_data_to_local_mean(VectorTag<2>::type{
-          {{evaluate_polynomial({{1., 0., 0., 0., 0.5, 0., 0., 0., 0.5}}),
-            evaluate_polynomial({{1., 0., 1., 1., 0., 0., 0., 0.}})}}});
-  get<VectorTag<2>>(vars_upper_eta) =
-      shift_data_to_local_mean(VectorTag<2>::type{
-          {{evaluate_polynomial({{1., 0., 0., 0.5, 1., 0., 0., 0., 0.}}),
-            evaluate_polynomial({{0., 0., 0., 1., 0., 0., 1., 1., 1.}})}}});
-
-  Limiters::Weno_detail::reconstruct_from_weighted_sum<VectorTag<2>>(
-      make_not_null(&vector), mesh, neighbor_linear_weight, neighbor_vars,
-      Limiters::Weno_detail::DerivativeWeight::Unity);
-
-  CHECK(mean_value(get<0>(vector), mesh) == approx(expected_vector_means[0]));
-  CHECK(mean_value(get<1>(vector), mesh) == approx(expected_vector_means[1]));
+      neighbor_data{};
+  neighbor_data[std::make_pair(Direction<2>::lower_xi(), ElementId<2>(1))] =
+      shift_data_to_local_mean(
+          evaluate_polynomial({{0., 1., 0., 0., 1., 1., 0., 0., 0}}));
+  neighbor_data[std::make_pair(Direction<2>::upper_xi(), ElementId<2>(2))] =
+      shift_data_to_local_mean(
+          evaluate_polynomial({{0., 0., 1., 1., 2., 1., 0., 1., 1.}}));
+  neighbor_data[std::make_pair(Direction<2>::lower_eta(), ElementId<2>(3))] =
+      shift_data_to_local_mean(
+          evaluate_polynomial({{1., 0., 0., 0., 0.5, 0., 0., 0., 0.5}}));
+  neighbor_data[std::make_pair(Direction<2>::upper_eta(), ElementId<2>(4))] =
+      shift_data_to_local_mean(
+          evaluate_polynomial({{1., 0., 0., 0.5, 1., 0., 0., 0., 0.}}));
 
   // Expected result computed in Mathematica by computing oscillation indicator
   // as in oscillation_indicator tests, then WENO weights, then superposition.
-  auto expected_reconstructed_vector = VectorTag<2>::type{
-      {{evaluate_polynomial(
-            {{2.010056442214612, 0.9705606381771584, 0.000026246579961852654,
-              1.4682459390241314, 0.9992393252122325, 0.0010535139634810797,
-              0.9695333707936392, 0.000026246579961852654,
-              0.0008131679476911193}}),
-        evaluate_polynomial(
-            {{1.3333271694137983, 0.10009196057382466, 0.00001162876091830289,
-              0.10010376454909513, 6.629378550236318e-6, 3.314689275118159e-6,
-              3.4899036272802205e-6, 6.80459290239838e-6,
-              0.00001011928217751654}})}}};
-  CHECK_ITERABLE_APPROX(vector, expected_reconstructed_vector);
+  const DataVector expected_reconstructed_data = evaluate_polynomial(
+      {{2.010056442214612, 0.9705606381771584, 0.000026246579961852654,
+        1.4682459390241314, 0.9992393252122325, 0.0010535139634810797,
+        0.9695333707936392, 0.000026246579961852654, 0.0008131679476911193}});
+
+  Limiters::Weno_detail::reconstruct_from_weighted_sum(
+      make_not_null(&local_data), mesh, neighbor_linear_weight, neighbor_data,
+      Limiters::Weno_detail::DerivativeWeight::Unity);
+  CHECK(mean_value(local_data, mesh) == approx(expected_local_mean));
+  CHECK_ITERABLE_APPROX(local_data, expected_reconstructed_data);
 }
 
 void test_reconstruction_3d() noexcept {
@@ -200,61 +142,47 @@ void test_reconstruction_3d() noexcept {
                       coeffs[5] * square(x) * y * square(z)};
   };
 
-  auto scalar =
-      ScalarTag::type{{{evaluate_polynomial({{1., 0.5, 0.5, 0.2, 0.2, 0.1}})}}};
+  DataVector local_data = evaluate_polynomial({{1., 0.5, 0.5, 0.2, 0.2, 0.1}});
   // WENO reconstruction should preserve the mean, so expected = initial
-  const double expected_scalar_mean = mean_value(get(scalar), mesh);
+  const double expected_local_mean = mean_value(local_data, mesh);
 
   const auto shift_data_to_local_mean =
-      [&mesh, &expected_scalar_mean ](const ScalarTag::type& data) noexcept {
-    auto result = data;
-    get(result) += expected_scalar_mean - mean_value(get(data), mesh);
-    return result;
+      [&mesh, &expected_local_mean ](const DataVector& neighbor_data) noexcept {
+    return neighbor_data + expected_local_mean -
+           mean_value(neighbor_data, mesh);
   };
 
   // We skip one neighbor, lower_eta, to simulate an external boundary
-  std::unordered_map<std::pair<Direction<3>, ElementId<3>>,
-                     Variables<tmpl::list<ScalarTag>>,
+  std::unordered_map<std::pair<Direction<3>, ElementId<3>>, DataVector,
                      boost::hash<std::pair<Direction<3>, ElementId<3>>>>
-      neighbor_vars{};
-  auto& vars_lower_xi =
-      neighbor_vars[std::make_pair(Direction<3>::lower_xi(), ElementId<3>(1))];
-  auto& vars_upper_xi =
-      neighbor_vars[std::make_pair(Direction<3>::upper_xi(), ElementId<3>(2))];
-  auto& vars_upper_eta =
-      neighbor_vars[std::make_pair(Direction<3>::upper_eta(), ElementId<3>(4))];
-  auto& vars_lower_zeta = neighbor_vars[std::make_pair(
-      Direction<3>::lower_zeta(), ElementId<3>(5))];
-  auto& vars_upper_zeta = neighbor_vars[std::make_pair(
-      Direction<3>::upper_zeta(), ElementId<3>(6))];
-  vars_lower_xi.initialize(mesh.number_of_grid_points());
-  vars_upper_xi.initialize(mesh.number_of_grid_points());
-  vars_upper_eta.initialize(mesh.number_of_grid_points());
-  vars_lower_zeta.initialize(mesh.number_of_grid_points());
-  vars_upper_zeta.initialize(mesh.number_of_grid_points());
-  get<ScalarTag>(vars_lower_xi) = shift_data_to_local_mean(
-      ScalarTag::type{{{evaluate_polynomial({{0.3, 0.2, 0.2, 0., 0., 0.1}})}}});
-  get<ScalarTag>(vars_upper_xi) = shift_data_to_local_mean(
-      ScalarTag::type{{{evaluate_polynomial({{2.5, 1., 0., 0., 1., 1.}})}}});
-  get<ScalarTag>(vars_upper_eta) = shift_data_to_local_mean(ScalarTag::type{
-      {{evaluate_polynomial({{1., 0.5, 0.5, 0.2, 0.2, 0.2}})}}});
-  get<ScalarTag>(vars_lower_zeta) = shift_data_to_local_mean(
-      ScalarTag::type{{{evaluate_polynomial({{1., 0.2, 0., 0., 0., 0.}})}}});
-  get<ScalarTag>(vars_upper_zeta) = shift_data_to_local_mean(ScalarTag::type{
-      {{evaluate_polynomial({{0.1, 0., 0.5, 0.2, 0.2, 0.2}})}}});
-
-  Limiters::Weno_detail::reconstruct_from_weighted_sum<ScalarTag>(
-      make_not_null(&scalar), mesh, neighbor_linear_weight, neighbor_vars,
-      Limiters::Weno_detail::DerivativeWeight::Unity);
-
-  CHECK(mean_value(get(scalar), mesh) == approx(expected_scalar_mean));
+      neighbor_data{};
+  neighbor_data[std::make_pair(Direction<3>::lower_xi(), ElementId<3>(1))] =
+      shift_data_to_local_mean(
+          evaluate_polynomial({{0.3, 0.2, 0.2, 0., 0., 0.1}}));
+  neighbor_data[std::make_pair(Direction<3>::upper_xi(), ElementId<3>(2))] =
+      shift_data_to_local_mean(
+          evaluate_polynomial({{2.5, 1., 0., 0., 1., 1.}}));
+  neighbor_data[std::make_pair(Direction<3>::upper_eta(), ElementId<3>(4))] =
+      shift_data_to_local_mean(
+          evaluate_polynomial({{1., 0.5, 0.5, 0.2, 0.2, 0.2}}));
+  neighbor_data[std::make_pair(Direction<3>::lower_zeta(), ElementId<3>(5))] =
+      shift_data_to_local_mean(
+          evaluate_polynomial({{1., 0.2, 0., 0., 0., 0.}}));
+  neighbor_data[std::make_pair(Direction<3>::upper_zeta(), ElementId<3>(6))] =
+      shift_data_to_local_mean(
+          evaluate_polynomial({{0.1, 0., 0.5, 0.2, 0.2, 0.2}}));
 
   // Expected result computed in Mathematica by computing oscillation indicator
   // as in oscillation_indicator tests, then WENO weights, then superposition.
-  auto expected_reconstructed_scalar = ScalarTag::type{{{evaluate_polynomial(
+  const DataVector expected_reconstructed_data = evaluate_polynomial(
       {{1., 0.32663481881058243, 0.21186828015830592, 0.08447466846582166,
-        0.08447504580872492, 0.04260655032204396}})}}};
-  CHECK_ITERABLE_APPROX(scalar, expected_reconstructed_scalar);
+        0.08447504580872492, 0.04260655032204396}});
+
+  Limiters::Weno_detail::reconstruct_from_weighted_sum(
+      make_not_null(&local_data), mesh, neighbor_linear_weight, neighbor_data,
+      Limiters::Weno_detail::DerivativeWeight::Unity);
+  CHECK(mean_value(local_data, mesh) == approx(expected_local_mean));
+  CHECK_ITERABLE_APPROX(local_data, expected_reconstructed_data);
 }
 
 }  // namespace


### PR DESCRIPTION
The new interface works for one DataVector at a time, where the old interface worked on an entire Tensor at a time. The new interface makes it easier to apply the WENO limiters to certain tensor components only.

Note: this is an intermediate step of a larger refactor, and introduces inefficiency by copying data into a temporary data structure - this copy will be removed in the next steps of the refactor.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

