### PR TITLE
Make BinaryCompactObject time dependent

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -5,9 +5,14 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
-#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
@@ -31,7 +36,16 @@ class Frustum;
 
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 class CoordinateMap;
+
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
 }  // namespace domain
+
+namespace Frame {
+struct Inertial;
+struct Logical;
+}  // namespace Frame
 /// \endcond
 
 namespace domain {
@@ -202,12 +216,20 @@ class BinaryCompactObject : public DomainCreator<3> {
     static type default_value() { return true; }
   };
 
+  struct TimeDependence {
+    using type =
+        std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>;
+    static constexpr OptionString help = {
+        "The time dependence of the moving mesh domain."};
+    static type default_value() noexcept;
+  };
+
   using options =
       tmpl::list<InnerRadiusObjectA, OuterRadiusObjectA, XCoordObjectA,
                  ExciseInteriorA, InnerRadiusObjectB, OuterRadiusObjectB,
                  XCoordObjectB, ExciseInteriorB, RadiusOuterCube,
                  RadiusOuterSphere, InitialRefinement, InitialGridPoints,
-                 UseEquiangularMap, UseProjectiveMap>;
+                 UseEquiangularMap, UseProjectiveMap, TimeDependence>;
 
   static constexpr OptionString help{
       "The BinaryCompactObject domain is a general domain for two compact \n"
@@ -241,6 +263,8 @@ class BinaryCompactObject : public DomainCreator<3> {
       typename InitialGridPoints::type initial_grid_points_per_dim,
       typename UseEquiangularMap::type use_equiangular_map,
       typename UseProjectiveMap::type use_projective_map = true,
+      std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+          time_dependence = nullptr,
       const OptionContext& context = {});
 
   BinaryCompactObject() = default;
@@ -256,6 +280,10 @@ class BinaryCompactObject : public DomainCreator<3> {
 
   std::vector<std::array<size_t, 3>> initial_refinement_levels() const
       noexcept override;
+
+  auto functions_of_time() const noexcept -> std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
  private:
   typename InnerRadiusObjectA::type inner_radius_object_A_{};
@@ -276,6 +304,8 @@ class BinaryCompactObject : public DomainCreator<3> {
   double translation_{};
   double length_inner_cube_{};
   double length_outer_cube_{};
+  std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+      time_dependence_;
 };
 }  // namespace creators
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -3,25 +3,59 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <array>
 #include <cstddef>
+#include <iterator>
+#include <limits>
 #include <memory>
+#include <pup.h>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
 #include "Domain/Block.hpp"                       // IWYU pragma: keep
 #include "Domain/BlockNeighbor.hpp"               // IWYU pragma: keep
+#include "Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 #include "Domain/Creators/BinaryCompactObject.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Framework/TestCreation.hpp"
+#include "Helpers/Domain/Creators/TestHelpers.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 
+namespace domain {
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
+}  // namespace domain
+
 namespace {
+using Translation = domain::CoordinateMaps::TimeDependent::Translation;
+using Translation3D = domain::CoordinateMaps::TimeDependent::ProductOf3Maps<
+    Translation, Translation, Translation>;
+
+template <typename... FuncsOfTime>
 void test_binary_compact_object_construction(
-    const domain::creators::BinaryCompactObject& binary_compact_object) {
+    const domain::creators::BinaryCompactObject& binary_compact_object,
+    double time = std::numeric_limits<double>::signaling_NaN(),
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time = {},
+    const std::tuple<std::pair<std::string, FuncsOfTime>...>&
+        expected_functions_of_time = {}) {
   const auto domain = binary_compact_object.create_domain();
   test_initial_domain(domain,
                       binary_compact_object.initial_refinement_levels());
-  test_physical_separation(binary_compact_object.create_domain().blocks());
+  test_physical_separation(binary_compact_object.create_domain().blocks(), time,
+                           functions_of_time);
+
+  TestHelpers::domain::creators::test_functions_of_time(
+      binary_compact_object, expected_functions_of_time);
 }
 
 void test_connectivity() {
@@ -63,6 +97,78 @@ void test_connectivity() {
         test_binary_compact_object_construction(binary_compact_object);
       }
     }
+  }
+}
+
+void test_bbh_time_dependent_factory() {
+  const auto binary_compact_object =
+      TestHelpers::test_factory_creation<DomainCreator<3>>(
+          "  BinaryCompactObject:\n"
+          "    InnerRadiusObjectA: 0.2\n"
+          "    OuterRadiusObjectA: 1.0\n"
+          "    XCoordObjectA: -2.0\n"
+          "    ExciseInteriorA: true\n"
+          "    InnerRadiusObjectB: 1.0\n"
+          "    OuterRadiusObjectB: 2.0\n"
+          "    XCoordObjectB: 3.0\n"
+          "    ExciseInteriorB: true\n"
+          "    RadiusOuterCube: 22.0\n"
+          "    RadiusOuterSphere: 25.0\n"
+          "    InitialRefinement: 2\n"
+          "    InitialGridPoints: 6\n"
+          "    UseEquiangularMap: true\n"
+          "    TimeDependence:\n"
+          "      UniformTranslation:\n"
+          "        InitialTime: 1.0\n"
+          "        Velocity: [2.3, -0.3, 0.5]\n"
+          "        FunctionOfTimeNames: [TranslationX, TranslationY, "
+          "TranslationZ]");
+  const std::array<double, 4> times_to_check{{0.0, 4.4, 7.8}};
+
+  constexpr double initial_time = 0.0;
+  constexpr double expected_time = 1.0; // matches InitialTime: 1.0 above
+  std::array<DataVector, 3> function_of_time_coefficients_x{
+      {{0.0}, {2.3}, {0.0}}};
+  const std::array<DataVector, 3> function_of_time_coefficients_y{
+      {{0.0}, {-0.3}, {0.0}}};
+  const std::array<DataVector, 3> function_of_time_coefficients_z{
+      {{0.0}, {0.5}, {0.0}}};
+
+  const std::tuple<
+      std::pair<std::string, domain::FunctionsOfTime::PiecewisePolynomial<2>>,
+      std::pair<std::string, domain::FunctionsOfTime::PiecewisePolynomial<2>>,
+      std::pair<std::string, domain::FunctionsOfTime::PiecewisePolynomial<2>>>
+      expected_functions_of_time = std::make_tuple(
+          std::pair<std::string,
+                    domain::FunctionsOfTime::PiecewisePolynomial<2>>{
+              "TranslationX"s,
+              {expected_time, function_of_time_coefficients_x}},
+          std::pair<std::string,
+                    domain::FunctionsOfTime::PiecewisePolynomial<2>>{
+              "TranslationY"s,
+              {expected_time, function_of_time_coefficients_y}},
+          std::pair<std::string,
+                    domain::FunctionsOfTime::PiecewisePolynomial<2>>{
+              "TranslationZ"s,
+              {expected_time, function_of_time_coefficients_z}});
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  functions_of_time["TranslationX"] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time, function_of_time_coefficients_x);
+  functions_of_time["TranslationY"] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time, function_of_time_coefficients_y);
+  functions_of_time["TranslationZ"] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time, function_of_time_coefficients_z);
+
+  for (const double time : times_to_check) {
+    test_binary_compact_object_construction(
+        dynamic_cast<const domain::creators::BinaryCompactObject&>(
+            *binary_compact_object),
+        time, functions_of_time, expected_functions_of_time);
   }
 }
 
@@ -248,6 +354,7 @@ void test_nsbh_equidistant_factory() {
 SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.FactoryTests",
                   "[Domain][Unit]") {
   test_connectivity();
+  test_bbh_time_dependent_factory();
   test_bbh_equiangular_factory();
   test_bbh_equidistant_factory();
   test_bns_equiangular_factory();

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -58,7 +59,11 @@ void test_domain_construction(
 // Test that two neighboring Blocks abut each other.
 template <size_t VolumeDim>
 void test_physical_separation(
-    const std::vector<Block<VolumeDim>>& blocks) noexcept;
+    const std::vector<Block<VolumeDim>>& blocks,
+    double time = std::numeric_limits<double>::signaling_NaN(),
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time = {}) noexcept;
 
 // Fraction of the logical volume of a block covered by an element
 // The sum of this over all the elements of a block should be one


### PR DESCRIPTION
## Proposed changes

Add time dependence to the BinaryCompactObject domain, so it can be used with moving meshes.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
