### PR TITLE
Loosen tolerance to fix 2078

### DIFF
--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
@@ -128,7 +128,7 @@ void test_characteristic_fields() noexcept {
   // VZero
   pypp::check_with_random_values<1>(
       field_with_tag<ScalarWave::Tags::VZero<Dim>, Dim>, "Characteristics",
-      "char_field_vzero", {{{-100., 100.}}}, used_for_size);
+      "char_field_vzero", {{{-100., 100.}}}, used_for_size, 1.e-11);
   // VPlus
   pypp::check_with_random_values<1>(
       field_with_tag<ScalarWave::Tags::VPlus, Dim>, "Characteristics",


### PR DESCRIPTION
## Proposed changes

Fixes #2078 by loosening tolerance.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
