### PR TITLE
Refactor Weno

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.cpp
@@ -111,7 +111,7 @@ namespace Weno_detail {
 
 template <size_t VolumeDim>
 Matrix inverse_a_matrix(
-    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
+    const Mesh<VolumeDim>& mesh, const Element<VolumeDim>& element,
     const DataVector& quadrature_weights,
     const DirectionMap<VolumeDim, Matrix>& interpolation_matrices,
     const DirectionMap<VolumeDim, DataVector>&
@@ -207,7 +207,7 @@ ConstrainedFitCache<VolumeDim>::ConstrainedFitCache(
       // here we stick the data into the (normally nonsensical) slot where
       // `dir_to_exclude == primary_dir`.
       inverse_a_matrices[primary_dir][primary_dir] = inverse_a_matrix(
-          element, mesh, quadrature_weights, interpolation_matrices,
+          mesh, element, quadrature_weights, interpolation_matrices,
           quadrature_weights_dot_interpolation_matrices, primary_dir,
           nothing_to_exclude);
     } else {
@@ -219,7 +219,7 @@ ConstrainedFitCache<VolumeDim>::ConstrainedFitCache(
           continue;
         }
         inverse_a_matrices[primary_dir][dir_to_exclude] = inverse_a_matrix(
-            element, mesh, quadrature_weights, interpolation_matrices,
+            mesh, element, quadrature_weights, interpolation_matrices,
             quadrature_weights_dot_interpolation_matrices, primary_dir,
             {{dir_to_exclude}});
       }
@@ -323,7 +323,7 @@ const ConstrainedFitCache<VolumeDim>& constrained_fit_cache(
 
 #define INSTANTIATE(_, data)                                                   \
   template Matrix inverse_a_matrix<DIM(data)>(                                 \
-      const Element<DIM(data)>&, const Mesh<DIM(data)>&, const DataVector&,    \
+      const Mesh<DIM(data)>&, const Element<DIM(data)>&, const DataVector&,    \
       const DirectionMap<DIM(data), Matrix>&,                                  \
       const DirectionMap<DIM(data), DataVector>&, const Direction<DIM(data)>&, \
       const std::vector<Direction<DIM(data)>>&) noexcept;                      \

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp
@@ -85,9 +85,9 @@ void simple_weno_impl(
 
   // Sum local and modified neighbor polynomials for the WENO reconstruction
   Weno_detail::reconstruct_from_weighted_sum(
-      make_not_null(&component_to_limit), mesh, neighbor_linear_weight,
-      *modified_neighbor_solution_buffer,
-      Weno_detail::DerivativeWeight::PowTwoEll);
+      make_not_null(&component_to_limit), neighbor_linear_weight,
+      Weno_detail::DerivativeWeight::PowTwoEll, mesh,
+      *modified_neighbor_solution_buffer);
 }
 
 // Compute the Simple WENO solution for one tensor

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -172,14 +172,14 @@ class Weno<VolumeDim, tmpl::list<Tags...>> {
 
   using limit_tags = tmpl::list<Tags...>;
   using limit_argument_tags =
-      tmpl::list<domain::Tags::Element<VolumeDim>,
-                 domain::Tags::Mesh<VolumeDim>,
+      tmpl::list<domain::Tags::Mesh<VolumeDim>,
+                 domain::Tags::Element<VolumeDim>,
                  domain::Tags::SizeOfElement<VolumeDim>>;
 
   /// \brief Limit the solution on the element
   bool operator()(
       const gsl::not_null<std::add_pointer_t<db::item_type<Tags>>>... tensors,
-      const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
+      const Mesh<VolumeDim>& mesh, const Element<VolumeDim>& element,
       const std::array<double, VolumeDim>& element_size,
       const std::unordered_map<
           std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
@@ -262,7 +262,7 @@ void Weno<VolumeDim, tmpl::list<Tags...>>::package_data(
 template <size_t VolumeDim, typename... Tags>
 bool Weno<VolumeDim, tmpl::list<Tags...>>::operator()(
     const gsl::not_null<std::add_pointer_t<db::item_type<Tags>>>... tensors,
-    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
+    const Mesh<VolumeDim>& mesh, const Element<VolumeDim>& element,
     const std::array<double, VolumeDim>& element_size,
     const std::unordered_map<
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -60,19 +60,24 @@ namespace Limiters {
 /// \brief A compact-stencil WENO limiter for DG
 ///
 /// Implements the simple WENO limiter of \cite Zhong2013 and the Hermite WENO
-/// (HWENO) limiter of \cite Zhu2016. These limiters require communication only
-/// between nearest-neighbor elements, but preserve the full order of the DG
-/// solution when the solution is smooth. Full volume data is communicated
-/// between neighbors.
+/// (HWENO) limiter of \cite Zhu2016 for an arbitrary set of tensors. These
+/// limiters require communication only between nearest-neighbor elements, but
+/// preserve the full order of the DG solution when the solution is smooth.
+/// Full volume data is communicated between neighbors.
 ///
-/// The limiter uses a Minmod-based troubled-cell indicator to identify elements
-/// that need limiting. The \f$\Lambda\Pi^N\f$ limiter of \cite Cockburn1999 is
-/// used. Note that the HWENO paper recommends a more sophisticated
-/// troubled-cell indicator instead, but the specific choice of indicator should
-/// not be too important for a high-order WENO limiter.
+/// The limiter uses the minmod-based TVB troubled-cell indicator (TCI) of
+/// \cite Cockburn1999 to identify elements that need limiting. The simple
+/// WENO implementation follows the paper: it checks the TCI independently
+/// to each tensor component, so that only certain tensor components may be
+/// limited. The HWENO implementation checks the TCI for all tensor components,
+/// and if any single component is troubled, then all components are limited.
+/// Note that the HWENO paper, because it specializes the limiter to the
+/// Newtonian Euler fluid system, uses a more sophisticated TCI that is adapted
+/// to the particulars of the fluid system. We instead use the TVB indicator
+/// because it is easily applied to a general set of tensors.
 ///
-/// On any identified "troubled" elements, the limited solution is obtained by
-/// WENO reconstruction --- a linear combination of the local DG solution and a
+/// For each tensor component to limit, the new solution is obtained by WENO
+/// reconstruction --- a linear combination of the local DG solution and a
 /// "modified" solution from each neighbor element. For the simple WENO limiter,
 /// the modified solution is obtained by simply extrapolating the neighbor
 /// solution onto the troubled element. For the HWENO limiter, the modified

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -115,6 +115,15 @@ class Weno<VolumeDim, tmpl::list<Tags...>> {
     static constexpr OptionString help = {
         "Linear weight for each neighbor element's solution"};
   };
+  /// \brief The TVB constant for the minmod TCI
+  ///
+  /// See `Limiters::Minmod` documentation for details.
+  struct TvbConstant {
+    using type = double;
+    static type default_value() noexcept { return 0.0; }
+    static type lower_bound() noexcept { return 0.0; }
+    static constexpr OptionString help = {"TVB constant 'm'"};
+  };
   /// \brief Turn the limiter off
   ///
   /// This option exists to temporarily disable the limiter for debugging
@@ -125,11 +134,12 @@ class Weno<VolumeDim, tmpl::list<Tags...>> {
     static type default_value() noexcept { return false; }
     static constexpr OptionString help = {"Disable the limiter"};
   };
-  using options = tmpl::list<Type, NeighborWeight, DisableForDebugging>;
+  using options =
+      tmpl::list<Type, NeighborWeight, TvbConstant, DisableForDebugging>;
   static constexpr OptionString help = {"A WENO limiter for DG"};
 
   Weno(WenoType weno_type, double neighbor_linear_weight,
-       bool disable_for_debugging = false) noexcept;
+       double tvb_constant = 0.0, bool disable_for_debugging = false) noexcept;
 
   Weno() noexcept = default;
   Weno(const Weno& /*rhs*/) = default;
@@ -194,15 +204,17 @@ class Weno<VolumeDim, tmpl::list<Tags...>> {
 
   WenoType weno_type_;
   double neighbor_linear_weight_;
+  double tvb_constant_;
   bool disable_for_debugging_;
 };
 
 template <size_t VolumeDim, typename... Tags>
 Weno<VolumeDim, tmpl::list<Tags...>>::Weno(
     const WenoType weno_type, const double neighbor_linear_weight,
-    const bool disable_for_debugging) noexcept
+    const double tvb_constant, const bool disable_for_debugging) noexcept
     : weno_type_(weno_type),
       neighbor_linear_weight_(neighbor_linear_weight),
+      tvb_constant_(tvb_constant),
       disable_for_debugging_(disable_for_debugging) {}
 
 template <size_t VolumeDim, typename... Tags>
@@ -210,6 +222,7 @@ template <size_t VolumeDim, typename... Tags>
 void Weno<VolumeDim, tmpl::list<Tags...>>::pup(PUP::er& p) noexcept {
   p | weno_type_;
   p | neighbor_linear_weight_;
+  p | tvb_constant_;
   p | disable_for_debugging_;
 }
 
@@ -295,10 +308,9 @@ bool Weno<VolumeDim, tmpl::list<Tags...>>::operator()(
   if (weno_type_ == WenoType::Hweno) {
     // Troubled-cell detection for HWENO flags the element for limiting if any
     // component of any tensor needs limiting.
-    const double tci_tvb_constant = 0.0;
     const bool cell_is_troubled =
         Tci::tvb_minmod_indicator<VolumeDim, PackagedData, Tags...>(
-            tci_tvb_constant, (*tensors)..., mesh, element, element_size,
+            tvb_constant_, (*tensors)..., mesh, element, element_size,
             neighbor_data);
     if (not cell_is_troubled) {
       // No limiting is needed
@@ -347,12 +359,11 @@ bool Weno<VolumeDim, tmpl::list<Tags...>>::operator()(
       for (size_t tensor_storage_index = 0;
            tensor_storage_index < tensor->size(); ++tensor_storage_index) {
         // Check TCI
-        const double tvb_constant = 0.0;
         const auto effective_neighbor_means =
             Minmod_detail::compute_effective_neighbor_means<decltype(tag)>(
                 tensor_storage_index, element, neighbor_data);
         const bool component_needs_limiting = Tci::tvb_minmod_indicator(
-            make_not_null(&tci_buffer), tvb_constant,
+            make_not_null(&tci_buffer), tvb_constant_,
             (*tensor)[tensor_storage_index], mesh, element, element_size,
             effective_neighbor_means, effective_neighbor_sizes);
 
@@ -390,6 +401,7 @@ bool operator==(const Weno<LocalDim, LocalTagList>& lhs,
                 const Weno<LocalDim, LocalTagList>& rhs) noexcept {
   return lhs.weno_type_ == rhs.weno_type_ and
          lhs.neighbor_linear_weight_ == rhs.neighbor_linear_weight_ and
+         lhs.tvb_constant_ == rhs.tvb_constant_ and
          lhs.disable_for_debugging_ == rhs.disable_for_debugging_;
 }
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp
@@ -7,8 +7,8 @@
 #include <unordered_map>
 #include <utility>
 
-#include "Domain/Direction.hpp"          // IWYU pragma: keep
-#include "Domain/ElementId.hpp"          // IWYU pragma: keep
+#include "Domain/Direction.hpp"  // IWYU pragma: keep
+#include "Domain/ElementId.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -39,13 +39,12 @@ namespace Weno_detail {
 // with an ASSERT.
 template <size_t VolumeDim>
 void reconstruct_from_weighted_sum(
-    gsl::not_null<DataVector*> local_polynomial, const Mesh<VolumeDim>& mesh,
-    double neighbor_linear_weight,
+    gsl::not_null<DataVector*> local_polynomial, double neighbor_linear_weight,
+    DerivativeWeight derivative_weight, const Mesh<VolumeDim>& mesh,
     const std::unordered_map<
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, DataVector,
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
-        neighbor_polynomials,
-    DerivativeWeight derivative_weight) noexcept;
+        neighbor_polynomials) noexcept;
 
 }  // namespace Weno_detail
 }  // namespace Limiters

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.cpp
@@ -98,8 +98,8 @@ double compute_sum_of_legendre_derivs(
 // computing only the (N-1)^2 matrix where we start at m, n >= 1.
 template <size_t VolumeDim>
 Matrix compute_indicator_matrix(
-    const Mesh<VolumeDim>& mesh,
-    const Limiters::Weno_detail::DerivativeWeight derivative_weight) noexcept {
+    const Limiters::Weno_detail::DerivativeWeight derivative_weight,
+    const Mesh<VolumeDim>& mesh) noexcept {
   ASSERT(mesh.basis() == make_array<VolumeDim>(Spectral::Basis::Legendre),
          "No implementation for mesh: " << mesh);
   Matrix result(mesh.number_of_grid_points() - 1,
@@ -183,9 +183,9 @@ std::ostream& operator<<(std::ostream& os,
 }
 
 template <size_t VolumeDim>
-double oscillation_indicator(
-    const DataVector& data, const Mesh<VolumeDim>& mesh,
-    const DerivativeWeight derivative_weight) noexcept {
+double oscillation_indicator(const DerivativeWeight derivative_weight,
+                             const DataVector& data,
+                             const Mesh<VolumeDim>& mesh) noexcept {
   ASSERT(mesh.basis() == make_array<VolumeDim>(Spectral::Basis::Legendre),
          "No implementation for mesh: " << mesh);
 
@@ -196,7 +196,7 @@ double oscillation_indicator(
       DerivativeWeight, DerivativeWeight::Unity, DerivativeWeight::PowTwoEll,
       DerivativeWeight::PowTwoEllOverEllFactorial>>(
       [&mesh](const DerivativeWeight dw) noexcept->Matrix {
-        return compute_indicator_matrix(mesh, dw);
+        return compute_indicator_matrix(dw, mesh);
       });
   const Matrix indicator_matrix = cache(derivative_weight);
 
@@ -234,7 +234,7 @@ double oscillation_indicator(
 
 #define INSTANTIATE(_, data)                        \
   template double oscillation_indicator<DIM(data)>( \
-      const DataVector&, const Mesh<DIM(data)>&, DerivativeWeight) noexcept;
+      DerivativeWeight, const DataVector&, const Mesh<DIM(data)>&) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp
@@ -40,9 +40,9 @@ std::ostream& operator<<(std::ostream& os,
 // use for the WENO reconstruction, and because it lends itself to an efficient
 // implementation.
 template <size_t VolumeDim>
-double oscillation_indicator(const DataVector& data,
-                             const Mesh<VolumeDim>& mesh,
-                             DerivativeWeight derivative_weight) noexcept;
+double oscillation_indicator(DerivativeWeight derivative_weight,
+                             const DataVector& data,
+                             const Mesh<VolumeDim>& mesh) noexcept;
 
 }  // namespace Weno_detail
 }  // namespace Limiters

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_HwenoImpl.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_HwenoImpl.cpp
@@ -179,7 +179,7 @@ void test_constrained_fit_1d() noexcept {
 
     DataVector constrained_fit;
     Limiters::Weno_detail::solve_constrained_fit<ScalarTag>(
-        make_not_null(&constrained_fit), local_data, 0, element, mesh,
+        make_not_null(&constrained_fit), local_data, 0, mesh, element,
         neighbor_data, primary_neighbor, neighbors_to_exclude);
 
     // The expected coefficient values for the result of the constrained fit are
@@ -232,8 +232,8 @@ void test_constrained_fit_1d() noexcept {
 
     DataVector constrained_fit;
     Limiters::Weno_detail::solve_constrained_fit<ScalarTag>(
-        make_not_null(&constrained_fit), local_data, 0,
-        element_at_lower_xi_bdry, mesh, neighbor_data_at_lower_xi_bdry,
+        make_not_null(&constrained_fit), local_data, 0, mesh,
+        element_at_lower_xi_bdry, neighbor_data_at_lower_xi_bdry,
         primary_neighbor, neighbors_to_exclude);
 
     // Coefficients from Mathematica, using code similar to the one above.
@@ -367,7 +367,7 @@ void test_constrained_fit_2d_vector() noexcept {
     for (size_t tensor_index = 0; tensor_index < 2; ++tensor_index) {
       Limiters::Weno_detail::solve_constrained_fit<VectorTag<2>>(
           make_not_null(&(constrained_fit.get(tensor_index))),
-          local_tensor.get(tensor_index), tensor_index, element, mesh,
+          local_tensor.get(tensor_index), tensor_index, mesh, element,
           neighbor_data, primary_neighbor, neighbors_to_exclude);
     }
 
@@ -470,8 +470,8 @@ void test_constrained_fit_2d_vector() noexcept {
     for (size_t tensor_index = 0; tensor_index < 2; ++tensor_index) {
       Limiters::Weno_detail::solve_constrained_fit<VectorTag<2>>(
           make_not_null(&(constrained_fit.get(tensor_index))),
-          local_tensor.get(tensor_index), tensor_index,
-          element_at_lower_eta_bdry, mesh, neighbor_data_at_lower_eta_bdry,
+          local_tensor.get(tensor_index), tensor_index, mesh,
+          element_at_lower_eta_bdry, neighbor_data_at_lower_eta_bdry,
           primary_neighbor, neighbors_to_exclude);
     }
 
@@ -632,7 +632,7 @@ void test_constrained_fit_3d() noexcept {
 
     DataVector constrained_fit;
     Limiters::Weno_detail::solve_constrained_fit<ScalarTag>(
-        make_not_null(&constrained_fit), local_data, 0, element, mesh,
+        make_not_null(&constrained_fit), local_data, 0, mesh, element,
         neighbor_data, primary_neighbor, neighbors_to_exclude);
 
     // The expected coefficient values for the result of the constrained fit are
@@ -809,8 +809,9 @@ void test_constrained_fit_3d() noexcept {
 
     DataVector constrained_fit;
     Limiters::Weno_detail::solve_constrained_fit<ScalarTag>(
-        make_not_null(&constrained_fit), local_data, 0, element_two_bdries,
-        mesh, neighbor_data_two_bdries, primary_neighbor, neighbors_to_exclude);
+        make_not_null(&constrained_fit), local_data, 0, mesh,
+        element_two_bdries, neighbor_data_two_bdries, primary_neighbor,
+        neighbors_to_exclude);
 
     // Coefficients from Mathematica, using code similar to the one above.
     const auto expected = [&logical_coords]() noexcept {
@@ -946,13 +947,13 @@ void test_hweno_work(
       DataVector& constrained_fit =
           expected_neighbor_polynomials[primary_neighbor];
       Limiters::Weno_detail::solve_constrained_fit<VectorTag<VolumeDim>>(
-          make_not_null(&constrained_fit), local_vector.get(i), i, element,
-          mesh, neighbor_data, primary_neighbor, neighbors_to_exclude);
+          make_not_null(&constrained_fit), local_vector.get(i), i, mesh,
+          element, neighbor_data, primary_neighbor, neighbors_to_exclude);
     }
     Limiters::Weno_detail::reconstruct_from_weighted_sum(
-        make_not_null(&expected_hweno.get(i)), mesh, neighbor_linear_weight,
-        expected_neighbor_polynomials,
-        Limiters::Weno_detail::DerivativeWeight::PowTwoEllOverEllFactorial);
+        make_not_null(&expected_hweno.get(i)), neighbor_linear_weight,
+        Limiters::Weno_detail::DerivativeWeight::PowTwoEllOverEllFactorial,
+        mesh, expected_neighbor_polynomials);
   }
 
   // Check limited fields as expected

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_HwenoImpl.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_HwenoImpl.cpp
@@ -7,6 +7,7 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -25,11 +26,13 @@
 #include "Domain/Neighbors.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp"
 #include "Helpers/Evolution/DiscontinuousGalerkin/Limiters/TestHelpers.hpp"
 #include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_SimpleWenoImpl.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_SimpleWenoImpl.cpp
@@ -185,9 +185,9 @@ void test_simple_weno_work(
           get<VectorTag<VolumeDim>>(neighbor_and_vars.second).get(i);
     }
     Limiters::Weno_detail::reconstruct_from_weighted_sum(
-        make_not_null(&(expected_vector.get(i))), mesh, neighbor_linear_weight,
-        expected_neighbor_polynomials,
-        Limiters::Weno_detail::DerivativeWeight::PowTwoEll);
+        make_not_null(&(expected_vector.get(i))), neighbor_linear_weight,
+        Limiters::Weno_detail::DerivativeWeight::PowTwoEll, mesh,
+        expected_neighbor_polynomials);
   }
   CHECK_ITERABLE_CUSTOM_APPROX(expected_vector, vector_to_limit, local_approx);
 }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Tags.cpp
@@ -10,7 +10,6 @@ namespace {
 struct SomeType {};
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Evolution.DiscontinuousGalerkin.Limiters.Tags",
-                  "[Unit][Evolution]") {
+SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.Tags", "[Unit][Evolution]") {
   TestHelpers::db::test_simple_tag<Tags::Limiter<SomeType>>("Limiter");
 }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
@@ -467,8 +467,8 @@ void test_weno_work(
         get(get<ScalarTag>(neighbor_and_vars.second));
   }
   Limiters::Weno_detail::reconstruct_from_weighted_sum(
-      make_not_null(&get(expected_scalar)), mesh, neighbor_linear_weight,
-      expected_neighbor_polynomials, derivative_weight);
+      make_not_null(&get(expected_scalar)), neighbor_linear_weight,
+      derivative_weight, mesh, expected_neighbor_polynomials);
   CHECK_ITERABLE_CUSTOM_APPROX(expected_scalar, scalar, local_approx);
 
   auto expected_vector = get<VectorTag<VolumeDim>>(local_vars);
@@ -478,8 +478,8 @@ void test_weno_work(
           get<VectorTag<VolumeDim>>(neighbor_and_vars.second).get(i);
     }
     Limiters::Weno_detail::reconstruct_from_weighted_sum(
-        make_not_null(&(expected_vector.get(i))), mesh, neighbor_linear_weight,
-        expected_neighbor_polynomials, derivative_weight);
+        make_not_null(&(expected_vector.get(i))), neighbor_linear_weight,
+        derivative_weight, mesh, expected_neighbor_polynomials);
   }
   CHECK_ITERABLE_CUSTOM_APPROX(expected_vector, vector, local_approx);
 }
@@ -899,7 +899,7 @@ void hweno_modified_neighbor_solution(
             primary_neighbor);
     Limiters::Weno_detail::solve_constrained_fit<Tag>(
         make_not_null(&(*modified_tensor)[tensor_index]),
-        local_tensor[tensor_index], tensor_index, element, mesh, neighbor_data,
+        local_tensor[tensor_index], tensor_index, mesh, element, neighbor_data,
         primary_neighbor, neighbors_to_exclude);
   }
 }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoHelpers.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoHelpers.cpp
@@ -61,8 +61,8 @@ void test_reconstruction_1d() noexcept {
         0.5006326303794342, 0.09987412556290375}});
 
   Limiters::Weno_detail::reconstruct_from_weighted_sum(
-      make_not_null(&local_data), mesh, neighbor_linear_weight, neighbor_data,
-      Limiters::Weno_detail::DerivativeWeight::Unity);
+      make_not_null(&local_data), neighbor_linear_weight,
+      Limiters::Weno_detail::DerivativeWeight::Unity, mesh, neighbor_data);
   CHECK(mean_value(local_data, mesh) == approx(expected_local_mean));
   CHECK_ITERABLE_APPROX(local_data, expected_reconstructed_data);
 }
@@ -118,8 +118,8 @@ void test_reconstruction_2d() noexcept {
         0.9695333707936392, 0.000026246579961852654, 0.0008131679476911193}});
 
   Limiters::Weno_detail::reconstruct_from_weighted_sum(
-      make_not_null(&local_data), mesh, neighbor_linear_weight, neighbor_data,
-      Limiters::Weno_detail::DerivativeWeight::Unity);
+      make_not_null(&local_data), neighbor_linear_weight,
+      Limiters::Weno_detail::DerivativeWeight::Unity, mesh, neighbor_data);
   CHECK(mean_value(local_data, mesh) == approx(expected_local_mean));
   CHECK_ITERABLE_APPROX(local_data, expected_reconstructed_data);
 }
