### PR TITLE
Fix typo in `SetupBoost.cmake`

### DIFF
--- a/cmake/SetupBoost.cmake
+++ b/cmake/SetupBoost.cmake
@@ -20,7 +20,7 @@ file(APPEND
 if(NOT TARGET Boost::boost)
   add_library(Boost::boost INTERFACE IMPORTED)
   set_property(TARGET Boost::boost PROPERTY
-    INTERFACE_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIR})
+    INTERFACE_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
 endif(NOT TARGET Boost::boost)
 
 if(NOT TARGET Boost::program_options)
@@ -28,5 +28,5 @@ if(NOT TARGET Boost::program_options)
   set_property(TARGET Boost::program_options
     APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${Boost_LIBRARIES})
   set_property(TARGET Boost::program_options PROPERTY
-    INTERFACE_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIR})
+    INTERFACE_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
 endif(NOT TARGET Boost::program_options)


### PR DESCRIPTION
## Proposed changes

- Missed an `S` in `Boost_INCLUDE_DIRS` at the end

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
