### PR TITLE
Add cubic crystalline constitutive relation

### DIFF
--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/CMakeLists.txt
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   ConstitutiveRelation.cpp
+  CubicCrystal.cpp
   IsotropicHomogeneous.cpp
   )
 
@@ -17,6 +18,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ConstitutiveRelation.hpp
+  CubicCrystal.hpp
   IsotropicHomogeneous.hpp
   Tags.hpp
   )

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp
@@ -14,6 +14,9 @@
 class DataVector;
 namespace Elasticity {
 namespace ConstitutiveRelations {
+
+struct CubicCrystal;  // IWYU pragma: keep
+
 template <size_t Dim>
 struct IsotropicHomogeneous;  // IWYU pragma: keep
 }  // namespace ConstitutiveRelations
@@ -53,7 +56,7 @@ class ConstitutiveRelation : public PUP::able {
  public:
   static constexpr size_t volume_dim = Dim;
 
-  using creatable_classes = tmpl::list<IsotropicHomogeneous<Dim>>;
+  using creatable_classes = tmpl::list<CubicCrystal, IsotropicHomogeneous<Dim>>;
 
   ConstitutiveRelation() = default;
   ConstitutiveRelation(const ConstitutiveRelation&) = default;
@@ -80,4 +83,5 @@ class ConstitutiveRelation : public PUP::able {
 }  // namespace ConstitutiveRelations
 }  // namespace Elasticity
 
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"  // IWYU pragma: keep

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.cpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.cpp
@@ -1,0 +1,81 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.hpp"
+
+#include <array>
+#include <pup.h>  // IWYU pragma: keep
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace Elasticity::ConstitutiveRelations {
+
+CubicCrystal::CubicCrystal(const double c_11, const double c_12,
+                           const double c_44) noexcept
+    : c_11_(c_11), c_12_(c_12), c_44_(c_44) {
+  ASSERT(
+      c_11_ >= c_12_,
+      "c_11 must be bigger than c_12, but are c_11="
+          << c_11 << " and c_12=" << c_12
+          << ". This is because the youngs_modulus "
+             "must be positive and the poisson ratio smaller or equal to 0.5.");
+}
+
+tnsr::II<DataVector, 3> CubicCrystal::stress(
+    const tnsr::ii<DataVector, 3>& strain,
+    const tnsr::I<DataVector, 3>& /*x*/) const noexcept {
+  auto result = make_with_value<tnsr::II<DataVector, 3>>(strain, 0.);
+  for (size_t i = 0; i < 3; i++) {
+    result.get(2, 2) -= strain.get(i, i);
+  }
+  result.get(2, 2) *= c_12_;
+  for (size_t i = 0; i < 3; i++) {
+    result.get(i, i) = result.get(2, 2) - (c_11_ - c_12_) * strain.get(i, i);
+    for (size_t j = 0; j < i; j++) {
+      result.get(i, j) = -2. * c_44_ * strain.get(i, j);
+    }
+  }
+  return result;
+}
+
+double CubicCrystal::c_11() const noexcept { return c_11_; }
+
+double CubicCrystal::c_12() const noexcept { return c_12_; }
+
+double CubicCrystal::c_44() const noexcept { return c_44_; }
+
+// through \lambda = c_{12} = \frac{E\nu}{(1+\nu)(1-2\nu)}
+double CubicCrystal::youngs_modulus() const noexcept {
+  return (c_11_ + 2. * c_12_) * (c_11_ - c_12_) / (c_11_ + c_12_);
+}
+
+double CubicCrystal::poisson_ratio() const noexcept {
+  return 1. / (1. + (c_11_ / c_12_));
+}
+
+/// \cond
+PUP::able::PUP_ID CubicCrystal::my_PUP_ID = 0;
+/// \endcond
+
+void CubicCrystal::pup(PUP::er& p) noexcept {
+  p | c_11_;
+  p | c_12_;
+  p | c_44_;
+}
+
+bool operator==(const CubicCrystal& lhs, const CubicCrystal& rhs) noexcept {
+  return lhs.c_11() == rhs.c_11() and lhs.c_12() == rhs.c_12() and
+         lhs.c_44() == rhs.c_44();
+}
+
+bool operator!=(const CubicCrystal& lhs, const CubicCrystal& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace Elasticity::ConstitutiveRelations

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.hpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.hpp
@@ -1,0 +1,146 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <pup.h>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace Elasticity::ConstitutiveRelations {
+
+/*!
+ * \brief A cubic crystalline material
+ *
+ * \details For a cubic crystalline material the Elasticity tensor in the linear
+ * constitutive relation \f$T^{ij}=-Y^{ijkl}S_{kl}\f$ reduces to
+ *
+ * \f[
+ * Y^{ijkl} =
+ * \begin{cases}
+ * c_{11} & \mathrm{for}\; i=j=k=l \\
+ * c_{12} & \mathrm{for}\; i=j,k=l,i \neq k \\
+ * c_{44} & \mathrm{for}\; i=k,j=l,i \neq j \;\mathrm{or}\; i=l,j=k,i\neq j \\
+ * \end{cases}
+ * \f]
+ *
+ * with the three independent parameters: the \f$\mathrm{Lam\acute{e}}\f$
+ * parameter \f$\lambda\f$, the Shear modulus \f$\mu\f$ and the %Poisson
+ * ratio \f$\nu\f$. In the parametrization chosen in this implementation we use
+ * the experimental group parameters \f$c_{11}\f$, \f$c_{12}\f$ and
+ * \f$c_{44}\f$, related by;
+ *
+ * \f[
+ * c_{11} = \frac{1 - \nu}{\nu} \lambda = \frac{(1 - \nu)E}{(1 + \nu)(1 -
+ * 2\nu)}, \quad
+ * c_{12} = \lambda = \frac{E\nu}{(1 + \nu)(1 - 2\nu)}, \quad
+ * c_{44} = \mu
+ * \f]
+ *
+ * and inversely;
+ *
+ * \f[
+ * E = \frac{(c_{11} + 2c_{12})(c_{11} - c_{12})}{c_{11} + c_{12}}, \quad
+ * \nu = \left(1 + \frac{c_{11}}{c_{12}}\right)^{-1}, \quad
+ * \mu = c_{44}
+ * \f]
+ *
+ * The stress-strain relation then reduces to
+ *
+ * \f[
+ * T^{ij} =
+ * \begin{cases}
+ * -(c_{11} - c_{12}) S^{ij} - c_{12} \mathrm{Tr}(S) & \mathrm{for}\; i=j \\
+ * -2 c_{44} S^{ij} & \mathrm{for}\; i \neq j \\
+ * \end{cases}
+ * \f]
+ *
+ * In the case where the shear modulus satisfies \f$c_{44} =
+ * \frac{c_{11}-c_{12}}{2}\f$ the constitutive relation is that of an isotropic
+ * material (see `Elasticity::ConstitutiveRelations::IsotropicHomogeneous`).
+ */
+
+class CubicCrystal : public ConstitutiveRelation<3> {
+ public:
+  static constexpr size_t volume_dim = 3;
+
+  struct C_11 {
+    using type = double;
+    static constexpr OptionString help = {"c_11 parameter for a cubic crystal"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct C_12 {
+    using type = double;
+    static constexpr OptionString help = {"c_12 parameter for a cubic crystal"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct C_44 {
+    using type = double;
+    static constexpr OptionString help = {"c_44 parameter for a cubic crystal"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  using options = tmpl::list<C_11, C_12, C_44>;
+
+  static constexpr OptionString help = {
+      "A constitutive relation that describes a cubic, crystalline material in "
+      "terms of the three independent group paremeters. The parameters "
+      "are measured in units of stress, typically Pascals."};
+
+  CubicCrystal() = default;
+  CubicCrystal(const CubicCrystal&) = default;
+  CubicCrystal& operator=(const CubicCrystal&) = default;
+  CubicCrystal(CubicCrystal&&) = default;
+  CubicCrystal& operator=(CubicCrystal&&) = default;
+  ~CubicCrystal() override = default;
+
+  CubicCrystal(double c_11, double c_12, double c_44) noexcept;
+
+  /// The constitutive relation that characterizes the elastic properties of a
+  /// material
+  tnsr::II<DataVector, 3> stress(const tnsr::ii<DataVector, 3>& strain,
+                                 const tnsr::I<DataVector, 3>& x) const
+      noexcept override;
+
+  /// The 1st group parameter \f$c_{11} = \frac{1 - \nu}{\nu} \lambda\f$
+  double c_11() const noexcept;
+  /// The 2nd group parameter; the \f$\mathrm{Lam\acute{e}}\f$ parameter
+  /// \f$c_{12} = \lambda\f$
+  double c_12() const noexcept;
+  /// The 3rd group parameter; the shear modulus (rigidity) \f$c_{44} = \mu\f$
+  double c_44() const noexcept;
+  /// The Young's modulus \f$E\f$
+  double youngs_modulus() const noexcept;
+  /// The %Poisson ratio \f$\nu\f$
+  double poisson_ratio() const noexcept;
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& /*p*/) noexcept override;  //  NOLINT
+
+  explicit CubicCrystal(CkMigrateMessage* /*unused*/) noexcept {}
+
+  WRAPPED_PUPable_decl_base_template(  // NOLINT
+      SINGLE_ARG(ConstitutiveRelation<3>), CubicCrystal);
+
+ private:
+  double c_11_ = std::numeric_limits<double>::signaling_NaN();
+  double c_12_ = std::numeric_limits<double>::signaling_NaN();
+  double c_44_ = std::numeric_limits<double>::signaling_NaN();
+};  // namespace ConstitutiveRelations
+
+bool operator==(const CubicCrystal& lhs, const CubicCrystal& rhs) noexcept;
+bool operator!=(const CubicCrystal& lhs, const CubicCrystal& rhs) noexcept;
+
+}  // namespace Elasticity::ConstitutiveRelations

--- a/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ConstitutiveRelations")
 
 set(LIBRARY_SOURCES
+  Test_CubicCrystal.cpp
   Test_IsotropicHomogeneous.cpp
   Test_Tags.cpp
   )

--- a/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.py
+++ b/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.py
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def stress(strain, x, c_11, c_12, c_44):
+    return -(c_11 - c_12 - 2 * c_44) * np.diag(np.diag(strain)) \
+        -c_12 * np.identity(3) * np.trace(strain) \
+        -2. * c_44 * strain

--- a/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/Test_CubicCrystal.cpp
+++ b/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/Test_CubicCrystal.cpp
@@ -1,0 +1,154 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <pup.h>
+#include <random>
+#include <tuple>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+
+void test_semantics() {
+  INFO("Test type traits");
+  const Elasticity::ConstitutiveRelations::CubicCrystal relation{3., 2., 1.};
+  CHECK(relation ==
+        Elasticity::ConstitutiveRelations::CubicCrystal{3., 2., 1.});
+  CHECK(relation !=
+        Elasticity::ConstitutiveRelations::CubicCrystal{2., 2., 2.});
+  CHECK(relation !=
+        Elasticity::ConstitutiveRelations::CubicCrystal{3., 0.2, 1.});
+  test_serialization(relation);
+  test_copy_semantics(relation);
+  const auto created_relation = TestHelpers::test_creation<
+      Elasticity::ConstitutiveRelations::CubicCrystal>(
+      "C_11: 3.\n"
+      "C_12: 2.\n"
+      "C_44: 1.\n");
+  CHECK(created_relation == relation);
+  Elasticity::ConstitutiveRelations::CubicCrystal moved_relation{3., 2., 1.};
+  test_move_semantics(std::move(moved_relation), relation);
+}
+
+void test_consistency(const tnsr::ii<DataVector, 3>& random_strain,
+                      const tnsr::I<DataVector, 3>& random_inertial_coords) {
+  INFO("Consistentcy between CubicCrystal and IsotropicHomogeneous");
+  const double youngs_modulus = 1.;
+  const double poisson_ratio = 1. / 3.;
+  const double isotropic_bulk_modulus =
+      youngs_modulus / (1. - 2. * poisson_ratio) / 3.;
+  const double isotropic_shear_modulus =
+      youngs_modulus / (1. + poisson_ratio) / 2.;
+  const Elasticity::ConstitutiveRelations::IsotropicHomogeneous<3>
+      isotropic_homogeneous_relation{isotropic_bulk_modulus,
+                                     isotropic_shear_modulus};
+  const double c_11 = youngs_modulus * (1.- poisson_ratio) /
+                      ((1. + poisson_ratio) * (1. - 2. * poisson_ratio));
+  const double c_12 = youngs_modulus * poisson_ratio /
+                      ((1. + poisson_ratio) * (1. - 2. * poisson_ratio));
+  const double c_44 = isotropic_shear_modulus;
+  // this should be isotropic homogeneous
+  const Elasticity::ConstitutiveRelations::CubicCrystal
+      cubic_crystalline_relation{c_11, c_12, c_44};
+  const auto cubic_crystalline_stress =
+      cubic_crystalline_relation.stress(random_strain, random_inertial_coords);
+  const auto isotropic_homogeneous_stress =
+      isotropic_homogeneous_relation.stress(random_strain,
+                                            random_inertial_coords);
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t j = 0; j < 3; j++) {
+      CHECK_ITERABLE_APPROX(cubic_crystalline_stress.get(i, j),
+                            isotropic_homogeneous_stress.get(i, j));
+    }
+  }
+  // This relation should be the negative identity
+  const Elasticity::ConstitutiveRelations::CubicCrystal relation{1., 0., 0.5};
+  const auto stress = relation.stress(random_strain, random_inertial_coords);
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t j = 0; j < 3; j++) {
+      CHECK_ITERABLE_APPROX(stress.get(i, j), -random_strain.get(i, j));
+    }
+  }
+}
+
+void test_implementation(const double youngs_modulus,
+                         const double poisson_ratio, double shear_modulus) {
+  const Elasticity::ConstitutiveRelations::CubicCrystal relation{
+      youngs_modulus, poisson_ratio, shear_modulus};
+  pypp::check_with_random_values<1>(
+      &Elasticity::ConstitutiveRelations::CubicCrystal::stress, relation,
+      "CubicCrystal", "stress", {{{-1., 1.}}},
+      std::tuple<double, double, double>{youngs_modulus, poisson_ratio,
+                                         shear_modulus},
+      DataVector(5));
+}
+
+void test_implementation_suite() {
+  INFO("Comparison to an independent Python implementation");
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/Elasticity/ConstitutiveRelations");
+  test_implementation(3., 2., 1.);
+  // Values taken from:
+  // R. E. Newnham: Properties of materials. Oxford University Press, 2005, ISBN
+  // 978-0-19-852075-7 Diamond: c_11=1020, c_12=250, c_44=492
+  test_implementation(1020., 250., 492.);
+  // Silicon: c_11=166, c_12=64, c_44=80
+  test_implementation(166., 64., 80.);
+  // Germanium: c_11=130, c_12=49, c_44=67
+  test_implementation(130., 49., 67.);
+  // Lithium: c_11=13.5, c_12=11.4, c_44=8.8
+  test_implementation(13.5, 11.4, 8.8);
+  // Sodium: c_11=7.4, c_12=6.2, c_44=4.2
+  test_implementation(7.4, 6.2, 4.2);
+  // Potassium: c_11=3.7, c_12=3.1, c_44=1.9
+  test_implementation(3.7, 3.1, 1.9);
+  // NaCl: c_11=48.5, c_12=12.5, c_44=12.7
+  test_implementation(48.5, 12.5, 12.7);
+  // KCl: c_11=40.5, c_12=6.6, c_44=6.3
+  test_implementation(40.5, 6.6, 6.3);
+  // RbCl: c_11=36.3, c_12=6.2, c_44=4.7
+  test_implementation(36.3, 6.2, 4.7);
+}
+
+void test_analytically() {
+  INFO("Comparison to analytic expressions");
+  // Generate random strain data
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> dist(-1., 1.);
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_dist = make_not_null(&dist);
+  const DataVector used_for_size{10};
+  const auto random_strain = make_with_random_values<tnsr::ii<DataVector, 3>>(
+      nn_generator, nn_dist, used_for_size);
+  const auto random_inertial_coords =
+      make_with_random_values<tnsr::I<DataVector, 3>>(nn_generator, nn_dist,
+                                                      used_for_size);
+
+  test_consistency(random_strain, random_inertial_coords);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elasticity.ConstitutiveRelations.CubicCrystal",
+                  "[PointwiseFunctions][Unit][Elasticity]") {
+  {
+    INFO("CubicyCrystal");
+    test_semantics();
+    test_analytically();
+    test_implementation_suite();
+  }
+}


### PR DESCRIPTION
## Proposed changes

This PR adds a ConstitutiveRelation for a cubic crystalline material. It describes the material in terms of the most commonly found, three independent group parameters C11, C12 and C44. These are analogous to the youngs modulus E, the poisson ration ν and the shear modulus µ from the isotropic homogeneous case, where the three parameters are coupled. This PR then allows tackling Elasticity problems for first anisotropic cases.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

A later PR should handle aligning the crystals axes with that of the coordinate system, as well as any dependence on the inertial coordinates.
