### PR TITLE
Add divergence of mesh velocity tags

### DIFF
--- a/src/Domain/TagsTimeDependent.cpp
+++ b/src/Domain/TagsTimeDependent.cpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Domain.hpp"
-#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 

--- a/src/Domain/TagsTimeDependent.hpp
+++ b/src/Domain/TagsTimeDependent.hpp
@@ -160,5 +160,11 @@ struct InertialMeshVelocityCompute : MeshVelocity<Dim, Frame::Inertial>,
 
   using argument_tags = tmpl::list<CoordinatesMeshVelocityAndJacobians<Dim>>;
 };
+
+/// The divergence of the mesh velocity
+struct DivMeshVelocity : db::SimpleTag {
+  using type = boost::optional<Scalar<DataVector>>;
+  static std::string name() noexcept { return "div(MeshVelocity)"; }
+};
 }  // namespace Tags
 }  // namespace domain

--- a/src/Evolution/CMakeLists.txt
+++ b/src/Evolution/CMakeLists.txt
@@ -1,6 +1,25 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(LIBRARY Evolution)
+
+set(LIBRARY_SOURCES
+  TagsDomain.cpp
+  )
+
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Domain
+  DataStructures
+  Utilities
+
+  PRIVATE
+  LinearOperators
+  )
+
 add_subdirectory(DiscontinuousGalerkin)
 add_subdirectory(Executables)
 add_subdirectory(Systems)

--- a/src/Evolution/TagsDomain.cpp
+++ b/src/Evolution/TagsDomain.cpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/TagsDomain.hpp"
+
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution {
+namespace domain {
+namespace Tags {
+template <size_t Dim>
+void DivMeshVelocityCompute<Dim>::function(
+    const gsl::not_null<boost::optional<Scalar<DataVector>>*> div_mesh_velocity,
+    const boost::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+        mesh_velocity,
+    const ::Mesh<Dim>& mesh,
+    const ::InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
+        inv_jac_logical_to_inertial) noexcept {
+  if (mesh_velocity) {
+    *div_mesh_velocity =
+        divergence(*mesh_velocity, mesh, inv_jac_logical_to_inertial);
+    return;
+  }
+  *div_mesh_velocity = boost::none;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data) template struct DivMeshVelocityCompute<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+}  // namespace Tags
+}  // namespace domain
+}  // namespace evolution

--- a/src/Evolution/TagsDomain.hpp
+++ b/src/Evolution/TagsDomain.hpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace evolution {
+namespace domain {
+namespace Tags {
+/// The divergence of the frame velocity
+template <size_t Dim>
+struct DivMeshVelocityCompute : db::ComputeTag,
+                                ::domain::Tags::DivMeshVelocity {
+  using base = DivMeshVelocity;
+  using return_type = typename base::type;
+
+  static void function(
+      gsl::not_null<boost::optional<Scalar<DataVector>>*> div_mesh_velocity,
+      const boost::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const ::Mesh<Dim>& mesh,
+      const ::InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
+          inv_jac_logical_to_inertial) noexcept;
+
+  using argument_tags = tmpl::list<
+      ::domain::Tags::MeshVelocity<Dim, Frame::Inertial>,
+      ::domain::Tags::Mesh<Dim>,
+      ::domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>>;
+};
+}  // namespace Tags
+}  // namespace domain
+}  // namespace evolution

--- a/tests/Unit/Domain/Test_TagsTimeDependent.cpp
+++ b/tests/Unit/Domain/Test_TagsTimeDependent.cpp
@@ -6,7 +6,9 @@
 #include <array>
 #include <boost/optional.hpp>
 #include <boost/optional/optional_io.hpp>
+#include <memory>
 #include <string>
+#include <unordered_map>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -27,6 +29,8 @@
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/Tags.hpp"
 #include "Domain/TagsTimeDependent.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -54,6 +58,8 @@ void test_tags() noexcept {
       "MeshVelocity");
   TestHelpers::db::test_compute_tag<
       domain::Tags::InertialMeshVelocityCompute<Dim>>("MeshVelocity");
+  TestHelpers::db::test_simple_tag<domain::Tags::DivMeshVelocity>(
+      "div(MeshVelocity)");
 }
 
 using TranslationMap = domain::CoordMapsTimeDependent::Translation;

