### PR TITLE
Move DH gauge into gauges namespace

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -324,7 +324,8 @@ struct EvolutionMetavars {
       Initialization::Actions::AddComputeTags<
           tmpl::list<evolution::Tags::AnalyticCompute<
               volume_dim, initial_data_tag, analytic_solution_fields>>>,
-      GeneralizedHarmonic::Actions::InitializeGauge<volume_dim>,
+      GeneralizedHarmonic::Actions::InitializeDampedHarmonicRollonGauge<
+          volume_dim>,
       GeneralizedHarmonic::Actions::InitializeConstraints<volume_dim>,
       dg::Actions::InitializeMortars<boundary_scheme, true>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -23,6 +23,7 @@
 // IWYU pragma: no_forward_declare Tensor
 
 namespace GeneralizedHarmonic {
+namespace gauges {
 namespace DampedHarmonicGauge_detail {
 // Spatial weight function used in the damped harmonic gauge source
 // function.
@@ -46,8 +47,7 @@ Scalar<DataType> weight_function(
     const tnsr::I<DataType, SpatialDim, Frame>& coords,
     const double sigma_r) noexcept {
   Scalar<DataType> weight{};
-  GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function(
-      make_not_null(&weight), coords, sigma_r);
+  weight_function(make_not_null(&weight), coords, sigma_r);
   return weight;
 }
 
@@ -79,9 +79,8 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_weight_function(
     const tnsr::I<DataType, SpatialDim, Frame>& coords,
     const double sigma_r) noexcept {
   tnsr::a<DataType, SpatialDim, Frame> d4_weight{};
-  GeneralizedHarmonic::DampedHarmonicGauge_detail::
-      spacetime_deriv_of_weight_function(make_not_null(&d4_weight), coords,
-                                         sigma_r);
+  spacetime_deriv_of_weight_function(make_not_null(&d4_weight), coords,
+                                     sigma_r);
   return d4_weight;
 }
 
@@ -141,8 +140,8 @@ Scalar<DataType> log_factor_metric_lapse(
     const Scalar<DataType>& sqrt_det_spatial_metric,
     const double exponent) noexcept {
   Scalar<DataType> logfac{};
-  GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse(
-      make_not_null(&logfac), lapse, sqrt_det_spatial_metric, exponent);
+  log_factor_metric_lapse(make_not_null(&logfac), lapse,
+                          sqrt_det_spatial_metric, exponent);
   return logfac;
 }
 
@@ -220,11 +219,10 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_log_factor_metric_lapse(
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
     const double exponent) noexcept {
   tnsr::a<DataType, SpatialDim, Frame> d4_logfac{};
-  GeneralizedHarmonic::DampedHarmonicGauge_detail::
-      spacetime_deriv_of_log_factor_metric_lapse(
-          make_not_null(&d4_logfac), lapse, shift, spacetime_unit_normal,
-          inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric,
-          pi, phi, exponent);
+  spacetime_deriv_of_log_factor_metric_lapse(
+      make_not_null(&d4_logfac), lapse, shift, spacetime_unit_normal,
+      inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric, pi,
+      phi, exponent);
   return d4_logfac;
 }
 
@@ -296,11 +294,10 @@ spacetime_deriv_of_power_log_factor_metric_lapse(
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi, const double g_exponent,
     const int exponent) noexcept {
   tnsr::a<DataType, SpatialDim, Frame> d4_powlogfac{};
-  GeneralizedHarmonic::DampedHarmonicGauge_detail::
-      spacetime_deriv_of_power_log_factor_metric_lapse(
-          make_not_null(&d4_powlogfac), lapse, shift, spacetime_unit_normal,
-          inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric,
-          pi, phi, g_exponent, exponent);
+  spacetime_deriv_of_power_log_factor_metric_lapse(
+      make_not_null(&d4_powlogfac), lapse, shift, spacetime_unit_normal,
+      inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric, pi,
+      phi, g_exponent, exponent);
   return d4_powlogfac;
 }
 }  // namespace DampedHarmonicGauge_detail
@@ -722,7 +719,6 @@ void spacetime_deriv_damped_harmonic_h(
     }
   }
 }
-}  // namespace GeneralizedHarmonic
 
 // Explicit Instantiations
 /// \cond
