### PR TITLE
Revamp the way we build the PCH

### DIFF
--- a/cmake/SetupPch.cmake
+++ b/cmake/SetupPch.cmake
@@ -3,153 +3,217 @@
 
 option(
   USE_PCH
-  "Use precompiled headers for STL, Blaze, and Brigand"
+  "Use precompiled header file tools/SpectrePch.hpp"
   ON
   )
 
-function(is_implicit_include_directory INCLUDE_DIR)
-  set(FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES OFF PARENT_SCOPE)
-  foreach(DIR ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
-    if("${INCLUDE_DIR}" STREQUAL "${DIR}")
-      set(FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES ON PARENT_SCOPE)
-    endif()
-  endforeach()
-endfunction()
-
 if (USE_PCH)
-  # We store the header to precompile in ${CMAKE_SOURCE_DIR}/tools so
-  # that it cannot accidentally be included incorrectly anywhere since
-  # ${CMAKE_SOURCE_DIR}/tools is not in the include list.
-  # We copy it to the build directory and include it from there because
-  # GCC's precompiled headers require the hpp and the precompiled header
-  # be in the same directory.
-  set(PCH_PATH "${CMAKE_BINARY_DIR}/SpectrePch.hpp")
+  # CMake does not have any support for precompiled headers (PCHs) before
+  # v3.16. After v3.16 PCHs are supported, but targets cannot share a PCH,
+  # which is exactly what we want to do. To this end, we implement handling
+  # of a global PCH (and could be generalized to multiple PCHs) below.
+  # Since the setup is somewhat complicated we give an overview of what is
+  # happening here, and various things to be aware of.
+  #
+  # We have the following requirements on the PCH:
+  # - it must be rebuilt whenever anything it includes is changed.
+  # - it must be removed when running `make clean`
+  # - it must be generated before any object files are built that
+  #   use it
+  # - it must be able to use flags from other targets (since in modern CMake
+  #   flags, etc. are propagated via targets)
+  # - the correct flags to include the PCH must be propagated to any targets
+  #   that use the PCH.
+  #
+  # We store the header that generates the PCH in ${CMAKE_SOURCE_DIR}/tools
+  # (variable ${SPECTRE_PCH_HEADER_SOURCE_PATH}) so that it is not
+  # accidentally included anywhere. We then symlink the header used to
+  # generate PCH to ${SPECTRE_PCH_HEADER_PATH}. The PCH will be generated
+  # as ${SPECTRE_PCH_PATH}.
+  #
+  # In order to track the PCH include dependencies we symlink
+  # ${SPECTRE_PCH_HEADER_SOURCE_PATH} into the build dir as
+  # ${SPECTRE_PCH_DEP_HEADER_PATH} and generate a source file
+  # ${SPECTRE_PCH_DEP_SOURCE_PATH} that includes ${SPECTRE_PCH_DEP_HEADER_PATH}
+  # and thus tracks the includes of its dependencies. If we were to include
+  # ${SPECTRE_PCH_HEADER_PATH} instead of ${SPECTRE_PCH_DEP_HEADER_PATH} then
+  # the compiler will automatically grab the PCH instead of doing a textual
+  # include, which breaks the dependency tracking. A library,
+  # ${SPECTRE_PCH_LIB} is created that builds
+  # ${SPECTRE_PCH_DEP_SOURCE_PATH}, but using `tools/WrapPchCompiler.sh`
+  # (achieved by setting the RULE_LAUNCH_COMPILE property on
+  # ${SPECTRE_PCH_LIB}).
+  #
+  # We wrap the compiler so that we can build both the object file and
+  # the PCH with the full flags. That is, it is pretty much impossible to
+  # figure out all the compiler flags (especially include flags) and so using
+  # a CMake custom command to invoke the compiler is really difficult (more
+  # on this below). The compiler wrapper script is very simple, it invokes the
+  # commands passed into it to build the object file, as well as strips out
+  # `-o XX -c YY` and then replaces them with
+  # `${SPECTRE_PCH_HEADER_PATH} -o ${SPECTRE_PCH_PATH}`. We make the
+  # ${SPECTRE_PCH_SOURCE_PATH}'s resulting object file depend on
+  # ${SPECTRE_PCH_COMPILER_WRAPPER} so that if the wrapper is changed the PCH
+  # is rebuilt (source file property OBJECT_DEPENDS). We also tell CMake that
+  # the source file build outputs ${SPECTRE_PCH_PATH} by setting the
+  # OBJECT_OUTPUTS property on ${SPECTRE_PCH_SOURCE_PATH}.
+  #
+  # To get CMake to track the PCH file rather than the object file we create
+  # the custom target ${SPECTRE_PCH} and have it depend on ${SPECTRE_PCH_LIB}.
+  # With the Ninja generator we can directly depend on the PCH file, but not
+  # with Makefiles. Any library or executable that should include the PCH
+  # must now depend on ${SPECTRE_PCH}.
+  #
+  # The next issue to deal with is having the PCH be removed by `make clean`
+  # or `ninja clean` calls (depending on which generator was used). Before
+  # CMake v3.15 the variable ${ADDITIONAL_MAKE_CLEAN_FILES} can be used to
+  # have `make clean` remove files, but this does not work when
+  # using Ninja. From CMake V3.15 onward the variable ${ADDITIONAL_CLEAN_FILES}
+  # can be used to specify additional files to remove regardless of the
+  # generator used.
+  #
+  # The major remaining step is setting the PCH include flag. For
+  # (Apple)Clang this is `-include-pch;${SPECTRE_PCH_PATH}`, while for GCC it
+  # is `-include;${SPECTRE_PCH_HEADER_PATH}`. We add
+  # `INTERFACE_COMPILE_OPTIONS` to ${SPECTRE_PCH} that libraries can grab
+  # using generator expressions:
+  #
+  #     target_compile_options(
+  #       ${TARGET_NAME}
+  #       PRIVATE
+  #       $<TARGET_PROPERTY:${SPECTRE_PCH},INTERFACE_COMPILE_OPTIONS>
+  #       )
+  #
+  # Source files in dependent targets must depend on the PCH file itself:
+  #
+  #     set_source_files_properties(
+  #       ${ARGN}
+  #       OBJECT_DEPENDS "${SPECTRE_PCH_PATH}"
+  #       )
+  #
+  # Finally, the add_spectre_library and add_spectre_executable functions
+  # both will have targets automatically include the PCH.
+  #
+  # Additional notes:
+  # - We used to have a custom_command that would invoke the compiler, which
+  #   required us to filter out compiler-internal include directories
+  #   (e.g. /usr/include) so as not to -isystem them and break compilation
+  #   for people who have Blaze, Brigand, or any other dependencies of the PCH
+  #   somewhere like `/usr/include`. Unfortunately, determining what to filter
+  #   out is difficult. CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES used to work, but
+  #   around CMake v3.11 CMake started adding the entries in CPATH into that,
+  #   which resulted in the PCH spewing warnings for anyone who didn't have
+  #   Blaze in a compiler-internal include directory (e.g. /usr/include).
+  #   CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES is also not helpful, and so the
+  #   only way to continue with this design would be to create a copy of
+  #   CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES, then remove everything in
+  #   $ENV{CPATH} from the copy, and avoid adding `-isystem` for any include
+  #   directories in the list. This design still doesn't allow for a good
+  #   way of handling flags that are passed around as targets, which is
+  #   the modern CMake way of handling flags rather than modifying
+  #   ${CMAKE_CXX_FLAGS}.
+
+  # Set up variables for PCH.
+  set(SPECTRE_PCH SpectrePch)
+  set(SPECTRE_PCH_HEADER_SOURCE_PATH
+    "${CMAKE_SOURCE_DIR}/tools/SpectrePch.hpp")
+  set(SPECTRE_PCH_HEADER_PATH "${CMAKE_BINARY_DIR}/SpectrePch.hpp")
+  set(SPECTRE_PCH_PATH "${SPECTRE_PCH_HEADER_PATH}.gch")
+  set(SPECTRE_PCH_LIB SpectrePchLib)
+  set(SPECTRE_PCH_LIB_DIR "${CMAKE_BINARY_DIR}/tmp/")
+  set(SPECTRE_PCH_DEP_HEADER_PATH
+    "${SPECTRE_PCH_LIB_DIR}.SpectrePchForDependencies.hpp")
+  set(SPECTRE_PCH_DEP_SOURCE_PATH
+    "${SPECTRE_PCH_LIB_DIR}.SpectrePchForDependencies.cpp")
+  set(SPECTRE_PCH_COMPILER_WRAPPER
+    "${CMAKE_BINARY_DIR}/tmp/WrapPchCompiler.sh")
+
+  # Symlink header file for PCH
   execute_process(
     COMMAND ${CMAKE_COMMAND}
     -E create_symlink
-    ${CMAKE_SOURCE_DIR}/tools/SpectrePch.hpp
-    ${CMAKE_BINARY_DIR}/SpectrePch.hpp
+    ${SPECTRE_PCH_HEADER_SOURCE_PATH}
+    ${SPECTRE_PCH_HEADER_PATH}
     )
-  # We create a second copy of the PCH and also a simple source file that
-  # includes the second copy, which we compile into an unused library. The
-  # library will be a dependency of the real PCH so that way if anything
-  # changes that the PCH depends on the PCH will be updated. While this means
-  # we technically compile the PCH twice, it is a generator-independent way of
-  # handling the dependencies. The other methods available in CMake 3.3 are
-  # generator dependent, even all the ones in CMake 3.11 are. We always add
-  # the PCH library as a static lib so we know the generated libs name.
-  set(PCH_LIB_NAME "PCH_SPECTRE_DEPENDENCIES")
-  set(PCH_LIB_DIR "${CMAKE_BINARY_DIR}/tmp/")
-  if(NOT EXISTS "${CMAKE_BINARY_DIR}/tmp/")
-    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/tmp/")
+
+  # Generate SPECTRE_PCH_LIB_DIR, and symlink SPECTRE_PCH_DEP_HEADER_PATH
+  if(NOT EXISTS ${SPECTRE_PCH_LIB_DIR})
+    file(MAKE_DIRECTORY ${SPECTRE_PCH_LIB_DIR})
   endif()
   execute_process(
     COMMAND ${CMAKE_COMMAND}
     -E create_symlink
-    ${CMAKE_SOURCE_DIR}/tools/SpectrePch.hpp
-    ${CMAKE_BINARY_DIR}/tmp/.SpectrePchForDependencies.hpp
+    ${SPECTRE_PCH_HEADER_SOURCE_PATH}
+    ${SPECTRE_PCH_DEP_HEADER_PATH}
     RESULT_VARIABLE RESULT_OF_LINK)
   if(NOT ${RESULT_VARIABLE} EQUAL 0)
     message(FATAL_ERROR
-      "Failed to create symbolic link for "
-      "${CMAKE_BINARY_DIR}/tmp/.SpectrePchForDependencies.hpp")
+      "Failed to create symbolic link for ${SPECTRE_PCH_DEP_HEADER_PATH}")
   endif()
