### PR TITLE
Factor out setting the variables from ConservativeSystem initialization action

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -25,6 +25,7 @@
 #include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/Limiter.hpp"
+#include "Evolution/Initialization/SetVariables.hpp"
 #include "Evolution/Systems/Burgers/System.hpp"
 #include "IO/Observer/Actions.hpp"
 #include "IO/Observer/Helpers.hpp"
@@ -185,6 +186,8 @@ struct EvolutionMetavars {
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
       evolution::dg::Initialization::Domain<1>,
       Initialization::Actions::ConservativeSystem,
+      evolution::Initialization::Actions::SetVariables<
+          domain::Tags::Coordinates<1, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
       dg::Actions::InitializeInterfaces<
           system,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -32,6 +32,7 @@
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/GrTagsForHydro.hpp"
 #include "Evolution/Initialization/Limiter.hpp"
+#include "Evolution/Initialization/SetVariables.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
@@ -298,6 +299,8 @@ struct EvolutionMetavars {
       evolution::dg::Initialization::Domain<3>,
       Initialization::Actions::GrTagsForHydro,
       Initialization::Actions::ConservativeSystem,
+      evolution::Initialization::Actions::SetVariables<
+          domain::Tags::Coordinates<3, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<
           VariableFixing::FixToAtmosphere<volume_dim, thermodynamic_dim>>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -28,6 +28,7 @@
 #include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/Limiter.hpp"
+#include "Evolution/Initialization/SetVariables.hpp"
 #include "Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp"
 #include "Evolution/Systems/NewtonianEuler/Sources/NoSource.hpp"
 #include "Evolution/Systems/NewtonianEuler/System.hpp"
@@ -234,6 +235,8 @@ struct EvolutionMetavars {
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
       evolution::dg::Initialization::Domain<Dim>,
       Initialization::Actions::ConservativeSystem,
+      evolution::Initialization::Actions::SetVariables<
+          domain::Tags::Coordinates<Dim, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
       Initialization::Actions::AddComputeTags<
           tmpl::list<NewtonianEuler::Tags::SoundSpeedSquaredCompute<DataVector>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveStandaloneM1.hpp
@@ -27,6 +27,7 @@
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/GrTagsForHydro.hpp"
 #include "Evolution/Initialization/Limiter.hpp"
+#include "Evolution/Initialization/SetVariables.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/Initialize.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/M1Closure.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/M1HydroCoupling.hpp"
@@ -221,6 +222,8 @@ struct EvolutionMetavars {
       evolution::dg::Initialization::Domain<volume_dim>,
       Initialization::Actions::GrTagsForHydro,
       Initialization::Actions::ConservativeSystem,
+      evolution::Initialization::Actions::SetVariables<
+          domain::Tags::Coordinates<volume_dim, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
       RadiationTransport::M1Grey::Actions::InitializeM1Tags,
       Actions::MutateApply<typename RadiationTransport::M1Grey::

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -29,6 +29,7 @@
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/GrTagsForHydro.hpp"
 #include "Evolution/Initialization/Limiter.hpp"
+#include "Evolution/Initialization/SetVariables.hpp"
 #include "Evolution/Systems/RelativisticEuler/Valencia/FixConservatives.hpp"
 #include "Evolution/Systems/RelativisticEuler/Valencia/System.hpp"
 #include "Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp"
@@ -233,6 +234,8 @@ struct EvolutionMetavars {
       evolution::dg::Initialization::Domain<Dim>,
       Initialization::Actions::GrTagsForHydro,
       Initialization::Actions::ConservativeSystem,
+      evolution::Initialization::Actions::SetVariables<
+          domain::Tags::Coordinates<Dim, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<
           VariableFixing::FixToAtmosphere<volume_dim, thermodynamic_dim>>,

--- a/src/Evolution/Initialization/ConservativeSystem.hpp
+++ b/src/Evolution/Initialization/ConservativeSystem.hpp
@@ -5,7 +5,8 @@
 
 #include <cstddef>
 #include <tuple>
-#include <utility>  // IWYU pragma: keep  // for move
+#include <type_traits>
+#include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -16,22 +17,17 @@
 #include "Domain/TagsTimeDependent.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Evolution/Initialization/InitialData.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"  // Needs to be included somewhere and here seems most natural.
 #include "Parallel/ConstGlobalCache.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TaggedTuple.hpp"
 
 /// \cond
 namespace Frame {
 struct Inertial;
 }  // namespace Frame
-namespace Initialization {
-namespace Tags {
-struct InitialTime;
-}  // namespace Tags
-}  // namespace Initialization
 
 namespace Tags {
 struct AnalyticSolutionOrData;
@@ -45,13 +41,17 @@ struct Mesh;
 }  // namespace Tags
 }  // namespace domain
 // IWYU pragma: no_forward_declare db::DataBox
+
+namespace tuples {
+template <class... Tags>
+class TaggedTuple;
+}  // namespace tuples
 /// \endcond
 
 namespace Initialization {
 namespace Actions {
 /// \ingroup InitializationGroup
-/// \brief Allocate and set variables needed for evolution of conservative
-/// systems
+/// \brief Allocate variables needed for evolution of conservative systems
 ///
 /// Uses:
 /// - DataBox:
@@ -66,17 +66,12 @@ namespace Actions {
 /// - Removes: nothing
 /// - Modifies: nothing
 struct ConservativeSystem {
-  using initialization_tags = tmpl::list<Initialization::Tags::InitialTime>;
-
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
-            typename ParallelComponent,
-            Requires<tmpl::list_contains_v<
-                typename db::DataBox<DbTagsList>::simple_item_tags,
-                Initialization::Tags::InitialTime>> = nullptr>
+            typename ParallelComponent>
   static auto apply(db::DataBox<DbTagsList>& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/, ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
     using system = typename Metavariables::system;
@@ -97,107 +92,46 @@ struct ConservativeSystem {
     typename fluxes_tag::type fluxes(num_grid_points);
     typename sources_tag::type sources(num_grid_points);
 
-    return std::make_tuple(initialize_vars(
-        merge_into_databox<ConservativeSystem, simple_tags, compute_tags>(
+    return std::make_tuple(
+        impl<Metavariables, simple_tags, compute_tags, system>(
+            std::integral_constant<
+                bool, system::has_primitive_and_conservative_vars>{},
             std::move(box), std::move(vars), std::move(fluxes),
-            std::move(sources)),
-        cache));
-  }
-
-  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent,
-            Requires<not tmpl::list_contains_v<
-                typename db::DataBox<DbTagsList>::simple_item_tags,
-                Initialization::Tags::InitialTime>> = nullptr>
-  static std::tuple<db::DataBox<DbTagsList>&&> apply(
-      db::DataBox<DbTagsList>& /*box*/,
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/) noexcept {
-    ERROR(
-        "Could not find dependency 'Initialization::Tags::InitialTime' in "
-        "DataBox.");
+            std::move(sources)));
   }
 
  private:
-  template <
-      typename DbTagsList, typename Metavariables,
-      Requires<Metavariables::system::has_primitive_and_conservative_vars> =
-          nullptr>
-  static auto initialize_vars(
-      db::DataBox<DbTagsList>&& box,
-      const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
-    using system = typename Metavariables::system;
-    static constexpr size_t dim = system::volume_dim;
-    using primitives_tag = typename system::primitive_variables_tag;
-    using simple_tags =
-        db::AddSimpleTags<primitives_tag,
-                          typename Metavariables::equation_of_state_tag>;
-    using compute_tags = db::AddComputeTags<>;
+  template <typename Metavariables, typename AddSimpleTagsList,
+            typename AddComputeTagsList, typename System, typename DbTagsList,
+            typename... Ts>
+  static auto impl(std::true_type /*has_primitive_tags*/,
+                   db::DataBox<DbTagsList>&& box, Ts&&... ts) noexcept {
+    static constexpr size_t dim = System::volume_dim;
+    using PrimitiveVars = typename System::primitive_variables_tag::type;
 
-    const double initial_time = db::get<Initialization::Tags::InitialTime>(box);
-    using PrimitiveVars = typename primitives_tag::type;
+    PrimitiveVars primitive_vars{
+        db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points()};
+    auto equation_of_state =
+        db::get<::Tags::AnalyticSolutionOrData>(box).equation_of_state();
 
-    const size_t num_grid_points =
-        db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points();
-
-    const auto inertial_coords =
-        db::get<domain::CoordinateMaps::Tags::CoordinateMap<dim, Frame::Grid,
-                                                            Frame::Inertial>>(
-            box)(
-            db::get<domain::Tags::ElementMap<dim, Frame::Grid>>(box)(
-                db::get<domain::Tags::Coordinates<dim, Frame::Logical>>(box)),
-            initial_time, db::get<domain::Tags::FunctionsOfTime>(box));
-
-    // Set initial data from analytic solution
-    const auto& solution_or_data =
-        Parallel::get<::Tags::AnalyticSolutionOrData>(cache);
-    PrimitiveVars primitive_vars{num_grid_points};
-    primitive_vars.assign_subset(evolution::initial_data(
-        solution_or_data, inertial_coords, initial_time,
-        typename Metavariables::analytic_variables_tags{}));
-    auto equation_of_state = solution_or_data.equation_of_state();
-
-    return Initialization::merge_into_databox<ConservativeSystem, simple_tags,
-                                              compute_tags>(
-        std::move(box), std::move(primitive_vars),
-        std::move(equation_of_state));
+    return merge_into_databox<
+        ConservativeSystem,
+        tmpl::push_back<AddSimpleTagsList,
+                        typename System::primitive_variables_tag,
+                        typename Metavariables::equation_of_state_tag>,
+        AddComputeTagsList>(std::move(box), std::forward<Ts>(ts)...,
+                            std::move(primitive_vars),
+                            std::move(equation_of_state));
   }
 
-  template <
-      typename DbTagsList, typename Metavariables,
-      Requires<not Metavariables::system::has_primitive_and_conservative_vars> =
-          nullptr>
-  static auto initialize_vars(
-      db::DataBox<DbTagsList>&& box,
-      const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
-    using system = typename Metavariables::system;
-    static constexpr size_t dim = system::volume_dim;
-    using variables_tag = typename system::variables_tag;
-
-    const double initial_time = db::get<Initialization::Tags::InitialTime>(box);
-
-    const auto inertial_coords =
-        db::get<domain::CoordinateMaps::Tags::CoordinateMap<dim, Frame::Grid,
-                                                            Frame::Inertial>>(
-            box)(
-            db::get<domain::Tags::ElementMap<dim, Frame::Grid>>(box)(
-                db::get<domain::Tags::Coordinates<dim, Frame::Logical>>(box)),
-            initial_time, db::get<domain::Tags::FunctionsOfTime>(box));
-
-    // Set initial data from analytic solution
-    using Vars = typename variables_tag::type;
-    db::mutate<variables_tag>(
-        make_not_null(&box), [&cache, &inertial_coords, initial_time ](
-                                 const gsl::not_null<Vars*> vars) noexcept {
-          vars->assign_subset(evolution::initial_data(
-              Parallel::get<::Tags::AnalyticSolutionOrData>(cache),
-              inertial_coords, initial_time, typename Vars::tags_list{}));
-        });
-
-    return std::move(box);
+  template <typename Metavariables, typename AddSimpleTagsList,
+            typename AddComputeTagsList, typename System, typename DbTagsList,
+            typename... Ts>
+  static auto impl(std::false_type /*has_primitive_tags*/,
+                   db::DataBox<DbTagsList>&& box, Ts&&... ts) noexcept {
+    return merge_into_databox<ConservativeSystem, AddSimpleTagsList,
+                              AddComputeTagsList>(std::move(box),
+                                                  std::forward<Ts>(ts)...);
   }
 };
 }  // namespace Actions

--- a/src/Evolution/Initialization/ConservativeSystem.hpp
+++ b/src/Evolution/Initialization/ConservativeSystem.hpp
@@ -20,6 +20,7 @@
 #include "NumericalAlgorithms/LinearOperators/Divergence.tpp"  // Needs to be included somewhere and here seems most natural.
 #include "Parallel/ConstGlobalCache.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -29,9 +30,6 @@ namespace Frame {
 struct Inertial;
 }  // namespace Frame
 
-namespace Tags {
-struct AnalyticSolutionOrData;
-}  // namespace Tags
 namespace domain {
 namespace Tags {
 template <size_t VolumeDim, typename Frame>

--- a/src/Evolution/Initialization/SetVariables.hpp
+++ b/src/Evolution/Initialization/SetVariables.hpp
@@ -1,0 +1,126 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/Initialization/InitialData.hpp"
+#include "Evolution/Initialization/Tags.hpp"
+#include "Evolution/TypeTraits.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace evolution {
+namespace Initialization {
+namespace Actions {
+/// \ingroup InitializationGroup
+/// \brief Sets variables needed for evolution of hyperbolic systems
+///
+/// Uses:
+/// - DataBox:
+///   * `CoordinatesTag`
+/// - ConstGlobalCache:
+///   * `OptionTags::AnalyticSolutionBase` or `OptionTags::AnalyticDataBase`
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   * System::variables_tag (if system has no primitive variables)
+///   * System::primitive_variables_tag (if system has primitive variables)
+template <typename LogicalCoordinatesTag>
+struct SetVariables {
+  using initialization_option_tags =
+      tmpl::list<::Initialization::Tags::InitialTime>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    if constexpr (tmpl::list_contains_v<
+                      typename db::DataBox<DbTagsList>::simple_item_tags,
+                      ::Initialization::Tags::InitialTime>) {
+      impl<Metavariables>(make_not_null(&box));
+    } else {
+      ERROR(
+          "Could not find dependency 'Initialization::Tags::InitialTime' in "
+          "DataBox.");
+    }
+    return {std::move(box)};
+  }
+
+ private:
+  template <typename Metavariables, typename DbTagsList>
+  static void impl(const gsl::not_null<db::DataBox<DbTagsList>*> box) noexcept {
+    const double initial_time =
+        db::get<::Initialization::Tags::InitialTime>(*box);
+    const auto inertial_coords =
+        db::get<::domain::CoordinateMaps::Tags::CoordinateMap<
+            Metavariables::volume_dim, Frame::Grid, Frame::Inertial>>(*box)(
+            db::get<::domain::Tags::ElementMap<Metavariables::volume_dim,
+                                               Frame::Grid>>(*box)(
+                db::get<LogicalCoordinatesTag>(*box)),
+            initial_time, db::get<::domain::Tags::FunctionsOfTime>(*box));
+
+    using system = typename Metavariables::system;
+
+    const auto& solution_or_data =
+        db::get<::Tags::AnalyticSolutionOrData>(*box);
+
+    if constexpr (Metavariables::system::has_primitive_and_conservative_vars) {
+      using primitives_tag = typename system::primitive_variables_tag;
+      // Set initial data from analytic solution
+      db::mutate<primitives_tag>(
+          box, [&initial_time, &inertial_coords, &solution_or_data](
+                   const gsl::not_null<db::item_type<primitives_tag>*>
+                       primitive_vars) noexcept {
+            primitive_vars->assign_subset(evolution::initial_data(
+                solution_or_data, inertial_coords, initial_time,
+                typename Metavariables::analytic_variables_tags{}));
+          });
+    } else {
+      using variables_tag = typename system::variables_tag;
+
+      // Set initial data from analytic solution
+      using Vars = typename variables_tag::type;
+      db::mutate<variables_tag>(
+          box, [&initial_time, &inertial_coords,
+                &solution_or_data](const gsl::not_null<Vars*> vars) noexcept {
+            vars->assign_subset(evolution::initial_data(
+                solution_or_data, inertial_coords, initial_time,
+                typename Vars::tags_list{}));
+          });
+    }
+  }
+};
+}  // namespace Actions
+}  // namespace Initialization
+}  // namespace evolution

--- a/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
@@ -7,6 +7,7 @@
 #include "Options/Options.hpp"
 #include "Parallel/Serialize.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace OptionTags {
 /// \ingroup OptionGroupsGroup

--- a/tests/Unit/Evolution/Initialization/CMakeLists.txt
+++ b/tests/Unit/Evolution/Initialization/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_EvolutionInitialization")
 
 set(LIBRARY_SOURCES
+  Test_ConservativeSystem.cpp
   Test_DgDomain.cpp
   Test_Tags.cpp
   Test_SetVariables.cpp

--- a/tests/Unit/Evolution/Initialization/CMakeLists.txt
+++ b/tests/Unit/Evolution/Initialization/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_EvolutionInitialization")
 set(LIBRARY_SOURCES
   Test_DgDomain.cpp
   Test_Tags.cpp
+  Test_SetVariables.cpp
   )
 
 add_test_library(
@@ -13,4 +14,9 @@ add_test_library(
   "Evolution/Initialization/"
   "${LIBRARY_SOURCES}"
   "DataStructures;Domain;Evolution;Utilities"
+  )
+
+add_dependencies(
+  ${LIBRARY}
+  module_ConstGlobalCache
   )

--- a/tests/Unit/Evolution/Initialization/Test_ConservativeSystem.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_ConservativeSystem.cpp
@@ -1,0 +1,135 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Initialization/ConservativeSystem.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct Var : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "Var"; }
+};
+
+struct PrimVar : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "PrimVar"; }
+};
+
+struct SystemAnalyticSolution : public MarkAsAnalyticSolution {
+  int equation_of_state() const noexcept { return 5; }
+
+  // NOLINTNEXTLINE
+  void pup(PUP::er& /*p*/) noexcept {}
+};
+
+template <size_t Dim, bool HasPrimitiveAndConservativeVars>
+struct System {
+  static constexpr bool is_in_flux_conservative_form = true;
+  static constexpr bool has_primitive_and_conservative_vars =
+      HasPrimitiveAndConservativeVars;
+  static constexpr size_t volume_dim = Dim;
+  using variables_tag = Tags::Variables<tmpl::list<Var>>;
+  using primitive_variables_tag = Tags::Variables<tmpl::list<PrimVar>>;
+};
+
+template <size_t Dim, typename Metavariables>
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  using initial_tags = tmpl::list<domain::Tags::Mesh<Dim>>;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<initial_tags>,
+                 Initialization::Actions::ConservativeSystem>>>;
+};
+
+template <size_t Dim, bool HasPrimitives>
+struct Metavariables {
+  using component_list = tmpl::list<component<Dim, Metavariables>>;
+  using system = System<Dim, HasPrimitives>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::AnalyticSolution<SystemAnalyticSolution>>;
+  enum class Phase { Initialization, Exit };
+
+  struct equation_of_state_tag : db::SimpleTag {
+    using type = int;
+  };
+};
+
+template <size_t Dim, typename Runner>
+void check_primitives(std::true_type /*has_prims*/, const Runner& runner,
+                      const size_t number_of_grid_points) noexcept {
+  using metavars = Metavariables<Dim, true>;
+  using comp = component<Dim, metavars>;
+  using prim_vars_tag = Tags::Variables<tmpl::list<PrimVar>>;
+  CHECK(ActionTesting::get_databox_tag<comp, prim_vars_tag>(runner, 0)
+            .number_of_grid_points() == number_of_grid_points);
+  CHECK(ActionTesting::get_databox_tag<
+            comp, typename Metavariables<Dim, true>::equation_of_state_tag>(
+            runner, 0) == 5);
+}
+
+template <size_t Dim, typename Runner>
+void check_primitives(std::false_type /*has_prims*/, const Runner& /*runner*/,
+                      const size_t /*number_of_grid_points*/) noexcept {}
+
+template <size_t Dim, bool HasPrimitives>
+void test() noexcept {
+  using metavars = Metavariables<Dim, HasPrimitives>;
+  using comp = component<Dim, metavars>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  MockRuntimeSystem runner{{SystemAnalyticSolution{}}};
+  Mesh<Dim> mesh{5, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+  ActionTesting::emplace_component_and_initialize<comp>(&runner, 0, {mesh});
+  // Invoke the ConservativeSystem action on the runner
+  ActionTesting::next_action<comp>(make_not_null(&runner), 0);
+  using vars_tag = Tags::Variables<tmpl::list<Var>>;
+  using fluxes_tag = db::add_tag_prefix<::Tags::Flux, vars_tag,
+                                        tmpl::size_t<Dim>, Frame::Inertial>;
+  using sources_tag = db::add_tag_prefix<::Tags::Source, vars_tag>;
+  // The numerical value that the vars are set to is undefined, but the number
+  // of grid points must be correct.
+  CHECK(ActionTesting::get_databox_tag<comp, vars_tag>(runner, 0)
+            .number_of_grid_points() == mesh.number_of_grid_points());
+  CHECK(ActionTesting::get_databox_tag<comp, fluxes_tag>(runner, 0)
+            .number_of_grid_points() == mesh.number_of_grid_points());
+  CHECK(ActionTesting::get_databox_tag<comp, sources_tag>(runner, 0)
+            .number_of_grid_points() == mesh.number_of_grid_points());
+  check_primitives<Dim>(std::integral_constant<bool, HasPrimitives>{}, runner,
+                        mesh.number_of_grid_points());
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Initialization.ConservativeSystem",
+                  "[Unit][Evolution][Actions]") {
+  test<1, true>();
+  test<2, true>();
+  test<3, true>();
+  test<1, false>();
+  test<2, false>();
+  test<3, false>();
+}
+}  // namespace

--- a/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
@@ -1,0 +1,316 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/CubicScale.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Initialization/SetVariables.hpp"
+#include "Evolution/Initialization/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Utilities/CloneUniquePtrs.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+struct TimeId : db::SimpleTag {
+  using type = double;
+};
+
+struct Var : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct PrimVar : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct EquationOfStateTag : db::SimpleTag {
+  using type = double;
+};
+
+struct SystemAnalyticSolution : public MarkAsAnalyticSolution {
+  template <size_t Dim>
+  tuples::TaggedTuple<Var> variables(const tnsr::I<DataVector, Dim>& x,
+                                     const double t,
+                                     tmpl::list<Var> /*meta*/) const noexcept {
+    tuples::TaggedTuple<Var> vars(x.get(0) + t);
+    for (size_t d = 1; d < Dim; ++d) {
+      get(get<Var>(vars)) += x.get(d) + t;
+    }
+    return vars;
+  }
+
+  template <size_t Dim>
+  tuples::TaggedTuple<PrimVar> variables(const tnsr::I<DataVector, Dim>& x,
+                                         const double t,
+                                         tmpl::list<PrimVar> /*meta*/) const
+      noexcept {
+    tuples::TaggedTuple<PrimVar> vars(2.0 * x.get(0) + t);
+    for (size_t d = 1; d < Dim; ++d) {
+      get(get<PrimVar>(vars)) += 2.0 * x.get(d) + t;
+    }
+    return vars;
+  }
+
+  // EoS just needs to be a dummy place holder
+  double equation_of_state() const noexcept { return 7.0; }
+
+  // clang-tidy: do not use references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+struct SystemAnalyticData : public MarkAsAnalyticData {
+  template <size_t Dim>
+  tuples::TaggedTuple<Var> variables(const tnsr::I<DataVector, Dim>& x,
+                                     tmpl::list<Var> /*meta*/) const noexcept {
+    tuples::TaggedTuple<Var> vars(x.get(0));
+    for (size_t d = 1; d < Dim; ++d) {
+      get(get<Var>(vars)) += square(x.get(d));
+    }
+    return vars;
+  }
+
+  template <size_t Dim>
+  tuples::TaggedTuple<PrimVar> variables(const tnsr::I<DataVector, Dim>& x,
+                                         tmpl::list<PrimVar> /*meta*/) const
+      noexcept {
+    tuples::TaggedTuple<PrimVar> vars(2.0 * x.get(0));
+    for (size_t d = 1; d < Dim; ++d) {
+      get(get<PrimVar>(vars)) += square(2.0 * x.get(d));
+    }
+    return vars;
+  }
+
+  // EoS just needs to be a dummy place holder
+  double equation_of_state() const noexcept { return 7.0; }
+
+  // clang-tidy: do not use references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+template <size_t Dim, bool HasPrimitiveAndConservativeVars>
+struct System {
+  // is_in_flux_conservative_form is unused
+  static constexpr bool is_in_flux_conservative_form = false;
+  static constexpr bool has_primitive_and_conservative_vars =
+      HasPrimitiveAndConservativeVars;
+  static constexpr size_t volume_dim = Dim;
+  using variables_tag = Tags::Variables<tmpl::list<Var>>;
+  using primitive_variables_tag = Tags::Variables<tmpl::list<PrimVar>>;
+};
+
+template <size_t Dim, typename Metavariables>
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  using initial_tags = tmpl::list<
+      Initialization::Tags::InitialTime, domain::Tags::FunctionsOfTime,
+      domain::Tags::Coordinates<Dim, Frame::Logical>,
+      domain::Tags::ElementMap<Dim, Frame::Grid>,
+      domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                  Frame::Inertial>,
+      Tags::Variables<tmpl::list<Var>>, Tags::Variables<tmpl::list<PrimVar>>>;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<initial_tags>,
+                 evolution::Initialization::Actions::SetVariables<
+                     domain::Tags::Coordinates<Dim, Frame::Logical>>>>>;
+};
+
+template <size_t Dim, typename Metavariables>
+auto emplace_component(
+    const gsl::not_null<ActionTesting::MockRuntimeSystem<Metavariables>*>
+        runner,
+    const double initial_time) {
+  using comp = component<Dim, Metavariables>;
+
+  const auto logical_coords = logical_coordinates(Mesh<Dim>{
+      5, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto});
+  ElementMap<Dim, Frame::Grid> logical_to_grid_map{
+      ElementId<Dim>{0},
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+          domain::CoordinateMaps::Identity<Dim>{})};
+  const std::string expansion_factor = "Expansion";
+  const auto grid_to_inertial_map =
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::TimeDependent::CubicScale<Dim>{
+              10.0, expansion_factor, expansion_factor});
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  functions_of_time.insert(std::make_pair(
+      expansion_factor,
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time, std::array<DataVector, 3>{{{1.0}, {-0.1}, {0.0}}})));
+  Variables<tmpl::list<Var>> var(get<0>(logical_coords).size(), 8.9999);
+  Variables<tmpl::list<PrimVar>> prim_var(get<0>(logical_coords).size(),
+                                          9.9999);
+  ActionTesting::emplace_component_and_initialize<comp>(
+      runner, 0,
+      {initial_time, clone_unique_ptrs(functions_of_time), logical_coords,
+       std::move(logical_to_grid_map), grid_to_inertial_map->get_clone(), var,
+       prim_var});
+  return (*grid_to_inertial_map)(
+      ActionTesting::get_databox_tag<
+          comp, domain::Tags::ElementMap<Dim, Frame::Grid>>(*runner,
+                                                            0)(logical_coords),
+      initial_time, functions_of_time);
+}
+
+template <size_t Dim, bool HasPrimitives>
+struct MetavariablesAnalyticSolution {
+  static constexpr size_t volume_dim = Dim;
+  using analytic_solution = SystemAnalyticSolution;
+  using component_list =
+      tmpl::list<component<Dim, MetavariablesAnalyticSolution>>;
+  using equation_of_state_tag = EquationOfStateTag;
+  using system = System<Dim, HasPrimitives>;
+  using analytic_variables_tags =
+      tmpl::conditional_t<HasPrimitives,
+                          typename system::primitive_variables_tag::tags_list,
+                          typename system::variables_tag::tags_list>;
+  using temporal_id = TimeId;
+  using const_global_cache_tags =
+      tmpl::list<Tags::AnalyticSolution<analytic_solution>>;
+  enum class Phase { Initialization, Exit };
+};
+
+template <size_t Dim, bool HasPrimitives>
+void test_analytic_solution() noexcept {
+  using metavars = MetavariablesAnalyticSolution<Dim, HasPrimitives>;
+  using comp = component<Dim, metavars>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  MockRuntimeSystem runner{{SystemAnalyticSolution{}}};
+  const double initial_time = 1.3;
+  const auto inertial_coords =
+      emplace_component<Dim>(make_not_null(&runner), initial_time);
+  Variables<tmpl::list<Var>> var(get<0>(inertial_coords).size(), 8.9999);
+  Variables<tmpl::list<PrimVar>> prim_var(get<0>(inertial_coords).size(),
+                                          9.9999);
+
+  // Invoke the SetVariables action on the runner
+  ActionTesting::next_action<comp>(make_not_null(&runner), 0);
+  if (HasPrimitives) {
+    prim_var.assign_subset(SystemAnalyticSolution{}.variables(
+        inertial_coords, initial_time, tmpl::list<PrimVar>{}));
+  } else {
+    var.assign_subset(SystemAnalyticSolution{}.variables(
+        inertial_coords, initial_time, tmpl::list<Var>{}));
+  }
+  CHECK(ActionTesting::get_databox_tag<comp, Var>(runner, 0) == get<Var>(var));
+  CHECK(ActionTesting::get_databox_tag<comp, PrimVar>(runner, 0) ==
+        get<PrimVar>(prim_var));
+}
+
+template <size_t Dim, bool HasPrimitives>
+struct MetavariablesAnalyticData {
+  static constexpr size_t volume_dim = Dim;
+  using analytic_data = SystemAnalyticData;
+  using component_list = tmpl::list<component<Dim, MetavariablesAnalyticData>>;
+  using equation_of_state_tag = EquationOfStateTag;
+  using system = System<Dim, HasPrimitives>;
+  using analytic_variables_tags =
+      tmpl::conditional_t<HasPrimitives,
+                          typename system::primitive_variables_tag::tags_list,
+                          typename system::variables_tag::tags_list>;
+  using temporal_id = TimeId;
+  using const_global_cache_tags = tmpl::list<Tags::AnalyticData<analytic_data>>;
+  enum class Phase { Initialization, Exit };
+};
+
+template <size_t Dim, bool HasPrimitives>
+void test_analytic_data() noexcept {
+  using metavars = MetavariablesAnalyticData<Dim, HasPrimitives>;
+  using comp = component<Dim, metavars>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  MockRuntimeSystem runner{{SystemAnalyticData{}}};
+  const double initial_time = 1.3;
+  const auto inertial_coords =
+      emplace_component<Dim>(make_not_null(&runner), initial_time);
+  Variables<tmpl::list<Var>> var(get<0>(inertial_coords).size(), 8.9999);
+  Variables<tmpl::list<PrimVar>> prim_var(get<0>(inertial_coords).size(),
+                                          9.9999);
+
+  // Invoke the SetVariables action on the runner
+  ActionTesting::next_action<comp>(make_not_null(&runner), 0);
+  if (HasPrimitives) {
+    prim_var.assign_subset(
+        SystemAnalyticData{}.variables(inertial_coords, tmpl::list<PrimVar>{}));
+  } else {
+    var.assign_subset(
+        SystemAnalyticData{}.variables(inertial_coords, tmpl::list<Var>{}));
+  }
+  CHECK(ActionTesting::get_databox_tag<comp, Var>(runner, 0) == get<Var>(var));
+  CHECK(ActionTesting::get_databox_tag<comp, PrimVar>(runner, 0) ==
+        get<PrimVar>(prim_var));
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Initialization.SetVariables",
+                  "[Unit][Evolution][Actions]") {
+  domain::FunctionsOfTime::register_derived_with_charm();
+  Parallel::register_classes_in_list<
+      tmpl::list<domain::CoordinateMap<Frame::Logical, Frame::Grid,
+                                       domain::CoordinateMaps::Identity<1>>,
+                 domain::CoordinateMap<Frame::Logical, Frame::Grid,
+                                       domain::CoordinateMaps::Identity<2>>,
+                 domain::CoordinateMap<Frame::Logical, Frame::Grid,
+                                       domain::CoordinateMaps::Identity<3>>,
+                 domain::CoordinateMap<
+                     Frame::Grid, Frame::Inertial,
+                     domain::CoordinateMaps::TimeDependent::CubicScale<1>>,
+                 domain::CoordinateMap<
+                     Frame::Grid, Frame::Inertial,
+                     domain::CoordinateMaps::TimeDependent::CubicScale<2>>,
+                 domain::CoordinateMap<
+                     Frame::Grid, Frame::Inertial,
+                     domain::CoordinateMaps::TimeDependent::CubicScale<3>>>>();
+
+  // Test setting variables from analytic solution
+  test_analytic_solution<1, false>();
+  test_analytic_solution<1, true>();
+  test_analytic_solution<2, false>();
+  test_analytic_solution<2, true>();
+  test_analytic_solution<3, false>();
+  test_analytic_solution<3, true>();
+
+  // Test setting variables from analytic data
+  test_analytic_data<1, false>();
+  test_analytic_data<1, true>();
+  test_analytic_data<2, false>();
+  test_analytic_data<2, true>();
+  test_analytic_data<3, false>();
+  test_analytic_data<3, true>();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

- I need to be able to set the variables separately for DG and the subcell grid so rather than copy-pasting code I think it's easier to factor out. The new `SetVariables` action will also be usable in the non-conservative systems once #2197 is in. I'll add a separate PR for that.
- Add a test for the `ConservativeSystem` action.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
