### PR TITLE
Have GH RHS compute internally instead of compute tags

### DIFF
--- a/cmake/SetupClangTidy.cmake
+++ b/cmake/SetupClangTidy.cmake
@@ -13,13 +13,30 @@
 # -cert-err58-cpp: many static variables we use do not throw, and if they do
 #                  we want to terminate anyway
 # -google-default-arguments: defaulting virtual functions in CoordinateMap
+# -modernize-use-trailing-return-type: this wants everything to use trailing
+#                                      return type syntax, which is silly.
+# -cert-oop54-cpp: checks for incorrectly implemented self-assignment checks.
+#                  However, it's broken.
+# -misc-definitions-in-headers: thinks constexpr variables in header files
+#                               cause ODR violations
+# -modernize-use-nodiscard: while it would be great to do this, changing
+#                           the entire source tree is something we don't have
+#                           the resources for.
+# -hicpp-*: redundant with other checks
+# -cppcoreguidelines-macro-usage: sometimes macros are the right answer.
+# -cppcoreguidelines-avoid-magic-numbers: too many inconvenient positives
+#                                         for us to deal with
+# -modernize-use-nodiscard: should be used, but requires possibly a lot of code
+#                           changes that we don't have the resources for
+# -cppcoreguidelines-non-private-member-variables-in-classes:
+#         public and protected member variables are fine
 #
 # Notes:
 # misc-move-const-arg: we keep this check because even though this gives
 #                      a lot of annoying warnings about moving trivially
 #                      copyable types, it warns about moving const objects,
 #                      which can have severe performance impacts.
-set(CLANG_TIDY_IGNORE_CHECKS "*,-cppcoreguidelines-no-malloc,-llvm-header-guard,-google-runtime-int,-readability-else-after-return,-misc-noexcept-move-constructor,-misc-unconventional-assign-operator,-cppcoreguidelines-c-copy-assignment-signature,-modernize-raw-string-literal,-hicpp-noexcept-move,-hicpp-no-assembler,-android-*,-cert-err58-cpp,-google-default-arguments,-fuchsia-*,-performance-noexcept-move-constructor")
+set(CLANG_TIDY_IGNORE_CHECKS "*,-cppcoreguidelines-no-malloc,-llvm-header-guard,-google-runtime-int,-readability-else-after-return,-misc-noexcept-move-constructor,-misc-unconventional-assign-operator,-cppcoreguidelines-c-copy-assignment-signature,-modernize-raw-string-literal,-hicpp-*,-android-*,-cert-err58-cpp,-google-default-arguments,-fuchsia-*,-performance-noexcept-move-constructor,-modernize-use-trailing-return-type,-cert-oop54-cpp,-misc-definitions-in-headers,-cppcoreguidelines-macro-usage,-cppcoreguidelines-avoid-magic-numbers,-modernize-use-nodiscard,-readability-magic-numbers,-bugprone-exception-escape,-cert-msc32-c,-misc-non-private-member-variables-in-classes,-cppcoreguidelines-avoid-c-arrays,-cppcoreguidelines-non-private-member-variables-in-classes,-cert-msc51-cpp,-bugprone-macro-parentheses")
 
 if(NOT CLANG_TIDY_ROOT)
   # Need to set to empty to avoid warnings with --warn-uninitialized

--- a/docs/References.bib
+++ b/docs/References.bib
@@ -575,6 +575,21 @@
   publisher  = "CRC Press"
 }
 
+@article{Lehner2010pn,
+  author =       "Lehner, Luis and Pretorius, Frans",
+  title =        "{Black Strings, Low Viscosity Fluids, and Violation of Cosmic
+                  Censorship}",
+  eprint =       "1006.5960",
+  archivePrefix ="arXiv",
+  primaryClass = "hep-th",
+  doi =          "10.1103/PhysRevLett.105.101102",
+  url =          "https://doi.org/10.1103/PhysRevLett.105.101102",
+  journal =      "Phys. Rev. Lett.",
+  volume =       "105",
+  pages =        "101102",
+  year =         "2010"
+}
+
 @article{Lindblom1998dp,
   author         = "Lindblom, Lee",
   title          = "Phase transitions and the mass radius curves of

--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -60,7 +60,7 @@ VECTOR_BLAZE_TRAIT_SPECIALIZE_ARITHMETIC_TRAITS(DataVector);
 VECTOR_BLAZE_TRAIT_SPECIALIZE_ALL_MAP_TRAITS(DataVector);
 }  // namespace blaze
 
