### PR TITLE
Orient std::vector

### DIFF
--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -108,6 +108,8 @@ class Variables<tmpl::list<Tags...>> {
       typename tmpl::front<tags_list>::type::type::value_type,
       typename tmpl::front<tags_list>::type::type>;
   using value_type = typename vector_type::value_type;
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
   using allocator_type = std::allocator<value_type>;
   using pointer_type =
       PointerVector<value_type, blaze_unaligned, blaze_unpadded,
@@ -211,8 +213,8 @@ class Variables<tmpl::list<Tags...>> {
 
   //{@
   /// Access pointer to underlying data
-  value_type* data() noexcept { return variable_data_.data(); }
-  const value_type* data() const noexcept { return variable_data_.data(); }
+  pointer data() noexcept { return variable_data_.data(); }
+  const_pointer data() const noexcept { return variable_data_.data(); }
   //@}
 
   /// \cond HIDDEN_SYMBOLS

--- a/src/Domain/OrientationMapHelpers.cpp
+++ b/src/Domain/OrientationMapHelpers.cpp
@@ -294,4 +294,33 @@ std::vector<size_t> oriented_offset_on_slice(
       neighbor_second_axis_is_aligned, neighbor_axes_are_transposed);
 }
 
+template <typename T>
+void orient_each_component(
+    const gsl::not_null<gsl::span<T>*> oriented_variables,
+    const gsl::span<const T>& variables, const size_t num_pts,
+    const std::vector<size_t>& oriented_offset) noexcept {
+  const size_t num_components = variables.size() / num_pts;
+  ASSERT(oriented_variables->size() == variables.size(),
+         "The number of oriented variables, "
+             << oriented_variables->size() / num_pts
+             << ", must be equal to the number of variables, "
+             << variables.size() / num_pts);
+  for (size_t component_index = 0; component_index < num_components;
+       ++component_index) {
+    const size_t offset = component_index * num_pts;
+    for (size_t s = 0; s < num_pts; ++s) {
+      gsl::at((*oriented_variables), offset + oriented_offset[s]) =
+          gsl::at(variables, offset + s);
+    }
+  }
+}
+
+template void orient_each_component(
+    const gsl::not_null<gsl::span<double>*> oriented_variables,
+    const gsl::span<const double>& variables, const size_t num_pts,
+    const std::vector<size_t>& oriented_offset) noexcept;
+template void orient_each_component(
+    const gsl::not_null<gsl::span<std::complex<double>>*> oriented_variables,
+    const gsl::span<const std::complex<double>>& variables,
+    const size_t num_pts, const std::vector<size_t>& oriented_offset) noexcept;
 }  // namespace OrientationMapHelpers_detail

--- a/src/Domain/OrientationMapHelpers.hpp
+++ b/src/Domain/OrientationMapHelpers.hpp
@@ -111,3 +111,19 @@ Variables<TagsList> orient_variables_on_slice(
   return oriented_variables;
 }
 // }@
+
+/// \ingroup ComputationalDomainGroup
+/// Orient data in a `std::vector<double>` representing one or more tensor
+/// components.
+///
+/// In most cases the `Variables` version of `orient_variables` should be
+/// called. However, in some cases the tags and thus the type of the data being
+/// sent is determined at runtime. In these cases the `std::vector` version of
+/// `orient_variables` is useful. A concrete example of this is when hybridizing
+/// DG with finite difference methods, where sometimes the data sent is both the
+/// variables for reconstruction and the fluxes for either the DG or finite
+/// difference scheme, while at other points only one of these three is sent.
+template <size_t VolumeDim>
+std::vector<double> orient_variables(
+    const std::vector<double>& variables, const Index<VolumeDim>& extents,
+    const OrientationMap<VolumeDim>& orientation_of_neighbor) noexcept;

