### PR TITLE
Have compute tags in GeneralRelativity use mutating functions 1/2

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
@@ -1044,6 +1044,7 @@ void two_index_constraint(
     const Scalar<DataType>& gamma2,
     const tnsr::iaa<DataType, SpatialDim, Frame>&
         three_index_constraint) noexcept {
+  destructive_resize_components(constraint, get_size(get(gamma2)));
   for (auto& component : *constraint) {
     component = 0.0;
   }

--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
@@ -8,6 +8,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+/// \cond
 namespace gr {
 template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
 void christoffel_first_kind(
@@ -38,8 +39,6 @@ tnsr::abb<DataType, SpatialDim, Frame, Index> christoffel_first_kind(
 }
 }  // namespace gr
 
-// Explicit Instantiations
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)

--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
@@ -60,9 +60,15 @@ struct SpatialChristoffelFirstKindCompute
   using argument_tags = tmpl::list<
       ::Tags::deriv<gr::Tags::SpatialMetric<SpatialDim, Frame, DataType>,
                     tmpl::size_t<SpatialDim>, Frame>>;
-  static constexpr tnsr::ijj<DataType, SpatialDim, Frame> (*function)(
-      const tnsr::ijj<DataType, SpatialDim, Frame>&) =
-      &christoffel_first_kind<SpatialDim, Frame, IndexType::Spatial, DataType>;
+
+  using return_type = tnsr::ijj<DataType, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<
+          tnsr::abb<DataType, SpatialDim, Frame, IndexType::Spatial>*>,
+      const tnsr::ijj<DataType, SpatialDim, Frame>&) noexcept>(
+      &christoffel_first_kind<SpatialDim, Frame, IndexType::Spatial, DataType>);
+
   using base = SpatialChristoffelFirstKind<SpatialDim, Frame, DataType>;
 };
 
@@ -78,12 +84,17 @@ struct SpatialChristoffelSecondKindCompute
   using argument_tags =
       tmpl::list<SpatialChristoffelFirstKind<SpatialDim, Frame, DataType>,
                  InverseSpatialMetric<SpatialDim, Frame, DataType>>;
-  static constexpr tnsr::Ijj<DataType, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::Ijj<DataType, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::Ijj<DataType, SpatialDim, Frame>*>,
       const tnsr::ijj<DataType, SpatialDim, Frame>&,
-      const tnsr::II<DataType, SpatialDim, Frame>&) =
+      const tnsr::II<DataType, SpatialDim, Frame>&) noexcept>(
       &raise_or_lower_first_index<DataType,
                                   SpatialIndex<SpatialDim, UpLo::Lo, Frame>,
-                                  SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
+                                  SpatialIndex<SpatialDim, UpLo::Lo, Frame>>);
+
   using base = SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>;
 };
 
@@ -100,11 +111,16 @@ struct TraceSpatialChristoffelFirstKindCompute
   using argument_tags =
       tmpl::list<SpatialChristoffelFirstKind<SpatialDim, Frame, DataType>,
                  InverseSpatialMetric<SpatialDim, Frame, DataType>>;
-  static constexpr tnsr::i<DataType, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::i<DataType, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::i<DataType, SpatialDim, Frame>*>,
       const tnsr::ijj<DataType, SpatialDim, Frame>&,
-      const tnsr::II<DataType, SpatialDim, Frame>&) =
+      const tnsr::II<DataType, SpatialDim, Frame>&) noexcept>(
       &trace_last_indices<DataType, SpatialIndex<SpatialDim, UpLo::Lo, Frame>,
-                          SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
+                          SpatialIndex<SpatialDim, UpLo::Lo, Frame>>);
+
   using base = TraceSpatialChristoffelFirstKind<SpatialDim, Frame, DataType>;
 };
 
@@ -121,11 +137,16 @@ struct TraceSpatialChristoffelSecondKindCompute
   using argument_tags =
       tmpl::list<SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>,
                  InverseSpatialMetric<SpatialDim, Frame, DataType>>;
-  static constexpr tnsr::I<DataType, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::I<DataType, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::I<DataType, SpatialDim, Frame>*>,
       const tnsr::Ijj<DataType, SpatialDim, Frame>&,
-      const tnsr::II<DataType, SpatialDim, Frame>&) =
+      const tnsr::II<DataType, SpatialDim, Frame>&) noexcept>(
       &trace_last_indices<DataType, SpatialIndex<SpatialDim, UpLo::Up, Frame>,
-                          SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
+                          SpatialIndex<SpatialDim, UpLo::Lo, Frame>>);
+
   using base = TraceSpatialChristoffelSecondKind<SpatialDim, Frame, DataType>;
 };
 
@@ -140,11 +161,18 @@ struct SpacetimeChristoffelFirstKindCompute
       db::ComputeTag {
   using argument_tags =
       tmpl::list<DerivativesOfSpacetimeMetric<SpatialDim, Frame, DataType>>;
-  static constexpr tnsr::abb<DataType, SpatialDim, Frame,
-                             IndexType::Spacetime> (*function)(
-      const tnsr::abb<DataType, SpatialDim, Frame, IndexType::Spacetime>&) =
-      &christoffel_first_kind<SpatialDim, Frame, IndexType::Spacetime,
-                              DataType>;
+
+  using return_type =
+      tnsr::abb<DataType, SpatialDim, Frame, IndexType::Spacetime>;
+
+  static constexpr auto function =
+      static_cast<void (*)(gsl::not_null<tnsr::abb<DataType, SpatialDim, Frame,
+                                                   IndexType::Spacetime>*>,
+                           const tnsr::abb<DataType, SpatialDim, Frame,
+                                           IndexType::Spacetime>&) noexcept>(
+          &christoffel_first_kind<SpatialDim, Frame, IndexType::Spacetime,
+                                  DataType>);
+
   using base = SpacetimeChristoffelFirstKind<SpatialDim, Frame, DataType>;
 };
 
@@ -160,12 +188,17 @@ struct SpacetimeChristoffelSecondKindCompute
   using argument_tags =
       tmpl::list<SpacetimeChristoffelFirstKind<SpatialDim, Frame, DataType>,
                  InverseSpacetimeMetric<SpatialDim, Frame, DataType>>;
-  static constexpr tnsr::Abb<DataType, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::Abb<DataType, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::Abb<DataType, SpatialDim, Frame>*>,
       const tnsr::abb<DataType, SpatialDim, Frame>&,
