### PR TITLE
Remove linker flag for unused-arguments

### DIFF
--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -46,17 +46,6 @@ endif()
 # but we don't care
 create_cxx_flag_target("-Wno-noexcept-type" SpectreWarnNoNoexceptType)
 
-if(CMAKE_SUPPORTS_LINK_OPTIONS)
-  create_cxx_link_flag_target("-Qunused-arguments" LinkUnusedArgument)
-  target_link_libraries(
-    SpectreFlags
-    INTERFACE
-    LinkUnusedArgument
-    )
-else(CMAKE_SUPPORTS_LINK_OPTIONS)
-  check_and_add_cxx_link_flag("-Qunused-arguments")
-endif(CMAKE_SUPPORTS_LINK_OPTIONS)
-
 target_link_libraries(
   SpectreWarnings
   INTERFACE


### PR DESCRIPTION
## Proposed changes

removes a linker flag that no longer is needed on my MacBook Pro

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
