### PR TITLE
Update Wheeler environment to Blaze 3.5

### DIFF
--- a/support/Environments/wheeler_clang.sh
+++ b/support/Environments/wheeler_clang.sh
@@ -9,7 +9,7 @@ spectre_setup_modules() {
 
 spectre_unload_modules() {
     module unload gcc/7.3.0
-    module unload blaze/3.2
+    module unload blaze/3.5
     module unload boost/1.65.0-gcc-6.4.0
     module unload brigand/master
     module unload catch/2.1.2
@@ -31,7 +31,7 @@ spectre_unload_modules() {
 
 spectre_load_modules() {
     module load gcc/7.3.0
-    module load blaze/3.2
+    module load blaze/3.5
     module load boost/1.65.0-gcc-6.4.0
     module load brigand/master
     module load catch/2.1.2

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -9,7 +9,7 @@ spectre_setup_modules() {
 
 spectre_unload_modules() {
     module unload gcc/7.3.0
-    module unload blaze/3.2
+    module unload blaze/3.5
     module unload boost/1.65.0-gcc-6.4.0
     module unload brigand/master
     module unload catch/2.1.2
@@ -31,7 +31,7 @@ spectre_unload_modules() {
 
 spectre_load_modules() {
     module load gcc/7.3.0
-    module load blaze/3.2
+    module load blaze/3.5
     module load boost/1.65.0-gcc-6.4.0
     module load brigand/master
     module load catch/2.1.2


### PR DESCRIPTION
## Proposed changes

Updates the Wheeler environment to use the (already existing) `blaze/3.5` module, restoring compatibility with current `develop`.

This goes towards fixing #2201 

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

