### PR TITLE
Add face normal tag for moving meshes

### DIFF
--- a/src/Domain/FaceNormal.cpp
+++ b/src/Domain/FaceNormal.cpp
@@ -9,19 +9,16 @@
 #include "Domain/Direction.hpp"                     // IWYU pragma: keep
 #include "Domain/ElementMap.hpp"                    // IWYU pragma: keep
 #include "Domain/LogicalCoordinates.hpp"
-#include "Domain/Mesh.hpp"                          // IWYU pragma: keep
+#include "Domain/Mesh.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace {
-template <typename TargetFrame, size_t VolumeDim, typename Map>
-tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal_impl(
-    const Mesh<VolumeDim - 1>& interface_mesh, const Map& map,
+template <size_t VolumeDim, typename TargetFrame>
+tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
+    const Mesh<VolumeDim - 1>& interface_mesh,
+    const InverseJacobian<DataVector, VolumeDim, Frame::Logical, TargetFrame>&
+        inv_jacobian_on_interface,
     const Direction<VolumeDim>& direction) noexcept {
-  auto interface_coords =
-      interface_logical_coordinates(interface_mesh, direction);
-  const auto inv_jacobian_on_interface =
-      map.inv_jacobian(std::move(interface_coords));
-
   const auto sliced_away_dim = direction.dimension();
   const double sign = direction.sign();
 
@@ -41,8 +38,11 @@ tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
     const Mesh<VolumeDim - 1>& interface_mesh,
     const ElementMap<VolumeDim, TargetFrame>& map,
     const Direction<VolumeDim>& direction) noexcept {
-  return unnormalized_face_normal_impl<TargetFrame>(interface_mesh, map,
-                                                    direction);
+  return unnormalized_face_normal(
+      interface_mesh,
+      map.inv_jacobian(
+          interface_logical_coordinates(interface_mesh, direction)),
+      direction);
 }
 
 template <size_t VolumeDim, typename TargetFrame>
@@ -51,8 +51,55 @@ tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
     const domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>&
         map,
     const Direction<VolumeDim>& direction) noexcept {
-  return unnormalized_face_normal_impl<TargetFrame>(interface_mesh, map,
-                                                    direction);
+  return unnormalized_face_normal(
+      interface_mesh,
+      map.inv_jacobian(
+          interface_logical_coordinates(interface_mesh, direction)),
+      direction);
+}
+
+template <size_t VolumeDim>
+tnsr::i<DataVector, VolumeDim, Frame::Inertial> unnormalized_face_normal(
+    const Mesh<VolumeDim - 1>& interface_mesh,
+    const ElementMap<VolumeDim, Frame::Grid>& logical_to_grid_map,
+    const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>&
+        grid_to_inertial_map,
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const Direction<VolumeDim>& direction) noexcept {
+  auto logical_to_grid_inv_jac = logical_to_grid_map.inv_jacobian(
+      interface_logical_coordinates(interface_mesh, direction));
+  ::InverseJacobian<DataVector, VolumeDim, Frame::Logical, Frame::Inertial>
+      logical_to_inertial_inv_jac{};
+
+  if (grid_to_inertial_map.is_identity()) {
+    for (size_t i = 0; i < logical_to_inertial_inv_jac.size(); ++i) {
+      logical_to_inertial_inv_jac[i] = std::move(logical_to_grid_inv_jac[i]);
+    }
+  } else {
+    const auto grid_to_inertial_inv_jac = grid_to_inertial_map.inv_jacobian(
+        logical_to_grid_map(
+            interface_logical_coordinates(interface_mesh, direction)),
+        time, functions_of_time);
+
+    for (size_t logical_i = 0; logical_i < VolumeDim; ++logical_i) {
+      for (size_t inertial_i = 0; inertial_i < VolumeDim; ++inertial_i) {
+        logical_to_inertial_inv_jac.get(logical_i, inertial_i) =
+            logical_to_grid_inv_jac.get(logical_i, 0) *
+            grid_to_inertial_inv_jac.get(0, inertial_i);
+        for (size_t grid_i = 1; grid_i < VolumeDim; ++grid_i) {
+          logical_to_inertial_inv_jac.get(logical_i, inertial_i) +=
+              logical_to_grid_inv_jac.get(logical_i, grid_i) *
+              grid_to_inertial_inv_jac.get(grid_i, inertial_i);
+        }
+      }
+    }
+  }
+
+  return unnormalized_face_normal(interface_mesh, logical_to_inertial_inv_jac,
+                                  direction);
 }
 
 #define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -72,6 +119,24 @@ tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),
                         (Frame::Inertial, Frame::Grid))
