### PR TITLE
Fix ObserveVolumeIntegrals: use DetInvJacobian in databox

### DIFF
--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -65,10 +65,11 @@ namespace Initialization {
  *   - `domain::Tags::CoordinatesMeshVelocityAndJacobiansCompute<
  *      CoordinateMap<Dim, Frame::Grid, Frame::Inertial>>`
  *   - `domain::Tags::Coordinates<Dim, Frame::Logical>`
- *   - `domain::Tags::Coordinates<Dim, Frame::Frid>`
+ *   - `domain::Tags::Coordinates<Dim, Frame::Grid>`
  *   - `domain::Tags::Coordinates<Dim, Frame::Inertial>`
  *   - `domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Grid>`
  *   - `domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>`
+ *   - `domain::Tags::DetInvJacobian<Frame::Logical, Frame::Inertial>`
  *   - `domain::Tags::MeshVelocity<Dim, Frame::Inertial>`
  *   - `domain::Tags::DivMeshVelocity`
  *   - `domain::Tags::MinimumGridSpacing<Dim, Frame::Inertial>>`
@@ -118,6 +119,8 @@ struct Domain {
 
         ::domain::Tags::InertialFromGridCoordinatesCompute<Dim>,
         ::domain::Tags::ElementToInertialInverseJacobian<Dim>,
+        ::domain::Tags::DetInvJacobianCompute<Dim, Frame::Logical,
+                                              Frame::Inertial>,
         ::domain::Tags::InertialMeshVelocityCompute<Dim>,
         evolution::domain::Tags::DivMeshVelocityCompute<Dim>,
         // Compute tags for other mesh quantities

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
@@ -55,6 +55,7 @@ namespace Actions {
  *   - `Tags::Coordinates<Dim, Frame::Inertial>`
  *   - `Tags::InverseJacobianCompute<
  *   Tags::ElementMap<Dim>, Tags::Coordinates<Dim, Frame::Logical>>`
+ *   - `Tags::DetInvJacobianCompute<Dim, Frame::Logical, Frame::Inertial>`
  *   - `Tags::MinimumGridSpacing<Dim, Frame::Inertial>>`
  * - Removes: nothing
  * - Modifies: nothing
@@ -88,6 +89,8 @@ struct InitializeDomain {
         domain ::Tags::InverseJacobianCompute<
             domain ::Tags::ElementMap<Dim>,
             domain::Tags::Coordinates<Dim, Frame::Logical>>,
+        domain::Tags::DetInvJacobianCompute<Dim, Frame::Logical,
+                                            Frame::Inertial>,
         domain::Tags::MinimumGridSpacing<Dim, Frame::Inertial>>>;
 
     const auto& initial_extents =

--- a/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
@@ -338,6 +338,15 @@ void test() noexcept {
             runner, self_id)),
         expected_logical_to_inertial_inv_jacobian);
 
+    const Scalar<DataVector> expected_logical_to_inertial_det_inv_jacobian =
+        determinant(expected_logical_to_inertial_inv_jacobian);
+    CHECK_ITERABLE_APPROX(
+        (ActionTesting::get_databox_tag<
+            component,
+            domain::Tags::DetInvJacobian<Frame::Logical, Frame::Inertial>>(
+            runner, self_id)),
+        expected_logical_to_inertial_det_inv_jacobian);
+
     const auto expected_coords_mesh_velocity_jacobians =
         grid_to_inertial_map.coords_frame_velocity_jacobians(
             ActionTesting::get_databox_tag<
@@ -455,6 +464,15 @@ void test() noexcept {
               runner, self_id)[i]
               .data());
     }
+
+    const Scalar<DataVector> expected_logical_to_inertial_det_inv_jacobian =
+        determinant(expected_logical_to_inertial_inv_jacobian);
+    CHECK_ITERABLE_APPROX(
+        (ActionTesting::get_databox_tag<
+            component,
+            domain::Tags::DetInvJacobian<Frame::Logical, Frame::Inertial>>(
+            runner, self_id)),
+        expected_logical_to_inertial_det_inv_jacobian);
 
     CHECK_FALSE(static_cast<bool>(
         ActionTesting::get_databox_tag<component,

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -141,9 +142,12 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     const auto& inertial_coords =
         get_tag(domain::Tags::Coordinates<1, Frame::Inertial>{});
     CHECK(inertial_coords == element_map(logical_coords));
-    CHECK(get_tag(domain::Tags::InverseJacobian<1, Frame::Logical,
-                                                Frame::Inertial>{}) ==
-          element_map.inv_jacobian(logical_coords));
+    const auto& inverse_jacobian = get_tag(
+        domain::Tags::InverseJacobian<1, Frame::Logical, Frame::Inertial>{});
+    CHECK(inverse_jacobian == element_map.inv_jacobian(logical_coords));
+    const auto& det_inv_jacobian = get_tag(
+        domain::Tags::DetInvJacobian<Frame::Logical, Frame::Inertial>{});
+    CHECK(det_inv_jacobian == determinant(inverse_jacobian));
   }
   {
     INFO("2D");
@@ -210,9 +214,12 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     const auto& inertial_coords =
         get_tag(domain::Tags::Coordinates<2, Frame::Inertial>{});
     CHECK(inertial_coords == element_map(logical_coords));
-    CHECK(get_tag(domain::Tags::InverseJacobian<2, Frame::Logical,
-                                                Frame::Inertial>{}) ==
-          element_map.inv_jacobian(logical_coords));
+    const auto& inverse_jacobian = get_tag(
+        domain::Tags::InverseJacobian<2, Frame::Logical, Frame::Inertial>{});
+    CHECK(inverse_jacobian == element_map.inv_jacobian(logical_coords));
+    const auto& det_inv_jacobian = get_tag(
+        domain::Tags::DetInvJacobian<Frame::Logical, Frame::Inertial>{});
+    CHECK(det_inv_jacobian == determinant(inverse_jacobian));
   }
   {
     INFO("3D");
@@ -292,8 +299,11 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     const auto& inertial_coords =
         get_tag(domain::Tags::Coordinates<3, Frame::Inertial>{});
     CHECK(inertial_coords == element_map(logical_coords));
-    CHECK(get_tag(domain::Tags::InverseJacobian<3, Frame::Logical,
-                                                Frame::Inertial>{}) ==
-          element_map.inv_jacobian(logical_coords));
+    const auto& inverse_jacobian = get_tag(
+        domain::Tags::InverseJacobian<3, Frame::Logical, Frame::Inertial>{});
+    CHECK(inverse_jacobian == element_map.inv_jacobian(logical_coords));
+    const auto& det_inv_jacobian = get_tag(
+        domain::Tags::DetInvJacobian<Frame::Logical, Frame::Inertial>{});
+    CHECK(det_inv_jacobian == determinant(inverse_jacobian));
   }
 }


### PR DESCRIPTION
## Proposed changes

~I've been carrying this fix for a while, but now that I've been changing branches on a daily basis, I'd like it to get merged. It is not clear to me how this will affect `Elliptic` systems, but I'd be happy to discuss that here or in a future PR.~

- Adds `DetInvJacobian<Frame::Logical, Frame::Inertial>` to the databox.
- Update `ObserveVolumeIntegrals` to use `DetInvJacobian` directly.

### Types of changes:

- [ x] Bugfix
- [ x] New feature
- [ ] Refactor

### Component:

- [x ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