@@ -179,8 +179,8 @@ void test_reconstruction_3d() noexcept {
         0.08447504580872492, 0.04260655032204396}});
 
   Limiters::Weno_detail::reconstruct_from_weighted_sum(
-      make_not_null(&local_data), mesh, neighbor_linear_weight, neighbor_data,
-      Limiters::Weno_detail::DerivativeWeight::Unity);
+      make_not_null(&local_data), neighbor_linear_weight,
+      Limiters::Weno_detail::DerivativeWeight::Unity, mesh, neighbor_data);
   CHECK(mean_value(local_data, mesh) == approx(expected_local_mean));
   CHECK_ITERABLE_APPROX(local_data, expected_reconstructed_data);
 }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoOscillationIndicator.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoOscillationIndicator.cpp
@@ -37,7 +37,7 @@ void test_oscillation_indicator_1d() noexcept {
 
   const auto data = DataVector{1. + x - pow<4>(x)};
   const auto indicator = Limiters::Weno_detail::oscillation_indicator(
-      data, mesh, Limiters::Weno_detail::DerivativeWeight::Unity);
+      Limiters::Weno_detail::DerivativeWeight::Unity, data, mesh);
 
   // Expected result computed in Mathematica:
   // f[x_] := 1 + x - x^4
@@ -49,15 +49,15 @@ void test_oscillation_indicator_1d() noexcept {
   // As above, but with derivative weights given by
   // w[i_] := 2^(2 i - 1)
   const auto indicator2 = Limiters::Weno_detail::oscillation_indicator(
-      data, mesh, Limiters::Weno_detail::DerivativeWeight::PowTwoEll);
+      Limiters::Weno_detail::DerivativeWeight::PowTwoEll, data, mesh);
   const double expected2 = 5607628. / 35.;
   CHECK(indicator2 == approx(expected2));
 
   // Again as above, but with derivative weights given by
   // w[i_] := 2^(2 i - 1) / (i!)^2
   const auto indicator3 = Limiters::Weno_detail::oscillation_indicator(
-      data, mesh,
-      Limiters::Weno_detail::DerivativeWeight::PowTwoEllOverEllFactorial);
+      Limiters::Weno_detail::DerivativeWeight::PowTwoEllOverEllFactorial, data,
+      mesh);
   const double expected3 = 76196. / 105.;
   CHECK(indicator3 == approx(expected3));
 }
