### PR TITLE
Add spectre_target_(sources|headers) and change DataStructures to use them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ include(ProhibitInSourceBuild)
 include(SpectreSetupFlagsTarget)
 include(SetupNinjaColors)
 include(SetOutputDirectory)
+include(SpectreTargetHeaders)
 include(SpectreTargetSources)
 # We need yapf before we set up the git hooks
 include(SetupYapf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ include(ProhibitInSourceBuild)
 include(SpectreSetupFlagsTarget)
 include(SetupNinjaColors)
 include(SetOutputDirectory)
+include(SpectreTargetSources)
 # We need yapf before we set up the git hooks
 include(SetupYapf)
 include(SetupGitHooks)

--- a/cmake/SpectreTargetHeaders.cmake
+++ b/cmake/SpectreTargetHeaders.cmake
@@ -1,0 +1,93 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Add header files for CMake to track for a given library
+# or executable.
+#
+# The header and source files together are used to track dependencies between
+# targets automatically in SpECTRE. Specifically, CI checks that the
+# dependencies of a target supply all the header files used in a library.
+# While this checking still requires includes to be correct (be they checked
+# manually or automatically), it significantly lowers the burden of correct
+# dependency management on developers.
+#
+# Additionally, some IDEs perform better if the header files for libraries
+# are known.
+#
+# Usage:
+#  spectre_target_headers(
+#    TARGET_NAME
+#    INCLUDE_DIRECTORY /path/to/include/relative/to
+#    HEADERS
+#    A.hpp
+#    B.hpp
+#    B.tpp
+#    C.hpp)
+#
+# Arguments:
+# - TARGET_NAME: the name of the library or executable
+# - INCLUDE_DIRECTORY: the directory relative to which the header
+#                      files must be included in C++ files. E.g.
+#                      `${CMAKE_SOURCE_DIR}/src` if the include paths are
+#                      relative to `${CMAKE_SOURCE_DIR}/src`.
+# - HEADERS: the HEADERS argument is a list of all the headers files
+#            to append, including tpp files, relative to the current
+#            source directory.
+function(spectre_target_headers TARGET_NAME)
+  cmake_parse_arguments(
+    ARG "" "INCLUDE_DIRECTORY" "HEADERS"
+    ${ARGN})
+
+  if(NOT ARG_INCLUDE_DIRECTORY)
+    message(FATAL_ERROR
+      "Must specify the include directory relative to which the "
+      "header files for a library will be included when calling "
+      "spectre_target_headers. The named argument is INCLUDE_DIRECTORY.")
+  endif(NOT ARG_INCLUDE_DIRECTORY)
+
+  get_property(
+    INCLUDE_DIRS
+    TARGET ${TARGET_NAME}
+    PROPERTY INCLUDE_DIRECTORIES
+    )
+  if(NOT ${ARG_INCLUDE_DIRECTORY} IN_LIST INCLUDE_DIRS)
+    set_property(
+      TARGET ${TARGET_NAME}
+      APPEND
+      PROPERTY INCLUDE_DIRECTORIES ${ARG_INCLUDE_DIRECTORY}
+      )
+  endif(NOT ${ARG_INCLUDE_DIRECTORY} IN_LIST INCLUDE_DIRS)
+
+  get_property(
+    INTERFACE_INCLUDE_DIRS
+    TARGET ${TARGET_NAME}
+    PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+    )
+  if(NOT ${ARG_INCLUDE_DIRECTORY} IN_LIST INTERFACE_INCLUDE_DIRS)
+    set_property(
+      TARGET ${TARGET_NAME}
+      APPEND
+      PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ARG_INCLUDE_DIRECTORY}
+      )
+  endif(NOT ${ARG_INCLUDE_DIRECTORY} IN_LIST INTERFACE_INCLUDE_DIRS)
+
+  unset(_HEADER_FILES)
+  foreach(HEADER ${ARG_HEADERS})
+    if(NOT HEADER STREQUAL "PRIVATE" AND
+        NOT HEADER STREQUAL "PUBLIC" AND
+        NOT HEADER STREQUAL "INTERFACE" AND
+        NOT IS_ABSOLUTE "${HEADER}")
+      set(_ABSOLUTE_PATH "${CMAKE_CURRENT_LIST_DIR}/${HEADER}")
+      file(RELATIVE_PATH HEADER ${ARG_INCLUDE_DIRECTORY} ${_ABSOLUTE_PATH})
+    endif()
+    list(APPEND _HEADER_FILES ${HEADER})
+  endforeach()
+
+  set_property(
+    TARGET ${TARGET_NAME}
+    APPEND
+    PROPERTY
+    PUBLIC_HEADERS
+    ${_HEADER_FILES}
+    )
+endfunction(spectre_target_headers TARGET_NAME)

