### PR TITLE
Refactor SimpleWeno

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp
@@ -1,0 +1,124 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <boost/functional/hash.hpp>  // IWYU pragma: keep
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/Mesh.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/WenoGridHelpers.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp"
+#include "NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp"
+#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Limiters {
+namespace Weno_detail {
+
+// Compute the Simple WENO solution for one tensor component
+//
+// This interface is intended for use in limiters that check the troubled-cell
+// indicator independently for each tensor component. These limiters generally
+// need to limit only a subset of the tensor components.
+template <typename Tag, size_t VolumeDim, typename PackagedData>
+void simple_weno_impl(
+    const gsl::not_null<std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+        intrp::RegularGrid<VolumeDim>,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>*>
+        interpolator_buffer,
+    const gsl::not_null<std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, DataVector,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>*>
+        modified_neighbor_solution_buffer,
+    const gsl::not_null<db::item_type<Tag>*> tensor,
+    const double neighbor_linear_weight, const size_t tensor_storage_index,
+    const Mesh<VolumeDim>& mesh, const Element<VolumeDim>& element,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_data) noexcept {
+  // Compute the modified neighbor solutions.
+  // First extrapolate neighbor data onto local grid points, then shift the
+  // extrapolated data so its mean matches the local mean.
+  DataVector& component_to_limit = (*tensor)[tensor_storage_index];
+  const double local_mean = mean_value(component_to_limit, mesh);
+  for (const auto& neighbor_and_data : neighbor_data) {
+    const auto& neighbor = neighbor_and_data.first;
+    const auto& data = neighbor_and_data.second;
+
+    if (interpolator_buffer->find(neighbor) == interpolator_buffer->end()) {
+      // No interpolator found => create one
+      const auto& direction = neighbor.first;
+      const auto& source_mesh = data.mesh;
+      const auto target_1d_logical_coords =
+          Weno_detail::local_grid_points_in_neighbor_logical_coords(
+              mesh, source_mesh, element, direction);
+      interpolator_buffer->insert(std::make_pair(
+          neighbor, intrp::RegularGrid<VolumeDim>(source_mesh, mesh,
+                                                  target_1d_logical_coords)));
+    }
+
+    // Avoid allocations by working directly in the preallocated buffer
+    DataVector& buffer = modified_neighbor_solution_buffer->at(neighbor);
+
+    interpolator_buffer->at(neighbor).interpolate(
+        make_not_null(&buffer),
+        get<Tag>(data.volume_data)[tensor_storage_index]);
+    const double neighbor_mean = mean_value(buffer, mesh);
+    buffer += (local_mean - neighbor_mean);
+  }
+
+  // Sum local and modified neighbor polynomials for the WENO reconstruction
+  Weno_detail::reconstruct_from_weighted_sum(
+      make_not_null(&component_to_limit), mesh, neighbor_linear_weight,
+      *modified_neighbor_solution_buffer, Weno_detail::DerivativeWeight::Unity);
+}
+
+// Compute the Simple WENO solution for one tensor
+//
+// This interface is intended for use in limiters that check the troubled-cell
+// indicator for the whole cell, and apply the limiter to all fields.
+template <typename Tag, size_t VolumeDim, typename PackagedData>
+void simple_weno_impl(
+    const gsl::not_null<std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+        intrp::RegularGrid<VolumeDim>,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>*>
+        interpolator_buffer,
+    const gsl::not_null<std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, DataVector,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>*>
+        modified_neighbor_solution_buffer,
+    const gsl::not_null<db::item_type<Tag>*> tensor,
+    const double neighbor_linear_weight, const Mesh<VolumeDim>& mesh,
+    const Element<VolumeDim>& element,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_data) noexcept {
+  for (size_t tensor_storage_index = 0; tensor_storage_index < tensor->size();
+       ++tensor_storage_index) {
+    simple_weno_impl<Tag>(interpolator_buffer,
+                          modified_neighbor_solution_buffer, tensor,
+                          neighbor_linear_weight, tensor_storage_index, mesh,
+                          element, neighbor_data);
+  }
+}
+
+}  // namespace Weno_detail
+}  // namespace Limiters

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp
@@ -86,7 +86,8 @@ void simple_weno_impl(
   // Sum local and modified neighbor polynomials for the WENO reconstruction
   Weno_detail::reconstruct_from_weighted_sum(
       make_not_null(&component_to_limit), mesh, neighbor_linear_weight,
-      *modified_neighbor_solution_buffer, Weno_detail::DerivativeWeight::Unity);
+      *modified_neighbor_solution_buffer,
+      Weno_detail::DerivativeWeight::PowTwoEll);
 }
 
 // Compute the Simple WENO solution for one tensor

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_Minmod.cpp
   Test_MinmodTci.cpp
   Test_MinmodType.cpp
