### PR TITLE
Rename GH char speeds, minor simple optimizations in GH DuDt

### DIFF
--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -1013,6 +1013,15 @@ template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
 using Tempiaa = TempTensor<N, tnsr::iaa<DataType, SpatialDim, Fr>>;
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
           typename DataType = DataVector>
+using TempIaa = TempTensor<N, tnsr::Iaa<DataType, SpatialDim, Fr>>;
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+          typename DataType = DataVector>
+using TempiaB = TempTensor<N, tnsr::iaB<DataType, SpatialDim, Fr>>;
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+          typename DataType = DataVector>
 using Tempabb = TempTensor<N, tnsr::abb<DataType, SpatialDim, Fr>>;
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+          typename DataType = DataVector>
+using TempabC = TempTensor<N, tnsr::abC<DataType, SpatialDim, Fr>>;
 // @}
 }  // namespace Tags

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
@@ -27,10 +27,11 @@ void characteristic_speeds(
     const tnsr::I<DataVector, Dim, Frame>& shift,
     const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept {
   const auto shift_dot_normal = get(dot_product(shift, unit_normal_one_form));
-  (*char_speeds)[0] = -(1. + get(gamma_1)) * shift_dot_normal;  // v(UPsi)
-  (*char_speeds)[1] = -shift_dot_normal;                        // v(UZero)
-  (*char_speeds)[2] = -shift_dot_normal + get(lapse);           // v(UPlus)
-  (*char_speeds)[3] = -shift_dot_normal - get(lapse);           // v(UMinus)
+  (*char_speeds)[0] =
+      -(1. + get(gamma_1)) * shift_dot_normal;  // lambda(VSpacetimeMetric)
+  (*char_speeds)[1] = -shift_dot_normal;        // lambda(VZero)
+  (*char_speeds)[2] = -shift_dot_normal + get(lapse);  // lambda(VPlus)
+  (*char_speeds)[3] = -shift_dot_normal - get(lapse);  // lambda(VMinus)
 }
 
 template <size_t Dim, typename Frame>
@@ -75,7 +76,7 @@ void characteristic_fields(
   for (size_t i = 0; i < Dim; ++i) {
     for (size_t a = 0; a < Dim + 1; ++a) {
       for (size_t b = 0; b < a + 1; ++b) {
-        get<Tags::UZero<Dim, Frame>>(*char_fields).get(i, a, b) =
+        get<Tags::VZero<Dim, Frame>>(*char_fields).get(i, a, b) =
             phi.get(i, a, b) -
             unit_normal_one_form.get(i) * phi_dot_normal.get(a, b);
       }
@@ -83,15 +84,15 @@ void characteristic_fields(
   }
 
   // Eq.(32) of Lindblom+ (2005)
-  get<Tags::UPsi<Dim, Frame>>(*char_fields) = spacetime_metric;
+  get<Tags::VSpacetimeMetric<Dim, Frame>>(*char_fields) = spacetime_metric;
 
   for (size_t a = 0; a < Dim + 1; ++a) {
     for (size_t b = 0; b < a + 1; ++b) {
       // Eq.(33) of Lindblom+ (2005)
-      get<Tags::UPlus<Dim, Frame>>(*char_fields).get(a, b) =
+      get<Tags::VPlus<Dim, Frame>>(*char_fields).get(a, b) =
           pi.get(a, b) + phi_dot_normal.get(a, b) -
           get(gamma_2) * spacetime_metric.get(a, b);
-      get<Tags::UMinus<Dim, Frame>>(*char_fields).get(a, b) =
+      get<Tags::VMinus<Dim, Frame>>(*char_fields).get(a, b) =
           pi.get(a, b) - phi_dot_normal.get(a, b) -
           get(gamma_2) * spacetime_metric.get(a, b);
     }

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -220,8 +220,9 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
   using base = Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>;
   using type = typename base::type;
   using argument_tags = tmpl::list<
-      Tags::ConstraintGamma2, Tags::UPsi<Dim, Frame>, Tags::UZero<Dim, Frame>,
-      Tags::UPlus<Dim, Frame>, Tags::UMinus<Dim, Frame>,
+      Tags::ConstraintGamma2, Tags::VSpacetimeMetric<Dim, Frame>,
+      Tags::VZero<Dim, Frame>, Tags::VPlus<Dim, Frame>,
+      Tags::VMinus<Dim, Frame>,
       ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
 
   static typename Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>::type

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
@@ -61,13 +61,13 @@ weight_char_fields(
     const db::const_item_type<Tags::CharacteristicSpeeds<Dim, Frame::Inertial>>&
         char_speeds_ext) noexcept {
   const auto& u_psi_int =
-      get<Tags::UPsi<Dim, Frame::Inertial>>(char_fields_int);
+      get<Tags::VSpacetimeMetric<Dim, Frame::Inertial>>(char_fields_int);
   const auto& u_zero_int =
-      get<Tags::UZero<Dim, Frame::Inertial>>(char_fields_int);
+      get<Tags::VZero<Dim, Frame::Inertial>>(char_fields_int);
   const auto& u_plus_int =
-      get<Tags::UPlus<Dim, Frame::Inertial>>(char_fields_int);
+      get<Tags::VPlus<Dim, Frame::Inertial>>(char_fields_int);
   const auto& u_minus_int =
-      get<Tags::UMinus<Dim, Frame::Inertial>>(char_fields_int);
+      get<Tags::VMinus<Dim, Frame::Inertial>>(char_fields_int);
 
   const DataVector& char_speed_u_psi_int{char_speeds_int[0]};
   const DataVector& char_speed_u_zero_int{char_speeds_int[1]};
@@ -75,13 +75,13 @@ weight_char_fields(
   const DataVector& char_speed_u_minus_int{char_speeds_int[3]};
 
   const auto& u_psi_ext =
-      get<Tags::UPsi<Dim, Frame::Inertial>>(char_fields_ext);
+      get<Tags::VSpacetimeMetric<Dim, Frame::Inertial>>(char_fields_ext);
   const auto& u_zero_ext =
-      get<Tags::UZero<Dim, Frame::Inertial>>(char_fields_ext);
+      get<Tags::VZero<Dim, Frame::Inertial>>(char_fields_ext);
   const auto& u_plus_ext =
-      get<Tags::UPlus<Dim, Frame::Inertial>>(char_fields_ext);
+      get<Tags::VPlus<Dim, Frame::Inertial>>(char_fields_ext);
   const auto& u_minus_ext =
-      get<Tags::UMinus<Dim, Frame::Inertial>>(char_fields_ext);
+      get<Tags::VMinus<Dim, Frame::Inertial>>(char_fields_ext);
 
   const DataVector& char_speed_u_psi_ext{char_speeds_ext[0]};
   const DataVector& char_speed_u_zero_ext{char_speeds_ext[1]};
@@ -92,18 +92,19 @@ weight_char_fields(
       db::const_item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>>(
       char_speed_u_psi_int, 0.0);
 
-  get<Tags::UPsi<Dim, Frame::Inertial>>(weighted_char_fields) =
-      weight_char_field<GeneralizedHarmonic::Tags::UPsi<Dim, Frame::Inertial>>(
-          u_psi_int, char_speed_u_psi_int, u_psi_ext, char_speed_u_psi_ext);
-  get<Tags::UZero<Dim, Frame::Inertial>>(weighted_char_fields) =
-      weight_char_field<GeneralizedHarmonic::Tags::UZero<Dim, Frame::Inertial>>(
-          u_zero_int, char_speed_u_zero_int, u_zero_ext, char_speed_u_zero_ext);
-  get<Tags::UPlus<Dim, Frame::Inertial>>(weighted_char_fields) =
-      weight_char_field<GeneralizedHarmonic::Tags::UPlus<Dim, Frame::Inertial>>(
-          u_plus_int, char_speed_u_plus_int, u_plus_ext, char_speed_u_plus_ext);
-  get<Tags::UMinus<Dim, Frame::Inertial>>(weighted_char_fields) =
+  get<Tags::VSpacetimeMetric<Dim, Frame::Inertial>>(weighted_char_fields) =
       weight_char_field<
-          GeneralizedHarmonic::Tags::UMinus<Dim, Frame::Inertial>>(
+          GeneralizedHarmonic::Tags::VSpacetimeMetric<Dim, Frame::Inertial>>(
+          u_psi_int, char_speed_u_psi_int, u_psi_ext, char_speed_u_psi_ext);
+  get<Tags::VZero<Dim, Frame::Inertial>>(weighted_char_fields) =
+      weight_char_field<GeneralizedHarmonic::Tags::VZero<Dim, Frame::Inertial>>(
+          u_zero_int, char_speed_u_zero_int, u_zero_ext, char_speed_u_zero_ext);
+  get<Tags::VPlus<Dim, Frame::Inertial>>(weighted_char_fields) =
+      weight_char_field<GeneralizedHarmonic::Tags::VPlus<Dim, Frame::Inertial>>(
+          u_plus_int, char_speed_u_plus_int, u_plus_ext, char_speed_u_plus_ext);
+  get<Tags::VMinus<Dim, Frame::Inertial>>(weighted_char_fields) =
+      weight_char_field<
+          GeneralizedHarmonic::Tags::VMinus<Dim, Frame::Inertial>>(
           u_minus_int, char_speed_u_minus_int, u_minus_ext,
           char_speed_u_minus_ext);
 
@@ -491,10 +492,11 @@ void UpwindFlux<Dim>::operator()(
   const auto weighted_evolved_fields =
       evolved_fields_from_characteristic_fields(
           gamma2_avg,
-          get<Tags::UPsi<Dim, Frame::Inertial>>(weighted_char_fields),
-          get<Tags::UZero<Dim, Frame::Inertial>>(weighted_char_fields),
-          get<Tags::UPlus<Dim, Frame::Inertial>>(weighted_char_fields),
-          get<Tags::UMinus<Dim, Frame::Inertial>>(weighted_char_fields),
+          get<Tags::VSpacetimeMetric<Dim, Frame::Inertial>>(
+              weighted_char_fields),
+          get<Tags::VZero<Dim, Frame::Inertial>>(weighted_char_fields),
+          get<Tags::VPlus<Dim, Frame::Inertial>>(weighted_char_fields),
+          get<Tags::VMinus<Dim, Frame::Inertial>>(weighted_char_fields),
           interface_unit_normal_int);
 
   *psi_normal_dot_numerical_flux =

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -177,19 +177,19 @@ struct SpacetimeDerivInitialGaugeH : db::SimpleTag {
 /// \details For details on how these are defined and computed, see
 /// CharacteristicSpeedsCompute
 template <size_t Dim, typename Frame>
-struct UPsi : db::SimpleTag {
+struct VSpacetimeMetric : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame>;
 };
 template <size_t Dim, typename Frame>
-struct UZero : db::SimpleTag {
+struct VZero : db::SimpleTag {
   using type = tnsr::iaa<DataVector, Dim, Frame>;
 };
 template <size_t Dim, typename Frame>
-struct UPlus : db::SimpleTag {
+struct VPlus : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame>;
 };
 template <size_t Dim, typename Frame>
-struct UMinus : db::SimpleTag {
+struct VMinus : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame>;
 };
 // @}
@@ -201,8 +201,9 @@ struct CharacteristicSpeeds : db::SimpleTag {
 
 template <size_t Dim, typename Frame>
 struct CharacteristicFields : db::SimpleTag {
-  using type = Variables<tmpl::list<UPsi<Dim, Frame>, UZero<Dim, Frame>,
-                                    UPlus<Dim, Frame>, UMinus<Dim, Frame>>>;
+  using type =
+      Variables<tmpl::list<VSpacetimeMetric<Dim, Frame>, VZero<Dim, Frame>,
+                           VPlus<Dim, Frame>, VMinus<Dim, Frame>>>;
 };
 
 template <size_t Dim, typename Frame>

--- a/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
@@ -33,13 +33,13 @@ template <size_t Dim, typename Frame = Frame::Inertial>
 struct SpacetimeDerivGaugeH;
 
 template <size_t Dim, typename Frame>
-struct UPsi;
+struct VSpacetimeMetric;
 template <size_t Dim, typename Frame>
-struct UZero;
+struct VZero;
 template <size_t Dim, typename Frame>
-struct UPlus;
+struct VPlus;
 template <size_t Dim, typename Frame>
-struct UMinus;
+struct VMinus;
 
 template <size_t Dim, typename Frame>
 struct CharacteristicSpeeds;

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -47,10 +47,10 @@
 
 // IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::Pi
 // IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::Phi
-// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UPsi
-// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UZero
-// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UMinus
-// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UPlus
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::VSpacetimeMetric
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::VZero
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::VMinus
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::VPlus
 // IWYU pragma: no_forward_declare Tags::dt
 // IWYU pragma: no_forward_declare Tensor
 // IWYU pragma: no_forward_declare Variables
@@ -178,29 +178,30 @@ void test_characteristic_fields() noexcept {
       GeneralizedHarmonic::CharacteristicFieldsCompute<Dim, Frame>>(
       "CharacteristicFields");
   const DataVector used_for_size(20);
-  // UPsi
+  // VSpacetimeMetric
   pypp::check_with_random_values<1>(
-      field_with_tag<GeneralizedHarmonic::Tags::UPsi<Dim, Frame>, Dim, Frame>,
+      field_with_tag<GeneralizedHarmonic::Tags::VSpacetimeMetric<Dim, Frame>,
+                     Dim, Frame>,
       "TestFunctions", "char_field_upsi", {{{-100., 100.}}}, used_for_size);
-  // UZero
+  // VZero
   pypp::check_with_random_values<1>(
-      field_with_tag<GeneralizedHarmonic::Tags::UZero<Dim, Frame>, Dim, Frame>,
+      field_with_tag<GeneralizedHarmonic::Tags::VZero<Dim, Frame>, Dim, Frame>,
       "TestFunctions", "char_field_uzero", {{{-100., 100.}}}, used_for_size,
       1.e-9);  // last argument loosens tolerance from
                // default of 1.0e-12 to avoid occasional
                // failures of this test, suspected from
                // accumulated roundoff error
-  // UPlus
+  // VPlus
   pypp::check_with_random_values<1>(
-      field_with_tag<GeneralizedHarmonic::Tags::UPlus<Dim, Frame>, Dim, Frame>,
+      field_with_tag<GeneralizedHarmonic::Tags::VPlus<Dim, Frame>, Dim, Frame>,
       "TestFunctions", "char_field_uplus", {{{-100., 100.}}}, used_for_size,
       1.e-10);  // last argument loosens tolerance from
                 // default of 1.0e-12 to avoid occasional
                 // failures of this test, suspected from
                 // accumulated roundoff error
-  // UMinus
+  // VMinus
   pypp::check_with_random_values<1>(
-      field_with_tag<GeneralizedHarmonic::Tags::UMinus<Dim, Frame>, Dim, Frame>,
+      field_with_tag<GeneralizedHarmonic::Tags::VMinus<Dim, Frame>, Dim, Frame>,
       "TestFunctions", "char_field_uminus", {{{-100., 100.}}}, used_for_size,
       1.e-10);  // last argument loosens tolerance from
                 // default of 1.0e-12 to avoid occasional
@@ -323,15 +324,16 @@ void test_characteristic_fields_analytic(
                                               unit_normal_one_form);
 
   const auto& upsi_from_func =
-      get<GeneralizedHarmonic::Tags::UPsi<spatial_dim, Frame::Inertial>>(uvars);
+      get<GeneralizedHarmonic::Tags::VSpacetimeMetric<spatial_dim,
+                                                      Frame::Inertial>>(uvars);
   const auto& uzero_from_func =
-      get<GeneralizedHarmonic::Tags::UZero<spatial_dim, Frame::Inertial>>(
+      get<GeneralizedHarmonic::Tags::VZero<spatial_dim, Frame::Inertial>>(
           uvars);
   const auto& uplus_from_func =
-      get<GeneralizedHarmonic::Tags::UPlus<spatial_dim, Frame::Inertial>>(
+      get<GeneralizedHarmonic::Tags::VPlus<spatial_dim, Frame::Inertial>>(
           uvars);
   const auto& uminus_from_func =
-      get<GeneralizedHarmonic::Tags::UMinus<spatial_dim, Frame::Inertial>>(
+      get<GeneralizedHarmonic::Tags::VMinus<spatial_dim, Frame::Inertial>>(
           uvars);
 
   CHECK_ITERABLE_APPROX(upsi, upsi_from_func);

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Tags.cpp
@@ -35,14 +35,15 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<
       GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<Dim, Frame>>(
       "SpacetimeDerivInitialGaugeH");
-  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::UPsi<Dim, Frame>>(
-      "UPsi");
   TestHelpers::db::test_simple_tag<
-      GeneralizedHarmonic::Tags::UZero<Dim, Frame>>("UZero");
+      GeneralizedHarmonic::Tags::VSpacetimeMetric<Dim, Frame>>(
+      "VSpacetimeMetric");
   TestHelpers::db::test_simple_tag<
-      GeneralizedHarmonic::Tags::UPlus<Dim, Frame>>("UPlus");
+      GeneralizedHarmonic::Tags::VZero<Dim, Frame>>("VZero");
   TestHelpers::db::test_simple_tag<
-      GeneralizedHarmonic::Tags::UMinus<Dim, Frame>>("UMinus");
+      GeneralizedHarmonic::Tags::VPlus<Dim, Frame>>("VPlus");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::VMinus<Dim, Frame>>("VMinus");
   TestHelpers::db::test_simple_tag<
       GeneralizedHarmonic::Tags::CharacteristicSpeeds<Dim, Frame>>(
       "CharacteristicSpeeds");

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_UpwindFlux.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_UpwindFlux.cpp
@@ -33,10 +33,10 @@
 
 // IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::Pi
 // IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::Phi
-// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UPsi
-// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UZero
-// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UMinus
-// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UPlus
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::VSpacetimeMetric
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::VZero
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::VMinus
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::VPlus
 // IWYU pragma: no_forward_declare Tags::CharSpeed
 // IWYU pragma: no_forward_declare Tags::dt
 // IWYU pragma: no_forward_declare Tensor


### PR DESCRIPTION
## Proposed changes

- Rename GH char speeds from `u` -> `v` in the code
- Add some more temp tags to `Variables.hpp`
- Group together allocations in `ComputeDuDt` for GH
- Avoid zero-initialization in `ComputeDuDt` for GH
- Avoid recomputing storage index in some common cases for `ComputeDuDt` for GH

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
