### PR TITLE
Adjust build system for macOS and add CI target

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -407,3 +407,177 @@ jobs:
           # We get occasional random timeouts, repeat tests to see if
           # it is a random timeout or systematic
           ctest -j2 --output-on-failure -L inputfiles --repeat after-timeout:3
+
+  # Build all test executables and run unit tests on macOS
+  unit_tests_macos:
+    name: Unit tests on macOS
+    # Don't run on `develop` since we don't require this check to pass for PR
+    # be merged. See `CONTRIBUTING.md` for details.
+    if: github.ref != 'refs/heads/develop'
+    runs-on: macos-latest
+    env:
+      # We install `openblas` instead of using the system version because we
+      # encountered this issue:
+      # https://github.com/sxs-collaboration/spectre/issues/2131
+      SPECTRE_BREW_DEPS: >-
+        cmake ccache autoconf boost openblas catch2 gsl jemalloc hdf5 pybind11
+        yaml-cpp
+      SPECTRE_PY_DEPS: numpy scipy h5py
+      SPECTRE_SPACK_DEPS: >-
+        blaze@3.5 brigand@master libxsmm libsharp~mpi~openmp
+      CHARM_VERSION: "6.8.0"
+      CHARM_PATCH: v6.8.patch
+      SPECTRE_MIN_MACOS: -mmacosx-version-min=10.11
+      CCACHE_DIR: $HOME/ccache
+      CCACHE_MAXSIZE: 400M
+      CCACHE_COMPRESS: 1
+      CCACHE_COMPRESSLEVEL: 6
+      CCACHE_COMPILERCHECK: content
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      # Install dependencies with Homebrew if we can so we don't have to build
+      # and cache them. We make sure to install only prebuilt "bottles" by
+      # fetching them first.
+      - name: Install Homebrew dependencies
+        run: >
+          brew fetch --deps --retry $SPECTRE_BREW_DEPS
+          && brew install $SPECTRE_BREW_DEPS
+      # Load an existing Python environment and install Python dependencies.
+      # We use Python 3.7 for now since Spack has an issue with Python 3.8:
+      # https://github.com/spack/spack/issues/14102
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+      - name: Install Python dependencies
+        run: |
+          pip install $SPECTRE_PY_DEPS
+      # We need to build the remaining dependencies from source, but we can
+      # cache them.
+      - name: Restore dependency cache
+        uses: actions/cache@v1
+        id: restore-dependencies
+        with:
+          path: ~/dependencies
+          key: dependencies-macos
+      - name: Setup dependency cache directory
+        if: steps.restore-dependencies.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p $HOME/dependencies/spack
+      # Install the remaining dependencies using Spack if possible. We install
+      # them in an environment that we can activate later. To avoid re-building
+      # packages that are already installed by Homebrew we reference them in a
+      # 'packages.yaml' file. Pre-built Spack dependencies from the cache are
+      # used if available by adding the cache as a Spack mirror.
+      - name: Install Spack dependencies
+        run: |
+          cd $HOME
+          mkdir -p .spack
+          SPACK_PACKAGES=.spack/packages.yaml
+          echo "packages:" > $SPACK_PACKAGES
+          echo "  all:" >> $SPACK_PACKAGES
+          echo "    compiler: [clang]" >> $SPACK_PACKAGES
+          echo "  cmake:" >> $SPACK_PACKAGES
+          echo "    paths:" >> $SPACK_PACKAGES
+          echo "      cmake: $(brew --prefix cmake)" >> $SPACK_PACKAGES
+          echo "    buildable: False" >> $SPACK_PACKAGES
+          echo "  autoconf:" >> $SPACK_PACKAGES
+          echo "    paths:" >> $SPACK_PACKAGES
+          echo "      autoconf: $(brew --prefix autoconf)" >> $SPACK_PACKAGES
+          echo "    buildable: False" >> $SPACK_PACKAGES
+          cat $SPACK_PACKAGES
+          git clone https://github.com/spack/spack.git
+          source ./spack/share/spack/setup-env.sh
+          spack compiler find --scope defaults
+          spack mirror add dependencies file://$HOME/dependencies/spack
+          spack env create spectre
+          spack env activate spectre
+          spack install -j4 --no-check-signature $SPECTRE_SPACK_DEPS
+          spack find -v
+      # After building the dependencies from source we cache them as compressed
+      # tarballs.
+      - name: Package built Spack dependencies for caching
+        run: |
+          cd $HOME
+          source ./spack/share/spack/setup-env.sh
+          spack env activate spectre
+          spack buildcache create -uf -m dependencies $SPECTRE_SPACK_DEPS
+      # Install Charm++ separately. We may be able to install it via Spack as
+      # well and patch it.
+      - name: Install Charm++
+        if: steps.restore-dependencies.outputs.cache-hit != 'true'
+        run: |
+          cd $HOME/dependencies
+          wget http://charm.cs.illinois.edu/distrib/charm-${CHARM_VERSION}.tar.bz2
+          tar -xjf charm-${CHARM_VERSION}.tar.bz2
+          cd ./charm-${CHARM_VERSION}
+          ./build charm++ multicore-darwin-x86_64 -j4 -O0 $SPECTRE_MIN_MACOS
+          git apply $GITHUB_WORKSPACE/support/Charm/${CHARM_PATCH}
+          rm ../charm-${CHARM_VERSION}.tar.bz2
+      # Replace the ccache directory that building the dependencies may have
+      # generated with the cached ccache directory.
+      - name: Clear ccache from dependencies
+        run: |
+          rm -rf $CCACHE_DIR
+          mkdir -p $CCACHE_DIR
+      - name: Restore ccache
+        uses: actions/cache@v1
+        with:
+          path: ~/ccache
+          key: ccache-macos
+      - name: Configure ccache
+        run: |
+          ccache -pz
+      # Configure, build and run tests. See the `unit_tests` job for details.
+      # We increase the timeout for tests because `ctest` on the GitHub-hosted
+      # macOS VMs appears to be quite slow.
+      - name: Configure build with cmake
+        run: >
+          mkdir build && cd build
+
+          source $HOME/spack/share/spack/setup-env.sh
+
+          spack env activate spectre
+
+          cmake
+          -D CMAKE_C_COMPILER=clang
+          -D CMAKE_CXX_COMPILER=clang++
+          -D CMAKE_Fortran_COMPILER=gfortran
+          -D CMAKE_CXX_FLAGS="-Werror"
+          -D OVERRIDE_ARCH=x86-64
+          -D CHARM_ROOT=$HOME/dependencies/charm-${CHARM_VERSION}
+          -D BLAS_ROOT=$(brew --prefix openblas)
+          -D MACOSX_MIN=10.11
+          -D CMAKE_BUILD_TYPE=Debug
+          -D DEBUG_SYMBOLS=OFF
+          -D RUN_TESTS_IN_TEST_EXECUTABLES=OFF
+          -D STUB_EXECUTABLE_OBJECT_FILES=ON
+          -D STUB_LIBRARY_OBJECT_FILES=ON
+          -D USE_PCH=ON
+          -D USE_CCACHE=ON
+          -D BUILD_PYTHON_BINDINGS=ON
+          -D SPECTRE_UNIT_TEST_TIMEOUT_FACTOR=3
+          -D SPECTRE_INPUT_FILE_TEST_TIMEOUT_FACTOR=3
+          -D SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR=3
+          $GITHUB_WORKSPACE
+      - name: Build tests
+        working-directory: build
+        run: |
+          make -j4 RunTests
+      - name: Build executables
+        working-directory: build
+        run: |
+          make test-executables
+      - name: Print size of build directory
+        working-directory: build
+        run: |
+          ls | xargs du -sh
+          du -sh .
+      - name: Diagnose ccache
+        run: |
+          ccache -s
+      - name: Run unit tests
+        working-directory: build
+        run: |
+          ctest --repeat after-timeout:3 --output-on-failure

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -62,8 +62,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Check python formatting
         run: |
           cd $GITHUB_WORKSPACE
