### PR TITLE
Add tag for char speeds on moving mesh

### DIFF
--- a/src/Domain/TagsCharacteresticSpeeds.hpp
+++ b/src/Domain/TagsCharacteresticSpeeds.hpp
@@ -1,0 +1,58 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <boost/optional.hpp>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // For Tags::Normalized
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain {
+namespace Tags {
+/// Compute the characteristic speeds on the moving mesh given the
+/// characteristic speeds if the mesh were stationary.
+///
+/// \note Assumes that `typename CharSpeedsComputeTag::return_type` is a
+/// `std::array<DataVector, NumberOfCharSpeeds>`
+template <typename CharSpeedsComputeTag, size_t Dim>
+struct CharSpeedCompute : CharSpeedsComputeTag {
+  using base = CharSpeedsComputeTag;
+  using return_type = typename CharSpeedsComputeTag::return_type;
+
+  template <typename... Ts, typename T, size_t NumberOfCharSpeeds>
+  static void function(
+      const gsl::not_null<std::array<T, NumberOfCharSpeeds>*> result,
+      const boost::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          grid_velocity,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_covector,
+      const Ts&... ts) noexcept {
+    // Note that while the CharSpeedsComputeTag almost certainly also needs the
+    // unit normal covector for computing the original characteristic speeds, we
+    // don't know which of the `ts` it is, and thus we need the unit normal
+    // covector to be passed explicitly.
+    CharSpeedsComputeTag::function(result, ts...);
+    if (static_cast<bool>(grid_velocity)) {
+      const Scalar<DataVector> normal_dot_velocity =
+          dot_product(*grid_velocity, unit_normal_covector);
+      for (size_t i = 0; i < result->size(); ++i) {
+        gsl::at(*result, i) -= get(normal_dot_velocity);
+      }
+    }
+  }
+
+  using argument_tags =
+      tmpl::push_front<typename CharSpeedsComputeTag::argument_tags,
+                       MeshVelocity<Dim, Frame::Inertial>,
+                       ::Tags::Normalized<UnnormalizedFaceNormal<Dim>>>;
+};
+}  // namespace Tags
+}  // namespace domain

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -38,6 +38,7 @@ set(LIBRARY_SOURCES
   Test_Side.cpp
   Test_SizeOfElement.cpp
   Test_Tags.cpp
+  Test_TagsCharacteristicSpeeds.cpp
   Test_TagsTimeDependent.cpp
   )
 

