### PR TITLE
Add filter matrix to zero out lowest modal coefficients

### DIFF
--- a/src/NumericalAlgorithms/Spectral/Filtering.cpp
+++ b/src/NumericalAlgorithms/Spectral/Filtering.cpp
@@ -9,6 +9,7 @@
 #include "Domain/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/StaticCache.hpp"
 
 namespace Spectral {
 namespace filtering {
@@ -26,6 +27,99 @@ Matrix exponential_filter(const Mesh<1>& mesh, const double alpha,
     filter_matrix(i, i) = exp(-alpha * pow(i / order, 2 * half_power));
   }
   return modal_to_nodal * filter_matrix * nodal_to_modal;
+}
+
+namespace {
+template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
+struct ZeroLowestModesImpl {
+  Matrix operator()(const size_t num_points,
+                    const size_t num_modes_to_zero) const noexcept {
+    const Matrix& nodal_to_modal =
+        Spectral::nodal_to_modal_matrix<BasisType, QuadratureType>(num_points);
+    const Matrix& modal_to_nodal =
+        Spectral::modal_to_nodal_matrix<BasisType, QuadratureType>(num_points);
+    Matrix filter_matrix(num_points, num_points, 0.0);
+    for (size_t i = num_modes_to_zero; i < num_points; ++i) {
+      filter_matrix(i, i) = 1.0;
+    }
+    return Matrix(modal_to_nodal * filter_matrix * nodal_to_modal);
+  }
+};
+}  // namespace
+
+const Matrix& zero_lowest_modes(const Mesh<1>& mesh,
+                                const size_t number_of_modes_to_zero) noexcept {
+  ASSERT(number_of_modes_to_zero < mesh.extents(0),
+         "For a 1d mesh with " << mesh.extents(0)
+                               << " grid points, you cannot zero "
+                               << number_of_modes_to_zero << " modes.");
+
+  switch (mesh.basis(0)) {
+    case Basis::Legendre:
+      switch (mesh.quadrature(0)) {
+        case Spectral::Quadrature::GaussLobatto: {
+          constexpr size_t max_num_points =
+              Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+          constexpr size_t min_num_points = Spectral::minimum_number_of_points<
+              Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
+          const auto cache =
+              make_static_cache<CacheRange<min_num_points, max_num_points + 1>,
+                                CacheRange<0, max_num_points>>(
+                  ZeroLowestModesImpl<Spectral::Basis::Legendre,
+                                      Spectral::Quadrature::GaussLobatto>{});
+          return cache(mesh.number_of_grid_points(), number_of_modes_to_zero);
+        }
+        case Spectral::Quadrature::Gauss: {
+          constexpr size_t max_num_points =
+              Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+          constexpr size_t min_num_points =
+              Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
+                                                 Spectral::Quadrature::Gauss>;
+          const auto cache =
+              make_static_cache<CacheRange<min_num_points, max_num_points + 1>,
+                                CacheRange<0, max_num_points>>(
+                  ZeroLowestModesImpl<Spectral::Basis::Legendre,
+                                      Spectral::Quadrature::Gauss>{});
+          return cache(mesh.number_of_grid_points(), number_of_modes_to_zero);
+        }
+        default:
+          ERROR("Unsupported quadrature type in filtering lowest modes: "
+                << mesh.quadrature(0));
+      };
+    case Basis::Chebyshev:
+      switch (mesh.quadrature(0)) {
+        case Spectral::Quadrature::GaussLobatto: {
+          constexpr size_t max_num_points =
+              Spectral::maximum_number_of_points<Spectral::Basis::Chebyshev>;
+          constexpr size_t min_num_points = Spectral::minimum_number_of_points<
+              Spectral::Basis::Chebyshev, Spectral::Quadrature::GaussLobatto>;
+          const auto cache =
+              make_static_cache<CacheRange<min_num_points, max_num_points + 1>,
+                                CacheRange<0, max_num_points>>(
+                  ZeroLowestModesImpl<Spectral::Basis::Chebyshev,
+                                      Spectral::Quadrature::GaussLobatto>{});
+          return cache(mesh.number_of_grid_points(), number_of_modes_to_zero);
+        }
+        case Spectral::Quadrature::Gauss: {
+          constexpr size_t max_num_points =
+              Spectral::maximum_number_of_points<Spectral::Basis::Chebyshev>;
+          constexpr size_t min_num_points =
+              Spectral::minimum_number_of_points<Spectral::Basis::Chebyshev,
+                                                 Spectral::Quadrature::Gauss>;
+          const auto cache =
+              make_static_cache<CacheRange<min_num_points, max_num_points + 1>,
+                                CacheRange<0, max_num_points>>(
+                  ZeroLowestModesImpl<Spectral::Basis::Chebyshev,
+                                      Spectral::Quadrature::Gauss>{});
+          return cache(mesh.number_of_grid_points(), number_of_modes_to_zero);
+        }
+        default:
+          ERROR("Unsupported quadrature type in filtering lowest modes: "
+                << mesh.quadrature(0));
+      };
+    default:
+      ERROR("Cannot filter basis type: " << mesh.basis(0));
+  };
 }
 }  // namespace filtering
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/Filtering.hpp
+++ b/src/NumericalAlgorithms/Spectral/Filtering.hpp
@@ -40,5 +40,30 @@ namespace filtering {
  */
 Matrix exponential_filter(const Mesh<1>& mesh, double alpha,
                           unsigned half_power) noexcept;
+
+/*!
+ * \brief Zeros the lowest `number_of_modes_to_zero` modal coefficients. Note
+ * that the matrix must be applied to a nodal representation.
+ *
+ * Given a function \f$u\f$
+ *
+ * \f{align}{
+ *   u(x)=\sum_{i=0}^N c_i P_i(x),
+ * \f}
+ *
+ * where \f$c_i\f$ are the modal coefficients and \f$P_i(x)\f$ is the basis
+ * (e.g. Legendre polynomials), the filter matrix will take the *nodal*
+ * representation of \f$u\f$ and zero out the lowest `number_of_modes_to_zero`
+ * modal coefficients. That is, after the filter is applied \f$u\to\bar{u}\f$ is
+ *
+ * \f{align}{
+ *   \bar{u}(x)=\sum_{i=k}^N c_i P_i(x),
+ * \f}
+ *
+ * where \f$k\f$ is the number of modes set to zero. The output \f$\bar{u}\f$ is
+ * also in the *nodal* representation.
+ */
+const Matrix& zero_lowest_modes(const Mesh<1>& mesh,
+                                size_t number_of_modes_to_zero) noexcept;
 }  // namespace filtering
 }  // namespace Spectral


### PR DESCRIPTION
## Proposed changes

- Zeroing out the lowest mode(s) is useful for detecting high-frequency noise in an element. This will be used by DG-subcell.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