-      const tnsr::AA<DataType, SpatialDim, Frame>&) =
+      const tnsr::AA<DataType, SpatialDim, Frame>&) noexcept>(
       &raise_or_lower_first_index<DataType,
                                   SpacetimeIndex<SpatialDim, UpLo::Lo, Frame>,
-                                  SpacetimeIndex<SpatialDim, UpLo::Lo, Frame>>;
+                                  SpacetimeIndex<SpatialDim, UpLo::Lo, Frame>>);
+
   using base = SpacetimeChristoffelSecondKind<SpatialDim, Frame, DataType>;
 };
 
@@ -182,11 +215,16 @@ struct TraceSpacetimeChristoffelFirstKindCompute
   using argument_tags =
       tmpl::list<SpacetimeChristoffelFirstKind<SpatialDim, Frame, DataType>,
                  InverseSpacetimeMetric<SpatialDim, Frame, DataType>>;
-  static constexpr tnsr::a<DataType, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::a<DataType, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*>,
       const tnsr::abb<DataType, SpatialDim, Frame>&,
-      const tnsr::AA<DataType, SpatialDim, Frame>&) =
+      const tnsr::AA<DataType, SpatialDim, Frame>&) noexcept>(
       &trace_last_indices<DataType, SpacetimeIndex<SpatialDim, UpLo::Lo, Frame>,
-                          SpacetimeIndex<SpatialDim, UpLo::Lo, Frame>>;
+                          SpacetimeIndex<SpatialDim, UpLo::Lo, Frame>>);
+
   using base = TraceSpacetimeChristoffelFirstKind<SpatialDim, Frame, DataType>;
 };
 }  // namespace Tags

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.cpp
@@ -17,6 +17,7 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
+/// \cond
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void phi(const gsl::not_null<tnsr::iaa<DataType, SpatialDim, Frame>*> phi,
@@ -758,7 +759,6 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_norm_of_shift(
 }
 }  // namespace GeneralizedHarmonic
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -19,16 +19,13 @@
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 
 // IWYU pragma: no_forward_declare Tags::deriv
 
 /// \cond
-namespace gsl {
-template <class T>
-class not_null;
-}  // namespace gsl
 namespace domain {
 namespace Tags {
 template <size_t Dim, typename Frame>
@@ -549,11 +546,16 @@ struct TimeDerivSpatialMetricCompute
       tmpl::list<gr::Tags::Lapse<DataVector>,
                  gr::Tags::Shift<SpatialDim, Frame, DataVector>,
                  Phi<SpatialDim, Frame>, Pi<SpatialDim, Frame>>;
-  static constexpr tnsr::ii<DataVector, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::ii<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::ii<DataVector, SpatialDim, Frame>*>,
       const Scalar<DataVector>&, const tnsr::I<DataVector, SpatialDim, Frame>&,
       const tnsr::iaa<DataVector, SpatialDim, Frame>&,
-      const tnsr::aa<DataVector, SpatialDim, Frame>&) =
-      &time_deriv_of_spatial_metric<SpatialDim, Frame>;
+      const tnsr::aa<DataVector, SpatialDim, Frame>&) noexcept>(
+      &time_deriv_of_spatial_metric<SpatialDim, Frame>);
+
   using base =
       ::Tags::dt<gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>>;
 };
@@ -573,12 +575,17 @@ struct TimeDerivLapseCompute : ::Tags::dt<gr::Tags::Lapse<DataVector>>,
                  gr::Tags::Shift<SpatialDim, Frame, DataVector>,
                  gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
                  Phi<SpatialDim, Frame>, Pi<SpatialDim, Frame>>;
-  static constexpr Scalar<DataVector> (*function)(
-      const Scalar<DataVector>&, const tnsr::I<DataVector, SpatialDim, Frame>&,
+
+  using return_type = Scalar<DataVector>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<DataVector>*>, const Scalar<DataVector>&,
+      const tnsr::I<DataVector, SpatialDim, Frame>&,
       const tnsr::A<DataVector, SpatialDim, Frame>&,
       const tnsr::iaa<DataVector, SpatialDim, Frame>&,
-      const tnsr::aa<DataVector, SpatialDim, Frame>&) =
-      &time_deriv_of_lapse<SpatialDim, Frame>;
+      const tnsr::aa<DataVector, SpatialDim, Frame>&) noexcept>(
+      &time_deriv_of_lapse<SpatialDim, Frame>);
+
   using base = ::Tags::dt<gr::Tags::Lapse<DataVector>>;
 };
 
@@ -599,13 +606,18 @@ struct TimeDerivShiftCompute
                  gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
                  gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
                  Phi<SpatialDim, Frame>, Pi<SpatialDim, Frame>>;
-  static constexpr tnsr::I<DataVector, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::I<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::I<DataVector, SpatialDim, Frame>*>,
       const Scalar<DataVector>&, const tnsr::I<DataVector, SpatialDim, Frame>&,
       const tnsr::II<DataVector, SpatialDim, Frame>&,
       const tnsr::A<DataVector, SpatialDim, Frame>&,
       const tnsr::iaa<DataVector, SpatialDim, Frame>&,
-      const tnsr::aa<DataVector, SpatialDim, Frame>&) =
-      &time_deriv_of_shift<SpatialDim, Frame, DataVector>;
+      const tnsr::aa<DataVector, SpatialDim, Frame>&) noexcept>(
+      &time_deriv_of_shift<SpatialDim, Frame, DataVector>);
+
   using base = ::Tags::dt<gr::Tags::Shift<SpatialDim, Frame, DataVector>>;
 };
 