--- a/tests/Unit/Domain/Test_TagsCharacteristicSpeeds.cpp
+++ b/tests/Unit/Domain/Test_TagsCharacteristicSpeeds.cpp
@@ -1,0 +1,152 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsCharacteresticSpeeds.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace {
+template <size_t Dim>
+struct CharSpeeds : db::ComputeTag {
+  static std::string name() noexcept { return "CharSpeeds"; }
+  using return_type = std::array<DataVector, 4>;
+
+  static void function(const gsl::not_null<std::array<DataVector, 4>*> result,
+                       const tnsr::I<DataVector, Dim, Frame::Inertial>&
+                           inertial_coords) noexcept {
+    gsl::at(*result, 0) = inertial_coords.get(0);
+    for (size_t i = 1; i < 4; ++i) {
+      gsl::at(*result, i) = inertial_coords.get(0) + 2.0 * i;
+    }
+  }
+  using argument_tags =
+      tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>>;
+};
+
+template <size_t Dim>
+struct Directions : db::SimpleTag {
+  static std::string name() noexcept { return "Directions"; }
+  using type = std::unordered_set<Direction<Dim>>;
+};
+
+template <size_t Dim>
+std::unordered_set<Direction<Dim>> get_directions();
+
+template <>
+std::unordered_set<Direction<1>> get_directions<1>() {
+  return std::unordered_set<Direction<1>>{Direction<1>::upper_xi()};
+}
+
+template <>
+std::unordered_set<Direction<2>> get_directions<2>() {
+  return std::unordered_set<Direction<2>>{Direction<2>::upper_xi(),
+                                          Direction<2>::lower_eta()};
+}
+
+template <>
+std::unordered_set<Direction<3>> get_directions<3>() {
+  return std::unordered_set<Direction<3>>{Direction<3>::upper_xi(),
+                                          Direction<3>::lower_eta(),
+                                          Direction<3>::lower_zeta()};
+}
+
+template <size_t Dim, bool MeshIsMoving>
+void test_tags() {
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> dist(-1., 1.);
+
+  TestHelpers::db::test_compute_tag<
+      domain::Tags::CharSpeedCompute<CharSpeeds<Dim>, Dim>>("CharSpeeds");
+
+  using simple_tags = db::AddSimpleTags<
+      Directions<Dim>,
+      domain::Tags::Interface<Directions<Dim>, domain::Tags::MeshVelocity<Dim>>,
+      domain::Tags::Interface<Directions<Dim>,
+                              domain::Tags::Coordinates<Dim, Frame::Inertial>>,
+      domain::Tags::Interface<
+          Directions<Dim>,
+          Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>>;
+
+  using compute_tags = db::AddComputeTags<domain::Tags::InterfaceCompute<
+      Directions<Dim>, domain::Tags::CharSpeedCompute<CharSpeeds<Dim>, Dim>>>;
+
+  const DataVector used_for_size(5);
+
+  std::unordered_map<Direction<Dim>,
+                     boost::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>>
+      mesh_velocity{};
+  std::unordered_map<Direction<Dim>, tnsr::I<DataVector, Dim, Frame::Inertial>>
+      coordinates{};
+  std::unordered_map<Direction<Dim>, tnsr::i<DataVector, Dim, Frame::Inertial>>
+      normals{};
+  for (const auto& direction : get_directions<Dim>()) {
+    if (MeshIsMoving) {
+      mesh_velocity[direction] =
+          make_with_random_values<tnsr::I<DataVector, Dim, Frame::Inertial>>(
+              make_not_null(&generator), make_not_null(&dist), used_for_size);
+    } else {
+      mesh_velocity[direction] = boost::none;
+    }
+    coordinates[direction] =
+        make_with_random_values<tnsr::I<DataVector, Dim, Frame::Inertial>>(
+            make_not_null(&generator), make_not_null(&dist), used_for_size);
+    normals[direction] =
+        make_with_random_values<tnsr::i<DataVector, Dim, Frame::Inertial>>(
+            make_not_null(&generator), make_not_null(&dist), used_for_size);
+  }
+
+  const auto box = db::create<simple_tags, compute_tags>(
+      get_directions<Dim>(), mesh_velocity, coordinates, normals);
+
+  std::unordered_map<Direction<Dim>, std::array<DataVector, 4>>
+      expected_char_speeds{};
+  for (const auto& direction : get_directions<Dim>()) {
+    CharSpeeds<Dim>::function(make_not_null(&expected_char_speeds[direction]),
+                              coordinates[direction]);
+    if (MeshIsMoving) {
+      const Scalar<DataVector> normal_dot_velocity =
+          dot_product(normals[direction], *(mesh_velocity[direction]));
+      for (size_t i = 0; i < expected_char_speeds[direction].size(); ++i) {
+        gsl::at(expected_char_speeds[direction], i) -= get(normal_dot_velocity);
+      }
+    }
+
+    CHECK_ITERABLE_APPROX(
+        (db::get<domain::Tags::Interface<Directions<Dim>, CharSpeeds<Dim>>>(box)
+             .at(direction)),
+        expected_char_speeds.at(direction));
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.TagsCharacteresticSpeeds", "[Unit][Actions]") {
+  test_tags<1, true>();
+  test_tags<2, true>();
+  test_tags<3, true>();
+
+  test_tags<1, false>();
+  test_tags<2, false>();
+  test_tags<3, false>();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

- Add a compute tag that wraps existing char speed computation tags and accounts the mesh velocity

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