-SPECTRE_ALWAYS_INLINE decltype(auto) fabs(const DataVector& t) noexcept {
+SPECTRE_ALWAYS_INLINE auto fabs(const DataVector& t) noexcept {
   return abs(~t);
 }
 

--- a/src/DataStructures/SliceIterator.hpp
+++ b/src/DataStructures/SliceIterator.hpp
@@ -81,6 +81,7 @@ class SliceIterator {
  */
 template <size_t VolumeDim>
 auto volume_and_slice_indices(const Index<VolumeDim>& extents) noexcept
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
     -> std::pair<std::unique_ptr<std::pair<size_t, size_t>[], decltype(&free)>,
                  std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,
                                       gsl::span<std::pair<size_t, size_t>>>,

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -424,6 +424,7 @@ class Variables<tmpl::list<Tags...>> {
   template <class FriendTags>
   friend class Variables;
 
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
   std::unique_ptr<value_type[], decltype(&free)> variable_data_impl_{nullptr,
                                                                      &free};
   size_t size_ = 0;

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -202,6 +202,7 @@ class VectorImpl
   destructive_resize(const size_t new_size) noexcept {
     if (UNLIKELY(size() != new_size)) {
       if (owning_) {
+        // NOLINTNEXTLINE(modernize-avoid-c-arrays)
         owned_data_ = std::unique_ptr<value_type[], decltype(&free)>{
             new_size > 0 ? static_cast<value_type*>(
                                malloc(new_size * sizeof(value_type)))
@@ -222,6 +223,7 @@ class VectorImpl
   void pup(PUP::er& p) noexcept;  // NOLINT
 
  protected:
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
   std::unique_ptr<value_type[], decltype(&free)> owned_data_{nullptr, &free};
   bool owning_{true};
 
@@ -323,6 +325,7 @@ VectorImpl<T, VectorType>& VectorImpl<T, VectorType>::operator=(
                 "assigning to.");
   if (owning_ and (~expression).size() != size()) {
     owned_data_.reset(static_cast<value_type*>(
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
         malloc((~expression).size() * sizeof(value_type))));
     reset_pointer_vector((~expression).size());
   } else if (not owning_) {

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -71,14 +71,7 @@ struct ComputeDuDt {
       ::Tags::deriv<Tags::Pi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
       ::Tags::deriv<Tags::Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
       Tags::ConstraintGamma0, Tags::ConstraintGamma1, Tags::ConstraintGamma2,
-      Tags::GaugeH<Dim>, Tags::SpacetimeDerivGaugeH<Dim>, gr::Tags::Lapse<>,
-      gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>,
-      gr::Tags::InverseSpacetimeMetric<Dim>,
-      gr::Tags::TraceSpacetimeChristoffelFirstKind<Dim>,
-      gr::Tags::SpacetimeChristoffelFirstKind<Dim>,
-      gr::Tags::SpacetimeChristoffelSecondKind<Dim>,
-      gr::Tags::SpacetimeNormalVector<Dim>,
-      gr::Tags::SpacetimeNormalOneForm<Dim>>;
+      Tags::GaugeH<Dim>, Tags::SpacetimeDerivGaugeH<Dim>>;
 
   static void apply(
       gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_spacetime_metric,
@@ -93,15 +86,7 @@ struct ComputeDuDt {
       const Scalar<DataVector>& gamma0, const Scalar<DataVector>& gamma1,
       const Scalar<DataVector>& gamma2,
       const tnsr::a<DataVector, Dim>& gauge_function,
-      const tnsr::ab<DataVector, Dim>& spacetime_deriv_gauge_function,
-      const Scalar<DataVector>& lapse, const tnsr::I<DataVector, Dim>& shift,
-      const tnsr::II<DataVector, Dim>& inverse_spatial_metric,
-      const tnsr::AA<DataVector, Dim>& inverse_spacetime_metric,
-      const tnsr::a<DataVector, Dim>& trace_christoffel,
-      const tnsr::abb<DataVector, Dim>& christoffel_first_kind,
-      const tnsr::Abb<DataVector, Dim>& christoffel_second_kind,
-      const tnsr::A<DataVector, Dim>& normal_spacetime_vector,
-      const tnsr::a<DataVector, Dim>& normal_spacetime_one_form);
+      const tnsr::ab<DataVector, Dim>& spacetime_deriv_gauge_function);
 };
 
 /*!

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -52,7 +52,52 @@ namespace GeneralizedHarmonic {
  * \brief Compute the RHS of the Generalized Harmonic formulation of
  * Einstein's equations.
  *
- * \details For the full form of the equations see \cite Lindblom2005qh.
+ * The evolved variables are the spacetime metric \f$g_{ab}\f$, its spatial
+ * derivative \f$\Phi_{iab}=\partial_i g_{ab}\f$, and conjugate momentum
+ * \f$\Pi_{ab}=n^c\partial_c g_{ab}\f$, where \f$n^a\f$ is the spacetime
+ * unit normal vector. The evolution equations are (Eqs. 35-57 of
+ * \cite Lindblom2005qh)
+ *
+ * \f{align}{
+ *   \partial_t g_{ab}-
+ *   &\left(1+\gamma_1\right)\beta^k\partial_k g_{ab} =
+ *     -\alpha \Pi_{ab}-\gamma_1\beta^i\Phi_{iab}, \\
+ *
+ *   \partial_t\Pi_{ab}-
+ *   &\beta^k\partial_k\Pi_{ab} + \alpha \gamma^{ki}\partial_k\Phi_{iab}
+ *     - \gamma_1\gamma_2\beta^k\partial_kg_{ab} \notag \\
+ *   =&2\alpha g^{cd}\left(\gamma^{ij}\Phi_{ica}\Phi_{jdb}
+ *      - \Pi_{ca}\Pi_{db} - g^{ef}\Gamma_{ace}\Gamma_{bdf}\right) \notag \\
+ *   &-2\alpha \nabla_{(a}H_{b)}
+ *     - \frac{1}{2}\alpha n^c n^d\Pi_{cd}\Pi_{ab}
+ *     - \alpha n^c \Pi_{ci}\gamma^{ij}\Phi_{jab} \notag \\
+ *   &+\alpha \gamma_0\left(2\delta^c{}_{(a} n_{b)}
+ *     - (1 + \gamma_3)g_{ab}n^c\right)\mathcal{C}_c \notag \\
+ *   &+ 2 \gamma_4 \alpha \Pi_{ab} n^c \mathcal{C}_c \notag \\
+ *   &- \gamma_5\alpha n^c\mathcal{C}_c \left(\frac{\mathcal{C}_a\mathcal{C}_b
+ *     - \frac{1}{2} g_{ab} \mathcal{C}_d \mathcal{C}^d}
+ *     {\epsilon_{5} + 2 n^d \mathcal{C}_d n^e \mathcal{C}_e
+ *     + \mathcal{C}_d \mathcal{C}^d} \right) \notag \\
+ *   &-\gamma_1\gamma_2 \beta^i\Phi_{iab} \notag \\
+ *   &-16\pi \alpha \left(T_{ab} - \frac{1}{2}g_{ab}T^c{}_c\right),\\
+ *
+ *   \partial_t\Phi_{iab}-
+ *   &\beta^k\partial_k\Phi_{iab} + \alpha \partial_i\Pi_{ab}
+ *     - \alpha \gamma_2\partial_ig_{ab} \notag \\
+ *   =&\frac{1}{2}\alpha n^c n^d\Phi_{icd}\Pi_{ab}
+ *      + \alpha \gamma^{jk}n^c\Phi_{ijc}\Phi_{kab} \notag \\
+ *   &-\alpha \gamma_2\Phi_{iab},
+ * \f}
+ *
+ * where \f$H_a\f$ is the gauge source function and
+ * \f$\mathcal{C}_a=H_a+\Gamma_a\f$ is the gauge constraint. The constraint
+ * damping parameters \f$\gamma_0\f$ \f$\gamma_1\f$, \f$\gamma_2\f$,
+ * \f$\gamma_3\f$, \f$\gamma_4\f$, and \f$\gamma_5\f$ have units of inverse time
+ * and control the time scales on which the constraints are damped to zero.
+ *
+ * \note We have not coded up the constraint damping terms for \f$\gamma_3\f$,
+ * \f$\gamma_4\f$, and \f$\gamma_5\f$. \f$\gamma_3\f$ was found to be essential
+ * for evolutions of black strings by Pretorius and Lehner \cite Lehner2010pn.
  */
 template <size_t Dim>
 struct ComputeDuDt {

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
@@ -63,7 +63,8 @@ void partial_derivatives_impl(
       Variables<DerivativeTags>::number_of_independent_components;
   double* pdu = du->data();
   const size_t num_grid_points = du->number_of_grid_points();
-  DataVector lhs{}, logical_du{};
+  DataVector lhs{};
+  DataVector logical_du{};
 
   std::array<std::array<size_t, Dim>, Dim> indices{};
   for (size_t deriv_index = 0; deriv_index < Dim; ++deriv_index) {
@@ -192,6 +193,7 @@ void partial_derivatives(
   // Using malloc instead of new is faster because we do not need to zero the
   // data.
   // clang-tidy: cppcoreguidelines-no-malloc
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
   std::unique_ptr<double[], decltype(&free)> logical_derivs_data(
       static_cast<double*>(
           malloc(Dim * u.number_of_grid_points() *  // NOLINT

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -92,12 +92,16 @@ std::ostream& operator<<(std::ostream& os,
 namespace detail {
 constexpr size_t minimum_number_of_points(
     const Basis /*basis*/, const Quadrature quadrature) noexcept {
+  // NOLINTNEXTLINE(bugprone-branch-clone)
   if (quadrature == Quadrature::Gauss) {
     return 1;
+    // NOLINTNEXTLINE(bugprone-branch-clone)
   } else if (quadrature == Quadrature::GaussLobatto) {
     return 2;
+    // NOLINTNEXTLINE(bugprone-branch-clone)
   } else if (quadrature == Quadrature::CellCentered) {
     return 1;
+    // NOLINTNEXTLINE(bugprone-branch-clone)
   } else if (quadrature == Quadrature::FaceCentered) {
     return 2;
   }

--- a/src/Parallel/PupStlCpp11.hpp
+++ b/src/Parallel/PupStlCpp11.hpp
@@ -169,7 +169,7 @@ inline void pup(PUP::er& p, std::unique_ptr<T>& t) {  // NOLINT
   bool is_nullptr = nullptr == t;
   p | is_nullptr;
   if (not is_nullptr) {
-    T* t1;
+    T* t1 = nullptr;
     if (p.isUnpacking()) {
       // clang-tidy: use gsl::owner for owning memory
       t1 = new T;  // NOLINT

--- a/src/Time/BoundaryHistory.hpp
+++ b/src/Time/BoundaryHistory.hpp
@@ -189,7 +189,8 @@ void BoundaryHistory<LocalVars, RemoteVars, CouplingResult>::pup(
   const size_t cache_size = PUP_stl_container_size(p, coupling_cache_);
   if (p.isUnpacking()) {
     for (size_t entry_num = 0; entry_num < cache_size; ++entry_num) {
-      size_t local_index, remote_index;
+      size_t local_index = 0;
+      size_t remote_index = 0;
       CouplingResult cache_value;
       p | local_index;
       p | remote_index;

--- a/src/Time/TimeStepId.hpp
+++ b/src/Time/TimeStepId.hpp
@@ -33,7 +33,6 @@ class TimeStepId {
       : time_runs_forward_(time_runs_forward),
         slab_number_(slab_number),
         step_time_(time),
-        substep_(0),
         substep_time_(time) {
     canonicalize();
   }

--- a/src/Utilities/Array.hpp
+++ b/src/Utilities/Array.hpp
@@ -16,6 +16,7 @@
 namespace cpp17 {
 namespace detail {
 template <typename T, size_t Size, size_t... Is>
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
 std::array<T, Size> convert_to_array(const T (&t)[Size],
                                      std::index_sequence<Is...> /*meta*/) {
   return {{t[Is]...}};
@@ -83,6 +84,7 @@ struct array {
   constexpr value_type* data() noexcept { return data_; }
   constexpr const value_type* data() const noexcept { return data_; }
 
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
   value_type data_[Size > 0 ? Size : 1];
 };
 namespace detail {

--- a/src/Utilities/Blas.hpp
+++ b/src/Utilities/Blas.hpp
@@ -122,9 +122,12 @@ inline void dgemm_<true>(const char& TRANSA, const char& TRANSB,
              'C' == TRANSB or 'c' == TRANSB,
          "TRANSB must be upper or lower case N, T, or C. See the BLAS "
          "documentation for help.");
-  const auto m = gsl::narrow_cast<int>(M), n = gsl::narrow_cast<int>(N),
-             k = gsl::narrow_cast<int>(K), lda = gsl::narrow_cast<int>(LDA),
-             ldb = gsl::narrow_cast<int>(LDB), ldc = gsl::narrow_cast<int>(LDC);
+  const auto m = gsl::narrow_cast<int>(M);
+  const auto n = gsl::narrow_cast<int>(N);
+  const auto k = gsl::narrow_cast<int>(K);
+  const auto lda = gsl::narrow_cast<int>(LDA);
+  const auto ldb = gsl::narrow_cast<int>(LDB);
+  const auto ldc = gsl::narrow_cast<int>(LDC);
   libxsmm_dgemm(&TRANSA, &TRANSB, &m, &n, &k, &ALPHA, A, &lda, B, &ldb, &BETA,
                 C, &ldc);
 }

--- a/src/Utilities/PointerVector.hpp
+++ b/src/Utilities/PointerVector.hpp
@@ -128,6 +128,7 @@ struct StepFunction {
 }  // namespace blaze
 
 template <typename VT, bool TF>
+// NOLINTNEXTLINE(readability-const-return-type)
 BLAZE_ALWAYS_INLINE decltype(auto) step_function(
     const blaze::DenseVector<VT, TF>& vec) noexcept {
   return map(~vec, blaze::StepFunction{});
@@ -399,6 +400,7 @@ struct PointerVector
   PointerVector& operator=(std::initializer_list<Type> list);
 
   template <typename Other, size_t N>
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
   PointerVector& operator=(const Other (&array)[N]);
 
   template <typename VT>
@@ -604,6 +606,7 @@ template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
 template <typename Other, size_t N>
 inline PointerVector<Type, AF, PF, TF, ExprResultType>&
 PointerVector<Type, AF, PF, TF, ExprResultType>::operator=(
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
     const Other (&array)[N]) {
   ASSERT(size_ == N, "Invalid array size");
   for (size_t i = 0UL; i < N; ++i) {

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -18,5 +18,5 @@ add_test_library(
   ${LIBRARY}
   "Evolution/Systems/GeneralizedHarmonic/"
   "${LIBRARY_SOURCES}"
-  "GeneralizedHarmonic;Test_GeneralRelativity"
+  "GeneralRelativityHelpers;GeneralizedHarmonic;Test_GeneralRelativity"
   )

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
@@ -236,9 +236,7 @@ void verify_time_independent_einstein_solution(
   GeneralizedHarmonic::ComputeDuDt<3>::apply(
       make_not_null(&dt_psi), make_not_null(&dt_pi), make_not_null(&dt_phi),
       psi, pi, phi, d_psi, d_pi, d_phi, gamma0, gamma1, gamma2, gauge_function,
-      d4_H, lapse, shift, upper_spatial_metric, upper_psi,
-      trace_christoffel_first_kind, christoffel_first_kind,
-      christoffel_second_kind, normal_vector, normal_one_form);
+      d4_H);
 
   // Make sure the RHS is zero.
   CHECK_ITERABLE_CUSTOM_APPROX(


### PR DESCRIPTION
## Proposed changes

- Reduces the number of compute tags, allocations, and I find makes the code easier to reason about. Specifically, things don't just magically appear from compute tags.
- As part of this I had to refactor the test so that it's not just comparing to SpEC, but written in such a way that we can also compare different implementations in SpECTRE to a reference implementation.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
