### PR TITLE
Add UniformRotationAboutZAxis TimeDependence

### DIFF
--- a/src/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/src/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   CubicScale.cpp
   None.cpp
   RegisterDerivedWithCharm.cpp
+  UniformRotationAboutZAxis.cpp
   UniformTranslation.cpp
   )
 

--- a/src/Domain/Creators/TimeDependence/TimeDependence.hpp
+++ b/src/Domain/Creators/TimeDependence/TimeDependence.hpp
@@ -32,6 +32,8 @@ class CubicScale;
 template <size_t MeshDim>
 class None;
 template <size_t MeshDim>
+class UniformRotationAboutZAxis;
+template <size_t MeshDim>
 class UniformTranslation;
 }  // namespace time_dependence
 }  // namespace creators
@@ -51,8 +53,21 @@ namespace time_dependence {
 /// communicate to the code that the domain is time-independent.
 template <size_t MeshDim>
 struct TimeDependence {
-  using creatable_classes = tmpl::list<CubicScale<MeshDim>, None<MeshDim>,
-                                       UniformTranslation<MeshDim>>;
+ private:
+  using creatable_classes_1d = tmpl::list<>;
+  using creatable_classes_2d = tmpl::list<UniformRotationAboutZAxis<2>>;
+  using creatable_classes_3d = tmpl::list<UniformRotationAboutZAxis<3>>;
+  using creatable_classes_any_dim =
+      tmpl::list<CubicScale<MeshDim>, None<MeshDim>,
+                 UniformTranslation<MeshDim>>;
+
+ public:
+  using creatable_classes =
+      tmpl::append<creatable_classes_any_dim,
+                   tmpl::conditional_t<
+                       MeshDim == 1, creatable_classes_1d,
+                       tmpl::conditional_t<MeshDim == 2, creatable_classes_2d,
+                                           creatable_classes_3d>>>;
 
   TimeDependence() = default;
   virtual ~TimeDependence() = 0;
@@ -90,4 +105,5 @@ TimeDependence<MeshDim>::~TimeDependence() = default;
 
 #include "Domain/Creators/TimeDependence/CubicScale.hpp"
 #include "Domain/Creators/TimeDependence/None.hpp"
+#include "Domain/Creators/TimeDependence/UniformRotationAboutZAxis.hpp"
 #include "Domain/Creators/TimeDependence/UniformTranslation.hpp"

--- a/src/Domain/Creators/TimeDependence/UniformRotationAboutZAxis.cpp
+++ b/src/Domain/Creators/TimeDependence/UniformRotationAboutZAxis.cpp
@@ -1,0 +1,142 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependence/UniformRotationAboutZAxis.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/MapInstantiationMacros.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ProductMaps.tpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+
+template <size_t MeshDim>
+UniformRotationAboutZAxis<MeshDim>::UniformRotationAboutZAxis(
+    const double initial_time, const double angular_velocity,
+    std::string function_of_time_name) noexcept
+    : initial_time_(initial_time),
+      angular_velocity_(angular_velocity),
+      function_of_time_name_(std::move(function_of_time_name)) {}
+
+template <size_t MeshDim>
+std::unique_ptr<TimeDependence<MeshDim>>
+UniformRotationAboutZAxis<MeshDim>::get_clone() const noexcept {
+  return std::make_unique<UniformRotationAboutZAxis>(
+      initial_time_, angular_velocity_, function_of_time_name_);
+}
+
+template <size_t MeshDim>
+std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, MeshDim>>>
+UniformRotationAboutZAxis<MeshDim>::block_maps(
+    const size_t number_of_blocks) const noexcept {
+  ASSERT(number_of_blocks > 0, "Must have at least one block to create.");
+  std::vector<std::unique_ptr<
+      domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, MeshDim>>>
+      result{number_of_blocks};
+  result[0] = std::make_unique<MapForComposition>(map_for_composition());
+  for (size_t i = 1; i < number_of_blocks; ++i) {
+    result[i] = result[0]->get_clone();
+  }
+  return result;
+}
+
+template <size_t MeshDim>
+std::unordered_map<std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+UniformRotationAboutZAxis<MeshDim>::functions_of_time() const noexcept {
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      result{};
+  // We use a `PiecewisePolynomial` with 2 derivs since some transformations
+  // between different frames for moving meshes can require Hessians.
+  result[function_of_time_name_] =
+      std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time_,
+          std::array<DataVector, 3>{{{0.0}, {angular_velocity_}, {0.0}}});
+  return result;
+}
+
+/// \cond
+template <>
+auto UniformRotationAboutZAxis<2>::map_for_composition() const noexcept
+    -> MapForComposition {
+  return MapForComposition{domain::CoordinateMaps::TimeDependent::Rotation<2>{
+      function_of_time_name_}};
+}
+
+template <>
+auto UniformRotationAboutZAxis<3>::map_for_composition() const noexcept
+    -> MapForComposition {
+  using ProductMap = domain::CoordinateMaps::TimeDependent::ProductOf2Maps<
+      domain::CoordinateMaps::TimeDependent::Rotation<2>,
+      domain::CoordinateMaps::Identity<1>>;
+  return MapForComposition{
+      ProductMap{domain::CoordinateMaps::TimeDependent::Rotation<2>{
+                     function_of_time_name_},
+                 domain::CoordinateMaps::Identity<1>{}}};
+}
+
+template <size_t Dim>
+bool operator==(const UniformRotationAboutZAxis<Dim>& lhs,
+                const UniformRotationAboutZAxis<Dim>& rhs) noexcept {
+  return lhs.initial_time_ == rhs.initial_time_ and
+         lhs.angular_velocity_ == rhs.angular_velocity_ and
+         lhs.function_of_time_name_ == rhs.function_of_time_name_;
+}
+
+template <size_t Dim>
+bool operator!=(const UniformRotationAboutZAxis<Dim>& lhs,
+                const UniformRotationAboutZAxis<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                   \
+  template class UniformRotationAboutZAxis<GET_DIM(data)>;       \
+  template bool operator==<GET_DIM(data)>(                       \
+      const UniformRotationAboutZAxis<GET_DIM(data)>&,           \
+      const UniformRotationAboutZAxis<GET_DIM(data)>&) noexcept; \
+  template bool operator!=<GET_DIM(data)>(                       \
+      const UniformRotationAboutZAxis<GET_DIM(data)>&,           \
+      const UniformRotationAboutZAxis<GET_DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (2, 3))
+
+#undef GET_DIM
+#undef INSTANTIATION
+/// \endcond
+}  // namespace time_dependence
+}  // namespace creators
+
+using Identity = CoordinateMaps::Identity<1>;
+using Rotation2d = CoordinateMaps::TimeDependent::Rotation<2>;
+using Rotation3d =
+    CoordinateMaps::TimeDependent::ProductOf2Maps<Rotation2d, Identity>;
+
+template class CoordinateMaps::TimeDependent::ProductOf2Maps<Rotation2d,
+                                                             Identity>;
+
+INSTANTIATE_MAPS_FUNCTIONS(((Rotation2d), (Rotation3d)), (Frame::Grid),
+                           (Frame::Inertial), (double, DataVector))
+
+}  // namespace domain