@@ -90,8 +88,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Fetch upstream/develop
         # We only want to check files that have changed in this pull request,
         # so we fetch its base branch and pass it to `clang-tidy-hash`.
@@ -136,8 +132,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Configure with cmake
         working-directory: /work
         run: >
@@ -192,8 +186,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Download built documentation
         uses: actions/download-artifact@v1
         with:
@@ -314,8 +306,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Restore ccache
         uses: actions/cache@v1
         with:

--- a/cmake/AddInputFileTests.cmake
+++ b/cmake/AddInputFileTests.cmake
@@ -1,6 +1,10 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+option(SPECTRE_INPUT_FILE_TEST_TIMEOUT_FACTOR
+  "Multiply timeout for input file tests by this factor"
+  1)
+
 find_package(PythonInterp REQUIRED)
 
 function(add_single_input_file_test INPUT_FILE EXECUTABLE CHECK_TYPE TIMEOUT)
@@ -51,6 +55,12 @@ function(add_single_input_file_test INPUT_FILE EXECUTABLE CHECK_TYPE TIMEOUT)
   # Double timeout if address sanitizer is enabled.
   if (ASAN)
     math(EXPR TIMEOUT "2 * ${TIMEOUT}")
+  endif()
+
+  # Multiply timeout by the user option
+  # Note: "1" is parsed as "ON" by cmake
+  if (NOT "${SPECTRE_INPUT_FILE_TEST_TIMEOUT_FACTOR}" STREQUAL ON)
+    math(EXPR TIMEOUT "${SPECTRE_INPUT_FILE_TEST_TIMEOUT_FACTOR} * ${TIMEOUT}")
   endif()
 
   set_tests_properties(

--- a/cmake/CheckBrokenArray0.cmake
+++ b/cmake/CheckBrokenArray0.cmake
@@ -13,10 +13,12 @@ try_compile(
   -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
   -DCMAKE_CXX_STANDARD_REQUIRED=${CMAKE_CXX_STANDARD_REQUIRED}
   -DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}
+  OUTPUT_VARIABLE TRY_COMPILE_OUTPUT
   )
 if (ARRAY0_WORKS)
   message(STATUS "Checking for broken std::array<..., 0> -- works")
 else (ARRAY0_WORKS)
   message(STATUS "Checking for broken std::array<..., 0> -- broken")
   add_definitions(-DHAVE_BROKEN_ARRAY0)
