### PR TITLE
Add domain moving mesh actions to non-conservative systems

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBS_TO_LINK
     DiscontinuousGalerkin
     Domain
     DomainCreators
+    Evolution
     GeneralRelativity
     GeneralRelativitySolutions
     GeneralizedHarmonic

--- a/src/Evolution/Executables/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarWave/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBS_TO_LINK
     CoordinateMaps
     DiscontinuousGalerkin
     DomainCreators
+    Evolution
     IO
     Informer
     LinearOperators

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -14,6 +14,7 @@
 #include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep
 #include "Evolution/ComputeTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"  // IWYU pragma: keep
+#include "Evolution/Initialization/DgDomain.hpp"
 #include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/NonconservativeSystem.hpp"
@@ -51,17 +52,17 @@
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
-#include "Time/Actions/AdvanceTime.hpp"            // IWYU pragma: keep
-#include "Time/Actions/ChangeSlabSize.hpp"         // IWYU pragma: keep
-#include "Time/Actions/ChangeStepSize.hpp"         // IWYU pragma: keep
-#include "Time/Actions/RecordTimeStepperData.hpp"  // IWYU pragma: keep
-#include "Time/Actions/SelfStartActions.hpp"       // IWYU pragma: keep
-#include "Time/Actions/UpdateU.hpp"                // IWYU pragma: keep
-#include "Time/StepChoosers/ByBlock.hpp"           // IWYU pragma: keep
-#include "Time/StepChoosers/Cfl.hpp"               // IWYU pragma: keep
-#include "Time/StepChoosers/Constant.hpp"          // IWYU pragma: keep
-#include "Time/StepChoosers/Increase.hpp"          // IWYU pragma: keep
-#include "Time/StepChoosers/PreventRapidIncrease.hpp"          // IWYU pragma: keep
+#include "Time/Actions/AdvanceTime.hpp"                // IWYU pragma: keep
+#include "Time/Actions/ChangeSlabSize.hpp"             // IWYU pragma: keep
+#include "Time/Actions/ChangeStepSize.hpp"             // IWYU pragma: keep
+#include "Time/Actions/RecordTimeStepperData.hpp"      // IWYU pragma: keep
+#include "Time/Actions/SelfStartActions.hpp"           // IWYU pragma: keep
+#include "Time/Actions/UpdateU.hpp"                    // IWYU pragma: keep
+#include "Time/StepChoosers/ByBlock.hpp"               // IWYU pragma: keep
+#include "Time/StepChoosers/Cfl.hpp"                   // IWYU pragma: keep
+#include "Time/StepChoosers/Constant.hpp"              // IWYU pragma: keep
+#include "Time/StepChoosers/Increase.hpp"              // IWYU pragma: keep
+#include "Time/StepChoosers/PreventRapidIncrease.hpp"  // IWYU pragma: keep
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepChoosers/StepToTimes.hpp"
 #include "Time/StepControllers/StepController.hpp"
@@ -179,14 +180,16 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
-      dg::Actions::InitializeDomain<system::volume_dim>,
+      evolution::dg::Initialization::Domain<system::volume_dim>,
       Initialization::Actions::NonconservativeSystem,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
       dg::Actions::InitializeInterfaces<
           system,
           dg::Initialization::slice_tags_to_face<
               typename system::variables_tag>,
-          dg::Initialization::slice_tags_to_exterior<>>,
+          dg::Initialization::slice_tags_to_exterior<>,
+          dg::Initialization::face_compute_tags<>,
+          dg::Initialization::exterior_compute_tags<>, true, true>,
       Initialization::Actions::AddComputeTags<
           tmpl::list<evolution::Tags::AnalyticCompute<
               Dim, initial_data_tag, analytic_solution_fields>>>,

