### PR TITLE
Add GSL quad integration functionality

### DIFF
--- a/src/NumericalAlgorithms/CMakeLists.txt
+++ b/src/NumericalAlgorithms/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_subdirectory(Convergence)
 add_subdirectory(DiscontinuousGalerkin)
+add_subdirectory(Integration)
 add_subdirectory(Interpolation)
 add_subdirectory(LinearAlgebra)
 add_subdirectory(LinearOperators)

--- a/src/NumericalAlgorithms/Integration/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Integration/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY Integration)
+
+set(LIBRARY_SOURCES
+  GslQuadAdaptive.cpp
+  )
+
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  ErrorHandling
+  GSL::gsl
+  Utilities
+  )
+

--- a/src/NumericalAlgorithms/Integration/GslQuadAdaptive.cpp
+++ b/src/NumericalAlgorithms/Integration/GslQuadAdaptive.cpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Integration/GslQuadAdaptive.hpp"
+
+#include <cstddef>
+#include <gsl/gsl_errno.h>
+#include <gsl/gsl_integration.h>
+#include <memory>
+#include <pup.h>
+
+#include "ErrorHandling/Exceptions.hpp"
+#include "Utilities/MakeString.hpp"
+
+namespace integration {
+
+namespace detail {
+
+GslQuadAdaptiveImpl::GslQuadAdaptiveImpl(const size_t max_intervals) noexcept
+    : max_intervals_(max_intervals), gsl_integrand_(gsl_function{}) {
+  initialize();
+}
+
+void GslQuadAdaptiveImpl::pup(PUP::er& p) noexcept {
+  p | max_intervals_;
+  if (p.isUnpacking()) {
+    initialize();
+  }
+}
+
+void GslQuadAdaptiveImpl::GslIntegrationWorkspaceDeleter::operator()(
+    gsl_integration_workspace* workspace) const noexcept {
+  gsl_integration_workspace_free(workspace);
+}
+
+void GslQuadAdaptiveImpl::initialize() noexcept {
+  workspace_ = std::unique_ptr<gsl_integration_workspace,
+                               GslIntegrationWorkspaceDeleter>{
+      gsl_integration_workspace_alloc(max_intervals_)};
+}
+
+void check_status_code(const int status_code) {
+  if (status_code != 0) {
+    throw convergence_error(MakeString{}
+                            << "Integration failed with GSL error: "
+                            << gsl_strerror(status_code));
+  }
+}
+
+void disable_gsl_error_handling() noexcept { gsl_set_error_handler_off(); }
+
+}  // namespace detail
+
+}  // namespace integration

