### PR TITLE
Change History::insert arguments to const refs

### DIFF
--- a/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.cpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.cpp
@@ -321,7 +321,7 @@ void check_dense_output(const TimeStepper& stepper,
     for (;;) {
       // Dense output is done after the last substep
       const auto next_time_id = stepper.next_time_id(time_id, step_size);
-      history.insert(time_id, y, static_cast<double>(y));
+      history.insert(time_id, y, y);
       if (next_time_id.substep() == 0 and
           time < next_time_id.step_time().value()) {
         stepper.dense_update_u(make_not_null(&y), history, time);

--- a/tests/Unit/Time/Test_History.cpp
+++ b/tests/Unit/Time/Test_History.cpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 #include <deque>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "Framework/TestHelpers.hpp"
@@ -116,12 +115,7 @@ SPECTRE_TEST_CASE("Unit.Time.History", "[Unit][Time]") {
 
   history.insert(make_time_id(0.), 0., get_output(0));
   history.insert_initial(make_time_id(-1.), -1., get_output(-1));
-  {
-    auto tmp = get_output(1);
-    history.insert(make_time_id(1.), 1., std::move(tmp));
-    // clang-tidy: misc-use-after-move
-    CHECK(tmp == get_output(1));  // NOLINT
-  }
+  history.insert(make_time_id(1.), 1., get_output(1));
   history.insert_initial(make_time_id(-2.), -2., get_output(-2));
   history.insert_initial(make_time_id(-3.), -3., get_output(-3));
 
@@ -132,12 +126,7 @@ SPECTRE_TEST_CASE("Unit.Time.History", "[Unit][Time]") {
   CHECK(history.size() == 3);
   CHECK(history.capacity() == 5);
 
-  {
-    auto tmp = get_output(2);
-    history.insert(make_time_id(2.), 2., std::move(tmp));
-    // clang-tidy: misc-use-after-move
-    CHECK(tmp == get_output(-3));  // NOLINT
-  }
+  history.insert(make_time_id(2.), 2., get_output(2));
   CHECK(history.size() == 4);
   CHECK(history.capacity() == 5);
 


### PR DESCRIPTION
The interface has evolved over time, and all the rvalue reference was
doing was avoiding a memory copy.  The old form was causing
complications for the CCE code.  (See #2035.)

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
