### PR TITLE
Fix include order in PointwiseFunctions/Hydro/Tags.hpp

### DIFF
--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -6,8 +6,8 @@
 #include <cstddef>
 #include <string>
 
-#include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 


### PR DESCRIPTION
## Proposed changes

- This slipped by somewhere... Fixes clang-tidy error

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