+
+#undef INSTANTIATION
+
+#define INSTANTIATION(_, data)                                              \
+  template tnsr::i<DataVector, GET_DIM(data), Frame::Inertial>              \
+  unnormalized_face_normal(                                                 \
+      const Mesh<GET_DIM(data) - 1>& interface_mesh,                        \
+      const ElementMap<GET_DIM(data), Frame::Grid>& logical_to_grid_map,    \
+      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial,         \
+                                      GET_DIM(data)>& grid_to_inertial_map, \
+      const double time,                                                    \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time,                                                \
+      const Direction<GET_DIM(data)>& direction) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef GET_DIM
 #undef GET_FRAME

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -15,8 +15,11 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/Tags.hpp"  // IWYU pragma: keep
+#include "Time/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -60,6 +63,18 @@ tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
     const domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>&
         map,
     const Direction<VolumeDim>& direction) noexcept;
+
+template <size_t VolumeDim>
+tnsr::i<DataVector, VolumeDim, Frame::Inertial> unnormalized_face_normal(
+    const Mesh<VolumeDim - 1>& interface_mesh,
+    const ElementMap<VolumeDim, Frame::Grid>& logical_to_grid_map,
+    const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>&
+        grid_to_inertial_map,
+    double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const Direction<VolumeDim>& direction) noexcept;
 // @}
 
 namespace domain {
@@ -84,6 +99,31 @@ struct UnnormalizedFaceNormalCompute
       tmpl::list<Mesh<VolumeDim - 1>, ElementMap<VolumeDim, Frame>,
                  Direction<VolumeDim>>;
   using volume_tags = tmpl::list<ElementMap<VolumeDim, Frame>>;
+};
+
+template <size_t VolumeDim>
+struct UnnormalizedFaceNormalMovingMeshCompute
+    : db::ComputeTag,
+      UnnormalizedFaceNormal<VolumeDim, Frame::Inertial> {
+  using base = UnnormalizedFaceNormal<VolumeDim, Frame::Inertial>;
+  static constexpr tnsr::i<DataVector, VolumeDim, Frame::Inertial> (*function)(
+      const ::Mesh<VolumeDim - 1>&, const ::ElementMap<VolumeDim, Frame::Grid>&,
+      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>&,
+      double,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&,
+      const ::Direction<VolumeDim>&) = unnormalized_face_normal;
+  using argument_tags =
+      tmpl::list<Mesh<VolumeDim - 1>, ElementMap<VolumeDim, Frame::Grid>,
+                 CoordinateMaps::Tags::CoordinateMap<VolumeDim, Frame::Grid,
+                                                     Frame::Inertial>,
+                 ::Tags::Time, Tags::FunctionsOfTime, Direction<VolumeDim>>;
+  using volume_tags =
+      tmpl::list<ElementMap<VolumeDim, Frame::Grid>,
+                 CoordinateMaps::Tags::CoordinateMap<VolumeDim, Frame::Grid,
+                                                     Frame::Inertial>,
+                 ::Tags::Time, Tags::FunctionsOfTime>;
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -128,5 +168,55 @@ struct InterfaceCompute<Tags::BoundaryDirectionsExterior<VolumeDim>,
   using argument_tags = tmpl::list<Tags::Interface<dirs, Mesh<VolumeDim - 1>>,
                                    Tags::ElementMap<VolumeDim, Frame>>;
 };
