### PR TITLE
Reduce passing of fundamental types by reference

### DIFF
--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -627,7 +627,7 @@ struct MakeWithValueImpl<Tensor<double, Structure...>, double> {
   /// \brief Returns a Tensor whose elements are set equal to `value` (`input`
   /// is ignored).
   static SPECTRE_ALWAYS_INLINE Tensor<double, Structure...> apply(
-      const double& /*input*/, const double value) noexcept {
+      const double /*input*/, const double value) noexcept {
     return Tensor<double, Structure...>(value);
   }
 };

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -19,8 +19,8 @@
 #include "ErrorHandling/Assert.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/MakeWithValue.hpp" // IWYU pragma: keep
-#include "Utilities/PointerVector.hpp" // IWYU pragma: keep
+#include "Utilities/MakeWithValue.hpp"  // IWYU pragma: keep
+#include "Utilities/PointerVector.hpp"  // IWYU pragma: keep
 #include "Utilities/PrintHelpers.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
@@ -242,7 +242,7 @@ class VectorImpl
    */
   void SPECTRE_ALWAYS_INLINE
   destructive_resize(const size_t new_size) noexcept {
-    if(UNLIKELY(size() != new_size)) {
+    if (UNLIKELY(size() != new_size)) {
       if (owning_) {
         owned_data_ = std::unique_ptr<value_type[], decltype(&free)>{
             new_size > 0 ? static_cast<value_type*>(

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -583,23 +583,23 @@ std::ostream& operator<<(std::ostream& os,
  *
  * \param VECTOR_TYPE The vector type (e.g. `DataVector`)
  */
-#define MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(VECTOR_TYPE)                      \
-  namespace MakeWithValueImpls {                                              \
-  template <>                                                                 \
-  struct MakeWithValueImpl<VECTOR_TYPE, VECTOR_TYPE> {                        \
-    static SPECTRE_ALWAYS_INLINE VECTOR_TYPE                                  \
-    apply(const VECTOR_TYPE& input,                                           \
-          const VECTOR_TYPE::value_type value) noexcept {                     \
-      return VECTOR_TYPE(input.size(), value);                                \
-    }                                                                         \
-  };                                                                          \
-  template <>                                                                 \
-  struct MakeWithValueImpl<VECTOR_TYPE, size_t> {                             \
-    static SPECTRE_ALWAYS_INLINE VECTOR_TYPE                                  \
-    apply(const size_t& size, const VECTOR_TYPE::value_type value) noexcept { \
-      return VECTOR_TYPE(size, value);                                        \
-    }                                                                         \
-  };                                                                          \
+#define MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(VECTOR_TYPE)                     \
+  namespace MakeWithValueImpls {                                             \
+  template <>                                                                \
+  struct MakeWithValueImpl<VECTOR_TYPE, VECTOR_TYPE> {                       \
+    static SPECTRE_ALWAYS_INLINE VECTOR_TYPE                                 \
+    apply(const VECTOR_TYPE& input,                                          \
+          const VECTOR_TYPE::value_type value) noexcept {                    \
+      return VECTOR_TYPE(input.size(), value);                               \
+    }                                                                        \
+  };                                                                         \
+  template <>                                                                \
+  struct MakeWithValueImpl<VECTOR_TYPE, size_t> {                            \
+    static SPECTRE_ALWAYS_INLINE VECTOR_TYPE                                 \
+    apply(const size_t size, const VECTOR_TYPE::value_type value) noexcept { \
+      return VECTOR_TYPE(size, value);                                       \
+    }                                                                        \
+  };                                                                         \
   }  // namespace MakeWithValueImpls
 
 // {@

--- a/src/Domain/CoordinateMaps/BulgedCube.cpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.cpp
@@ -57,7 +57,7 @@ class RootFunction {
                      1.0 / sqrt(2.0 + square(rho) * y_sq_over_r_sq) -
                      1.0 / sqrt(2.0 + square(rho) * z_sq_over_r_sq)));
   }
-  const double& get_r_sq() noexcept { return physical_r_squared_; }
+  double get_r_sq() const noexcept { return physical_r_squared_; }
 
  private:
   const double radius_;
@@ -69,7 +69,7 @@ class RootFunction {
 };
 
 boost::optional<double> scaling_factor(RootFunction&& rootfunction) noexcept {
-  const double& physical_r_squared = rootfunction.get_r_sq();
+  const double physical_r_squared = rootfunction.get_r_sq();
   try {
     constexpr double tol = 10.0 * std::numeric_limits<double>::epsilon();
     // Use a small nonzero number since the inverse map is singular at r==0 and

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -283,9 +283,7 @@ class VolumeCornerIterator {
     return local_corner_number_ < two_to_the(VolumeDim);
   }
 
-  const size_t& local_corner_number() const noexcept {
-    return local_corner_number_;
-  }
+  size_t local_corner_number() const noexcept { return local_corner_number_; }
 
   size_t global_corner_number() const noexcept {
     std::array<size_t, VolumeDim> new_indices{};

--- a/src/Evolution/ComputeTags.hpp
+++ b/src/Evolution/ComputeTags.hpp
@@ -32,7 +32,7 @@ struct AnalyticCompute
       const db::const_item_type<AnalyticSolutionTag>&
           analytic_solution_computer,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
-      const double& time) noexcept {
+      const double time) noexcept {
     return db::const_item_type<base>(
         variables_from_tagged_tuple(analytic_solution_computer.variables(
             inertial_coords, time, AnalyticFieldsTagList{})));

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -137,16 +137,15 @@ struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
       Tags::GaugeHSpatialWeightDecayWidth<Frame>>;
 
   static constexpr db::const_item_type<Tags::GaugeH<SpatialDim, Frame>>
-  function(
-      const db::const_item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
-          gauge_h_init,
-      const Scalar<DataVector>& lapse,
-      const tnsr::I<DataVector, SpatialDim, Frame>& shift,
-      const Scalar<DataVector>& sqrt_det_spatial_metric,
-      const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
-      const double& time, const double& t_start, const double& sigma_t,
-      const tnsr::I<DataVector, SpatialDim, Frame>& coords,
-      const double& sigma_r) noexcept {
+  function(const db::const_item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+               gauge_h_init,
+           const Scalar<DataVector>& lapse,
+           const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+           const Scalar<DataVector>& sqrt_det_spatial_metric,
+           const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+           const double time, const double t_start, const double sigma_t,
+           const tnsr::I<DataVector, SpatialDim, Frame>& coords,
+           const double sigma_r) noexcept {
     db::item_type<Tags::GaugeH<SpatialDim, Frame>> gauge_h{
         get_size(get(lapse))};
     GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame>(
@@ -297,10 +296,10 @@ struct SpacetimeDerivDampedHarmonicHCompute
       const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
       const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
       const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
-      const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const double& time,
-      const double& t_start, const double& sigma_t,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const double time,
+      const double t_start, const double sigma_t,
       const tnsr::I<DataVector, SpatialDim, Frame>& coords,
-      const double& sigma_r) noexcept {
+      const double sigma_r) noexcept {
     db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>> d4_gauge_h{
         get_size(get(lapse))};
     GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h(

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
@@ -75,7 +75,7 @@ struct InitializeResidual {
     db::mutate<initial_residual_magnitude_tag>(
         make_not_null(&box),
         [](const gsl::not_null<double*> local_initial_residual_magnitude,
-           const double& initial_residual_magnitude) noexcept {
+           const double initial_residual_magnitude) noexcept {
           *local_initial_residual_magnitude = initial_residual_magnitude;
         },
         get<residual_magnitude_tag>(box));

--- a/src/ParallelAlgorithms/LinearSolver/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Tags.hpp
@@ -144,7 +144,7 @@ template <typename MagnitudeSquareTag,
 struct MagnitudeCompute
     : db::add_tag_prefix<Magnitude, db::remove_tag_prefix<MagnitudeSquareTag>>,
       db::ComputeTag {
-  static constexpr double function(const double& magnitude_square) noexcept {
+  static constexpr double function(const double magnitude_square) noexcept {
     return sqrt(magnitude_square);
   }
   using argument_tags = tmpl::list<MagnitudeSquareTag>;
@@ -230,8 +230,8 @@ struct HasConvergedCompute : LinearSolver::Tags::HasConverged, db::ComputeTag {
                  initial_residual_magnitude_tag>;
   static db::const_item_type<LinearSolver::Tags::HasConverged> function(
       const Convergence::Criteria& convergence_criteria,
-      const size_t& iteration_id, const double& residual_magnitude,
-      const double& initial_residual_magnitude) noexcept {
+      const size_t& iteration_id, const double residual_magnitude,
+      const double initial_residual_magnitude) noexcept {
     return Convergence::HasConverged(convergence_criteria, iteration_id,
                                      residual_magnitude,
                                      initial_residual_magnitude);

--- a/src/ParallelAlgorithms/LinearSolver/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Tags.hpp
@@ -230,7 +230,7 @@ struct HasConvergedCompute : LinearSolver::Tags::HasConverged, db::ComputeTag {
                  initial_residual_magnitude_tag>;
   static db::const_item_type<LinearSolver::Tags::HasConverged> function(
       const Convergence::Criteria& convergence_criteria,
-      const size_t& iteration_id, const double residual_magnitude,
+      const size_t iteration_id, const double residual_magnitude,
       const double initial_residual_magnitude) noexcept {
     return Convergence::HasConverged(convergence_criteria, iteration_id,
                                      residual_magnitude,
@@ -324,7 +324,7 @@ template <>
 struct NextCompute<LinearSolver::Tags::IterationId>
     : Next<LinearSolver::Tags::IterationId>, db::ComputeTag {
   using argument_tags = tmpl::list<LinearSolver::Tags::IterationId>;
-  static size_t function(const size_t& iteration_id) noexcept {
+  static size_t function(const size_t iteration_id) noexcept {
     return iteration_id + 1;
   }
 };

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.cpp
@@ -20,10 +20,10 @@
 namespace {
 template <typename DataType>
 Scalar<DataType> compute_piecewise(const tnsr::I<DataType, 3>& x,
-                                   const double& inner_radius,
-                                   const double& outer_radius,
-                                   const double& inner_value,
-                                   const double& outer_value) noexcept {
+                                   const double inner_radius,
+                                   const double outer_radius,
+                                   const double inner_value,
+                                   const double outer_value) noexcept {
   const DataType cylindrical_radius =
       sqrt(square(get<0>(x)) + square(get<1>(x)));
   auto piecewise_scalar = make_with_value<Scalar<DataType>>(x, 0.0);

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.cpp
@@ -7,7 +7,7 @@
 #include <ostream>
 #include <pup.h>
 
-#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "Parallel/PupStlCpp11.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -15,7 +15,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
-#include "Utilities/Math.hpp" // IWYU pragma: keep
+#include "Utilities/Math.hpp"  // IWYU pragma: keep
 
 namespace {
 template <typename DataType>

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.cpp
@@ -23,9 +23,10 @@
 
 namespace {
 template <typename DataType>
-Scalar<DataType> compute_piecewise(
-    const tnsr::I<DataType, 3>& x, const double rotor_radius,
-    const double rotor_value, const double background_value) noexcept {
+Scalar<DataType> compute_piecewise(const tnsr::I<DataType, 3>& x,
+                                   const double rotor_radius,
+                                   const double rotor_value,
+                                   const double background_value) noexcept {
   const DataType cylindrical_radius =
       sqrt(square(get<0>(x)) + square(get<1>(x)));
   return Scalar<DataType>(rotor_value -
@@ -186,11 +187,11 @@ bool operator!=(const MagneticRotor& lhs, const MagneticRotor& rhs) noexcept {
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define TAG(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE_SCALARS(_, data)                         \
-  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>>     \
-      MagneticRotor::variables(                              \
-          const tnsr::I<DTYPE(data), 3>& x, \
-          tmpl::list<TAG(data) < DTYPE(data)>> /*meta*/) const noexcept;
+#define INSTANTIATE_SCALARS(_, data)                                          \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>>                      \
+      MagneticRotor::variables(const tnsr::I<DTYPE(data), 3>& x,              \
+                               tmpl::list<TAG(data) < DTYPE(data)>> /*meta*/) \
+          const noexcept;
 
 GENERATE_INSTANTIATIONS(
     INSTANTIATE_SCALARS, (double, DataVector),
@@ -198,12 +199,11 @@ GENERATE_INSTANTIATIONS(
      hydro::Tags::Pressure, hydro::Tags::DivergenceCleaningField,
      hydro::Tags::LorentzFactor, hydro::Tags::SpecificEnthalpy))
 
-#define INSTANTIATE_VECTORS(_, data)                                         \
-  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>>                  \
-      MagneticRotor::variables(                                              \
+#define INSTANTIATE_VECTORS(_, data)                        \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>> \
+      MagneticRotor::variables(                             \
           const tnsr::I<DTYPE(data), 3>& x,                 \
-          tmpl::list<TAG(data) < DTYPE(data), 3>> /*meta*/) \
-          const noexcept;
+          tmpl::list<TAG(data) < DTYPE(data), 3>> /*meta*/) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
                         (hydro::Tags::SpatialVelocity,

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.cpp
@@ -147,7 +147,7 @@ tnsr::I<DataType, 3> MagnetizedFmDisk::unnormalized_magnetic_field(
   // A_phi \propto rho - rho_threshold. Normalization comes later.
   const auto mag_potential =
       [ this, &threshold_rest_mass_density, &inner_edge_potential ](
-          const double& r, const double& sin_theta_squared) noexcept {
+          const double r, const double sin_theta_squared) noexcept {
     // enthalpy = exp(Win - W(r,theta)), as in the Fishbone-Moncrief disk
     return get(equation_of_state_.rest_mass_density_from_enthalpy(
                Scalar<double>{

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.cpp
@@ -16,7 +16,7 @@ namespace Solutions {
 
 template <typename DataType>
 Scalar<DataType> kerr_horizon_radius(
-    const std::array<DataType, 2>& theta_phi, const double& mass,
+    const std::array<DataType, 2>& theta_phi, const double mass,
     const std::array<double, 3>& dimensionless_spin) noexcept {
   const double spin_magnitude_squared = square(magnitude(dimensionless_spin));
   const double mass_squared = square(mass);
@@ -57,11 +57,11 @@ Scalar<DataType> kerr_horizon_radius(
 }
 
 template Scalar<DataVector> kerr_horizon_radius(
-    const std::array<DataVector, 2>& theta_phi, const double& mass,
+    const std::array<DataVector, 2>& theta_phi, const double mass,
     const std::array<double, 3>& dimensionless_spin) noexcept;
 
 template Scalar<double> kerr_horizon_radius(
-    const std::array<double, 2>& theta_phi, const double& mass,
+    const std::array<double, 2>& theta_phi, const double mass,
     const std::array<double, 3>& dimensionless_spin) noexcept;
 
 }  // namespace Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp
@@ -59,7 +59,7 @@ namespace Solutions {
  */
 template <typename DataType>
 Scalar<DataType> kerr_horizon_radius(
-    const std::array<DataType, 2>& theta_phi, const double& mass,
+    const std::array<DataType, 2>& theta_phi, double mass,
     const std::array<double, 3>& dimensionless_spin) noexcept;
 
 }  // namespace Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.cpp
@@ -115,11 +115,10 @@ ConstantM1::variables(
   return {Scalar<DataVector>{DataVector(get<0>(x).size(), W)}};
 }
 
-tuples::TaggedTuple<
-    hydro::Tags::SpatialVelocity<DataVector, 3>>
-ConstantM1::variables(const tnsr::I<DataVector, 3>& x, double /*t*/,
-                      tmpl::list<hydro::Tags::SpatialVelocity<
-                          DataVector, 3>> /*meta*/) const
+tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataVector, 3>>
+ConstantM1::variables(
+    const tnsr::I<DataVector, 3>& x, double /*t*/,
+    tmpl::list<hydro::Tags::SpatialVelocity<DataVector, 3>> /*meta*/) const
     noexcept {
   auto result = make_with_value<tnsr::I<DataVector, 3>>(x, mean_velocity_[0]);
   get<1>(result) = mean_velocity_[1];

--- a/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.hpp
@@ -38,7 +38,6 @@ namespace Solutions {
  */
 class ConstantM1 : public MarkAsAnalyticSolution {
  public:
-
   /// The mean flow velocity.
   struct MeanVelocity {
     using type = std::array<double, 3>;

--- a/src/Time/TimeSteppers/AdamsBashforthN.cpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.cpp
@@ -51,7 +51,7 @@ std::vector<double> AdamsBashforthN::get_coefficients_impl(
   const size_t order = steps.size();
   ASSERT(order >= 1 and order <= maximum_order, "Bad order" << order);
   if (std::all_of(steps.begin(), steps.end(),
-                  [=](const double& s) { return s == 1.; })) {
+                  [=](const double s) { return s == 1.; })) {
     return constant_coefficients(order);
   }
 

--- a/src/Utilities/PointerVector.hpp
+++ b/src/Utilities/PointerVector.hpp
@@ -307,7 +307,7 @@ BLAZE_ALWAYS_INLINE SIMDdouble step_function(const SIMDf64<T>& v) noexcept
 }
 #endif
 
-BLAZE_ALWAYS_INLINE double step_function(const double& v) noexcept {
+BLAZE_ALWAYS_INLINE double step_function(const double v) noexcept {
   return v < 0.0 ? 0.0 : 1.0;
 }
 

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
@@ -23,8 +23,7 @@ namespace Schwarzschild {
 
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ii<DataType, SpatialDim, Frame> spatial_ricci(
-    const tnsr::I<DataType, SpatialDim, Frame>& x,
-    const double& mass) noexcept {
+    const tnsr::I<DataType, SpatialDim, Frame>& x, const double mass) noexcept {
   auto ricci = make_with_value<tnsr::ii<DataType, SpatialDim, Frame>>(x, 0.);
 
   constexpr auto dimensionality = index_dim<0>(ricci);
@@ -72,8 +71,8 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature_sphere(
 namespace Kerr {
 template <typename DataType>
 Scalar<DataType> horizon_ricci_scalar(
-    const Scalar<DataType>& horizon_radius, const double& mass,
-    const double& dimensionless_spin_z) noexcept {
+    const Scalar<DataType>& horizon_radius, const double mass,
+    const double dimensionless_spin_z) noexcept {
   // Compute Kerr spin parameter a
   // This is the magnitude of the dimensionless spin times the mass
   double kerr_spin_a = mass * dimensionless_spin_z;
@@ -98,7 +97,7 @@ template <typename DataType>
 Scalar<DataType> horizon_ricci_scalar(
     const Scalar<DataType>& horizon_radius_with_spin_on_z_axis,
     const YlmSpherepack& ylm_with_spin_on_z_axis, const YlmSpherepack& ylm,
-    const double& mass,
+    const double mass,
     const std::array<double, 3>& dimensionless_spin) noexcept {
   // get the dimensionless spin magnitude and direction
   const double spin_magnitude = magnitude(dimensionless_spin);
@@ -204,7 +203,7 @@ Scalar<DataType> horizon_ricci_scalar(
   template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>     \
   TestHelpers::Schwarzschild::spatial_ricci(                 \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x, \
-      const double& mass) noexcept;                          \
+      const double mass) noexcept;                           \
   template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>     \
   TestHelpers::Minkowski::extrinsic_curvature_sphere(        \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x) noexcept;
@@ -219,9 +218,9 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (3), (double, DataVector),
 #undef INSTANTIATE
 
 template Scalar<DataVector> TestHelpers::Kerr::horizon_ricci_scalar(
-    const Scalar<DataVector>& horizon_radius, const double& mass,
-    const double& dimensionless_spin_z) noexcept;
+    const Scalar<DataVector>& horizon_radius, const double mass,
+    const double dimensionless_spin_z) noexcept;
 template Scalar<DataVector> TestHelpers::Kerr::horizon_ricci_scalar(
     const Scalar<DataVector>& horizon_radius_with_spin_on_z_axis,
     const YlmSpherepack& ylm_with_spin_on_z_axis, const YlmSpherepack& ylm,
-    const double& mass, const std::array<double, 3>& spin) noexcept;
+    const double mass, const std::array<double, 3>& spin) noexcept;

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
@@ -90,7 +90,7 @@ Scalar<DataType> horizon_ricci_scalar(
       (3.0 * square(get(horizon_radius)) - 2.0 * square(kerr_r_plus) -
        3.0 * square(kerr_spin_a)));
   get(ricci_scalar) /= cube(-1.0 * square(get(horizon_radius)) +
-                               square(kerr_spin_a) + 2.0 * square(kerr_r_plus));
+                            square(kerr_spin_a) + 2.0 * square(kerr_r_plus));
   return ricci_scalar;
 }
 

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp
@@ -26,7 +26,7 @@ namespace Schwarzschild {
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ii<DataType, SpatialDim, Frame> spatial_ricci(
-    const tnsr::I<DataType, SpatialDim, Frame>& x, const double& mass) noexcept;
+    const tnsr::I<DataType, SpatialDim, Frame>& x, double mass) noexcept;
 }  // namespace Schwarzschild
 
 namespace Minkowski {
@@ -56,9 +56,9 @@ namespace Kerr {
  * in terms of mass `mass` and dimensionless spin `dimensionless_spin_z`.
  */
 template <typename DataType>
-Scalar<DataType> horizon_ricci_scalar(
-    const Scalar<DataType>& horizon_radius, const double& mass,
-    const double& dimensionless_spin_z) noexcept;
+Scalar<DataType> horizon_ricci_scalar(const Scalar<DataType>& horizon_radius,
+                                      double mass,
+                                      double dimensionless_spin_z) noexcept;
 
 /*!
  * \ingroup TestingFrameworkGroup
@@ -73,8 +73,7 @@ template <typename DataType>
 Scalar<DataType> horizon_ricci_scalar(
     const Scalar<DataType>& horizon_radius_with_spin_on_z_axis,
     const YlmSpherepack& ylm_with_spin_on_z_axis, const YlmSpherepack& ylm,
-    const double& mass,
-    const std::array<double, 3>& dimensionless_spin) noexcept;
+    double mass, const std::array<double, 3>& dimensionless_spin) noexcept;
 
 }  // namespace Kerr
 }  // namespace TestHelpers

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -222,7 +222,7 @@ void test_ricci_scalar(const Solution& solution,
 }
 
 template <typename Solution, typename ExpectedLambda>
-void test_area_element(const Solution& solution, const double& surface_radius,
+void test_area_element(const Solution& solution, const double surface_radius,
                        const ExpectedLambda& expected) noexcept {
   const auto box = db::create<
       db::AddSimpleTags<StrahlkorperTags::items_tags<Frame::Inertial>>,

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -40,8 +40,8 @@ template <typename X, typename Symm, typename IndexList>
 class Tensor;
 
 namespace {
-double multiply_by_two(const double& value) { return 2.0 * value; }
-std::string append_word(const std::string& text, const double& value) {
+double multiply_by_two(const double value) { return 2.0 * value; }
+std::string append_word(const std::string& text, const double value) {
   std::stringstream ss;
   ss << value;
   return text + ss.str();
@@ -96,7 +96,7 @@ struct TagTensor : db::ComputeTag {
 /// [compute_item_tag_function]
 struct ComputeLambda0 : db::ComputeTag {
   static std::string name() noexcept { return "ComputeLambda0"; }
-  static constexpr double function(const double& a) { return 3.0 * a; }
+  static constexpr double function(const double a) { return 3.0 * a; }
   using argument_tags = tmpl::list<Tag0>;
 };
 /// [compute_item_tag_function]
@@ -466,7 +466,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate",
       make_not_null(&original_box),
       [](const gsl::not_null<double*> tag0,
          const gsl::not_null<std::vector<double>*> tag1,
-         const double& compute_tag0) {
+         const double compute_tag0) {
         CHECK(6.28 == compute_tag0);
         *tag0 = 10.32;
         (*tag1)[0] = 837.2;
@@ -1484,7 +1484,7 @@ static_assert(
 
 namespace {
 void multiply_by_two_mutate(const gsl::not_null<std::vector<double>*> t,
-                            const double& value) {
+                            const double value) {
   if (t->empty()) {
     t->resize(10);
   }
@@ -1492,7 +1492,7 @@ void multiply_by_two_mutate(const gsl::not_null<std::vector<double>*> t,
     p = 2.0 * value;
   }
 }
-std::vector<double> multiply_by_two_non_mutate(const double& value) {
+std::vector<double> multiply_by_two_non_mutate(const double value) {
   return std::vector<double>(10, 2.0 * value);
 }
 
@@ -1501,7 +1501,7 @@ void mutate_variables(
     const gsl::not_null<Variables<tmpl::list<test_databox_tags::ScalarTag,
                                              test_databox_tags::VectorTag>>*>
         t,
-    const double& value) {
+    const double value) {
   if (t->number_of_grid_points() != 10) {
     *t = Variables<
         tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>(
@@ -1595,7 +1595,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutating_compute_item",
       make_not_null(&original_box),
       [](const gsl::not_null<double*> tag0,
          const gsl::not_null<std::vector<double>*> tag1,
-         const double& compute_tag0) {
+         const double compute_tag0) {
         CHECK(6.28 == compute_tag0);
         *tag0 = 10.32;
         (*tag1)[0] = 837.2;
@@ -2179,7 +2179,7 @@ struct OverloadType : db::ComputeTag {
 
   static constexpr double function(const int& a) noexcept { return 5 * a; }
 
-  static constexpr double function(const double& a) noexcept { return 3.2 * a; }
+  static constexpr double function(const double a) noexcept { return 3.2 * a; }
   using argument_tags = tmpl::list<ArgumentTag>;
 };
 /// [overload_compute_tag_type]
@@ -2189,9 +2189,9 @@ template <typename ArgumentTag0, typename ArgumentTag1 = void>
 struct OverloadNumberOfArgs : db::ComputeTag {
   static std::string name() noexcept { return "OverloadNumberOfArgs"; }
 
-  static constexpr double function(const double& a) noexcept { return 3.2 * a; }
+  static constexpr double function(const double a) noexcept { return 3.2 * a; }
 
-  static constexpr double function(const double& a, const double& b) noexcept {
+  static constexpr double function(const double a, const double b) noexcept {
     return a * b;
   }
 

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxDocumentation.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxDocumentation.cpp
@@ -310,7 +310,7 @@ return density * volume *  velocity * velocity / radius;
 }
 
 double mass_from_density_and_volume(
-  const double& density, const double& volume) noexcept {
+  const double density, const double volume) noexcept {
   return density * volume;
 }
 /// [compute_tags]
@@ -322,7 +322,7 @@ struct MassCompute : db::ComputeTag, Mass {
 /// [compute_tags]
 
 double acceleration_from_velocity_and_radius(
-  const double& velocity, const double& radius) noexcept {
+  const double velocity, const double radius) noexcept {
   return velocity * velocity / radius;
 }
 
@@ -344,7 +344,7 @@ struct Force : db::SimpleTag {
 struct ForceCompute : db::ComputeTag, Force {
   static std::string name() noexcept { return "ForceCompute"; }
   static constexpr auto function(
-    const double& mass, const double& acceleration) noexcept {
+    const double mass, const double acceleration) noexcept {
     return mass * acceleration; }
   using argument_tags = tmpl::list<Mass, Acceleration>;
 };
@@ -478,8 +478,8 @@ db::mutate_apply<
   tmpl::list<TimeStep, EarthGravity>>(
   [](const gsl::not_null<double*> time,
      const gsl::not_null<double*> falling_speed,
-     const double& time_step,
-     const double& earth_gravity) {
+     const double time_step,
+     const double earth_gravity) {
     *time += time_step;
     *falling_speed += time_step * earth_gravity;
   },

--- a/tests/Unit/DataStructures/DataBox/Test_Deferred.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_Deferred.cpp
@@ -22,7 +22,7 @@ struct func {
 double dummy() { return 6.7; }
 
 struct func2 {
-  double operator()(const double& t) const { return t; }
+  double operator()(const double t) const { return t; }
 };
 
 double lazy_function(const double t) { return 10.0 * t; }

--- a/tests/Unit/Domain/Test_InterfaceHelpers.cpp
+++ b/tests/Unit/Domain/Test_InterfaceHelpers.cpp
@@ -42,8 +42,8 @@ void test_interface_apply(
   const auto computed_number_on_interfaces =
       interface_apply<DirectionsTag, tmpl::list<SomeNumber, SomeVolumeArgument>,
                       tmpl::list<SomeVolumeArgument>>(
-          [](const double& some_number_on_interface,
-             const double& volume_argument, const double factor) noexcept {
+          [](const double some_number_on_interface,
+             const double volume_argument, const double factor) noexcept {
             return factor * some_number_on_interface + volume_argument;
           },
           box, 2.);
@@ -61,8 +61,8 @@ void test_interface_apply(
   const auto computed_numbers_with_base_tag =
       interface_apply<DirectionsTag, tmpl::list<SomeNumber, VolumeArgumentBase>,
                       tmpl::list<VolumeArgumentBase>>(
-          [](const double& some_number_on_interface,
-             const double& volume_argument, const double factor) noexcept {
+          [](const double some_number_on_interface,
+             const double volume_argument, const double factor) noexcept {
             return factor * some_number_on_interface + volume_argument;
           },
           box, 2.);

--- a/tests/Unit/Elliptic/Test_FirstOrderComputeTags.cpp
+++ b/tests/Unit/Elliptic/Test_FirstOrderComputeTags.cpp
@@ -36,7 +36,7 @@ struct Fluxes {
   using argument_tags = tmpl::list<AnArgument>;
   static void apply(
       const gsl::not_null<tnsr::I<DataVector, Dim>*> flux_for_field,
-      const double& an_argument,
+      const double an_argument,
       const tnsr::i<DataVector, Dim>& auxiliary_field) {
     for (size_t d = 0; d < Dim; d++) {
       flux_for_field->get(d) = auxiliary_field.get(d) * an_argument;
@@ -44,7 +44,7 @@ struct Fluxes {
   }
   static void apply(
       const gsl::not_null<tnsr::Ij<DataVector, Dim>*> flux_for_aux_field,
-      const double& an_argument, const Scalar<DataVector>& field) {
+      const double an_argument, const Scalar<DataVector>& field) {
     std::fill(flux_for_aux_field->begin(), flux_for_aux_field->end(), 0.);
     for (size_t d = 0; d < Dim; d++) {
       flux_for_aux_field->get(d, d) = get(field) * an_argument;
@@ -55,7 +55,7 @@ struct Fluxes {
 struct Sources {
   using argument_tags = tmpl::list<AnArgument>;
   static void apply(const gsl::not_null<Scalar<DataVector>*> source_for_field,
-                    const double& an_argument,
+                    const double an_argument,
                     const Scalar<DataVector>& field) {
     get(*source_for_field) = get(field) * square(an_argument);
   }

--- a/tests/Unit/Elliptic/Test_FirstOrderOperator.cpp
+++ b/tests/Unit/Elliptic/Test_FirstOrderOperator.cpp
@@ -46,7 +46,7 @@ struct Fluxes {
   using argument_tags = tmpl::list<AnArgument>;
   static void apply(
       const gsl::not_null<tnsr::I<DataVector, Dim>*> flux_for_field,
-      const double& an_argument,
+      const double an_argument,
       const tnsr::i<DataVector, Dim>& auxiliary_field) {
     for (size_t d = 0; d < Dim; d++) {
       flux_for_field->get(d) = auxiliary_field.get(d) * an_argument;
@@ -54,7 +54,7 @@ struct Fluxes {
   }
   static void apply(
       const gsl::not_null<tnsr::Ij<DataVector, Dim>*> flux_for_aux_field,
-      const double& an_argument, const Scalar<DataVector>& field) {
+      const double an_argument, const Scalar<DataVector>& field) {
     std::fill(flux_for_aux_field->begin(), flux_for_aux_field->end(), 0.);
     for (size_t d = 0; d < Dim; d++) {
       flux_for_aux_field->get(d, d) = get(field) * an_argument;
@@ -65,7 +65,7 @@ struct Fluxes {
 struct Sources {
   using argument_tags = tmpl::list<AnArgument>;
   static void apply(const gsl::not_null<Scalar<DataVector>*> source_for_field,
-                    const double& an_argument,
+                    const double an_argument,
                     const Scalar<DataVector>& field) {
     get(*source_for_field) = get(field) * square(an_argument);
   }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -111,13 +111,13 @@ struct TestFunctionHelper;
 template <>
 struct TestFunctionHelper<Tags::Square> {
   static constexpr size_t npts = 15;
-  static double apply(const double& a) noexcept { return square(a); }
+  static double apply(const double a) noexcept { return square(a); }
   static double coords(size_t i) noexcept { return 1.0 + 0.1 * i; }
 };
 template <>
 struct TestFunctionHelper<Tags::Negate> {
   static constexpr size_t npts = 17;
-  static double apply(const double& a) noexcept { return -square(a); }
+  static double apply(const double a) noexcept { return -square(a); }
   static double coords(size_t i) noexcept { return 1.1 + 0.0875 * i; }
 };
 

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_GslMultiRoot.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_GslMultiRoot.cpp
@@ -19,7 +19,7 @@ namespace {
 // f_2 (x0, x1) = b (x1 - x0**2)
 class Rosenbrock {
  public:
-  Rosenbrock(const double& a, const double& b) : a_(a), b_(b) {}
+  Rosenbrock(const double a, const double b) : a_(a), b_(b) {}
   std::array<double, 2> operator()(const std::array<double, 2>& x) const
       noexcept {
     const double y0 = a_ * (1.0 - x[0]);
@@ -38,7 +38,7 @@ class Rosenbrock {
 
 class RosenbrockNoJac {
  public:
-  RosenbrockNoJac(const double& a, const double& b) : a_(a), b_(b) {}
+  RosenbrockNoJac(const double a, const double b) : a_(a), b_(b) {}
   std::array<double, 2> operator()(const std::array<double, 2>& x) const
       noexcept {
     const double y0 = a_ * (1.0 - x[0]);
@@ -55,7 +55,7 @@ class RosenbrockNoJac {
 // f_2 (x0, x1) = a*x0 + b*x1 + c
 class BadFunction {
  public:
-  BadFunction(const double& a, const double& b, const double& c)
+  BadFunction(const double a, const double b, const double c)
       : a_(a), b_(b), c_(c) {}
   std::array<double, 2> operator()(const std::array<double, 2>& x) const
       noexcept {

--- a/tests/Unit/Parallel/Actions/Test_Goto.cpp
+++ b/tests/Unit/Parallel/Actions/Test_Goto.cpp
@@ -23,7 +23,7 @@ struct Counter : db::SimpleTag {
 
 struct HasConverged : db::ComputeTag {
   using argument_tags = tmpl::list<Counter>;
-  static bool function(const size_t& counter) noexcept { return counter >= 2; }
+  static bool function(const size_t counter) noexcept { return counter >= 2; }
   static std::string name() noexcept { return "HasConverged"; }
 };
 

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -303,7 +303,7 @@ struct test_args {
             typename ArrayIndex>
   static void apply(db::DataBox<DbTags>& /*box*/,
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/, const double& v0,
+                    const ArrayIndex& /*array_index*/, const double v0,
                     std::vector<double>&& v1) noexcept {
     SPECTRE_PARALLEL_REQUIRE(v0 == 4.82937);
     SPECTRE_PARALLEL_REQUIRE(v1 == (std::vector<double>{3.2, -8.4, 7.5}));

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddComputeTags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddComputeTags.cpp
@@ -25,7 +25,7 @@ struct SquareNumber : db::SimpleTag {
 };
 
 struct SquareNumberCompute : SquareNumber, db::ComputeTag {
-  static double function(const double& some_number) noexcept {
+  static double function(const double some_number) noexcept {
     return square(some_number);
   }
   using argument_tags = tmpl::list<SomeNumber>;

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
@@ -39,7 +39,7 @@ struct DummyTimeTag : db::SimpleTag {
 template <typename Tag>
 struct TagMultiplyByTwo : db::ComputeTag {
   static std::string name() noexcept { return "MultiplyByTwo"; }
-  static double function(const double& t) noexcept { return t * 2.0; }
+  static double function(const double t) noexcept { return t * 2.0; }
   using argument_tags = tmpl::list<Tag>;
 };
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_WrappedGr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_WrappedGr.cpp
@@ -28,8 +28,8 @@
 
 namespace {
 void compare_different_wrapped_solutions(
-    const double& mass, const std::array<double, 3>& spin,
-    const std::array<double, 3>& center, const double& mass2,
+    const double mass, const std::array<double, 3>& spin,
+    const std::array<double, 3>& center, const double mass2,
     const std::array<double, 3>& spin2,
     const std::array<double, 3>& center2) noexcept {
   const gr::Solutions::KerrSchild& solution{mass, spin, center};

--- a/tests/Unit/Pypp/CheckWithRandomValues.hpp
+++ b/tests/Unit/Pypp/CheckWithRandomValues.hpp
@@ -77,7 +77,7 @@ struct ConvertToTensorImpl;
 
 template <typename UsedForSize>
 struct ConvertToTensorImpl<double, UsedForSize> {
-  static auto apply(const double& value,
+  static auto apply(const double value,
                     const UsedForSize& used_for_size) noexcept {
     return make_with_value<Scalar<DataVector>>(used_for_size, value);
   }
@@ -743,7 +743,7 @@ void check_with_random_values(
  *
  * \code
  * template <class Arg1, size_t Arg2, class Arg3>
- * my_function(const double& var_1, const int& var_2) noexcept { ... }
+ * my_function(const double var_1, const int& var_2) noexcept { ... }
  * \endcode
  *
  * can be invoked by writing

--- a/tests/Unit/Pypp/Pypp.hpp
+++ b/tests/Unit/Pypp/Pypp.hpp
@@ -129,7 +129,7 @@ struct SliceContainerImpl<Scalar<SpinWeighted<ValueType, Spin>>> {
 
 template <>
 struct SliceContainerImpl<double> {
-  static double apply(const double& t, const size_t /*slice_index*/) noexcept {
+  static double apply(const double t, const size_t /*slice_index*/) noexcept {
     return t;
   }
 };

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -136,7 +136,7 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
         make_not_null(&before_box),
         [&rhs, &substep, &substep_times ](
             const gsl::not_null<db::item_type<history_tag>*> history,
-            const double& vars) noexcept {
+            const double vars) noexcept {
           const Time& time = gsl::at(substep_times, substep);
           history->insert(TimeStepId(true, 0, time), vars,
                           rhs(time.value(), vars));
@@ -152,7 +152,7 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
         [&rhs, &substep, &substep_times ](
             const gsl::not_null<db::item_type<alternative_history_tag>*>
                 alternative_history,
-            const double& alternative_vars) noexcept {
+            const double alternative_vars) noexcept {
           const Time& time = gsl::at(substep_times, substep);
           alternative_history->insert(TimeStepId(true, 0, time),
                                       alternative_vars,

--- a/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.cpp
+++ b/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.cpp
@@ -216,7 +216,7 @@ void equal_rate_boundary(const LtsTimeStepper& stepper,
 
   auto analytic = [](double t) { return sin(t); };
   auto driver = [](double t) { return cos(t); };
-  auto coupling = [=](const double& local, const double& remote) {
+  auto coupling = [=](const double local, const double remote) {
     CHECK(local == unused_local_deriv);
     return remote;
   };


### PR DESCRIPTION
## Proposed changes

This is a "cleanup" PR.

Reduces some unneeded pass-by-reference of function arguments 
- `const double&` -> `const double`
- `const size_t&` -> `const size_t`

Changes most return-by-reference functions `const double& func(...)` to return by value, although not in the case of `const T& operator[]`.

Does _not_ remove references from
- "alias" uses like `const double& x = indexing into some data structure`
- cases where reference is needed for template-matching
- BLAS interface cases 


### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