--- a/cmake/SpectreTargetSources.cmake
+++ b/cmake/SpectreTargetSources.cmake
@@ -1,0 +1,62 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Add sources to a target.
+#
+# Before CMake v3.13 CMake's target_sources always found files relative to
+# the target's directory, which is rather unnatural while in subdirectories.
+# This wrapper function provides the new CMake behavior for older versions
+# of CMake.
+#
+# Usage:
+#   spectre_target_sources(
+#     TARGET
+#     PRIVATE
+#     A.cpp
+#     B.cpp
+#     C.cpp
+#     )
+#
+# Note that unless you know for sure a source file should be PUBLIC or INTERFACE
+# just mark it PRIVATE. A particular source file should be marked
+# PUBLIC/INTERFACE only if it should also be built by consuming targets.
+#
+# Arguments:
+# - TARGET: the name of the target to which to add the sources.
+# - EXTRA_ARGS: the sources, PUBLIC/PRIVATE/INTERFACE keywords, and generator
+#               expressions to set the sources to.
+function(spectre_target_sources TARGET)
+  if(POLICY CMP0076)
+    # New behavior is available, so just forward to it by ensuring
+    # that we have the policy set to request the new behavior, but
+    # don't change the policy setting for the calling scope
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0076 NEW)
+    target_sources(${TARGET} ${ARGN})
+    cmake_policy(POP)
+    return()
+  endif()
+
+  # Must be using CMake 3.12 or earlier, so simulate the new behavior
+  unset(_SOURCE_FILES)
+  get_target_property(_TARGET_SOURCE_DIR ${TARGET} SOURCE_DIR)
+
+  foreach(SOURCE_FILE ${ARGN})
+    string(FIND "${SOURCE_FILE}" "$<" GENERATOR_EXPR_START_INDEX)
+    set(_IS_GENERATOR_EXPR OFF)
+    if(${GENERATOR_EXPR_START_INDEX} EQUAL 0)
+      set(_IS_GENERATOR_EXPR ON)
+    endif(${GENERATOR_EXPR_START_INDEX} EQUAL 0)
+
+    if(NOT SOURCE_FILE STREQUAL "PRIVATE" AND
+        NOT SOURCE_FILE STREQUAL "PUBLIC" AND
+        NOT SOURCE_FILE STREQUAL "INTERFACE" AND
+        NOT IS_ABSOLUTE "${SOURCE_FILE}" AND
+        NOT _IS_GENERATOR_EXPR)
+      # Absolute path to source
+      set(SOURCE_FILE "${CMAKE_CURRENT_LIST_DIR}/${SOURCE_FILE}")
+    endif()
+    list(APPEND _SOURCE_FILES ${SOURCE_FILE})
+  endforeach()
+  target_sources(${TARGET} ${_SOURCE_FILES})
+endfunction()

--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -3,17 +3,50 @@
 
 set(LIBRARY DataStructures)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   Index.cpp
   IndexIterator.cpp
   LeviCivitaIterator.cpp
   SliceIterator.cpp
   StripeIterator.cpp
-  Tensor/EagerMath/OrthonormalOneform.cpp
-  Tensor/TensorData.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoostMultiArray.hpp
+  CachedTempBuffer.hpp
+  ComplexDataVector.hpp
+  ComplexDiagonalModalOperator.hpp
+  ComplexModalVector.hpp
+  DataVector.hpp
+  DenseMatrix.hpp
+  DenseVector.hpp
+  DiagonalModalOperator.hpp
+  FixedHashMap.hpp
+  GeneralIndexIterator.hpp
+  IdPair.hpp
+  Index.hpp
+  IndexIterator.hpp
+  LeviCivitaIterator.hpp
+  Matrix.hpp
+  ModalVector.hpp
+  SliceIterator.hpp
+  SliceTensorToVariables.hpp
+  SliceVariables.hpp
+  SpinWeighted.hpp
+  StripeIterator.hpp
+  Tags.hpp
+  TempBuffer.hpp
+  Variables.hpp
+  VariablesTag.hpp
+  VectorImpl.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}
@@ -24,4 +57,6 @@ target_link_libraries(
   Options
   )
 
+add_subdirectory(DataBox)
 add_subdirectory(Python)
+add_subdirectory(Tensor)

--- a/src/DataStructures/DataBox/CMakeLists.txt
+++ b/src/DataStructures/DataBox/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  DataStructures
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  DataBox.hpp
+  DataBoxHelpers.hpp
+  DataBoxTag.hpp
+  DataOnSlice.hpp
+  Deferred.hpp
+  PrefixHelpers.hpp
+  Prefixes.hpp
+  Tag.hpp
+  TagName.hpp
+  TagTraits.hpp
+  )

--- a/src/DataStructures/Tensor/CMakeLists.txt
+++ b/src/DataStructures/Tensor/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  DataStructures
+  PRIVATE
+  TensorData.cpp
+  )
+
+spectre_target_headers(
+  DataStructures
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Identity.hpp
+  IndexType.hpp
+  MathFunctions.hpp
+  Slice.hpp
+  Structure.hpp
+  Symmetry.hpp
+  Tensor.hpp
+  TensorData.hpp
+  TypeAliases.hpp
+  )
+
+
+add_subdirectory(EagerMath)
+add_subdirectory(Expressions)

--- a/src/DataStructures/Tensor/EagerMath/CMakeLists.txt
+++ b/src/DataStructures/Tensor/EagerMath/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  DataStructures
+  PRIVATE
+  OrthonormalOneform.cpp
+  )
+
+spectre_target_headers(
+  DataStructures
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  CrossProduct.hpp
+  Determinant.hpp
+  DeterminantAndInverse.hpp
+  DotProduct.hpp
+  Magnitude.hpp
+  Norms.hpp
+  OrthonormalOneform.hpp
+  )

--- a/src/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/src/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  DataStructures
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  AddSubtract.hpp
+  Contract.hpp
+  Evaluate.hpp
+  Product.hpp
+  TensorExpression.hpp
+  )


### PR DESCRIPTION
## Proposed changes

- The functions `spectre_target_sources` and `spectre_target_headers` should be used to add source and header files to going forward. These will allow us to check correct dependencies as part of CI.
- I've converted `DataStructures` using the new functions to give an example.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
