### PR TITLE
Pass Metavariables to option_tags and add apply utility to TaggedTuple

### DIFF
--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -71,10 +71,11 @@ class Main : public CBase_Main<Metavariables> {
 
  private:
   template <typename ParallelComponent>
-  using parallel_component_options = Parallel::get_option_tags<
-      typename ParallelComponent::initialization_tags>;
+  using parallel_component_options =
+      Parallel::get_option_tags<typename ParallelComponent::initialization_tags,
+                                Metavariables>;
   using option_list = tmpl::remove_duplicates<tmpl::flatten<tmpl::list<
-      Parallel::get_option_tags<const_global_cache_tags>,
+      Parallel::get_option_tags<const_global_cache_tags, Metavariables>,
       tmpl::transform<component_list,
                       tmpl::bind<parallel_component_options, tmpl::_1>>>>>;
   using parallel_component_tag_list = tmpl::transform<

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -151,19 +151,33 @@ using get_initialization_tags_to_keep =
         detail::get_initialization_tags_to_keep_from_action<tmpl::_1>>>>;
 
 namespace detail {
-template <typename InitializationTag>
-struct get_option_tags_from_initialization_tag {
+template <typename InitializationTag, typename Metavariables,
+          bool PassMetavariables = InitializationTag::pass_metavariables>
+struct get_option_tags_from_initialization_tag_impl {
   using type = typename InitializationTag::option_tags;
+};
+template <typename InitializationTag, typename Metavariables>
+struct get_option_tags_from_initialization_tag_impl<InitializationTag,
+                                                    Metavariables, true> {
+  using type = typename InitializationTag::template option_tags<Metavariables>;
+};
+template <typename Metavariables>
+struct get_option_tags_from_initialization_tag {
+  template <typename InitializationTag>
+  using f = tmpl::type_from<get_option_tags_from_initialization_tag_impl<
+      InitializationTag, Metavariables>>;
 };
 }  // namespace detail
 
 /// \ingroup ParallelGroup
 /// \brief Given a list of initialization tags, returns a list of the
 /// unique option tags required to construct them.
-template <typename InitializationTagsList>
-using get_option_tags = tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
-    InitializationTagsList,
-    detail::get_option_tags_from_initialization_tag<tmpl::_1>>>>;
+template <typename InitializationTagsList, typename Metavariables>
+using get_option_tags = tmpl::remove_duplicates<tmpl::flatten<
+    tmpl::transform<InitializationTagsList,
+                    tmpl::bind<detail::get_option_tags_from_initialization_tag<
+                                   Metavariables>::template f,
+                               tmpl::_1>>>>;
 
 /// \cond
 namespace Algorithms {

--- a/src/Utilities/TaggedTuple.hpp
+++ b/src/Utilities/TaggedTuple.hpp
@@ -776,4 +776,44 @@ std::ostream& operator<<(std::ostream& os,
   return os << ")";
 }
 
+namespace TaggedTuple_detail {
+
+template <typename F, typename... Tags, typename... ApplyTags>
+constexpr decltype(auto) apply_impl(F&& f, const TaggedTuple<Tags...>& t,
+                                    tmpl::list<ApplyTags...> /* meta */) {
+  return std::forward<F>(f)(get<ApplyTags>(t)...);
+}
+
+}  // namespace TaggedTuple_detail
+
+// @{
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Invoke `f` with the `ApplyTags` taken from `t` expanded in a parameter
+ * pack
+ *
+ * `ApplyTags` defaults to the full list of tags in `t`.
+ *
+ * Here is an example how to use the function:
+ *
+ * \snippet Test_TaggedTuple.cpp expand_tuple_example
+ *
+ * This is the function being called in the above example:
+ *
+ * \snippet Test_TaggedTuple.cpp expand_tuple_example_function
+ *
+ * \see cpp17::apply
+ */
+template <typename ApplyTags, typename F, typename... Tags>
+constexpr decltype(auto) apply(F&& f, const TaggedTuple<Tags...>& t) {
+  return TaggedTuple_detail::apply_impl(std::forward<F>(f), t, ApplyTags{});
+}
+
+template <typename F, typename... Tags>
+constexpr decltype(auto) apply(F&& f, const TaggedTuple<Tags...>& t) {
+  return TaggedTuple_detail::apply_impl(
+      std::forward<F>(f), t, typename TaggedTuple<Tags...>::tags_list{});
+}
+// @}
+
 }  // namespace tuples

--- a/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
+++ b/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
@@ -294,11 +294,12 @@ struct Sides {
   }
 };
 struct FullGreeting {
-  using option_tags = tmpl::list<OptionTags::Greeting, OptionTags::Name>;
   using type = std::string;
 
   static constexpr bool pass_metavariables = true;
-  template <typename Metavariables, typename... Tags>
+  template <typename Metavariables>
+  using option_tags = tmpl::list<OptionTags::Greeting, OptionTags::Name>;
+  template <typename Metavariables>
   static std::string create_from_options(const std::string& greeting,
                                          const std::string& name) noexcept {
     if (std::is_same<Metavariables, MetavariablesGreeting>::value) {
@@ -321,17 +322,19 @@ using initialization_tags_2 =
     tmpl::list<Initialization::Tags::Yards, Initialization::Tags::Feet,
                Initialization::Tags::FullGreeting>;
 
-static_assert(cpp17::is_same_v<Parallel::get_option_tags<initialization_tags_0>,
-                               tmpl::list<>>,
+static_assert(cpp17::is_same_v<
+                  Parallel::get_option_tags<initialization_tags_0, NoSuchType>,
+                  tmpl::list<>>,
               "Failed testing get_option_tags");
 
-static_assert(cpp17::is_same_v<Parallel::get_option_tags<initialization_tags_1>,
-                               tmpl::list<OptionTags::Yards, OptionTags::Dim>>,
+static_assert(cpp17::is_same_v<
+                  Parallel::get_option_tags<initialization_tags_1, NoSuchType>,
+                  tmpl::list<OptionTags::Yards, OptionTags::Dim>>,
               "Failed testing get_option_tags");
 
 static_assert(
     cpp17::is_same_v<
-        Parallel::get_option_tags<initialization_tags_2>,
+        Parallel::get_option_tags<initialization_tags_2, NoSuchType>,
         tmpl::list<OptionTags::Yards, OptionTags::Greeting, OptionTags::Name>>,
     "Failed testing get_option_tags");
 
@@ -343,7 +346,8 @@ void check_initialization_items(
     const Options<all_option_tags>& all_options,
     const tuples::TaggedTuple<InitializationTags...>& expected_items) {
   using initialization_tags = tmpl::list<InitializationTags...>;
-  using option_tags = Parallel::get_option_tags<initialization_tags>;
+  using option_tags =
+      Parallel::get_option_tags<initialization_tags, Metavariables>;
   const auto options = all_options.apply<option_tags>([](
       auto... args) noexcept {
     return tuples::tagged_tuple_from_typelist<option_tags>(std::move(args)...);


### PR DESCRIPTION
## Proposed changes

- Pass Metavariables to `option_tags` when the tag requests `pass_metavariables` (previously the Metavariables were passed only to the `create_from_options` function, but if that depends on the metavars then the `option_tags` may also). Used in #1915 
- To implement this feature, add a `tuples::apply` utility function to `TaggedTuple` that's analogous to `cpp17::apply`. It expands a list of tags from the TaggedTuple into a parameter pack.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