--- a/src/NumericalAlgorithms/Integration/GslQuadAdaptive.hpp
+++ b/src/NumericalAlgorithms/Integration/GslQuadAdaptive.hpp
@@ -1,0 +1,295 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <gsl/gsl_integration.h>
+#include <memory>
+#include <vector>
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+/// \ingroup NumericalAlgorithmsGroup
+/// Numerical integration algorithms
+namespace integration {
+
+namespace detail {
+
+// The GSL functions require the integrand to have this particular function
+// signature. In particular, any extra parameters to the functions must be
+// passed as a void* and re-interpreted appropriately.
+template <typename IntegrandType>
+double integrand(const double x, void* const params) {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  const auto function = reinterpret_cast<IntegrandType*>(params);
+  return (*function)(x);
+}
+
+class GslQuadAdaptiveImpl {
+ public:
+  explicit GslQuadAdaptiveImpl(size_t max_intervals) noexcept;
+
+  GslQuadAdaptiveImpl() = default;
+  GslQuadAdaptiveImpl(const GslQuadAdaptiveImpl&) = delete;
+  GslQuadAdaptiveImpl& operator=(const GslQuadAdaptiveImpl&) = delete;
+  GslQuadAdaptiveImpl(GslQuadAdaptiveImpl&&) noexcept = default;
+  GslQuadAdaptiveImpl& operator=(GslQuadAdaptiveImpl&& rhs) noexcept = default;
+  ~GslQuadAdaptiveImpl() noexcept = default;
+
+  void pup(PUP::er& p) noexcept;  // NOLINT(google-runtime-references)
+
+ protected:
+  template <typename IntegrandType>
+  gsl_function* gsl_integrand(IntegrandType&& integrand) const noexcept {
+    gsl_integrand_.function = &detail::integrand<IntegrandType>;
+    gsl_integrand_.params = &integrand;
+    return &gsl_integrand_;
+  }
+
+  struct GslIntegrationWorkspaceDeleter {
+    void operator()(gsl_integration_workspace* workspace) const noexcept;
+  };
+
+  size_t max_intervals_ = 0;
+  std::unique_ptr<gsl_integration_workspace, GslIntegrationWorkspaceDeleter>
+      workspace_{};
+
+ private:
+  void initialize() noexcept;
+
+  mutable gsl_function gsl_integrand_{};
+};
+
+void check_status_code(int status_code);
+
+void disable_gsl_error_handling() noexcept;
+
+}  // namespace detail
+
+/// Each type specifies which algorithm from GSL should be used. It should be
+/// chosen according to the problem.
+enum class GslIntegralType {
+  /// gsl_integration_qag()
+  StandardGaussKronrod,
+  /// gsl_integration_qags()
+  IntegrableSingularitiesPresent,
+  /// gsl_integration_qagp()
+  IntegrableSingularitiesKnown,
+  /// gsl_integration_qagi()
+  InfiniteInterval,
+  /// gsl_integration_qagiu()
+  UpperBoundaryInfinite,
+  /// gsl_integration_qagil()
+  LowerBoundaryInfinite
+};
+
+/*!
+ * \brief A wrapper around the GSL adaptive integration procedures
+ *
+ * All templates take upper bounds to the absolute and relative error;
+ * `tolerance_abs` and `tolerance_rel(default = 0.0)`, respectively. To compute
+ * to a specified absolute error, set `tolerance_rel` to zero. To compute to a
+ * specified relative error, set `tolerance_abs` to zero. For details on the
+ * algorithm see the GSL documentation on `gsl_integration`.
+ *
+ * Here is an example how to use this class. For the function:
+ *
+ * \snippet Test_GslQuadAdaptive.cpp integrated_function
+ *
+ * the integration should look like:
+ *
+ * \snippet Test_GslQuadAdaptive.cpp integration_example
+ */
+template <GslIntegralType TheIntegralType>
+class GslQuadAdaptive;
+
+/*!
+ * \brief Use Gauss-Kronrod rule to integrate a 1D-function
+ *
+ * The algorithm for "StandardGaussKronrod" uses the QAG algorithm to employ an
+ * adaptive Gauss-Kronrod n-points integration rule. Its function takes a
+ * `lower_boundary` and `upper_boundary` to the integration region, an upper
+ * bound for the absolute error `tolerance_abs` and a `key`. The latter is an
+ * index to the array [15, 21, 31, 41, 51, 61], where each element denotes how
+ * many function evaluations take place in each subinterval. A higher-order rule
+ * serves better for smooth functions, whereas a lower-order rule saves time for
+ * functions with local difficulties, such as discontinuities.
+ */
+template <>
+class GslQuadAdaptive<GslIntegralType::StandardGaussKronrod>
+    : public detail::GslQuadAdaptiveImpl {
+ public:
+  using detail::GslQuadAdaptiveImpl::GslQuadAdaptiveImpl;
+  template <typename IntegrandType>
+  double operator()(IntegrandType&& integrand, const double lower_boundary,
+                    const double upper_boundary, const double tolerance_abs,
+                    const int key, const double tolerance_rel = 0.) const {
+    double result;
+    double error;
+    detail::disable_gsl_error_handling();
+    const int status_code = gsl_integration_qag(
+        gsl_integrand(std::forward<IntegrandType>(integrand)), lower_boundary,
+        upper_boundary, tolerance_abs, tolerance_rel, this->max_intervals_, key,
+        this->workspace_.get(), &result, &error);
+    detail::check_status_code(status_code);
+    return result;
+  }
+};
+
+/*!
+ * \brief Integrates a 1D-function with singularities
+ *
+ * The algorithm for "IntegrableSingularitiesPresent" concentrates new,
+ * increasingly smaller subintervals around an unknown singularity and makes
+ * successive approximations to the integral which should converge towards a
+ * limit. The integration region is defined by `lower_boundary` and
+ * `upper_boundary`.
+ */
+template <>
+class GslQuadAdaptive<GslIntegralType::IntegrableSingularitiesPresent>
+    : public detail::GslQuadAdaptiveImpl {
+ public:
+  using detail::GslQuadAdaptiveImpl::GslQuadAdaptiveImpl;
+  template <typename IntegrandType>
+  double operator()(IntegrandType&& integrand, const double lower_boundary,
+                    const double upper_boundary, const double tolerance_abs,
+                    const double tolerance_rel = 0.) const {
+    double result;
+    double error;
+    detail::disable_gsl_error_handling();
+    const int status_code = gsl_integration_qags(
+        gsl_integrand(std::forward<IntegrandType>(integrand)), lower_boundary,
+        upper_boundary, tolerance_abs, tolerance_rel, this->max_intervals_,
+        this->workspace_.get(), &result, &error);
+    detail::check_status_code(status_code);
+    return result;
+  }
+};
+
+/*!
+ * \brief Integrates a 1D-function where singularities are known
+ *
+ * The algorithm for "IntegrableSingularitiesKnown" uses user-defined
+ * subintervals given by a vector of doubles `points`, where each element
+ * denotes an interval boundary.
+ */
+template <>
+class GslQuadAdaptive<GslIntegralType::IntegrableSingularitiesKnown>
+    : public detail::GslQuadAdaptiveImpl {
+ public:
+  using detail::GslQuadAdaptiveImpl::GslQuadAdaptiveImpl;
+  template <typename IntegrandType>
+  double operator()(IntegrandType&& integrand,
+                    const std::vector<double>& points,
+                    const double tolerance_abs,
+                    const double tolerance_rel = 0.) const {
+    double result;
+    double error;
+    detail::disable_gsl_error_handling();
+    // The const_cast is necessary because GSL has a weird interface where
+    // the number of singularities does not change, but it doesn't take
+    // the argument as a `const double*`. However, the first thing
+    // `gsl_integration_qagp` does internally is forward to another function
+    // that does take `points` by `const double*`. If `gsl_integration_qagp`
+    // were to change the size of `points` this code would be severely broken
+    // because `std::vector` allocates with `new`, while GSL would likely use
+    // `malloc` (or some other C allocator). Mixing (de)allocators in such a way
+    // is undefined behavior.
+    const int status_code = gsl_integration_qagp(
+        gsl_integrand(std::forward<IntegrandType>(integrand)),
+        const_cast<double*>(points.data()),  // NOLINT
+        points.size(), tolerance_abs, tolerance_rel, this->max_intervals_,
+        this->workspace_.get(), &result, &error);
+    detail::check_status_code(status_code);
+    return result;
+  }
+};
+
+/*!
+ * \brief Integrates a 1D-function over the interval \f$ (-\infty, +\infty) \f$
+ *
+ * The algorithm for "InfiniteInterval" uses the semi-open interval
+ * \f$ (0, 1] \f$ to map to an infinite interval \f$ (-\infty, +\infty) \f$. Its
+ * function takes no parameters other than limits `tolerance_abs` and optional
+ * `tolerance_rel` for the absolute error and the relative error.
+ */
+template <>
+class GslQuadAdaptive<GslIntegralType::InfiniteInterval>
+    : public detail::GslQuadAdaptiveImpl {
+ public:
+  using detail::GslQuadAdaptiveImpl::GslQuadAdaptiveImpl;
+  template <typename IntegrandType>
+  double operator()(IntegrandType&& integrand, const double tolerance_abs,
+                    const double tolerance_rel = 0.) const {
+    double result;
+    double error;
+    detail::disable_gsl_error_handling();
+    const int status_code = gsl_integration_qagi(
+        gsl_integrand(std::forward<IntegrandType>(integrand)), tolerance_abs,
+        tolerance_rel, this->max_intervals_, this->workspace_.get(), &result,
+        &error);
+    detail::check_status_code(status_code);
+    return result;
+  }
+};
+
+/*!
+ * \brief Integrates a 1D-function over the interval \f$ [a, +\infty) \f$
+ *
+ * The algorithm for "UpperBoundaryInfinite" maps the semi-open interval
+ * \f$ (0, 1] \f$ to a semi-infinite interval \f$ [a, +\infty) \f$, where
+ * \f$ a \f$ is given by `lower_boundary`.
+ */
+template <>
+class GslQuadAdaptive<GslIntegralType::UpperBoundaryInfinite>
+    : public detail::GslQuadAdaptiveImpl {
+ public:
+  using detail::GslQuadAdaptiveImpl::GslQuadAdaptiveImpl;
+  template <typename IntegrandType>
+  double operator()(IntegrandType&& integrand, const double lower_boundary,
+                    const double tolerance_abs,
+                    const double tolerance_rel = 0.) const {
+    double result;
+    double error;
+    detail::disable_gsl_error_handling();
+    const int status_code = gsl_integration_qagiu(
+        gsl_integrand(std::forward<IntegrandType>(integrand)), lower_boundary,
+        tolerance_abs, tolerance_rel, this->max_intervals_,
+        this->workspace_.get(), &result, &error);
+    detail::check_status_code(status_code);
+    return result;
+  }
+};
+
+/*!
+ * \brief Integrates a 1D-function over the interval \f$ (-\infty, b] \f$
+ *
+ * The algorithm for "LowerBoundaryInfinite" maps the semi-open interval
+ * \f$ (0, 1] \f$ to a semi-infinite interval \f$ (-\infty, b] \f$, where
+ * \f$ b \f$ is given by `upper_boundary`.
+ */
+template <>
+class GslQuadAdaptive<GslIntegralType::LowerBoundaryInfinite>
+    : public detail::GslQuadAdaptiveImpl {
+ public:
+  using detail::GslQuadAdaptiveImpl::GslQuadAdaptiveImpl;
+  template <typename IntegrandType>
+  double operator()(IntegrandType&& integrand, const double upper_boundary,
+                    const double tolerance_abs,
+                    const double tolerance_rel = 0.) const {
+    double result;
+    double error;
+    detail::disable_gsl_error_handling();
+    const int status_code = gsl_integration_qagil(
+        gsl_integrand(std::forward<IntegrandType>(integrand)), upper_boundary,
+        tolerance_abs, tolerance_rel, this->max_intervals_,
+        this->workspace_.get(), &result, &error);
+    detail::check_status_code(status_code);
+    return result;
+  }
+};
+}  // namespace integration

