### PR TITLE
Fix linking with AppleClang

### DIFF
--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -42,17 +42,19 @@ add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}
+  PUBLIC
+  Boost::boost
+  DataStructures
+  ErrorHandling
+  Options
+  Utilities
+
   INTERFACE
   FunctionsOfTime
   Time
 
   # PUBLIC
-  Boost::boost
   CoordinateMaps
-  DataStructures
-  ErrorHandling
-  Options
-  Utilities
 
   # PRIVATE
   DomainCreators

--- a/src/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/src/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -14,12 +14,16 @@ add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}
-  INTERFACE
+  PUBLIC
   CoordinateMaps
   DataStructures
-  Domain
-  ErrorHandling
-  FunctionsOfTime
   Options
   Utilities
+
+  PRIVATE
+  ErrorHandling
+
+  INTERFACE
+  Domain
+  FunctionsOfTime
   )

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -44,7 +44,16 @@ add_test_library(
   ${LIBRARY}
   "DataStructures"
   "${LIBRARY_SOURCES}"
-  "DataStructures;Options;Utilities"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  Domain
+  Options
+  Utilities
   )
 
 # [example_add_pybindings_test]

--- a/tests/Unit/DataStructures/Tensor/EagerMath/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/CMakeLists.txt
@@ -22,7 +22,7 @@ add_test_library(
 
 target_link_libraries(
   ${LIBRARY}
-  INTERFACE
+  PRIVATE
   DataStructures
   DomainHelpers
   ErrorHandling

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -54,7 +54,7 @@ add_test_library(
 
 target_link_libraries(
   ${LIBRARY}
-  INTERFACE
+  PRIVATE
   Domain
   DomainCreators
   DomainHelpers

--- a/tests/Unit/Evolution/Conservative/CMakeLists.txt
+++ b/tests/Unit/Evolution/Conservative/CMakeLists.txt
@@ -16,7 +16,7 @@ add_test_library(
 
 target_link_libraries(
   ${LIBRARY}
-  INTERFACE
+  PRIVATE
   CoordinateMaps
   DataStructures
   Domain


### PR DESCRIPTION
## Proposed changes

#2166 broke develop for AppleClang, so this PR fixes that.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