@@ -622,9 +634,14 @@ struct DerivSpatialMetricCompute
                     tmpl::size_t<SpatialDim>, Frame>,
       db::ComputeTag {
   using argument_tags = tmpl::list<Phi<SpatialDim, Frame>>;
-  static constexpr tnsr::ijj<DataVector, SpatialDim, Frame> (*function)(
-      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
-      &deriv_spatial_metric<SpatialDim, Frame>;
+
+  using return_type = tnsr::ijj<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::ijj<DataVector, SpatialDim, Frame>*>,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) noexcept>(
+      &deriv_spatial_metric<SpatialDim, Frame>);
+
   using base =
       ::Tags::deriv<gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>,
                     tmpl::size_t<SpatialDim>, Frame>;
@@ -645,10 +662,15 @@ struct DerivLapseCompute : ::Tags::deriv<gr::Tags::Lapse<DataVector>,
       tmpl::list<gr::Tags::Lapse<DataVector>,
                  gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
                  Phi<SpatialDim, Frame>>;
-  static constexpr tnsr::i<DataVector, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::i<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame>*>,
       const Scalar<DataVector>&, const tnsr::A<DataVector, SpatialDim, Frame>&,
-      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
-      &spatial_deriv_of_lapse<SpatialDim, Frame>;
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) noexcept>(
+      &spatial_deriv_of_lapse<SpatialDim, Frame>);
+
   using base = ::Tags::deriv<gr::Tags::Lapse<DataVector>,
                              tmpl::size_t<SpatialDim>, Frame>;
 };
@@ -670,11 +692,16 @@ struct DerivShiftCompute
       gr::Tags::InverseSpacetimeMetric<SpatialDim, Frame, DataVector>,
       gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
       Phi<SpatialDim, Frame>>;
-  static constexpr tnsr::iJ<DataVector, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::iJ<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::iJ<DataVector, SpatialDim, Frame>*>,
       const Scalar<DataVector>&, const tnsr::AA<DataVector, SpatialDim, Frame>&,
       const tnsr::A<DataVector, SpatialDim, Frame>&,
-      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
-      &spatial_deriv_of_shift<SpatialDim, Frame, DataVector>;
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) noexcept>(
+      &spatial_deriv_of_shift<SpatialDim, Frame, DataVector>);
+
   using base = ::Tags::deriv<gr::Tags::Shift<SpatialDim, Frame, DataVector>,
                              tmpl::size_t<SpatialDim>, Frame>;
 };
@@ -698,13 +725,18 @@ struct PhiCompute : Phi<SpatialDim, Frame>, db::ComputeTag {
       gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>,
       ::Tags::deriv<gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>,
                     tmpl::size_t<SpatialDim>, Frame>>;
-  static constexpr tnsr::iaa<DataVector, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::iaa<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::iaa<DataVector, SpatialDim, Frame>*>,
       const Scalar<DataVector>&, const tnsr::i<DataVector, SpatialDim, Frame>&,
       const tnsr::I<DataVector, SpatialDim, Frame>&,
       const tnsr::iJ<DataVector, SpatialDim, Frame>&,
       const tnsr::ii<DataVector, SpatialDim, Frame>&,
-      const tnsr::ijj<DataVector, SpatialDim, Frame>&) =
-      &phi<SpatialDim, Frame, DataVector>;
+      const tnsr::ijj<DataVector, SpatialDim, Frame>&) noexcept>(
+      &phi<SpatialDim, Frame, DataVector>);
+
   using base = Phi<SpatialDim, Frame>;
 };
 
@@ -723,14 +755,19 @@ struct PiCompute : Pi<SpatialDim, Frame>, db::ComputeTag {
       gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>,
       ::Tags::dt<gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>>,
       Phi<SpatialDim, Frame>>;
-  static constexpr tnsr::aa<DataVector, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::aa<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::aa<DataVector, SpatialDim, Frame>*>,
       const Scalar<DataVector>&, const Scalar<DataVector>&,
       const tnsr::I<DataVector, SpatialDim, Frame>&,
       const tnsr::I<DataVector, SpatialDim, Frame>&,
       const tnsr::ii<DataVector, SpatialDim, Frame>&,
       const tnsr::ii<DataVector, SpatialDim, Frame>&,
-      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
-      &pi<SpatialDim, Frame, DataVector>;
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) noexcept>(
+      &pi<SpatialDim, Frame, DataVector>);
+
   using base = Pi<SpatialDim, Frame>;
 };
 
@@ -780,9 +817,14 @@ struct TraceExtrinsicCurvatureCompute
   using argument_tags =
       tmpl::list<gr::Tags::ExtrinsicCurvature<SpatialDim, Frame, DataVector>,
                  gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>>;
-  static constexpr Scalar<DataVector> (*function)(
+
+  using return_type = Scalar<DataVector>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<DataVector>*>,
       const tnsr::ii<DataVector, SpatialDim, Frame>&,
-      const tnsr::II<DataVector, SpatialDim, Frame>&) = &trace;
+      const tnsr::II<DataVector, SpatialDim, Frame>&) noexcept>(&trace);
+
   using base = gr::Tags::TraceExtrinsicCurvature<DataVector>;
 };
 
@@ -923,15 +965,20 @@ struct GaugeConstraintCompute : GaugeConstraint<SpatialDim, Frame>,
       gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
       gr::Tags::InverseSpacetimeMetric<SpatialDim, Frame, DataVector>,
       Pi<SpatialDim, Frame>, Phi<SpatialDim, Frame>>;
-  static constexpr tnsr::a<DataVector, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::a<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::a<DataVector, SpatialDim, Frame>*>,
       const tnsr::a<DataVector, SpatialDim, Frame>&,
       const tnsr::a<DataVector, SpatialDim, Frame>&,
       const tnsr::A<DataVector, SpatialDim, Frame>&,
       const tnsr::II<DataVector, SpatialDim, Frame>&,
       const tnsr::AA<DataVector, SpatialDim, Frame>&,
       const tnsr::aa<DataVector, SpatialDim, Frame>&,
-      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
-      &gauge_constraint<SpatialDim, Frame, DataVector>;
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) noexcept>(
+      &gauge_constraint<SpatialDim, Frame, DataVector>);
+
   using base = GaugeConstraint<SpatialDim, Frame>;
 };
 
@@ -955,7 +1002,11 @@ struct FConstraintCompute : FConstraint<SpatialDim, Frame>, db::ComputeTag {
       ::Tags::deriv<Pi<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
       ::Tags::deriv<Phi<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
       ConstraintGamma2, ThreeIndexConstraint<SpatialDim, Frame>>;
-  static constexpr tnsr::a<DataVector, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::a<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::a<DataVector, SpatialDim, Frame>*>,
       const tnsr::a<DataVector, SpatialDim, Frame>&,
       const tnsr::ia<DataVector, SpatialDim, Frame>&,
       const tnsr::a<DataVector, SpatialDim, Frame>&,
@@ -967,8 +1018,9 @@ struct FConstraintCompute : FConstraint<SpatialDim, Frame>, db::ComputeTag {
       const tnsr::iaa<DataVector, SpatialDim, Frame>&,
       const tnsr::ijaa<DataVector, SpatialDim, Frame>&,
       const Scalar<DataVector>&,
-      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
-      &f_constraint<SpatialDim, Frame, DataVector>;
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) noexcept>(
+      &f_constraint<SpatialDim, Frame, DataVector>);
+
   using base = FConstraint<SpatialDim, Frame>;
 };
 
