### PR TITLE
Add block-specific h-refinement

### DIFF
--- a/src/Domain/CreateInitialElement.cpp
+++ b/src/Domain/CreateInitialElement.cpp
@@ -3,10 +3,12 @@
 
 #include "Domain/CreateInitialElement.hpp"
 
+#include <unordered_set>
 #include <utility>
 
+#include "DataStructures/Index.hpp"
+#include "DataStructures/IndexIterator.hpp"
 #include "Domain/Block.hpp"          // IWYU pragma: keep
-#include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/Direction.hpp"
 #include "Domain/Element.hpp"
 #include "Domain/ElementId.hpp"
@@ -14,41 +16,111 @@
 #include "Domain/OrientationMap.hpp"
 #include "Domain/SegmentId.hpp"
 #include "Domain/Side.hpp"
+#include "ErrorHandling/Error.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
-
-namespace Frame {
-struct Grid;      // IWYU pragma: keep
-struct Inertial;  // IWYU pragma: keep
-}  // namespace Frame
+#include "Utilities/MakeArray.hpp"
 
 namespace domain {
 namespace Initialization {
 template <size_t VolumeDim>
 Element<VolumeDim> create_initial_element(
-    const ElementId<VolumeDim>& element_id,
-    const Block<VolumeDim>& block) noexcept {
+    const ElementId<VolumeDim>& element_id, const Block<VolumeDim>& block,
+    const std::vector<std::array<size_t, VolumeDim>>&
+        initial_refinement_levels) noexcept {
   const auto& neighbors_of_block = block.neighbors();
   const auto& segment_ids = element_id.segment_ids();
 
   // Declare two helper lambdas for setting the neighbors of an element
-  const auto compute_element_neighbor_in_other_block = [&neighbors_of_block,
-                                                        &segment_ids](
-      const Direction<VolumeDim>& direction) noexcept {
+  const auto compute_element_neighbor_in_other_block =
+      [&block, &initial_refinement_levels, &neighbors_of_block, &segment_ids](
+          const Direction<VolumeDim>& direction) noexcept {
     const auto& block_neighbor = neighbors_of_block.at(direction);
     const auto& orientation = block_neighbor.orientation();
     // TODO(): An illustration of what is happening here would be useful
-    auto segment_ids_of_neighbor = orientation(segment_ids);
-    auto& segment_to_flip =
-        gsl::at(segment_ids_of_neighbor, orientation(direction).dimension());
-    segment_to_flip = segment_to_flip.id_if_flipped();
+    const auto direction_in_neighbor = orientation(direction);
+
+    // SegmentIds of the current element using the neighbor's axes.
+    auto segment_ids_of_unrefined_neighbor = orientation(segment_ids);
+    const auto& refinement_of_neighbor =
+        initial_refinement_levels[block_neighbor.id()];
+
+    // Check whether each dimension will have multiple neighbors
+    // because the neighboring block is more refined.  For dimensions
+    // that have only one neighbor, adjust the SegmentId to that of
+    // the neighbor if necessary.
+    auto neighbor_is_refined = make_array<VolumeDim>(false);
+    for (size_t d = 0; d < VolumeDim; ++d) {
+      switch (static_cast<int>(gsl::at(refinement_of_neighbor, d)) -
+              static_cast<int>(gsl::at(segment_ids_of_unrefined_neighbor, d)
+                                   .refinement_level())) {
+        case 0:
+          break;
+        case 1:
+          gsl::at(neighbor_is_refined, d) = true;
+          break;
+        case -1:
+          gsl::at(segment_ids_of_unrefined_neighbor, d) =
+              gsl::at(segment_ids_of_unrefined_neighbor, d).id_of_parent();
+          break;
+        default:
+          ERROR("Refinement levels "
+                << gsl::at(refinement_of_neighbor, d) << " and "
+                << gsl::at(segment_ids_of_unrefined_neighbor, d)
+                       .refinement_level()
+                << " in blocks " << block_neighbor.id() << " and " << block.id()
+                << " differ by more than one.");
+      }
+    }
+
+    // Refinement in the dimension perpendicular to the interface
+    // never causes additional neighbors, even if the neighboring
+    // elements are smaller.
+    {
+      auto& perpendicular_segment = gsl::at(segment_ids_of_unrefined_neighbor,
+                                            direction_in_neighbor.dimension());
+      auto& perpendicular_refinement =
+          gsl::at(neighbor_is_refined, direction_in_neighbor.dimension());
+      if (perpendicular_refinement) {
+        perpendicular_segment =
+            perpendicular_segment.id_of_child(direction_in_neighbor.side());
+        perpendicular_refinement = false;
+      }
+      perpendicular_segment = perpendicular_segment.id_if_flipped();
+    }
+
+    // Consider all possible neighbors by looping over all elements of
+    // the product set {Lower, Upper}^VolumeDim, checking whether each
+    // actually describes a neighbor.  For dimensions where the
+    // interface is not split, we arbitrarily call all neighbors Lower
+    // and consider any Upper neighbors invalid.
+    std::unordered_set<ElementId<VolumeDim>> neighbor_ids;
+    for (IndexIterator<VolumeDim> index(Index<VolumeDim>(2)); index; ++index) {
+      std::array<SegmentId, VolumeDim> segment_ids_of_neighbor;
+      for (size_t d = 0; d < VolumeDim; ++d) {
+        const auto& unrefined_segment =
+            gsl::at(segment_ids_of_unrefined_neighbor, d);
+        auto& segment = gsl::at(segment_ids_of_neighbor, d);
+        if (not gsl::at(neighbor_is_refined, d)) {
+          if ((*index)[d] == 0) {
+            segment = unrefined_segment;
+          } else {
+            goto next_index;
+          }
+        } else {
+          if ((*index)[d] == 0) {
+            segment = unrefined_segment.id_of_child(Side::Lower);
+          } else {
+            segment = unrefined_segment.id_of_child(Side::Upper);
+          }
+        }
+      }
+      neighbor_ids.insert({block_neighbor.id(), segment_ids_of_neighbor});
+    next_index:;
+    }
     return std::make_pair(
-        direction,
-        Neighbors<VolumeDim>(
-            {{ElementId<VolumeDim>{block_neighbor.id(),
-                                   std::move(segment_ids_of_neighbor)}}},
-            orientation));
+        direction, Neighbors<VolumeDim>(std::move(neighbor_ids), orientation));
   };
 
   const auto compute_element_neighbor_in_same_block = [&element_id,
@@ -105,7 +177,8 @@ Element<VolumeDim> create_initial_element(
 #define INSTANTIATE(_, data)                                 \
   template Element<DIM(data)>                                \
   domain::Initialization::create_initial_element<DIM(data)>( \
-      const ElementId<DIM(data)>&, const Block<DIM(data)>&) noexcept;
+      const ElementId<DIM(data)>&, const Block<DIM(data)>&,  \
+      const std::vector<std::array<size_t, DIM(data)>>&) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Domain/CreateInitialElement.hpp
+++ b/src/Domain/CreateInitialElement.hpp
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
+#include <vector>
 
 #include "Domain/Element.hpp"
 
@@ -22,14 +24,13 @@ namespace Initialization {
  *
  * \details This function creates an element at the refinement level and
  * position specified by the `element_id` within the `block`. It assumes
- * that all of its neighboring elements are at the same refinement level. Thus,
- * the created element's `neighbors` has one neighbor per direction (or zero on
- * an external boundary), with each neighbor at the same refinement level as the
- * element.
+ * that all elements in a given block have the same refinement level,
+ * given in `initial_refinement_levels`.
  */
 template <size_t VolumeDim>
 Element<VolumeDim> create_initial_element(
-    const ElementId<VolumeDim>& element_id,
-    const Block<VolumeDim>& block) noexcept;
+    const ElementId<VolumeDim>& element_id, const Block<VolumeDim>& block,
+    const std::vector<std::array<size_t, VolumeDim>>&
+        initial_refinement_levels) noexcept;
 }  // namespace Initialization
 }  // namespace domain

--- a/src/Domain/Creators/AlignedLattice.hpp
+++ b/src/Domain/Creators/AlignedLattice.hpp
@@ -57,8 +57,8 @@ struct RefinementRegion {
 
   static constexpr OptionString help = {
       "A region to be refined differently from the default for the lattice.\n"
-      "The region is a box between the block boundaries indexed by the bound\n"
-      "options."};
+      "The region is a box between the block boundaries indexed by the\n"
+      "Lower- and UpperCornerIndex options."};
   using options = tmpl::list<LowerCornerIndex, UpperCornerIndex, Refinement>;
   RefinementRegion(const std::array<size_t, VolumeDim>& lower_corner_index_in,
                    const std::array<size_t, VolumeDim>& upper_corner_index_in,
@@ -119,7 +119,7 @@ class AlignedLattice : public DomainCreator<VolumeDim> {
     }
   };
 
-  struct InitialRefinement {
+  struct InitialLevels {
     using type = std::array<size_t, VolumeDim>;
     static constexpr OptionString help = {
         "Initial refinement level in each dimension."};
@@ -131,10 +131,17 @@ class AlignedLattice : public DomainCreator<VolumeDim> {
         "Initial number of grid points in each dimension."};
   };
 
+  struct RefinedLevels {
+    using type = std::vector<RefinementRegion<VolumeDim>>;
+    static constexpr OptionString help = {
+        "h-refined regions.  Later entries take priority."};
+    static type default_value() noexcept { return {}; }
+  };
+
   struct RefinedGridPoints {
     using type = std::vector<RefinementRegion<VolumeDim>>;
     static constexpr OptionString help = {
-        "Refined regions.  Later entries take priority."};
+        "p-refined regions.  Later entries take priority."};
     static type default_value() noexcept { return {}; }
   };
 
@@ -147,9 +154,9 @@ class AlignedLattice : public DomainCreator<VolumeDim> {
     }
   };
 