+
+  # Set up compiler wrapper
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/tools/WrapPchCompiler.sh
+    ${SPECTRE_PCH_COMPILER_WRAPPER}
+    @ONLY
+    )
+
   # We write a temp file and use configure_file so we don't trigger
   # a rebuild of the PCH every time CMake is run.
   file(WRITE
-    ${CMAKE_BINARY_DIR}/tmp/.SpectrePchForDependencies.cpp.out
-    "#include \"${CMAKE_BINARY_DIR}/tmp/.SpectrePchForDependencies.hpp\"\n"
+    ${SPECTRE_PCH_DEP_SOURCE_PATH}.out
+    "#include \"${SPECTRE_PCH_DEP_HEADER_PATH}\"\n"
     )
   configure_file(
-    ${CMAKE_BINARY_DIR}/tmp/.SpectrePchForDependencies.cpp.out
-    ${CMAKE_BINARY_DIR}/tmp/.SpectrePchForDependencies.cpp
+    ${SPECTRE_PCH_DEP_SOURCE_PATH}.out
+    ${SPECTRE_PCH_DEP_SOURCE_PATH}
     )
+
+  # Create SPECTRE_PCH_LIB, specify ${SPECTRE_PCH_LIB_DIR} and
+  # ${SPECTRE_PCH_COMPILER_WRAPPER}
   add_library(
-    ${PCH_LIB_NAME} STATIC
-    ${CMAKE_BINARY_DIR}/tmp/.SpectrePchForDependencies.cpp
+    ${SPECTRE_PCH_LIB}
+    ${SPECTRE_PCH_DEP_SOURCE_PATH}
     )
   target_link_libraries(
-    ${PCH_LIB_NAME}
+    ${SPECTRE_PCH_LIB}
     PRIVATE
     Blaze
     Brigand
     )
   set_target_properties(
-    PCH_SPECTRE_DEPENDENCIES
+    ${SPECTRE_PCH_LIB}
     PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY ${PCH_LIB_DIR}
-    )
-  set(PCH_LIB_PATH "${PCH_LIB_DIR}/lib${PCH_LIB_NAME}.a")
-
-  # The compiler flags need to be turned into a CMake list
-  if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-    string(REPLACE " " ";" PCH_COMPILE_FLAGS
-      "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}"
-      )
-  elseif("${CMAKE_BUILD_TYPE}" STREQUAL "None")
-    string(REPLACE " " ";" PCH_COMPILE_FLAGS "${CMAKE_CXX_FLAGS}")
-  else()
-    string(REPLACE " " ";" PCH_COMPILE_FLAGS
-      "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}"
-      )
-  endif()
-
-  is_implicit_include_directory(${BLAZE_INCLUDE_DIR})
-  if(NOT ${FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES})
-    set(BLAZE_INCLUDE_ARGUMENT "-isystem${BLAZE_INCLUDE_DIR}")
-  else()
-    set(BLAZE_INCLUDE_ARGUMENT "")
-  endif()
-
-  is_implicit_include_directory(${BRIGAND_INCLUDE_DIR})
-  if(NOT ${FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES})
-    set(BRIGAND_INCLUDE_ARGUMENT "-isystem${BRIGAND_INCLUDE_DIR}")
-  else()
-    set(BRIGAND_INCLUDE_ARGUMENT "")
-  endif()
-
-  is_implicit_include_directory(${CHARM_INCLUDE_DIRS})
-  if(NOT ${FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES})
-    set(CHARM_INCLUDE_ARGUMENT "-isystem${CHARM_INCLUDE_DIRS}")
-  else()
-    set(CHARM_INCLUDE_ARGUMENT "")
-  endif()
-
-  add_custom_command(
-    OUTPUT ${PCH_PATH}.gch
-    COMMAND ${CMAKE_CXX_COMPILER}
-    ARGS
-    -std=c++14
-    ${PCH_COMPILE_FLAGS}
-    -I${CMAKE_SOURCE_DIR}/src
-    ${BLAZE_INCLUDE_ARGUMENT}
-    ${BRIGAND_INCLUDE_ARGUMENT}
-    ${CHARM_INCLUDE_ARGUMENT}
-    ${PCH_PATH}
-    -o ${PCH_PATH}.gch
-    DEPENDS
-    ${PCH_LIB_PATH}
+    ARCHIVE_OUTPUT_DIRECTORY ${SPECTRE_PCH_LIB_DIR}
+    RULE_LAUNCH_COMPILE ${SPECTRE_PCH_COMPILER_WRAPPER}
     )
 
