### PR TITLE
Support volume base tags in elliptic code

### DIFF
--- a/src/Elliptic/FirstOrderComputeTags.hpp
+++ b/src/Elliptic/FirstOrderComputeTags.hpp
@@ -9,65 +9,70 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/InterfaceHelpers.hpp"
 #include "Elliptic/FirstOrderOperator.hpp"
 #include "Elliptic/Tags.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace elliptic {
 namespace Tags {
 
-template <typename System, typename VarsTag = typename System::variables_tag,
-          typename FluxesComputer = typename System::fluxes,
-          typename PrimalVars = typename System::primal_variables,
-          typename AuxiliaryVars = typename System::auxiliary_variables,
-          typename FluxesArgs = typename FluxesComputer::argument_tags>
-struct FirstOrderFluxesCompute;
-
-template <typename System, typename VarsTag, typename FluxesComputer,
-          typename PrimalVars, typename AuxiliaryVars, typename... FluxesArgs>
-struct FirstOrderFluxesCompute<System, VarsTag, FluxesComputer, PrimalVars,
-                               AuxiliaryVars, tmpl::list<FluxesArgs...>>
-    : db::add_tag_prefix<::Tags::Flux, VarsTag,
+template <typename System>
+struct FirstOrderFluxesCompute
+    : db::add_tag_prefix<::Tags::Flux, typename System::variables_tag,
                          tmpl::size_t<System::volume_dim>, Frame::Inertial>,
       db::ComputeTag {
  private:
   static constexpr size_t volume_dim = System::volume_dim;
+  using vars_tag = typename System::variables_tag;
+  using FluxesComputer = typename System::fluxes;
   using fluxes_computer_tag = elliptic::Tags::FluxesComputer<FluxesComputer>;
 
  public:
-  using base = db::add_tag_prefix<::Tags::Flux, VarsTag,
+  using base = db::add_tag_prefix<::Tags::Flux, vars_tag,
                                   tmpl::size_t<volume_dim>, Frame::Inertial>;
-  using argument_tags = tmpl::list<VarsTag, fluxes_computer_tag, FluxesArgs...>;
-  using volume_tags = tmpl::list<fluxes_computer_tag>;
-  static constexpr db::item_type<base> (*function)(
-      const db::const_item_type<VarsTag>&, const FluxesComputer&,
-      const db::const_item_type<FluxesArgs>&...) =
-      &elliptic::first_order_fluxes<volume_dim, PrimalVars, AuxiliaryVars,
-                                    db::get_variables_tags_list<VarsTag>,
-                                    FluxesComputer,
-                                    db::const_item_type<FluxesArgs>...>;
+  using argument_tags = tmpl::push_front<typename FluxesComputer::argument_tags,
+                                         vars_tag, fluxes_computer_tag>;
+  using volume_tags =
+      tmpl::push_front<get_volume_tags<FluxesComputer>, fluxes_computer_tag>;
+  using return_type = db::item_type<base>;
+  template <typename... FluxesArgs>
+  static void function(const gsl::not_null<return_type*> fluxes,
+                       const db::const_item_type<vars_tag>& vars,
+                       const FluxesComputer& fluxes_computer,
+                       const FluxesArgs&... fluxes_args) noexcept {
+    *fluxes = return_type{vars.number_of_grid_points()};
+    elliptic::first_order_fluxes<volume_dim, typename System::primal_variables,
+                                 typename System::auxiliary_variables>(
+        fluxes, vars, fluxes_computer, fluxes_args...);
+  }
 };
 
-template <typename System, typename VarsTag = typename System::variables_tag,
-          typename SourcesComputer = typename System::sources,
-          typename PrimalVars = typename System::primal_variables,
-          typename AuxiliaryVars = typename System::auxiliary_variables,
-          typename SourcesArgs = typename SourcesComputer::argument_tags>
-struct FirstOrderSourcesCompute;
+template <typename System>
+struct FirstOrderSourcesCompute
+    : db::add_tag_prefix<::Tags::Source, typename System::variables_tag>,
+      db::ComputeTag {
+ private:
+  using vars_tag = typename System::variables_tag;
+  using SourcesComputer = typename System::sources;
 
-template <typename System, typename VarsTag, typename SourcesComputer,
-          typename PrimalVars, typename AuxiliaryVars, typename... SourcesArgs>
-struct FirstOrderSourcesCompute<System, VarsTag, SourcesComputer, PrimalVars,
-                                AuxiliaryVars, tmpl::list<SourcesArgs...>>
-    : db::add_tag_prefix<::Tags::Source, VarsTag>, db::ComputeTag {
-  using base = db::add_tag_prefix<::Tags::Source, VarsTag>;
-  using argument_tags = tmpl::list<VarsTag, SourcesArgs...>;
-  static constexpr db::item_type<base> (*function)(
-      const db::const_item_type<VarsTag>&,
-      const db::const_item_type<SourcesArgs>&...) =
-      &elliptic::first_order_sources<PrimalVars, AuxiliaryVars, SourcesComputer,
-                                     db::get_variables_tags_list<VarsTag>,
-                                     db::const_item_type<SourcesArgs>...>;
+ public:
+  using base = db::add_tag_prefix<::Tags::Source, vars_tag>;
+  using argument_tags =
+      tmpl::push_front<typename SourcesComputer::argument_tags, vars_tag>;
+  using volume_tags = get_volume_tags<SourcesComputer>;
+  using return_type = db::item_type<base>;
+  template <typename... SourcesArgs>
+  static void function(const gsl::not_null<return_type*> sources,
+                       const db::const_item_type<vars_tag>& vars,
+                       const SourcesArgs&... sources_args) noexcept {
+    *sources = return_type{vars.number_of_grid_points()};
+    elliptic::first_order_sources<typename System::primal_variables,
+                                  typename System::auxiliary_variables,
+                                  SourcesComputer>(sources, vars,
+                                                   sources_args...);
+  }
 };
 
 }  // namespace Tags

--- a/src/Elliptic/Systems/Elasticity/Equations.hpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.hpp
@@ -62,6 +62,7 @@ struct Fluxes {
   using argument_tags =
       tmpl::list<Tags::ConstitutiveRelationBase,
                  domain::Tags::Coordinates<Dim, Frame::Inertial>>;
+  using volume_tags = tmpl::list<Tags::ConstitutiveRelationBase>;
   static void apply(
       const gsl::not_null<tnsr::IJ<DataVector, Dim>*> flux_for_displacement,
       const ConstitutiveRelations::ConstitutiveRelation<Dim>&

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/Test_FirstOrderInternalPenalty.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/Test_FirstOrderInternalPenalty.cpp
@@ -79,7 +79,7 @@ void apply_ip_flux(
       face_normal_int, std::numeric_limits<double>::signaling_NaN());
   numerical_flux.package_data(
       make_not_null(&packaged_data_interior), n_dot_aux_flux_int,
-      div_aux_flux_int, fluxes_computer, fluxes_argument, face_normal_int);
+      div_aux_flux_int, face_normal_int, fluxes_computer, fluxes_argument);
   auto packaged_data_exterior = make_with_value<PackagedData>(
       face_normal_int, std::numeric_limits<double>::signaling_NaN());
   tnsr::i<DataVector, Dim> face_normal_ext{face_normal_int};
@@ -88,7 +88,7 @@ void apply_ip_flux(
   }
   numerical_flux.package_data(
       make_not_null(&packaged_data_exterior), n_dot_aux_flux_ext,
-      div_aux_flux_ext, fluxes_computer, fluxes_argument, face_normal_ext);
+      div_aux_flux_ext, face_normal_ext, fluxes_computer, fluxes_argument);
 
   EllipticNumericalFluxesTestHelpers::apply_numerical_flux(
       numerical_flux, packaged_data_interior, packaged_data_exterior,
@@ -111,8 +111,8 @@ void apply_ip_dirichlet_flux(
   Fluxes<Dim> fluxes_computer{};
 
   numerical_flux.compute_dirichlet_boundary(n_dot_num_f_field, n_dot_num_f_aux,
-                                            dirichlet_field, fluxes_computer,
-                                            fluxes_argument, face_normal);
+                                            dirichlet_field, face_normal,
+                                            fluxes_computer, fluxes_argument);
 }
 
 template <size_t Dim>

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
@@ -90,10 +90,10 @@ template <size_t Dim>
 struct NumericalFlux {
   void compute_dirichlet_boundary(
       const gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
-      const Scalar<DataVector>& field, const Fluxes<Dim>& /*flux_computer*/,
+      const Scalar<DataVector>& field,
       const tnsr::i<DataVector, Dim,
-                    Frame::Inertial>& /*interface_unit_normal*/) const
-      noexcept {
+                    Frame::Inertial>& /*interface_unit_normal*/,
+      const Fluxes<Dim>& /*flux_computer*/) const noexcept {
     numerical_flux_for_field->get() = 2. * get(field);
   }
 

--- a/tests/Unit/Elliptic/Test_FirstOrderComputeTags.cpp
+++ b/tests/Unit/Elliptic/Test_FirstOrderComputeTags.cpp
@@ -31,33 +31,43 @@ struct AnArgument : db::SimpleTag {
   using type = double;
 };
 
+struct BaseArgumentTag : db::BaseTag {};
+
+struct DerivedArgumentTag : BaseArgumentTag, db::SimpleTag {
+  using type = double;
+};
+
 template <size_t Dim>
 struct Fluxes {
-  using argument_tags = tmpl::list<AnArgument>;
+  using argument_tags = tmpl::list<AnArgument, BaseArgumentTag>;
   static void apply(
       const gsl::not_null<tnsr::I<DataVector, Dim>*> flux_for_field,
-      const double an_argument,
+      const double an_argument, const double base_tag_argument,
       const tnsr::i<DataVector, Dim>& auxiliary_field) {
     for (size_t d = 0; d < Dim; d++) {
-      flux_for_field->get(d) = auxiliary_field.get(d) * an_argument;
+      flux_for_field->get(d) =
+          auxiliary_field.get(d) * an_argument + base_tag_argument;
     }
   }
   static void apply(
       const gsl::not_null<tnsr::Ij<DataVector, Dim>*> flux_for_aux_field,
-      const double an_argument, const Scalar<DataVector>& field) {
+      const double an_argument, const double base_tag_argument,
+      const Scalar<DataVector>& field) {
     std::fill(flux_for_aux_field->begin(), flux_for_aux_field->end(), 0.);
     for (size_t d = 0; d < Dim; d++) {
-      flux_for_aux_field->get(d, d) = get(field) * an_argument;
+      flux_for_aux_field->get(d, d) =
+          get(field) * an_argument + base_tag_argument;
     }
   }
 };
 
 struct Sources {
-  using argument_tags = tmpl::list<AnArgument>;
+  using argument_tags = tmpl::list<AnArgument, BaseArgumentTag>;
   static void apply(const gsl::not_null<Scalar<DataVector>*> source_for_field,
-                    const double an_argument,
+                    const double an_argument, const double base_tag_argument,
                     const Scalar<DataVector>& field) {
-    get(*source_for_field) = get(field) * square(an_argument);
+    get(*source_for_field) =
+        get(field) * square(an_argument) + base_tag_argument;
   }
 };
 
@@ -98,18 +108,19 @@ void test_first_order_compute_tags() {
 
   // Construct DataBox for testing the compute tags
   const auto box =
-      db::create<db::AddSimpleTags<vars_tag, fluxes_computer_tag, AnArgument>,
+      db::create<db::AddSimpleTags<vars_tag, fluxes_computer_tag, AnArgument,
+                                   DerivedArgumentTag>,
                  db::AddComputeTags<first_order_fluxes_compute_tag,
                                     first_order_sources_compute_tag>>(
-          std::move(vars), FluxesComputer{}, 3.);
+          std::move(vars), FluxesComputer{}, 3., 1.);
 
   // Check computed fluxes
   for (size_t d = 0; d < Dim; d++) {
     CHECK(get<::Tags::Flux<FieldTag, tmpl::size_t<Dim>, Frame::Inertial>>(box)
-              .get(d) == DataVector{num_points, 3. * (d + 1.)});
+              .get(d) == DataVector{num_points, 3. * (d + 1.) + 1.});
     CHECK(get<::Tags::Flux<AuxiliaryFieldTag<Dim>, tmpl::size_t<Dim>,
                            Frame::Inertial>>(box)
-              .get(d, d) == DataVector{num_points, 6.});
+              .get(d, d) == DataVector{num_points, 7.});
     for (size_t i0 = 0; i0 < Dim; i0++) {
       if (i0 != d) {
         CHECK(get<::Tags::Flux<AuxiliaryFieldTag<Dim>, tmpl::size_t<Dim>,
@@ -120,7 +131,7 @@ void test_first_order_compute_tags() {
   }
 
   // Check computed sources
-  CHECK(get(get<::Tags::Source<FieldTag>>(box)) == DataVector{num_points, 18.});
+  CHECK(get(get<::Tags::Source<FieldTag>>(box)) == DataVector{num_points, 19.});
   for (size_t d = 0; d < Dim; d++) {
     CHECK(get<::Tags::Source<AuxiliaryFieldTag<Dim>>>(box).get(d) ==
           get<AuxiliaryFieldTag<Dim>>(box).get(d));


### PR DESCRIPTION
## Proposed changes

Allows elliptic fluxes to use base tags. See also #2111 

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