@@ -992,7 +1044,11 @@ struct TwoIndexConstraintCompute : TwoIndexConstraint<SpatialDim, Frame>,
       ::Tags::deriv<Pi<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
       ::Tags::deriv<Phi<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
       ConstraintGamma2, ThreeIndexConstraint<SpatialDim, Frame>>;
-  static constexpr tnsr::ia<DataVector, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::ia<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::ia<DataVector, SpatialDim, Frame>*>,
       const tnsr::ia<DataVector, SpatialDim, Frame>&,
       const tnsr::a<DataVector, SpatialDim, Frame>&,
       const tnsr::A<DataVector, SpatialDim, Frame>&,
@@ -1003,8 +1059,9 @@ struct TwoIndexConstraintCompute : TwoIndexConstraint<SpatialDim, Frame>,
       const tnsr::iaa<DataVector, SpatialDim, Frame>&,
       const tnsr::ijaa<DataVector, SpatialDim, Frame>&,
       const Scalar<DataVector>&,
-      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
-      &two_index_constraint<SpatialDim, Frame, DataVector>;
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) noexcept>(
+      &two_index_constraint<SpatialDim, Frame, DataVector>);
+
   using base = TwoIndexConstraint<SpatialDim, Frame>;
 };
 
@@ -1021,10 +1078,15 @@ struct ThreeIndexConstraintCompute : ThreeIndexConstraint<SpatialDim, Frame>,
   using argument_tags =
       tmpl::list<gr::Tags::DerivSpacetimeMetric<SpatialDim, Frame>,
                  Phi<SpatialDim, Frame>>;
-  static constexpr tnsr::iaa<DataVector, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::iaa<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::iaa<DataVector, SpatialDim, Frame>*>,
       const tnsr::iaa<DataVector, SpatialDim, Frame>&,
-      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
-      &three_index_constraint<SpatialDim, Frame, DataVector>;
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) noexcept>(
+      &three_index_constraint<SpatialDim, Frame, DataVector>);
+
   using base = ThreeIndexConstraint<SpatialDim, Frame>;
 };
 
@@ -1040,9 +1102,14 @@ struct FourIndexConstraintCompute : FourIndexConstraint<SpatialDim, Frame>,
                                     db::ComputeTag {
   using argument_tags = tmpl::list<
       ::Tags::deriv<Phi<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>>;
-  static constexpr tnsr::iaa<DataVector, SpatialDim, Frame> (*function)(
-      const tnsr::ijaa<DataVector, SpatialDim, Frame>&) =
-      &four_index_constraint<SpatialDim, Frame, DataVector>;
+
+  using return_type = tnsr::iaa<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::iaa<DataVector, SpatialDim, Frame>*>,
+      const tnsr::ijaa<DataVector, SpatialDim, Frame>&) noexcept>(
+      &four_index_constraint<SpatialDim, Frame, DataVector>);
+
   using base = FourIndexConstraint<SpatialDim, Frame>;
 };
 
@@ -1064,7 +1131,11 @@ struct ConstraintEnergyCompute : ConstraintEnergy<SpatialDim, Frame>,
                  FourIndexConstraint<SpatialDim, Frame>,
                  gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
                  gr::Tags::DetSpatialMetric<DataVector>>;
+
+  using return_type = Scalar<DataVector>;
+
   static constexpr auto function(
+      const gsl::not_null<Scalar<DataVector>*> energy,
       const tnsr::a<DataVector, SpatialDim, Frame>& gauge_constraint,
       const tnsr::a<DataVector, SpatialDim, Frame>& f_constraint,
       const tnsr::ia<DataVector, SpatialDim, Frame>& two_index_constraint,
@@ -1072,11 +1143,12 @@ struct ConstraintEnergyCompute : ConstraintEnergy<SpatialDim, Frame>,
       const tnsr::iaa<DataVector, SpatialDim, Frame>& four_index_constraint,
       const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
       const Scalar<DataVector>& spatial_metric_determinant) noexcept {
-    return constraint_energy<SpatialDim, Frame, DataVector>(
-        gauge_constraint, f_constraint, two_index_constraint,
+    constraint_energy<SpatialDim, Frame, DataVector>(
+        energy, gauge_constraint, f_constraint, two_index_constraint,
         three_index_constraint, four_index_constraint, inverse_spatial_metric,
         spatial_metric_determinant);
   }
+
   using base = ConstraintEnergy<SpatialDim, Frame>;
 };
 }  // namespace Tags

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -160,6 +160,7 @@ tnsr::a<DataType, SpatialDim, Frame> gauge_source(
         trace_christoffel_last_indices) noexcept;
 //@}
 