+  message(STATUS "Output when trying to compile broken array test:\n${TRY_COMPILE_OUTPUT}")
 endif (ARRAY0_WORKS)

--- a/cmake/SetupMacOsx.cmake
+++ b/cmake/SetupMacOsx.cmake
@@ -8,4 +8,5 @@ if(APPLE)
   endif()
   set(CMAKE_EXE_LINKER_FLAGS
     "${CMAKE_EXE_LINKER_FLAGS} -mmacosx-version-min=${SPECTRE_MACOSX_MIN}")
+  message(STATUS "Minimum macOS version: ${SPECTRE_MACOSX_MIN}")
 endif()

--- a/cmake/SpectreAddCatchTests.cmake
+++ b/cmake/SpectreAddCatchTests.cmake
@@ -37,6 +37,10 @@
 #               example, to match "some (word) and" you must specify the
 #               string "some \(word\) and".
 
+option(SPECTRE_UNIT_TEST_TIMEOUT_FACTOR
+  "Multiply timeout for unit tests by this factor"
+  1)
+
 find_package(PythonInterp REQUIRED)
 
 # Main function - the only one designed to be called from outside this module.
@@ -193,6 +197,12 @@ function(spectre_parse_file SOURCE_FILE TEST_TARGET)
     # Double timeout if address sanitizer is enabled.
     if (ASAN)
       math(EXPR TIMEOUT "2 * ${TIMEOUT}")
+    endif()
+
+    # Multiply timeout by the user option
+    # Note: "1" is parsed as "ON" by cmake
+    if (NOT "${SPECTRE_UNIT_TEST_TIMEOUT_FACTOR}" STREQUAL ON)
+      math(EXPR TIMEOUT "${SPECTRE_UNIT_TEST_TIMEOUT_FACTOR} * ${TIMEOUT}")
     endif()
 
     # Add the test and set its properties

--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -1,6 +1,10 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+option(SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR
+  "Multiply timeout for Python tests by this factor"
+  1)
+
 set(SPECTRE_PYTHON_PREFIX "${CMAKE_BINARY_DIR}/bin/python/spectre/")
 get_filename_component(
   SPECTRE_PYTHON_PREFIX
@@ -308,13 +312,21 @@ function(SPECTRE_ADD_PYTHON_TEST TEST_NAME FILE TAGS)
     ${FILE}
     )
 
