### PR TITLE
Add action to add mesh velocity divergence source term

### DIFF
--- a/src/Evolution/Actions/AddMeshVelocitySourceTerms.hpp
+++ b/src/Evolution/Actions/AddMeshVelocitySourceTerms.hpp
@@ -1,0 +1,82 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/optional.hpp>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace evolution {
+namespace Actions {
+/*!
+ * \ingroup ActionsGroup
+ * \brief Compute and add the source term modification for moving meshes
+ *
+ * Adds to the time derivative *not* the source terms because some systems do
+ * not have source terms and so we optimize for that. The term being added to
+ * the time derivative is:
+ *
+ * \f{align}{
+ *  -u_\alpha \partial_i v^i_g,
+ * \f}
+ *
+ * where \f$u_\alpha\f$ are the evolved variables and \f$v^i_g\f$ is the
+ * velocity of the mesh.
+ *
+ * Uses:
+ * - DataBox:
+ *   - `System::variables_tags`
+ *   - `domain::Tags::DivFrameVelocity`
+ *
+ * DataBox changes:
+ * - Adds: nothing
+ * - Removes: nothing
+ * - Modifies: `Tags::dt<system::variable_tags>`
+ */
+struct AddMeshVelocitySourceTerms {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {  // NOLINT const
+    using variables_tag = typename Metavariables::system::variables_tag;
+    using dt_variables_tag = db::add_tag_prefix<Tags::dt, variables_tag>;
+    db::mutate<dt_variables_tag>(
+        make_not_null(&box),
+        [](const auto dt_vars_ptr, const auto& vars,
+           const boost::optional<Scalar<DataVector>>&
+               div_grid_velocity) noexcept {
+          if (div_grid_velocity) {
+            *dt_vars_ptr -= vars * get(*div_grid_velocity);
+          }
+        },
+        db::get<variables_tag>(box),
+        db::get<domain::Tags::DivMeshVelocity>(box));
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions
+}  // namespace evolution

--- a/tests/Unit/Evolution/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Actions/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_EvolutionActions")
 
 set(LIBRARY_SOURCES
+  Test_AddMeshVelocitySourceTerms.cpp
   Test_ComputeTimeDerivative.cpp
   Test_ComputeVolumeFluxes.cpp
   Test_ComputeVolumeSources.cpp

--- a/tests/Unit/Evolution/Actions/Test_AddMeshVelocitySourceTerms.cpp
+++ b/tests/Unit/Evolution/Actions/Test_AddMeshVelocitySourceTerms.cpp
@@ -1,0 +1,113 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <string>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/Actions/AddMeshVelocitySourceTerms.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace {
+struct Var1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct Var2 : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3, Frame::Inertial>;
+};
+
+struct System {
+  using variables_tag = Tags::Variables<tmpl::list<Var1, Var2>>;
+  using sourced_variables = tmpl::list<>;
+};
+
+template <typename Metavariables>
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using simple_tags =
+      tmpl::list<System::variables_tag,
+                 db::add_tag_prefix<Tags::dt, System::variables_tag>,
+                 domain::Tags::DivMeshVelocity>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<evolution::Actions::AddMeshVelocitySourceTerms>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<component<Metavariables>>;
+  using system = System;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+template <bool HasMeshVelocity>
+void test() {
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+
+  boost::optional<Scalar<DataVector>> div_frame_velocity{};
+  if (HasMeshVelocity) {
+    div_frame_velocity = Scalar<DataVector>{{{{5., 6.}}}};
+  }
+
+  db::item_type<db::add_tag_prefix<Tags::dt, System::variables_tag>> dt_vars(
+      2, 0.);
+  db::item_type<System::variables_tag> vars(2);
+  get(get<Var1>(vars)) = 3.;
+  for (size_t i = 0; i < 3; ++i) {
+    get<Var2>(vars)[i] = 5. + i;
+  }
+
+  using simple_tags = typename component<Metavariables>::simple_tags;
+  MockRuntimeSystem runner{{}};
+  ActionTesting::emplace_component_and_initialize<component<Metavariables>>(
+      &runner, 0, {vars, dt_vars, div_frame_velocity});
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Metavariables::Phase::Testing);
+  runner.next_action<component<Metavariables>>(0);
+
+  const auto& box =
+      ActionTesting::get_databox<component<Metavariables>, simple_tags>(runner,
+                                                                        0);
+
+  const DataVector expected = []() noexcept {
+    if (HasMeshVelocity) {
+      return DataVector{-5., -6.};
+    }
+    return DataVector{0., 0.};
+  }();
+
+  CHECK(get(db::get<Tags::dt<Var1>>(box)) == expected * get(get<Var1>(vars)));
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK(db::get<Tags::dt<Var2>>(box).get(i) ==
+          expected * get<Var2>(vars).get(i));
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.AddMeshVelocitySourceTerms",
+                  "[Unit][Evolution][Actions]") {
+  test<true>();
+  test<false>();
+}


### PR DESCRIPTION
## Proposed changes

- Adds the action that adds mesh velocity source term that appears in conservative systems to the time derivative. This is added to du/dt instead of S_\alpha because not all systems have S_\alpha and so rather than tricking a bunch of extra work there, we just modify du/dt directly.

Only new commit is:
- Add GridVelocitySourceTerms action

Depends on:
- [x] #2067 
- [x] #2064 
- [x] #2063 

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
