### PR TITLE
Add test for Initialization::Actions::NonconservativeSystem

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -23,6 +23,7 @@
 #include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/NonconservativeSystem.hpp"
+#include "Evolution/Initialization/SetVariables.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Initialize.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
@@ -274,6 +275,8 @@ struct EvolutionMetavars {
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
       evolution::dg::Initialization::Domain<volume_dim>,
       Initialization::Actions::NonconservativeSystem,
+      evolution::Initialization::Actions::SetVariables<
+          domain::Tags::Coordinates<volume_dim, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
       GeneralizedHarmonic::Actions::InitializeGhAnd3Plus1Variables<volume_dim>,
       dg::Actions::InitializeInterfaces<

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -18,6 +18,7 @@
 #include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/NonconservativeSystem.hpp"
+#include "Evolution/Initialization/SetVariables.hpp"
 #include "Evolution/Systems/ScalarWave/Equations.hpp"  // IWYU pragma: keep // for UpwindFlux
 #include "Evolution/Systems/ScalarWave/Initialize.hpp"
 #include "Evolution/Systems/ScalarWave/System.hpp"
@@ -203,6 +204,8 @@ struct EvolutionMetavars {
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
       evolution::dg::Initialization::Domain<system::volume_dim>,
       Initialization::Actions::NonconservativeSystem,
+      evolution::Initialization::Actions::SetVariables<
+          domain::Tags::Coordinates<Dim, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
       ScalarWave::Actions::InitializeConstraints<volume_dim>,
       dg::Actions::InitializeInterfaces<

--- a/tests/Unit/Evolution/Initialization/CMakeLists.txt
+++ b/tests/Unit/Evolution/Initialization/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_EvolutionInitialization")
 set(LIBRARY_SOURCES
   Test_ConservativeSystem.cpp
   Test_DgDomain.cpp
+  Test_NonconservativeSystem.cpp
   Test_Tags.cpp
   Test_SetVariables.cpp
   )

--- a/tests/Unit/Evolution/Initialization/Test_NonconservativeSystem.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_NonconservativeSystem.cpp
@@ -1,0 +1,80 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Initialization/NonconservativeSystem.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct Var : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct System {
+  static constexpr bool is_in_flux_conservative_form = false;
+  static constexpr bool has_primitive_and_conservative_vars = false;
+  static constexpr size_t volume_dim = Dim;
+  using variables_tag = Tags::Variables<tmpl::list<Var>>;
+};
+
+template <size_t Dim, typename Metavariables>
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  using initial_tags = tmpl::list<domain::Tags::Mesh<Dim>>;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<initial_tags>,
+                 Initialization::Actions::NonconservativeSystem>>>;
+};
+
+template <size_t Dim>
+struct Metavariables {
+  using component_list = tmpl::list<component<Dim, Metavariables>>;
+  using system = System<Dim>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  enum class Phase { Initialization, Exit };
+};
+
+template <size_t Dim>
+void test() noexcept {
+  using metavars = Metavariables<Dim>;
+  using comp = component<Dim, metavars>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  MockRuntimeSystem runner{{}};
+  Mesh<Dim> mesh{5, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+  ActionTesting::emplace_component_and_initialize<comp>(&runner, 0, {mesh});
+  // Invoke the NonconservativeSystem action on the runner
+  ActionTesting::next_action<comp>(make_not_null(&runner), 0);
+  using vars_tag = Tags::Variables<tmpl::list<Var>>;
+  // The numerical value that the vars are set to is undefined, but the number
+  // of grid points must be correct.
+  CHECK(ActionTesting::get_databox_tag<comp, vars_tag>(runner, 0)
+            .number_of_grid_points() == mesh.number_of_grid_points());
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Initialization.NonconservativeSystem",
+                  "[Unit][Evolution][Actions]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Add a test for the nonconservative system initialization action and use SetVariables in nonconservative executables.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
