### PR TITLE
Interpolation events are now per target.

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -202,9 +202,9 @@ struct EvolutionMetavars {
   using triggers = Triggers::time_triggers;
 
   // Events include the observation events and finding the horizon
-  using events = tmpl::push_back<
-      observation_events,
-      intrp::Events::Registrars::Interpolate<3, interpolator_source_vars>>;
+  using events = tmpl::push_back<observation_events,
+                                 intrp::Events::Registrars::Interpolate<
+                                     3, Horizon, interpolator_source_vars>>;
 
   // A tmpl::list of tags to be added to the ConstGlobalCache by the
   // metavariables

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -163,7 +163,7 @@ struct EvolutionMetavars {
         tmpl::list<StrahlkorperGr::Tags::AreaElement<Frame::Inertial>>;
   };
 
-  struct Horizon {
+  struct AhA {
     using tags_to_observe =
         tmpl::list<StrahlkorperGr::Tags::SurfaceIntegral<Unity, frame>>;
     using compute_items_on_source = tmpl::list<
@@ -180,14 +180,14 @@ struct EvolutionMetavars {
         tmpl::list<StrahlkorperGr::Tags::AreaElement<frame>, Unity>,
         tags_to_observe>;
     using compute_target_points =
-        intrp::Actions::ApparentHorizon<Horizon, ::Frame::Inertial>;
+        intrp::Actions::ApparentHorizon<AhA, ::Frame::Inertial>;
     using post_interpolation_callback =
-        intrp::callbacks::FindApparentHorizon<Horizon>;
+        intrp::callbacks::FindApparentHorizon<AhA>;
     using post_horizon_find_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, Horizon,
-                                                     Horizon>;
+        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA,
+                                                     AhA>;
   };
-  using interpolation_target_tags = tmpl::list<Horizon>;
+  using interpolation_target_tags = tmpl::list<AhA>;
   using interpolator_source_vars =
       tmpl::list<gr::Tags::SpacetimeMetric<volume_dim, frame>,
                  GeneralizedHarmonic::Tags::Pi<volume_dim, frame>,
@@ -204,7 +204,7 @@ struct EvolutionMetavars {
   // Events include the observation events and finding the horizon
   using events = tmpl::push_back<observation_events,
                                  intrp::Events::Registrars::Interpolate<
-                                     3, Horizon, interpolator_source_vars>>;
+                                     3, AhA, interpolator_source_vars>>;
 
   // A tmpl::list of tags to be added to the ConstGlobalCache by the
   // metavariables
@@ -220,7 +220,7 @@ struct EvolutionMetavars {
 
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       tmpl::push_back<Event<observation_events>::creatable_classes,
-                      typename Horizon::post_horizon_find_callback>>;
+                      typename AhA::post_horizon_find_callback>>;
 
   using step_actions = tmpl::flatten<tmpl::list<
       dg::Actions::ComputeNonconservativeBoundaryFluxes<
@@ -300,7 +300,7 @@ struct EvolutionMetavars {
       observers::Observer<EvolutionMetavars>,
       observers::ObserverWriter<EvolutionMetavars>,
       intrp::Interpolator<EvolutionMetavars>,
-      intrp::InterpolationTarget<EvolutionMetavars, Horizon>,
+      intrp::InterpolationTarget<EvolutionMetavars, AhA>,
       DgElementArray<
           EvolutionMetavars,
           tmpl::list<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -33,7 +33,7 @@ endfunction(add_grmhd_executable)
 
 add_grmhd_executable(
   FishboneMoncriefDisk
-  RelativisticEuler::Solutions::FishboneMoncriefDisk,Horizon
+  RelativisticEuler::Solutions::FishboneMoncriefDisk,KerrHorizon
   )
 target_link_libraries(
   EvolveFishboneMoncriefDisk

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -218,9 +218,10 @@ struct EvolutionMetavars {
           tmpl::conditional_t<evolution::is_analytic_solution_v<initial_data>,
                               analytic_variables_tags, tmpl::list<>>>,
       Events::Registrars::ChangeSlabSize<slab_choosers>>>;
-  using events = tmpl::push_back<
-      observation_events,
-      intrp::Events::Registrars::Interpolate<3, interpolator_source_vars>>;
+  using interpolation_events =
+      tmpl::list<intrp::Events::Registrars::Interpolate<
+          3, InterpolationTargetTags, interpolator_source_vars>...>;
+  using events = tmpl::append<observation_events, interpolation_events>;
 
   using triggers = Triggers::time_triggers;
 

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -123,7 +123,7 @@ class CProxy_ConstGlobalCache;
 }  // namespace Parallel
 /// \endcond
 
-struct Horizon {
+struct KerrHorizon {
   using tags_to_observe =
       tmpl::list<StrahlkorperTags::EuclideanSurfaceIntegralVector<
           hydro::Tags::MassFlux<DataVector, 3, ::Frame::Inertial>,
@@ -140,10 +140,10 @@ struct Horizon {
       StrahlkorperTags::EuclideanAreaElement<::Frame::Inertial>,
       hydro::Tags::MassFluxCompute<DataVector, 3, ::Frame::Inertial>>;
   using compute_target_points =
-      intrp::Actions::KerrHorizon<Horizon, ::Frame::Inertial>;
+      intrp::Actions::KerrHorizon<KerrHorizon, ::Frame::Inertial>;
   using post_interpolation_callback =
-      intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, Horizon,
-                                                   Horizon>;
+      intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, KerrHorizon,
+                                                   KerrHorizon>;
 };
 
 template <typename InitialData, typename...InterpolationTargetTags>

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanFwd.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanFwd.hpp
@@ -35,7 +35,7 @@ class OrszagTangVortex;
 }  // namespace AnalyticData
 }  // namespace grmhd
 
-struct Horizon;
+struct KerrHorizon;
 template <typename InitialData, typename...InterpolationTargetTags>
 struct EvolutionMetavars;
 /// \endcond

--- a/src/Options/Factory.hpp
+++ b/src/Options/Factory.hpp
@@ -16,7 +16,6 @@
 
 #include "ErrorHandling/Assert.hpp"
 #include "Options/Options.hpp"
-#include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -35,7 +34,7 @@ std::unique_ptr<BaseClass> create_derived(const std::string& id,
                                           const Option& opts) {
   using derived = tmpl::front<CreateList>;
 
-  if (pretty_type::short_name<derived>() != id) {
+  if (option_name<derived>() != id) {
     return create_derived<BaseClass, tmpl::pop_front<CreateList>,
                           Metavariables>(id, opts);
   }
@@ -60,7 +59,7 @@ struct print_derived {
     std::ostringstream ss;
     ss << std::left
        << std::setw(name_col) << ""
-       << std::setw(help_col - name_col - 1) << pretty_type::short_name<T>();
+       << std::setw(help_col - name_col - 1) << option_name<T>();
     if (ss.str().size() >= help_col) {
       ss << "\n" << std::setw(help_col - 1) << "";
     }
@@ -90,7 +89,7 @@ std::unique_ptr<BaseClass> create(const Option& options) {
   const auto& node = options.node();
   Option derived_opts(options.context());
   derived_opts.append_context("While operating factory for " +
-                              pretty_type::short_name<BaseClass>());
+                              option_name<BaseClass>());
   std::string id;
   if (node.IsScalar()) {
     id = node.as<std::string>();

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -54,7 +54,7 @@ EventsAndTriggers:
   ? EveryNSlabs:
       N: 5
       Offset: 2
-  : - Horizon
+  : - AhA
   ? SpecifiedSlabs:
       Slabs: [3]
   : - Completion
@@ -64,7 +64,7 @@ Observers:
   ReductionFileName: "GhKerrSchildReductionData"
 
 ApparentHorizons:
-  Horizon:
+  AhA:
     InitialGuess:
       Lmax: 4
       Radius: 2.2

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -54,7 +54,7 @@ EventsAndTriggers:
   ? EveryNSlabs:
       N: 5
       Offset: 2
-  : - Interpolate
+  : - Horizon
   ? SpecifiedSlabs:
       Slabs: [3]
   : - Completion

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -31,8 +31,8 @@ DomainCreator:
 
 AnalyticSolution:
   FishboneMoncriefDisk:
-    BhMass: 1.0
-    BhDimlessSpin: 0.9375
+    BhMass: &BhMass 1.0
+    BhDimlessSpin: &BhDimlessSpin 0.9375
     InnerEdgeRadius: 6.0
     MaxPressureRadius: 12.0
     PolytropicConstant: 0.001
@@ -90,5 +90,5 @@ InterpolationTargets:
   KerrHorizon:
     Lmax: 10
     Center: [0.0, 0.0, 0.0]
-    Mass: 1.0
-    DimensionlessSpin: [0.0, 0.0, 0.9375]
+    Mass: *BhMass
+    DimensionlessSpin: [0.0, 0.0, *BhDimlessSpin]

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -87,7 +87,7 @@ Observers:
   ReductionFileName: "GrMhdReductions"
 
 InterpolationTargets:
-  Horizon:
+  KerrHorizon:
     Lmax: 10
     Center: [0.0, 0.0, 0.0]
     Mass: 1.0

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -160,22 +160,6 @@ struct MockInterpolationTargetReceiveVars {
   }
 };
 
-size_t called_mock_add_temporal_ids_to_interpolation_target = 0;
-template <typename InterpolationTargetTag>
-struct MockAddTemporalIdsToInterpolationTarget {
-  template <typename ParallelComponent, typename DbTags, typename Metavariables,
-            typename ArrayIndex>
-  static void apply(db::DataBox<DbTags>& /*box*/,
-                    Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/,
-                    std::vector<typename Metavariables::temporal_id::type>&&
-                    /*temporal_ids*/) noexcept {
-    // We are not testing this Action here.
-    // Do nothing except make sure it is called once.
-    ++called_mock_add_temporal_ids_to_interpolation_target;
-  }
-};
-
 template <typename Metavariables, typename InterpolationTargetTag>
 struct mock_interpolation_target {
   using metavariables = Metavariables;
@@ -198,14 +182,10 @@ struct mock_interpolation_target {
 
   using replace_these_simple_actions =
       tmpl::list<intrp::Actions::InterpolationTargetReceiveVars<
-                     typename Metavariables::InterpolationTargetA>,
-                 intrp::Actions::AddTemporalIdsToInterpolationTarget<
-                     typename Metavariables::InterpolationTargetA>>;
+          typename Metavariables::InterpolationTargetA>>;
   using with_these_simple_actions =
       tmpl::list<MockInterpolationTargetReceiveVars<
-                     typename Metavariables::InterpolationTargetA>,
-                 MockAddTemporalIdsToInterpolationTarget<
-                     typename Metavariables::InterpolationTargetA>>;
+          typename Metavariables::InterpolationTargetA>>;
 };
 
 template <typename Metavariables>
@@ -341,13 +321,6 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceiveVolumeData",
             target_component, intrp::Tags::TemporalIds<temporal_id_type>>(
             runner, 0)
             .empty());
-
-  // Should be two queued simple actions. First is
-  // MockAddTemporalIdsToInterpolationTarget.
-  runner.invoke_queued_simple_action<target_component>(0);
-
-  // Make sure MockAddTemporalIdsToInterpolationTarget was called once.
-  CHECK(called_mock_add_temporal_ids_to_interpolation_target == 1);
 
   // Should be one queued simple action, MockInterpolationTargetReceiveVars.
   runner.invoke_queued_simple_action<target_component>(0);


### PR DESCRIPTION
## Proposed changes

Previously there was only one Interpolation event, so (e.g.) if you wanted to have a different
event for finding each of three apparent horizons AhA, AhB, and AhC, there was no way to do it.

Now the interpolation event is templated by the InterpolationTarget, and you specify one event
per target in the input file. Furthermore, the name of the event in the input file is the name of the
InterpolationTarget.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments
