### PR TITLE
Change option help formatting to allow longer names+help

### DIFF
--- a/src/Options/OptionsDetails.hpp
+++ b/src/Options/OptionsDetails.hpp
@@ -160,10 +160,10 @@ struct has_upper_bound_on_size<
 
 template <typename Group, typename OptionList, typename = std::nullptr_t>
 struct print_impl {
-  static std::string apply(const int max_label_size) noexcept {
+  static std::string apply() noexcept {
     std::ostringstream ss;
-    ss << "  " << std::setw(max_label_size + 2) << std::left
-       << option_name<Group>() << Group::help << "\n\n";
+    ss << "  " << option_name<Group>() << ":\n"
+       << "    " << Group::help << "\n\n";
     return ss.str();
   }
 };
@@ -262,41 +262,38 @@ struct print_impl<Tag, OptionList,
     return "";
   }
 
-  static std::string apply(const int max_label_size) noexcept {
+  static std::string apply() noexcept {
     std::ostringstream ss;
-    ss << "  " << std::setw(max_label_size + 2) << std::left
-       << option_name<Tag>() << yaml_type<typename Tag::type>::value();
+    ss << "  " << option_name<Tag>() << ":\n"
+       << "    " << "type=" << yaml_type<typename Tag::type>::value();
     std::string limits;
     for (const auto& limit :
          {print_default<Tag>(), print_lower_bound<Tag>(),
           print_upper_bound<Tag>(), print_lower_bound_on_size<Tag>(),
           print_upper_bound_on_size<Tag>()}) {
       if (not limits.empty() and not limit.empty()) {
-        limits += ", ";
+        limits += "\n    ";
       }
       limits += limit;
     }
     if (not limits.empty()) {
-      ss << " [" << limits << "]";
+      ss << "\n    " << limits;
     }
-    ss << "\n" << std::setw(max_label_size + 4) << "" << Tag::help << "\n\n";
+    ss << "\n"
+       << "    " << Tag::help << "\n\n";
     return ss.str();
   }
 };
 
 template <typename OptionList>
 struct print {
-  explicit print(const int max_label_size) noexcept
-      : max_label_size_(max_label_size) {}
+  print() = default;
   using value_type = std::string;
   template <typename Tag>
   void operator()(tmpl::type_<Tag> /*meta*/) noexcept {
-    value += print_impl<Tag, OptionList>::apply(max_label_size_);
+    value += print_impl<Tag, OptionList>::apply();
   }
   value_type value{};
-
- private:
-  const int max_label_size_;
 };
 
 // TMP function to create an unordered_set of option names.

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -204,11 +204,8 @@ class Options {
   using tags_and_subgroups_list = tmpl::remove_duplicates<tmpl::transform<
       OptionList, Options_detail::find_subgroup<tmpl::_1, Group>>>;
 
-  // The maximum length of an option label. 21 characters fits
-  // "DiscontinuousGalerkin".
-  static constexpr int max_label_size_ = 21;
-  // The maximum length of option help strings.
-  static constexpr size_t max_help_size_ = 55;
+  // The maximum length of an option label.
+  static constexpr int max_label_size_ = 70;
 
   //@{
   /// Check that the size is not smaller than the lower bound
@@ -349,11 +346,6 @@ Options<OptionList, Group>::Options(std::string help_text) noexcept
                               << max_label_size_ << " characters or fewer");
     ASSERT(std::strlen(T::help) > 0,
            "You must supply a help string of non-zero length for " << label);
-    ASSERT(std::strlen(T::help) <= max_help_size_,
-           "Option help strings should be short and to the point.  "
-           "The help string for "
-               << label << " should have " << max_help_size_
-               << " characters or fewer.");
   });
 }
 