+//@{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes extrinsic curvature from generalized harmonic variables
@@ -174,10 +175,18 @@ tnsr::a<DataType, SpatialDim, Frame> gauge_source(
  * \f}
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
+void extrinsic_curvature(
+    gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*> ex_curv,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+//@}
 
 // @{
 /*!
@@ -739,8 +748,16 @@ struct ExtrinsicCurvatureCompute
   using argument_tags =
       tmpl::list<gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
                  Pi<SpatialDim, Frame>, Phi<SpatialDim, Frame>>;
-  static constexpr auto function =
-      &extrinsic_curvature<SpatialDim, Frame, DataVector>;
+
+  using return_type = tnsr::ii<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::ii<DataVector, SpatialDim, Frame>*>,
+      const tnsr::A<DataVector, SpatialDim, Frame>&,
+      const tnsr::aa<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) noexcept>(
+      &extrinsic_curvature<SpatialDim, Frame, DataVector>);
+
   using base = gr::Tags::ExtrinsicCurvature<SpatialDim, Frame, DataVector>;
 };
 

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -120,6 +120,7 @@ tnsr::aa<DataType, SpatialDim, Frame> pi(
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
 // @}
 
+//@{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief  Computes generalized harmonic gauge source function.
@@ -134,6 +135,19 @@ tnsr::aa<DataType, SpatialDim, Frame> pi(
  * See Eqs. 8 and 9 of \cite Lindblom2005qh
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
+void gauge_source(
+    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> gauge_source_h,
+    const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
+    const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
+    const tnsr::iJ<DataType, SpatialDim, Frame>& deriv_shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const Scalar<DataType>& trace_extrinsic_curvature,
+    const tnsr::i<DataType, SpatialDim, Frame>&
+        trace_christoffel_last_indices) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::a<DataType, SpatialDim, Frame> gauge_source(
     const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
     const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
@@ -144,6 +158,7 @@ tnsr::a<DataType, SpatialDim, Frame> gauge_source(
     const Scalar<DataType>& trace_extrinsic_curvature,
     const tnsr::i<DataType, SpatialDim, Frame>&
         trace_christoffel_last_indices) noexcept;
+//@}
 
 /*!
  * \ingroup GeneralRelativityGroup
@@ -825,7 +840,20 @@ struct GaugeHImplicitFrom3p1QuantitiesCompute : GaugeH<SpatialDim, Frame>,
                  gr::Tags::TraceExtrinsicCurvature<DataVector>,
                  gr::Tags::TraceSpatialChristoffelFirstKind<SpatialDim, Frame,
                                                             DataVector>>;
-  static constexpr auto function = &gauge_source<SpatialDim, Frame, DataVector>;
+
+  using return_type = tnsr::a<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::a<DataVector, SpatialDim, Frame>*>,
+      const Scalar<DataVector>&, const Scalar<DataVector>&,
+      const tnsr::i<DataVector, SpatialDim, Frame>&,
+      const tnsr::I<DataVector, SpatialDim, Frame>&,
+      const tnsr::I<DataVector, SpatialDim, Frame>&,
+      const tnsr::iJ<DataVector, SpatialDim, Frame>&,
+      const tnsr::ii<DataVector, SpatialDim, Frame>&, const Scalar<DataVector>&,
+      const tnsr::i<DataVector, SpatialDim, Frame>&) noexcept>(
+      &gauge_source<SpatialDim, Frame, DataVector>);
+
   using base = GaugeH<SpatialDim, Frame>;
 };
 

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
@@ -14,6 +14,7 @@
 
 // IWYU pragma: no_include <complex>
 
+/// \cond
 namespace gr {
 template <size_t Dim, typename Frame, typename DataType>
 void spacetime_metric(
@@ -336,7 +337,6 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
 }
 }  // namespace gr
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)

--- a/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.cpp
@@ -8,6 +8,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
+/// \cond
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
 
@@ -98,7 +99,6 @@ void trace(
   }
 }
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.cpp
@@ -4,36 +4,52 @@
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 /// \cond
 namespace gr {
 template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
-tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
+void ricci_tensor(
+    const gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame, Index>*> result,
     const tnsr::Abb<DataType, SpatialDim, Frame, Index>& christoffel_2nd_kind,
     const tnsr::aBcc<DataType, SpatialDim, Frame, Index>&
         d_christoffel_2nd_kind) noexcept {
-  auto ricci = make_with_value<tnsr::aa<DataType, SpatialDim, Frame, Index>>(
-      christoffel_2nd_kind, 0.);
-  constexpr auto dimensionality = index_dim<0>(ricci);
+  destructive_resize_components(result,
+                                get_size(get<0, 0, 0>(christoffel_2nd_kind)));
+  for (auto& component : *result) {
+    component = 0.0;
+  }
+  const auto dimensionality = index_dim<0>(*result);
   for (size_t i = 0; i < dimensionality; ++i) {
     for (size_t j = i; j < dimensionality; ++j) {
       for (size_t m = 0; m < dimensionality; ++m) {
-        ricci.get(i, j) += d_christoffel_2nd_kind.get(m, m, i, j) -
-                           0.5 * (d_christoffel_2nd_kind.get(i, m, m, j) +
-                                  d_christoffel_2nd_kind.get(j, m, m, i));
+        result->get(i, j) += d_christoffel_2nd_kind.get(m, m, i, j) -
+                             0.5 * (d_christoffel_2nd_kind.get(i, m, m, j) +
+                                    d_christoffel_2nd_kind.get(j, m, m, i));
 
         for (size_t n = 0; n < dimensionality; ++n) {
-          ricci.get(i, j) += christoffel_2nd_kind.get(m, i, j) *
-                                 christoffel_2nd_kind.get(n, n, m) -
-                             christoffel_2nd_kind.get(m, i, n) *
-                                 christoffel_2nd_kind.get(n, m, j);
+          result->get(i, j) += christoffel_2nd_kind.get(m, i, j) *
+                                   christoffel_2nd_kind.get(n, n, m) -
+                               christoffel_2nd_kind.get(m, i, n) *
+                                   christoffel_2nd_kind.get(n, m, j);
         }
       }
     }
   }
-  return ricci;
+}
+
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
+    const tnsr::Abb<DataType, SpatialDim, Frame, Index>& christoffel_2nd_kind,
+    const tnsr::aBcc<DataType, SpatialDim, Frame, Index>&
+        d_christoffel_2nd_kind) noexcept {
+  tnsr::aa<DataType, SpatialDim, Frame, Index> result{};
+  ricci_tensor(make_not_null(&result), christoffel_2nd_kind,
+               d_christoffel_2nd_kind);
+  return result;
 }
 } // namespace gr
 
@@ -43,6 +59,14 @@ tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
 #define INDEXTYPE(data) BOOST_PP_TUPLE_ELEM(3, data)
 
 #define INSTANTIATE(_, data)                                                  \
+  template void gr::ricci_tensor(                                             \
+      const gsl::not_null<                                                    \
+          tnsr::aa<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>*>    \
+          result,                                                             \
+      const tnsr::Abb<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>&  \
+          christoffel_2nd_kind,                                               \
+      const tnsr::aBcc<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>& \
+          d_christoffel_2nd_kind) noexcept;                                   \
   template tnsr::aa<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>     \
   gr::ricci_tensor(                                                           \
       const tnsr::Abb<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>&  \

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.cpp
@@ -7,6 +7,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+/// \cond
 namespace gr {
 template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
 tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
@@ -36,8 +37,6 @@ tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
 }
 } // namespace gr
 
-// Explicit Instantiations
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
@@ -12,8 +12,16 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
 namespace gr {
 
+//@{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes Ricci tensor from the (spatial or spacetime)
@@ -26,10 +34,18 @@ namespace gr {
  * where \f$\Gamma^{a}_{bc}\f$ is the Christoffel symbol of the second kind.
  */
 template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+void ricci_tensor(
+    gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame, Index>*> result,
+    const tnsr::Abb<DataType, SpatialDim, Frame, Index>& christoffel_2nd_kind,
+    const tnsr::aBcc<DataType, SpatialDim, Frame, Index>&
+        d_christoffel_2nd_kind) noexcept;
+
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
 tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
     const tnsr::Abb<DataType, SpatialDim, Frame, Index>& christoffel_2nd_kind,
     const tnsr::aBcc<DataType, SpatialDim, Frame, Index>&
         d_christoffel_2nd_kind) noexcept;
