### PR TITLE
Correct argument_tags of ThreeIndexConstraintCompute

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -107,7 +107,6 @@ struct InitializeGhAnd3Plus1Variables {
         GeneralizedHarmonic::Tags::TimeDerivLapseCompute<Dim, frame>,
         GeneralizedHarmonic::Tags::TimeDerivShiftCompute<Dim, frame>,
         gr::Tags::DerivativesOfSpacetimeMetricCompute<Dim, frame>,
-        gr::Tags::DerivSpacetimeMetricCompute<Dim, frame>,
         GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<Dim, frame>,
         gr::Tags::SpacetimeChristoffelFirstKindCompute<Dim, frame, DataVector>,
         gr::Tags::SpacetimeChristoffelSecondKindCompute<Dim, frame, DataVector>,

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -1113,7 +1113,8 @@ template <size_t SpatialDim, typename Frame>
 struct ThreeIndexConstraintCompute : ThreeIndexConstraint<SpatialDim, Frame>,
                                      db::ComputeTag {
   using argument_tags =
-      tmpl::list<gr::Tags::DerivSpacetimeMetric<SpatialDim, Frame>,
+      tmpl::list<::Tags::deriv<gr::Tags::SpacetimeMetric<SpatialDim, Frame>,
+                               tmpl::size_t<SpatialDim>, Frame>,
                  Phi<SpatialDim, Frame>>;
 
   using return_type = tnsr::iaa<DataVector, SpatialDim, Frame>;

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -501,44 +501,6 @@ struct DerivativesOfSpacetimeMetricCompute
 };
 
 /*!
- * \brief Compute item to get spatial derivative of spacetime metric from
- * spatial metric, lapse, shift, and their space and time derivatives.
- *
- * \details Extracts spatial derivatives from spacetime derivatives computed
- * with `derivatives_of_spacetime_metric()`. Can be retrieved using
- * `gr::Tags::SpacetimeMetric` wrapped in `Tags::deriv`.
- */
-template <size_t SpatialDim, typename Frame>
-struct DerivSpacetimeMetricCompute
-    : gr::Tags::DerivSpacetimeMetric<SpatialDim, Frame, DataVector>,
-      db::ComputeTag {
-  using argument_tags = tmpl::list<
-      gr::Tags::DerivativesOfSpacetimeMetric<SpatialDim, Frame, DataVector>>;
-
-  using return_type = tnsr::iaa<DataVector, SpatialDim, Frame>;
-
-  static constexpr auto function(
-      const gsl::not_null<tnsr::iaa<DataVector, SpatialDim, Frame>*>
-          deriv_spacetime_metric,
-      const tnsr::abb<DataVector, SpatialDim, Frame>&
-          spacetime_deriv_of_spacetime_metric) noexcept {
-    destructive_resize_components(
-        deriv_spacetime_metric,
-        spacetime_deriv_of_spacetime_metric.begin()->size());
-    for (size_t i = 0; i < SpatialDim; ++i) {
-      for (size_t a = 0; a < SpatialDim + 1; ++a) {
-        for (size_t b = a; b < SpatialDim + 1; ++b) {
-          deriv_spacetime_metric->get(i, a, b) =
-              spacetime_deriv_of_spacetime_metric.get(i + 1, a, b);
-        }
-      }
-    }
-  }
-
-  using base = gr::Tags::DerivSpacetimeMetric<SpatialDim, Frame, DataVector>;
-};
-
-/*!
  * \brief Compute item to get the square root of the determinant of the spatial
  * metric \f$\sqrt{g}\f$ via `gr::Tags::DetAndInverseSpatialMetric`.
  *

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -55,17 +55,6 @@ struct Lapse : db::SimpleTag {
 /*!
  * \brief Spacetime derivatives of the spacetime metric
  *
- * \details Spatial derivatives of the spacetime metric
- * \f$\partial_i \psi_{bc}\f$ assembled from the spatial
- * derivatives of evolved 3+1 variables.
- */
-template <size_t Dim, typename Frame, typename DataType>
-struct DerivSpacetimeMetric : db::SimpleTag {
-  using type = tnsr::iaa<DataType, Dim, Frame>;
-};
-/*!
- * \brief Spacetime derivatives of the spacetime metric
- *
  * \details Spacetime derivatives of the spacetime metric
  * \f$\partial_a \psi_{bc}\f$ assembled from the spatial and temporal
  * derivatives of evolved 3+1 variables.

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -38,9 +38,6 @@ template <typename DataType = DataVector>
 struct Lapse;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
-struct DerivSpacetimeMetric;
-template <size_t Dim, typename Frame = Frame::Inertial,
-          typename DataType = DataVector>
 struct DerivativesOfSpacetimeMetric;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -225,9 +225,6 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
   TestHelpers::db::test_compute_tag<
       gr::Tags::DerivativesOfSpacetimeMetricCompute<3, Frame::Inertial>>(
       "DerivativesOfSpacetimeMetric");
-  TestHelpers::db::test_compute_tag<
-      gr::Tags::DerivSpacetimeMetricCompute<3, Frame::Inertial>>(
-      "DerivSpacetimeMetric");
 
   // Second, put the compute items into a data box and check that they
   // put the correct results
@@ -349,10 +346,6 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
           expected_lapse, dt_lapse, deriv_lapse, expected_shift, dt_shift,
           deriv_shift, expected_spatial_metric, dt_spatial_metric,
           deriv_spatial_metric);
-  tnsr::iaa<DataVector, 3, Frame::Inertial> expected_deriv_spacetime_metric{};
-  gr::Tags::DerivSpacetimeMetricCompute<3, Frame::Inertial>::function(
-      make_not_null(&expected_deriv_spacetime_metric),
-      expected_derivatives_of_spacetime_metric);
 
   const auto third_box = db::create<
       db::AddSimpleTags<
@@ -369,14 +362,11 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
           ::Tags::dt<gr::Tags::Lapse<DataVector>>,
           ::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>>,
       db::AddComputeTags<
-          gr::Tags::DerivativesOfSpacetimeMetricCompute<3, Frame::Inertial>,
-          gr::Tags::DerivSpacetimeMetricCompute<3, Frame::Inertial>>>(
+          gr::Tags::DerivativesOfSpacetimeMetricCompute<3, Frame::Inertial>>>(
       expected_spatial_metric, expected_lapse, expected_shift,
       deriv_spatial_metric, deriv_lapse, deriv_shift, dt_spatial_metric,
       dt_lapse, dt_shift);
   CHECK(db::get<gr::Tags::DerivativesOfSpacetimeMetric<3, Frame::Inertial,
                                                        DataVector>>(
             third_box) == expected_derivatives_of_spacetime_metric);
-  CHECK(db::get<gr::Tags::DerivSpacetimeMetric<3, Frame::Inertial, DataVector>>(
-            third_box) == expected_deriv_spacetime_metric);
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
@@ -31,8 +31,6 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<gr::Tags::Shift<Dim, Frame, Type>>("Shift");
   TestHelpers::db::test_simple_tag<gr::Tags::Lapse<Type>>("Lapse");
   TestHelpers::db::test_simple_tag<
-      gr::Tags::DerivSpacetimeMetric<Dim, Frame, Type>>("DerivSpacetimeMetric");
-  TestHelpers::db::test_simple_tag<
       gr::Tags::DerivativesOfSpacetimeMetric<Dim, Frame, Type>>(
       "DerivativesOfSpacetimeMetric");
   TestHelpers::db::test_simple_tag<


### PR DESCRIPTION
## Proposed changes

As @nilsdeppe has pointed out, as currently coded, the 3-index constraint ComputeTag is incorrectly coded. It should subtract the derivative of the spacetime metric and Phi, but instead, it computes the derivative assuming Phi = 0. This is because its first argument in argument_tags was incorrectly set.

This PR fixes this: the first argument of the ComputeTag is now the numerical spatial derivative of the spacetime metric, and the corresponding test is updated to correctly compute this argument tag by taking a numerical derivative.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