+  Test_SimpleWenoImpl.cpp
   Test_Tags.cpp
   Test_Weno.cpp
   Test_WenoGridHelpers.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_SimpleWenoImpl.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_SimpleWenoImpl.cpp
@@ -187,7 +187,7 @@ void test_simple_weno_work(
     Limiters::Weno_detail::reconstruct_from_weighted_sum(
         make_not_null(&(expected_vector.get(i))), mesh, neighbor_linear_weight,
         expected_neighbor_polynomials,
-        Limiters::Weno_detail::DerivativeWeight::Unity);
+        Limiters::Weno_detail::DerivativeWeight::PowTwoEll);
   }
   CHECK_ITERABLE_CUSTOM_APPROX(expected_vector, vector_to_limit, local_approx);
 }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_SimpleWenoImpl.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_SimpleWenoImpl.cpp
@@ -1,0 +1,543 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <functional>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"  // IWYU pragma: keep
+#include "Domain/ElementId.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Side.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp"
+#include "NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/TestHelpers.hpp"
+
+// IWYU pragma: no_include "Domain/OrientationMapHelpers.hpp"
+// IWYU pragma: no_forward_declare Tags::Mean
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare Variables
+
+namespace {
+
+template <size_t VolumeDim>
+struct VectorTag : db::SimpleTag {
+  using type = tnsr::I<DataVector, VolumeDim>;
+};
+
+template <size_t VolumeDim, typename Tag>
+struct DummyPackagedData {
+  Variables<tmpl::list<Tag>> volume_data;
+  tuples::TaggedTuple<::Tags::Mean<Tag>> means;
+  Mesh<VolumeDim> mesh;
+};
+
+template <size_t VolumeDim>
+using VariablesMap = std::unordered_map<
+    std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+    Variables<tmpl::list<VectorTag<VolumeDim>>>,
+    boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>;
+
+template <size_t VolumeDim>
+std::unordered_map<
+    std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+    DummyPackagedData<VolumeDim, VectorTag<VolumeDim>>,
+    boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>
+make_neighbor_data_from_neighbor_vars(
+    const Mesh<VolumeDim>& mesh, const Element<VolumeDim>& element,
+    const VariablesMap<VolumeDim>& neighbor_vars) noexcept {
+  const auto make_tuple_of_means = [&mesh](
+      const Variables<tmpl::list<VectorTag<VolumeDim>>>&
+          vars_to_average) noexcept {
+    tuples::TaggedTuple<::Tags::Mean<VectorTag<VolumeDim>>> result;
+    for (size_t d = 0; d < VolumeDim; ++d) {
+      get<::Tags::Mean<VectorTag<VolumeDim>>>(result).get(d) =
+          mean_value(get<VectorTag<VolumeDim>>(vars_to_average).get(d), mesh);
+    }
+    return result;
+  };
+
+  std::unordered_map<
+      std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+      DummyPackagedData<VolumeDim, VectorTag<VolumeDim>>,
+      boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>
+      neighbor_data{};
+
+  for (const auto& neighbor : element.neighbors()) {
+    const auto dir = neighbor.first;
+    const auto id = *(neighbor.second.cbegin());
+    const auto dir_and_id = std::make_pair(dir, id);
+    neighbor_data[dir_and_id].volume_data = neighbor_vars.at(dir_and_id);
+    neighbor_data[dir_and_id].means =
+        make_tuple_of_means(neighbor_vars.at(dir_and_id));
+    neighbor_data[dir_and_id].mesh = mesh;
+  }
+
+  return neighbor_data;
+}
+
+template <size_t VolumeDim>
+void test_simple_weno_work(
+    const tnsr::I<DataVector, VolumeDim>& local_data,
+    const Mesh<VolumeDim>& mesh, const Element<VolumeDim>& element,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+        DummyPackagedData<VolumeDim, VectorTag<VolumeDim>>,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_data,
+    const VariablesMap<VolumeDim>& expected_neighbor_modified_vars,
+    Approx local_approx = approx) noexcept {
+  // First run some sanity checks on the input, and make sure the test function
+  // is being called in a reasonable way
+  if (element.neighbors().size() != neighbor_data.size()) {
+    ERROR("Different number of neighbors from element, neighbor_data");
+  }
+  if (neighbor_data.size() != expected_neighbor_modified_vars.size()) {
+    ERROR("Different sizes for neighbor_data, expected_neighbor_modified_vars");
+  }
+  for (const auto& neighbor : element.neighbors()) {
+    if (neighbor.second.ids().size() > 1) {
+      ERROR("Too many neighbors: h-refinement is not yet supported");
+    }
+    const auto dir = neighbor.first;
+    const auto id = *(neighbor.second.cbegin());
+    const auto dir_and_id = std::make_pair(dir, id);
+    if (neighbor_data.find(dir_and_id) == neighbor_data.end()) {
+      ERROR("Missing neighbor_data at an internal boundary");
+    }
+    if (expected_neighbor_modified_vars.find(dir_and_id) ==
+        expected_neighbor_modified_vars.end()) {
+      ERROR("Missing expected_neighbor_modified_vars at an internal boundary");
+    }
+  }
+
+  // Buffers for simple WENO implementation
+  std::unordered_map<
+      std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+      intrp::RegularGrid<VolumeDim>,
+      boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>
+      interpolator_buffer{};
+  std::unordered_map<
+      std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, DataVector,
+      boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>
+      modified_neighbor_solution_buffer{};
+  for (const auto& neighbor_and_data : neighbor_data) {
+    const auto& neighbor = neighbor_and_data.first;
+    modified_neighbor_solution_buffer.insert(
+        make_pair(neighbor, DataVector(mesh.number_of_grid_points())));
+  }
+
+  // WENO should preserve the mean, so expected means = initial means
+  const auto expected_vector_means = [&local_data, &mesh ]() noexcept {
+    std::array<double, VolumeDim> means{};
+    for (size_t d = 0; d < VolumeDim; ++d) {
+      gsl::at(means, d) = mean_value(local_data.get(d), mesh);
+    }
+    return means;
+  }
+  ();
+
+  auto vector_to_limit = local_data;
+  const double neighbor_linear_weight = 0.001;
+  // The "tensor" interface is a thin wrapper around the "single component"
+  // interface, so no need to test both overloads separately.
+  Limiters::Weno_detail::simple_weno_impl<VectorTag<VolumeDim>>(
+      make_not_null(&interpolator_buffer),
+      make_not_null(&modified_neighbor_solution_buffer),
+      make_not_null(&vector_to_limit), neighbor_linear_weight, mesh, element,
+      neighbor_data);
+
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    CHECK(mean_value(vector_to_limit.get(d), mesh) ==
+          approx(gsl::at(expected_vector_means, d)));
+  }
+
+  auto expected_vector = local_data;
+  std::unordered_map<
+      std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, DataVector,
+      boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>
+      expected_neighbor_polynomials;
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (auto& neighbor_and_vars : expected_neighbor_modified_vars) {
+      expected_neighbor_polynomials[neighbor_and_vars.first] =
+          get<VectorTag<VolumeDim>>(neighbor_and_vars.second).get(i);
+    }
+    Limiters::Weno_detail::reconstruct_from_weighted_sum(
+        make_not_null(&(expected_vector.get(i))), mesh, neighbor_linear_weight,
+        expected_neighbor_polynomials,
+        Limiters::Weno_detail::DerivativeWeight::Unity);
+  }
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_vector, vector_to_limit, local_approx);
+}
+
+void test_simple_weno_1d(const std::unordered_set<Direction<1>>&
+                             directions_of_external_boundaries = {}) noexcept {
+  INFO("Test simple_weno_impl in 1D");
+  CAPTURE(directions_of_external_boundaries);
+  const auto mesh =
+      Mesh<1>(3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
+  const auto element =
+      TestHelpers::Limiters::make_element<1>(directions_of_external_boundaries);
+  const auto logical_coords = logical_coordinates(mesh);
+
+  // Functions to produce dummy data on each element
+  const auto make_center_tensor =
+      [](const tnsr::I<DataVector, 1, Frame::Logical>& coords) noexcept {
+    const auto& x = get<0>(coords);
+    return tnsr::I<DataVector, 1>{{{0.4 * x - 0.1 * square(x)}}};
+  };
+  const auto make_lower_xi_vars =
+      [](const tnsr::I<DataVector, 1, Frame::Logical>& coords,
+         const double offset = 0.0) noexcept {
+    const auto x = get<0>(coords) + offset;
+    Variables<tmpl::list<VectorTag<1>>> vars(x.size());
+    get<0>(get<VectorTag<1>>(vars)) = -0.1 + 0.3 * x - 0.1 * square(x);
+    return vars;
+  };
+  const auto make_upper_xi_vars =
+      [](const tnsr::I<DataVector, 1, Frame::Logical>& coords,
+         const double offset = 0.0) noexcept {
+    const auto x = get<0>(coords) + offset;
+    Variables<tmpl::list<VectorTag<1>>> vars(x.size());
+    get<0>(get<VectorTag<1>>(vars)) = 0.6 * x - 0.3 * square(x);
+    return vars;
+  };
+
+  const auto local_data = make_center_tensor(logical_coords);
+  VariablesMap<1> neighbor_vars{};
+  VariablesMap<1> neighbor_modified_vars{};
+
+  const auto shift_vars_to_local_means = [&mesh, &local_data ](
+      const Variables<tmpl::list<VectorTag<1>>>& input) noexcept {
+    auto result = input;
+    auto& v = get<VectorTag<1>>(result);
+    get<0>(v) +=
+        mean_value(get<0>(local_data), mesh) - mean_value(get<0>(v), mesh);
+    return result;
+  };
+
+  const auto make_neighbor_vars =
+      [
+        &logical_coords, &directions_of_external_boundaries, &neighbor_vars,
+        &neighbor_modified_vars, &shift_vars_to_local_means
+      ](const std::pair<Direction<1>, ElementId<1>>& neighbor,
+        const auto make_vars) noexcept {
+    if (directions_of_external_boundaries.count(neighbor.first) == 0) {
+      const double offset = (neighbor.first.side() == Side::Lower ? -2.0 : 2.0);
+      neighbor_vars[neighbor] = make_vars(logical_coords, offset);
+      neighbor_modified_vars[neighbor] =
+          shift_vars_to_local_means(make_vars(logical_coords));
+    }
+  };
+
+  make_neighbor_vars(std::make_pair(Direction<1>::lower_xi(), ElementId<1>(1)),
+                     make_lower_xi_vars);
+
+  make_neighbor_vars(std::make_pair(Direction<1>::upper_xi(), ElementId<1>(2)),
+                     make_upper_xi_vars);
+
+  const auto neighbor_data =
+      make_neighbor_data_from_neighbor_vars(mesh, element, neighbor_vars);
+
+  test_simple_weno_work<1>(local_data, mesh, element, neighbor_data,
+                           neighbor_modified_vars);
+}
+
+void test_simple_weno_2d(const std::unordered_set<Direction<2>>&
+                             directions_of_external_boundaries = {}) noexcept {
+  INFO("Test simple_weno_impl in 2D");
+  CAPTURE(directions_of_external_boundaries);
+  const auto mesh =
+      Mesh<2>(3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
+  const auto element =
+      TestHelpers::Limiters::make_element<2>(directions_of_external_boundaries);
+  const auto logical_coords = logical_coordinates(mesh);
+
+  const auto make_center_tensor =
+      [](const tnsr::I<DataVector, 2, Frame::Logical>& coords) noexcept {
+    const auto& x = get<0>(coords);
+    const auto& y = get<1>(coords);
+    return tnsr::I<DataVector, 2>{
+        {{x + 2.5 * y, 0.1 + 0.2 * x - 0.4 * y + 0.3 * square(x) * square(y)}}};
+  };
+  const auto make_lower_xi_vars =
+      [](const tnsr::I<DataVector, 2, Frame::Logical>& coords,
+         const double xi_offset = 0.0) noexcept {
+    const auto x = get<0>(coords) + xi_offset;
+    const auto& y = get<1>(coords);
+    Variables<tmpl::list<VectorTag<2>>> vars(x.size());
+    get<0>(get<VectorTag<2>>(vars)) = x + 2.5 * y;
+    get<1>(get<VectorTag<2>>(vars)) = 3.0 + 0.2 * y;
+    return vars;
+  };
+  const auto make_upper_xi_vars =
+      [](const tnsr::I<DataVector, 2, Frame::Logical>& coords,
+         const double xi_offset = 0.0) noexcept {
+    const auto x = get<0>(coords) + xi_offset;
+    const auto& y = get<1>(coords);
+    Variables<tmpl::list<VectorTag<2>>> vars(x.size());
+    get<0>(get<VectorTag<2>>(vars)) = x + 2.5 * y;
+    get<1>(get<VectorTag<2>>(vars)) = -2.4 + square(x);
+    return vars;
+  };
+  const auto make_lower_eta_vars =
+      [](const tnsr::I<DataVector, 2, Frame::Logical>& coords,
+         const double eta_offset = 0.0) noexcept {
+    const auto& x = get<0>(coords);
+    const auto y = get<1>(coords) + eta_offset;
+    Variables<tmpl::list<VectorTag<2>>> vars(x.size());
+    get<0>(get<VectorTag<2>>(vars)) = x + 2.5 * y;
+    get<1>(get<VectorTag<2>>(vars)) = 0.2 - y;
+    return vars;
+  };
+  const auto make_upper_eta_vars =
+      [](const tnsr::I<DataVector, 2, Frame::Logical>& coords,
+         const double eta_offset = 0.0) noexcept {
+    const auto& x = get<0>(coords);
+    const auto y = get<1>(coords) + eta_offset;
+    Variables<tmpl::list<VectorTag<2>>> vars(x.size());
+    get<0>(get<VectorTag<2>>(vars)) = x + 2.5 * y;
+    get<1>(get<VectorTag<2>>(vars)) = 0.4 + 0.3 * x * square(y);
+    return vars;
+  };
+
+  const auto local_data = make_center_tensor(logical_coords);
+  VariablesMap<2> neighbor_vars{};
+  VariablesMap<2> neighbor_modified_vars{};
+
+  const auto shift_vars_to_local_means = [&mesh, &local_data ](
+      const Variables<tmpl::list<VectorTag<2>>>& input) noexcept {
+    auto result = input;
+    auto& v = get<VectorTag<2>>(result);
+    get<0>(v) +=
+        mean_value(get<0>(local_data), mesh) - mean_value(get<0>(v), mesh);
+    get<1>(v) +=
+        mean_value(get<1>(local_data), mesh) - mean_value(get<1>(v), mesh);
+    return result;
+  };
+
+  const auto make_neighbor_vars =
+      [
+        &logical_coords, &directions_of_external_boundaries, &neighbor_vars,
+        &neighbor_modified_vars, &shift_vars_to_local_means
+      ](const std::pair<Direction<2>, ElementId<2>>& neighbor,
+        const auto make_vars) noexcept {
+    if (directions_of_external_boundaries.count(neighbor.first) == 0) {
+      const double offset = (neighbor.first.side() == Side::Lower ? -2.0 : 2.0);
+      neighbor_vars[neighbor] = make_vars(logical_coords, offset);
+      neighbor_modified_vars[neighbor] =
+          shift_vars_to_local_means(make_vars(logical_coords));
+    }
+  };
+
+  make_neighbor_vars(std::make_pair(Direction<2>::lower_xi(), ElementId<2>(1)),
+                     make_lower_xi_vars);
+
+  make_neighbor_vars(std::make_pair(Direction<2>::upper_xi(), ElementId<2>(2)),
+                     make_upper_xi_vars);
+
+  make_neighbor_vars(std::make_pair(Direction<2>::lower_eta(), ElementId<2>(3)),
+                     make_lower_eta_vars);
+
+  make_neighbor_vars(std::make_pair(Direction<2>::upper_eta(), ElementId<2>(4)),
+                     make_upper_eta_vars);
+
+  const auto neighbor_data =
+      make_neighbor_data_from_neighbor_vars(mesh, element, neighbor_vars);
+
+  test_simple_weno_work<2>(local_data, mesh, element, neighbor_data,
+                           neighbor_modified_vars);
+}
+
+void test_simple_weno_3d(const std::unordered_set<Direction<3>>&
+                             directions_of_external_boundaries = {}) noexcept {
+  INFO("Test simple_weno_impl in 3D");
+  CAPTURE(directions_of_external_boundaries);
+  const auto mesh = Mesh<3>({{3, 4, 5}}, Spectral::Basis::Legendre,
+                            Spectral::Quadrature::GaussLobatto);
+  const auto element =
+      TestHelpers::Limiters::make_element<3>(directions_of_external_boundaries);
+  const auto logical_coords = logical_coordinates(mesh);
+
+  const auto make_center_tensor =
+      [](const tnsr::I<DataVector, 3, Frame::Logical>& coords) noexcept {
+    const auto& x = get<0>(coords);
+    const auto& y = get<1>(coords);
+    const auto& z = get<2>(coords);
+    return tnsr::I<DataVector, 3>{
+        {{0.4 * x * y * z + square(z), z, x + square(y) + cube(z)}}};
+  };
+  const auto make_lower_xi_vars =
+      [](const tnsr::I<DataVector, 3, Frame::Logical>& coords,
+         const double xi_offset = 0.0) noexcept {
+    const auto x = get<0>(coords) + xi_offset;
+    const auto& y = get<1>(coords);
+    const auto& z = get<2>(coords);
+    Variables<tmpl::list<VectorTag<3>>> vars(x.size());
+    get<0>(get<VectorTag<3>>(vars)) = 0.4 * x * y * z + square(z);
+    get<1>(get<VectorTag<3>>(vars)) = 0.8 * z + 0.3 * x * y;
+    get<2>(get<VectorTag<3>>(vars)) = x + y;
+    return vars;
+  };
+  const auto make_upper_xi_vars =
+      [](const tnsr::I<DataVector, 3, Frame::Logical>& coords,
+         const double xi_offset = 0.0) noexcept {
+    const auto x = get<0>(coords) + xi_offset;
+    const auto& y = get<1>(coords);
+    const auto& z = get<2>(coords);
+    Variables<tmpl::list<VectorTag<3>>> vars(x.size());
+    get<0>(get<VectorTag<3>>(vars)) = 0.4 * x * y * z + square(z);
+    get<1>(get<VectorTag<3>>(vars)) = z + 0.1 * square(x);
+    get<2>(get<VectorTag<3>>(vars)) = y + square(x) * z;
+    return vars;
+  };
+  const auto make_lower_eta_vars =
+      [](const tnsr::I<DataVector, 3, Frame::Logical>& coords,
+         const double eta_offset = 0.0) noexcept {
+    const auto& x = get<0>(coords);
+    const auto y = get<1>(coords) + eta_offset;
+    const auto& z = get<2>(coords);
+    Variables<tmpl::list<VectorTag<3>>> vars(x.size());
+    get<0>(get<VectorTag<3>>(vars)) = 0.4 * x * y * z + square(z);
+    get<1>(get<VectorTag<3>>(vars)) = -0.1 * y + z;
+    get<2>(get<VectorTag<3>>(vars)) = -square(z);
+    return vars;
+  };
+  const auto make_upper_eta_vars =
+      [](const tnsr::I<DataVector, 3, Frame::Logical>& coords,
+         const double eta_offset = 0.0) noexcept {
+    const auto& x = get<0>(coords);
+    const auto y = get<1>(coords) + eta_offset;
+    const auto& z = get<2>(coords);
+    Variables<tmpl::list<VectorTag<3>>> vars(x.size());
+    get<0>(get<VectorTag<3>>(vars)) = 0.4 * x * y * z + square(z);
+    get<1>(get<VectorTag<3>>(vars)) = z + 0.4 * x * cube(z);
+    get<2>(get<VectorTag<3>>(vars)) = y * z + square(y) + cube(z);
+    return vars;
+  };
+  const auto make_lower_zeta_vars =
+      [](const tnsr::I<DataVector, 3, Frame::Logical>& coords,
+         const double zeta_offset = 0.0) noexcept {
+    const auto& x = get<0>(coords);
+    const auto& y = get<1>(coords);
+    const auto z = get<2>(coords) + zeta_offset;
+    Variables<tmpl::list<VectorTag<3>>> vars(x.size());
+    get<0>(get<VectorTag<3>>(vars)) = 0.4 * x * y * z + square(z);
+    get<1>(get<VectorTag<3>>(vars)) = 0.9 * z - 2. * x * z;
+    get<2>(get<VectorTag<3>>(vars)) = y + cube(z);
+    return vars;
+  };
+  const auto make_upper_zeta_vars =
+      [](const tnsr::I<DataVector, 3, Frame::Logical>& coords,
+         const double zeta_offset = 0.0) noexcept {
+    const auto& x = get<0>(coords);
+    const auto& y = get<1>(coords);
+    const auto z = get<2>(coords) + zeta_offset;
+    Variables<tmpl::list<VectorTag<3>>> vars(x.size());
+    get<0>(get<VectorTag<3>>(vars)) = 0.4 * x * y * z + square(z);
+    get<1>(get<VectorTag<3>>(vars)) = 1.3 * square(y) * square(z);
+    get<2>(get<VectorTag<3>>(vars)) = -x * y * z + square(y);
+    return vars;
+  };
+
+  const auto local_data = make_center_tensor(logical_coords);
+  VariablesMap<3> neighbor_vars{};
+  VariablesMap<3> neighbor_modified_vars{};
+
+  const auto shift_vars_to_local_means = [&mesh, &local_data ](
+      const Variables<tmpl::list<VectorTag<3>>>& input) noexcept {
+    auto result = input;
+    auto& v = get<VectorTag<3>>(result);
+    get<0>(v) +=
+        mean_value(get<0>(local_data), mesh) - mean_value(get<0>(v), mesh);
+    get<1>(v) +=
+        mean_value(get<1>(local_data), mesh) - mean_value(get<1>(v), mesh);
+    get<2>(v) +=
+        mean_value(get<2>(local_data), mesh) - mean_value(get<2>(v), mesh);
+    return result;
+  };
+
+  const auto make_neighbor_vars =
+      [
+        &logical_coords, &directions_of_external_boundaries, &neighbor_vars,
+        &neighbor_modified_vars, &shift_vars_to_local_means
+      ](const std::pair<Direction<3>, ElementId<3>>& neighbor,
+        const auto make_vars) noexcept {
+    if (directions_of_external_boundaries.count(neighbor.first) == 0) {
+      const double offset = (neighbor.first.side() == Side::Lower ? -2.0 : 2.0);
+      neighbor_vars[neighbor] = make_vars(logical_coords, offset);
+      neighbor_modified_vars[neighbor] =
+          shift_vars_to_local_means(make_vars(logical_coords));
+    }
+  };
+
+  make_neighbor_vars(std::make_pair(Direction<3>::lower_xi(), ElementId<3>(1)),
+                     make_lower_xi_vars);
+
+  make_neighbor_vars(std::make_pair(Direction<3>::upper_xi(), ElementId<3>(2)),
+                     make_upper_xi_vars);
+
+  make_neighbor_vars(std::make_pair(Direction<3>::lower_eta(), ElementId<3>(3)),
+                     make_lower_eta_vars);
+
+  make_neighbor_vars(std::make_pair(Direction<3>::upper_eta(), ElementId<3>(4)),
+                     make_upper_eta_vars);
+
+  make_neighbor_vars(
+      std::make_pair(Direction<3>::lower_zeta(), ElementId<3>(5)),
+      make_lower_zeta_vars);
+
+  make_neighbor_vars(
+      std::make_pair(Direction<3>::upper_zeta(), ElementId<3>(6)),
+      make_upper_zeta_vars);
+
+  const auto neighbor_data =
+      make_neighbor_data_from_neighbor_vars(mesh, element, neighbor_vars);
+
+  // The 3D Simple WENO solution has slightly larger numerical error, presumably
+  // arising from the 3D extrapolation
+  Approx custom_approx = Approx::custom().epsilon(1.e-11).scale(1.0);
+  test_simple_weno_work<3>(local_data, mesh, element, neighbor_data,
+                           neighbor_modified_vars, custom_approx);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.SimpleWenoImpl",
+                  "[Limiters][Unit]") {
+  test_simple_weno_1d();
+  test_simple_weno_2d();
+  test_simple_weno_3d();
+
+  // Test with particular boundaries labeled as external
+  test_simple_weno_1d({{Direction<1>::lower_xi()}});
+  test_simple_weno_2d({{Direction<2>::lower_eta()}});
+  test_simple_weno_2d({{Direction<2>::lower_xi(), Direction<2>::lower_eta(),
+                        Direction<2>::upper_eta()}});
+  test_simple_weno_3d({{Direction<3>::lower_zeta()}});
+  test_simple_weno_3d({{Direction<3>::lower_xi(), Direction<3>::upper_xi(),
+                        Direction<3>::lower_eta(), Direction<3>::lower_zeta(),
+                        Direction<3>::lower_zeta()}});
+}

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
@@ -388,8 +388,9 @@ make_neighbor_data_from_neighbor_vars(
 
 template <size_t VolumeDim>
 void test_weno_work(
-    const Limiters::WenoType& weno_type, const Element<VolumeDim>& element,
-    const Mesh<VolumeDim>& mesh,
+    const Limiters::WenoType& weno_type,
+    const Limiters::Weno_detail::DerivativeWeight derivative_weight,
+    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
     const Variables<tmpl::list<ScalarTag, VectorTag<VolumeDim>>>& local_vars,
     const std::unordered_map<
@@ -467,8 +468,7 @@ void test_weno_work(
   }
   Limiters::Weno_detail::reconstruct_from_weighted_sum(
       make_not_null(&get(expected_scalar)), mesh, neighbor_linear_weight,
-      expected_neighbor_polynomials,
-      Limiters::Weno_detail::DerivativeWeight::Unity);
+      expected_neighbor_polynomials, derivative_weight);
   CHECK_ITERABLE_CUSTOM_APPROX(expected_scalar, scalar, local_approx);
 
   auto expected_vector = get<VectorTag<VolumeDim>>(local_vars);
@@ -479,8 +479,7 @@ void test_weno_work(
     }
     Limiters::Weno_detail::reconstruct_from_weighted_sum(
         make_not_null(&(expected_vector.get(i))), mesh, neighbor_linear_weight,
-        expected_neighbor_polynomials,
-        Limiters::Weno_detail::DerivativeWeight::Unity);
+        expected_neighbor_polynomials, derivative_weight);
   }
   CHECK_ITERABLE_CUSTOM_APPROX(expected_vector, vector, local_approx);
 }
