### PR TITLE
Decouple elliptic system from linear solver

### DIFF
--- a/src/Elliptic/Actions/InitializeSystem.hpp
+++ b/src/Elliptic/Actions/InitializeSystem.hpp
@@ -96,9 +96,14 @@ struct InitializeSystem {
         domain::Tags::ElementMap<Dim>,
         domain::Tags::Coordinates<Dim, Frame::Logical>>;
 
-    using fluxes_compute_tag = elliptic::Tags::FirstOrderFluxesCompute<system>;
-    using sources_compute_tag =
-        elliptic::Tags::FirstOrderSourcesCompute<system>;
+    using fluxes_compute_tag = elliptic::Tags::FirstOrderFluxesCompute<
+        Dim, typename system::fluxes, typename system::variables_tag,
+        typename system::primal_variables,
+        typename system::auxiliary_variables>;
+    using sources_compute_tag = elliptic::Tags::FirstOrderSourcesCompute<
+        typename system::sources, typename system::variables_tag,
+        typename system::primal_variables,
+        typename system::auxiliary_variables>;
 
     using simple_tags =
         db::AddSimpleTags<fields_tag, linear_operator_applied_to_fields_tag,

--- a/src/Elliptic/Actions/InitializeSystem.hpp
+++ b/src/Elliptic/Actions/InitializeSystem.hpp
@@ -14,9 +14,6 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
-#include "Elliptic/FirstOrderComputeTags.hpp"
-#include "Elliptic/Tags.hpp"
-#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
@@ -28,18 +25,9 @@ namespace Actions {
 /*!
  * \brief Initializes the DataBox tags related to the elliptic system
  *
- * The system fields are initially set to zero. The linear solver operand and
- * the linear operator applied to it are also added, but initialized to
- * undefined values.
+ * The system fields are initially set to zero.
  *
  * \note Currently the sources are always retrieved from an analytic solution.
- *
- * With:
- * - `linear_operand_tag` = `db::add_tag_prefix<LinearSolver::Tags::Operand,
- * fields_tag>`
- * - `fluxes_tag` = `db::add_tag_prefix<Tags::Flux, linear_operand_tag,
- * tmpl::size_t<Dim>, Frame::Inertial>`
- * - `sources_tag` = `db::add_tag_prefix<Tags::Source, linear_operand_tag>`
  *
  * Uses:
  * - Metavariables:
@@ -47,28 +35,14 @@ namespace Actions {
  * - System:
  *   - `fields_tag`
  *   - `primal_fields`
- *   - `primal_variables`
- *   - `auxiliary_variables`
- *   - `fluxes`
- *   - `sources`
  * - DataBox:
  *   - `Tags::Mesh<Dim>`
  *   - `Tags::Coordinates<Dim, Frame::Inertial>`
- *   - All items required by the added compute tags
  *
  * DataBox:
- * - Uses:
- *   - `elliptic::Tags::FluxesComputer<fluxes>`
  * - Adds:
  *   - `fields_tag`
- *   - `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, fields_tag>`
  *   - `db::add_tag_prefix<::Tags::FixedSource, fields_tag>`
- *   - `linear_operand_tag`
- *   - `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
- *   linear_operand_tag>`
- *   - `fluxes_tag`
- *   - `sources_tag`
- *   - `Tags::div<fluxes_tag>`
  */
 struct InitializeSystem {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
@@ -85,44 +59,28 @@ struct InitializeSystem {
         db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, fields_tag>;
     using fixed_sources_tag =
         db::add_tag_prefix<::Tags::FixedSource, fields_tag>;
-    using linear_operand_tag =
-        db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
-    using linear_operator_applied_to_operand_tag =
-        db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
-                           linear_operand_tag>;
-    using fluxes_tag = db::add_tag_prefix<::Tags::Flux, linear_operand_tag,
-                                          tmpl::size_t<Dim>, Frame::Inertial>;
-    using inv_jacobian_tag = domain::Tags::InverseJacobianCompute<
-        domain::Tags::ElementMap<Dim>,
-        domain::Tags::Coordinates<Dim, Frame::Logical>>;
-
-    using fluxes_compute_tag = elliptic::Tags::FirstOrderFluxesCompute<
-        Dim, typename system::fluxes, typename system::variables_tag,
-        typename system::primal_variables,
-        typename system::auxiliary_variables>;
-    using sources_compute_tag = elliptic::Tags::FirstOrderSourcesCompute<
-        typename system::sources, typename system::variables_tag,
-        typename system::primal_variables,
-        typename system::auxiliary_variables>;
-
-    using simple_tags =
-        db::AddSimpleTags<fields_tag, linear_operator_applied_to_fields_tag,
-                          fixed_sources_tag, linear_operand_tag,
-                          linear_operator_applied_to_operand_tag>;
-    using compute_tags = db::AddComputeTags<
-        fluxes_compute_tag, sources_compute_tag,
-        ::Tags::DivVariablesCompute<fluxes_tag, inv_jacobian_tag>>;
 
     const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
     const size_t num_grid_points = mesh.number_of_grid_points();
     const auto& inertial_coords =
         get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box);
 
-    // Set initial data to zero. Non-zero initial data would require us to also
-    // compute the linear operator applied to the the initial data.
+    // Set initial data to zero (for now).
     db::item_type<fields_tag> fields{num_grid_points, 0.};
-    db::item_type<linear_operator_applied_to_fields_tag>
-        linear_operator_applied_to_fields{num_grid_points, 0.};
+    // Since the initial data is zero we don't need to apply the DG operator but
+    // may just set it to zero as well. Once this condition is relaxed we will
+    // have to add a communication step to the initialization that computes the
+    // DG operator to the initial data.
+    db::mutate<linear_operator_applied_to_fields_tag>(
+        make_not_null(&box),
+        [&num_grid_points](
+            const gsl::not_null<
+                db::item_type<linear_operator_applied_to_fields_tag>*>
+                linear_operator_applied_to_fields) noexcept {
+          *linear_operator_applied_to_fields =
+              db::item_type<linear_operator_applied_to_fields_tag>{
+                  num_grid_points, 0.};
+        });
 
     // Retrieve the sources of the elliptic system from the analytic solution,
     // which defines the problem we want to solve.
@@ -135,23 +93,10 @@ struct InitializeSystem {
                        db::wrap_tags_in<::Tags::FixedSource,
                                         typename system::primal_fields>{}));
 
-    // Initialize the variables for the elliptic solve. Their initial value is
-    // determined by the linear solver. The value is also updated by the linear
-    // solver in every step.
-    db::item_type<linear_operand_tag> linear_operand{num_grid_points};
-
-    // Initialize the linear operator applied to the variables. It needs no
-    // initial value, but is computed in every step of the elliptic solve.
-    db::item_type<linear_operator_applied_to_operand_tag>
-        linear_operator_applied_to_operand{num_grid_points};
-
     return std::make_tuple(
-        ::Initialization::merge_into_databox<InitializeSystem, simple_tags,
-                                             compute_tags>(
-            std::move(box), std::move(fields),
-            std::move(linear_operator_applied_to_fields),
-            std::move(fixed_sources), std::move(linear_operand),
-            std::move(linear_operator_applied_to_operand)));
+        ::Initialization::merge_into_databox<
+            InitializeSystem, db::AddSimpleTags<fields_tag, fixed_sources_tag>>(
+            std::move(box), std::move(fields), std::move(fixed_sources)));
   }
 };
 