+  # Make the source file ${SPECTRE_PCH_DEP_SOURCE_PATH} depend on
+  # ${SPECTRE_PCH_COMPILER_WRAPPER} and set the source file to produce
+  # ${SPECTRE_PCH_PATH}.
+  set_source_files_properties(
+    ${SPECTRE_PCH_DEP_SOURCE_PATH}
+    PROPERTIES
+    OBJECT_DEPENDS ${SPECTRE_PCH_COMPILER_WRAPPER}
+    OBJECT_OUTPUTS ${SPECTRE_PCH_PATH}
+    )
+
+  # Create the ${SPECTRE_PCH} that libraries and executables will depend on
   add_custom_target(
-    pch
-    DEPENDS
-    ${PCH_PATH}.gch
-    ${PCH_LIB_PATH}
+    ${SPECTRE_PCH}
     )
-
   add_dependencies(
-    pch
-    ${PCH_LIB_NAME}
+    ${SPECTRE_PCH}
+    ${SPECTRE_PCH_LIB}
     )
 
-  # Prepend the compiler-dependent flags needed to use precompiled headers
+  # Set the compiler-dependent flags needed to use precompiled headers
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    set(PCH_FLAG "-include;${PCH_PATH}")
+    set(SPECTRE_PCH_FLAG "-include;${SPECTRE_PCH_HEADER_PATH}")
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(PCH_FLAG "-include-pch;${PCH_PATH}.gch")
+    set(SPECTRE_PCH_FLAG "-include-pch;${SPECTRE_PCH_PATH}")
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-    set(PCH_FLAG "-include-pch;${PCH_PATH}.gch")
+    set(SPECTRE_PCH_FLAG "-include-pch;${SPECTRE_PCH_PATH}")
   else()
     message(
       STATUS "Precompiled headers have not been configured for"
@@ -157,38 +221,18 @@ if (USE_PCH)
       )
   endif()
 