+//@}
 
 namespace Tags {
 /// Compute item for spatial Ricci tensor \f$R_{ij}\f$
@@ -44,10 +60,15 @@ struct SpatialRicciCompute : SpatialRicci<SpatialDim, Frame, DataType>,
       ::Tags::deriv<
           gr::Tags::SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>,
           tmpl::size_t<SpatialDim>, Frame>>;
-  static constexpr tnsr::ii<DataType, SpatialDim, Frame> (*function)(
+
+  using return_type = tnsr::ii<DataType, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*>,
       const tnsr::Ijj<DataType, SpatialDim, Frame>&,
-      const tnsr::iJkk<DataType, SpatialDim, Frame>&) =
-      &ricci_tensor<SpatialDim, Frame, IndexType::Spatial, DataType>;
+      const tnsr::iJkk<DataType, SpatialDim, Frame>&)>(
+      &ricci_tensor<SpatialDim, Frame, IndexType::Spatial, DataType>);
+
   using base = SpatialRicci<SpatialDim, Frame, DataType>;
 };
 }  // namespace Tags

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
@@ -35,10 +35,10 @@ namespace Tags {
 /// Compute item for spatial Ricci tensor \f$R_{ij}\f$
 /// computed from SpatialChristoffelSecondKind and its spatial derivatives.
 ///
-/// Can be retrieved using `gr::Tags::RicciTensor`
+/// Can be retrieved using `gr::Tags::SpatialRicci`
 template <size_t SpatialDim, typename Frame, typename DataType>
-struct RicciTensorCompute : RicciTensor<SpatialDim, Frame, DataType>,
-                            db::ComputeTag {
+struct SpatialRicciCompute : SpatialRicci<SpatialDim, Frame, DataType>,
+                             db::ComputeTag {
   using argument_tags = tmpl::list<
       gr::Tags::SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>,
       ::Tags::deriv<
@@ -48,7 +48,7 @@ struct RicciTensorCompute : RicciTensor<SpatialDim, Frame, DataType>,
       const tnsr::Ijj<DataType, SpatialDim, Frame>&,
       const tnsr::iJkk<DataType, SpatialDim, Frame>&) =
       &ricci_tensor<SpatialDim, Frame, IndexType::Spatial, DataType>;
-  using base = RicciTensor<SpatialDim, Frame, DataType>;
+  using base = SpatialRicci<SpatialDim, Frame, DataType>;
 };
 }  // namespace Tags
 } // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -127,12 +127,11 @@ struct TraceExtrinsicCurvature : db::SimpleTag {
 };
 
 /*!
- * \brief Computes Ricci tensor from the (spatial or spacetime)
+ * \brief Computes the spatial Ricci tensor from the spatial
  * Christoffel symbol of the second kind and its derivative.
  */
-
 template <size_t Dim, typename Frame, typename DataType>
-struct RicciTensor : db::SimpleTag {
+struct SpatialRicci : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
 };
 

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -74,7 +74,9 @@ template <size_t Dim, typename Frame = Frame::Inertial,
 struct ExtrinsicCurvature;
 template <typename DataType = DataVector>
 struct TraceExtrinsicCurvature;
-
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct SpatialRicci;
 template <typename DataType = DataVector>
 struct EnergyDensity;
 }  // namespace Tags

--- a/src/PointwiseFunctions/GeneralRelativity/WeylElectric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylElectric.cpp
@@ -39,12 +39,9 @@ void weyl_electric(
       for (size_t k = 0; k < SpatialDim; ++k) {
         for (size_t l = 0; l < SpatialDim; ++l) {
           weyl_electric_part->get(i, j) +=
-              extrinsic_curvature.get(k, l) *
-                  (inverse_spatial_metric.get(k, l)) *
-                  extrinsic_curvature.get(i, j) -
-              extrinsic_curvature.get(i, l) *
-                  (inverse_spatial_metric.get(k, l)) *
-                  extrinsic_curvature.get(k, j);
+              inverse_spatial_metric.get(k, l) *
+              (extrinsic_curvature.get(k, l) * extrinsic_curvature.get(i, j) -
+               extrinsic_curvature.get(i, l) * extrinsic_curvature.get(k, j));
         }
       }
     }

--- a/src/PointwiseFunctions/GeneralRelativity/WeylElectric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylElectric.cpp
@@ -10,6 +10,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+/// \cond
 namespace gr {
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ii<DataType, SpatialDim, Frame> weyl_electric(
@@ -51,8 +52,6 @@ void weyl_electric(
 }
 }  // namespace gr
 
-// Explicit Instantiations
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)