--- a/src/Elliptic/DiscontinuousGalerkin/InitializeFirstOrderOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/InitializeFirstOrderOperator.hpp
@@ -9,11 +9,14 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
 #include "Elliptic/FirstOrderComputeTags.hpp"
 #include "Elliptic/Tags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
-#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -33,28 +36,29 @@ namespace dg {
 namespace Actions {
 
 /*!
- * \brief Initialize DataBox tags related to discontinuous Galerkin fluxes
- *
- * Uses:
- * - System:
- *   - `volume_dim`
- *   - `variables_tag`
- *   - `fluxes`
+ * \brief Initialize DataBox tags for building the first-order elliptic DG
+ * operator
  */
-template <typename Metavariables>
-struct InitializeFluxes {
+template <size_t Dim, typename FluxesComputer, typename SourcesComputer,
+          typename VariablesTag, typename PrimalVariables,
+          typename AuxiliaryVariables>
+struct InitializeFirstOrderOperator {
  private:
-  using system = typename Metavariables::system;
-  static constexpr size_t volume_dim = system::volume_dim;
-  using vars_tag = typename system::variables_tag;
+  static constexpr size_t volume_dim = Dim;
+  using vars_tag = VariablesTag;
+  using exterior_vars_tag = domain::Tags::Interface<
+      domain::Tags::BoundaryDirectionsExterior<volume_dim>, vars_tag>;
   using fluxes_tag =
       db::add_tag_prefix<::Tags::Flux, vars_tag, tmpl::size_t<volume_dim>,
                          Frame::Inertial>;
   using div_fluxes_tag = db::add_tag_prefix<::Tags::div, fluxes_tag>;
+  using inv_jacobian_tag =
+      domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>;
 
   template <typename Directions>
   using face_tags =
-      tmpl::list<domain::Tags::Slice<Directions, fluxes_tag>,
+      tmpl::list<domain::Tags::Slice<Directions, vars_tag>,
+                 domain::Tags::Slice<Directions, fluxes_tag>,
                  domain::Tags::Slice<Directions, div_fluxes_tag>,
                  // For the strong first-order DG scheme we also need the
                  // interface normal dotted into the fluxes
@@ -62,9 +66,12 @@ struct InitializeFluxes {
                      Directions, ::Tags::NormalDotFluxCompute<
                                      vars_tag, volume_dim, Frame::Inertial>>>;
 
-  using fluxes_compute_tag = elliptic::Tags::FirstOrderFluxesCompute<
-      volume_dim, typename system::fluxes, typename system::variables_tag,
-      typename system::primal_variables, typename system::auxiliary_variables>;
+  using fluxes_compute_tag =
+      elliptic::Tags::FirstOrderFluxesCompute<volume_dim, FluxesComputer,
+                                              vars_tag, PrimalVariables,
+                                              AuxiliaryVariables>;
+  using sources_compute_tag = elliptic::Tags::FirstOrderSourcesCompute<
+      SourcesComputer, vars_tag, PrimalVariables, AuxiliaryVariables>;
 
   using exterior_tags = tmpl::list<
       // On exterior (ghost) boundary faces we compute the fluxes from the
@@ -81,22 +88,34 @@ struct InitializeFluxes {
                           div_fluxes_tag>>;
 
  public:
-  template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
-            typename ActionList, typename ParallelComponent>
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
   static auto apply(db::DataBox<DbTagsList>& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
+    // Initialize the variables on exterior (ghost) boundary faces. They are
+    // updated throughout the algorithm to impose boundary conditions.
+    db::item_type<exterior_vars_tag> exterior_boundary_vars{};
+    const auto& mesh = db::get<domain::Tags::Mesh<volume_dim>>(box);
+    for (const auto& direction : db::get<domain::Tags::Element<volume_dim>>(box)
+                                     .external_boundaries()) {
+      exterior_boundary_vars[direction] = db::item_type<vars_tag>{
+          mesh.slice_away(direction.dimension()).number_of_grid_points()};
+    }
     using compute_tags = tmpl::flatten<tmpl::list<
+        fluxes_compute_tag, sources_compute_tag,
+        ::Tags::DivVariablesCompute<fluxes_tag, inv_jacobian_tag>,
         face_tags<domain::Tags::InternalDirections<volume_dim>>,
         face_tags<domain::Tags::BoundaryDirectionsInterior<volume_dim>>,
         exterior_tags>>;
     return std::make_tuple(
-        ::Initialization::merge_into_databox<InitializeFluxes,
-                                             db::AddSimpleTags<>, compute_tags>(
-            std::move(box)));
+        ::Initialization::merge_into_databox<
+            InitializeFirstOrderOperator, db::AddSimpleTags<exterior_vars_tag>,
+            compute_tags>(std::move(box), std::move(exterior_boundary_vars)));
   }
 };
 }  // namespace Actions

--- a/src/Elliptic/DiscontinuousGalerkin/InitializeFluxes.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/InitializeFluxes.hpp
@@ -62,7 +62,9 @@ struct InitializeFluxes {
                      Directions, ::Tags::NormalDotFluxCompute<
                                      vars_tag, volume_dim, Frame::Inertial>>>;
 
-  using fluxes_compute_tag = elliptic::Tags::FirstOrderFluxesCompute<system>;
+  using fluxes_compute_tag = elliptic::Tags::FirstOrderFluxesCompute<
+      volume_dim, typename system::fluxes, typename system::variables_tag,
+      typename system::primal_variables, typename system::auxiliary_variables>;
 
   using exterior_tags = tmpl::list<
       // On exterior (ghost) boundary faces we compute the fluxes from the

--- a/src/Elliptic/Executables/Linear/SolveLinearEllipticProblem.hpp
+++ b/src/Elliptic/Executables/Linear/SolveLinearEllipticProblem.hpp
@@ -159,7 +159,7 @@ struct Metavariables {
           volume_dim, LinearSolver::Tags::OperatorAppliedTo,
           typename system::variables_tag>>,
       elliptic::dg::Actions::ImposeHomogeneousDirichletBoundaryConditions<
-          Metavariables>,
+          typename system::variables_tag, typename system::primal_variables>,
       dg::Actions::CollectDataForFluxes<
           boundary_scheme,
           domain::Tags::BoundaryDirectionsInterior<volume_dim>>,

--- a/src/Elliptic/Executables/Linear/SolveLinearEllipticProblem.hpp
+++ b/src/Elliptic/Executables/Linear/SolveLinearEllipticProblem.hpp
@@ -93,8 +93,6 @@ struct Metavariables {
   using linear_solver_iteration_id =
       LinearSolver::Tags::IterationId<typename linear_solver::options_group>;
 
-  using temporal_id = linear_solver_iteration_id;
-
   // Parse numerical flux parameters from the input file to store in the cache.
   using normal_dot_numerical_flux = Tags::NumericalFlux<
       elliptic::dg::NumericalFluxes::FirstOrderInternalPenalty<

--- a/src/Elliptic/Systems/Elasticity/Equations.cpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.cpp
@@ -72,22 +72,5 @@ void auxiliary_fluxes(
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))
 
-// Instantiate derivative templates
-template <size_t Dim>
-using variables_tag = typename Elasticity::FirstOrderSystem<Dim>::variables_tag;
-template <size_t Dim>
-using fluxes_tags_list = db::get_variables_tags_list<db::add_tag_prefix<
-    ::Tags::Flux, variables_tag<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
-
-#define INSTANTIATE_DERIVS(_, data)                                            \
-  template Variables<db::wrap_tags_in<Tags::div, fluxes_tags_list<DIM(data)>>> \
-  divergence<fluxes_tags_list<DIM(data)>, DIM(data), Frame::Inertial>(         \
-      const Variables<fluxes_tags_list<DIM(data)>>&, const Mesh<DIM(data)>&,   \
-      const InverseJacobian<DataVector, DIM(data), Frame::Logical,             \
-                            Frame::Inertial>&) noexcept;
-
-GENERATE_INSTANTIATIONS(INSTANTIATE_DERIVS, (2, 3))
-
 #undef INSTANTIATE
-#undef INSTANTIATE_DERIVS
 #undef DIM

--- a/src/Elliptic/Systems/Elasticity/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Elasticity/FirstOrderSystem.hpp
@@ -11,18 +11,8 @@
 #include "Elliptic/Systems/Elasticity/Equations.hpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
-#include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp"
 #include "Utilities/TMPL.hpp"
-
-/// \cond
-namespace LinearSolver {
-namespace Tags {
-template <typename>
-struct Operand;
-}  // namespace Tags
-}  // namespace LinearSolver
-/// \endcond
 
 namespace Elasticity {
 
@@ -73,14 +63,6 @@ struct FirstOrderSystem {
   using auxiliary_fields = tmpl::list<strain>;
   using fields_tag =
       ::Tags::Variables<tmpl::append<primal_fields, auxiliary_fields>>;
-
-  // The variables to compute bulk contributions and fluxes for.
-  using variables_tag =
-      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
-  using primal_variables =
-      db::wrap_tags_in<LinearSolver::Tags::Operand, primal_fields>;
-  using auxiliary_variables =
-      db::wrap_tags_in<LinearSolver::Tags::Operand, auxiliary_fields>;
 
   using fluxes = Fluxes<Dim>;
   using sources = Sources<Dim>;

--- a/src/Elliptic/Systems/Poisson/Equations.cpp
+++ b/src/Elliptic/Systems/Poisson/Equations.cpp
@@ -66,30 +66,5 @@ void auxiliary_fluxes(gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*>
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
-// Instantiate derivative templates
-#include "DataStructures/DataBox/Prefixes.hpp"
-#include "Elliptic/Systems/Poisson/FirstOrderSystem.hpp"
-#include "Elliptic/Systems/Poisson/Geometry.hpp"
-#include "Elliptic/Systems/Poisson/Tags.hpp"  // IWYU pragma: keep
-#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"  // IWYU pragma: keep
-#include "Utilities/TMPL.hpp"
-
-template <size_t Dim>
-using variables_tag = typename Poisson::FirstOrderSystem<
-    Dim, Poisson::Geometry::Euclidean>::variables_tag;
-template <size_t Dim>
-using fluxes_tags_list = db::get_variables_tags_list<db::add_tag_prefix<
-    ::Tags::Flux, variables_tag<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
-
-#define INSTANTIATE_DERIVS(_, data)                                            \
-  template Variables<db::wrap_tags_in<Tags::div, fluxes_tags_list<DIM(data)>>> \
-  divergence<fluxes_tags_list<DIM(data)>, DIM(data), Frame::Inertial>(         \
-      const Variables<fluxes_tags_list<DIM(data)>>&, const Mesh<DIM(data)>&,   \
-      const InverseJacobian<DataVector, DIM(data), Frame::Logical,             \
-                            Frame::Inertial>&) noexcept;
-
-GENERATE_INSTANTIATIONS(INSTANTIATE_DERIVS, (1, 2, 3))
-
 #undef INSTANTIATE
-#undef INSTANTIATE_DERIVS
 #undef DIM

--- a/src/Elliptic/Systems/Poisson/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Poisson/FirstOrderSystem.hpp
@@ -15,18 +15,8 @@
 #include "Elliptic/Systems/Poisson/Geometry.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
-#include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
-
-/// \cond
-namespace LinearSolver {
-namespace Tags {
-template <typename>
-struct Operand;
-}  // namespace Tags
-}  // namespace LinearSolver
-/// \endcond
 
 namespace Poisson {
 
@@ -93,14 +83,6 @@ struct FirstOrderSystem {
   using auxiliary_fields = tmpl::list<field_gradient>;
   using fields_tag =
       ::Tags::Variables<tmpl::append<primal_fields, auxiliary_fields>>;
-
-  // The variables to compute bulk contributions and fluxes for.
-  using variables_tag =
-      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
-  using primal_variables =
-      db::wrap_tags_in<LinearSolver::Tags::Operand, primal_fields>;
-  using auxiliary_variables =
-      db::wrap_tags_in<LinearSolver::Tags::Operand, auxiliary_fields>;
 
   using fluxes =
       tmpl::conditional_t<BackgroundGeometry == Geometry::Euclidean,

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
@@ -28,6 +28,12 @@ template <typename FieldsTag, typename OptionsGroup>
 struct InitializeElement {
  private:
   using fields_tag = FieldsTag;
+  using operator_applied_to_fields_tag =
+      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, fields_tag>;
+  using operand_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
+  using operator_applied_to_operand_tag =
+      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, operand_tag>;
   using residual_tag =
       db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>;
 
@@ -47,14 +53,21 @@ struct InitializeElement {
         ::Initialization::merge_into_databox<
             InitializeElement,
             db::AddSimpleTags<LinearSolver::Tags::IterationId<OptionsGroup>,
-                              residual_tag,
+                              operator_applied_to_fields_tag, operand_tag,
+                              operator_applied_to_operand_tag, residual_tag,
                               LinearSolver::Tags::HasConverged<OptionsGroup>>,
-            compute_tags>(std::move(box),
-                          // The `PrepareSolve` action populates these tags with
-                          // initial values
-                          std::numeric_limits<size_t>::max(),
-                          db::item_type<residual_tag>{},
-                          Convergence::HasConverged{}));
+            compute_tags>(
+            std::move(box),
+            // The `PrepareSolve` action populates these tags with initial
+            // values, except for `operator_applied_to_fields_tag` which is
+            // expected to be filled at that point and
+            // `operator_applied_to_operand_tag` which is expected to be updated
+            // in every iteration of the algorithm.
+            std::numeric_limits<size_t>::max(),
+            db::item_type<operator_applied_to_fields_tag>{},
+            db::item_type<operand_tag>{},
+            db::item_type<operator_applied_to_operand_tag>{},
+            db::item_type<residual_tag>{}, Convergence::HasConverged{}));
   }
 };
 

--- a/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
@@ -21,12 +21,11 @@
 #include "Domain/Creators/Brick.hpp"
 #include "Domain/Creators/Interval.hpp"
 #include "Domain/Creators/Rectangle.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/Tags.hpp"
 #include "Elliptic/Actions/InitializeSystem.hpp"
-#include "Elliptic/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
-#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
@@ -44,50 +43,18 @@ struct AuxiliaryFieldTag : db::SimpleTag {
 };
 
 template <size_t Dim>
-struct Fluxes {
-  using argument_tags = tmpl::list<>;
-  static void apply(
-      const gsl::not_null<tnsr::I<DataVector, Dim>*> flux_for_field,
-      const tnsr::i<DataVector, Dim>& auxiliary_field) {
-    for (size_t d = 0; d < Dim; d++) {
-      flux_for_field->get(d) = auxiliary_field.get(d);
-    }
-  }
-  static void apply(
-      const gsl::not_null<tnsr::Ij<DataVector, Dim>*> flux_for_aux_field,
-      const Scalar<DataVector>& field) {
-    for (size_t d = 0; d < Dim; d++) {
-      flux_for_aux_field->get(d, d) = get(field);
-    }
-  }
-  // clang-tidy: no runtime references
-  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
-};
-
-struct Sources {
-  using argument_tags = tmpl::list<>;
-  static void apply(const gsl::not_null<Scalar<DataVector>*> source_for_field,
-                    const Scalar<DataVector>& field) {
-    get(*source_for_field) = get(field);
-  }
-};
-
-template <size_t Dim>
 struct System {
   static constexpr size_t volume_dim = Dim;
   using fields_tag =
       Tags::Variables<tmpl::list<ScalarFieldTag, AuxiliaryFieldTag<Dim>>>;
   using primal_fields = tmpl::list<ScalarFieldTag>;
   using auxiliary_fields = tmpl::list<AuxiliaryFieldTag<Dim>>;
-  using variables_tag =
-      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
-  using primal_variables =
-      db::wrap_tags_in<LinearSolver::Tags::Operand, primal_fields>;
-  using auxiliary_variables =
-      db::wrap_tags_in<LinearSolver::Tags::Operand, auxiliary_fields>;
-  using fluxes = Fluxes<Dim>;
-  using sources = Sources;
 };
+
+template <size_t Dim>
+using linear_operator_applied_to_fields_tag =
+    db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
+                       typename System<Dim>::fields_tag>;
 
 template <size_t Dim>
 struct AnalyticSolution {
@@ -113,9 +80,10 @@ struct ElementArray {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<ActionTesting::InitializeDataBox<
-                         tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
-                                    domain::Tags::InitialExtents<Dim>>>,
+          tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<
+                         domain::Tags::InitialRefinementLevels<Dim>,
+                         domain::Tags::InitialExtents<Dim>,
+                         linear_operator_applied_to_fields_tag<Dim>>>,
                      dg::Actions::InitializeDomain<Dim>>>,
 
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -128,65 +96,31 @@ struct Metavariables {
   using system = System<Dim>;
   using component_list = tmpl::list<ElementArray<Dim, Metavariables>>;
   using analytic_solution_tag = Tags::AnalyticSolution<AnalyticSolution<Dim>>;
-  using const_global_cache_tags =
-      tmpl::list<analytic_solution_tag,
-                 elliptic::Tags::FluxesComputer<Fluxes<Dim>>>;
+  using const_global_cache_tags = tmpl::list<analytic_solution_tag>;
   enum class Phase { Initialization, Testing, Exit };
 };
-
-template <size_t Dim>
-void check_compute_items(
-    const ActionTesting::MockRuntimeSystem<Metavariables<Dim>>& runner,
-    const ElementId<Dim>& element_id) {
-  // The compute items themselves are tested elsewhere, so just check if they
-  // were indeed added by the initializer
-  const auto tag_is_retrievable = [&runner,
-                                   &element_id](auto tag_v) -> decltype(auto) {
-    using tag = std::decay_t<decltype(tag_v)>;
-    return ActionTesting::tag_is_retrievable<
-        ElementArray<Dim, Metavariables<Dim>>, tag>(runner, element_id);
-  };
-  CHECK(tag_is_retrievable(
-      ::Tags::Flux<LinearSolver::Tags::Operand<ScalarFieldTag>,
-                   tmpl::size_t<Dim>, Frame::Inertial>{}));
-  CHECK(tag_is_retrievable(
-      ::Tags::Flux<LinearSolver::Tags::Operand<AuxiliaryFieldTag<Dim>>,
-                   tmpl::size_t<Dim>, Frame::Inertial>{}));
-  CHECK(tag_is_retrievable(
-      ::Tags::div<::Tags::Flux<LinearSolver::Tags::Operand<ScalarFieldTag>,
-                               tmpl::size_t<Dim>, Frame::Inertial>>{}));
-  CHECK(tag_is_retrievable(
-      ::Tags::div<
-          ::Tags::Flux<LinearSolver::Tags::Operand<AuxiliaryFieldTag<Dim>>,
-                       tmpl::size_t<Dim>, Frame::Inertial>>{}));
-  CHECK(tag_is_retrievable(
-      ::Tags::Source<LinearSolver::Tags::Operand<ScalarFieldTag>>{}));
-  CHECK(tag_is_retrievable(
-      ::Tags::Source<LinearSolver::Tags::Operand<AuxiliaryFieldTag<Dim>>>{}));
-}
 
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
                   "[Unit][Elliptic][Actions]") {
+  domain::creators::register_derived_with_charm();
   {
     INFO("1D");
     // Which element we work with does not matter for this test
     const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
     const domain::creators::Interval domain_creator{
         {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
-    // Register the coordinate map for serialization
-    PUPable_reg(
-        SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,
-                                         domain::CoordinateMaps::Affine>));
 
     using metavariables = Metavariables<1>;
     using element_array = ElementArray<1, metavariables>;
     ActionTesting::MockRuntimeSystem<metavariables> runner{
-        {AnalyticSolution<1>{}, Fluxes<1>{}, domain_creator.create_domain()}};
+        {AnalyticSolution<1>{}, domain_creator.create_domain()}};
     ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id, {domain_creator.initial_refinement_levels(),
-                              domain_creator.initial_extents()});
+        &runner, element_id,
+        {domain_creator.initial_refinement_levels(),
+         domain_creator.initial_extents(),
+         db::item_type<linear_operator_applied_to_fields_tag<1>>{4}});
     ActionTesting::next_action<element_array>(make_not_null(&runner),
                                               element_id);
     ActionTesting::set_phase(make_not_null(&runner),
@@ -198,8 +132,6 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
       return ActionTesting::get_databox_tag<element_array, tag>(runner,
                                                                 element_id);
     };
-
-    check_compute_items(runner, element_id);
 
     // Test the initial guess is zero
     CHECK(get_tag(ScalarFieldTag{}) == Scalar<DataVector>{{{{4, 0.}}}});
@@ -212,12 +144,6 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
           // This check is against the source computed by the
           // analytic solution above
           get<0>(inertial_coords));
-    // Test the linear solver quantities are initialized, but value is undefined
-    CHECK(get(get_tag(LinearSolver::Tags::Operand<ScalarFieldTag>{})).size() ==
-          4);
-    CHECK(get(get_tag(LinearSolver::Tags::OperatorAppliedTo<
-                      LinearSolver::Tags::Operand<ScalarFieldTag>>{}))
-              .size() == 4);
   }
   {
     INFO("2D");
@@ -225,20 +151,16 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
     const ElementId<2> element_id{0, {{SegmentId{2, 1}, SegmentId{0, 0}}}};
     const domain::creators::Rectangle domain_creator{
         {{-0.5, 0.}}, {{1.5, 2.}}, {{false, false}}, {{2, 0}}, {{4, 3}}};
-    // Register the coordinate map for serialization
-    PUPable_reg(
-        SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,
-                                         domain::CoordinateMaps::ProductOf2Maps<
-                                             domain::CoordinateMaps::Affine,
-                                             domain::CoordinateMaps::Affine>>));
 
     using metavariables = Metavariables<2>;
     using element_array = ElementArray<2, metavariables>;
     ActionTesting::MockRuntimeSystem<metavariables> runner{
-        {AnalyticSolution<2>{}, Fluxes<2>{}, domain_creator.create_domain()}};
+        {AnalyticSolution<2>{}, domain_creator.create_domain()}};
     ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id, {domain_creator.initial_refinement_levels(),
-                              domain_creator.initial_extents()});
+        &runner, element_id,
+        {domain_creator.initial_refinement_levels(),
+         domain_creator.initial_extents(),
+         db::item_type<linear_operator_applied_to_fields_tag<2>>{12}});
     ActionTesting::next_action<element_array>(make_not_null(&runner),
                                               element_id);
     ActionTesting::set_phase(make_not_null(&runner),
@@ -250,8 +172,6 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
       return ActionTesting::get_databox_tag<element_array, tag>(runner,
                                                                 element_id);
     };
-
-    check_compute_items(runner, element_id);
 
     // Test the initial guess is zero
     CHECK(get_tag(ScalarFieldTag{}) == Scalar<DataVector>{{{{12, 0.}}}});
@@ -264,11 +184,6 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
           // This check is against the source computed by the
           // analytic solution above
           get<0>(inertial_coords) + get<1>(inertial_coords));
-    CHECK(get(get_tag(LinearSolver::Tags::Operand<ScalarFieldTag>{})).size() ==
-          12);
-    CHECK(get(get_tag(LinearSolver::Tags::OperatorAppliedTo<
-                      LinearSolver::Tags::Operand<ScalarFieldTag>>{}))
-              .size() == 12);
   }
   {
     INFO("3D");
@@ -280,21 +195,16 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
                                                  {{false, false, false}},
                                                  {{2, 0, 1}},
                                                  {{4, 3, 2}}};
-    // Register the coordinate map for serialization
-    PUPable_reg(SINGLE_ARG(
-        domain::CoordinateMap<
-            Frame::Logical, Frame::Inertial,
-            domain::CoordinateMaps::ProductOf3Maps<
-                domain::CoordinateMaps::Affine, domain::CoordinateMaps::Affine,
-                domain::CoordinateMaps::Affine>>));
 
     using metavariables = Metavariables<3>;
     using element_array = ElementArray<3, metavariables>;
     ActionTesting::MockRuntimeSystem<metavariables> runner{
-        {AnalyticSolution<3>{}, Fluxes<3>{}, domain_creator.create_domain()}};
+        {AnalyticSolution<3>{}, domain_creator.create_domain()}};
     ActionTesting::emplace_component_and_initialize<element_array>(
-        &runner, element_id, {domain_creator.initial_refinement_levels(),
-                              domain_creator.initial_extents()});
+        &runner, element_id,
+        {domain_creator.initial_refinement_levels(),
+         domain_creator.initial_extents(),
+         db::item_type<linear_operator_applied_to_fields_tag<3>>{24}});
     ActionTesting::next_action<element_array>(make_not_null(&runner),
                                               element_id);
     ActionTesting::set_phase(make_not_null(&runner),
@@ -306,8 +216,6 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
       return ActionTesting::get_databox_tag<element_array, tag>(runner,
                                                                 element_id);
     };
