### PR TITLE
Set cmake policy using <PACKAGE_NAME>_ROOT variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,16 @@ cmake_minimum_required(VERSION 3.3.2)
 # Fortran below is needed for SPHEREPACK.
 project(SpECTRE VERSION 0.0.0 LANGUAGES CXX C Fortran)
 
+# Policies
+# The `cmake_minimum_required` above sets policies to `NEW` that are compatible
+# with the given minimum cmake version. Here we overwrite policies that we
+# have back-ported in our cmake code.
+# - We use `<PACKAGE_NAME>_ROOT` variables to provide search paths for
+#   dependencies
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+  cmake_policy(SET CMP0074 NEW)
+endif ()
+
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
 site_name(HOSTNAME)

--- a/cmake/FindBlaze.cmake
+++ b/cmake/FindBlaze.cmake
@@ -5,7 +5,7 @@ find_path(
     BLAZE_INCLUDE_DIR
     PATH_SUFFIXES include
     NAMES blaze/Blaze.h
-    HINTS ${BLAZE_ROOT}
+    HINTS ${BLAZE_ROOT} ENV BLAZE_ROOT
     DOC "Blaze include directory. Used BLAZE_ROOT to set a search dir."
 )
 

--- a/cmake/FindBrigand.cmake
+++ b/cmake/FindBrigand.cmake
@@ -5,7 +5,7 @@ find_path(
     BRIGAND_INCLUDE_DIR
     PATH_SUFFIXES include
     NAMES brigand/brigand.hpp
-    HINTS ${BRIGAND_ROOT}
+    HINTS ${BRIGAND_ROOT} ENV BRIGAND_ROOT
     DOC "Brigand include directory. Used BRIGAND_ROOT to set a search dir."
 )
 

--- a/cmake/FindCatch.cmake
+++ b/cmake/FindCatch.cmake
@@ -2,7 +2,7 @@
 # Copyright (C) 2011-2016 Peter Spiess-Knafl
 
 # SpECTRE modifications:
-# - add PATH_SUFFIXES to find_path
+# - add PATH_SUFFIXES and HINTS ENV to find_path
 # - call function _get_catch_version (taken from another source)
 # - pass version to find_package_handle_standard_args
 
@@ -25,7 +25,7 @@ find_path(
   CATCH_INCLUDE_DIR
   PATH_SUFFIXES single_include include catch catch2
   NAMES catch.hpp
-  HINTS ${CATCH_ROOT}
+  HINTS ${CATCH_ROOT} ENV CATCH_ROOT
   DOC "catch include dir"
   )
 

--- a/cmake/FindCharm.cmake
+++ b/cmake/FindCharm.cmake
@@ -21,7 +21,7 @@ endif ()
 find_path(
     CHARM_INCLUDE_DIRS charm.h
     PATH_SUFFIXES include
-    HINTS ${CHARM_ROOT}
+    HINTS ${CHARM_ROOT} ENV CHARM_ROOT
 )
 
 if (EXISTS "${CHARM_INCLUDE_DIRS}/VERSION")
