### PR TITLE
Fix warnings with newer versions of CMake

### DIFF
--- a/cmake/SetupPch.cmake
+++ b/cmake/SetupPch.cmake
@@ -7,15 +7,6 @@ option(
   ON
   )
 
-function(is_implicit_include_directory INCLUDE_DIR)
-  set(FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES OFF PARENT_SCOPE)
-  foreach(DIR ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
-    if("${INCLUDE_DIR}" STREQUAL "${DIR}")
-      set(FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES ON PARENT_SCOPE)
-    endif()
-  endforeach()
-endfunction()
-
 if (USE_PCH)
   # We store the header to precompile in ${CMAKE_SOURCE_DIR}/tools so
   # that it cannot accidentally be included incorrectly anywhere since
@@ -88,27 +79,6 @@ if (USE_PCH)
       )
   endif()
 
-  is_implicit_include_directory(${BLAZE_INCLUDE_DIR})
-  if(NOT ${FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES})
-    set(BLAZE_INCLUDE_ARGUMENT "-isystem${BLAZE_INCLUDE_DIR}")
-  else()
-    set(BLAZE_INCLUDE_ARGUMENT "")
-  endif()
-
-  is_implicit_include_directory(${BRIGAND_INCLUDE_DIR})
-  if(NOT ${FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES})
-    set(BRIGAND_INCLUDE_ARGUMENT "-isystem${BRIGAND_INCLUDE_DIR}")
-  else()
-    set(BRIGAND_INCLUDE_ARGUMENT "")
-  endif()
-
-  is_implicit_include_directory(${CHARM_INCLUDE_DIRS})
-  if(NOT ${FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES})
-    set(CHARM_INCLUDE_ARGUMENT "-isystem${CHARM_INCLUDE_DIRS}")
-  else()
-    set(CHARM_INCLUDE_ARGUMENT "")
-  endif()
-
   add_custom_command(
     OUTPUT ${PCH_PATH}.gch
     COMMAND ${CMAKE_CXX_COMPILER}
@@ -116,9 +86,9 @@ if (USE_PCH)
     -std=c++14
     ${PCH_COMPILE_FLAGS}
     -I${CMAKE_SOURCE_DIR}/src
-    ${BLAZE_INCLUDE_ARGUMENT}
-    ${BRIGAND_INCLUDE_ARGUMENT}
-    ${CHARM_INCLUDE_ARGUMENT}
+    "-isystem${BLAZE_INCLUDE_DIR}"
+    "-isystem${BRIGAND_INCLUDE_DIR}"
+    "-isystem${CHARM_INCLUDE_DIRS}"
     ${PCH_PATH}
     -o ${PCH_PATH}.gch
     DEPENDS


### PR DESCRIPTION
## Proposed changes

The -isystem flags weren't added in CMake versions ~3.11 and newer to the PCH
and then we got warnings out of the Blaze headers.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
