### PR TITLE
Fix doxygen warning on newer versions of doxygen

### DIFF
--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -55,11 +55,11 @@ class Variables;
  * `db::SimpleTag`. In general, they should be DataBoxTags that are not compute
  * items. For example,
  *
- * \snippet TestTags.hpp simple_variables_tag
+ * \snippet Helpers/DataStructures/TestTags.hpp simple_variables_tag
  *
  * Prefix tags can also be stored and their format is:
  *
- * \snippet TestTags.hpp prefix_variables_tag
+ * \snippet Helpers/DataStructures/TestTags.hpp prefix_variables_tag
  *
  * #### Design Decisions
  *


### PR DESCRIPTION
## Proposed changes

Life is easier without this warning.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
