### PR TITLE
Fix Hweno cache bug

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <bitset>
 #include <cstddef>
+#include <exception>
 #include <ostream>
 #include <vector>
 
@@ -118,6 +119,8 @@ Matrix inverse_a_matrix(
         quadrature_weights_dot_interpolation_matrices,
     const Direction<VolumeDim>& primary_direction,
     const std::vector<Direction<VolumeDim>>& directions_to_exclude) noexcept {
+  ASSERT(not alg::found(directions_to_exclude, primary_direction),
+         "Logical inconsistency: trying to exclude the primary direction.");
   const size_t number_of_grid_points = mesh.number_of_grid_points();
   Matrix a(number_of_grid_points, number_of_grid_points, 0.);
 
@@ -172,7 +175,12 @@ Matrix inverse_a_matrix(
   }
 
   // Invert matrix in-place before returning
-  blaze::invert<blaze::asSymmetric>(a);
+  try {
+    blaze::invert<blaze::asSymmetric>(a);
+  } catch (const std::exception& e) {
+    ERROR("Blaze matrix inversion failed with exception:\n" << e.what());
+  }
+
   return a;
 }
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.cpp
@@ -202,7 +202,7 @@ ConstrainedFitCache<VolumeDim>::ConstrainedFitCache(
   for (const auto& primary_dir : directions_with_neighbors) {
     if (directions_with_neighbors.size() == 1) {
       // With a single neighbor, there can be no neighbors to exclude.
-      std::vector<Direction<VolumeDim>> nothing_to_exclude{{}};
+      std::vector<Direction<VolumeDim>> nothing_to_exclude{};
       // To reuse the same data structure from the more common `else` branch,
       // here we stick the data into the (normally nonsensical) slot where
       // `dir_to_exclude == primary_dir`.


### PR DESCRIPTION
## Proposed changes

* Fix a bug in the Hweno matrix cache
* Add a new test that would identify the bug
* Add a `try ... catch` around call to `blaze::invert` because it can throw

About the bug: this was a rare corner case bug that should not have affected any real runs.

Elements with a single neighbor should label that neighbor as the primary neighbor for the Hweno fit, and there should be no neighbors to exclude from the fit. The bug was in the construction of the (should-have-been) empty list of neighbors to exclude: it incorrectly contained one direction, with the default value of lower_xi. The bug manifested itself when trying to limit on an element with a single neighbor in lower_xi: that neighbor would simultaneously be the primary neighbor for the fit AND ALSO be excluded.

The vector is now correctly empty.


### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