@@ -51,14 +51,14 @@ set(CHARM_VERSION
 find_library(CHARM_LIBCK
     NAMES ck
     PATH_SUFFIXES lib
-    HINTS ${CHARM_ROOT}
+    HINTS ${CHARM_ROOT} ENV CHARM_ROOT
 )
 get_filename_component(CHARM_LIBRARIES ${CHARM_LIBCK} DIRECTORY)
 
 find_program(CHARM_COMPILER
   NAMES charmc
   PATH_SUFFIXES bin
-  HINTS ${CHARM_ROOT}
+  HINTS ${CHARM_ROOT} ENV CHARM_ROOT
   DOC "The full-path to the charm++ compiler"
   )
 

--- a/cmake/FindGoogleBenchmark.cmake
+++ b/cmake/FindGoogleBenchmark.cmake
@@ -7,12 +7,12 @@
 
 find_path(GOOGLE_BENCHMARK_INCLUDE_DIRS benchmark.h
     PATH_SUFFIXES include/benchmark
-    HINTS ${GOOGLE_BENCHMARK_ROOT})
+    HINTS ${GOOGLE_BENCHMARK_ROOT} ENV GOOGLE_BENCHMARK_ROOT)
 
 find_library(GOOGLE_BENCHMARK_LIBRARIES
     NAMES benchmark
     PATH_SUFFIXES lib64 lib
-    HINTS ${GOOGLE_BENCHMARK_ROOT})
+    HINTS ${GOOGLE_BENCHMARK_ROOT} ENV GOOGLE_BENCHMARK_ROOT)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(GOOGLE_BENCHMARK

--- a/cmake/FindJEMALLOC.cmake
+++ b/cmake/FindJEMALLOC.cmake
@@ -8,12 +8,12 @@
 # find the jemalloc include directory
 find_path(JEMALLOC_INCLUDE_DIRS jemalloc/jemalloc.h
     PATH_SUFFIXES include
-    HINTS ${JEMALLOC_ROOT})
+    HINTS ${JEMALLOC_ROOT} ENV JEMALLOC_ROOT)
 
 find_library(JEMALLOC_LIBRARIES
     NAMES jemalloc
     PATH_SUFFIXES lib64 lib
-    HINTS ${JEMALLOC_ROOT})
+    HINTS ${JEMALLOC_ROOT} ENV JEMALLOC_ROOT)
 
 # Extract version info from header
 file(READ

--- a/cmake/FindLIBXSMM.cmake
+++ b/cmake/FindLIBXSMM.cmake
@@ -8,12 +8,12 @@
 # find the LIBXSMM include directory
 find_path(LIBXSMM_INCLUDE_DIRS libxsmm.h
     PATH_SUFFIXES include
-    HINTS ${LIBXSMM_ROOT})
+    HINTS ${LIBXSMM_ROOT} ENV LIBXSMM_ROOT)
 
 find_library(LIBXSMM_LIBRARIES
     NAMES xsmm
     PATH_SUFFIXES lib64 lib
-    HINTS ${LIBXSMM_ROOT})
+    HINTS ${LIBXSMM_ROOT} ENV LIBXSMM_ROOT)
 
 # Extract version info from header
 file(READ

--- a/cmake/FindLibsharp.cmake
+++ b/cmake/FindLibsharp.cmake
@@ -10,22 +10,22 @@ include (CheckCXXSourceRuns)
 # find the libsharp include directory
 find_path(LIBSHARP_INCLUDE_DIRS sharp_cxx.h
     PATH_SUFFIXES include
-    HINTS ${LIBSHARP_ROOT}/include/)
+    HINTS ${LIBSHARP_ROOT}/include/ ENV LIBSHARP_ROOT)
 
 find_library(LIBSHARP_LIBFFTPACK
     NAMES libfftpack libfftpack.a
     PATH_SUFFIXES lib64 lib
-    HINTS ${LIBSHARP_ROOT})
+    HINTS ${LIBSHARP_ROOT} ENV LIBSHARP_ROOT)
 
 find_library(LIBSHARP_LIBRARIES
     NAMES libsharp libsharp.a
     PATH_SUFFIXES lib64 lib
-    HINTS ${LIBSHARP_ROOT})
+    HINTS ${LIBSHARP_ROOT} ENV LIBSHARP_ROOT)
 
 find_library(LIBSHARP_LIBCUTILS
     NAMES libc_utils libc_utils.a
     PATH_SUFFIXES lib64 lib
-    HINTS ${LIBSHARP_ROOT})
+    HINTS ${LIBSHARP_ROOT} ENV LIBSHARP_ROOT)
 
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindTCMALLOC.cmake
+++ b/cmake/FindTCMALLOC.cmake
@@ -8,12 +8,12 @@
 # find the tcmalloc include directory
 find_path(TCMALLOC_INCLUDE_DIRS gperftools/tcmalloc.h
     PATH_SUFFIXES include
-    HINTS ${TCMALLOC_ROOT})
+    HINTS ${TCMALLOC_ROOT} ENV TCMALLOC_ROOT)
 
 find_library(TCMALLOC_LIBRARIES
     NAMES tcmalloc
     PATH_SUFFIXES lib64 lib
-    HINTS ${TCMALLOC_ROOT})
+    HINTS ${TCMALLOC_ROOT} ENV TCMALLOC_ROOT)
 
 # Extract version info from header
 file(READ

--- a/cmake/FindYAMLCPP.cmake
+++ b/cmake/FindYAMLCPP.cmake
@@ -11,7 +11,7 @@ include (CheckCXXSourceRuns)
 # find the yaml-cpp include directory
 find_path(YAMLCPP_INCLUDE_DIRS yaml-cpp/yaml.h
     PATH_SUFFIXES include
-    HINTS ${YAMLCPP_ROOT}/include/)
+    HINTS ${YAMLCPP_ROOT}/include/ ENV YAMLCPP_ROOT)
 
 if(YAMLCPP_STATIC_LIBRARY)
   set(YAMLCPP_STATIC libyaml-cpp.a)
@@ -20,7 +20,7 @@ endif()
 find_library(YAMLCPP_LIBRARIES
     NAMES ${YAMLCPP_STATIC} yaml-cpp
     PATH_SUFFIXES lib64 lib
-    HINTS ${YAMLCPP_ROOT})
+    HINTS ${YAMLCPP_ROOT} ENV YAMLCPP_ROOT)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(YAMLCPP

--- a/cmake/Findpybind11.cmake
+++ b/cmake/Findpybind11.cmake
@@ -5,7 +5,7 @@ find_path(
     pybind11_INCLUDE_DIR
     PATH_SUFFIXES include
     NAMES pybind11/pybind11.h
-    HINTS ${pybind11_ROOT}
+    HINTS ${pybind11_ROOT} ENV pybind11_ROOT
     DOC "Pybind11 include directory. Used pybind11_ROOT to set a search dir."
 )
 


### PR DESCRIPTION
## Proposed changes

We use `<PACKAGE_NAME>_ROOT` variables to provide search paths for our
dependencies. This is the default from cmake 3.12, but we implement it
explicitly so it works also on older versions.
This commit sets the corresponding cmake policy to silence warnings when
configuring cmake with these variables set.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
