### PR TITLE
CCE GH boundary component part 2

### DIFF
--- a/src/Evolution/Systems/Cce/Actions/BoundaryComputeAndSendToEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Actions/BoundaryComputeAndSendToEvolution.hpp
@@ -10,8 +10,12 @@
 #include "DataStructures/VariablesTag.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Evolution/Systems/Cce/Actions/ReceiveWorldtubeData.hpp"
+#include "Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/WorldtubeInterfaceManager.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
 #include "Evolution/Systems/Cce/ReceiveTags.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Printf.hpp"
@@ -23,6 +27,38 @@
 
 namespace Cce {
 namespace Actions {
+
+/*!
+ * \ingroup ActionsGroup
+ * \brief Obtains the CCE boundary data at the specified `time`, and reports it
+ * to the `EvolutionComponent` via `Actions::ReceiveWorldtubeData`.
+ *
+ * \details See the template partial specializations of this class for details
+ * on the different strategies for each component type.
+ */
+template <typename BoundaryComponent, typename EvolutionComponent>
+struct BoundaryComputeAndSendToEvolution;
+
+/*!
+ * \ingroup ActionsGroup
+ * \brief Computes Bondi boundary data from GH evolution variables and sends the
+ * result to the `EvolutionComponent` (template argument).
+ *
+ * \details After the computation, this action will call
+ * `Cce::Actions::ReceiveWorldtubeData` on the `EvolutionComponent` with each of
+ * the types from `typename Metavariables::cce_boundary_communication_tags` sent
+ * as arguments
+ *
+ * \ref DataBoxGroup changes:
+ * - Adds: nothing
+ * - Removes: nothing
+ * - Modifies:
+ *   - `Tags::Variables<typename
+ *   Metavariables::cce_boundary_communication_tags>` (every tensor)
+ */
+template <typename BoundaryComponent, typename EvolutionComponent>
+struct SendToEvolution;
+
 /*!
  * \ingroup ActionsGroup
  * \brief Obtains the CCE boundary data at the specified `time`, and reports it
@@ -46,10 +82,10 @@ namespace Actions {
  *   - `Tags::Variables<typename
  * Metavariables::cce_boundary_communication_tags>` (every tensor)
  */
-template <typename EvolutionComponent>
-struct BoundaryComputeAndSendToEvolution {
-  template <typename ParallelComponent, typename... DbTags,
-            typename Metavariables, typename ArrayIndex,
+template <typename Metavariables, typename EvolutionComponent>
+struct BoundaryComputeAndSendToEvolution<H5WorldtubeBoundary<Metavariables>,
+                                         EvolutionComponent> {
+  template <typename ParallelComponent, typename... DbTags, typename ArrayIndex,
             Requires<tmpl2::flat_any_v<cpp17::is_same_v<
                 ::Tags::Variables<
                     typename Metavariables::cce_boundary_communication_tags>,
@@ -72,5 +108,88 @@ struct BoundaryComputeAndSendToEvolution {
         true);
   }
 };
+
+/*!
+ * \ingroup ActionsGroup
+ * \brief Submits a request for CCE boundary data at the specified `time` to the
+ * `Cce::GhWorldtubeInterfaceManager`, and sends the data to the
+ * `EvolutionComponent` (template argument) if it is ready.
+ *
+ * \details This uses the `Cce::GhWorldtubeInterfaceManager` to perform all of
+ * the work of managing the buffer of data sent from the GH system and
+ * interpolating if necessary and supported. This dispatches then to
+ * `Cce::Actions::SendToEvolution<GhWorldtubeBoundary<Metavariables>,
+ * EvolutionComponent>` if the boundary data is ready, otherwise
+ * simply submits the request and waits for data to become available via
+ * `Cce::Actions::ReceiveGhWorldtubeData`, which will call
+ * `Cce::Actions::SendToEvolution<GhWorldtubeBoundary<Metavariables>,
+ * EvolutionComponent>` as soon as the data becomes available.
+ *
+ * \ref DataBoxGroup changes:
+ * - Adds: nothing
+ * - Removes: nothing
+ * - Modifies:
+ *   - `Tags::GhInterfaceManager`
+ */
+template <typename Metavariables, typename EvolutionComponent>
+struct BoundaryComputeAndSendToEvolution<GhWorldtubeBoundary<Metavariables>,
+                                         EvolutionComponent> {
+  template <typename ParallelComponent, typename... DbTags, typename ArrayIndex,
+            Requires<tmpl2::flat_any_v<cpp17::is_same_v<
+                ::Tags::Variables<
+                    typename Metavariables::cce_boundary_communication_tags>,
+                DbTags>...>> = nullptr>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const TimeStepId& time) noexcept {
+    db::mutate<Tags::GhInterfaceManager>(
+        make_not_null(&box),
+        [&time, &cache](
+            const gsl::not_null<std::unique_ptr<GhWorldtubeInterfaceManager>*>
+                interface_manager) noexcept {
+          (*interface_manager)->request_gh_data(time);
+          const auto gh_data =
+              (*interface_manager)->retrieve_and_remove_first_ready_gh_data();
+          if (static_cast<bool>(gh_data)) {
+            Parallel::simple_action<Actions::SendToEvolution<
+                GhWorldtubeBoundary<Metavariables>, EvolutionComponent>>(
+                Parallel::get_parallel_component<
+                    GhWorldtubeBoundary<Metavariables>>(cache),
+                get<0>(*gh_data), get<1>(*gh_data), get<2>(*gh_data),
+                get<3>(*gh_data));
+          }
+        });
+  }
+};
+
+/// \cond
+template <typename Metavariables, typename EvolutionComponent>
+struct SendToEvolution<GhWorldtubeBoundary<Metavariables>, EvolutionComponent> {
+  template <typename ParallelComponent, typename... DbTags, typename ArrayIndex,
+            Requires<tmpl2::flat_any_v<cpp17::is_same_v<
+                ::Tags::Variables<
+                    typename Metavariables::cce_boundary_communication_tags>,
+                DbTags>...>> = nullptr>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/, const TimeStepId& time,
+                    const tnsr::aa<DataVector, 3>& spacetime_metric,
+                    const tnsr::iaa<DataVector, 3>& phi,
+                    const tnsr::aa<DataVector, 3>& pi) noexcept {
+    create_bondi_boundary_data(
+        make_not_null(&box), phi, pi, spacetime_metric,
+        db::get<InitializationTags::ExtractionRadius>(box),
+        db::get<Tags::LMax>(box));
+    Parallel::receive_data<Cce::ReceiveTags::BoundaryData<
+      typename Metavariables::cce_boundary_communication_tags>>(
+          Parallel::get_parallel_component<EvolutionComponent>(cache), time,
+          db::get<::Tags::Variables<
+          typename Metavariables::cce_boundary_communication_tags>>(box),
+          true);
+  }
+};
+/// \endcond
+
 }  // namespace Actions
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/Actions/ReceiveGhWorldtubeData.hpp
+++ b/src/Evolution/Systems/Cce/Actions/ReceiveGhWorldtubeData.hpp
@@ -1,0 +1,87 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/Actions/BoundaryComputeAndSendToEvolution.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/WorldtubeInterfaceManager.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace Cce {
+namespace Actions {
+
+/*!
+ * \ingroup ActionsGroup
+ * \brief Stores the boundary data from the GH evolution in the
+ * `Cce::GhWorldtubeInterfaceManager`, and sends to the `EvolutionComponent`
+ * (template argument) if the data fulfills a prior request.
+ *
+ * \details If the new data fulfills a prior request submitted to the
+ * `Cce::GhWorldtubeInterfaceManager`, this will dispatch the result to
+ * `Cce::Actions::SendToEvolution<GhWorldtubeBoundary<Metavariables>,
+ * EvolutionComponent>` for sending the processed boundary data to
+ * the `EvolutionComponent`.
+ *
+ * \ref DataBoxGroup changes:
+ * - Adds: nothing
+ * - Removes: nothing
+ * - Modifies:
+ *   - `Tags::GhInterfaceManager`
+ */
+template <typename EvolutionComponent>
+struct ReceiveGhWorldtubeData {
+  template <typename ParallelComponent, typename... DbTags,
+            typename Metavariables, typename ArrayIndex,
+            Requires<tmpl::list_contains_v<tmpl::list<DbTags...>,
+                                           Tags::GhInterfaceManager>> = nullptr>
+  static void apply(
+      db::DataBox<tmpl::list<DbTags...>>& box,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const TimeStepId& time,
+      const tnsr::aa<DataVector, 3>& spacetime_metric,
+      const tnsr::iaa<DataVector, 3>& phi, const tnsr::aa<DataVector, 3>& pi,
+      const tnsr::aa<DataVector, 3>& dt_spacetime_metric =
+          tnsr::aa<DataVector, 3>{},
+      const tnsr::iaa<DataVector, 3>& dt_phi = tnsr::iaa<DataVector, 3>{},
+      const tnsr::aa<DataVector, 3>& dt_pi =
+          tnsr::aa<DataVector, 3>{}) noexcept {
+    db::mutate<Tags::GhInterfaceManager>(
+        make_not_null(&box),
+        [&spacetime_metric, &phi, &pi, &dt_spacetime_metric, &dt_phi, &dt_pi,
+         &time, &cache](
+            const gsl::not_null<std::unique_ptr<GhWorldtubeInterfaceManager>*>
+                interface_manager) noexcept {
+          (*interface_manager)
+              ->insert_gh_data(time, spacetime_metric, phi, pi,
+                               dt_spacetime_metric, dt_phi, dt_pi);
+          const auto gh_data =
+              (*interface_manager)->retrieve_and_remove_first_ready_gh_data();
+          if (static_cast<bool>(gh_data)) {
+            Parallel::simple_action<Actions::SendToEvolution<
+                GhWorldtubeBoundary<Metavariables>, EvolutionComponent>>(
+                Parallel::get_parallel_component<
+                    GhWorldtubeBoundary<Metavariables>>(cache),
+                get<0>(*gh_data), get<1>(*gh_data), get<2>(*gh_data),
+                get<3>(*gh_data));
+          }
+        });
+  }
+};
+}  // namespace Actions
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstepInterfaceManager.hpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstepInterfaceManager.hpp
@@ -93,4 +93,4 @@ class GhLockstepInterfaceManager : public GhWorldtubeInterfaceManager {
       provided_data_;
 };
 
-}
+}  // namespace Cce