@@ -73,7 +73,7 @@ void test_oscillation_indicator_2d() noexcept {
   const auto data =
       DataVector{square(x) + cube(y) - 2.5 * x * y + square(x) * y};
   const auto indicator = Limiters::Weno_detail::oscillation_indicator(
-      data, mesh, Limiters::Weno_detail::DerivativeWeight::Unity);
+      Limiters::Weno_detail::DerivativeWeight::Unity, data, mesh);
 
   // Expected result computed in Mathematica:
   // g[x_, y_] := x^2 + y^3 - (5/2) x y + x^2 y
@@ -89,14 +89,14 @@ void test_oscillation_indicator_2d() noexcept {
 
   // w[i_] := 2^(2 i - 1)
   const auto indicator2 = Limiters::Weno_detail::oscillation_indicator(
-      data, mesh, Limiters::Weno_detail::DerivativeWeight::PowTwoEll);
+      Limiters::Weno_detail::DerivativeWeight::PowTwoEll, data, mesh);
   const double expected2 = 26938. / 9.;
   CHECK(indicator2 == approx(expected2));
 
   // w[i_] := 2^(2 i - 1) / (i!)^2
   const auto indicator3 = Limiters::Weno_detail::oscillation_indicator(
-      data, mesh,
-      Limiters::Weno_detail::DerivativeWeight::PowTwoEllOverEllFactorial);
+      Limiters::Weno_detail::DerivativeWeight::PowTwoEllOverEllFactorial, data,
+      mesh);
   const double expected3 = 3178. / 9.;
   CHECK(indicator3 == approx(expected3));
 }
