### PR TITLE
Cce ID: Zero Nonsmooth

### DIFF
--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -8,7 +8,9 @@
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
 #include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
 #include "Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp"
-#include "Evolution/Systems/Cce/InitializeCce.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Evolution/Systems/Cce/Initialize/InverseCubic.hpp"
+#include "Evolution/Systems/Cce/Initialize/ZeroNonSmooth.hpp"
 #include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
@@ -115,7 +117,8 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling,
     &Parallel::register_derived_classes_with_charm<
         Cce::ReducedWorldtubeBufferUpdater>,
-    &Parallel::register_derived_classes_with_charm<Cce::InitializeJ>,
+    &Parallel::register_derived_classes_with_charm<
+        Cce::InitializeJ::InitializeJ>,
     &Parallel::register_derived_classes_with_charm<Cce::WorldtubeBufferUpdater>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<intrp::SpanInterpolator>};

--- a/src/Evolution/Systems/Cce/Actions/InitializeFirstHypersurface.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeFirstHypersurface.hpp
@@ -8,7 +8,7 @@
 #include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "Evolution/Systems/Cce/InitializeCce.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/ScriPlusValues.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
@@ -48,7 +48,8 @@ struct InitializeFirstHypersurface {
       const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
-    db::mutate_apply<InitializeJ::mutate_tags, InitializeJ::argument_tags>(
+    db::mutate_apply<InitializeJ::InitializeJ::mutate_tags,
+                     InitializeJ::InitializeJ::argument_tags>(
         db::get<Tags::InitializeJ>(box), make_not_null(&box));
     db::mutate_apply<InitializeScriPlusValue<Tags::InertialRetardedTime>>(
         make_not_null(&box));

--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -7,7 +7,9 @@ set(LIBRARY_SOURCES
   BoundaryData.cpp
   Equations.cpp
   GaugeTransformBoundaryData.cpp
-  InitializeCce.cpp
+  Initialize/InitializeJ.cpp
+  Initialize/InverseCubic.cpp
+  Initialize/ZeroNonSmooth.cpp
   InterfaceManagers/GhLockstepInterfaceManager.cpp
   LinearOperators.cpp
   LinearSolve.cpp

--- a/src/Evolution/Systems/Cce/Initialize/InitializeJ.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/InitializeJ.cpp
@@ -1,0 +1,361 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce {
+namespace InitializeJ {
+namespace detail {
+// perform an iterative solve for the set of angular coordinates necessary to
+// set the gauge transformed version of `surface_j` to zero. This reliably
+// converges eventually provided `surface_j` is initially reasonably small. As a
+// comparatively primitive method, the convergence often takes several
+// iterations (10-100) to reach roundoff; However, the iterations are fast, and
+// the computation is for initial data that needs to be computed only once
+// during a simulation, so it is not currently an optimization priority. If this
+// function becomes a bottleneck, the numerical procedure of the iterative
+// method should be revisited.
+double adjust_angular_coordinates_for_j(
+    const gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_cauchy_coordinates,
+    const gsl::not_null<
+        tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
+        angular_cauchy_coordinates,
+    const SpinWeighted<ComplexDataVector, 2>& surface_j, const size_t l_max,
+    const double tolerance, const size_t max_steps) noexcept {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
+      Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
+  for (const auto& collocation_point : collocation) {
+    get<0>(*angular_cauchy_coordinates)[collocation_point.offset] =
+        collocation_point.theta;
+    get<1>(*angular_cauchy_coordinates)[collocation_point.offset] =
+        collocation_point.phi;
+  }
+  get<0>(*cartesian_cauchy_coordinates) =
+      sin(get<0>(*angular_cauchy_coordinates)) *
+      cos(get<1>(*angular_cauchy_coordinates));
+  get<1>(*cartesian_cauchy_coordinates) =
+      sin(get<0>(*angular_cauchy_coordinates)) *
+      sin(get<1>(*angular_cauchy_coordinates));
+  get<2>(*cartesian_cauchy_coordinates) =
+      cos(get<0>(*angular_cauchy_coordinates));
+
+  Variables<tmpl::list<
+      // cartesian coordinates
+      ::Tags::SpinWeighted<::Tags::TempScalar<0, ComplexDataVector>,
+                           std::integral_constant<int, 0>>,
+      ::Tags::SpinWeighted<::Tags::TempScalar<1, ComplexDataVector>,
+                           std::integral_constant<int, 0>>,
+      ::Tags::SpinWeighted<::Tags::TempScalar<2, ComplexDataVector>,
+                           std::integral_constant<int, 0>>,
+      // eth of cartesian coordinates
+      ::Tags::SpinWeighted<::Tags::TempScalar<3, ComplexDataVector>,
+                           std::integral_constant<int, 1>>,
+      ::Tags::SpinWeighted<::Tags::TempScalar<4, ComplexDataVector>,
+                           std::integral_constant<int, 1>>,
+      ::Tags::SpinWeighted<::Tags::TempScalar<5, ComplexDataVector>,
+                           std::integral_constant<int, 1>>,
+      // eth of gauge-transformed cartesian coordinates
+      ::Tags::SpinWeighted<::Tags::TempScalar<6, ComplexDataVector>,
+                           std::integral_constant<int, 1>>,
+      ::Tags::SpinWeighted<::Tags::TempScalar<7, ComplexDataVector>,
+                           std::integral_constant<int, 1>>,
+      ::Tags::SpinWeighted<::Tags::TempScalar<8, ComplexDataVector>,
+                           std::integral_constant<int, 1>>,
+      // iterated J
+      ::Tags::SpinWeighted<::Tags::TempScalar<9, ComplexDataVector>,
+                           std::integral_constant<int, 2>>,
+      // intermediate J buffer
+      ::Tags::SpinWeighted<::Tags::TempScalar<10, ComplexDataVector>,
+                           std::integral_constant<int, 2>>,
+      // K buffer
+      ::Tags::SpinWeighted<::Tags::TempScalar<11, ComplexDataVector>,
+                           std::integral_constant<int, 0>>,
+      // gauge Jacobians
+      ::Tags::SpinWeighted<::Tags::TempScalar<12, ComplexDataVector>,
+                           std::integral_constant<int, 2>>,
+      ::Tags::SpinWeighted<::Tags::TempScalar<13, ComplexDataVector>,
+                           std::integral_constant<int, 0>>,
+      // gauge Jacobians on next iteration
+      ::Tags::SpinWeighted<::Tags::TempScalar<14, ComplexDataVector>,
+                           std::integral_constant<int, 2>>,
+      ::Tags::SpinWeighted<::Tags::TempScalar<15, ComplexDataVector>,
+                           std::integral_constant<int, 0>>,
+      // gauge conformal factor
+      ::Tags::SpinWeighted<::Tags::TempScalar<16, ComplexDataVector>,
+                           std::integral_constant<int, 0>>,
+      // cartesian coordinates steps
+      ::Tags::SpinWeighted<::Tags::TempScalar<17, ComplexDataVector>,
+                           std::integral_constant<int, 0>>,
+      ::Tags::SpinWeighted<::Tags::TempScalar<18, ComplexDataVector>,
+                           std::integral_constant<int, 0>>,
+      ::Tags::SpinWeighted<::Tags::TempScalar<19, ComplexDataVector>,
+                           std::integral_constant<int, 0>>>>
+      computation_buffers{number_of_angular_points};
+
+  auto& x =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<0, ComplexDataVector>,
+                                   std::integral_constant<int, 0>>>(
+          computation_buffers));
+  auto& y =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<1, ComplexDataVector>,
+                                   std::integral_constant<int, 0>>>(
+          computation_buffers));
+  auto& z =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<2, ComplexDataVector>,
+                                   std::integral_constant<int, 0>>>(
+          computation_buffers));
+
+  x.data() =
+      std::complex<double>(1.0, 0.0) * get<0>(*cartesian_cauchy_coordinates);
+  y.data() =
+      std::complex<double>(1.0, 0.0) * get<1>(*cartesian_cauchy_coordinates);
+  z.data() =
+      std::complex<double>(1.0, 0.0) * get<2>(*cartesian_cauchy_coordinates);
+
+  auto& eth_x =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<3, ComplexDataVector>,
+                                   std::integral_constant<int, 1>>>(
+          computation_buffers));
+  auto& eth_y =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<4, ComplexDataVector>,
+                                   std::integral_constant<int, 1>>>(
+          computation_buffers));
+  auto& eth_z =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<5, ComplexDataVector>,
+                                   std::integral_constant<int, 1>>>(
+          computation_buffers));
+
+  Spectral::Swsh::angular_derivatives<
+      tmpl::list<Spectral::Swsh::Tags::Eth, Spectral::Swsh::Tags::Eth,
+                 Spectral::Swsh::Tags::Eth>>(l_max, 1, make_not_null(&eth_x),
+                                             make_not_null(&eth_y),
+                                             make_not_null(&eth_z), x, y, z);
+
+  auto& evolution_gauge_eth_x =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<6, ComplexDataVector>,
+                                   std::integral_constant<int, 1>>>(
+          computation_buffers));
+  auto& evolution_gauge_eth_y =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<7, ComplexDataVector>,
+                                   std::integral_constant<int, 1>>>(
+          computation_buffers));
+  auto& evolution_gauge_eth_z =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<8, ComplexDataVector>,
+                                   std::integral_constant<int, 1>>>(
+          computation_buffers));
+
+  auto& evolution_gauge_surface_j =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<9, ComplexDataVector>,
+                                   std::integral_constant<int, 2>>>(
+          computation_buffers));
+
+  auto& interpolated_j =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<10, ComplexDataVector>,
+                                   std::integral_constant<int, 2>>>(
+          computation_buffers));
+  auto& interpolated_k =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<11, ComplexDataVector>,
+                                   std::integral_constant<int, 0>>>(
+          computation_buffers));
+
+  auto& gauge_c =
+      get<::Tags::SpinWeighted<::Tags::TempScalar<12, ComplexDataVector>,
+                               std::integral_constant<int, 2>>>(
+          computation_buffers);
+  auto& gauge_d =
+      get<::Tags::SpinWeighted<::Tags::TempScalar<13, ComplexDataVector>,
+                               std::integral_constant<int, 0>>>(
+          computation_buffers);
+
+  auto& next_gauge_c =
+      get<::Tags::SpinWeighted<::Tags::TempScalar<14, ComplexDataVector>,
+                               std::integral_constant<int, 2>>>(
+          computation_buffers);
+  auto& next_gauge_d =
+      get<::Tags::SpinWeighted<::Tags::TempScalar<15, ComplexDataVector>,
+                               std::integral_constant<int, 0>>>(
+          computation_buffers);
+
+  auto& gauge_omega =
+      get<::Tags::SpinWeighted<::Tags::TempScalar<16, ComplexDataVector>,
+                               std::integral_constant<int, 0>>>(
+          computation_buffers);
+
+  auto& x_step =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<17, ComplexDataVector>,
+                                   std::integral_constant<int, 0>>>(
+          computation_buffers));
+  auto& y_step =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<18, ComplexDataVector>,
+                                   std::integral_constant<int, 0>>>(
+          computation_buffers));
+  auto& z_step =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<19, ComplexDataVector>,
+                                   std::integral_constant<int, 0>>>(
+          computation_buffers));
+
+  double max_error = 1.0;
+  size_t number_of_steps = 0;
+  while (true) {
+    GaugeUpdateAngularFromCartesian<
+        Tags::CauchyAngularCoords,
+        Tags::CauchyCartesianCoords>::apply(angular_cauchy_coordinates,
+                                            cartesian_cauchy_coordinates);
+
+    Spectral::Swsh::SwshInterpolator iteration_interpolator{
+      get<0>(*angular_cauchy_coordinates),
+      get<1>(*angular_cauchy_coordinates), l_max};
+
+    GaugeUpdateJacobianFromCoordinates<
+        Tags::GaugeC, Tags::GaugeD, Tags::CauchyAngularCoords,
+        Tags::CauchyCartesianCoords>::apply(make_not_null(&gauge_c),
+                                            make_not_null(&gauge_d),
+                                            angular_cauchy_coordinates,
+                                            *cartesian_cauchy_coordinates,
+                                            l_max);
+
+    iteration_interpolator.interpolate(make_not_null(&interpolated_j),
+                                       surface_j);
+    interpolated_k.data() =
+        sqrt(1.0 + interpolated_j.data() * conj(interpolated_j.data()));
+
+    get(gauge_omega).data() =
+        0.5 * sqrt(get(gauge_d).data() * conj(get(gauge_d).data()) -
+                   get(gauge_c).data() * conj(get(gauge_c).data()));
+    // the fully computed j in the coordinate system determined so far
+    // (`previous_angular_cauchy_coordinates`)
+    evolution_gauge_surface_j.data() =
+        0.25 *
+        (square(conj(get(gauge_d).data())) * interpolated_j.data() +
+         square(get(gauge_c).data()) * conj(interpolated_j.data()) +
+         2.0 * get(gauge_c).data() * conj(get(gauge_d).data()) *
+             interpolated_k.data()) /
+        square(get(gauge_omega).data());
+
+    // check completion conditions
+    max_error = max(abs(evolution_gauge_surface_j.data()));
+    ++number_of_steps;
+    if (max_error > 5.0e-3) {
+      ERROR(
+          "Iterative solve for surface coordinates of initial data failed. The "
+          "strain is too large to be fully eliminated by a well-behaved "
+          "alteration of the spherical mesh. For this data, please use an "
+          "alternative initial data generator such as "
+          "`InitializeJInverseCubic`.");
+    }
+    if (max_error < tolerance or number_of_steps > max_steps) {
+      break;
+    }
+    // The alteration in each of the spin-weighted Jacobian factors determined
+    // by linearizing the system in small J
+    get(next_gauge_c).data() = -0.5 * evolution_gauge_surface_j.data() *
+                               square(get(gauge_omega).data()) /
+                               (get(gauge_d).data() * interpolated_k.data());
+    get(next_gauge_d).data() = get(next_gauge_c).data() *
+                               conj(get(gauge_c).data()) /
+                               conj(get(gauge_d).data());
+
+    iteration_interpolator.interpolate(make_not_null(&evolution_gauge_eth_x),
+                                       eth_x);
+    iteration_interpolator.interpolate(make_not_null(&evolution_gauge_eth_y),
+                                       eth_y);
+    iteration_interpolator.interpolate(make_not_null(&evolution_gauge_eth_z),
+                                       eth_z);
+
+    evolution_gauge_eth_x =
+        0.5 * ((get(next_gauge_c)) * conj(evolution_gauge_eth_x) +
+               conj((get(next_gauge_d))) * evolution_gauge_eth_x);
+    evolution_gauge_eth_y =
+        0.5 * ((get(next_gauge_c)) * conj(evolution_gauge_eth_y) +
+               conj((get(next_gauge_d))) * evolution_gauge_eth_y);
+    evolution_gauge_eth_z =
+        0.5 * ((get(next_gauge_c)) * conj(evolution_gauge_eth_z) +
+               conj((get(next_gauge_d))) * evolution_gauge_eth_z);
+
+    // here we attempt to just update the current value according to the
+    // alteration suggested. Ideally that's the `dominant` part of the needed
+    // alteration
+    Spectral::Swsh::angular_derivatives<tmpl::list<
+        Spectral::Swsh::Tags::InverseEth, Spectral::Swsh::Tags::InverseEth,
+        Spectral::Swsh::Tags::InverseEth>>(
+        l_max, 1, make_not_null(&x_step), make_not_null(&y_step),
+        make_not_null(&z_step), evolution_gauge_eth_x, evolution_gauge_eth_y,
+        evolution_gauge_eth_z);
+
+    get<0>(*cartesian_cauchy_coordinates) += real(x_step.data());
+    get<1>(*cartesian_cauchy_coordinates) += real(y_step.data());
+    get<2>(*cartesian_cauchy_coordinates) += real(z_step.data());
+  }
+
+  GaugeUpdateAngularFromCartesian<
+      Tags::CauchyAngularCoords,
+      Tags::CauchyCartesianCoords>::apply(angular_cauchy_coordinates,
+                                          cartesian_cauchy_coordinates);
+
+  GaugeUpdateJacobianFromCoordinates<
+      Tags::GaugeC, Tags::GaugeD, Tags::CauchyAngularCoords,
+      Tags::CauchyCartesianCoords>::apply(make_not_null(&gauge_c),
+                                          make_not_null(&gauge_d),
+                                          angular_cauchy_coordinates,
+                                          *cartesian_cauchy_coordinates, l_max);
+  return max_error;
+}
+}  // namespace detail
+
+void GaugeAdjustInitialJ::apply(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> volume_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& gauge_c,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& gauge_d,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& gauge_omega,
+    const tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>&
+        cauchy_angular_coordinates,
+    const size_t l_max) noexcept {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  const size_t number_of_radial_points =
+      get(*volume_j).size() /
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  Scalar<SpinWeighted<ComplexDataVector, 2>> evolution_coords_j_buffer{
+      number_of_angular_points};
+  Spectral::Swsh::SwshInterpolator interpolator{
+      get<0>(cauchy_angular_coordinates), get<1>(cauchy_angular_coordinates),
+      l_max};
+  for (size_t i = 0; i < number_of_radial_points; ++i) {
+    Scalar<SpinWeighted<ComplexDataVector, 2>> angular_view_j;
+    get(angular_view_j)
+        .set_data_ref(
+            get(*volume_j).data().data() + i * number_of_angular_points,
+            number_of_angular_points);
+    get(evolution_coords_j_buffer) = get(angular_view_j);
+    GaugeAdjustedBoundaryValue<Tags::BondiJ>::apply(
+        make_not_null(&angular_view_j), evolution_coords_j_buffer, gauge_c,
+        gauge_d, gauge_omega, interpolator);
+  }
+}
+}  // namespace InitializeJ
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/Initialize/InverseCubic.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/InverseCubic.cpp
@@ -1,31 +1,33 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "Evolution/Systems/Cce/InitializeCce.hpp"
+#include "Evolution/Systems/Cce/Initialize/InverseCubic.hpp"
 
 #include <cstddef>
 #include <memory>