--- a/src/PointwiseFunctions/GeneralRelativity/WeylElectric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylElectric.hpp
@@ -44,7 +44,7 @@ void weyl_electric(
 
 namespace Tags {
 /// Compute item for the electric part of the weyl tensor in vacuum
-/// Computed from the RicciTensor, ExtrinsicCurvature, and InverseSpatialMetric
+/// Computed from the SpatialRicci, ExtrinsicCurvature, and InverseSpatialMetric
 ///
 /// Can be retrieved using gr::Tags::WeylElectric
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -56,7 +56,7 @@ struct WeylElectricCompute : WeylElectric<SpatialDim, Frame, DataType>,
       const tnsr::II<DataType, SpatialDim, Frame>&) =
           &weyl_electric<SpatialDim, Frame, DataType>;
   using argument_tags = tmpl::list<
-      gr::Tags::RicciTensor<SpatialDim, Frame, DataType>,
+      gr::Tags::SpatialRicci<SpatialDim, Frame, DataType>,
       gr::Tags::ExtrinsicCurvature<SpatialDim, Frame, DataType>,
       gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataType>>;
   using base = WeylElectric<SpatialDim, Frame, DataType>;

--- a/src/PointwiseFunctions/GeneralRelativity/WeylElectric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylElectric.hpp
@@ -9,10 +9,16 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
-#include "Utilities/Gsl.hpp"
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
 
 namespace gr {
 
+//@(
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the electric part of the Weyl tensor in vacuum.
@@ -41,6 +47,7 @@ void weyl_electric(
     const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
     const tnsr::II<DataType, SpatialDim, Frame>&
         inverse_spatial_metric) noexcept;
+//@}
 
 namespace Tags {
 /// Compute item for the electric part of the weyl tensor in vacuum
@@ -50,15 +57,20 @@ namespace Tags {
 template <size_t SpatialDim, typename Frame, typename DataType>
 struct WeylElectricCompute : WeylElectric<SpatialDim, Frame, DataType>,
                              db::ComputeTag {
-  static constexpr tnsr::ii<DataType, SpatialDim, Frame> (*function)(
-      const tnsr::ii<DataType, SpatialDim, Frame>&,
-      const tnsr::ii<DataType, SpatialDim, Frame>&,
-      const tnsr::II<DataType, SpatialDim, Frame>&) =
-          &weyl_electric<SpatialDim, Frame, DataType>;
   using argument_tags = tmpl::list<
       gr::Tags::SpatialRicci<SpatialDim, Frame, DataType>,
       gr::Tags::ExtrinsicCurvature<SpatialDim, Frame, DataType>,
       gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+
+  using return_type = tnsr::ii<DataType, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*>,
+      const tnsr::ii<DataType, SpatialDim, Frame>&,
+      const tnsr::ii<DataType, SpatialDim, Frame>&,
+      const tnsr::II<DataType, SpatialDim, Frame>&)>(
+      &weyl_electric<SpatialDim, Frame, DataType>);
+
   using base = WeylElectric<SpatialDim, Frame, DataType>;
 };
 }  // namespace Tags

--- a/src/PointwiseFunctions/Hydro/LorentzFactor.hpp
+++ b/src/PointwiseFunctions/Hydro/LorentzFactor.hpp
@@ -10,10 +10,12 @@
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 
+/// \cond
 namespace gsl {
 template <typename>
 struct not_null;
 }  // namespace gsl
+/// \endcond
 
 namespace hydro {
 // @{

--- a/src/PointwiseFunctions/Hydro/MassFlux.hpp
+++ b/src/PointwiseFunctions/Hydro/MassFlux.hpp
@@ -18,10 +18,12 @@
 // IWYU pragma: no_forward_declare hydro::Tags::RestMassDensity
 // IWYU pragma: no_forward_declare hydro::Tags::SpatialVelocity
 
+/// \cond
 namespace gsl {
 template <typename>
 struct not_null;
 }  // namespace gsl
+/// \endcond
 
 namespace hydro {
 //@{

--- a/src/PointwiseFunctions/Hydro/SpecificEnthalpy.hpp
+++ b/src/PointwiseFunctions/Hydro/SpecificEnthalpy.hpp
@@ -8,10 +8,12 @@
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
 namespace gsl {
 template <typename>
 struct not_null;
 }  // namespace gsl
+/// \endcond
 
 namespace hydro {
 //@{

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -88,7 +88,16 @@ void test_compute_pi(const DataType& used_for_size) {
 template <size_t Dim, typename DataType>
 void test_compute_gauge_source(const DataType& used_for_size) {
   pypp::check_with_random_values<1>(
-      &GeneralizedHarmonic::gauge_source<Dim, Frame::Inertial, DataType>,
+      static_cast<tnsr::a<DataType, Dim, Frame::Inertial> (*)(
+          const Scalar<DataType>&, const Scalar<DataType>&,
+          const tnsr::i<DataType, Dim, Frame::Inertial>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&,
+          const tnsr::iJ<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const Scalar<DataType>&,
+          const tnsr::i<DataType, Dim, Frame::Inertial>&) noexcept>(
+          &::GeneralizedHarmonic::gauge_source<Dim, Frame::Inertial, DataType>),
       "GeneralRelativity.ComputeGhQuantities", "gauge_source", {{{-10., 10.}}},
       used_for_size, 1.e-11);
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
@@ -4,13 +4,17 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <cstddef>
+#include <random>
 
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
 
 // IWYU pragma: no_include <boost/preprocessor/arithmetic/dec.hpp>
 // IWYU pragma: no_include <boost/preprocessor/repetition/enum.hpp>
@@ -18,10 +22,49 @@
 
 namespace {
 template <size_t Dim, IndexType TypeOfIndex, typename DataType>
+void test_compute_item_in_databox(const DataType& used_for_size) noexcept {
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::SpatialRicciCompute<3, Frame::Inertial, DataType>>(
+      "SpatialRicci");
+
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(-3.0, 3.0);
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+
+  const auto christoffel_2nd_kind = make_with_random_values<
+      tnsr::Abb<DataType, Dim, Frame::Inertial, TypeOfIndex>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto d_christoffel_2nd_kind = make_with_random_values<
+      tnsr::aBcc<DataType, Dim, Frame::Inertial, TypeOfIndex>>(
+      nn_generator, nn_distribution, used_for_size);
+
+  const auto box = db::create<
+      db::AddSimpleTags<gr::Tags::SpatialChristoffelSecondKind<
+                            Dim, Frame::Inertial, DataType>,
+                        ::Tags::deriv<gr::Tags::SpatialChristoffelSecondKind<
+                                          Dim, Frame::Inertial, DataType>,
+                                      tmpl::size_t<Dim>, Frame::Inertial>>,
+      db::AddComputeTags<
+          gr::Tags::SpatialRicciCompute<Dim, Frame::Inertial, DataType>>>(
+      christoffel_2nd_kind, d_christoffel_2nd_kind);
+
+  const auto expected =
+      gr::ricci_tensor(christoffel_2nd_kind, d_christoffel_2nd_kind);
+  CHECK_ITERABLE_APPROX(
+      (db::get<gr::Tags::SpatialRicci<Dim, Frame::Inertial, DataType>>(box)),
+      expected);
+}
+
+template <size_t Dim, IndexType TypeOfIndex, typename DataType>
 void test_ricci(const DataType& used_for_size) {
   pypp::check_with_random_values<1>(
-      &gr::ricci_tensor<Dim, Frame::Inertial, TypeOfIndex, DataType>, "Ricci",
-      "ricci_tensor", {{{-1., 1.}}}, used_for_size);
+      static_cast<tnsr::aa<DataType, Dim, Frame::Inertial, TypeOfIndex> (*)(
+          const tnsr::Abb<DataType, Dim, Frame::Inertial, TypeOfIndex>&,
+          const tnsr::aBcc<DataType, Dim, Frame::Inertial,
+                           TypeOfIndex>&) noexcept>(
+          &gr::ricci_tensor<Dim, Frame::Inertial, TypeOfIndex, DataType>),
+      "Ricci", "ricci_tensor", {{{-1., 1.}}}, used_for_size);
 }
 }  // namespace
 
@@ -34,8 +77,6 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Ricci.",
 
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_ricci, (1, 2, 3),
                                     (IndexType::Spatial, IndexType::Spacetime));
-
-  TestHelpers::db::test_compute_tag<
-      gr::Tags::SpatialRicciCompute<3, Frame::Inertial, DataVector>>(
-      "SpatialRicci");
+  test_compute_item_in_databox<3, IndexType::Spatial>(d);
+  test_compute_item_in_databox<3, IndexType::Spatial>(dv);
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
@@ -36,6 +36,6 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Ricci.",
                                     (IndexType::Spatial, IndexType::Spacetime));
 
   TestHelpers::db::test_compute_tag<
-      gr::Tags::RicciTensorCompute<3, Frame::Inertial, DataVector>>(
-      "RicciTensor");
+      gr::Tags::SpatialRicciCompute<3, Frame::Inertial, DataVector>>(
+      "SpatialRicci");
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
@@ -66,8 +66,8 @@ void test_simple_tags() {
       gr::Tags::ExtrinsicCurvature<Dim, Frame, Type>>("ExtrinsicCurvature");
   TestHelpers::db::test_simple_tag<gr::Tags::TraceExtrinsicCurvature<Type>>(
       "TraceExtrinsicCurvature");
-  TestHelpers::db::test_simple_tag<gr::Tags::RicciTensor<Dim, Frame, Type>>(
-      "RicciTensor");
+  TestHelpers::db::test_simple_tag<gr::Tags::SpatialRicci<Dim, Frame, Type>>(
+      "SpatialRicci");
   TestHelpers::db::test_simple_tag<gr::Tags::EnergyDensity<Type>>(
       "EnergyDensity");
   TestHelpers::db::test_simple_tag<gr::Tags::WeylElectric<Dim, Frame, Type>>(

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylElectric.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylElectric.cpp
@@ -4,19 +4,62 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <cstddef>
+#include <random>
 
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
 #include "tests/Unit/DataStructures/DataBox/TestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
 
 // IWYU pragma: no_include <boost/preprocessor/arithmetic/dec.hpp>
 // IWYU pragma: no_include <boost/preprocessor/repetition/enum.hpp>
 // IWYU pragma: no_include <boost/preprocessor/tuple/reverse.hpp>
 
 namespace {
+template <size_t SpatialDim, typename DataType>
+void test_compute_item_in_databox(const DataType& used_for_size) noexcept {
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::WeylElectricCompute<SpatialDim, Frame::Inertial, DataType>>(
+      "WeylElectric");
+
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(-3.0, 3.0);
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+
+  const auto spatial_ricci =
+      make_with_random_values<tnsr::ii<DataType, SpatialDim>>(
+          nn_generator, nn_distribution, used_for_size);
+  const auto extrinsic_curvature =
+      make_with_random_values<tnsr::ii<DataType, SpatialDim>>(
+          nn_generator, nn_distribution, used_for_size);
+  const auto inv_spatial_metric =
+      make_with_random_values<tnsr::II<DataType, SpatialDim>>(
+          nn_generator, nn_distribution, used_for_size);
+
+  const auto box = db::create<
+      db::AddSimpleTags<
+          gr::Tags::SpatialRicci<SpatialDim, Frame::Inertial, DataType>,
+          gr::Tags::ExtrinsicCurvature<SpatialDim, Frame::Inertial, DataType>,
+          gr::Tags::InverseSpatialMetric<SpatialDim, Frame::Inertial,
+                                         DataType>>,
+      db::AddComputeTags<gr::Tags::WeylElectricCompute<
+          SpatialDim, Frame::Inertial, DataType>>>(
+      spatial_ricci, extrinsic_curvature, inv_spatial_metric);
+
+  const auto expected =
+      gr::weyl_electric(spatial_ricci, extrinsic_curvature, inv_spatial_metric);
+  CHECK_ITERABLE_APPROX(
+      (db::get<gr::Tags::WeylElectric<SpatialDim, Frame::Inertial, DataType>>(
+          box)),
+      expected);
+}
+
 template <size_t SpatialDim, typename DataType>
 void test_weyl_electric(const DataType& used_for_size) {
   tnsr::ii<DataType, SpatialDim, Frame::Inertial> (*f)(
@@ -37,8 +80,6 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.WeylElectric",
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
 
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_weyl_electric, (1, 2, 3));
-
-  TestHelpers::db::test_compute_tag<
-      gr::Tags::WeylElectricCompute<3, Frame::Inertial, DataVector>>(
-      "WeylElectric");
+  test_compute_item_in_databox<3>(d);
+  test_compute_item_in_databox<3>(dv);
 }


### PR DESCRIPTION
## Proposed changes

This set of commits allow compute items in GR to use the mutating (return-by-reference) version of the corresponding functions.

The treatment for ComputeSpacetimeQuantities will be left for a separate PR.

Commit order should be

- Relocate/Add missing \cond
- Rename RicciTensor SpatialRicci
- Add mutating overload for Ricci
- Cleanup WeylElectric
- Have Christoffel compute items use mutating function
- Add mutating overload for gauge source
- Add mutating overload for extrinsic curvature
- Ensure correct size in two_index_constraint calculation
- Have GH compute items use mutating function

### Types of changes:

- [ ] Bugfix
- [ x] New feature
- [ ] Refactor

### Component:

- [x ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
