### PR TITLE
Template ConservativeDuDt on dg::Formulation

### DIFF
--- a/src/Evolution/Conservative/ConservativeDuDt.hpp
+++ b/src/Evolution/Conservative/ConservativeDuDt.hpp
@@ -13,6 +13,7 @@
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
 #include "ErrorHandling/Assert.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -28,7 +29,7 @@ namespace dg {
 ///
 /// Source terms are only added for variables in the
 /// `System::sourced_variables` type list.
-template <typename System>
+template <typename System, ::dg::Formulation DgFormulation>
 struct ConservativeDuDt {
   static constexpr size_t volume_dim = System::volume_dim;
   using frame = Frame::Inertial;
@@ -56,6 +57,10 @@ struct ConservativeDuDt {
                                               Frame::Inertial>...>>& fluxes,
       const Variables<tmpl::list<::Tags::Source<VarsTags>...>>&
           sources) noexcept {
+    static_assert(DgFormulation == ::dg::Formulation::StrongInertial,
+                  "Curently only support StrongInertial DG formulation in "
+                  "ConservativeDuDt.");
+
     const Variables<tmpl::list<::Tags::div<
         ::Tags::Flux<VarsTags, tmpl::size_t<Dim>, Frame::Inertial>>...>>
         div_fluxes = divergence(fluxes, mesh, inverse_jacobian);

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -29,6 +29,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
@@ -82,6 +83,8 @@ class CProxy_ConstGlobalCache;
 struct EvolutionMetavars {
   static constexpr size_t volume_dim = 1;
   using system = Burgers::System;
+  static constexpr dg::Formulation dg_formulation =
+      dg::Formulation::StrongInertial;
   using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = false;
   using initial_data_tag = Tags::AnalyticSolution<Burgers::Solutions::Step>;
@@ -137,7 +140,7 @@ struct EvolutionMetavars {
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       Actions::ComputeTimeDerivative<
-          evolution::dg::ConservativeDuDt<Burgers::System>>,
+          evolution::dg::ConservativeDuDt<Burgers::System, dg_formulation>>,
       dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -43,6 +43,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp"
@@ -147,6 +148,8 @@ struct Horizon {
 template <typename InitialData, typename...InterpolationTargetTags>
 struct EvolutionMetavars {
   static constexpr size_t volume_dim = 3;
+  static constexpr dg::Formulation dg_formulation =
+      dg::Formulation::StrongInertial;
   using initial_data = InitialData;
   static_assert(
       evolution::is_analytic_data_v<initial_data> xor
@@ -238,7 +241,8 @@ struct EvolutionMetavars {
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       Actions::ComputeVolumeSources,
-      Actions::ComputeTimeDerivative<evolution::dg::ConservativeDuDt<system>>,
+      Actions::ComputeTimeDerivative<
+          evolution::dg::ConservativeDuDt<system, dg_formulation>>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -35,6 +35,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Hll.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
@@ -91,6 +92,9 @@ class CProxy_ConstGlobalCache;
 template <size_t Dim, typename InitialData>
 struct EvolutionMetavars {
   static constexpr size_t volume_dim = Dim;
+  static constexpr dg::Formulation dg_formulation =
+      dg::Formulation::StrongInertial;
+
   using initial_data = InitialData;
   static_assert(
       evolution::is_analytic_data_v<initial_data> xor
@@ -177,7 +181,8 @@ struct EvolutionMetavars {
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<has_source_terms, Actions::ComputeVolumeSources,
                           tmpl::list<>>,
-      Actions::ComputeTimeDerivative<evolution::dg::ConservativeDuDt<system>>,
+      Actions::ComputeTimeDerivative<
+          evolution::dg::ConservativeDuDt<system, dg_formulation>>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
@@ -37,6 +37,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
@@ -91,6 +92,9 @@ class CProxy_ConstGlobalCache;
 
 struct EvolutionMetavars {
   static constexpr size_t volume_dim = 3;
+  static constexpr dg::Formulation dg_formulation =
+      dg::Formulation::StrongInertial;
+
   // To switch which initial data is evolved you only need to change the
   // line `using initial_data = ...;` and include the header file for the
   // solution.
@@ -162,7 +166,8 @@ struct EvolutionMetavars {
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       Actions::ComputeVolumeSources,
-      Actions::ComputeTimeDerivative<evolution::dg::ConservativeDuDt<system>>,
+      Actions::ComputeTimeDerivative<
+          evolution::dg::ConservativeDuDt<system, dg_formulation>>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -38,6 +38,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
@@ -93,6 +94,9 @@ class CProxy_ConstGlobalCache;
 template <size_t Dim, typename InitialData>
 struct EvolutionMetavars {
   static constexpr size_t volume_dim = Dim;
+  static constexpr dg::Formulation dg_formulation =
+      dg::Formulation::StrongInertial;
+
   using initial_data = InitialData;
   static_assert(
       evolution::is_analytic_data_v<initial_data> xor
@@ -173,7 +177,8 @@ struct EvolutionMetavars {
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       Actions::ComputeVolumeSources,
-      Actions::ComputeTimeDerivative<evolution::dg::ConservativeDuDt<system>>,
+      Actions::ComputeTimeDerivative<
+          evolution::dg::ConservativeDuDt<system, dg_formulation>>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/tests/Unit/Evolution/Conservative/Test_ConservativeDuDt.cpp
+++ b/tests/Unit/Evolution/Conservative/Test_ConservativeDuDt.cpp
@@ -20,6 +20,7 @@
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "Evolution/Conservative/ConservativeDuDt.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.tpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "PointwiseFunctions/MathFunctions/PowX.hpp"
@@ -117,60 +118,75 @@ using expected_argument_tags = tmpl::list<
                        typename System<SourcedVariables, Dim>::variables_tag>>;
 
 static_assert(
-    cpp17::is_same_v<
-        evolution::dg::ConservativeDuDt<System<tmpl::list<>, 1>>::argument_tags,
-        expected_argument_tags<tmpl::list<>, 1>>,
+    cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                         System<tmpl::list<>, 1>,
+                         dg::Formulation::StrongInertial>::argument_tags,
+                     expected_argument_tags<tmpl::list<>, 1>>,
     "Failed testing ConservativeDuDt::argument_tags");
-static_assert(
-    cpp17::is_same_v<
-        evolution::dg::ConservativeDuDt<System<tmpl::list<>, 2>>::argument_tags,
-        expected_argument_tags<tmpl::list<>, 2>>,
-    "Failed testing ConservativeDuDt::argument_tags");
-static_assert(
-    cpp17::is_same_v<
-        evolution::dg::ConservativeDuDt<System<tmpl::list<>, 3>>::argument_tags,
-        expected_argument_tags<tmpl::list<>, 3>>,
-    "Failed testing ConservativeDuDt::argument_tags");
-static_assert(cpp17::is_same_v<evolution::dg::ConservativeDuDt<
-                                   System<tmpl::list<Var1>, 1>>::argument_tags,
-                               expected_argument_tags<tmpl::list<Var1>, 1>>,
-              "Failed testing ConservativeDuDt::argument_tags");
-static_assert(cpp17::is_same_v<evolution::dg::ConservativeDuDt<
-                                   System<tmpl::list<Var1>, 2>>::argument_tags,
-                               expected_argument_tags<tmpl::list<Var1>, 2>>,
-              "Failed testing ConservativeDuDt::argument_tags");
-static_assert(cpp17::is_same_v<evolution::dg::ConservativeDuDt<
-                                   System<tmpl::list<Var1>, 3>>::argument_tags,
-                               expected_argument_tags<tmpl::list<Var1>, 3>>,
-              "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
     cpp17::is_same_v<evolution::dg::ConservativeDuDt<
-                         System<tmpl::list<Var2<1>>, 1>>::argument_tags,
+                         System<tmpl::list<>, 2>,
+                         dg::Formulation::StrongInertial>::argument_tags,
+                     expected_argument_tags<tmpl::list<>, 2>>,
+    "Failed testing ConservativeDuDt::argument_tags");
+static_assert(
+    cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                         System<tmpl::list<>, 3>,
+                         dg::Formulation::StrongInertial>::argument_tags,
+                     expected_argument_tags<tmpl::list<>, 3>>,
+    "Failed testing ConservativeDuDt::argument_tags");
+static_assert(
+    cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                         System<tmpl::list<Var1>, 1>,
+                         dg::Formulation::StrongInertial>::argument_tags,
+                     expected_argument_tags<tmpl::list<Var1>, 1>>,
+    "Failed testing ConservativeDuDt::argument_tags");
+static_assert(
+    cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                         System<tmpl::list<Var1>, 2>,
+                         dg::Formulation::StrongInertial>::argument_tags,
+                     expected_argument_tags<tmpl::list<Var1>, 2>>,
+    "Failed testing ConservativeDuDt::argument_tags");
+static_assert(
+    cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                         System<tmpl::list<Var1>, 3>,
+                         dg::Formulation::StrongInertial>::argument_tags,
+                     expected_argument_tags<tmpl::list<Var1>, 3>>,
+    "Failed testing ConservativeDuDt::argument_tags");
+static_assert(
+    cpp17::is_same_v<evolution::dg::ConservativeDuDt<
+                         System<tmpl::list<Var2<1>>, 1>,
+                         dg::Formulation::StrongInertial>::argument_tags,
                      expected_argument_tags<tmpl::list<Var2<1>>, 1>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
     cpp17::is_same_v<evolution::dg::ConservativeDuDt<
-                         System<tmpl::list<Var2<2>>, 2>>::argument_tags,
+                         System<tmpl::list<Var2<2>>, 2>,
+                         dg::Formulation::StrongInertial>::argument_tags,
                      expected_argument_tags<tmpl::list<Var2<2>>, 2>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
     cpp17::is_same_v<evolution::dg::ConservativeDuDt<
-                         System<tmpl::list<Var2<3>>, 3>>::argument_tags,
+                         System<tmpl::list<Var2<3>>, 3>,
+                         dg::Formulation::StrongInertial>::argument_tags,
                      expected_argument_tags<tmpl::list<Var2<3>>, 3>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
     cpp17::is_same_v<evolution::dg::ConservativeDuDt<
-                         System<tmpl::list<Var1, Var2<1>>, 1>>::argument_tags,
+                         System<tmpl::list<Var1, Var2<1>>, 1>,
+                         dg::Formulation::StrongInertial>::argument_tags,
                      expected_argument_tags<tmpl::list<Var1, Var2<1>>, 1>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
     cpp17::is_same_v<evolution::dg::ConservativeDuDt<
-                         System<tmpl::list<Var1, Var2<2>>, 2>>::argument_tags,
+                         System<tmpl::list<Var1, Var2<2>>, 2>,
+                         dg::Formulation::StrongInertial>::argument_tags,
                      expected_argument_tags<tmpl::list<Var1, Var2<2>>, 2>>,
     "Failed testing ConservativeDuDt::argument_tags");
 static_assert(
     cpp17::is_same_v<evolution::dg::ConservativeDuDt<
-                         System<tmpl::list<Var1, Var2<3>>, 3>>::argument_tags,
+                         System<tmpl::list<Var1, Var2<3>>, 3>,
+                         dg::Formulation::StrongInertial>::argument_tags,
                      expected_argument_tags<tmpl::list<Var1, Var2<3>>, 3>>,
     "Failed testing ConservativeDuDt::argument_tags");
 
@@ -200,7 +216,7 @@ auto make_affine_map<3>() noexcept {
                Affine{-1.0, 1.0, 2.3, 2.8}});
 }
 
-template <size_t Dim>
+template <dg::Formulation DgFormulation, size_t Dim>
 void test(
     const Mesh<Dim>& mesh,
     std::array<std::unique_ptr<MathFunction<1>>, Dim> functions) noexcept {
@@ -235,8 +251,10 @@ void test(
             Functions<FluxTag>::divergence_of_flux(f, inertial_coords);
       });
 
-  evolution::dg::ConservativeDuDt<System<tmpl::list<>, Dim>>::apply(
-      make_not_null(&dt_vars), mesh, inverse_jacobian, fluxes, sources);
+  evolution::dg::ConservativeDuDt<System<tmpl::list<>, Dim>,
+                                  DgFormulation>::apply(make_not_null(&dt_vars),
+                                                        mesh, inverse_jacobian,
+                                                        fluxes, sources);
   CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
         -get(get<Tags::div<Flux1>>(expected_div_fluxes)));
   for (size_t i = 0; i < Dim; ++i) {
@@ -247,8 +265,10 @@ void test(
   // Test with Tags::Source<Var1>
   get(get<Tags::Source<Var1>>(sources)) = 0.9 * get<0>(inertial_coords);
 
-  evolution::dg::ConservativeDuDt<System<tmpl::list<Var1>, Dim>>::apply(
-      make_not_null(&dt_vars), mesh, inverse_jacobian, fluxes, sources);
+  evolution::dg::ConservativeDuDt<System<tmpl::list<Var1>, Dim>,
+                                  DgFormulation>::apply(make_not_null(&dt_vars),
+                                                        mesh, inverse_jacobian,
+                                                        fluxes, sources);
   CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
         -get(get<Tags::div<Flux1>>(expected_div_fluxes)) +
             get(get<Tags::Source<Var1>>(sources)));
@@ -263,8 +283,10 @@ void test(
         0.9 * (i + 1.0) * inertial_coords.get(i);
   }
 
-  evolution::dg::ConservativeDuDt<System<tmpl::list<Var2<Dim>>, Dim>>::apply(
-      make_not_null(&dt_vars), mesh, inverse_jacobian, fluxes, sources);
+  evolution::dg::ConservativeDuDt<System<tmpl::list<Var2<Dim>>, Dim>,
+                                  DgFormulation>::apply(make_not_null(&dt_vars),
+                                                        mesh, inverse_jacobian,
+                                                        fluxes, sources);
   CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
         -get(get<Tags::div<Flux1>>(expected_div_fluxes)));
   for (size_t i = 0; i < Dim; ++i) {
@@ -274,8 +296,10 @@ void test(
   }
 
   // Test with both sources
-  evolution::dg::ConservativeDuDt<System<tmpl::list<Var1, Var2<Dim>>, Dim>>::
-      apply(make_not_null(&dt_vars), mesh, inverse_jacobian, fluxes, sources);
+  evolution::dg::ConservativeDuDt<System<tmpl::list<Var1, Var2<Dim>>, Dim>,
+                                  DgFormulation>::apply(make_not_null(&dt_vars),
+                                                        mesh, inverse_jacobian,
+                                                        fluxes, sources);
   CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
         -get(get<Tags::div<Flux1>>(expected_div_fluxes)) +
             get(get<Tags::Source<Var1>>(sources)));
@@ -293,16 +317,19 @@ SPECTRE_TEST_CASE("Unit.Evolution.ConservativeDuDt", "[Unit][Evolution]") {
 
   const Mesh<1> mesh_1d{num_points, Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
-  test(mesh_1d, {{std::make_unique<MathFunctions::PowX>(num_points - 1)}});
+  test<dg::Formulation::StrongInertial>(
+      mesh_1d, {{std::make_unique<MathFunctions::PowX>(num_points - 1)}});
 
   const Mesh<2> mesh_2d{num_points, Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
-  test(mesh_2d, {{std::make_unique<MathFunctions::PowX>(num_points - 1),
-                  std::make_unique<MathFunctions::PowX>(num_points - 1)}});
+  test<dg::Formulation::StrongInertial>(
+      mesh_2d, {{std::make_unique<MathFunctions::PowX>(num_points - 1),
+                 std::make_unique<MathFunctions::PowX>(num_points - 1)}});
 
   const Mesh<3> mesh_3d{num_points, Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
-  test(mesh_3d, {{std::make_unique<MathFunctions::PowX>(num_points - 1),
-                  std::make_unique<MathFunctions::PowX>(num_points - 1),
-                  std::make_unique<MathFunctions::PowX>(num_points - 1)}});
+  test<dg::Formulation::StrongInertial>(
+      mesh_3d, {{std::make_unique<MathFunctions::PowX>(num_points - 1),
+                 std::make_unique<MathFunctions::PowX>(num_points - 1),
+                 std::make_unique<MathFunctions::PowX>(num_points - 1)}});
 }

--- a/tests/Unit/Evolution/Systems/Burgers/Test_Fluxes.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Test_Fluxes.cpp
@@ -16,6 +16,7 @@
 #include "Evolution/Systems/Burgers/Fluxes.hpp"
 #include "Evolution/Systems/Burgers/System.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -60,8 +61,9 @@ SPECTRE_TEST_CASE("Unit.Burgers.Fluxes", "[Unit][Burgers]") {
   Variables<tmpl::list<flux_tag>> flux(num_points);
   Burgers::Fluxes::apply(&get<flux_tag>(flux), get<Burgers::Tags::U>(vars));
   const auto div_flux = divergence(flux, mesh, identity);
-  evolution::dg::ConservativeDuDt<Burgers::System>::apply(
-      make_not_null(&dt_vars), mesh, identity, flux, sources);
+  evolution::dg::
+      ConservativeDuDt<Burgers::System, dg::Formulation::StrongInertial>::apply(
+          make_not_null(&dt_vars), mesh, identity, flux, sources);
   CHECK_ITERABLE_APPROX(get<Tags::dt<Burgers::Tags::U>>(dt_vars),
                         dudt_expected);
 }


### PR DESCRIPTION
## Proposed changes

- Template `ConservativeDuDt` on `dg::Formulation` so that in a future PR we can support both the weak and the strong form.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
