### PR TITLE
Add expand_tuple utility

### DIFF
--- a/src/Utilities/Tuple.hpp
+++ b/src/Utilities/Tuple.hpp
@@ -174,3 +174,37 @@ constexpr inline void tuple_transform(
       tuple, std::forward<N_aryOp>(op),
       std::make_index_sequence<sizeof...(Elements)>{}, args...);
 }
+
+namespace cpp17 {
+
+namespace detail {
+
+template <class F, class Tuple, std::size_t... I>
+constexpr decltype(auto) apply_impl(F&& f, Tuple&& t,
+                                    std::index_sequence<I...> /* meta */) {
+  return std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...);
+}
+
+}  // namespace detail
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Invoke `f` with the arguments `t` expanded in a parameter pack
+ *
+ * Here is an example how to use the function:
+ *
+ * \snippet Test_Tuple.cpp expand_tuple_example
+ *
+ * This is the function being called in the above example:
+ *
+ * \snippet Test_Tuple.cpp expand_tuple_example_function
+ */
+template <class F, class Tuple>
+constexpr decltype(auto) apply(F&& f, Tuple&& t) {
+  return detail::apply_impl(
+      std::forward<F>(f), std::forward<Tuple>(t),
+      std::make_index_sequence<
+          std::tuple_size<std::remove_reference_t<Tuple>>::value>{});
+}
+
+}  // namespace cpp17

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
@@ -19,6 +19,7 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Numeric.hpp"
+#include "Utilities/Tuple.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 #include "tests/Utilities/MakeWithRandomValues.hpp"
 
@@ -33,52 +34,6 @@ struct OperatorAppliedTo : db::SimpleTag, db::PrefixTag {
 };
 
 }  // namespace Tags
-
-namespace detail {
-
-template <typename System,
-          typename FluxesArgs =
-              tmpl::transform<typename System::fluxes::argument_tags,
-                              tmpl::bind<db::const_item_type, tmpl::_1>>,
-          typename FluxesArgsIndices =
-              std::make_index_sequence<tmpl::size<FluxesArgs>::value>,
-          typename SourcesArgs =
-              tmpl::transform<typename System::sources::argument_tags,
-                              tmpl::bind<db::const_item_type, tmpl::_1>>,
-          typename SourcesArgsIndices =
-              std::make_index_sequence<tmpl::size<SourcesArgs>::value>>
-struct ExpandTuplesImpl;
-
-template <typename System, typename... FluxesArgs, size_t... FluxesArgsIndices,
-          typename... SourcesArgs, size_t... SourcesArgsIndices>
-struct ExpandTuplesImpl<System, tmpl::list<FluxesArgs...>,
-                        std::index_sequence<FluxesArgsIndices...>,
-                        tmpl::list<SourcesArgs...>,
-                        std::index_sequence<SourcesArgsIndices...>> {
-  static constexpr size_t volume_dim = System::volume_dim;
-  using all_fields = db::get_variables_tags_list<typename System::fields_tag>;
-  using primal_fields = typename System::primal_fields;
-  using auxiliary_fields = typename System::auxiliary_fields;
-
-  static auto first_order_fluxes(
-      const Variables<all_fields>& vars,
-      const typename System::fluxes& fluxes_computer,
-      const std::tuple<FluxesArgs...>& fluxes_args) noexcept {
-    return elliptic::first_order_fluxes<volume_dim, primal_fields,
-                                        auxiliary_fields>(
-        vars, fluxes_computer, get<FluxesArgsIndices>(fluxes_args)...);
-  }
-
-  static auto first_order_sources(
-      const Variables<all_fields>& vars,
-      const std::tuple<SourcesArgs...>& sources_args) noexcept {
-    return elliptic::first_order_sources<primal_fields, auxiliary_fields,
-                                         typename System::sources>(
-        vars, get<SourcesArgsIndices>(sources_args)...);
-  }
-};
-
-}  // namespace detail
 
 /// \ingroup TestingFrameworkGroup
 /// Test that the `solution` numerically solves the `System` on the given grid
