### PR TITLE
Cce ID options

### DIFF
--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -86,9 +86,6 @@ struct EvolutionMetavars {
 
   using cce_boundary_component = Cce::H5WorldtubeBoundary<EvolutionMetavars>;
 
-  using cce_hypersurface_initialization =
-      Cce::InitializeJ<Cce::Tags::BoundaryValue>;
-
   using component_list =
       tmpl::list<observers::ObserverWriter<EvolutionMetavars>,
                  cce_boundary_component,
@@ -118,6 +115,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling,
     &Parallel::register_derived_classes_with_charm<
         Cce::ReducedWorldtubeBufferUpdater>,
+    &Parallel::register_derived_classes_with_charm<Cce::InitializeJ>,
     &Parallel::register_derived_classes_with_charm<Cce::WorldtubeBufferUpdater>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<intrp::SpanInterpolator>};

--- a/src/Evolution/Systems/Cce/Actions/InitializeFirstHypersurface.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeFirstHypersurface.hpp
@@ -28,16 +28,16 @@ namespace Actions {
  * an initialization phase or early (before a `Actions::Goto` loop or similar)
  * in the `Evolve` phase.
  *
- * Internally, this dispatches to
- * `Metavariables::cce_hypersufrace_initialization`, which designates a
- * hypersurface initial data generator, `InitializeGauge`,
- * and `InitializeScriPlusValue<Tags::InertialRetardedTime>` to perform the
+ * Internally, this dispatches to the call function of
+ * `Tags::InitializeJ`, which designates a hypersurface initial data generator
+ * chosen by input file options, `InitializeGauge`, and
+ * `InitializeScriPlusValue<Tags::InertialRetardedTime>` to perform the
  * computations. Refer to the documentation for those mutators for mathematical
  * details.
  */
 struct InitializeFirstHypersurface {
   using const_global_cache_tags =
-      tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints>;
+      tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints, Tags::InitializeJ>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -48,9 +48,8 @@ struct InitializeFirstHypersurface {
       const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
-    db::mutate_apply<typename Metavariables::cce_hypersurface_initialization>(
-        make_not_null(&box));
-    db::mutate_apply<InitializeGauge>(make_not_null(&box));
+    db::mutate_apply<InitializeJ::mutate_tags, InitializeJ::argument_tags>(
+        db::get<Tags::InitializeJ>(box), make_not_null(&box));
     db::mutate_apply<InitializeScriPlusValue<Tags::InertialRetardedTime>>(
         make_not_null(&box));
     return {std::move(box)};

--- a/src/Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp
+++ b/src/Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp
@@ -13,7 +13,6 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
@@ -22,6 +21,13 @@
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
+
+namespace Tags {
+/// \cond
+struct LMax;
+struct NumberOfRadialPoints;
+/// \endcond
+}  // namespace Tags
 
 /// The set of tags that should be calculated before the initial data is
 /// computed on the first hypersurface.

--- a/src/Evolution/Systems/Cce/InitializeCce.hpp
+++ b/src/Evolution/Systems/Cce/InitializeCce.hpp
@@ -3,9 +3,17 @@
 
 #pragma once
 
+#include <cstddef>
+#include <memory>
+#include <string>
+
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -14,6 +22,58 @@ class ComplexDataVector;
 /// \endcond
 
 namespace Cce {
+namespace Tags {
+/// \cond
+struct LMax;
+struct NumberOfRadialPoints;
+/// \endcond
+}  // namespace Tags
+
+struct InitializeJInverseCubic;
+
+/*!
+ * \brief Abstract base class for an initial hypersurface data generator for
+ * Cce.
+ *
+ * \details The functions that are required to be overriden in the derived
+ * classes are:
+ * - `InitializeJ::get_clone()`: should return a
+ * `std::unique_ptr<InitializeJ>` with cloned state.
+ * - `InitializeJ::operator() const`: should take as arguments, first a set of
+ * `gsl::not_null` pointers represented by `mutate_tags`, followed by a set of
+ * `const` references to quantities represented by `argument_tags`.
+ * \note The `InitializeJ::operator()` should be const, and therefore not alter
+ * the internal state of the generator. This is compatible with all known
+ * use-cases and permits the `InitializeJ` generator to be placed in the
+ * `ConstGlobalCache`.
+ */
+struct InitializeJ : public PUP::able {
+  using boundary_tags = tmpl::list<Tags::BoundaryValue<Tags::BondiJ>,
+                                   Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
+                                   Tags::BoundaryValue<Tags::BondiR>>;
+
+  using mutate_tags = tmpl::list<Tags::BondiJ, Tags::CauchyCartesianCoords,
+                                 Tags::CauchyAngularCoords>;
+  using argument_tags =
+      tmpl::push_back<boundary_tags, Tags::LMax, Tags::NumberOfRadialPoints>;
+
+  using creatable_classes = tmpl::list<InitializeJInverseCubic>;
+
+  WRAPPED_PUPable_abstract(InitializeJ);  // NOLINT
+
+  virtual std::unique_ptr<InitializeJ> get_clone() const noexcept = 0;
+
+  virtual void operator()(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+      gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_cauchy_coordinates,
+      gsl::not_null<
+          tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
+          angular_cauchy_coordinates,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& r, size_t l_max,
+      size_t number_of_radial_points) const noexcept = 0;
+};
 
 /*!
  * \brief Initialize \f$J\f$ on the first hypersurface from provided boundary
@@ -21,8 +81,7 @@ namespace Cce {
  *
  * \details This initial data is chosen to take the function:
  *
- *\f[ J = \frac{A}{r} + \frac{B}{r^3},
- *\f]
+ * \f[ J = \frac{A}{r} + \frac{B}{r^3},\f]
  *
  * where
  *
@@ -32,19 +91,33 @@ namespace Cce {
  * B &= - \frac{1}{2} R^3 (J|_{r = R} + R \partial_r J|_{r = R})
  * \f}
  */
-template <template <typename> class BoundaryPrefix>
-struct InitializeJ {
-  using boundary_tags = tmpl::list<BoundaryPrefix<Tags::BondiJ>,
-                                   BoundaryPrefix<Tags::Dr<Tags::BondiJ>>,
-                                   BoundaryPrefix<Tags::BondiR>>;
+struct InitializeJInverseCubic : InitializeJ {
+  using options = tmpl::list<>;
+  static constexpr OptionString help = {
+      "Initialization process where J is set to a simple Ansatz with a\n"
+      " A/r + B/r^3 piece such that it is smooth with the Cauchy data at the \n"
+      "worldtube"};
 
-  using return_tags = tmpl::list<Tags::BondiJ>;
-  using argument_tags = tmpl::append<boundary_tags>;
+  static std::string name() noexcept { return "InverseCubic"; }
 
-  static void apply(
+  WRAPPED_PUPable_decl_template(InitializeJInverseCubic);  // NOLINT
+  explicit InitializeJInverseCubic(CkMigrateMessage* /*unused*/) noexcept {}
+
+  InitializeJInverseCubic() = default;
+
+  std::unique_ptr<InitializeJ> get_clone() const noexcept override;
+
+  void operator()(
       gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+      gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_cauchy_coordinates,
+      gsl::not_null<
+          tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
+          angular_cauchy_coordinates,
       const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
       const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
-      const Scalar<SpinWeighted<ComplexDataVector, 0>>& r) noexcept;
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& r, size_t l_max,
+      size_t number_of_radial_points) const noexcept override;
+
+  void pup(PUP::er& /*p*/) noexcept override;
 };
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -7,6 +7,7 @@
 #include <limits>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "Evolution/Systems/Cce/InitializeCce.hpp"
 #include "Evolution/Systems/Cce/InterfaceManagers/GhLockstepInterfaceManager.hpp"
 #include "Evolution/Systems/Cce/InterfaceManagers/WorldtubeInterfaceManager.hpp"
 #include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
@@ -14,6 +15,9 @@
 #include "Options/Options.hpp"
 
 namespace Cce {
+/// \cond
+struct InitializeJ;
+/// \endcond
 namespace OptionTags {
 
 /// %Option group
@@ -140,6 +144,13 @@ struct ScriOutputDensity {
   static constexpr OptionString help{
       "Number of scri output points per timestep."};
   static size_t default_value() noexcept { return 1; }
+  using group = Cce;
+};
+
+struct InitializeJ {
+  using type = std::unique_ptr<::Cce::InitializeJ>;
+  static constexpr OptionString help{
+      "The initialization for the first hypersurface for J"};
   using group = Cce;
 };
 
@@ -320,6 +331,17 @@ struct GhInterfaceManager : db::SimpleTag {
   create_from_options(const std::unique_ptr<::Cce::GhWorldtubeInterfaceManager>&
                           interface_manager) noexcept {
     return interface_manager->get_clone();
+  }
+};
+
+struct InitializeJ : db::SimpleTag {
+  using type = std::unique_ptr<::Cce::InitializeJ>;
+  using option_tags = tmpl::list<OptionTags::InitializeJ>;
+
+  static constexpr bool pass_metavariables = false;
+  static std::unique_ptr<::Cce::InitializeJ> create_from_options(
+      const std::unique_ptr<::Cce::InitializeJ>& initialize_j) noexcept {
+    return initialize_j->get_clone();
   }
 };
 

--- a/src/NumericalAlgorithms/Spectral/SwshDerivatives.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshDerivatives.cpp
@@ -120,9 +120,13 @@ GENERATE_INSTANTIATIONS(DERIVKIND_AND_SPIN_INSTANTIATION,
                         (Tags::EthEthbar, Tags::EthbarEth), (-2, -1, 0, 1, 2))
 GENERATE_INSTANTIATIONS(DERIVKIND_AND_SPIN_INSTANTIATION, (Tags::Eth),
                         (-2, -1, 0, 1))
+GENERATE_INSTANTIATIONS(DERIVKIND_AND_SPIN_INSTANTIATION, (Tags::InverseEthbar),
+                        (-2, -1, 0, 1))
 GENERATE_INSTANTIATIONS(DERIVKIND_AND_SPIN_INSTANTIATION, (Tags::EthEth),
                         (-2, -1, 0))
 GENERATE_INSTANTIATIONS(DERIVKIND_AND_SPIN_INSTANTIATION, (Tags::Ethbar),
+                        (-1, 0, 1, 2))
+GENERATE_INSTANTIATIONS(DERIVKIND_AND_SPIN_INSTANTIATION, (Tags::InverseEth),
                         (-1, 0, 1, 2))
 GENERATE_INSTANTIATIONS(DERIVKIND_AND_SPIN_INSTANTIATION, (Tags::EthbarEthbar),
                         (0, 1, 2))
@@ -156,11 +160,19 @@ GENERATE_INSTANTIATIONS(FULL_DERIVATIVE_INSTANTIATION,
 GENERATE_INSTANTIATIONS(FULL_DERIVATIVE_INSTANTIATION,
                         (ComplexRepresentation::Interleaved,
                          ComplexRepresentation::RealsThenImags),
+                        (Tags::InverseEthbar), (-2, -1, 0, 1))
+GENERATE_INSTANTIATIONS(FULL_DERIVATIVE_INSTANTIATION,
+                        (ComplexRepresentation::Interleaved,
+                         ComplexRepresentation::RealsThenImags),
                         (Tags::EthEth), (-2, -1, 0))
 GENERATE_INSTANTIATIONS(FULL_DERIVATIVE_INSTANTIATION,
                         (ComplexRepresentation::Interleaved,
                          ComplexRepresentation::RealsThenImags),
                         (Tags::Ethbar), (-1, 0, 1, 2))
+GENERATE_INSTANTIATIONS(FULL_DERIVATIVE_INSTANTIATION,
+                        (ComplexRepresentation::Interleaved,
+                         ComplexRepresentation::RealsThenImags),
+                        (Tags::InverseEth), (-1, 0, 1, 2))
 GENERATE_INSTANTIATIONS(FULL_DERIVATIVE_INSTANTIATION,
                         (ComplexRepresentation::Interleaved,
                          ComplexRepresentation::RealsThenImags),

--- a/src/NumericalAlgorithms/Spectral/SwshTags.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTags.cpp
@@ -38,6 +38,16 @@ std::string compose_spin_weighted_derivative_name<EthbarEthbar>(
   return "EthbarEthbar(" + suffix + ")";
 }
 template <>
+std::string compose_spin_weighted_derivative_name<InverseEth>(
+    const std::string& suffix) noexcept {
+  return "InverseEth(" + suffix + ")";
+}
+template <>
+std::string compose_spin_weighted_derivative_name<InverseEthbar>(
+    const std::string& suffix) noexcept {
+  return "InverseEthbar(" + suffix + ")";
+}
+template <>
 std::string compose_spin_weighted_derivative_name<NoDerivative>(
     const std::string& suffix) noexcept {
   return "NoDerivative(" + suffix + ")";

--- a/src/NumericalAlgorithms/Spectral/SwshTags.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTags.hpp
@@ -47,6 +47,16 @@ struct EthEthbar {};
 /// \brief Struct for labeling the \f$\bar{\eth}^2\f$ spin-weighted derivative
 /// in tags
 struct EthbarEthbar {};
+
+/// \ingroup SwshGroup
+/// \brief Struct for labeling the inverse \f$\eth^{-1}\f$ spin-weighted
+/// derivative in tags
+struct InverseEth {};
+/// \ingroup SwshGroup
+/// \brief Struct for labeling the inverse\f$\bar{\eth}^{-1}\f$ spin-weighted
+/// derivative in tags
+struct InverseEthbar {};
+
 /// \brief Struct which acts as a placeholder for a spin-weighted derivative
 /// label in the spin-weighted derivative utilities, but represents a 'no-op':
 /// no derivative is taken.
@@ -55,9 +65,11 @@ struct NoDerivative {};
 namespace detail {
 template <typename DerivativeKind>
 inline constexpr int derivative_spin_weight_impl() noexcept {
-  if (cpp17::is_same_v<DerivativeKind, Eth>) {
+  if (cpp17::is_same_v<DerivativeKind, Eth> or
+      cpp17::is_same_v<DerivativeKind, InverseEthbar>) {
     return 1;
-  } else if (cpp17::is_same_v<DerivativeKind, Ethbar>) {
+  } else if (cpp17::is_same_v<DerivativeKind, Ethbar> or
+             cpp17::is_same_v<DerivativeKind, InverseEth>) {
     return -1;
   } else if (cpp17::is_same_v<DerivativeKind, EthEth>) {
     return 2;

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -16,6 +16,9 @@ Cce:
   NumberOfRadialPoints: 12
   ObservationLMax: 8
 
+  InitializeJ:
+    InverseCubic
+
   StartTime: 0.0
   EndTime: 1000.0
   TargetStepSize: 1.0

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -28,6 +28,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
 
   TestHelpers::db::test_simple_tag<Cce::Tags::StartTime>("StartTime");
   TestHelpers::db::test_simple_tag<Cce::Tags::EndTime>("EndTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::InitializeJ>("InitializeJ");
 
   CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::LMax>("8") == 8_st);
   CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::FilterLMax>("7") ==
@@ -68,6 +69,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
 
   CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::ScriOutputDensity>(
             "6") == 6_st);
+
+  TestHelpers::test_creation<std::unique_ptr<::Cce::InitializeJ>,
+                             Cce::OptionTags::InitializeJ>("InverseCubic");
 
   const std::string filename = "OptionTagsTestCceR0100.h5";
   if (file_system::check_if_file_exists(filename)) {

--- a/tests/Unit/Helpers/NumericalAlgorithms/Spectral/SwshTestHelpers.cpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/Spectral/SwshTestHelpers.cpp
@@ -110,6 +110,32 @@ derivative_of_spin_weighted_spherical_harmonic<Tags::EthbarEthbar>(
              s - 1, l, m, theta, phi);
 }
 
+template <>
+std::complex<double>
+derivative_of_spin_weighted_spherical_harmonic<Tags::InverseEth>(
+    const int s, const int l, const int m, const double theta,
+    const double phi) noexcept {
+  return (l - s + 1) * (l + s) == 0
+             ? 0.0
+             : spin_weighted_spherical_harmonic(s - 1, l, m, theta, phi) /
+                   sqrt(static_cast<std::complex<double>>((l - s + 1) *
+                                                          (l + s)));
+}
+
+template <>
+std::complex<double>
+derivative_of_spin_weighted_spherical_harmonic<Tags::InverseEthbar>(
+    const int s, const int l, const int m, const double theta,
+    const double phi) noexcept {
+  return (l + s + 1) * (l - s) == 0
+             ? 0.0
+             : spin_weighted_spherical_harmonic(s + 1, l, m, theta, phi) /
+                   -sqrt(static_cast<std::complex<double>>((l + s + 1) *
+                                                           (l - s)));
+  ;
+}
+
+
 }  // namespace TestHelpers
 }  // namespace Swsh
 }  // namespace Spectral

--- a/tests/Unit/Helpers/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp
@@ -10,12 +10,12 @@
 
 #include "DataStructures/ComplexModalVector.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"  // IWYU pragma: keep
 #include "Utilities/Gsl.hpp"
-#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 
 /// \cond
 class ComplexDataVector;


### PR DESCRIPTION
## Proposed changes

Add two new initial data generation options and the utilities necessary to support them. Also, this converts the initial data generation choice from a metavariable to a factory-created class determined from the options in the input file.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies
- [x] #2035