--- a/tests/Unit/Evolution/CMakeLists.txt
+++ b/tests/Unit/Evolution/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY "Test_Evolution")
 
 set(LIBRARY_SOURCES
   Test_ComputeTags.cpp
+  Test_TagsDomain.cpp
   Test_TypeTraits.cpp
   )
 
@@ -19,5 +20,5 @@ add_test_library(
   ${LIBRARY}
   "Evolution"
   "${LIBRARY_SOURCES}"
-  "Utilities"
+  "Evolution;Utilities"
   )

--- a/tests/Unit/Evolution/Test_TagsDomain.cpp
+++ b/tests/Unit/Evolution/Test_TagsDomain.cpp
@@ -1,0 +1,210 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <boost/optional.hpp>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.hpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.tpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/CoordinateMaps/Translation.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/TagsDomain.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace {
+template <size_t Dim>
+void test_tags() noexcept {
+  TestHelpers::db::test_compute_tag<
+      evolution::domain::Tags::DivMeshVelocityCompute<Dim>>(
+      "div(MeshVelocity)");
+}
+
+using TranslationMap = domain::CoordMapsTimeDependent::Translation;
+using TranslationMap2d =
+    domain::CoordMapsTimeDependent::ProductOf2Maps<TranslationMap,
+                                                   TranslationMap>;
+using TranslationMap3d = domain::CoordMapsTimeDependent::ProductOf3Maps<
+    TranslationMap, TranslationMap, TranslationMap>;
+
+using AffineMap = domain::CoordinateMaps::Affine;
+using AffineMap2d =
+    domain::CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
+using AffineMap3d =
+    domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+
+template <size_t MeshDim>
+using ConcreteMap = tmpl::conditional_t<
+    MeshDim == 1,
+    domain::CoordinateMap<Frame::Grid, Frame::Inertial, TranslationMap,
+                          AffineMap>,
+    tmpl::conditional_t<MeshDim == 2,
+                        domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                                              TranslationMap2d, AffineMap2d>,
+                        domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                                              TranslationMap3d, AffineMap3d>>>;
+
+template <size_t MeshDim>
+ConcreteMap<MeshDim> create_coord_map(
+    const std::array<std::string, 3>& f_of_t_names);
+
+template <>
+ConcreteMap<1> create_coord_map<1>(
+    const std::array<std::string, 3>& f_of_t_names) {
+  return ConcreteMap<1>{TranslationMap{f_of_t_names[0]},
+                        AffineMap{-1.0, 1.0, 2.0, 7.2}};
+}
+
+template <>
+ConcreteMap<2> create_coord_map<2>(
+    const std::array<std::string, 3>& f_of_t_names) {
+  return ConcreteMap<2>{
+      {TranslationMap{f_of_t_names[0]}, TranslationMap{f_of_t_names[1]}},
+      {AffineMap{-1.0, 1.0, -2.0, 2.2}, AffineMap{-1.0, 1.0, 2.0, 7.2}}};
+}
+
+template <>
+ConcreteMap<3> create_coord_map<3>(
+    const std::array<std::string, 3>& f_of_t_names) {
+  return ConcreteMap<3>{
+      {TranslationMap{f_of_t_names[0]}, TranslationMap{f_of_t_names[1]},
+       TranslationMap{f_of_t_names[2]}},
+      {AffineMap{-1.0, 1.0, -2.0, 2.2}, AffineMap{-1.0, 1.0, 2.0, 7.2},
+       AffineMap{-1.0, 1.0, 1.0, 3.5}}};
+}
+
+template <size_t Dim, bool IsTimeDependent>
+void test() noexcept {
+  using simple_tags = db::AddSimpleTags<
+      Tags::Time, domain::Tags::Mesh<Dim>,
+      domain::Tags::Coordinates<Dim, Frame::Grid>,
+      domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Grid>,
+      domain::Tags::FunctionsOfTime,
+      domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                  Frame::Inertial>>;
+  using compute_tags = db::AddComputeTags<
+      domain::Tags::CoordinatesMeshVelocityAndJacobiansCompute<
+          domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                      Frame::Inertial>>,
+      domain::Tags::InertialFromGridCoordinatesCompute<Dim>,
+      domain::Tags::ElementToInertialInverseJacobian<Dim>,
+      domain::Tags::InertialMeshVelocityCompute<Dim>,
+      evolution::domain::Tags::DivMeshVelocityCompute<Dim>>;
+
+  const std::array<double, 3> velocity{{1.2, 0.2, -8.9}};
+  const double initial_time = 0.0;
+  // In 1d, the helper function create_coord_map will only use the first name,
+  // i.e., TranslationX. In 2d, it uses the first two names, TranslationX and
+  // TranslationY.
+  const std::array<std::string, 3> functions_of_time_names{
+      {"TranslationX", "TranslationY", "TranslationZ"}};
+
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<double> dist(-10.0, 10.0);
+
+  const Mesh<Dim> mesh{5, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const size_t num_pts = mesh.number_of_grid_points();
+
+  tnsr::I<DataVector, Dim, Frame::Grid> grid_coords{num_pts};
+  fill_with_random_values(make_not_null(&grid_coords), make_not_null(&gen),
+                          make_not_null(&dist));
+  InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Grid>
+      element_to_grid_inverse_jacobian{num_pts};
+  fill_with_random_values(make_not_null(&element_to_grid_inverse_jacobian),
+                          make_not_null(&gen), make_not_null(&dist));
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  functions_of_time[functions_of_time_names[0]] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time,
+          std::array<DataVector, 3>{{{0.0}, {velocity[0]}, {0.0}}});
+  functions_of_time[functions_of_time_names[1]] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time,
+          std::array<DataVector, 3>{{{0.0}, {velocity[1]}, {0.0}}});
+  functions_of_time[functions_of_time_names[2]] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time,
+          std::array<DataVector, 3>{{{0.0}, {velocity[2]}, {0.0}}});
+
+  using MapPtr = std::unique_ptr<
+      domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, Dim>>;
+  const MapPtr grid_to_inertial_map =
+      IsTimeDependent ? MapPtr(std::make_unique<ConcreteMap<Dim>>(
+                            create_coord_map<Dim>(functions_of_time_names)))
+                      : MapPtr(std::make_unique<domain::CoordinateMap<
+                                   Frame::Grid, Frame::Inertial,
+                                   domain::CoordinateMaps::Identity<Dim>>>());
+
+  const double time = 3.0;
+  auto box = db::create<simple_tags, compute_tags>(
+      time, mesh, grid_coords, element_to_grid_inverse_jacobian,
+      std::move(functions_of_time), grid_to_inertial_map->get_clone());
+
+  const auto check_helper = [&box, &mesh]() noexcept {
+    if (IsTimeDependent) {
+      const boost::optional<Scalar<DataVector>>& div_frame_velocity =
+          db::get<domain::Tags::DivMeshVelocity>(box);
+      REQUIRE(static_cast<bool>(div_frame_velocity));
+      CHECK(*div_frame_velocity ==
+            divergence(
+                db::get<domain::Tags::MeshVelocity<Dim>>(box).get(), mesh,
+                db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical,
+                                                      Frame::Inertial>>(box)));
+    } else {
+      // In the time-independent case, check that the divergence of the mesh
+      // velocity is not set.
+      CHECK_FALSE(
+          static_cast<bool>(db::get<domain::Tags::DivMeshVelocity>(box)));
+    }
+  };
+  check_helper();
+
+  db::mutate<Tags::Time>(make_not_null(&box),
+                         [](const gsl::not_null<double*> local_time) noexcept {
+                           *local_time = 4.5;
+                         });
+  check_helper();
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.TagsDomain", "[Unit][Evolution]") {
+  test_tags<1>();
+  test_tags<2>();
+  test_tags<3>();
+
+  test<1, true>();
+  test<2, true>();
+  test<3, true>();
+
+  test<1, false>();
+  test<2, false>();
+  test<3, false>();
+}


### PR DESCRIPTION
## Proposed changes

- Adds divergence tags for the mesh velocity. The divergence is computed numerically since I don't want to work out Hessians for every map if I can avoid it. Since `LinearOperators` depends on `Domain` the compute tag is added to `Evolution` so we don't end up with circular dependencies

New commits:
- Add divergence of frame velocity tags

Depends on:
- [x] #2063 
- [x] #2064

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