+
+template <size_t VolumeDim>
+struct InterfaceCompute<Tags::BoundaryDirectionsExterior<VolumeDim>,
+                        UnnormalizedFaceNormalMovingMeshCompute<VolumeDim>>
+    : db::PrefixTag,
+      db::ComputeTag,
+      Tags::Interface<
+          Tags::BoundaryDirectionsExterior<VolumeDim>,
+          Tags::UnnormalizedFaceNormal<VolumeDim, Frame::Inertial>> {
+  using dirs = BoundaryDirectionsExterior<VolumeDim>;
+
+  static std::string name() noexcept {
+    return "BoundaryDirectionsExterior<UnnormalizedFaceNormal>";
+  }
+
+  static auto function(
+      const db::const_item_type<Tags::Interface<dirs, Mesh<VolumeDim - 1>>>&
+          meshes,
+      const ::ElementMap<VolumeDim, Frame::Grid>& logical_to_grid_map,
+      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>&
+          grid_to_inertial_map,
+      const double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) noexcept {
+    std::unordered_map<::Direction<VolumeDim>,
+                       tnsr::i<DataVector, VolumeDim, Frame::Inertial>>
+        normals{};
+    for (const auto& direction_and_mesh : meshes) {
+      const auto& direction = direction_and_mesh.first;
+      const auto& mesh = direction_and_mesh.second;
+      auto internal_face_normal = unnormalized_face_normal(
+          mesh, logical_to_grid_map, grid_to_inertial_map, time,
+          functions_of_time, direction);
+      std::transform(internal_face_normal.begin(), internal_face_normal.end(),
+                     internal_face_normal.begin(), std::negate<>());
+      normals[direction] = std::move(internal_face_normal);
+    }
+    return normals;
+  }
+
+  using argument_tags =
+      tmpl::list<Tags::Interface<dirs, Mesh<VolumeDim - 1>>,
+                 Tags::ElementMap<VolumeDim, Frame::Grid>,
+                 CoordinateMaps::Tags::CoordinateMap<VolumeDim, Frame::Grid,
+                                                     Frame::Inertial>,
+                 ::Tags::Time, Tags::FunctionsOfTime>;
+};
+
 }  // namespace Tags
 }  // namespace domain

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -66,9 +66,9 @@ void check(const Map& map,
     }
   }
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.CoordMap", "[Unit][Domain]") {
+void test_face_normal_coordinate_map() {
+  INFO("Test coordinate map");
   /// [face_normal_example]
   const Mesh<0> mesh_0d;
   const auto map_1d = make_coordinate_map<Frame::Logical, Frame::Grid>(
@@ -95,7 +95,6 @@ SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.CoordMap", "[Unit][Domain]") {
         {{{{0.4, 0., 0.}}, {{0., 0.6, 0.8}}, {{0., -0.8, 0.6}}}});
 }
 
-namespace {
 template <typename TargetFrame>
 void test_face_normal_element_map() {
   const Mesh<0> mesh_0d;
@@ -127,20 +126,14 @@ void test_face_normal_element_map() {
                     CoordinateMaps::Rotation<2>(atan2(4., 3.))))),
         {{{{0.4, 0., 0.}}, {{0., 0.6, 0.8}}, {{0., -0.8, 0.6}}}});
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.ElementMap", "[Unit][Domain]") {
-  test_face_normal_element_map<Frame::Inertial>();
-  test_face_normal_element_map<Frame::Grid>();
-}
-
-namespace {
 struct Directions : db::SimpleTag {
   static std::string name() noexcept { return "Directions"; }
   using type = std::unordered_set<Direction<2>>;
 };
-}  // namespace
-SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.ComputeItem", "[Unit][Domain]") {
+
+void test_compute_item() {
+  INFO("Testing compute item");
   const auto box = db::create<
       db::AddSimpleTags<Tags::Element<2>, Directions, Tags::Mesh<2>,
                         Tags::ElementMap<2>>,
@@ -238,5 +231,13 @@ SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.ComputeItem", "[Unit][Domain]") {
         (invert(db::get<Tags::Interface<Tags::BoundaryDirectionsInterior<2>,
                                         Tags::UnnormalizedFaceNormal<2>>>(
             box_with_non_affine_map))));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.FaceNormal", "[Unit][Domain]") {
+  test_face_normal_coordinate_map();
+  test_face_normal_element_map<Frame::Inertial>();
+  test_face_normal_element_map<Frame::Grid>();
+  test_compute_item();
 }
 }  // namespace domain


### PR DESCRIPTION
## Proposed changes

- Reduce test cases in face normal tests
- Add function and tags to compute face normal with a moving mesh. This is currently rather inefficient, but that's largely because our interface code is all very inefficient and will get dealt with soon.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
