### PR TITLE
Change Domain compute tags to use mutating functions

### DIFF
--- a/src/DataStructures/Tensor/EagerMath/Determinant.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Determinant.hpp
@@ -16,7 +16,7 @@ struct DeterminantImpl;
 template <typename Symm, typename Index>
 struct DeterminantImpl<Symm, Index, Requires<Index::dim == 1>> {
   template <typename T>
-  static typename T::type apply(const T& tensor) {
+  static typename T::type apply(const T& tensor) noexcept {
     return get<0, 0>(tensor);
   }
 };
@@ -24,7 +24,7 @@ struct DeterminantImpl<Symm, Index, Requires<Index::dim == 1>> {
 template <typename Symm, typename Index>
 struct DeterminantImpl<Symm, Index, Requires<Index::dim == 2>> {
   template <typename T>
-  static typename T::type apply(const T& tensor) {
+  static typename T::type apply(const T& tensor) noexcept {
     const auto& t00 = get<0, 0>(tensor);
     const auto& t01 = get<0, 1>(tensor);
     const auto& t10 = get<1, 0>(tensor);
@@ -36,7 +36,7 @@ struct DeterminantImpl<Symm, Index, Requires<Index::dim == 2>> {
 template <typename Index>
 struct DeterminantImpl<Symmetry<2, 1>, Index, Requires<Index::dim == 3>> {
   template <typename T>
-  static typename T::type apply(const T& tensor) {
+  static typename T::type apply(const T& tensor) noexcept {
     const auto& t00 = get<0, 0>(tensor);
     const auto& t01 = get<0, 1>(tensor);
     const auto& t02 = get<0, 2>(tensor);
@@ -54,7 +54,7 @@ struct DeterminantImpl<Symmetry<2, 1>, Index, Requires<Index::dim == 3>> {
 template <typename Index>
 struct DeterminantImpl<Symmetry<1, 1>, Index, Requires<Index::dim == 3>> {
   template <typename T>
-  static typename T::type apply(const T& tensor) {
+  static typename T::type apply(const T& tensor) noexcept {
     const auto& t00 = get<0, 0>(tensor);
     const auto& t01 = get<0, 1>(tensor);
     const auto& t02 = get<0, 2>(tensor);
@@ -69,7 +69,7 @@ struct DeterminantImpl<Symmetry<1, 1>, Index, Requires<Index::dim == 3>> {
 template <typename Index>
 struct DeterminantImpl<Symmetry<2, 1>, Index, Requires<Index::dim == 4>> {
   template <typename T>
-  static typename T::type apply(const T& tensor) {
+  static typename T::type apply(const T& tensor) noexcept {
     const auto& t00 = get<0, 0>(tensor);
     const auto& t01 = get<0, 1>(tensor);
     const auto& t02 = get<0, 2>(tensor);
@@ -102,7 +102,7 @@ struct DeterminantImpl<Symmetry<2, 1>, Index, Requires<Index::dim == 4>> {
 template <typename Index>
 struct DeterminantImpl<Symmetry<1, 1>, Index, Requires<Index::dim == 4>> {
   template <typename T>
-  static typename T::type apply(const T& tensor) {
+  static typename T::type apply(const T& tensor) noexcept {
     const auto& t00 = get<0, 0>(tensor);
     const auto& t01 = get<0, 1>(tensor);
     const auto& t02 = get<0, 2>(tensor);

--- a/src/DataStructures/Tensor/EagerMath/Determinant.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Determinant.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
 
 namespace detail {
 template <typename Symm, typename Index, typename = std::nullptr_t>
@@ -126,22 +127,32 @@ struct DeterminantImpl<Symmetry<1, 1>, Index, Requires<Index::dim == 4>> {
 };
 }  // namespace detail
 
+//@{
 /*!
  * \ingroup TensorGroup
  * \brief Computes the determinant of a rank-2 Tensor `tensor`.
  *
- * \returns The determinant of `tensor`.
  * \requires That `tensor` be a rank-2 Tensor, with both indices sharing the
  *           same dimension and type.
  */
 template <typename T, typename Symm, typename Index0, typename Index1>
-Scalar<T> determinant(
-    const Tensor<T, Symm, index_list<Index0, Index1>>& tensor) {
+void determinant(
+    const gsl::not_null<Scalar<T>*> det_tensor,
+    const Tensor<T, Symm, index_list<Index0, Index1>>& tensor) noexcept {
   static_assert(Index0::dim == Index1::dim,
                 "Cannot take the determinant of a Tensor whose Indices are not "
                 "of the same dimensionality.");
   static_assert(Index0::index_type == Index1::index_type,
                 "Taking the determinant of a mixed Spatial and Spacetime index "
                 "Tensor is not allowed since it's not clear what that means.");
-  return Scalar<T>{detail::DeterminantImpl<Symm, Index0>::apply(tensor)};
+  get(*det_tensor) = detail::DeterminantImpl<Symm, Index0>::apply(tensor);
 }
+
+template <typename T, typename Symm, typename Index0, typename Index1>
+Scalar<T> determinant(
+    const Tensor<T, Symm, index_list<Index0, Index1>>& tensor) noexcept {
+  Scalar<T> result{};
+  determinant(make_not_null(&result), tensor);
+  return result;
+}
+//@}

--- a/src/Domain/LogicalCoordinates.hpp
+++ b/src/Domain/LogicalCoordinates.hpp
@@ -26,8 +26,14 @@ class Mesh;
 class DataVector;
 template <size_t Dim>
 class Direction;
+
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
 /// \endcond
 
+// @{
 /*!
  * \ingroup ComputationalDomainGroup
  * \brief Compute the logical coordinates in an Element.
@@ -35,14 +41,19 @@ class Direction;
  * \details The logical coordinates are the collocation points associated to the
  * spectral basis functions and quadrature of the \p mesh.
  *
- * \returns logical-frame vector holding coordinates
- *
  * \example
  * \snippet Test_LogicalCoordinates.cpp logical_coordinates_example
  */
 template <size_t VolumeDim>
+void logical_coordinates(
+    gsl::not_null<tnsr::I<DataVector, VolumeDim, Frame::Logical>*>
+        logical_coords,
+    const Mesh<VolumeDim>& mesh) noexcept;
+
+template <size_t VolumeDim>
 tnsr::I<DataVector, VolumeDim, Frame::Logical> logical_coordinates(
     const Mesh<VolumeDim>& mesh) noexcept;
+// @}
 
 /*!
  * \ingroup ComputationalDomainGroup
@@ -66,8 +77,12 @@ namespace Tags {
 template <size_t VolumeDim>
 struct LogicalCoordinates : Coordinates<VolumeDim, Frame::Logical>,
                             db::ComputeTag {
-  using argument_tags = tmpl::list<Tags::Mesh<VolumeDim>>;
-  static constexpr auto function = logical_coordinates<VolumeDim>;
+  using base = Coordinates<VolumeDim, Frame::Logical>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<Mesh<VolumeDim>>;
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<return_type*>, const ::Mesh<VolumeDim>&) noexcept>(
+      &logical_coordinates<VolumeDim>);
 };
 }  // namespace Tags
 }  // namespace domain

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -175,12 +175,14 @@ struct InverseJacobianCompute
       db::ComputeTag {
   using base = InverseJacobian<MapTag::dim, typename MapTag::source_frame,
                                typename MapTag::target_frame>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<MapTag, SourceCoordsTag>;
   static constexpr auto function(
+      const gsl::not_null<return_type*> inv_jacobian,
       const db::const_item_type<MapTag>& element_map,
       const db::const_item_type<SourceCoordsTag>& source_coords) noexcept {
-    return element_map.inv_jacobian(source_coords);
+    *inv_jacobian = element_map.inv_jacobian(source_coords);
   }
-  using argument_tags = tmpl::list<MapTag, SourceCoordsTag>;
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -231,13 +231,13 @@ template <size_t VolumeDim>
 struct InternalDirections : db::ComputeTag {
   static constexpr size_t volume_dim = VolumeDim;
   static std::string name() noexcept { return "InternalDirections"; }
+  using return_type = std::unordered_set<::Direction<VolumeDim>>;
   using argument_tags = tmpl::list<Element<VolumeDim>>;
-  static constexpr auto function(const ::Element<VolumeDim>& element) noexcept {
-    std::unordered_set<::Direction<VolumeDim>> result;
+  static void function(const gsl::not_null<return_type*> directions,
+                       const ::Element<VolumeDim>& element) noexcept {
     for (const auto& direction_neighbors : element.neighbors()) {
-      result.insert(direction_neighbors.first);
+      directions->insert(direction_neighbors.first);
     }
-    return result;
   }
 };
 
@@ -250,9 +250,11 @@ template <size_t VolumeDim>
 struct BoundaryDirectionsInterior : db::ComputeTag {
   static constexpr size_t volume_dim = VolumeDim;
   static std::string name() noexcept { return "BoundaryDirectionsInterior"; }
+  using return_type = std::unordered_set<::Direction<VolumeDim>>;
   using argument_tags = tmpl::list<Element<VolumeDim>>;
-  static constexpr auto function(const ::Element<VolumeDim>& element) noexcept {
-    return element.external_boundaries();
+  static void function(const gsl::not_null<return_type*> directions,
+                       const ::Element<VolumeDim>& element) noexcept {
+    *directions = element.external_boundaries();
   }
 };
 
@@ -265,9 +267,11 @@ template <size_t VolumeDim>
 struct BoundaryDirectionsExterior : db::ComputeTag {
   static constexpr size_t volume_dim = VolumeDim;
   static std::string name() noexcept { return "BoundaryDirectionsExterior"; }
+  using return_type = std::unordered_set<::Direction<VolumeDim>>;
   using argument_tags = tmpl::list<Element<VolumeDim>>;
-  static constexpr auto function(const ::Element<VolumeDim>& element) noexcept {
-    return element.external_boundaries();
+  static constexpr auto function(const gsl::not_null<return_type*> directions,
+                                 const ::Element<VolumeDim>& element) noexcept {
+    *directions = element.external_boundaries();
   }
 };
 

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -141,12 +141,15 @@ template <class MapTag, class SourceCoordsTag>
 struct MappedCoordinates
     : Coordinates<MapTag::dim, typename MapTag::target_frame>,
       db::ComputeTag {
+  using base = Coordinates<MapTag::dim, typename MapTag::target_frame>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<MapTag, SourceCoordsTag>;
   static constexpr auto function(
+      const gsl::not_null<return_type*> target_coords,
       const db::const_item_type<MapTag>& element_map,
       const db::const_item_type<SourceCoordsTag>& source_coords) noexcept {
-    return element_map(source_coords);
+    *target_coords = element_map(source_coords);
   }
-  using argument_tags = tmpl::list<MapTag, SourceCoordsTag>;
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/tests/Unit/Domain/Test_Tags.cpp
+++ b/tests/Unit/Domain/Test_Tags.cpp
@@ -5,14 +5,25 @@
 
 #include <string>
 
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Rotation.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/SegmentId.hpp"
 #include "Domain/Tags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Utilities/MakeArray.hpp"
 
 namespace domain {
 namespace {
 template <size_t Dim>
-void test() noexcept {
+void test_simple_tags() noexcept {
   TestHelpers::db::test_simple_tag<Tags::Domain<Dim>>("Domain");
   TestHelpers::db::test_simple_tag<Tags::InitialExtents<Dim>>("InitialExtents");
   TestHelpers::db::test_simple_tag<Tags::InitialRefinementLevels<Dim>>(
@@ -32,15 +43,80 @@ void test() noexcept {
   TestHelpers::db::test_simple_tag<
       Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>>(
       "InverseJacobian(Logical,Inertial)");
-  CHECK(db::tag_name<Tags::InverseJacobianCompute<
-            Tags::ElementMap<Dim>, Tags::Coordinates<Dim, Frame::Logical>>>() ==
-        "InverseJacobian(Logical,Inertial)");
+}
+
+template <size_t Dim>
+ElementMap<Dim, Frame::Grid> element_map() noexcept;
+
+template <>
+ElementMap<1, Frame::Grid> element_map() noexcept {
+  constexpr size_t dim = 1;
+  const auto segment_ids = std::array<SegmentId, dim>({{SegmentId(2, 3)}});
+  const CoordinateMaps::Affine first_map{-3.0, 8.7, 0.4, 5.5};
+  const CoordinateMaps::Affine second_map{1.0, 8.0, -2.5, -1.0};
+  const ElementId<dim> element_id(0, segment_ids);
+  return ElementMap<dim, Frame::Grid>{
+      element_id, make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+                      first_map, second_map)};
+}
+
+template <>
+ElementMap<2, Frame::Grid> element_map() noexcept {
+  constexpr size_t dim = 2;
+  const auto segment_ids =
+      std::array<SegmentId, dim>({{SegmentId(2, 3), SegmentId(1, 0)}});
+  const CoordinateMaps::Rotation<dim> first_map(1.6);
+  const CoordinateMaps::Rotation<dim> second_map(3.1);
+  const ElementId<dim> element_id(0, segment_ids);
+  return ElementMap<dim, Frame::Grid>{
+      element_id, make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+                      first_map, second_map)};
+}
+
+template <>
+ElementMap<3, Frame::Grid> element_map() noexcept {
+  constexpr size_t dim = 3;
+  const auto segment_ids = std::array<SegmentId, dim>(
+      {{SegmentId(2, 3), SegmentId(1, 0), SegmentId(2, 1)}});
+  const CoordinateMaps::Rotation<dim> first_map{M_PI_4, M_PI_4, M_PI_2};
+  const CoordinateMaps::Rotation<dim> second_map{M_PI_4, M_PI_2, M_PI_2};
+  const ElementId<dim> element_id(0, segment_ids);
+  return ElementMap<dim, Frame::Grid>{
+      element_id, make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+                      first_map, second_map)};
+}
+
+template <size_t Dim>
+void test_compute_tags() noexcept {
+  TestHelpers::db::test_compute_tag<Tags::InverseJacobianCompute<
+      Tags::ElementMap<Dim>, Tags::Coordinates<Dim, Frame::Logical>>>(
+      "InverseJacobian(Logical,Inertial)");
+
+  auto map = element_map<Dim>();
+  const tnsr::I<DataVector, Dim, Frame::Logical> logical_coords(
+      make_array<Dim>(DataVector{-1.0, -0.5, 0.0, 0.5, 1.0}));
+  const auto expected_inv_jacobian = map.inv_jacobian(logical_coords);
+
+  const auto box =
+      db::create<tmpl::list<Tags::ElementMap<Dim, Frame::Grid>,
+                            Tags::Coordinates<Dim, Frame::Logical>>,
+                 db::AddComputeTags<Tags::InverseJacobianCompute<
+                     Tags::ElementMap<Dim, Frame::Grid>,
+                     Tags::Coordinates<Dim, Frame::Logical>>>>(std::move(map),
+                                                               logical_coords);
+  CHECK_ITERABLE_APPROX(
+      (db::get<Tags::InverseJacobian<Dim, Frame::Logical, Frame::Grid>>(box)),
+      expected_inv_jacobian);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Tags", "[Unit][Domain]") {
-  test<1>();
-  test<2>();
-  test<3>();
+  test_simple_tags<1>();
+  test_simple_tags<2>();
+  test_simple_tags<3>();
+
+  test_compute_tags<1>();
+  test_compute_tags<2>();
+  test_compute_tags<3>();
 }
 }  // namespace
 }  // namespace domain


### PR DESCRIPTION
## Proposed changes

Mostly, this PR changes compute tags in Domain to use `function` members that return by reference. In addition, this PR adds a compute item for the determinant of the inverse Jacobian.

Some of these changes might not be necessary, so I split them into several commits so it is easier for me to `drop` the ones we do not need.

I left some `const_item_type` in the tags because I'm not sure if they can be removed at all. I didn't try super hard though, so feel free to point me to where the change is effectively possible.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
