### PR TITLE
Fix some CMake target link libraries

### DIFF
--- a/cmake/SpectreAddLibraries.cmake
+++ b/cmake/SpectreAddLibraries.cmake
@@ -37,9 +37,17 @@ function(ADD_SPECTRE_LIBRARY LIBRARY_NAME)
       $<TARGET_PROPERTY:${SPECTRE_PCH},INTERFACE_COMPILE_OPTIONS>
       )
   endif()
-  target_link_libraries(
-    ${LIBRARY_NAME}
-    PUBLIC
-    SpectreFlags
-    )
+  if (${LIBRARY_TYPE} STREQUAL INTERFACE_LIBRARY)
+    target_link_libraries(
+      ${LIBRARY_NAME}
+      INTERFACE
+      SpectreFlags
+      )
+  else()
+    target_link_libraries(
+      ${LIBRARY_NAME}
+      PUBLIC
+      SpectreFlags
+      )
+  endif()
 endfunction()

--- a/src/Domain/Amr/CMakeLists.txt
+++ b/src/Domain/Amr/CMakeLists.txt
@@ -13,6 +13,8 @@ add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}
-  INTERFACE Domain
-  INTERFACE ErrorHandling
+  PRIVATE
+  Domain
+  ErrorHandling
+  Utilities
   )

--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "BlockLogicalCoordinates.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
 
 #include <cstddef>
 #include <vector>

--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -42,13 +42,19 @@ add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}
+  INTERFACE
+  FunctionsOfTime
+  Time
+
   PUBLIC
   Boost::boost
   CoordinateMaps
   DataStructures
   ErrorHandling
-  FunctionsOfTime
   Options
-  Spectral
   Utilities
+
+  PRIVATE
+  DomainCreators
+  Spectral
   )

--- a/src/Domain/Mesh.cpp
+++ b/src/Domain/Mesh.cpp
@@ -8,6 +8,7 @@
 #include <pup.h>  // IWYU pragma: keep
 
 #include "ErrorHandling/Assert.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
 #include "Utilities/GenerateInstantiations.hpp"
 

--- a/src/Options/CMakeLists.txt
+++ b/src/Options/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 set(LIBRARY Options)
 
-add_library(${LIBRARY} INTERFACE)
+add_spectre_library(${LIBRARY} INTERFACE)
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -3,3 +3,18 @@
 
 add_charm_module(ConstGlobalCache)
 add_charm_module(Main)
+
+set(LIBRARY Parallel)
+
+add_spectre_library(${LIBRARY} INTERFACE)
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  Boost::boost
+  DataStructures
+  ErrorHandling
+  Informer
+  Options
+  Utilities
+  )

--- a/src/ParallelAlgorithms/LinearSolver/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 set(LIBRARY ParallelLinearSolver)
 
-add_library(${LIBRARY} INTERFACE)
+add_spectre_library(${LIBRARY} INTERFACE)
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ErrorHandling/CMakeLists.txt
+++ b/tests/Unit/ErrorHandling/CMakeLists.txt
@@ -16,3 +16,9 @@ add_test_library(
   "${LIBRARY_SOURCES}"
   "ErrorHandling"
   )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Framework
+  )

--- a/tests/Unit/Framework/CMakeLists.txt
+++ b/tests/Unit/Framework/CMakeLists.txt
@@ -13,9 +13,20 @@ add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}
+  INTERFACE
+  Boost::boost
+  DataStructures
+  DataStructuresHelpers
+  Options
+  Parallel
+  Utilities
+
   PRIVATE
-  ErrorHandling
+  Informer
   NumPy
+
+  PUBLIC
+  ErrorHandling
   )
 
 target_include_directories(

--- a/tests/Unit/Helpers/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/Helpers/ApparentHorizons/CMakeLists.txt
@@ -9,3 +9,11 @@ set(LIBRARY_SOURCES
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  ApparentHorizons
+  DataStructures
+  Utilities
+  )

--- a/tests/Unit/Helpers/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/Helpers/ControlSystem/CMakeLists.txt
@@ -8,3 +8,14 @@ set(LIBRARY_SOURCES
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  DataStructures
+  ControlSystem
+
+  PRIVATE
+  FunctionsOfTime
+  Utilities
+  )

--- a/tests/Unit/Helpers/DataStructures/CMakeLists.txt
+++ b/tests/Unit/Helpers/DataStructures/CMakeLists.txt
@@ -8,3 +8,10 @@ set(LIBRARY_SOURCES
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  DataStructures
+  Utilities
+  )

--- a/tests/Unit/Helpers/Domain/CMakeLists.txt
+++ b/tests/Unit/Helpers/Domain/CMakeLists.txt
@@ -8,3 +8,20 @@ set(LIBRARY_SOURCES
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  Boost::boost
+  CoordinateMaps
+  FunctionsOfTime
+
+  PRIVATE
+  DomainCreators
+  ErrorHandling
+
+  PUBLIC
+  DataStructures
+  Domain
+  Utilities
+  )

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -8,3 +8,12 @@ set(LIBRARY_SOURCES
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Utilities
+
+  PUBLIC
+  DataStructures
+  )

--- a/tests/Unit/Helpers/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/Helpers/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -8,3 +8,13 @@ set(LIBRARY_SOURCES
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructuresHelpers
+  Utilities
+
+  PUBLIC
+  DataStructures
+  )

--- a/tests/Unit/Helpers/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/tests/Unit/Helpers/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -8,3 +8,16 @@ set(LIBRARY_SOURCES
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  Hydro
+
+  PRIVATE
+  DataStructuresHelpers
+
+  PUBLIC
+  DataStructures
+  Utilities
+  )

--- a/tests/Unit/Helpers/Time/TimeSteppers/CMakeLists.txt
+++ b/tests/Unit/Helpers/Time/TimeSteppers/CMakeLists.txt
@@ -8,3 +8,11 @@ set(LIBRARY_SOURCES
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  ErrorHandling
+  Time
+  Utilities
+  )

--- a/tests/Unit/Parallel/Actions/CMakeLists.txt
+++ b/tests/Unit/Parallel/Actions/CMakeLists.txt
@@ -19,3 +19,9 @@ add_dependencies(
   ${LIBRARY}
   module_ConstGlobalCache
   )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Parallel
+  )

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/CMakeLists.txt
@@ -19,3 +19,9 @@ add_dependencies(
   ${LIBRARY}
   module_ConstGlobalCache
   )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Parallel
+  )


### PR DESCRIPTION
## Proposed changes

The recent test refactor changed some libraries around, and did not always correctly add/update dependencies. On my system, this causes builds to emit abundant warnings from boost and yaml includes.

This PR fixes (some) `target_link_libraries` to address warnings on my system. Presumably, there are other places where the dependencies need fixing as well, but this PR does not claim to fix all dependencies.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