-  using options =
-      tmpl::list<BlockBounds, IsPeriodicIn, InitialRefinement,
-                 InitialGridPoints, RefinedGridPoints, BlocksToExclude>;
+  using options = tmpl::list<BlockBounds, IsPeriodicIn, InitialLevels,
+                             InitialGridPoints, RefinedLevels,
+                             RefinedGridPoints, BlocksToExclude>;
 
   static constexpr OptionString help = {
       "AlignedLattice creates a regular lattice of blocks whose corners are\n"
@@ -165,8 +172,9 @@ class AlignedLattice : public DomainCreator<VolumeDim> {
 
   AlignedLattice(typename BlockBounds::type block_bounds,
                  typename IsPeriodicIn::type is_periodic_in,
-                 typename InitialRefinement::type initial_refinement_levels,
+                 typename InitialLevels::type initial_refinement_levels,
                  typename InitialGridPoints::type initial_number_of_grid_points,
+                 typename RefinedLevels::type refined_refinement,
                  typename RefinedGridPoints::type refined_grid_points,
                  typename BlocksToExclude::type blocks_to_exclude) noexcept;
 
@@ -189,10 +197,11 @@ class AlignedLattice : public DomainCreator<VolumeDim> {
   typename BlockBounds::type block_bounds_{
       make_array<VolumeDim, std::vector<double>>({})};
   typename IsPeriodicIn::type is_periodic_in_{make_array<VolumeDim>(false)};
-  typename InitialRefinement::type initial_refinement_levels_{
+  typename InitialLevels::type initial_refinement_levels_{
       make_array<VolumeDim>(std::numeric_limits<size_t>::max())};
   typename InitialGridPoints::type initial_number_of_grid_points_{
       make_array<VolumeDim>(std::numeric_limits<size_t>::max())};
+  typename RefinedLevels::type refined_refinement_{};
   typename RefinedGridPoints::type refined_grid_points_{};
   typename BlocksToExclude::type blocks_to_exclude_{};
   Index<VolumeDim> number_of_blocks_by_dim_{};

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
@@ -61,12 +61,16 @@ namespace Actions {
  */
 template <size_t Dim>
 struct InitializeDomain {
-  using initialization_tags = tmpl::list<domain::Tags::InitialExtents<Dim>>;
+  using initialization_tags =
+      tmpl::list<domain::Tags::InitialExtents<Dim>,
+                 domain::Tags::InitialRefinementLevels<Dim>>;
 
-  template <typename DataBox, typename... InboxTags, typename Metavariables,
-            typename ActionList, typename ParallelComponent,
-            Requires<db::tag_is_retrievable_v<domain::Tags::InitialExtents<Dim>,
-                                              DataBox>> = nullptr>
+  template <
+      typename DataBox, typename... InboxTags, typename Metavariables,
+      typename ActionList, typename ParallelComponent,
+      Requires<tmpl::all<initialization_tags,
+                         tmpl::bind<db::tag_is_retrievable, tmpl::_1,
+                                    tmpl::pin<DataBox>>>::value> = nullptr>
   static auto apply(DataBox& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
@@ -88,14 +92,16 @@ struct InitializeDomain {
 
     const auto& initial_extents =
         db::get<domain::Tags::InitialExtents<Dim>>(box);
+    const auto& initial_refinement =
+        db::get<domain::Tags::InitialRefinementLevels<Dim>>(box);
     const auto& domain = db::get<domain::Tags::Domain<Dim>>(box);
 
     const ElementId<Dim> element_id{array_index};
     const auto& my_block = domain.blocks()[element_id.block_id()];
     Mesh<Dim> mesh = domain::Initialization::create_initial_mesh(
         initial_extents, element_id);
-    Element<Dim> element =
-        domain::Initialization::create_initial_element(element_id, my_block);
+    Element<Dim> element = domain::Initialization::create_initial_element(
+        element_id, my_block, initial_refinement);
     if (my_block.is_time_dependent()) {
       ERROR(
           "The version of the InitializeDomain action being used is for "
@@ -112,11 +118,12 @@ struct InitializeDomain {
             std::move(element_map)));
   }
 
-  template <typename DataBox, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent,
-            Requires<not db::tag_is_retrievable_v<
-                domain::Tags::InitialExtents<Dim>, DataBox>> = nullptr>
+  template <
+      typename DataBox, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      Requires<not tmpl::all<initialization_tags,
+                             tmpl::bind<db::tag_is_retrievable, tmpl::_1,
+                                        tmpl::pin<DataBox>>>::value> = nullptr>
   static std::tuple<DataBox&&> apply(
       DataBox& /*box*/, const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
       const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -496,12 +496,12 @@ void test_radial_block_layers(const double inner_radius,
   }
   size_t element_count = 0;
   for (const auto& block : domain.blocks()) {
-    const auto initial_ref_levs = shell.initial_refinement_levels()[block.id()];
+    const auto initial_ref_levs = shell.initial_refinement_levels();
     const std::vector<ElementId<3>> element_ids =
-        initial_element_ids(block.id(), initial_ref_levs);
+        initial_element_ids(block.id(), initial_ref_levs[block.id()]);
     for (const auto& element_id : element_ids) {
-      const auto element =
-          domain::Initialization::create_initial_element(element_id, block);
+      const auto element = domain::Initialization::create_initial_element(
+          element_id, block, initial_ref_levs);
       // Creating elements through InitialRefinement creates Elements in all
       // three logical dimensions. It is sufficient to only check the elements
       // in the radial direction lying along a ray at a fixed angle.

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -3,14 +3,21 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <algorithm>
+#include <array>
+#include <boost/functional/hash.hpp>
+#include <cstddef>
 #include <functional>
+#include <initializer_list>
 #include <memory>
 #include <pup.h>
+#include <tuple>
+#include <unordered_set>
+#include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Block.hpp"
 #include "Domain/BlockNeighbor.hpp"
-#include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CreateInitialElement.hpp"
@@ -21,16 +28,351 @@
 #include "Domain/Neighbors.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Domain/SegmentId.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/StdHelpers.hpp"
 
 namespace {
 void test_create_initial_element(
     const ElementId<2>& element_id, const Block<2>& block,
+    const std::vector<std::array<size_t, 2>>& refinement_levels,
     const DirectionMap<2, Neighbors<2>>& expected_neighbors) noexcept {
-  const auto created_element =
-      domain::Initialization::create_initial_element(element_id, block);
+  const auto created_element = domain::Initialization::create_initial_element(
+      element_id, block, refinement_levels);
   const Element<2> expected_element{element_id, expected_neighbors};
   CHECK(created_element == expected_element);
+}
+
+void test_h_refinement() noexcept {
+  const auto check_upper =
+      [](const OrientationMap<3>& neighbor_orientation,
+         const std::array<size_t, 3>& neighbor_refinement,
+         const std::unordered_set<ElementId<3>>& expected_neighbors) noexcept {
+    CAPTURE(neighbor_orientation);
+    CAPTURE(neighbor_refinement);
+    const ElementId<3> self_id(0, {{{1, 1}, {1, 0}, {1, 1}}});
+    const Block<3> self_block(
+        domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            domain::CoordinateMaps::Identity<3>{}),
+        0, {{Direction<3>::upper_xi(), {1, neighbor_orientation}}});
+    const std::vector<std::array<size_t, 3>> refinement_levels{
+        {{1, 1, 1}}, neighbor_refinement};
+
+    const auto refined_neighbors =
+        domain::Initialization::create_initial_element(self_id, self_block,
+                                                       refinement_levels)
+            .neighbors()
+            .at(Direction<3>::upper_xi())
+            .ids();
+    CHECK(refined_neighbors == expected_neighbors);
+  };
+
+  const auto check_lower =
+      [](const OrientationMap<3>& neighbor_orientation,
+         const std::array<size_t, 3>& neighbor_refinement,
+         const std::unordered_set<ElementId<3>>& expected_neighbors) noexcept {
+    CAPTURE(neighbor_orientation);
+    CAPTURE(neighbor_refinement);
+    const ElementId<3> self_id(0, {{{1, 0}, {1, 0}, {1, 1}}});
+    const Block<3> self_block(
+        domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            domain::CoordinateMaps::Identity<3>{}),
+        0, {{Direction<3>::lower_xi(), {1, neighbor_orientation}}});
+    const std::vector<std::array<size_t, 3>> refinement_levels{
+        {{1, 1, 1}}, neighbor_refinement};
+
+    const auto refined_neighbors =
+        domain::Initialization::create_initial_element(self_id, self_block,
+                                                       refinement_levels)
+            .neighbors()
+            .at(Direction<3>::lower_xi())
+            .ids();
+    CHECK(refined_neighbors == expected_neighbors);
+  };
+
+  const OrientationMap<3> aligned{};
+  const OrientationMap<3> rotated{
+      {{Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+        Direction<3>::upper_eta()}}};
+  const OrientationMap<3> reflected{
+      {{Direction<3>::lower_xi(), Direction<3>::lower_eta(),
+        Direction<3>::upper_zeta()}}};
+
+  // Same tangential refinement
+  check_upper(aligned, {{1, 1, 1}}, {{1, {{{1, 0}, {1, 0}, {1, 1}}}}});
+  check_lower(aligned, {{1, 1, 1}}, {{1, {{{1, 1}, {1, 0}, {1, 1}}}}});
+  check_upper(rotated, {{1, 1, 1}}, {{1, {{{1, 0}, {1, 1}, {1, 0}}}}});
+  check_lower(rotated, {{1, 1, 1}}, {{1, {{{1, 0}, {1, 1}, {1, 1}}}}});
+  check_upper(reflected, {{1, 1, 1}}, {{1, {{{1, 1}, {1, 1}, {1, 1}}}}});
+  check_lower(reflected, {{1, 1, 1}}, {{1, {{{1, 0}, {1, 1}, {1, 1}}}}});
+
+  check_upper(aligned, {{0, 1, 1}}, {{1, {{{0, 0}, {1, 0}, {1, 1}}}}});
+  check_lower(aligned, {{0, 1, 1}}, {{1, {{{0, 0}, {1, 0}, {1, 1}}}}});
+  check_upper(rotated, {{1, 1, 0}}, {{1, {{{1, 0}, {1, 1}, {0, 0}}}}});
+  check_lower(rotated, {{1, 1, 0}}, {{1, {{{1, 0}, {1, 1}, {0, 0}}}}});
+  check_upper(reflected, {{0, 1, 1}}, {{1, {{{0, 0}, {1, 1}, {1, 1}}}}});
+  check_lower(reflected, {{0, 1, 1}}, {{1, {{{0, 0}, {1, 1}, {1, 1}}}}});
+
+  check_upper(aligned, {{2, 1, 1}}, {{1, {{{2, 0}, {1, 0}, {1, 1}}}}});
+  check_lower(aligned, {{2, 1, 1}}, {{1, {{{2, 3}, {1, 0}, {1, 1}}}}});
+  check_upper(rotated, {{1, 1, 2}}, {{1, {{{1, 0}, {1, 1}, {2, 0}}}}});
+  check_lower(rotated, {{1, 1, 2}}, {{1, {{{1, 0}, {1, 1}, {2, 3}}}}});
+  check_upper(reflected, {{2, 1, 1}}, {{1, {{{2, 3}, {1, 1}, {1, 1}}}}});
+  check_lower(reflected, {{2, 1, 1}}, {{1, {{{2, 0}, {1, 1}, {1, 1}}}}});
+
+  // Larger in both dimensions
+  check_upper(aligned, {{1, 0, 0}}, {{1, {{{1, 0}, {0, 0}, {0, 0}}}}});
+  check_lower(aligned, {{1, 0, 0}}, {{1, {{{1, 1}, {0, 0}, {0, 0}}}}});
+  check_upper(rotated, {{0, 0, 1}}, {{1, {{{0, 0}, {0, 0}, {1, 0}}}}});
+  check_lower(rotated, {{0, 0, 1}}, {{1, {{{0, 0}, {0, 0}, {1, 1}}}}});
+  check_upper(reflected, {{1, 0, 0}}, {{1, {{{1, 1}, {0, 0}, {0, 0}}}}});
+  check_lower(reflected, {{1, 0, 0}}, {{1, {{{1, 0}, {0, 0}, {0, 0}}}}});
+
+  check_upper(aligned, {{0, 0, 0}}, {{1, {{{0, 0}, {0, 0}, {0, 0}}}}});
+  check_lower(aligned, {{0, 0, 0}}, {{1, {{{0, 0}, {0, 0}, {0, 0}}}}});
+  check_upper(rotated, {{0, 0, 0}}, {{1, {{{0, 0}, {0, 0}, {0, 0}}}}});
+  check_lower(rotated, {{0, 0, 0}}, {{1, {{{0, 0}, {0, 0}, {0, 0}}}}});
+  check_upper(reflected, {{0, 0, 0}}, {{1, {{{0, 0}, {0, 0}, {0, 0}}}}});
+  check_lower(reflected, {{0, 0, 0}}, {{1, {{{0, 0}, {0, 0}, {0, 0}}}}});
+
+  check_upper(aligned, {{2, 0, 0}}, {{1, {{{2, 0}, {0, 0}, {0, 0}}}}});
+  check_lower(aligned, {{2, 0, 0}}, {{1, {{{2, 3}, {0, 0}, {0, 0}}}}});
+  check_upper(rotated, {{0, 0, 2}}, {{1, {{{0, 0}, {0, 0}, {2, 0}}}}});
+  check_lower(rotated, {{0, 0, 2}}, {{1, {{{0, 0}, {0, 0}, {2, 3}}}}});
+  check_upper(reflected, {{2, 0, 0}}, {{1, {{{2, 3}, {0, 0}, {0, 0}}}}});
+  check_lower(reflected, {{2, 0, 0}}, {{1, {{{2, 0}, {0, 0}, {0, 0}}}}});
+
+  // Smaller in both dimensions
+  check_upper(aligned, {{1, 2, 2}},
+              {{1, {{{1, 0}, {2, 0}, {2, 2}}}},
+               {1, {{{1, 0}, {2, 0}, {2, 3}}}},
+               {1, {{{1, 0}, {2, 1}, {2, 2}}}},
+               {1, {{{1, 0}, {2, 1}, {2, 3}}}}});
+  check_lower(aligned, {{1, 2, 2}},
+              {{1, {{{1, 1}, {2, 0}, {2, 2}}}},
+               {1, {{{1, 1}, {2, 0}, {2, 3}}}},
+               {1, {{{1, 1}, {2, 1}, {2, 2}}}},
+               {1, {{{1, 1}, {2, 1}, {2, 3}}}}});
+  check_upper(rotated, {{2, 2, 1}},
+              {{1, {{{2, 0}, {2, 2}, {1, 0}}}},
+               {1, {{{2, 0}, {2, 3}, {1, 0}}}},
+               {1, {{{2, 1}, {2, 2}, {1, 0}}}},
+               {1, {{{2, 1}, {2, 3}, {1, 0}}}}});
+  check_lower(rotated, {{2, 2, 1}},
+              {{1, {{{2, 0}, {2, 2}, {1, 1}}}},
+               {1, {{{2, 0}, {2, 3}, {1, 1}}}},
+               {1, {{{2, 1}, {2, 2}, {1, 1}}}},
+               {1, {{{2, 1}, {2, 3}, {1, 1}}}}});
+  check_upper(reflected, {{1, 2, 2}},
+              {{1, {{{1, 1}, {2, 3}, {2, 2}}}},
+               {1, {{{1, 1}, {2, 3}, {2, 3}}}},
+               {1, {{{1, 1}, {2, 2}, {2, 2}}}},
+               {1, {{{1, 1}, {2, 2}, {2, 3}}}}});
+  check_lower(reflected, {{1, 2, 2}},
+              {{1, {{{1, 0}, {2, 3}, {2, 2}}}},
+               {1, {{{1, 0}, {2, 3}, {2, 3}}}},
+               {1, {{{1, 0}, {2, 2}, {2, 2}}}},
+               {1, {{{1, 0}, {2, 2}, {2, 3}}}}});
+
+  check_upper(aligned, {{0, 2, 2}},
+              {{1, {{{0, 0}, {2, 0}, {2, 2}}}},
+               {1, {{{0, 0}, {2, 0}, {2, 3}}}},
+               {1, {{{0, 0}, {2, 1}, {2, 2}}}},
+               {1, {{{0, 0}, {2, 1}, {2, 3}}}}});
+  check_lower(aligned, {{0, 2, 2}},
+              {{1, {{{0, 0}, {2, 0}, {2, 2}}}},
+               {1, {{{0, 0}, {2, 0}, {2, 3}}}},
+               {1, {{{0, 0}, {2, 1}, {2, 2}}}},
+               {1, {{{0, 0}, {2, 1}, {2, 3}}}}});
+  check_upper(rotated, {{2, 2, 0}},
+              {{1, {{{2, 0}, {2, 2}, {0, 0}}}},
+               {1, {{{2, 0}, {2, 3}, {0, 0}}}},
+               {1, {{{2, 1}, {2, 2}, {0, 0}}}},
+               {1, {{{2, 1}, {2, 3}, {0, 0}}}}});
+  check_lower(rotated, {{2, 2, 0}},
+              {{1, {{{2, 0}, {2, 2}, {0, 0}}}},
+               {1, {{{2, 0}, {2, 3}, {0, 0}}}},
+               {1, {{{2, 1}, {2, 2}, {0, 0}}}},
+               {1, {{{2, 1}, {2, 3}, {0, 0}}}}});
+  check_upper(reflected, {{0, 2, 2}},
+              {{1, {{{0, 0}, {2, 3}, {2, 2}}}},
+               {1, {{{0, 0}, {2, 3}, {2, 3}}}},
+               {1, {{{0, 0}, {2, 2}, {2, 2}}}},
+               {1, {{{0, 0}, {2, 2}, {2, 3}}}}});
+  check_lower(reflected, {{0, 2, 2}},
+              {{1, {{{0, 0}, {2, 3}, {2, 2}}}},
+               {1, {{{0, 0}, {2, 3}, {2, 3}}}},
+               {1, {{{0, 0}, {2, 2}, {2, 2}}}},
+               {1, {{{0, 0}, {2, 2}, {2, 3}}}}});
+
+  check_upper(aligned, {{2, 2, 2}},
+              {{1, {{{2, 0}, {2, 0}, {2, 2}}}},
+               {1, {{{2, 0}, {2, 0}, {2, 3}}}},
+               {1, {{{2, 0}, {2, 1}, {2, 2}}}},
+               {1, {{{2, 0}, {2, 1}, {2, 3}}}}});
+  check_lower(aligned, {{2, 2, 2}},
+              {{1, {{{2, 3}, {2, 0}, {2, 2}}}},
+               {1, {{{2, 3}, {2, 0}, {2, 3}}}},
+               {1, {{{2, 3}, {2, 1}, {2, 2}}}},
+               {1, {{{2, 3}, {2, 1}, {2, 3}}}}});
+  check_upper(rotated, {{2, 2, 2}},
+              {{1, {{{2, 0}, {2, 2}, {2, 0}}}},
+               {1, {{{2, 0}, {2, 3}, {2, 0}}}},
+               {1, {{{2, 1}, {2, 2}, {2, 0}}}},
+               {1, {{{2, 1}, {2, 3}, {2, 0}}}}});
+  check_lower(rotated, {{2, 2, 2}},
+              {{1, {{{2, 0}, {2, 2}, {2, 3}}}},
+               {1, {{{2, 0}, {2, 3}, {2, 3}}}},
+               {1, {{{2, 1}, {2, 2}, {2, 3}}}},
+               {1, {{{2, 1}, {2, 3}, {2, 3}}}}});
+  check_upper(reflected, {{2, 2, 2}},
+              {{1, {{{2, 3}, {2, 3}, {2, 2}}}},
+               {1, {{{2, 3}, {2, 3}, {2, 3}}}},
+               {1, {{{2, 3}, {2, 2}, {2, 2}}}},
+               {1, {{{2, 3}, {2, 2}, {2, 3}}}}});
+  check_lower(reflected, {{2, 2, 2}},
+              {{1, {{{2, 0}, {2, 3}, {2, 2}}}},
+               {1, {{{2, 0}, {2, 3}, {2, 3}}}},
+               {1, {{{2, 0}, {2, 2}, {2, 2}}}},
+               {1, {{{2, 0}, {2, 2}, {2, 3}}}}});
+
+  // Larger in one dimension
+  check_upper(aligned, {{1, 0, 1}}, {{1, {{{1, 0}, {0, 0}, {1, 1}}}}});
+  check_lower(aligned, {{1, 0, 1}}, {{1, {{{1, 1}, {0, 0}, {1, 1}}}}});
+  check_upper(rotated, {{0, 1, 1}}, {{1, {{{0, 0}, {1, 1}, {1, 0}}}}});
+  check_lower(rotated, {{0, 1, 1}}, {{1, {{{0, 0}, {1, 1}, {1, 1}}}}});
+  check_upper(reflected, {{1, 0, 1}}, {{1, {{{1, 1}, {0, 0}, {1, 1}}}}});
+  check_lower(reflected, {{1, 0, 1}}, {{1, {{{1, 0}, {0, 0}, {1, 1}}}}});
+
+  check_upper(aligned, {{0, 0, 1}}, {{1, {{{0, 0}, {0, 0}, {1, 1}}}}});
+  check_lower(aligned, {{0, 0, 1}}, {{1, {{{0, 0}, {0, 0}, {1, 1}}}}});
+  check_upper(rotated, {{0, 1, 0}}, {{1, {{{0, 0}, {1, 1}, {0, 0}}}}});
+  check_lower(rotated, {{0, 1, 0}}, {{1, {{{0, 0}, {1, 1}, {0, 0}}}}});
+  check_upper(reflected, {{0, 0, 1}}, {{1, {{{0, 0}, {0, 0}, {1, 1}}}}});
+  check_lower(reflected, {{0, 0, 1}}, {{1, {{{0, 0}, {0, 0}, {1, 1}}}}});
+
+  check_upper(aligned, {{2, 0, 1}}, {{1, {{{2, 0}, {0, 0}, {1, 1}}}}});
+  check_lower(aligned, {{2, 0, 1}}, {{1, {{{2, 3}, {0, 0}, {1, 1}}}}});
+  check_upper(rotated, {{0, 1, 2}}, {{1, {{{0, 0}, {1, 1}, {2, 0}}}}});
+  check_lower(rotated, {{0, 1, 2}}, {{1, {{{0, 0}, {1, 1}, {2, 3}}}}});
+  check_upper(reflected, {{2, 0, 1}}, {{1, {{{2, 3}, {0, 0}, {1, 1}}}}});
+  check_lower(reflected, {{2, 0, 1}}, {{1, {{{2, 0}, {0, 0}, {1, 1}}}}});
+
+  // Smaller in one dimension
+  check_upper(
+      aligned, {{1, 2, 1}},
+      {{1, {{{1, 0}, {2, 0}, {1, 1}}}}, {1, {{{1, 0}, {2, 1}, {1, 1}}}}});
+  check_lower(
+      aligned, {{1, 2, 1}},
+      {{1, {{{1, 1}, {2, 0}, {1, 1}}}}, {1, {{{1, 1}, {2, 1}, {1, 1}}}}});
+  check_upper(
+      rotated, {{2, 1, 1}},
+      {{1, {{{2, 0}, {1, 1}, {1, 0}}}}, {1, {{{2, 1}, {1, 1}, {1, 0}}}}});
+  check_lower(
+      rotated, {{2, 1, 1}},
+      {{1, {{{2, 0}, {1, 1}, {1, 1}}}}, {1, {{{2, 1}, {1, 1}, {1, 1}}}}});
+  check_upper(
+      reflected, {{1, 2, 1}},
+      {{1, {{{1, 1}, {2, 3}, {1, 1}}}}, {1, {{{1, 1}, {2, 2}, {1, 1}}}}});
+  check_lower(
+      reflected, {{1, 2, 1}},
+      {{1, {{{1, 0}, {2, 3}, {1, 1}}}}, {1, {{{1, 0}, {2, 2}, {1, 1}}}}});
+
+  check_upper(
+      aligned, {{0, 2, 1}},
+      {{1, {{{0, 0}, {2, 0}, {1, 1}}}}, {1, {{{0, 0}, {2, 1}, {1, 1}}}}});
+  check_lower(
+      aligned, {{0, 2, 1}},
+      {{1, {{{0, 0}, {2, 0}, {1, 1}}}}, {1, {{{0, 0}, {2, 1}, {1, 1}}}}});
+  check_upper(
+      rotated, {{2, 1, 0}},
+      {{1, {{{2, 0}, {1, 1}, {0, 0}}}}, {1, {{{2, 1}, {1, 1}, {0, 0}}}}});
+  check_lower(
+      rotated, {{2, 1, 0}},
+      {{1, {{{2, 0}, {1, 1}, {0, 0}}}}, {1, {{{2, 1}, {1, 1}, {0, 0}}}}});
+  check_upper(
+      reflected, {{0, 2, 1}},
+      {{1, {{{0, 0}, {2, 3}, {1, 1}}}}, {1, {{{0, 0}, {2, 2}, {1, 1}}}}});
+  check_lower(
+      reflected, {{0, 2, 1}},
+      {{1, {{{0, 0}, {2, 3}, {1, 1}}}}, {1, {{{0, 0}, {2, 2}, {1, 1}}}}});
+
+  check_upper(
+      aligned, {{2, 2, 1}},
+      {{1, {{{2, 0}, {2, 0}, {1, 1}}}}, {1, {{{2, 0}, {2, 1}, {1, 1}}}}});
+  check_lower(
+      aligned, {{2, 2, 1}},
+      {{1, {{{2, 3}, {2, 0}, {1, 1}}}}, {1, {{{2, 3}, {2, 1}, {1, 1}}}}});
+  check_upper(
+      rotated, {{2, 1, 2}},
+      {{1, {{{2, 0}, {1, 1}, {2, 0}}}}, {1, {{{2, 1}, {1, 1}, {2, 0}}}}});
+  check_lower(
+      rotated, {{2, 1, 2}},
+      {{1, {{{2, 0}, {1, 1}, {2, 3}}}}, {1, {{{2, 1}, {1, 1}, {2, 3}}}}});
+  check_upper(
+      reflected, {{2, 2, 1}},
+      {{1, {{{2, 3}, {2, 3}, {1, 1}}}}, {1, {{{2, 3}, {2, 2}, {1, 1}}}}});
+  check_lower(
+      reflected, {{2, 2, 1}},
+      {{1, {{{2, 0}, {2, 3}, {1, 1}}}}, {1, {{{2, 0}, {2, 2}, {1, 1}}}}});
+
+  // Larger in one dimension and smaller in another dimension
+  check_upper(
+      aligned, {{1, 2, 0}},
+      {{1, {{{1, 0}, {2, 0}, {0, 0}}}}, {1, {{{1, 0}, {2, 1}, {0, 0}}}}});
+  check_lower(
+      aligned, {{1, 2, 0}},
+      {{1, {{{1, 1}, {2, 0}, {0, 0}}}}, {1, {{{1, 1}, {2, 1}, {0, 0}}}}});
+  check_upper(
+      rotated, {{2, 0, 1}},
+      {{1, {{{2, 0}, {0, 0}, {1, 0}}}}, {1, {{{2, 1}, {0, 0}, {1, 0}}}}});
+  check_lower(
+      rotated, {{2, 0, 1}},
+      {{1, {{{2, 0}, {0, 0}, {1, 1}}}}, {1, {{{2, 1}, {0, 0}, {1, 1}}}}});
+  check_upper(
+      reflected, {{1, 2, 0}},
+      {{1, {{{1, 1}, {2, 3}, {0, 0}}}}, {1, {{{1, 1}, {2, 2}, {0, 0}}}}});
+  check_lower(
+      reflected, {{1, 2, 0}},
+      {{1, {{{1, 0}, {2, 3}, {0, 0}}}}, {1, {{{1, 0}, {2, 2}, {0, 0}}}}});
+
+  check_upper(
+      aligned, {{0, 2, 0}},
+      {{1, {{{0, 0}, {2, 0}, {0, 0}}}}, {1, {{{0, 0}, {2, 1}, {0, 0}}}}});
+  check_lower(
+      aligned, {{0, 2, 0}},
+      {{1, {{{0, 0}, {2, 0}, {0, 0}}}}, {1, {{{0, 0}, {2, 1}, {0, 0}}}}});
+  check_upper(
+      rotated, {{2, 0, 0}},
+      {{1, {{{2, 0}, {0, 0}, {0, 0}}}}, {1, {{{2, 1}, {0, 0}, {0, 0}}}}});
+  check_lower(
+      rotated, {{2, 0, 0}},
+      {{1, {{{2, 0}, {0, 0}, {0, 0}}}}, {1, {{{2, 1}, {0, 0}, {0, 0}}}}});
+  check_upper(
+      reflected, {{0, 2, 0}},
+      {{1, {{{0, 0}, {2, 3}, {0, 0}}}}, {1, {{{0, 0}, {2, 2}, {0, 0}}}}});
+  check_lower(
+      reflected, {{0, 2, 0}},
+      {{1, {{{0, 0}, {2, 3}, {0, 0}}}}, {1, {{{0, 0}, {2, 2}, {0, 0}}}}});
+
+  check_upper(
+      aligned, {{2, 2, 0}},
+      {{1, {{{2, 0}, {2, 0}, {0, 0}}}}, {1, {{{2, 0}, {2, 1}, {0, 0}}}}});
+  check_lower(
+      aligned, {{2, 2, 0}},
+      {{1, {{{2, 3}, {2, 0}, {0, 0}}}}, {1, {{{2, 3}, {2, 1}, {0, 0}}}}});
+  check_upper(
+      rotated, {{2, 0, 2}},
+      {{1, {{{2, 0}, {0, 0}, {2, 0}}}}, {1, {{{2, 1}, {0, 0}, {2, 0}}}}});
+  check_lower(
+      rotated, {{2, 0, 2}},
+      {{1, {{{2, 0}, {0, 0}, {2, 3}}}}, {1, {{{2, 1}, {0, 0}, {2, 3}}}}});
+  check_upper(
+      reflected, {{2, 2, 0}},
+      {{1, {{{2, 3}, {2, 3}, {0, 0}}}}, {1, {{{2, 3}, {2, 2}, {0, 0}}}}});
+  check_lower(
+      reflected, {{2, 2, 0}},
+      {{1, {{{2, 0}, {2, 3}, {0, 0}}}}, {1, {{{2, 0}, {2, 2}, {0, 0}}}}});
 }
 }  // namespace
 
@@ -39,19 +381,18 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
       make_array(Direction<2>::upper_xi(), Direction<2>::upper_eta()));
   OrientationMap<2> unaligned(
       make_array(Direction<2>::lower_eta(), Direction<2>::upper_xi()));
-  OrientationMap<2> inverse_of_unaligned(
-      {{Direction<2>::lower_eta(), Direction<2>::upper_xi()}},
-      {{Direction<2>::upper_xi(), Direction<2>::upper_eta()}});
   Block<2> test_block(
       domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           domain::CoordinateMaps::Identity<2>{}),
       0,
       {{Direction<2>::upper_xi(), BlockNeighbor<2>{1, aligned}},
        {Direction<2>::upper_eta(), BlockNeighbor<2>{2, unaligned}}});
+  std::vector<std::array<size_t, 2>> refinement{{{2, 3}}, {{2, 3}}, {{3, 2}}};
 
   // interior element
   test_create_initial_element(
       ElementId<2>{0, {{SegmentId{2, 2}, SegmentId{3, 4}}}}, test_block,
+      refinement,
       {{Direction<2>::upper_xi(),
         Neighbors<2>{{ElementId<2>{0, {{SegmentId{2, 3}, SegmentId{3, 4}}}}},
                      aligned}},
@@ -68,6 +409,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
   // element on external boundary
   test_create_initial_element(
       ElementId<2>{0, {{SegmentId{2, 0}, SegmentId{3, 0}}}}, test_block,
+      refinement,
       {{Direction<2>::upper_xi(),
         Neighbors<2>{{ElementId<2>{0, {{SegmentId{2, 1}, SegmentId{3, 0}}}}},
                      aligned}},
@@ -78,6 +420,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
   // element bounding aligned neighbor block
   test_create_initial_element(
       ElementId<2>{0, {{SegmentId{2, 3}, SegmentId{3, 4}}}}, test_block,
+      refinement,
       {{Direction<2>::upper_xi(),
         Neighbors<2>{{ElementId<2>{1, {{SegmentId{2, 0}, SegmentId{3, 4}}}}},
                      aligned}},
@@ -94,6 +437,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
   // element bounding unaligned neighbor block
   test_create_initial_element(
       ElementId<2>{0, {{SegmentId{2, 2}, SegmentId{3, 7}}}}, test_block,
+      refinement,
       {{Direction<2>::upper_xi(),
         Neighbors<2>{{ElementId<2>{0, {{SegmentId{2, 3}, SegmentId{3, 7}}}}},
                      aligned}},
@@ -110,6 +454,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
   // element bounding both neighbor blocks
   test_create_initial_element(
       ElementId<2>{0, {{SegmentId{2, 3}, SegmentId{3, 7}}}}, test_block,
+      refinement,
       {{Direction<2>::upper_xi(),
         Neighbors<2>{{ElementId<2>{1, {{SegmentId{2, 0}, SegmentId{3, 7}}}}},
                      aligned}},
@@ -122,4 +467,6 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
        {Direction<2>::lower_eta(),
         Neighbors<2>{{ElementId<2>{0, {{SegmentId{2, 3}, SegmentId{3, 6}}}}},
                      aligned}}});
+
+  test_h_refinement();
 }

--- a/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
@@ -114,7 +114,8 @@ struct ElementArray {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
-                         tmpl::list<domain::Tags::InitialExtents<Dim>>>,
+                         tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
+                                    domain::Tags::InitialExtents<Dim>>>,
                      dg::Actions::InitializeDomain<Dim>>>,
 
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -184,7 +185,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
     ActionTesting::MockRuntimeSystem<metavariables> runner{
         {AnalyticSolution<1>{}, Fluxes<1>{}, domain_creator.create_domain()}};
     ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id, {domain_creator.initial_extents()});
+        &runner, element_id, {domain_creator.initial_refinement_levels(),
+                              domain_creator.initial_extents()});
     ActionTesting::next_action<element_array>(make_not_null(&runner),
                                               element_id);
     ActionTesting::set_phase(make_not_null(&runner),
@@ -235,7 +237,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
     ActionTesting::MockRuntimeSystem<metavariables> runner{
         {AnalyticSolution<2>{}, Fluxes<2>{}, domain_creator.create_domain()}};
     ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id, {domain_creator.initial_extents()});
+        &runner, element_id, {domain_creator.initial_refinement_levels(),
+                              domain_creator.initial_extents()});
     ActionTesting::next_action<element_array>(make_not_null(&runner),
                                               element_id);
     ActionTesting::set_phase(make_not_null(&runner),
@@ -290,7 +293,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
     ActionTesting::MockRuntimeSystem<metavariables> runner{
         {AnalyticSolution<3>{}, Fluxes<3>{}, domain_creator.create_domain()}};
     ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id, {domain_creator.initial_extents()});
+        &runner, element_id, {domain_creator.initial_refinement_levels(),
+                              domain_creator.initial_extents()});
     ActionTesting::next_action<element_array>(make_not_null(&runner),
                                               element_id);
     ActionTesting::set_phase(make_not_null(&runner),

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
@@ -111,7 +111,9 @@ struct ElementArray {
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<
               ActionTesting::InitializeDataBox<tmpl::list<
-                  domain::Tags::Domain<Dim>, domain::Tags::InitialExtents<Dim>,
+                  domain::Tags::Domain<Dim>,
+                  domain::Tags::InitialRefinementLevels<Dim>,
+                  domain::Tags::InitialExtents<Dim>,
                   db::add_tag_prefix<
                       ::Tags::FixedSource,
                       typename Metavariables::system::fields_tag>>>,
@@ -158,8 +160,9 @@ void test_impose_inhomogeneous_boundary_conditions_on_source(
       {Fluxes<Dim>{}, AnalyticSolution<Dim>{}, NumericalFlux<Dim>{}}};
   ActionTesting::emplace_component_and_initialize<element_array>(
       &runner, element_id,
-      {domain_creator.create_domain(), domain_creator.initial_extents(),
-       std::move(source_vars)});
+      {domain_creator.create_domain(),
+       domain_creator.initial_refinement_levels(),
+       domain_creator.initial_extents(), std::move(source_vars)});
   ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
   ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
   ActionTesting::set_phase(make_not_null(&runner),

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
@@ -91,7 +91,8 @@ struct ElementArray {
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<
               ActionTesting::InitializeDataBox<
-                  tmpl::list<domain::Tags::InitialExtents<Dim>, vars_tag<Dim>>>,
+                  tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
+                  domain::Tags::InitialExtents<Dim>, vars_tag<Dim>>>,
               dg::Actions::InitializeDomain<Dim>,
               Initialization::Actions::AddComputeTags<
                   tmpl::list<elliptic::Tags::FirstOrderFluxesCompute<
@@ -162,7 +163,8 @@ void test_initialize_fluxes(const DomainCreator<Dim>& domain_creator,
   ActionTesting::MockRuntimeSystem<metavariables> runner{
       {Fluxes<Dim>{}, domain_creator.create_domain()}};
   ActionTesting::emplace_component_and_initialize<element_array>(
-      &runner, element_id, {std::move(initial_extents), std::move(vars)});
+      &runner, element_id, {domain_creator.initial_refinement_levels(),
+                            std::move(initial_extents), std::move(vars)});
   ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
   ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
   ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);

--- a/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
@@ -155,6 +155,7 @@ struct Component {
 
   using simple_tags =
       db::AddSimpleTags<domain::Tags::InitialExtents<dim>,
+                        domain::Tags::InitialRefinementLevels<dim>,
                         domain::Tags::InitialFunctionsOfTime<dim>, Tags::Time>;
 
   using phase_dependent_action_list = tmpl::list<
@@ -188,6 +189,8 @@ void test() noexcept {
 
   const std::vector<std::array<size_t, Dim>> initial_extents{
       make_array<Dim>(4_st)};
+  const std::vector<std::array<size_t, Dim>> initial_refinement{
+      make_array<Dim>(0_st)};
   const size_t num_pts = pow<Dim>(4_st);
   const std::array<double, 3> velocity{{1.2, 0.2, -8.9}};
   const double initial_time = 0.0;
@@ -222,8 +225,8 @@ void test() noexcept {
   ActionTesting::MockRuntimeSystem<metavars> runner{{std::move(domain)}};
   ActionTesting::emplace_component_and_initialize<component>(
       &runner, self_id,
-      {initial_extents, std::move(clone_unique_ptrs(functions_of_time)),
-       initial_time});
+      {initial_extents, initial_refinement,
+       std::move(clone_unique_ptrs(functions_of_time)), initial_time});
   runner.set_phase(metavars::Phase::Testing);
   CHECK(ActionTesting::get_next_action_index<component>(runner, self_id) == 0);
   ActionTesting::next_action<component>(make_not_null(&runner), self_id);

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
@@ -416,7 +416,8 @@ void test_initial_domain(const Domain<VolumeDim>& domain,
   for (const auto& element_id : element_ids) {
     elements.emplace(element_id,
                      domain::Initialization::create_initial_element(
-                         element_id, blocks[element_id.block_id()]));
+                         element_id, blocks[element_id.block_id()],
+                         initial_refinement_levels));
   }
   domain::test_domain_connectivity(domain, elements);
   domain::test_refinement_levels_of_neighbors<0>(elements);

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
@@ -42,7 +42,8 @@ struct ElementArray {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
-              tmpl::list<domain::Tags::InitialExtents<Dim>>>>>,
+              tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
+                         domain::Tags::InitialExtents<Dim>>>>>,
 
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
@@ -101,7 +102,8 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     ActionTesting::MockRuntimeSystem<metavariables> runner{
         {domain_creator.create_domain()}};
     ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id, {domain_creator.initial_extents()});
+        &runner, element_id, {domain_creator.initial_refinement_levels(),
+                              domain_creator.initial_extents()});
     ActionTesting::set_phase(make_not_null(&runner),
                              metavariables::Phase::Testing);
     ActionTesting::next_action<element_array>(make_not_null(&runner),
@@ -166,7 +168,8 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     ActionTesting::MockRuntimeSystem<metavariables> runner{
         {domain_creator.create_domain()}};
     ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id, {domain_creator.initial_extents()});
+        &runner, element_id, {domain_creator.initial_refinement_levels(),
+                              domain_creator.initial_extents()});
     ActionTesting::set_phase(make_not_null(&runner),
                              metavariables::Phase::Testing);
     ActionTesting::next_action<element_array>(make_not_null(&runner),
@@ -234,7 +237,8 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     ActionTesting::MockRuntimeSystem<metavariables> runner{
         {domain_creator.create_domain()}};
     ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id, {domain_creator.initial_extents()});
+        &runner, element_id, {domain_creator.initial_refinement_levels(),
+                              domain_creator.initial_extents()});
     ActionTesting::set_phase(make_not_null(&runner),
                              metavariables::Phase::Testing);
     ActionTesting::next_action<element_array>(make_not_null(&runner),

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
@@ -88,7 +88,8 @@ struct ElementArray {
                       evolution::dg::Initialization::Domain<Dim>>,
                   tmpl::list<dg::Actions::InitializeDomain<Dim>>>,
               ActionTesting::InitializeDataBox<tmpl::append<
-                  tmpl::list<domain::Tags::InitialExtents<Dim>, vars_tag,
+                  tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
+                             domain::Tags::InitialExtents<Dim>, vars_tag,
                              other_vars_tag>,
                   tmpl::conditional_t<
                       use_moving_mesh,
@@ -189,7 +190,8 @@ void create_runner_and_run_tests(
   ActionTesting::emplace_component_and_initialize<
       typename Metavariables::element_array>(
       &runner, element_id,
-      {domain_creator.initial_extents(), vars, other_vars, 0.0, 0.1, 0.1,
+      {domain_creator.initial_refinement_levels(),
+       domain_creator.initial_extents(), vars, other_vars, 0.0, 0.1, 0.1,
        domain_creator.functions_of_time()});
 
   ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
@@ -217,7 +219,8 @@ void create_runner_and_run_tests(
   ActionTesting::emplace_component_and_initialize<
       typename Metavariables::element_array>(
       &runner, element_id,
-      {domain_creator.initial_extents(), vars, other_vars});
+      {domain_creator.initial_refinement_levels(),
+       domain_creator.initial_extents(), vars, other_vars});
 
   ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
   ActionTesting::set_phase(make_not_null(&runner),

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
@@ -59,6 +59,7 @@ struct ElementArray {
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<
               ActionTesting::InitializeDataBox<tmpl::list<
+                  domain::Tags::InitialRefinementLevels<Dim>,
                   domain::Tags::InitialExtents<Dim>, ::Tags::Next<TemporalId>>>,
               dg::Actions::InitializeDomain<Dim>,
               Initialization::Actions::AddComputeTags<
@@ -132,7 +133,8 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeMortars", "[Unit][Actions]") {
     ActionTesting::MockRuntimeSystem<metavariables> runner{
         {domain_creator.create_domain()}};
     ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id, {domain_creator.initial_extents(), 0});
+        &runner, element_id, {domain_creator.initial_refinement_levels(),
+                              domain_creator.initial_extents(), 0});
     ActionTesting::next_action<element_array>(make_not_null(&runner),
                                               element_id);
     ActionTesting::next_action<element_array>(make_not_null(&runner),
@@ -192,7 +194,8 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeMortars", "[Unit][Actions]") {
     ActionTesting::MockRuntimeSystem<metavariables> runner{
         {domain_creator.create_domain()}};
     ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id, {domain_creator.initial_extents(), 0});
+        &runner, element_id, {domain_creator.initial_refinement_levels(),
+                              domain_creator.initial_extents(), 0});
     ActionTesting::next_action<element_array>(make_not_null(&runner),
                                               element_id);
     ActionTesting::next_action<element_array>(make_not_null(&runner),
@@ -273,7 +276,8 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeMortars", "[Unit][Actions]") {
     ActionTesting::MockRuntimeSystem<metavariables> runner{
         {domain_creator.create_domain()}};
     ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id, {domain_creator.initial_extents(), 0});
+        &runner, element_id, {domain_creator.initial_refinement_levels(),
+                              domain_creator.initial_extents(), 0});
     ActionTesting::next_action<element_array>(make_not_null(&runner),
                                               element_id);
     ActionTesting::next_action<element_array>(make_not_null(&runner),


### PR DESCRIPTION
There is one naming awkwardness with AlignedLattice.  Based on previous option names, we have the new option
| | |
| --- | --- |
| InitialGridPoints | RefinedGridPoints |
| InitialRefinement | **RefinedRefinement** |

This reads oddly to me, but I couldn't come up with anything better.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