@@ -95,6 +50,8 @@ void verify_solution(
     const std::tuple<FluxesArgs...>& fluxes_args = std::tuple<>{},
     const std::tuple<SourcesArgs...>& sources_args = std::tuple<>{}) {
   using all_fields = db::get_variables_tags_list<typename System::fields_tag>;
+  using primal_fields = typename System::primal_fields;
+  using auxiliary_fields = typename System::auxiliary_fields;
 
   const size_t num_points = mesh.number_of_grid_points();
   const auto logical_coords = logical_coordinates(mesh);
@@ -103,12 +60,23 @@ void verify_solution(
       solution.variables(inertial_coords, all_fields{}));
 
   // Apply operator to solution fields
-  auto fluxes = detail::ExpandTuplesImpl<System>::first_order_fluxes(
-      solution_fields, fluxes_computer, fluxes_args);
+  auto fluxes = cpp17::apply(
+      [&solution_fields,
+       &fluxes_computer](const auto&... expanded_fluxes_args) {
+        return ::elliptic::first_order_fluxes<System::volume_dim, primal_fields,
+                                              auxiliary_fields>(
+            solution_fields, fluxes_computer, expanded_fluxes_args...);
+      },
+      fluxes_args);
   auto div_fluxes = divergence(std::move(fluxes), mesh,
                                coord_map.inv_jacobian(logical_coords));
-  auto sources = detail::ExpandTuplesImpl<System>::first_order_sources(
-      solution_fields, sources_args);
+  auto sources = cpp17::apply(
+      [&solution_fields](const auto&... expanded_sources_args) {
+        return ::elliptic::first_order_sources<primal_fields, auxiliary_fields,
+                                               typename System::sources>(
+            solution_fields, expanded_sources_args...);
+      },
+      sources_args);
   Variables<db::wrap_tags_in<Tags::OperatorAppliedTo, all_fields>>
       operator_applied_to_fields{num_points};
   elliptic::first_order_operator(make_not_null(&operator_applied_to_fields),
@@ -119,8 +87,7 @@ void verify_solution(
   Variables<db::wrap_tags_in<::Tags::FixedSource, all_fields>> fixed_sources{
       num_points, 0.};
   fixed_sources.assign_subset(solution.variables(
-      inertial_coords,
-      db::wrap_tags_in<::Tags::FixedSource, typename System::primal_fields>{}));
+      inertial_coords, db::wrap_tags_in<::Tags::FixedSource, primal_fields>{}));
 
   // Check error norms against the given tolerance
   tmpl::for_each<all_fields>([&operator_applied_to_fields, &fixed_sources,

--- a/tests/Unit/Utilities/Test_Tuple.cpp
+++ b/tests/Unit/Utilities/Test_Tuple.cpp
@@ -249,3 +249,26 @@ SPECTRE_TEST_CASE("Unit.Utilities.tuple_transform", "[Utilities][Unit]") {
                     std::string("test sentence"), test_sentence2)),
                 "Failed testing noexcept-ness of tuple_transform");
 }
+
+namespace {
+/// [expand_tuple_example_function]
+double test_function(const int first_arg, const double second_arg) {
+  return static_cast<double>(first_arg) + second_arg;
+}
+/// [expand_tuple_example_function]
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Utilities.ExpandTuple", "[Unit][Utilities]") {
+  /// [expand_tuple_example]
+  const double extra_factor = 3.;
+  const double result = cpp17::apply(
+      [&extra_factor](const auto&... expanded_args) {
+        return extra_factor * test_function(expanded_args...);
+      },
+      std::tuple<int, double>{1, 2.});
+  /// [expand_tuple_example]
+  CHECK(result == 9.);
+  CHECK(1 ==
+        cpp17::apply([](const int arg) { return arg; }, std::tuple<int>{1}));
+  CHECK(0 == cpp17::apply([]() { return 0; }, std::tuple<>{}));
+}


### PR DESCRIPTION
## Proposed changes

A utility function that helps expanding a tuple in a parameter pack. Simplifies some existing code and also helps with code in #2077 and upcoming PRs.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
