### PR TITLE
Fix Dormand-Prince 5 timestepper problem

### DIFF
--- a/src/Time/TimeSteppers/DormandPrince5.cpp
+++ b/src/Time/TimeSteppers/DormandPrince5.cpp
@@ -65,7 +65,8 @@ constexpr std::array<double, 3> DormandPrince5::_a4;
 constexpr std::array<double, 4> DormandPrince5::_a5;
 constexpr std::array<double, 5> DormandPrince5::_a6;
 constexpr std::array<double, 6> DormandPrince5::_b;
-constexpr std::array<double, 5> DormandPrince5::_c;
+const std::array<Time::rational_t, 5> DormandPrince5::_c = {
+    {{1, 5}, {3, 10}, {4, 5}, {8, 9}, {1, 1}}};
 constexpr std::array<double, 6> DormandPrince5::_d;
 }  // namespace TimeSteppers
 

--- a/src/Time/TimeSteppers/DormandPrince5.hpp
+++ b/src/Time/TimeSteppers/DormandPrince5.hpp
@@ -119,7 +119,7 @@ class DormandPrince5 : public TimeStepper::Inherit {
   static constexpr std::array<double, 6> _b{{35.0 / 384.0, 0.0, 500.0 / 1113.0,
                                              125.0 / 192.0, -2187.0 / 6784.0,
                                              11.0 / 84.0}};
-  static constexpr std::array<double, 5> _c{{0.2, 0.3, 0.8, 8.0 / 9.0, 1.0}};
+  static const std::array<Time::rational_t, 5> _c;
 
   // Coefficients for dense output, taken from Sec. 7.2 of
   // \cite NumericalRecipes
@@ -148,7 +148,7 @@ void DormandPrince5::update_u(
   const auto& u0 = history->begin().value();
   const double dt = time_step.value();
 
-  const auto increment_u = [&u, &history, &dt ](const auto& coeffs) noexcept {
+  const auto increment_u = [&u, &history, &dt](const auto& coeffs) noexcept {
     for (size_t i = 0; i < coeffs.size(); ++i) {
       *u += (gsl::at(coeffs, i) * dt) *
             (history->begin() + static_cast<int>(i)).derivative();

--- a/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp
@@ -19,6 +19,11 @@ void check_substep_properties(const TimeStepper& stepper) noexcept;
 void integrate_test(const TimeStepper& stepper, size_t number_of_past_steps,
                     double integration_time, double epsilon) noexcept;
 
+void integrate_test_explicit_time_dependence(const TimeStepper& stepper,
+                                             size_t number_of_past_steps,
+                                             double integration_time,
+                                             double epsilon) noexcept;
+
 void integrate_variable_test(const TimeStepper& stepper,
                              size_t number_of_past_steps,
                              double epsilon) noexcept;

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -37,6 +37,8 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN", "[Unit][Time]") {
       INFO(start_points);
       const double epsilon = std::max(std::pow(1e-3, start_points + 1), 1e-14);
       TimeStepperTestUtils::integrate_test(stepper, start_points, 1., epsilon);
+      TimeStepperTestUtils::integrate_test_explicit_time_dependence(
+          stepper, start_points, 1., epsilon);
     }
     TimeStepperTestUtils::check_convergence_order(stepper, order);
     TimeStepperTestUtils::check_dense_output(stepper, order);
@@ -99,6 +101,8 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Backwards",
       INFO(start_points);
       const double epsilon = std::max(std::pow(1e-3, start_points + 1), 1e-14);
       TimeStepperTestUtils::integrate_test(
+          TimeSteppers::AdamsBashforthN(order), start_points, -1., epsilon);
+      TimeStepperTestUtils::integrate_test_explicit_time_dependence(
           TimeSteppers::AdamsBashforthN(order), start_points, -1., epsilon);
     }
   }

--- a/tests/Unit/Time/TimeSteppers/Test_DormandPrince5.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_DormandPrince5.cpp
@@ -15,6 +15,8 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.DormandPrince5", "[Unit][Time]") {
   TimeStepperTestUtils::check_substep_properties(stepper);
   TimeStepperTestUtils::integrate_test(stepper, 0, 1.0, 1.0e-9);
   TimeStepperTestUtils::integrate_test(stepper, 0, -1.0, 1.0e-9);
+  TimeStepperTestUtils::integrate_test_explicit_time_dependence(stepper, 0,
+                                                                -1.0, 1.0e-9);
   TimeStepperTestUtils::integrate_variable_test(stepper, 0, 1.0e-9);
   TimeStepperTestUtils::check_convergence_order(stepper, 5);
   TimeStepperTestUtils::stability_test(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
@@ -15,6 +15,8 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3", "[Unit][Time]") {
   TimeStepperTestUtils::check_substep_properties(stepper);
   TimeStepperTestUtils::integrate_test(stepper, 0, 1., 1e-9);
   TimeStepperTestUtils::integrate_test(stepper, 0, -1., 1e-9);
+  TimeStepperTestUtils::integrate_test_explicit_time_dependence(stepper, 0,
+                                                                -1.0, 1.0e-9);
   TimeStepperTestUtils::integrate_variable_test(stepper, 0, 1e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, 3);

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta4.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta4.cpp
@@ -15,6 +15,8 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta4", "[Unit][Time]") {
   TimeStepperTestUtils::check_substep_properties(stepper);
   TimeStepperTestUtils::integrate_test(stepper, 0, 1.0, 1.0e-9);
   TimeStepperTestUtils::integrate_test(stepper, 0, -1.0, 1.0e-9);
+  TimeStepperTestUtils::integrate_test_explicit_time_dependence(stepper, 0,
+                                                                -1.0, 1.0e-9);
   TimeStepperTestUtils::integrate_variable_test(stepper, 0, 1.0e-9);
   TimeStepperTestUtils::check_convergence_order(stepper, 4);
   TimeStepperTestUtils::stability_test(stepper);


### PR DESCRIPTION
## Proposed changes

Adjust the math in the substep times for Dormand-Prince, and add a test that integrates a differential equation with explicit time dependence.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
