### PR TITLE
Improve documentation and checks of WENO buffers

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.hpp
@@ -521,6 +521,10 @@ void solve_constrained_fit(
  * p-refinement; this is checked by some assertions. The implementation is
  * untested for grids where elements are curved, and it should not be expected
  * to work in these cases.
+ *
+ * When calling `hweno_impl`, `modified_neighbor_solution_buffer` should contain
+ * one DataVector for each neighboring element (i.e. for each entry in
+ * `neighbor_data`).
  */
 template <typename Tag, size_t VolumeDim, typename PackagedData>
 void hweno_impl(
@@ -535,6 +539,13 @@ void hweno_impl(
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
         neighbor_data) noexcept {
+  ASSERT(modified_neighbor_solution_buffer->size() == neighbor_data.size(),
+         "modified_neighbor_solution_buffer->size() = "
+         << modified_neighbor_solution_buffer->size()
+         << "\nneighbor_data.size() = " << neighbor_data.size()
+         << "\nmodified_neighbor_solution_buffer was incorrectly initialized "
+            "before calling hweno_impl.");
+
   alg::for_each(neighbor_data, [&element, &
                                 mesh ](const auto& neighbor_and_data) noexcept {
     ASSERT(Weno_detail::check_element_has_one_similar_neighbor_in_direction(

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp
@@ -34,6 +34,11 @@ namespace Weno_detail {
 // This interface is intended for use in limiters that check the troubled-cell
 // indicator independently for each tensor component. These limiters generally
 // need to limit only a subset of the tensor components.
+//
+// When calling `simple_weno_impl`,
+// - `interpolator_buffer` may be empty
+// - `modified_neighbor_solution_buffer` should contain one DataVector for each
+//   neighboring element (i.e. for each entry in `neighbor_data`)
 template <typename Tag, size_t VolumeDim, typename PackagedData>
 void simple_weno_impl(
     const gsl::not_null<std::unordered_map<
@@ -52,6 +57,13 @@ void simple_weno_impl(
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
         neighbor_data) noexcept {
+  ASSERT(modified_neighbor_solution_buffer->size() == neighbor_data.size(),
+         "modified_neighbor_solution_buffer->size() = "
+         << modified_neighbor_solution_buffer->size()
+         << "\nneighbor_data.size() = " << neighbor_data.size()
+         << "\nmodified_neighbor_solution_buffer was incorrectly initialized "
+            "before calling simple_weno_impl.");
+
   // Compute the modified neighbor solutions.
   // First extrapolate neighbor data onto local grid points, then shift the
   // extrapolated data so its mean matches the local mean.
@@ -94,6 +106,11 @@ void simple_weno_impl(
 //
 // This interface is intended for use in limiters that check the troubled-cell
 // indicator for the whole cell, and apply the limiter to all fields.
+//
+// When calling `simple_weno_impl`,
+// - `interpolator_buffer` may be empty
+// - `modified_neighbor_solution_buffer` should contain one DataVector for each
+//   neighboring element (i.e. for each entry in `neighbor_data`)
 template <typename Tag, size_t VolumeDim, typename PackagedData>
 void simple_weno_impl(
     const gsl::not_null<std::unordered_map<


### PR DESCRIPTION
## Proposed changes

I got confused by my own code from a month ago, so clearly the documentation and checking needed improvement 😛 

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

