### PR TITLE
Increase timeout for ReadBoundaryDataH5

### DIFF
--- a/tests/Unit/Evolution/Systems/Cce/Test_ReadBoundaryDataH5.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_ReadBoundaryDataH5.cpp
@@ -690,6 +690,10 @@ void test_reduced_spec_worldtube_buffer_updater(
 }
 }  // namespace
 
+// An increased timeout because this test seems to have high variance in
+// duration. It usually finishes within ~3 seconds. The high variance may be due
+// to the comparatively high magnitude of disk operations in this test.
+// [[TimeOut, 10]]
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.ReadBoundaryDataH5",
                   "[Unit][Cce]") {
   MAKE_GENERATOR(gen);


### PR DESCRIPTION
## Proposed changes

It seems to have a comparatively high-variance execution time, especially when running in parallel. I suspect the culprit is the magnitude of disk operations needed to verify that all of the read/write operations work appropriately.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

