### PR TITLE
Support multiple consecutive and nested linear solves

### DIFF
--- a/src/Elliptic/Executables/Linear/SolveLinearEllipticProblem.hpp
+++ b/src/Elliptic/Executables/Linear/SolveLinearEllipticProblem.hpp
@@ -53,6 +53,16 @@
 #include "Utilities/Functional.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace SolveLinearEllipticProblem {
+namespace OptionTags {
+struct LinearSolverGroup {
+  static std::string name() noexcept { return "LinearSolver"; }
+  static constexpr OptionString help =
+      "Options for the iterative linear solver";
+};
+}  // namespace OptionTags
+}  // namespace SolveLinearEllipticProblem
+
 /// \cond
 template <typename System, typename InitialGuess, typename BoundaryConditions>
 struct Metavariables {
@@ -77,9 +87,13 @@ struct Metavariables {
 
   // The linear solver algorithm. We must use GMRES since the operator is
   // not positive-definite for the first-order system.
-  using linear_solver =
-      LinearSolver::Gmres<Metavariables, typename system::fields_tag>;
-  using temporal_id = LinearSolver::Tags::IterationId;
+  using linear_solver = LinearSolver::Gmres<
+      Metavariables, typename system::fields_tag,
+      SolveLinearEllipticProblem::OptionTags::LinearSolverGroup>;
+  using linear_solver_iteration_id =
+      LinearSolver::Tags::IterationId<typename linear_solver::options_group>;
+
+  using temporal_id = linear_solver_iteration_id;
 
   // This is needed for InitializeMortars and will be removed ASAP.
   static constexpr bool local_time_stepping = false;
@@ -95,14 +109,14 @@ struct Metavariables {
   using observe_fields =
       db::get_variables_tags_list<typename system::fields_tag>;
   using analytic_solution_fields = observe_fields;
-  using events = tmpl::list<
-      dg::Events::Registrars::ObserveFields<
-          volume_dim, LinearSolver::Tags::IterationId, observe_fields,
-          analytic_solution_fields>,
-      dg::Events::Registrars::ObserveErrorNorms<LinearSolver::Tags::IterationId,
-                                                analytic_solution_fields>>;
+  using events =
+      tmpl::list<dg::Events::Registrars::ObserveFields<
+                     volume_dim, linear_solver_iteration_id, observe_fields,
+                     analytic_solution_fields>,
+                 dg::Events::Registrars::ObserveErrorNorms<
+                     linear_solver_iteration_id, analytic_solution_fields>>;
   using triggers = tmpl::list<elliptic::Triggers::Registrars::EveryNIterations<
-      LinearSolver::Tags::IterationId>>;
+      linear_solver_iteration_id>>;
 
   // Collect all items to store in the cache.
   using const_global_cache_tags =
@@ -153,7 +167,7 @@ struct Metavariables {
                      Phase, Phase::RegisterWithObserver,
                      tmpl::list<observers::Actions::RegisterWithObservers<
                                     observers::RegisterObservers<
-                                        LinearSolver::Tags::IterationId,
+                                        linear_solver_iteration_id,
                                         element_observation_type>>,
                                 // We prepare the linear solve here to avoid
                                 // adding an extra phase. We can't do that
@@ -166,7 +180,8 @@ struct Metavariables {
                      Phase, Phase::Solve,
                      tmpl::list<typename linear_solver::prepare_step,
                                 Actions::RunEventsAndTriggers,
-                                LinearSolver::Actions::TerminateIfConverged,
+                                LinearSolver::Actions::TerminateIfConverged<
+                                    typename linear_solver::options_group>,
                                 build_linear_operator_actions,
                                 typename linear_solver::perform_step>>>>;
 

--- a/src/Elliptic/Executables/Linear/SolveLinearEllipticProblem.hpp
+++ b/src/Elliptic/Executables/Linear/SolveLinearEllipticProblem.hpp
@@ -133,45 +133,47 @@ struct Metavariables {
       typename linear_solver::initialize_element,
       dg::Actions::InitializeMortars<Metavariables>,
       elliptic::dg::Actions::InitializeFluxes<Metavariables>,
-      // Initialization is done. Avoid introducing an extra phase by
-      // advancing the linear solver to the first step here.
-      typename linear_solver::prepare_step,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
+  using build_linear_operator_actions = tmpl::list<
+      dg::Actions::SendDataForFluxes<Metavariables>,
+      Actions::MutateApply<elliptic::FirstOrderOperator<
+          volume_dim, LinearSolver::Tags::OperatorAppliedTo,
+          typename system::variables_tag>>,
+      elliptic::dg::Actions::ImposeHomogeneousDirichletBoundaryConditions<
+          Metavariables>,
+      dg::Actions::ReceiveDataForFluxes<Metavariables>,
+      dg::Actions::ApplyFluxes>;
+
+  using dg_element_array = elliptic::DgElementArray<
+      Metavariables,
+      tmpl::list<Parallel::PhaseActions<Phase, Phase::Initialization,
+                                        initialization_actions>,
+                 Parallel::PhaseActions<
+                     Phase, Phase::RegisterWithObserver,
+                     tmpl::list<observers::Actions::RegisterWithObservers<
+                                    observers::RegisterObservers<
+                                        LinearSolver::Tags::IterationId,
+                                        element_observation_type>>,
+                                // We prepare the linear solve here to avoid
+                                // adding an extra phase. We can't do that
+                                // before registration because the
+                                // `prepare_solve` action may contribute to
+                                // observers.
+                                typename linear_solver::prepare_solve,
+                                Parallel::Actions::TerminatePhase>>,
+                 Parallel::PhaseActions<
+                     Phase, Phase::Solve,
+                     tmpl::list<typename linear_solver::prepare_step,
+                                Actions::RunEventsAndTriggers,
+                                LinearSolver::Actions::TerminateIfConverged,
+                                build_linear_operator_actions,
+                                typename linear_solver::perform_step>>>>;
+
   // Specify all parallel components that will execute actions at some point.
-  using component_list = tmpl::append<
-      tmpl::list<elliptic::DgElementArray<
-          Metavariables,
-          tmpl::list<
-              Parallel::PhaseActions<Phase, Phase::Initialization,
-                                     initialization_actions>,
-
-              Parallel::PhaseActions<
-                  Phase, Phase::RegisterWithObserver,
-                  tmpl::list<observers::Actions::RegisterWithObservers<
-                                 observers::RegisterObservers<
-                                     LinearSolver::Tags::IterationId,
-                                     element_observation_type>>,
-                             Parallel::Actions::TerminatePhase>>,
-
-              Parallel::PhaseActions<
-                  Phase, Phase::Solve,
-                  tmpl::list<
-                      Actions::RunEventsAndTriggers,
-                      LinearSolver::Actions::TerminateIfConverged,
-                      dg::Actions::SendDataForFluxes<Metavariables>,
-                      Actions::MutateApply<elliptic::FirstOrderOperator<
-                          volume_dim, LinearSolver::Tags::OperatorAppliedTo,
-                          typename system::variables_tag>>,
-                      elliptic::dg::Actions::
-                          ImposeHomogeneousDirichletBoundaryConditions<
-                              Metavariables>,
-                      dg::Actions::ReceiveDataForFluxes<Metavariables>,
-                      dg::Actions::ApplyFluxes,
-                      typename linear_solver::perform_step,
-                      typename linear_solver::prepare_step>>>>>,
-      typename linear_solver::component_list,
-      tmpl::list<observers::Observer<Metavariables>,
+  using component_list = tmpl::flatten<
+      tmpl::list<dg_element_array, typename linear_solver::component_list,
+                 observers::Observer<Metavariables>,
                  observers::ObserverWriter<Metavariables>>>;
 
   // Specify the transitions between phases.

--- a/src/ParallelAlgorithms/LinearSolver/Actions/TerminateIfConverged.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/TerminateIfConverged.hpp
@@ -27,8 +27,9 @@ namespace Actions {
  *
  * Uses:
  * - DataBox:
- *   - `LinearSolver::Tags::HasConverged`
+ *   - `LinearSolver::Tags::HasConverged<OptionsGroup>`
  */
+template <typename OptionsGroup>
 struct TerminateIfConverged {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -40,7 +41,8 @@ struct TerminateIfConverged {
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
     return std::tuple<db::DataBox<DbTagsList>&&, bool>(
-        std::move(box), db::get<LinearSolver::Tags::HasConverged>(box));
+        std::move(box),
+        db::get<LinearSolver::Tags::HasConverged<OptionsGroup>>(box));
   }
 };
 

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
@@ -120,9 +120,7 @@ struct ConjugateGradient {
    *
    * \see `initialize_element`
    */
-  using reinitialize_element =
-      cg_detail::InitializeElement<FieldsTag,
-                                   ::Initialization::MergePolicy::Overwrite>;
+  using prepare_solve = cg_detail::PrepareSolve<FieldsTag>;
 
   // Compile-time interface for observers
   using observed_reduction_data_tags = observers::make_reduction_data_tags<

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
@@ -53,13 +53,16 @@ namespace LinearSolver {
  * \see Gmres for a linear solver that can invert nonsymmetric operators
  * \f$A\f$.
  */
-template <typename Metavariables, typename FieldsTag>
+template <typename Metavariables, typename FieldsTag, typename OptionsGroup>
 struct ConjugateGradient {
+  using fields_tag = FieldsTag;
+  using options_group = OptionsGroup;
+
   /*!
    * \brief The parallel components used by the conjugate gradient linear solver
    */
-  using component_list =
-      tmpl::list<cg_detail::ResidualMonitor<Metavariables, FieldsTag>>;
+  using component_list = tmpl::list<
+      cg_detail::ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>;
 
   /*!
    * \brief Initialize the tags used by the conjugate gradient linear solver.
@@ -98,7 +101,8 @@ struct ConjugateGradient {
    * not need to be initialized until it is computed for the first time in the
    * first step of the algorithm.
    */
-  using initialize_element = cg_detail::InitializeElement<FieldsTag>;
+  using initialize_element =
+      cg_detail::InitializeElement<FieldsTag, OptionsGroup>;
 
   /*!
    * \brief Reset the linear solver to its initial state.
@@ -120,7 +124,7 @@ struct ConjugateGradient {
    *
    * \see `initialize_element`
    */
-  using prepare_solve = cg_detail::PrepareSolve<FieldsTag>;
+  using prepare_solve = cg_detail::PrepareSolve<FieldsTag, OptionsGroup>;
 
   // Compile-time interface for observers
   using observed_reduction_data_tags = observers::make_reduction_data_tags<
@@ -136,7 +140,7 @@ struct ConjugateGradient {
    *   * `LinearSolver::Tags::IterationId`
    *   * `Tags::Next<LinearSolver::Tags::IterationId>`
    */
-  using prepare_step = cg_detail::PrepareStep;
+  using prepare_step = cg_detail::PrepareStep<FieldsTag, OptionsGroup>;
 
   /*!
    * \brief Perform an iteration of the conjugate gradient linear solver.
@@ -159,7 +163,7 @@ struct ConjugateGradient {
    *   * `residual_tag`
    *   * `LinearSolver::Tags::HasConverged`
    */
-  using perform_step = cg_detail::PerformStep<FieldsTag>;
+  using perform_step = cg_detail::PerformStep<FieldsTag, OptionsGroup>;
 };
 
 }  // namespace LinearSolver

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp
@@ -35,6 +35,91 @@ struct ResidualMonitor;
 namespace LinearSolver {
 namespace cg_detail {
 
+template <typename FieldsTag>
+struct PrepareSolve {
+ private:
+  using fields_tag = FieldsTag;
+  using source_tag = db::add_tag_prefix<::Tags::FixedSource, fields_tag>;
+  using operator_applied_to_fields_tag =
+      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, fields_tag>;
+  using operand_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
+  using residual_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>;
+
+ public:
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<LinearSolver::Tags::IterationId, operand_tag, residual_tag>(
+        make_not_null(&box),
+        [](const gsl::not_null<size_t*> iteration_id,
+           const gsl::not_null<db::item_type<operand_tag>*> operand,
+           const gsl::not_null<db::item_type<residual_tag>*> residual,
+           const db::item_type<source_tag>& source,
+           const db::item_type<operator_applied_to_fields_tag>&
+               operator_applied_to_fields) noexcept {
+          // We have not started iterating yet, so we initialize the current
+          // iteration ID such that the _next_ iteration ID is zero.
+          *iteration_id = std::numeric_limits<size_t>::max();
+          *operand = source - operator_applied_to_fields;
+          *residual = *operand;
+        },
+        get<source_tag>(box), get<operator_applied_to_fields_tag>(box));
+
+    // Perform global reduction to compute initial residual magnitude square for
+    // residual monitor
+    const auto& residual = get<residual_tag>(box);
+    Parallel::contribute_to_reduction<
+        cg_detail::InitializeResidual<FieldsTag, ParallelComponent>>(
+        Parallel::ReductionData<
+            Parallel::ReductionDatum<double, funcl::Plus<>>>{
+            inner_product(residual, residual)},
+        Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
+        Parallel::get_parallel_component<
+            ResidualMonitor<Metavariables, FieldsTag>>(cache));
+
+    return {
+        std::move(box),
+        // Terminate algorithm for now. The `ResidualMonitor` will receive the
+        // reduction that is performed above and then broadcast to the following
+        // action, which is responsible for restarting the algorithm.
+        true};
+  }
+};
+
+template <typename FieldsTag>
+struct InitializeHasConverged {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex,
+            typename DataBox = db::DataBox<DbTagsList>,
+            Requires<db::tag_is_retrievable_v<LinearSolver::Tags::HasConverged,
+                                              DataBox>> = nullptr>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index,
+                    const db::item_type<LinearSolver::Tags::HasConverged>&
+                        has_converged) noexcept {
+    db::mutate<LinearSolver::Tags::HasConverged>(
+        make_not_null(&box),
+        [&has_converged](const gsl::not_null<
+                         db::item_type<LinearSolver::Tags::HasConverged>*>
+                             local_has_converged) noexcept {
+          *local_has_converged = has_converged;
+        });
+
+    // Proceed with algorithm
+    Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
+        .perform_algorithm(true);
+  }
+};
+
 struct PrepareStep {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
@@ -11,41 +11,23 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "NumericalAlgorithms/LinearSolver/InnerProduct.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
-#include "Parallel/Info.hpp"
-#include "Parallel/Invoke.hpp"
-#include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
-#include "Utilities/MakeWithValue.hpp"
 
 /// \cond
 namespace tuples {
 template <typename...>
 class TaggedTuple;
 }  // namespace tuples
-namespace LinearSolver {
-namespace cg_detail {
-template <typename Metavariables, typename FieldsTag>
-struct ResidualMonitor;
-template <typename FieldsTag, typename BroadcastTarget>
-struct InitializeResidual;
-}  // namespace cg_detail
-}  // namespace LinearSolver
 /// \endcond
 
 namespace LinearSolver {
 namespace cg_detail {
 
-template <typename FieldsTag, Initialization::MergePolicy MergePolicy =
-                                  Initialization::MergePolicy::Error>
+template <typename FieldsTag>
 struct InitializeElement {
  private:
   using fields_tag = FieldsTag;
-  using source_tag = db::add_tag_prefix<::Tags::FixedSource, fields_tag>;
-  using operator_applied_to_fields_tag =
-      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, fields_tag>;
-  using operand_tag =
-      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
   using residual_tag =
       db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>;
 
@@ -55,31 +37,10 @@ struct InitializeElement {
             typename ParallelComponent>
   static auto apply(db::DataBox<DbTagsList>& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    Parallel::ConstGlobalCache<Metavariables>& cache,
-                    const ArrayIndex& array_index, const ActionList /*meta*/,
+                    Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    db::mutate<operand_tag>(
-        make_not_null(&box),
-        [](const gsl::not_null<db::item_type<operand_tag>*> operand,
-           const db::const_item_type<source_tag>& source,
-           const db::const_item_type<operator_applied_to_fields_tag>&
-               operator_applied_to_fields) noexcept {
-          *operand = source - operator_applied_to_fields;
-        },
-        get<source_tag>(box), get<operator_applied_to_fields_tag>(box));
-    auto residual = db::item_type<residual_tag>{get<operand_tag>(box)};
-
-    // Perform global reduction to compute initial residual magnitude square for
-    // residual monitor
-    Parallel::contribute_to_reduction<
-        cg_detail::InitializeResidual<FieldsTag, ParallelComponent>>(
-        Parallel::ReductionData<
-            Parallel::ReductionDatum<double, funcl::Plus<>>>{
-            inner_product(residual, residual)},
-        Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
-        Parallel::get_parallel_component<
-            ResidualMonitor<Metavariables, FieldsTag>>(cache));
-
     using compute_tags = db::AddComputeTags<
         ::Tags::NextCompute<LinearSolver::Tags::IterationId>>;
     return std::make_tuple(
@@ -87,42 +48,12 @@ struct InitializeElement {
             InitializeElement,
             db::AddSimpleTags<LinearSolver::Tags::IterationId, residual_tag,
                               LinearSolver::Tags::HasConverged>,
-            compute_tags, MergePolicy>(
-            std::move(box),
-            // We have not started iterating yet, so we initialize the current
-            // iteration ID such that the _next_ iteration ID is zero.
-            std::numeric_limits<size_t>::max(), std::move(residual),
-            db::item_type<LinearSolver::Tags::HasConverged>{}),
-        // Terminate algorithm for now. The `ResidualMonitor` will receive the
-        // reduction that is performed above and then broadcast to the following
-        // action, which is responsible for restarting the algorithm.
-        true);
-  }
-};
-
-template <typename FieldsTag>
-struct InitializeHasConverged {
-  template <typename ParallelComponent, typename DbTagsList,
-            typename Metavariables, typename ArrayIndex,
-            typename DataBox = db::DataBox<DbTagsList>,
-            Requires<db::tag_is_retrievable_v<LinearSolver::Tags::HasConverged,
-                                              DataBox>> = nullptr>
-  static void apply(db::DataBox<DbTagsList>& box,
-                    Parallel::ConstGlobalCache<Metavariables>& cache,
-                    const ArrayIndex& array_index,
-                    const db::const_item_type<LinearSolver::Tags::HasConverged>&
-                        has_converged) noexcept {
-    db::mutate<LinearSolver::Tags::HasConverged>(
-        make_not_null(&box), [&has_converged](
-                                 const gsl::not_null<db::item_type<
-                                     LinearSolver::Tags::HasConverged>*>
-                                     local_has_converged) noexcept {
-          *local_has_converged = has_converged;
-        });
-
-    // Proceed with algorithm
-    Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
-        .perform_algorithm(true);
+            compute_tags>(std::move(box),
+                          // The `PrepareSolve` action populates these tags with
+                          // initial values
+                          std::numeric_limits<size_t>::max(),
+                          db::item_type<residual_tag>{},
+                          db::item_type<LinearSolver::Tags::HasConverged>{}));
   }
 };
 

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
@@ -99,7 +99,9 @@ struct InitializeResidualMonitor {
                               residual_square_tag,
                               initial_residual_magnitude_tag>,
             compute_tags>(std::move(box),
-                          db::item_type<LinearSolver::Tags::IterationId>{0},
+                          // The `InitializeResidual` action populates these
+                          // tags with initial values
+                          std::numeric_limits<size_t>::max(),
                           std::numeric_limits<double>::signaling_NaN(),
                           std::numeric_limits<double>::signaling_NaN()),
         true);

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
@@ -67,8 +67,6 @@ struct InitializeResidual {
                                  const gsl::not_null<double*>
                                      local_residual_square) noexcept {
           *local_residual_square = residual_square;
-          // Also setting the LinearSolver::Tags::IterationId so
-          // re-initialization works:
           *iteration_id = 0;
         });
     // Perform a separate `db::mutate` so that we can retrieve the

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp
@@ -36,6 +36,112 @@ struct ResidualMonitor;
 namespace LinearSolver {
 namespace gmres_detail {
 
+template <typename FieldsTag>
+struct PrepareSolve {
+ private:
+  using fields_tag = FieldsTag;
+  using initial_fields_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Initial, fields_tag>;
+  using source_tag = db::add_tag_prefix<::Tags::FixedSource, fields_tag>;
+  using operator_applied_to_fields_tag =
+      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, fields_tag>;
+  using operand_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
+  using basis_history_tag = LinearSolver::Tags::KrylovSubspaceBasis<fields_tag>;
+
+ public:
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<LinearSolver::Tags::IterationId, operand_tag, initial_fields_tag,
+               basis_history_tag>(
+        make_not_null(&box),
+        [](const gsl::not_null<size_t*> iteration_id,
+           const gsl::not_null<db::item_type<operand_tag>*> operand,
+           const gsl::not_null<db::item_type<initial_fields_tag>*>
+               initial_fields,
+           const gsl::not_null<db::item_type<basis_history_tag>*> basis_history,
+           const db::item_type<source_tag>& source,
+           const db::item_type<operator_applied_to_fields_tag>&
+               operator_applied_to_fields,
+           const db::item_type<fields_tag>& fields) noexcept {
+          // We have not started iterating yet, so we initialize the current
+          // iteration ID such that the _next_ iteration ID is zero.
+          *iteration_id = std::numeric_limits<size_t>::max();
+          *operand = source - operator_applied_to_fields;
+          *initial_fields = fields;
+          *basis_history = db::item_type<basis_history_tag>{};
+        },
+        get<source_tag>(box), get<operator_applied_to_fields_tag>(box),
+        get<fields_tag>(box));
+
+    Parallel::contribute_to_reduction<gmres_detail::InitializeResidualMagnitude<
+        FieldsTag, ParallelComponent>>(
+        Parallel::ReductionData<
+            Parallel::ReductionDatum<double, funcl::Plus<>, funcl::Sqrt<>>>{
+            inner_product(get<operand_tag>(box), get<operand_tag>(box))},
+        Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
+        Parallel::get_parallel_component<
+            ResidualMonitor<Metavariables, FieldsTag>>(cache));
+
+    return {
+        std::move(box),
+        // Terminate algorithm for now. The `ResidualMonitor` will receive the
+        // reduction that is performed above and then broadcast to the following
+        // action, which is responsible for restarting the algorithm.
+        true};
+  }
+};
+
+template <typename FieldsTag>
+struct NormalizeInitialOperand {
+ private:
+  using fields_tag = FieldsTag;
+  using operand_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
+  using basis_history_tag = LinearSolver::Tags::KrylovSubspaceBasis<fields_tag>;
+
+ public:
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex,
+            typename DataBox = db::DataBox<DbTagsList>,
+            Requires<db::tag_is_retrievable_v<operand_tag, DataBox> and
+                     db::tag_is_retrievable_v<basis_history_tag, DataBox> and
+                     db::tag_is_retrievable_v<LinearSolver::Tags::HasConverged,
+                                              DataBox>> = nullptr>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index,
+                    const double residual_magnitude,
+                    const db::item_type<LinearSolver::Tags::HasConverged>&
+                        has_converged) noexcept {
+    db::mutate<operand_tag, basis_history_tag,
+               LinearSolver::Tags::HasConverged>(
+        make_not_null(&box),
+        [residual_magnitude, &has_converged](
+            const gsl::not_null<db::item_type<operand_tag>*> operand,
+            const gsl::not_null<db::item_type<basis_history_tag>*>
+                basis_history,
+            const gsl::not_null<
+                db::item_type<LinearSolver::Tags::HasConverged>*>
+                local_has_converged) noexcept {
+          *operand /= residual_magnitude;
+          basis_history->push_back(*operand);
+          *local_has_converged = has_converged;
+        });
+
+    // Proceed with algorithm
+    Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
+        .perform_algorithm(true);
+  }
+};
+
 struct PrepareStep {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
@@ -61,13 +61,16 @@ namespace LinearSolver {
  * \see ConjugateGradient for a linear solver that is more efficient when the
  * linear operator \f$A\f$ is symmetric.
  */
-template <typename Metavariables, typename FieldsTag>
+template <typename Metavariables, typename FieldsTag, typename OptionsGroup>
 struct Gmres {
+  using fields_tag = FieldsTag;
+  using options_group = OptionsGroup;
+
   /*!
    * \brief The parallel components used by the GMRES linear solver
    */
-  using component_list =
-      tmpl::list<gmres_detail::ResidualMonitor<Metavariables, FieldsTag>>;
+  using component_list = tmpl::list<
+      gmres_detail::ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>;
 
   /*!
    * \brief Initialize the tags used by the GMRES linear solver.
@@ -113,7 +116,8 @@ struct Gmres {
    * not need to be initialized until it is computed for the first time in the
    * first step of the algorithm.
    */
-  using initialize_element = gmres_detail::InitializeElement<FieldsTag>;
+  using initialize_element =
+      gmres_detail::InitializeElement<FieldsTag, OptionsGroup>;
 
   /*!
    * \brief Reset the linear solver to its initial state.
@@ -146,7 +150,7 @@ struct Gmres {
    *
    * \see `initialize_element`
    */
-  using prepare_solve = gmres_detail::PrepareSolve<FieldsTag>;
+  using prepare_solve = gmres_detail::PrepareSolve<FieldsTag, OptionsGroup>;
 
   // Compile-time interface for observers
   using observed_reduction_data_tags = observers::make_reduction_data_tags<
@@ -163,7 +167,7 @@ struct Gmres {
    *   * `Tags::Next<LinearSolver::Tags::IterationId>`
    *   * `orthogonalization_iteration_id_tag`
    */
-  using prepare_step = gmres_detail::PrepareStep;
+  using prepare_step = gmres_detail::PrepareStep<FieldsTag, OptionsGroup>;
 
   /*!
    * \brief Perform an iteration of the GMRES linear solver.
@@ -190,7 +194,7 @@ struct Gmres {
    *   * `basis_history_tag`
    *   * `LinearSolver::Tags::HasConverged`
    */
-  using perform_step = gmres_detail::PerformStep<FieldsTag>;
+  using perform_step = gmres_detail::PerformStep<FieldsTag, OptionsGroup>;
 };
 
 }  // namespace LinearSolver

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
@@ -146,9 +146,7 @@ struct Gmres {
    *
    * \see `initialize_element`
    */
-  using reinitialize_element =
-      gmres_detail::InitializeElement<FieldsTag,
-                                      ::Initialization::MergePolicy::Overwrite>;
+  using prepare_solve = gmres_detail::PrepareSolve<FieldsTag>;
 
   // Compile-time interface for observers
   using observed_reduction_data_tags = observers::make_reduction_data_tags<

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/InitializeElement.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/InitializeElement.hpp
@@ -10,43 +10,25 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
-#include "Parallel/Info.hpp"
-#include "Parallel/Invoke.hpp"
-#include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
-#include "Utilities/MakeWithValue.hpp"
 
 /// \cond
 namespace tuples {
 template <typename...>
 class TaggedTuple;
 }  // namespace tuples
-namespace LinearSolver {
-namespace gmres_detail {
-template <typename Metavariables, typename FieldsTag>
-struct ResidualMonitor;
-template <typename FieldsTag, typename BroadcastTarget>
-struct InitializeResidualMagnitude;
-}  // namespace gmres_detail
-}  // namespace LinearSolver
 /// \endcond
 
 namespace LinearSolver {
 namespace gmres_detail {
 
-template <typename FieldsTag, Initialization::MergePolicy MergePolicy =
-                                  Initialization::MergePolicy::Error>
+template <typename FieldsTag>
 struct InitializeElement {
  private:
   using fields_tag = FieldsTag;
   using initial_fields_tag =
       db::add_tag_prefix<LinearSolver::Tags::Initial, fields_tag>;
-  using source_tag = db::add_tag_prefix<::Tags::FixedSource, fields_tag>;
-  using operator_applied_to_fields_tag =
-      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, fields_tag>;
-  using operand_tag =
-      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
   using orthogonalization_iteration_id_tag =
       db::add_tag_prefix<LinearSolver::Tags::Orthogonalization,
                          LinearSolver::Tags::IterationId>;
@@ -58,95 +40,25 @@ struct InitializeElement {
             typename ParallelComponent>
   static auto apply(db::DataBox<DbTagsList>& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    Parallel::ConstGlobalCache<Metavariables>& cache,
-                    const ArrayIndex& array_index, const ActionList /*meta*/,
+                    Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    db::mutate<operand_tag>(
-        make_not_null(&box),
-        [](const gsl::not_null<db::item_type<operand_tag>*> operand,
-           const db::const_item_type<source_tag>& source,
-           const db::const_item_type<operator_applied_to_fields_tag>&
-               operator_applied_to_fields) noexcept {
-          *operand = source - operator_applied_to_fields;
-        },
-        get<source_tag>(box), get<operator_applied_to_fields_tag>(box));
-    const auto& operand = get<operand_tag>(box);
-
-    Parallel::contribute_to_reduction<gmres_detail::InitializeResidualMagnitude<
-        FieldsTag, ParallelComponent>>(
-        Parallel::ReductionData<
-            Parallel::ReductionDatum<double, funcl::Plus<>, funcl::Sqrt<>>>{
-            inner_product(operand, operand)},
-        Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
-        Parallel::get_parallel_component<
-            ResidualMonitor<Metavariables, FieldsTag>>(cache));
-
-    db::item_type<initial_fields_tag> x0(get<fields_tag>(box));
-    db::item_type<basis_history_tag> basis_history{};
-
     using compute_tags = db::AddComputeTags<
         ::Tags::NextCompute<LinearSolver::Tags::IterationId>>;
-    return std::make_tuple(
-        ::Initialization::merge_into_databox<
-            InitializeElement,
-            db::AddSimpleTags<
-                LinearSolver::Tags::IterationId, initial_fields_tag,
-                orthogonalization_iteration_id_tag, basis_history_tag,
-                LinearSolver::Tags::HasConverged>,
-            compute_tags, MergePolicy>(
-            std::move(box),
-            // We have not started iterating yet, so we initialize the current
-            // iteration ID such that the _next_ iteration ID is zero.
-            std::numeric_limits<size_t>::max(), std::move(x0),
-            db::item_type<orthogonalization_iteration_id_tag>{0},
-            std::move(basis_history),
-            db::item_type<LinearSolver::Tags::HasConverged>{}),
-        // Terminate algorithm for now. The `ResidualMonitor` will receive the
-        // reduction that is performed above and then broadcast to the following
-        // action, which is responsible for restarting the algorithm.
-        true);
-  }
-};
-
-template <typename FieldsTag>
-struct NormalizeInitialOperand {
- private:
-  using fields_tag = FieldsTag;
-  using operand_tag =
-      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
-  using basis_history_tag = LinearSolver::Tags::KrylovSubspaceBasis<fields_tag>;
-
- public:
-  template <typename ParallelComponent, typename DbTagsList,
-            typename Metavariables, typename ArrayIndex,
-            typename DataBox = db::DataBox<DbTagsList>,
-            Requires<db::tag_is_retrievable_v<operand_tag, DataBox> and
-                     db::tag_is_retrievable_v<basis_history_tag, DataBox> and
-                     db::tag_is_retrievable_v<LinearSolver::Tags::HasConverged,
-                                              DataBox>> = nullptr>
-  static void apply(db::DataBox<DbTagsList>& box,
-                    Parallel::ConstGlobalCache<Metavariables>& cache,
-                    const ArrayIndex& array_index,
-                    const double residual_magnitude,
-                    const db::const_item_type<LinearSolver::Tags::HasConverged>&
-                        has_converged) noexcept {
-    db::mutate<operand_tag, basis_history_tag,
-               LinearSolver::Tags::HasConverged>(
-        make_not_null(&box),
-        [
-          residual_magnitude, &has_converged
-        ](const gsl::not_null<db::item_type<operand_tag>*> operand,
-          const gsl::not_null<db::item_type<basis_history_tag>*> basis_history,
-          const gsl::not_null<db::item_type<LinearSolver::Tags::HasConverged>*>
-              local_has_converged) noexcept {
-          *operand /= residual_magnitude;
-          basis_history->push_back(*operand);
-          *local_has_converged = has_converged;
-        });
-
-    // Proceed with algorithm
-    Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
-        .perform_algorithm(true);
+    return std::make_tuple(::Initialization::merge_into_databox<
+                           InitializeElement,
+                           db::AddSimpleTags<LinearSolver::Tags::IterationId,
+                                             initial_fields_tag,
+                                             orthogonalization_iteration_id_tag,
+                                             basis_history_tag,
+                                             LinearSolver::Tags::HasConverged>,
+                           compute_tags>(
+        std::move(box),
+        // The `PrepareSolve` action populates these tags with initial values
+        std::numeric_limits<size_t>::max(), db::item_type<initial_fields_tag>{},
+        std::numeric_limits<size_t>::max(), db::item_type<basis_history_tag>{},
+        db::item_type<LinearSolver::Tags::HasConverged>{}));
   }
 };
 

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -25,7 +25,7 @@ class TaggedTuple;
 }  // namespace tuples
 namespace LinearSolver {
 namespace gmres_detail {
-template <typename FieldsTag>
+template <typename FieldsTag, typename OptionsGroup>
 struct InitializeResidualMonitor;
 }  // namespace gmres_detail
 }  // namespace LinearSolver
@@ -37,17 +37,17 @@ struct Criteria;
 namespace LinearSolver {
 namespace gmres_detail {
 
-template <typename Metavariables, typename FieldsTag>
+template <typename Metavariables, typename FieldsTag, typename OptionsGroup>
 struct ResidualMonitor {
   using chare_type = Parallel::Algorithms::Singleton;
   using const_global_cache_tags =
-      tmpl::list<LinearSolver::Tags::Verbosity,
-                 LinearSolver::Tags::ConvergenceCriteria>;
+      tmpl::list<LinearSolver::Tags::Verbosity<OptionsGroup>,
+                 LinearSolver::Tags::ConvergenceCriteria<OptionsGroup>>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
-                             tmpl::list<InitializeResidualMonitor<FieldsTag>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<InitializeResidualMonitor<FieldsTag, OptionsGroup>>>,
 
       Parallel::PhaseActions<
           typename Metavariables::Phase,
@@ -66,7 +66,7 @@ struct ResidualMonitor {
   }
 };
 
-template <typename FieldsTag>
+template <typename FieldsTag, typename OptionsGroup>
 struct InitializeResidualMonitor {
  private:
   using fields_tag = FieldsTag;
@@ -77,7 +77,7 @@ struct InitializeResidualMonitor {
       db::add_tag_prefix<LinearSolver::Tags::Initial, residual_magnitude_tag>;
   using orthogonalization_iteration_id_tag =
       db::add_tag_prefix<LinearSolver::Tags::Orthogonalization,
-                         LinearSolver::Tags::IterationId>;
+                         LinearSolver::Tags::IterationId<OptionsGroup>>;
   using orthogonalization_history_tag =
       db::add_tag_prefix<LinearSolver::Tags::OrthogonalizationHistory,
                          fields_tag>;
@@ -92,14 +92,14 @@ struct InitializeResidualMonitor {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using compute_tags =
-        db::AddComputeTags<LinearSolver::Tags::HasConvergedCompute<fields_tag>>;
+    using compute_tags = db::AddComputeTags<
+        LinearSolver::Tags::HasConvergedCompute<fields_tag, OptionsGroup>>;
     return std::make_tuple(
         ::Initialization::merge_into_databox<
             InitializeResidualMonitor,
             db::AddSimpleTags<residual_magnitude_tag,
                               initial_residual_magnitude_tag,
-                              LinearSolver::Tags::IterationId,
+                              LinearSolver::Tags::IterationId<OptionsGroup>,
                               orthogonalization_iteration_id_tag,
                               orthogonalization_history_tag>,
             compute_tags>(std::move(box),

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -103,11 +103,13 @@ struct InitializeResidualMonitor {
                               orthogonalization_iteration_id_tag,
                               orthogonalization_history_tag>,
             compute_tags>(std::move(box),
+                          // The `InitializeResidualMagnitude` action populates
+                          // these tags with initial values
                           std::numeric_limits<double>::signaling_NaN(),
                           std::numeric_limits<double>::signaling_NaN(),
-                          db::item_type<LinearSolver::Tags::IterationId>{0},
-                          db::item_type<orthogonalization_iteration_id_tag>{0},
-                          DenseMatrix<double>{2, 1, 0.}),
+                          std::numeric_limits<size_t>::max(),
+                          std::numeric_limits<size_t>::max(),
+                          DenseMatrix<double>{}),
         true);
   }
 };

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
@@ -80,10 +80,6 @@ struct InitializeResidualMagnitude {
                 orthogonalization_history) noexcept {
           *local_residual_magnitude = *initial_residual_magnitude =
               residual_magnitude;
-          // Also setting the following tags so re-initialization works:
-          // - LinearSolver::Tags::IterationId
-          // - orthogonalization_iteration_id_tag
-          // - orthogonalization_history_tag
           *iteration_id = 0;
           *orthogonalization_iteration_id = 0;
           *orthogonalization_history = DenseMatrix<double>{2, 1, 0.};

--- a/src/ParallelAlgorithms/LinearSolver/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Tags.hpp
@@ -26,6 +26,7 @@
 /// \cond
 namespace LinearSolver {
 namespace Tags {
+template <typename OptionsGroup>
 struct ConvergenceCriteria;
 }  // namespace Tags
 }  // namespace LinearSolver
@@ -76,10 +77,10 @@ struct OperatorAppliedTo : db::PrefixTag, db::SimpleTag {
  * \brief Holds an `IterationId` that identifies a step in the linear solver
  * algorithm
  */
+template <typename OptionsGroup>
 struct IterationId : db::SimpleTag {
   static std::string name() noexcept {
-    // Add "Linear" prefix to abbreviate the namespace for uniqueness
-    return "LinearIterationId";
+    return "IterationId(" + option_name<OptionsGroup>() + ")";
   }
   using type = size_t;
   template <typename Tag>
@@ -206,8 +207,11 @@ struct KrylovSubspaceBasis : db::PrefixTag, db::SimpleTag {
  * \brief Holds a `Convergence::HasConverged` flag that signals the linear
  * solver has converged, along with the reason for convergence.
  */
+template <typename OptionsGroup>
 struct HasConverged : db::SimpleTag {
-  static std::string name() noexcept { return "LinearSolverHasConverged"; }
+  static std::string name() noexcept {
+    return "HasConverged(" + option_name<OptionsGroup>() + ")";
+  }
   using type = Convergence::HasConverged;
 };
 
@@ -215,8 +219,9 @@ struct HasConverged : db::SimpleTag {
  * \brief Employs the `LinearSolver::Tags::ConvergenceCriteria` to
  * determine the linear solver has converged.
  */
-template <typename FieldsTag>
-struct HasConvergedCompute : LinearSolver::Tags::HasConverged, db::ComputeTag {
+template <typename FieldsTag, typename OptionsGroup>
+struct HasConvergedCompute : LinearSolver::Tags::HasConverged<OptionsGroup>,
+                             db::ComputeTag {
  private:
   using residual_magnitude_tag = db::add_tag_prefix<
       LinearSolver::Tags::Magnitude,
@@ -226,16 +231,15 @@ struct HasConvergedCompute : LinearSolver::Tags::HasConverged, db::ComputeTag {
 
  public:
   using argument_tags =
-      tmpl::list<LinearSolver::Tags::ConvergenceCriteria,
-                 LinearSolver::Tags::IterationId, residual_magnitude_tag,
-                 initial_residual_magnitude_tag>;
-  static db::const_item_type<LinearSolver::Tags::HasConverged> function(
+      tmpl::list<LinearSolver::Tags::ConvergenceCriteria<OptionsGroup>,
+                 LinearSolver::Tags::IterationId<OptionsGroup>,
+                 residual_magnitude_tag, initial_residual_magnitude_tag>;
+  static Convergence::HasConverged function(
       const Convergence::Criteria& convergence_criteria,
       const size_t iteration_id, const double residual_magnitude,
       const double initial_residual_magnitude) noexcept {
-    return Convergence::HasConverged(convergence_criteria, iteration_id,
-                                     residual_magnitude,
-                                     initial_residual_magnitude);
+    return {convergence_criteria, iteration_id, residual_magnitude,
+            initial_residual_magnitude};
   }
 };
 
@@ -247,28 +251,19 @@ struct HasConvergedCompute : LinearSolver::Tags::HasConverged, db::ComputeTag {
  */
 namespace OptionTags {
 
-/*!
- * \ingroup OptionGroupsGroup
- * \brief Groups option tags related to the iterative linear solver, e.g.
- * convergence criteria.
- */
-struct Group {
-  static std::string name() noexcept { return "LinearSolver"; }
-  static constexpr OptionString help =
-      "Options for the iterative linear solver";
-};
-
+template <typename OptionsGroup>
 struct ConvergenceCriteria {
   static constexpr OptionString help =
       "Determine convergence of the linear solve";
   using type = Convergence::Criteria;
-  using group = Group;
+  using group = OptionsGroup;
 };
 
+template <typename OptionsGroup>
 struct Verbosity {
   using type = ::Verbosity;
   static constexpr OptionString help = "Logging verbosity";
-  using group = Group;
+  using group = OptionsGroup;
   static type default_value() noexcept { return ::Verbosity::Quiet; }
 };
 
@@ -295,9 +290,14 @@ namespace Tags {
  * remain. Therefore, ideally choose the absolute or relative residual criteria
  * based on an estimate of the discretization residual.
  */
+template <typename OptionsGroup>
 struct ConvergenceCriteria : db::SimpleTag {
+  static std::string name() noexcept {
+    return "ConvergenceCriteria(" + option_name<OptionsGroup>() + ")";
+  }
   using type = Convergence::Criteria;
-  using option_tags = tmpl::list<LinearSolver::OptionTags::ConvergenceCriteria>;
+  using option_tags =
+      tmpl::list<LinearSolver::OptionTags::ConvergenceCriteria<OptionsGroup>>;
 
   static constexpr bool pass_metavariables = false;
   static Convergence::Criteria create_from_options(
@@ -306,9 +306,14 @@ struct ConvergenceCriteria : db::SimpleTag {
   }
 };
 
+template <typename OptionsGroup>
 struct Verbosity : db::SimpleTag {
+  static std::string name() noexcept {
+    return "Verbosity(" + option_name<OptionsGroup>() + ")";
+  }
   using type = ::Verbosity;
-  using option_tags = tmpl::list<LinearSolver::OptionTags::Verbosity>;
+  using option_tags =
+      tmpl::list<LinearSolver::OptionTags::Verbosity<OptionsGroup>>;
 
   static constexpr bool pass_metavariables = false;
   static ::Verbosity create_from_options(
@@ -321,10 +326,11 @@ struct Verbosity : db::SimpleTag {
 
 namespace Tags {
 
-template <>
-struct NextCompute<LinearSolver::Tags::IterationId>
-    : Next<LinearSolver::Tags::IterationId>, db::ComputeTag {
-  using argument_tags = tmpl::list<LinearSolver::Tags::IterationId>;
+template <typename OptionsGroup>
+struct NextCompute<LinearSolver::Tags::IterationId<OptionsGroup>>
+    : Next<LinearSolver::Tags::IterationId<OptionsGroup>>, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<LinearSolver::Tags::IterationId<OptionsGroup>>;
   static size_t function(const size_t iteration_id) noexcept {
     return iteration_id + 1;
   }

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -278,20 +278,22 @@ template <typename Metavariables>
 struct ElementArray {
   using chare_type = Parallel::Algorithms::Array;
   using metavariables = Metavariables;
+  using linear_solver = typename Metavariables::linear_solver;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<InitializeElement,
-                     typename Metavariables::linear_solver::initialize_element,
+                     typename linear_solver::initialize_element,
+                     typename linear_solver::prepare_solve,
                      Parallel::Actions::TerminatePhase>>,
 
       Parallel::PhaseActions<
           typename Metavariables::Phase,
           Metavariables::Phase::PerformLinearSolve,
           tmpl::list<LinearSolver::Actions::TerminateIfConverged,
-                     typename Metavariables::linear_solver::prepare_step,
+                     typename linear_solver::prepare_step,
                      ComputeOperatorAction,
-                     typename Metavariables::linear_solver::perform_step>>,
+                     typename linear_solver::perform_step>>,
 
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::TestResult,

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -197,6 +197,7 @@ struct ElementArray {
   using chare_type = Parallel::Algorithms::Array;
   using array_index = int;
   using metavariables = Metavariables;
+  using linear_solver = typename Metavariables::linear_solver;
   // In each step of the algorithm we must provide A(p). The linear solver then
   // takes care of updating x and p, as well as the internal variables r, its
   // magnitude and the iteration step number.
@@ -205,16 +206,17 @@ struct ElementArray {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<InitializeElement,
-                     typename Metavariables::linear_solver::initialize_element,
+                     typename linear_solver::initialize_element,
+                     typename linear_solver::prepare_solve,
                      Parallel::Actions::TerminatePhase>>,
 
       Parallel::PhaseActions<
           typename Metavariables::Phase,
           Metavariables::Phase::PerformLinearSolve,
           tmpl::list<LinearSolver::Actions::TerminateIfConverged,
-                     typename Metavariables::linear_solver::prepare_step,
+                     typename linear_solver::prepare_step,
                      ComputeOperatorAction,
-                     typename Metavariables::linear_solver::perform_step>>,
+                     typename linear_solver::perform_step>>,
 
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::TestResult,

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -127,10 +127,10 @@ struct ComputeOperatorAction {
       const ParallelComponent* const /*meta*/) noexcept {
     db::mutate<operator_tag>(
         make_not_null(&box),
-        [
-        ](const gsl::not_null<DenseVector<double>*> operator_applied_to_operand,
-          const DenseMatrix<double>& linear_operator,
-          const DenseVector<double>& operand) noexcept {
+        [](const gsl::not_null<DenseVector<double>*>
+               operator_applied_to_operand,
+           const DenseMatrix<double>& linear_operator,
+           const DenseVector<double>& operand) noexcept {
           *operator_applied_to_operand = linear_operator * operand;
         },
         get<LinearOperator>(cache), get<operand_tag>(box));
@@ -139,6 +139,7 @@ struct ComputeOperatorAction {
 };
 
 // Checks for the correct solution after the algorithm has terminated.
+template <typename OptionsGroup>
 struct TestResult {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent>
@@ -152,7 +153,8 @@ struct TestResult {
       const ActionList /*meta*/,
       // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
       const ParallelComponent* const /*meta*/) noexcept {
-    const auto& has_converged = get<LinearSolver::Tags::HasConverged>(box);
+    const auto& has_converged =
+        get<LinearSolver::Tags::HasConverged<OptionsGroup>>(box);
     SPECTRE_PARALLEL_REQUIRE(has_converged);
     SPECTRE_PARALLEL_REQUIRE(has_converged.reason() ==
                              Convergence::Reason::AbsoluteResidual);
@@ -213,14 +215,15 @@ struct ElementArray {
       Parallel::PhaseActions<
           typename Metavariables::Phase,
           Metavariables::Phase::PerformLinearSolve,
-          tmpl::list<LinearSolver::Actions::TerminateIfConverged,
+          tmpl::list<LinearSolver::Actions::TerminateIfConverged<
+                         typename linear_solver::options_group>,
                      typename linear_solver::prepare_step,
                      ComputeOperatorAction,
                      typename linear_solver::perform_step>>,
 
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::TestResult,
-                             tmpl::list<TestResult>>>;
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::TestResult,
+          tmpl::list<TestResult<typename linear_solver::options_group>>>>;
   /// [action_list]
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_TerminateIfConverged.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_TerminateIfConverged.cpp
@@ -55,8 +55,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Actions.TerminateIfConverged",
     INFO("ProceedIfNotConverged");
     MockRuntimeSystem runner{{}};
     ActionTesting::emplace_component_and_initialize<component>(
-        &runner, self_id,
-        {db::item_type<LinearSolver::Tags::HasConverged<DummyOptionsGroup>>{}});
+        &runner, self_id, {Convergence::HasConverged{}});
     ActionTesting::set_phase(make_not_null(&runner),
                              Metavariables::Phase::Testing);
 
@@ -76,9 +75,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Actions.TerminateIfConverged",
     INFO("TerminateIfConverged");
     MockRuntimeSystem runner{{}};
     ActionTesting::emplace_component_and_initialize<component>(
-        &runner, self_id,
-        {db::item_type<LinearSolver::Tags::HasConverged<DummyOptionsGroup>>{
-            {1, 0., 0.}, 1, 0., 0.}});
+        &runner, self_id, {Convergence::HasConverged{{1, 0., 0.}, 1, 0., 0.}});
     ActionTesting::set_phase(make_not_null(&runner),
                              Metavariables::Phase::Testing);
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_TerminateIfConverged.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_TerminateIfConverged.cpp
@@ -18,7 +18,10 @@
 
 namespace {
 
-using simple_tags = db::AddSimpleTags<LinearSolver::Tags::HasConverged>;
+struct DummyOptionsGroup {};
+
+using simple_tags =
+    db::AddSimpleTags<LinearSolver::Tags::HasConverged<DummyOptionsGroup>>;
 
 template <typename Metavariables>
 struct ElementArray {
@@ -31,7 +34,8 @@ struct ElementArray {
           tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<LinearSolver::Actions::TerminateIfConverged>>>;
+          tmpl::list<
+              LinearSolver::Actions::TerminateIfConverged<DummyOptionsGroup>>>>;
 };
 
 struct Metavariables {
@@ -51,18 +55,21 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Actions.TerminateIfConverged",
     INFO("ProceedIfNotConverged");
     MockRuntimeSystem runner{{}};
     ActionTesting::emplace_component_and_initialize<component>(
-        &runner, self_id, {db::item_type<LinearSolver::Tags::HasConverged>{}});
+        &runner, self_id,
+        {db::item_type<LinearSolver::Tags::HasConverged<DummyOptionsGroup>>{}});
     ActionTesting::set_phase(make_not_null(&runner),
                              Metavariables::Phase::Testing);
 
     CHECK_FALSE(ActionTesting::get_databox_tag<
-                component, LinearSolver::Tags::HasConverged>(runner, self_id));
+                component, LinearSolver::Tags::HasConverged<DummyOptionsGroup>>(
+        runner, self_id));
 
     // This should do nothing
     runner.next_action<component>(self_id);
 
     CHECK_FALSE(ActionTesting::get_databox_tag<
-                component, LinearSolver::Tags::HasConverged>(runner, self_id));
+                component, LinearSolver::Tags::HasConverged<DummyOptionsGroup>>(
+        runner, self_id));
     CHECK_FALSE(ActionTesting::get_terminate<component>(runner, self_id));
   }
   {
@@ -70,20 +77,20 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Actions.TerminateIfConverged",
     MockRuntimeSystem runner{{}};
     ActionTesting::emplace_component_and_initialize<component>(
         &runner, self_id,
-        {db::item_type<LinearSolver::Tags::HasConverged>{
+        {db::item_type<LinearSolver::Tags::HasConverged<DummyOptionsGroup>>{
             {1, 0., 0.}, 1, 0., 0.}});
     ActionTesting::set_phase(make_not_null(&runner),
                              Metavariables::Phase::Testing);
 
-    CHECK(ActionTesting::get_databox_tag<component,
-                                         LinearSolver::Tags::HasConverged>(
+    CHECK(ActionTesting::get_databox_tag<
+          component, LinearSolver::Tags::HasConverged<DummyOptionsGroup>>(
         runner, self_id));
 
     // This should terminate the algorithm
     runner.next_action<component>(self_id);
 
-    CHECK(ActionTesting::get_databox_tag<component,
-                                         LinearSolver::Tags::HasConverged>(
+    CHECK(ActionTesting::get_databox_tag<
+          component, LinearSolver::Tags::HasConverged<DummyOptionsGroup>>(
         runner, self_id));
     CHECK(ActionTesting::get_terminate<component>(runner, self_id));
   }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
@@ -19,9 +19,15 @@ namespace helpers = LinearSolverAlgorithmTestHelpers;
 
 namespace {
 
+struct SerialCg {
+  static constexpr OptionString help =
+      "Options for the iterative linear solver";
+};
+
 struct Metavariables {
   using linear_solver =
-      LinearSolver::ConjugateGradient<Metavariables, helpers::fields_tag>;
+      LinearSolver::ConjugateGradient<Metavariables, helpers::fields_tag,
+                                      SerialCg>;
 
   using component_list =
       tmpl::append<tmpl::list<helpers::ElementArray<Metavariables>,

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.yaml
@@ -10,7 +10,7 @@ Observers:
   VolumeFileName: "Test_ConjugateGradientAlgorithm_Volume"
   ReductionFileName: "Test_ConjugateGradientAlgorithm_Reductions"
 
-LinearSolver:
+SerialCg:
   ConvergenceCriteria:
     MaxIterations: 2
     AbsoluteResidual: 1e-14

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
@@ -21,10 +21,14 @@ namespace helpers_distributed = DistributedLinearSolverAlgorithmTestHelpers;
 
 namespace {
 
+struct ParallelCg {
+  static constexpr OptionString help =
+      "Options for the iterative linear solver";
+};
+
 struct Metavariables {
-  using linear_solver =
-      LinearSolver::ConjugateGradient<Metavariables,
-                                      typename helpers_distributed::fields_tag>;
+  using linear_solver = LinearSolver::ConjugateGradient<
+      Metavariables, typename helpers_distributed::fields_tag, ParallelCg>;
 
   using component_list =
       tmpl::append<tmpl::list<helpers_distributed::ElementArray<Metavariables>,

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.yaml
@@ -29,7 +29,7 @@ Observers:
   VolumeFileName: "Test_DistributedConjugateGradientAlgorithm_Volume"
   ReductionFileName: "Test_DistributedConjugateGradientAlgorithm_Reductions"
 
-LinearSolver:
+ParallelCg:
   ConvergenceCriteria:
     MaxIterations: 6
     AbsoluteResidual: 1e-14

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ElementActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ElementActions.cpp
@@ -77,7 +77,7 @@ SPECTRE_TEST_CASE(
       make_not_null(&runner), 0,
       {DenseVector<double>(3, 0.), DenseVector<double>(3, 2.),
        std::numeric_limits<size_t>::max(), DenseVector<double>(3, 1.),
-       db::item_type<LinearSolver::Tags::HasConverged<DummyOptionsGroup>>{}});
+       Convergence::HasConverged{}});
 
   // DataBox shortcuts
   const auto get_tag = [&runner](auto tag_v) -> decltype(auto) {
@@ -98,8 +98,7 @@ SPECTRE_TEST_CASE(
         element_array, LinearSolver::cg_detail::InitializeHasConverged<
                            fields_tag, DummyOptionsGroup>>(
         make_not_null(&runner), 0,
-        db::item_type<LinearSolver::Tags::HasConverged<DummyOptionsGroup>>{
-            {1, 0., 0.}, 1, 0., 0.});
+        Convergence::HasConverged{{1, 0., 0.}, 1, 0., 0.});
     CHECK(get_tag(LinearSolver::Tags::HasConverged<DummyOptionsGroup>{}));
   }
   SECTION("PrepareStep") {
@@ -116,8 +115,7 @@ SPECTRE_TEST_CASE(
         element_array,
         LinearSolver::cg_detail::UpdateOperand<fields_tag, DummyOptionsGroup>>(
         make_not_null(&runner), 0, 2.,
-        db::item_type<LinearSolver::Tags::HasConverged<DummyOptionsGroup>>{
-            {1, 0., 0.}, 1, 0., 0.});
+        Convergence::HasConverged{{1, 0., 0.}, 1, 0., 0.});
     CHECK(get_tag(LinearSolver::Tags::Operand<VectorTag>{}) ==
           DenseVector<double>(3, 5.));
     CHECK(get_tag(LinearSolver::Tags::HasConverged<DummyOptionsGroup>{}));

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
@@ -41,11 +41,11 @@ class ConstGlobalCache;
 }  // namespace Parallel
 namespace LinearSolver {
 namespace cg_detail {
-template <typename FieldsTag>
+template <typename FieldsTag, typename OptionsGroup>
 struct InitializeHasConverged;
-template <typename FieldsTag>
+template <typename FieldsTag, typename OptionsGroup>
 struct UpdateFieldValues;
-template <typename FieldsTag>
+template <typename FieldsTag, typename OptionsGroup>
 struct UpdateOperand;
 }  // namespace cg_detail
 }  // namespace LinearSolver
@@ -53,6 +53,8 @@ struct UpdateOperand;
 namespace helpers = ResidualMonitorActionsTestHelpers;
 
 namespace {
+
+struct TestLinearSolver {};
 
 struct VectorTag : db::SimpleTag {
   using type = DenseVector<double>;
@@ -72,14 +74,15 @@ struct CheckValueTag : db::SimpleTag {
   using type = double;
 };
 
-using CheckConvergedTag = LinearSolver::Tags::HasConverged;
+using CheckConvergedTag = LinearSolver::Tags::HasConverged<TestLinearSolver>;
 
 using check_tags = tmpl::list<CheckValueTag, CheckConvergedTag>;
 
 template <typename Metavariables>
 struct MockResidualMonitor {
   using component_being_mocked =
-      LinearSolver::cg_detail::ResidualMonitor<Metavariables, fields_tag>;
+      LinearSolver::cg_detail::ResidualMonitor<Metavariables, fields_tag,
+                                               TestLinearSolver>;
   using metavariables = Metavariables;
   // We represent the singleton as an array with only one element for the action
   // testing framework
@@ -87,11 +90,11 @@ struct MockResidualMonitor {
   using array_index = int;
   using const_global_cache_tags =
       typename LinearSolver::cg_detail::ResidualMonitor<
-          Metavariables, fields_tag>::const_global_cache_tags;
+          Metavariables, fields_tag, TestLinearSolver>::const_global_cache_tags;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<
-          LinearSolver::cg_detail::InitializeResidualMonitor<fields_tag>>>>;
+      tmpl::list<LinearSolver::cg_detail::InitializeResidualMonitor<
+          fields_tag, TestLinearSolver>>>>;
 };
 
 struct MockInitializeHasConverged {
@@ -102,12 +105,11 @@ struct MockInitializeHasConverged {
   static void apply(db::DataBox<DbTagsList>& box,  // NOLINT
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
-                    const db::const_item_type<LinearSolver::Tags::HasConverged>&
-                        has_converged) noexcept {
+                    const Convergence::HasConverged& has_converged) noexcept {
     db::mutate<CheckConvergedTag>(
-        make_not_null(&box), [&has_converged](const gsl::not_null<
-                                              db::item_type<CheckConvergedTag>*>
-                                                  check_converged) noexcept {
+        make_not_null(&box),
+        [&has_converged](const gsl::not_null<Convergence::HasConverged*>
+                             check_converged) noexcept {
           *check_converged = has_converged;
         });
   }
@@ -123,8 +125,8 @@ struct MockUpdateFieldValues {
                     const ArrayIndex& /*array_index*/,
                     const double alpha) noexcept {
     db::mutate<CheckValueTag>(
-        make_not_null(&box), [alpha](const gsl::not_null<double*>
-                                         check_value) noexcept {
+        make_not_null(&box),
+        [alpha](const gsl::not_null<double*> check_value) noexcept {
           *check_value = alpha;
         });
   }
@@ -138,14 +140,12 @@ struct MockUpdateOperand {
   static void apply(db::DataBox<DbTagsList>& box,  // NOLINT
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/, const double res_ratio,
-                    const db::const_item_type<LinearSolver::Tags::HasConverged>&
-                        has_converged) noexcept {
+                    const Convergence::HasConverged& has_converged) noexcept {
     db::mutate<CheckValueTag, CheckConvergedTag>(
-        make_not_null(&box),
-        [ res_ratio, &
-          has_converged ](const gsl::not_null<double*> check_value,
-                          const gsl::not_null<db::item_type<CheckConvergedTag>*>
-                              check_converged) noexcept {
+        make_not_null(&box), [res_ratio, &has_converged](
+                                 const gsl::not_null<double*> check_value,
+                                 const gsl::not_null<Convergence::HasConverged*>
+                                     check_converged) noexcept {
           *check_value = res_ratio;
           *check_converged = has_converged;
         });
@@ -163,10 +163,11 @@ struct MockElementArray {
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<check_tags>>>>;
 
-  using replace_these_simple_actions =
-      tmpl::list<LinearSolver::cg_detail::InitializeHasConverged<fields_tag>,
-                 LinearSolver::cg_detail::UpdateFieldValues<fields_tag>,
-                 LinearSolver::cg_detail::UpdateOperand<fields_tag>>;
+  using replace_these_simple_actions = tmpl::list<
+      LinearSolver::cg_detail::InitializeHasConverged<fields_tag,
+                                                      TestLinearSolver>,
+      LinearSolver::cg_detail::UpdateFieldValues<fields_tag, TestLinearSolver>,
+      LinearSolver::cg_detail::UpdateOperand<fields_tag, TestLinearSolver>>;
   using with_these_simple_actions =
       tmpl::list<MockInitializeHasConverged, MockUpdateFieldValues,
                  MockUpdateOperand>;
@@ -228,8 +229,8 @@ SPECTRE_TEST_CASE(
 
   SECTION("InitializeResidual") {
     ActionTesting::simple_action<
-        residual_monitor,
-        LinearSolver::cg_detail::InitializeResidual<fields_tag, element_array>>(
+        residual_monitor, LinearSolver::cg_detail::InitializeResidual<
+                              fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 4.);
     ActionTesting::invoke_queued_threaded_action<observer_writer>(
         make_not_null(&runner), 0);
@@ -238,8 +239,10 @@ SPECTRE_TEST_CASE(
     // Test residual monitor state
     CHECK(get_residual_monitor_tag(residual_square_tag{}) == 4.);
     CHECK(get_residual_monitor_tag(initial_residual_magnitude_tag{}) == 2.);
-    CHECK(get_residual_monitor_tag(LinearSolver::Tags::IterationId{}) == 0);
-    CHECK_FALSE(get_residual_monitor_tag(LinearSolver::Tags::HasConverged{}));
+    CHECK(get_residual_monitor_tag(
+              LinearSolver::Tags::IterationId<TestLinearSolver>{}) == 0);
+    CHECK_FALSE(get_residual_monitor_tag(
+        LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
     // Test element state
     CHECK_FALSE(get_element_tag(CheckConvergedTag{}));
     // Test observer writer state
@@ -247,7 +250,7 @@ SPECTRE_TEST_CASE(
           observers::ObservationId{
               0, LinearSolver::observe_detail::ObservationType{}});
     CHECK(get_observer_writer_tag(helpers::CheckSubfileNameTag{}) ==
-          "/linear_residuals");
+          "/TestLinearSolverResiduals");
     CHECK(get_observer_writer_tag(helpers::CheckReductionNamesTag{}) ==
           std::vector<std::string>{"Iteration", "Residual"});
     CHECK(get<0>(get_observer_writer_tag(helpers::CheckReductionDataTag{})) ==
@@ -258,52 +261,55 @@ SPECTRE_TEST_CASE(
 
   SECTION("InitializeResidualAndConverge") {
     ActionTesting::simple_action<
-        residual_monitor,
-        LinearSolver::cg_detail::InitializeResidual<fields_tag, element_array>>(
+        residual_monitor, LinearSolver::cg_detail::InitializeResidual<
+                              fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 0.);
     ActionTesting::invoke_queued_simple_action<element_array>(
         make_not_null(&runner), 0);
     // Test residual monitor state
     CHECK(get_residual_monitor_tag(residual_square_tag{}) == 0.);
     CHECK(get_residual_monitor_tag(initial_residual_magnitude_tag{}) == 0.);
-    CHECK(get_residual_monitor_tag(LinearSolver::Tags::IterationId{}) == 0);
-    CHECK(get_residual_monitor_tag(LinearSolver::Tags::HasConverged{}));
+    CHECK(get_residual_monitor_tag(
+              LinearSolver::Tags::IterationId<TestLinearSolver>{}) == 0);
+    CHECK(get_residual_monitor_tag(
+        LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
     // Test element state
     CHECK(get_element_tag(CheckConvergedTag{}));
   }
 
   SECTION("ComputeAlpha") {
     ActionTesting::simple_action<
-        residual_monitor,
-        LinearSolver::cg_detail::InitializeResidual<fields_tag, element_array>>(
+        residual_monitor, LinearSolver::cg_detail::InitializeResidual<
+                              fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 1.);
     ActionTesting::invoke_queued_simple_action<element_array>(
         make_not_null(&runner), 0);
     ActionTesting::simple_action<
-        residual_monitor,
-        LinearSolver::cg_detail::ComputeAlpha<fields_tag, element_array>>(
+        residual_monitor, LinearSolver::cg_detail::ComputeAlpha<
+                              fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 2.);
     ActionTesting::invoke_queued_simple_action<element_array>(
         make_not_null(&runner), 0);
     // Test residual monitor state
     CHECK(get_residual_monitor_tag(residual_square_tag{}) == 1.);
-    CHECK(get_residual_monitor_tag(LinearSolver::Tags::IterationId{}) == 0);
+    CHECK(get_residual_monitor_tag(
+              LinearSolver::Tags::IterationId<TestLinearSolver>{}) == 0);
     // Test element state
     CHECK(get_element_tag(CheckValueTag{}) == 0.5);
   }
 
   SECTION("UpdateResidual") {
     ActionTesting::simple_action<
-        residual_monitor,
-        LinearSolver::cg_detail::InitializeResidual<fields_tag, element_array>>(
+        residual_monitor, LinearSolver::cg_detail::InitializeResidual<
+                              fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 9.);
     ActionTesting::invoke_queued_threaded_action<observer_writer>(
         make_not_null(&runner), 0);
     ActionTesting::invoke_queued_simple_action<element_array>(
         make_not_null(&runner), 0);
     ActionTesting::simple_action<
-        residual_monitor,
-        LinearSolver::cg_detail::UpdateResidual<fields_tag, element_array>>(
+        residual_monitor, LinearSolver::cg_detail::UpdateResidual<
+                              fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 4.);
     ActionTesting::invoke_queued_simple_action<element_array>(
         make_not_null(&runner), 0);
@@ -312,18 +318,21 @@ SPECTRE_TEST_CASE(
     // Test residual monitor state
     CHECK(get_residual_monitor_tag(residual_square_tag{}) == 4.);
     CHECK(get_residual_monitor_tag(initial_residual_magnitude_tag{}) == 3.);
-    CHECK(get_residual_monitor_tag(LinearSolver::Tags::IterationId{}) == 1);
-    CHECK_FALSE(get_residual_monitor_tag(LinearSolver::Tags::HasConverged{}));
+    CHECK(get_residual_monitor_tag(
+              LinearSolver::Tags::IterationId<TestLinearSolver>{}) == 1);
+    CHECK_FALSE(get_residual_monitor_tag(
+        LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
     // Test element state
     CHECK(get_element_tag(CheckValueTag{}) == approx(4. / 9.));
     CHECK(get_element_tag(CheckConvergedTag{}) ==
-          get_residual_monitor_tag(LinearSolver::Tags::HasConverged{}));
+          get_residual_monitor_tag(
+              LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
     // Test observer writer state
     CHECK(get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
           observers::ObservationId{
               1, LinearSolver::observe_detail::ObservationType{}});
     CHECK(get_observer_writer_tag(helpers::CheckSubfileNameTag{}) ==
-          "/linear_residuals");
+          "/TestLinearSolverResiduals");
     CHECK(get_observer_writer_tag(helpers::CheckReductionNamesTag{}) ==
           std::vector<std::string>{"Iteration", "Residual"});
     CHECK(get<0>(get_observer_writer_tag(helpers::CheckReductionDataTag{})) ==
@@ -334,89 +343,98 @@ SPECTRE_TEST_CASE(
 
   SECTION("ConvergeByAbsoluteResidual") {
     ActionTesting::simple_action<
-        residual_monitor,
-        LinearSolver::cg_detail::InitializeResidual<fields_tag, element_array>>(
+        residual_monitor, LinearSolver::cg_detail::InitializeResidual<
+                              fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 1.);
     ActionTesting::invoke_queued_simple_action<element_array>(
         make_not_null(&runner), 0);
     ActionTesting::simple_action<
-        residual_monitor,
-        LinearSolver::cg_detail::UpdateResidual<fields_tag, element_array>>(
+        residual_monitor, LinearSolver::cg_detail::UpdateResidual<
+                              fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 0.);
     ActionTesting::invoke_queued_simple_action<element_array>(
         make_not_null(&runner), 0);
     // Test residual monitor state
     CHECK(get_residual_monitor_tag(residual_square_tag{}) == 0.);
     CHECK(get_residual_monitor_tag(initial_residual_magnitude_tag{}) == 1.);
-    CHECK(get_residual_monitor_tag(LinearSolver::Tags::IterationId{}) == 1);
-    CHECK(get_residual_monitor_tag(LinearSolver::Tags::HasConverged{}));
-    CHECK(
-        get_residual_monitor_tag(LinearSolver::Tags::HasConverged{}).reason() ==
-        Convergence::Reason::AbsoluteResidual);
+    CHECK(get_residual_monitor_tag(
+              LinearSolver::Tags::IterationId<TestLinearSolver>{}) == 1);
+    CHECK(get_residual_monitor_tag(
+        LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
+    CHECK(get_residual_monitor_tag(
+              LinearSolver::Tags::HasConverged<TestLinearSolver>{})
+              .reason() == Convergence::Reason::AbsoluteResidual);
     // Test element state
     CHECK(get_element_tag(CheckValueTag{}) == 0.);
     CHECK(get_element_tag(CheckConvergedTag{}) ==
-          get_residual_monitor_tag(LinearSolver::Tags::HasConverged{}));
+          get_residual_monitor_tag(
+              LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
   }
 
   SECTION("ConvergeByMaxIterations") {
     ActionTesting::simple_action<
-        residual_monitor,
-        LinearSolver::cg_detail::InitializeResidual<fields_tag, element_array>>(
+        residual_monitor, LinearSolver::cg_detail::InitializeResidual<
+                              fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 1.);
     ActionTesting::invoke_queued_simple_action<element_array>(
         make_not_null(&runner), 0);
     // Perform 2 mock iterations
     ActionTesting::simple_action<
-        residual_monitor,
-        LinearSolver::cg_detail::UpdateResidual<fields_tag, element_array>>(
+        residual_monitor, LinearSolver::cg_detail::UpdateResidual<
+                              fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 1.);
     ActionTesting::invoke_queued_simple_action<element_array>(
         make_not_null(&runner), 0);
     ActionTesting::simple_action<
-        residual_monitor,
-        LinearSolver::cg_detail::UpdateResidual<fields_tag, element_array>>(
+        residual_monitor, LinearSolver::cg_detail::UpdateResidual<
+                              fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 1.);
     ActionTesting::invoke_queued_simple_action<element_array>(
         make_not_null(&runner), 0);
     // Test residual monitor state
     CHECK(get_residual_monitor_tag(residual_square_tag{}) == 1.);
     CHECK(get_residual_monitor_tag(initial_residual_magnitude_tag{}) == 1.);
-    CHECK(get_residual_monitor_tag(LinearSolver::Tags::IterationId{}) == 2);
-    CHECK(get_residual_monitor_tag(LinearSolver::Tags::HasConverged{}));
-    CHECK(
-        get_residual_monitor_tag(LinearSolver::Tags::HasConverged{}).reason() ==
-        Convergence::Reason::MaxIterations);
+    CHECK(get_residual_monitor_tag(
+              LinearSolver::Tags::IterationId<TestLinearSolver>{}) == 2);
+    CHECK(get_residual_monitor_tag(
+        LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
+    CHECK(get_residual_monitor_tag(
+              LinearSolver::Tags::HasConverged<TestLinearSolver>{})
+              .reason() == Convergence::Reason::MaxIterations);
     // Test element state
     CHECK(get_element_tag(CheckValueTag{}) == 1.);
     CHECK(get_element_tag(CheckConvergedTag{}) ==
-          get_residual_monitor_tag(LinearSolver::Tags::HasConverged{}));
+          get_residual_monitor_tag(
+              LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
   }
 
   SECTION("ConvergeByRelativeResidual") {
     ActionTesting::simple_action<
-        residual_monitor,
-        LinearSolver::cg_detail::InitializeResidual<fields_tag, element_array>>(
+        residual_monitor, LinearSolver::cg_detail::InitializeResidual<
+                              fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 1.);
     ActionTesting::invoke_queued_simple_action<element_array>(
         make_not_null(&runner), 0);
     ActionTesting::simple_action<
-        residual_monitor,
-        LinearSolver::cg_detail::UpdateResidual<fields_tag, element_array>>(
+        residual_monitor, LinearSolver::cg_detail::UpdateResidual<
+                              fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 0.25);
     ActionTesting::invoke_queued_simple_action<element_array>(
         make_not_null(&runner), 0);
     // Test residual monitor state
     CHECK(get_residual_monitor_tag(residual_square_tag{}) == 0.25);
     CHECK(get_residual_monitor_tag(initial_residual_magnitude_tag{}) == 1.);
-    CHECK(get_residual_monitor_tag(LinearSolver::Tags::IterationId{}) == 1);
-    CHECK(get_residual_monitor_tag(LinearSolver::Tags::HasConverged{}));
-    CHECK(
-        get_residual_monitor_tag(LinearSolver::Tags::HasConverged{}).reason() ==
-        Convergence::Reason::RelativeResidual);
+    CHECK(get_residual_monitor_tag(
+              LinearSolver::Tags::IterationId<TestLinearSolver>{}) == 1);
+    CHECK(get_residual_monitor_tag(
+        LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
+    CHECK(get_residual_monitor_tag(
+              LinearSolver::Tags::HasConverged<TestLinearSolver>{})
+              .reason() == Convergence::Reason::RelativeResidual);
     // Test element state
     CHECK(get_element_tag(CheckValueTag{}) == 0.25);
     CHECK(get_element_tag(CheckConvergedTag{}) ==
-          get_residual_monitor_tag(LinearSolver::Tags::HasConverged{}));
+          get_residual_monitor_tag(
+              LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
   }
 }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
@@ -200,7 +200,7 @@ SPECTRE_TEST_CASE(
   ActionTesting::emplace_component_and_initialize<element_array>(
       &runner, 0,
       {std::numeric_limits<double>::signaling_NaN(),
-       db::item_type<CheckConvergedTag>{}});
+       Convergence::HasConverged{}});
 
   // Setup mock observer writer
   ActionTesting::emplace_component_and_initialize<observer_writer>(

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
@@ -21,9 +21,15 @@ namespace helpers_distributed = DistributedLinearSolverAlgorithmTestHelpers;
 
 namespace {
 
+struct ParallelGmres {
+  static constexpr OptionString help =
+      "Options for the iterative linear solver";
+};
+
 struct Metavariables {
   using linear_solver =
-      LinearSolver::Gmres<Metavariables, helpers_distributed::fields_tag>;
+      LinearSolver::Gmres<Metavariables, helpers_distributed::fields_tag,
+                          ParallelGmres>;
 
   using component_list =
       tmpl::append<tmpl::list<helpers_distributed::ElementArray<Metavariables>,

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.yaml
@@ -29,7 +29,7 @@ Observers:
   VolumeFileName: "Test_DistributedGmresAlgorithm_Volume"
   ReductionFileName: "Test_DistributedGmresAlgorithm_Reductions"
 
-LinearSolver:
+ParallelGmres:
   ConvergenceCriteria:
     MaxIterations: 6
     AbsoluteResidual: 1e-14

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
@@ -87,7 +87,7 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Gmres.ElementActions",
        size_t{0},
        std::vector<DenseVector<double>>{DenseVector<double>(3, 0.5),
                                         DenseVector<double>(3, 1.5)},
-       db::item_type<LinearSolver::Tags::HasConverged<DummyOptionsGroup>>{}});
+       Convergence::HasConverged{}});
 
   // DataBox shortcuts
   const auto get_tag = [&runner](auto tag_v) -> decltype(auto) {
@@ -108,8 +108,7 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Gmres.ElementActions",
         element_array, LinearSolver::gmres_detail::NormalizeInitialOperand<
                            fields_tag, DummyOptionsGroup>>(
         make_not_null(&runner), 0, 4.,
-        db::item_type<LinearSolver::Tags::HasConverged<DummyOptionsGroup>>{
-            {1, 0., 0.}, 1, 0., 0.});
+        Convergence::HasConverged{{1, 0., 0.}, 1, 0., 0.});
     CHECK_ITERABLE_APPROX(get_tag(operand_tag{}), DenseVector<double>(3, 0.5));
     CHECK(get_tag(basis_history_tag{}).size() == 3);
     CHECK(get_tag(basis_history_tag{})[2] == get_tag(operand_tag{}));
@@ -131,8 +130,7 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Gmres.ElementActions",
         LinearSolver::gmres_detail::NormalizeOperandAndUpdateField<
             fields_tag, DummyOptionsGroup>>(
         make_not_null(&runner), 0, 4., DenseVector<double>{2., 4.},
-        db::item_type<LinearSolver::Tags::HasConverged<DummyOptionsGroup>>{
-            {1, 0., 0.}, 1, 0., 0.});
+        Convergence::HasConverged{{1, 0., 0.}, 1, 0., 0.});
     CHECK_ITERABLE_APPROX(get_tag(operand_tag{}), DenseVector<double>(3, 0.5));
     CHECK(get_tag(basis_history_tag{}).size() == 3);
     CHECK(get_tag(basis_history_tag{})[2] == get_tag(operand_tag{}));

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
@@ -28,6 +28,8 @@
 
 namespace {
 
+struct DummyOptionsGroup {};
+
 struct VectorTag : db::SimpleTag {
   using type = DenseVector<double>;
 };
@@ -38,7 +40,7 @@ using initial_fields_tag =
 using operand_tag = db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
 using orthogonalization_iteration_id_tag =
     db::add_tag_prefix<LinearSolver::Tags::Orthogonalization,
-                       LinearSolver::Tags::IterationId>;
+                       LinearSolver::Tags::IterationId<DummyOptionsGroup>>;
 using basis_history_tag = LinearSolver::Tags::KrylovSubspaceBasis<fields_tag>;
 
 template <typename Metavariables>
@@ -51,15 +53,17 @@ struct ElementArray {
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
               tmpl::list<VectorTag, operand_tag,
-                         LinearSolver::Tags::IterationId, initial_fields_tag,
-                         orthogonalization_iteration_id_tag, basis_history_tag,
-                         LinearSolver::Tags::HasConverged>,
-              tmpl::list<
-                  ::Tags::NextCompute<LinearSolver::Tags::IterationId>>>>>,
+                         LinearSolver::Tags::IterationId<DummyOptionsGroup>,
+                         initial_fields_tag, orthogonalization_iteration_id_tag,
+                         basis_history_tag,
+                         LinearSolver::Tags::HasConverged<DummyOptionsGroup>>,
+              tmpl::list<::Tags::NextCompute<
+                  LinearSolver::Tags::IterationId<DummyOptionsGroup>>>>>>,
 
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<LinearSolver::gmres_detail::PrepareStep>>>;
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Testing,
+                             tmpl::list<LinearSolver::gmres_detail::PrepareStep<
+                                 fields_tag, DummyOptionsGroup>>>>;
 };
 
 struct Metavariables {
@@ -83,7 +87,7 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Gmres.ElementActions",
        size_t{0},
        std::vector<DenseVector<double>>{DenseVector<double>(3, 0.5),
                                         DenseVector<double>(3, 1.5)},
-       db::item_type<LinearSolver::Tags::HasConverged>{}});
+       db::item_type<LinearSolver::Tags::HasConverged<DummyOptionsGroup>>{}});
 
   // DataBox shortcuts
   const auto get_tag = [&runner](auto tag_v) -> decltype(auto) {
@@ -101,35 +105,39 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Gmres.ElementActions",
 
   SECTION("NormalizeInitialOperand") {
     ActionTesting::simple_action<
-        element_array,
-        LinearSolver::gmres_detail::NormalizeInitialOperand<fields_tag>>(
+        element_array, LinearSolver::gmres_detail::NormalizeInitialOperand<
+                           fields_tag, DummyOptionsGroup>>(
         make_not_null(&runner), 0, 4.,
-        db::item_type<LinearSolver::Tags::HasConverged>{
+        db::item_type<LinearSolver::Tags::HasConverged<DummyOptionsGroup>>{
             {1, 0., 0.}, 1, 0., 0.});
     CHECK_ITERABLE_APPROX(get_tag(operand_tag{}), DenseVector<double>(3, 0.5));
     CHECK(get_tag(basis_history_tag{}).size() == 3);
     CHECK(get_tag(basis_history_tag{})[2] == get_tag(operand_tag{}));
-    CHECK(get_tag(LinearSolver::Tags::HasConverged{}));
+    CHECK(get_tag(LinearSolver::Tags::HasConverged<DummyOptionsGroup>{}));
   }
   SECTION("PrepareStep") {
     ActionTesting::next_action<element_array>(make_not_null(&runner), 0);
-    CHECK(get_tag(LinearSolver::Tags::IterationId{}) == 0);
-    CHECK(get_tag(Tags::Next<LinearSolver::Tags::IterationId>{}) == 1);
+    CHECK(get_tag(LinearSolver::Tags::IterationId<DummyOptionsGroup>{}) == 0);
+    CHECK(
+        get_tag(
+            Tags::Next<LinearSolver::Tags::IterationId<DummyOptionsGroup>>{}) ==
+        1);
     CHECK(get_tag(orthogonalization_iteration_id_tag{}) == 0);
   }
   SECTION("NormalizeOperandAndUpdateField") {
     ActionTesting::next_action<element_array>(make_not_null(&runner), 0);
     ActionTesting::simple_action<
         element_array,
-        LinearSolver::gmres_detail::NormalizeOperandAndUpdateField<fields_tag>>(
+        LinearSolver::gmres_detail::NormalizeOperandAndUpdateField<
+            fields_tag, DummyOptionsGroup>>(
         make_not_null(&runner), 0, 4., DenseVector<double>{2., 4.},
-        db::item_type<LinearSolver::Tags::HasConverged>{
+        db::item_type<LinearSolver::Tags::HasConverged<DummyOptionsGroup>>{
             {1, 0., 0.}, 1, 0., 0.});
     CHECK_ITERABLE_APPROX(get_tag(operand_tag{}), DenseVector<double>(3, 0.5));
     CHECK(get_tag(basis_history_tag{}).size() == 3);
     CHECK(get_tag(basis_history_tag{})[2] == get_tag(operand_tag{}));
     // minres * basis_history - initial = 2 * 0.5 + 4 * 1.5 - 1 = 6
     CHECK_ITERABLE_APPROX(get_tag(VectorTag{}), DenseVector<double>(3, 6.));
-    CHECK(get_tag(LinearSolver::Tags::HasConverged{}));
+    CHECK(get_tag(LinearSolver::Tags::HasConverged<DummyOptionsGroup>{}));
   }
 }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
@@ -19,8 +19,14 @@ namespace helpers = LinearSolverAlgorithmTestHelpers;
 
 namespace {
 
+struct SerialGmres {
+  static constexpr OptionString help =
+      "Options for the iterative linear solver";
+};
+
 struct Metavariables {
-  using linear_solver = LinearSolver::Gmres<Metavariables, helpers::fields_tag>;
+  using linear_solver =
+      LinearSolver::Gmres<Metavariables, helpers::fields_tag, SerialGmres>;
 
   using component_list =
       tmpl::append<tmpl::list<helpers::ElementArray<Metavariables>,

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.yaml
@@ -10,7 +10,7 @@ Observers:
   VolumeFileName: "Test_GmresAlgorithm_Volume"
   ReductionFileName: "Test_GmresAlgorithm_Reductions"
 
-LinearSolver:
+SerialGmres:
   ConvergenceCriteria:
     MaxIterations: 2
     AbsoluteResidual: 1e-14


### PR DESCRIPTION
## Proposed changes

The iterative parallel linear solvers are the backbone of elliptic solves. For preconditioning we need to run a linear solve in each iteration of another linear solve, so they need to be nested. And for both preconditioning and nonlinear solves we need to run a linear solver multiple times consecutively, resetting it in-between.
Here's what is being done to make the parallel linear solvers support this:
- Identify each linear solver by an option group. So the linear solver reads configuration such as convergence criteria from a named section in the input files. The option group also identifies tags such as the iteration ID in the DataBox.
- Initial values for a linear solve are now set in a `prepare` action instead of in the initialization action.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
