### PR TITLE
Add action to receive interpolated variables from element.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/Actions/ElementInitInterpPoints.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Actions/ElementInitInterpPoints.hpp
@@ -47,13 +47,16 @@ struct ElementInitInterpPoints {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
+    // It appears that clang-tidy is unhappy with 'if constexpr',
+    // hence the directives below.
     if constexpr (tmpl::list_contains_v<
+                      // NOLINTNEXTLINE clang-tidy wants extra braces.
                       DbTags, intrp::Tags::InterpPointInfo<Metavariables>>) {
       ERROR(
           "Found 'intrp::Tags::InterpPointInfo<Metavariables>' in DataBox, but "
           "it should not be there because ElementInitInterpPoints adds it.");
       return std::forward_as_tuple(std::move(box));
-    } else {
+    } else {  // NOLINT clang-tidy thinks 'if' and 'else' not indented the same
       using point_info_type = tuples::tagged_tuple_from_typelist<
           db::wrap_tags_in<Tags::point_info_detail::WrappedPointInfoTag,
                            typename Metavariables::interpolation_target_tags,

--- a/src/NumericalAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
@@ -1,0 +1,116 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace intrp {
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \brief Receives interpolated variables from an `Element` on a subset
+///  of the target points.
+///
+/// If interpolated variables for all target points have been received, then
+/// - Calls `InterpolationTargetTag::post_interpolation_callback`
+/// - Removes the finished `temporal_id` from `Tags::TemporalIds<TemporalId>`
+///   and adds it to `Tags::CompletedTemporalIds<TemporalId>`
+/// - Removes `Tags::InterpolatedVars<InterpolationTargetTag,TemporalId>`,
+///   `Tags::IndicesOfFilledInterpPoints`, and
+///   `Tags::IndicesOfInvalidInterpPoints` for the finished `temporal_id`.
+///
+/// Uses:
+/// - DataBox:
+///   - `Tags::TemporalIds<TemporalId>`
+///   - `Tags::IndicesOfFilledInterpPoints<TemporalId>`
+///   - `Tags::InterpolatedVars<InterpolationTargetTag,TemporalId>`
+///   - `Tags::InterpolatedVars<InterpolationTargetTag,TemporalId>`
+///   - `::Tags::Variables<typename
+///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - `Tags::TemporalIds<TemporalId>`
+///   - `Tags::CompletedTemporalIds<TemporalId>`
+///   - `Tags::IndicesOfFilledInterpPoints<TemporalId>`
+///   - `Tags::InterpolatedVars<InterpolationTargetTag,TemporalId>`
+///   - `::Tags::Variables<typename
+///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
+///
+/// For requirements on InterpolationTargetTag, see InterpolationTarget
+template <typename InterpolationTargetTag>
+struct InterpolationTargetVarsFromElement {
+  /// For requirements on Metavariables, see InterpolationTarget
+  template <
+      typename ParallelComponent, typename DbTags, typename Metavariables,
+      typename ArrayIndex, typename TemporalId,
+      Requires<tmpl::list_contains_v<DbTags, Tags::TemporalIds<TemporalId>>> =
+          nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/,
+      const std::vector<Variables<
+          typename InterpolationTargetTag::vars_to_interpolate_to_target>>&
+          vars_src,
+      const std::vector<std::vector<size_t>>& global_offsets,
+      const TemporalId& temporal_id) noexcept {
+    static_assert(
+        not InterpolationTargetTag::compute_target_points::is_sequential::value,
+        "Use InterpolationTargetGetVarsFromElement only with non-sequential"
+        " compute_target_points");
+
+    // Call set_up_interpolation only if it has not been called for this
+    // temporal_id.
+    // If flag_temporal_ids_for_interpolation returns an empty list, then
+    // flag_temporal_ids_for_interpolation has already been called for the
+    // same temporal_id (by an invocation of InterpolationTargetVarsFromElement
+    // by a different Element) and hence set_up_interpolation has already
+    // been called.
+    if (not InterpolationTarget_detail::flag_temporal_ids_for_interpolation<
+                InterpolationTargetTag>(make_not_null(&box),
+                                        std::vector<TemporalId>{{temporal_id}})
+                .empty()) {
+      InterpolationTarget_detail::set_up_interpolation<InterpolationTargetTag>(
+          make_not_null(&box), temporal_id,
+          InterpolationTarget_detail::block_logical_coords<
+              InterpolationTargetTag>(box, tmpl::type_<Metavariables>{}));
+    }
+
+    InterpolationTarget_detail::add_received_variables<InterpolationTargetTag>(
+        make_not_null(&box), vars_src, global_offsets, temporal_id);
+
+    if (InterpolationTarget_detail::have_data_at_all_points<
+            InterpolationTargetTag>(box, temporal_id)) {
+      // All the valid points have been interpolated.
+      // We throw away the return value of call_callback in this case
+      // (it is known to be always true; it can be false only for
+      //  sequential interpolations, which is static-asserted against above).
+      InterpolationTarget_detail::call_callback<InterpolationTargetTag>(
+          make_not_null(&box), make_not_null(&cache), temporal_id);
+      InterpolationTarget_detail::clean_up_interpolation_target<
+          InterpolationTargetTag>(make_not_null(&box), temporal_id);
+    }
+  }
+};
+}  // namespace Actions
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -14,6 +14,7 @@
 #include "DataStructures/IdPair.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Tags.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Utilities/Gsl.hpp"

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
   Test_InterpolationTargetKerrHorizon.cpp
   Test_InterpolationTargetLineSegment.cpp
   Test_InterpolationTargetReceiveVars.cpp
+  Test_InterpolationTargetVarsFromElement.cpp
   Test_InterpolationTargetWedgeSectionTorus.cpp
   Test_InterpolatorReceivePoints.cpp
   Test_InterpolatorReceiveVolumeData.cpp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
@@ -148,11 +148,11 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ElementReceivePoints",
           runner, 0);
 
   CHECK(get<intrp::Vars::PointInfoTag<metavars::InterpolationTargetA,
-                                      metavars::volume_dim>>(
-            init_point_infos) == point_info_type{});
+                                      metavars::volume_dim>>(init_point_infos)
+            .empty());
   CHECK(get<intrp::Vars::PointInfoTag<metavars::InterpolationTargetB,
-                                      metavars::volume_dim>>(
-            init_point_infos) == point_info_type{});
+                                      metavars::volume_dim>>(init_point_infos)
+            .empty());
 
   // Now invoke the only Registration action (InterpolationTargetSendPoints).
   ActionTesting::next_action<target_component_a>(make_not_null(&runner), 0);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