+#include <type_traits>
 
 #include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tags.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
-#include "Time/History.hpp"
-#include "Time/TimeSteppers/RungeKutta3.hpp"
-#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace Cce {
+namespace InitializeJ {
 
-std::unique_ptr<InitializeJ> InitializeJInverseCubic::get_clone() const
+std::unique_ptr<InitializeJ> InverseCubic::get_clone() const
     noexcept {
-  return std::make_unique<InitializeJInverseCubic>();
+  return std::make_unique<InverseCubic>();
 }
 
-void InitializeJInverseCubic::operator()(
+void InverseCubic::operator()(
     const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
     const gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_cauchy_coordinates,
     const gsl::not_null<
@@ -74,9 +76,10 @@ void InitializeJInverseCubic::operator()(
       cos(get<0>(*angular_cauchy_coordinates));
 }
 
-void InitializeJInverseCubic::pup(PUP::er& /*p*/) noexcept {}
+void InverseCubic::pup(PUP::er& /*p*/) noexcept {}
 
 /// \cond
-PUP::able::PUP_ID InitializeJInverseCubic::my_PUP_ID = 0;
+PUP::able::PUP_ID InverseCubic::my_PUP_ID = 0;
 /// \endcond
+}  // namespace InitializeJ
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/Initialize/InverseCubic.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/InverseCubic.hpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/Cce/Initialize/InverseCubic.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class ComplexDataVector;
+/// \endcond
+
+namespace Cce {
+namespace InitializeJ {
+
+/*!
+ * \brief Initialize \f$J\f$ on the first hypersurface from provided boundary
+ * values of \f$J\f$, \f$R\f$, and \f$\partial_r J\f$.
+ *
+ * \details This initial data is chosen to take the function:
+ *
+ * \f[ J = \frac{A}{r} + \frac{B}{r^3},\f]
+ *
+ * where
+ *
+ * \f{align*}{
+ * A &= R \left( \frac{3}{2} J|_{r = R} + \frac{1}{2} R \partial_r J|_{r =
+ * R}\right) \notag\\
+ * B &= - \frac{1}{2} R^3 (J|_{r = R} + R \partial_r J|_{r = R})
+ * \f}
+ */
+struct InverseCubic : InitializeJ {
+  using options = tmpl::list<>;
+  static constexpr OptionString help = {
+      "Initialization process where J is set to a simple Ansatz with a\n"
+      " A/r + B/r^3 piece such that it is smooth with the Cauchy data at the \n"
+      "worldtube"};
+
+  WRAPPED_PUPable_decl_template(InverseCubic);  // NOLINT
+  explicit InverseCubic(CkMigrateMessage* /*unused*/) noexcept {}
+
+  InverseCubic() = default;
+
+  std::unique_ptr<InitializeJ> get_clone() const noexcept override;
+
+  void operator()(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+      gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_cauchy_coordinates,
+      gsl::not_null<
+          tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
+          angular_cauchy_coordinates,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& r, size_t l_max,
+      size_t number_of_radial_points) const noexcept override;
+
+  void pup(PUP::er& /*p*/) noexcept override;
+};
+}  // namespace InitializeJ
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/Initialize/ZeroNonSmooth.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/ZeroNonSmooth.cpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/Initialize/ZeroNonSmooth.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/Printf.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce {
+namespace InitializeJ {
+
+ZeroNonSmooth::ZeroNonSmooth(const double angular_coordinate_tolerance,
+                             const size_t max_iterations,
+                             const bool error_if_not_converged) noexcept
+    : angular_coordinate_tolerance_{angular_coordinate_tolerance},
+      max_iterations_{max_iterations},
+      error_if_not_converged_{error_if_not_converged} {}
+
+std::unique_ptr<InitializeJ> ZeroNonSmooth::get_clone() const noexcept {
+  return std::make_unique<ZeroNonSmooth>(angular_coordinate_tolerance_,
+                                         max_iterations_);
+}
+
+void ZeroNonSmooth::operator()(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+    const gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_cauchy_coordinates,
+    const gsl::not_null<
+        tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
+        angular_cauchy_coordinates,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& /* boundary_dr_j*/,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& /*r*/, const size_t l_max,
+    const size_t /*number_of_radial_points*/) const noexcept {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  const SpinWeighted<ComplexDataVector, 2> j_boundary_view;
+  make_const_view(make_not_null(&j_boundary_view), get(*j), 0,
+                  number_of_angular_points);
+
+  get(*j).data() = 0.0;
+  const double final_angular_coordinate_deviation =
+      detail::adjust_angular_coordinates_for_j(
+          cartesian_cauchy_coordinates, angular_cauchy_coordinates,
+          get(boundary_j), l_max, angular_coordinate_tolerance_,
+          max_iterations_);
+  if (final_angular_coordinate_deviation > angular_coordinate_tolerance_ and
+      error_if_not_converged_) {
+    ERROR(MakeString{}
+          << "Initial data iterative angular solve did not reach "
+             "target tolerance "
+          << angular_coordinate_tolerance_ << ".\n"
+          << "Exited after " << max_iterations_
+          << " iterations, achieving final\n"
+             "maximum over collocation points deviation of J from target of "
+          << final_angular_coordinate_deviation);
+  } else if (final_angular_coordinate_deviation >
+             angular_coordinate_tolerance_) {
+    Parallel::printf(
+        "Warning: iterative angular solve did not reach "
+        "target tolerance %e.\n"
+        "Exited after %zu iterations, achieving final maximum over "
+        "collocation points deviation of J from target of %e\n"
+        "Proceeding with evolution using the partial result from partial "
+        "angular solve.",
+        angular_coordinate_tolerance_, max_iterations_,
+        final_angular_coordinate_deviation);
+  }
+}
+
+void ZeroNonSmooth::pup(PUP::er& p) noexcept {
+  p | angular_coordinate_tolerance_;
+  p | max_iterations_;
+}
+
+/// \cond
+PUP::able::PUP_ID ZeroNonSmooth::my_PUP_ID = 0;
+/// \endcond
+}  // namespace InitializeJ
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/Initialize/ZeroNonSmooth.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/ZeroNonSmooth.hpp
@@ -1,0 +1,99 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class ComplexDataVector;
+/// \endcond
+
+namespace Cce {
+namespace InitializeJ {
+
+/*!
+ * \brief Initialize \f$J\f$ on the first hypersurface to be vanishing, finding
+ * the appropriate angular coordinates to be continuous with the provided
+ * worldtube boundary data.
+ *
+ * \details Internally, this performs an iterative solve for the angular
+ * coordinates necessary to give rise to a vanishing gauge-transformed J on the
+ * worldtube boundary. The parameters for the iterative procedure are determined
+ * by options `ZeroNonSmooth::AngularCoordinateTolerance` and
+ * `ZeroNonSmooth::MaxIterations`. The resulting `J` will necessarily
+ * have vanishing first radial derivative, and so will typically not be smooth
+ * (only continuous) with the provided Cauchy data at the worldtube boundary.
+ */
+struct ZeroNonSmooth : InitializeJ {
+  struct AngularCoordinateTolerance {
+    using type = double;
+    static std::string name() noexcept { return "AngularCoordTolerance"; }
+    static constexpr OptionString help = {
+        "Tolerance of initial angular coordinates for CCE"};
+    static type lower_bound() noexcept { return 1.0e-14; }
+    static type upper_bound() noexcept { return 1.0e-3; }
+    static type default_value() noexcept { return 1.0e-10; }
+  };
+
+  struct MaxIterations {
+    using type = size_t;
+    static constexpr OptionString help = {
+        "Number of linearized inversion iterations."};
+    static type lower_bound() noexcept { return 10; }
+    static type upper_bound() noexcept { return 1000; }
+    static type default_value() noexcept { return 300; }
+  };
+
+  struct RequireConvergence {
+    using type = bool;
+    static constexpr OptionString help = {
+        "If true, initialization will error if it hits MaxIterations"};
+    static type default_value() noexcept { return false; }
+  };
+  using options =
+      tmpl::list<AngularCoordinateTolerance, MaxIterations, RequireConvergence>;
+
+  static constexpr OptionString help = {
+      "Initialization process where J is set so Psi0 is vanishing\n"
+      "(roughly a no incoming radiation condition)"};
+
+  WRAPPED_PUPable_decl_template(ZeroNonSmooth);  // NOLINT
+  explicit ZeroNonSmooth(CkMigrateMessage* /*unused*/) noexcept {}
+
+  ZeroNonSmooth(double angular_coordinate_tolerance, size_t max_iterations,
+                bool error_if_not_converged = false) noexcept;
+
+  ZeroNonSmooth() = default;
+
+  std::unique_ptr<InitializeJ> get_clone() const noexcept override;
+
+  void operator()(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+      gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_cauchy_coordinates,
+      gsl::not_null<
+          tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
+          angular_cauchy_coordinates,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& r, size_t l_max,
+      size_t number_of_radial_points) const noexcept override;
+
+  void pup(PUP::er& p) noexcept override;
+
+ private:
+  double angular_coordinate_tolerance_ = 1.0e-10;
+  size_t max_iterations_ = 300;
+  bool error_if_not_converged_ = false;
+};
+}  // namespace InitializeJ
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -7,7 +7,7 @@
 #include <limits>
 
 #include "DataStructures/DataBox/Tag.hpp"
-#include "Evolution/Systems/Cce/InitializeCce.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
 #include "Evolution/Systems/Cce/InterfaceManagers/GhLockstepInterfaceManager.hpp"
 #include "Evolution/Systems/Cce/InterfaceManagers/WorldtubeInterfaceManager.hpp"
 #include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
@@ -15,9 +15,6 @@
 #include "Options/Options.hpp"
 
 namespace Cce {
-/// \cond
-struct InitializeJ;
-/// \endcond
 namespace OptionTags {
 
 /// %Option group
@@ -148,7 +145,7 @@ struct ScriOutputDensity {
 };
 
 struct InitializeJ {
-  using type = std::unique_ptr<::Cce::InitializeJ>;
+  using type = std::unique_ptr<::Cce::InitializeJ::InitializeJ>;
   static constexpr OptionString help{
       "The initialization for the first hypersurface for J"};
   using group = Cce;
@@ -335,12 +332,13 @@ struct GhInterfaceManager : db::SimpleTag {
 };
 
 struct InitializeJ : db::SimpleTag {
-  using type = std::unique_ptr<::Cce::InitializeJ>;
+  using type = std::unique_ptr<::Cce::InitializeJ::InitializeJ>;
   using option_tags = tmpl::list<OptionTags::InitializeJ>;
 
   static constexpr bool pass_metavariables = false;
-  static std::unique_ptr<::Cce::InitializeJ> create_from_options(
-      const std::unique_ptr<::Cce::InitializeJ>& initialize_j) noexcept {
+  static std::unique_ptr<::Cce::InitializeJ::InitializeJ> create_from_options(
+      const std::unique_ptr<::Cce::InitializeJ::InitializeJ>&
+          initialize_j) noexcept {
     return initialize_j->get_clone();
   }
 };

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -21,7 +21,8 @@
 #include "Evolution/Systems/Cce/Actions/ReceiveWorldtubeData.hpp"
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
 #include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
-#include "Evolution/Systems/Cce/InitializeCce.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Evolution/Systems/Cce/Initialize/InverseCubic.hpp"
 #include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
@@ -181,7 +182,7 @@ SPECTRE_TEST_CASE(
       {l_max, number_of_radial_points,
        std::make_unique<::TimeSteppers::RungeKutta3>(), start_time,
        start_time + target_step_size,
-       std::make_unique<InitializeJInverseCubic>()}};
+       std::make_unique<InitializeJ::InverseCubic>()}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            metavariables::Phase::Initialization);
@@ -267,8 +268,9 @@ SPECTRE_TEST_CASE(
   ActionTesting::next_action<component>(make_not_null(&runner), 0);
 
   // perform the expected transformations on the `boundary_box`
-  db::mutate_apply<InitializeJ::mutate_tags, InitializeJ::argument_tags>(
-      InitializeJInverseCubic{}, make_not_null(&boundary_box));
+  db::mutate_apply<InitializeJ::InitializeJ::mutate_tags,
+                   InitializeJ::InitializeJ::argument_tags>(
+      InitializeJ::InverseCubic{}, make_not_null(&boundary_box));
 
   db::mutate_apply<InitializeGauge>(make_not_null(&boundary_box));
   db::mutate_apply<GaugeUpdateAngularFromCartesian<

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
@@ -14,6 +14,8 @@
 #include "Evolution/Systems/Cce/Actions/UpdateGauge.hpp"
 #include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
 #include "Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Evolution/Systems/Cce/Initialize/InverseCubic.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
@@ -76,7 +78,6 @@ struct metavariables {
   using component_list =
       tmpl::list<mock_characteristic_evolution<metavariables>>;
 
-  using cce_hypersurface_initialization = InitializeJInverseCubic;
   enum class Phase { Initialization, Testing, Exit };
 };
 }  // namespace
@@ -96,7 +97,7 @@ SPECTRE_TEST_CASE(
   using component = mock_characteristic_evolution<metavariables>;
   ActionTesting::MockRuntimeSystem<metavariables> runner{
       {l_max, number_of_radial_points,
-       std::make_unique<InitializeJInverseCubic>()}};
+       std::make_unique<InitializeJ::InverseCubic>()}};
 
   Variables<real_boundary_tags_to_compute> real_variables{
       Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
@@ -141,9 +142,9 @@ SPECTRE_TEST_CASE(
   ActionTesting::next_action<component>(make_not_null(&runner), 0);
 
   // apply the corresponding mutators to the `expected_box`
-  db::mutate_apply<Cce::InitializeJ::mutate_tags,
-                   Cce::InitializeJ::argument_tags>(
-      Cce::InitializeJInverseCubic{}, make_not_null(&expected_box));
+  db::mutate_apply<Cce::InitializeJ::InitializeJ::mutate_tags,
+                   Cce::InitializeJ::InitializeJ::argument_tags>(
+      Cce::InitializeJ::InverseCubic{}, make_not_null(&expected_box));
   db::mutate_apply<GaugeUpdateAngularFromCartesian<
       Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords>>(
       make_not_null(&expected_box));

--- a/tests/Unit/Evolution/Systems/Cce/Test_GaugeTransformBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_GaugeTransformBoundaryData.cpp
@@ -7,7 +7,7 @@
 #include "DataStructures/DataBox/TagName.hpp"
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
 #include "Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp"
-#include "Evolution/Systems/Cce/InitializeCce.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/PreSwshDerivatives.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
@@ -22,7 +22,7 @@
 namespace Cce {
 namespace {
 
-struct InitializeJInverseCubicEvolutionGauge {
+struct InverseCubicEvolutionGauge {
   using boundary_tags =
       tmpl::list<Tags::EvolutionGaugeBoundaryValue<Tags::BondiJ>,
                  Tags::EvolutionGaugeBoundaryValue<Tags::Dr<Tags::BondiJ>>,
@@ -34,7 +34,7 @@ struct InitializeJInverseCubicEvolutionGauge {
       tmpl::append<boundary_tags,
                    tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints>>;
 
-  InitializeJInverseCubicEvolutionGauge() = default;
+  InverseCubicEvolutionGauge() = default;
 
   void operator()(
       const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
@@ -404,14 +404,12 @@ void test_gauge_transforms_via_inverse_coordinate_map(
         check_gauge_adjustment_against_inverse);
   }
 
-  db::mutate_apply<InitializeJInverseCubicEvolutionGauge::mutate_tags,
-                   InitializeJInverseCubicEvolutionGauge::argument_tags>(
-      InitializeJInverseCubicEvolutionGauge{},
-      make_not_null(&forward_transform_box));
-  db::mutate_apply<InitializeJInverseCubicEvolutionGauge::mutate_tags,
-                   InitializeJInverseCubicEvolutionGauge::argument_tags>(
-      InitializeJInverseCubicEvolutionGauge{},
-      make_not_null(&inverse_transform_box));
+  db::mutate_apply<InverseCubicEvolutionGauge::mutate_tags,
+                   InverseCubicEvolutionGauge::argument_tags>(
+      InverseCubicEvolutionGauge{}, make_not_null(&forward_transform_box));
+  db::mutate_apply<InverseCubicEvolutionGauge::mutate_tags,
+                   InverseCubicEvolutionGauge::argument_tags>(
+      InverseCubicEvolutionGauge{}, make_not_null(&inverse_transform_box));
 
   db::mutate_apply<PreSwshDerivatives<Tags::Dy<Tags::BondiJ>>>(
       make_not_null(&forward_transform_box));

--- a/tests/Unit/Evolution/Systems/Cce/Test_InitializeCce.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_InitializeCce.cpp
@@ -10,70 +10,29 @@
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Mesh.hpp"
-#include "Evolution/Systems/Cce/InitializeCce.hpp"
+#include "Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Evolution/Systems/Cce/Initialize/InverseCubic.hpp"
+#include "Evolution/Systems/Cce/Initialize/ZeroNonSmooth.hpp"
 #include "Evolution/Systems/Cce/LinearOperators.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace Cce {
 
-SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.InitializeJ",
-                  "[Unit][Cce]") {
-  MAKE_GENERATOR(generator);
-  UniformCustomDistribution<size_t> sdist{5, 8};
-  const size_t l_max = sdist(generator);
-  const size_t number_of_radial_points = sdist(generator);
-
-  using boundary_variables_tag =
-      ::Tags::Variables<InitializeJInverseCubic::boundary_tags>;
-  using pre_swsh_derivatives_variables_tag =
-      ::Tags::Variables<tmpl::list<Tags::BondiJ>>;
-  using tensor_variables_tag = ::Tags::Variables<
-      tmpl::list<Tags::CauchyCartesianCoords, Tags::CauchyAngularCoords>>;
-
-  const size_t number_of_boundary_points =
-      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
-  const size_t number_of_volume_points =
-      number_of_boundary_points * number_of_radial_points;
-  auto box_to_initialize = db::create<db::AddSimpleTags<
-      boundary_variables_tag, pre_swsh_derivatives_variables_tag,
-      tensor_variables_tag, Tags::LMax, Tags::NumberOfRadialPoints>>(
-      typename boundary_variables_tag::type{number_of_boundary_points},
-      typename pre_swsh_derivatives_variables_tag::type{
-          number_of_volume_points},
-      typename tensor_variables_tag::type{number_of_boundary_points}, l_max,
-      number_of_radial_points);
-
-  // generate some random values for the boundary data
-  UniformCustomDistribution<double> dist(0.1, 1.0);
-  db::mutate<Tags::BoundaryValue<Tags::BondiR>,
-             Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
-             Tags::BoundaryValue<Tags::BondiJ>>(
-      make_not_null(&box_to_initialize),
-      [&generator, &dist, &l_max](
-          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
-              boundary_r,
-          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
-              boundary_dr_j,
-          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
-              boundary_j) {
-        get(*boundary_j).data() = make_with_random_values<ComplexDataVector>(
-            make_not_null(&generator), make_not_null(&dist),
-            Spectral::Swsh::number_of_swsh_collocation_points(l_max));
-        get(*boundary_r).data() = make_with_random_values<ComplexDataVector>(
-            make_not_null(&generator), make_not_null(&dist),
-            Spectral::Swsh::number_of_swsh_collocation_points(l_max));
-        get(*boundary_dr_j).data() = make_with_random_values<ComplexDataVector>(
-            make_not_null(&generator), make_not_null(&dist),
-            Spectral::Swsh::number_of_swsh_collocation_points(l_max));
-      });
-
-  db::mutate_apply<InitializeJ::mutate_tags, InitializeJ::argument_tags>(
-      InitializeJInverseCubic{}, make_not_null(&box_to_initialize));
+template <typename DbTags>
+void test_initialize_j_inverse_cubic(
+    const gsl::not_null<db::DataBox<DbTags>*> box_to_initialize,
+    const size_t l_max, const size_t number_of_radial_points) noexcept {
+  db::mutate_apply<InitializeJ::InitializeJ::mutate_tags,
+                   InitializeJ::InitializeJ::argument_tags>(
+      InitializeJ::InverseCubic{}, box_to_initialize);
 
   SpinWeighted<ComplexDataVector, 2> dy_j{
       number_of_radial_points *
@@ -83,7 +42,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.InitializeJ",
       Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
   logical_partial_directional_derivative_of_complex(
       make_not_null(&dy_j.data()),
-      get(db::get<Tags::BondiJ>(box_to_initialize)).data(),
+      get(db::get<Tags::BondiJ>(*box_to_initialize)).data(),
       Mesh<3>{{{Spectral::Swsh::number_of_swsh_theta_collocation_points(l_max),
                 Spectral::Swsh::number_of_swsh_phi_collocation_points(l_max),
                 number_of_radial_points}},
@@ -99,11 +58,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.InitializeJ",
               Spectral::Quadrature::GaussLobatto},
       2);
 
-  // The goal for the initial data is that it should:
+  // The goal for this initial data is that it should:
   // - match the value of J and its first derivative on the boundary
   // - have vanishing value and second derivative at scri+
   ComplexDataVector mutable_j_copy =
-      get(db::get<Tags::BondiJ>(box_to_initialize)).data();
+      get(db::get<Tags::BondiJ>(*box_to_initialize)).data();
   const auto boundary_slice_j = ComplexDataVector{
       mutable_j_copy.data(),
       Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
@@ -127,16 +86,17 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.InitializeJ",
           .scale(1.0);
 
   CHECK_ITERABLE_CUSTOM_APPROX(
-      get(db::get<Tags::BoundaryValue<Tags::BondiJ>>(box_to_initialize)).data(),
+      get(db::get<Tags::BoundaryValue<Tags::BondiJ>>(*box_to_initialize))
+          .data(),
       boundary_slice_j, cce_approx);
   const auto boundary_slice_dr_j =
-      (2.0 / get(db::get<Tags::BoundaryValue<Tags::BondiR>>(box_to_initialize))
+      (2.0 / get(db::get<Tags::BoundaryValue<Tags::BondiR>>(*box_to_initialize))
                  .data()) *
       boundary_slice_dy_j;
   CHECK_ITERABLE_CUSTOM_APPROX(
       boundary_slice_dr_j,
       get(db::get<Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>>(
-              box_to_initialize))
+              *box_to_initialize))
           .data(),
       cce_approx);
   const ComplexDataVector scri_plus_zeroes{
@@ -144,5 +104,216 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.InitializeJ",
   CHECK_ITERABLE_CUSTOM_APPROX(scri_slice_j, scri_plus_zeroes, cce_approx);
   CHECK_ITERABLE_CUSTOM_APPROX(scri_slice_dy_dy_j, scri_plus_zeroes,
                                cce_approx);
+}
+template <typename DbTags>
+void test_initialize_j_zero_nonsmooth(
+    const gsl::not_null<db::DataBox<DbTags>*> box_to_initialize,
+    const size_t /*l_max*/, const size_t /*number_of_radial_points*/) noexcept {
+  // The iterative procedure can reach error levels better than 1.0e-8, but it
+  // is difficult to do so reliably and quickly for randomly generated data.
+  db::mutate_apply<InitializeJ::InitializeJ::mutate_tags,
+                   InitializeJ::InitializeJ::argument_tags>(
+      InitializeJ::ZeroNonSmooth{1.0e-8, 400}, box_to_initialize);
+
+  // generate the extra gauge quantities and verify that the boundary value for
+  // J is indeed within the tolerance.
+  db::mutate_apply<GaugeUpdateAngularFromCartesian<
+      Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords>>(
+      box_to_initialize);
+  db::mutate_apply<GaugeUpdateJacobianFromCoordinates<
+      Tags::GaugeC, Tags::GaugeD, Tags::CauchyAngularCoords,
+      Tags::CauchyCartesianCoords>>(box_to_initialize);
+  db::mutate_apply<GaugeUpdateInterpolator<Tags::CauchyAngularCoords>>(
+      box_to_initialize);
+  db::mutate_apply<GaugeUpdateOmega>(box_to_initialize);
+
+  db::mutate_apply<GaugeAdjustedBoundaryValue<Tags::BondiJ>>(box_to_initialize);
+
+  const auto& gauge_adjusted_boundary_j =
+      db::get<Tags::EvolutionGaugeBoundaryValue<Tags::BondiJ>>(
+          *box_to_initialize);
+  for (auto val : get(gauge_adjusted_boundary_j).data()) {
+    CHECK(real(val) < 1.0e-8);
+    CHECK(imag(val) < 1.0e-8);
+  }
+
+  const auto& initialized_j = db::get<Tags::BondiJ>(*box_to_initialize);
+  for (auto val : get(initialized_j).data()) {
+    CHECK(real(val) < 1.0e-8);
+    CHECK(imag(val) < 1.0e-8);
+  }
+}
+
+// [[OutputRegex, Initial data iterative angular solve]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.Cce.InitializeJ.ZeroNonSmoothError",
+    "[Unit][Cce]") {
+  ERROR_TEST();
+  MAKE_GENERATOR(generator);
+  UniformCustomDistribution<size_t> sdist{5, 8};
+  const size_t l_max = sdist(generator);
+  const size_t number_of_radial_points = sdist(generator);
+
+  using boundary_variables_tag =
+      ::Tags::Variables<InitializeJ::InverseCubic::boundary_tags>;
+  using pre_swsh_derivatives_variables_tag =
+      ::Tags::Variables<tmpl::list<Tags::BondiJ>>;
+  using tensor_variables_tag = ::Tags::Variables<
+      tmpl::list<Tags::CauchyCartesianCoords, Tags::CauchyAngularCoords>>;
+
+  const size_t number_of_boundary_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  const size_t number_of_volume_points =
+      number_of_boundary_points * number_of_radial_points;
+  auto box_to_initialize = db::create<db::AddSimpleTags<
+      boundary_variables_tag, pre_swsh_derivatives_variables_tag,
+      tensor_variables_tag, Tags::LMax, Tags::NumberOfRadialPoints,
+      Spectral::Swsh::Tags::SwshInterpolator<Tags::CauchyAngularCoords>>>(
+      typename boundary_variables_tag::type{number_of_boundary_points},
+      typename pre_swsh_derivatives_variables_tag::type{
+          number_of_volume_points},
+      typename tensor_variables_tag::type{number_of_boundary_points}, l_max,
+      number_of_radial_points, Spectral::Swsh::SwshInterpolator{});
+
+  // generate some random values for the boundary data. Mode magnitudes are
+  // roughly representative of typical strains seen in simulations, and are of a
+  // scale that can be fully solved by the iterative procedure used in the more
+  // elaborate initial data generators.
+  UniformCustomDistribution<double> dist(1.0e-5, 1.0e-4);
+  db::mutate<Tags::BoundaryValue<Tags::BondiR>,
+             Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
+             Tags::BoundaryValue<Tags::BondiJ>>(
+      make_not_null(&box_to_initialize),
+      [&generator, &dist, &l_max](
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+              boundary_r,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
+              boundary_dr_j,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
+              boundary_j) {
+        SpinWeighted<ComplexModalVector, 2> generated_modes{
+            Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+        Spectral::Swsh::TestHelpers::generate_swsh_modes<2>(
+            make_not_null(&generated_modes.data()), make_not_null(&generator),
+            make_not_null(&dist), 1, l_max);
+
+        get(*boundary_j) =
+            Spectral::Swsh::inverse_swsh_transform(l_max, 1, generated_modes);
+        Spectral::Swsh::filter_swsh_boundary_quantity(
+            make_not_null(&get(*boundary_j)), l_max, l_max / 2);
+
+        Spectral::Swsh::TestHelpers::generate_swsh_modes<2>(
+            make_not_null(&generated_modes.data()), make_not_null(&generator),
+            make_not_null(&dist), 1, l_max);
+        get(*boundary_dr_j) =
+            Spectral::Swsh::inverse_swsh_transform(l_max, 1, generated_modes) /
+            10.0;
+
+        SpinWeighted<ComplexModalVector, 0> generated_r_modes{
+          Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+        Spectral::Swsh::TestHelpers::generate_swsh_modes<0>(
+            make_not_null(&generated_modes.data()), make_not_null(&generator),
+            make_not_null(&dist), 1, l_max);
+
+        get(*boundary_r) = Spectral::Swsh::inverse_swsh_transform(
+                               l_max, 1, generated_r_modes) +
+                           10.0;
+        Spectral::Swsh::filter_swsh_boundary_quantity(
+            make_not_null(&get(*boundary_r)), l_max, l_max / 2);
+
+      });
+  db::mutate_apply<InitializeJ::InitializeJ::mutate_tags,
+                   InitializeJ::InitializeJ::argument_tags>(
+      InitializeJ::ZeroNonSmooth{1.0e-12, 1, true},
+      make_not_null(&box_to_initialize));
+  ERROR("Failed to trigger ERROR in an error test");
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.InitializeJ", "[Unit][Cce]") {
+  MAKE_GENERATOR(generator);
+  UniformCustomDistribution<size_t> sdist{5, 8};
+  const size_t l_max = sdist(generator);
+  const size_t number_of_radial_points = sdist(generator);
+
+  using boundary_variables_tag = ::Tags::Variables<
+      tmpl::push_back<InitializeJ::InverseCubic::boundary_tags, Tags::GaugeC,
+                      Tags::GaugeD, Tags::GaugeOmega,
+                      Spectral::Swsh::Tags::Derivative<
+                          Tags::GaugeOmega, Spectral::Swsh::Tags::Eth>,
+                      Tags::EvolutionGaugeBoundaryValue<Tags::BondiJ>>>;
+  using pre_swsh_derivatives_variables_tag =
+      ::Tags::Variables<tmpl::list<Tags::BondiJ>>;
+  using tensor_variables_tag = ::Tags::Variables<
+      tmpl::list<Tags::CauchyCartesianCoords, Tags::CauchyAngularCoords>>;
+
+  const size_t number_of_boundary_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  const size_t number_of_volume_points =
+      number_of_boundary_points * number_of_radial_points;
+  auto box_to_initialize = db::create<db::AddSimpleTags<
+      boundary_variables_tag, pre_swsh_derivatives_variables_tag,
+      tensor_variables_tag, Tags::LMax, Tags::NumberOfRadialPoints,
+      Spectral::Swsh::Tags::SwshInterpolator<Tags::CauchyAngularCoords>>>(
+      typename boundary_variables_tag::type{number_of_boundary_points},
+      typename pre_swsh_derivatives_variables_tag::type{
+          number_of_volume_points},
+      typename tensor_variables_tag::type{number_of_boundary_points}, l_max,
+      number_of_radial_points, Spectral::Swsh::SwshInterpolator{});
+
+  // generate some random values for the boundary data. Mode magnitudes are
+  // roughly representative of typical strains seen in simulations, and are of a
+  // scale that can be fully solved by the iterative procedure used in the more
+  // elaborate initial data generators.
+  UniformCustomDistribution<double> dist(1.0e-5, 1.0e-4);
+  db::mutate<Tags::BoundaryValue<Tags::BondiR>,
+             Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
+             Tags::BoundaryValue<Tags::BondiJ>>(
+      make_not_null(&box_to_initialize),
+      [&generator, &dist, &l_max](
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+              boundary_r,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
+              boundary_dr_j,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
+              boundary_j) {
+        SpinWeighted<ComplexModalVector, 2> generated_modes{
+            Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+        Spectral::Swsh::TestHelpers::generate_swsh_modes<2>(
+            make_not_null(&generated_modes.data()), make_not_null(&generator),
+            make_not_null(&dist), 1, l_max);
+
+        get(*boundary_j) =
+            Spectral::Swsh::inverse_swsh_transform(l_max, 1, generated_modes);
+        Spectral::Swsh::filter_swsh_boundary_quantity(
+            make_not_null(&get(*boundary_j)), l_max, l_max / 2);
+
+        Spectral::Swsh::TestHelpers::generate_swsh_modes<2>(
+            make_not_null(&generated_modes.data()), make_not_null(&generator),
+            make_not_null(&dist), 1, l_max);
+        get(*boundary_dr_j) =
+            Spectral::Swsh::inverse_swsh_transform(l_max, 1, generated_modes) /
+            10.0;
+
+        SpinWeighted<ComplexModalVector, 0> generated_r_modes{
+          Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+        Spectral::Swsh::TestHelpers::generate_swsh_modes<0>(
+            make_not_null(&generated_modes.data()), make_not_null(&generator),
+            make_not_null(&dist), 1, l_max);
+
+        get(*boundary_r) = Spectral::Swsh::inverse_swsh_transform(
+                               l_max, 1, generated_r_modes) +
+                           10.0;
+        Spectral::Swsh::filter_swsh_boundary_quantity(
+            make_not_null(&get(*boundary_r)), l_max, l_max / 2);
+
+      });
+  SECTION("Check inverse cubic initial data generator") {
+    test_initialize_j_inverse_cubic(make_not_null(&box_to_initialize), l_max,
+                                    number_of_radial_points);
+  }
+  SECTION("Check zero nonsmooth initial data generator") {
+    test_initialize_j_zero_nonsmooth(make_not_null(&box_to_initialize), l_max,
+                                     number_of_radial_points);
+  }
 }
 }  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -7,6 +7,9 @@
 #include <limits>
 #include <string>
 
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Evolution/Systems/Cce/Initialize/InverseCubic.hpp"
+#include "Evolution/Systems/Cce/Initialize/ZeroNonSmooth.hpp"
 #include "Evolution/Systems/Cce/InterfaceManagers/WorldtubeInterfaceManager.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
@@ -70,7 +73,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::ScriOutputDensity>(
             "6") == 6_st);
 
-  TestHelpers::test_creation<std::unique_ptr<::Cce::InitializeJ>,
+  TestHelpers::test_creation<std::unique_ptr<::Cce::InitializeJ::InitializeJ>,
                              Cce::OptionTags::InitializeJ>("InverseCubic");
 
   const std::string filename = "OptionTagsTestCceR0100.h5";


### PR DESCRIPTION
## Proposed changes

Adds another initial data option to CCE, split off from PR #2136 .

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies
- [x] #2136 
