### PR TITLE
Add first-order DG boundary scheme

### DIFF
--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -288,8 +288,8 @@ template <typename DirectionsTag, typename Tag>
 struct Interface : virtual db::SimpleTag,
                    Interface_detail::GetBaseTagIfPresent<DirectionsTag, Tag> {
   static std::string name() noexcept {
-    return "Interface<" + DirectionsTag::name() + ", " + db::tag_name<Tag>() +
-           ">";
+    return "Interface<" + db::tag_name<DirectionsTag>() + ", " +
+           db::tag_name<Tag>() + ">";
   };
   using tag = Tag;
   // The use of db::const_item_type<Tag> assumes we will never store

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -20,6 +20,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"
 #include "Domain/OptionTags.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
@@ -35,8 +36,6 @@ template <size_t VolumeDim>
 class Domain;
 template <size_t VolumeDim>
 class DomainCreator;
-template <size_t VolumeDim>
-class Element;
 template <size_t VolumeDim, typename Frame>
 class ElementMap;
 template <size_t VolumeDim>

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryFlux.hpp
@@ -41,12 +41,15 @@ namespace FirstOrderScheme {
  * integrals to preserve conservation; this only happens if the two operations
  * are done on the same grid.
  */
-template <size_t FaceDim, typename NumericalFluxType,
+template <size_t FaceDim, typename NumericalFluxType, typename AllFieldsTags,
+          typename AllExtraDataTags,
           Requires<tt::conforms_to_v<NumericalFluxType,
                                      dg::protocols::NumericalFlux>> = nullptr>
 Variables<typename NumericalFluxType::variables_tags> boundary_flux(
-    const BoundaryData<NumericalFluxType>& local_boundary_data,
-    const BoundaryData<NumericalFluxType>& remote_boundary_data,
+    const dg::SimpleBoundaryData<AllFieldsTags, AllExtraDataTags>&
+        local_boundary_data,
+    const dg::SimpleBoundaryData<AllFieldsTags, AllExtraDataTags>&
+        remote_boundary_data,
     const NumericalFluxType& numerical_flux_computer,
     const Scalar<DataVector>& magnitude_of_face_normal,
     const size_t extent_perpendicular_to_boundary,

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp
@@ -1,0 +1,169 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceHelpers.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryData.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryFlux.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace dg {
+namespace FirstOrderScheme {
+
+namespace detail {
+
+template <size_t Dim, typename VariablesTag, typename NumericalFluxComputerTag,
+          typename NumericalFlux =
+              db::const_item_type<NumericalFluxComputerTag>,
+          typename ArgsTagsList = typename NumericalFlux::argument_tags>
+struct boundary_data_computer_impl;
+
+template <size_t Dim, typename VariablesTag, typename NumericalFluxComputerTag,
+          typename NumericalFlux, typename... ArgsTags>
+struct boundary_data_computer_impl<Dim, VariablesTag, NumericalFluxComputerTag,
+                                   NumericalFlux, tmpl::list<ArgsTags...>> {
+  using n_dot_fluxes_tag =
+      db::add_tag_prefix<::Tags::NormalDotFlux, VariablesTag>;
+  using argument_tags =
+      tmpl::list<NumericalFluxComputerTag, domain::Tags::Mesh<Dim - 1>,
+                 n_dot_fluxes_tag, ArgsTags...>;
+  using volume_tags = tmpl::append<tmpl::list<NumericalFluxComputerTag>,
+                                   get_volume_tags<NumericalFlux>>;
+  static auto apply(
+      const NumericalFlux& numerical_flux_computer,
+      const Mesh<Dim - 1>& face_mesh,
+      const db::const_item_type<n_dot_fluxes_tag>& normal_dot_fluxes,
+      const db::const_item_type<ArgsTags>&... args) noexcept {
+    return dg::FirstOrderScheme::package_boundary_data(
+        numerical_flux_computer, face_mesh, normal_dot_fluxes, args...);
+  }
+};
+
+}  // namespace detail
+
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief Boundary contributions for a first-order DG scheme
+ *
+ * Computes Eq. (2.20) in \cite Teukolsky2015ega and lifts it to the
+ * volume (see `dg::lift_flux`) on all mortars that touch an element. The
+ * resulting boundary contributions are added to the DG operator data in
+ * `db::add_tag_prefix<TemporalIdTag::template step_prefix, VariablesTag>`.
+ */
+template <size_t Dim, typename VariablesTag, typename NumericalFluxComputerTag,
+          typename TemporalIdTag>
+struct FirstOrderScheme {
+  static constexpr size_t volume_dim = Dim;
+  using variables_tag = VariablesTag;
+  using numerical_flux_computer_tag = NumericalFluxComputerTag;
+  using NumericalFlux = db::const_item_type<NumericalFluxComputerTag>;
+  using temporal_id_tag = TemporalIdTag;
+  using receive_temporal_id_tag = temporal_id_tag;
+  using dt_variables_tag =
+      db::add_tag_prefix<TemporalIdTag::template step_prefix, variables_tag>;
+
+  static_assert(
+      tt::conforms_to_v<NumericalFlux, dg::protocols::NumericalFlux>,
+      "The type held by the 'NumericalFluxComputerTag' must conform to the "
+      "'dg::protocols::NumericalFlux'.");
+  // We need the `VariablesTag` as an explicit template parameter only because
+  // it may be prefixed.
+  static_assert(cpp17::is_same_v<typename NumericalFlux::variables_tags,
+                                 db::get_variables_tags_list<variables_tag>>,
+                "The 'VariablesTag' and the 'NumericalFluxComputerTag' must "
+                "have the same list of variables.");
+
+  using BoundaryData = dg::FirstOrderScheme::BoundaryData<NumericalFlux>;
+  using boundary_data_computer =
+      detail::boundary_data_computer_impl<Dim, VariablesTag,
+                                          NumericalFluxComputerTag>;
+
+  using mortar_data_tag =
+      Tags::SimpleMortarData<db::const_item_type<TemporalIdTag>, BoundaryData,
+                             BoundaryData>;
+
+  // Only a shortcut
+  using magnitude_of_face_normal_tag =
+      ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<volume_dim>>;
+
+  using return_tags =
+      tmpl::list<dt_variables_tag, ::Tags::Mortars<mortar_data_tag, Dim>>;
+  using argument_tags = tmpl::list<
+      domain::Tags::Mesh<Dim>,
+      ::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>,
+      ::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>,
+      NumericalFluxComputerTag,
+      domain::Tags::Interface<domain::Tags::InternalDirections<Dim>,
+                              magnitude_of_face_normal_tag>,
+      domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<Dim>,
+                              magnitude_of_face_normal_tag>>;
+
+  static void apply(
+      const gsl::not_null<db::item_type<dt_variables_tag>*> dt_variables,
+      const gsl::not_null<db::item_type<::Tags::Mortars<mortar_data_tag, Dim>>*>
+          all_mortar_data,
+      const Mesh<Dim>& volume_mesh,
+      const db::const_item_type<
+          ::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>>& mortar_meshes,
+      const db::const_item_type<
+          ::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>>& mortar_sizes,
+      const NumericalFlux& normal_dot_numerical_flux_computer,
+      const db::const_item_type<domain::Tags::Interface<
+          domain::Tags::InternalDirections<Dim>, magnitude_of_face_normal_tag>>&
+          face_normal_magnitudes_internal,
+      const db::const_item_type<
+          domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<Dim>,
+                                  magnitude_of_face_normal_tag>>&
+          face_normal_magnitudes_boundary) noexcept {
+    // Iterate over all mortars
+    for (auto& mortar_id_and_data : *all_mortar_data) {
+      // Retrieve mortar data
+      const auto& mortar_id = mortar_id_and_data.first;
+      auto& mortar_data = mortar_id_and_data.second;
+      const auto& direction = mortar_id.first;
+      const size_t dimension = direction.dimension();
+
+      // Extract local and remote data
+      const auto extracted_mortar_data = mortar_data.extract();
+      const auto& local_data = extracted_mortar_data.first;
+      const auto& remote_data = extracted_mortar_data.second;
+
+      const auto& magnitude_of_face_normal =
+          mortar_id.second == ElementId<Dim>::external_boundary_id()
+              ? face_normal_magnitudes_boundary.at(direction)
+              : face_normal_magnitudes_internal.at(direction);
+
+      auto boundary_flux_on_slice =
+          db::item_type<dt_variables_tag>(boundary_flux(
+              local_data, remote_data, normal_dot_numerical_flux_computer,
+              magnitude_of_face_normal, volume_mesh.extents(dimension),
+              volume_mesh.slice_away(dimension), mortar_meshes.at(mortar_id),
+              mortar_sizes.at(mortar_id)));
+
+      // Add the flux contribution to the volume data
+      add_slice_to_data(dt_variables, std::move(boundary_flux_on_slice),
+                        volume_mesh.extents(), dimension,
+                        index_to_slice_at(volume_mesh.extents(), direction));
+    }
+  }
+};
+
+}  // namespace FirstOrderScheme
+}  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderSchemeLts.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderSchemeLts.hpp
@@ -1,0 +1,167 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryFlux.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace dg {
+namespace FirstOrderScheme {
+
+namespace detail {
+
+template <size_t Dim, typename VariablesTag, typename NumericalFluxComputerTag,
+          typename BoundaryData,
+          typename NumericalFlux =
+              db::const_item_type<NumericalFluxComputerTag>,
+          typename ArgsTagsList = typename NumericalFlux::argument_tags>
+struct boundary_data_computer_lts_impl;
+
+template <size_t Dim, typename VariablesTag, typename NumericalFluxComputerTag,
+          typename BoundaryData, typename NumericalFlux, typename... ArgsTags>
+struct boundary_data_computer_lts_impl<Dim, VariablesTag,
+                                       NumericalFluxComputerTag, BoundaryData,
+                                       NumericalFlux, tmpl::list<ArgsTags...>> {
+  using n_dot_fluxes_tag =
+      db::add_tag_prefix<::Tags::NormalDotFlux, VariablesTag>;
+  using magnitude_of_face_normal_tag =
+      ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>;
+  using argument_tags = tmpl::list<NumericalFluxComputerTag, n_dot_fluxes_tag,
+                                   magnitude_of_face_normal_tag, ArgsTags...>;
+  using volume_tags = tmpl::append<tmpl::list<NumericalFluxComputerTag>,
+                                   get_volume_tags<NumericalFlux>>;
+  static auto apply(
+      const NumericalFlux& numerical_flux_computer,
+      const db::const_item_type<n_dot_fluxes_tag>& normal_dot_fluxes,
+      const Scalar<DataVector>& face_normal_magnitude,
+      const db::const_item_type<ArgsTags>&... args) noexcept {
+    BoundaryData boundary_data{normal_dot_fluxes.number_of_grid_points()};
+    boundary_data.field_data.assign_subset(normal_dot_fluxes);
+    dg::NumericalFluxes::package_data(make_not_null(&boundary_data),
+                                      numerical_flux_computer, args...);
+    get<magnitude_of_face_normal_tag>(boundary_data.extra_data) =
+        face_normal_magnitude;
+    return boundary_data;
+  }
+};
+
+}  // namespace detail
+
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief Boundary contributions for a first-order DG scheme with local
+ * time-stepping
+ *
+ * This class is the local time-stepping equivalent to the
+ * `dg::FirstOrderScheme::FirstOrderScheme`. Notable differences are:
+ *
+ * - Boundary contributions are added to the `VariablesTag` directly.
+ * - We use the `Tags::BoundaryHistory` on mortars.
+ * - We need to store the face-normal magnitude in the boundary history, as
+ * opposed to the non-LTS case where we can retrieve it when needed.
+ */
+template <size_t Dim, typename VariablesTag, typename NumericalFluxComputerTag,
+          typename TemporalIdTag, typename TimeStepperTag>
+struct FirstOrderSchemeLts {
+ private:
+  using base = FirstOrderScheme<Dim, VariablesTag, NumericalFluxComputerTag,
+                                TemporalIdTag>;
+
+ public:
+  static constexpr size_t volume_dim = Dim;
+  using variables_tag = VariablesTag;
+  using numerical_flux_computer_tag = NumericalFluxComputerTag;
+  using NumericalFlux = db::const_item_type<NumericalFluxComputerTag>;
+  using temporal_id_tag = TemporalIdTag;
+  using receive_temporal_id_tag = ::Tags::Next<temporal_id_tag>;
+  using time_stepper_tag = TimeStepperTag;
+
+  using magnitude_of_face_normal_tag =
+      ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<volume_dim>>;
+  using BoundaryData = dg::SimpleBoundaryData<
+      typename base::BoundaryData::field_tags,
+      tmpl::push_back<typename base::BoundaryData::extra_data_tags,
+                      magnitude_of_face_normal_tag>>;
+  using boundary_data_computer = detail::boundary_data_computer_lts_impl<
+      volume_dim, variables_tag, numerical_flux_computer_tag, BoundaryData>;
+
+  using mortar_data_tag =
+      Tags::BoundaryHistory<BoundaryData, BoundaryData,
+                            db::const_item_type<variables_tag>>;
+
+  using return_tags =
+      tmpl::list<variables_tag, ::Tags::Mortars<mortar_data_tag, Dim>>;
+  using argument_tags =
+      tmpl::list<domain::Tags::Mesh<Dim>,
+                 ::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>,
+                 ::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>,
+                 NumericalFluxComputerTag, time_stepper_tag, ::Tags::TimeStep>;
+
+  static void apply(
+      const gsl::not_null<db::item_type<variables_tag>*> variables,
+      const gsl::not_null<db::item_type<::Tags::Mortars<mortar_data_tag, Dim>>*>
+          all_mortar_data,
+      const Mesh<Dim>& volume_mesh,
+      const db::const_item_type<
+          ::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>>& mortar_meshes,
+      const db::const_item_type<
+          ::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>>& mortar_sizes,
+      const NumericalFlux& normal_dot_numerical_flux_computer,
+      const db::const_item_type<time_stepper_tag>& time_stepper,
+      const db::const_item_type<Tags::TimeStep>& time_step) noexcept {
+    // Iterate over all mortars
+    for (auto& mortar_id_and_data : *all_mortar_data) {
+      // Retrieve mortar data
+      const auto& mortar_id = mortar_id_and_data.first;
+      auto& mortar_data = mortar_id_and_data.second;
+      const auto& direction = mortar_id.first;
+      const size_t dimension = direction.dimension();
+
+      const auto& mortar_mesh = mortar_meshes.at(mortar_id);
+      const auto& mortar_size = mortar_sizes.at(mortar_id);
+      const auto face_mesh = volume_mesh.slice_away(dimension);
+      const size_t extent_perpendicular_to_face =
+          volume_mesh.extents(dimension);
+
+      // This lambda must only capture quantities that are
+      // independent of the simulation state.
+      const auto coupling = [&face_mesh, &mortar_mesh, &mortar_size,
+                             &extent_perpendicular_to_face,
+                             &normal_dot_numerical_flux_computer](
+                                const BoundaryData& local_data,
+                                const BoundaryData& remote_data) noexcept {
+        return boundary_flux(
+            local_data, remote_data, normal_dot_numerical_flux_computer,
+            get<magnitude_of_face_normal_tag>(local_data.extra_data),
+            extent_perpendicular_to_face, face_mesh, mortar_mesh, mortar_size);
+      };
+
+      const auto lifted_data = time_stepper.compute_boundary_delta(
+          coupling, make_not_null(&mortar_data), time_step);
+
+      // Add the flux contribution to the volume data
+      add_slice_to_data(variables, lifted_data, volume_mesh.extents(),
+                        dimension,
+                        index_to_slice_at(volume_mesh.extents(), direction));
+    }
+  }
+};
+
+}  // namespace FirstOrderScheme
+}  // namespace dg

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_BoundaryData.cpp
   Test_BoundaryFlux.cpp
   Test_FirstOrderScheme.cpp
+  Test_FirstOrderSchemeLts.cpp
   )
 
 add_test_library(

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_FirstOrderDgScheme")
 set(LIBRARY_SOURCES
   Test_BoundaryData.cpp
   Test_BoundaryFlux.cpp
+  Test_FirstOrderScheme.cpp
   )
 
 add_test_library(

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderScheme.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderScheme.cpp
@@ -1,0 +1,242 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace {
+
+struct SomeField : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+using variables_tag = ::Tags::Variables<tmpl::list<SomeField>>;
+
+struct ExtraDataTag : db::SimpleTag {
+  using type = int;
+};
+
+struct NumericalFlux : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  using variables_tags = tmpl::list<SomeField>;
+  using argument_tags = tmpl::list<SomeField, ExtraDataTag>;
+  using volume_tags = tmpl::list<ExtraDataTag>;
+  using package_field_tags = tmpl::list<SomeField>;
+  using package_extra_tags = tmpl::list<ExtraDataTag>;
+  static void package_data(
+      const gsl::not_null<Scalar<DataVector>*> packaged_field,
+      const gsl::not_null<int*> packaged_extra_data,
+      const Scalar<DataVector>& field, const int& extra_data) noexcept {
+    *packaged_field = field;
+    *packaged_extra_data = extra_data;
+  }
+  void operator()(const gsl::not_null<Scalar<DataVector>*> numerical_flux,
+                  const Scalar<DataVector>& field_int,
+                  const int& extra_data_int,
+                  const Scalar<DataVector>& field_ext,
+                  const int& extra_data_ext) const noexcept {
+    CHECK(extra_data_int == extra_data_ext);
+    get(*numerical_flux) = 0.5 * (get(field_int) + get(field_ext));
+  }
+};
+
+struct NumericalFluxTag : db::SimpleTag {
+  using type = NumericalFlux;
+};
+
+template <typename Tag>
+struct BoundaryContribution : db::SimpleTag, db::PrefixTag {
+  using tag = Tag;
+  using type = db::item_type<Tag>;
+};
+
+struct TemporalIdTag : db::SimpleTag {
+  using type = int;
+  template <typename Tag>
+  using step_prefix = BoundaryContribution<Tag>;
+};
+
+// Helper function to combine local and remote boundary data to mortar data
+template <typename BoundaryScheme,
+          typename BoundaryData = typename BoundaryScheme::BoundaryData>
+auto make_mortar_data(const dg::MortarId<BoundaryScheme::volume_dim>& mortar_id,
+                      const int time, BoundaryData&& interior_data,
+                      BoundaryData&& exterior_data) noexcept {
+  db::item_type<typename BoundaryScheme::mortar_data_tag> mortar_data{};
+  mortar_data.local_insert(time, std::forward<BoundaryData>(interior_data));
+  mortar_data.remote_insert(time, std::forward<BoundaryData>(exterior_data));
+  return db::item_type<::Tags::Mortars<typename BoundaryScheme::mortar_data_tag,
+                                       BoundaryScheme::volume_dim>>{
+      {mortar_id, std::move(mortar_data)}};
+}
+
+template <size_t Dim>
+void test_first_order_scheme() {
+  CAPTURE(Dim);
+  using boundary_scheme =
+      dg::FirstOrderScheme::FirstOrderScheme<Dim, variables_tag,
+                                             NumericalFluxTag, TemporalIdTag>;
+
+  using BoundaryData = typename boundary_scheme::BoundaryData;
+  using mortar_data_tag = typename boundary_scheme::mortar_data_tag;
+  using all_normal_dot_fluxes_tag = domain::Tags::Interface<
+      domain::Tags::InternalDirections<Dim>,
+      db::add_tag_prefix<::Tags::NormalDotFlux, variables_tag>>;
+  {
+    INFO("Collect boundary data from a DataBox");
+    // Create a DataBox that holds the arguments for the numerical flux plus
+    // those for the strong first-order boundary scheme
+    const Mesh<Dim> mesh{3, Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+    const size_t num_points = mesh.number_of_grid_points();
+    const ElementId<Dim> element_id{0};
+    const auto face_direction = Direction<Dim>::upper_xi();
+    const ElementId<Dim> neighbor_id{1};
+    const Element<Dim> element{element_id,
+                               {{face_direction, {{neighbor_id}, {}}}}};
+    const size_t num_points_on_face =
+        mesh.slice_away(face_direction.dimension()).number_of_grid_points();
+    db::item_type<db::add_tag_prefix<::Tags::NormalDotFlux, variables_tag>>
+        normal_dot_fluxes{num_points_on_face};
+    get<::Tags::NormalDotFlux<SomeField>>(normal_dot_fluxes) =
+        Scalar<DataVector>{num_points_on_face, 3.};
+    const int extra_data = 2;
+    const auto box = db::create<
+        db::AddSimpleTags<NumericalFluxTag, SomeField, ExtraDataTag,
+                          domain::Tags::Mesh<Dim>, domain::Tags::Element<Dim>,
+                          all_normal_dot_fluxes_tag>,
+        db::AddComputeTags<
+            domain::Tags::InternalDirections<Dim>,
+            domain::Tags::InterfaceCompute<
+                domain::Tags::InternalDirections<Dim>,
+                domain::Tags::Direction<Dim>>,
+            domain::Tags::InterfaceCompute<
+                domain::Tags::InternalDirections<Dim>,
+                domain::Tags::InterfaceMesh<Dim>>,
+            domain::Tags::Slice<domain::Tags::InternalDirections<Dim>,
+                                SomeField>>>(
+        NumericalFlux{}, Scalar<DataVector>{num_points, 2.}, extra_data, mesh,
+        element,
+        db::item_type<all_normal_dot_fluxes_tag>{
+            {face_direction, std::move(normal_dot_fluxes)}});
+    // Collect the boundary data needed by the boundary scheme
+    const auto all_boundary_data =
+        interface_apply<domain::Tags::InternalDirections<Dim>,
+                        typename boundary_scheme::boundary_data_computer>(box);
+    // Make sure the collected boundary data is what we expect
+    const auto& boundary_data = all_boundary_data.at(face_direction);
+    CHECK(get<SomeField>(boundary_data.field_data) ==
+          Scalar<DataVector>{num_points_on_face, 2.});
+    CHECK(get<::Tags::NormalDotFlux<SomeField>>(boundary_data.field_data) ==
+          Scalar<DataVector>{num_points_on_face, 3.});
+    CHECK(get<ExtraDataTag>(boundary_data.extra_data) == extra_data);
+  }
+  {
+    // This part only tests that the boundary scheme can be applied to mutate a
+    // DataBox. It can be replaced by a generic test that checks the struct
+    // conforms to the interface that `mutate_apply` expects (once we have such
+    // a test).
+    INFO("Apply to DataBox");
+    MAKE_GENERATOR(generator);
+    std::uniform_real_distribution<> dist(-1., 1.);
+    const auto nn_generator = make_not_null(&generator);
+    const auto nn_dist = make_not_null(&dist);
+    // Setup a volume mesh
+    const Mesh<Dim> mesh{3, Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+    const size_t num_points = mesh.number_of_grid_points();
+    const int extra_data = 2;
+    const int dummy_time = 1;
+    // Setup a mortar
+    const auto mortar_mesh = mesh.slice_away(0);
+    const size_t mortar_num_points = mortar_mesh.number_of_grid_points();
+    const dg::MortarId<Dim> mortar_id{Direction<Dim>::upper_xi(),
+                                      ElementId<Dim>{1}};
+    dg::MortarSize<Dim - 1> mortar_size{};
+    mortar_size.fill(Spectral::MortarSize::Full);
+    const DataVector used_for_size_on_mortar{mortar_num_points};
+    // Fake some boundary data
+    const auto make_boundary_data = [&used_for_size_on_mortar, &nn_generator,
+                                     &nn_dist]() noexcept {
+      BoundaryData boundary_data{used_for_size_on_mortar.size()};
+      get<SomeField>(boundary_data.field_data) =
+          make_with_random_values<Scalar<DataVector>>(nn_generator, nn_dist,
+                                                      used_for_size_on_mortar);
+      get<::Tags::NormalDotFlux<SomeField>>(boundary_data.field_data) =
+          make_with_random_values<Scalar<DataVector>>(nn_generator, nn_dist,
+                                                      used_for_size_on_mortar);
+      get<ExtraDataTag>(boundary_data.extra_data) = extra_data;
+      return boundary_data;
+    };
+    auto all_mortar_data = make_mortar_data<boundary_scheme>(
+        mortar_id, dummy_time, make_boundary_data(), make_boundary_data());
+    // Assemble a DataBox and test
+    db::item_type<db::add_tag_prefix<BoundaryContribution, variables_tag>>
+        boundary_contributions{num_points, 0.};
+    auto box = db::create<db::AddSimpleTags<
+        NumericalFluxTag, domain::Tags::Mesh<Dim>,
+        domain::Tags::Interface<
+            domain::Tags::InternalDirections<Dim>,
+            ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>>,
+        domain::Tags::Interface<
+            domain::Tags::BoundaryDirectionsInterior<Dim>,
+            ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>>,
+        ::Tags::Mortars<mortar_data_tag, Dim>,
+        ::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>,
+        ::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>,
+        db::add_tag_prefix<BoundaryContribution, variables_tag>>>(
+        NumericalFlux{}, mesh,
+        std::unordered_map<Direction<Dim>, Scalar<DataVector>>{
+            {mortar_id.first,
+             make_with_random_values<Scalar<DataVector>>(
+                 nn_generator, nn_dist, used_for_size_on_mortar)}},
+        std::unordered_map<Direction<Dim>, Scalar<DataVector>>{},
+        all_mortar_data,
+        dg::MortarMap<Dim, Mesh<Dim - 1>>{{mortar_id, mortar_mesh}},
+        dg::MortarMap<Dim, dg::MortarSize<Dim - 1>>{{mortar_id, mortar_size}},
+        std::move(boundary_contributions));
+    db::mutate_apply<boundary_scheme>(make_not_null(&box));
+    db::item_type<db::add_tag_prefix<BoundaryContribution, variables_tag>>
+        expected_boundary_contributions{num_points, 0.};
+    boundary_scheme::apply(
+        make_not_null(&expected_boundary_contributions),
+        make_not_null(&all_mortar_data), mesh,
+        get<::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>>(box),
+        get<::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>>(box),
+        get<NumericalFluxTag>(box),
+        get<domain::Tags::Interface<
+            domain::Tags::InternalDirections<Dim>,
+            ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>>>(box),
+        get<domain::Tags::Interface<
+            domain::Tags::BoundaryDirectionsInterior<Dim>,
+            ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>>>(
+            box));
+    const auto& mutated_boundary_contributions =
+        get<db::add_tag_prefix<BoundaryContribution, variables_tag>>(box);
+    CHECK_VARIABLES_APPROX(mutated_boundary_contributions,
+                           expected_boundary_contributions);
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DG.FirstOrderScheme", "[Unit][NumericalAlgorithms]") {
+  test_first_order_scheme<1>();
+  test_first_order_scheme<2>();
+  test_first_order_scheme<3>();
+}

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderSchemeLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderSchemeLts.cpp
@@ -1,0 +1,399 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderSchemeLts.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace {
+
+struct SomeField : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+using variables_tag = ::Tags::Variables<tmpl::list<SomeField>>;
+
+struct ExtraDataTag : db::SimpleTag {
+  using type = int;
+};
+
+struct NumericalFlux : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  using variables_tags = tmpl::list<SomeField>;
+  using argument_tags = tmpl::list<SomeField, ExtraDataTag>;
+  using volume_tags = tmpl::list<ExtraDataTag>;
+  using package_field_tags = tmpl::list<SomeField>;
+  using package_extra_tags = tmpl::list<ExtraDataTag>;
+  static void package_data(
+      const gsl::not_null<Scalar<DataVector>*> packaged_field,
+      const gsl::not_null<int*> packaged_extra_data,
+      const Scalar<DataVector>& field, const int& extra_data) noexcept {
+    *packaged_field = field;
+    *packaged_extra_data = extra_data;
+  }
+  void operator()(const gsl::not_null<Scalar<DataVector>*> numerical_flux,
+                  const Scalar<DataVector>& field_int,
+                  const int& extra_data_int,
+                  const Scalar<DataVector>& field_ext,
+                  const int& extra_data_ext) const noexcept {
+    CHECK(extra_data_int == extra_data_ext);
+    get(*numerical_flux) = 0.5 * (get(field_int) + get(field_ext));
+  }
+};
+
+template <typename NumericalFluxType>
+struct NumericalFluxTag : db::SimpleTag {
+  using type = NumericalFluxType;
+};
+
+template <typename Tag>
+struct BoundaryContribution : db::SimpleTag, db::PrefixTag {
+  using tag = Tag;
+  using type = db::item_type<Tag>;
+};
+
+struct TemporalIdTag : db::SimpleTag {
+  using type = int;
+  template <typename Tag>
+  using step_prefix = BoundaryContribution<Tag>;
+};
+
+// Helper function to combine local and remote boundary data to mortar data
+template <typename BoundaryScheme,
+          typename BoundaryData = typename BoundaryScheme::BoundaryData>
+auto make_mortar_data(const dg::MortarId<BoundaryScheme::volume_dim>& mortar_id,
+                      const TimeStepId& time, BoundaryData&& interior_data,
+                      BoundaryData&& exterior_data) noexcept {
+  db::item_type<::Tags::Mortars<typename BoundaryScheme::mortar_data_tag,
+                                BoundaryScheme::volume_dim>>
+      all_mortar_data;
+  all_mortar_data[mortar_id].local_insert(
+      time, std::forward<BoundaryData>(interior_data));
+  all_mortar_data[mortar_id].remote_insert(
+      time, std::forward<BoundaryData>(exterior_data));
+  return all_mortar_data;
+}
+
+template <size_t Dim>
+void test_first_order_scheme_lts() {
+  CAPTURE(Dim);
+  using time_stepper_tag = Tags::TimeStepper<TimeSteppers::AdamsBashforthN>;
+  using boundary_scheme = dg::FirstOrderScheme::FirstOrderSchemeLts<
+      Dim, variables_tag, NumericalFluxTag<NumericalFlux>, TemporalIdTag,
+      time_stepper_tag>;
+
+  using BoundaryData = typename boundary_scheme::BoundaryData;
+  using mortar_data_tag = typename boundary_scheme::mortar_data_tag;
+  using all_normal_dot_fluxes_tag = domain::Tags::Interface<
+      domain::Tags::InternalDirections<Dim>,
+      db::add_tag_prefix<::Tags::NormalDotFlux, variables_tag>>;
+  using magnitude_of_face_normal_tag =
+      ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>;
+  using all_magnitude_of_face_normals_tag =
+      domain::Tags::Interface<domain::Tags::InternalDirections<Dim>,
+                              magnitude_of_face_normal_tag>;
+  {
+    INFO("Collect boundary data from a DataBox");
+    // Create a DataBox that holds the arguments for the numerical flux plus
+    // those for the strong first-order boundary scheme
+    const Mesh<Dim> mesh{3, Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+    const size_t num_points = mesh.number_of_grid_points();
+    const ElementId<Dim> element_id{0};
+    const auto face_direction = Direction<Dim>::upper_xi();
+    const ElementId<Dim> neighbor_id{1};
+    const Element<Dim> element{element_id,
+                               {{face_direction, {{neighbor_id}, {}}}}};
+    const size_t num_points_on_face =
+        mesh.slice_away(face_direction.dimension()).number_of_grid_points();
+    db::item_type<db::add_tag_prefix<::Tags::NormalDotFlux, variables_tag>>
+        normal_dot_fluxes{num_points_on_face};
+    get<::Tags::NormalDotFlux<SomeField>>(normal_dot_fluxes) =
+        Scalar<DataVector>{num_points_on_face, 3.};
+    Scalar<DataVector> magnitude_of_face_normal{num_points_on_face, 1.5};
+    const int extra_data = 2;
+    const auto box = db::create<
+        db::AddSimpleTags<NumericalFluxTag<NumericalFlux>, SomeField,
+                          ExtraDataTag, domain::Tags::Mesh<Dim>,
+                          domain::Tags::Element<Dim>, all_normal_dot_fluxes_tag,
+                          all_magnitude_of_face_normals_tag>,
+        db::AddComputeTags<
+            domain::Tags::InternalDirections<Dim>,
+            domain::Tags::InterfaceCompute<
+                domain::Tags::InternalDirections<Dim>,
+                domain::Tags::Direction<Dim>>,
+            domain::Tags::InterfaceCompute<
+                domain::Tags::InternalDirections<Dim>,
+                domain::Tags::InterfaceMesh<Dim>>,
+            domain::Tags::Slice<domain::Tags::InternalDirections<Dim>,
+                                SomeField>>>(
+        NumericalFlux{}, Scalar<DataVector>{num_points, 2.}, extra_data, mesh,
+        element,
+        db::item_type<all_normal_dot_fluxes_tag>{
+            {face_direction, std::move(normal_dot_fluxes)}},
+        db::item_type<all_magnitude_of_face_normals_tag>{
+            {face_direction, magnitude_of_face_normal}});
+    // Collect the boundary data needed by the boundary scheme
+    const auto all_boundary_data =
+        interface_apply<domain::Tags::InternalDirections<Dim>,
+                        typename boundary_scheme::boundary_data_computer>(box);
+    // Make sure the collected boundary data is what we expect
+    const auto& boundary_data = all_boundary_data.at(face_direction);
+    CHECK(get<SomeField>(boundary_data.field_data) ==
+          Scalar<DataVector>{num_points_on_face, 2.});
+    CHECK(get<::Tags::NormalDotFlux<SomeField>>(boundary_data.field_data) ==
+          Scalar<DataVector>{num_points_on_face, 3.});
+    CHECK(get<ExtraDataTag>(boundary_data.extra_data) == extra_data);
+    CHECK(get<magnitude_of_face_normal_tag>(boundary_data.extra_data) ==
+          magnitude_of_face_normal);
+  }
+  {
+    // This part only tests that the boundary scheme can be applied to mutate a
+    // DataBox. It can be replaced by a generic test that checks the struct
+    // conforms to the interface that `mutate_apply` expects (once we have such
+    // a test).
+    INFO("Apply to DataBox");
+    MAKE_GENERATOR(generator);
+    std::uniform_real_distribution<> dist(-1., 1.);
+    std::uniform_real_distribution<> dist_positive(0.5, 1.);
+    const auto nn_generator = make_not_null(&generator);
+    const auto nn_dist = make_not_null(&dist);
+    const auto nn_dist_positive = make_not_null(&dist_positive);
+    // Setup a volume mesh
+    const Mesh<Dim> mesh{3, Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+    const size_t num_points = mesh.number_of_grid_points();
+    const int extra_data = 2;
+
+    const Slab slab{0., 1.};
+    const auto time_step = slab.duration() / 2;
+    const auto now = slab.start() + time_step;
+
+    // Setup a mortar
+    const auto mortar_mesh = mesh.slice_away(0);
+    const size_t mortar_num_points = mortar_mesh.number_of_grid_points();
+    const dg::MortarId<Dim> mortar_id{Direction<Dim>::upper_xi(),
+                                      ElementId<Dim>{1}};
+    dg::MortarSize<Dim - 1> mortar_size{};
+    mortar_size.fill(Spectral::MortarSize::Full);
+    const DataVector used_for_size_on_mortar{mortar_num_points};
+    // Fake some boundary data
+    const auto make_boundary_data = [&used_for_size_on_mortar, &nn_generator,
+                                     &nn_dist, &nn_dist_positive]() noexcept {
+      BoundaryData boundary_data{used_for_size_on_mortar.size()};
+      get<SomeField>(boundary_data.field_data) =
+          make_with_random_values<Scalar<DataVector>>(nn_generator, nn_dist,
+                                                      used_for_size_on_mortar);
+      get<::Tags::NormalDotFlux<SomeField>>(boundary_data.field_data) =
+          make_with_random_values<Scalar<DataVector>>(nn_generator, nn_dist,
+                                                      used_for_size_on_mortar);
+      get<ExtraDataTag>(boundary_data.extra_data) = extra_data;
+      get<magnitude_of_face_normal_tag>(boundary_data.extra_data) =
+          make_with_random_values<Scalar<DataVector>>(
+              nn_generator, nn_dist_positive, used_for_size_on_mortar);
+      return boundary_data;
+    };
+    const auto local_boundary_data = make_boundary_data();
+    const auto remote_boundary_data = make_boundary_data();
+    auto all_mortar_data = make_mortar_data<boundary_scheme>(
+        mortar_id, {true, 0, now}, local_boundary_data, remote_boundary_data);
+    auto all_mortar_data_copy = make_mortar_data<boundary_scheme>(
+        mortar_id, {true, 0, now}, local_boundary_data, remote_boundary_data);
+    // Assemble a DataBox and test
+    db::item_type<variables_tag> boundary_contributions{num_points, 0.};
+    auto box = db::create<db::AddSimpleTags<
+        NumericalFluxTag<NumericalFlux>, domain::Tags::Mesh<Dim>,
+        ::Tags::Mortars<mortar_data_tag, Dim>,
+        ::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>,
+        ::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>, variables_tag,
+        time_stepper_tag, Tags::TimeStep>>(
+        NumericalFlux{}, mesh,
+        std::move(all_mortar_data),
+        dg::MortarMap<Dim, Mesh<Dim - 1>>{{mortar_id, mortar_mesh}},
+        dg::MortarMap<Dim, dg::MortarSize<Dim - 1>>{{mortar_id, mortar_size}},
+        std::move(boundary_contributions),
+        std::make_unique<TimeSteppers::AdamsBashforthN>(1), time_step);
+    db::mutate_apply<boundary_scheme>(make_not_null(&box));
+    db::item_type<variables_tag> expected_boundary_contributions{num_points,
+                                                                 0.};
+    boundary_scheme::apply(
+        make_not_null(&expected_boundary_contributions),
+        make_not_null(&all_mortar_data_copy), mesh,
+        get<::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>>(box),
+        get<::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>>(box),
+        get<NumericalFluxTag<NumericalFlux>>(box), get<time_stepper_tag>(box),
+        get<Tags::TimeStep>(box));
+    const auto& mutated_boundary_contributions = get<variables_tag>(box);
+    CHECK_VARIABLES_APPROX(mutated_boundary_contributions,
+                           expected_boundary_contributions);
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DG.FirstOrderScheme.Lts",
+                  "[Unit][NumericalAlgorithms]") {
+  test_first_order_scheme_lts<1>();
+  test_first_order_scheme_lts<2>();
+  test_first_order_scheme_lts<3>();
+
+  {
+    // This test is carried over from:
+    // tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/
+    // Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
+    INFO("Slow and fast mortar");
+
+    struct TestNumericalFlux : tt::ConformsTo<dg::protocols::NumericalFlux> {
+      using variables_tags = tmpl::list<SomeField>;
+      using argument_tags = tmpl::list<Tags::NormalDotFlux<SomeField>>;
+      using package_field_tags = argument_tags;
+      using package_extra_tags = tmpl::list<>;
+      static void package_data(
+          const gsl::not_null<Scalar<DataVector>*> packaged_n_dot_field,
+          const Scalar<DataVector>& n_dot_field) noexcept {
+        *packaged_n_dot_field = n_dot_field;
+      }
+      void operator()(const gsl::not_null<Scalar<DataVector>*> numerical_flux,
+                      const Scalar<DataVector>& ndotf_internal,
+                      const Scalar<DataVector>& ndotf_external) const {
+        get(*numerical_flux) =
+            10. * get(ndotf_internal) + 12. * get(ndotf_external);
+      }
+    };
+
+    using time_stepper_tag = Tags::TimeStepper<TimeSteppers::AdamsBashforthN>;
+    using boundary_scheme = dg::FirstOrderScheme::FirstOrderSchemeLts<
+        2, variables_tag, NumericalFluxTag<TestNumericalFlux>, TemporalIdTag,
+        time_stepper_tag>;
+
+    using BoundaryData = typename boundary_scheme::BoundaryData;
+    using mortar_data_tag = typename boundary_scheme::mortar_data_tag;
+    using magnitude_of_face_normal_tag =
+        ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<2>>;
+
+    const Slab slab(0., 1.);
+    const auto time_step = slab.duration() / 2;
+    const auto now = slab.start() + time_step;
+
+    const ElementId<2> id(0);
+    const auto face_direction = Direction<2>::upper_xi();
+    const auto face_dimension = face_direction.dimension();
+    const Mesh<2> mesh(3, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto);
+    const auto slow_mortar = std::make_pair(
+        Direction<2>::upper_xi(), ElementId<2>(1, {{{0, 0}, {1, 0}}}));
+    const auto fast_mortar = std::make_pair(
+        Direction<2>::upper_xi(), ElementId<2>(1, {{{0, 0}, {1, 1}}}));
+
+    typename Tags::Mortars<domain::Tags::Mesh<1>, 2>::type mortar_meshes{
+        {slow_mortar, mesh.slice_away(face_dimension)},
+        {fast_mortar, mesh.slice_away(face_dimension)}};
+    typename Tags::Mortars<Tags::MortarSize<1>, 2>::type mortar_sizes{
+        {slow_mortar,
+         dg::mortar_size(id, slow_mortar.second, face_dimension, {})},
+        {fast_mortar,
+         dg::mortar_size(id, fast_mortar.second, face_dimension, {})}};
+
+    using Vars = Variables<tmpl::list<SomeField>>;
+    Vars variables(mesh.number_of_grid_points(), 2.);
+
+    auto local_data = make_array<2, BoundaryData>(
+        mesh.slice_away(face_dimension).number_of_grid_points());
+    auto remote_data = make_array<3, BoundaryData>(
+        mesh.slice_away(face_dimension).number_of_grid_points());
+    get(get<Tags::NormalDotFlux<SomeField>>(
+        gsl::at(local_data, 0).field_data)) = DataVector{2., 3., 5.};
+    get(get<magnitude_of_face_normal_tag>(gsl::at(local_data, 0).extra_data)) =
+        DataVector{7., 11., 13.};
+    get(get<Tags::NormalDotFlux<SomeField>>(
+        gsl::at(local_data, 1).field_data)) = DataVector{17., 19., 23.};
+    get(get<magnitude_of_face_normal_tag>(gsl::at(local_data, 1).extra_data)) =
+        DataVector{29., 31., 37.};
+    get(get<Tags::NormalDotFlux<SomeField>>(
+        gsl::at(remote_data, 0).field_data)) = DataVector{41., 43., 47.};
+    get(get<Tags::NormalDotFlux<SomeField>>(
+        gsl::at(remote_data, 1).field_data)) = DataVector{53., 59., 61.};
+    get(get<Tags::NormalDotFlux<SomeField>>(
+        gsl::at(remote_data, 2).field_data)) = DataVector{67., 71., 73.};
+
+    db::item_type<::Tags::Mortars<mortar_data_tag, 2>> mortar_data;
+    mortar_data[slow_mortar].local_insert(TimeStepId(true, 0, now),
+                                          gsl::at(local_data, 0));
+    mortar_data[fast_mortar].local_insert(TimeStepId(true, 0, now),
+                                          gsl::at(local_data, 1));
+    mortar_data[slow_mortar].remote_insert(
+        TimeStepId(true, 0, now - time_step / 2), gsl::at(remote_data, 0));
+    mortar_data[fast_mortar].remote_insert(TimeStepId(true, 0, now),
+                                           gsl::at(remote_data, 1));
+    mortar_data[fast_mortar].remote_insert(
+        TimeStepId(true, 0, now + time_step / 3), gsl::at(remote_data, 2));
+
+    auto box = db::create<db::AddSimpleTags<
+        NumericalFluxTag<TestNumericalFlux>, domain::Tags::Mesh<2>,
+        ::Tags::Mortars<mortar_data_tag, 2>,
+        ::Tags::Mortars<domain::Tags::Mesh<1>, 2>,
+        ::Tags::Mortars<::Tags::MortarSize<1>, 2>, variables_tag,
+        time_stepper_tag, Tags::TimeStep>>(
+        TestNumericalFlux{}, mesh, std::move(mortar_data), mortar_meshes,
+        mortar_sizes, variables,
+        std::make_unique<TimeSteppers::AdamsBashforthN>(1), time_step);
+    db::mutate_apply<boundary_scheme>(make_not_null(&box));
+
+    add_slice_to_data(
+        make_not_null(&variables),
+        Vars(time_step.value() *
+             dg::FirstOrderScheme::boundary_flux(
+                 gsl::at(local_data, 0), gsl::at(remote_data, 0),
+                 TestNumericalFlux{},
+                 get<magnitude_of_face_normal_tag>(
+                     gsl::at(local_data, 0).extra_data),
+                 mesh.extents(face_dimension), mesh.slice_away(face_dimension),
+                 mortar_meshes.at(slow_mortar), mortar_sizes.at(slow_mortar))),
+        mesh.extents(), face_dimension,
+        index_to_slice_at(mesh.extents(), face_direction));
+
+    add_slice_to_data(
+        make_not_null(&variables),
+        Vars((time_step / 3).value() *
+             dg::FirstOrderScheme::boundary_flux(
+                 gsl::at(local_data, 1), gsl::at(remote_data, 1),
+                 TestNumericalFlux{},
+                 get<magnitude_of_face_normal_tag>(
+                     gsl::at(local_data, 1).extra_data),
+                 mesh.extents(face_dimension), mesh.slice_away(face_dimension),
+                 mortar_meshes.at(fast_mortar), mortar_sizes.at(fast_mortar))),
+        mesh.extents(), face_dimension,
+        index_to_slice_at(mesh.extents(), face_direction));
+
+    add_slice_to_data(
+        make_not_null(&variables),
+        Vars((time_step * 2 / 3).value() *
+             dg::FirstOrderScheme::boundary_flux(
+                 gsl::at(local_data, 1), gsl::at(remote_data, 2),
+                 TestNumericalFlux{},
+                 get<magnitude_of_face_normal_tag>(
+                     gsl::at(local_data, 1).extra_data),
+                 mesh.extents(face_dimension), mesh.slice_away(face_dimension),
+                 mortar_meshes.at(fast_mortar), mortar_sizes.at(fast_mortar))),
+        mesh.extents(), face_dimension,
+        index_to_slice_at(mesh.extents(), face_direction));
+
+    CHECK_ITERABLE_APPROX(get<SomeField>(variables), get<SomeField>(box));
+  }
+}


### PR DESCRIPTION
## Proposed changes

This is the next step towards #1725, i.e. to replace the `FluxCommTypes` that couple all of the DG, fluxcomm and local time-stepping code together with free functions that work on their own. This PR adds a "boundary scheme" struct that knows about databoxes and tags (as opposed to the functions added in #2037 that are independent of the databox) and provides the compile-time interface for the fluxcomm actions that will be added in the next (and final) PR. It also adds a local time-stepping version.

The classes in this PR will replace the actions `ApplyFluxes` and `ApplyFluxesLocalTimeStepping` (in the next PR).

Note that the boundary scheme uses the interface-tag infrastructure because there is currently no alternative. However, all the interface code is confined to the boundary scheme class and the collect-data action that I'll add in the next PR, so once we move away from the interface-tags these are the only places that would need to change.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
