### PR TITLE
Add assert in SegmentId::set_block_id

### DIFF
--- a/src/Domain/SegmentId.cpp
+++ b/src/Domain/SegmentId.cpp
@@ -43,39 +43,6 @@ static_assert(std::is_pod<SegmentId>::value, "SegmentId is not POD");
 static_assert(sizeof(SegmentId) == sizeof(int),
               "SegmentId does not fit in an int");
 
-void SegmentId::pup(PUP::er& p) noexcept {
-  // Because we need to use bitfields for the `SegmentId` to be used by Charm++,
-  // we need to copy data into fundamental types and then send them. We could
-  // alternatively treat `this` as an array of characters and send that at the
-  // expense of readability, if the current copy/send implementation is too
-  // slow.
-  unsigned short block_id = block_id_;
-  unsigned short refinement_level = refinement_level_;
-  unsigned index = index_;
-
-  // Make sure that the sizes of the types used for sending are sufficiently
-  // large not to drop precision.
-  static_assert(8 * sizeof(std::decay_t<decltype(block_id)>) >= block_id_bits,
-                "The number of bits specified in block_id_bits is larger than "
-                "that of the type of `block_id`.");
-  static_assert(
-      8 * sizeof(std::decay_t<decltype(refinement_level)>) >= refinement_bits,
-      "The number of bits specified in refinement_bits is larger than "
-      "that of the type of `refinement_level`.");
-  static_assert(
-      8 * sizeof(std::decay_t<decltype(index)>) >= max_refinement_level,
-      "The number of bits specified in max_refinement_level is larger than "
-      "that of the type of `index`.");
-  p | block_id;
-  p | refinement_level;
-  p | index;
-  if (p.isUnpacking()) {
-    block_id_ = block_id;
-    refinement_level_ = refinement_level;
-    index_ = index;
-  }
-}
-
 std::ostream& operator<<(std::ostream& os, const SegmentId& id) noexcept {
   os << 'L' << id.refinement_level() << 'I' << id.index();
   return os;

--- a/src/Domain/SegmentId.hpp
+++ b/src/Domain/SegmentId.hpp
@@ -121,7 +121,12 @@ class SegmentId {
 
   SegmentId(size_t block_id, size_t refinement_level, size_t index) noexcept;
   size_t block_id() const noexcept { return block_id_; }
-  void set_block_id(const size_t block_id) noexcept { block_id_ = block_id; }
+  void set_block_id(const size_t block_id) noexcept {
+    ASSERT(block_id < two_to_the(block_id_bits),
+           "Block id out of bounds: " << block_id << "\nMaximum value is: "
+                                      << two_to_the(block_id_bits) - 1);
+    block_id_ = block_id;
+  }
 
   unsigned block_id_ : block_id_bits;
   unsigned refinement_level_ : refinement_bits;

--- a/src/Domain/SegmentId.hpp
+++ b/src/Domain/SegmentId.hpp
@@ -115,9 +115,6 @@ class SegmentId {
   /// Does the segment overlap with another?
   bool overlaps(const SegmentId& other) const noexcept;
 
-  /// Serialization for Charm++
-  void pup(PUP::er& p) noexcept;  // NOLINT
-
  private:
   template <size_t VolumeDim>
   friend class ElementId;
@@ -130,6 +127,11 @@ class SegmentId {
   unsigned refinement_level_ : refinement_bits;
   unsigned index_ : max_refinement_level;
 };
+
+/// \cond
+// macro that generate the pup operator for SegmentId
+PUPbytes(SegmentId)
+/// \endcond
 
 /// Output operator for SegmentId.
 std::ostream& operator<<(std::ostream& os, const SegmentId& id) noexcept;

--- a/tests/Unit/Domain/Test_ElementId.cpp
+++ b/tests/Unit/Domain/Test_ElementId.cpp
@@ -158,3 +158,14 @@ SPECTRE_TEST_CASE("Unit.Domain.ElementId", "[Domain][Unit]") {
   test_serialization<2>();
   test_serialization<3>();
 }
+
+// [[OutputRegex, Block id out of bounds]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.ElementId.BadBlockId",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto failed_element_id = ElementId<1>(two_to_the(SegmentId::block_id_bits));
+  static_cast<void>(failed_element_id);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}


### PR DESCRIPTION
## Proposed changes

Adds an assert in SegmentId::set_block_id that will trigger when ElementId is created with an invalid block id

Also switched the PUPing of SegmentId to use `PUPbytes`, and added more testing of the serialization
of ElementId.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
