### PR TITLE
Add function to compute spacetime derivative of spacetime metric

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -240,6 +240,24 @@ tnsr::aa<DataType, SpatialDim, Frame> time_derivative_of_spacetime_metric(
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
 //@}
 
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the spacetime derivative of the spacetime metric,
+ * \f$\partial_a g_{bc}\f$
+ *
+ * \f{align*}{
+ * \partial_t g_{ab}&=-\alpha \Pi_{ab} + \beta^i \Phi_{iab} \\
+ * \partial_i g_{ab}&=\Phi_{iab}
+ * \f}
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_derivative_of_spacetime_metric(
+    gsl::not_null<tnsr::abb<DataType, SpatialDim, Frame>*> da_spacetime_metric,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+
 // @{
 /*!
  * \ingroup GeneralRelativityGroup


### PR DESCRIPTION
## Proposed changes

Add a function to compute the spacetime derivative of the spacetime metric from
the lapse, shift, Pi_{ab}, and Phi_{iab}. So far the GH code has done this by computing all the 3+1 items, and then reassembling the spacetime derivative...

Note that the vast majority of the diff is clang-format change up a macro...

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
