### PR TITLE
Fix CI failure on re-running checks on mac os

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -428,7 +428,7 @@ jobs:
       CCACHE_COMPILERCHECK: content
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       # Install dependencies with Homebrew if we can so we don't have to build
       # and cache them. We make sure to install only prebuilt "bottles" by
       # fetching them first.


### PR DESCRIPTION
Need to use GitHub actions/checkout@v2

There is apparently an [issue with GitHub actions/checkout@v1](https://github.com/actions/checkout/issues/23)


## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