@@ -113,7 +113,7 @@ void test_oscillation_indicator_3d() noexcept {
   const auto data = DataVector{square(x) + 2. * y + z - 6. * cube(z) -
                                3. * x * square(y) * cube(z) - x * y + y * z};
   const auto indicator = Limiters::Weno_detail::oscillation_indicator(
-      data, mesh, Limiters::Weno_detail::DerivativeWeight::Unity);
+      Limiters::Weno_detail::DerivativeWeight::Unity, data, mesh);
 
   // Expected result computed in Mathematica:
   // h[x_, y_, z_] := x^2 + 2 y + z - 6 z^3 - 3 x y^2 z^3 - x y + y z
@@ -136,14 +136,14 @@ void test_oscillation_indicator_3d() noexcept {
 
   // w[i_] := 2^(2 i - 1)
   const auto indicator2 = Limiters::Weno_detail::oscillation_indicator(
-      data, mesh, Limiters::Weno_detail::DerivativeWeight::PowTwoEll);
+      Limiters::Weno_detail::DerivativeWeight::PowTwoEll, data, mesh);
   const double expected2 = 3611348444. / 525.;
   CHECK(indicator2 == approx(expected2));
 
   // w[i_] := 2^(2 i - 1) / (i!)^2
   const auto indicator3 = Limiters::Weno_detail::oscillation_indicator(
-      data, mesh,
-      Limiters::Weno_detail::DerivativeWeight::PowTwoEllOverEllFactorial);
+      Limiters::Weno_detail::DerivativeWeight::PowTwoEllOverEllFactorial, data,
+      mesh);
   const double expected3 = 54886604. / 525.;
   CHECK(indicator3 == approx(expected3));
 }


### PR DESCRIPTION
## Proposed changes

This concludes the refactor of the WENO-related code. The earlier refactor PRs were primarily focused on various helper functions, this PR primarily updates the limiter itself and its tests.

In addition to various small fixes, this PR:
- does some more reordering of function arguments for consistency with other limiter code
- updates the Weno test: after previous PRs added helper functions for `simple_weno_impl` and `hweno_impl` with detailed tests, the parts of the Weno test that checked the correctness of the reconstruction are redundant (and less detailed anyway). These are now removed, and instead the test focuses on checking that the TCI and limiting are correctly integrated.
- adds the ability to choose a TvbConstant for the TVB indicator used in the limiter
- improves the documentation of the TCI used in the limiter

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

