### PR TITLE
Fix clang tidy PCH dependency, fix clang-tidy warnings

### DIFF
--- a/cmake/SetupClangTidy.cmake
+++ b/cmake/SetupClangTidy.cmake
@@ -49,8 +49,8 @@ if (CLANG_TIDY_BIN)
     module_Main
     module_Test_ConstGlobalCache
     )
-  if (TARGET pch)
-    list(APPEND MODULES_TO_DEPEND_ON pch)
+  if (TARGET SpectrePch)
+    list(APPEND MODULES_TO_DEPEND_ON SpectrePch)
   endif()
   configure_file(
     ${CMAKE_SOURCE_DIR}/tools/ClangTidyAll.sh

--- a/src/Domain/SegmentId.hpp
+++ b/src/Domain/SegmentId.hpp
@@ -135,7 +135,7 @@ class SegmentId {
 
 /// \cond
 // macro that generate the pup operator for SegmentId
-PUPbytes(SegmentId)
+PUPbytes(SegmentId)  // NOLINT
 /// \endcond
 
 /// Output operator for SegmentId.

--- a/src/Utilities/FakeVirtual.hpp
+++ b/src/Utilities/FakeVirtual.hpp
@@ -60,7 +60,7 @@
   template <typename Classes, typename... TArgs, typename Base,                \
             typename... Args>                                                  \
   decltype(auto) fake_virtual_##function(Base* obj, Args&&... args) noexcept { \
-    /* clang-tidy: macro arg in parentheses */                                 \
+    /* NOLINTNEXTLINE(misc-macro-parentheses) */                               \
     return call_with_dynamic_type<decltype(obj->template function<TArgs...>(   \
                                       args...)), /* NOLINT */                  \
                                   Classes>(                                    \

--- a/src/Utilities/TypeTraits/FunctionInfo.hpp
+++ b/src/Utilities/TypeTraits/FunctionInfo.hpp
@@ -25,12 +25,13 @@ struct function_info_impl<Ret(Args...) noexcept> {
   using class_type = void;
 };
 
-#define FUNCTION_INFO_IMPL_FUNCTION_PTR(MODIFIERS, NOEXCEPT_STATUS)      \
-  template <typename Ret, typename... Args>                              \
-  struct function_info_impl<Ret (*MODIFIERS)(Args...) NOEXCEPT_STATUS> { \
-    using return_type = Ret;                                             \
-    using argument_types = tmpl::list<Args...>;                          \
-    using class_type = void;                                             \
+#define FUNCTION_INFO_IMPL_FUNCTION_PTR(MODIFIERS, NOEXCEPT_STATUS)        \
+  template <typename Ret,                                                  \
+            typename... Args> /* NOLINTNEXTLINE(misc-macro-parentheses) */ \
+  struct function_info_impl<Ret (*MODIFIERS)(Args...) NOEXCEPT_STATUS> {   \
+    using return_type = Ret;                                               \
+    using argument_types = tmpl::list<Args...>;                            \
+    using class_type = void;                                               \
   }
 
 FUNCTION_INFO_IMPL_FUNCTION_PTR(, );
@@ -43,12 +44,13 @@ FUNCTION_INFO_IMPL_FUNCTION_PTR(const volatile, );
 FUNCTION_INFO_IMPL_FUNCTION_PTR(const volatile, noexcept);
 #undef FUNCTION_INFO_IMPL_FUNCTION_PTR
 
-#define FUNCTION_INFO_IMPL_CLASS(MODIFIERS)                      \
-  template <typename Ret, typename Class, typename... Args>      \
-  struct function_info_impl<Ret (Class::*)(Args...) MODIFIERS> { \
-    using return_type = Ret;                                     \
-    using argument_types = tmpl::list<Args...>;                  \
-    using class_type = Class;                                    \
+#define FUNCTION_INFO_IMPL_CLASS(MODIFIERS)                                \
+  template <typename Ret, typename Class,                                  \
+            typename... Args> /* NOLINTNEXTLINE(misc-macro-parentheses) */ \
+  struct function_info_impl<Ret (Class::*)(Args...) MODIFIERS> {           \
+    using return_type = Ret;                                               \
+    using argument_types = tmpl::list<Args...>;                            \
+    using class_type = Class;                                              \
   }
 
 FUNCTION_INFO_IMPL_CLASS();


### PR DESCRIPTION
## Proposed changes

- The PCH dependency of clang-tidy didn't get updated when the PCH got updated
- Fix some clang-tidy complaints that got into develop

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