@@ -507,7 +499,7 @@ std::string Options<OptionList, Group>::help() const noexcept {
   if (tmpl::size<tags_and_subgroups_list>::value > 0) {
     ss << "\n\nOptions:\n"
        << tmpl::for_each<tags_and_subgroups_list>(
-              Options_detail::print<OptionList>{max_label_size_})
+              Options_detail::print<OptionList>{})
               .value;
   } else {
     ss << "\n\n<No options>\n";

--- a/tests/Unit/Options/Test_Factory.cpp
+++ b/tests/Unit/Options/Test_Factory.cpp
@@ -237,13 +237,18 @@ void test_factory_object_map() {
 
 void test_factory_format() {
   Options<tmpl::list<OptionType>> opts("");
-  INFO(opts.help());
+  const std::string expected1{"default=Test1\n"};
+  const std::string expected2{"default=Test2\n"};
+  INFO("Help string:\n"
+       << opts.help() << "\n\nExpected to find:\n"
+       << expected2 << "\nExpected not to find:\n"
+       << expected1);
   // The compiler puts "(anonymous namespace)::" before the type, but
   // I don't want to rely on that, so just check that the type is at
   // the end of the line, which should ensure it is not in a template
   // parameter or something.
-  CHECK(opts.help().find("OptionTest [default=Test2]\n") != std::string::npos);
-  CHECK(opts.help().find("OptionTest [default=Test1]\n") == std::string::npos);
+  CHECK(opts.help().find(expected2) != std::string::npos);
+  CHECK(opts.help().find(expected1) == std::string::npos);
 }
 }  // namespace
 

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -602,13 +602,17 @@ struct NamedDuplicate {
 }
 
 #ifdef SPECTRE_DEBUG
-struct TooooooooooooooooooooLong {
+struct
+    ToooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooLong {
   using type = int;
   static constexpr OptionString help = {"halp"};
 };
 struct NamedTooLong {
   using type = int;
-  static std::string name() noexcept { return "TooooooooooooooooooooLong"; }
+  static std::string name() noexcept {
+    return "Toooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+           "oLong";
+  }
   static constexpr OptionString help = {"halp"};
 };
 struct NoHelp {
@@ -620,31 +624,24 @@ struct NamedNoHelp {
   static std::string name() noexcept { return "NoHelp"; }
   static constexpr OptionString help = {""};
 };
-struct TooLongHelp {
-  using type = int;
-  static constexpr OptionString help = {
-      "halp halp halp halp halp halp halp halp halp halp halp halp"};
-};
-struct NamedTooLongHelp {
-  using type = int;
-  static std::string name() noexcept { return "TooLongHelp"; }
-  static constexpr OptionString help = {
-      "halp halp halp halp halp halp halp halp halp halp halp halp"};
-};
 #endif  // SPECTRE_DEBUG
 
-// [[OutputRegex, The option name TooooooooooooooooooooLong is too long for
-// nice formatting]]
+// [[OutputRegex, The option name
+// ToooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooLong is
+// too long for nice formatting]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Options.TooLong", "[Unit][Options]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  Options<tmpl::list<TooooooooooooooooooooLong>> opts("");
+  Options<tmpl::list<
+      ToooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooLong>>
+      opts("");
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
-// [[OutputRegex, The option name TooooooooooooooooooooLong is too long for
-// nice formatting]]
+// [[OutputRegex, The option name
+// ToooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooLong is
+// too long for nice formatting]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Options.NamedTooLong", "[Unit][Options]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
@@ -667,25 +664,6 @@ struct NamedTooLongHelp {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Options<tmpl::list<NamedNoHelp>> opts("");
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, The help string for TooLongHelp should have]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Options.TooLongHelp", "[Unit][Options]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  Options<tmpl::list<TooLongHelp>> opts("");
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, The help string for TooLongHelp should have]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Options.NamedTooLongHelp",
-                               "[Unit][Options]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  Options<tmpl::list<NamedTooLongHelp>> opts("");
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
@@ -767,9 +745,12 @@ void test_options_format() {
   const auto check = [](auto opt) noexcept {
     using Opt = decltype(opt);
     Options<tmpl::list<Opt>> opts("");
-    INFO(opts.help());
+    INFO("Help string:\n"
+         << opts.help() << "\n\nExpected to find:\n"
+         << "  type="s + Opt::expected + "\n");
     // Add whitespace to check that we've got the entire type
-    CHECK(opts.help().find("  "s + Opt::expected + "\n") != std::string::npos);
+    CHECK(opts.help().find("type="s + Opt::expected + "\n"s) !=
+          std::string::npos);
   };
   check(FormatMap{});
   check(FormatVector{});


### PR DESCRIPTION
## Proposed changes

- Change the formatting of the help text to:
```
Options:
  Bounded:
    type= int
    default=3
    min=2
    max=10
    Option with bounds and a default value
```
- Change the character limit on option names to 70 from 21
- Change the character limit on option help strings to 300 from 55


### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