@@ -85,8 +85,6 @@ struct MockMetavariables {
   };
   using temporal_id = ::Tags::TimeStepId;
   static constexpr size_t volume_dim = 3;
-  using interpolator_source_vars =
-      typename InterpolationTargetA::vars_to_interpolate_to_target;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA,
                                                InterpolationTargetB>;
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
@@ -1,0 +1,360 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/Shell.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Rational.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace {
+
+namespace Tags {
+// Simple Variables tag for test.
+struct TestSolution : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+// Simple DataBoxItem to test.
+struct Square : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+struct SquareComputeItem : Square, db::ComputeTag {
+  static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
+    auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
+    get<>(result) = square(get<>(x));
+    return result;
+  }
+  using argument_tags = tmpl::list<Tags::TestSolution>;
+  using base = Square;
+};
+}  // namespace Tags
+
+struct MockComputeTargetPoints {
+  using is_sequential = std::false_type;
+  template <typename Metavariables, typename DbTags>
+  static tnsr::I<DataVector, 3, Frame::Inertial> points(
+      const db::DataBox<DbTags>& /*box*/,
+      const tmpl::type_<Metavariables>& /*meta*/) noexcept {
+    // Need 10 points to agree with test.
+    const size_t num_pts = 10;
+    // Doesn't matter what the points are; they are not used except
+    // that they need to be inside the domain.
+    tnsr::I<DataVector, 3, Frame::Inertial> target_points(num_pts);
+    for (size_t n = 0; n < num_pts; ++n) {
+      for (size_t d=0;d<3;++d) {
+        target_points.get(d)[n] = 1.0 + 0.01 * n + 0.5 * d;
+      }
+    }
+    return target_points;
+  }
+};
+
+struct MockPostInterpolationCallback {
+  template <typename DbTags, typename Metavariables>
+  static void apply(
+      const db::DataBox<DbTags>& box,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const typename Metavariables::temporal_id::type& temporal_id) noexcept {
+    // This callback simply checks that the points are as expected.
+    Slab slab(0.0, 1.0);
+    const TimeStepId first_temporal_id(true, 0, Time(slab, Rational(13, 15)));
+    const TimeStepId second_temporal_id(true, 0, Time(slab, Rational(14, 15)));
+    if (temporal_id == first_temporal_id) {
+      const Scalar<DataVector> expected{
+          DataVector{{0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0, 81.0}}};
+      CHECK_ITERABLE_APPROX(expected, db::get<Tags::Square>(box));
+    } else if (temporal_id == second_temporal_id) {
+      const Scalar<DataVector> expected{DataVector{
+          {0.0, 4.0, 16.0, 36.0, 64.0, 100.0, 144.0, 196.0, 256.0, 324.0}}};
+      CHECK_ITERABLE_APPROX(expected, db::get<Tags::Square>(box));
+    } else {
+      // Should never get here.
+      CHECK(false);
+    }
+  }
+};
+
+template <typename Metavariables, typename InterpolationTargetTag>
+struct mock_interpolation_target {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using component_being_mocked =
+      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>;
+  using simple_tags =
+      db::get_items<typename intrp::Actions::InitializeInterpolationTarget<
+          Metavariables, InterpolationTargetTag>::return_tag_list>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<
+          simple_tags,
+          typename InterpolationTargetTag::compute_items_on_target>>>>;
+};
+
+struct MockMetavariables {
+  struct InterpolationTargetA {
+    using vars_to_interpolate_to_target = tmpl::list<Tags::TestSolution>;
+    using compute_items_on_target = tmpl::list<Tags::SquareComputeItem>;
+    using compute_target_points = MockComputeTargetPoints;
+    using post_interpolation_callback = MockPostInterpolationCallback;
+  };
+  using temporal_id = ::Tags::TimeStepId;
+  static constexpr size_t volume_dim = 3;
+  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
+
+  using component_list = tmpl::list<
+      mock_interpolation_target<MockMetavariables, InterpolationTargetA>>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.TargetVarsFromElement",
+                  "[Unit]") {
+  using metavars = MockMetavariables;
+  using temporal_id_type = typename metavars::temporal_id::type;
+  using target_component =
+      mock_interpolation_target<metavars,
+                                typename metavars::InterpolationTargetA>;
+
+  Slab slab(0.0, 1.0);
+  const TimeStepId first_temporal_id(true, 0, Time(slab, Rational(13, 15)));
+  const TimeStepId second_temporal_id(true, 0, Time(slab, Rational(14, 15)));
+  const auto domain_creator =
+      domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
+
+  // Type alias for better readability below.
+  using vars_type = Variables<
+      typename metavars::InterpolationTargetA::vars_to_interpolate_to_target>;
+
+  // Initialization
+  ActionTesting::MockRuntimeSystem<metavars> runner{
+      {domain_creator.create_domain()}};
+  ActionTesting::emplace_component_and_initialize<target_component>(
+      &runner, 0,
+      {std::unordered_map<temporal_id_type, std::unordered_set<size_t>>{},
+       std::unordered_map<temporal_id_type, std::unordered_set<size_t>>{},
+       std::deque<temporal_id_type>{}, std::deque<temporal_id_type>{},
+       std::unordered_map<temporal_id_type,
+                          Variables<typename metavars::InterpolationTargetA::
+                                        vars_to_interpolate_to_target>>{},
+       // Default-constructed Variables cause problems, so below
+       // we construct the Variables with a single point.
+       vars_type{1}});
+  ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
+
+  // Now set up the vars and global offsets
+  std::vector<db::item_type<::Tags::Variables<
+      typename metavars::InterpolationTargetA::vars_to_interpolate_to_target>>>
+      vars_src;
+  std::vector<std::vector<size_t>> global_offsets;
+
+  // Lambda that adds more data to vars_src and global_offsets.
+  auto add_to_vars_src = [&vars_src, &global_offsets](
+                             const std::vector<double>& vals,
+                             const std::vector<size_t>& offset_vals) {
+    vars_src.emplace_back(
+        db::item_type<
+            ::Tags::Variables<typename metavars::InterpolationTargetA::
+                                  vars_to_interpolate_to_target>>{vals.size()});
+    global_offsets.emplace_back(offset_vals);
+    auto& scalar = get<Tags::TestSolution>(vars_src.back());
+    for (size_t i = 0; i < vals.size(); ++i) {
+      get<>(scalar)[i] = vals[i];
+    }
+  };
+
+  // Add points at first_temporal_id
+  add_to_vars_src({{3.0, 6.0}}, {{3, 6}});
+  add_to_vars_src({{2.0, 7.0}}, {{2, 7}});
+  ActionTesting::simple_action<
+      target_component, intrp::Actions::InterpolationTargetVarsFromElement<
+                            typename metavars::InterpolationTargetA>>(
+      make_not_null(&runner), 0, vars_src, global_offsets, first_temporal_id);
+
+  // It should know about only one temporal_id
+  CHECK(ActionTesting::get_databox_tag<
+            target_component, intrp::Tags::TemporalIds<temporal_id_type>>(
+            runner, 0)
+            .size() == 1);
+  // It should have accumulated 4 points by now.
+  CHECK(
+      ActionTesting::get_databox_tag<
+          target_component,
+          intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(runner, 0)
+          .at(first_temporal_id)
+          .size() == 4);
+
+  // Add some more points at first_temporal_id
+  vars_src.clear();
+  global_offsets.clear();
+  add_to_vars_src({{1.0, 888888.0}},
+                  {{1, 6}});  // 6 is repeated, point will be ignored.
+  add_to_vars_src({{8.0, 0.0, 4.0}}, {{8, 0, 4}});
+  ActionTesting::simple_action<
+      target_component, intrp::Actions::InterpolationTargetVarsFromElement<
+                            typename metavars::InterpolationTargetA>>(
+      make_not_null(&runner), 0, vars_src, global_offsets, first_temporal_id);
+
+  // It should have interpolated 8 points by now. (The ninth point had
+  // a repeated global_offsets so it should be ignored)
+  CHECK(
+      ActionTesting::get_databox_tag<
+          target_component,
+          intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(runner, 0)
+          .at(first_temporal_id)
+          .size() == 8);
+
+  // Add points at second_temporal_id
+  vars_src.clear();
+  global_offsets.clear();
+  add_to_vars_src({{10.0, 16.0}}, {{5, 8}});
+  add_to_vars_src({{6.0, 8.0}}, {{3, 4}});
+  ActionTesting::simple_action<
+      target_component, intrp::Actions::InterpolationTargetVarsFromElement<
+                            typename metavars::InterpolationTargetA>>(
+      make_not_null(&runner), 0, vars_src, global_offsets, second_temporal_id);
+
+  // It should know about two temporal_ids
+  CHECK(ActionTesting::get_databox_tag<
+            target_component, intrp::Tags::TemporalIds<temporal_id_type>>(
+            runner, 0)
+            .size() == 2);
+  // It should have accumulated 4 points for second_temporal_id.
+  CHECK(
+      ActionTesting::get_databox_tag<
+          target_component,
+          intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(runner, 0)
+          .at(second_temporal_id)
+          .size() == 4);
+  // ... and still have 8 points for first_temporal_id.
+  CHECK(
+      ActionTesting::get_databox_tag<
+          target_component,
+          intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(runner, 0)
+          .at(first_temporal_id)
+          .size() == 8);
+
+  // Add more points at second_temporal_id
+  vars_src.clear();
+  global_offsets.clear();
+  add_to_vars_src({{2.0, 888888.0}},
+                  {{1, 5}});  // 5 is repeated, point will be ignored.
+  add_to_vars_src({{4.0, 0.0, 12.0}}, {{2, 0, 6}});
+  ActionTesting::simple_action<
+      target_component, intrp::Actions::InterpolationTargetVarsFromElement<
+                            typename metavars::InterpolationTargetA>>(
+      make_not_null(&runner), 0, vars_src, global_offsets, second_temporal_id);
+
+  // It should have interpolated 8 points by now. (The ninth point had
+  // a repeated global_offsets so it should be ignored)
+  CHECK(
+      ActionTesting::get_databox_tag<
+          target_component,
+          intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(runner, 0)
+          .at(second_temporal_id)
+          .size() == 8);
+
+  // Now add enough points at second_temporal_id so it triggers the
+  // callback.  (The first temporal id doesn't yet have enough points, so
+  // here we also test asynchronicity).
+  vars_src.clear();
+  global_offsets.clear();
+  add_to_vars_src({{18.0, 14.0}}, {{9, 7}});
+  ActionTesting::simple_action<
+      target_component, intrp::Actions::InterpolationTargetVarsFromElement<
+                            typename metavars::InterpolationTargetA>>(
+      make_not_null(&runner), 0, vars_src, global_offsets, second_temporal_id);
+
+  // It should have interpolated all the points by now,
+  // and the list of points should have been cleaned up.
+  CHECK(
+      ActionTesting::get_databox_tag<
+          target_component,
+          intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(runner, 0)
+          .count(second_temporal_id) == 0);
+  // There should be only 1 temporal_id left.
+  // And its value should be first_temporal_id.
+  CHECK(ActionTesting::get_databox_tag<
+            target_component, intrp::Tags::TemporalIds<temporal_id_type>>(
+            runner, 0)
+            .size() == 1);
+  CHECK(ActionTesting::get_databox_tag<
+            target_component, intrp::Tags::TemporalIds<temporal_id_type>>(
+            runner, 0)
+            .front() == first_temporal_id);
+  // There should be 1 CompletedTemporalId, and its value
+  // should be second_temporal_id.
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            intrp::Tags::CompletedTemporalIds<temporal_id_type>>(runner, 0)
+            .size() == 1);
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            intrp::Tags::CompletedTemporalIds<temporal_id_type>>(runner, 0)
+            .front() == second_temporal_id);
+
+  // Now add enough points at first_temporal_id so it triggers the
+  // callback.
+  vars_src.clear();
+  global_offsets.clear();
+  add_to_vars_src({{9.0, 5.0}}, {{9, 5}});
+  ActionTesting::simple_action<
+      target_component, intrp::Actions::InterpolationTargetVarsFromElement<
+                            typename metavars::InterpolationTargetA>>(
+      make_not_null(&runner), 0, vars_src, global_offsets, first_temporal_id);
+
+  // It should have interpolated all the points by now,
+  // and the list of points should have been cleaned up.
+  CHECK(
+      ActionTesting::get_databox_tag<
+          target_component,
+          intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(runner, 0)
+          .count(first_temporal_id) == 0);
+  // There should be no temporal_ids left.
+  CHECK(ActionTesting::get_databox_tag<
+            target_component, intrp::Tags::TemporalIds<temporal_id_type>>(
+            runner, 0)
+            .empty());
+  // There should be 2 CompletedTemporalIds
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            intrp::Tags::CompletedTemporalIds<temporal_id_type>>(runner, 0)
+            .size() == 2);
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            intrp::Tags::CompletedTemporalIds<temporal_id_type>>(runner, 0)
+            .at(0) == second_temporal_id);
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            intrp::Tags::CompletedTemporalIds<temporal_id_type>>(runner, 0)
+            .at(1) == first_temporal_id);
+
+  // Should be no queued simple action.
+  CHECK(
+      ActionTesting::is_simple_action_queue_empty<target_component>(runner, 0));
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Adds a new Action (invoked on an InterpolationTarget) that receives interpolated variables
from an Element.  Adds a test too.  Also a few minor fixes with includes and removing an unneeded type alias.

Eventually this new Action will be called by an Action invoked on an Element (next PR).

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
