### PR TITLE
Work around clang 10 bug

### DIFF
--- a/tests/Unit/Evolution/Systems/Cce/Test_GaugeTransformBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_GaugeTransformBoundaryData.cpp
@@ -164,10 +164,17 @@ void test_gauge_transforms_via_inverse_coordinate_map(
   const double variation_amplitude = value_dist(*gen);
   db::mutate<Tags::CauchyCartesianCoords>(
       make_not_null(&forward_transform_box),
-      [&variation_amplitude](const gsl::not_null<tnsr::i<DataVector, 3>*>
+      [&l_max,
+       &variation_amplitude](const gsl::not_null<tnsr::i<DataVector, 3>*>
                                  cauchy_cartesian_coordinates) noexcept {
         tnsr::i<DataVector, 2> cauchy_angular_coordinates{
             get<0>(*cauchy_cartesian_coordinates).size()};
+        // There is a bug in Clang 10.0.0 that gives a nonsensical
+        // error message for the following call to
+        // cached_collocation_metadata unless l_max is captured in
+        // this lambda.  (The capture should not be necessary.)  This
+        // line silences the (correct) "unused capture" warnings.
+        (void)l_max;
         const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
             Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
         for (const auto& collocation_point : collocation) {
@@ -201,11 +208,17 @@ void test_gauge_transforms_via_inverse_coordinate_map(
 
   db::mutate<Tags::CauchyCartesianCoords>(
       make_not_null(&inverse_transform_box),
-      [&variation_amplitude](
+      [&l_max, &variation_amplitude](
           const gsl::not_null<tnsr::i<DataVector, 3>*>
               inverse_cauchy_cartesian_coordinates) noexcept {
         tnsr::i<DataVector, 2> inverse_cauchy_angular_coordinates{
             get<0>(*inverse_cauchy_cartesian_coordinates).size()};
+        // There is a bug in Clang 10.0.0 that gives a nonsensical
+        // error message for the following call to
+        // cached_collocation_metadata unless l_max is captured in
+        // this lambda.  (The capture should not be necessary.)  This
+        // line silences the (correct) "unused capture" warnings.
+        (void)l_max;
         const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
             Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
         for (const auto& collocation_point : collocation) {


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
