### PR TITLE
Enable moving mesh for conservative systems

### DIFF
--- a/src/Domain/SizeOfElement.cpp
+++ b/src/Domain/SizeOfElement.cpp
@@ -3,23 +3,39 @@
 
 #include "Domain/SizeOfElement.hpp"
 
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/ElementMap.hpp"  // IWYU pragma: keep
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/Side.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/StdArrayHelpers.hpp"  // IWYU pragma: keep
 
 template <size_t VolumeDim>
-std::array<double, VolumeDim> size_of_element(
-    const ElementMap<VolumeDim, Frame::Inertial>& element_map) noexcept {
-  auto result = make_array<VolumeDim>(0.0);
+void size_of_element(
+    const gsl::not_null<std::array<double, VolumeDim>*> result,
+    const ElementMap<VolumeDim, Frame::Grid>& logical_to_grid_map,
+    const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>&
+        grid_to_inertial_map,
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) noexcept {
+  *result = make_array<VolumeDim>(0.0);
   for (size_t logical_dim = 0; logical_dim < VolumeDim; ++logical_dim) {
-    const auto face_center =
-        [&logical_dim, &element_map ](const Side& side) noexcept {
+    const auto face_center = [&functions_of_time, &grid_to_inertial_map,
+                              &logical_dim, &logical_to_grid_map,
+                              time](const Side& side) noexcept {
       tnsr::I<double, VolumeDim, Frame::Logical> logical_center{{{0.0}}};
       logical_center.get(logical_dim) = (side == Side::Lower ? -1.0 : 1.0);
       const tnsr::I<double, VolumeDim, Frame::Inertial> inertial_center =
-          element_map(logical_center);
+          grid_to_inertial_map(logical_to_grid_map(logical_center), time,
+                               functions_of_time);
       return inertial_center;
     };
     const auto lower_center = face_center(Side::Lower);
@@ -32,17 +48,24 @@ std::array<double, VolumeDim> size_of_element(
           upper_center.get(inertial_dim) - lower_center.get(inertial_dim);
     }
 
-    result.at(logical_dim) = magnitude(center_to_center);
+    result->at(logical_dim) = magnitude(center_to_center);
   }
-  return result;
 }
 
 // Explicit instantiations
 #define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(r, data)                                \
-  template std::array<double, GET_DIM(data)> size_of_element( \
-      const ElementMap<GET_DIM(data), Frame::Inertial>&) noexcept;
+#define INSTANTIATION(r, data)                                              \
+  template void size_of_element(                                            \
+      gsl::not_null<std::array<double, GET_DIM(data)>*> result,             \
+      const ElementMap<GET_DIM(data), Frame::Grid>& logical_to_grid_map,    \
+      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial,         \
+                                      GET_DIM(data)>& grid_to_inertial_map, \
+      const double time,                                                    \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Evolution/Actions/ComputeVolumeFluxes.hpp
+++ b/src/Evolution/Actions/ComputeVolumeFluxes.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "Domain/TagsTimeDependent.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -25,18 +26,34 @@ class ConstGlobalCache;
 /// \endcond
 
 namespace Actions {
-/// \ingroup ActionsGroup
-/// \brief Compute the volume fluxes of the evolved variables
-///
-/// Uses:
-/// - DataBox: Items in system::volume_fluxes::argument_tags
-///
-/// DataBox changes:
-/// - Adds: nothing
-/// - Removes: nothing
-/// - Modifies:
-///   db::add_tag_prefix<Tags::Flux, variables_tag,
-///                      tmpl::size_t<system::volume_dim>, Frame::Inertial>
+/*!
+ * \ingroup ActionsGroup
+ * \brief Compute the volume fluxes of the evolved variables
+ *
+ * The mesh velocity is added to the flux automatically if the mesh is moving.
+ * That is,
+ *
+ * \f{align}{
+ *  F^i_{\alpha}\to F^i_{\alpha}-v^i_{g} u_{\alpha}
+ * \f}
+ *
+ * where \f$F^i_{\alpha}\f$ are the fluxes when the mesh isn't moving,
+ * \f$v^i_g\f$ is the velocity of the mesh, and \f$u_{\alpha}\f$ are the evolved
+ * variables.
+ *
+ * Uses:
+ * - DataBox:
+ *   - Items in system::volume_fluxes::argument_tags
+ *   - `domain::Tags::MeshVelocity<Metavariables::volume_dim>`
+ *   - `Metavariables::system::variables_tag`
+ *
+ * DataBox changes:
+ * - Adds: nothing
+ * - Removes: nothing
+ * - Modifies:
+ *   db::add_tag_prefix<Tags::Flux, variables_tag,
+ *                      tmpl::size_t<system::volume_dim>, Frame::Inertial>
+ */
 struct ComputeVolumeFluxes {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -50,6 +67,43 @@ struct ComputeVolumeFluxes {
       const ParallelComponent* const /*meta*/) noexcept {  // NOLINT const
     db::mutate_apply<typename Metavariables::system::volume_fluxes>(
         make_not_null(&box));
+    const auto use_moving_mesh = static_cast<bool>(
+        db::get<domain::Tags::MeshVelocity<Metavariables::volume_dim>>(box));
+    if (use_moving_mesh) {
+      using variables_tag = typename Metavariables::system::variables_tag;
+      using fluxes_tag =
+          db::add_tag_prefix<::Tags::Flux, variables_tag,
+                             tmpl::size_t<Metavariables::volume_dim>,
+                             Frame::Inertial>;
+      db::mutate<fluxes_tag>(
+          make_not_null(&box),
+          [](const auto fluxes_ptr, const auto& evolved_vars,
+             const tnsr::I<DataVector, Metavariables::volume_dim,
+                           Frame::Inertial>& grid_velocity) noexcept {
+            tmpl::for_each<typename fluxes_tag::tag::tags_list>(
+                [&evolved_vars, &fluxes_ptr,
+                 &grid_velocity](auto tag_v) noexcept {
+                  using ::get;
+                  using flux_tag = typename decltype(tag_v)::type;
+                  using var_tag = db::remove_tag_prefix<flux_tag>;
+                  auto& flux_tensor = get<flux_tag>(*fluxes_ptr);
+                  for (size_t storage_index = 0;
+                       storage_index < flux_tensor.size(); ++storage_index) {
+                    const auto flux_tensor_index =
+                        flux_tensor.get_tensor_index(storage_index);
+                    const auto tensor_index =
+                        all_but_specified_element_of(flux_tensor_index, 0);
+                    const size_t flux_index = gsl::at(flux_tensor_index, 0);
+
+                    flux_tensor[storage_index] -=
+                        get<var_tag>(evolved_vars).get(tensor_index) *
+                        grid_velocity.get(flux_index);
+                  }
+                });
+          },
+          db::get<variables_tag>(box),
+          *db::get<domain::Tags::MeshVelocity<Metavariables::volume_dim>>(box));
+    }
     return std::forward_as_tuple(std::move(box));
   }
 };

--- a/src/Evolution/Executables/Burgers/CMakeLists.txt
+++ b/src/Evolution/Executables/Burgers/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBS_TO_LINK
   BurgersSolutions
   DiscontinuousGalerkin
   DomainCreators
+  Evolution
   IO
   Informer
   Limiters

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBS_TO_LINK
   CoordinateMaps
   DiscontinuousGalerkin
   DomainCreators
+  Evolution
   GeneralRelativitySolutions
   GrMhdAnalyticData
   GrMhdSolutions

--- a/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBS_TO_LINK
   CoordinateMaps
   DiscontinuousGalerkin
   DomainCreators
+  Evolution
   Hydro
   IO
   Informer

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -8,8 +8,11 @@
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Domain/Tags.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "Evolution/Actions/AddMeshVelocitySourceTerms.hpp"
 #include "Evolution/Actions/ComputeTimeDerivative.hpp"
 #include "Evolution/Actions/ComputeVolumeFluxes.hpp"
 #include "Evolution/Actions/ComputeVolumeSources.hpp"
@@ -21,6 +24,7 @@
 #include "Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp"
 #include "Evolution/Initialization/ConservativeSystem.hpp"
+#include "Evolution/Initialization/DgDomain.hpp"
 #include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/Limiter.hpp"
@@ -184,6 +188,7 @@ struct EvolutionMetavars {
                           tmpl::list<>>,
       Actions::ComputeTimeDerivative<
           evolution::dg::ConservativeDuDt<system, dg_formulation>>,
+      evolution::Actions::AddMeshVelocitySourceTerms,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
@@ -211,7 +216,7 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
-      dg::Actions::InitializeDomain<Dim>,
+      evolution::dg::Initialization::Domain<Dim>,
       Initialization::Actions::ConservativeSystem,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
       Initialization::Actions::AddComputeTags<
@@ -226,7 +231,9 @@ struct EvolutionMetavars {
               NewtonianEuler::Tags::SoundSpeed<DataVector>>,
           dg::Initialization::slice_tags_to_exterior<
               typename system::primitive_variables_tag,
-              NewtonianEuler::Tags::SoundSpeed<DataVector>>>,
+              NewtonianEuler::Tags::SoundSpeed<DataVector>>,
+          dg::Initialization::face_compute_tags<>,
+          dg::Initialization::exterior_compute_tags<>, true, true>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           Initialization::Actions::AddComputeTags<
@@ -307,6 +314,8 @@ struct EvolutionMetavars {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling,
     &domain::creators::register_derived_with_charm,
+    &domain::creators::time_dependence::register_derived_with_charm,
+    &domain::FunctionsOfTime::register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<
         Event<metavariables::events>>,
     &Parallel::register_derived_classes_with_charm<

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBS_TO_LINK
   CoordinateMaps
   DiscontinuousGalerkin
   DomainCreators
+  Evolution
   GeneralRelativitySolutions
   Hydro
   IO

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBS_TO_LINK
   CoordinateMaps
   DiscontinuousGalerkin
   DomainCreators
+  Evolution
   GeneralRelativitySolutions
   Hydro
   IO

--- a/src/Evolution/Initialization/ConservativeSystem.hpp
+++ b/src/Evolution/Initialization/ConservativeSystem.hpp
@@ -10,6 +10,10 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Evolution/Initialization/InitialData.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
@@ -139,8 +143,13 @@ struct ConservativeSystem {
     const size_t num_grid_points =
         db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points();
 
-    const auto& inertial_coords =
-        db::get<domain::Tags::Coordinates<dim, Frame::Inertial>>(box);
+    const auto inertial_coords =
+        db::get<domain::CoordinateMaps::Tags::CoordinateMap<dim, Frame::Grid,
+                                                            Frame::Inertial>>(
+            box)(
+            db::get<domain::Tags::ElementMap<dim, Frame::Grid>>(box)(
+                db::get<domain::Tags::Coordinates<dim, Frame::Logical>>(box)),
+            initial_time, db::get<domain::Tags::FunctionsOfTime>(box));
 
     // Set initial data from analytic solution
     const auto& solution_or_data =
@@ -169,8 +178,14 @@ struct ConservativeSystem {
     using variables_tag = typename system::variables_tag;
 
     const double initial_time = db::get<Initialization::Tags::InitialTime>(box);
-    const auto& inertial_coords =
-        db::get<domain::Tags::Coordinates<dim, Frame::Inertial>>(box);
+
+    const auto inertial_coords =
+        db::get<domain::CoordinateMaps::Tags::CoordinateMap<dim, Frame::Grid,
+                                                            Frame::Inertial>>(
+            box)(
+            db::get<domain::Tags::ElementMap<dim, Frame::Grid>>(box)(
+                db::get<domain::Tags::Coordinates<dim, Frame::Logical>>(box)),
+            initial_time, db::get<domain::Tags::FunctionsOfTime>(box));
 
     // Set initial data from analytic solution
     using Vars = typename variables_tag::type;

--- a/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
+++ b/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
@@ -21,6 +21,8 @@
 #include "Domain/Neighbors.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Domain/Tags.hpp"
+#include "Domain/TagsCharacteresticSpeeds.hpp"
+#include "Domain/TagsTimeDependent.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
@@ -158,7 +160,10 @@ struct DiscontinuousGalerkin {
                                tmpl::size_t<dim>, Frame::Inertial>>,
         interface_compute_tag<::Tags::NormalDotFluxCompute<
             typename LocalSystem::variables_tag, dim, Frame::Inertial>>,
-        interface_compute_tag<char_speed_tag>,
+        domain::Tags::Slice<domain::Tags::InternalDirections<dim>,
+                            domain::Tags::MeshVelocity<dim>>,
+        interface_compute_tag<
+            domain::Tags::CharSpeedCompute<char_speed_tag, dim>>,
         domain::Tags::Slice<
             domain::Tags::BoundaryDirectionsInterior<dim>,
             db::add_tag_prefix<::Tags::Flux,
@@ -174,7 +179,10 @@ struct DiscontinuousGalerkin {
                                tmpl::size_t<dim>, Frame::Inertial>>,
         boundary_exterior_compute_tag<::Tags::NormalDotFluxCompute<
             typename LocalSystem::variables_tag, dim, Frame::Inertial>>,
-        boundary_exterior_compute_tag<char_speed_tag>>;
+        domain::Tags::Slice<domain::Tags::BoundaryDirectionsExterior<dim>,
+                            domain::Tags::MeshVelocity<dim>>,
+        boundary_exterior_compute_tag<
+            domain::Tags::CharSpeedCompute<char_speed_tag, dim>>>;
 
     template <typename TagsList>
     static auto initialize(db::DataBox<TagsList>&& box) noexcept {

--- a/src/Evolution/Initialization/GrTagsForHydro.hpp
+++ b/src/Evolution/Initialization/GrTagsForHydro.hpp
@@ -8,6 +8,9 @@
 #include <utility>  // IWYU pragma: keep  // for move
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Tags.hpp"
 #include "Evolution/Initialization/InitialData.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
@@ -16,6 +19,7 @@
 
 /// \cond
 namespace Frame {
+struct Grid;
 struct Inertial;
 }  // namespace Frame
 namespace Initialization {
@@ -75,8 +79,13 @@ struct GrTagsForHydro {
 
     const size_t num_grid_points =
         db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points();
-    const auto& inertial_coords =
-        db::get<domain::Tags::Coordinates<dim, Frame::Inertial>>(box);
+    const auto inertial_coords =
+        db::get<domain::CoordinateMaps::Tags::CoordinateMap<dim, Frame::Grid,
+                                                            Frame::Inertial>>(
+            box)(
+            db::get<domain::Tags::ElementMap<dim, Frame::Grid>>(box)(
+                db::get<domain::Tags::Coordinates<dim, Frame::Logical>>(box)),
+            initial_time, db::get<domain::Tags::FunctionsOfTime>(box));
 
     // Set initial data from analytic solution
     GrVars gr_vars{num_grid_points};

--- a/src/Evolution/Initialization/Limiter.hpp
+++ b/src/Evolution/Initialization/Limiter.hpp
@@ -34,7 +34,7 @@ namespace Actions {
 template <size_t Dim>
 struct Minmod {
   using simple_tags = db::AddSimpleTags<>;
-  using compute_tags = tmpl::list<domain::Tags::SizeOfElement<Dim>>;
+  using compute_tags = tmpl::list<domain::Tags::SizeOfElementCompute<Dim>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,

--- a/tests/Unit/Domain/Test_SizeOfElement.cpp
+++ b/tests/Unit/Domain/Test_SizeOfElement.cpp
@@ -13,95 +13,226 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/CubicScale.hpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Domain/SegmentId.hpp"
 #include "Domain/SizeOfElement.hpp"
 #include "Domain/Tags.hpp"
+#include "Time/Tags.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
-void test_1d() noexcept {
+template <size_t Dim>
+using CubicScale = domain::CoordMapsTimeDependent::CubicScale<Dim>;
+
+std::unordered_map<std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+make_single_expansion_functions_of_time() noexcept {
+  const double initial_time = 0.0;
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  functions_of_time.insert(std::make_pair(
+      "Expansion",
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time, std::array<DataVector, 3>{{{0.0}, {1.0}, {0.0}}})));
+  return functions_of_time;
+}
+
+template <bool UseMovingMesh>
+void test_1d(const std::array<double, 4>& times_to_check) noexcept {
   INFO("1d");
-  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
       domain::CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.2));
   const ElementId<1> element_id(0,
                                 std::array<SegmentId, 1>({{SegmentId(2, 3)}}));
-  const ElementMap<1, Frame::Inertial> element_map(element_id, std::move(map));
-  const auto size = size_of_element(element_map);
-  // for this affine map, expected size = width of block / number of elements
-  const auto size_expected = make_array<1>(0.225);
-  CHECK_ITERABLE_APPROX(size, size_expected);
+  const ElementMap<1, Frame::Grid> logical_to_grid_map(element_id,
+                                                       std::move(map));
+  const std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time = make_single_expansion_functions_of_time();
+
+  const auto check_helper =
+      [&functions_of_time, &logical_to_grid_map,
+       &times_to_check](const auto& grid_to_inertial_map) noexcept {
+        std::array<double, 1> element_size{};
+        for (const double time : times_to_check) {
+          size_of_element(make_not_null(&element_size), logical_to_grid_map,
+                          grid_to_inertial_map, time, functions_of_time);
+          // for this affine map, expected size = width of block / number of
+          // elements
+          const auto expected_size_of_element =
+              make_array<1>(0.225 * (UseMovingMesh ? time : 1.0));
+          CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
+        }
+      };
+
+  if (UseMovingMesh) {
+    check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
+        CubicScale<1>{10.0, "Expansion", "Expansion"}));
+
+  } else {
+    check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
+        domain::CoordinateMaps::Identity<1>{}));
+  }
 }
 
-void test_2d() noexcept {
+template <bool UseMovingMesh>
+void test_2d(const std::array<double, 4>& times_to_check) noexcept {
   INFO("2d");
   using Affine = domain::CoordinateMaps::Affine;
   using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
       Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
       domain::CoordinateMaps::DiscreteRotation<2>(
           OrientationMap<2>{std::array<Direction<2>, 2>{
               {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
   const ElementId<2> element_id(
       0, std::array<SegmentId, 2>({{SegmentId(1, 1), SegmentId(2, 0)}}));
-  const ElementMap<2, Frame::Inertial> element_map(element_id, std::move(map));
-  const auto size = size_of_element(element_map);
-  const auto size_expected = make_array(0.05, 0.425);
-  CHECK_ITERABLE_APPROX(size, size_expected);
+  const ElementMap<2, Frame::Grid> logical_to_grid_map(element_id,
+                                                       std::move(map));
+  const std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time = make_single_expansion_functions_of_time();
+
+  const auto check_helper =
+      [&functions_of_time, &logical_to_grid_map,
+       &times_to_check](const auto& grid_to_inertial_map) noexcept {
+        std::array<double, 2> element_size{};
+        for (const double time : times_to_check) {
+          size_of_element(make_not_null(&element_size), logical_to_grid_map,
+                          grid_to_inertial_map, time, functions_of_time);
+          const auto expected_size_of_element =
+              make_array(0.05, 0.425) * (UseMovingMesh ? time : 1.0);
+          CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
+        }
+      };
+
+  if (UseMovingMesh) {
+    check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
+        CubicScale<2>{10.0, "Expansion", "Expansion"}));
+
+  } else {
+    check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
+        domain::CoordinateMaps::Identity<2>{}));
+  }
 }
 
-void test_3d() noexcept {
+template <bool UseMovingMesh>
+void test_3d(const std::array<double, 4>& times_to_check) noexcept {
   INFO("3d");
   using Affine = domain::CoordinateMaps::Affine;
   using Affine3D =
       domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
-  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
       Affine3D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2),
                Affine(-1.0, 1.0, 12.0, 12.5)},
       domain::CoordinateMaps::Rotation<3>(0.7, 2.3, -0.4));
   const ElementId<3> element_id(
       0, std::array<SegmentId, 3>(
              {{SegmentId(3, 5), SegmentId(1, 0), SegmentId(2, 3)}}));
-  const ElementMap<3, Frame::Inertial> element_map(element_id, std::move(map));
-  const auto size = size_of_element(element_map);
-  const auto size_expected = make_array(0.0125, 0.85, 0.125);
-  CHECK_ITERABLE_APPROX(size, size_expected);
+  const ElementMap<3, Frame::Grid> logical_to_grid_map(element_id,
+                                                       std::move(map));
+  const std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time = make_single_expansion_functions_of_time();
+
+  const auto check_helper =
+      [&functions_of_time, &logical_to_grid_map,
+       &times_to_check](const auto& grid_to_inertial_map) noexcept {
+        std::array<double, 3> element_size{};
+        for (const double time : times_to_check) {
+          size_of_element(make_not_null(&element_size), logical_to_grid_map,
+                          grid_to_inertial_map, time, functions_of_time);
+          const auto expected_size_of_element =
+              make_array(0.0125, 0.85, 0.125) * (UseMovingMesh ? time : 1.0);
+          CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
+        }
+      };
+
+  if (UseMovingMesh) {
+    check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
+        CubicScale<3>{10.0, "Expansion", "Expansion"}));
+
+  } else {
+    check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
+        domain::CoordinateMaps::Identity<3>{}));
+  }
 }
 
-void test_compute_tag() noexcept {
+template <bool UseMovingMesh>
+void test_compute_tag(const std::array<double, 4>& times_to_check) noexcept {
   INFO("compute tag");
   using Affine = domain::CoordinateMaps::Affine;
   using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
       Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
       domain::CoordinateMaps::DiscreteRotation<2>(
           OrientationMap<2>{std::array<Direction<2>, 2>{
               {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
   const ElementId<2> element_id(
       0, std::array<SegmentId, 2>({{SegmentId(1, 1), SegmentId(2, 0)}}));
-  ElementMap<2, Frame::Inertial> element_map(element_id, std::move(map));
-  const auto box = db::create<
-      db::AddSimpleTags<domain::Tags::ElementMap<2, Frame::Inertial>>,
-      db::AddComputeTags<domain::Tags::SizeOfElement<2>>>(
-      std::move(element_map));
+  ElementMap<2, Frame::Grid> logical_to_grid_map(element_id, std::move(map));
+  std::unique_ptr<domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 2>>
+      grid_to_inertial_map = nullptr;
+  if (UseMovingMesh) {
+    grid_to_inertial_map =
+        domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+            CubicScale<2>{10.0, "Expansion", "Expansion"});
+  } else {
+    grid_to_inertial_map =
+        domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+            domain::CoordinateMaps::Identity<2>{});
+  }
 
-  const auto size_compute_item = db::get<domain::Tags::SizeOfElement<2>>(box);
-  const auto size_expected = make_array(0.05, 0.425);
-  CHECK_ITERABLE_APPROX(size_compute_item, size_expected);
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time = make_single_expansion_functions_of_time();
+
+  auto box =
+      db::create<db::AddSimpleTags<domain::Tags::ElementMap<2, Frame::Grid>,
+                                   domain::CoordinateMaps::Tags::CoordinateMap<
+                                       2, Frame::Grid, Frame::Inertial>,
+                                   ::Tags::Time, domain::Tags::FunctionsOfTime>,
+                 db::AddComputeTags<domain::Tags::SizeOfElementCompute<2>>>(
+          std::move(logical_to_grid_map), std::move(grid_to_inertial_map), 0.0,
+          std::move(functions_of_time));
+
+  for (const double time : times_to_check) {
+    db::mutate<::Tags::Time>(
+        make_not_null(&box),
+        [time](const gsl::not_null<double*> time_ptr) noexcept {
+          *time_ptr = time;
+        });
+    const auto expected_size_of_element =
+        make_array(0.05, 0.425) * (UseMovingMesh ? time : 1.0);
+    CHECK_ITERABLE_APPROX(db::get<domain::Tags::SizeOfElement<2>>(box),
+                          expected_size_of_element);
+  }
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.SizeOfElement", "[Domain][Unit]") {
-  test_1d();
-  test_2d();
-  test_3d();
-  test_compute_tag();
+  const std::array<double, 4> times_to_check{{0.0, 0.3, 1.1, 7.8}};
+
+  test_1d<false>(times_to_check);
+  test_2d<false>(times_to_check);
+  test_3d<false>(times_to_check);
+  test_compute_tag<false>(times_to_check);
+
+  test_1d<true>(times_to_check);
+  test_2d<true>(times_to_check);
+  test_3d<true>(times_to_check);
+  test_compute_tag<true>(times_to_check);
 }

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
@@ -13,6 +13,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/ElementIndex.hpp"
+#include "Domain/TagsTimeDependent.hpp"
 #include "Evolution/Actions/ComputeVolumeFluxes.hpp"  // IWYU pragma: keep
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
@@ -29,29 +30,32 @@ namespace {
 constexpr size_t dim = 2;
 
 struct Var1 : db::SimpleTag {
-  using type = Scalar<double>;
+  using type = Scalar<DataVector>;
 };
 
 struct Var2 : db::SimpleTag {
-  using type = tnsr::I<double, dim, Frame::Inertial>;
+  using type = tnsr::I<DataVector, dim, Frame::Inertial>;
 };
 
-using flux_tag = Tags::Flux<Var1, tmpl::size_t<dim>, Frame::Inertial>;
+using flux_tag =
+    db::add_tag_prefix<::Tags::Flux, Tags::Variables<tmpl::list<Var1>>,
+                       tmpl::size_t<dim>, Frame::Inertial>;
 
 struct ComputeFluxes {
   using argument_tags = tmpl::list<Var2, Var1>;
-  using return_tags = tmpl::list<flux_tag>;
+  using return_tags =
+      tmpl::list<::Tags::Flux<Var1, tmpl::size_t<dim>, Frame::Inertial>>;
   static void apply(
-      const gsl::not_null<tnsr::I<double, dim, Frame::Inertial>*> flux1,
-      const tnsr::I<double, dim, Frame::Inertial>& var2,
-      const Scalar<double>& var1) noexcept {
+      const gsl::not_null<tnsr::I<DataVector, dim, Frame::Inertial>*> flux1,
+      const tnsr::I<DataVector, dim, Frame::Inertial>& var2,
+      const Scalar<DataVector>& var1) noexcept {
     get<0>(*flux1) = get(var1) * (get<0>(var2) - get<1>(var2));
     get<1>(*flux1) = get(var1) * (get<0>(var2) + get<1>(var2));
   }
 };
 
 struct System {
-  using variables_tag = Var1;
+  using variables_tag = Tags::Variables<tmpl::list<Var1>>;
   using volume_fluxes = ComputeFluxes;
 };
 
@@ -62,7 +66,8 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndexType;
-  using simple_tags = tmpl::list<Var1, Var2, flux_tag>;
+  using simple_tags = tmpl::list<Tags::Variables<tmpl::list<Var1>>, Var2,
+                                 flux_tag, domain::Tags::MeshVelocity<dim>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -73,30 +78,47 @@ struct component {
 };
 
 struct Metavariables {
+  static constexpr size_t volume_dim = dim;
   using component_list = tmpl::list<component<Metavariables>>;
   using system = System;
   enum class Phase { Initialization, Testing, Exit };
 };
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeFluxes",
-                  "[Unit][Evolution][Actions]") {
+template <bool UseMovingMesh>
+void test() noexcept {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-
+  const double var1_value = 3.;
   const ElementId<dim> self_id(1);
-
-  using simple_tags = db::AddSimpleTags<Var1, Var2, flux_tag>;
   MockRuntimeSystem runner{{}};
+
+  boost::optional<tnsr::I<DataVector, dim, Frame::Inertial>> mesh_velocity{};
+  if (UseMovingMesh) {
+    mesh_velocity =
+        tnsr::I<DataVector, dim, Frame::Inertial>{{{{1.2}, {-1.4}}}};
+  }
   ActionTesting::emplace_component_and_initialize<component<Metavariables>>(
       &runner, self_id,
-      {db::item_type<Var1>{{{3.}}}, db::item_type<Var2>{{{7., 12.}}},
-       db::item_type<flux_tag>{{{-100.}}}});
+      {Variables<tmpl::list<Var1>>{1, var1_value},
+       tnsr::I<DataVector, dim, Frame::Inertial>{{{{7.}, {12.}}}},
+       db::item_type<flux_tag>{1, -100.}, mesh_velocity});
   ActionTesting::set_phase(make_not_null(&runner),
                            Metavariables::Phase::Testing);
   runner.next_action<component<Metavariables>>(self_id);
 
-  auto& box = ActionTesting::get_databox<component<Metavariables>, simple_tags>(
-      runner, self_id);
-  CHECK(get<0>(db::get<flux_tag>(box)) == -15.);
-  CHECK(get<1>(db::get<flux_tag>(box)) == 57.);
+  tnsr::I<DataVector, dim, Frame::Inertial> expected_flux{{{{-15.}, {57.}}}};
+  if (UseMovingMesh) {
+    get<0>(expected_flux) -= get<0>(*mesh_velocity) * var1_value;
+    get<1>(expected_flux) -= get<1>(*mesh_velocity) * var1_value;
+  }
+  CHECK(ActionTesting::get_databox_tag<
+            component<Metavariables>,
+            Tags::Flux<Var1, tmpl::size_t<dim>, Frame::Inertial>>(
+            runner, self_id) == expected_flux);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeFluxes",
+                  "[Unit][Evolution][Actions]") {
+  test<false>();
+  test<true>();
 }


### PR DESCRIPTION
## Proposed changes

This is the final PR to add support for moving meshes to conservative systems. It's a fairly heavy refactor because supporting the current code in develop and moving meshes would've been an even bigger change. The major changes are to `SizeOfElement` and `ComputeVolumeFluxes`, everything else is just enabling the moving mesh code in the conservative executables.

Only the commit:
- `Add support for moving meshes to conservative systems` is new in this PR

Depends on:
- [x] #2108 

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
