### PR TITLE
Add Strain to Analytic Solution of BentBeam

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
@@ -38,6 +38,19 @@ tuples::TaggedTuple<Tags::Displacement<2>> BentBeam::variables(
              square(length_) / 4.)}}}};
 }
 
+tuples::TaggedTuple<Tags::Strain<2>> BentBeam::variables(
+    const tnsr::I<DataVector, 2>& x, tmpl::list<Tags::Strain<2>> /*meta*/) const
+    noexcept {
+  const double youngs_modulus = constitutive_relation_.youngs_modulus();
+  const double poisson_ratio = constitutive_relation_.poisson_ratio();
+  const double prefactor =
+      12. * bending_moment_ / (youngs_modulus * cube(height_));
+  auto result = make_with_value<tnsr::ii<DataVector, 2>>(x, 0.);
+  get<0, 0>(result) = -prefactor * get<1>(x);
+  get<1, 1>(result) = prefactor * poisson_ratio * get<1>(x);
+  return {std::move(result)};
+}
+
 tuples::TaggedTuple<Tags::Stress<2>> BentBeam::variables(
     const tnsr::I<DataVector, 2>& x, tmpl::list<Tags::Stress<2>> /*meta*/) const
     noexcept {

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
@@ -39,26 +39,32 @@ namespace Solutions {
  * \ref Elasticity equations reduce to \f$\nabla_i T^{ij}=0\f$, but the bending
  * moment \f$M\f$ generates the stress
  *
- * \f[
- * T^{xx} = \frac{12 M}{H^3} y \\
- * T^{xy} = 0 = T^{yy} \text{.}
- * \f]
+ * \f{align}
+ * T^{xx} &= \frac{12 M}{H^3} y \\
+ * T^{xy} &= 0 = T^{yy} \text{.}
+ * \f}
  *
  * By fixing the rigid-body motions to
  *
  * \f[
- * u^x(0,y)=0 \quad \text{and} \quad u^y\left(\pm \frac{L}{2},0\right)=0
+ * \xi^x(0,y)=0 \quad \text{and} \quad \xi^y\left(\pm \frac{L}{2},0\right)=0
  * \f]
  *
  * we find that this stress is produced by the displacement field
  *
  * \f{align}
- * u^x&=-\frac{12 M}{EH^3}xy \\
- * u^y&=\frac{6 M}{EH^3}\left(x^2+\nu y^2-\frac{L^2}{4}\right)
+ * \xi^x&=-\frac{12 M}{EH^3}xy \\
+ * \xi^y&=\frac{6 M}{EH^3}\left(x^2+\nu y^2-\frac{L^2}{4}\right)
  * \f}
  *
  * in terms of the Young's modulus \f$E\f$ and the Poisson ration \f$\nu\f$ of
