### PR TITLE
Cce gh boundary component

### DIFF
--- a/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
@@ -11,6 +11,8 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/GhLockstepInterfaceManager.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/WorldtubeInterfaceManager.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
@@ -25,6 +27,7 @@
 #include "Utilities/TaggedTuple.hpp"
 
 namespace Cce {
+namespace Actions {
 /*!
  * \ingroup ActionsGroup
  * \brief Initializes a H5WorldtubeBoundary
@@ -106,4 +109,81 @@ struct InitializeH5WorldtubeBoundary {
     return std::make_tuple(std::move(box));
   }
 };
+
+/*!
+ * \ingroup ActionsGroup
+ * \brief Initializes a GhWorldtubeBoundary
+ *
+ * \details Uses:
+ * - initialization tag
+ * `Cce::InitializationTags::GhWorldtubeBoundaryDataManager`,
+ * - const global cache tags `InitializationTags::LMax`,
+ * `InitializationTags::ExtractionRadius`.
+ *
+ * Databox changes:
+ * - Adds:
+ *   - `Tags::Variables<typename
+ * Metavariables::cce_boundary_communication_tags>`
+ *   - `Tags::GhInterfaceManager` (cloned from
+ * `InitializationTags::GhInterfaceManager`)
+ * - Removes: nothing
+ * - Modifies: nothing
+ */
+struct InitializeGhWorldtubeBoundary {
+  using initialization_tags = tmpl::list<Tags::GhInterfaceManager>;
+
+  using initialization_tags_to_keep = tmpl::list<Tags::GhInterfaceManager>;
+
+  using const_global_cache_tags =
+      tmpl::list<Tags::LMax, InitializationTags::ExtractionRadius>;
+
+  template <class Metavariables>
+  using gh_boundary_manager_simple_tags = db::AddSimpleTags<
+      ::Tags::Variables<
+          typename Metavariables::cce_boundary_communication_tags>,
+      Tags::GhInterfaceManager>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::list_contains_v<DbTags, Tags::GhInterfaceManager>> =
+                nullptr>
+  static auto apply(db::DataBox<DbTags>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    const size_t l_max = db::get<Tags::LMax>(box);
+    Variables<typename Metavariables::cce_boundary_communication_tags>
+        boundary_variables{
+            Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+
+    auto initial_box = Initialization::merge_into_databox<
+        InitializeGhWorldtubeBoundary,
+        gh_boundary_manager_simple_tags<Metavariables>, db::AddComputeTags<>,
+        Initialization::MergePolicy::Overwrite>(
+        std::move(box), std::move(boundary_variables),
+        db::get<Tags::GhInterfaceManager>(box).get_clone());
+
+    return std::make_tuple(std::move(initial_box));
+  }
+
+  template <
+      typename DbTags, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      Requires<not tmpl::list_contains_v<DbTags, Tags::GhInterfaceManager>> =
+          nullptr>
+  static auto apply(db::DataBox<DbTags>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    ERROR(
+        "Required tag `Tags::GhInterfaceManager` is missing from the DataBox");
+    return std::make_tuple(std::move(box));
+  }
+};
+}  // namespace Actions
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Equations.cpp
   GaugeTransformBoundaryData.cpp
   InitializeCce.cpp
+  InterfaceManagers/GhLockstepInterfaceManager.cpp
   LinearOperators.cpp
   LinearSolve.cpp
   PrecomputeCceDependencies.cpp

--- a/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
@@ -40,7 +40,7 @@ struct H5WorldtubeBoundary {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
   using initialize_action_list =
-      tmpl::list<InitializeH5WorldtubeBoundary,
+      tmpl::list<Actions::InitializeH5WorldtubeBoundary,
                  Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;
@@ -75,4 +75,71 @@ struct H5WorldtubeBoundary {
     }
   }
 };
+
+/*!
+ * \brief Component that supplies CCE worldtube boundary data sourced from a
+ * running GH system.
+ *
+ * \details The \ref DataBoxGroup associated with the worldtube boundary
+ * component contains an interface manager (derived from
+ * `Cce::GhWorldtubeInterfaceManager`) that stores and provides the data
+ * received from the GH system. The data manager handles buffering
+ * and interpolating to desired target time points when requested via the simple
+ * action `Cce::Actions::BoundaryComputeAndSendToEvolution`, at which point it
+ * will send the required collection of boundary quantities to the identified
+ * `CharacteristicEvolution` component. It is assumed that the simple action
+ * `Cce::Actions::BoundaryComputeAndSendToEvolution` will only be called during
+ * the `Evolve` phase.
+ *
+ * Uses const global tags:
+ * - `InitializationTags::LMax`
+ * - `InitializationTags::ExtractionRadius`
+ *
+ * `Metavariables` must contain:
+ * - the `enum` `Phase` with at least `Initialization` and `Evolve` phases.
+ * - a type alias `cce_boundary_communication_tags` for the set of tags to send
+ * from the worldtube to the evolution component. This will typically be
+ * `Cce::Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>`.
+ */
+template <class Metavariables>
+struct GhWorldtubeBoundary {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using metavariables = Metavariables;
+  using initialize_action_list =
+      tmpl::list<Actions::InitializeGhWorldtubeBoundary,
+                 Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+  using initialization_tags =
+      Parallel::get_initialization_tags<initialize_action_list>;
+
+  using worldtube_boundary_computation_steps = tmpl::list<>;
+
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        initialize_action_list>,
+                 Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Evolve,
+                                        worldtube_boundary_computation_steps>>;
+
+  using const_global_cache_tag_list =
+      Parallel::detail::get_const_global_cache_tags_from_pdal<
+          phase_dependent_action_list>;
+
+  using options = tmpl::list<>;
+
+  static void initialize(Parallel::CProxy_ConstGlobalCache<
+                         Metavariables>& /*global_cache*/) noexcept {}
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      const Parallel::CProxy_ConstGlobalCache<Metavariables>&
+          global_cache) noexcept {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    if (next_phase == Metavariables::Phase::Evolve) {
+      Parallel::get_parallel_component<H5WorldtubeBoundary>(local_cache)
+          .start_phase(next_phase);
+    }
+  }
+};
+
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstepInterfaceManager.cpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstepInterfaceManager.cpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/InterfaceManagers/GhLockstepInterfaceManager.hpp"
+
+#include <deque>
+#include <memory>
+#include <tuple>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Time/TimeStepId.hpp"
+
+namespace Cce {
+
+std::unique_ptr<GhWorldtubeInterfaceManager>
+GhLockstepInterfaceManager::get_clone() const noexcept {
+  return std::make_unique<GhLockstepInterfaceManager>(*this);
+}
+
+void GhLockstepInterfaceManager::insert_gh_data(
+    TimeStepId time_id, tnsr::aa<DataVector, 3> spacetime_metric,
+    tnsr::iaa<DataVector, 3> phi, tnsr::aa<DataVector, 3> pi,
+    const tnsr::aa<DataVector, 3> /*dt_spacetime_metric*/,
+    const tnsr::iaa<DataVector, 3> /*dt_phi*/,
+    const tnsr::aa<DataVector, 3> /*dt_pi*/) noexcept {
+  provided_data_.emplace_back(std::move(time_id), std::move(spacetime_metric),
+                              std::move(phi), std::move(pi));
+}
+
+boost::optional<std::tuple<TimeStepId, tnsr::aa<DataVector, 3>,
+                           tnsr::iaa<DataVector, 3>, tnsr::aa<DataVector, 3>>>
+GhLockstepInterfaceManager::retrieve_and_remove_first_ready_gh_data() noexcept {
+  if (provided_data_.empty()) {
+    return boost::none;
+  }
+  const auto return_data = std::move(provided_data_.front());
+  provided_data_.pop_front();
+  return return_data;
+}
+
+void GhLockstepInterfaceManager::pup(PUP::er& p) noexcept {
+  p | provided_data_;
+}
+
+/// \cond
+PUP::able::PUP_ID Cce::GhLockstepInterfaceManager::my_PUP_ID = 0;
+/// \endcond
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstepInterfaceManager.hpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstepInterfaceManager.hpp
@@ -1,0 +1,96 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/optional.hpp>
+#include <deque>
+#include <memory>
+#include <tuple>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/WorldtubeInterfaceManager.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Time/TimeStepId.hpp"
+
+namespace Cce {
+
+/*!
+ * \brief Simple implementation of a `GhWorldtubeInterfaceManager` that only
+ * provides boundary data on matching `TimeStepId`s
+ *
+ * \details This version of the interface manager assumes that the CCE system
+ * and the generalized harmonic system that it communicates with evolve with an
+ * identical time stepper and on identical time step intervals (they evolve in
+ * 'lock step'). As a result, and to streamline communications, new data is
+ * always immediately 'ready' and requests are ignored to produce the behavior
+ * of just immediately gauge-transforming and sending the data to the CCE
+ * component as soon as it becomes available from the GH system.
+ *
+ * \warning Using this interface manager when the GH components and the CCE
+ * evolution are not identically stepped is considered undefined behavior. The
+ * outcome will likely be that CCE will fail to evolve and the boundary data
+ * will be continually inserted into a rapidly expanding inbox.
+ */
+class GhLockstepInterfaceManager : public GhWorldtubeInterfaceManager {
+ public:
+
+  static constexpr OptionString help{
+    "Pass data between GH and CCE systems on matching timesteps only."};
+
+  using options = tmpl::list<>;
+
+  GhLockstepInterfaceManager() = default;
+
+  explicit GhLockstepInterfaceManager(CkMigrateMessage* /*unused*/) noexcept {}
+
+  WRAPPED_PUPable_decl_template(GhLockstepInterfaceManager);  // NOLINT
+
+  std::unique_ptr<GhWorldtubeInterfaceManager> get_clone() const
+      noexcept override;
+
+  /// \brief Store a provided data set in a `std::deque`.
+  ///
+  /// \details The lock-step constraint ensures that only the generalized
+  /// harmonic variables `spacetime_metric`, `phi`, and `pi` are used. The
+  /// remaining variables are accepted to comply with the more general abstract
+  /// interface.
+  void insert_gh_data(TimeStepId time_id,
+                      tnsr::aa<DataVector, 3> spacetime_metric,
+                      tnsr::iaa<DataVector, 3> phi, tnsr::aa<DataVector, 3> pi,
+                      tnsr::aa<DataVector, 3> dt_spacetime_metric = {},
+                      tnsr::iaa<DataVector, 3> dt_phi = {},
+                      tnsr::aa<DataVector, 3> dt_pi = {}) noexcept override;
+
+  /// \brief Requests are ignored by this implementation, so this is a no-op.
+  void request_gh_data(const TimeStepId& /*time_id*/) noexcept override {}
+
+  /// \brief Return a `boost::optional<std::tuple>` of the least recently
+  /// submitted generalized harmonic boundary data if any exists and removes it
+  /// from the internal `std::deque`, otherwise returns `boost::none`.
+  auto retrieve_and_remove_first_ready_gh_data() noexcept -> boost::optional<
+      std::tuple<TimeStepId, tnsr::aa<DataVector, 3>, tnsr::iaa<DataVector, 3>,
+                 tnsr::aa<DataVector, 3>>> override;
+
+  /// \brief This class ignores requests to ensure a one-way communication
+  /// pattern, so the number of requests is always 0.
+  size_t number_of_pending_requests() const noexcept override { return 0; }
+
+  /// \brief The number of times at which data from a GH evolution have been
+  /// stored and not yet retrieved
+  size_t number_of_gh_times() const noexcept override {
+    return provided_data_.size();
+  }
+
+  /// Serialization for Charm++.
+  void pup(PUP::er& p) noexcept override;
+
+ private:
+  std::deque<std::tuple<TimeStepId, tnsr::aa<DataVector, 3>,
+                        tnsr::iaa<DataVector, 3>, tnsr::aa<DataVector, 3>>>
+      provided_data_;
+};
+
+}

--- a/src/Evolution/Systems/Cce/InterfaceManagers/WorldtubeInterfaceManager.hpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/WorldtubeInterfaceManager.hpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/optional.hpp>
+#include <memory>
+#include <tuple>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Time/TimeStepId.hpp"
+
+namespace Cce {
+/// \cond
+class GhLockstepInterfaceManager;
+/// \endcond
+
+/*!
+ * \brief Abstract base class for storage and retrieval of generalized harmonic
+ * quantities communicated from a Cauchy simulation to the Cce system.
+ *
+ * \details The functions that are required to be overriden in the derived
+ * classes are:
+ * - `GhWorldtubeInterfaceManager::get_clone()`: should return a
+ * `std::unique_ptr<GhWorldtubeInterfaceManager>` with cloned state.
+ * - `GhWorldtubeInterfaceManager::insert_gh_data()`: should store the portions
+ * of the provided generalized harmonic data that are required to provide useful
+ * boundary values for the CCE evolution at requested timesteps.
+ * - `GhWorldtubeInterfaceManager::request_gh_data()`: should register requests
+ * from the CCE evolution for boundary data.
+ * - `GhWorldtubeInterfaceManager::retrieve_and_remove_first_ready_gh_data()`:
+ * should return a `boost::optional<std::tuple<TimeStepId, tnsr::aa<DataVector,
+ * 3>, tnsr::iaa<DataVector, 3>, tnsr::aa<DataVector, 3>>>` containing the
+ * boundary data associated with the oldest requested timestep if enough data
+ * has been supplied via `insert_gh_data()` to determine the boundary data.
+ * Otherwise, return a `boost::none` to indicate that the CCE system must
+ * continue waiting for generalized harmonic input.
+ * - `GhWorldtubeInterfaceManager::number_of_pending_requests()`: should return
+ * the number of requests that have been registered to the class that do not yet
+ * been retrieved via `retrieve_and_remove_first_ready_gh_data()`.
+ * - `GhWorldtubeInterfaceManager::number_of_gh_times()`: should return the
+ * number of time steps sent to `insert_gh_data()` that have not yet been
+ * retrieved via `retrieve_and_remove_first_ready_gh_data()`.
+ */
+class GhWorldtubeInterfaceManager : public PUP::able {
+ public:
+  using creatable_classes = tmpl::list<GhLockstepInterfaceManager>;
+
+  WRAPPED_PUPable_abstract(GhWorldtubeInterfaceManager);  // NOLINT
+
+  virtual std::unique_ptr<GhWorldtubeInterfaceManager> get_clone() const
+      noexcept = 0;
+
+  virtual void insert_gh_data(TimeStepId time_id,
+                              tnsr::aa<DataVector, 3> spacetime_metric,
+                              tnsr::iaa<DataVector, 3> phi,
+                              tnsr::aa<DataVector, 3> pi,
+                              tnsr::aa<DataVector, 3> dt_spacetime_metric,
+                              tnsr::iaa<DataVector, 3> dt_phi,
+                              tnsr::aa<DataVector, 3> dt_pi) noexcept = 0;
+
+  virtual void request_gh_data(const TimeStepId&) noexcept = 0;
+
+  virtual auto retrieve_and_remove_first_ready_gh_data() noexcept
+      -> boost::optional<
+          std::tuple<TimeStepId, tnsr::aa<DataVector, 3>,
+                     tnsr::iaa<DataVector, 3>, tnsr::aa<DataVector, 3>>> = 0;
+
+  virtual size_t number_of_pending_requests() const noexcept = 0;
+
+  virtual size_t number_of_gh_times() const noexcept = 0;
+};
+
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -7,6 +7,8 @@
 #include <limits>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/GhLockstepInterfaceManager.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/WorldtubeInterfaceManager.hpp"
 #include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
 #include "NumericalAlgorithms/Interpolation/SpanInterpolator.hpp"
 #include "Options/Options.hpp"
@@ -65,6 +67,12 @@ struct NumberOfRadialPoints {
   using group = Cce;
 };
 
+struct ExtractionRadius {
+  using type = double;
+  static constexpr OptionString help{"Extraction radius from the GH system."};
+  using group = Cce;
+};
+
 struct EndTime {
   using type = double;
   static constexpr OptionString help{"End time for the Cce Evolution."};
@@ -109,6 +117,13 @@ struct H5Interpolator {
   using type = std::unique_ptr<intrp::SpanInterpolator>;
   static constexpr OptionString help{
       "The interpolator for imported h5 worldtube data."};
+  using group = Cce;
+};
+
+struct GhInterfaceManager {
+  using type = std::unique_ptr<GhWorldtubeInterfaceManager>;
+  static constexpr OptionString help{
+      "Class to manage worldtube data from a GH system."};
   using group = Cce;
 };
 
@@ -167,6 +182,16 @@ struct TargetStepSize : db::SimpleTag {
   static constexpr bool pass_metavariables = false;
   static double create_from_options(const double target_step_size) noexcept {
     return target_step_size;
+  }
+};
+
+struct ExtractionRadius : db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<OptionTags::ExtractionRadius>;
+
+  template <typename Metavariables>
+  static double create_from_options(const double extraction_radius) noexcept {
+    return extraction_radius;
   }
 };
 
@@ -283,6 +308,18 @@ struct EndTime : db::SimpleTag {
       end_time = time_buffer[time_buffer.size() - 1];
     }
     return end_time;
+  }
+};
+
+struct GhInterfaceManager : db::SimpleTag {
+  using type = std::unique_ptr<GhWorldtubeInterfaceManager>;
+  using option_tags = tmpl::list<OptionTags::GhInterfaceManager>;
+
+  template <typename Metavariables>
+  static std::unique_ptr<::Cce::GhWorldtubeInterfaceManager>
+  create_from_options(const std::unique_ptr<::Cce::GhWorldtubeInterfaceManager>&
+                          interface_manager) noexcept {
+    return interface_manager->get_clone();
   }
 };
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -4,12 +4,12 @@
 set(LIBRARY "Test_Cce_Actions")
 
 set(LIBRARY_SOURCES
-  Test_BoundaryCommunication.cpp
   Test_CalculateScriInputs.cpp
   Test_CharacteristicEvolutionBondiCalculations.cpp
   Test_InitializeFirstHypersurface.cpp
   Test_InsertInterpolationScriData.cpp
   Test_FilterSwshVolumeQuantity.cpp
+  Test_H5BoundaryCommunication.cpp
   Test_InitializeCharacteristicEvolution.cpp
   Test_InitializeWorldtubeBoundary.cpp
   Test_RequestBoundaryData.cpp

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -49,7 +49,8 @@ struct mock_h5_worldtube_boundary {
   using replace_these_simple_actions = tmpl::list<>;
   using with_these_simple_actions = tmpl::list<>;
 
-  using initialize_action_list = tmpl::list<InitializeH5WorldtubeBoundary>;
+  using initialize_action_list =
+      tmpl::list<Actions::InitializeH5WorldtubeBoundary>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -29,50 +29,53 @@
 namespace Cce {
 
 namespace {
-struct metavariables {
+struct H5Metavariables {
   using cce_boundary_communication_tags =
       Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>;
-  using const_global_cache_tag_list = tmpl::list<Tags::LMax>;
-  using component_list = tmpl::list<mock_h5_worldtube_boundary<metavariables>>;
+  using component_list =
+      tmpl::list<mock_h5_worldtube_boundary<H5Metavariables>>;
   enum class Phase { Initialization, Evolve, Exit };
 };
-}  // namespace
 
-SPECTRE_TEST_CASE(
-    "Unit.Evolution.Systems.Cce.Actions.InitializeWorldtubeBoundary",
-    "[Unit][Cce]") {
-  using component = mock_h5_worldtube_boundary<metavariables>;
-  // this probably needs to be adjusted for the const global tags and option
-  // tags we need.
+struct GhMetavariables {
+  using cce_boundary_communication_tags =
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>;
+  using component_list =
+      tmpl::list<mock_gh_worldtube_boundary<GhMetavariables>>;
+  enum class Phase { Initialization, Evolve, Exit };
+};
+
+template <typename Generator>
+void test_h5_initialization(const gsl::not_null<Generator*> gen) noexcept {
+  using component = mock_h5_worldtube_boundary<H5Metavariables>;
   const size_t l_max = 8;
-  ActionTesting::MockRuntimeSystem<metavariables> runner{
+  ActionTesting::MockRuntimeSystem<H5Metavariables> runner{
       tuples::tagged_tuple_from_typelist<
-          Parallel::get_const_global_cache_tags<metavariables>>{l_max}};
+          Parallel::get_const_global_cache_tags<H5Metavariables>>{l_max}};
 
   const size_t buffer_size = 8;
   const std::string filename = "InitializeWorldtubeBoundaryTest_CceR0100.h5";
 
   // create the test file, because on initialization the manager will need to
   // get basic data out of the file
-  MAKE_GENERATOR(gen);
   UniformCustomDistribution<double> value_dist{0.1, 0.5};
   // first prepare the input for the modal version
-  const double mass = value_dist(gen);
+  const double mass = value_dist(*gen);
   const std::array<double, 3> spin{
-      {value_dist(gen), value_dist(gen), value_dist(gen)}};
+      {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
   const std::array<double, 3> center{
-      {value_dist(gen), value_dist(gen), value_dist(gen)}};
+      {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
   gr::Solutions::KerrSchild solution{mass, spin, center};
 
   const double extraction_radius = 100.0;
-  const double frequency = 0.1 * value_dist(gen);
-  const double amplitude = 0.1 * value_dist(gen);
-  const double target_time = 50.0 * value_dist(gen);
+  const double frequency = 0.1 * value_dist(*gen);
+  const double amplitude = 0.1 * value_dist(*gen);
+  const double target_time = 50.0 * value_dist(*gen);
   TestHelpers::write_test_file(solution, filename, target_time,
                                extraction_radius, frequency, amplitude, l_max);
 
   ActionTesting::set_phase(make_not_null(&runner),
-                           metavariables::Phase::Initialization);
+                           H5Metavariables::Phase::Initialization);
   ActionTesting::emplace_component<component>(
       &runner, 0,
       InitializationTags::H5WorldtubeBoundaryDataManager::create_from_options(
@@ -84,7 +87,7 @@ SPECTRE_TEST_CASE(
   ActionTesting::next_action<component>(make_not_null(&runner), 0);
   ActionTesting::next_action<component>(make_not_null(&runner), 0);
   ActionTesting::set_phase(make_not_null(&runner),
-                           metavariables::Phase::Evolve);
+                           H5Metavariables::Phase::Evolve);
   // check that the h5 data manager copied out of the databox has the correct
   // properties that we can examine without running the other actions
   const auto& data_manager =
@@ -99,9 +102,10 @@ SPECTRE_TEST_CASE(
   // check that the Variables is in the expected state (here we just make sure
   // it has the right size - it shouldn't have been written to yet)
   const auto& variables = ActionTesting::get_databox_tag<
-      component, ::Tags::Variables<
-                     typename metavariables::cce_boundary_communication_tags>>(
-      runner, 0);
+      component,
+      ::Tags::Variables<
+          typename H5Metavariables::cce_boundary_communication_tags>>(runner,
+                                                                      0);
 
   CHECK(get(get<Tags::BoundaryValue<Tags::BondiBeta>>(variables)).size() ==
         Spectral::Swsh::number_of_swsh_collocation_points(l_max));
@@ -109,5 +113,52 @@ SPECTRE_TEST_CASE(
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);
   }
+}
+
+void test_gh_initialization() noexcept {
+  using component = mock_gh_worldtube_boundary<GhMetavariables>;
+  const size_t l_max = 8;
+  const double extraction_radius = 100.0;
+  ActionTesting::MockRuntimeSystem<GhMetavariables> runner{
+      tuples::tagged_tuple_from_typelist<
+          Parallel::get_const_global_cache_tags<GhMetavariables>>{
+          l_max, extraction_radius}};
+
+  runner.set_phase(GhMetavariables::Phase::Initialization);
+  ActionTesting::emplace_component<component>(
+      &runner, 0,
+      Tags::GhInterfaceManager::create_from_options<GhMetavariables>(
+          std::make_unique<GhLockstepInterfaceManager>()));
+
+  // this should run the initialization
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  runner.set_phase(GhMetavariables::Phase::Evolve);
+  // check that the GH data manager copied out of the databox has the correct
+  // properties that we can examine without running the other actions
+  const auto& interface_manager =
+      ActionTesting::get_databox_tag<component, Tags::GhInterfaceManager>(
+          runner, 0);
+  CHECK(cpp17::is_same_v<decltype(interface_manager),
+                         const GhWorldtubeInterfaceManager&>);
+
+  // check that the Variables is in the expected state (here we just make sure
+  // it has the right size - it shouldn't have been written to yet)
+  const auto& variables = ActionTesting::get_databox_tag<
+      component,
+      ::Tags::Variables<
+          typename GhMetavariables::cce_boundary_communication_tags>>(runner,
+                                                                      0);
+  CHECK(get(get<Tags::BoundaryValue<Tags::BondiBeta>>(variables)).size() ==
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.Cce.Actions.InitializeWorldtubeBoundary",
+    "[Unit][Cce]") {
+  MAKE_GENERATOR(gen);
+  test_h5_initialization(make_not_null(&gen));
+  test_gh_initialization();
 }
 }  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(Actions)
 set(LIBRARY "Test_Cce")
 
 set(LIBRARY_SOURCES
+  InterfaceManagers/Test_GhLockstepInterfaceManager.cpp
   Test_BoundaryData.cpp
   Test_Equations.cpp
   Test_GaugeTransformBoundaryData.cpp

--- a/tests/Unit/Evolution/Systems/Cce/InterfaceManagers/Test_GhLockstepInterfaceManager.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/InterfaceManagers/Test_GhLockstepInterfaceManager.cpp
@@ -1,0 +1,130 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
+#include <cstddef>
+#include <memory>
+#include <tuple>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/GhLockstepInterfaceManager.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/WorldtubeInterfaceManager.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/Literals.hpp"
+
+namespace Cce {
+namespace {
+
+template <typename Generator>
+void test_gh_lockstep_interface_manager(
+    const gsl::not_null<Generator*> gen) noexcept {
+  UniformCustomDistribution<double> value_dist{-5.0, 5.0};
+  UniformCustomDistribution<size_t> timestep_dist{1, 5};
+
+  std::vector<std::tuple<TimeStepId, tnsr::aa<DataVector, 3>,
+                         tnsr::iaa<DataVector, 3>, tnsr::aa<DataVector, 3>>>
+      expected_gh_data(7);
+  size_t running_total = 0;
+  GhLockstepInterfaceManager interface_manager{};
+  tnsr::aa<DataVector, 3> spacetime_metric{5_st};
+  tnsr::iaa<DataVector, 3> phi{5_st};
+  tnsr::aa<DataVector, 3> pi{5_st};
+  // insert some time ids
+  for (size_t i = 0; i < 7; ++i) {
+    const size_t substep = running_total % 3;
+    const size_t step = running_total / 3;
+    // RK3-style substep
+    int substep_numerator = 0;
+    if (substep == 1) {
+      substep_numerator = 2;
+    } else if (substep == 2) {
+      substep_numerator = 1;
+    }
+    const Time step_time{{static_cast<double>(step), step + 1.0}, {0, 1}};
+    const Time substep_time{{static_cast<double>(step), step + 1.0},
+                            {substep_numerator, 2}};
+    const TimeStepId time_id{true, static_cast<int64_t>(step), step_time,
+                             substep, substep_time};
+    fill_with_random_values(make_not_null(&spacetime_metric), gen,
+                            make_not_null(&value_dist));
+    fill_with_random_values(make_not_null(&phi), gen,
+                            make_not_null(&value_dist));
+    fill_with_random_values(make_not_null(&pi), gen,
+                            make_not_null(&value_dist));
+    interface_manager.insert_gh_data(time_id, spacetime_metric, phi, pi);
+    expected_gh_data[i] = std::make_tuple(time_id, spacetime_metric, phi, pi);
+    running_total += timestep_dist(*gen);
+  }
+
+  const auto check_data_retrieval_against_vector =
+      [&expected_gh_data](const gsl::not_null<GhWorldtubeInterfaceManager*>
+                              local_interface_manager,
+                          const size_t expected_number_of_gh_times,
+                          const size_t vector_index) noexcept {
+        CHECK(local_interface_manager->number_of_pending_requests() == 0);
+        CHECK(local_interface_manager->number_of_gh_times() ==
+              expected_number_of_gh_times);
+        auto retrieved_data =
+            local_interface_manager->retrieve_and_remove_first_ready_gh_data();
+        REQUIRE(retrieved_data);
+        CHECK(get<0>(*retrieved_data) ==
+              get<0>(expected_gh_data[vector_index]));
+        CHECK(get<1>(*retrieved_data) ==
+              get<1>(expected_gh_data[vector_index]));
+        CHECK(get<2>(*retrieved_data) ==
+              get<2>(expected_gh_data[vector_index]));
+        CHECK(get<3>(*retrieved_data) ==
+              get<3>(expected_gh_data[vector_index]));
+
+        CHECK(local_interface_manager->number_of_pending_requests() == 0);
+        CHECK(local_interface_manager->number_of_gh_times() ==
+              expected_number_of_gh_times - 1);
+      };
+  {
+    INFO("Retrieve data from directly constructed manager");
+    // choose a timestep to request - requests should do nothing
+    interface_manager.request_gh_data(get<0>(expected_gh_data[1]));
+    interface_manager.request_gh_data(get<0>(expected_gh_data[2]));
+    check_data_retrieval_against_vector(make_not_null(&interface_manager), 7_st,
+                                        0_st);
+    check_data_retrieval_against_vector(make_not_null(&interface_manager), 6_st,
+                                        1_st);
+  }
+  {
+    INFO("Retrieve data from serialized and deserialized manager");
+    // check that the state is preserved during serialization
+    auto serialized_and_deserialized_interface_manager =
+        serialize_and_deserialize(interface_manager);
+    serialized_and_deserialized_interface_manager.request_gh_data(
+        get<0>(expected_gh_data[2]));
+    check_data_retrieval_against_vector(
+        make_not_null(&serialized_and_deserialized_interface_manager), 5_st,
+        2_st);
+  }
+
+  {
+    INFO("Retrieve data from cloned unique_ptr to manager");
+    // check that the state is preserved through cloning
+    auto cloned_interface_manager = interface_manager.get_clone();
+    cloned_interface_manager->request_gh_data(get<0>(expected_gh_data[2]));
+    check_data_retrieval_against_vector(
+        make_not_null(cloned_interface_manager.get()), 5_st, 2_st);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.WorldtubeInterfaceManager",
+                  "[Unit][Cce]") {
+  MAKE_GENERATOR(gen);
+  test_gh_lockstep_interface_manager(make_not_null(&gen));
+}
+}  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <string>
 
+#include "Evolution/Systems/Cce/InterfaceManagers/WorldtubeInterfaceManager.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
 #include "Framework/TestCreation.hpp"
@@ -16,6 +17,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Literals.hpp"
+#include "Utilities/TypeTraits.hpp"
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   TestHelpers::db::test_simple_tag<
@@ -40,6 +42,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   CHECK(
       TestHelpers::test_creation<size_t, Cce::OptionTags::NumberOfRadialPoints>(
           "3") == 3_st);
+  CHECK(TestHelpers::test_creation<double, Cce::OptionTags::ExtractionRadius>(
+            "100.0") == 100.0);
+
   CHECK(TestHelpers::test_creation<double, Cce::OptionTags::EndTime>("4.0") ==
         4.0);
   CHECK(TestHelpers::test_creation<double, Cce::OptionTags::StartTime>("2.0") ==
@@ -54,6 +59,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   CHECK(TestHelpers::test_creation<size_t,
                                    Cce::OptionTags::ScriInterpolationOrder>(
             "4") == 4_st);
+
+  auto option_created_lockstep_interface_manager = TestHelpers::test_creation<
+      std::unique_ptr<Cce::GhWorldtubeInterfaceManager>,
+      Cce::OptionTags::GhInterfaceManager>("GhLockstepInterfaceManager");
+  CHECK(cpp17::is_same_v<decltype(option_created_lockstep_interface_manager),
+                         std::unique_ptr<Cce::GhWorldtubeInterfaceManager>>);
 
   CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::ScriOutputDensity>(
             "6") == 6_st);

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp
@@ -42,7 +42,36 @@ struct mock_h5_worldtube_boundary {
           mock_characteristic_evolution<test_metavariables>>>;
 
   using initialize_action_list =
-      tmpl::list<InitializeH5WorldtubeBoundary,
+      tmpl::list<Actions::InitializeH5WorldtubeBoundary,
+                 Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+  using initialization_tags =
+      Parallel::get_initialization_tags<initialize_action_list>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  using simple_tags = tmpl::list<>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             initialize_action_list>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Evolve, tmpl::list<>>>;
+};
+
+template <typename Metavariables>
+struct mock_gh_worldtube_boundary {
+  using component_being_mocked = GhWorldtubeBoundary<Metavariables>;
+  using replace_these_simple_actions =
+      tmpl::list<Actions::BoundaryComputeAndSendToEvolution<
+          mock_characteristic_evolution<test_metavariables>>>;
+  using with_these_simple_actions =
+      tmpl::list<Actions::MockBoundaryComputeAndSendToEvolution<
+          mock_characteristic_evolution<test_metavariables>>>;
+
+  using initialize_action_list =
+      tmpl::list<Actions::InitializeGhWorldtubeBoundary,
                  Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;


### PR DESCRIPTION
## Proposed changes

Add a new component that is interchangable with the file-based worldtube component for accepting data from a running Generalized Harmonic evolution. Currently, the only manager component offered is a 'lockstep' manager that demands both systems evolve at the same, fixed, steps, but is created in such a way that it will be easy to update it to a more sophisticated system based on local time-stepping in the near future.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies

- [x] #2035