### PR TITLE
Add not_null determinant and inverse, remove unused includes in type traits

### DIFF
--- a/src/Utilities/TypeTraits/CanBeCopyConstructed.hpp
+++ b/src/Utilities/TypeTraits/CanBeCopyConstructed.hpp
@@ -5,8 +5,6 @@
 
 #include <type_traits>
 
-#include "Utilities/TypeTraits.hpp"
-
 namespace tt {
 // @{
 /*!

--- a/src/Utilities/TypeTraits/CreateHasStaticMemberVariable.hpp
+++ b/src/Utilities/TypeTraits/CreateHasStaticMemberVariable.hpp
@@ -6,7 +6,6 @@
 #include <type_traits>
 
 #include "Utilities/NoSuchType.hpp"
-#include "Utilities/TypeTraits.hpp"
 
 // @{
 /*!

--- a/src/Utilities/TypeTraits/CreateHasTypeAlias.hpp
+++ b/src/Utilities/TypeTraits/CreateHasTypeAlias.hpp
@@ -6,7 +6,6 @@
 #include <type_traits>
 
 #include "Utilities/NoSuchType.hpp"
-#include "Utilities/TypeTraits.hpp"
 
 // @{
 /*!

--- a/src/Utilities/TypeTraits/CreateIsCallable.hpp
+++ b/src/Utilities/TypeTraits/CreateIsCallable.hpp
@@ -5,8 +5,6 @@
 
 #include <type_traits>
 
-#include "Utilities/TypeTraits.hpp"
-
 /*!
  * \ingroup TypeTraitsGroup
  * \brief Generate a type trait to check if a class has a member function that

--- a/src/Utilities/TypeTraits/GetFundamentalType.hpp
+++ b/src/Utilities/TypeTraits/GetFundamentalType.hpp
@@ -7,7 +7,6 @@
 
 #include "Utilities/NoSuchType.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TypeTraits.hpp"
 
 namespace tt {
 // @{

--- a/src/Utilities/TypeTraits/HasEquivalence.hpp
+++ b/src/Utilities/TypeTraits/HasEquivalence.hpp
@@ -5,8 +5,6 @@
 
 #include <type_traits>
 
-#include "Utilities/TypeTraits.hpp"
-
 namespace tt {
 // @{
 /// \ingroup TypeTraitsGroup

--- a/src/Utilities/TypeTraits/HasInequivalence.hpp
+++ b/src/Utilities/TypeTraits/HasInequivalence.hpp
@@ -5,8 +5,6 @@
 
 #include <type_traits>
 
-#include "Utilities/TypeTraits.hpp"
-
 namespace tt {
 // @{
 /// \ingroup TypeTraitsGroup

--- a/src/Utilities/TypeTraits/IsCallable.hpp
+++ b/src/Utilities/TypeTraits/IsCallable.hpp
@@ -5,8 +5,6 @@
 
 #include <type_traits>
 
-#include "Utilities/TypeTraits.hpp"
-
 namespace tt {
 // @{
 /// \ingroup TypeTraitsGroup

--- a/src/Utilities/TypeTraits/IsComplexOfFundamental.hpp
+++ b/src/Utilities/TypeTraits/IsComplexOfFundamental.hpp
@@ -6,8 +6,6 @@
 #include <complex>
 #include <type_traits>
 
-#include "Utilities/TypeTraits.hpp"
-
 namespace tt {
 // @{
 /// \ingroup TypeTraitsGroup

--- a/src/Utilities/TypeTraits/IsIterable.hpp
+++ b/src/Utilities/TypeTraits/IsIterable.hpp
@@ -5,8 +5,6 @@
 
 #include <type_traits>
 
-#include "Utilities/TypeTraits.hpp"
-
 namespace tt {
 // @{
 /// \ingroup TypeTraitsGroup

--- a/src/Utilities/TypeTraits/IsMaplike.hpp
+++ b/src/Utilities/TypeTraits/IsMaplike.hpp
@@ -6,7 +6,6 @@
 #include <type_traits>
 
 #include "Utilities/Requires.hpp"
-#include "Utilities/TypeTraits.hpp"
 #include "Utilities/TypeTraits/IsIterable.hpp"
 
 namespace tt {

--- a/src/Utilities/TypeTraits/IsStreamable.hpp
+++ b/src/Utilities/TypeTraits/IsStreamable.hpp
@@ -7,7 +7,6 @@
 
 #include "Utilities/Requires.hpp"
 #include "Utilities/StlStreamDeclarations.hpp"
-#include "Utilities/TypeTraits.hpp"
 
 namespace tt {
 // @{


### PR DESCRIPTION
## Proposed changes

- Remove some unused `include "Utilities/TypeTraits.hpp"` from `Utilities/TypeTraits/*hpp`
- Add `gsl::not_null` overloads of `determinant_and_inverse`

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
