### PR TITLE
Add action to initialize time-dependent DG domain

### DIFF
--- a/src/Evolution/Evolution.hpp
+++ b/src/Evolution/Evolution.hpp
@@ -2,9 +2,21 @@
 // See LICENSE.txt for details.
 
 /// \file
-/// Documents the `evolution` namespace
+/// Documents the `evolution`, `evolution::dg`, `evolution::dg::Actions`, and
+/// `evolution::dg::Initialization` namespaces
 
 #pragma once
 
 /// Functionality for evolving hyperbolic partial differential equations.
-namespace evolution {}
+namespace evolution {
+/// Functionality for evolving hyperbolic partial differential equations using
+/// the discontinuous Galerkin method.
+namespace dg {
+/// %Actions for using the discontinuous Galerkin to evolve hyperbolic partial
+/// differential equations.
+namespace Actions {}
+/// Functionality for initializing the discontinuous Galerkin to evolve
+/// hyperbolic partial differential equations.
+namespace Initialization {}
+}  // namespace dg
+}  // namespace evolution

--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -1,0 +1,185 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/CreateInitialMesh.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/MinimumGridSpacing.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/TagsDomain.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class ElementIndex;
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace evolution {
+namespace dg {
+namespace Initialization {
+/*!
+ * \ingroup InitializationGroup
+ * \brief Initialize items related to the basic structure of the element
+ *
+ * ConstGlobalCache:
+ * - Uses:
+ *   - `domain::Tags::Domain<Dim, Frame::Inertial>`
+ * DataBox:
+ * - Uses:
+ *   - `domain::Tags::InitialExtents<Dim>`
+ *   - `domain::Tags::InitialFunctionsOfTime<Dim>`
+ * - Adds:
+ *   - `domain::Tags::Mesh<Dim>`
+ *   - `domain::Tags::Element<Dim>`
+ *   - `domain::Tags::ElementMap<Dim, Frame::Inertial>`
+ *   - `domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+ *      Frame::Inertial>`
+ *   - `domain::Tags::FunctionsOfTime`
+ *   - `domain::Tags::CoordinatesMeshVelocityAndJacobiansCompute<
+ *      CoordinateMap<Dim, Frame::Grid, Frame::Inertial>>`
+ *   - `domain::Tags::Coordinates<Dim, Frame::Logical>`
+ *   - `domain::Tags::Coordinates<Dim, Frame::Frid>`
+ *   - `domain::Tags::Coordinates<Dim, Frame::Inertial>`
+ *   - `domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Grid>`
+ *   - `domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>`
+ *   - `domain::Tags::MeshVelocity<Dim, Frame::Inertial>`
+ *   - `domain::Tags::DivMeshVelocity`
+ *   - `domain::Tags::MinimumGridSpacing<Dim, Frame::Inertial>>`
+ * - Removes: nothing
+ * - Modifies: nothing
+ */
+template <size_t Dim>
+struct Domain {
+  using initialization_tags =
+      tmpl::list<::domain::Tags::InitialExtents<Dim>,
+                 ::domain::Tags::InitialFunctionsOfTime<Dim>>;
+  using const_global_cache_tags = tmpl::list<::domain::Tags::Domain<Dim>>;
+
+  template <typename DataBox, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent,
+            Requires<db::tag_is_retrievable_v<
+                ::domain::Tags::InitialExtents<Dim>, DataBox>> = nullptr>
+  static auto apply(DataBox& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ElementIndex<Dim>& array_index,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using simple_tags = db::AddSimpleTags<
+        ::domain::Tags::Mesh<Dim>, ::domain::Tags::Element<Dim>,
+        ::domain::Tags::ElementMap<Dim, Frame::Grid>,
+        ::domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                      Frame::Inertial>,
+        ::domain::Tags::FunctionsOfTime>;
+
+    using compute_tags = db::AddComputeTags<
+        ::domain::Tags::LogicalCoordinates<Dim>,
+        // Compute tags for Frame::Grid quantities
+        ::domain::Tags::MappedCoordinates<
+            ::domain::Tags::ElementMap<Dim, Frame::Grid>,
+            ::domain::Tags::Coordinates<Dim, Frame::Logical>>,
+        ::domain::Tags::InverseJacobianCompute<
+            ::domain::Tags::ElementMap<Dim, Frame::Grid>,
+            ::domain::Tags::Coordinates<Dim, Frame::Logical>>,
+        // Compute tags for Frame::Inertial quantities
+        ::domain::Tags::CoordinatesMeshVelocityAndJacobiansCompute<
+            ::domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                          Frame::Inertial>>,
+
+        ::domain::Tags::InertialFromGridCoordinatesCompute<Dim>,
+        ::domain::Tags::ElementToInertialInverseJacobian<Dim>,
+        ::domain::Tags::InertialMeshVelocityCompute<Dim>,
+        evolution::domain::Tags::DivMeshVelocityCompute<Dim>,
+        // Compute tags for other mesh quantities
+        ::domain::Tags::MinimumGridSpacing<Dim, Frame::Inertial>>;
+
+    const auto& initial_extents =
+        db::get<::domain::Tags::InitialExtents<Dim>>(box);
+    const auto& domain = db::get<::domain::Tags::Domain<Dim>>(box);
+
+    const ElementId<Dim> element_id{array_index};
+    const auto& my_block = domain.blocks()[element_id.block_id()];
+    Mesh<Dim> mesh = ::domain::Initialization::create_initial_mesh(
+        initial_extents, element_id);
+    Element<Dim> element =
+        ::domain::Initialization::create_initial_element(element_id, my_block);
+    ElementMap<Dim, Frame::Grid> element_map{
+        element_id, my_block.is_time_dependent()
+                        ? my_block.moving_mesh_logical_to_grid_map().get_clone()
+                        : my_block.stationary_map().get_to_grid_frame()};
+
+    const auto& initial_functions_of_time =
+        db::get<::domain::Tags::InitialFunctionsOfTime<Dim>>(box);
+
+    std::unordered_map<
+        std::string, std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
+        functions_of_time{};
+    for (const auto& name_and_function : initial_functions_of_time) {
+      functions_of_time.insert(std::make_pair(
+          name_and_function.first, name_and_function.second->get_clone()));
+    }
+
+    std::unique_ptr<
+        ::domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, Dim>>
+        grid_to_inertial_map;
+    if (my_block.is_time_dependent()) {
+      grid_to_inertial_map =
+          my_block.moving_mesh_grid_to_inertial_map().get_clone();
+    } else {
+      grid_to_inertial_map =
+          ::domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+              ::domain::CoordinateMaps::Identity<Dim>{});
+    }
+
+    return std::make_tuple(::Initialization::merge_into_databox<
+                           Domain, simple_tags, compute_tags,
+                           ::Initialization::MergePolicy::Overwrite>(
+        std::move(box), std::move(mesh), std::move(element),
+        std::move(element_map), std::move(grid_to_inertial_map),
+        std::move(functions_of_time)));
+  }
+
+  template <typename DataBox, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<not db::tag_is_retrievable_v<
+                ::domain::Tags::InitialExtents<Dim>, DataBox>> = nullptr>
+  static std::tuple<DataBox&&> apply(
+      DataBox& /*box*/, const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    ERROR(
+        "Dependencies not fulfilled. Did you forget to terminate the phase "
+        "after removing options?");
+  }
+};
+}  // namespace Initialization
+}  // namespace dg
+}  // namespace evolution

