### PR TITLE
Drop support for GCC 6 and Clang 4

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -216,8 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [gcc-6, gcc-7, gcc-8, gcc-9, clang-4.0, clang-5.0,
-          clang-8, clang-9]
+        compiler: [gcc-7, gcc-8, gcc-9, clang-5.0, clang-8, clang-9]
         build_type: [Debug, Release]
         use_pch: [OFF, ON]
 
@@ -237,9 +236,6 @@ jobs:
             build_type: Release
           - use_pch: OFF
             build_type: Debug
-            compiler: gcc-6
-          - use_pch: OFF
-            build_type: Debug
             compiler: gcc-7
           - use_pch: OFF
             build_type: Debug
@@ -247,9 +243,6 @@ jobs:
           - use_pch: OFF
             build_type: Debug
             compiler: gcc-9
-          - use_pch: OFF
-            build_type: Debug
-            compiler: clang-4.0
           - use_pch: OFF
             build_type: Debug
             compiler: clang-5.0

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -33,8 +33,7 @@ RUN apt-get update -y \
 # The system MPI libraries are usually configured to take advantage of
 # InfiniBand or various other networking layers.
 RUN apt-get update -y \
-    && apt-get install -y gcc-6 g++-6 gfortran-6 \
-                          gcc-7 g++-7 gfortran-7 \
+    && apt-get install -y gcc-7 g++-7 gfortran-7 \
                           gcc-8 g++-8 gfortran-8 \
                           gcc-9 g++-9 gfortran-9 \
                           gdb git cmake autoconf \
@@ -49,11 +48,11 @@ RUN apt-get update -y \
                           libboost-tools-dev libssl-dev \
                           libbenchmark-dev
 
-# Add clang 4 and 8
+# Add clang 8 and 9
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main' \
     && apt-get update -y \
-    && apt-get install -y clang-4.0 clang-8 clang-9
+    && apt-get install -y clang-8 clang-9
 
 # Update is needed to get libc++ correctly
 # Install jemalloc

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -12,8 +12,8 @@ installation_on_clusters "Installation on clusters" page.
 
 #### Required:
 
-* [GCC](https://gcc.gnu.org/) 5.4 or later,
-[Clang](https://clang.llvm.org/) 3.6 or later, or AppleClang 6.0 or later
+* [GCC](https://gcc.gnu.org/) 7.0 or later,
+[Clang](https://clang.llvm.org/) 5.0 or later, or AppleClang 6.0 or later
 * [CMake](https://cmake.org/) 3.3.2 or later
 * [Charm++](http://charm.cs.illinois.edu/) 6.8 or newer (must be compiled from source)
 * [Git](https://git-scm.com/)


### PR DESCRIPTION
## Proposed changes

Since we don't need to support BlueWaters anymore, we can drop GCC 6. This reduces the number of CI builds and the human effort to work around GCC 6 issues. See https://github.com/sxs-collaboration/spectre/issues/442

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