-  # Override the default add_library function provided by CMake and override
-  # add_spectre_executable function so that it adds the precompiled header as a
-  # dependency to all of them.
-  #
-  # In addition to the library/executable depending on the precompiled header,
-  # all source files (technically the objects generated from them) must also
-  # depend on the precompiled header.
-  function(add_library TARGET_NAME)
-    _add_library(${TARGET_NAME} ${ARGN})
-    get_target_property(
-      TARGET_IS_IMPORTED
-      ${TARGET_NAME}
-      IMPORTED
-      )
-    get_target_property(
-      TARGET_TYPE
-      ${TARGET_NAME}
-      TYPE
-      )
-    if (NOT "${TARGET_NAME}" MATCHES "^PCH"
-        AND NOT ${TARGET_IS_IMPORTED}
-        AND NOT ${TARGET_TYPE} STREQUAL INTERFACE_LIBRARY)
-      add_dependencies(${TARGET_NAME} pch)
-      set_source_files_properties(
-        ${ARGN}
-        OBJECT_DEPENDS "${PCH_PATH};${PCH_PATH}.gch"
-        )
-      target_compile_options(
-        ${TARGET_NAME}
-        PRIVATE
-        $<$<COMPILE_LANGUAGE:CXX>:${PCH_FLAG}>
-        )
-    endif()
-  endfunction()
+  set_property(TARGET ${SPECTRE_PCH}
+    APPEND PROPERTY INTERFACE_COMPILE_OPTIONS
+    $<$<COMPILE_LANGUAGE:CXX>:${SPECTRE_PCH_FLAG}>
+    )
+
+  # Have `make clean` (and `ninja clean` on CMake v3.15 and newer) remove
+  # the PCH.
+  if(CMAKE_VERSION VERSION_EQUAL 3.15 OR CMAKE_VERSION VERSION_GREATER 3.15)
+    set_property(DIRECTORY APPEND PROPERTY
+      ADDITIONAL_CLEAN_FILES "${SPECTRE_PCH_PATH}")
+  else(CMAKE_VERSION VERSION_EQUAL 3.15 OR CMAKE_VERSION VERSION_GREATER 3.15)
+    set_property(DIRECTORY APPEND PROPERTY
+      ADDITIONAL_MAKE_CLEAN_FILES "${SPECTRE_PCH_PATH}")
+  endif(CMAKE_VERSION VERSION_EQUAL 3.15 OR CMAKE_VERSION VERSION_GREATER 3.15)
 endif (USE_PCH)

