### PR TITLE
Fix bug in CheckPythonFormatting script

### DIFF
--- a/tools/CheckPythonFormatting.sh
+++ b/tools/CheckPythonFormatting.sh
@@ -14,12 +14,13 @@ if ! find ./src/ \
      -print0 \
         | xargs -0 yapf --parallel -d
 then
-    printf "\n\nFound bad formatting in python files. See diff above \n" \
-           "for details. You can run yapf on a file as:\n" \
-           "  yapf -i PYTHON_FILE.py\n" \
-           "or on the entire repository by running:\n" \
-           "  ./tools/FormatPythonCode.py\n" \
-           "in the SpECTRE root directory.\n"
+    printf '%s\n' '' '' \
+           'Found bad formatting in python files. See diff above' \
+           'for details. You can run yapf on a file as:' \
+           '  yapf -i PYTHON_FILE.py' \
+           'or on the entire repository by running:' \
+           '  ./tools/FormatPythonCode.py' \
+           'in the SpECTRE root directory.'
     exit 1
 fi
 


### PR DESCRIPTION
Previously, the error message only printed the first line when the check
failed.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
