### PR TITLE
Only add 4 index constraint in 3d to GH, fix CMake formatting, add missing link dep

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -2,24 +2,24 @@
 # See LICENSE.txt for details.
 
 set(LIBS_TO_LINK
-    ApparentHorizons
-    CoordinateMaps
-    DiscontinuousGalerkin
-    Domain
-    DomainCreators
-    Evolution
-    GeneralRelativity
-    GeneralRelativitySolutions
-    GeneralizedHarmonic
-    GeneralizedHarmonicGaugeSourceFunctions
-    IO
-    Informer
-    Interpolation
-    LinearOperators
-    MathFunctions
-    Options
-    Time
-    Utilities
+  ApparentHorizons
+  CoordinateMaps
+  DiscontinuousGalerkin
+  Domain
+  DomainCreators
+  Evolution
+  GeneralRelativity
+  GeneralRelativitySolutions
+  GeneralizedHarmonic
+  GeneralizedHarmonicGaugeSourceFunctions
+  IO
+  Informer
+  Interpolation
+  LinearOperators
+  MathFunctions
+  Options
+  Time
+  Utilities
   )
 
 add_spectre_parallel_executable(
@@ -28,4 +28,4 @@ add_spectre_parallel_executable(
   Evolution/Executables/GeneralizedHarmonic
   EvolutionMetavars
   "${LIBS_TO_LINK}"
-)
+  )

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -156,14 +156,17 @@ struct EvolutionMetavars {
   using analytic_solution_fields =
       db::get_variables_tags_list<typename system::variables_tag>;
   using observe_fields = tmpl::append<
-      analytic_solution_fields,
-      tmpl::list<
+      tmpl::push_back<
+          analytic_solution_fields,
           ::Tags::PointwiseL2Norm<
               GeneralizedHarmonic::Tags::GaugeConstraint<volume_dim, frame>>,
           ::Tags::PointwiseL2Norm<GeneralizedHarmonic::Tags::
-                                      ThreeIndexConstraint<volume_dim, frame>>,
-          ::Tags::PointwiseL2Norm<GeneralizedHarmonic::Tags::
-                                      FourIndexConstraint<volume_dim, frame>>>>;
+                                      ThreeIndexConstraint<volume_dim, frame>>>,
+      tmpl::conditional_t<volume_dim == 3,
+                          tmpl::list<::Tags::PointwiseL2Norm<
+                              GeneralizedHarmonic::Tags::FourIndexConstraint<
+                                  volume_dim, frame>>>,
+                          tmpl::list<>>>;
 
   // HACK until we merge in a compute tag StrahlkorperGr::AreaCompute.
   // For now, simply do a surface integral of unity on the horizon to get the

--- a/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -18,5 +18,6 @@ target_link_libraries(
   PUBLIC
   DataStructures
   ErrorHandling
+  GeneralRelativity
   Options
   )

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -54,16 +54,22 @@ struct InitializeConstraints {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using compute_tags = db::AddComputeTags<
+    using compute_tags = tmpl::flatten<db::AddComputeTags<
         GeneralizedHarmonic::Tags::GaugeConstraintCompute<Dim, frame>,
-        GeneralizedHarmonic::Tags::FourIndexConstraintCompute<Dim, frame>,
         // following tags added to observe constraints
         ::Tags::PointwiseL2NormCompute<
             GeneralizedHarmonic::Tags::GaugeConstraint<Dim, frame>>,
         ::Tags::PointwiseL2NormCompute<
             GeneralizedHarmonic::Tags::ThreeIndexConstraint<Dim, frame>>,
-        ::Tags::PointwiseL2NormCompute<
-            GeneralizedHarmonic::Tags::FourIndexConstraint<Dim, frame>>>;
+        // The 4-index constraint is only implemented in 3d
+        tmpl::conditional_t<
+            Dim == 3,
+            tmpl::list<GeneralizedHarmonic::Tags::FourIndexConstraintCompute<
+                           Dim, frame>,
+                       ::Tags::PointwiseL2NormCompute<
+                           GeneralizedHarmonic::Tags::FourIndexConstraint<
+                               Dim, frame>>>,
+            tmpl::list<>>>>;
 
     return std::make_tuple(
         Initialization::merge_into_databox<InitializeConstraints,


### PR DESCRIPTION
## Proposed changes

- The 4 index constraint is only available in 3d, so only add it to the 3d GH executables
- The formatting of the CMake file for GH exec is corrected
- Add missing link dependency for GH library

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
