### PR TITLE
Increase timeout for binary factory tests

### DIFF
--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -243,6 +243,8 @@ void test_nsbh_equidistant_factory() {
 }
 }  // namespace
 
+// Test times out sometimes, increase timeout to make it pass reliably.
+// [[TimeOut, 10]]
 SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.FactoryTests",
                   "[Domain][Unit]") {
   test_connectivity();


### PR DESCRIPTION
## Proposed changes

I've had these tests timeout quite frequently (enough to be annoying). I've also seen it come up in CI a decent amount, which means we need to then rebuild everything because of it.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