-
-    check_compute_items(runner, element_id);
 
     // Test the initial guess is zero
     CHECK(get_tag(ScalarFieldTag{}) == Scalar<DataVector>{{{{24, 0.}}}});
@@ -321,11 +229,5 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
           // analytic solution above
           get<0>(inertial_coords) + get<1>(inertial_coords) +
               get<2>(inertial_coords));
-    // Test the linear solver quantities are initialized, but value is undefined
-    CHECK(get(get_tag(LinearSolver::Tags::Operand<ScalarFieldTag>{})).size() ==
-          24);
-    CHECK(get(get_tag(LinearSolver::Tags::OperatorAppliedTo<
-                      LinearSolver::Tags::Operand<ScalarFieldTag>>{}))
-              .size() == 24);
   }
 }

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
@@ -8,7 +8,7 @@ set(LIBRARY "Test_EllipticDG")
 set(LIBRARY_SOURCES
   Test_ImposeBoundaryConditions.cpp
   Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
-  Test_InitializeFluxes.cpp
+  Test_InitializeFirstOrderOperator.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFirstOrderOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFirstOrderOperator.cpp
@@ -25,7 +25,7 @@
 #include "Domain/Mesh.hpp"
 #include "Domain/SegmentId.hpp"
 #include "Domain/Tags.hpp"
-#include "Elliptic/DiscontinuousGalerkin/InitializeFluxes.hpp"
+#include "Elliptic/DiscontinuousGalerkin/InitializeFirstOrderOperator.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
@@ -54,6 +54,11 @@ using fluxes_tag = db::add_tag_prefix<::Tags::Flux, vars_tag<Dim>,
 template <size_t Dim>
 using div_fluxes_tag = db::add_tag_prefix<::Tags::div, fluxes_tag<Dim>>;
 template <size_t Dim>
+using n_dot_fluxes_tag =
+    db::add_tag_prefix<::Tags::NormalDotFlux, vars_tag<Dim>>;
+template <size_t Dim>
+using sources_tag = db::add_tag_prefix<::Tags::Source, vars_tag<Dim>>;
+template <size_t Dim>
 using inv_jacobian_tag = domain::Tags::InverseJacobianCompute<
     domain::Tags::ElementMap<Dim>,
     domain::Tags::Coordinates<Dim, Frame::Logical>>;
@@ -79,6 +84,14 @@ struct Fluxes {
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 };
 
+struct Sources {
+  using argument_tags = tmpl::list<>;
+  static void apply(const gsl::not_null<Scalar<DataVector>*> source_for_field,
+                    const Scalar<DataVector>& field) {
+    get(*source_for_field) = get(field);
+  }
+};
+
 template <size_t Dim, typename Metavariables>
 struct ElementArray {
   using metavariables = Metavariables;
@@ -88,38 +101,28 @@ struct ElementArray {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<
-              ActionTesting::InitializeDataBox<
-                  tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
-                  domain::Tags::InitialExtents<Dim>, vars_tag<Dim>>>,
-              dg::Actions::InitializeDomain<Dim>,
-              Initialization::Actions::AddComputeTags<tmpl::list<
-                  elliptic::Tags::FirstOrderFluxesCompute<
-                      Dim, typename metavariables::system::fluxes,
-                      typename metavariables::system::variables_tag,
-                      typename metavariables::system::primal_variables,
-                      typename metavariables::system::auxiliary_variables>,
-                  ::Tags::DivVariablesCompute<fluxes_tag<Dim>,
-                                              inv_jacobian_tag<Dim>>>>,
-              dg::Actions::InitializeInterfaces<
-                  typename Metavariables::system,
-                  dg::Initialization::slice_tags_to_face<vars_tag<Dim>>,
-                  dg::Initialization::slice_tags_to_exterior<vars_tag<Dim>>,
-                  dg::Initialization::face_compute_tags<>,
-                  dg::Initialization::exterior_compute_tags<>, false>>>,
+          tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<
+                         domain::Tags::InitialRefinementLevels<Dim>,
+                         domain::Tags::InitialExtents<Dim>, vars_tag<Dim>>>,
+                     dg::Actions::InitializeDomain<Dim>,
+                     dg::Actions::InitializeInterfaces<
+                         typename Metavariables::system,
+                         dg::Initialization::slice_tags_to_face<>,
+                         dg::Initialization::slice_tags_to_exterior<>,
+                         dg::Initialization::face_compute_tags<>,
+                         dg::Initialization::exterior_compute_tags<>, false>>>,
 
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<elliptic::dg::Actions::InitializeFluxes<metavariables>>>>;
+          tmpl::list<elliptic::dg::Actions::InitializeFirstOrderOperator<
+              Dim, Fluxes<Dim>, Sources, vars_tag<Dim>,
+              tmpl::list<ScalarFieldTag>,
+              tmpl::list<AuxiliaryFieldTag<Dim>>>>>>;
 };
 
 template <size_t Dim>
 struct System {
   static constexpr size_t volume_dim = Dim;
-  using variables_tag = vars_tag<Dim>;
-  using primal_variables = tmpl::list<ScalarFieldTag>;
-  using auxiliary_variables = tmpl::list<AuxiliaryFieldTag<Dim>>;
-  using fluxes = Fluxes<Dim>;
   template <typename Tag>
   using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;
 };
@@ -146,8 +149,29 @@ void check_compute_items(
     return ActionTesting::tag_is_retrievable<
         ElementArray<Dim, Metavariables<Dim>>, tag>(runner, element_id);
   };
-  CHECK(tag_is_retrievable(
-      ::Tags::Flux<ScalarFieldTag, tmpl::size_t<Dim>, Frame::Inertial>{}));
+  // Volume items
+  using volume_tags =
+      tmpl::list<fluxes_tag<Dim>, div_fluxes_tag<Dim>, sources_tag<Dim>>;
+  tmpl::for_each<volume_tags>([&tag_is_retrievable](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    CAPTURE(db::tag_name<tag>());
+    CHECK(tag_is_retrievable(tag{}));
+  });
+  // Interface items
+  using face_tags = tmpl::list<vars_tag<Dim>, fluxes_tag<Dim>,
+                               div_fluxes_tag<Dim>, n_dot_fluxes_tag<Dim>>;
+  tmpl::for_each<face_tags>([&tag_is_retrievable](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    CAPTURE(db::tag_name<tag>());
+    CHECK(tag_is_retrievable(
+        domain::Tags::Interface<domain::Tags::InternalDirections<Dim>, tag>{}));
+    CHECK(tag_is_retrievable(
+        domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<Dim>,
+                                tag>{}));
+    CHECK(tag_is_retrievable(
+        domain::Tags::Interface<domain::Tags::BoundaryDirectionsExterior<Dim>,
+                                tag>{}));
+  });
 }
 
 template <size_t Dim>
@@ -165,9 +189,9 @@ void test_initialize_fluxes(const DomainCreator<Dim>& domain_creator,
   ActionTesting::MockRuntimeSystem<metavariables> runner{
       {Fluxes<Dim>{}, domain_creator.create_domain()}};
   ActionTesting::emplace_component_and_initialize<element_array>(
-      &runner, element_id, {domain_creator.initial_refinement_levels(),
-                            std::move(initial_extents), std::move(vars)});
-  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+      &runner, element_id,
+      {domain_creator.initial_refinement_levels(), std::move(initial_extents),
+       std::move(vars)});
   ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
   ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
   ActionTesting::set_phase(make_not_null(&runner),
@@ -175,11 +199,25 @@ void test_initialize_fluxes(const DomainCreator<Dim>& domain_creator,
   ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
 
   check_compute_items(runner, element_id);
+
+  // Check the variables on exterior boundaries exist (for imposing boundary
+  // conditions)
+  const auto& exterior_boundary_vars = ActionTesting::get_databox_tag<
+      element_array,
+      domain::Tags::Interface<domain::Tags::BoundaryDirectionsExterior<Dim>,
+                              vars_tag<Dim>>>(runner, element_id);
+  const auto& exterior_directions = ActionTesting::get_databox_tag<
+      element_array, domain::Tags::BoundaryDirectionsExterior<Dim>>(runner,
+                                                                    element_id);
+  for (const auto& direction : exterior_directions) {
+    CHECK(exterior_boundary_vars.find(direction) !=
+          exterior_boundary_vars.end());
+  }
 }
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Elliptic.DG.Actions.InitializeFluxes",
+SPECTRE_TEST_CASE("Unit.Elliptic.DG.Actions.InitializeFirstOrderOperator",
                   "[Unit][Elliptic][Actions]") {
   domain::creators::register_derived_with_charm();
   {

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
@@ -93,11 +93,14 @@ struct ElementArray {
                   tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
                   domain::Tags::InitialExtents<Dim>, vars_tag<Dim>>>,
               dg::Actions::InitializeDomain<Dim>,
-              Initialization::Actions::AddComputeTags<
-                  tmpl::list<elliptic::Tags::FirstOrderFluxesCompute<
-                                 typename metavariables::system>,
-                             ::Tags::DivVariablesCompute<
-                                 fluxes_tag<Dim>, inv_jacobian_tag<Dim>>>>,
+              Initialization::Actions::AddComputeTags<tmpl::list<
+                  elliptic::Tags::FirstOrderFluxesCompute<
+                      Dim, typename metavariables::system::fluxes,
+                      typename metavariables::system::variables_tag,
+                      typename metavariables::system::primal_variables,
+                      typename metavariables::system::auxiliary_variables>,
+                  ::Tags::DivVariablesCompute<fluxes_tag<Dim>,
+                                              inv_jacobian_tag<Dim>>>>,
               dg::Actions::InitializeInterfaces<
                   typename Metavariables::system,
                   dg::Initialization::slice_tags_to_face<vars_tag<Dim>>,

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -151,8 +151,10 @@ using operator_applied_to_operand_tag =
 // an input file.
 
 // Forward declare to keep these actions in the order they are used
+template <typename OperandTag>
 struct CollectOperatorAction;
 
+template <typename OperandTag>
 struct ComputeOperatorAction {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent>
@@ -170,17 +172,17 @@ struct ComputeOperatorAction {
     const auto number_of_elements = operator_matrices.size();
     const auto& linear_operator = gsl::at(operator_matrices, array_index);
     const auto number_of_grid_points = linear_operator.columns();
-    const auto& operand = get<operand_tag>(box);
+    const auto& operand = get<OperandTag>(box);
 
-    db::item_type<fields_tag> operator_applied_to_operand{
+    db::item_type<OperandTag> operator_applied_to_operand{
         number_of_grid_points * number_of_elements};
     dgemv_('N', linear_operator.rows(), linear_operator.columns(), 1,
            linear_operator.data(), linear_operator.spacing(), operand.data(), 1,
            0, operator_applied_to_operand.data(), 1);
 
-    Parallel::contribute_to_reduction<CollectOperatorAction>(
+    Parallel::contribute_to_reduction<CollectOperatorAction<OperandTag>>(
         Parallel::ReductionData<
-            Parallel::ReductionDatum<db::item_type<fields_tag>, funcl::Plus<>>>{
+            Parallel::ReductionDatum<db::item_type<OperandTag>, funcl::Plus<>>>{
             operator_applied_to_operand},
         Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
         Parallel::get_parallel_component<ParallelComponent>(cache));
@@ -191,28 +193,38 @@ struct ComputeOperatorAction {
   }
 };
 
+template <typename OperandTag>
 struct CollectOperatorAction {
-  template <
-      typename ParallelComponent, typename DbTagsList, typename Metavariables,
-      Requires<tmpl::list_contains_v<DbTagsList, ScalarFieldTag>> = nullptr>
+  using local_operator_applied_to_operand_tag =
+      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, OperandTag>;
+
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ScalarFieldOperandTag,
+            Requires<tmpl::list_contains_v<
+                DbTagsList, local_operator_applied_to_operand_tag>> = nullptr>
   static void apply(db::DataBox<DbTagsList>& box,
                     const Parallel::ConstGlobalCache<Metavariables>& cache,
                     const int array_index,
-                    const db::item_type<fields_tag>& Ap_global_data) noexcept {
+                    const Variables<tmpl::list<ScalarFieldOperandTag>>&
+                        Ap_global_data) noexcept {
     // This could be generalized to work on the Variables instead of the
     // Scalar, but it's only for the purpose of this test.
     const auto number_of_grid_points = get<LinearOperator>(cache)[0].columns();
-    const auto& Ap_global = get<ScalarFieldTag>(Ap_global_data).get();
+    const auto& Ap_global = get<ScalarFieldOperandTag>(Ap_global_data).get();
     DataVector Ap_local{number_of_grid_points};
     std::copy(Ap_global.begin() +
                   array_index * static_cast<int>(number_of_grid_points),
               Ap_global.begin() +
                   (array_index + 1) * static_cast<int>(number_of_grid_points),
               Ap_local.begin());
-    db::mutate<LinearSolver::Tags::OperatorAppliedTo<
-        LinearSolver::Tags::Operand<ScalarFieldTag>>>(
+    db::mutate<local_operator_applied_to_operand_tag>(
         make_not_null(&box),
-        [&Ap_local](auto Ap) noexcept { *Ap = Scalar<DataVector>(Ap_local); });
+        [&Ap_local, &number_of_grid_points](auto Ap) noexcept {
+          *Ap = db::item_type<local_operator_applied_to_operand_tag>{
+              number_of_grid_points};
+          get(get<LinearSolver::Tags::OperatorAppliedTo<ScalarFieldOperandTag>>(
+              *Ap)) = Ap_local;
+        });
     // Proceed with algorithm
     Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
         .perform_algorithm(true);
@@ -262,17 +274,9 @@ struct InitializeElement {
 
     return std::make_tuple(
         ::Initialization::merge_into_databox<
-            InitializeElement,
-            db::AddSimpleTags<fields_tag, sources_tag,
-                              operator_applied_to_fields_tag, operand_tag,
-                              operator_applied_to_operand_tag>>(
+            InitializeElement, db::AddSimpleTags<fields_tag, sources_tag>>(
             std::move(box), db::item_type<fields_tag>{num_points, 0.},
-            db::item_type<sources_tag>{source},
-            db::item_type<operator_applied_to_fields_tag>{num_points, 0.},
-            db::item_type<operand_tag>{
-                num_points, std::numeric_limits<double>::signaling_NaN()},
-            db::item_type<operator_applied_to_operand_tag>{
-                num_points, std::numeric_limits<double>::signaling_NaN()}));
+            db::item_type<sources_tag>{source}));
   }
 };
 
@@ -286,6 +290,7 @@ struct ElementArray {
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<InitializeElement,
                      typename linear_solver::initialize_element,
+                     ComputeOperatorAction<fields_tag>,
                      typename linear_solver::prepare_solve,
                      Parallel::Actions::TerminatePhase>>,
 
@@ -295,7 +300,7 @@ struct ElementArray {
           tmpl::list<LinearSolver::Actions::TerminateIfConverged<
                          typename linear_solver::options_group>,
                      typename linear_solver::prepare_step,
-                     ComputeOperatorAction,
+                     ComputeOperatorAction<operand_tag>,
                      typename linear_solver::perform_step>>,
 
       Parallel::PhaseActions<

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -168,7 +168,7 @@ struct ComputeOperatorAction {
       const ActionList /*meta*/,
       // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
       const ParallelComponent* const /*meta*/) noexcept {
-    const auto& operator_matrices = get<LinearOperator>(cache);
+    const auto& operator_matrices = get<LinearOperator>(box);
     const auto number_of_elements = operator_matrices.size();
     const auto& linear_operator = gsl::at(operator_matrices, array_index);
     const auto number_of_grid_points = linear_operator.columns();
@@ -209,7 +209,7 @@ struct CollectOperatorAction {
                         Ap_global_data) noexcept {
     // This could be generalized to work on the Variables instead of the
     // Scalar, but it's only for the purpose of this test.
-    const auto number_of_grid_points = get<LinearOperator>(cache)[0].columns();
+    const auto number_of_grid_points = get<LinearOperator>(box)[0].columns();
     const auto& Ap_global = get<ScalarFieldOperandTag>(Ap_global_data).get();
     DataVector Ap_local{number_of_grid_points};
     std::copy(Ap_global.begin() +
@@ -239,7 +239,7 @@ struct TestResult {
   static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
       db::DataBox<DbTagsList>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
       const int array_index,
       // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
@@ -252,7 +252,7 @@ struct TestResult {
     SPECTRE_PARALLEL_REQUIRE(has_converged.reason() ==
                              Convergence::Reason::AbsoluteResidual);
     const auto& expected_result =
-        gsl::at(get<ExpectedResult>(cache), array_index);
+        gsl::at(get<ExpectedResult>(box), array_index);
     const auto& result = get<ScalarFieldTag>(box).get();
     for (size_t i = 0; i < expected_result.size(); i++) {
       SPECTRE_PARALLEL_REQUIRE(result[i] == approx(expected_result[i]));
@@ -266,10 +266,10 @@ struct InitializeElement {
             typename ActionList, typename ParallelComponent>
   static auto apply(db::DataBox<DbTagsList>& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const int array_index, const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    const auto& source = gsl::at(get<Source>(cache), array_index);
+    const auto& source = gsl::at(get<Source>(box), array_index);
     const size_t num_points = source.size();
 
     return std::make_tuple(

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -119,7 +119,7 @@ struct ComputeOperatorAction {
   static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
       db::DataBox<DbTagsList>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
       const int /*array_index*/,
       // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
@@ -134,7 +134,7 @@ struct ComputeOperatorAction {
            const DenseVector<double>& operand) noexcept {
           *operator_applied_to_operand = linear_operator * operand;
         },
-        get<LinearOperator>(cache), get<OperandTag>(box));
+        get<LinearOperator>(box), get<OperandTag>(box));
     return {std::move(box), false};
   }
 };
@@ -147,7 +147,7 @@ struct TestResult {
   static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
       db::DataBox<DbTagsList>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
       const int /*array_index*/,
       // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
@@ -160,7 +160,7 @@ struct TestResult {
     SPECTRE_PARALLEL_REQUIRE(has_converged.reason() ==
                              Convergence::Reason::AbsoluteResidual);
     const auto& result = get<VectorTag>(box);
-    const auto& expected_result = get<ExpectedResult>(cache);
+    const auto& expected_result = get<ExpectedResult>(box);
     for (size_t i = 0; i < expected_result.size(); i++) {
       SPECTRE_PARALLEL_REQUIRE(result[i] == approx(expected_result[i]));
     }
@@ -173,14 +173,14 @@ struct InitializeElement {
             typename ActionList, typename ParallelComponent>
   static auto apply(db::DataBox<DbTagsList>& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const int /*array_index*/, const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
     return std::make_tuple(
         ::Initialization::merge_into_databox<
             InitializeElement,
             db::AddSimpleTags<VectorTag, ::Tags::FixedSource<VectorTag>>>(
-            std::move(box), get<InitialGuess>(cache), get<Source>(cache)));
+            std::move(box), get<InitialGuess>(box), get<Source>(box)));
   }
 };  // namespace
 
@@ -250,11 +250,11 @@ struct CleanOutput {
   static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
       db::DataBox<DbTagsList>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
     const auto& reductions_file_name =
-        get<observers::Tags::ReductionFileName>(cache) + ".h5";
+        get<observers::Tags::ReductionFileName>(box) + ".h5";
     if (file_system::check_if_file_exists(reductions_file_name)) {
       file_system::rm(reductions_file_name, true);
     } else if (CheckExpectedOutput) {


### PR DESCRIPTION
## Proposed changes

- Move linear solver variables from elliptic system to Metavariables
- Template some actions on the variables instead of the system
- Initialize linear solver variables by linear solver and all quantities related to the DG operator in another action

**Details:**

Some linear solvers such as GMRES and CG work by applying the linear operator to an internal "operand" quantity, or even a "preconditioned operand" when they support preconditioning, whereas others such as the Schwarz smoother alloy the linear operator to the system fields directly. The elliptic system does not need to know that, so this PR moves the logic to the Metavariables that chooses which linear solver to use and that defines the algorithm.

**Note to reviewers:** I split the diff into a bunch of commits to make reviewing easier, but will squash the commits labeled `[squash]` into one once the review is complete because they don't compile independently.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
