### PR TITLE
Allow registering elements for multiple reductions

### DIFF
--- a/src/IO/Observer/Actions.hpp
+++ b/src/IO/Observer/Actions.hpp
@@ -168,10 +168,11 @@ struct RegisterSenderWithSelf {
       db::mutate<observers::Tags::ReductionArrayComponentIds>(
           make_not_null(&box), [&component_id](
                                    const auto array_component_ids) noexcept {
-            ASSERT(array_component_ids->count(component_id) == 0,
-                   "Trying to insert a component_id more than once for "
-                   "reduction. This means an element is registering itself "
-                   "with the observers more than once.");
+            // It's ok to register an element more than once for reduction. The
+            // `component_id` is identical, so the `array_component_ids` will
+            // not contain the element multiple times, but the `observation_id`
+            // should have a different `observation_type_hash` for each
+            // registration event.
             array_component_ids->insert(component_id);
           });
       const auto my_proc = static_cast<size_t>(Parallel::my_proc());


### PR DESCRIPTION
## Proposed changes

The "observation type" already distinguishes different reductions from the same elements, but registering the different reductions hit this assertion. Looks like everything works as expected by just removing the assertion.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
