### PR TITLE
Adjust GaugeWave option bounds and remove defaults

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.cpp
@@ -11,7 +11,6 @@
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "ErrorHandling/Assert.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -41,13 +40,19 @@ DataType gauge_wave_deriv_h(const tnsr::I<DataType, Dim>& x, const double t,
 namespace gr {
 namespace Solutions {
 template <size_t Dim>
-GaugeWave<Dim>::GaugeWave(const double amplitude,
-                          const double wavelength) noexcept
+GaugeWave<Dim>::GaugeWave(const double amplitude, const double wavelength,
+                          const OptionContext& context)
     : amplitude_(amplitude), wavelength_(wavelength) {
-  ASSERT(amplitude > 0.0,
-         "Amplitude must be non-negative. Given amplitude: " << amplitude_);
-  ASSERT(wavelength > 0.0,
-         "Wavelength must be non-negative. Given wavelength: " << wavelength_);
+  if (abs(amplitude) >= 1.0) {
+    PARSE_ERROR(context,
+                "Amplitude must be less than one. Given amplitude: "
+                << amplitude_);
+  }
+  if (wavelength <= 0.0) {
+    PARSE_ERROR(context,
+                "Wavelength must be non-negative. Given wavelength: "
+                << wavelength_);
+  }
 }
 
 template <size_t Dim>

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.hpp
@@ -88,8 +88,8 @@ namespace Solutions {
  * \f}
  *
  * The following are input file options that can be specified:
- *  - Amplitude (default: 1.)
- *  - Wavelength (default: 1.)
+ *  - Amplitude
+ *  - Wavelength
  */
 template <size_t Dim>
 class GaugeWave : public MarkAsAnalyticSolution {
@@ -101,20 +101,20 @@ class GaugeWave : public MarkAsAnalyticSolution {
   struct Amplitude {
     using type = double;
     static constexpr OptionString help = {"Amplitude of the gauge wave"};
-    static type default_value() noexcept { return 1.; }
-    static type lower_bound() noexcept { return 0.; }
+    static type upper_bound() noexcept { return 1.; }
+    static type lower_bound() noexcept { return -1.; }
   };
   struct Wavelength {
     using type = double;
     static constexpr OptionString help = {"Wavelength of the gauge wave"};
-    static type default_value() noexcept { return 1.; }
     static type lower_bound() noexcept { return 0.; }
   };
 
   using options = tmpl::list<Amplitude, Wavelength>;
   static constexpr OptionString help{"Gauge wave in flat spacetime"};
 
-  GaugeWave(double amplitude, double wavelength) noexcept;
+  GaugeWave(double amplitude, double wavelength,
+            const OptionContext& context = {});
 
   GaugeWave() = default;
   GaugeWave(const GaugeWave& /*rhs*/) = default;

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_GaugeWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_GaugeWave.cpp
@@ -223,7 +223,7 @@ void test_gauge_wave(const gr::Solutions::GaugeWave<Dim>& solution,
 }
 
 void test_consistency() noexcept {
-  const gr::Solutions::GaugeWave<3> solution(1.3, 2.4);
+  const gr::Solutions::GaugeWave<3> solution(0.3, 2.4);
   TestHelpers::VerifyGrSolution::verify_consistency(
       solution, 1.234, tnsr::I<double, 3>{{{1.2, 2.3, 3.4}}}, 0.01, 1.0e-8);
 }
@@ -250,12 +250,6 @@ void test_construct_from_options() {
       "  Wavelength: 4.4");
   CHECK(opts.get<GaugeWaveOptionTag>() ==
         gr::Solutions::GaugeWave<3>(0.24, 4.4));
-
-  Options<tmpl::list<GaugeWaveOptionTag>> opts_default("");
-  opts_default.parse("GaugeWaveOptionTag:\n");
-  CHECK(opts_default.get<GaugeWaveOptionTag>() ==
-        gr::Solutions::GaugeWave<3>(1.0, 1.0));
-  test_gauge_wave(opts.get<GaugeWaveOptionTag>(), DataVector{5});
 }
 
 }  // namespace
@@ -288,39 +282,31 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.GaugeWave",
   test_construct_from_options();
 }
 
-// [[OutputRegex, Amplitude must be non-negative]]
+// [[OutputRegex, Amplitude must be less than one]]
 SPECTRE_TEST_CASE(
     "Unit.PointwiseFunctions.AnalyticSolutions.Gr.GaugeWaveAmplitude",
     "[PointwiseFunctions][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const gr::Solutions::GaugeWave<3> solution(-0.25, 1.0);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-  CHECK(true);
+  ERROR_TEST();
+  const gr::Solutions::GaugeWave<3> solution(-1.25, 1.0);
 }
 
 // [[OutputRegex, Wavelength must be non-negative]]
 SPECTRE_TEST_CASE(
     "Unit.PointwiseFunctions.AnalyticSolutions.Gr.GaugeWaveWavelength",
     "[PointwiseFunctions][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const gr::Solutions::GaugeWave<3> solution(1.0, -0.25);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-  CHECK(true);
+  ERROR_TEST();
+  const gr::Solutions::GaugeWave<3> solution(0.0, -0.25);
 }
 
-// [[OutputRegex, In string:.*At line 2 column 14:.Value -0.25 is below the
-// lower bound of 0]]
+// [[OutputRegex, In string:.*At line 2 column 14:.Value -1.25 is below the
+// lower bound of -1]]
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.GaugeWaveOptA",
                   "[PointwiseFunctions][Unit]") {
   ERROR_TEST();
   Options<tmpl::list<GaugeWaveOptionTag>> opts("");
   opts.parse(
       "GaugeWaveOptionTag:\n"
-      "  Amplitude: -0.25\n"
+      "  Amplitude: -1.25\n"
       "  Wavelength: 1.0");
   opts.get<GaugeWaveOptionTag>();
 }


### PR DESCRIPTION
The default amplitude produced a singular metric.  The code now checks
for that case.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