--- a/cmake/SpectreAddLibraries.cmake
+++ b/cmake/SpectreAddLibraries.cmake
@@ -12,4 +12,29 @@ function(ADD_SPECTRE_LIBRARY LIBRARY_NAME)
     RULE_LAUNCH_LINK "${CMAKE_BINARY_DIR}/tmp/WrapLibraryLinker.sh"
     LINK_DEPENDS "${CMAKE_BINARY_DIR}/tmp/WrapLibraryLinker.sh"
     )
+
+  get_target_property(
+    LIBRARY_IS_IMPORTED
+    ${LIBRARY_NAME}
+    IMPORTED
+    )
+  get_target_property(
+    LIBRARY_TYPE
+    ${LIBRARY_NAME}
+    TYPE
+    )
+  if (NOT "${LIBRARY_NAME}" MATCHES "^${SPECTRE_PCH}"
+      AND NOT ${LIBRARY_IS_IMPORTED}
+      AND NOT ${LIBRARY_TYPE} STREQUAL INTERFACE_LIBRARY)
+    add_dependencies(${LIBRARY_NAME} ${SPECTRE_PCH})
+    set_source_files_properties(
+        ${ARGN}
+        OBJECT_DEPENDS "${SPECTRE_PCH_PATH}"
+        )
+    target_compile_options(
+      ${LIBRARY_NAME}
+      PRIVATE
+      $<TARGET_PROPERTY:${SPECTRE_PCH},INTERFACE_COMPILE_OPTIONS>
+      )
+  endif()
 endfunction()

