### PR TITLE
Update scalar wave char tags to work with moving mesh

### DIFF
--- a/src/Evolution/Executables/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarWave/CMakeLists.txt
@@ -2,19 +2,19 @@
 # See LICENSE.txt for details.
 
 set(LIBS_TO_LINK
-    CoordinateMaps
-    DiscontinuousGalerkin
-    DomainCreators
-    Evolution
-    IO
-    Informer
-    LinearOperators
-    MathFunctions
-    ScalarWave
-    Time
-    Options
-    Utilities
-    WaveEquation
+  CoordinateMaps
+  DiscontinuousGalerkin
+  DomainCreators
+  Evolution
+  IO
+  Informer
+  LinearOperators
+  MathFunctions
+  ScalarWave
+  Time
+  Options
+  Utilities
+  WaveEquation
   )
 
 function(add_scalar_wave_executable EXECUTABLE_NAME DIM INITIAL_DATA)

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -201,7 +201,7 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
-      evolution::dg::Initialization::Domain<system::volume_dim>,
+      evolution::dg::Initialization::Domain<volume_dim>,
       Initialization::Actions::NonconservativeSystem,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
       ScalarWave::Actions::InitializeConstraints<volume_dim>,

--- a/src/Evolution/Systems/ScalarWave/Characteristics.cpp
+++ b/src/Evolution/Systems/ScalarWave/Characteristics.cpp
@@ -17,8 +17,10 @@ namespace ScalarWave {
 template <size_t Dim>
 void characteristic_speeds(
     const gsl::not_null<std::array<DataVector, 4>*> char_speeds,
-    const tnsr::i<DataVector, Dim,
-                  Frame::Inertial>& /*unit_normal_one_form*/) noexcept {
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        unit_normal_one_form) noexcept {
+  destructive_resize_components(char_speeds,
+                                get<0>(unit_normal_one_form).size());
   (*char_speeds)[0] = 0.;   // v(VPsi)
   (*char_speeds)[1] = 0.;   // v(VZero)
   (*char_speeds)[2] = 1.;   // v(VPlus)
@@ -45,6 +47,9 @@ void characteristic_fields(
     const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>&
         unit_normal_one_form) noexcept {
+  if (UNLIKELY(char_fields->number_of_grid_points() != get(psi).size())) {
+    char_fields->initialize(get(psi).size());
+  }
   // Compute phi_dot_normal = n^i \Phi_{i} = \sum_i n_i \Phi_{i}
   // (we use normal_one_form and normal_vector interchangeably in flat space)
   const auto phi_dot_normal = dot_product(unit_normal_one_form, phi);
@@ -89,6 +94,9 @@ void evolved_fields_from_characteristic_fields(
     const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
     const tnsr::i<DataVector, Dim, Frame::Inertial>&
         unit_normal_one_form) noexcept {
+  if (UNLIKELY(evolved_fields->number_of_grid_points() != get(v_psi).size())) {
+    evolved_fields->initialize(get(v_psi).size());
+  }
   // Eq.(36) of Holst+ (2004) for Psi
   get<Psi>(*evolved_fields) = v_psi;
 

--- a/src/Evolution/Systems/ScalarWave/Characteristics.cpp
+++ b/src/Evolution/Systems/ScalarWave/Characteristics.cpp
@@ -137,7 +137,7 @@ evolved_fields_from_characteristic_fields(
   template std::array<DataVector, 4> ScalarWave::characteristic_speeds(        \
       const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
           unit_normal_one_form) noexcept;                                      \
-  template struct ScalarWave::CharacteristicSpeedsCompute<DIM(data)>;          \
+  template struct ScalarWave::Tags::CharacteristicSpeedsCompute<DIM(data)>;    \
   template void ScalarWave::characteristic_fields(                             \
       const gsl::not_null<Variables<tmpl::list<                                \
           ScalarWave::Tags::VPsi, ScalarWave::Tags::VZero<DIM(data)>,          \
@@ -157,7 +157,7 @@ evolved_fields_from_characteristic_fields(
       const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi,              \
       const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
           unit_normal_one_form) noexcept;                                      \
-  template struct ScalarWave::CharacteristicFieldsCompute<DIM(data)>;          \
+  template struct ScalarWave::Tags::CharacteristicFieldsCompute<DIM(data)>;    \
   template void ScalarWave::evolved_fields_from_characteristic_fields(         \
       const gsl::not_null<Variables<tmpl::list<                                \
           ScalarWave::Psi, ScalarWave::Pi, ScalarWave::Phi<DIM(data)>>>*>      \
@@ -175,8 +175,8 @@ evolved_fields_from_characteristic_fields(
       const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,     \
       const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
           unit_normal_one_form) noexcept;                                      \
-  template struct ScalarWave::EvolvedFieldsFromCharacteristicFieldsCompute<    \
-      DIM(data)>;
+  template struct ScalarWave::Tags::                                           \
+      EvolvedFieldsFromCharacteristicFieldsCompute<DIM(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Evolution/Systems/ScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/ScalarWave/Characteristics.hpp
@@ -63,6 +63,7 @@ void characteristic_speeds(
     const tnsr::i<DataVector, Dim, Frame::Inertial>&
         unit_normal_one_form) noexcept;
 
+namespace Tags {
 template <size_t Dim>
 struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim>,
                                      db::ComputeTag {
@@ -77,6 +78,7 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim>,
     characteristic_speeds(char_speeds, unit_normal_one_form);
   }
 };
+}  // namespace Tags
 // @}
 
 // @{
@@ -84,11 +86,11 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim>,
  * \ingroup ScalarWave
  * \brief Computes characteristic fields from evolved fields
  *
- * \ref CharacteristicFieldsCompute and
- * \ref EvolvedFieldsFromCharacteristicFieldsCompute convert between
+ * \ref Tags::CharacteristicFieldsCompute and
+ * \ref Tags::EvolvedFieldsFromCharacteristicFieldsCompute convert between
  * characteristic and evolved fields for the scalar-wave system.
  *
- * \ref CharacteristicFieldsCompute computes
+ * \ref Tags::CharacteristicFieldsCompute computes
  * characteristic fields as described in "Optimal constraint projection for
  * hyperbolic evolution systems" by Holst et al. \cite Holst2004wt .
  * Their names used here differ from this paper:
@@ -114,9 +116,9 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim>,
  * is a constraint damping parameter, and \f$n_k\f$ is the unit normal to the
  * surface along which the characteristic fields are defined.
  *
- * \ref EvolvedFieldsFromCharacteristicFieldsCompute computes evolved fields
- * \f$u_\alpha\f$ in terms of the characteristic fields. This uses the inverse
- * of above relations:
+ * \ref Tags::EvolvedFieldsFromCharacteristicFieldsCompute computes evolved
+ * fields \f$u_\alpha\f$ in terms of the characteristic fields. This uses the
+ * inverse of above relations:
  *
  * \f{align*}
  * \psi =& v^{\hat \psi}, \\
@@ -125,7 +127,7 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim>,
  * \f}
  *
  * The corresponding characteristic speeds \f$\lambda_{\hat \alpha}\f$
- * are computed by \ref CharacteristicSpeedsCompute .
+ * are computed by \ref Tags::CharacteristicSpeedsCompute .
  */
 template <size_t Dim>
 Variables<tmpl::list<Tags::VPsi, Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus>>
@@ -147,6 +149,7 @@ void characteristic_fields(
     const tnsr::i<DataVector, Dim, Frame::Inertial>&
         unit_normal_one_form) noexcept;
 
+namespace Tags {
 template <size_t Dim>
 struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim>,
                                      db::ComputeTag {
@@ -167,6 +170,7 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim>,
                           unit_normal_one_form);
   };
 };
+}  // namespace Tags
 // @}
 
 // @{
@@ -175,7 +179,7 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim>,
  * \brief Compute evolved fields from characteristic fields.
  *
  * For expressions used here to compute evolved fields from characteristic ones,
- * see \ref CharacteristicFieldsCompute.
+ * see \ref Tags::CharacteristicFieldsCompute.
  */
 template <size_t Dim>
 Variables<tmpl::list<Psi, Pi, Phi<Dim>>>
@@ -195,6 +199,7 @@ void evolved_fields_from_characteristic_fields(
     const tnsr::i<DataVector, Dim, Frame::Inertial>&
         unit_normal_one_form) noexcept;
 
+namespace Tags {
 template <size_t Dim>
 struct EvolvedFieldsFromCharacteristicFieldsCompute
     : Tags::EvolvedFieldsFromCharacteristicFields<Dim>,
@@ -219,5 +224,6 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
                                               unit_normal_one_form);
   };
 };
+}  // namespace Tags
 // @}
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/ScalarWave/Characteristics.hpp
@@ -67,15 +67,15 @@ template <size_t Dim>
 struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim>,
                                      db::ComputeTag {
   using base = Tags::CharacteristicSpeeds<Dim>;
-  using type = typename base::type;
+  using return_type = typename base::type;
   using argument_tags =
       tmpl::list<::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
 
-  static typename Tags::CharacteristicSpeeds<Dim>::type function(
-      const tnsr::i<DataVector, Dim, Frame::Inertial>&
-          unit_normal_one_form) noexcept {
-    return characteristic_speeds(unit_normal_one_form);
-  };
+  static void function(gsl::not_null<return_type*> char_speeds,
+                       const tnsr::i<DataVector, Dim, Frame::Inertial>&
+                           unit_normal_one_form) noexcept {
+    characteristic_speeds(char_speeds, unit_normal_one_form);
+  }
 };
 // @}
 
@@ -151,18 +151,20 @@ template <size_t Dim>
 struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim>,
                                      db::ComputeTag {
   using base = Tags::CharacteristicFields<Dim>;
-  using type = typename base::type;
+  using return_type = typename base::type;
   using argument_tags =
       tmpl::list<Tags::ConstraintGamma2, Psi, Pi, Phi<Dim>,
                  ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
 
-  static typename Tags::CharacteristicFields<Dim>::type function(
-      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,
-      const Scalar<DataVector>& pi,
-      const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
-      const tnsr::i<DataVector, Dim, Frame::Inertial>&
-          unit_normal_one_form) noexcept {
-    return characteristic_fields(gamma_2, psi, pi, phi, unit_normal_one_form);
+  static void function(const gsl::not_null<return_type*> char_fields,
+                       const Scalar<DataVector>& gamma_2,
+                       const Scalar<DataVector>& psi,
+                       const Scalar<DataVector>& pi,
+                       const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+                       const tnsr::i<DataVector, Dim, Frame::Inertial>&
+                           unit_normal_one_form) noexcept {
+    characteristic_fields(char_fields, gamma_2, psi, pi, phi,
+                          unit_normal_one_form);
   };
 };
 // @}
@@ -198,20 +200,23 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
     : Tags::EvolvedFieldsFromCharacteristicFields<Dim>,
       db::ComputeTag {
   using base = Tags::EvolvedFieldsFromCharacteristicFields<Dim>;
-  using type = typename base::type;
+  using return_type = typename base::type;
   using argument_tags =
       tmpl::list<Tags::ConstraintGamma2, Tags::VPsi, Tags::VZero<Dim>,
                  Tags::VPlus, Tags::VMinus,
                  ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
 
-  static typename Tags::EvolvedFieldsFromCharacteristicFields<Dim>::type
-  function(const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
-           const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
-           const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
-           const tnsr::i<DataVector, Dim, Frame::Inertial>&
-               unit_normal_one_form) noexcept {
-    return evolved_fields_from_characteristic_fields(
-        gamma_2, v_psi, v_zero, v_plus, v_minus, unit_normal_one_form);
+  static void function(const gsl::not_null<return_type*> evolved_fields,
+                       const Scalar<DataVector>& gamma_2,
+                       const Scalar<DataVector>& v_psi,
+                       const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
+                       const Scalar<DataVector>& v_plus,
+                       const Scalar<DataVector>& v_minus,
+                       const tnsr::i<DataVector, Dim, Frame::Inertial>&
+                           unit_normal_one_form) noexcept {
+    evolved_fields_from_characteristic_fields(evolved_fields, gamma_2, v_psi,
+                                              v_zero, v_plus, v_minus,
+                                              unit_normal_one_form);
   };
 };
 // @}

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/VariablesTag.hpp"
+#include "Evolution/Systems/ScalarWave/Characteristics.hpp"
 #include "Evolution/Systems/ScalarWave/Equations.hpp"
 #include "Evolution/Systems/ScalarWave/Tags.hpp"
 #include "Utilities/TMPL.hpp"
@@ -46,6 +47,8 @@ struct System {
   using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;
   using compute_largest_characteristic_speed =
       ComputeLargestCharacteristicSpeed;
+
+  using char_speeds_tag = Tags::CharacteristicSpeedsCompute<Dim>;
 
   template <typename Tag>
   using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
@@ -50,7 +50,8 @@ Scalar<DataVector> speed_with_index(
 template <size_t Dim>
 void test_characteristic_speeds() noexcept {
   TestHelpers::db::test_compute_tag<
-      ScalarWave::CharacteristicSpeedsCompute<Dim>>("CharacteristicSpeeds");
+      ScalarWave::Tags::CharacteristicSpeedsCompute<Dim>>(
+      "CharacteristicSpeeds");
   const DataVector used_for_size(5);
   pypp::check_with_random_values<1>(speed_with_index<0, Dim>, "Characteristics",
                                     "char_speed_vpsi", {{{-10.0, 10.0}}},
@@ -91,8 +92,8 @@ void test_characteristic_speeds_analytic(
 
   // Check that locally computed fields match returned ones
   std::array<DataVector, 4> char_speeds{};
-  ScalarWave::CharacteristicSpeedsCompute<Dim>::function(&char_speeds,
-                                                         unit_normal_one_form);
+  ScalarWave::Tags::CharacteristicSpeedsCompute<Dim>::function(
+      &char_speeds, unit_normal_one_form);
   const auto& vpsi_speed = char_speeds[0];
   const auto& vzero_speed = char_speeds[1];
   const auto& vplus_speed = char_speeds[2];
@@ -115,7 +116,7 @@ typename Tag::type field_with_tag(
   Variables<tmpl::list<ScalarWave::Tags::VPsi, ScalarWave::Tags::VZero<Dim>,
                        ScalarWave::Tags::VPlus, ScalarWave::Tags::VMinus>>
       char_fields{};
-  ScalarWave::CharacteristicFieldsCompute<Dim>::function(
+  ScalarWave::Tags::CharacteristicFieldsCompute<Dim>::function(
       make_not_null(&char_fields), gamma_2, psi, pi, phi, normal_one_form);
   return get<Tag>(char_fields);
 }
@@ -123,7 +124,8 @@ typename Tag::type field_with_tag(
 template <size_t Dim>
 void test_characteristic_fields() noexcept {
   TestHelpers::db::test_compute_tag<
-      ScalarWave::CharacteristicFieldsCompute<Dim>>("CharacteristicFields");
+      ScalarWave::Tags::CharacteristicFieldsCompute<Dim>>(
+      "CharacteristicFields");
   const DataVector used_for_size(5);
   // VPsi
   pypp::check_with_random_values<1>(field_with_tag<ScalarWave::Tags::VPsi, Dim>,
@@ -205,7 +207,7 @@ void test_characteristic_fields_analytic(
   Variables<tmpl::list<ScalarWave::Tags::VPsi, ScalarWave::Tags::VZero<Dim>,
                        ScalarWave::Tags::VPlus, ScalarWave::Tags::VMinus>>
       uvars{};
-  ScalarWave::CharacteristicFieldsCompute<Dim>::function(
+  ScalarWave::Tags::CharacteristicFieldsCompute<Dim>::function(
       make_not_null(&uvars), gamma_2, psi, pi, phi, unit_normal_one_form);
 
   const auto& vpsi = get<ScalarWave::Tags::VPsi>(uvars);
@@ -229,7 +231,7 @@ typename Tag::type evol_field_with_tag(
     const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
   Variables<tmpl::list<ScalarWave::Psi, ScalarWave::Pi, ScalarWave::Phi<Dim>>>
       evolved_vars{};
-  ScalarWave::EvolvedFieldsFromCharacteristicFieldsCompute<Dim>::function(
+  ScalarWave::Tags::EvolvedFieldsFromCharacteristicFieldsCompute<Dim>::function(
       make_not_null(&evolved_vars), gamma_2, v_psi, v_zero, v_plus, v_minus,
       unit_normal_one_form);
   return get<Tag>(evolved_vars);
@@ -238,7 +240,7 @@ typename Tag::type evol_field_with_tag(
 template <size_t Dim>
 void test_evolved_from_characteristic_fields() noexcept {
   TestHelpers::db::test_compute_tag<
-      ScalarWave::EvolvedFieldsFromCharacteristicFieldsCompute<Dim>>(
+      ScalarWave::Tags::EvolvedFieldsFromCharacteristicFieldsCompute<Dim>>(
       "EvolvedFieldsFromCharacteristicFields");
   const DataVector used_for_size(5);
   // Psi
@@ -318,9 +320,9 @@ void test_evolved_from_characteristic_fields_analytic(
   {
     Variables<tmpl::list<ScalarWave::Psi, ScalarWave::Pi, ScalarWave::Phi<Dim>>>
         fields{};
-    ScalarWave::EvolvedFieldsFromCharacteristicFieldsCompute<Dim>::function(
-        make_not_null(&fields), gamma_2, vpsi, vzero, vplus, vminus,
-        unit_normal_one_form);
+    ScalarWave::Tags::EvolvedFieldsFromCharacteristicFieldsCompute<
+        Dim>::function(make_not_null(&fields), gamma_2, vpsi, vzero, vplus,
+                       vminus, unit_normal_one_form);
     const auto& psi = get<ScalarWave::Psi>(fields);
     const auto& pi = get<ScalarWave::Pi>(fields);
     const auto& phi = get<ScalarWave::Phi<Dim>>(fields);


### PR DESCRIPTION
## Proposed changes

- CMake file formatting
- Move SW char tags into `Tags` namespace
- Have SW char speed tags be mutating (needed for moving mesh compliance)
- Add a `char_speeds_tag` type alias to SW system (needed for moving mesh compliance)

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
