### PR TITLE
Update Doxygen description about \brief

### DIFF
--- a/docs/DevGuide/WritingDox.md
+++ b/docs/DevGuide/WritingDox.md
@@ -51,7 +51,7 @@ either a triple slash `///` or a `/*!`.
 
 Examples:
 \verbatim
-/// \brief A brief description of the object to be documented
+/// A brief description of the object to be documented
 ///
 /// Doxygen comments can be made
 /// using triple slashes...
@@ -81,6 +81,9 @@ Doxygen also conveniently provides two additional organizations of the files,
 Topics and Namespaces. To ensure that your documentation is easily found from
 within Doxygen, we recommend that you add any new objects to Topics and any
 new namespaces to Namespaces.
+
+\note The `///` Doxygen syntax does not require a `\brief`, while the C-style
+`/*!` does.
 
 ## Add your object to an existing Topic:
 


### PR DESCRIPTION
## Proposed changes

- Make clear when one (generally) needs `\brief` and when not. Of course, Doxygen may have bugs :P

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
