### PR TITLE
Add AnalyticData for NewtonianEuler

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -774,6 +774,19 @@
   year      = "2003",
 }
 
+@article{Schaal2015,
+  author   = "Schaal, K. and Bauer, A. and Chandrashekar, P. and Pakmor, R. and
+              Klingenberg, C. and Springel, V.",
+  title    = "Astrophysical hydrodynamics with a high-order discontinuous
+              Galerkin scheme and adaptive mesh refinement",
+  year     = "2015",
+  url      = "https://academic.oup.com/mnras/article/453/4/4278/2593686",
+  doi      = "10.1093/mnras/stv1859",
+  journal  = "MNRAS",
+  pages    = "4278--4300",
+  volume   = "453",
+}
+
 @book{Shapiro1983,
   author = "Shapiro, Stuart L. and Teukolsky, Saul A.",
   title  = "Black holes, white dwarfs, and neutron stars:

--- a/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBS_TO_LINK
   LinearOperators
   MathFunctions
   NewtonianEuler
+  NewtonianEulerAnalyticData
   NewtonianEulerNumericalFluxes
   NewtonianEulerSolutions
   NewtonianEulerSources
@@ -63,3 +64,14 @@ function(add_lane_emden_executable)
 endfunction(add_lane_emden_executable)
 
 add_lane_emden_executable()
+
+function(add_kh_instability_executable DIM)
+  add_newtonian_euler_executable(
+    KhInstability
+    ${DIM}
+    NewtonianEuler::AnalyticData::KhInstability<${DIM}>
+    )
+endfunction(add_kh_instability_executable)
+
+add_kh_instability_executable(2)
+add_kh_instability_executable(3)

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -62,6 +62,7 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.hpp"

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEulerFwd.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEulerFwd.hpp
@@ -6,6 +6,11 @@
 #include <cstddef>
 
 namespace NewtonianEuler {
+namespace AnalyticData {
+template <size_t Dim>
+class KhInstability;
+}  // namespace AnalyticData
+
 namespace Solutions {
 template <size_t Dim>
 class IsentropicVortex;

--- a/src/Evolution/Systems/NewtonianEuler/Sources/NoSource.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/NoSource.hpp
@@ -5,6 +5,12 @@
 
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
 namespace NewtonianEuler {
 namespace Sources {
 

--- a/src/PointwiseFunctions/AnalyticData/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/CMakeLists.txt
@@ -3,3 +3,4 @@
 
 add_subdirectory(Burgers)
 add_subdirectory(GrMhd)
+add_subdirectory(NewtonianEuler)

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/AnalyticData.hpp
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/AnalyticData.hpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace NewtonianEuler {
+/*!
+ * \ingroup AnalyticDataGroup
+ * \brief Holds classes implementing analytic data for the NewtonianEuler system
+ */
+namespace AnalyticData {}
+}  // namespace NewtonianEuler

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY NewtonianEulerAnalyticData)
+
+set(LIBRARY_SOURCES
+  KhInstability.cpp
+  )
+
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC DataStructures
+  INTERFACE ErrorHandling
+  INTERFACE Hydro
+  INTERFACE NewtonianEuler
+  )

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.cpp
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.cpp
@@ -1,0 +1,209 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+/// \cond
+namespace NewtonianEuler {
+namespace AnalyticData {
+
+template <size_t Dim>
+KhInstability<Dim>::KhInstability(
+    const double adiabatic_index, const double strip_bimedian_height,
+    const double strip_thickness, const double strip_density,
+    const double strip_velocity, const double background_density,
+    const double background_velocity, const double pressure,
+    const double perturbation_amplitude, const double perturbation_width)
+    : adiabatic_index_(adiabatic_index),
+      strip_bimedian_height_(strip_bimedian_height),
+      strip_half_thickness_(0.5 * strip_thickness),
+      strip_density_(strip_density),
+      strip_velocity_(strip_velocity),
+      background_density_(background_density),
+      background_velocity_(background_velocity),
+      pressure_(pressure),
+      perturbation_amplitude_(perturbation_amplitude),
+      perturbation_width_(perturbation_width),
+      equation_of_state_(adiabatic_index) {
+  ASSERT(strip_density_ > 0.0 and background_density_ > 0.0,
+         "The mass density must be positive everywhere. Inner "
+         "density: "
+             << strip_density_ << ", Outer density: " << background_density_
+             << ".");
+  ASSERT(pressure_ > 0.0, "The pressure must be positive. The value given was "
+                              << pressure_ << ".");
+  ASSERT(perturbation_width_ > 0.0,
+         "The damping factor must be positive. The value given was "
+             << perturbation_width_ << ".");
+  ASSERT(strip_thickness > 0.0,
+         "The strip thickness must be positive. The value given was "
+             << strip_thickness << ".");
+}
+
+template <size_t Dim>
+void KhInstability<Dim>::pup(PUP::er& p) noexcept {
+  p | adiabatic_index_;
+  p | strip_bimedian_height_;
+  p | strip_half_thickness_;
+  p | strip_density_;
+  p | strip_velocity_;
+  p | background_density_;
+  p | background_velocity_;
+  p | pressure_;
+  p | perturbation_amplitude_;
+  p | perturbation_width_;
+  p | equation_of_state_;
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<Tags::MassDensity<DataType>> KhInstability<Dim>::variables(
+    const tnsr::I<DataType, Dim, Frame::Inertial>& x,
+    tmpl::list<Tags::MassDensity<DataType>> /*meta*/) const noexcept {
+  auto result = make_with_value<Scalar<DataType>>(x, 0.0);
+  const size_t n_pts = get_size(get<0>(x));
+  for (size_t s = 0; s < n_pts; ++s) {
+    get_element(get(result), s) =
+        abs(get_element(get<Dim - 1>(x), s) - strip_bimedian_height_) <
+                strip_half_thickness_
+            ? strip_density_
+            : background_density_;
+  }
+  return {std::move(result)};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<Tags::Velocity<DataType, Dim, Frame::Inertial>>
+KhInstability<Dim>::variables(
+    const tnsr::I<DataType, Dim, Frame::Inertial>& x,
+    tmpl::list<Tags::Velocity<DataType, Dim, Frame::Inertial>> /*meta*/) const
+    noexcept {
+  auto result =
+      make_with_value<tnsr::I<DataType, Dim, Frame::Inertial>>(x, 0.0);
+
+  const size_t n_pts = get_size(get<0>(x));
+  for (size_t s = 0; s < n_pts; ++s) {
+    get_element(get<0>(result), s) =
+        abs(get_element(get<Dim - 1>(x), s) - strip_bimedian_height_) <
+                strip_half_thickness_
+            ? strip_velocity_
+            : background_velocity_;
+  }
+
+  const double one_over_two_sigma_squared = 0.5 / square(perturbation_width_);
+  const double strip_lower_bound =
+      strip_bimedian_height_ - strip_half_thickness_;
+  const double strip_upper_bound =
+      strip_bimedian_height_ + strip_half_thickness_;
+  get<Dim - 1>(result) = exp(-one_over_two_sigma_squared *
+                             square(get<Dim - 1>(x) - strip_lower_bound)) +
+                         exp(-one_over_two_sigma_squared *
+                             square(get<Dim - 1>(x) - strip_upper_bound));
+  get<Dim - 1>(result) *= perturbation_amplitude_ * sin(4.0 * M_PI * get<0>(x));
+
+  return {std::move(result)};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<Tags::SpecificInternalEnergy<DataType>>
+KhInstability<Dim>::variables(
+    const tnsr::I<DataType, Dim, Frame::Inertial>& x,
+    tmpl::list<Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
+    noexcept {
+  return equation_of_state_.specific_internal_energy_from_density_and_pressure(
+      get<Tags::MassDensity<DataType>>(
+          variables(x, tmpl::list<Tags::MassDensity<DataType>>{})),
+      get<Tags::Pressure<DataType>>(
+          variables(x, tmpl::list<Tags::Pressure<DataType>>{})));
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<Tags::Pressure<DataType>> KhInstability<Dim>::variables(
+    const tnsr::I<DataType, Dim, Frame::Inertial>& x,
+    tmpl::list<Tags::Pressure<DataType>> /*meta*/) const noexcept {
+  return make_with_value<Scalar<DataType>>(x, pressure_);
+}
+
+template <size_t Dim>
+bool operator==(const KhInstability<Dim>& lhs,
+                const KhInstability<Dim>& rhs) noexcept {
+  // No comparison for equation_of_state_. Comparing adiabatic_index_ should
+  // suffice.
+  return lhs.adiabatic_index_ == rhs.adiabatic_index_ and
+         lhs.strip_bimedian_height_ == rhs.strip_bimedian_height_ and
+         lhs.strip_half_thickness_ == rhs.strip_half_thickness_ and
+         lhs.strip_density_ == rhs.strip_density_ and
+         lhs.strip_velocity_ == rhs.strip_velocity_ and
+         lhs.background_density_ == rhs.background_density_ and
+         lhs.background_velocity_ == rhs.background_velocity_ and
+         lhs.pressure_ == rhs.pressure_ and
+         lhs.perturbation_amplitude_ == rhs.perturbation_amplitude_ and
+         lhs.perturbation_width_ == rhs.perturbation_width_;
+}
+
+template <size_t Dim>
+bool operator!=(const KhInstability<Dim>& lhs,
+                const KhInstability<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define TAG(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE_CLASS(_, data)                                    \
+  template class KhInstability<DIM(data)>;                            \
+  template bool operator==(const KhInstability<DIM(data)>&,           \
+                           const KhInstability<DIM(data)>&) noexcept; \
+  template bool operator!=(const KhInstability<DIM(data)>&,           \
+                           const KhInstability<DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_CLASS, (2, 3))
+
+#define INSTANTIATE_SCALARS(_, data)                                 \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>>             \
+      KhInstability<DIM(data)>::variables(                           \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>& x, \
+          tmpl::list<TAG(data) < DTYPE(data)>>) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_SCALARS, (2, 3), (double, DataVector),
+                        (Tags::MassDensity, Tags::SpecificInternalEnergy,
+                         Tags::Pressure))
+
+#define INSTANTIATE_VELOCITY(_, data)                                       \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data), DIM(data),          \
+                               Frame::Inertial>>                            \
+      KhInstability<DIM(data)>::variables(                                  \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>& x,        \
+          tmpl::list<TAG(data) < DTYPE(data), DIM(data), Frame::Inertial>>) \
+          const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_VELOCITY, (2, 3), (double, DataVector),
+                        (Tags::Velocity))
+
+#undef INSTANTIATE_VELOCITY
+#undef INSTANTIATE_SCALARS
+#undef INSTANTIATE_CLASS
+#undef TAG
+#undef DTYPE
+#undef DIM
+}  // namespace AnalyticData
+}  // namespace NewtonianEuler
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.hpp
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.hpp
@@ -1,0 +1,266 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/NewtonianEuler/Sources/NoSource.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PUP {
+class er;  // IWYU pragma: keep
+}  // namespace PUP
+/// \endcond
+
+namespace NewtonianEuler {
+namespace AnalyticData {
+
+/*!
+ * \brief Initial data to simulate the Kelvin-Helmholtz instability.
+ *
+ * For comparison purposes, this class implements the planar shear of
+ * \cite Schaal2015, which is evolved using periodic boundary conditions.
+ * The initial state consists of a horizontal strip of mass
+ * density \f$\rho_\text{in}\f$ moving with horizontal speed
+ * \f$v_{\text{in}}\f$. The rest of the fluid possesses mass density
+ * \f$\rho_\text{out}\f$, and its horizontal velocity is \f$v_{\text{out}}\f$,
+ * both constant. Mathematically,
+ *
+ * \f{align*}
+ * \rho(x, y) =
+ * \begin{cases}
+ * \rho_\text{in}, & \left|y - y_\text{mid}\right| < b/2\\
+ * \rho_\text{out}, & \text{otherwise},
+ * \end{cases}
+ * \f}
+ *
+ * and
+ *
+ * \f{align*}
+ * v_x(x, y) =
+ * \begin{cases}
+ * v_{\text{in}}, & \left|y - y_\text{mid}\right| < b/2\\
+ * v_{\text{out}}, & \text{otherwise},
+ * \end{cases}
+ * \f}
+ *
+ * where \f$b > 0\f$ is the thickness of the strip, and \f$y = y_\text{mid}\f$
+ * is its horizontal bimedian. The initial pressure is set equal to a constant,
+ * and the system is evolved assuming an ideal fluid of known adiabatic index.
+ * Finally, in order to excite the instability, the vertical velocity is
+ * initialized to
+ *
+ * \f{align*}
+ * v_y(x, y) = A\sin(4\pi x)
+ * \left[\exp\left(-\dfrac{(y - y_\text{top})^2}{2\sigma^2}\right) +
+ * \exp\left(-\dfrac{(y - y_\text{bot})^2}{2\sigma^2}\right)\right],
+ * \f}
+ *
+ * whose net effect is to perturb the horizontal boundaries of the strip
+ * periodically along the \f$x-\f$axis. Here \f$A\f$ is the amplitude,
+ * \f$\sigma\f$ is a characteristic length for the perturbation width,
+ * and \f$y_\text{top} = y_\text{mid} + b/2\f$ and
+ * \f$y_\text{bot} = y_\text{mid} - b/2\f$ are the vertical coordinates
+ * of the top and bottom boundaries of the strip, respectively.
+ *
+ * \note The periodic form of the perturbation enforces the horizontal
+ * extent of the domain to be a multiple of 0.5. The domain chosen in
+ * \cite Schaal2015 is the square \f$[0, 1]^2\f$, which covers two wavelengths
+ * of the perturbation. In addition, the authors ran their simulations using
+ *
+ * ```
+ * AdiabaticIndex: 1.4
+ * StripBimedianHeight: 0.5
+ * StripThickness: 0.5
+ * StripDensity: 2.0
+ * StripVelocity: 0.5
+ * BackgroundDensity: 1.0
+ * BackgroundVelocity: -0.5
+ * Pressure: 2.5
+ * PerturbAmplitude: 0.1
+ * PerturbWidth: 0.035355339059327376 # 0.05/sqrt(2)
+ * ```
+ *
+ * \note This class can be used to initialize 2D and 3D data. In 3D, the strip
+ * is aligned to the \f$xy-\f$plane, and the vertical direction is taken to be
+ * the \f$z-\f$axis.
+ */
+template <size_t Dim>
+class KhInstability : public MarkAsAnalyticData {
+ public:
+  using equation_of_state_type = EquationsOfState::IdealFluid<false>;
+  using source_term_type = Sources::NoSource;
+
+  /// The adiabatic index of the fluid.
+  struct AdiabaticIndex {
+    using type = double;
+    static constexpr OptionString help = {"The adiabatic index of the fluid."};
+  };
+
+  /// The vertical coordinate of the horizontal bimedian of the strip.
+  struct StripBimedianHeight {
+    using type = double;
+    static constexpr OptionString help = {"The height of the strip center."};
+  };
+
+  /// The thickness of the strip.
+  struct StripThickness {
+    using type = double;
+    static type lower_bound() noexcept { return 0.0; }
+    static constexpr OptionString help = {
+        "The thickness of the horizontal strip."};
+  };
+
+  /// The mass density in the strip
+  struct StripDensity {
+    using type = double;
+    static type lower_bound() noexcept { return 0.0; }
+    static constexpr OptionString help = {
+        "The mass density in the horizontal strip."};
+  };
+
+  /// The velocity along \f$x\f$ in the strip
+  struct StripVelocity {
+    using type = double;
+    static constexpr OptionString help = {
+        "The velocity along x in the horizontal strip."};
+  };
+
+  /// The mass density outside of the strip
+  struct BackgroundDensity {
+    using type = double;
+    static type lower_bound() noexcept { return 0.0; }
+    static constexpr OptionString help = {
+        "The mass density outside of the strip."};
+  };
+
+  /// The velocity along \f$x\f$ outside of the strip
+  struct BackgroundVelocity {
+    using type = double;
+    static constexpr OptionString help = {
+        "The velocity along x outside of the strip."};
+  };
+
+  /// The initial (constant) pressure of the fluid
+  struct Pressure {
+    using type = double;
+    static type lower_bound() noexcept { return 0.0; }
+    static constexpr OptionString help = {"The initial (constant) pressure."};
+  };
+
+  /// The amplitude of the perturbation
+  struct PerturbAmplitude {
+    using type = double;
+    static constexpr OptionString help = {"The amplitude of the perturbation."};
+  };
+
+  /// The characteristic length for the width of the perturbation
+  struct PerturbWidth {
+    using type = double;
+    static type lower_bound() noexcept { return 0.0; }
+    static constexpr OptionString help = {
+        "The characteristic length for the width of the perturbation."};
+  };
+
+  using options =
+      tmpl::list<AdiabaticIndex, StripBimedianHeight, StripThickness,
+                 StripDensity, StripVelocity, BackgroundDensity,
+                 BackgroundVelocity, Pressure, PerturbAmplitude, PerturbWidth>;
+
+  static constexpr OptionString help = {
+      "Initial data to simulate the KH instability."};
+
+  KhInstability() = default;
+  KhInstability(const KhInstability& /*rhs*/) = delete;
+  KhInstability& operator=(const KhInstability& /*rhs*/) = delete;
+  KhInstability(KhInstability&& /*rhs*/) noexcept = default;
+  KhInstability& operator=(KhInstability&& /*rhs*/) noexcept = default;
+  ~KhInstability() = default;
+
+  KhInstability(double adiabatic_index, double strip_bimedian_height,
+                double strip_thickness, double strip_density,
+                double strip_velocity, double background_density,
+                double background_velocity, double pressure,
+                double perturbation_amplitude, double perturbation_width);
+
+  /// Retrieve a collection of hydrodynamic variables at position x
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataType, Dim, Frame::Inertial>& x,
+      tmpl::list<Tags...> /*meta*/) const noexcept {
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  const EquationsOfState::IdealFluid<false>& equation_of_state() const
+      noexcept {
+    return equation_of_state_;
+  }
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
+
+ private:
+  // @{
+  /// Retrieve hydro variable at `x`
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, Dim, Frame::Inertial>& x,
+                 tmpl::list<Tags::MassDensity<DataType>> /*meta*/
+                 ) const noexcept
+      -> tuples::TaggedTuple<Tags::MassDensity<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, Dim, Frame::Inertial>& x,
+      tmpl::list<Tags::Velocity<DataType, Dim, Frame::Inertial>> /*meta*/) const
+      noexcept
+      -> tuples::TaggedTuple<Tags::Velocity<DataType, Dim, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, Dim, Frame::Inertial>& x,
+                 tmpl::list<Tags::SpecificInternalEnergy<DataType>> /*meta*/
+                 ) const noexcept
+      -> tuples::TaggedTuple<Tags::SpecificInternalEnergy<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, Dim, Frame::Inertial>& x,
+                 tmpl::list<Tags::Pressure<DataType>> /*meta*/
+                 ) const noexcept
+      -> tuples::TaggedTuple<Tags::Pressure<DataType>>;
+  // @}
+
+  template <size_t SpatialDim>
+  friend bool
+  operator==(  // NOLINT (clang-tidy: readability-redundant-declaration)
+      const KhInstability<SpatialDim>& lhs,
+      const KhInstability<SpatialDim>& rhs) noexcept;
+
+  double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();
+  double strip_bimedian_height_ = std::numeric_limits<double>::signaling_NaN();
+  double strip_half_thickness_ = std::numeric_limits<double>::signaling_NaN();
+  double strip_density_ = std::numeric_limits<double>::signaling_NaN();
+  double strip_velocity_ = std::numeric_limits<double>::signaling_NaN();
+  double background_density_ = std::numeric_limits<double>::signaling_NaN();
+  double background_velocity_ = std::numeric_limits<double>::signaling_NaN();
+  double pressure_ = std::numeric_limits<double>::signaling_NaN();
+  double perturbation_amplitude_ = std::numeric_limits<double>::signaling_NaN();
+  double perturbation_width_ = std::numeric_limits<double>::signaling_NaN();
+  EquationsOfState::IdealFluid<false> equation_of_state_{};
+};
+
+template <size_t Dim>
+bool operator!=(const KhInstability<Dim>& lhs,
+                const KhInstability<Dim>& rhs) noexcept;
+
+}  // namespace AnalyticData
+}  // namespace NewtonianEuler

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CMakeLists.txt
@@ -16,3 +16,4 @@ add_test_library(
 
 add_subdirectory(Burgers)
 add_subdirectory(GrMhd)
+add_subdirectory(NewtonianEuler)

--- a/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_NewtonianEulerAnalyticData")
+
+set(LIBRARY_SOURCES
+  Test_KhInstability.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "PointwiseFunctions/AnalyticData/NewtonianEuler"
+  "${LIBRARY_SOURCES}"
+  "NewtonianEulerAnalyticData;Options;Utilities"
+  )

--- a/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.py
@@ -1,0 +1,50 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def mass_density(x, adiabatic_index, strip_bimedian_height, strip_thickness,
+                 strip_density, strip_velocity, background_density,
+                 background_velocity, pressure, perturbation_amplitude,
+                 perturbation_width):
+    return strip_density if np.absolute(
+        x[x.size - 1] -
+        strip_bimedian_height) < 0.5 * strip_thickness else background_density
+
+
+def velocity(x, adiabatic_index, strip_bimedian_height, strip_thickness,
+             strip_density, strip_velocity, background_density,
+             background_velocity, pressure, perturbation_amplitude,
+             perturbation_width):
+    dim = x.size
+    result = np.zeros(dim)
+    result[0] = strip_velocity if (
+        np.absolute(x[x.size - 1] - strip_bimedian_height) < 0.5 *
+        strip_thickness) else background_velocity
+    strip_lower_bound = strip_bimedian_height - 0.5 * strip_thickness
+    strip_upper_bound = strip_bimedian_height + 0.5 * strip_thickness
+    result[dim - 1] = (
+        np.exp(-0.5 *
+               ((x[dim - 1] - strip_lower_bound) / perturbation_width)**2) +
+        np.exp(-0.5 *
+               ((x[dim - 1] - strip_upper_bound) / perturbation_width)**2))
+    result[dim - 1] *= perturbation_amplitude * np.sin(4 * np.pi * x[0])
+    return result
+
+
+def specific_internal_energy(x, adiabatic_index, strip_bimedian_height,
+                             strip_thickness, strip_density, strip_velocity,
+                             background_density, background_velocity, pressure,
+                             perturbation_amplitude, perturbation_width):
+    return pressure / (adiabatic_index - 1.0) / strip_density if np.absolute(
+        x[x.size - 1] -
+        strip_bimedian_height) < 0.5 * strip_thickness else pressure / (
+            adiabatic_index - 1.0) / background_density
+
+
+def pressure(x, adiabatic_index, strip_bimedian_height, strip_thickness,
+             strip_density, strip_velocity, background_density,
+             background_velocity, pressure, perturbation_amplitude,
+             perturbation_width):
+    return pressure

--- a/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/Test_KhInstability.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/Test_KhInstability.cpp
@@ -1,0 +1,340 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+template <size_t Dim>
+struct KhInstabilityProxy : NewtonianEuler::AnalyticData::KhInstability<Dim> {
+  using NewtonianEuler::AnalyticData::KhInstability<Dim>::KhInstability;
+
+  template <typename DataType>
+  using variables_tags =
+      tmpl::list<NewtonianEuler::Tags::MassDensity<DataType>,
+                 NewtonianEuler::Tags::Velocity<DataType, Dim, Frame::Inertial>,
+                 NewtonianEuler::Tags::SpecificInternalEnergy<DataType>,
+                 NewtonianEuler::Tags::Pressure<DataType>>;
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<variables_tags<DataType>>
+  primitive_variables(const tnsr::I<DataType, Dim, Frame::Inertial>& x) const
+      noexcept {
+    return this->variables(x, variables_tags<DataType>{});
+  }
+};
+
+template <size_t Dim, typename DataType>
+void test_analytic_data(const DataType& used_for_size) noexcept {
+  const double adiabatic_index = 1.43;
+  const double strip_bimedian_height = 0.5;
+  const double strip_thickness = 0.4;
+  const double strip_density = 2.1;
+  const double strip_velocity = 0.3;
+  const double background_density = 2.0;
+  const double background_velocity = -0.2;
+  const double pressure = 1.1;
+  const double perturbation_amplitude = 0.1;
+  const double perturbation_width = 0.01;
+  const auto members = std::make_tuple(
+      adiabatic_index, strip_bimedian_height, strip_thickness, strip_density,
+      strip_velocity, background_density, background_velocity, pressure,
+      perturbation_amplitude, perturbation_width);
+
+  KhInstabilityProxy<Dim> kh_inst(
+      adiabatic_index, strip_bimedian_height, strip_thickness, strip_density,
+      strip_velocity, background_density, background_velocity, pressure,
+      perturbation_amplitude, perturbation_width);
+  pypp::check_with_random_values<
+      1, typename KhInstabilityProxy<Dim>::template variables_tags<DataType>>(
+      &KhInstabilityProxy<Dim>::template primitive_variables<DataType>, kh_inst,
+      "KhInstability",
+      {"mass_density", "velocity", "specific_internal_energy", "pressure"},
+      {{{0.0, 1.0}}}, members, used_for_size);
+
+  const auto kh_inst_from_options = TestHelpers::test_creation<
+      NewtonianEuler::AnalyticData::KhInstability<Dim>>(
+      "  AdiabaticIndex: 1.43\n"
+      "  StripBimedianHeight: 0.5\n"
+      "  StripThickness: 0.4\n"
+      "  StripDensity: 2.1\n"
+      "  StripVelocity: 0.3\n"
+      "  BackgroundDensity: 2.0\n"
+      "  BackgroundVelocity: -0.2\n"
+      "  Pressure: 1.1\n"
+      "  PerturbAmplitude: 0.1\n"
+      "  PerturbWidth: 0.01");
+  CHECK(kh_inst_from_options == kh_inst);
+
+  KhInstabilityProxy<Dim> kh_inst_to_move(
+      adiabatic_index, strip_bimedian_height, strip_thickness, strip_density,
+      strip_velocity, background_density, background_velocity, pressure,
+      perturbation_amplitude, perturbation_width);
+  test_move_semantics(std::move(kh_inst_to_move), kh_inst);  //  NOLINT
+
+  // run post-serialized state through checks with random numbers
+  pypp::check_with_random_values<
+      1, typename KhInstabilityProxy<Dim>::template variables_tags<DataType>>(
+      &KhInstabilityProxy<Dim>::template primitive_variables<DataType>,
+      serialize_and_deserialize(kh_inst), "KhInstability",
+      {"mass_density", "velocity", "specific_internal_energy", "pressure"},
+      {{{0.0, 1.0}}}, members, used_for_size);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability",
+    "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticData/NewtonianEuler"};
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_analytic_data, (2, 3));
+}
+
+template <size_t Dim>
+struct Instability {
+  using type = NewtonianEuler::AnalyticData::KhInstability<Dim>;
+  static constexpr OptionString help = {
+      "Initial data to simulate the KH instability."};
+};
+
+// [[OutputRegex, In string:.*At line 5 column 17:.Value -2.1 is below the
+// lower bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.RhoOut2d",
+    "[Unit][PointwiseFunctions]") {
+  ERROR_TEST();
+  Options<tmpl::list<Instability<2>>> test_options("");
+  test_options.parse(
+      "Instability:\n"
+      "  AdiabaticIndex: 1.43\n"
+      "  StripBimedianHeight: 0.5\n"
+      "  StripThickness: 0.4\n"
+      "  StripDensity: -2.1\n"
+      "  StripVelocity: 0.3\n"
+      "  BackgroundDensity: 2.0\n"
+      "  BackgroundVelocity: -0.2\n"
+      "  Pressure: 1.1\n"
+      "  PerturbAmplitude: 0.1\n"
+      "  PerturbWidth: 0.01");
+  test_options.get<Instability<2>>();
+}
+
+// [[OutputRegex, In string:.*At line 5 column 17:.Value -2.1 is below the
+// lower bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.RhoOut3d",
+    "[Unit][PointwiseFunctions]") {
+  ERROR_TEST();
+  Options<tmpl::list<Instability<3>>> test_options("");
+  test_options.parse(
+      "Instability:\n"
+      "  AdiabaticIndex: 1.43\n"
+      "  StripBimedianHeight: 0.5\n"
+      "  StripThickness: 0.4\n"
+      "  StripDensity: -2.1\n"
+      "  StripVelocity: 0.3\n"
+      "  BackgroundDensity: 2.0\n"
+      "  BackgroundVelocity: -0.2\n"
+      "  Pressure: 1.1\n"
+      "  PerturbAmplitude: 0.1\n"
+      "  PerturbWidth: 0.01");
+  test_options.get<Instability<3>>();
+}
+
+// [[OutputRegex, In string:.*At line 7 column 22:.Value -2 is below the
+// lower bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.RhoIn2d",
+    "[Unit][PointwiseFunctions]") {
+  ERROR_TEST();
+  Options<tmpl::list<Instability<2>>> test_options("");
+  test_options.parse(
+      "Instability:\n"
+      "  AdiabaticIndex: 1.43\n"
+      "  StripBimedianHeight: 0.5\n"
+      "  StripThickness: 0.4\n"
+      "  StripDensity: 2.1\n"
+      "  StripVelocity: 0.3\n"
+      "  BackgroundDensity: -2.0\n"
+      "  BackgroundVelocity: -0.2\n"
+      "  Pressure: 1.1\n"
+      "  PerturbAmplitude: 0.1\n"
+      "  PerturbWidth: 0.01");
+  test_options.get<Instability<2>>();
+}
+
+// [[OutputRegex, In string:.*At line 7 column 22:.Value -2 is below the
+// lower bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.RhoIn3d",
+    "[Unit][PointwiseFunctions]") {
+  ERROR_TEST();
+  Options<tmpl::list<Instability<3>>> test_options("");
+  test_options.parse(
+      "Instability:\n"
+      "  AdiabaticIndex: 1.43\n"
+      "  StripBimedianHeight: 0.5\n"
+      "  StripThickness: 0.4\n"
+      "  StripDensity: 2.1\n"
+      "  StripVelocity: 0.3\n"
+      "  BackgroundDensity: -2.0\n"
+      "  BackgroundVelocity: -0.2\n"
+      "  Pressure: 1.1\n"
+      "  PerturbAmplitude: 0.1\n"
+      "  PerturbWidth: 0.01");
+  test_options.get<Instability<3>>();
+}
+
+// [[OutputRegex, In string:.*At line 9 column 13:.Value -1.1 is below the
+// lower bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.Pressure2d",
+    "[Unit][PointwiseFunctions]") {
+  ERROR_TEST();
+  Options<tmpl::list<Instability<2>>> test_options("");
+  test_options.parse(
+      "Instability:\n"
+      "  AdiabaticIndex: 1.43\n"
+      "  StripBimedianHeight: 0.5\n"
+      "  StripThickness: 0.4\n"
+      "  StripDensity: 2.1\n"
+      "  StripVelocity: 0.3\n"
+      "  BackgroundDensity: 2.0\n"
+      "  BackgroundVelocity: -0.2\n"
+      "  Pressure: -1.1\n"
+      "  PerturbAmplitude: 0.1\n"
+      "  PerturbWidth: 0.01");
+  test_options.get<Instability<2>>();
+}
+
+// [[OutputRegex, In string:.*At line 9 column 13:.Value -1.1 is below the
+// lower bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.Pressure3d",
+    "[Unit][PointwiseFunctions]") {
+  ERROR_TEST();
+  Options<tmpl::list<Instability<3>>> test_options("");
+  test_options.parse(
+      "Instability:\n"
+      "  AdiabaticIndex: 1.43\n"
+      "  StripBimedianHeight: 0.5\n"
+      "  StripThickness: 0.4\n"
+      "  StripDensity: 2.1\n"
+      "  StripVelocity: 0.3\n"
+      "  BackgroundDensity: 2.0\n"
+      "  BackgroundVelocity: -0.2\n"
+      "  Pressure: -1.1\n"
+      "  PerturbAmplitude: 0.1\n"
+      "  PerturbWidth: 0.01");
+  test_options.get<Instability<3>>();
+}
+
+// [[OutputRegex, In string:.*At line 11 column 17:.Value -0.01 is below the
+// lower bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.PertWidth2d",
+    "[Unit][PointwiseFunctions]") {
+  ERROR_TEST();
+  Options<tmpl::list<Instability<2>>> test_options("");
+  test_options.parse(
+      "Instability:\n"
+      "  AdiabaticIndex: 1.43\n"
+      "  StripBimedianHeight: 0.5\n"
+      "  StripThickness: 0.4\n"
+      "  StripDensity: 2.1\n"
+      "  StripVelocity: 0.3\n"
+      "  BackgroundDensity: 2.0\n"
+      "  BackgroundVelocity: -0.2\n"
+      "  Pressure: 1.1\n"
+      "  PerturbAmplitude: 0.1\n"
+      "  PerturbWidth: -0.01");
+  test_options.get<Instability<2>>();
+}
+
+// [[OutputRegex, In string:.*At line 11 column 17:.Value -0.01 is below the
+// lower bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.PertWidth3d",
+    "[Unit][PointwiseFunctions]") {
+  ERROR_TEST();
+  Options<tmpl::list<Instability<3>>> test_options("");
+  test_options.parse(
+      "Instability:\n"
+      "  AdiabaticIndex: 1.43\n"
+      "  StripBimedianHeight: 0.5\n"
+      "  StripThickness: 0.4\n"
+      "  StripDensity: 2.1\n"
+      "  StripVelocity: 0.3\n"
+      "  BackgroundDensity: 2.0\n"
+      "  BackgroundVelocity: -0.2\n"
+      "  Pressure: 1.1\n"
+      "  PerturbAmplitude: 0.1\n"
+      "  PerturbWidth: -0.01");
+  test_options.get<Instability<3>>();
+}
+
+// [[OutputRegex, In string:.*At line 4 column 19:.Value -0.4 is below the
+// lower bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.StripThick2d",
+    "[Unit][PointwiseFunctions]") {
+  ERROR_TEST();
+  Options<tmpl::list<Instability<2>>> test_options("");
+  test_options.parse(
+      "Instability:\n"
+      "  AdiabaticIndex: 1.43\n"
+      "  StripBimedianHeight: 0.5\n"
+      "  StripThickness: -0.4\n"
+      "  StripDensity: 2.1\n"
+      "  StripVelocity: 0.3\n"
+      "  BackgroundDensity: 2.0\n"
+      "  BackgroundVelocity: -0.2\n"
+      "  Pressure: 1.1\n"
+      "  PerturbAmplitude: 0.1\n"
+      "  PerturbWidth: 0.01");
+  test_options.get<Instability<2>>();
+}
+
+// [[OutputRegex, In string:.*At line 4 column 19:.Value -0.4 is below the
+// lower bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.StripThick3d",
+    "[Unit][PointwiseFunctions]") {
+  ERROR_TEST();
+  Options<tmpl::list<Instability<3>>> test_options("");
+  test_options.parse(
+      "Instability:\n"
+      "  AdiabaticIndex: 1.43\n"
+      "  StripBimedianHeight: 0.5\n"
+      "  StripThickness: -0.4\n"
+      "  StripDensity: 2.1\n"
+      "  StripVelocity: 0.3\n"
+      "  BackgroundDensity: 2.0\n"
+      "  BackgroundVelocity: -0.2\n"
+      "  Pressure: 1.1\n"
+      "  PerturbAmplitude: 0.1\n"
+      "  PerturbWidth: 0.01");
+  test_options.get<Instability<3>>();
+}


### PR DESCRIPTION
## Proposed changes

Different turbulence simulations require analytic initial data that are not solutions to the Euler equations. We currently don't have the directories for `PointwiseFunctions/AnalyticData/NewtonianEuler` so this PR is meant to add that support.

- Add directories for analytic data for NewtonianEuler
- Add initial data for Kelvin-Helmholtz instability. (This choice was arbitrary but simple + I've been using it quite a bit these past 2-3 weeks. Feel free to suggest a better alternative if you'd like.)

The PR is ~900 lines long but most of the code is just usual testing for pointwise functions.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