--- a/tests/Unit/Domain/Test_OrientationMapHelpers.cpp
+++ b/tests/Unit/Domain/Test_OrientationMapHelpers.cpp
@@ -51,11 +51,16 @@ void test_1d_orient_variables() noexcept {
   Variables<tmpl::list<ScalarTensor, Coords<1>>> vars(extents.product());
   get(get<ScalarTensor>(vars)) = DataVector{{1.0, 2.0, 3.0, 4.0}};
   get<0>(get<Coords<1>>(vars)) = DataVector{{0.5, 0.6, 0.7, 0.8}};
+  const std::vector<double> vars_vector(vars.data(), vars.data() + vars.size());
 
   // Check aligned case
   {
     const auto oriented_vars = orient_variables(vars, extents, {});
     CHECK(oriented_vars == vars);
+
+    const std::vector<double> oriented_vars_vector =
+        orient_variables(vars_vector, extents, {});
+    CHECK(oriented_vars_vector == vars_vector);
   }
 
   // Check anti-aligned case
@@ -68,6 +73,12 @@ void test_1d_orient_variables() noexcept {
     get(get<ScalarTensor>(expected_vars)) = DataVector{{4.0, 3.0, 2.0, 1.0}};
     get<0>(get<Coords<1>>(expected_vars)) = DataVector{{0.8, 0.7, 0.6, 0.5}};
     CHECK(oriented_vars == expected_vars);
+
+    const std::vector<double> oriented_vars_vector =
+        orient_variables(vars_vector, extents, orientation_map);
+    const std::vector<double> expected_vars_vector(
+        expected_vars.data(), expected_vars.data() + expected_vars.size());
+    CHECK(oriented_vars_vector == expected_vars_vector);
   }
 }
 
@@ -88,6 +99,13 @@ void test_2d_orient_variables_simple_case_by_hand() noexcept {
   get(get<ScalarTensor>(expected_vars)) =
       DataVector{{2.0, 4.0, 6.0, 1.0, 3.0, 5.0}};
   CHECK(oriented_vars == expected_vars);
+
+  const std::vector<double> vars_vector(vars.data(), vars.data() + vars.size());
+  const std::vector<double> oriented_vars_vector =
+      orient_variables(vars_vector, extents, orientation_map);
+  const std::vector<double> expected_vars_vector(
+      expected_vars.data(), expected_vars.data() + expected_vars.size());
+  CHECK(oriented_vars_vector == expected_vars_vector);
 }
 
 // Test orient_variables using a general orientation.
@@ -122,6 +140,13 @@ void test_2d_with_orientation(
   get<Coords<2>>(expected_vars) =
       map_oriented(logical_coordinates(orientation_map.inverse_map()(mesh)));
   CHECK(oriented_vars == expected_vars);
+
+  const std::vector<double> vars_vector(vars.data(), vars.data() + vars.size());
+  const std::vector<double> oriented_vars_vector =
+      orient_variables(vars_vector, extents, orientation_map);
+  const std::vector<double> expected_vars_vector(
+      expected_vars.data(), expected_vars.data() + expected_vars.size());
+  CHECK(oriented_vars_vector == expected_vars_vector);
 }
 
 void test_2d_orient_variables() noexcept {
@@ -165,6 +190,13 @@ void test_3d_orient_variables_simple_case_by_hand() noexcept {
       {0.0, 6.0, 12.0, 18.0, 2.0, 8.0, 14.0, 20.0, 4.0, 10.0, 16.0, 22.0,
        1.0, 7.0, 13.0, 19.0, 3.0, 9.0, 15.0, 21.0, 5.0, 11.0, 17.0, 23.0}};
   CHECK(oriented_vars == expected_vars);
+
+  const std::vector<double> vars_vector(vars.data(), vars.data() + vars.size());
+  const std::vector<double> oriented_vars_vector =
+      orient_variables(vars_vector, extents, orientation_map);
+  const std::vector<double> expected_vars_vector(
+      expected_vars.data(), expected_vars.data() + expected_vars.size());
+  CHECK(oriented_vars_vector == expected_vars_vector);
 }
 
 // Test orient_variables using a general orientation.


### PR DESCRIPTION
## Proposed changes

- Add `(const_)pointer` type alias to `Variables` to be more STL compliant
- Use spans in orientation functions so they are not as tied to specific data structures
- Add function to orient a `std::vector`, which will be used in DG-subcell

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
