### PR TITLE
Housekeeping for parallel linear solvers

### DIFF
--- a/src/Elliptic/Executables/Linear/SolveLinearEllipticProblem.hpp
+++ b/src/Elliptic/Executables/Linear/SolveLinearEllipticProblem.hpp
@@ -197,10 +197,10 @@ struct Metavariables {
                                 Parallel::Actions::TerminatePhase>>,
                  Parallel::PhaseActions<
                      Phase, Phase::Solve,
-                     tmpl::list<typename linear_solver::prepare_step,
-                                Actions::RunEventsAndTriggers,
+                     tmpl::list<Actions::RunEventsAndTriggers,
                                 LinearSolver::Actions::TerminateIfConverged<
                                     typename linear_solver::options_group>,
+                                typename linear_solver::prepare_step,
                                 build_linear_operator_actions,
                                 typename linear_solver::perform_step>>>>;
 

--- a/src/NumericalAlgorithms/Convergence/Convergence.hpp
+++ b/src/NumericalAlgorithms/Convergence/Convergence.hpp
@@ -1,0 +1,10 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Documents the `Convergence` namespace
+
+#pragma once
+
+/// Items related to checking the convergence of numerical algorithms
+namespace Convergence {}

--- a/src/NumericalAlgorithms/Convergence/HasConverged.hpp
+++ b/src/NumericalAlgorithms/Convergence/HasConverged.hpp
@@ -20,15 +20,20 @@ class er;
 namespace Convergence {
 
 /*!
- * \brief Determine whether the \p criteria are met.
+ * \brief Determine whether the `criteria` are met.
  *
- * \note This function assumes the \p iteration_id is that of the next, but
- * not yet performed step. For instance, a `MaxIteration` criterion of 1 will
- * match if the \p iteration_id is 1 or higher, since the first iteration
- * (with id 0) has been completed. At this point, also the \p residual_magnitude
- * reflects the state of the algorithm after completion of the first iteration.
- * The `initial_residual_magnitude` always refers to the state before the first
- * iteration has begun.
+ * \note This function assumes the `iteration_id` is that of the latest
+ * completed step and that it is zero-indexed, where zero indicates the initial
+ * state of the algorithm. Therefore, the `MaxIteration` criterion will match if
+ * the `iteration_id` is equal or higher. For example, a `MaxIteration` of 0
+ * means the algorithm should run no iterations, so it matches if the
+ * `iteration_id` is 0 or higher since that's the initial state before any
+ * steps have been performed. A `MaxIteration` of 1 matches if the
+ * `iteration_id` is 1 or higher since one iteration is complete. At this point,
+ * also the `residual_magnitude` reflects the state of the algorithm after
+ * completion of the first iteration. The `initial_residual_magnitude` always
+ * refers to the state before the first iteration has begun, i.e. where the
+ * `iteration_id` is zero.
  *
  * \returns a `Convergence::Reason` if the criteria are met, or
  * `boost::none` otherwise.

--- a/src/NumericalAlgorithms/Convergence/Reason.cpp
+++ b/src/NumericalAlgorithms/Convergence/Reason.cpp
@@ -4,8 +4,12 @@
 #include "NumericalAlgorithms/Convergence/Reason.hpp"
 
 #include <ostream>
+#include <string>
 
 #include "ErrorHandling/Error.hpp"
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/GetOutput.hpp"
 
 namespace Convergence {
 
@@ -23,3 +27,23 @@ std::ostream& operator<<(std::ostream& os, const Reason& reason) noexcept {
 }
 
 }  // namespace Convergence
+
+template <>
+Convergence::Reason create_from_yaml<Convergence::Reason>::create<void>(
+    const Option& options) {
+  const std::string type_read = options.parse_as<std::string>();
+  if (type_read == get_output(Convergence::Reason::MaxIterations)) {
+    return Convergence::Reason::MaxIterations;
+  } else if (type_read == get_output(Convergence::Reason::AbsoluteResidual)) {
+    return Convergence::Reason::AbsoluteResidual;
+  } else if (type_read == get_output(Convergence::Reason::RelativeResidual)) {
+    return Convergence::Reason::RelativeResidual;
+  }
+  PARSE_ERROR(options.context(),
+              "Failed to convert \""
+                  << type_read << "\" to Convergence::Reason. Must be one of '"
+                  << get_output(Convergence::Reason::MaxIterations) << "', '"
+                  << get_output(Convergence::Reason::AbsoluteResidual)
+                  << "' or '"
+                  << get_output(Convergence::Reason::RelativeResidual) << "'.");
+}

--- a/src/NumericalAlgorithms/Convergence/Reason.hpp
+++ b/src/NumericalAlgorithms/Convergence/Reason.hpp
@@ -5,6 +5,12 @@
 
 #include <iosfwd>
 
+/// \cond
+template <typename T>
+struct create_from_yaml;
+class Option;
+/// \endcond
+
 namespace Convergence {
 
 /*!
@@ -17,3 +23,14 @@ enum class Reason { MaxIterations, AbsoluteResidual, RelativeResidual };
 std::ostream& operator<<(std::ostream& os, const Reason& reason) noexcept;
 
 }  // namespace Convergence
+
+template <>
+struct create_from_yaml<Convergence::Reason> {
+  template <typename Metavariables>
+  static Convergence::Reason create(const Option& options) {
+    return create<void>(options);
+  }
+};
+template <>
+Convergence::Reason create_from_yaml<Convergence::Reason>::create<void>(
+    const Option& options);

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
@@ -58,6 +58,10 @@ struct ConjugateGradient {
   using fields_tag = FieldsTag;
   using options_group = OptionsGroup;
 
+  /// Apply the linear operator to this tag in each iteration
+  using operand_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
+
   /*!
    * \brief The parallel components used by the conjugate gradient linear solver
    */

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
@@ -47,16 +47,13 @@ struct InitializeElement {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using compute_tags = db::AddComputeTags<
-        ::Tags::NextCompute<LinearSolver::Tags::IterationId<OptionsGroup>>>;
     return std::make_tuple(
         ::Initialization::merge_into_databox<
             InitializeElement,
             db::AddSimpleTags<LinearSolver::Tags::IterationId<OptionsGroup>,
                               operator_applied_to_fields_tag, operand_tag,
                               operator_applied_to_operand_tag, residual_tag,
-                              LinearSolver::Tags::HasConverged<OptionsGroup>>,
-            compute_tags>(
+                              LinearSolver::Tags::HasConverged<OptionsGroup>>>(
             std::move(box),
             // The `PrepareSolve` action populates these tags with initial
             // values, except for `operator_applied_to_fields_tag` which is

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
@@ -91,13 +91,21 @@ struct InitializeResidual {
     const auto& has_converged =
         db::get<LinearSolver::Tags::HasConverged<OptionsGroup>>(box);
 
+    // Do some logging
+    if (UNLIKELY(static_cast<int>(
+                     get<LinearSolver::Tags::Verbosity<OptionsGroup>>(cache)) >=
+                 static_cast<int>(::Verbosity::Verbose))) {
+      Parallel::printf("Linear solver '" + option_name<OptionsGroup>() +
+                           "' initialized with residual: %e\n",
+                       get<residual_magnitude_tag>(box));
+    }
     if (UNLIKELY(has_converged and
                  static_cast<int>(
                      get<LinearSolver::Tags::Verbosity<OptionsGroup>>(cache)) >=
                      static_cast<int>(::Verbosity::Quiet))) {
-      Parallel::printf(
-          "The linear solver has converged without any iterations: %s\n",
-          has_converged);
+      Parallel::printf("The linear solver '" + option_name<OptionsGroup>() +
+                           "' has converged without any iterations: %s\n",
+                       has_converged);
     }
 
     Parallel::simple_action<InitializeHasConverged<FieldsTag, OptionsGroup>>(
@@ -180,19 +188,19 @@ struct UpdateResidual {
     if (UNLIKELY(static_cast<int>(
                      get<LinearSolver::Tags::Verbosity<OptionsGroup>>(cache)) >=
                  static_cast<int>(::Verbosity::Verbose))) {
-      Parallel::printf(
-          "Linear solver iteration %zu done. Remaining residual: %e\n",
-          get<LinearSolver::Tags::IterationId<OptionsGroup>>(box),
-          get<residual_magnitude_tag>(box));
+      Parallel::printf("Linear solver '" + option_name<OptionsGroup>() +
+                           "' iteration %zu done. Remaining residual: %e\n",
+                       get<LinearSolver::Tags::IterationId<OptionsGroup>>(box),
+                       get<residual_magnitude_tag>(box));
     }
     if (UNLIKELY(has_converged and
                  static_cast<int>(
                      get<LinearSolver::Tags::Verbosity<OptionsGroup>>(cache)) >=
                      static_cast<int>(::Verbosity::Quiet))) {
-      Parallel::printf(
-          "The linear solver has converged in %zu iterations: %s\n",
-          get<LinearSolver::Tags::IterationId<OptionsGroup>>(box),
-          has_converged);
+      Parallel::printf("The linear solver '" + option_name<OptionsGroup>() +
+                           "' has converged in %zu iterations: %s\n",
+                       get<LinearSolver::Tags::IterationId<OptionsGroup>>(box),
+                       has_converged);
     }
 
     Parallel::simple_action<UpdateOperand<FieldsTag, OptionsGroup>>(

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
@@ -66,6 +66,10 @@ struct Gmres {
   using fields_tag = FieldsTag;
   using options_group = OptionsGroup;
 
+  /// Apply the linear operator to this tag in each iteration
+  using operand_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
+
   /*!
    * \brief The parallel components used by the GMRES linear solver
    */

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/InitializeElement.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/InitializeElement.hpp
@@ -50,8 +50,6 @@ struct InitializeElement {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using compute_tags = db::AddComputeTags<
-        ::Tags::NextCompute<LinearSolver::Tags::IterationId<OptionsGroup>>>;
     return std::make_tuple(
         ::Initialization::merge_into_databox<
             InitializeElement,
@@ -60,8 +58,7 @@ struct InitializeElement {
                 initial_fields_tag, operator_applied_to_fields_tag, operand_tag,
                 operator_applied_to_operand_tag,
                 orthogonalization_iteration_id_tag, basis_history_tag,
-                LinearSolver::Tags::HasConverged<OptionsGroup>>,
-            compute_tags>(
+                LinearSolver::Tags::HasConverged<OptionsGroup>>>(
             std::move(box),
             // The `PrepareSolve` action populates these tags with initial
             // values, except for `operator_applied_to_fields_tag` which is

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
@@ -94,6 +94,13 @@ struct InitializeResidualMagnitude {
         db::get<LinearSolver::Tags::HasConverged<OptionsGroup>>(box);
 
     // Do some logging
+    if (UNLIKELY(static_cast<int>(
+                     get<LinearSolver::Tags::Verbosity<OptionsGroup>>(cache)) >=
+                 static_cast<int>(::Verbosity::Verbose))) {
+      Parallel::printf("Linear solver '" + option_name<OptionsGroup>() +
+                           "' initialized with residual: %e\n",
+                       residual_magnitude);
+    }
     if (UNLIKELY(has_converged and
                  static_cast<int>(
                      get<LinearSolver::Tags::Verbosity<OptionsGroup>>(cache)) >=

--- a/src/ParallelAlgorithms/LinearSolver/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Tags.hpp
@@ -100,6 +100,25 @@ struct Residual : db::PrefixTag, db::SimpleTag {
   using tag = Tag;
 };
 
+/// Compute the residual \f$r=b - Ax\f$ from the `SourceTag` \f$b\f$ and the
+/// `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, FieldsTag>`
+/// \f$Ax\f$.
+template <typename FieldsTag, typename SourceTag>
+struct ResidualCompute : db::add_tag_prefix<Residual, FieldsTag>,
+                         db::ComputeTag {
+  using base = db::add_tag_prefix<Residual, FieldsTag>;
+  using argument_tags =
+      tmpl::list<SourceTag, db::add_tag_prefix<OperatorAppliedTo, FieldsTag>>;
+  using return_type = typename base::type;
+  static void function(
+      const gsl::not_null<return_type*> residual,
+      const db::const_item_type<SourceTag>& source,
+      const db::item_type<db::add_tag_prefix<OperatorAppliedTo, FieldsTag>>&
+          operator_applied_to_fields) noexcept {
+    *residual = source - operator_applied_to_fields;
+  }
+};
+
 template <typename Tag>
 struct Initial : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -235,6 +235,9 @@ struct CollectOperatorAction {
 // Checks for the correct solution after the algorithm has terminated.
 template <typename OptionsGroup>
 struct TestResult {
+  using const_global_cache_tags =
+      tmpl::list<ExpectedResult, helpers::ExpectedConvergenceReason>;
+
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent>
   static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
@@ -250,8 +253,8 @@ struct TestResult {
     const auto& has_converged =
         get<LinearSolver::Tags::HasConverged<OptionsGroup>>(box);
     SPECTRE_PARALLEL_REQUIRE(has_converged);
-    SPECTRE_PARALLEL_REQUIRE(has_converged.reason() ==
-                             Convergence::Reason::AbsoluteResidual);
+    SPECTRE_PARALLEL_REQUIRE(
+        has_converged.reason() == get<helpers::ExpectedConvergenceReason>(box));
     const auto& expected_result =
         gsl::at(get<ExpectedResult>(box), array_index);
     const auto& result = get<ScalarFieldTag>(box).get();

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -140,9 +140,6 @@ using fields_tag = Tags::Variables<tmpl::list<ScalarFieldTag>>;
 using sources_tag = db::add_tag_prefix<::Tags::FixedSource, fields_tag>;
 using operator_applied_to_fields_tag =
     db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, fields_tag>;
-using operand_tag = db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
-using operator_applied_to_operand_tag =
-    db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, operand_tag>;
 
 // In the following `ComputeOperatorAction` and `CollectOperatorAction` actions
 // we compute A(p)=sum_elements(A_element(p_element)) in a global reduction and
@@ -301,7 +298,7 @@ struct ElementArray {
           tmpl::list<LinearSolver::Actions::TerminateIfConverged<
                          typename linear_solver::options_group>,
                      typename linear_solver::prepare_step,
-                     ComputeOperatorAction<operand_tag>,
+                     ComputeOperatorAction<typename linear_solver::operand_tag>,
                      typename linear_solver::perform_step>>,
 
       Parallel::PhaseActions<

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -25,6 +25,7 @@
 #include "DataStructures/Variables.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"
 #include "IO/Observer/Tags.hpp"
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
@@ -44,7 +45,7 @@
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
-// IWYU pragma: no_forward_declare db::DataBox
+namespace helpers = LinearSolverAlgorithmTestHelpers;
 
 namespace DistributedLinearSolverAlgorithmTestHelpers {
 
@@ -339,5 +340,12 @@ struct ElementArray {
     local_component.start_phase(next_phase);
   }
 };
+
+template <typename Metavariables>
+using component_list =
+    tmpl::push_back<typename Metavariables::linear_solver::component_list,
+                    ElementArray<Metavariables>,
+                    observers::ObserverWriter<Metavariables>,
+                    helpers::OutputCleaner<Metavariables>>;
 
 }  // namespace DistributedLinearSolverAlgorithmTestHelpers

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "AlgorithmArray.hpp"
+#include "AlgorithmSingleton.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
@@ -111,8 +112,6 @@ struct VectorTag : db::SimpleTag {
 };
 
 using fields_tag = VectorTag;
-using operand_tag = LinearSolver::Tags::Operand<fields_tag>;
-using operator_tag = LinearSolver::Tags::OperatorAppliedTo<operand_tag>;
 
 template <typename OperandTag>
 struct ComputeOperatorAction {
@@ -211,7 +210,7 @@ struct ElementArray {
           tmpl::list<LinearSolver::Actions::TerminateIfConverged<
                          typename linear_solver::options_group>,
                      typename linear_solver::prepare_step,
-                     ComputeOperatorAction<operand_tag>,
+                     ComputeOperatorAction<typename linear_solver::operand_tag>,
                      typename linear_solver::perform_step>>,
 
       Parallel::PhaseActions<

--- a/tests/Unit/NumericalAlgorithms/Convergence/Test_Reason.cpp
+++ b/tests/Unit/NumericalAlgorithms/Convergence/Test_Reason.cpp
@@ -6,7 +6,32 @@
 #include <string>
 
 #include "NumericalAlgorithms/Convergence/Reason.hpp"
+#include "Options/ParseOptions.hpp"
 #include "Utilities/GetOutput.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+struct ConvergenceReasonOptionTag {
+  using type = Convergence::Reason;
+  static std::string name() noexcept { return "ConvergenceReason"; }
+  static constexpr OptionString help{"A convergence reason for testing"};
+};
+
+template <Convergence::Reason TheConvergenceReason>
+void test_construct_from_options() noexcept {
+  Options<tmpl::list<ConvergenceReasonOptionTag>> opts("");
+  opts.parse("ConvergenceReason: " + get_output(TheConvergenceReason) + "\n");
+  CHECK(opts.get<ConvergenceReasonOptionTag>() == TheConvergenceReason);
+}
+
+void test_construct_from_options_fail() noexcept {
+  Options<tmpl::list<ConvergenceReasonOptionTag>> opts("");
+  opts.parse("ConvergenceReason: Miracle\n");  // Meant to fail.
+  opts.get<ConvergenceReasonOptionTag>();
+}
+
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.Convergence.Reason",
                   "[Unit][NumericalAlgorithms]") {
@@ -15,4 +40,15 @@ SPECTRE_TEST_CASE("Unit.Numerical.Convergence.Reason",
         "AbsoluteResidual");
   CHECK(get_output(Convergence::Reason::RelativeResidual) ==
         "RelativeResidual");
+
+  test_construct_from_options<Convergence::Reason::MaxIterations>();
+  test_construct_from_options<Convergence::Reason::AbsoluteResidual>();
+  test_construct_from_options<Convergence::Reason::RelativeResidual>();
+}
+
+// [[OutputRegex, Failed to convert "Miracle" to Convergence::Reason]]
+SPECTRE_TEST_CASE("Unit.Numerical.Convergence.Reason.FailOptionParsing",
+                  "[Unit][NumericalAlgorithms]") {
+  ERROR_TEST();
+  test_construct_from_options_fail();
 }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
@@ -8,9 +8,6 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_subdirectory(ConjugateGradient)
-add_subdirectory(Gmres)
-
 add_test_library(
   ${LIBRARY}
   "ParallelAlgorithms/LinearSolver/"
@@ -22,3 +19,50 @@ add_dependencies(
   ${LIBRARY}
   module_ConstGlobalCache
   )
+
+function(add_linear_solver_algorithm_test TEST_NAME)
+  set(EXECUTABLE_NAME Test_${TEST_NAME})
+  set(TEST_IDENTIFIER Integration.LinearSolver.${TEST_NAME})
+
+  add_spectre_executable(
+    ${EXECUTABLE_NAME}
+    ${EXECUTABLE_NAME}.cpp
+    )
+
+  add_dependencies(
+    ${EXECUTABLE_NAME}
+    module_ConstGlobalCache
+    module_Main
+    )
+
+  target_link_libraries(
+    ${EXECUTABLE_NAME}
+    PUBLIC
+    # Link against Boost::program_options for now until we have proper
+    # dependency handling for header-only libs
+    Boost::program_options
+    DataStructures
+    ErrorHandling
+    IO
+    Informer
+    ParallelLinearSolver
+    )
+
+  add_dependencies(test-executables ${EXECUTABLE_NAME})
+
+  add_test(
+    NAME "\"${TEST_IDENTIFIER}\""
+    COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file
+    ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}.yaml
+    )
+
+  set_tests_properties(
+    "\"${TEST_IDENTIFIER}\""
+    PROPERTIES
+    TIMEOUT 5
+    LABELS "integration"
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+endfunction()
+
+add_subdirectory(ConjugateGradient)
+add_subdirectory(Gmres)

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
@@ -20,51 +20,5 @@ add_dependencies(
   module_ConstGlobalCache
   )
 
-# This code is adapted from Parallel/CMakeLists.txt
-
-function(add_algorithm_test TEST_NAME)
-  set(EXECUTABLE_NAME Test_${TEST_NAME})
-  set(TEST_IDENTIFIER Integration.LinearSolver.${TEST_NAME})
-
-  add_spectre_executable(
-    ${EXECUTABLE_NAME}
-    ${EXECUTABLE_NAME}.cpp
-    )
-
-  add_dependencies(
-    ${EXECUTABLE_NAME}
-    module_ConstGlobalCache
-    module_Main
-    )
-
-  target_link_libraries(
-    ${EXECUTABLE_NAME}
-    PUBLIC
-    # Link against Boost::program_options for now until we have proper
-    # dependency handling for header-only libs
-    Boost::program_options
-    DataStructures
-    ErrorHandling
-    Informer
-    IO
-    ParallelLinearSolver
-    )
-
-  add_dependencies(test-executables ${EXECUTABLE_NAME})
-
-  add_test(
-    NAME "\"${TEST_IDENTIFIER}\""
-    COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file
-    ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}.yaml
-    )
-
-  set_tests_properties(
-    "\"${TEST_IDENTIFIER}\""
-    PROPERTIES
-    TIMEOUT 5
-    LABELS "integration"
-    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
-endfunction()
-
-add_algorithm_test("ConjugateGradientAlgorithm")
-add_algorithm_test("DistributedConjugateGradientAlgorithm")
+add_linear_solver_algorithm_test("ConjugateGradientAlgorithm")
+add_linear_solver_algorithm_test("DistributedConjugateGradientAlgorithm")

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
@@ -30,6 +30,7 @@ struct Metavariables {
                                       SerialCg>;
 
   using component_list = helpers::component_list<Metavariables>;
+  using element_observation_type = helpers::element_observation_type;
   using observed_reduction_data_tags =
       helpers::observed_reduction_data_tags<Metavariables>;
   static constexpr bool ignore_unrecognized_command_line_options = false;

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
@@ -7,9 +7,6 @@
 
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"
-#include "IO/Observer/Helpers.hpp"            // IWYU pragma: keep
-#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
-#include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Main.hpp"
 #include "ParallelAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp"
@@ -25,49 +22,20 @@ struct SerialCg {
 };
 
 struct Metavariables {
+  static constexpr const char* const help{
+      "Test the conjugate gradient linear solver algorithm"};
+
   using linear_solver =
       LinearSolver::ConjugateGradient<Metavariables, helpers::fields_tag,
                                       SerialCg>;
 
-  using component_list =
-      tmpl::append<tmpl::list<helpers::ElementArray<Metavariables>,
-                              observers::ObserverWriter<Metavariables>,
-                              helpers::OutputCleaner<Metavariables>>,
-                   typename linear_solver::component_list>;
-
+  using component_list = helpers::component_list<Metavariables>;
   using observed_reduction_data_tags =
-      observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;
-
-  static constexpr const char* const help{
-      "Test the conjugate gradient linear solver algorithm"};
+      helpers::observed_reduction_data_tags<Metavariables>;
   static constexpr bool ignore_unrecognized_command_line_options = false;
-
-  enum class Phase {
-    Initialization,
-    RegisterWithObserver,
-    PerformLinearSolve,
-    TestResult,
-    CleanOutput,
-    Exit
-  };
-
-  static Phase determine_next_phase(
-      const Phase& current_phase,
-      const Parallel::CProxy_ConstGlobalCache<
-          Metavariables>& /*cache_proxy*/) noexcept {
-    switch (current_phase) {
-      case Phase::Initialization:
-        return Phase::RegisterWithObserver;
-      case Phase::RegisterWithObserver:
-        return Phase::PerformLinearSolve;
-      case Phase::PerformLinearSolve:
-        return Phase::TestResult;
-      case Phase::TestResult:
-        return Phase::CleanOutput;
-      default:
-        return Phase::Exit;
-    }
-  }
+  using Phase = helpers::Phase;
+  static constexpr auto determine_next_phase =
+      helpers::determine_next_phase<Metavariables>;
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.yaml
@@ -16,3 +16,5 @@ SerialCg:
     AbsoluteResidual: 1e-14
     RelativeResidual: 0
   Verbosity: Verbose
+
+ConvergenceReason: AbsoluteResidual

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
@@ -32,6 +32,7 @@ struct Metavariables {
       Metavariables, typename helpers_distributed::fields_tag, ParallelCg>;
 
   using component_list = helpers_distributed::component_list<Metavariables>;
+  using element_observation_type = helpers::element_observation_type;
   using observed_reduction_data_tags =
       helpers::observed_reduction_data_tags<Metavariables>;
   static constexpr bool ignore_unrecognized_command_line_options = false;

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.yaml
@@ -35,3 +35,5 @@ ParallelCg:
     AbsoluteResidual: 1e-14
     RelativeResidual: 0
   Verbosity: Verbose
+
+ConvergenceReason: AbsoluteResidual

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.yaml
@@ -31,7 +31,7 @@ Observers:
 
 ParallelCg:
   ConvergenceCriteria:
-    MaxIterations: 6
+    MaxIterations: 3
     AbsoluteResidual: 1e-14
     RelativeResidual: 0
   Verbosity: Verbose

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ElementActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ElementActions.cpp
@@ -123,15 +123,8 @@ SPECTRE_TEST_CASE(
         Convergence::HasConverged{{1, 0., 0.}, 1, 0., 0.});
     CHECK(get_tag(LinearSolver::Tags::HasConverged<DummyOptionsGroup>{}));
   }
-  SECTION("PrepareStep") {
-    ActionTesting::next_action<element_array>(make_not_null(&runner), 0);
-    CHECK(get_tag(LinearSolver::Tags::IterationId<DummyOptionsGroup>{}) == 0);
-    CHECK(
-        get_tag(
-            Tags::Next<LinearSolver::Tags::IterationId<DummyOptionsGroup>>{}) ==
-        1);
-  }
   SECTION("UpdateOperand") {
+    set_tag(LinearSolver::Tags::IterationId<DummyOptionsGroup>{}, size_t{0});
     set_tag(operand_tag{}, DenseVector<double>(3, 2.));
     set_tag(residual_tag{}, DenseVector<double>(3, 1.));
     ActionTesting::next_action<element_array>(make_not_null(&runner), 0);
@@ -142,6 +135,7 @@ SPECTRE_TEST_CASE(
         Convergence::HasConverged{{1, 0., 0.}, 1, 0., 0.});
     CHECK(get_tag(LinearSolver::Tags::Operand<VectorTag>{}) ==
           DenseVector<double>(3, 5.));
+    CHECK(get_tag(LinearSolver::Tags::IterationId<DummyOptionsGroup>{}) == 1);
     CHECK(get_tag(LinearSolver::Tags::HasConverged<DummyOptionsGroup>{}));
   }
 }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
@@ -20,51 +20,5 @@ add_dependencies(
   module_ConstGlobalCache
   )
 
-# This code is adapted from Parallel/CMakeLists.txt
-
-function(add_algorithm_test TEST_NAME)
-  set(EXECUTABLE_NAME Test_${TEST_NAME})
-  set(TEST_IDENTIFIER Integration.LinearSolver.${TEST_NAME})
-
-  add_spectre_executable(
-    ${EXECUTABLE_NAME}
-    ${EXECUTABLE_NAME}.cpp
-    )
-
-  add_dependencies(
-    ${EXECUTABLE_NAME}
-    module_ConstGlobalCache
-    module_Main
-    )
-
-  target_link_libraries(
-    ${EXECUTABLE_NAME}
-    PUBLIC
-    # Link against Boost::program_options for now until we have proper
-    # dependency handling for header-only libs
-    Boost::program_options
-    DataStructures
-    ErrorHandling
-    Informer
-    IO
-    ParallelLinearSolver
-    )
-
-  add_dependencies(test-executables ${EXECUTABLE_NAME})
-
-  add_test(
-    NAME "\"${TEST_IDENTIFIER}\""
-    COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file
-    ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}.yaml
-    )
-
-  set_tests_properties(
-    "\"${TEST_IDENTIFIER}\""
-    PROPERTIES
-    TIMEOUT 5
-    LABELS "integration"
-    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
-endfunction()
-
-add_algorithm_test("GmresAlgorithm")
-add_algorithm_test("DistributedGmresAlgorithm")
+add_linear_solver_algorithm_test("GmresAlgorithm")
+add_linear_solver_algorithm_test("DistributedGmresAlgorithm")

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
@@ -7,10 +7,7 @@
 
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp"
-#include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"  // IWYU pragma: keep
-#include "IO/Observer/Helpers.hpp"            // IWYU pragma: keep
-#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
-#include "Parallel/ConstGlobalCache.hpp"
+#include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Main.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
@@ -27,49 +24,20 @@ struct ParallelGmres {
 };
 
 struct Metavariables {
+  static constexpr const char* const help{
+      "Test the GMRES linear solver algorithm on multiple elements"};
+
   using linear_solver =
       LinearSolver::Gmres<Metavariables, helpers_distributed::fields_tag,
                           ParallelGmres>;
 
-  using component_list =
-      tmpl::append<tmpl::list<helpers_distributed::ElementArray<Metavariables>,
-                              observers::ObserverWriter<Metavariables>,
-                              helpers::OutputCleaner<Metavariables>>,
-                   typename linear_solver::component_list>;
-
+  using component_list = helpers_distributed::component_list<Metavariables>;
   using observed_reduction_data_tags =
-      observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;
-
-  static constexpr const char* const help{
-      "Test the GMRES linear solver algorithm on multiple elements"};
+      helpers::observed_reduction_data_tags<Metavariables>;
   static constexpr bool ignore_unrecognized_command_line_options = false;
-
-  enum class Phase {
-    Initialization,
-    RegisterWithObserver,
-    PerformLinearSolve,
-    TestResult,
-    CleanOutput,
-    Exit
-  };
-
-  static Phase determine_next_phase(
-      const Phase& current_phase,
-      const Parallel::CProxy_ConstGlobalCache<
-          Metavariables>& /*cache_proxy*/) noexcept {
-    switch (current_phase) {
-      case Phase::Initialization:
-        return Phase::RegisterWithObserver;
-      case Phase::RegisterWithObserver:
-        return Phase::PerformLinearSolve;
-      case Phase::PerformLinearSolve:
-        return Phase::TestResult;
-      case Phase::TestResult:
-        return Phase::CleanOutput;
-      default:
-        return Phase::Exit;
-    }
-  }
+  using Phase = helpers::Phase;
+  static constexpr auto determine_next_phase =
+      helpers::determine_next_phase<Metavariables>;
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
@@ -32,6 +32,7 @@ struct Metavariables {
                           ParallelGmres>;
 
   using component_list = helpers_distributed::component_list<Metavariables>;
+  using element_observation_type = helpers::element_observation_type;
   using observed_reduction_data_tags =
       helpers::observed_reduction_data_tags<Metavariables>;
   static constexpr bool ignore_unrecognized_command_line_options = false;

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.yaml
@@ -31,7 +31,7 @@ Observers:
 
 ParallelGmres:
   ConvergenceCriteria:
-    MaxIterations: 6
+    MaxIterations: 3
     AbsoluteResidual: 1e-14
     RelativeResidual: 0
   Verbosity: Verbose

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.yaml
@@ -35,3 +35,5 @@ ParallelGmres:
     AbsoluteResidual: 1e-14
     RelativeResidual: 0
   Verbosity: Verbose
+
+ConvergenceReason: AbsoluteResidual

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
@@ -138,16 +138,8 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Gmres.ElementActions",
     CHECK(get_tag(basis_history_tag{})[2] == get_tag(operand_tag{}));
     CHECK(get_tag(LinearSolver::Tags::HasConverged<DummyOptionsGroup>{}));
   }
-  SECTION("PrepareStep") {
-    ActionTesting::next_action<element_array>(make_not_null(&runner), 0);
-    CHECK(get_tag(LinearSolver::Tags::IterationId<DummyOptionsGroup>{}) == 0);
-    CHECK(
-        get_tag(
-            Tags::Next<LinearSolver::Tags::IterationId<DummyOptionsGroup>>{}) ==
-        1);
-    CHECK(get_tag(orthogonalization_iteration_id_tag{}) == 0);
-  }
   SECTION("NormalizeOperandAndUpdateField") {
+    set_tag(LinearSolver::Tags::IterationId<DummyOptionsGroup>{}, size_t{2});
     set_tag(initial_fields_tag{}, DenseVector<double>(3, -1.));
     set_tag(operand_tag{}, DenseVector<double>(3, 2.));
     set_tag(basis_history_tag{},
@@ -165,6 +157,7 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Gmres.ElementActions",
     CHECK(get_tag(basis_history_tag{})[2] == get_tag(operand_tag{}));
     // minres * basis_history - initial = 2 * 0.5 + 4 * 1.5 - 1 = 6
     CHECK_ITERABLE_APPROX(get_tag(VectorTag{}), DenseVector<double>(3, 6.));
+    CHECK(get_tag(LinearSolver::Tags::IterationId<DummyOptionsGroup>{}) == 3);
     CHECK(get_tag(LinearSolver::Tags::HasConverged<DummyOptionsGroup>{}));
   }
 }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
@@ -29,6 +29,7 @@ struct Metavariables {
       LinearSolver::Gmres<Metavariables, helpers::fields_tag, SerialGmres>;
 
   using component_list = helpers::component_list<Metavariables>;
+  using element_observation_type = helpers::element_observation_type;
   using observed_reduction_data_tags =
       helpers::observed_reduction_data_tags<Metavariables>;
   static constexpr bool ignore_unrecognized_command_line_options = false;

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
@@ -6,10 +6,7 @@
 #include <vector>
 
 #include "ErrorHandling/FloatingPointExceptions.hpp"
-#include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"  // IWYU pragma: keep
-#include "IO/Observer/Helpers.hpp"            // IWYU pragma: keep
-#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
-#include "Parallel/ConstGlobalCache.hpp"
+#include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Main.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
@@ -25,48 +22,19 @@ struct SerialGmres {
 };
 
 struct Metavariables {
+  static constexpr const char* const help{
+      "Test the GMRES linear solver algorithm"};
+
   using linear_solver =
       LinearSolver::Gmres<Metavariables, helpers::fields_tag, SerialGmres>;
 
-  using component_list =
-      tmpl::append<tmpl::list<helpers::ElementArray<Metavariables>,
-                              observers::ObserverWriter<Metavariables>,
-                              helpers::OutputCleaner<Metavariables>>,
-                   typename linear_solver::component_list>;
-
+  using component_list = helpers::component_list<Metavariables>;
   using observed_reduction_data_tags =
-      observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;
-
-  static constexpr const char* const help{
-      "Test the GMRES linear solver algorithm"};
+      helpers::observed_reduction_data_tags<Metavariables>;
   static constexpr bool ignore_unrecognized_command_line_options = false;
-
-  enum class Phase {
-    Initialization,
-    RegisterWithObserver,
-    PerformLinearSolve,
-    TestResult,
-    CleanOutput,
-    Exit
-  };
-
-  static Phase determine_next_phase(
-      const Phase& current_phase,
-      const Parallel::CProxy_ConstGlobalCache<
-          Metavariables>& /*cache_proxy*/) noexcept {
-    switch (current_phase) {
-      case Phase::Initialization:
-        return Phase::RegisterWithObserver;
-      case Phase::RegisterWithObserver:
-        return Phase::PerformLinearSolve;
-      case Phase::PerformLinearSolve:
-        return Phase::TestResult;
-      case Phase::TestResult:
-        return Phase::CleanOutput;
-      default:
-        return Phase::Exit;
-    }
-  }
+  using Phase = helpers::Phase;
+  static constexpr auto determine_next_phase =
+      helpers::determine_next_phase<Metavariables>;
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.yaml
@@ -16,3 +16,5 @@ SerialGmres:
     AbsoluteResidual: 1e-14
     RelativeResidual: 0
   Verbosity: Verbose
+
+ConvergenceReason: AbsoluteResidual

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Test_Tags.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "NumericalAlgorithms/Convergence/Criteria.hpp"
@@ -97,6 +98,20 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Tags",
     CHECK(db::get<LinearSolver::Tags::HasConverged<TestOptionsGroup>>(box));
     CHECK(db::get<LinearSolver::Tags::HasConverged<TestOptionsGroup>>(box)
               .reason() == Convergence::Reason::AbsoluteResidual);
+  }
+
+  {
+    INFO("ResidualCompute");
+    TestHelpers::db::test_compute_tag<
+        LinearSolver::Tags::ResidualCompute<Tag, ::Tags::Source<Tag>>>(
+        "LinearResidual(Tag)");
+    const auto box = db::create<
+        db::AddSimpleTags<::Tags::Source<Tag>,
+                          LinearSolver::Tags::OperatorAppliedTo<Tag>>,
+        db::AddComputeTags<
+            LinearSolver::Tags::ResidualCompute<Tag, ::Tags::Source<Tag>>>>(3,
+                                                                            2);
+    CHECK(db::get<LinearSolver::Tags::Residual<Tag>>(box) == 1);
   }
 
   {


### PR DESCRIPTION
## Proposed changes

A few housekeeping commits for the parallel linear solvers in preparation for the upcoming preconditioner PRs.

- Share more testing code between the linear solvers and improve it
- Expose the linear solver's "operand", i.e. the quantity it expects the linear operator is applied to in each iteration
- Add a compute tag for the residual. It will be used in upcoming PRs.
- Simplify how the iteration IDs are incremented. This is made possible since #1725 was merged (see commit description for details)
- Output the initial residual of the algorithms

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
