### PR TITLE
Have AH compute tags function return by reference

### DIFF
--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -15,12 +15,18 @@ template <typename Frame>
 class Strahlkorper;
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
+
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
 /// \endcond
 
 /// \ingroup SurfacesGroup
 /// Contains functions that depend both on a Strahlkorper and a metric.
 namespace StrahlkorperGr {
 
+//@{
 /// \ingroup SurfacesGroup
 /// \brief Computes normalized unit normal one-form to a Strahlkorper.
 ///
@@ -30,10 +36,18 @@ namespace StrahlkorperGr {
 /// is \f$1/\sqrt{g^{ij}n_i n_j}\f$, which can be computed using (one
 /// over) the `magnitude` function.
 template <typename Frame>
-tnsr::i<DataVector, 3, Frame> unit_normal_one_form(
+void unit_normal_one_form(
+    gsl::not_null<tnsr::i<DataVector, 3, Frame>*> result,
     const tnsr::i<DataVector, 3, Frame>& normal_one_form,
     const DataVector& one_over_one_form_magnitude) noexcept;
 
+template <typename Frame>
+tnsr::i<DataVector, 3, Frame> unit_normal_one_form(
+    const tnsr::i<DataVector, 3, Frame>& normal_one_form,
+    const DataVector& one_over_one_form_magnitude) noexcept;
+//@}
+
+//@{
 /// \ingroup SurfacesGroup
 /// \brief Computes 3-covariant gradient \f$D_i S_j\f$ of a
 /// Strahlkorper's normal.
@@ -52,13 +66,24 @@ tnsr::i<DataVector, 3, Frame> unit_normal_one_form(
 /// using (one over) the `magnitude` function.  The input argument
 /// `unit_normal_one_form` is \f$S_j\f$,the normalized one-form.
 template <typename Frame>
-tnsr::ii<DataVector, 3, Frame> grad_unit_normal_one_form(
+void grad_unit_normal_one_form(
+    gsl::not_null<tnsr::ii<DataVector, 3, Frame>*> result,
     const tnsr::i<DataVector, 3, Frame>& r_hat, const DataVector& radius,
     const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
     const tnsr::ii<DataVector, 3, Frame>& d2x_radius,
     const DataVector& one_over_one_form_magnitude,
     const tnsr::Ijj<DataVector, 3, Frame>& christoffel_2nd_kind) noexcept;
 
+template <typename Frame>
+tnsr::ii<DataVector, 3, Frame> grad_unit_normal_one_form(
+    const tnsr::i<DataVector, 3, Frame>& r_hat, const DataVector& radius,
+    const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
+    const tnsr::ii<DataVector, 3, Frame>& d2x_radius,
+    const DataVector& one_over_one_form_magnitude,
+    const tnsr::Ijj<DataVector, 3, Frame>& christoffel_2nd_kind) noexcept;
+//@}
+
+//@{
 /// \ingroup SurfacesGroup
 /// \brief Computes inverse 2-metric \f$g^{ij}-S^i S^j\f$ of a Strahlkorper.
 ///
@@ -71,10 +96,18 @@ tnsr::ii<DataVector, 3, Frame> grad_unit_normal_one_form(
 /// appropriate choice of basis. The input argument `unit_normal_vector` is
 /// \f$S^i = g^{ij} S_j\f$, where \f$S_j\f$ is the unit normal one form.
 template <typename Frame>
-tnsr::II<DataVector, 3, Frame> inverse_surface_metric(
+void inverse_surface_metric(
+    gsl::not_null<tnsr::II<DataVector, 3, Frame>*> result,
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
     const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept;
 
+template <typename Frame>
+tnsr::II<DataVector, 3, Frame> inverse_surface_metric(
+    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
+    const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept;
+//@}
+
+//@{
 /// \ingroup SurfacesGroup
 /// \brief Expansion of a `Strahlkorper`. Should be zero on apparent horizons.
 ///
@@ -83,11 +116,20 @@ tnsr::II<DataVector, 3, Frame> inverse_surface_metric(
 /// `StrahlkorperGr::grad_unit_normal_one_form`, and `inverse_surface_metric`
 /// is the quantity returned by `StrahlkorperGr::inverse_surface_metric`.
 template <typename Frame>
-Scalar<DataVector> expansion(
+void expansion(
+    gsl::not_null<Scalar<DataVector>*> result,
     const tnsr::ii<DataVector, 3, Frame>& grad_normal,
     const tnsr::II<DataVector, 3, Frame>& inverse_surface_metric,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept;
 
+template <typename Frame>
+Scalar<DataVector> expansion(
+    const tnsr::ii<DataVector, 3, Frame>& grad_normal,
+    const tnsr::II<DataVector, 3, Frame>& inverse_surface_metric,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept;
+//@}
+
+//@{
 /*!
  * \ingroup SurfacesGroup
  * \brief Extrinsic curvature of a 2D `Strahlkorper` embedded in a 3D space.
@@ -107,11 +149,20 @@ Scalar<DataVector> expansion(
  * + S_i S_j S^k S^l \nabla_{k} n_{l}\f$.
  */
 template <typename Frame>
-tnsr::ii<DataVector, 3, Frame> extrinsic_curvature(
+void extrinsic_curvature(
+    const gsl::not_null<tnsr::ii<DataVector, 3, Frame>*> result,
     const tnsr::ii<DataVector, 3, Frame>& grad_normal,
     const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector) noexcept;
 
+template <typename Frame>
+tnsr::ii<DataVector, 3, Frame> extrinsic_curvature(
+    const tnsr::ii<DataVector, 3, Frame>& grad_normal,
+    const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
+    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector) noexcept;
+//@}
+
+//@{
 /// \ingroup SurfacesGroup
 /// \brief Intrinsic Ricci scalar of a 2D `Strahlkorper`.
 ///
@@ -128,12 +179,22 @@ tnsr::ii<DataVector, 3, Frame> extrinsic_curvature(
 /// and `unit_normal_vector` is
 /// \f$S^i = g^{ij} S_j\f$ where \f$S_j\f$ is the unit normal one form.
 template <typename Frame>
-Scalar<DataVector> ricci_scalar(
+void ricci_scalar(
+    gsl::not_null<Scalar<DataVector>*> result,
     const tnsr::ii<DataVector, 3, Frame>& spatial_ricci_tensor,
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
     const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept;
 
+template <typename Frame>
+Scalar<DataVector> ricci_scalar(
+    const tnsr::ii<DataVector, 3, Frame>& spatial_ricci_tensor,
+    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept;
+//@}
+
+//@{
 /*!
  * \ingroup SurfacesGroup
  * \brief Area element of a 2D `Strahlkorper`.
@@ -156,13 +217,23 @@ Scalar<DataVector> ricci_scalar(
  * `definite_integral` defined in `YlmSpherePack.hpp`.
  */
 template <typename Frame>
+void area_element(gsl::not_null<Scalar<DataVector>*> result,
+                  const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+                  const StrahlkorperTags::aliases::Jacobian<Frame>& jacobian,
+                  const tnsr::i<DataVector, 3, Frame>& normal_one_form,
+                  const DataVector& radius,
+                  const tnsr::i<DataVector, 3, Frame>& r_hat) noexcept;
+
+template <typename Frame>
 Scalar<DataVector> area_element(
     const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
     const StrahlkorperTags::aliases::Jacobian<Frame>& jacobian,
     const tnsr::i<DataVector, 3, Frame>& normal_one_form,
     const DataVector& radius,
     const tnsr::i<DataVector, 3, Frame>& r_hat) noexcept;
+//@}
 
+//@{
 /*!
  * \ingroup SurfacesGroup
  * \brief Euclidean area element of a 2D `Strahlkorper`.
@@ -188,11 +259,20 @@ Scalar<DataVector> area_element(
  * `definite_integral` defined in `YlmSpherePack.hpp`.
  */
 template <typename Frame>
+void euclidean_area_element(
+    gsl::not_null<Scalar<DataVector>*> result,
+    const StrahlkorperTags::aliases::Jacobian<Frame>& jacobian,
+    const tnsr::i<DataVector, 3, Frame>& normal_one_form,
+    const DataVector& radius,
+    const tnsr::i<DataVector, 3, Frame>& r_hat) noexcept;
+
+template <typename Frame>
 Scalar<DataVector> euclidean_area_element(
     const StrahlkorperTags::aliases::Jacobian<Frame>& jacobian,
     const tnsr::i<DataVector, 3, Frame>& normal_one_form,
     const DataVector& radius,
     const tnsr::i<DataVector, 3, Frame>& r_hat) noexcept;
+//@}
 
 /*!
  * \ingroup SurfacesGroup
@@ -228,6 +308,7 @@ double euclidean_surface_integral_of_vector(
     const tnsr::i<DataVector, 3, Frame>& normal_one_form,
     const Strahlkorper<Frame>& strahlkorper) noexcept;
 
+//@{
 /*!
  * \ingroup SurfacesGroup
  * \brief Spin function of a 2D `Strahlkorper`.
@@ -262,12 +343,22 @@ double euclidean_surface_integral_of_vector(
  * StrahlkorperDataBox using the `StrahlkorperTags::Tangents` tag.
  */
 template <typename Frame>
+void spin_function(
+    gsl::not_null<Scalar<DataVector>*> result,
+    const StrahlkorperTags::aliases::Jacobian<Frame>& tangents,
+    const YlmSpherepack& ylm,
+    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
+    const Scalar<DataVector>& area_element,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept;
+
+template <typename Frame>
 Scalar<DataVector> spin_function(
     const StrahlkorperTags::aliases::Jacobian<Frame>& tangents,
     const YlmSpherepack& ylm,
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
     const Scalar<DataVector>& area_element,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept;
+//@}
 
 /*!
  * \ingroup SurfacesGroup

--- a/src/ApparentHorizons/Tags.cpp
+++ b/src/ApparentHorizons/Tags.cpp
@@ -9,77 +9,77 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 namespace StrahlkorperTags {
 
 template <typename Frame>
-aliases::ThetaPhi<Frame> ThetaPhi<Frame>::function(
+void ThetaPhi<Frame>::function(
+    const gsl::not_null<aliases::ThetaPhi<Frame>*> theta_phi,
     const ::Strahlkorper<Frame>& strahlkorper) noexcept {
   auto temp = strahlkorper.ylm_spherepack().theta_phi_points();
-  auto theta_phi = make_with_value<aliases::ThetaPhi<Frame>>(temp[0], 0.0);
-  get<0>(theta_phi) = temp[0];
-  get<1>(theta_phi) = temp[1];
-  return theta_phi;
+  destructive_resize_components(theta_phi, temp[0].size());
+  get<0>(*theta_phi) = temp[0];
+  get<1>(*theta_phi) = temp[1];
 }
 
 template <typename Frame>
-aliases::OneForm<Frame> Rhat<Frame>::function(
-    const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
+void Rhat<Frame>::function(const gsl::not_null<aliases::OneForm<Frame>*> r_hat,
+                           const aliases::ThetaPhi<Frame>& theta_phi) noexcept {
   const auto& theta = get<0>(theta_phi);
   const auto& phi = get<1>(theta_phi);
 
-  auto r_hat = make_with_value<aliases::OneForm<Frame>>(phi, 0.0);
-
+  destructive_resize_components(r_hat, theta.size());
   const DataVector sin_theta = sin(theta);
-  get<0>(r_hat) = sin_theta * cos(phi);
-  get<1>(r_hat) = sin_theta * sin(phi);
-  get<2>(r_hat) = cos(theta);
-  return r_hat;
+  get<0>(*r_hat) = sin_theta * cos(phi);
+  get<1>(*r_hat) = sin_theta * sin(phi);
+  get<2>(*r_hat) = cos(theta);
 }
 
 template <typename Frame>
-aliases::Jacobian<Frame> Jacobian<Frame>::function(
-    const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
+void Jacobian<Frame>::function(
+    const gsl::not_null<aliases::Jacobian<Frame>*> jac,
+    const aliases::ThetaPhi<Frame>& theta_phi) noexcept {
   const auto& theta = get<0>(theta_phi);
   const auto& phi = get<1>(theta_phi);
   const DataVector sin_phi = sin(phi);
   const DataVector cos_phi = cos(phi);
   const DataVector cos_theta = cos(theta);
 
-  auto jac = make_with_value<aliases::Jacobian<Frame>>(phi, 0.0);
-  get<0, 0>(jac) = cos_theta * cos_phi;  // 1/R dx/dth
-  get<1, 0>(jac) = cos_theta * sin_phi;  // 1/R dy/dth
-  get<2, 0>(jac) = -sin(theta);          // 1/R dz/dth
-  get<0, 1>(jac) = -sin_phi;             // 1/(R sin(th)) dx/dph
-  get<1, 1>(jac) = cos_phi;              // 1/(R sin(th)) dy/dph
-
-  return jac;
+  destructive_resize_components(jac, cos_theta.size());
+  get<0, 0>(*jac) = cos_theta * cos_phi;  // 1/R dx/dth
+  get<1, 0>(*jac) = cos_theta * sin_phi;  // 1/R dy/dth
+  get<2, 0>(*jac) = -sin(theta);          // 1/R dz/dth
+  get<0, 1>(*jac) = -sin_phi;             // 1/(R sin(th)) dx/dph
+  get<1, 1>(*jac) = cos_phi;              // 1/(R sin(th)) dy/dph
+  get<2, 1>(*jac) = 0.0;                  // 1/(R sin(th)) dz/dph
 }
 
 template <typename Frame>
-aliases::InvJacobian<Frame> InvJacobian<Frame>::function(
-    const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
+void InvJacobian<Frame>::function(
+    const gsl::not_null<aliases::InvJacobian<Frame>*> inv_jac,
+    const aliases::ThetaPhi<Frame>& theta_phi) noexcept {
   const auto& theta = get<0>(theta_phi);
   const auto& phi = get<1>(theta_phi);
   const DataVector sin_phi = sin(phi);
   const DataVector cos_phi = cos(phi);
   const DataVector cos_theta = cos(theta);
 
-  auto inv_jac = make_with_value<aliases::InvJacobian<Frame>>(phi, 0.0);
-  get<0, 0>(inv_jac) = cos_theta * cos_phi;  // R dth/dx
-  get<0, 1>(inv_jac) = cos_theta * sin_phi;  // R dth/dy
-  get<0, 2>(inv_jac) = -sin(theta);          // R dth/dz
-  get<1, 0>(inv_jac) = -sin_phi;             // R sin(th) dph/dx
-  get<1, 1>(inv_jac) = cos_phi;              // R sin(th) dph/dy
-
-  return inv_jac;
+  destructive_resize_components(inv_jac, cos_theta.size());
+  get<0, 0>(*inv_jac) = cos_theta * cos_phi;  // R dth/dx
+  get<0, 1>(*inv_jac) = cos_theta * sin_phi;  // R dth/dy
+  get<0, 2>(*inv_jac) = -sin(theta);          // R dth/dz
+  get<1, 0>(*inv_jac) = -sin_phi;             // R sin(th) dph/dx
+  get<1, 1>(*inv_jac) = cos_phi;              // R sin(th) dph/dy
+  get<1, 2>(*inv_jac) = 0.0;                  // R sin(th) dph/dz
 }
 
 template <typename Frame>
-aliases::InvHessian<Frame> InvHessian<Frame>::function(
-    const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
+void InvHessian<Frame>::function(
+    const gsl::not_null<aliases::InvHessian<Frame>*> inv_hess,
+    const aliases::ThetaPhi<Frame>& theta_phi) noexcept {
   const auto& theta = get<0>(theta_phi);
   const auto& phi = get<1>(theta_phi);
   const DataVector sin_phi = sin(phi);
@@ -87,7 +87,6 @@ aliases::InvHessian<Frame> InvHessian<Frame>::function(
   const DataVector sin_theta = sin(theta);
   const DataVector cos_theta = cos(theta);
 
-  auto inv_hess = make_with_value<aliases::InvHessian<Frame>>(phi, 0.0);
   const DataVector sin_sq_theta = square(sin_theta);
   const DataVector cos_sq_theta = square(cos_theta);
   const DataVector sin_theta_cos_theta = sin_theta * cos_theta;
@@ -98,74 +97,94 @@ aliases::InvHessian<Frame> InvHessian<Frame>::function(
   const DataVector f1 = 1.0 + 2.0 * sin_sq_theta;
   const DataVector cot_theta = cos_theta * csc_theta;
 
+  destructive_resize_components(inv_hess, cos_theta.size());
   // R^2 d^2 th/(dx^2)
-  get<0, 0, 0>(inv_hess) = cot_theta * (1.0 - cos_sq_phi * f1);
+  get<0, 0, 0>(*inv_hess) = cot_theta * (1.0 - cos_sq_phi * f1);
   // R^2 d^2 th/(dxdy)
-  get<0, 0, 1>(inv_hess) = -cot_theta * sin_phi_cos_phi * f1;
+  get<0, 0, 1>(*inv_hess) = -cot_theta * sin_phi_cos_phi * f1;
   // R^2 d^2 th/(dxdz)
-  get<0, 0, 2>(inv_hess) = (sin_sq_theta - cos_sq_theta) * cos_phi;
+  get<0, 0, 2>(*inv_hess) = (sin_sq_theta - cos_sq_theta) * cos_phi;
   // R^2 d^2 th/(dydx)
-  get<0, 1, 0>(inv_hess) = get<0, 0, 1>(inv_hess);
+  get<0, 1, 0>(*inv_hess) = get<0, 0, 1>(*inv_hess);
   // R^2 d^2 th/(dy^2)
-  get<0, 1, 1>(inv_hess) = cot_theta * (1.0 - sin_sq_phi * f1);
+  get<0, 1, 1>(*inv_hess) = cot_theta * (1.0 - sin_sq_phi * f1);
   // R^2 d^2 th/(dydz)
-  get<0, 1, 2>(inv_hess) = (sin_sq_theta - cos_sq_theta) * sin_phi;
+  get<0, 1, 2>(*inv_hess) = (sin_sq_theta - cos_sq_theta) * sin_phi;
   // R^2 d^2 th/(dzdx)
-  get<0, 2, 0>(inv_hess) = get<0, 0, 2>(inv_hess);
+  get<0, 2, 0>(*inv_hess) = get<0, 0, 2>(*inv_hess);
   // R^2 d^2 th/(dzdy)
-  get<0, 2, 1>(inv_hess) = get<0, 1, 2>(inv_hess);
+  get<0, 2, 1>(*inv_hess) = get<0, 1, 2>(*inv_hess);
   // R^2 d^2 th/(dz^2)
-  get<0, 2, 2>(inv_hess) = 2.0 * sin_theta_cos_theta;
+  get<0, 2, 2>(*inv_hess) = 2.0 * sin_theta_cos_theta;
   // R^2 d/dx (sin(th) dph/dx)
-  get<1, 0, 0>(inv_hess) = sin_phi_cos_phi * (1.0 + sin_sq_theta) * csc_theta;
+  get<1, 0, 0>(*inv_hess) = sin_phi_cos_phi * (1.0 + sin_sq_theta) * csc_theta;
   // R^2 d/dx (sin(th) dph/dy)
-  get<1, 0, 1>(inv_hess) = (sin_sq_phi - sin_sq_theta * cos_sq_phi) * csc_theta;
+  get<1, 0, 1>(*inv_hess) =
+      (sin_sq_phi - sin_sq_theta * cos_sq_phi) * csc_theta;
+  // R^2 d/dx (sin(th) dph/dz)
+  get<1, 0, 2>(*inv_hess) = 0.0;
   // R^2 d/dy (sin(th) dph/dx)
-  get<1, 1, 0>(inv_hess) = (sin_sq_theta * sin_sq_phi - cos_sq_phi) * csc_theta;
+  get<1, 1, 0>(*inv_hess) =
+      (sin_sq_theta * sin_sq_phi - cos_sq_phi) * csc_theta;
   // R^2 d/dy (sin(th) dph/dy)
-  get<1, 1, 1>(inv_hess) = -get<1, 0, 0>(inv_hess);
+  get<1, 1, 1>(*inv_hess) = -get<1, 0, 0>(*inv_hess);
+  // R^2 d/dy (sin(th) dph/dz)
+  get<1, 1, 2>(*inv_hess) = 0.0;
   // R^2 d/dz (sin(th) dph/dx)
-  get<1, 2, 0>(inv_hess) = cos_theta * sin_phi;
+  get<1, 2, 0>(*inv_hess) = cos_theta * sin_phi;
   // R^2 d/dz (sin(th) dph/dy)
-  get<1, 2, 1>(inv_hess) = -cos_theta * cos_phi;
-
-  return inv_hess;
+  get<1, 2, 1>(*inv_hess) = -cos_theta * cos_phi;
+  // R^2 d/dz (sin(th) dph/dz)
+  get<1, 2, 2>(*inv_hess) = 0.0;
 }
 
 template <typename Frame>
-aliases::Vector<Frame> CartesianCoords<Frame>::function(
+void Radius<Frame>::function(
+    const gsl::not_null<DataVector*> radius,
+    const ::Strahlkorper<Frame>& strahlkorper) noexcept {
+  radius->destructive_resize(strahlkorper.ylm_spherepack().physical_size());
+  *radius =
+      strahlkorper.ylm_spherepack().spec_to_phys(strahlkorper.coefficients());
+}
+
+template <typename Frame>
+void CartesianCoords<Frame>::function(
+    const gsl::not_null<aliases::Vector<Frame>*> coords,
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-    const db::const_item_type<Rhat<Frame>>& r_hat) noexcept {
-  auto coords = make_with_value<aliases::Vector<Frame>>(radius, 0.0);
+    const aliases::OneForm<Frame>& r_hat) noexcept {
+  destructive_resize_components(coords, radius.size());
   for (size_t d = 0; d < 3; ++d) {
-    coords.get(d) = gsl::at(strahlkorper.center(), d) + r_hat.get(d) * radius;
+    coords->get(d) = gsl::at(strahlkorper.center(), d) + r_hat.get(d) * radius;
   }
-  return coords;
 }
 
 template <typename Frame>
-aliases::OneForm<Frame> DxRadius<Frame>::function(
+void DxRadius<Frame>::function(
+    const gsl::not_null<aliases::OneForm<Frame>*> dx_radius,
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-    const db::const_item_type<InvJacobian<Frame>>& inv_jac) noexcept {
-  auto dx_radius = make_with_value<aliases::OneForm<Frame>>(radius, 0.0);
+    const aliases::InvJacobian<Frame>& inv_jac) noexcept {
+  destructive_resize_components(dx_radius, radius.size());
   const DataVector one_over_r = 1.0 / radius;
   const auto dr = strahlkorper.ylm_spherepack().gradient(radius);
-  get<0>(dx_radius) =
+  get<0>(*dx_radius) =
       (get<0, 0>(inv_jac) * get<0>(dr) + get<1, 0>(inv_jac) * get<1>(dr)) *
       one_over_r;
-  get<1>(dx_radius) =
+  get<1>(*dx_radius) =
       (get<0, 1>(inv_jac) * get<0>(dr) + get<1, 1>(inv_jac) * get<1>(dr)) *
       one_over_r;
-  get<2>(dx_radius) = get<0, 2>(inv_jac) * get<0>(dr) * one_over_r;
-  return dx_radius;
+  get<2>(*dx_radius) = get<0, 2>(inv_jac) * get<0>(dr) * one_over_r;
 }
 
 template <typename Frame>
-aliases::SecondDeriv<Frame> D2xRadius<Frame>::function(
+void D2xRadius<Frame>::function(
+    const gsl::not_null<aliases::SecondDeriv<Frame>*> d2x_radius,
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-    const db::const_item_type<InvJacobian<Frame>>& inv_jac,
-    const db::const_item_type<InvHessian<Frame>>& inv_hess) noexcept {
-  auto d2x_radius = make_with_value<aliases::SecondDeriv<Frame>>(radius, 0.0);
+    const aliases::InvJacobian<Frame>& inv_jac,
+    const aliases::InvHessian<Frame>& inv_hess) noexcept {
+  destructive_resize_components(d2x_radius, radius.size());
+  for (auto& component : *d2x_radius) {
+    component = 0.0;
+  }
   const DataVector one_over_r_squared = 1.0 / square(radius);
   const auto derivs =
       strahlkorper.ylm_spherepack().first_and_second_derivative(radius);
@@ -173,65 +192,66 @@ aliases::SecondDeriv<Frame> D2xRadius<Frame>::function(
   for (size_t i = 0; i < 3; ++i) {
     // Diagonal terms.  Divide by square(r) later.
     for (size_t k = 0; k < 2; ++k) {  // Angular derivs are 2-dimensional
-      d2x_radius.get(i, i) += derivs.first.get(k) * inv_hess.get(k, i, i);
+      d2x_radius->get(i, i) += derivs.first.get(k) * inv_hess.get(k, i, i);
       for (size_t l = 0; l < 2; ++l) {  // Angular derivs are 2-dimensional
-        d2x_radius.get(i, i) +=
+        d2x_radius->get(i, i) +=
             derivs.second.get(l, k) * inv_jac.get(k, i) * inv_jac.get(l, i);
       }
     }
-    d2x_radius.get(i, i) *= one_over_r_squared;
+    d2x_radius->get(i, i) *= one_over_r_squared;
     // off_diagonal terms.  Symmetrize over i and j.
     // Divide by 2*square(r) later.
     for (size_t j = i + 1; j < 3; ++j) {
       for (size_t k = 0; k < 2; ++k) {  // Angular derivs are 2-dimensional
-        d2x_radius.get(i, j) += derivs.first.get(k) *
-                                (inv_hess.get(k, i, j) + inv_hess.get(k, j, i));
+        d2x_radius->get(i, j) += derivs.first.get(k) * (inv_hess.get(k, i, j) +
+                                                        inv_hess.get(k, j, i));
         for (size_t l = 0; l < 2; ++l) {  // Angular derivs are 2-dimensional
-          d2x_radius.get(i, j) +=
+          d2x_radius->get(i, j) +=
               derivs.second.get(l, k) * (inv_jac.get(k, i) * inv_jac.get(l, j) +
                                          inv_jac.get(k, j) * inv_jac.get(l, i));
         }
       }
-      d2x_radius.get(i, j) *= 0.5 * one_over_r_squared;
+      d2x_radius->get(i, j) *= 0.5 * one_over_r_squared;
     }
   }
-  return d2x_radius;
 }
 
 template <typename Frame>
-DataVector LaplacianRadius<Frame>::function(
+void LaplacianRadius<Frame>::function(
+    const gsl::not_null<DataVector*> lap_radius,
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-    const db::const_item_type<ThetaPhi<Frame>>& theta_phi) noexcept {
+    const aliases::ThetaPhi<Frame>& theta_phi) noexcept {
+  lap_radius->destructive_resize(radius.size());
   const auto derivs =
       strahlkorper.ylm_spherepack().first_and_second_derivative(radius);
-  return get<0, 0>(derivs.second) + get<1, 1>(derivs.second) +
-         get<0>(derivs.first) / tan(get<0>(theta_phi));
+  *lap_radius = get<0, 0>(derivs.second) + get<1, 1>(derivs.second) +
+                get<0>(derivs.first) / tan(get<0>(theta_phi));
 }
 
 template <typename Frame>
-aliases::OneForm<Frame> NormalOneForm<Frame>::function(
-    const db::const_item_type<DxRadius<Frame>>& dx_radius,
-    const db::const_item_type<Rhat<Frame>>& r_hat) noexcept {
-  auto one_form = make_with_value<aliases::OneForm<Frame>>(r_hat, 0.0);
+void NormalOneForm<Frame>::function(
+    const gsl::not_null<aliases::OneForm<Frame>*> one_form,
+    const aliases::OneForm<Frame>& dx_radius,
+    const aliases::OneForm<Frame>& r_hat) noexcept {
+  destructive_resize_components(one_form, r_hat.begin()->size());
   for (size_t d = 0; d < 3; ++d) {
-    one_form.get(d) = r_hat.get(d) - dx_radius.get(d);
+    one_form->get(d) = r_hat.get(d) - dx_radius.get(d);
   }
-  return one_form;
 }
 
 template <typename Frame>
-aliases::Jacobian<Frame> Tangents<Frame>::function(
+void Tangents<Frame>::function(
+    const gsl::not_null<aliases::Jacobian<Frame>*> tangents,
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
-    const db::const_item_type<Rhat<Frame>>& r_hat,
-    const db::const_item_type<Jacobian<Frame>>& jac) noexcept {
+    const aliases::OneForm<Frame>& r_hat,
+    const aliases::Jacobian<Frame>& jac) noexcept {
+  destructive_resize_components(tangents, radius.size());
   const auto dr = strahlkorper.ylm_spherepack().gradient(radius);
-  auto tangents = make_with_value<aliases::Jacobian<Frame>>(radius, 0.0);
   for (size_t i = 0; i < 2; ++i) {
     for (size_t j = 0; j < 3; ++j) {
-      tangents.get(j, i) = dr.get(i) * r_hat.get(j) + radius * jac.get(j, i);
+      tangents->get(j, i) = dr.get(i) * r_hat.get(j) + radius * jac.get(j, i);
     }
   }
-  return tangents;
 }
 
 }  // namespace StrahlkorperTags
@@ -242,6 +262,7 @@ template struct Rhat<Frame::Inertial>;
 template struct Jacobian<Frame::Inertial>;
 template struct InvJacobian<Frame::Inertial>;
 template struct InvHessian<Frame::Inertial>;
+template struct Radius<Frame::Inertial>;
 template struct CartesianCoords<Frame::Inertial>;
 template struct DxRadius<Frame::Inertial>;
 template struct D2xRadius<Frame::Inertial>;

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -235,8 +235,13 @@ struct Tangents : db::ComputeTag {
 template <typename Frame>
 struct EuclideanAreaElement : db::ComputeTag {
   static std::string name() noexcept { return "EuclideanAreaElement"; }
-  static constexpr auto function =
-      ::StrahlkorperGr::euclidean_area_element<Frame>;
+  using return_type = Scalar<DataVector>;
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<DataVector>*>,
+      const StrahlkorperTags::aliases::Jacobian<Frame>&,
+      const tnsr::i<DataVector, 3, Frame>&, const DataVector&,
+      const tnsr::i<DataVector, 3, Frame>&) noexcept>(
+      &::StrahlkorperGr::euclidean_area_element<Frame>);
   using argument_tags = tmpl::list<
       StrahlkorperTags::Jacobian<Frame>, StrahlkorperTags::NormalOneForm<Frame>,
       StrahlkorperTags::Radius<Frame>, StrahlkorperTags::Rhat<Frame>>;
@@ -248,6 +253,7 @@ struct EuclideanSurfaceIntegral : db::ComputeTag {
   static std::string name() noexcept {
     return "EuclideanSurfaceIntegral(" + db::tag_name<IntegrandTag>() + ")";
   }
+  // return type is `double` so returning by value is OK
   static constexpr auto function =
       ::StrahlkorperGr::surface_integral_of_scalar<Frame>;
   using argument_tags = tmpl::list<EuclideanAreaElement<Frame>, IntegrandTag,
@@ -266,6 +272,7 @@ struct EuclideanSurfaceIntegralVector : db::ComputeTag {
     return "EuclideanSurfaceIntegralVector(" + db::tag_name<IntegrandTag>() +
            ")";
   }
+  // return type is `double` so returning by value is OK
   static constexpr auto function =
       ::StrahlkorperGr::euclidean_surface_integral_of_vector<Frame>;
   using argument_tags = tmpl::list<EuclideanAreaElement<Frame>, IntegrandTag,
@@ -295,7 +302,12 @@ namespace Tags {
 template <typename Frame>
 struct AreaElement : db::ComputeTag {
   static std::string name() noexcept { return "AreaElement"; }
-  static constexpr auto function = area_element<Frame>;
+  using return_type = Scalar<DataVector>;
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<DataVector>*>, const tnsr::ii<DataVector, 3, Frame>&,
+      const StrahlkorperTags::aliases::Jacobian<Frame>&,
+      const tnsr::i<DataVector, 3, Frame>&, const DataVector&,
+      const tnsr::i<DataVector, 3, Frame>&) noexcept>(&area_element<Frame>);
   using argument_tags = tmpl::list<
       gr::Tags::SpatialMetric<3, Frame>, StrahlkorperTags::Jacobian<Frame>,
       StrahlkorperTags::NormalOneForm<Frame>, StrahlkorperTags::Radius<Frame>,
@@ -308,6 +320,7 @@ struct SurfaceIntegral : db::ComputeTag {
   static std::string name() noexcept {
     return "SurfaceIntegral(" + db::tag_name<IntegrandTag>() + ")";
   }
+  // return type is `double` so returning by value is OK
   static constexpr auto function = surface_integral_of_scalar<Frame>;
   using argument_tags = tmpl::list<AreaElement<Frame>, IntegrandTag,
                                    StrahlkorperTags::Strahlkorper<Frame>>;


### PR DESCRIPTION
## Proposed changes

~I have a couple of extra commits that work out the compute tags in `Tags.hpp` too (in progress). However, I wanted to make sure we actually want to have them as such, given that they are only used as arguments to initialize the prolonged coords in  `ApparentHorizon` (currently in `NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp`). Is the intended idea to give those items their own allocation throughout an evolution at all?~

~Opening this PR in order to see what changes I should actually push.~


Long story short: `NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp` has some allocations used to compute `prolonged_coords` (see `Have compute tags in AH Tags.hpp return by reference` commit). which I'm not sure if can (or should) be avoided.

### Types of changes:

- [ ] Bugfix
- [x ] New feature
- [ ] Refactor

### Component:

- [x ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