--- a/src/Utilities/ContainerHelpers.hpp
+++ b/src/Utilities/ContainerHelpers.hpp
@@ -175,6 +175,7 @@ SPECTRE_ALWAYS_INLINE decltype(auto) get_size(
 template <typename Container,
           typename DestructiveResizeFunction = ContainerDestructiveResize>
 void SPECTRE_ALWAYS_INLINE destructive_resize_components(
+    // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
     const gsl::not_null<Container*> container, const size_t new_size,
     DestructiveResizeFunction destructive_resize =
         ContainerDestructiveResize{}) noexcept {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_InitializeFirstHypersurface.cpp
   Test_InsertInterpolationScriData.cpp
   Test_FilterSwshVolumeQuantity.cpp
+  Test_GhBoundaryCommunication.cpp
   Test_H5BoundaryCommunication.cpp
   Test_InitializeCharacteristicEvolution.cpp
   Test_InitializeWorldtubeBoundary.cpp

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -95,11 +95,11 @@ struct mock_characteristic_evolution {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Evolve,
           tmpl::list<Actions::RequestBoundaryData<
-                         mock_h5_worldtube_boundary<Metavariables>,
+                         H5WorldtubeBoundary<Metavariables>,
                          mock_characteristic_evolution<Metavariables>>,
                      Actions::ReceiveWorldtubeData<Metavariables>,
                      Actions::RequestNextBoundaryData<
-                         mock_h5_worldtube_boundary<Metavariables>,
+                         H5WorldtubeBoundary<Metavariables>,
                          mock_characteristic_evolution<Metavariables>>>>>;
   using const_global_cache_tags =
       Parallel::get_const_global_cache_tags_from_actions<
@@ -113,6 +113,7 @@ struct test_metavariables {
       tmpl::list<Tags::CauchyCartesianCoords, Tags::InertialRetardedTime>>;
   using cce_boundary_communication_tags =
       Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>;
+  using cce_boundary_component = H5WorldtubeBoundary<test_metavariables>;
   using cce_gauge_boundary_tags = tmpl::flatten<tmpl::list<
       tmpl::transform<
           tmpl::list<Tags::BondiR, Tags::DuRDividedByR, Tags::BondiJ,
@@ -152,14 +153,14 @@ struct test_metavariables {
 };
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.BoundaryCommunication",
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
                   "[Unit][Cce]") {
   using evolution_component = mock_characteristic_evolution<test_metavariables>;
   using worldtube_component = mock_h5_worldtube_boundary<test_metavariables>;
   const size_t number_of_radial_points = 10;
   const size_t l_max = 8;
 
-  const std::string filename = "BoundaryCommunicationTestCceR0100.h5";
+  const std::string filename = "H5BoundaryCommunicationTestCceR0100.h5";
   // create the test file, because on initialization the manager will need to
   // get basic data out of the file
 

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp
@@ -5,14 +5,15 @@
 
 #include <cstddef>
 
+#include "Evolution/Systems/Cce/Actions/BoundaryComputeAndSendToEvolution.hpp"
 #include "Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp"
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
 #include "Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Framework/ActionTesting.hpp"
 
 namespace Cce {
 /// \cond
@@ -23,11 +24,9 @@ struct mock_characteristic_evolution;
 }  // namespace
 namespace Actions {
 namespace {  // NOLINT
-template <typename EvolutionComponent>
+template <typename BoundaryComponent, typename EvolutionComponent>
 struct MockBoundaryComputeAndSendToEvolution;
 }  // namespace
-template <typename EvolutionComponent>
-struct BoundaryComputeAndSendToEvolution;
 }  // namespace Actions
 /// \endcond
 
@@ -36,9 +35,11 @@ struct mock_h5_worldtube_boundary {
   using component_being_mocked = H5WorldtubeBoundary<Metavariables>;
   using replace_these_simple_actions =
       tmpl::list<Actions::BoundaryComputeAndSendToEvolution<
+          H5WorldtubeBoundary<Metavariables>,
           mock_characteristic_evolution<test_metavariables>>>;
   using with_these_simple_actions =
       tmpl::list<Actions::MockBoundaryComputeAndSendToEvolution<
+          H5WorldtubeBoundary<Metavariables>,
           mock_characteristic_evolution<test_metavariables>>>;
 
   using initialize_action_list =
@@ -65,9 +66,11 @@ struct mock_gh_worldtube_boundary {
   using component_being_mocked = GhWorldtubeBoundary<Metavariables>;
   using replace_these_simple_actions =
       tmpl::list<Actions::BoundaryComputeAndSendToEvolution<
+          GhWorldtubeBoundary<Metavariables>,
           mock_characteristic_evolution<test_metavariables>>>;
   using with_these_simple_actions =
       tmpl::list<Actions::MockBoundaryComputeAndSendToEvolution<
+          GhWorldtubeBoundary<Metavariables>,
           mock_characteristic_evolution<test_metavariables>>>;
 
   using initialize_action_list =


### PR DESCRIPTION
## Proposed changes

Split off from #2132 , completes the set of utilities needed for minimal CCE-GH interface.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies
- [x] #2132