### PR TITLE
Add 0-dimensional specialization of definite_integral

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.cpp
@@ -24,6 +24,17 @@
 // Note: The inner loop is over x because the memory layout used by SpECTRE is
 //       x-varies-fastest.
 
+// This specialization enables dim-independent integrals on boundaries:
+// a 0-dimensional mesh arises at the boundary of a 1-dimensional element.
+template <>
+double definite_integral<0>(const DataVector& integrand,
+                            const Mesh<0>& /*mesh*/) noexcept {
+  ASSERT(integrand.size() == 1,
+         "A 0-dimensional mesh has one point, but integrand has "
+             << integrand.size() << " points");
+  return integrand[0];
+}
+
 template <>
 double definite_integral<1>(const DataVector& integrand,
                             const Mesh<1>& mesh) noexcept {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
@@ -16,6 +16,12 @@
 #include "Utilities/Literals.hpp"
 
 namespace {
+void test_definite_integral_0d() {
+  const double value = 1.234;
+  const DataVector data(1, value);
+  CHECK(value == approx(definite_integral(data, Mesh<0>{})));
+}
+
 void test_definite_integral_1d(const Mesh<1>& mesh) {
   const DataVector& x = Spectral::collocation_points(mesh);
   DataVector integrand(mesh.number_of_grid_points());
@@ -78,6 +84,8 @@ void test_definite_integral_3d(const Mesh<3>& mesh) {
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.DefiniteIntegral",
                   "[NumericalAlgorithms][LinearOperators][Unit]") {
+  test_definite_integral_0d();
+
   constexpr size_t min_extents =
       Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
                                          Spectral::Quadrature::GaussLobatto>;


### PR DESCRIPTION
## Proposed changes

This specialization enables dimension-independent integrals on boundaries: a 0-dimensional mesh arises at the boundary of a 1-dimensional element.

(Or was there a particular reason we didn't already have this specialization? Is there a preference for special handling of the 1-dimensional case in order to avoid integrations on the boundaries?)

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
