### PR TITLE
Set cmake policy using <PACKAGE_NAME>_ROOT variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,14 @@ cmake_minimum_required(VERSION 3.3.2)
 # Fortran below is needed for SPHEREPACK.
 project(SpECTRE VERSION 0.0.0 LANGUAGES CXX C Fortran)
 
+# Policies
+# The `cmake_minimum_required` above sets policies to `NEW` that are compatible
+# with the given minimum cmake version. Here we overwrite policies that we
+# have implemented explicitly in our cmake code.
+# - We use `<PACKAGE_NAME>_ROOT` variables to provide search paths for
+#   dependencies
+cmake_policy(SET CMP0074 NEW)
+
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
 site_name(HOSTNAME)


### PR DESCRIPTION
## Proposed changes

Set cmake policy using <PACKAGE_NAME>_ROOT variables

We use `<PACKAGE_NAME>_ROOT` variables to provide search paths for our
dependencies. This is the default from cmake 3.12, but we implement it
explicitly so it works also on older versions.
This commit sets the corresponding cmake policy to silence warnings when
configuring cmake with these variables set.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
