### PR TITLE
Small cleanup for Newtonian Euler

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.cpp
@@ -8,7 +8,9 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/Tags.hpp"  // IWYU pragma: keep
+#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/Overloader.hpp"
 
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
@@ -17,38 +19,56 @@
 namespace NewtonianEuler {
 
 template <typename DataType, size_t ThermodynamicDim>
-Scalar<DataType> sound_speed_squared(
+void sound_speed_squared(
+    const gsl::not_null<Scalar<DataType>*> result,
     const Scalar<DataType>& mass_density,
     const Scalar<DataType>& specific_internal_energy,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
         equation_of_state) noexcept {
-  DataType sound_speed_squared{};
+  destructive_resize_components(result, get_size(get(mass_density)));
   make_overloader(
       [&mass_density,
-       &sound_speed_squared ](const EquationsOfState::EquationOfState<false, 1>&
-                                  the_equation_of_state) noexcept {
-        sound_speed_squared =
+       &result ](const EquationsOfState::EquationOfState<false, 1>&
+                     the_equation_of_state) noexcept {
+        get(*result) =
             get(the_equation_of_state.chi_from_density(mass_density)) +
             get(the_equation_of_state
                     .kappa_times_p_over_rho_squared_from_density(mass_density));
       },
       [&mass_density, &specific_internal_energy,
-       &sound_speed_squared ](const EquationsOfState::EquationOfState<false, 2>&
-                                  the_equation_of_state) noexcept {
-        sound_speed_squared =
+       &result ](const EquationsOfState::EquationOfState<false, 2>&
+                     the_equation_of_state) noexcept {
+        get(*result) =
             get(the_equation_of_state.chi_from_density_and_energy(
                 mass_density, specific_internal_energy)) +
             get(the_equation_of_state
                     .kappa_times_p_over_rho_squared_from_density_and_energy(
                         mass_density, specific_internal_energy));
       })(equation_of_state);
-  return Scalar<DataType>{sound_speed_squared};
+}
+
+template <typename DataType, size_t ThermodynamicDim>
+Scalar<DataType> sound_speed_squared(
+    const Scalar<DataType>& mass_density,
+    const Scalar<DataType>& specific_internal_energy,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+        equation_of_state) noexcept {
+  Scalar<DataType> result{};
+  sound_speed_squared(make_not_null(&result), mass_density,
+                      specific_internal_energy, equation_of_state);
+  return result;
 }
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATE(_, data)                                            \
+  template void sound_speed_squared(                                    \
+      const gsl::not_null<Scalar<DTYPE(data)>*> result,                 \
+      const Scalar<DTYPE(data)>& mass_density,                          \
+      const Scalar<DTYPE(data)>& specific_internal_energy,              \
+      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>& \
+          equation_of_state) noexcept;                                  \
   template Scalar<DTYPE(data)> sound_speed_squared(                     \
       const Scalar<DTYPE(data)>& mass_density,                          \
       const Scalar<DTYPE(data)>& specific_internal_energy,              \

--- a/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp
@@ -6,16 +6,20 @@
 #include <cstddef>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/Tags.hpp"  // IWYU pragma: keep
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 // IWYU pragma: no_forward_declare hydro::Tags::EquationOfState
 
 namespace NewtonianEuler {
+//@{
 /// Computes the Newtonian sound speed squared
 /// \f$c_s^2 = \chi + p\kappa / \rho^2\f$, where
 /// \f$p\f$ is the fluid pressure, \f$\rho\f$ is the mass density,
@@ -23,11 +27,20 @@ namespace NewtonianEuler {
 /// \f$\kappa = (\partial p/ \partial \epsilon)_\rho\f$, where
 /// \f$\epsilon\f$ is the specific internal energy.
 template <typename DataType, size_t ThermodynamicDim>
+void sound_speed_squared(
+    gsl::not_null<Scalar<DataType>*> result,
+    const Scalar<DataType>& mass_density,
+    const Scalar<DataType>& specific_internal_energy,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+        equation_of_state) noexcept;
+
+template <typename DataType, size_t ThermodynamicDim>
 Scalar<DataType> sound_speed_squared(
     const Scalar<DataType>& mass_density,
     const Scalar<DataType>& specific_internal_energy,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
         equation_of_state) noexcept;
+//@}
 
 namespace Tags {
 /// Compute item for the sound speed squared \f$c_s^2\f$.
@@ -36,18 +49,22 @@ namespace Tags {
 /// Can be retrieved using `NewtonianEuler::Tags::SoundSpeedSquared`
 template <typename DataType>
 struct SoundSpeedSquaredCompute : SoundSpeedSquared<DataType>, db::ComputeTag {
-  using base = SoundSpeedSquared<DataType>;
-  template <typename EquationOfStateType>
-  static Scalar<DataType> function(
-      const Scalar<DataType>& mass_density,
-      const Scalar<DataType>& specific_internal_energy,
-      const EquationOfStateType& equation_of_state) noexcept {
-    return sound_speed_squared(mass_density, specific_internal_energy,
-                               equation_of_state);
-  }
   using argument_tags =
       tmpl::list<MassDensity<DataType>, SpecificInternalEnergy<DataType>,
                  hydro::Tags::EquationOfStateBase>;
+
+  using return_type = Scalar<DataType>;
+
+  template <typename EquationOfStateType>
+  static void function(const gsl::not_null<Scalar<DataType>*> result,
+                       const Scalar<DataType>& mass_density,
+                       const Scalar<DataType>& specific_internal_energy,
+                       const EquationOfStateType& equation_of_state) noexcept {
+    sound_speed_squared(result, mass_density, specific_internal_energy,
+                        equation_of_state);
+  }
+
+  using base = SoundSpeedSquared<DataType>;
 };
 
 /// Compute item for the sound speed \f$c_s\f$.
@@ -55,12 +72,16 @@ struct SoundSpeedSquaredCompute : SoundSpeedSquared<DataType>, db::ComputeTag {
 /// Can be retrieved using `NewtonianEuler::Tags::SoundSpeed`
 template <typename DataType>
 struct SoundSpeedCompute : SoundSpeed<DataType>, db::ComputeTag {
-  using base = SoundSpeed<DataType>;
-  static Scalar<DataType> function(
-      const Scalar<DataType>& sound_speed_squared) noexcept {
-    return Scalar<DataType>{sqrt(get(sound_speed_squared))};
-  }
   using argument_tags = tmpl::list<SoundSpeedSquared<DataType>>;
+
+  using return_type = Scalar<DataType>;
+
+  static void function(const gsl::not_null<Scalar<DataType>*> result,
+                       const Scalar<DataType>& sound_speed_squared) noexcept {
+    get(*result) = sqrt(get(sound_speed_squared));
+  }
+
+  using base = SoundSpeed<DataType>;
 };
 }  // namespace Tags
 }  // namespace NewtonianEuler

--- a/src/Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp
@@ -27,11 +27,8 @@ struct Pressure;
 template <typename DataType>
 struct SoundSpeed;
 template <typename DataType>
-struct SoundSpeedCompute;
-template <typename DataType>
 struct SoundSpeedSquared;
-template <typename DataType>
-struct SoundSpeedSquaredCompute;
+
 struct SourceTermBase;
 template <typename InitialDataType>
 struct SourceTerm;


### PR DESCRIPTION
## Proposed changes

- Remove unnecessary allocation
- Remove unnecessary declarations
- Cleanup in char speeds test
- Add mutating overload for sound speed functions

### Types of changes:

- [ ] Bugfix
- [ x] New feature
- [x ] Refactor

### Component:

- [x ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
