### PR TITLE
GH gauge refactors to make it easier to support different gauges

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -32,9 +32,9 @@ namespace DampedHarmonicGauge_detail {
 // This function can be written with an extra factor inside the exponent in
 // literature, e.g. \cite Deppe2018uye. We absorb that in \f$\sigma_r\f$.
 template <size_t SpatialDim, typename Frame, typename DataType>
-void weight_function(const gsl::not_null<Scalar<DataType>*> weight,
-                     const tnsr::I<DataType, SpatialDim, Frame>& coords,
-                     const double sigma_r) noexcept {
+void spatial_weight_function(const gsl::not_null<Scalar<DataType>*> weight,
+                             const tnsr::I<DataType, SpatialDim, Frame>& coords,
+                             const double sigma_r) noexcept {
   if (UNLIKELY(get_size(get(*weight)) != get_size(get<0>(coords)))) {
     *weight = Scalar<DataType>(get_size(get<0>(coords)));
   }
@@ -43,11 +43,11 @@ void weight_function(const gsl::not_null<Scalar<DataType>*> weight,
 }
 
 template <size_t SpatialDim, typename Frame, typename DataType>
-Scalar<DataType> weight_function(
+Scalar<DataType> spatial_weight_function(
     const tnsr::I<DataType, SpatialDim, Frame>& coords,
     const double sigma_r) noexcept {
   Scalar<DataType> weight{};
-  weight_function(make_not_null(&weight), coords, sigma_r);
+  spatial_weight_function(make_not_null(&weight), coords, sigma_r);
   return weight;
 }
 
@@ -58,7 +58,7 @@ Scalar<DataType> weight_function(
 // \partial_a W(x^i)= \partial_a \exp(- (r/\sigma_r)^2)
 //                  = (-2 * x^i / \sigma_r^2) * exp(-(r/\sigma_r)^2)
 template <size_t SpatialDim, typename Frame, typename DataType>
-void spacetime_deriv_of_weight_function(
+void spacetime_deriv_of_spatial_weight_function(
     const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_weight,
     const tnsr::I<DataType, SpatialDim, Frame>& coords,
     const double sigma_r) noexcept {
@@ -66,7 +66,7 @@ void spacetime_deriv_of_weight_function(
     *d4_weight = tnsr::a<DataType, SpatialDim, Frame>(get_size(get<0>(coords)));
   }
   const DataType pre_factor =
-      get(weight_function(coords, sigma_r)) * (-2. / pow<2>(sigma_r));
+      get(spatial_weight_function(coords, sigma_r)) * (-2. / pow<2>(sigma_r));
   // time derivative of weight function is zero
   get<0>(*d4_weight) = 0.;
   for (size_t i = 0; i < SpatialDim; ++i) {
@@ -75,12 +75,12 @@ void spacetime_deriv_of_weight_function(
 }
 
 template <size_t SpatialDim, typename Frame, typename DataType>
-tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_weight_function(
+tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_spatial_weight_function(
     const tnsr::I<DataType, SpatialDim, Frame>& coords,
     const double sigma_r) noexcept {
   tnsr::a<DataType, SpatialDim, Frame> d4_weight{};
-  spacetime_deriv_of_weight_function(make_not_null(&d4_weight), coords,
-                                     sigma_r);
+  spacetime_deriv_of_spatial_weight_function(make_not_null(&d4_weight), coords,
+                                             sigma_r);
   return d4_weight;
 }
 
@@ -372,7 +372,8 @@ void damped_harmonic_h(
       time, t_start_L2, sigma_t_L2);
   const double roll_on_S =
       DampedHarmonicGauge_detail::roll_on_function(time, t_start_S, sigma_t_S);
-  DampedHarmonicGauge_detail::weight_function<SpatialDim, Frame, DataVector>(
+  DampedHarmonicGauge_detail::spatial_weight_function<SpatialDim, Frame,
+                                                      DataVector>(
       make_not_null(&weight), coords, sigma_r);
 
   get(mu_L1) =
@@ -545,7 +546,8 @@ void spacetime_deriv_damped_harmonic_h(
       time, t_start_L2, sigma_t_L2);
   const auto roll_on_S =
       DampedHarmonicGauge_detail::roll_on_function(time, t_start_S, sigma_t_S);
-  DampedHarmonicGauge_detail::weight_function<SpatialDim, Frame, DataVector>(
+  DampedHarmonicGauge_detail::spatial_weight_function<SpatialDim, Frame,
+                                                      DataVector>(
       make_not_null(&weight), coords, sigma_r);
 
   // coeffs that enter gauge source function
@@ -576,7 +578,7 @@ void spacetime_deriv_damped_harmonic_h(
           time, t_start_L2, sigma_t_L2);
 
   // Calc \f$ \partial_a [R W] \f$
-  DampedHarmonicGauge_detail::spacetime_deriv_of_weight_function<
+  DampedHarmonicGauge_detail::spacetime_deriv_of_spatial_weight_function<
       SpatialDim, Frame, DataVector>(make_not_null(&d4_weight), coords,
                                      sigma_r);
   d4_RW_L1 = d4_weight;
@@ -728,21 +730,22 @@ void spacetime_deriv_damped_harmonic_h(
 #define DTYPE_SCAL(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
-  template void DampedHarmonicGauge_detail::weight_function(                  \
+  template void DampedHarmonicGauge_detail::spatial_weight_function(          \
       const gsl::not_null<Scalar<DTYPE(data)>*> weight,                       \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,             \
       const double sigma_r) noexcept;                                         \
-  template Scalar<DTYPE(data)> DampedHarmonicGauge_detail::weight_function(   \
+  template Scalar<DTYPE(data)>                                                \
+  DampedHarmonicGauge_detail::spatial_weight_function(                        \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,             \
       const double sigma_r) noexcept;                                         \
   template void                                                               \
-  DampedHarmonicGauge_detail::spacetime_deriv_of_weight_function(             \
+  DampedHarmonicGauge_detail::spacetime_deriv_of_spatial_weight_function(     \
       const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>      \
           d4_weight,                                                          \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,             \
       const double sigma_r) noexcept;                                         \
   template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \
-  DampedHarmonicGauge_detail::spacetime_deriv_of_weight_function(             \
+  DampedHarmonicGauge_detail::spacetime_deriv_of_spatial_weight_function(     \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,             \
       const double sigma_r) noexcept;                                         \
   template void                                                               \

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.py
@@ -12,13 +12,13 @@ from PointwiseFunctions.GeneralRelativity.ComputeSpacetimeQuantities import (
     spacetime_normal_vector)
 
 
-def weight_function(coords, r_max):
+def spatial_weight_function(coords, r_max):
     r2 = np.sum([coords[i]**2 for i in range(len(coords))])
     return np.exp(-r2 / r_max / r_max)
 
 
-def spacetime_deriv_weight_function(coords, r_max):
-    W = weight_function(coords, r_max)
+def spacetime_deriv_spatial_weight_function(coords, r_max):
+    W = spatial_weight_function(coords, r_max)
     DW = np.zeros(len(coords) + 1)
     DW[1:] = -2. * W / r_max / r_max * coords
     return DW
@@ -91,7 +91,7 @@ def damped_harmonic_gauge_source_function(gauge_h_init, lapse, shift,
     log_sqrtg_over_lapse = log_fac(lapse, sqrt_det_spatial_metric, 0.5)
     log_one_over_lapse = log_fac(lapse, sqrt_det_spatial_metric, 0.)
     R = roll_on_function(time, t_start, sigma_t)
-    W = weight_function(coords, r_max)
+    W = spatial_weight_function(coords, r_max)
     muL1 = R * W * log_sqrtg_over_lapse**4
     muL2 = R * W * log_one_over_lapse**4
     muS = muL1
@@ -124,7 +124,7 @@ def spacetime_deriv_damped_harmonic_gauge_source_function(
     log_one_over_lapse_pow5 = log_one_over_lapse * log_one_over_lapse_pow4
 
     R = roll_on_function(time, t_start, sigma_t)
-    W = weight_function(coords, r_max)
+    W = spatial_weight_function(coords, r_max)
 
     muL1 = R * W * log_sqrtg_over_lapse_pow4
     muS_over_N = muL1 / lapse
@@ -132,7 +132,7 @@ def spacetime_deriv_damped_harmonic_gauge_source_function(
     mu1 = muL1 * log_sqrtg_over_lapse
     mu2 = R * W * log_one_over_lapse_pow5
 
-    d4_W = spacetime_deriv_weight_function(coords, r_max)
+    d4_W = spacetime_deriv_spatial_weight_function(coords, r_max)
     d0_R = time_deriv_roll_on_function(time, t_start, sigma_t)
     d4_RW = R * d4_W
     d4_RW[0] += W * d0_R

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -60,12 +60,12 @@ namespace DampedHarmonicGauge_detail {
 // The `detail` functions below are forward-declared to enable their independent
 // testing
 template <size_t SpatialDim, typename Frame, typename DataType>
-Scalar<DataType> weight_function(
+Scalar<DataType> spatial_weight_function(
     const tnsr::I<DataType, SpatialDim, Frame>& coords,
     double sigma_r) noexcept;
 
 template <size_t SpatialDim, typename Frame, typename DataType>
-tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_weight_function(
+tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_spatial_weight_function(
     const tnsr::I<DataType, SpatialDim, Frame>& coords,
     double sigma_r) noexcept;
 
@@ -181,21 +181,22 @@ void test_detail_functions(const DataType& used_for_size) noexcept {
       static_cast<Scalar<DataType> (*)(
           const tnsr::I<DataType, SpatialDim, Frame>&, const double)>(
           &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
-              weight_function<SpatialDim, Frame, DataType>),
+              spatial_weight_function<SpatialDim, Frame, DataType>),
       "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
       "DampedHarmonic",
-      "weight_function",
+      "spatial_weight_function",
       {{{-10., 10.}, {std::numeric_limits<double>::denorm_min(), 10.}}},
       used_for_size);
-  // spacetime_deriv_of_weight_function
+  // spacetime_deriv_of_spatial_weight_function
   pypp::check_with_random_values<2>(
       static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
           const tnsr::I<DataType, SpatialDim, Frame>&, const double)>(
           &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
-              spacetime_deriv_of_weight_function<SpatialDim, Frame, DataType>),
+              spacetime_deriv_of_spatial_weight_function<SpatialDim, Frame,
+                                                         DataType>),
       "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
       "DampedHarmonic",
-      "spacetime_deriv_weight_function",
+      "spacetime_deriv_spatial_weight_function",
       {{{-10., 10.}, {std::numeric_limits<double>::denorm_min(), 10.}}},
       used_for_size);
   // roll_on_function
@@ -456,9 +457,9 @@ void test_damped_harmonic_h_function_term_2_of_4(
   const double roll_on_L1 =
       GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L1, sigma_t_L1);
-  const auto weight =
-      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
-          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  const auto weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+      spatial_weight_function<SpatialDim, Frame::Inertial, DataVector>(x,
+                                                                       r_max);
 
   const auto h_prefac1 = amp_coef_L1 * roll_on_L1 * get(weight) *
                          pow(log_fac_1, exp_L1) * log_fac_1;
@@ -555,9 +556,9 @@ void test_damped_harmonic_h_function_term_3_of_4(
   const double roll_on_L2 =
       GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L2, sigma_t_L2);
-  const auto weight =
-      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
-          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  const auto weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+      spatial_weight_function<SpatialDim, Frame::Inertial, DataVector>(x,
+                                                                       r_max);
 
   const auto log_fac_2 = log(1. / get(lapse));
   const auto h_prefac1 = amp_coef_L2 * roll_on_L2 * get(weight) *
@@ -653,9 +654,9 @@ void test_damped_harmonic_h_function_term_4_of_4(
   const double roll_on_S =
       GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_S, sigma_t_S);
-  const auto weight =
-      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
-          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  const auto weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+      spatial_weight_function<SpatialDim, Frame::Inertial, DataVector>(x,
+                                                                       r_max);
 
   const auto log_fac_1 = log(get(sqrt_det_spatial_metric) * one_over_lapse);
   const auto h_prefac2 = -amp_coef_S * roll_on_S * get(weight) *
@@ -742,9 +743,9 @@ void test_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
   const double roll_on_L1 =
       GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L1, sigma_t_L1);
-  const auto weight =
-      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
-          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  const auto weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+      spatial_weight_function<SpatialDim, Frame::Inertial, DataVector>(x,
+                                                                       r_max);
 
   const auto gauge_h_init = make_with_value<db::item_type<
       GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
@@ -866,9 +867,9 @@ void test_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
   const double roll_on_L2 =
       GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_L2, sigma_t_L2);
-  const auto weight =
-      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
-          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  const auto weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+      spatial_weight_function<SpatialDim, Frame::Inertial, DataVector>(x,
+                                                                       r_max);
 
   const auto gauge_h_init = make_with_value<db::item_type<
       GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
@@ -975,9 +976,9 @@ void test_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
   const double roll_on_S =
       GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::roll_on_function(
           t, t_start_S, sigma_t_S);
-  const auto weight =
-      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
-          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  const auto weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+      spatial_weight_function<SpatialDim, Frame::Inertial, DataVector>(x,
+                                                                       r_max);
 
   const auto gauge_h_init = make_with_value<db::item_type<
       GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
@@ -1365,12 +1366,12 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4(
   const auto d0_roll_on_L1 =
       GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
           time_deriv_of_roll_on_function(t, t_start_L1, sigma_t_L1);
-  const auto weight =
-      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
-          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  const auto weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+      spatial_weight_function<SpatialDim, Frame::Inertial, DataVector>(x,
+                                                                       r_max);
   auto d4_weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
-      spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
-                                         DataVector>(x, r_max);
+      spacetime_deriv_of_spatial_weight_function<SpatialDim, Frame::Inertial,
+                                                 DataVector>(x, r_max);
 
   // coeffs that enter gauge source function
   const auto mu_L1 =
@@ -1570,12 +1571,12 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4(
   const auto d0_roll_on_L2 =
       GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
           time_deriv_of_roll_on_function(t, t_start_L2, sigma_t_L2);
-  const auto weight =
-      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
-          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  const auto weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+      spatial_weight_function<SpatialDim, Frame::Inertial, DataVector>(x,
+                                                                       r_max);
   auto d4_weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
-      spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
-                                         DataVector>(x, r_max);
+      spacetime_deriv_of_spatial_weight_function<SpatialDim, Frame::Inertial,
+                                                 DataVector>(x, r_max);
 
   // coeffs that enter gauge source function
   const auto mu_L2 =
@@ -1778,12 +1779,12 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4(
   const auto d0_roll_on_S =
       GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
           time_deriv_of_roll_on_function(t, t_start_S, sigma_t_S);
-  const auto weight =
-      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
-          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  const auto weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+      spatial_weight_function<SpatialDim, Frame::Inertial, DataVector>(x,
+                                                                       r_max);
   auto d4_weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
-      spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
-                                         DataVector>(x, r_max);
+      spacetime_deriv_of_spatial_weight_function<SpatialDim, Frame::Inertial,
+                                                 DataVector>(x, r_max);
 
   // coeffs that enter gauge source function
   const auto mu_S =
@@ -1999,12 +2000,12 @@ void test_deriv_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
   const auto d0_roll_on_L1 =
       GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
           time_deriv_of_roll_on_function(t, t_start_L1, sigma_t_L1);
-  const auto weight =
-      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
-          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  const auto weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+      spatial_weight_function<SpatialDim, Frame::Inertial, DataVector>(x,
+                                                                       r_max);
   auto d4_weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
-      spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
-                                         DataVector>(x, r_max);
+      spacetime_deriv_of_spatial_weight_function<SpatialDim, Frame::Inertial,
+                                                 DataVector>(x, r_max);
 
   // Evaluate analytic solution for Schwarzschild, ab initio.
   const double mass = solution.mass();
@@ -2299,12 +2300,12 @@ void test_deriv_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
   const auto d0_roll_on_L2 =
       GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
           time_deriv_of_roll_on_function(t, t_start_L2, sigma_t_L2);
-  const auto weight =
-      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
-          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  const auto weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+      spatial_weight_function<SpatialDim, Frame::Inertial, DataVector>(x,
+                                                                       r_max);
   auto d4_weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
-      spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
-                                         DataVector>(x, r_max);
+      spacetime_deriv_of_spatial_weight_function<SpatialDim, Frame::Inertial,
+                                                 DataVector>(x, r_max);
 
   // Evaluate analytic solution for Schwarzschild, ab initio.
   const double mass = solution.mass();
@@ -2600,12 +2601,12 @@ void test_deriv_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
   const auto d0_roll_on_S =
       GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
           time_deriv_of_roll_on_function(t, t_start_S, sigma_t_S);
-  const auto weight =
-      GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::weight_function<
-          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  const auto weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+      spatial_weight_function<SpatialDim, Frame::Inertial, DataVector>(x,
+                                                                       r_max);
   auto d4_weight = GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
-      spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
-                                         DataVector>(x, r_max);
+      spacetime_deriv_of_spatial_weight_function<SpatialDim, Frame::Inertial,
+                                                 DataVector>(x, r_max);
 
   // Evaluate analytic solution for Schwarzschild, ab initio.
   const double mass = solution.mass();


### PR DESCRIPTION
## Proposed changes

- Move GH gauges into `gauges` namespace
- Rename DH weight function to `spatial_weight_function`

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
