### PR TITLE
Blaze upgrade

### DIFF
--- a/cmake/SetupBlaze.cmake
+++ b/cmake/SetupBlaze.cmake
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-find_package(Blaze 3.2 REQUIRED)
+find_package(Blaze 3.5 REQUIRED)
 
 message(STATUS "Blaze incl: ${BLAZE_INCLUDE_DIR}")
 message(STATUS "Blaze vers: ${BLAZE_VERSION}")

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -99,7 +99,7 @@ RUN apt-get update -y \
 # build time of the Docker image.
 
 # Install blaze, brigand, catch2, libsharp, libxsmm, yaml-cpp in /usr/local
-RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.2.tar.gz -O blaze.tar.gz \
+RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.7.tar.gz -O blaze.tar.gz \
     && tar -xzf blaze.tar.gz \
     && mv blaze-* blaze \
     && mv blaze/blaze /usr/local/include \

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -18,7 +18,7 @@ installation_on_clusters "Installation on clusters" page.
 * [Charm++](http://charm.cs.illinois.edu/) 6.8 or newer (must be compiled from source)
 * [Git](https://git-scm.com/)
 * BLAS (e.g. [OpenBLAS](http://www.openblas.net))
-* [Blaze](https://bitbucket.org/blaze-lib/blaze/overview) v3.2
+* [Blaze](https://bitbucket.org/blaze-lib/blaze/overview) v3.5
 * [Boost](http://www.boost.org/) 1.60.0 or later
 * [Brigand](https://github.com/edouarda/brigand)
 * [Catch](https://github.com/philsquared/Catch) 2.1.0 or later

--- a/src/DataStructures/ComplexDataVector.hpp
+++ b/src/DataStructures/ComplexDataVector.hpp
@@ -63,28 +63,6 @@ class ComplexDataVector
 namespace blaze {
 VECTOR_BLAZE_TRAIT_SPECIALIZE_ARITHMETIC_TRAITS(ComplexDataVector);
 VECTOR_BLAZE_TRAIT_SPECIALIZE_ALL_MAP_TRAITS(ComplexDataVector);
-#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
-template <>
-struct UnaryMapTrait<ComplexDataVector, blaze::Real> {
-  using Type = DataVector;
-};
-template <>
-struct UnaryMapTrait<ComplexDataVector, blaze::Imag> {
-  using Type = DataVector;
-};
-template <>
-struct UnaryMapTrait<DataVector, blaze::Real> {
-  using Type = DataVector;
-};
-template <>
-struct UnaryMapTrait<DataVector, blaze::Imag> {
-  using Type = DataVector;
-};
-template <>
-struct UnaryMapTrait<ComplexDataVector, blaze::Abs> {
-  using Type = DataVector;
-};
-#else
 template <>
 struct MapTrait<ComplexDataVector, blaze::Real> {
   using Type = DataVector;
@@ -105,7 +83,6 @@ template <>
 struct MapTrait<ComplexDataVector, blaze::Abs> {
   using Type = DataVector;
 };
-#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
 
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDataVector, DataVector,
                                                AddTrait, ComplexDataVector);
@@ -134,17 +111,6 @@ BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(DataVector, std::complex<double>,
 BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(DataVector, std::complex<double>,
                                                SubTrait, ComplexDataVector);
 
-
-#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
-template <typename Operator>
-struct BinaryMapTrait<DataVector, ComplexDataVector, Operator> {
-  using Type = ComplexDataVector;
-};
-template <typename Operator>
-struct BinaryMapTrait<ComplexDataVector, DataVector, Operator> {
-  using Type = ComplexDataVector;
-};
-#else
 template <typename Operator>
 struct MapTrait<DataVector, ComplexDataVector, Operator> {
   using Type = ComplexDataVector;
@@ -153,7 +119,6 @@ template <typename Operator>
 struct MapTrait<ComplexDataVector, DataVector, Operator> {
   using Type = ComplexDataVector;
 };
-#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
 }  // namespace blaze
 
 MAKE_STD_ARRAY_VECTOR_BINOPS(ComplexDataVector)
@@ -191,9 +156,9 @@ namespace blaze {
 // ComplexDataVector. This does *not* prevent taking the norm of the square (or
 // some other math expression) of a ComplexDataVector.
 template <typename Abs, typename Power>
-struct DVecNormHelper<
-    PointerVector<std::complex<double>, false, false, false, ComplexDataVector>,
-    Abs, Power> {};
+struct DVecNormHelper<PointerVector<std::complex<double>, blaze_unaligned,
+                                    blaze_unpadded, false, ComplexDataVector>,
+                      Abs, Power> {};
 }  // namespace blaze
 /// \endcond
 

--- a/src/DataStructures/ComplexDiagonalModalOperator.hpp
+++ b/src/DataStructures/ComplexDiagonalModalOperator.hpp
@@ -130,58 +130,7 @@ struct MultTrait<ComplexDiagonalModalOperator, ModalVector> {
   using Type = ComplexModalVector;
 };
 
-#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
-template <typename Operator>
-struct UnaryMapTrait<ComplexDiagonalModalOperator, Operator> {
-  // Selectively allow unary operations for spectral coefficient operators
-  static_assert(
-      tmpl::list_contains_v<
-          tmpl::list<
-              blaze::Conj, blaze::Sqrt,
-              // these traits are required for operators acting with doubles
-              blaze::AddScalar<ComplexDiagonalModalOperator::ElementType>,
-              blaze::SubScalarRhs<ComplexDiagonalModalOperator::ElementType>,
-              blaze::SubScalarLhs<ComplexDiagonalModalOperator::ElementType>,
-              blaze::DivideScalarByVector<
-                  ComplexDiagonalModalOperator::ElementType>,
-              blaze::AddScalar<DiagonalModalOperator::ElementType>,
-              blaze::SubScalarRhs<DiagonalModalOperator::ElementType>,
-              blaze::SubScalarLhs<DiagonalModalOperator::ElementType>,
-              blaze::DivideScalarByVector<DiagonalModalOperator::ElementType>>,
-          Operator>,
-      "This unary operation is not permitted on a "
-      "ComplexDiagonalModalOperator");
-  using Type = ComplexDiagonalModalOperator;
-};
-template <>
-struct UnaryMapTrait<ComplexDiagonalModalOperator, blaze::Imag> {
-  using Type = DiagonalModalOperator;
-};
-template <>
-struct UnaryMapTrait<ComplexDiagonalModalOperator, blaze::Real> {
-  using Type = DiagonalModalOperator;
-};
-template <>
-struct UnaryMapTrait<DiagonalModalOperator, blaze::Imag> {
-  using Type = DiagonalModalOperator;
-};
-template <>
-struct UnaryMapTrait<DiagonalModalOperator, blaze::Real> {
-  using Type = DiagonalModalOperator;
-};
-
-template <typename Operator>
-struct BinaryMapTrait<ComplexDiagonalModalOperator,
-                      ComplexDiagonalModalOperator, Operator> {
-  // Forbid math operations in this specialization of BinaryMap traits for
-  // ComplexDiagonalModalOperator that are unlikely to be used on spectral
-  // coefficients. Currently no non-arithmetic binary operations are supported.
-  static_assert(tmpl::list_contains_v<tmpl::list<>, Operator>,
-                "This binary operation is not permitted on a "
-                "ComplexDiagonalModalOperator.");
-  using Type = ComplexDiagonalModalOperator;
-};
-#else
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION < 6))
 template <typename Operator>
 struct MapTrait<ComplexDiagonalModalOperator, Operator> {
   // Selectively allow unary operations for spectral coefficient operators
@@ -232,7 +181,70 @@ struct MapTrait<ComplexDiagonalModalOperator, ComplexDiagonalModalOperator,
                 "ComplexDiagonalModalOperator.");
   using Type = ComplexDiagonalModalOperator;
 };
-#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
+#else
+template <typename Operator>
+struct MapTrait<ComplexDiagonalModalOperator, Operator> {
+  // Selectively allow unary operations for spectral coefficient operators
+  static_assert(
+      tmpl::list_contains_v<
+          tmpl::list<
+              blaze::Conj, blaze::Sqrt,
+              // these traits are required for operators acting with doubles
+              blaze::AddScalar<ComplexDiagonalModalOperator::ElementType>,
+              blaze::SubScalarRhs<ComplexDiagonalModalOperator::ElementType>,
+              blaze::SubScalarLhs<ComplexDiagonalModalOperator::ElementType>,
+              blaze::DivideScalarByVector<
+                  ComplexDiagonalModalOperator::ElementType>,
+              blaze::AddScalar<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarRhs<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarLhs<DiagonalModalOperator::ElementType>,
+              blaze::DivideScalarByVector<DiagonalModalOperator::ElementType>,
+              blaze::Bind1st<blaze::Add, std::complex<double>>,
+              blaze::Bind2nd<blaze::Add, std::complex<double>>,
+              blaze::Bind1st<blaze::Div, std::complex<double>>,
+              blaze::Bind2nd<blaze::Div, std::complex<double>>,
+              blaze::Bind1st<blaze::Sub, std::complex<double>>,
+              blaze::Bind2nd<blaze::Sub, std::complex<double>>,
+              blaze::Bind1st<blaze::Add, double>,
+              blaze::Bind2nd<blaze::Add, double>,
+              blaze::Bind1st<blaze::Div, double>,
+              blaze::Bind2nd<blaze::Div, double>,
+              blaze::Bind1st<blaze::Sub, double>,
+              blaze::Bind2nd<blaze::Sub, double>>,
+          Operator>,
+      "This unary operation is not permitted on a "
+      "ComplexDiagonalModalOperator");
+  using Type = ComplexDiagonalModalOperator;
+};
+template <>
+struct MapTrait<ComplexDiagonalModalOperator, blaze::Imag> {
+  using Type = DiagonalModalOperator;
+};
+template <>
+struct MapTrait<ComplexDiagonalModalOperator, blaze::Real> {
+  using Type = DiagonalModalOperator;
+};
+template <>
+struct MapTrait<DiagonalModalOperator, blaze::Imag> {
+  using Type = DiagonalModalOperator;
+};
+template <>
+struct MapTrait<DiagonalModalOperator, blaze::Real> {
+  using Type = DiagonalModalOperator;
+};
+
+template <typename Operator>
+struct MapTrait<ComplexDiagonalModalOperator, ComplexDiagonalModalOperator,
+                Operator> {
+  // Forbid math operations in this specialization of BinaryMap traits for
+  // ComplexDiagonalModalOperator that are unlikely to be used on spectral
+  // coefficients. Currently no non-arithmetic binary operations are supported.
+  static_assert(tmpl::list_contains_v<tmpl::list<>, Operator>,
+                "This binary operation is not permitted on a "
+                "ComplexDiagonalModalOperator.");
+  using Type = ComplexDiagonalModalOperator;
+};
+#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION < 6))
 }  // namespace blaze
 
 MAKE_STD_ARRAY_VECTOR_BINOPS(ComplexDiagonalModalOperator)

--- a/src/DataStructures/ComplexModalVector.hpp
+++ b/src/DataStructures/ComplexModalVector.hpp
@@ -88,9 +88,9 @@ struct DivTrait<ComplexModalVector, double> {
   using Type = ComplexModalVector;
 };
 
-#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION < 6))
 template <typename Operator>
-struct UnaryMapTrait<ComplexModalVector, Operator> {
+struct MapTrait<ComplexModalVector, Operator> {
   // Selectively allow unary operations for spectral coefficients
   static_assert(
       tmpl::list_contains_v<
@@ -108,26 +108,24 @@ struct UnaryMapTrait<ComplexModalVector, Operator> {
   using Type = ComplexModalVector;
 };
 template <>
-struct UnaryMapTrait<ComplexModalVector, blaze::Imag> {
+struct MapTrait<ComplexModalVector, blaze::Imag> {
   using Type = ModalVector;
 };
 template <>
-struct UnaryMapTrait<ComplexModalVector, blaze::Real> {
-  using Type = ModalVector;
-};
-// for consistency with the std::imag and std::real, these operations should be
-// supported on real types
-template <>
-struct UnaryMapTrait<ModalVector, blaze::Imag> {
+struct MapTrait<ComplexModalVector, blaze::Real> {
   using Type = ModalVector;
 };
 template <>
-struct UnaryMapTrait<ModalVector, blaze::Real> {
+struct MapTrait<ModalVector, blaze::Imag> {
+  using Type = ModalVector;
+};
+template <>
+struct MapTrait<ModalVector, blaze::Real> {
   using Type = ModalVector;
 };
 
 template <typename Operator>
-struct BinaryMapTrait<ComplexModalVector, ComplexModalVector, Operator> {
+struct MapTrait<ComplexModalVector, ComplexModalVector, Operator> {
   // Forbid math operations in this specialization of BinaryMap traits for
   // ComplexModalVector that are unlikely to be used on spectral coefficients.
   // Currently no non-arithmetic binary operations are supported.
@@ -149,7 +147,15 @@ struct MapTrait<ComplexModalVector, Operator> {
                      blaze::SubScalarRhs<ComplexModalVector::ElementType>,
                      blaze::SubScalarLhs<ComplexModalVector::ElementType>,
                      blaze::AddScalar<double>, blaze::SubScalarRhs<double>,
-                     blaze::SubScalarLhs<double>>,
+                     blaze::SubScalarLhs<double>,
+                     blaze::Bind1st<blaze::Add, std::complex<double>>,
+                     blaze::Bind2nd<blaze::Add, std::complex<double>>,
+                     blaze::Bind1st<blaze::Sub, std::complex<double>>,
+                     blaze::Bind2nd<blaze::Sub, std::complex<double>>,
+                     blaze::Bind1st<blaze::Add, double>,
+                     blaze::Bind2nd<blaze::Add, double>,
+                     blaze::Bind1st<blaze::Sub, double>,
+                     blaze::Bind2nd<blaze::Sub, double>>,
           Operator>,
       "Only unary operations permitted on a ComplexModalVector are:"
       " conj, imag, and real");
@@ -200,8 +206,8 @@ namespace blaze {
 // ComplexModalVector. This does *not* prevent taking the norm of the square (or
 // some other math expression) of a ComplexModalVector.
 template <typename Abs, typename Power>
-struct DVecNormHelper<PointerVector<std::complex<double>, false, false, false,
-                                    ComplexModalVector>,
+struct DVecNormHelper<PointerVector<std::complex<double>, blaze_unaligned,
+                                    blaze_unpadded, false, ComplexModalVector>,
                       Abs, Power> {};
 }  // namespace blaze
 /// \endcond

--- a/src/DataStructures/DiagonalModalOperator.hpp
+++ b/src/DataStructures/DiagonalModalOperator.hpp
@@ -57,43 +57,7 @@ BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ModalVector,
                                                DiagonalModalOperator,
                                                MultTrait, ModalVector);
 
-#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
-template <typename Operator>
-struct UnaryMapTrait<DiagonalModalOperator, Operator> {
-  // Selectively allow unary operations for spectral coefficient operators
-  static_assert(
-      tmpl::list_contains_v<
-          tmpl::list<
-              // these traits are required for operators acting with doubles
-              blaze::AddScalar<DiagonalModalOperator::ElementType>,
-              blaze::SubScalarRhs<DiagonalModalOperator::ElementType>,
-              blaze::SubScalarLhs<DiagonalModalOperator::ElementType>,
-              blaze::DivideScalarByVector<DiagonalModalOperator::ElementType>,
-              // With these and the blaze traits in
-              // `ComplexDiagonalModalOperator.hpp`, the `DiagonalModalOperator`
-              // can be operated with a `std::complex<double>` to produce a
-              // `ComplexDiagonalModalOperator`, analogous to implicit casting
-              // in the standard library
-              blaze::AddScalar<std::complex<double>>,
-              blaze::SubScalarRhs<std::complex<double>>,
-              blaze::SubScalarLhs<std::complex<double>>,
-              blaze::DivideScalarByVector<std::complex<double>>>,
-          Operator>,
-      "This unary operation is not permitted on a DiagonalModalOperator");
-  using Type = DiagonalModalOperator;
-};
-
-template <typename Operator>
-struct BinaryMapTrait<DiagonalModalOperator, DiagonalModalOperator, Operator> {
-  // Forbid math operations in this specialization of BinaryMap traits for
-  // DiagonalModalOperator that are unlikely to be used on spectral
-  // coefficients. Currently no non-arithmetic binary operations are supported.
-  static_assert(
-      tmpl::list_contains_v<tmpl::list<>, Operator>,
-      "This binary operation is not permitted on a DiagonalModalOperator.");
-  using Type = DiagonalModalOperator;
-};
-#else
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION < 6))
 template <typename Operator>
 struct MapTrait<DiagonalModalOperator, Operator> {
   // Selectively allow unary operations for spectral coefficient operators
@@ -129,7 +93,55 @@ struct MapTrait<DiagonalModalOperator, DiagonalModalOperator, Operator> {
       "This binary operation is not permitted on a DiagonalModalOperator.");
   using Type = DiagonalModalOperator;
 };
-#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
+#else
+template <typename Operator>
+struct MapTrait<DiagonalModalOperator, Operator> {
+  // Selectively allow unary operations for spectral coefficient operators
+  static_assert(
+      tmpl::list_contains_v<
+          tmpl::list<
+              // these traits are required for operators acting with doubles
+              blaze::AddScalar<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarRhs<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarLhs<DiagonalModalOperator::ElementType>,
+              blaze::DivideScalarByVector<DiagonalModalOperator::ElementType>,
+              // With these and the blaze traits in
+              // `ComplexDiagonalModalOperator.hpp`, the `DiagonalModalOperator`
+              // can be operated with a `std::complex<double>` to produce a
+              // `ComplexDiagonalModalOperator`, analogous to implicit casting
+              // in the standard library
+              blaze::AddScalar<std::complex<double>>,
+              blaze::SubScalarRhs<std::complex<double>>,
+              blaze::SubScalarLhs<std::complex<double>>,
+              blaze::DivideScalarByVector<std::complex<double>>,
+              blaze::Bind1st<blaze::Add, double>,
+              blaze::Bind2nd<blaze::Add, double>,
+              blaze::Bind1st<blaze::Div, double>,
+              blaze::Bind2nd<blaze::Div, double>,
+              blaze::Bind1st<blaze::Sub, double>,
+              blaze::Bind2nd<blaze::Sub, double>,
+              blaze::Bind1st<blaze::Add, std::complex<double>>,
+              blaze::Bind2nd<blaze::Add, std::complex<double>>,
+              blaze::Bind1st<blaze::Div, std::complex<double>>,
+              blaze::Bind2nd<blaze::Div, std::complex<double>>,
+              blaze::Bind1st<blaze::Sub, std::complex<double>>,
+              blaze::Bind2nd<blaze::Sub, std::complex<double>>>,
+          Operator>,
+      "This unary operation is not permitted on a DiagonalModalOperator");
+  using Type = DiagonalModalOperator;
+};
+
+template <typename Operator>
+struct MapTrait<DiagonalModalOperator, DiagonalModalOperator, Operator> {
+  // Forbid math operations in this specialization of BinaryMap traits for
+  // DiagonalModalOperator that are unlikely to be used on spectral
+  // coefficients. Currently no non-arithmetic binary operations are supported.
+  static_assert(
+      tmpl::list_contains_v<tmpl::list<>, Operator>,
+      "This binary operation is not permitted on a DiagonalModalOperator.");
+  using Type = DiagonalModalOperator;
+};
+#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION < 6))
 }  // namespace blaze
 
 MAKE_STD_ARRAY_VECTOR_BINOPS(DiagonalModalOperator)

--- a/src/DataStructures/Python/Matrix.cpp
+++ b/src/DataStructures/Python/Matrix.cpp
@@ -50,7 +50,7 @@ void bind_matrix(py::module& m) {  // NOLINT
             {matrix.rows(), matrix.columns()},
             // Stride for each index (in bytes). Data is stored
             // in column-major layout (see `Matrix.hpp`).
-            {sizeof(double), sizeof(double) * matrix.rows()});
+            {sizeof(double), sizeof(double) * matrix.spacing()});
       })
       .def_property_readonly(
           "shape",

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -111,7 +111,7 @@ class Variables<tmpl::list<Tags...>> {
   using value_type = typename vector_type::value_type;
   using allocator_type = std::allocator<value_type>;
   using pointer_type =
-      PointerVector<value_type, blaze::unaligned, blaze::unpadded,
+      PointerVector<value_type, blaze_unaligned, blaze_unpadded,
                     transpose_flag,
                     blaze::DynamicVector<value_type, transpose_flag>>;
 

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -26,49 +26,6 @@
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TypeTraits/IsComplexOfFundamental.hpp"
 
-// IWYU doesn't like that we want PointerVector.hpp to expose Blaze and also
-// have VectorImpl.hpp to expose PointerVector.hpp without including Blaze
-// directly in VectorImpl.hpp
-//
-// IWYU pragma: no_include <blaze/math/AlignmentFlag.h>
-// IWYU pragma: no_include <blaze/math/PaddingFlag.h>
-// IWYU pragma: no_include <blaze/math/dense/DenseVector.h>
-// IWYU pragma: no_include <blaze/math/expressions/DVecDVecAddExpr.h>
-// IWYU pragma: no_include <blaze/math/expressions/DVecDVecDivExpr.h>
-// IWYU pragma: no_include <blaze/math/expressions/DVecDVecMultExpr.h>
-// IWYU pragma: no_include <blaze/math/expressions/DVecDVecSubExpr.h>
-// IWYU pragma: no_include <blaze/math/expressions/DVecMapExpr.h>
-// IWYU pragma: no_include <blaze/math/expressions/DVecScalarDivExpr.h>
-// IWYU pragma: no_include <blaze/math/expressions/DVecScalarMultExpr.h>
-// IWYU pragma: no_include <blaze/math/expressions/DenseVector.h>
-// IWYU pragma: no_include <blaze/math/expressions/Forward.h>
-// IWYU pragma: no_include <blaze/math/expressions/Vector.h>
-// IWYU pragma: no_include <blaze/math/traits/AddTrait.h>
-// IWYU pragma: no_include <blaze/math/traits/DivTrait.h>
-// IWYU pragma: no_include <blaze/math/traits/MultTrait.h>
-// IWYU pragma: no_include <blaze/math/traits/SubTrait.h>
-// IWYU pragma: no_include <blaze/math/typetraits/IsVector.h>
-// IWYU pragma: no_include <blaze/system/TransposeFlag.h>
-#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
-// IWYU pragma: no_include <blaze/math/traits/BinaryMapTrait.h>
-// IWYU pragma: no_include <blaze/math/traits/UnaryMapTrait.h>
-#else
-// IWYU pragma: no_include <blaze/math/traits/MapTrait.h>
-#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
-// IWYU pragma: no_include <blaze/math/typetraits/TransposeFlag.h>
-
-// IWYU pragma: no_forward_declare blaze::DenseVector
-#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
-// IWYU pragma: no_forward_declare blaze::UnaryMapTrait
-// IWYU pragma: no_forward_declare blaze::BinaryMapTrait
-#else
-// IWYU pragma: no_forward_declare blaze::MapTrait
-#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
-// IWYU pragma: no_forward_declare blaze::IsVector
-// IWYU pragma: no_forward_declare blaze::TransposeFlag
-
-// IWYU pragma: no_include "DataStructures/DataVector.hpp"
-
 /*!
  * \ingroup DataStructuresGroup
  * \brief Base class template for various DataVector and related types
@@ -112,7 +69,7 @@
  */
 template <typename T, typename VectorType>
 class VectorImpl
-    : public PointerVector<T, blaze::unaligned, blaze::unpadded,
+    : public PointerVector<T, blaze_unaligned, blaze_unpadded,
                            blaze::defaultTransposeFlag, VectorType> {
  public:
   using value_type = T;
@@ -507,17 +464,6 @@ std::ostream& operator<<(std::ostream& os,
  * \param VECTOR_TYPE The vector type, which for the `Map` operations is
  * the type of the operation result (e.g. `DataVector`)
  */
-#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
-#define VECTOR_BLAZE_TRAIT_SPECIALIZE_ALL_MAP_TRAITS(VECTOR_TYPE) \
-  template <typename Operator>                                    \
-  struct UnaryMapTrait<VECTOR_TYPE, Operator> {                   \
-    using Type = VECTOR_TYPE;                                     \
-  };                                                              \
-  template <typename Operator>                                    \
-  struct BinaryMapTrait<VECTOR_TYPE, VECTOR_TYPE, Operator> {     \
-    using Type = VECTOR_TYPE;                                     \
-  }
-#else
 #define VECTOR_BLAZE_TRAIT_SPECIALIZE_ALL_MAP_TRAITS(VECTOR_TYPE) \
   template <typename Operator>                                    \
   struct MapTrait<VECTOR_TYPE, Operator> {                        \
@@ -527,7 +473,6 @@ std::ostream& operator<<(std::ostream& os,
   struct MapTrait<VECTOR_TYPE, VECTOR_TYPE, Operator> {           \
     using Type = VECTOR_TYPE;                                     \
   }
-#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
 
 /*!
  * \ingroup DataStructuresGroup

--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
@@ -79,8 +79,9 @@ void Irregular<Dim>::interpolate(
   if (result->number_of_grid_points() != m) {
     *result = Variables<TagsList>(m, 0.);
   }
-  dgemm_('n', 'n', m, n, k, 1.0, interpolation_matrix_.data(), m, vars.data(),
-         k, 0.0, result->data(), m);
+  dgemm_('n', 'n', m, n, k, 1.0, interpolation_matrix_.data(),
+         interpolation_matrix_.spacing(), vars.data(), k, 0.0, result->data(),
+         m);
 }
 
 template <size_t Dim>

--- a/src/NumericalAlgorithms/LinearAlgebra/FindGeneralizedEigenvalues.cpp
+++ b/src/NumericalAlgorithms/LinearAlgebra/FindGeneralizedEigenvalues.cpp
@@ -85,13 +85,16 @@ void find_generalized_eigenvalues(
   //  info > 0: some other failure
   int info = 0;
 
+  int matrix_a_spacing = matrix_a.spacing();
+  int matrix_b_spacing = matrix_b.spacing();
+  int eigenvectors_spacing = eigenvectors->spacing();
+
   dggev_(&compute_left_eigenvectors, &compute_right_eigenvectors,
-         &matrix_and_vector_size, matrix_a.data(), &matrix_and_vector_size,
-         matrix_b.data(), &matrix_and_vector_size,
-         eigenvalues_real_part->data(), eigenvalues_imaginary_part->data(),
-         eigenvalue_normalization.data(), eigenvectors->data(),
-         &matrix_and_vector_size, eigenvectors->data(), &matrix_and_vector_size,
-         lapack_work.data(), &work_size, &info);
+         &matrix_and_vector_size, matrix_a.data(), &matrix_a_spacing,
+         matrix_b.data(), &matrix_b_spacing, eigenvalues_real_part->data(),
+         eigenvalues_imaginary_part->data(), eigenvalue_normalization.data(),
+         eigenvectors->data(), &eigenvectors_spacing, eigenvectors->data(),
+         &eigenvectors_spacing, lapack_work.data(), &work_size, &info);
 
   if (UNLIKELY(info != 0)) {
     ERROR(

--- a/src/NumericalAlgorithms/LinearOperators/ApplyMatrices.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/ApplyMatrices.cpp
@@ -27,7 +27,7 @@ void multiply_in_first_dimension(const gsl::not_null<double*> result,
                matrix.columns(),  // columns of matrix and rows of u
                1.0,               // overall multiplier
                matrix.data(),     // matrix
-               matrix.rows(),     // rows of matrix
+               matrix.spacing(),  // rows of matrix including padding
                data,              // u
                matrix.columns(),  // rows of u
                0.0,               // multiplier for unused term

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
@@ -252,8 +252,8 @@ struct LogicalImpl<1, VariableTags, DerivativeTags> {
         Spectral::differentiation_matrix(mesh.slice_through(0));
     dgemm_<true>('N', 'N', mesh.extents(0), deriv_size / mesh.extents(0),
                  mesh.extents(0), 1.0, differentiation_matrix_xi.data(),
-                 mesh.extents(0), u.data(), mesh.extents(0), 0.0,
-                 logical_partial_derivatives_of_u[0], mesh.extents(0));
+                 differentiation_matrix_xi.spacing(), u.data(), mesh.extents(0),
+                 0.0, logical_partial_derivatives_of_u[0], mesh.extents(0));
   }
 };
 
@@ -278,8 +278,8 @@ struct LogicalImpl<2, VariableTags, DerivativeTags> {
     const size_t num_components_times_xi_slices = deriv_size / mesh.extents(0);
     dgemm_<true>('N', 'N', mesh.extents(0), num_components_times_xi_slices,
                  mesh.extents(0), 1.0, differentiation_matrix_xi.data(),
-                 mesh.extents(0), u.data(), mesh.extents(0), 0.0,
-                 logical_partial_derivatives_of_u[0], mesh.extents(0));
+                 differentiation_matrix_xi.spacing(), u.data(), mesh.extents(0),
+                 0.0, logical_partial_derivatives_of_u[0], mesh.extents(0));
 
     const auto u_eta_fastest =
         transpose<Variables<VariableTags>, Variables<DerivativeTags>>(
@@ -289,8 +289,9 @@ struct LogicalImpl<2, VariableTags, DerivativeTags> {
     const size_t num_components_times_eta_slices = deriv_size / mesh.extents(1);
     dgemm_<true>('N', 'N', mesh.extents(1), num_components_times_eta_slices,
                  mesh.extents(1), 1.0, differentiation_matrix_eta.data(),
-                 mesh.extents(1), u_eta_fastest.data(), mesh.extents(1), 0.0,
-                 partial_u_wrt_eta->data(), mesh.extents(1));
+                 differentiation_matrix_eta.spacing(), u_eta_fastest.data(),
+                 mesh.extents(1), 0.0, partial_u_wrt_eta->data(),
+                 mesh.extents(1));
     raw_transpose(make_not_null(logical_partial_derivatives_of_u[1]),
                   partial_u_wrt_eta->data(), num_components_times_xi_slices,
                   mesh.extents(0));
@@ -318,8 +319,8 @@ struct LogicalImpl<3, VariableTags, DerivativeTags> {
     const size_t num_components_times_xi_slices = deriv_size / mesh.extents(0);
     dgemm_<true>('N', 'N', mesh.extents(0), num_components_times_xi_slices,
                  mesh.extents(0), 1.0, differentiation_matrix_xi.data(),
-                 mesh.extents(0), u.data(), mesh.extents(0), 0.0,
-                 logical_partial_derivatives_of_u[0], mesh.extents(0));
+                 differentiation_matrix_xi.spacing(), u.data(), mesh.extents(0),
+                 0.0, logical_partial_derivatives_of_u[0], mesh.extents(0));
 
     auto u_eta_or_zeta_fastest =
         transpose<Variables<VariableTags>, Variables<DerivativeTags>>(
@@ -329,8 +330,9 @@ struct LogicalImpl<3, VariableTags, DerivativeTags> {
     const size_t num_components_times_eta_slices = deriv_size / mesh.extents(1);
     dgemm_<true>('N', 'N', mesh.extents(1), num_components_times_eta_slices,
                  mesh.extents(1), 1.0, differentiation_matrix_eta.data(),
-                 mesh.extents(1), u_eta_or_zeta_fastest.data(), mesh.extents(1),
-                 0.0, partial_u_wrt_eta_or_zeta->data(), mesh.extents(1));
+                 differentiation_matrix_eta.spacing(),
+                 u_eta_or_zeta_fastest.data(), mesh.extents(1), 0.0,
+                 partial_u_wrt_eta_or_zeta->data(), mesh.extents(1));
     raw_transpose(make_not_null(logical_partial_derivatives_of_u[1]),
                   partial_u_wrt_eta_or_zeta->data(),
                   num_components_times_xi_slices, mesh.extents(0));
@@ -345,8 +347,9 @@ struct LogicalImpl<3, VariableTags, DerivativeTags> {
         deriv_size / mesh.extents(2);
     dgemm_<true>('N', 'N', mesh.extents(2), num_components_times_zeta_slices,
                  mesh.extents(2), 1.0, differentiation_matrix_zeta.data(),
-                 mesh.extents(2), u_eta_or_zeta_fastest.data(), mesh.extents(2),
-                 0.0, partial_u_wrt_eta_or_zeta->data(), mesh.extents(2));
+                 differentiation_matrix_zeta.spacing(),
+                 u_eta_or_zeta_fastest.data(), mesh.extents(2), 0.0,
+                 partial_u_wrt_eta_or_zeta->data(), mesh.extents(2));
     raw_transpose(make_not_null(logical_partial_derivatives_of_u[2]),
                   partial_u_wrt_eta_or_zeta->data(), number_of_chunks,
                   chunk_size);

--- a/src/NumericalAlgorithms/LinearSolver/Lapack.cpp
+++ b/src/NumericalAlgorithms/LinearSolver/Lapack.cpp
@@ -12,7 +12,11 @@
 #include "Utilities/Gsl.hpp"
 
 extern "C" {
-extern void dgesv_(int*, int*, double*, int*, int*, double*, int*, int*);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wredundant-decls"
+extern void dgesv_(int*, int*, double*, int*, int*, double*, int*,  // NOLINT
+                   int*);
+#pragma GCC diagnostic pop
 }
 
 namespace lapack {
@@ -32,6 +36,7 @@ int general_matrix_linear_solve(
     const gsl::not_null<Matrix*> matrix_operator, int number_of_rhs) noexcept {
   int output_vector_size = matrix_operator->columns();
   int rhs_vector_size = matrix_operator->rows();
+  int matrix_spacing = matrix_operator->spacing();
   ASSERT(output_vector_size == rhs_vector_size,
          "The LAPACK-based general linear solve requires a square matrix "
          "input, not "
@@ -55,7 +60,7 @@ int general_matrix_linear_solve(
          "The single DataVector passed to the LAPACK call must be sufficiently "
          "large to contain x and b in A x = b");
   dgesv_(&rhs_vector_size, &number_of_rhs, matrix_operator->data(),
-         &output_vector_size, pivots->data(), rhs_in_solution_out->data(),
+         &matrix_spacing, pivots->data(), rhs_in_solution_out->data(),
          &output_vector_size, &info);
   return info;
 }

--- a/src/NumericalAlgorithms/Spectral/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.cpp
@@ -255,12 +255,13 @@ struct LinearFilterMatrixGenerator {
     // `nodal_to_modal_matrix` with the first two rows of
     // `modal_to_nodal_matrix`.
     Matrix lin_filter(num_points, num_points);
-    dgemm_('N', 'N', num_points, num_points, std::min(size_t{2}, num_points),
-           1.0,
-           modal_to_nodal_matrix<BasisType, QuadratureType>(num_points).data(),
-           num_points,
-           nodal_to_modal_matrix<BasisType, QuadratureType>(num_points).data(),
-           num_points, 0.0, lin_filter.data(), num_points);
+    dgemm_(
+        'N', 'N', num_points, num_points, std::min(size_t{2}, num_points), 1.0,
+        modal_to_nodal_matrix<BasisType, QuadratureType>(num_points).data(),
+        modal_to_nodal_matrix<BasisType, QuadratureType>(num_points).spacing(),
+        nodal_to_modal_matrix<BasisType, QuadratureType>(num_points).data(),
+        nodal_to_modal_matrix<BasisType, QuadratureType>(num_points).spacing(),
+        0.0, lin_filter.data(), lin_filter.spacing());
     return lin_filter;
   }
 };

--- a/src/Utilities/Blaze.hpp
+++ b/src/Utilities/Blaze.hpp
@@ -24,11 +24,16 @@ constexpr bool useStreaming = true;
 constexpr bool useOptimizedKernels = true;
 }
 
+namespace blaze {
+constexpr bool useDefaultInitialization = false;
+}
+
 // Override SMP configurations
 #define _BLAZE_SYSTEM_SMP_H_
 #define BLAZE_USE_SHARED_MEMORY_PARALLELIZATION 0
 #define BLAZE_OPENMP_PARALLEL_MODE 0
 #define BLAZE_CPP_THREADS_PARALLEL_MODE 0
+#define BLAZE_BOOST_THREADS_PARALLEL_MODE 0
 
 // Disable MPI parallelization
 #define _BLAZE_SYSTEM_MPI_H_

--- a/tests/Unit/DataStructures/Test_DenseMatrix.cpp
+++ b/tests/Unit/DataStructures/Test_DenseMatrix.cpp
@@ -60,7 +60,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DenseMatrix", "[DataStructures][Unit]") {
   test_serialization(A);
   test_copy_semantics(A);
   auto matrix_copy = A;
-  test_move_semantics(std::move(A), matrix_copy);
+  // Currently, the `columnMajor` storage order for Blaze matrix types does not
+  // qualify as `nothrow`, so the move semantics must be tested using the
+  // alternative test helper. If, in the future, the Matrix types' move
+  // assignment and constructors become appropriately `noexcept`, this call
+  // should be reverted to `test_move_semantics`.
+  test_throwing_move_semantics(std::move(A), matrix_copy);
 
   {
     Options<tmpl::list<RowMajorMatrix, ColumnMajorMatrix>> opts("");

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -175,8 +175,8 @@ struct ComputeOperatorAction {
     db::item_type<fields_tag> operator_applied_to_operand{
         number_of_grid_points * number_of_elements};
     dgemv_('N', linear_operator.rows(), linear_operator.columns(), 1,
-           linear_operator.data(), linear_operator.rows(), operand.data(), 1, 0,
-           operator_applied_to_operand.data(), 1);
+           linear_operator.data(), linear_operator.spacing(), operand.data(), 1,
+           0, operator_applied_to_operand.data(), 1);
 
     Parallel::contribute_to_reduction<CollectOperatorAction>(
         Parallel::ReductionData<
@@ -211,9 +211,8 @@ struct CollectOperatorAction {
               Ap_local.begin());
     db::mutate<LinearSolver::Tags::OperatorAppliedTo<
         LinearSolver::Tags::Operand<ScalarFieldTag>>>(
-        make_not_null(&box), [&Ap_local](auto Ap) noexcept {
-          *Ap = Scalar<DataVector>(Ap_local);
-        });
+        make_not_null(&box),
+        [&Ap_local](auto Ap) noexcept { *Ap = Scalar<DataVector>(Ap_local); });
     // Proceed with algorithm
     Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
         .perform_algorithm(true);

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
@@ -45,7 +45,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Linearize",
             const auto slice_points = mesh.extents(d);
             DataVector u_s(slice_points);
             dgemv_('N', slice_points, slice_points, 1., inv_v.data(),
-                   slice_points, u_lin.data() + s.offset(),  // NOLINT
+                   inv_v.spacing(), u_lin.data() + s.offset(),  // NOLINT
                    s.stride(), 0.0, u_s.data(), 1);
             for (size_t i = 2; i < slice_points; ++i) {
               CHECK(0.0 == approx(u_s[i]));
@@ -112,7 +112,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LinearizeInOneDim",
             const auto slice_points = mesh.extents(d);
             DataVector u_s(slice_points);
             dgemv_('N', slice_points, slice_points, 1., inv_v.data(),
-                   slice_points, u_lin.data() + s.offset(),  // NOLINT
+                   inv_v.spacing(), u_lin.data() + s.offset(),  // NOLINT
                    s.stride(), 0.0, u_s.data(), 1);
             for (size_t i = 2; i < slice_points; ++i) {
               CHECK(0.0 == approx(u_s[i]));

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Filtering.cpp
@@ -39,9 +39,9 @@ void test_exponential_filter(const double alpha, const unsigned half_power,
     DataVector filtered_nodal_coeffs(num_pts);
     const Matrix filter_matrix =
         Spectral::filtering::exponential_filter(mesh, alpha, half_power);
-    dgemv_('N', num_pts, num_pts, 1., filter_matrix.data(), num_pts,
-           initial_nodal_coeffs.data(), 1, 0.0, filtered_nodal_coeffs.data(),
-           1);
+    dgemv_('N', num_pts, num_pts, 1., filter_matrix.data(),
+           filter_matrix.spacing(), initial_nodal_coeffs.data(), 1, 0.0,
+           filtered_nodal_coeffs.data(), 1);
     const ModalVector filtered_modal_coeffs =
         to_modal_coefficients(filtered_nodal_coeffs, mesh);
     const double basis_order = num_pts - 1;

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_IndefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_IndefiniteIntegral.cpp
@@ -21,8 +21,8 @@ DataVector integrate(const DataVector& u, const Mesh<1>& mesh) noexcept {
   const size_t num_pts = mesh.number_of_grid_points();
   DataVector result(num_pts, 0.0);
   const Matrix& indef_int_with_constant = integration_matrix(mesh);
-  dgemv_('N', num_pts, num_pts, 1.0, indef_int_with_constant.data(), num_pts,
-         u.data(), 1, 0.0, result.data(), 1);
+  dgemv_('N', num_pts, num_pts, 1.0, indef_int_with_constant.data(),
+         indef_int_with_constant.spacing(), u.data(), 1, 0.0, result.data(), 1);
   return result;
 }
 

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -66,8 +66,8 @@ void test_exact_differentiation(const Function& max_poly_deg) {
           Spectral::differentiation_matrix<BasisType, QuadratureType>(n);
       const auto u = unit_polynomial(p, collocation_pts);
       DataVector numeric_derivative{n};
-      dgemv_('N', n, n, 1., diff_matrix.data(), n, u.data(), 1, 0.0,
-             numeric_derivative.data(), 1);
+      dgemv_('N', n, n, 1., diff_matrix.data(), diff_matrix.spacing(), u.data(),
+             1, 0.0, numeric_derivative.data(), 1);
       const auto analytic_derivative =
           unit_polynomial_derivative(p, collocation_pts);
       CHECK_ITERABLE_APPROX(analytic_derivative, numeric_derivative);
@@ -117,7 +117,8 @@ void test_weak_differentiation() {
             Spectral::collocation_points<BasisType, QuadratureType>(n);
         const auto u = unit_polynomial(p, collocation_pts);
         DataVector numeric_derivative{n};
-        dgemv_('N', n, n, 1., weak_diff_matrix.data(), n, u.data(), 1, 0.0,
+        dgemv_('N', n, n, 1., weak_diff_matrix.data(),
+               weak_diff_matrix.spacing(), u.data(), 1, 0.0,
                numeric_derivative.data(), 1);
         const auto analytic_derivative =
             unit_polynomial_derivative(p, collocation_pts);
@@ -163,11 +164,12 @@ void test_linear_filter() {
         Spectral::collocation_points<BasisType, QuadratureType>(n);
     const DataVector u = exp(collocation_pts);
     DataVector u_filtered(n);
-    dgemv_('N', n, n, 1.0, filter_matrix.data(), n, u.data(), 1, 0.0,
-           u_filtered.data(), 1);
+    dgemv_('N', n, n, 1.0, filter_matrix.data(), filter_matrix.spacing(),
+           u.data(), 1, 0.0, u_filtered.data(), 1);
     DataVector u_filtered_spectral(n);
-    dgemv_('N', n, n, 1.0, nodal_to_modal_matrix.data(), n, u_filtered.data(),
-           1, 0.0, u_filtered_spectral.data(), 1);
+    dgemv_('N', n, n, 1.0, nodal_to_modal_matrix.data(),
+           nodal_to_modal_matrix.spacing(), u_filtered.data(), 1, 0.0,
+           u_filtered_spectral.data(), 1);
     for (size_t s = 2; s < n; ++s) {
       CHECK(0.0 == approx(u_filtered_spectral[s]));
     }
@@ -216,7 +218,8 @@ void test_interpolation_matrix(const DataVector& target_points,
     for (size_t p = 0; p <= max_poly_deg(n); p++) {
       const DataVector u = unit_polynomial(p, collocation_pts);
       dgemv_('n', target_points.size(), n, 1., interp_matrix.data(),
-             target_points.size(), u.data(), 1, 0., interpolated_u.data(), 1);
+             interp_matrix.spacing(), u.data(), 1, 0., interpolated_u.data(),
+             1);
       CHECK(interpolated_u.size() == target_points.size());
       if (eps <= 0.) {
         CHECK_ITERABLE_APPROX(unit_polynomial(p, target_points),


### PR DESCRIPTION
## Proposed changes

This was more of a hassle than I anticipated going into it. Blaze changed around a bunch of their template expression type aliases to use their `Bind1st` and `Bind2nd` structs. Also, they changed their matrix class to be padded by default, which broke all of our lapack calls.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
