### PR TITLE
Add function to wrap text, wrap option help strings to 77 chars

### DIFF
--- a/src/Options/OptionsDetails.hpp
+++ b/src/Options/OptionsDetails.hpp
@@ -26,6 +26,7 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "Utilities/TypeTraits/IsA.hpp"
+#include "Utilities/WrapText.hpp"
 
 /// Holds details of the implementation of Options
 namespace Options_detail {
@@ -162,7 +163,7 @@ struct print_impl {
   static std::string apply() noexcept {
     std::ostringstream ss;
     ss << "  " << option_name<Group>() << ":\n"
-       << "    " << Group::help << "\n\n";
+       << wrap_text(Group::help, 77, "    ") << "\n\n";
     return ss.str();
   }
 };
@@ -278,8 +279,7 @@ struct print_impl<Tag, OptionList,
     if (not limits.empty()) {
       ss << "\n    " << limits;
     }
-    ss << "\n"
-       << "    " << Tag::help << "\n\n";
+    ss << "\n" << wrap_text(Tag::help, 77, "    ") << "\n\n";
     return ss.str();
   }
 };

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   OptimizerHacks.cpp
   PrettyType.cpp
   Rational.cpp
+  WrapText.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Utilities/WrapText.cpp
+++ b/src/Utilities/WrapText.cpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Utilities/WrapText.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "ErrorHandling/Assert.hpp"
+
+std::string wrap_text(std::string str, const size_t line_length,
+                      const std::string& indentation) noexcept {
+  str = indentation + str;
+  ASSERT(indentation.size() < line_length,
+         "The indentation must be shorter than the line length. Indentation "
+         "length is: "
+             << indentation.size() << " while line length is: " << line_length);
+
+  // Insert indentation at newlines in the string first to ensure all new lines
+  // are indented correctly.
+  if (not indentation.empty()) {
+    size_t newline_location = str.find('\n');
+    while (newline_location != std::string::npos) {
+      str.insert(newline_location + 1, indentation);
+      newline_location = str.find('\n', newline_location + 1);
+    }
+  }
+
+  // Wrap the string to the set length of characters
+  for (size_t i = 0; i + line_length < str.size();) {
+    // Find the last newline, and split there if it is within the next
+    // line_length characters.
+    if (const size_t last_newline = str.rfind('\n', i + line_length);
+        last_newline != std::string::npos and last_newline > i) {
+      i = last_newline + 1;
+    } else if (const size_t last_space = str.rfind(' ', i + line_length);
+               last_space <= i + indentation.size() or
+               last_space == std::string::npos or
+               (i == 0 and str.substr(i, last_space + 1) ==
+                               std::string(last_space + 1, ' '))) {
+      // The last 'or' condition of the `if` above handles the edge case where
+      // the first space in the first line is precedes only spaces.
+      const size_t insert_location = i + line_length - 1;
+      str.insert(insert_location, "-\n" + indentation);
+      i = insert_location + 2;
+    } else {
+      str.at(last_space) = '\n';
+      str.insert(last_space + 1, indentation);
+      i = last_space + 1;
+    }
+  }
+  return str;
+}