--- a/src/Domain/Creators/TimeDependence/UniformRotationAboutZAxis.hpp
+++ b/src/Domain/Creators/TimeDependence/UniformRotationAboutZAxis.hpp
@@ -1,0 +1,161 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/Rotation.hpp"
+#include "Domain/Creators/TimeDependence/GenerateCoordinateMap.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain {
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
+namespace CoordinateMaps {
+namespace TimeDependent {
+template <typename Map1, typename Map2>
+class ProductOf2Maps;
+}  // namespace TimeDependent
+}  // namespace CoordinateMaps
+
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+
+namespace Frame {
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+/*!
+ * \brief A uniform rotation about the \f$z\f$ axis:
+ * \f{eqnarray*}
+ * x &\to& x \cos \alpha(t) - y \sin \alpha(t)\text{,} \\
+ * y &\to& x \sin \alpha(t) + y \cos \alpha(t)\text{,}
+ * \f}
+ * where \f$\alpha(t)\f$ is a `domain::FunctionsOfTime::FunctionOfTime`. For 3
+ * spatial dimensions, \f$z \to z\f$, and the rotation is implemented as a
+ * product of the 2D rotation and an identity map. The rotation is undefined
+ * (and therefore unimplemented here) for 1 spatial dimension.
+ */
+template <size_t MeshDim>
+class UniformRotationAboutZAxis final : public TimeDependence<MeshDim> {
+  static_assert(
+      MeshDim > 1,
+      "UniformRotationAboutZAxis<MeshDim> undefined for MeshDim == 1");
+
+ private:
+  using Identity = domain::CoordinateMaps::Identity<1>;
+  using Rotation = domain::CoordinateMaps::TimeDependent::Rotation<2>;
+
+ public:
+  using maps_list = tmpl::list<
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial, Rotation>,
+      domain::CoordinateMap<
+          Frame::Grid, Frame::Inertial,
+          CoordinateMaps::TimeDependent::ProductOf2Maps<Rotation, Identity>>>;
+
+  static constexpr size_t mesh_dim = MeshDim;
+
+  /// \brief The initial time of the function of time.
+  struct InitialTime {
+    using type = double;
+    static constexpr OptionString help = {
+        "The initial time of the function of time"};
+  };
+  /// \brief The \f$x\f$-, \f$y\f$-, and \f$z\f$-velocity.
+  struct AngularVelocity {
+    using type = double;
+    static constexpr OptionString help = {"The angular velocity of the map."};
+  };
+  /// \brief The name of the function of time to be added to the DataBox.
+  ///
+  /// The default is `"RotationAngle"`.
+  struct FunctionOfTimeName {
+    using type = std::string;
+    static constexpr OptionString help = {
+        "Name of the rotation angle function of time."};
+    static type default_value() noexcept {
+      return std::string{"RotationAngle"};
+    }
+  };
+
+  using MapForComposition = detail::generate_coordinate_map_t<
+      tmpl::list<tmpl::conditional_t<MeshDim == 2, Rotation,
+                                     domain::CoordinateMaps::TimeDependent::
+                                         ProductOf2Maps<Rotation, Identity>>>>;
+
+  using options = tmpl::list<InitialTime, AngularVelocity, FunctionOfTimeName>;
+
+  static constexpr OptionString help = {
+      "A spatially uniform rotation about the z axis initialized with a "
+      "constant angular velocity."};
+
+  UniformRotationAboutZAxis() = default;
+  ~UniformRotationAboutZAxis() override = default;
+  UniformRotationAboutZAxis(const UniformRotationAboutZAxis&) = delete;
+  UniformRotationAboutZAxis(UniformRotationAboutZAxis&&) noexcept = default;
+  UniformRotationAboutZAxis& operator=(const UniformRotationAboutZAxis&) =
+      delete;
+  UniformRotationAboutZAxis& operator=(UniformRotationAboutZAxis&&) noexcept =
+      default;
+
+  UniformRotationAboutZAxis(
+      double initial_time, double angular_velocity,
+      std::string function_of_time_name = "RotationAngle") noexcept;
+
+  auto get_clone() const noexcept
+      -> std::unique_ptr<TimeDependence<MeshDim>> override;
+
+  auto block_maps(size_t number_of_blocks) const noexcept
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Grid, Frame::Inertial, MeshDim>>> override;
+
+  auto functions_of_time() const noexcept -> std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
+
+  /// Returns the map for each block to be used in a composition of
+  /// `TimeDependence`s.
+  MapForComposition map_for_composition() const noexcept;
+
+ private:
+  template <size_t LocalDim>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(
+      const UniformRotationAboutZAxis<LocalDim>& lhs,
+      const UniformRotationAboutZAxis<LocalDim>& rhs) noexcept;
+
+  double initial_time_{std::numeric_limits<double>::signaling_NaN()};
+  double angular_velocity_{std::numeric_limits<double>::signaling_NaN()};
+  std::string function_of_time_name_{};
+};
+
+template <size_t Dim>
+bool operator==(const UniformRotationAboutZAxis<Dim>& lhs,
+                const UniformRotationAboutZAxis<Dim>& rhs) noexcept;
+
+template <size_t Dim>
+bool operator!=(const UniformRotationAboutZAxis<Dim>& lhs,
+                const UniformRotationAboutZAxis<Dim>& rhs) noexcept;
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_Composition.cpp
   Test_CubicScale.cpp
   Test_None.cpp
+  Test_UniformRotationAboutZAxis.cpp
   Test_UniformTranslation.cpp
   )
 

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_UniformRotationAboutZAxis.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_UniformRotationAboutZAxis.cpp
@@ -1,0 +1,238 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/TimeDependent/Rotation.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Domain/Creators/TimeDependence/UniformRotationAboutZAxis.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Domain/Creators/TimeDependence/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain {
+namespace creators {
+namespace time_dependence {
+
+namespace {
+using Identity = domain::CoordinateMaps::Identity<1>;
+using Rotation = domain::CoordinateMaps::TimeDependent::Rotation<2>;
+
+template <size_t MeshDim>
+using ConcreteMap = tmpl::conditional_t<
+    MeshDim == 2, domain::CoordinateMap<Frame::Grid, Frame::Inertial, Rotation>,
+    domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                          domain::CoordinateMaps::TimeDependent::ProductOf2Maps<
+                              Rotation, Identity>>>;
+
+template <size_t MeshDim>
+ConcreteMap<MeshDim> create_coord_map(const std::string& f_of_t_name);
+
+template <>
+ConcreteMap<2> create_coord_map<2>(const std::string& f_of_t_name) {
+  return ConcreteMap<2>{{Rotation{f_of_t_name}}};
+}
+
+template <>
+ConcreteMap<3> create_coord_map<3>(const std::string& f_of_t_name) {
+  return ConcreteMap<3>{{Rotation{f_of_t_name}, Identity{}}};
+}
+
+template <size_t MeshDim>
+void test(const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr,
+          const double initial_time, const std::string& f_of_t_name) noexcept {
+  MAKE_GENERATOR(gen);
+  CAPTURE(initial_time);
+  CAPTURE(f_of_t_name);
+
+  CHECK_FALSE(time_dep_unique_ptr->is_none());
+
+  // We downcast to the expected derived class to make sure that factory
+  // creation worked correctly. In order to maximize code reuse this check is
+  // done here as opposed to separately elsewhere.
+  const auto* const time_dep =
+      dynamic_cast<const UniformRotationAboutZAxis<MeshDim>*>(
+          time_dep_unique_ptr.get());
+  REQUIRE(time_dep != nullptr);
+
+  // Test coordinate maps
+  UniformCustomDistribution<size_t> dist_size_t{1, 10};
+  const size_t num_blocks = dist_size_t(gen);
+  CAPTURE(num_blocks);
+
+  const auto expected_block_map = create_coord_map<MeshDim>(f_of_t_name);
+
+  const auto block_maps = time_dep_unique_ptr->block_maps(num_blocks);
+  for (const auto& block_map_unique_ptr : block_maps) {
+    const auto* const block_map =
+        dynamic_cast<const ConcreteMap<MeshDim>*>(block_map_unique_ptr.get());
+    REQUIRE(block_map != nullptr);
+    CHECK(*block_map == expected_block_map);
+  }
+
+  // Test functions of time
+  const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
+  REQUIRE(functions_of_time.size() == 1);
+
+  // Test map for composition
+  CHECK(time_dep->map_for_composition() == expected_block_map);
+
+  // For a random point at a random time check that the values agree. This is to
+  // check that the internals were assigned the correct function of times.
+  TIME_DEPENDENCE_GENERATE_COORDS(make_not_null(&gen), MeshDim, -1.0, 1.0);
+
+  for (const auto& block_map : block_maps) {
+    // We've checked equivalence above
+    // (CHECK(*block_map == expected_block_map);), but have sometimes been
+    // burned by incorrect operator== implementations so we check that the
+    // mappings behave as expected.
+    const double time_offset = dist(gen) + 1.2;
+    CHECK_ITERABLE_APPROX(
+        expected_block_map(grid_coords_dv, initial_time + time_offset,
+                           functions_of_time),
+        (*block_map)(grid_coords_dv, initial_time + time_offset,
+                     functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map(grid_coords_double, initial_time + time_offset,
+                           functions_of_time),
+        (*block_map)(grid_coords_double, initial_time + time_offset,
+                     functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        *expected_block_map.inverse(inertial_coords_double,
+                                    initial_time + time_offset,
+                                    functions_of_time),
+        *block_map->inverse(inertial_coords_double, initial_time + time_offset,
+                            functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.inv_jacobian(
+            grid_coords_dv, initial_time + time_offset, functions_of_time),
+        block_map->inv_jacobian(grid_coords_dv, initial_time + time_offset,
+                                functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.inv_jacobian(
+            grid_coords_double, initial_time + time_offset, functions_of_time),
+        block_map->inv_jacobian(grid_coords_double, initial_time + time_offset,
+                                functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.jacobian(grid_coords_dv, initial_time + time_offset,
+                                    functions_of_time),
+        block_map->jacobian(grid_coords_dv, initial_time + time_offset,
+                            functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.jacobian(
+            grid_coords_double, initial_time + time_offset, functions_of_time),
+        block_map->jacobian(grid_coords_double, initial_time + time_offset,
+                            functions_of_time));
+  }
+}
+
+void test_equivalence() noexcept {
+  {
+    UniformRotationAboutZAxis<2> ur0{1.0, 2.0, "RotationAnglePhi"};
+    UniformRotationAboutZAxis<2> ur1{1.2, 2.0, "RotationAnglePhi"};
+    UniformRotationAboutZAxis<2> ur2{1.0, 3.0, "RotationAnglePhi"};
+    UniformRotationAboutZAxis<2> ur3{1.0, 2.0, "RotationAngleTheta"};
+    CHECK(ur0 == ur0);
+    CHECK_FALSE(ur0 != ur0);
+    CHECK(ur0 != ur1);
+    CHECK_FALSE(ur0 == ur1);
+    CHECK(ur0 != ur2);
+    CHECK_FALSE(ur0 == ur2);
+    CHECK(ur0 != ur3);
+    CHECK_FALSE(ur0 == ur3);
+  }
+  {
+    UniformRotationAboutZAxis<3> ur0{1.0, 2.0, "RotationAnglePhi"};
+    UniformRotationAboutZAxis<3> ur1{1.2, 2.0, "RotationAnglePhi"};
+    UniformRotationAboutZAxis<3> ur2{1.0, 3.0, "RotationAnglePhi"};
+    UniformRotationAboutZAxis<3> ur3{1.0, 2.0, "RotationAngleTheta"};
+    CHECK(ur0 == ur0);
+    CHECK_FALSE(ur0 != ur0);
+    CHECK(ur0 != ur1);
+    CHECK_FALSE(ur0 == ur1);
+    CHECK(ur0 != ur2);
+    CHECK_FALSE(ur0 == ur2);
+    CHECK(ur0 != ur3);
+    CHECK_FALSE(ur0 == ur3);
+  }
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Domain.Creators.TimeDependence.UniformRotationAboutZAxis",
+    "[Domain][Unit]") {
+  const double initial_time = 1.3;
+  constexpr double angular_velocity = 2.4;
+  const std::string f_of_t_name{"RotationAngle"};
+  {
+    // 2d
+    const std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
+        time_dep = std::make_unique<UniformRotationAboutZAxis<2>>(
+            initial_time, angular_velocity, f_of_t_name);
+    test(time_dep, initial_time, f_of_t_name);
+    test(time_dep->get_clone(), initial_time, f_of_t_name);
+
+    test(TestHelpers::test_factory_creation<TimeDependence<2>>(
+             "UniformRotationAboutZAxis:\n"
+             "  InitialTime: 1.3\n"
+             "  AngularVelocity: 2.4\n"
+             "  FunctionOfTimeName: RotationAngle\n"),
+         initial_time, f_of_t_name);
+
+    test(TestHelpers::test_factory_creation<TimeDependence<2>>(
+             "UniformRotationAboutZAxis:\n"
+             "  InitialTime: 1.3\n"
+             "  AngularVelocity: 2.4\n"),
+         initial_time, "RotationAngle");
+  }
+
+  {
+    // 3d
+    const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+        time_dep = std::make_unique<UniformRotationAboutZAxis<3>>(
+            initial_time, angular_velocity, f_of_t_name);
+    test(time_dep, initial_time, f_of_t_name);
+    test(time_dep->get_clone(), initial_time, f_of_t_name);
+
+    test(TestHelpers::test_factory_creation<TimeDependence<3>>(
+             "UniformRotationAboutZAxis:\n"
+             "  InitialTime: 1.3\n"
+             "  AngularVelocity: 2.4\n"
+             "  FunctionOfTimeName: RotationAngle\n"),
+         initial_time, f_of_t_name);
+
+    test(TestHelpers::test_factory_creation<TimeDependence<3>>(
+             "UniformRotationAboutZAxis:\n"
+             "  InitialTime: 1.3\n"
+             "  AngularVelocity: 2.4\n"),
+         initial_time, "RotationAngle");
+  }
+
+  test_equivalence();
+}
+}  // namespace
+
+}  // namespace time_dependence
+}  // namespace creators
+}  // namespace domain


### PR DESCRIPTION
## Proposed changes

Add a TimeDependence that implements a uniform rotation about the z axis. In 3D, this is done via a product of a 2D rotation and an identity map. For 1D, the TimeDependence is simply the identity map.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