- * the material.
+ * the material. The corresponding strain \f$S_{ij}=\partial_{(i}\xi_{j)}\f$ is
+ *
+ * \f{align}
+ * S_{xx} &= -\frac{12 M}{EH^3} y \\
+ * S_{yy} &= \frac{12 M}{EH^3} \nu y \\
+ * S_{xy} &= S_{yx} = 0 \text{.}
+ * \f}
  */
 class BentBeam {
  public:
@@ -112,6 +118,10 @@ class BentBeam {
   auto variables(const tnsr::I<DataVector, 2>& x,
                  tmpl::list<Tags::Displacement<2>> /*meta*/) const noexcept
       -> tuples::TaggedTuple<Tags::Displacement<2>>;
+
+  auto variables(const tnsr::I<DataVector, 2>& x,
+                 tmpl::list<Tags::Strain<2>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<Tags::Strain<2>>;
 
   auto variables(const tnsr::I<DataVector, 2>& x,
                  tmpl::list<Tags::Stress<2>> /*meta*/) const noexcept

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.py
@@ -2,19 +2,29 @@
 # See LICENSE.txt for details.
 
 import numpy as np
+from Elasticity.ConstitutiveRelations.IsotropicHomogeneous import (
+    youngs_modulus, poisson_ratio)
 
 
 def displacement(x, length, height, bending_moment, bulk_modulus,
                  shear_modulus):
-    youngs_modulus = 9. * bulk_modulus * shear_modulus / \
-        (3. * bulk_modulus + shear_modulus)
-    poisson_ratio = (3. * bulk_modulus - 2. * shear_modulus) / \
-        (6. * bulk_modulus + 2. * shear_modulus)
-    prefactor = 12. * bending_moment / (youngs_modulus * height**3)
+    local_youngs_modulus = youngs_modulus(bulk_modulus, shear_modulus)
+    local_poisson_ratio = poisson_ratio(bulk_modulus, shear_modulus)
+    prefactor = 12. * bending_moment / (local_youngs_modulus * height**3)
     return np.array([
-        -prefactor * x[0] * x[1],
-        prefactor / 2. * (x[0]**2 + poisson_ratio * x[1]**2 - length**2 / 4.)
+        -prefactor * x[0] * x[1], prefactor / 2. *
+        (x[0]**2 + local_poisson_ratio * x[1]**2 - length**2 / 4.)
     ])
+
+
+def strain(x, length, height, bending_moment, bulk_modulus, shear_modulus):
+    local_youngs_modulus = youngs_modulus(bulk_modulus, shear_modulus)
+    local_poisson_ratio = poisson_ratio(bulk_modulus, shear_modulus)
+    prefactor = 12. * bending_moment / (local_youngs_modulus * height**3)
+    result = np.zeros((2, 2))
+    result[0, 0] = -prefactor * x[1]
+    result[1, 1] = prefactor * local_poisson_ratio * x[1]
+    return result
 
 
 def stress(x, length, height, bending_moment, bulk_modulus, shear_modulus):

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
@@ -10,12 +10,23 @@
 #include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Elliptic/Systems/Elasticity/Equations.hpp"
+#include "Elliptic/Systems/Elasticity/FirstOrderSystem.hpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"  // IWYU pragma: keep
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
 #include "Utilities/TMPL.hpp"
@@ -28,8 +39,9 @@ namespace {
 struct BentBeamProxy : Elasticity::Solutions::BentBeam {
   using Elasticity::Solutions::BentBeam::BentBeam;
 
-  using field_tags = tmpl::list<Elasticity::Tags::Displacement<2>,
-                                Elasticity::Tags::Stress<2>>;
+  using field_tags =
+      tmpl::list<Elasticity::Tags::Displacement<2>, Elasticity::Tags::Strain<2>,
+                 Elasticity::Tags::Stress<2>>;
   using source_tags =
       tmpl::list<Tags::FixedSource<Elasticity::Tags::Displacement<2>>>;
 
@@ -65,39 +77,68 @@ SPECTRE_TEST_CASE(
   CHECK(created_solution == check_solution);
   test_serialization(check_solution);
 
-  pypp::SetupLocalPythonEnvironment local_python_env{
-      "PointwiseFunctions/AnalyticSolutions/Elasticity"};
-  const BentBeamProxy solution{
-      5., 1., 0.5,
-      Elasticity::ConstitutiveRelations::IsotropicHomogeneous<2>{
-          79.36507936507935, 38.75968992248062}};
+  pypp::SetupLocalPythonEnvironment local_python_env{"PointwiseFunctions"};
+  const Elasticity::ConstitutiveRelations::IsotropicHomogeneous<2>
+      constitutive_relation{79.36507936507935, 38.75968992248062};
+  const BentBeamProxy solution{5., 1., 0.5, constitutive_relation};
 
   tnsr::I<DataVector, 2> x{{{{1., 2.}, {2., 1.}}}};
-  const auto solution_vars = variables_from_tagged_tuple(
-      solution.variables(x, tmpl::list<Elasticity::Tags::Displacement<2>,
-                                       Elasticity::Tags::Stress<2>>{}));
-  Variables<tmpl::list<Elasticity::Tags::Displacement<2>,
-                       Elasticity::Tags::Stress<2>>>
+  const auto solution_vars = variables_from_tagged_tuple(solution.variables(
+      x,
+      tmpl::list<Elasticity::Tags::Displacement<2>, Elasticity::Tags::Strain<2>,
+                 Elasticity::Tags::Stress<2>>{}));
+  Variables<
+      tmpl::list<Elasticity::Tags::Displacement<2>, Elasticity::Tags::Strain<2>,
+                 Elasticity::Tags::Stress<2>>>
       expected_vars{2};
   auto& expected_displacement =
       get<Elasticity::Tags::Displacement<2>>(expected_vars);
   get<0>(expected_displacement) = DataVector{-0.12, -0.12};
   get<1>(expected_displacement) = DataVector{-0.1227, -0.0588};
+  auto& expected_strain = get<Elasticity::Tags::Strain<2>>(expected_vars);
+  get<0, 0>(expected_strain) = DataVector{-0.12, -0.06};
+  get<1, 0>(expected_strain) = DataVector{0., 0.};
+  get<1, 1>(expected_strain) = DataVector{0.0348, 0.0174};
   auto& expected_stress = get<Elasticity::Tags::Stress<2>>(expected_vars);
   get<0, 0>(expected_stress) = DataVector{12., 6.};
   get<1, 0>(expected_stress) = DataVector{0., 0.};
   get<1, 1>(expected_stress) = DataVector{0., 0.};
   CHECK_VARIABLES_APPROX(solution_vars, expected_vars);
 
-  pypp::check_with_random_values<1,
-                                 tmpl::list<Elasticity::Tags::Displacement<2>,
-                                            Elasticity::Tags::Stress<2>>>(
-      &BentBeamProxy::field_variables, solution, "BentBeam",
-      {"displacement", "stress"}, {{{-5., 5.}}},
+  pypp::check_with_random_values<
+      1, tmpl::list<Elasticity::Tags::Displacement<2>,
+                    Elasticity::Tags::Strain<2>, Elasticity::Tags::Stress<2>>>(
+      &BentBeamProxy::field_variables, solution,
+      "AnalyticSolutions.Elasticity.BentBeam",
+      {"displacement", "strain", "stress"}, {{{-5., 5.}}},
       std::make_tuple(5., 1., 0.5, 79.36507936507935, 38.75968992248062),
       DataVector(5));
   pypp::check_with_random_values<
       1, tmpl::list<Tags::FixedSource<Elasticity::Tags::Displacement<2>>>>(
-      &BentBeamProxy::source_variables, solution, "BentBeam", {"source"},
-      {{{-5., 5.}}}, std::make_tuple(), DataVector(5));
+      &BentBeamProxy::source_variables, solution,
+      "AnalyticSolutions.Elasticity.BentBeam", {"source"}, {{{-5., 5.}}},
+      std::make_tuple(), DataVector(5));
+
+  {
+    INFO("Test elasticity system with bent beam");
+    // Verify that the solution numerically solves the system
+    using system = Elasticity::FirstOrderSystem<2>;
+    const typename system::fluxes fluxes_computer{};
+    using AffineMap = domain::CoordinateMaps::Affine;
+    using AffineMap2D =
+        domain::CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
+    const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap2D>
+        coord_map{{{-1., 1., -2.5, 2.5}, {-1., 1., -0.5, 0.5}}};
+    // Since the solution is a polynomial of degree 2 it should numerically
+    // solve the system equations to machine precision on 3 grid points per
+    // dimension.
+    const Mesh<2> mesh{3, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+    const auto logical_coords = logical_coordinates(mesh);
+    const auto inertial_coords = coord_map(logical_coords);
+    FirstOrderEllipticSolutionsTestHelpers::verify_solution<system>(
+        solution, fluxes_computer, mesh, coord_map,
+        std::numeric_limits<double>::epsilon() * 100.,
+        std::make_tuple(constitutive_relation, inertial_coords));
+  };
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/__init__.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.py
+++ b/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.py
@@ -18,3 +18,13 @@ def stress(strain, x, bulk_modulus, shear_modulus):
         raise NotImplementedError
     return -trace_factor * strain_trace * krond \
         - 2 * shear_modulus * traceless_strain
+
+
+def youngs_modulus(bulk_modulus, shear_modulus):
+    return 9. * bulk_modulus * shear_modulus / \
+        (3. * bulk_modulus + shear_modulus)
+
+
+def poisson_ratio(bulk_modulus, shear_modulus):
+    return (3. * bulk_modulus - 2. * shear_modulus) / \
+        (6. * bulk_modulus + 2. * shear_modulus)

--- a/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/__init__.py
+++ b/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tests/Unit/PointwiseFunctions/Elasticity/__init__.py
+++ b/tests/Unit/PointwiseFunctions/Elasticity/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.


### PR DESCRIPTION
## Proposed changes
Implements the strain for the analytic solution of a BentBeam and tests whether it satisfies primary and auxiliary field equations.
<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