--- a/src/Utilities/WrapText.hpp
+++ b/src/Utilities/WrapText.hpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+/// \ingroup UtilitiesGroup
+/// \brief Wrap the string `str` so that it is no longer than `line_length` and
+/// indent each new line with `indentation`. The first line is also indented.
+///
+/// Single words longer than `line_length` are hyphenated.
+std::string wrap_text(std::string str, size_t line_length,
+                      const std::string& indentation = "") noexcept;

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -60,7 +60,13 @@ struct Simple {
 struct NamedSimple {
   using type = int;
   static std::string name() noexcept { return "SomeName"; }
-  static constexpr OptionString help = {"halp"};
+  static constexpr OptionString help = {
+      "halp halp halp halp halp halp halp halp halp halp halp halp\n"
+      "halp halp halp halp halp halp halp halp halp halp halp halp"
+      "halp halp halp halp halp halp halp halp halp halp halp halp"
+      "halp halp halp halp halp halp halp halp halp halp halp halp"
+      "halp halp halp halp halp halp halp halp halp halp halp halp"
+      "halp halp halp halp halp halp halp halp halp halp halp halp"};
 };
 
 void test_options_simple_success() {
@@ -74,6 +80,25 @@ void test_options_simple_success() {
     opts.parse("SomeName: -4");
     CHECK(opts.get<NamedSimple>() == -4);
   }
+}
+
+void test_options_print_long_help() {
+  Options<tmpl::list<NamedSimple>> opts("");
+  CHECK(opts.help() ==
+        R"(
+==== Description of expected options:
+
+
+Options:
+  SomeName:
+    type=int
+    halp halp halp halp halp halp halp halp halp halp halp halp
+    halp halp halp halp halp halp halp halp halp halp halp halphalp halp halp
+    halp halp halp halp halp halp halp halp halphalp halp halp halp halp halp
+    halp halp halp halp halp halphalp halp halp halp halp halp halp halp halp
+    halp halp halphalp halp halp halp halp halp halp halp halp halp halp halp
+
+)");
 }
 
 // [[OutputRegex, In string:.*At line 2 column 1:.Option 'Simple' specified
@@ -806,6 +831,7 @@ void test_options_explicit_constructor() {
 SPECTRE_TEST_CASE("Unit.Options", "[Unit][Options]") {
   test_options_empty_success();
   test_options_simple_success();
+  test_options_print_long_help();
   test_options_grouped();
   test_options_default_specified();
   test_options_default_defaulted();

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -41,6 +41,7 @@ set(LIBRARY_SOURCES
   Test_TMPL.cpp
   Test_Tuple.cpp
   Test_VectorAlgebra.cpp
+  Test_WrapText.cpp
   )
 
 add_subdirectory(TypeTraits)

--- a/tests/Unit/Utilities/Test_WrapText.cpp
+++ b/tests/Unit/Utilities/Test_WrapText.cpp
@@ -1,0 +1,109 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "Utilities/WrapText.hpp"
+
+SPECTRE_TEST_CASE("Unit.Utilities.WrapText", "[Utilities][Unit]") {
+  CHECK(
+      wrap_text(
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          "aa",
+          50, "         ") ==
+      std::string("         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-\n"
+                  "         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-\n"
+                  "         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-\n"
+                  "         aaaaaaaaaaaaaaaaaa"));
+  CHECK(wrap_text("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                  "aaaaaaaaaaaaaaaaaa",
+                  50) ==
+        std::string("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-\n"
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-\n"
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+
+  CHECK(wrap_text("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  50) ==
+        std::string("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-\n"
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+
+  CHECK(wrap_text("thisisareallylongwordthatwouldcauseproblemssoweneedtoerror "
+                  "I want to wrap \n\nthis text  "
+                  "thisisareallylongwordthatwouldcauseproblemssoweneedtoerror "
+                  "after about 50 characters please.",
+                  50, "   ") ==
+        std::string("   thisisareallylongwordthatwouldcauseproblemssow-\n"
+                    "   eneedtoerror I want to wrap \n   \n   "
+                    "this text \n"
+                    "   thisisareallylongwordthatwouldcauseproblemssow-\n"
+                    "   eneedtoerror after about 50 characters please."));
+  CHECK(wrap_text("thisisareallylongwordthatwouldcauseproblemssoweneedtoerror "
+                  "I want to wrap \n\nthis text  "
+                  "thisisareallylongwordthatwouldcauseproblemssoweneedtoerror "
+                  "after about 50 characters please.",
+                  50) ==
+        std::string("thisisareallylongwordthatwouldcauseproblemssowene-\n"
+                    "edtoerror I want to wrap \n\n"
+                    "this text \n"
+                    "thisisareallylongwordthatwouldcauseproblemssowene-\n"
+                    "edtoerror after about 50 characters please."));
+  CHECK(
+      wrap_text("   thisisareallylongwordthatwouldcauseproblemssoweneedtoerror "
+                "I want to wrap \n\nthis text  "
+                "thisisareallylongwordthatwouldcauseproblemssoweneedtoerror "
+                "after about 50 characters please.",
+                50) ==
+      std::string("   thisisareallylongwordthatwouldcauseproblemssow-\n"
+                  "eneedtoerror I want to wrap \n\n"
+                  "this text \n"
+                  "thisisareallylongwordthatwouldcauseproblemssowene-\n"
+                  "edtoerror after about 50 characters please."));
+  CHECK(wrap_text("I want to wrap \n\nthis text  "
+                  "thisisareallylongwordthatwouldcauseproblemssoweneedtoerror "
+                  "after about 50 characters please.",
+                  50) ==
+        std::string("I want to wrap \n\n"
+                    "this text \n"
+                    "thisisareallylongwordthatwouldcauseproblemssowene-\n"
+                    "edtoerror after about 50 characters please."));
+  CHECK(wrap_text("I want to wrap \n\nthis text  "
+                  "thisisareallylongwordthatwouldcauseproblemssoweneedtoerror "
+                  "after about 20 characters please.",
+                  20) ==
+        std::string("I want to wrap \n\nthis text \n"
+                    "thisisareallylongwo-\nrdthatwouldcausepro-\n"
+                    "blemssoweneedtoerror\nafter about 20\n"
+                    "characters please."));
+  CHECK(
+      wrap_text("I want to wrap \n\nthis text\n"
+                "thisisareallylongwordthatwouldcauseproblemssoweneedtoerror "
+                "after about 20 characters please.",
+                20) ==
+      std::string("I want to wrap \n\nthis text\nthisisareallylongwo-\n"
+                  "rdthatwouldcausepro-\nblemssoweneedtoerror\nafter about 20\n"
+                  "characters please."));
+  CHECK(wrap_text("I want to wrap \n\nthis text\nand this text\n"
+                  "thisisareallylongwordthatwouldcauseproblemssoweneedtoerror "
+                  "after about 50 characters please.",
+                  50, "    ") ==
+        std::string(
+            "    I want to wrap \n    \n    this text\n    and this text\n"
+            "    thisisareallylongwordthatwouldcauseproblemsso-\n"
+            "    weneedtoerror after about 50 characters\n"
+            "    please."));
+  CHECK(wrap_text("I want to wrap \n\na\nand this text\n"
+                  "thisisareallylongwordthatwouldcauseproblemssoweneedtoerror "
+                  "after about 50 characters please.",
+                  50, "    ") ==
+        std::string(
+            "    I want to wrap \n    \n    a\n    and this text\n"
+            "    thisisareallylongwordthatwouldcauseproblemsso-\n"
+            "    weneedtoerror after about 50 characters\n"
+            "    please."));
+}


### PR DESCRIPTION
## Proposed changes

- Add a function to wrap text with indentation to a specified number of characters
- Have options automatically wrap help string output to 77 characters.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
