### PR TITLE
Fix curved scalar wave upwind flux in develop

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.cpp
@@ -175,7 +175,19 @@ void ComputeNormalDotFluxes<Dim>::apply(
 
 template <size_t Dim>
 void UpwindFlux<Dim>::package_data(
-    const gsl::not_null<Variables<package_tags>*> packaged_data,
+    const gsl::not_null<Scalar<DataVector>*> packaged_pi,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        packaged_phi,
+    const gsl::not_null<Scalar<DataVector>*> packaged_psi,
+    const gsl::not_null<Scalar<DataVector>*> packaged_lapse,
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+        packaged_shift,
+    const gsl::not_null<tnsr::II<DataVector, Dim, Frame::Inertial>*>
+        packaged_inverse_spatial_metric,
+    const gsl::not_null<Scalar<DataVector>*> packaged_gamma1,
+    const gsl::not_null<Scalar<DataVector>*> packaged_gamma2,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        packaged_interface_unit_normal,
     const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
     const Scalar<DataVector>& psi, const Scalar<DataVector>& lapse,
@@ -184,19 +196,15 @@ void UpwindFlux<Dim>::package_data(
     const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
     const noexcept {
-  get<Psi>(*packaged_data) = psi;
-  get<Pi>(*packaged_data) = pi;
-  get<Phi<Dim>>(*packaged_data) = phi;
-  get<gr::Tags::Lapse<DataVector>>(*packaged_data) = lapse;
-  get<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>(*packaged_data) =
-      shift;
-  get<gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>(
-      *packaged_data) = inverse_spatial_metric;
-  get<Tags::ConstraintGamma1>(*packaged_data) = gamma1;
-  get<Tags::ConstraintGamma2>(*packaged_data) = gamma2;
-  get<::Tags::Normalized<
-      domain::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>(
-      *packaged_data) = interface_unit_normal;
+  *packaged_psi = psi;
+  *packaged_pi = pi;
+  *packaged_phi = phi;
+  *packaged_lapse = lapse;
+  *packaged_shift = shift;
+  *packaged_inverse_spatial_metric = inverse_spatial_metric;
+  *packaged_gamma1 = gamma1;
+  *packaged_gamma2 = gamma2;
+  *packaged_interface_unit_normal = interface_unit_normal;
 }
 
 template <size_t Dim>

--- a/src/Time/StepControllers/SimpleTimes.hpp
+++ b/src/Time/StepControllers/SimpleTimes.hpp
@@ -57,7 +57,7 @@ class SimpleTimes : public StepController {
     const double full_slab = time.slab().duration().value();
     const auto current_position = time.fraction().value();
     using Fraction = Time::rational_t;
-    Fraction step_end = simplest_fraction_in_interval<Fraction>(
+    auto step_end = simplest_fraction_in_interval<Fraction>(
         current_position + min_step / full_slab,
         current_position + desired_step / full_slab);
 

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_UpwindFlux.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_UpwindFlux.cpp
@@ -178,21 +178,16 @@ void test_upwind_flux_random() noexcept {
   // numerical flux reduces to the flux
   INFO("test consistency of the curved-scalar-wave upwind flux")
   CurvedScalarWave::UpwindFlux<Dim> flux_computer{};
-  auto packaged_data_int = make_with_value<
-      Variables<typename CurvedScalarWave::UpwindFlux<Dim>::package_tags>>(
-      used_for_size, std::numeric_limits<double>::signaling_NaN());
-  flux_computer.package_data(make_not_null(&packaged_data_int), pi_int, phi_int,
-                             psi_int, lapse_int, shift_int,
-                             inverse_spatial_metric_int, gamma_1, gamma_2,
-                             unit_normal_one_form_int);
+  auto packaged_data_int = ::TestHelpers::NumericalFluxes::get_packaged_data(
+      flux_computer, used_for_size, pi_int, phi_int, psi_int, lapse_int,
+      shift_int, inverse_spatial_metric_int, gamma_1, gamma_2,
+      unit_normal_one_form_int);
 
-  auto packaged_data_int_opposite_normal = make_with_value<
-      Variables<typename CurvedScalarWave::UpwindFlux<Dim>::package_tags>>(
-      used_for_size, std::numeric_limits<double>::signaling_NaN());
-  flux_computer.package_data(make_not_null(&packaged_data_int_opposite_normal),
-                             pi_int, phi_int, psi_int, lapse_int, shift_int,
-                             inverse_spatial_metric_int, gamma_1, gamma_2,
-                             minus_unit_normal_one_form_int);
+  auto packaged_data_int_opposite_normal =
+      ::TestHelpers::NumericalFluxes::get_packaged_data(
+          flux_computer, used_for_size, pi_int, phi_int, psi_int, lapse_int,
+          shift_int, inverse_spatial_metric_int, gamma_1, gamma_2,
+          minus_unit_normal_one_form_int);
 
   auto psi_normal_dot_numerical_flux = make_with_value<
       db::item_type<::Tags::NormalDotNumericalFlux<CurvedScalarWave::Psi>>>(
@@ -203,7 +198,7 @@ void test_upwind_flux_random() noexcept {
   auto phi_normal_dot_numerical_flux = make_with_value<db::item_type<
       ::Tags::NormalDotNumericalFlux<CurvedScalarWave::Phi<Dim>>>>(
       used_for_size, std::numeric_limits<double>::signaling_NaN());
-  ::TestHelpers::NumericalFluxes::apply_numerical_flux(
+  dg::NumericalFluxes::normal_dot_numerical_fluxes(
       flux_computer, packaged_data_int, packaged_data_int_opposite_normal,
       make_not_null(&pi_normal_dot_numerical_flux),
       make_not_null(&phi_normal_dot_numerical_flux),


### PR DESCRIPTION
## Proposed changes

- fix upwind flux
- fix clang-tidy warning in `SimpleTimes.hpp`

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
