### PR TITLE
Fix error in LaneEmdenGravitationalField

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.hpp"
 #include "Utilities/Gsl.hpp"
@@ -25,13 +26,11 @@ void LaneEmdenGravitationalField::apply(
     const NewtonianEuler::Solutions::LaneEmdenStar& star,
     const tnsr::I<DataVector, 3>& x) noexcept {
   const auto gravitational_field = star.gravitational_field(x);
-  get(*source_energy_density) = 0.0;
   for (size_t i = 0; i < 3; ++i) {
     source_momentum_density->get(i) =
         get(mass_density_cons) * gravitational_field.get(i);
-    get(*source_energy_density) +=
-        momentum_density.get(i) * gravitational_field.get(i);
   }
+  *source_energy_density = dot_product(momentum_density, gravitational_field);
 }
 
 }  // Namespace Sources

--- a/src/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.hpp
@@ -21,12 +21,18 @@ struct LaneEmdenStar;
 namespace PUP {
 class er;
 }  // namespace PUP
+
 namespace Tags {
-template <size_t Dim, typename Frame>
-struct Coordinates;
 template <typename SolutionType>
 struct AnalyticSolution;
 }  // namespace Tags
+
+namespace domain {
+namespace Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace Tags
+}  // namespace domain
 
 namespace gsl {
 template <typename T>
@@ -84,7 +90,7 @@ struct LaneEmdenGravitationalField {
   using argument_tags = tmpl::list<
       Tags::MassDensityCons, Tags::MomentumDensity<3>,
       ::Tags::AnalyticSolution<NewtonianEuler::Solutions::LaneEmdenStar>,
-      ::Tags::Coordinates<3, Frame::Inertial>>;
+      domain::Tags::Coordinates<3, Frame::Inertial>>;
 
   static void apply(
       gsl::not_null<tnsr::I<DataVector, 3>*> source_momentum_density,


### PR DESCRIPTION
## Proposed changes

Update the namespace for a Tag in LaneEmdenGravitationalField - the incorrect namespace led to a linking error when compiling the `EvolveLaneEmdenStar3D` executable.

Question for discussion: should `EvolveLaneEmdenStar3D` be compiled and "input file tested" like the other solutions? I didn't do this in the original PR to avoid adding yet another executable, but then the code can break...

Also make a small cleanup change in the math for the gravitational field.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
