### PR TITLE
Fix strange behavior of 0-dimensional Meshes

### DIFF
--- a/src/Domain/Mesh.hpp
+++ b/src/Domain/Mesh.hpp
@@ -10,6 +10,7 @@
 #include <cstddef>
 
 #include "DataStructures/Index.hpp"
+#include "ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
@@ -64,6 +65,9 @@ class Mesh {
   Mesh(const size_t isotropic_extents, const Spectral::Basis basis,
        const Spectral::Quadrature quadrature) noexcept
       : extents_(isotropic_extents) {
+    ASSERT(Dim > 0 or isotropic_extents == 1,
+           "Can't make a 0-dimensional Mesh with " << isotropic_extents
+                                                   << " points");
     bases_.fill(basis);
     quadratures_.fill(quadrature);
   }

--- a/tests/Unit/Domain/Test_Mesh.cpp
+++ b/tests/Unit/Domain/Test_Mesh.cpp
@@ -12,7 +12,6 @@
 #include "DataStructures/Index.hpp"
 #include "DataStructures/IndexIterator.hpp"
 #include "Domain/Mesh.hpp"
-#include "Domain/Tags.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/GetOutput.hpp"
@@ -53,6 +52,26 @@ void test_extents_basis_and_quadrature(
   }
 }
 
+// A Mesh in 0d has some unique behavior, tested separately here
+void test_mesh_0d() noexcept {
+  INFO("Test Mesh<0>");
+  const Mesh<0> mesh0d{};
+  CHECK(mesh0d.number_of_grid_points() == 1);
+  CHECK(mesh0d ==
+        Mesh<0>(1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss));
+  CHECK(mesh0d ==
+        Mesh<0>(1, Spectral::Basis::Chebyshev, Spectral::Quadrature::Gauss));
+  CHECK(mesh0d == Mesh<0>(1, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto));
+
+  CHECK(Mesh<0>{}.slice_through() == Mesh<0>{});
+
+  const Mesh<0> mesh0d5(5, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::Gauss);
+  CHECK(mesh0d == mesh0d5);
+  CHECK(mesh0d5.number_of_grid_points() == 1);
+}
+
 void test_uniform_lgl_mesh() noexcept {
   INFO("Uniform LGL mesh");
   const Mesh<1> mesh1d_lgl{3, Spectral::Basis::Legendre,
@@ -79,7 +98,6 @@ void test_uniform_lgl_mesh() noexcept {
 
 void test_explicit_choices_per_dimension() noexcept {
   INFO("Explicit choices per dimension");
-  CHECK(Mesh<0>{}.slice_through() == Mesh<0>{});
   const Mesh<1> mesh1d{{{2}},
                        {{Spectral::Basis::Legendre}},
                        {{Spectral::Quadrature::GaussLobatto}}};
@@ -242,6 +260,7 @@ void test_serialization() noexcept {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Mesh", "[Domain][Unit]") {
+  test_mesh_0d();
   test_uniform_lgl_mesh();
   test_explicit_choices_per_dimension();
   test_equality();

--- a/tests/Unit/Domain/Test_Mesh.cpp
+++ b/tests/Unit/Domain/Test_Mesh.cpp
@@ -65,11 +65,6 @@ void test_mesh_0d() noexcept {
                           Spectral::Quadrature::GaussLobatto));
 
   CHECK(Mesh<0>{}.slice_through() == Mesh<0>{});
-
-  const Mesh<0> mesh0d5(5, Spectral::Basis::Legendre,
-                        Spectral::Quadrature::Gauss);
-  CHECK(mesh0d == mesh0d5);
-  CHECK(mesh0d5.number_of_grid_points() == 1);
 }
 
 void test_uniform_lgl_mesh() noexcept {

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_BoundaryFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_BoundaryFlux.cpp
@@ -103,7 +103,8 @@ Scalar<DataVector> simple_boundary_flux(
   CAPTURE(num_points_per_dim);
   using BoundaryData = dg::FirstOrderScheme::BoundaryData<NumericalFluxType>;
   // Setup a mortar
-  const Mesh<Dim - 1> mortar_mesh{num_points_per_dim, Spectral::Basis::Legendre,
+  const Mesh<Dim - 1> mortar_mesh{(Dim == 1 ? 1 : num_points_per_dim),
+                                  Spectral::Basis::Legendre,
                                   Spectral::Quadrature::GaussLobatto};
   const size_t mortar_num_points = mortar_mesh.number_of_grid_points();
   dg::MortarSize<Dim - 1> mortar_size{};


### PR DESCRIPTION
## Proposed changes

It was previously possible to call the constructor of a 0d Mesh with extents larger than 1, even though the resulting Mesh would only have a single grid point.

This commit adds a check that a 0d Mesh is constructed with a single grid point, so that the constructor call actually resembles the final Mesh.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