@@ -732,56 +728,52 @@ void spacetime_deriv_damped_harmonic_h(
 #define DTYPE_SCAL(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
-  template void                                                               \
-  GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function(           \
+  template void DampedHarmonicGauge_detail::weight_function(                  \
       const gsl::not_null<Scalar<DTYPE(data)>*> weight,                       \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,             \
       const double sigma_r) noexcept;                                         \
-  template Scalar<DTYPE(data)>                                                \
-  GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function(           \
+  template Scalar<DTYPE(data)> DampedHarmonicGauge_detail::weight_function(   \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,             \
       const double sigma_r) noexcept;                                         \
-  template void GeneralizedHarmonic::DampedHarmonicGauge_detail::             \
-      spacetime_deriv_of_weight_function(                                     \
-          const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>  \
-              d4_weight,                                                      \
-          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,         \
-          const double sigma_r) noexcept;                                     \
-  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)> GeneralizedHarmonic:: \
-      DampedHarmonicGauge_detail::spacetime_deriv_of_weight_function(         \
-          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,         \
-          const double sigma_r) noexcept;                                     \
-  template void GeneralizedHarmonic::DampedHarmonicGauge_detail::             \
-      spacetime_deriv_of_log_factor_metric_lapse(                             \
-          const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>  \
-              d4_logfac,                                                      \
-          const Scalar<DTYPE(data)>& lapse,                                   \
-          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,          \
-          const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                 \
-              spacetime_unit_normal,                                          \
-          const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
-              inverse_spatial_metric,                                         \
-          const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                 \
-          const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                \
-              dt_spatial_metric,                                              \
-          const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,            \
-          const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,          \
-          const double exponent) noexcept;                                    \
-  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)> GeneralizedHarmonic:: \
-      DampedHarmonicGauge_detail::spacetime_deriv_of_log_factor_metric_lapse( \
-          const Scalar<DTYPE(data)>& lapse,                                   \
-          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,          \
-          const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                 \
-              spacetime_unit_normal,                                          \
-          const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
-              inverse_spatial_metric,                                         \
-          const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                 \
-          const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                \
-              dt_spatial_metric,                                              \
-          const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,            \
-          const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,          \
-          const double exponent) noexcept;                                    \
-  template void GeneralizedHarmonic::DampedHarmonicGauge_detail::             \
+  template void                                                               \
+  DampedHarmonicGauge_detail::spacetime_deriv_of_weight_function(             \
+      const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>      \
+          d4_weight,                                                          \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,             \
+      const double sigma_r) noexcept;                                         \
+  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \
+  DampedHarmonicGauge_detail::spacetime_deriv_of_weight_function(             \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,             \
+      const double sigma_r) noexcept;                                         \
+  template void                                                               \
+  DampedHarmonicGauge_detail::spacetime_deriv_of_log_factor_metric_lapse(     \
+      const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>      \
+          d4_logfac,                                                          \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal,                                              \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spatial_metric,                                             \
+      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                     \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,                \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const double exponent) noexcept;                                        \
+  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \
+  DampedHarmonicGauge_detail::spacetime_deriv_of_log_factor_metric_lapse(     \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal,                                              \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spatial_metric,                                             \
+      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                     \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,                \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const double exponent) noexcept;                                        \
+  template void DampedHarmonicGauge_detail::                                  \
       spacetime_deriv_of_power_log_factor_metric_lapse(                       \
           const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>  \
               d4_powlogfac,                                                   \
@@ -798,7 +790,7 @@ void spacetime_deriv_damped_harmonic_h(
           const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,          \
           const double g_exponent, const int exponent) noexcept;              \
   template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \
-  GeneralizedHarmonic::DampedHarmonicGauge_detail::                           \
+  DampedHarmonicGauge_detail::                                                \
       spacetime_deriv_of_power_log_factor_metric_lapse(                       \
           const Scalar<DTYPE(data)>& lapse,                                   \
           const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,          \
@@ -814,12 +806,11 @@ void spacetime_deriv_damped_harmonic_h(
           const double g_exponent, const int exponent) noexcept;
 
 #define INSTANTIATE_DV_FUNC(_, data)                                           \
-  template void GeneralizedHarmonic::damped_harmonic_h(                        \
-      const gsl::not_null<db::item_type<                                       \
-          GeneralizedHarmonic::Tags::GaugeH<DIM(data), FRAME(data)>>*>         \
+  template void damped_harmonic_h(                                             \
+      const gsl::not_null<                                                     \
+          db::item_type<Tags::GaugeH<DIM(data), FRAME(data)>>*>                \
           gauge_h,                                                             \
-      const db::item_type<                                                     \
-          GeneralizedHarmonic::Tags::InitialGaugeH<DIM(data), FRAME(data)>>&   \
+      const db::item_type<Tags::InitialGaugeH<DIM(data), FRAME(data)>>&        \
           gauge_h_init,                                                        \
       const Scalar<DataVector>& lapse,                                         \
       const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,                \
@@ -834,17 +825,15 @@ void spacetime_deriv_damped_harmonic_h(
       const double sigma_t_L1, const double t_start_L2,                        \
       const double sigma_t_L2, const double t_start_S, const double sigma_t_S, \
       const double sigma_r) noexcept;                                          \
-  template void GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h(        \
+  template void spacetime_deriv_damped_harmonic_h(                             \
       const gsl::not_null<                                                     \
-          db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<       \
-              DIM(data), FRAME(data)>>*>                                       \
+          db::item_type<Tags::SpacetimeDerivGaugeH<DIM(data), FRAME(data)>>*>  \
           d4_gauge_h,                                                          \
-      const db::item_type<                                                     \
-          GeneralizedHarmonic::Tags::InitialGaugeH<DIM(data), FRAME(data)>>&   \
+      const db::item_type<Tags::InitialGaugeH<DIM(data), FRAME(data)>>&        \
           gauge_h_init,                                                        \
       const db::item_type<                                                     \
-          GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<              \
-              DIM(data), FRAME(data)>>& dgauge_h_init,                         \
+          Tags::SpacetimeDerivInitialGaugeH<DIM(data), FRAME(data)>>&          \
+          dgauge_h_init,                                                       \
       const Scalar<DataVector>& lapse,                                         \
       const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,                \
       const tnsr::a<DataVector, DIM(data), FRAME(data)>&                       \
@@ -865,17 +854,16 @@ void spacetime_deriv_damped_harmonic_h(
       const double sigma_t_L2, const double t_start_S, const double sigma_t_S, \
       const double sigma_r) noexcept;
 
-#define INSTANTIATE_SCALAR_FUNC(_, data)                                    \
-  template void                                                             \
-  GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse( \
-      const gsl::not_null<Scalar<DTYPE_SCAL(data)>*> logfac,                \
-      const Scalar<DTYPE_SCAL(data)>& lapse,                                \
-      const Scalar<DTYPE_SCAL(data)>& sqrt_det_spatial_metric,              \
-      const double exponent) noexcept;                                      \
-  template Scalar<DTYPE_SCAL(data)>                                         \
-  GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse( \
-      const Scalar<DTYPE_SCAL(data)>& lapse,                                \
-      const Scalar<DTYPE_SCAL(data)>& sqrt_det_spatial_metric,              \
+#define INSTANTIATE_SCALAR_FUNC(_, data)                             \
+  template void DampedHarmonicGauge_detail::log_factor_metric_lapse( \
+      const gsl::not_null<Scalar<DTYPE_SCAL(data)>*> logfac,         \
+      const Scalar<DTYPE_SCAL(data)>& lapse,                         \
+      const Scalar<DTYPE_SCAL(data)>& sqrt_det_spatial_metric,       \
+      const double exponent) noexcept;                               \
+  template Scalar<DTYPE_SCAL(data)>                                  \
+  DampedHarmonicGauge_detail::log_factor_metric_lapse(               \
+      const Scalar<DTYPE_SCAL(data)>& lapse,                         \
+      const Scalar<DTYPE_SCAL(data)>& sqrt_det_spatial_metric,       \
       const double exponent) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
@@ -894,3 +882,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_SCALAR_FUNC, (double, DataVector))
 #undef INSTANTIATE_DV_FUNC
 #undef INSTANTIATE_SCALAR_FUNC
 /// \endcond
+}  // namespace gauges
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -44,6 +44,7 @@ class not_null;
 // IWYU pragma: no_forward_declare gr::Tags::SqrtDetSpatialMetric
 
 namespace GeneralizedHarmonic {
+namespace gauges {
 /*!
  * \brief Damped harmonic gauge source function.
  *
@@ -163,16 +164,16 @@ struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
            const double sigma_r) noexcept {
     db::item_type<Tags::GaugeH<SpatialDim, Frame>> gauge_h{
         get_size(get(lapse))};
-    GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame>(
-        make_not_null(&gauge_h), gauge_h_init, lapse, shift,
-        sqrt_det_spatial_metric, spacetime_metric, time, coords, 1., 1.,
-        1.,                // amp_coef_{L1, L2, S}
-        4, 4, 4,           // exp_{L1, L2, S}
-        t_start, sigma_t,  // _h_init
-        t_start, sigma_t,  // _L1
-        t_start, sigma_t,  // _L2
-        t_start, sigma_t,  // _S
-        sigma_r);
+    damped_harmonic_h<SpatialDim, Frame>(make_not_null(&gauge_h), gauge_h_init,
+                                         lapse, shift, sqrt_det_spatial_metric,
+                                         spacetime_metric, time, coords, 1., 1.,
+                                         1.,       // amp_coef_{L1, L2, S}
+                                         4, 4, 4,  // exp_{L1, L2, S}
+                                         t_start, sigma_t,  // _h_init
+                                         t_start, sigma_t,  // _L1
+                                         t_start, sigma_t,  // _L2
+                                         t_start, sigma_t,  // _S
+                                         sigma_r);
     return gauge_h;
   }
 };
@@ -333,7 +334,7 @@ struct SpacetimeDerivDampedHarmonicHCompute
       const double sigma_r) noexcept {
     db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>> d4_gauge_h{
         get_size(get(lapse))};
-    GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h(
+    spacetime_deriv_damped_harmonic_h(
         make_not_null(&d4_gauge_h), gauge_h_init, dgauge_h_init, lapse, shift,
         spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
         inverse_spatial_metric, spacetime_metric, pi, phi, time, coords, 1., 1.,
@@ -347,4 +348,5 @@ struct SpacetimeDerivDampedHarmonicHCompute
     return d4_gauge_h;
   }
 };
+}  // namespace gauges
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Gauges.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Gauges.hpp
@@ -1,0 +1,9 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace GeneralizedHarmonic {
+/// \brief Gauge conditions for generalized harmonic evolution systems.
+namespace gauges {}
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -131,7 +131,7 @@ struct InitializeGhAnd3Plus1Variables {
 };
 
 template <size_t Dim>
-struct InitializeGauge {
+struct InitializeDampedHarmonicRollonGauge {
   using frame = Frame::Inertial;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
@@ -207,7 +207,7 @@ struct InitializeGauge {
     // Finally, insert gauge related quantities to the box
     return std::make_tuple(
         Initialization::merge_into_databox<
-            InitializeGauge,
+            InitializeDampedHarmonicRollonGauge,
             db::AddSimpleTags<
                 GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>,
                 GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<Dim,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -201,8 +201,9 @@ struct InitializeDampedHarmonicRollonGauge {
                               std::move(d_initial_gauge_source));
     // Add gauge tags
     using compute_tags = db::AddComputeTags<
-        GeneralizedHarmonic::DampedHarmonicHCompute<Dim, frame>,
-        GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<Dim, frame>>;
+        GeneralizedHarmonic::gauges::DampedHarmonicHCompute<Dim, frame>,
+        GeneralizedHarmonic::gauges::SpacetimeDerivDampedHarmonicHCompute<
+            Dim, frame>>;
 
     // Finally, insert gauge related quantities to the box
     return std::make_tuple(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -55,6 +55,7 @@ struct dt;
 /// \endcond
 
 namespace GeneralizedHarmonic {
+namespace gauges {
 namespace DampedHarmonicGauge_detail {
 // The `detail` functions below are forward-declared to enable their independent
 // testing
@@ -116,6 +117,7 @@ spacetime_deriv_of_power_log_factor_metric_lapse(
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi, double g_exponent,
     int exponent) noexcept;
 }  // namespace DampedHarmonicGauge_detail
+}  // namespace gauges
 }  // namespace GeneralizedHarmonic
 
 // Wrap `wrap_spacetime_deriv_of_power_log_factor_metric_lapse` here to make its
@@ -135,7 +137,7 @@ wrap_spacetime_deriv_of_power_log_factor_metric_lapse(
     const double d_exponent) noexcept {
   const auto exponent = static_cast<int>(d_exponent);
   tnsr::a<DataType, SpatialDim, Frame> d4_powlogfac{};
-  GeneralizedHarmonic::DampedHarmonicGauge_detail::
+  GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
       spacetime_deriv_of_power_log_factor_metric_lapse(
           make_not_null(&d4_powlogfac), lapse, shift, spacetime_unit_normal,
           inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric,
@@ -178,8 +180,8 @@ void test_detail_functions(const DataType& used_for_size) noexcept {
   pypp::check_with_random_values<2>(
       static_cast<Scalar<DataType> (*)(
           const tnsr::I<DataType, SpatialDim, Frame>&, const double)>(
-          &::GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
-              SpatialDim, Frame, DataType>),
+          &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+              weight_function<SpatialDim, Frame, DataType>),
       "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
       "DampedHarmonic",
       "weight_function",
@@ -189,7 +191,7 @@ void test_detail_functions(const DataType& used_for_size) noexcept {
   pypp::check_with_random_values<2>(
       static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
           const tnsr::I<DataType, SpatialDim, Frame>&, const double)>(
-          &::GeneralizedHarmonic::DampedHarmonicGauge_detail::
+          &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
               spacetime_deriv_of_weight_function<SpatialDim, Frame, DataType>),
       "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
       "DampedHarmonic",
@@ -198,14 +200,15 @@ void test_detail_functions(const DataType& used_for_size) noexcept {
       used_for_size);
   // roll_on_function
   pypp::check_with_random_values<1>(
-      &::GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function,
+      &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+          roll_on_function,
       "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
       "DampedHarmonic",
       "roll_on_function", {{{std::numeric_limits<double>::denorm_min(), 10.}}},
       used_for_size);
   // time_deriv_of_roll_on_function
   pypp::check_with_random_values<1>(
-      &::GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
           time_deriv_of_roll_on_function,
       "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
       "DampedHarmonic",
@@ -215,7 +218,7 @@ void test_detail_functions(const DataType& used_for_size) noexcept {
   pypp::check_with_random_values<1>(
       static_cast<Scalar<DataType> (*)(const Scalar<DataType>&,
                                        const Scalar<DataType>&, const double)>(
-          &::GeneralizedHarmonic::DampedHarmonicGauge_detail::
+          &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
               log_factor_metric_lapse<DataType>),
       "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
       "DampedHarmonic",
@@ -230,7 +233,7 @@ void test_detail_functions(const DataType& used_for_size) noexcept {
           const tnsr::ii<DataType, SpatialDim, Frame>&,
           const tnsr::aa<DataType, SpatialDim, Frame>&,
           const tnsr::iaa<DataType, SpatialDim, Frame>&, const double)>(
-          &::GeneralizedHarmonic::DampedHarmonicGauge_detail::
+          &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
               spacetime_deriv_of_log_factor_metric_lapse<SpatialDim, Frame,
                                                          DataType>),
       "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
@@ -266,7 +269,7 @@ wrap_DampedHarmonicHCompute(
     const double t, const double t_start, const double sigma_t,
     const tnsr::I<DataVector, SpatialDim, Frame>& coords,
     const double sigma_r) noexcept {
-  return GeneralizedHarmonic::DampedHarmonicHCompute<
+  return GeneralizedHarmonic::gauges::DampedHarmonicHCompute<
       SpatialDim, Frame>::function(gauge_h_init, lapse, shift,
                                    sqrt_det_spatial_metric, spacetime_metric, t,
                                    t_start, sigma_t, coords, sigma_r);
@@ -358,7 +361,7 @@ void test_damped_harmonic_h_function_term_1_of_4(
       GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
       make_not_null(&generator), make_not_null(&rdist), x);
   const double roll_on_HI =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_HI, sigma_t_HI);
 
   // local H_a
@@ -372,7 +375,7 @@ void test_damped_harmonic_h_function_term_1_of_4(
   // Check that locally computed H_a matches the returned one
   db::item_type<GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>
       gauge_h{};
-  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame::Inertial>(
+  GeneralizedHarmonic::gauges::damped_harmonic_h<SpatialDim, Frame::Inertial>(
       make_not_null(&gauge_h), gauge_h_init, lapse, shift,
       sqrt_det_spatial_metric, spacetime_metric, t, x, 0., 0., 0., 0, 0,
       0,  // exponents
@@ -451,10 +454,10 @@ void test_damped_harmonic_h_function_term_2_of_4(
 
   const auto log_fac_1 = log(get(sqrt_det_spatial_metric) / get(lapse));
   const double roll_on_L1 =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L1, sigma_t_L1);
   const auto weight =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
 
   const auto h_prefac1 = amp_coef_L1 * roll_on_L1 * get(weight) *
@@ -473,7 +476,7 @@ void test_damped_harmonic_h_function_term_2_of_4(
   // Check that locally computed H_a matches the returned one
   db::item_type<GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>
       gauge_h{};
-  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame::Inertial>(
+  GeneralizedHarmonic::gauges::damped_harmonic_h<SpatialDim, Frame::Inertial>(
       make_not_null(&gauge_h), gauge_h_init, lapse, shift,
       sqrt_det_spatial_metric, spacetime_metric, t, x, amp_coef_L1, 0., 0.,
       exp_L1, 0, 0,  // exponents
@@ -550,10 +553,10 @@ void test_damped_harmonic_h_function_term_3_of_4(
   const double r_max = pdist(generator) * 0.7;
 
   const double roll_on_L2 =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L2, sigma_t_L2);
   const auto weight =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
 
   const auto log_fac_2 = log(1. / get(lapse));
@@ -573,7 +576,7 @@ void test_damped_harmonic_h_function_term_3_of_4(
   // Check that locally computed H_a matches the returned one
   db::item_type<GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>
       gauge_h{};
-  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame::Inertial>(
+  GeneralizedHarmonic::gauges::damped_harmonic_h<SpatialDim, Frame::Inertial>(
       make_not_null(&gauge_h), gauge_h_init, lapse, shift,
       sqrt_det_spatial_metric, spacetime_metric, t, x, 0., amp_coef_L2, 0., 0,
       exp_L2, 0,  // exponents
@@ -648,10 +651,10 @@ void test_damped_harmonic_h_function_term_4_of_4(
   const double r_max = pdist(generator) * 0.7;
 
   const double roll_on_S =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_S, sigma_t_S);
   const auto weight =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
 
   const auto log_fac_1 = log(get(sqrt_det_spatial_metric) * one_over_lapse);
@@ -674,7 +677,7 @@ void test_damped_harmonic_h_function_term_4_of_4(
   // Check that locally computed H_a match returned one
   db::item_type<GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>
       gauge_h{};
-  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame::Inertial>(
+  GeneralizedHarmonic::gauges::damped_harmonic_h<SpatialDim, Frame::Inertial>(
       make_not_null(&gauge_h), gauge_h_init, lapse, shift,
       sqrt_det_spatial_metric, spacetime_metric, t, x, 0., 0., amp_coef_S, 0, 0,
       exp_S,  // exponents
@@ -737,10 +740,10 @@ void test_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
   const double sigma_t_L1 = pdist(generator) * 0.2;
   const double r_max = pdist(generator) * 0.7;
   const double roll_on_L1 =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L1, sigma_t_L1);
   const auto weight =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
 
   const auto gauge_h_init = make_with_value<db::item_type<
@@ -748,7 +751,7 @@ void test_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
       x, 0.);
   db::item_type<GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>
       gauge_h{};
-  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame::Inertial>(
+  GeneralizedHarmonic::gauges::damped_harmonic_h<SpatialDim, Frame::Inertial>(
       make_not_null(&gauge_h), gauge_h_init, lapse, shift,
       sqrt_det_spatial_metric, spacetime_metric, t, x, amp_coef_L1, 0., 0.,
       exp_L1, 0, 0,  // exponents
@@ -861,10 +864,10 @@ void test_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
   const double sigma_t_L2 = pdist(generator) * 0.2;
   const double r_max = pdist(generator) * 0.7;
   const double roll_on_L2 =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L2, sigma_t_L2);
   const auto weight =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
 
   const auto gauge_h_init = make_with_value<db::item_type<
@@ -872,7 +875,7 @@ void test_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
       x, 0.);
   db::item_type<GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>
       gauge_h{};
-  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame::Inertial>(
+  GeneralizedHarmonic::gauges::damped_harmonic_h<SpatialDim, Frame::Inertial>(
       make_not_null(&gauge_h), gauge_h_init, lapse, shift,
       sqrt_det_spatial_metric, spacetime_metric, t, x, 0., amp_coef_L2, 0., 0,
       exp_L2, 0,  // exponents
@@ -970,10 +973,10 @@ void test_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
   const double sigma_t_S = pdist(generator) * 0.2;
   const double r_max = pdist(generator) * 0.7;
   const double roll_on_S =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_S, sigma_t_S);
   const auto weight =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
 
   const auto gauge_h_init = make_with_value<db::item_type<
@@ -981,7 +984,7 @@ void test_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
       x, 0.);
   db::item_type<GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>
       gauge_h{};
-  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame::Inertial>(
+  GeneralizedHarmonic::gauges::damped_harmonic_h<SpatialDim, Frame::Inertial>(
       make_not_null(&gauge_h), gauge_h_init, lapse, shift,
       sqrt_det_spatial_metric, spacetime_metric, t, x, 0., 0., amp_coef_S, 0, 0,
       exp_S,  // exponents
@@ -1081,7 +1084,7 @@ wrap_SpacetimeDerivDampedHarmonicHCompute(
     const double t_start, const double sigma_t,
     const tnsr::I<DataVector, SpatialDim, Frame>& coords,
     const double sigma_r) noexcept {
-  return GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<
+  return GeneralizedHarmonic::gauges::SpacetimeDerivDampedHarmonicHCompute<
       SpatialDim, Frame>::function(gauge_h_init, dgauge_h_init, lapse, shift,
                                    spacetime_unit_normal_one_form,
                                    sqrt_det_spatial_metric,
@@ -1208,10 +1211,11 @@ void test_deriv_damped_harmonic_h_function_term_1_of_4(
 
   // Tempering functions
   const double roll_on_HI =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_HI, sigma_t_HI);
-  const auto d0_roll_on_HI = GeneralizedHarmonic::DampedHarmonicGauge_detail::
-      time_deriv_of_roll_on_function(t, t_start_HI, sigma_t_HI);
+  const auto d0_roll_on_HI =
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+          time_deriv_of_roll_on_function(t, t_start_HI, sigma_t_HI);
 
   // Initialize initial gauge function and its roll-off function
   const auto gauge_h_init = make_with_random_values<db::item_type<
@@ -1239,8 +1243,8 @@ void test_deriv_damped_harmonic_h_function_term_1_of_4(
   db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
       SpatialDim, Frame::Inertial>>
       d4_gauge_h{};
-  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h<SpatialDim,
-                                                         Frame::Inertial>(
+  GeneralizedHarmonic::gauges::spacetime_deriv_damped_harmonic_h<
+      SpatialDim, Frame::Inertial>(
       make_not_null(&d4_gauge_h), gauge_h_init, d4_gauge_h_init, lapse, shift,
       spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
       inverse_spatial_metric, spacetime_metric, pi, phi, t, x, 0., 0., 0., 0, 0,
@@ -1343,9 +1347,9 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4(
 
   // commonly used terms
   const auto exp_fac_1 = 1. / 2.;
-  const auto log_fac_1 =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
-          DataVector>(lapse, sqrt_det_spatial_metric, exp_fac_1);
+  const auto log_fac_1 = GeneralizedHarmonic::gauges::
+      DampedHarmonicGauge_detail::log_factor_metric_lapse<DataVector>(
+          lapse, sqrt_det_spatial_metric, exp_fac_1);
 
   // Initialize settings
   const double amp_coef_L1 = pdist(generator);
@@ -1356,14 +1360,15 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4(
 
   // Tempering functions
   const double roll_on_L1 =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L1, sigma_t_L1);
-  const auto d0_roll_on_L1 = GeneralizedHarmonic::DampedHarmonicGauge_detail::
-      time_deriv_of_roll_on_function(t, t_start_L1, sigma_t_L1);
+  const auto d0_roll_on_L1 =
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+          time_deriv_of_roll_on_function(t, t_start_L1, sigma_t_L1);
   const auto weight =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
-  auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+  auto d4_weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
       spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
                                          DataVector>(x, r_max);
 
@@ -1387,7 +1392,7 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4(
           get(lapse), 0.);
   {
     const auto d4_log_fac_mu1 =
-        GeneralizedHarmonic::DampedHarmonicGauge_detail ::
+        GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail ::
             spacetime_deriv_of_power_log_factor_metric_lapse<
                 SpatialDim, Frame::Inertial, DataVector>(
                 lapse, shift, spacetime_unit_normal, inverse_spatial_metric,
@@ -1442,8 +1447,8 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4(
   db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
       SpatialDim, Frame::Inertial>>
       d4_gauge_h{};
-  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h<SpatialDim,
-                                                         Frame::Inertial>(
+  GeneralizedHarmonic::gauges::spacetime_deriv_damped_harmonic_h<
+      SpatialDim, Frame::Inertial>(
       make_not_null(&d4_gauge_h), gauge_h_init, d4_gauge_h_init, lapse, shift,
       spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
       inverse_spatial_metric, spacetime_metric, pi, phi, t, x, amp_coef_L1, 0.,
@@ -1546,9 +1551,9 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4(
 
   // commonly used terms
   const auto exp_fac_2 = 0.;
-  const auto log_fac_2 =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
-          DataVector>(lapse, sqrt_det_spatial_metric, exp_fac_2);
+  const auto log_fac_2 = GeneralizedHarmonic::gauges::
+      DampedHarmonicGauge_detail::log_factor_metric_lapse<DataVector>(
+          lapse, sqrt_det_spatial_metric, exp_fac_2);
 
   // Initialize settings
   const double amp_coef_L2 = pdist(generator);
@@ -1560,14 +1565,15 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4(
 
   // Tempering functions
   const double roll_on_L2 =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L2, sigma_t_L2);
-  const auto d0_roll_on_L2 = GeneralizedHarmonic::DampedHarmonicGauge_detail::
-      time_deriv_of_roll_on_function(t, t_start_L2, sigma_t_L2);
+  const auto d0_roll_on_L2 =
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+          time_deriv_of_roll_on_function(t, t_start_L2, sigma_t_L2);
   const auto weight =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
-  auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+  auto d4_weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
       spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
                                          DataVector>(x, r_max);
 
@@ -1591,7 +1597,7 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4(
           get(lapse), 0.);
   {
     const auto d4_log_fac_mu2 =
-        GeneralizedHarmonic::DampedHarmonicGauge_detail ::
+        GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail ::
             spacetime_deriv_of_power_log_factor_metric_lapse<
                 SpatialDim, Frame::Inertial, DataVector>(
                 lapse, shift, spacetime_unit_normal, inverse_spatial_metric,
@@ -1646,8 +1652,8 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4(
   db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
       SpatialDim, Frame::Inertial>>
       d4_gauge_h{};
-  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h<SpatialDim,
-                                                         Frame::Inertial>(
+  GeneralizedHarmonic::gauges::spacetime_deriv_damped_harmonic_h<
+      SpatialDim, Frame::Inertial>(
       make_not_null(&d4_gauge_h), gauge_h_init, d4_gauge_h_init, lapse, shift,
       spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
       inverse_spatial_metric, spacetime_metric, pi, phi, t, x, 0., amp_coef_L2,
@@ -1754,9 +1760,9 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4(
   // commonly used terms
   const auto exp_fac_1 = 1. / 2.;
   const auto one_over_lapse = 1. / get(lapse);
-  const auto log_fac_1 =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
-          DataVector>(lapse, sqrt_det_spatial_metric, exp_fac_1);
+  const auto log_fac_1 = GeneralizedHarmonic::gauges::
+      DampedHarmonicGauge_detail::log_factor_metric_lapse<DataVector>(
+          lapse, sqrt_det_spatial_metric, exp_fac_1);
 
   // Initialize settings
   const double amp_coef_S = pdist(generator);
@@ -1767,14 +1773,15 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4(
 
   // Tempering functions
   const double roll_on_S =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_S, sigma_t_S);
-  const auto d0_roll_on_S = GeneralizedHarmonic::DampedHarmonicGauge_detail::
-      time_deriv_of_roll_on_function(t, t_start_S, sigma_t_S);
+  const auto d0_roll_on_S =
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+          time_deriv_of_roll_on_function(t, t_start_S, sigma_t_S);
   const auto weight =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
-  auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+  auto d4_weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
       spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
                                          DataVector>(x, r_max);
 
@@ -1796,7 +1803,7 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4(
           get(lapse), 0.);
   {
     const auto d4_log_fac_muS =
-        GeneralizedHarmonic::DampedHarmonicGauge_detail ::
+        GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail ::
             spacetime_deriv_of_power_log_factor_metric_lapse<
                 SpatialDim, Frame::Inertial, DataVector>(
                 lapse, shift, spacetime_unit_normal, inverse_spatial_metric,
@@ -1874,8 +1881,8 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4(
   db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
       SpatialDim, Frame::Inertial>>
       d4_gauge_h{};
-  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h<SpatialDim,
-                                                         Frame::Inertial>(
+  GeneralizedHarmonic::gauges::spacetime_deriv_damped_harmonic_h<
+      SpatialDim, Frame::Inertial>(
       make_not_null(&d4_gauge_h), gauge_h_init, d4_gauge_h_init, lapse, shift,
       spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
       inverse_spatial_metric, spacetime_metric, pi, phi, t, x, 0., 0.,
@@ -1975,8 +1982,8 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
   db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
       SpatialDim, Frame::Inertial>>
       d4_gauge_h{};
-  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h<SpatialDim,
-                                                         Frame::Inertial>(
+  GeneralizedHarmonic::gauges::spacetime_deriv_damped_harmonic_h<
+      SpatialDim, Frame::Inertial>(
       make_not_null(&d4_gauge_h), gauge_h_init, d4_gauge_h_init, lapse, shift,
       spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
       inverse_spatial_metric, spacetime_metric, pi, phi, t, x, amp_coef_L1, 0.,
@@ -1987,14 +1994,15 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
 
   // Tempering functions
   const double roll_on_L1 =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L1, sigma_t_L1);
-  const auto d0_roll_on_L1 = GeneralizedHarmonic::DampedHarmonicGauge_detail::
-      time_deriv_of_roll_on_function(t, t_start_L1, sigma_t_L1);
+  const auto d0_roll_on_L1 =
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+          time_deriv_of_roll_on_function(t, t_start_L1, sigma_t_L1);
   const auto weight =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
-  auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+  auto d4_weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
       spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
                                          DataVector>(x, r_max);
 
@@ -2113,10 +2121,9 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
 
   // commonly used terms
   const auto exp_fac_1 = 1. / 2.;
-  const auto log_fac_1 =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
-          DataVector>(lapse_ab_initio, sqrt_det_spatial_metric_ab_initio,
-                      exp_fac_1);
+  const auto log_fac_1 = GeneralizedHarmonic::gauges::
+      DampedHarmonicGauge_detail::log_factor_metric_lapse<DataVector>(
+          lapse_ab_initio, sqrt_det_spatial_metric_ab_initio, exp_fac_1);
 
   // compute GR dependent terms
   // coeffs that enter gauge source function
@@ -2139,7 +2146,7 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
           get(lapse), 0.);
   {
     const auto d4_log_fac_mu1 =
-        GeneralizedHarmonic::DampedHarmonicGauge_detail ::
+        GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail ::
             spacetime_deriv_of_power_log_factor_metric_lapse<
                 SpatialDim, Frame::Inertial, DataVector>(
                 lapse_ab_initio, shift_ab_initio,
@@ -2275,8 +2282,8 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
   db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
       SpatialDim, Frame::Inertial>>
       d4_gauge_h{};
-  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h<SpatialDim,
-                                                         Frame::Inertial>(
+  GeneralizedHarmonic::gauges::spacetime_deriv_damped_harmonic_h<
+      SpatialDim, Frame::Inertial>(
       make_not_null(&d4_gauge_h), gauge_h_init, d4_gauge_h_init, lapse, shift,
       spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
       inverse_spatial_metric, spacetime_metric, pi, phi, t, x, 0., amp_coef_L2,
@@ -2287,14 +2294,15 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
 
   // Tempering functions
   const double roll_on_L2 =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L2, sigma_t_L2);
-  const auto d0_roll_on_L2 = GeneralizedHarmonic::DampedHarmonicGauge_detail::
-      time_deriv_of_roll_on_function(t, t_start_L2, sigma_t_L2);
+  const auto d0_roll_on_L2 =
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+          time_deriv_of_roll_on_function(t, t_start_L2, sigma_t_L2);
   const auto weight =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
-  auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+  auto d4_weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
       spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
                                          DataVector>(x, r_max);
 
@@ -2413,10 +2421,9 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
 
   // commonly used terms
   const auto exp_fac_2 = 0.;
-  const auto log_fac_2 =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
-          DataVector>(lapse_ab_initio, sqrt_det_spatial_metric_ab_initio,
-                      exp_fac_2);
+  const auto log_fac_2 = GeneralizedHarmonic::gauges::
+      DampedHarmonicGauge_detail::log_factor_metric_lapse<DataVector>(
+          lapse_ab_initio, sqrt_det_spatial_metric_ab_initio, exp_fac_2);
 
   // coeffs that enter gauge source function
   const auto mu_L2 =
@@ -2438,7 +2445,7 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
           get(lapse_ab_initio), 0.);
   {
     const auto d4_log_fac_mu2 =
-        GeneralizedHarmonic::DampedHarmonicGauge_detail ::
+        GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail ::
             spacetime_deriv_of_power_log_factor_metric_lapse<
                 SpatialDim, Frame::Inertial, DataVector>(
                 lapse_ab_initio, shift_ab_initio,
@@ -2576,8 +2583,8 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
   db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
       SpatialDim, Frame::Inertial>>
       d4_gauge_h{};
-  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h<SpatialDim,
-                                                         Frame::Inertial>(
+  GeneralizedHarmonic::gauges::spacetime_deriv_damped_harmonic_h<
+      SpatialDim, Frame::Inertial>(
       make_not_null(&d4_gauge_h), gauge_h_init, d4_gauge_h_init, lapse, shift,
       spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
       inverse_spatial_metric, spacetime_metric, pi, phi, t, x, 0., 0.,
@@ -2588,14 +2595,15 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
 
   // Tempering functions
   const double roll_on_S =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_S, sigma_t_S);
-  const auto d0_roll_on_S = GeneralizedHarmonic::DampedHarmonicGauge_detail::
-      time_deriv_of_roll_on_function(t, t_start_S, sigma_t_S);
+  const auto d0_roll_on_S =
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+          time_deriv_of_roll_on_function(t, t_start_S, sigma_t_S);
   const auto weight =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
           SpatialDim, Frame::Inertial, DataVector>(x, r_max);
-  auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+  auto d4_weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
       spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
                                          DataVector>(x, r_max);
 
@@ -2714,10 +2722,9 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
   // commonly used terms
   const auto exp_fac_1 = 1. / 2.;
   const auto one_over_lapse = 1. / get(lapse_ab_initio);
-  const auto log_fac_1 =
-      GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
-          DataVector>(lapse_ab_initio, sqrt_det_spatial_metric_ab_initio,
-                      exp_fac_1);
+  const auto log_fac_1 = GeneralizedHarmonic::gauges::
+      DampedHarmonicGauge_detail::log_factor_metric_lapse<DataVector>(
+          lapse_ab_initio, sqrt_det_spatial_metric_ab_initio, exp_fac_1);
 
   // coeffs that enter gauge source function
   const auto mu_S =
@@ -2737,7 +2744,7 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
           get(lapse_ab_initio), 0.);
   {
     const auto d4_log_fac_muS =
-        GeneralizedHarmonic::DampedHarmonicGauge_detail ::
+        GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail ::
             spacetime_deriv_of_power_log_factor_metric_lapse<
                 SpatialDim, Frame::Inertial, DataVector>(
                 lapse_ab_initio, shift_ab_initio,
@@ -2934,10 +2941,10 @@ void test_damped_harmonic_compute_tags(const size_t grid_size_each_dimension,
   //
   // First, check that the names are correct
   TestHelpers::db::test_compute_tag<
-      GeneralizedHarmonic::DampedHarmonicHCompute<3, Frame::Inertial>>(
+      GeneralizedHarmonic::gauges::DampedHarmonicHCompute<3, Frame::Inertial>>(
       "GaugeH");
   TestHelpers::db::test_compute_tag<
-      GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<
+      GeneralizedHarmonic::gauges::SpacetimeDerivDampedHarmonicHCompute<
           3, Frame::Inertial>>("SpacetimeDerivGaugeH");
 
   const auto box = db::create<
@@ -2959,8 +2966,9 @@ void test_damped_harmonic_compute_tags(const size_t grid_size_each_dimension,
           GeneralizedHarmonic::Tags::GaugeHSpatialWeightDecayWidth<
               Frame::Inertial>>,
       db::AddComputeTags<
-          GeneralizedHarmonic::DampedHarmonicHCompute<3, Frame::Inertial>,
-          GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<
+          GeneralizedHarmonic::gauges::DampedHarmonicHCompute<3,
+                                                              Frame::Inertial>,
+          GeneralizedHarmonic::gauges::SpacetimeDerivDampedHarmonicHCompute<
               3, Frame::Inertial>>>(gauge_h_init, d4_gauge_h_init, lapse, shift,
                                     spacetime_unit_normal_one_form,
                                     sqrt_det_spatial_metric,


### PR DESCRIPTION
## Proposed changes

- Add a `GeneralizedHarmonic::gauges` namespace and put the GH gauge inside

A lot of this is clang-format white space changes with a macro, and the rest is adding `gauges::` into places

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