@@ -560,8 +559,10 @@ void test_simple_weno_1d(const std::unordered_set<Direction<1>>&
   const auto neighbor_data = make_neighbor_data_from_neighbor_vars(
       element, mesh, element_size, neighbor_vars);
 
-  test_weno_work<1>(Limiters::WenoType::SimpleWeno, element, mesh, element_size,
-                    local_vars, neighbor_data, neighbor_modified_vars);
+  test_weno_work<1>(Limiters::WenoType::SimpleWeno,
+                    Limiters::Weno_detail::DerivativeWeight::PowTwoEll, element,
+                    mesh, element_size, local_vars, neighbor_data,
+                    neighbor_modified_vars);
 }
 
 void test_simple_weno_2d(const std::unordered_set<Direction<2>>&
@@ -686,8 +687,10 @@ void test_simple_weno_2d(const std::unordered_set<Direction<2>>&
   const auto neighbor_data = make_neighbor_data_from_neighbor_vars(
       element, mesh, element_size, neighbor_vars);
 
-  test_weno_work<2>(Limiters::WenoType::SimpleWeno, element, mesh, element_size,
-                    local_vars, neighbor_data, neighbor_modified_vars);
+  test_weno_work<2>(Limiters::WenoType::SimpleWeno,
+                    Limiters::Weno_detail::DerivativeWeight::PowTwoEll, element,
+                    mesh, element_size, local_vars, neighbor_data,
+                    neighbor_modified_vars);
 }
 
 void test_simple_weno_3d(const std::unordered_set<Direction<3>>&
@@ -866,9 +869,10 @@ void test_simple_weno_3d(const std::unordered_set<Direction<3>>&
 
   // The 3D Simple WENO solution has slightly larger numerical error
   Approx custom_approx = Approx::custom().epsilon(1.e-11).scale(1.0);
-  test_weno_work<3>(Limiters::WenoType::SimpleWeno, element, mesh, element_size,
-                    local_vars, neighbor_data, neighbor_modified_vars,
-                    custom_approx);
+  test_weno_work<3>(Limiters::WenoType::SimpleWeno,
+                    Limiters::Weno_detail::DerivativeWeight::PowTwoEll, element,
+                    mesh, element_size, local_vars, neighbor_data,
+                    neighbor_modified_vars, custom_approx);
 }
 
 void test_hweno_1d(const std::unordered_set<Direction<1>>&
@@ -957,8 +961,10 @@ void test_hweno_1d(const std::unordered_set<Direction<1>>&
         mesh, neighbor_data, upper_xi);
   }
 
-  test_weno_work<1>(Limiters::WenoType::Hweno, element, mesh, element_size,
-                    local_vars, neighbor_data, neighbor_modified_vars);
+  test_weno_work<1>(Limiters::WenoType::Hweno,
+                    Limiters::Weno_detail::DerivativeWeight::Unity, element,
+                    mesh, element_size, local_vars, neighbor_data,
+                    neighbor_modified_vars);
 }
 
 }  // namespace


### PR DESCRIPTION
## Proposed changes

This is part of the ongoing WENO refactor.

Introduces a new helper function that encodes the action of the simple WENO limiter. This helper will make it easier to have different implementations of simple WENO, e.g., for acting on conserved vs. characteristic variables. Splitting off the simple WENO logic also makes it easier to test it more thoroughly, which is now done in a new test.

This PR also fixes two oversimplifications of the previous implementation:
- the simple WENO limiter now checks the TCI and limits each tensor component separately, instead of limiting all tensor components when a single one triggered the TCI
- the correct weight is now assigned to higher derivatives when computing the oscillation indicator.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