--- a/tests/Unit/NumericalAlgorithms/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_subdirectory(Convergence)
 add_subdirectory(DiscontinuousGalerkin)
+add_subdirectory(Integration)
 add_subdirectory(Interpolation)
 add_subdirectory(LinearAlgebra)
 add_subdirectory(LinearOperators)

--- a/tests/Unit/NumericalAlgorithms/Integration/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Integration/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_NumericalIntegration")
+
+set(LIBRARY_SOURCES
+  Test_GslQuadAdaptive.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "NumericalAlgorithms/Integration/"
+  "${LIBRARY_SOURCES}"
+  "Integration"
+  )

--- a/tests/Unit/NumericalAlgorithms/Integration/Test_GslQuadAdaptive.cpp
+++ b/tests/Unit/NumericalAlgorithms/Integration/Test_GslQuadAdaptive.cpp
@@ -1,0 +1,138 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Integration/GslQuadAdaptive.hpp"
+
+namespace {
+/// [integrated_function]
+double gaussian(const double x, const double mean,
+                const double factor) noexcept {
+  return 2. * factor / sqrt(M_PI) * exp(-square(x - mean));
+}
+/// [integrated_function]
+
+double integrable_singularity(const double x, const double factor) noexcept {
+  return factor * cos(sqrt(abs(x))) / sqrt(abs(x));
+}
+
+SPECTRE_TEST_CASE("Unit.Numerical.Integration.GslQuadAdaptive",
+                  "[Unit][NumericalAlgorithms]") {
+  const double absolute_tolerance = 1.e-10;
+  Approx custom_approx = Approx::custom().epsilon(absolute_tolerance);
+
+  const double error_causing_tolerance =
+      1.e-3 * std::numeric_limits<double>::epsilon();
+
+  {
+    INFO("StandardGaussKronrod");
+    // Construct the integration and give an example
+    /// [integration_example]
+    const integration::GslQuadAdaptive<
+        integration::GslIntegralType::StandardGaussKronrod>
+        integration{20};
+    const double mean = 5.;
+    const double factor = 2.;
+    const double lower_boundary = -4.;
+    const double upper_boundary = 10.;
+    const auto result = integration(
+        [&mean, &factor](const double x) { return gaussian(x, mean, factor); },
+        lower_boundary, upper_boundary, absolute_tolerance, 4);
+    /// [integration_example]
+    CHECK(result == custom_approx(factor * erf(upper_boundary - mean) -
+                                  factor * erf(lower_boundary - mean)));
+    CHECK_THROWS(integration(
+        [&mean, &factor](const double x) { return gaussian(x, mean, factor); },
+        lower_boundary, upper_boundary, error_causing_tolerance, 4));
+  }
+
+  {
+    INFO("InfiniteInterval");
+    const integration::GslQuadAdaptive<
+        integration::GslIntegralType::InfiniteInterval>
+        integration{20};
+    const double mean = 5.;
+    const double factor = 2.;
+    const auto result = integration(
+        [&mean, &factor](const double x) { return gaussian(x, mean, factor); },
+        absolute_tolerance);
+    CHECK(result == custom_approx(2. * factor));
+    CHECK_THROWS(integration(
+        [&mean, &factor](const double x) { return gaussian(x, mean, factor); },
+        error_causing_tolerance));
+  }
+
+  {
+    INFO("UpperBoundaryInfinite");
+    const integration::GslQuadAdaptive<
+        integration::GslIntegralType::UpperBoundaryInfinite>
+        integration{20};
+    const double mean = 5.;
+    const double factor = 2.;
+    const double lower_boundary = -4.;
+    auto result = integration(
+        [&mean, &factor](const double x) { return gaussian(x, mean, factor); },
+        lower_boundary, absolute_tolerance);
+    CHECK(result == custom_approx(factor * (1. - erf(lower_boundary - mean))));
+    CHECK_THROWS(integration(
+        [&mean, &factor](const double x) { return gaussian(x, mean, factor); },
+        lower_boundary, error_causing_tolerance));
+  }
+
+  {
+    INFO("LowerBoundaryInfinite");
+    const integration::GslQuadAdaptive<
+        integration::GslIntegralType::LowerBoundaryInfinite>
+        integration{20};
+    const double mean = 5.;
+    const double factor = 2.;
+    const double upper_boundary = 10.;
+    auto result = integration(
+        [&mean, &factor](const double x) { return gaussian(x, mean, factor); },
+        upper_boundary, absolute_tolerance);
+    CHECK(result == custom_approx(factor * (1. + erf(upper_boundary - mean))));
+    CHECK_THROWS(integration(
+        [&mean, &factor](const double x) { return gaussian(x, mean, factor); },
+        upper_boundary, error_causing_tolerance));
+  }
+
+  {
+    INFO("IntegrableSingularitiesPresent");
+    const integration::GslQuadAdaptive<
+        integration::GslIntegralType::IntegrableSingularitiesPresent>
+        integration{20};
+    const double factor = 2.;
+    const double upper_boundary = square(0.5 * M_PI);
+    auto result = integration(
+        [&factor](const double x) { return integrable_singularity(x, factor); },
+        0., upper_boundary, absolute_tolerance);
+    CHECK(result == custom_approx(2. * factor * (sin(sqrt(upper_boundary)))));
+    CHECK_THROWS(integration(
+        [&factor](const double x) { return integrable_singularity(x, factor); },
+        0., upper_boundary, error_causing_tolerance));
+  }
+
+  {
+    INFO("IntegrableSingularitiesKnown");
+    const integration::GslQuadAdaptive<
+        integration::GslIntegralType::IntegrableSingularitiesKnown>
+        integration{30};
+    const double factor = 2.;
+    const double upper_boundary = square(0.5 * M_PI);
+    const std::vector<double> points{-upper_boundary, 0., upper_boundary};
+    auto result = integration(
+        [&factor](const double x) { return integrable_singularity(x, factor); },
+        points, absolute_tolerance);
+    CHECK(result == custom_approx(4. * factor * sin(sqrt(upper_boundary))));
+    CHECK_THROWS(integration(
+        [&factor](const double x) { return integrable_singularity(x, factor); },
+        points, error_causing_tolerance));
+  }
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Implements adaptive integration algorithms from GSL. The documentation for which can be found at https://www.gnu.org/software/gsl/doc/html/integration.html#introduction.
<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments
The GslQuadAdaptiveImpl handles the allocation of workspace in its initialiser and handles the unpacking of a parameter pack into separate function parameters. This is in part necessary because the algorithms integrate only functions with one argument and don't allow for lambda functions to be passed.
GslQuadAdaptive inherits from GslQuadAdaptiveImpl and is templated on the different algorithms in the pack, such as gsl_integration_qags() for integration of a function with integrable singularities.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
