### PR TITLE
Speed up interpolator AH finder test

### DIFF
--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -378,8 +378,8 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ApparentHorizonFinder",
                   "[Unit]") {
   test_apparent_horizon<TestSchwarzschildHorizon>(
-      &test_schwarzschild_horizon_called, 4, 5, 1.0, {{0.0, 0.0, 0.0}});
-  test_apparent_horizon<TestKerrHorizon>(&test_kerr_horizon_called, 8, 5, 1.1,
+      &test_schwarzschild_horizon_called, 3, 3, 1.0, {{0.0, 0.0, 0.0}});
+  test_apparent_horizon<TestKerrHorizon>(&test_kerr_horizon_called, 3, 5, 1.1,
                                          {{0.12, 0.23, 0.45}});
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

The AH finder with interpolator test times out fairly frequently. I reduced the resolution to speed it up by a factor of 2.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