--- a/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
+++ b/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
@@ -150,7 +150,9 @@ struct DiscontinuousGalerkin {
     using boundary_exterior_compute_tag = domain::Tags::InterfaceCompute<
         domain::Tags::BoundaryDirectionsExterior<dim>, Tag>;
 
-    using char_speed_tag = typename LocalSystem::char_speeds_tag;
+    using char_speed_tag =
+        domain::Tags::CharSpeedCompute<typename LocalSystem::char_speeds_tag,
+                                       dim>;
 
     using compute_tags = db::AddComputeTags<
         domain::Tags::Slice<
@@ -162,8 +164,7 @@ struct DiscontinuousGalerkin {
             typename LocalSystem::variables_tag, dim, Frame::Inertial>>,
         domain::Tags::Slice<domain::Tags::InternalDirections<dim>,
                             domain::Tags::MeshVelocity<dim>>,
-        interface_compute_tag<
-            domain::Tags::CharSpeedCompute<char_speed_tag, dim>>,
+        interface_compute_tag<char_speed_tag>,
         domain::Tags::Slice<
             domain::Tags::BoundaryDirectionsInterior<dim>,
             db::add_tag_prefix<::Tags::Flux,
@@ -171,6 +172,8 @@ struct DiscontinuousGalerkin {
                                tmpl::size_t<dim>, Frame::Inertial>>,
         boundary_interior_compute_tag<::Tags::NormalDotFluxCompute<
             typename LocalSystem::variables_tag, dim, Frame::Inertial>>,
+        domain::Tags::Slice<domain::Tags::BoundaryDirectionsInterior<dim>,
+                            domain::Tags::MeshVelocity<dim>>,
         boundary_interior_compute_tag<char_speed_tag>,
         domain::Tags::Slice<
             domain::Tags::BoundaryDirectionsExterior<dim>,
@@ -181,8 +184,7 @@ struct DiscontinuousGalerkin {
             typename LocalSystem::variables_tag, dim, Frame::Inertial>>,
         domain::Tags::Slice<domain::Tags::BoundaryDirectionsExterior<dim>,
                             domain::Tags::MeshVelocity<dim>>,
-        boundary_exterior_compute_tag<
-            domain::Tags::CharSpeedCompute<char_speed_tag, dim>>>;
+        boundary_exterior_compute_tag<char_speed_tag>>;
 
     template <typename TagsList>
     static auto initialize(db::DataBox<TagsList>&& box) noexcept {

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
@@ -22,8 +22,7 @@ namespace GeneralizedHarmonic {
 
 template <size_t Dim, typename Frame>
 void characteristic_speeds(
-    const gsl::not_null<typename Tags::CharacteristicSpeeds<Dim, Frame>::type*>
-        char_speeds,
+    const gsl::not_null<std::array<DataVector, 4>*> char_speeds,
     const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim, Frame>& shift,
     const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept {
@@ -35,7 +34,7 @@ void characteristic_speeds(
 }
 
 template <size_t Dim, typename Frame>
-typename Tags::CharacteristicSpeeds<Dim, Frame>::type characteristic_speeds(
+std::array<DataVector, 4> characteristic_speeds(
     const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim, Frame>& shift,
     const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept {
@@ -179,77 +178,73 @@ double ComputeLargestCharacteristicSpeed<Dim, Frame>::apply(
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATION(_, data)                                                \
-  template void GeneralizedHarmonic::characteristic_speeds(                   \
-      const gsl::not_null<                                                    \
-          typename GeneralizedHarmonic::Tags::CharacteristicSpeeds<           \
-              DIM(data), FRAME(data)>::type*>                                 \
-          char_speeds,                                                        \
-      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,     \
-      const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,               \
-      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                      \
-          unit_normal_one_form) noexcept;                                     \
-  template GeneralizedHarmonic::Tags::CharacteristicSpeeds<DIM(data),         \
-                                                           FRAME(data)>::type \
-  GeneralizedHarmonic::characteristic_speeds(                                 \
-      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,     \
-      const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,               \
-      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                      \
-          unit_normal_one_form) noexcept;                                     \
-  template struct GeneralizedHarmonic::CharacteristicSpeedsCompute<           \
-      DIM(data), FRAME(data)>;                                                \
-  template void GeneralizedHarmonic::characteristic_fields(                   \
-      const gsl::not_null<                                                    \
-          typename GeneralizedHarmonic::Tags::CharacteristicFields<           \
-              DIM(data), FRAME(data)>::type*>                                 \
-          char_fields,                                                        \
-      const Scalar<DataVector>& gamma_2,                                      \
-      const tnsr::II<DataVector, DIM(data), FRAME(data)>&                     \
-          inverse_spatial_metric,                                             \
-      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& spacetime_metric,   \
-      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& pi,                 \
-      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& phi,               \
-      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                      \
-          unit_normal_one_form) noexcept;                                     \
-  template typename GeneralizedHarmonic::Tags::CharacteristicFields<          \
-      DIM(data), FRAME(data)>::type                                           \
-  GeneralizedHarmonic::characteristic_fields(                                 \
-      const Scalar<DataVector>& gamma_2,                                      \
-      const tnsr::II<DataVector, DIM(data), FRAME(data)>&                     \
-          inverse_spatial_metric,                                             \
-      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& spacetime_metric,   \
-      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& pi,                 \
-      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& phi,               \
-      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                      \
-          unit_normal_one_form) noexcept;                                     \
-  template struct GeneralizedHarmonic::CharacteristicFieldsCompute<           \
-      DIM(data), FRAME(data)>;                                                \
-  template void                                                               \
-  GeneralizedHarmonic::evolved_fields_from_characteristic_fields(             \
-      const gsl::not_null<typename GeneralizedHarmonic::Tags::                \
-                              EvolvedFieldsFromCharacteristicFields<          \
-                                  DIM(data), FRAME(data)>::type*>             \
-          evolved_fields,                                                     \
-      const Scalar<DataVector>& gamma_2,                                      \
-      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_psi,              \
-      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& u_zero,            \
-      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_plus,             \
-      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_minus,            \
-      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                      \
-          unit_normal_one_form) noexcept;                                     \
-  template typename GeneralizedHarmonic::Tags::                               \
-      EvolvedFieldsFromCharacteristicFields<DIM(data), FRAME(data)>::type     \
-      GeneralizedHarmonic::evolved_fields_from_characteristic_fields(         \
-          const Scalar<DataVector>& gamma_2,                                  \
-          const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_psi,          \
-          const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& u_zero,        \
-          const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_plus,         \
-          const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_minus,        \
-          const tnsr::i<DataVector, DIM(data), FRAME(data)>&                  \
-              unit_normal_one_form) noexcept;                                 \
-  template struct GeneralizedHarmonic::                                       \
-      EvolvedFieldsFromCharacteristicFieldsCompute<DIM(data), FRAME(data)>;   \
-  template struct GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<     \
+#define INSTANTIATION(_, data)                                              \
+  template void GeneralizedHarmonic::characteristic_speeds(                 \
+      const gsl::not_null<std::array<DataVector, 4>*> char_speeds,          \
+      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,   \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,             \
+      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                    \
+          unit_normal_one_form) noexcept;                                   \
+  template std::array<DataVector, 4>                                        \
+  GeneralizedHarmonic::characteristic_speeds(                               \
+      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,   \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,             \
+      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                    \
+          unit_normal_one_form) noexcept;                                   \
+  template struct GeneralizedHarmonic::CharacteristicSpeedsCompute<         \
+      DIM(data), FRAME(data)>;                                              \
+  template void GeneralizedHarmonic::characteristic_fields(                 \
+      const gsl::not_null<                                                  \
+          typename GeneralizedHarmonic::Tags::CharacteristicFields<         \
+              DIM(data), FRAME(data)>::type*>                               \
+          char_fields,                                                      \
+      const Scalar<DataVector>& gamma_2,                                    \
+      const tnsr::II<DataVector, DIM(data), FRAME(data)>&                   \
+          inverse_spatial_metric,                                           \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& spacetime_metric, \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& pi,               \
+      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& phi,             \
+      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                    \
+          unit_normal_one_form) noexcept;                                   \
+  template typename GeneralizedHarmonic::Tags::CharacteristicFields<        \
+      DIM(data), FRAME(data)>::type                                         \
+  GeneralizedHarmonic::characteristic_fields(                               \
+      const Scalar<DataVector>& gamma_2,                                    \
+      const tnsr::II<DataVector, DIM(data), FRAME(data)>&                   \
+          inverse_spatial_metric,                                           \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& spacetime_metric, \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& pi,               \
+      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& phi,             \
+      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                    \
+          unit_normal_one_form) noexcept;                                   \
+  template struct GeneralizedHarmonic::CharacteristicFieldsCompute<         \
+      DIM(data), FRAME(data)>;                                              \
+  template void                                                             \
+  GeneralizedHarmonic::evolved_fields_from_characteristic_fields(           \
+      const gsl::not_null<typename GeneralizedHarmonic::Tags::              \
+                              EvolvedFieldsFromCharacteristicFields<        \
+                                  DIM(data), FRAME(data)>::type*>           \
+          evolved_fields,                                                   \
+      const Scalar<DataVector>& gamma_2,                                    \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_psi,            \
+      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& u_zero,          \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_plus,           \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_minus,          \
+      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                    \
+          unit_normal_one_form) noexcept;                                   \
+  template typename GeneralizedHarmonic::Tags::                             \
+      EvolvedFieldsFromCharacteristicFields<DIM(data), FRAME(data)>::type   \
+      GeneralizedHarmonic::evolved_fields_from_characteristic_fields(       \
+          const Scalar<DataVector>& gamma_2,                                \
+          const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_psi,        \
+          const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& u_zero,      \
+          const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_plus,       \
+          const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_minus,      \
+          const tnsr::i<DataVector, DIM(data), FRAME(data)>&                \
+              unit_normal_one_form) noexcept;                               \
+  template struct GeneralizedHarmonic::                                     \
+      EvolvedFieldsFromCharacteristicFieldsCompute<DIM(data), FRAME(data)>; \
+  template struct GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<   \
       DIM(data), FRAME(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -58,15 +58,14 @@ namespace GeneralizedHarmonic {
  * surface.
  */
 template <size_t Dim, typename Frame>
-typename Tags::CharacteristicSpeeds<Dim, Frame>::type characteristic_speeds(
+std::array<DataVector, 4> characteristic_speeds(
     const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim, Frame>& shift,
     const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
 
 template <size_t Dim, typename Frame>
 void characteristic_speeds(
-    gsl::not_null<typename Tags::CharacteristicSpeeds<Dim, Frame>::type*>
-        char_speeds,
+    gsl::not_null<std::array<DataVector, 4>*> char_speeds,
     const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim, Frame>& shift,
     const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
@@ -81,11 +80,14 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim, Frame>,
       gr::Tags::Shift<Dim, Frame, DataVector>,
       ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
 
-  static typename Tags::CharacteristicSpeeds<Dim, Frame>::type function(
+  using return_type = typename base::type;
+
+  static void function(
+      const gsl::not_null<return_type*> result,
       const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, Dim, Frame>& shift,
       const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept {
-    return characteristic_speeds(gamma_1, lapse, shift, unit_normal_one_form);
+    characteristic_speeds(result, gamma_1, lapse, shift, unit_normal_one_form);
   };
 };
 // @}

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -61,9 +61,8 @@ Scalar<DataVector> speed_with_index(
     const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim, Frame>& shift,
     const tnsr::i<DataVector, Dim, Frame>& normal) {
-  return Scalar<DataVector>{
-      GeneralizedHarmonic::CharacteristicSpeedsCompute<Dim, Frame>::function(
-          gamma_1, lapse, shift, normal)[Index]};
+  return Scalar<DataVector>{GeneralizedHarmonic::characteristic_speeds(
+      gamma_1, lapse, shift, normal)[Index]};
 }
 
 template <size_t Dim, typename Frame>
@@ -141,10 +140,11 @@ void test_characteristic_speeds_analytic(
   const auto uminus_speed = -get(shift_dot_normal) - get(lapse);
 
   // Check that locally computed fields match returned ones
-  const auto char_speeds_from_func =
-      GeneralizedHarmonic::CharacteristicSpeedsCompute<
-          spatial_dim, Frame::Inertial>::function(gamma_1, lapse, shift,
-                                                  unit_normal_one_form);
+  std::array<DataVector, 4> char_speeds_from_func{};
+  GeneralizedHarmonic::
+      CharacteristicSpeedsCompute<spatial_dim, Frame::Inertial>::function(
+          make_not_null(&char_speeds_from_func), gamma_1, lapse, shift,
+          unit_normal_one_form);
   const auto& upsi_speed_from_func = char_speeds_from_func[0];
   const auto& uzero_speed_from_func = char_speeds_from_func[1];
   const auto& uplus_speed_from_func = char_speeds_from_func[2];


### PR DESCRIPTION
## Proposed changes

- Fix missing char speed change in conservative systems
- Have GH char speeds return by reference
- Add moving mesh domain items to non-conservative systems

### Types of changes:

- [x] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
