### PR TITLE
Add support for Sphinx+Breathe documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ include(SetupClangTidy)
 include(SetupIwyu)
 include(SetupCppCheck)
 include(SetupDoxygen)
+include(SetupSphinx)
 include(CodeCoverageDetection)
 include(SpectreAddLibraries)
 

--- a/cmake/FindBreathe.cmake
+++ b/cmake/FindBreathe.cmake
@@ -1,0 +1,34 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+if(NOT BREATHE_ROOT)
+  # Need to set to empty to avoid warnings with --warn-uninitialized
+  set(BREATHE_ROOT "")
+  set(BREATHE_ROOT $ENV{BREATHE_ROOT})
+endif()
+
+# Look for an executable called breathe-apidoc
+find_program(
+  BREATHE_APIDOC_EXECUTABLE
+  NAMES breathe-apidoc
+  PATHS ${BREATHE_ROOT}
+  DOC "Path to breathe-apidoc executable")
+
+execute_process(COMMAND "${BREATHE_APIDOC_EXECUTABLE}" "--version"
+  RESULT_VARIABLE VERSION_RESULT
+  OUTPUT_VARIABLE VERSION_OUTPUT
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+include(FindPackageHandleStandardArgs)
+
+if(VERSION_RESULT MATCHES 0)
+  string(REGEX MATCH "[0-9]+\.[0-9]+[\.]?[0-9]*"
+    BREATHE_APIDOC_VERSION ${VERSION_OUTPUT})
+  set(BREATHE_VERSION ${BREATHE_APIDOC_VERSION})
+endif(VERSION_RESULT MATCHES 0)
+
+# Handle standard arguments to find_package like REQUIRED and QUIET
+find_package_handle_standard_args(Breathe
+  REQUIRED_VARS BREATHE_APIDOC_EXECUTABLE BREATHE_VERSION
+  BREATHE_APIDOC_VERSION
+  VERSION_VAR BREATHE_VERSION)

--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -1,0 +1,31 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+if(NOT SPHINX_ROOT)
+  # Need to set to empty to avoid warnings with --warn-uninitialized
+  set(SPHINX_ROOT "")
+  set(SPHINX_ROOT $ENV{SPHINX_ROOT})
+endif()
+
+# Look for an executable called sphinx-build or sphinx-build2
+find_program(
+  SPHINX_EXECUTABLE
+  NAMES sphinx-build sphinx-build2
+  PATHS ${SPHINX_ROOT}
+  DOC "Path to sphinx-build or sphinx-build2 executable")
+
+execute_process(COMMAND "${SPHINX_EXECUTABLE}" "--version"
+  RESULT_VARIABLE VERSION_RESULT
+  OUTPUT_VARIABLE VERSION_OUTPUT
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(VERSION_RESULT MATCHES 0)
+  string(REGEX REPLACE "sphinx-build[2]? " "" SPHINX_VERSION ${VERSION_OUTPUT})
+endif(VERSION_RESULT MATCHES 0)
+
+include(FindPackageHandleStandardArgs)
+# Handle standard arguments to find_package like REQUIRED and QUIET
+find_package_handle_standard_args(Sphinx
+  REQUIRED_VARS SPHINX_EXECUTABLE SPHINX_VERSION
+  VERSION_VAR SPHINX_VERSION
+  )

--- a/cmake/SetupSphinx.cmake
+++ b/cmake/SetupSphinx.cmake
@@ -1,0 +1,46 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+
+# We cannot fully support Sphinx+Breathe until Sphinx version 3.0.0. We have
+# an issue sxs-collaboration/spectre#2138 for tracking Sphinx bugs that
+# block us from being able to use Sphinx+Breathe.
+#
+# Some notes:
+# - Currently one must manually run make doc-xml before running Sphinx
+#   in order to get the Doxygen XML output. We will want to automate
+#   this in the future with true tracking of files needed for building
+#   Doxygen and Sphinx. Doing so will reduce the time it takes to rebuild
+#   documentation.
+# - Breathe's XML parser is horribly slow. See sxs-collaboration/spectre#2138
+option(USE_SPHINX
+  "When enabled, find and set up Sphinx+Breathe for documentation"
+  OFF)
+
+if (DOXYGEN_FOUND AND USE_SPHINX)
+  find_package(Sphinx REQUIRED)
+  find_package(Breathe REQUIRED)
+
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/docs/conf.py
+    ${CMAKE_BINARY_DIR}/docs/conf.py
+    @ONLY
+    )
+
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/docs/index.rst
+    ${CMAKE_BINARY_DIR}/docs/index.rst
+    )
+
+  set(SPHINX_SOURCE ${CMAKE_BINARY_DIR}/docs)
+  set(SPHINX_BUILD ${CMAKE_BINARY_DIR}/docs/sphinx)
+  set(SPHINX_INDEX_FILE ${SPHINX_BUILD}/index.html)
+
+  add_custom_target(Sphinx ALL
+    COMMAND
+    ${SPHINX_EXECUTABLE} -b html
+    ${SPHINX_SOURCE} ${SPHINX_BUILD}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Generating documentation with Sphinx"
+    )
+endif(DOXYGEN_FOUND AND USE_SPHINX)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,101 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+
+# pybtex.* are needed for customizing the reference formatting.
+from pybtex.style.formatting.unsrt import Style as UnsrtStyle
+from pybtex.style.labels import BaseLabelStyle
+from pybtex.plugin import register_plugin
+
+sys.path.insert(0, '@CMAKE_SOURCE_DIR@/docs')
+
+# -- Project information -----------------------------------------------------
+
+project = 'SpECTRE'
+copyright = '2017-2020, SXS Collaboration'
+author = 'SXS Collaboration'
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc', 'sphinx.ext.mathjax', 'sphinxcontrib.bibtex',
+    'breathe'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+# Tell sphinx what the primary language being documented is.
+primary_domain = 'cpp'
+
+# Tell sphinx what the pygments highlight language should be.
+highlight_language = 'cpp'
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+# Configure Breathe for parsing and including C++ documentation.
+breathe_projects = {'SpECTRE': '@CMAKE_BINARY_DIR@/docs/xml'}
+breathe_default_project = "SpECTRE"
+
+# Setup the Exhale extension for automatically building namespace,
+# file, and group documentation. We have had issues with Exhale
+# failing when dealing with function overloads. To enable you must
+# add `'exhale'` to the extensions.
+#
+# exhale_args = {
+#     # These arguments are required
+#     "containmentFolder": "./api",
+#     "rootFileName": "library_root.rst",
+#     "rootFileTitle": "Library API",
+#     "doxygenStripFromPath": "..",
+#     # Suggested optional arguments
+#     "createTreeView": True,
+#     # TIP: if using the sphinx-bootstrap-theme, you need
+#     # "treeViewIsBootstrap": True,
+#     "exhaleExecutesDoxygen": False
+#     # "exhaleDoxygenStdin": "INPUT = ../include"
+# }
+
+# # a simple label style which uses the bibtex keys for labels
+# class NumberedLabelStyle(BaseLabelStyle):
+#     def format_labels(self, sorted_entries):
+#         for entry in sorted_entries:
+#             # Add one since refs usually start at 1 not 0
+#             yield str(sorted_entries.index(entry) + 1)
+
+# class SpectreBibStyle(UnsrtStyle):
+#     default_label_style = NumberedLabelStyle
+
+# register_plugin('pybtex.style.formatting', 'SpectreStyle', SpectreBibStyle)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,65 @@
+.. Distributed under the MIT License.
+   See LICENSE.txt for details.
+Welcome to SpECTRE's documentation!
+===================================
+
+.. raw:: html
+
+   <a
+   href="https://github.com/sxs-collaboration/spectre/blob/develop/LICENSE.txt"><img
+   src="https://img.shields.io/badge/license-MIT-blue.svg"
+   alt="license"
+   data-canonical-src="https://img.shields.io/badge/license-MIT-blue.svg"
+   style="max-width:100%;"></a>
+
+   <a href="https://en.wikipedia.org/wiki/C%2B%2B#Standardization"
+   rel="nofollow"><img
+   src="https://camo.githubusercontent.com/14eafa365535119df0dc48953fd71c5647cc6b90/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f632532422532422d31342d626c75652e737667"
+   alt="Standard"
+   data-canonical-src="https://img.shields.io/badge/c%2B%2B-14-blue.svg"
+   style="max-width:100%;"></a>
+
+   <a href="https://github.com/sxs-collaboration/spectre/actions" rel="nofollow"><img
+   src="https://github.com/sxs-collaboration/spectre/workflows/Tests/badge.svg?branch=develop"
+   alt="Build Status"
+   data-canonical-src="https://github.com/sxs-collaboration/spectre/workflows/Tests/badge.svg?branch=develop"
+   style="max-width:100%;"></a>
+
+   <a href="https://coveralls.io/github/sxs-collaboration/spectre?branch=develop"
+   rel="nofollow"><img
+   src="https://camo.githubusercontent.com/9ac925f8d36b285f98b8dbc9b977606a5148d9b5/68747470733a2f2f636f766572616c6c732e696f2f7265706f732f6769746875622f7378732d636f6c6c61626f726174696f6e2f737065637472652f62616467652e7376673f6272616e63683d646576656c6f70"
+   alt="Coverage Status"
+   data-canonical-src="https://coveralls.io/repos/github/sxs-collaboration/spectre/badge.svg?branch=develop"
+   style="max-width:100%;"></a>
+
+   <a href="https://codecov.io/gh/sxs-collaboration/spectre" rel="nofollow"><img
+   src="https://camo.githubusercontent.com/ac504b33d403e271c9fb3831d1133118f1886317/68747470733a2f2f636f6465636f762e696f2f67682f7378732d636f6c6c61626f726174696f6e2f737065637472652f6272616e63682f646576656c6f702f67726170682f62616467652e737667"
+   alt="codecov"
+   data-canonical-src="https://codecov.io/gh/sxs-collaboration/spectre/branch/develop/graph/badge.svg"
+   style="max-width:100%;"></a>
+
+.. doxygengroup:: ActionsGroup
+   :members:
+
+.. doxygengroup:: ConstantExpressionsGroup
+   :members:
+
+.. doxygengroup:: DataBoxGroup
+   :members:
+
+.. doxygengroup:: DataStructuresGroup
+   :members:
+
+.. doxygengroup:: EvolutionSystemsGroup
+   :members:
+
+.. doxygengroup:: UtilitiesGroup
+   :members:
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
## Proposed changes

Adds support within CMake for building documentation using
Sphinx+Breathe+Doxygen (Breathe uses Doxygen's XML output). There are still a
few issues in Sphinx that need to be fixed before we can explore Sphinx+Breathe
further, but this adds initial support.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [x] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