+  set(TIMEOUT 2)
+
+  # Multiply timeout by the user option
+  # Note: "1" is parsed as "ON" by cmake
+  if (NOT "${SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR}" STREQUAL ON)
+    math(EXPR TIMEOUT "${SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR} * ${TIMEOUT}")
+  endif()
+
   # The fail regular expression is what Python.unittest returns when no
   # tests are found to be run. We treat this as a test failure.
   set_tests_properties(
     "\"${TEST_NAME}\""
     PROPERTIES
     FAIL_REGULAR_EXPRESSION "Ran 0 test"
-    TIMEOUT 2
+    TIMEOUT ${TIMEOUT}
     LABELS "${TAGS};Python"
     ENVIRONMENT "PYTHONPATH=${SPECTRE_PYTHON_PREFIX_PARENT}:\$PYTHONPATH"
     )

--- a/cmake/StripSymbols.cmake
+++ b/cmake/StripSymbols.cmake
@@ -4,5 +4,10 @@
 option(STRIP_SYMBOLS "Strip symbols from executables" OFF)
 
 if (STRIP_SYMBOLS)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--strip-all")
+  if (APPLE)
+    message(FATAL_ERROR "Stripping all symbols is currently not supported on "
+    "macOS. Please disable the `STRIP_SYMBOLS` flag.")
+  else (APPLE)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--strip-all")
+  endif (APPLE)
 endif(STRIP_SYMBOLS)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -184,6 +184,14 @@ maintainers:
    > that the failure was a false positive, then we will open an issue
    > to track that problem with our status check suite.
 
+   Only those status check failures that occur in the containerized build
+   environment are your responsibility to fix. If you encounter an issue with a
+   status check that runs in an environment that you do not have access to, e.g.
+   on macOS or on a supercomputer, please notify
+   `@sxs-collaboration/spectre-core-devs`. They will refer the issue to a person
+   who has access to that environment. Unless requested by the reviewers, the PR
+   will not be held up until the issue is resolved.
+
 While the prerequisites above must be satisfied prior to having your
 pull request reviewed, the reviewers may ask you to complete
 additional design work, tests, or other changes before your pull

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -206,6 +206,11 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
   - This is useful for drastically reducing the build size in CI, but since the
     object files are replaced with empty stubs will generally cause linking
     problems if used during development.
+- SPECTRE_UNIT_TEST_TIMEOUT_FACTOR, SPECTRE_INPUT_FILE_TEST_TIMEOUT_FACTOR and
+  SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR
+  - Multiply the timeout for the respective set of tests by this factor (default
+    is `1`).
+  - This is useful to run tests on slower machines.
 
 ## Formaline
 

--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -396,10 +396,15 @@ std::vector<std::string> get_attribute_names(const hid_t file_id,
   // attributes retrieving their names and storing them in names
   detail::OpenGroup my_group(file_id, group_name, AccessType::ReadOnly);
   const hid_t group_id = my_group.id();
-  H5O_info_t group_info{};
   std::string name;
   std::vector<std::string> names;
+#if H5_VERSION_GE(1, 12, 0)
+  H5O_info1_t group_info{};
+  CHECK_H5(H5Oget_info1(group_id, &group_info), "Failed to get group info");
+#else
+  H5O_info_t group_info{};
   CHECK_H5(H5Oget_info(group_id, &group_info), "Failed to get group info");
+#endif
   names.reserve(group_info.num_attrs);
   for (size_t i = 0; i < group_info.num_attrs; ++i) {
 #pragma GCC diagnostic push


### PR DESCRIPTION
## Proposed changes

Builds executables and runs unit tests on macOS outside the container on our CI. To get the macOS build working, this PR also makes a bunch of adjustments to our build system for macOS:

- [x] #2158 
- Fix the version for an H5 function: For the macOS build I install HDF5 1.12. But the `H5Oget_info` function we use in `IO` is versioned and changes in HDF5 1.12, so it's fixed to version `H5Oget_info1`.
- Output some more diagnostics for macOS cmake configurations
- Disable `STRIP_SYMBOLS` on macOS: It's probably possible to get this working cross-platform, but I haven't tried very hard.
- Add options to increase test timeouts: The macOS VMs on GitHub-hosted runners seem to be slightly slower than the linux VMs. Some tests randomly time out even when running `ctest` in a single thread. This commit allows increasing the default test timeouts by a user-defined factor.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