--- a/tests/Unit/Evolution/Initialization/CMakeLists.txt
+++ b/tests/Unit/Evolution/Initialization/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_EvolutionInitialization")
 
 set(LIBRARY_SOURCES
+  Test_DgDomain.cpp
   Test_Tags.cpp
   )
 
@@ -11,5 +12,5 @@ add_test_library(
   ${LIBRARY}
   "Evolution/Initialization/"
   "${LIBRARY_SOURCES}"
-  ""
+  "DataStructures;Domain;Utilities"
   )

--- a/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
@@ -1,0 +1,495 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.hpp"
+#include "Domain/CoordinateMaps/ProductMapsTimeDep.tpp"
+#include "Domain/CoordinateMaps/Translation.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/Initialization/DgDomain.hpp"
+#include "Utilities/CloneUniquePtrs.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace {
+using TranslationMap = domain::CoordMapsTimeDependent::Translation;
+using TranslationMap2d =
+    domain::CoordMapsTimeDependent::ProductOf2Maps<TranslationMap,
+                                                   TranslationMap>;
+using TranslationMap3d = domain::CoordMapsTimeDependent::ProductOf3Maps<
+    TranslationMap, TranslationMap, TranslationMap>;
+
+using AffineMap = domain::CoordinateMaps::Affine;
+using AffineMap2d =
+    domain::CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
+using AffineMap3d =
+    domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+
+template <size_t MeshDim, typename TargetFrame>
+using TimeIndependentMap = tmpl::conditional_t<
+    MeshDim == 1, domain::CoordinateMap<Frame::Logical, TargetFrame, AffineMap>,
+    tmpl::conditional_t<
+        MeshDim == 2,
+        domain::CoordinateMap<Frame::Logical, TargetFrame, AffineMap2d>,
+        domain::CoordinateMap<Frame::Logical, TargetFrame, AffineMap3d>>>;
+
+template <size_t MeshDim>
+using TimeDependentMap = tmpl::conditional_t<
+    MeshDim == 1,
+    domain::CoordinateMap<Frame::Grid, Frame::Inertial, TranslationMap>,
+    tmpl::conditional_t<
+        MeshDim == 2,
+        domain::CoordinateMap<Frame::Grid, Frame::Inertial, TranslationMap2d>,
+        domain::CoordinateMap<Frame::Grid, Frame::Inertial, TranslationMap3d>>>;
+
+template <size_t MeshDim, typename TargetFrame>
+struct CreateAffineMap;
+
+template <typename TargetFrame>
+struct CreateAffineMap<1, TargetFrame> {
+  static TimeIndependentMap<1, TargetFrame> apply() {
+    return TimeIndependentMap<1, TargetFrame>{AffineMap{-1.0, 1.0, 2.0, 7.2}};
+  }
+};
+
+template <typename TargetFrame>
+struct CreateAffineMap<2, TargetFrame> {
+  static TimeIndependentMap<2, TargetFrame> apply() {
+    return TimeIndependentMap<2, TargetFrame>{
+        {AffineMap{-1.0, 1.0, -2.0, 2.2}, AffineMap{-1.0, 1.0, 2.0, 7.2}}};
+  }
+};
+
+template <typename TargetFrame>
+struct CreateAffineMap<3, TargetFrame> {
+  static TimeIndependentMap<3, TargetFrame> apply() {
+    return TimeIndependentMap<3, TargetFrame>{{AffineMap{-1.0, 1.0, -2.0, 2.2},
+                                               AffineMap{-1.0, 1.0, 2.0, 7.2},
+                                               AffineMap{-1.0, 1.0, 1.0, 3.5}}};
+  }
+};
+
+template <size_t MeshDim, typename TargetFrame>
+TimeIndependentMap<MeshDim, TargetFrame> create_affine_map() {
+  return CreateAffineMap<MeshDim, TargetFrame>::apply();
+}
+
+template <size_t MeshDim>
+TimeDependentMap<MeshDim> create_translation_map(
+    const std::array<std::string, 3>& f_of_t_names);
+
+template <>
+TimeDependentMap<1> create_translation_map<1>(
+    const std::array<std::string, 3>& f_of_t_names) {
+  return TimeDependentMap<1>{TranslationMap{f_of_t_names[0]}};
+}
+
+template <>
+TimeDependentMap<2> create_translation_map<2>(
+    const std::array<std::string, 3>& f_of_t_names) {
+  return TimeDependentMap<2>{
+      {TranslationMap{f_of_t_names[0]}, TranslationMap{f_of_t_names[1]}}};
+}
+
+template <>
+TimeDependentMap<3> create_translation_map<3>(
+    const std::array<std::string, 3>& f_of_t_names) {
+  return TimeDependentMap<3>{{TranslationMap{f_of_t_names[0]},
+                              TranslationMap{f_of_t_names[1]},
+                              TranslationMap{f_of_t_names[2]}}};
+}
+
+namespace Actions {
+struct IncrementTime {
+  template <typename DataBox, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent,
+            typename ArrayIndex>
+  static auto apply(DataBox& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<Tags::Time>(
+        make_not_null(&box),
+        [](const gsl::not_null<double*> time) noexcept { *time += 1.2; });
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  static constexpr size_t dim = metavariables::dim;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndex<dim>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<dim>>;
+
+  using simple_tags =
+      db::AddSimpleTags<domain::Tags::InitialExtents<dim>,
+                        domain::Tags::InitialFunctionsOfTime<dim>, Tags::Time>;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<evolution::dg::Initialization::Domain<dim>,
+                     Actions::IncrementTime, Actions::IncrementTime>>>;
+};
+
+template <size_t Dim>
+struct Metavariables {
+  using component_list = tmpl::list<Component<Metavariables>>;
+  static constexpr size_t dim = Dim;
+
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+template <size_t Dim, bool TimeDependent>
+void test() noexcept {
+  using metavars = Metavariables<Dim>;
+  using component = Component<metavars>;
+
+  PUPable_reg(SINGLE_ARG(TimeIndependentMap<Dim, Frame::Inertial>));
+  PUPable_reg(SINGLE_ARG(TimeIndependentMap<Dim, Frame::Grid>));
+  PUPable_reg(TimeDependentMap<Dim>);
+  PUPable_reg(domain::FunctionsOfTime::PiecewisePolynomial<2>);
+
+  const std::vector<std::array<size_t, Dim>> initial_extents{
+      make_array<Dim>(4_st)};
+  const size_t num_pts = pow<Dim>(4_st);
+  const std::array<double, 3> velocity{{1.2, 0.2, -8.9}};
+  const double initial_time = 0.0;
+  const std::array<std::string, 3> functions_of_time_names{
+      {"TranslationX", "TranslationY", "TranslationZ"}};
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  for (size_t i = 0; i < velocity.size(); ++i) {
+    functions_of_time.insert(std::make_pair(
+        gsl::at(functions_of_time_names, i),
+        std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+            initial_time, std::array<DataVector, 3>{
+                              {{0.0}, {gsl::at(velocity, i)}, {0.0}}})));
+  }
+
+  std::vector<Block<Dim>> blocks{1};
+  blocks[0] =
+      Block<Dim>{std::make_unique<TimeIndependentMap<Dim, Frame::Inertial>>(
+                     create_affine_map<Dim, Frame::Inertial>()),
+                 0,
+                 {}};
+  Domain<Dim> domain{std::move(blocks)};
+
+  if (TimeDependent) {
+    domain.inject_time_dependent_map_for_block(
+        0, std::make_unique<TimeDependentMap<Dim>>(
+               create_translation_map<Dim>(functions_of_time_names)));
+  }
+
+  const ElementId<Dim> self_id(0);
+  ActionTesting::MockRuntimeSystem<metavars> runner{{std::move(domain)}};
+  ActionTesting::emplace_component_and_initialize<component>(
+      &runner, self_id,
+      {initial_extents, std::move(clone_unique_ptrs(functions_of_time)),
+       initial_time});
+  runner.set_phase(metavars::Phase::Testing);
+  CHECK(ActionTesting::get_next_action_index<component>(runner, self_id) == 0);
+  ActionTesting::next_action<component>(make_not_null(&runner), self_id);
+
+  // Set up data to be used for checking correctness
+  const auto logical_to_grid_map = create_affine_map<Dim, Frame::Grid>();
+  const auto grid_to_inertial_map =
+      create_translation_map<Dim>(functions_of_time_names);
+  const auto logical_coords = ActionTesting::get_databox_tag<
+      component, domain::Tags::Coordinates<Dim, Frame::Logical>>(runner,
+                                                                 self_id);
+
+  const auto check_domain_tags_time_dependent = [&functions_of_time,
+                                                 &grid_to_inertial_map,
+                                                 &logical_coords,
+                                                 &logical_to_grid_map, num_pts,
+                                                 &runner, &self_id,
+                                                 &velocity](const double
+                                                                time) noexcept {
+    REQUIRE(ActionTesting::get_databox_tag<component, Tags::Time>(
+                runner, self_id) == time);
+    CHECK(ActionTesting::get_databox_tag<
+              component, domain::Tags::Coordinates<Dim, Frame::Inertial>>(
+              runner, self_id) ==
+          grid_to_inertial_map(logical_to_grid_map(logical_coords), time,
+                               functions_of_time));
+
+    const auto expected_grid_coords = logical_to_grid_map(logical_coords);
+    const tnsr::I<DataVector, Dim, Frame::Inertial> expected_coords =
+        grid_to_inertial_map(expected_grid_coords, time, functions_of_time);
+
+    CHECK(ActionTesting::get_databox_tag<
+              component, domain::Tags::Coordinates<Dim, Frame::Grid>>(
+              runner, self_id) == expected_grid_coords);
+
+    const auto expected_logical_to_grid_inv_jacobian =
+        logical_to_grid_map.inv_jacobian(logical_coords);
+
+    CHECK(ActionTesting::get_databox_tag<
+              component,
+              domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Grid>>(
+              runner, self_id) == expected_logical_to_grid_inv_jacobian);
+
+    const InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>
+        expected_inv_jacobian_grid_to_inertial =
+            grid_to_inertial_map.inv_jacobian(expected_grid_coords, time,
+                                              functions_of_time);
+
+    InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
+        expected_logical_to_inertial_inv_jacobian{num_pts};
+
+    for (size_t logical_i = 0; logical_i < Dim; ++logical_i) {
+      for (size_t inertial_i = 0; inertial_i < Dim; ++inertial_i) {
+        expected_logical_to_inertial_inv_jacobian.get(logical_i, inertial_i) =
+            expected_logical_to_grid_inv_jacobian.get(logical_i, 0) *
+            expected_inv_jacobian_grid_to_inertial.get(0, inertial_i);
+        for (size_t grid_i = 1; grid_i < Dim; ++grid_i) {
+          expected_logical_to_inertial_inv_jacobian.get(logical_i,
+                                                        inertial_i) +=
+              expected_logical_to_grid_inv_jacobian.get(logical_i, grid_i) *
+              expected_inv_jacobian_grid_to_inertial.get(grid_i, inertial_i);
+        }
+      }
+    }
+
+    REQUIRE(static_cast<bool>(
+        ActionTesting::get_databox_tag<
+            component, domain::Tags::CoordinatesMeshVelocityAndJacobians<Dim>>(
+            runner, self_id)));
+    const auto& coordinates_mesh_velocity_and_jacobians =
+        *ActionTesting::get_databox_tag<
+            component, domain::Tags::CoordinatesMeshVelocityAndJacobians<Dim>>(
+            runner, self_id);
+
+    for (size_t i = 0; i < Dim; ++i) {
+      // Check that the `const_cast`s and set_data_ref inside the compute tag
+      // functions worked correctly
+      CHECK(ActionTesting::get_databox_tag<
+                component, domain::Tags::Coordinates<Dim, Frame::Inertial>>(
+                runner, self_id)
+                .get(i)
+                .data() ==
+            std::get<0>(coordinates_mesh_velocity_and_jacobians).get(i).data());
+    }
+    CHECK_ITERABLE_APPROX(
+        (ActionTesting::get_databox_tag<
+            component, domain::Tags::Coordinates<Dim, Frame::Inertial>>(
+            runner, self_id)),
+        expected_coords);
+
+    for (size_t i = 0;
+         i < ActionTesting::get_databox_tag<
+                 component, domain::Tags::InverseJacobian<Dim, Frame::Logical,
+                                                          Frame::Inertial>>(
+                 runner, self_id)
+                 .size();
+         ++i) {
+      CHECK(ActionTesting::get_databox_tag<
+                component, domain::Tags::InverseJacobian<Dim, Frame::Logical,
+                                                         Frame::Inertial>>(
+                runner, self_id)[i]
+                .data() !=
+            std::get<1>(coordinates_mesh_velocity_and_jacobians)[i].data());
+    }
+    CHECK_ITERABLE_APPROX(
+        (ActionTesting::get_databox_tag<
+            component, domain::Tags::InverseJacobian<Dim, Frame::Logical,
+                                                     Frame::Inertial>>(
+            runner, self_id)),
+        expected_logical_to_inertial_inv_jacobian);
+
+    const auto expected_coords_mesh_velocity_jacobians =
+        grid_to_inertial_map.coords_frame_velocity_jacobians(
+            ActionTesting::get_databox_tag<
+                component, domain::Tags::Coordinates<Dim, Frame::Grid>>(
+                runner, self_id),
+            ActionTesting::get_databox_tag<component, ::Tags::Time>(runner,
+                                                                    self_id),
+            ActionTesting::get_databox_tag<component,
+                                           domain::Tags::FunctionsOfTime>(
+                runner, self_id));
+
+    for (size_t i = 0; i < Dim; ++i) {
+      // Check that the `const_cast`s and set_data_ref inside the compute tag
+      // functions worked correctly
+      CHECK(ActionTesting::get_databox_tag<component,
+                                           domain::Tags::MeshVelocity<Dim>>(
+                runner, self_id)
+                ->get(i)
+                .data() ==
+            std::get<3>(coordinates_mesh_velocity_and_jacobians).get(i).data());
+    }
+    CHECK_ITERABLE_APPROX(
+        (ActionTesting::get_databox_tag<component,
+                                        domain::Tags::MeshVelocity<Dim>>(
+             runner, self_id))
+            .get(),
+        std::get<3>(expected_coords_mesh_velocity_jacobians));
+
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(
+          (ActionTesting::get_databox_tag<component,
+                                          domain::Tags::MeshVelocity<Dim>>(
+               runner, self_id)
+               .get()
+               .get(i)),
+          DataVector(num_pts, gsl::at(velocity, i)));
+    }
+  };
+
+  const auto check_domain_tags_time_independent = [&logical_coords,
+                                                   &logical_to_grid_map,
+                                                   &runner, &self_id](
+                                                      const double
+                                                          time) noexcept {
+    const auto logical_to_inertial_map =
+        create_affine_map<Dim, Frame::Inertial>();
+    REQUIRE(ActionTesting::get_databox_tag<component, Tags::Time>(
+                runner, self_id) == time);
+    CHECK(ActionTesting::get_databox_tag<
+              component, domain::Tags::Coordinates<Dim, Frame::Inertial>>(
+              runner, self_id) == logical_to_inertial_map(logical_coords));
+
+    const auto expected_grid_coords = logical_to_grid_map(logical_coords);
+    CHECK(ActionTesting::get_databox_tag<
+              component, domain::Tags::Coordinates<Dim, Frame::Grid>>(
+              runner, self_id) == expected_grid_coords);
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK(ActionTesting::get_databox_tag<
+                component, domain::Tags::Coordinates<Dim, Frame::Inertial>>(
+                runner, self_id)
+                .get(i) == expected_grid_coords.get(i));
+    }
+
+    for (size_t i = 0; i < Dim; ++i) {
+      // Check that the `const_cast`s and set_data_ref inside the compute
+      // tag functions worked correctly
+      CHECK(ActionTesting::get_databox_tag<
+                component, domain::Tags::Coordinates<Dim, Frame::Inertial>>(
+                runner, self_id)
+                .get(i)
+                .data() ==
+            ActionTesting::get_databox_tag<
+                component, domain::Tags::Coordinates<Dim, Frame::Grid>>(runner,
+                                                                        self_id)
+                .get(i)
+                .data());
+    }
+
+    const auto expected_logical_to_grid_inv_jacobian =
+        logical_to_grid_map.inv_jacobian(logical_coords);
+
+    CHECK(ActionTesting::get_databox_tag<
+              component,
+              domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Grid>>(
+              runner, self_id) == expected_logical_to_grid_inv_jacobian);
+
+    const InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
+        expected_logical_to_inertial_inv_jacobian =
+            logical_to_inertial_map.inv_jacobian(logical_coords);
+
+    CHECK_ITERABLE_APPROX(
+        (ActionTesting::get_databox_tag<
+            component, domain::Tags::InverseJacobian<Dim, Frame::Logical,
+                                                     Frame::Inertial>>(
+            runner, self_id)),
+        expected_logical_to_inertial_inv_jacobian);
+    for (size_t i = 0;
+         i < ActionTesting::get_databox_tag<
+                 component, domain::Tags::InverseJacobian<Dim, Frame::Logical,
+                                                          Frame::Inertial>>(
+                 runner, self_id)
+                 .size();
+         ++i) {
+      // Check that the `const_cast`s and set_data_ref inside the compute
+      // tag functions worked correctly
+      CHECK(
+          ActionTesting::get_databox_tag<
+              component, domain::Tags::InverseJacobian<Dim, Frame::Logical,
+                                                       Frame::Inertial>>(
+              runner, self_id)[i]
+              .data() ==
+          ActionTesting::get_databox_tag<
+              component,
+              domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Grid>>(
+              runner, self_id)[i]
+              .data());
+    }
+
+    CHECK_FALSE(static_cast<bool>(
+        ActionTesting::get_databox_tag<component,
+                                       domain::Tags::MeshVelocity<Dim>>(
+            runner, self_id)));
+    CHECK_FALSE(static_cast<bool>(
+        ActionTesting::get_databox_tag<component,
+                                       domain::Tags::DivMeshVelocity>(
+            runner, self_id)));
+  };
+
+  if (TimeDependent) {
+    check_domain_tags_time_dependent(0.0);
+
+    ActionTesting::next_action<component>(make_not_null(&runner), self_id);
+    check_domain_tags_time_dependent(1.2);
+
+    ActionTesting::next_action<component>(make_not_null(&runner), self_id);
+    check_domain_tags_time_dependent(2.4);
+  } else {
+    check_domain_tags_time_independent(0.0);
+
+    ActionTesting::next_action<component>(make_not_null(&runner), self_id);
+    check_domain_tags_time_independent(1.2);
+
+    ActionTesting::next_action<component>(make_not_null(&runner), self_id);
+    check_domain_tags_time_independent(2.4);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Initialization.DgDomain",
+                  "[Parallel][Unit]") {
+  test<1, true>();
+  test<2, true>();
+  test<3, true>();
+
+  test<1, false>();
+  test<2, false>();
+  test<3, false>();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

- Add action to initialize the DG domain for the evolution code. This needs to be separate from the elliptic initialization action since the elliptic code doesn't need time-dependent domains. 

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
