### PR TITLE
Report low-level I/O errors in input file parsing

### DIFF
--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -8,6 +8,7 @@
 
 #include <cstring>
 #include <exception>
+#include <ios>
 #include <iterator>
 #include <map>
 #include <ostream>
@@ -358,10 +359,12 @@ void Options<OptionList, Group>::parse_file(
   context_.append("In " + file_name);
   try {
     parse(YAML::LoadFile(file_name));
-  } catch (YAML::BadFile& /*e*/) {
+  } catch (const YAML::BadFile& /*e*/) {
     ERROR("Could not open the input file " << file_name);
   } catch (const YAML::Exception& e) {
     parser_error(e);
+  } catch (const std::ios_base::failure& e) {
+    ERROR("I/O error reading " << file_name << ": " << e.what());
   }
 }
 


### PR DESCRIPTION
Usually, this means your input file is actually a directory.

Also add a const while I'm in the area.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
