### PR TITLE
Moving mesh in InitalizeInterfaces and refactor SizeOfElement tests

### DIFF
--- a/src/Evolution/Actions/AddMeshVelocitySourceTerms.hpp
+++ b/src/Evolution/Actions/AddMeshVelocitySourceTerms.hpp
@@ -45,7 +45,7 @@ namespace Actions {
  * Uses:
  * - DataBox:
  *   - `System::variables_tags`
- *   - `domain::Tags::DivFrameVelocity`
+ *   - `domain::Tags::DivMeshVelocity`
  *
  * DataBox changes:
  * - Adds: nothing

--- a/src/Evolution/CMakeLists.txt
+++ b/src/Evolution/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY Evolution)
 
 set(LIBRARY_SOURCES
+  Initialization/DgDomain.cpp
   TagsDomain.cpp
   )
 

--- a/src/Evolution/Initialization/DgDomain.cpp
+++ b/src/Evolution/Initialization/DgDomain.cpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Initialization/DgDomain.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(r, data)                                              \
+  template std::unique_ptr<                                               \
+      domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, DIM(data)>> \
+      domain::make_coordinate_map_base<                                   \
+          Frame::Grid, Frame::Inertial,                                   \
+          domain::CoordinateMaps::Identity<DIM(data)>>(                   \
+          domain::CoordinateMaps::Identity<DIM(data)> &&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM

--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
 #include <tuple>
 #include <utility>
 #include <vector>

--- a/tests/Unit/Domain/Test_SizeOfElement.cpp
+++ b/tests/Unit/Domain/Test_SizeOfElement.cpp
@@ -27,77 +27,81 @@
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace {
+void test_1d() noexcept {
+  INFO("1d");
+  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      domain::CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.2));
+  const ElementId<1> element_id(0,
+                                std::array<SegmentId, 1>({{SegmentId(2, 3)}}));
+  const ElementMap<1, Frame::Inertial> element_map(element_id, std::move(map));
+  const auto size = size_of_element(element_map);
+  // for this affine map, expected size = width of block / number of elements
+  const auto size_expected = make_array<1>(0.225);
+  CHECK_ITERABLE_APPROX(size, size_expected);
+}
+
+void test_2d() noexcept {
+  INFO("2d");
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
+      domain::CoordinateMaps::DiscreteRotation<2>(
+          OrientationMap<2>{std::array<Direction<2>, 2>{
+              {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
+  const ElementId<2> element_id(
+      0, std::array<SegmentId, 2>({{SegmentId(1, 1), SegmentId(2, 0)}}));
+  const ElementMap<2, Frame::Inertial> element_map(element_id, std::move(map));
+  const auto size = size_of_element(element_map);
+  const auto size_expected = make_array(0.05, 0.425);
+  CHECK_ITERABLE_APPROX(size, size_expected);
+}
+
+void test_3d() noexcept {
+  INFO("3d");
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      Affine3D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2),
+               Affine(-1.0, 1.0, 12.0, 12.5)},
+      domain::CoordinateMaps::Rotation<3>(0.7, 2.3, -0.4));
+  const ElementId<3> element_id(
+      0, std::array<SegmentId, 3>(
+             {{SegmentId(3, 5), SegmentId(1, 0), SegmentId(2, 3)}}));
+  const ElementMap<3, Frame::Inertial> element_map(element_id, std::move(map));
+  const auto size = size_of_element(element_map);
+  const auto size_expected = make_array(0.0125, 0.85, 0.125);
+  CHECK_ITERABLE_APPROX(size, size_expected);
+}
+
+void test_compute_tag() noexcept {
+  INFO("compute tag");
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
+      domain::CoordinateMaps::DiscreteRotation<2>(
+          OrientationMap<2>{std::array<Direction<2>, 2>{
+              {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
+  const ElementId<2> element_id(
+      0, std::array<SegmentId, 2>({{SegmentId(1, 1), SegmentId(2, 0)}}));
+  ElementMap<2, Frame::Inertial> element_map(element_id, std::move(map));
+  const auto box = db::create<
+      db::AddSimpleTags<domain::Tags::ElementMap<2, Frame::Inertial>>,
+      db::AddComputeTags<domain::Tags::SizeOfElement<2>>>(
+      std::move(element_map));
+
+  const auto size_compute_item = db::get<domain::Tags::SizeOfElement<2>>(box);
+  const auto size_expected = make_array(0.05, 0.425);
+  CHECK_ITERABLE_APPROX(size_compute_item, size_expected);
+}
+}  // namespace
+
 SPECTRE_TEST_CASE("Unit.Domain.SizeOfElement", "[Domain][Unit]") {
-  SECTION("1D") {
-    auto map =
-        domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-            domain::CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.2));
-    const ElementId<1> element_id(
-        0, std::array<SegmentId, 1>({{SegmentId(2, 3)}}));
-    const ElementMap<1, Frame::Inertial> element_map(element_id,
-                                                     std::move(map));
-    const auto size = size_of_element(element_map);
-    // for this affine map, expected size = width of block / number of elements
-    const auto size_expected = make_array<1>(0.225);
-    CHECK_ITERABLE_APPROX(size, size_expected);
-  }
-
-  SECTION("2D") {
-    using Affine = domain::CoordinateMaps::Affine;
-    using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-    auto map =
-        domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-            Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
-            domain::CoordinateMaps::DiscreteRotation<2>(
-                OrientationMap<2>{std::array<Direction<2>, 2>{
-                    {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
-    const ElementId<2> element_id(
-        0, std::array<SegmentId, 2>({{SegmentId(1, 1), SegmentId(2, 0)}}));
-    const ElementMap<2, Frame::Inertial> element_map(element_id,
-                                                     std::move(map));
-    const auto size = size_of_element(element_map);
-    const auto size_expected = make_array(0.05, 0.425);
-    CHECK_ITERABLE_APPROX(size, size_expected);
-  }
-
-  SECTION("3D") {
-    using Affine = domain::CoordinateMaps::Affine;
-    using Affine3D =
-        domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
-    auto map =
-        domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-            Affine3D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2),
-                     Affine(-1.0, 1.0, 12.0, 12.5)},
-            domain::CoordinateMaps::Rotation<3>(0.7, 2.3, -0.4));
-    const ElementId<3> element_id(
-        0, std::array<SegmentId, 3>(
-               {{SegmentId(3, 5), SegmentId(1, 0), SegmentId(2, 3)}}));
-    const ElementMap<3, Frame::Inertial> element_map(element_id,
-                                                     std::move(map));
-    const auto size = size_of_element(element_map);
-    const auto size_expected = make_array(0.0125, 0.85, 0.125);
-    CHECK_ITERABLE_APPROX(size, size_expected);
-  }
-
-  SECTION("ComputeTag") {
-    using Affine = domain::CoordinateMaps::Affine;
-    using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-    auto map =
-        domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-            Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
-            domain::CoordinateMaps::DiscreteRotation<2>(
-                OrientationMap<2>{std::array<Direction<2>, 2>{
-                    {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
-    const ElementId<2> element_id(
-        0, std::array<SegmentId, 2>({{SegmentId(1, 1), SegmentId(2, 0)}}));
-    ElementMap<2, Frame::Inertial> element_map(element_id, std::move(map));
-    const auto box = db::create<
-        db::AddSimpleTags<domain::Tags::ElementMap<2, Frame::Inertial>>,
-        db::AddComputeTags<domain::Tags::SizeOfElement<2>>>(
-        std::move(element_map));
-
-    const auto size_compute_item = db::get<domain::Tags::SizeOfElement<2>>(box);
-    const auto size_expected = make_array(0.05, 0.425);
-    CHECK_ITERABLE_APPROX(size_compute_item, size_expected);
-  }
+  test_1d();
+  test_2d();
+  test_3d();
+  test_compute_tag();
 }

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
@@ -23,8 +23,15 @@
 #include "Domain/Domain.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/Tags.hpp"
+#include "Evolution/Initialization/DgDomain.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -62,16 +69,35 @@ struct System {
 template <size_t Dim, typename Metavariables>
 struct ElementArray {
   using metavariables = Metavariables;
+  static constexpr bool use_moving_mesh = Metavariables::use_moving_mesh;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
-  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<Dim>>;
+  using const_global_cache_tags = tmpl::append<
+      tmpl::list<domain::Tags::Domain<Dim>>,
+      tmpl::conditional_t<use_moving_mesh,
+                          tmpl::list<Tags::TimeStepper<TimeStepper>>,
+                          tmpl::list<>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<
-              ActionTesting::InitializeDataBox<tmpl::list<
-                  domain::Tags::InitialExtents<Dim>, vars_tag, other_vars_tag>>,
-              dg::Actions::InitializeDomain<Dim>>>,
+          tmpl::push_front<
+              tmpl::conditional_t<
+                  use_moving_mesh,
+                  tmpl::list<
+                      Initialization::Actions::TimeAndTimeStep<Metavariables>,
+                      evolution::dg::Initialization::Domain<Dim>>,
+                  tmpl::list<dg::Actions::InitializeDomain<Dim>>>,
+              ActionTesting::InitializeDataBox<tmpl::append<
+                  tmpl::list<domain::Tags::InitialExtents<Dim>, vars_tag,
+                             other_vars_tag>,
+                  tmpl::conditional_t<
+                      use_moving_mesh,
+                      tmpl::list<Initialization::Tags::InitialTime,
+                                 Initialization::Tags::InitialTimeDelta,
+                                 Initialization::Tags::InitialSlabSize<
+                                     Metavariables::local_time_stepping>,
+                                 domain::Tags::InitialFunctionsOfTime<Dim>>,
+                      tmpl::list<>>>>>>,
 
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
@@ -80,27 +106,33 @@ struct ElementArray {
               dg::Initialization::slice_tags_to_exterior<other_vars_tag>,
               dg::Initialization::face_compute_tags<SomeComputeTag<vars_tag>>,
               dg::Initialization::exterior_compute_tags<
-                  SomeComputeTag<other_vars_tag>>>>>>;
+                  SomeComputeTag<other_vars_tag>>,
+              true, use_moving_mesh>>>>;
 };
 
-template <size_t Dim>
+template <size_t Dim, bool UseMovingMesh>
 struct Metavariables {
+  static constexpr size_t dim = Dim;
+  static constexpr bool use_moving_mesh = UseMovingMesh;
+  static constexpr bool local_time_stepping = false;
   using system = System<Dim>;
-  using component_list = tmpl::list<ElementArray<Dim, Metavariables>>;
+  using element_array = ElementArray<Dim, Metavariables>;
+  using component_list = tmpl::list<element_array>;
   enum class Phase { Initialization, Testing, Exit };
 };
 
-template <size_t Dim>
-void check_compute_items(
-    const ActionTesting::MockRuntimeSystem<Metavariables<Dim>>& runner,
-    const ElementId<Dim>& element_id) {
+template <size_t Dim, bool UseMovingMesh>
+void check_compute_items(const ActionTesting::MockRuntimeSystem<
+                             Metavariables<Dim, UseMovingMesh>>& runner,
+                         const ElementId<Dim>& element_id) noexcept {
   // The compute items themselves are tested elsewhere, so just check if they
   // were indeed added by the initializer
   const auto tag_is_retrievable = [&runner,
                                    &element_id](auto tag_v) -> decltype(auto) {
     using tag = std::decay_t<decltype(tag_v)>;
     return ActionTesting::tag_is_retrievable<
-        ElementArray<Dim, Metavariables<Dim>>, tag>(runner, element_id);
+        ElementArray<Dim, Metavariables<Dim, UseMovingMesh>>, tag>(runner,
+                                                                   element_id);
   };
   CHECK(tag_is_retrievable(domain::Tags::InternalDirections<Dim>{}));
   CHECK(tag_is_retrievable(domain::Tags::BoundaryDirectionsInterior<Dim>{}));
@@ -140,6 +172,62 @@ void check_compute_items(
           ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>{}));
 }
 
+template <typename Metavariables,
+          Requires<Metavariables::use_moving_mesh> = nullptr>
+void create_runner_and_run_tests(
+    const DomainCreator<Metavariables::dim>& domain_creator,
+    const ElementId<Metavariables::dim>& element_id) {
+  using element_array = typename Metavariables::element_array;
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      {domain_creator.create_domain(),
+       std::make_unique<TimeSteppers::RungeKutta3>()}};
+  constexpr size_t num_points =
+      Metavariables::dim == 1 ? 4 : Metavariables::dim == 2 ? 12 : 24;
+  db::item_type<vars_tag> vars{num_points, 0.};
+  db::item_type<other_vars_tag> other_vars{num_points, 0.};
+
+  ActionTesting::emplace_component_and_initialize<
+      typename Metavariables::element_array>(
+      &runner, element_id,
+      {domain_creator.initial_extents(), vars, other_vars, 0.0, 0.1, 0.1,
+       domain_creator.functions_of_time()});
+
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Metavariables::Phase::Testing);
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+
+  check_compute_items(runner, element_id);
+}
+
+template <typename Metavariables,
+          Requires<not Metavariables::use_moving_mesh> = nullptr>
+void create_runner_and_run_tests(
+    const DomainCreator<Metavariables::dim>& domain_creator,
+    const ElementId<Metavariables::dim>& element_id) {
+  using element_array = typename Metavariables::element_array;
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      {domain_creator.create_domain()}};
+  constexpr size_t num_points =
+      Metavariables::dim == 1 ? 4 : Metavariables::dim == 2 ? 12 : 24;
+  db::item_type<vars_tag> vars{num_points, 0.};
+  db::item_type<other_vars_tag> other_vars{num_points, 0.};
+
+  ActionTesting::emplace_component_and_initialize<
+      typename Metavariables::element_array>(
+      &runner, element_id,
+      {domain_creator.initial_extents(), vars, other_vars});
+
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Metavariables::Phase::Testing);
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+
+  check_compute_items(runner, element_id);
+}
+
+template <bool UseMovingMesh>
 void test_1d() {
   INFO("1D");
   // Reference element:
@@ -152,24 +240,11 @@ void test_1d() {
       SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,
                                        domain::CoordinateMaps::Affine>));
 
-  db::item_type<vars_tag> vars{4, 0.};
-  db::item_type<other_vars_tag> other_vars{4, 0.};
-
-  using metavariables = Metavariables<1>;
-  using element_array = ElementArray<1, metavariables>;
-  ActionTesting::MockRuntimeSystem<metavariables> runner{
-      {domain_creator.create_domain()}};
-  ActionTesting::emplace_component_and_initialize<element_array>(
-      &runner, element_id,
-      {domain_creator.initial_extents(), vars, other_vars});
-  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
-  ActionTesting::set_phase(make_not_null(&runner),
-                           metavariables::Phase::Testing);
-  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
-
-  check_compute_items(runner, element_id);
+  create_runner_and_run_tests<Metavariables<1, UseMovingMesh>>(domain_creator,
+                                                               element_id);
 }
 
+template <bool UseMovingMesh>
 void test_2d() {
   INFO("2D");
   // Reference element:
@@ -187,24 +262,11 @@ void test_2d() {
                                            domain::CoordinateMaps::Affine,
                                            domain::CoordinateMaps::Affine>>));
 
-  db::item_type<vars_tag> vars{12, 0.};
-  db::item_type<other_vars_tag> other_vars{12, 0.};
-
-  using metavariables = Metavariables<2>;
-  using element_array = ElementArray<2, metavariables>;
-  ActionTesting::MockRuntimeSystem<metavariables> runner{
-      {domain_creator.create_domain()}};
-  ActionTesting::emplace_component_and_initialize<element_array>(
-      &runner, element_id,
-      {domain_creator.initial_extents(), vars, other_vars});
-  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
-  ActionTesting::set_phase(make_not_null(&runner),
-                           metavariables::Phase::Testing);
-  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
-
-  check_compute_items(runner, element_id);
+  create_runner_and_run_tests<Metavariables<2, UseMovingMesh>>(domain_creator,
+                                                               element_id);
 }
 
+template <bool UseMovingMesh>
 void test_3d() {
   INFO("3D");
   const ElementId<3> element_id{
@@ -222,27 +284,17 @@ void test_3d() {
               domain::CoordinateMaps::Affine, domain::CoordinateMaps::Affine,
               domain::CoordinateMaps::Affine>>));
 
-  db::item_type<vars_tag> vars{24, 0.};
-  db::item_type<other_vars_tag> other_vars{24, 0.};
-
-  using metavariables = Metavariables<3>;
-  using element_array = ElementArray<3, metavariables>;
-  ActionTesting::MockRuntimeSystem<metavariables> runner{
-      {domain_creator.create_domain()}};
-  ActionTesting::emplace_component_and_initialize<element_array>(
-      &runner, element_id,
-      {domain_creator.initial_extents(), vars, other_vars});
-  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
-  ActionTesting::set_phase(make_not_null(&runner),
-                           metavariables::Phase::Testing);
-  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
-
-  check_compute_items(runner, element_id);
+  create_runner_and_run_tests<Metavariables<3, UseMovingMesh>>(domain_creator,
+                                                               element_id);
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeInterfaces", "[Unit][Actions]") {
-  test_1d();
-  test_2d();
-  test_3d();
+  test_1d<false>();
+  test_2d<false>();
+  test_3d<false>();
+
+  test_1d<true>();
+  test_2d<true>();
+  test_3d<true>();
 }

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
@@ -140,110 +140,109 @@ void check_compute_items(
           ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>{}));
 }
 