--- a/cmake/SpectreAddTestLibs.cmake
+++ b/cmake/SpectreAddTestLibs.cmake
@@ -84,6 +84,8 @@ function(add_test_library LIBRARY FOLDER LIBRARY_SOURCES LINK_LIBS)
     endif()
   endforeach()
 
+  # We do not use `add_spectre_library` since that adds libraries
+  # to the `libs` target, which should not include tests.
   add_library(
     ${LIBRARY}
     ${LIBRARY_SOURCES}
@@ -96,6 +98,21 @@ function(add_test_library LIBRARY FOLDER LIBRARY_SOURCES LINK_LIBS)
     LINK_DEPENDS "${CMAKE_BINARY_DIR}/tmp/WrapLibraryLinker.sh"
     )
 
+  # Add PCH to test libs
+  if(TARGET ${SPECTRE_PCH})
+    set_source_files_properties(
+      ${LIBRARY_SOURCES}
+      OBJECT_DEPENDS "${SPECTRE_PCH_PATH}"
+      )
+    add_dependencies(${LIBRARY} ${SPECTRE_PCH})
+    target_compile_options(
+      ${LIBRARY}
+      PRIVATE
+      $<TARGET_PROPERTY:${SPECTRE_PCH},INTERFACE_COMPILE_OPTIONS>
+      )
+  endif(TARGET ${SPECTRE_PCH})
+
+  # Add link dependencies
   target_link_libraries(
     ${LIBRARY}
     PRIVATE

--- a/cmake/UpdateAddExecutables.cmake
+++ b/cmake/UpdateAddExecutables.cmake
@@ -5,21 +5,21 @@ function(add_spectre_executable TARGET_NAME)
   _add_spectre_executable(${TARGET_NAME} ${ARGN})
 
   if (USE_PCH)
-    add_dependencies(${TARGET_NAME} pch)
-    set_source_files_properties(
-      ${ARGN}
-      OBJECT_DEPENDS "${PCH_PATH};${PCH_PATH}.gch"
-      )
     get_target_property(
       TARGET_IS_IMPORTED
       ${TARGET_NAME}
       IMPORTED
       )
     if(NOT ${TARGET_IS_IMPORTED})
+      add_dependencies(${TARGET_NAME} ${SPECTRE_PCH})
+      set_source_files_properties(
+        ${ARGN}
+        OBJECT_DEPENDS "${SPECTRE_PCH_PATH}"
+        )
       target_compile_options(
         ${TARGET_NAME}
         PRIVATE
-        $<$<COMPILE_LANGUAGE:CXX>:${PCH_FLAG}>
+        $<TARGET_PROPERTY:${SPECTRE_PCH},INTERFACE_COMPILE_OPTIONS>
         )
     endif()
   endif (USE_PCH)

--- a/tools/WrapPchCompiler.sh
+++ b/tools/WrapPchCompiler.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+compiler_invokation=("$@")
+
+pch_args=()
+while [ $# -ne 0 ] ; do
+  case "$1" in
+    -c|-o)
+      shift 2
+      ;;
+    *)
+      pch_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+"${pch_args[@]}" @SPECTRE_PCH_HEADER_PATH@ -o @SPECTRE_PCH_PATH@
+
+"${compiler_invokation[@]}"


### PR DESCRIPTION
## Proposed changes

The way we used to build the PCH was very fragile and didn't work properly for
versions of CMake newer than 3.10. This completely revamps the way we build the
PCH with a detailed description of what we do and why.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
