### PR TITLE
Add action for nonconservative moving meshes

### DIFF
--- a/src/Evolution/Actions/AddMeshVelocityNonconservative.hpp
+++ b/src/Evolution/Actions/AddMeshVelocityNonconservative.hpp
@@ -1,0 +1,113 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/optional.hpp>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace evolution {
+namespace Actions {
+/*!
+ * \ingroup ActionsGroup
+ * \brief Compute and add the advective term for nonconservative systems on
+ * moving meshes
+ *
+ * Adds the following term to the time derivative:
+ *
+ * \f{align}{
+ *  v^i_g \partial_i u_\alpha,
+ * \f}
+ *
+ * where \f$u_\alpha\f$ are the evolved variables and \f$v^i_g\f$ is the
+ * velocity of the mesh.
+ *
+ * \note The term is always added in the `Frame::Inertial` frame, and the plus
+ * sign arises because we add it to the time derivative.
+ *
+ * Uses:
+ * - DataBox:
+ *   - `Tags::deriv<system::variables_tags, Dim, Frame::Inertial>`
+ *   - `domain::Tags::MeshVelocity<Dim>`
+ *
+ * DataBox changes:
+ * - Adds: nothing
+ * - Removes: nothing
+ * - Modifies: `Tags::dt<system::variable_tags>`
+ */
+struct AddMeshVelocityNonconservative {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {  // NOLINT const
+    using variables_tags =
+        typename Metavariables::system::variables_tag::tags_list;
+    const auto& mesh_velocity =
+        db::get<::domain::Tags::MeshVelocity<Metavariables::volume_dim>>(box);
+
+    if (static_cast<bool>(mesh_velocity)) {
+      tmpl::for_each<variables_tags>([&box, &mesh_velocity](
+                                         auto variables_tag_v) noexcept {
+        using variable_tag = typename decltype(variables_tag_v)::type;
+        using dt_variable_tag = db::add_tag_prefix<::Tags::dt, variable_tag>;
+        using deriv_tag =
+            db::add_tag_prefix<::Tags::deriv, variable_tag,
+                               tmpl::size_t<Metavariables::volume_dim>,
+                               Frame::Inertial>;
+
+        db::mutate<dt_variable_tag>(
+            make_not_null(&box),
+            [](const auto dt_var_ptr, const auto& deriv_tensor,
+               const boost::optional<tnsr::I<
+                   DataVector, Metavariables::volume_dim, Frame::Inertial>>&
+                   grid_velocity) noexcept {
+              for (size_t storage_index = 0;
+                   storage_index < deriv_tensor.size(); ++storage_index) {
+                // We grab the `deriv_tensor_index`, which would be e.g.
+                // `(i, a, b)`, so `(0, 2, 3)`
+                const auto deriv_tensor_index =
+                    deriv_tensor.get_tensor_index(storage_index);
+                // Then we drop the derivative index (the first entry) to get
+                // `(a, b)` (or `(2, 3)`)
+                const auto tensor_index =
+                    all_but_specified_element_of(deriv_tensor_index, 0);
+                // Set `deriv_index` to `i` (or `0` in the example)
+                const size_t deriv_index = gsl::at(deriv_tensor_index, 0);
+                dt_var_ptr->get(tensor_index) +=
+                    grid_velocity->get(deriv_index) *
+                    deriv_tensor[storage_index];
+              }
+            },
+            db::get<deriv_tag>(box), mesh_velocity);
+      });
+    }
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions
+}  // namespace evolution

--- a/tests/Unit/Evolution/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Actions/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_EvolutionActions")
 
 set(LIBRARY_SOURCES
+  Test_AddMeshVelocityNonconservative.cpp
   Test_AddMeshVelocitySourceTerms.cpp
   Test_ComputeTimeDerivative.cpp
   Test_ComputeVolumeFluxes.cpp

--- a/tests/Unit/Evolution/Actions/Test_AddMeshVelocityNonconservative.cpp
+++ b/tests/Unit/Evolution/Actions/Test_AddMeshVelocityNonconservative.cpp
@@ -1,0 +1,159 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/Actions/AddMeshVelocityNonconservative.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct Var1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct Var2 : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim, Frame::Inertial>;
+};
+
+template <size_t Dim, typename GradientsTags>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+  using variables_tag = Tags::Variables<tmpl::list<Var1, Var2<Dim>>>;
+  using gradients_tags = GradientsTags;
+};
+
+template <typename Metavariables>
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using simple_tags = tmpl::list<
+      db::add_tag_prefix<
+          ::Tags::deriv, typename Metavariables::system::variables_tag,
+          tmpl::size_t<Metavariables::volume_dim>, Frame::Inertial>,
+      db::add_tag_prefix<Tags::dt,
+                         typename Metavariables::system::variables_tag>,
+      domain::Tags::MeshVelocity<Metavariables::volume_dim>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<evolution::Actions::AddMeshVelocityNonconservative>>>;
+};
+
+template <typename System>
+struct Metavariables {
+  static constexpr size_t volume_dim = System::volume_dim;
+  using component_list = tmpl::list<component<Metavariables>>;
+  using system = System;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+template <bool HasMeshVelocity, size_t Dim, typename GradientsTags>
+void test() noexcept {
+  using system = System<Dim, GradientsTags>;
+  using metavars = Metavariables<system>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+
+  boost::optional<tnsr::I<DataVector, Dim, Frame::Inertial>> frame_velocity{};
+  if (HasMeshVelocity) {
+    frame_velocity = tnsr::I<DataVector, Dim, Frame::Inertial>{};
+    for (size_t d = 0; d < Dim; ++d) {
+      frame_velocity->get(d) = DataVector{(1. + d) * 5., (1. + d) * 6.};
+    }
+  }
+
+  db::item_type<db::add_tag_prefix<Tags::dt, typename system::variables_tag>>
+      dt_vars(2, 0.);
+  using deriv_tag =
+      db::add_tag_prefix<::Tags::deriv, typename system::variables_tag,
+                         tmpl::size_t<Dim>, Frame::Inertial>;
+  db::item_type<deriv_tag> deriv_vars(2);
+  for (size_t i = 0; i < Dim; ++i) {
+    get<::Tags::deriv<Var1, tmpl::size_t<Dim>, Frame::Inertial>>(deriv_vars)
+        .get(i) = (1. + i) * 3.;
+    for (size_t d = 0; d < Dim; ++d) {
+      get<::Tags::deriv<Var2<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>(
+          deriv_vars)
+          .get(d, i) = (1. + d) * (5. + i);
+    }
+  }
+
+  using simple_tags = typename component<metavars>::simple_tags;
+  MockRuntimeSystem runner{{}};
+  ActionTesting::emplace_component_and_initialize<component<metavars>>(
+      &runner, 0, {deriv_vars, dt_vars, frame_velocity});
+  ActionTesting::set_phase(make_not_null(&runner), metavars ::Phase::Testing);
+  ActionTesting::next_action<component<metavars>>(make_not_null(&runner), 0);
+
+  const auto& box =
+      ActionTesting::get_databox<component<metavars>, simple_tags>(runner, 0);
+
+  for (size_t i = 0; i < Dim; ++i) {
+    DataVector expected{2, 0.};
+    if (HasMeshVelocity) {
+      for (size_t d = 0; d < Dim; ++d) {
+        expected +=
+            frame_velocity->get(d) *
+            get<::Tags::deriv<Var2<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>(
+                deriv_vars)
+                .get(d, i);
+      }
+    }
+    CHECK_ITERABLE_APPROX(db::get<Tags::dt<Var2<Dim>>>(box).get(i), expected);
+  }
+
+  DataVector expected{2, 0.};
+  if (HasMeshVelocity) {
+    for (size_t d = 0; d < Dim; ++d) {
+      expected += frame_velocity->get(d) *
+                  get<::Tags::deriv<Var1, tmpl::size_t<Dim>, Frame::Inertial>>(
+                      deriv_vars)
+                      .get(d);
+    }
+  }
+  CHECK_ITERABLE_APPROX(get(db::get<Tags::dt<Var1>>(box)), expected);
+}
+
+template <size_t Dim>
+void test_dispatch() noexcept {
+  test<true, Dim, tmpl::list<Var1, Var2<Dim>>>();
+  test<false, Dim, tmpl::list<Var1, Var2<Dim>>>();
+
+  test<true, Dim, tmpl::list<Var1>>();
+  test<false, Dim, tmpl::list<Var1>>();
+
+  test<true, Dim, tmpl::list<Var2<Dim>>>();
+  test<false, Dim, tmpl::list<Var2<Dim>>>();
+
+  test<true, Dim, tmpl::list<>>();
+  test<false, Dim, tmpl::list<>>();
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.AddMeshVelocityNonconservative",
+                  "[Unit][Evolution][Actions]") {
+  test_dispatch<1>();
+  test_dispatch<2>();
+  test_dispatch<3>();
+}


### PR DESCRIPTION
## Proposed changes

Add the action that adds the grid velocity volume term for nonconservative systems.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