+void test_1d() {
+  INFO("1D");
+  // Reference element:
+  // [ |X| | ]-> xi
+  const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
+  const domain::creators::Interval domain_creator{
+      {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
+  // Register the coordinate map for serialization
+  PUPable_reg(
+      SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                                       domain::CoordinateMaps::Affine>));
+
+  db::item_type<vars_tag> vars{4, 0.};
+  db::item_type<other_vars_tag> other_vars{4, 0.};
+
+  using metavariables = Metavariables<1>;
+  using element_array = ElementArray<1, metavariables>;
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
+      {domain_creator.create_domain()}};
+  ActionTesting::emplace_component_and_initialize<element_array>(
+      &runner, element_id,
+      {domain_creator.initial_extents(), vars, other_vars});
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  ActionTesting::set_phase(make_not_null(&runner),
+                           metavariables::Phase::Testing);
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+
+  check_compute_items(runner, element_id);
+}
+
+void test_2d() {
+  INFO("2D");
+  // Reference element:
+  // ^ eta
+  // +-+-+-+-+> xi
+  // | |X| | |
+  // +-+-+-+-+
+  const ElementId<2> element_id{0, {{SegmentId{2, 1}, SegmentId{0, 0}}}};
+  const domain::creators::Rectangle domain_creator{
+      {{-0.5, 0.}}, {{1.5, 2.}}, {{false, false}}, {{2, 0}}, {{4, 3}}};
+  // Register the coordinate map for serialization
+  PUPable_reg(
+      SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                                       domain::CoordinateMaps::ProductOf2Maps<
+                                           domain::CoordinateMaps::Affine,
+                                           domain::CoordinateMaps::Affine>>));
+
+  db::item_type<vars_tag> vars{12, 0.};
+  db::item_type<other_vars_tag> other_vars{12, 0.};
+
+  using metavariables = Metavariables<2>;
+  using element_array = ElementArray<2, metavariables>;
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
+      {domain_creator.create_domain()}};
+  ActionTesting::emplace_component_and_initialize<element_array>(
+      &runner, element_id,
+      {domain_creator.initial_extents(), vars, other_vars});
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  ActionTesting::set_phase(make_not_null(&runner),
+                           metavariables::Phase::Testing);
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+
+  check_compute_items(runner, element_id);
+}
+
+void test_3d() {
+  INFO("3D");
+  const ElementId<3> element_id{
+      0, {{SegmentId{2, 1}, SegmentId{0, 0}, SegmentId{1, 1}}}};
+  const domain::creators::Brick domain_creator{{{-0.5, 0., -1.}},
+                                               {{1.5, 2., 3.}},
+                                               {{false, false, false}},
+                                               {{2, 0, 1}},
+                                               {{4, 3, 2}}};
+  // Register the coordinate map for serialization
+  PUPable_reg(SINGLE_ARG(
+      domain::CoordinateMap<
+          Frame::Logical, Frame::Inertial,
+          domain::CoordinateMaps::ProductOf3Maps<
+              domain::CoordinateMaps::Affine, domain::CoordinateMaps::Affine,
+              domain::CoordinateMaps::Affine>>));
+
+  db::item_type<vars_tag> vars{24, 0.};
+  db::item_type<other_vars_tag> other_vars{24, 0.};
+
+  using metavariables = Metavariables<3>;
+  using element_array = ElementArray<3, metavariables>;
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
+      {domain_creator.create_domain()}};
+  ActionTesting::emplace_component_and_initialize<element_array>(
+      &runner, element_id,
+      {domain_creator.initial_extents(), vars, other_vars});
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  ActionTesting::set_phase(make_not_null(&runner),
+                           metavariables::Phase::Testing);
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+
+  check_compute_items(runner, element_id);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeInterfaces", "[Unit][Actions]") {
-  {
-    INFO("1D");
-    // Reference element:
-    // [ |X| | ]-> xi
-    const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
-    const domain::creators::Interval domain_creator{
-        {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
-    // Register the coordinate map for serialization
-    PUPable_reg(
-        SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,
-                                         domain::CoordinateMaps::Affine>));
-
-    db::item_type<vars_tag> vars{4, 0.};
-    db::item_type<other_vars_tag> other_vars{4, 0.};
-
-    using metavariables = Metavariables<1>;
-    using element_array = ElementArray<1, metavariables>;
-    ActionTesting::MockRuntimeSystem<metavariables> runner{
-        {domain_creator.create_domain()}};
-    ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id,
-        {domain_creator.initial_extents(), vars, other_vars});
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
-    ActionTesting::set_phase(make_not_null(&runner),
-                             metavariables::Phase::Testing);
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
-
-    check_compute_items(runner, element_id);
-  }
-  {
-    INFO("2D");
-    // Reference element:
-    // ^ eta
-    // +-+-+-+-+> xi
-    // | |X| | |
-    // +-+-+-+-+
-    const ElementId<2> element_id{0, {{SegmentId{2, 1}, SegmentId{0, 0}}}};
-    const domain::creators::Rectangle domain_creator{
-        {{-0.5, 0.}}, {{1.5, 2.}}, {{false, false}}, {{2, 0}}, {{4, 3}}};
-    // Register the coordinate map for serialization
-    PUPable_reg(
-        SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,
-                                         domain::CoordinateMaps::ProductOf2Maps<
-                                             domain::CoordinateMaps::Affine,
-                                             domain::CoordinateMaps::Affine>>));
-
-    db::item_type<vars_tag> vars{12, 0.};
-    db::item_type<other_vars_tag> other_vars{12, 0.};
-
-    using metavariables = Metavariables<2>;
-    using element_array = ElementArray<2, metavariables>;
-    ActionTesting::MockRuntimeSystem<metavariables> runner{
-        {domain_creator.create_domain()}};
-    ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id,
-        {domain_creator.initial_extents(), vars, other_vars});
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
-    ActionTesting::set_phase(make_not_null(&runner),
-                             metavariables::Phase::Testing);
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
-
-    check_compute_items(runner, element_id);
-  }
-  {
-    INFO("3D");
-    const ElementId<3> element_id{
-        0, {{SegmentId{2, 1}, SegmentId{0, 0}, SegmentId{1, 1}}}};
-    const domain::creators::Brick domain_creator{{{-0.5, 0., -1.}},
-                                                 {{1.5, 2., 3.}},
-                                                 {{false, false, false}},
-                                                 {{2, 0, 1}},
-                                                 {{4, 3, 2}}};
-    // Register the coordinate map for serialization
-    PUPable_reg(SINGLE_ARG(
-        domain::CoordinateMap<
-            Frame::Logical, Frame::Inertial,
-            domain::CoordinateMaps::ProductOf3Maps<
-                domain::CoordinateMaps::Affine, domain::CoordinateMaps::Affine,
-                domain::CoordinateMaps::Affine>>));
-
-    db::item_type<vars_tag> vars{24, 0.};
-    db::item_type<other_vars_tag> other_vars{24, 0.};
-
-    using metavariables = Metavariables<3>;
-    using element_array = ElementArray<3, metavariables>;
-    ActionTesting::MockRuntimeSystem<metavariables> runner{
-        {domain_creator.create_domain()}};
-    ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id,
-        {domain_creator.initial_extents(), vars, other_vars});
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
-    ActionTesting::set_phase(make_not_null(&runner),
-                             metavariables::Phase::Testing);
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
-
-    check_compute_items(runner, element_id);
-  }
+  test_1d();
+  test_2d();
+  test_3d();
 }


### PR DESCRIPTION
## Proposed changes

Mostly some refactors and cleanups before enabling moving mesh in all conservative systems.

- We need explicit instantiations of `Identity` maps for the moving mesh code because that's how it signals to parts of the code at runtime that the mesh is time-independent
- Allow `InitializeInterfaces` to handle moving meshes. This is done via simple `tmpl::conditional_t`s
- Refactor `SizeOfElement` test because it will need to support moving meshes and doing the refactor separately will make the next part easier to digest.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
