### PR TITLE
Remove constraint on perpendicular refinement

### DIFF
--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -383,7 +383,7 @@ template <size_t VolumeDim>
 FaceCornerIterator<VolumeDim>::FaceCornerIterator(
     Direction<VolumeDim> direction) noexcept
     : direction_(std::move(direction)),
-      index_(direction.side() == Side::Upper
+      index_(direction_.side() == Side::Upper
                  ? two_to_the(direction_.dimension())
                  : 0) {
   for (size_t i = 0; i < VolumeDim; ++i) {

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -132,6 +132,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
                         {{72.0, 91.0}, {{6, 7}}}, {{70.0, 92.0}, {{2, 3}}},
                         {{71.0, 92.0}, {{2, 3}}}, {{72.0, 92.0}, {{6, 7}}}};
     const auto domain = refined_domain->create_domain();
+    test_initial_domain(domain, refined_domain->initial_refinement_levels());
+
     const auto& blocks = domain.blocks();
     const auto extents = refined_domain->initial_extents();
     REQUIRE(blocks.size() == extents.size());
@@ -153,8 +155,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
 
   {
     // Expected domain refinement:
-    // 25 25 36
-    // 25 35 36
+    // 25 25 46
+    // 25 35 46
     // 25 XX 35
     const auto refined_domain =
         TestHelpers::test_factory_creation<DomainCreator<2>>(
@@ -169,17 +171,19 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
             "    Refinement: [3, 5]\n"
             "  - LowerCornerIndex: [2, 1]\n"
             "    UpperCornerIndex: [3, 3]\n"
-            "    Refinement: [3, 6]");
+            "    Refinement: [4, 6]");
     std::unordered_set<
         std::pair<std::vector<double>, std::array<size_t, 2>>,
         boost::hash<std::pair<std::vector<double>, std::array<size_t, 2>>>>
         expected_blocks{{{70.0, 90.0}, {{2, 5}}}, {{72.0, 90.0}, {{3, 5}}},
                         {{70.0, 91.0}, {{2, 5}}}, {{71.0, 91.0}, {{3, 5}}},
-                        {{72.0, 91.0}, {{3, 6}}}, {{70.0, 92.0}, {{2, 5}}},
-                        {{71.0, 92.0}, {{2, 5}}}, {{72.0, 92.0}, {{3, 6}}}};
+                        {{72.0, 91.0}, {{4, 6}}}, {{70.0, 92.0}, {{2, 5}}},
+                        {{71.0, 92.0}, {{2, 5}}}, {{72.0, 92.0}, {{4, 6}}}};
     const auto domain = refined_domain->create_domain();
-    const auto& blocks = domain.blocks();
     const auto refinement_levels = refined_domain->initial_refinement_levels();
+    test_initial_domain(domain, refinement_levels);
+
+    const auto& blocks = domain.blocks();
     REQUIRE(blocks.size() == refinement_levels.size());
     for (size_t i = 0; i < blocks.size(); ++i) {
       const auto location =

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.hpp
@@ -72,8 +72,8 @@ boost::rational<size_t> fraction_of_block_volume(
     const ElementId<VolumeDim>& element_id) noexcept;
 
 // Test that the Elements of the initial domain are connected and cover the
-// computational domain, as well as that neighboring Elements  are at the same
-// refinement level.
+// computational domain, as well as that neighboring Elements' refinement
+// levels do not differ too much.
 template <size_t VolumeDim>
 void test_initial_domain(const Domain<VolumeDim>& domain,
                          const std::vector<std::array<size_t, VolumeDim>>&


### PR DESCRIPTION
The perpendicular direction does not appear on the interface, so we
don't need restrictions to allow projection.  Larger refinement jumps
may actually result in more uniform domains if the map Jacobians are
different in the two blocks.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
