### PR TITLE
Add Pybindings for more domain creators

### DIFF
--- a/src/Domain/Creators/Python/Bindings.cpp
+++ b/src/Domain/Creators/Python/Bindings.cpp
@@ -14,6 +14,8 @@ void bind_cylinder(py::module& m);        // NOLINT
 void bind_domain_creator(py::module& m);  // NOLINT
 void bind_interval(py::module& m);        // NOLINT
 void bind_rectangle(py::module& m);       // NOLINT
+void bind_shell(py::module& m);           // NOLINT
+void bind_sphere(py::module& m);          // NOLINT
 }  // namespace py_bindings
 
 PYBIND11_MODULE(_PyDomainCreators, m) {  // NOLINT
@@ -24,6 +26,8 @@ PYBIND11_MODULE(_PyDomainCreators, m) {  // NOLINT
   py_bindings::bind_cylinder(m);
   py_bindings::bind_interval(m);
   py_bindings::bind_rectangle(m);
+  py_bindings::bind_shell(m);
+  py_bindings::bind_sphere(m);
 }
 
 }  // namespace creators

--- a/src/Domain/Creators/Python/Bindings.cpp
+++ b/src/Domain/Creators/Python/Bindings.cpp
@@ -9,13 +9,21 @@ namespace domain {
 namespace creators {
 
 namespace py_bindings {
-void bind_cylinder(py::module& m);  // NOLINT
+void bind_brick(py::module& m);           // NOLINT
+void bind_cylinder(py::module& m);        // NOLINT
 void bind_domain_creator(py::module& m);  // NOLINT
+void bind_interval(py::module& m);        // NOLINT
+void bind_rectangle(py::module& m);       // NOLINT
 }  // namespace py_bindings
 
 PYBIND11_MODULE(_PyDomainCreators, m) {  // NOLINT
+  // Order is important: The base class `DomainCreator` needs to have its
+  // bindings set up before the derived classes
   py_bindings::bind_domain_creator(m);
+  py_bindings::bind_brick(m);
   py_bindings::bind_cylinder(m);
+  py_bindings::bind_interval(m);
+  py_bindings::bind_rectangle(m);
 }
 
 }  // namespace creators

--- a/src/Domain/Creators/Python/Brick.cpp
+++ b/src/Domain/Creators/Python/Brick.cpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+#include "Domain/Creators/Brick.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+
+namespace py = pybind11;
+
+namespace domain {
+namespace creators {
+namespace py_bindings {
+void bind_brick(py::module& m) {  // NOLINT
+  py::class_<Brick, DomainCreator<3>>(m, "Brick")
+      .def(py::init<std::array<double, 3>, std::array<double, 3>,
+                    std::array<bool, 3>, std::array<size_t, 3>,
+                    std::array<size_t, 3>>(),
+           py::arg("lower_xyz"), py::arg("upper_xyz"),
+           py::arg("is_periodic_in_xyz"),
+           py::arg("initial_refinement_level_xyz"),
+           py::arg("initial_number_of_grid_points_in_xyz"));
+}
+}  // namespace py_bindings
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/Python/CMakeLists.txt
+++ b/src/Domain/Creators/Python/CMakeLists.txt
@@ -9,12 +9,20 @@ spectre_python_add_module(
   MODULE_PATH "Domain"
   SOURCES
   Bindings.cpp
+  Brick.cpp
   Cylinder.cpp
   DomainCreator.cpp
+  Interval.cpp
+  Rectangle.cpp
   )
 
 spectre_python_link_libraries(
   ${LIBRARY}
   PRIVATE
   DomainCreators
+  )
+
+spectre_python_add_dependencies(
+  ${LIBRARY}
+  PyDomain
   )

--- a/src/Domain/Creators/Python/CMakeLists.txt
+++ b/src/Domain/Creators/Python/CMakeLists.txt
@@ -14,6 +14,8 @@ spectre_python_add_module(
   DomainCreator.cpp
   Interval.cpp
   Rectangle.cpp
+  Shell.cpp
+  Sphere.cpp
   )
 
 spectre_python_link_libraries(

--- a/src/Domain/Creators/Python/Interval.cpp
+++ b/src/Domain/Creators/Python/Interval.cpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/Interval.hpp"
+
+namespace py = pybind11;
+
+namespace domain {
+namespace creators {
+namespace py_bindings {
+void bind_interval(py::module& m) {  // NOLINT
+  py::class_<Interval, DomainCreator<1>>(m, "Interval")
+      .def(py::init<std::array<double, 1>, std::array<double, 1>,
+                    std::array<bool, 1>, std::array<size_t, 1>,
+                    std::array<size_t, 1>>(),
+           py::arg("lower_x"), py::arg("upper_x"), py::arg("is_periodic_in_x"),
+           py::arg("initial_refinement_level_x"),
+           py::arg("initial_number_of_grid_points_in_x"));
+}
+}  // namespace py_bindings
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/Python/Rectangle.cpp
+++ b/src/Domain/Creators/Python/Rectangle.cpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/Rectangle.hpp"
+
+namespace py = pybind11;
+
+namespace domain {
+namespace creators {
+namespace py_bindings {
+void bind_rectangle(py::module& m) {  // NOLINT
+  py::class_<Rectangle, DomainCreator<2>>(m, "Rectangle")
+      .def(py::init<std::array<double, 2>, std::array<double, 2>,
+                    std::array<bool, 2>, std::array<size_t, 2>,
+                    std::array<size_t, 2>>(),
+           py::arg("lower_xy"), py::arg("upper_xy"),
+           py::arg("is_periodic_in_xy"), py::arg("initial_refinement_level_xy"),
+           py::arg("initial_number_of_grid_points_in_xy"));
+}
+}  // namespace py_bindings
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/Python/Shell.cpp
+++ b/src/Domain/Creators/Python/Shell.cpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/Shell.hpp"
+
+namespace py = pybind11;
+
+namespace domain {
+namespace creators {
+namespace py_bindings {
+void bind_shell(py::module& m) {  // NOLINT
+  py::class_<Shell, DomainCreator<3>>(m, "Shell")
+      .def(py::init<double, double, size_t, std::array<size_t, 2>, bool, double,
+                    bool>(),
+           py::arg("inner_radius"), py::arg("outer_radius"),
+           py::arg("initial_refinement"),
+           py::arg("initial_number_of_grid_points"),
+           py::arg("use_equiangular_map") = true, py::arg("aspect_ratio") = 1.,
+           py::arg("use_logarithmic_map") = false);
+}
+}  // namespace py_bindings
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/Python/Sphere.cpp
+++ b/src/Domain/Creators/Python/Sphere.cpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/Sphere.hpp"
+
+namespace py = pybind11;
+
+namespace domain {
+namespace creators {
+namespace py_bindings {
+void bind_sphere(py::module& m) {  // NOLINT
+  py::class_<Sphere, DomainCreator<3>>(m, "Sphere")
+      .def(py::init<double, double, size_t, std::array<size_t, 2>, bool>(),
+           py::arg("inner_radius"), py::arg("outer_radius"),
+           py::arg("initial_refinement"),
+           py::arg("initial_number_of_grid_points"),
+           py::arg("use_equiangular_map"));
+}
+}  // namespace py_bindings
+}  // namespace creators
+}  // namespace domain

--- a/src/Domain/Creators/Shell.hpp
+++ b/src/Domain/Creators/Shell.hpp
@@ -125,7 +125,7 @@ class Shell : public DomainCreator<3> {
         typename OuterRadius::type outer_radius,
         typename InitialRefinement::type initial_refinement,
         typename InitialGridPoints::type initial_number_of_grid_points,
-        typename UseEquiangularMap::type use_equiangular_map,
+        typename UseEquiangularMap::type use_equiangular_map = true,
         typename AspectRatio::type aspect_ratio = 1.0,
         typename UseLogarithmicMap::type use_logarithmic_map = false,
         typename WhichWedges::type which_wedges = ShellWedges::All,

--- a/tests/Unit/Domain/Creators/Python/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/Python/CMakeLists.txt
@@ -20,3 +20,13 @@ spectre_add_python_bindings_test(
   "Unit.Domain.Creators.Python.Rectangle"
   Test_Rectangle.py
   "Unit;Domain")
+
+spectre_add_python_bindings_test(
+  "Unit.Domain.Creators.Python.Shell"
+  Test_Shell.py
+  "Unit;Domain")
+
+spectre_add_python_bindings_test(
+  "Unit.Domain.Creators.Python.Sphere"
+  Test_Sphere.py
+  "Unit;Domain")

--- a/tests/Unit/Domain/Creators/Python/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/Python/CMakeLists.txt
@@ -2,6 +2,21 @@
 # See LICENSE.txt for details.
 
 spectre_add_python_bindings_test(
+  "Unit.Domain.Creators.Python.Brick"
+  Test_Brick.py
+  "Unit;Domain")
+
+spectre_add_python_bindings_test(
   "Unit.Domain.Creators.Python.Cylinder"
   Test_Cylinder.py
+  "Unit;Domain")
+
+spectre_add_python_bindings_test(
+  "Unit.Domain.Creators.Python.Interval"
+  Test_Interval.py
+  "Unit;Domain")
+
+spectre_add_python_bindings_test(
+  "Unit.Domain.Creators.Python.Rectangle"
+  Test_Rectangle.py
   "Unit;Domain")

--- a/tests/Unit/Domain/Creators/Python/Test_Brick.py
+++ b/tests/Unit/Domain/Creators/Python/Test_Brick.py
@@ -1,0 +1,19 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.Domain.Creators import Brick, DomainCreator3D
+import unittest
+
+
+class TestBrick(unittest.TestCase):
+    def test_construction(self):
+        brick = Brick(lower_xyz=[1., 0., 2.],
+                      upper_xyz=[2., 1., 3.],
+                      is_periodic_in_xyz=[False, False, False],
+                      initial_refinement_level_xyz=[1, 0, 1],
+                      initial_number_of_grid_points_in_xyz=[3, 4, 2])
+        self.assertIsInstance(brick, DomainCreator3D)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/Unit/Domain/Creators/Python/Test_Interval.py
+++ b/tests/Unit/Domain/Creators/Python/Test_Interval.py
@@ -1,0 +1,19 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.Domain.Creators import Interval, DomainCreator1D
+import unittest
+
+
+class TestInterval(unittest.TestCase):
+    def test_construction(self):
+        interval = Interval(lower_x=[1.],
+                            upper_x=[2.],
+                            is_periodic_in_x=[False],
+                            initial_refinement_level_x=[1],
+                            initial_number_of_grid_points_in_x=[3])
+        self.assertIsInstance(interval, DomainCreator1D)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/Unit/Domain/Creators/Python/Test_Rectangle.py
+++ b/tests/Unit/Domain/Creators/Python/Test_Rectangle.py
@@ -1,0 +1,19 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.Domain.Creators import Rectangle, DomainCreator2D
+import unittest
+
+
+class TestRectangle(unittest.TestCase):
+    def test_construction(self):
+        rectangle = Rectangle(lower_xy=[1., 0.],
+                              upper_xy=[2., 1.],
+                              is_periodic_in_xy=[False, False],
+                              initial_refinement_level_xy=[1, 0],
+                              initial_number_of_grid_points_in_xy=[3, 4])
+        self.assertIsInstance(rectangle, DomainCreator2D)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/Unit/Domain/Creators/Python/Test_Shell.py
+++ b/tests/Unit/Domain/Creators/Python/Test_Shell.py
@@ -1,0 +1,21 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.Domain.Creators import Shell, DomainCreator3D
+import unittest
+
+
+class TestShell(unittest.TestCase):
+    def test_construction(self):
+        shell = Shell(inner_radius=1.,
+                      outer_radius=2.,
+                      initial_refinement=1,
+                      initial_number_of_grid_points=[3, 3],
+                      use_equiangular_map=False,
+                      aspect_ratio=1.,
+                      use_logarithmic_map=False)
+        self.assertIsInstance(shell, DomainCreator3D)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/Unit/Domain/Creators/Python/Test_Sphere.py
+++ b/tests/Unit/Domain/Creators/Python/Test_Sphere.py
@@ -1,0 +1,19 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.Domain.Creators import Sphere, DomainCreator3D
+import unittest
+
+
+class TestSphere(unittest.TestCase):
+    def test_construction(self):
+        sphere = Sphere(inner_radius=1.,
+                        outer_radius=2.,
+                        initial_refinement=1,
+                        initial_number_of_grid_points=[3, 3],
+                        use_equiangular_map=False)
+        self.assertIsInstance(sphere, DomainCreator3D)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Adds Python bindings for `Interval`, `Rectangle`, `Brick`, `Shell` and `Sphere`.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
