### PR TITLE
Actions and Events for interpolating without interp component

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.hpp
@@ -149,7 +149,7 @@ class CubicScale {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
-  bool is_identity() const noexcept { return false; }
+  static bool is_identity() noexcept { return false; }
 
  private:
   template <size_t LocalDim>

--- a/src/Domain/CoordinateMaps/TimeDependent/Rotation.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Rotation.hpp
@@ -102,7 +102,7 @@ class Rotation<2> {
 
   void pup(PUP::er& p) noexcept;  // NOLINT
 
-  bool is_identity() const noexcept { return false; }
+  static bool is_identity() noexcept { return false; }
 
  private:
   friend bool operator==(const Rotation<2>& lhs,

--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.hpp
@@ -75,7 +75,7 @@ class Translation {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
-  bool is_identity() const noexcept { return false; }
+  static bool is_identity() noexcept { return false; }
 
  private:
   friend bool operator==(const Translation& lhs,

--- a/src/NumericalAlgorithms/Interpolation/Actions/InterpolateToTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Actions/InterpolateToTarget.hpp
@@ -1,0 +1,124 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "NumericalAlgorithms/Interpolation/PointInfoTag.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace tuples {
+template <typename... Tags>
+class TaggedTuple;
+}  // namespace tuples
+/// \endcond
+
+namespace intrp {
+namespace Actions {
+
+/// \ingroup ActionsGroup
+/// \brief Interpolates and sends points to an InterpolationTarget.
+///
+/// This is invoked on DgElementArray.
+///
+/// Uses:
+/// - DataBox:
+///   - `intrp::Tags::InterpPointInfo<Metavariables>`
+///   - `Tags::Mesh<Metavariables::volume_dim>`
+///   - Variables tagged by
+///     InterpolationTargetTag::vars_to_interpolate_to_target
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies: nothing
+template <typename InterpolationTargetTag>
+struct InterpolateToTarget {
+  template <typename DbTags, typename Metavariables, typename... InboxTags,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTags>&&> apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    static constexpr size_t dim = Metavariables::volume_dim;
+
+    // Get element logical coordinates.
+    const auto& block_logical_coords =
+        get<Vars::PointInfoTag<InterpolationTargetTag, dim>>(
+            db::get<Tags::InterpPointInfo<Metavariables>>(box));
+    const std::vector<ElementId<dim>> element_ids{{array_index}};
+    const auto element_coord_holders =
+        element_logical_coordinates(element_ids, block_logical_coords);
+
+    // There is exactly one element_id in the list of element_ids.
+    if (element_coord_holders.count(element_ids[0]) == 0) {
+      // There are no points in this element, so we don't need
+      // to do anything.
+      return std::forward_as_tuple(std::move(box));
+    }
+
+    // There are points in this element, so interpolate to them and
+    // send the interpolated data to the target.  This is done
+    // in several steps:
+    const auto& element_coord_holder = element_coord_holders.at(element_ids[0]);
+
+    using compute_items_in_new_box = tmpl::list_difference<
+        typename InterpolationTargetTag::compute_items_on_source, DbTags>;
+
+    // 1. Create a new DataBox that contains
+    // InterpolationTargetTag::compute_items_on_source
+    auto new_box =
+        db::create_from<db::RemoveTags<>, db::AddSimpleTags<>,
+                        db::AddComputeTags<compute_items_in_new_box>>(
+            std::move(box));
+
+    // 2. Set up local variables to hold vars_to_interpolate and fill it
+    const auto& mesh = db::get<domain::Tags::Mesh<dim>>(new_box);
+    Variables<typename InterpolationTargetTag::vars_to_interpolate_to_target>
+        local_vars(mesh.number_of_grid_points());
+
+    tmpl::for_each<
+        typename InterpolationTargetTag::vars_to_interpolate_to_target>(
+        [&new_box, &local_vars ](auto tag_v) noexcept {
+          using tag = typename decltype(tag_v)::type;
+          get<tag>(local_vars) = db::get<tag>(new_box);
+        });
+
+    // 3. Set up interpolator
+    intrp::Irregular<dim> interpolator(
+        mesh, element_coord_holder.element_logical_coords);
+
+    // 4. Interpolate and send interpolated data to target
+    auto& receiver_proxy = Parallel::get_parallel_component<
+        InterpolationTarget<Metavariables, InterpolationTargetTag>>(cache);
+    Parallel::simple_action<
+        Actions::InterpolationTargetVarsFromElement<InterpolationTargetTag>>(
+        receiver_proxy,
+        std::vector<Variables<
+            typename InterpolationTargetTag::vars_to_interpolate_to_target>>(
+            {interpolator.interpolate(local_vars)}),
+        std::vector<std::vector<size_t>>({element_coord_holder.offsets}),
+        db::get<typename Metavariables::temporal_id>(new_box));
+
+    // 5. Put back original DataBox.
+    box = db::create_from<db::RemoveTags<compute_items_in_new_box>,
+                          db::AddSimpleTags<>>(std::move(new_box));
+
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
@@ -1,0 +1,192 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/ElementId.hpp"
+#include "NumericalAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "NumericalAlgorithms/Interpolation/PointInfoTag.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Tags {
+struct TimeStepId;
+}  // namespace Tags
+namespace domain {
+namespace Tags {
+template <size_t VolumeDim>
+struct Mesh;
+}  // namespace Tags
+}  // namespace domain
+namespace Tags {
+template <typename TagsList>
+struct Variables;
+}  // namespace Tags
+template <size_t Dim>
+class Mesh;
+template <size_t VolumeDim>
+class ElementId;
+namespace intrp {
+template <typename Metavariables, typename Tag>
+struct InterpolationTarget;
+namespace Registrars {
+template <size_t VolumeDim, typename InterpolationTargetTag,
+          typename Metavariables, typename Tensors>
+struct InterpolateWithoutInterpComponent;
+}  // namespace Registrars
+namespace Events {
+template <size_t VolumeDim, typename InterpolationTargetTag,
+          typename Metavariables, typename Tensors,
+          typename EventRegistrars =
+              tmpl::list<Registrars::InterpolateWithoutInterpComponent<
+                  VolumeDim, InterpolationTargetTag, Metavariables, Tensors>>>
+class InterpolateWithoutInterpComponent;
+}  // namespace Events
+}  // namespace intrp
+/// \endcond
+
+namespace intrp {
+
+/// \cond
+namespace Registrars {
+template <size_t VolumeDim, typename InterpolationTargetTag,
+          typename Metavariables, typename Tensors>
+struct InterpolateWithoutInterpComponent {
+  template <typename RegistrarList>
+  using f = Events::InterpolateWithoutInterpComponent<
+      VolumeDim, InterpolationTargetTag, Metavariables, Tensors, RegistrarList>;
+};
+}  // namespace Registrars
+/// \endcond
+
+namespace Events {
+/// Does an interpolation onto an InterpolationTargetTag by calling Actions on
+/// the InterpolationTarget component.
+template <size_t VolumeDim, typename InterpolationTargetTag,
+          typename Metavariables, typename... Tensors, typename EventRegistrars>
+class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
+                                        Metavariables, tmpl::list<Tensors...>,
+                                        EventRegistrars>
+    : public Event<EventRegistrars> {
+  /// \cond
+  explicit InterpolateWithoutInterpComponent(
+      CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(InterpolateWithoutInterpComponent);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::list<>;
+  static constexpr OptionString help =
+      "Does interpolation using the given InterpolationTargetTag, "
+      "without an Interpolator ParallelComponent.";
+
+  static std::string name() noexcept {
+    return option_name<InterpolationTargetTag>();
+  }
+
+  InterpolateWithoutInterpComponent() = default;
+
+  using argument_tags =
+      tmpl::list<::Tags::TimeStepId, Tags::InterpPointInfo<Metavariables>,
+                 domain::Tags::Mesh<VolumeDim>, Tensors...>;
+
+  template <typename ParallelComponent>
+  void operator()(
+      const TimeStepId& time_id,
+      const db::item_type<Tags::InterpPointInfo<Metavariables>>& point_infos,
+      const Mesh<VolumeDim>& mesh,
+      const db::const_item_type<Tensors>&... tensors,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ElementId<VolumeDim>& array_index,
+      const ParallelComponent* const /*meta*/) const noexcept {
+    // Get element logical coordinates of the target points.
+    const auto& block_logical_coords =
+        get<Vars::PointInfoTag<InterpolationTargetTag, VolumeDim>>(point_infos);
+    const std::vector<ElementId<VolumeDim>> element_ids{{array_index}};
+    const auto element_coord_holders =
+        element_logical_coordinates(element_ids, block_logical_coords);
+
+    // There is exactly one element_id in the list of element_ids.
+    if (element_coord_holders.count(element_ids[0]) == 0) {
+      // There are no target points in this element, so we don't need
+      // to do anything.
+      return;
+    }
+
+    // There are points in this element, so interpolate to them and
+    // send the interpolated data to the target.  This is done
+    // in several steps:
+    const auto& element_coord_holder = element_coord_holders.at(element_ids[0]);
+
+    // 1. Get the list of variables
+    Variables<typename InterpolationTargetTag::vars_to_interpolate_to_target>
+        interp_vars(mesh.number_of_grid_points());
+
+    // Clang-tidy wants extra braces for `if constexpr`
+    if constexpr (std::is_same_v<tmpl::list<>, typename InterpolationTargetTag::
+                                                   compute_items_on_source>) {
+      // 1.a Copy the tensors directly into the variables; no need to
+      // make a DataBox because we have no ComputeItems.
+      [[maybe_unused]] const auto copy_to_variables = [&interp_vars](
+          const auto tensor_tag_v, const auto& tensor) noexcept {
+        using tensor_tag = tmpl::type_from<decltype(tensor_tag_v)>;
+        get<tensor_tag>(interp_vars) = tensor;
+        return 0;
+      };
+      expand_pack(copy_to_variables(tmpl::type_<Tensors>{}, tensors)...);
+    } else {
+      // 1.b Make a DataBox and insert ComputeItems
+      const auto box = db::create<
+          db::AddSimpleTags<Tensors...>,
+          db::AddComputeTags<
+              typename InterpolationTargetTag::compute_items_on_source>>(
+          tensors...);
+      // Copy vars_to_interpolate_to_target from databox to vars
+      tmpl::for_each<
+          typename InterpolationTargetTag::vars_to_interpolate_to_target>(
+          [&box, &interp_vars ](auto tag_v) noexcept {
+            using tag = typename decltype(tag_v)::type;
+            get<tag>(interp_vars) = db::get<tag>(box);
+          });
+    }
+
+    // 2. Set up interpolator
+    intrp::Irregular<VolumeDim> interpolator(
+        mesh, element_coord_holder.element_logical_coords);
+
+    // 3. Interpolate and send interpolated data to target
+    auto& receiver_proxy = Parallel::get_parallel_component<
+        InterpolationTarget<Metavariables, InterpolationTargetTag>>(cache);
+    Parallel::simple_action<
+        Actions::InterpolationTargetVarsFromElement<InterpolationTargetTag>>(
+        receiver_proxy,
+        std::vector<Variables<
+            typename InterpolationTargetTag::vars_to_interpolate_to_target>>(
+            {interpolator.interpolate(interp_vars)}),
+        std::vector<std::vector<size_t>>({element_coord_holder.offsets}),
+        time_id);
+  }
+};
+
+/// \cond
+template <size_t VolumeDim, typename InterpolationTargetTag,
+          typename Metavariables, typename... Tensors, typename EventRegistrars>
+PUP::able::PUP_ID InterpolateWithoutInterpComponent<
+    VolumeDim, InterpolationTargetTag, Metavariables, tmpl::list<Tensors...>,
+    EventRegistrars>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+
+}  // namespace Events
+}  // namespace intrp

--- a/tests/Unit/Helpers/NumericalAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
@@ -1,0 +1,241 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Creators/Shell.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementLogicalCoordinates.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/InitialElementIds.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/PointInfoTag.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+
+/// Holds code that is shared between multiple tests. Currently used by
+/// - Test_InterpolateToTarget
+/// - Test_InterpolateWithoutInterpolatorComponent.
+namespace InterpolateOnElementTestHelpers {
+
+namespace Tags {
+// Simple Variables tag for test.
+struct TestSolution : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+// Tag holding inertial-frame target points for test.
+struct TestTargetPoints : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3, Frame::Inertial>;
+};
+// ComputeItem for test.
+struct MultiplyByTwo : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+struct MultiplyByTwoComputeItem : MultiplyByTwo, db::ComputeTag {
+  static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
+    auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
+    get<>(result) = get<>(x) * 2.0;
+    return result;
+  }
+  using argument_tags = tmpl::list<TestSolution>;
+  using base = MultiplyByTwo;
+};
+}  // namespace Tags
+
+template <typename TagName, typename VarsTagList>
+void fill_variables(
+    const gsl::not_null<Variables<VarsTagList>*> vars,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& coords) noexcept {
+  // Some analytic solution used to fill the volume data and
+  // to test the interpolated data.
+  auto& solution = get<TagName>(*vars);
+  get(solution) =
+      (2.0 * get<0>(coords) + 3.0 * get<1>(coords) + 5.0 * get<2>(coords));
+
+  if constexpr (std::is_same_v<TagName, Tags::MultiplyByTwo>) {
+    get(solution) *= 2.0;
+  } else if constexpr (not std::is_same_v<TagName, Tags::TestSolution>) {
+    ERROR("Do not understand the given TagName");
+  }
+}
+
+template <typename InterpolationTargetTag>
+struct MockInterpolationTargetVarsFromElement {
+  template <
+      typename ParallelComponent, typename DbTags, typename Metavariables,
+      typename ArrayIndex, typename TemporalId,
+      Requires<tmpl::list_contains_v<DbTags, Tags::TestTargetPoints>> = nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/,
+      const std::vector<Variables<
+          typename InterpolationTargetTag::vars_to_interpolate_to_target>>&
+          vars_src,
+      const std::vector<std::vector<size_t>>& global_offsets,
+      const TemporalId& /*temporal_id*/) noexcept {
+    CHECK(global_offsets.size() == vars_src.size());
+    // global_offsets and vars_src always have a size of 1 for calls
+    // directly from the elements; the outer vector is used only by
+    // the Interpolator parallel component.
+    CHECK(global_offsets.size() == 1);
+
+    // Here we have received only some of the points.
+    const size_t num_pts_received = global_offsets[0].size();
+
+    // Create a new target_points containing only the ones we have received.
+    const auto& all_target_points = db::get<Tags::TestTargetPoints>(box);
+    tnsr::I<DataVector, 3, Frame::Inertial> target_points(num_pts_received);
+    for (size_t i = 0; i < num_pts_received; ++i) {
+      for (size_t d = 0; d < 3; ++d) {
+        target_points.get(d)[i] =
+            all_target_points.get(d)[global_offsets[0][i]];
+      }
+    }
+
+    static_assert(
+        tmpl::count<typename InterpolationTargetTag::
+                        vars_to_interpolate_to_target>::value == 1,
+        "For this test, we assume only a single interpolated variable");
+    using solution_tag = tmpl::front<
+        typename InterpolationTargetTag::vars_to_interpolate_to_target>;
+    const auto& test_solution = get<solution_tag>(vars_src[0]);
+
+    // Expected solution
+    Variables<tmpl::list<solution_tag>> expected_vars(vars_src[0].size());
+    fill_variables<solution_tag>(make_not_null(&expected_vars), target_points);
+    const auto& expected_solution = get<solution_tag>(expected_vars);
+
+    // We don't have that many points, so interpolation is good for
+    // only a few digits.
+    Approx custom_approx = Approx::custom().epsilon(1.e-5).scale(1.0);
+    CHECK_ITERABLE_CUSTOM_APPROX(test_solution, expected_solution,
+                                 custom_approx);
+  }
+};
+
+template <typename Metavariables, typename InterpolationTargetTag>
+struct mock_interpolation_target {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using component_being_mocked =
+      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
+  using simple_tags = tmpl::list<Tags::TestTargetPoints>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+  using replace_these_simple_actions =
+      tmpl::list<intrp::Actions::InterpolationTargetVarsFromElement<
+          InterpolationTargetTag>>;
+  using with_these_simple_actions = tmpl::list<
+      MockInterpolationTargetVarsFromElement<InterpolationTargetTag>>;
+};
+
+template <typename DomainCreator>
+std::tuple<Variables<tmpl::list<Tags::TestSolution>>, Mesh<3>>
+make_volume_data_and_mesh(const DomainCreator& domain_creator,
+                          const Domain<3>& domain,
+                          const ElementId<3>& element_id) noexcept {
+  const auto& block = domain.blocks()[element_id.block_id()];
+  Mesh<3> mesh{domain_creator.initial_extents()[element_id.block_id()],
+               Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
+  if (block.is_time_dependent()) {
+    ERROR("The block must be time-independent");
+  }
+
+  // create volume data without the compute_items_on_source
+  ElementMap<3, Frame::Inertial> map{element_id,
+                                     block.stationary_map().get_clone()};
+  const auto inertial_coords = map(logical_coordinates(mesh));
+  Variables<tmpl::list<Tags::TestSolution>> vars(mesh.number_of_grid_points());
+  fill_variables<Tags::TestSolution>(make_not_null(&vars), inertial_coords);
+  return std::make_tuple(std::move(vars), mesh);
+}
+
+// This is the main test; Takes a functor as an argument so that
+// different tests can call it to do slightly different things.
+template <typename Metavariables, typename elem_component, typename Functor>
+void test_interpolate_on_element(
+    Functor initialize_elements_and_queue_simple_actions) noexcept {
+  using metavars = Metavariables;
+  using target_component =
+      mock_interpolation_target<metavars,
+                                typename metavars::InterpolationTargetA>;
+
+  const auto domain_creator =
+      domain::creators::Shell(0.9, 2.9, 2, {{7, 7}}, false);
+  const auto domain = domain_creator.create_domain();
+  Slab slab(0.0, 1.0);
+  TimeStepId temporal_id(true, 0, Time(slab, Rational(11, 15)));
+
+  // Create Element_ids.
+  std::vector<ElementId<3>> element_ids{};
+  for (const auto& block : domain.blocks()) {
+    const auto initial_ref_levs =
+        domain_creator.initial_refinement_levels()[block.id()];
+    auto elem_ids = initial_element_ids(block.id(), initial_ref_levs);
+    element_ids.insert(element_ids.end(), elem_ids.begin(), elem_ids.end());
+  }
+
+  // Create target points and interp_point_info
+  const size_t num_points = 10;
+  tnsr::I<DataVector, 3, Frame::Inertial> target_points(num_points);
+  const typename intrp::Tags::InterpPointInfo<
+      metavars>::type interp_point_info = [&domain, &target_points]() {
+    MAKE_GENERATOR(gen);
+    std::uniform_real_distribution<> r_dist(0.9001, 2.8999);
+    std::uniform_real_distribution<> theta_dist(0.0, M_PI);
+    std::uniform_real_distribution<> phi_dist(0.0, 2 * M_PI);
+    for (size_t i = 0; i < num_points; ++i) {
+      const double r = r_dist(gen);
+      const double theta = theta_dist(gen);
+      const double phi = phi_dist(gen);
+      get<0>(target_points)[i] = r * sin(theta) * cos(phi);
+      get<1>(target_points)[i] = r * sin(theta) * sin(phi);
+      get<2>(target_points)[i] = r * cos(theta);
+    }
+    typename intrp::Tags::InterpPointInfo<metavars>::type interp_point_info_l{};
+    get<intrp::Vars::PointInfoTag<typename metavars::InterpolationTargetA, 3>>(
+        interp_point_info_l) = block_logical_coordinates(domain, target_points);
+    return interp_point_info_l;
+  }();
+
+  // Emplace target component.
+  ActionTesting::MockRuntimeSystem<metavars> runner{{}};
+  ActionTesting::set_phase(make_not_null(&runner),
+                           metavars::Phase::Initialization);
+  ActionTesting::emplace_component_and_initialize<target_component>(
+      &runner, 0, {target_points});
+
+  initialize_elements_and_queue_simple_actions(domain_creator, domain,
+                                               element_ids, interp_point_info,
+                                               runner, temporal_id);
+
+  // Only some of the actions/events just invoked on elements (those elements
+  // which contain target points) will queue a simple action on the
+  // InterpolationTarget.  Invoke those simple actions now.
+  while (not ActionTesting::is_simple_action_queue_empty<target_component>(
+      runner, 0)) {
+    runner.template invoke_queued_simple_action<target_component>(0);
+  }
+}
+}  // namespace InterpolateOnElementTestHelpers

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_InitializeInterpolator.cpp
   Test_InterpolateEvent.cpp
   Test_InterpolateToTarget.cpp
+  Test_InterpolateWithoutInterpComponent.cpp
   Test_InterpolationTargetApparentHorizon.cpp
   Test_InterpolationTargetKerrHorizon.cpp
   Test_InterpolationTargetLineSegment.cpp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_InitializeInterpolationTarget.cpp
   Test_InitializeInterpolator.cpp
   Test_InterpolateEvent.cpp
+  Test_InterpolateToTarget.cpp
   Test_InterpolationTargetApparentHorizon.cpp
   Test_InterpolationTargetKerrHorizon.cpp
   Test_InterpolationTargetLineSegment.cpp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateToTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateToTarget.cpp
@@ -1,0 +1,128 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Domain.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/NumericalAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp"
+#include "NumericalAlgorithms/Interpolation/Actions/InterpolateToTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+template <typename Metavariables, bool AddComputeItemToBox>
+struct mock_element {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<Metavariables::volume_dim>;
+  using simple_tags =
+      tmpl::list<typename Metavariables::temporal_id,
+                 domain::Tags::Mesh<Metavariables::volume_dim>,
+                 ::Tags::Variables<tmpl::list<
+                     InterpolateOnElementTestHelpers::Tags::TestSolution>>,
+                 intrp::Tags::InterpPointInfo<Metavariables>>;
+  using compute_tags = tmpl::conditional_t<
+      AddComputeItemToBox,
+      tmpl::list<
+          InterpolateOnElementTestHelpers::Tags::MultiplyByTwoComputeItem>,
+      tmpl::list<>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<
+              ActionTesting::InitializeDataBox<simple_tags, compute_tags>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<intrp::Actions::InterpolateToTarget<
+              typename Metavariables::InterpolationTargetA>>>>;
+};
+
+template <typename Metavariables, typename ElemComponent>
+struct initialize_elements_and_queue_simple_actions {
+  template <typename InterpPointInfo, typename Runner, typename TemporalId>
+  void operator()(const DomainCreator<3>& domain_creator,
+                  const Domain<3>& domain,
+                  const std::vector<ElementId<3>>& element_ids,
+                  const InterpPointInfo& interp_point_info, Runner& runner,
+                  const TemporalId& temporal_id) noexcept {
+    using metavars = Metavariables;
+    using elem_component = ElemComponent;
+
+    // Emplace elements.
+    for (const auto& element_id : element_ids) {
+      // 1. Get vars and mesh
+      auto [vars, mesh] =
+          InterpolateOnElementTestHelpers::make_volume_data_and_mesh(
+              domain_creator, domain, element_id);
+
+      // 2. emplace element.
+      ActionTesting::emplace_component_and_initialize<elem_component>(
+          &runner, element_id,
+          {temporal_id, mesh, std::move(vars), interp_point_info});
+    }
+
+    ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
+
+    // Call the action on all the elements.
+    for (const auto& element_id : element_ids) {
+      ActionTesting::next_action<elem_component>(make_not_null(&runner),
+                                                 element_id);
+    }
+  }
+};
+
+template <bool HaveComputeItemsOnSource, bool AddComputeItemToBox>
+struct MockMetavariables {
+  static constexpr bool add_compute_item_to_box = AddComputeItemToBox;
+  struct InterpolationTargetA {
+    using vars_to_interpolate_to_target = tmpl::list<tmpl::conditional_t<
+        HaveComputeItemsOnSource,
+        InterpolateOnElementTestHelpers::Tags::MultiplyByTwo,
+        InterpolateOnElementTestHelpers::Tags::TestSolution>>;
+    using compute_items_on_source = tmpl::conditional_t<
+        HaveComputeItemsOnSource,
+        tmpl::list<
+            InterpolateOnElementTestHelpers::Tags::MultiplyByTwoComputeItem>,
+        tmpl::list<>>;
+  };
+  using temporal_id = ::Tags::TimeStepId;
+  static constexpr size_t volume_dim = 3;
+  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
+
+  using component_list =
+      tmpl::list<InterpolateOnElementTestHelpers::mock_interpolation_target<
+                     MockMetavariables, InterpolationTargetA>,
+                 mock_element<MockMetavariables, AddComputeItemToBox>>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+template <typename MockMetavariables>
+void run_test() noexcept {
+  using metavars = MockMetavariables;
+  using elem_component =
+      mock_element<metavars, metavars::add_compute_item_to_box>;
+  InterpolateOnElementTestHelpers::test_interpolate_on_element<metavars,
+                                                               elem_component>(
+      initialize_elements_and_queue_simple_actions<metavars, elem_component>{});
+}
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateToTarget",
+                  "[Unit]") {
+  run_test<MockMetavariables<false,false>>();
+  run_test<MockMetavariables<true,true>>();
+  run_test<MockMetavariables<true,false>>();
+  run_test<MockMetavariables<false,true>>();
+}
+
+}  // namespace

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
@@ -1,0 +1,126 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <type_traits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Mesh.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/NumericalAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp"
+#include "NumericalAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+template <typename Metavariables>
+struct mock_element {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<Metavariables::volume_dim>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+  using initial_databox = db::compute_databox_type<db::AddSimpleTags<>>;
+};
+
+template <typename Metavariables, typename ElemComponent>
+struct initialize_elements_and_queue_simple_actions {
+  template <typename InterpPointInfo, typename Runner, typename TemporalId>
+  void operator()(const DomainCreator<3>& domain_creator,
+                  const Domain<3>& domain,
+                  const std::vector<ElementId<3>>& element_ids,
+                  const InterpPointInfo& interp_point_info, Runner& runner,
+                  const TemporalId& temporal_id) noexcept {
+    using metavars = Metavariables;
+    using elem_component = ElemComponent;
+    // Emplace elements.
+    for (const auto& element_id : element_ids) {
+      ActionTesting::emplace_component<elem_component>(&runner, element_id);
+      ActionTesting::next_action<elem_component>(make_not_null(&runner),
+                                                 element_id);
+    }
+    ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
+
+    // Create event.
+    intrp::Events::InterpolateWithoutInterpComponent<
+        metavars::volume_dim, typename metavars::InterpolationTargetA, metavars,
+        tmpl::list<InterpolateOnElementTestHelpers::Tags::TestSolution>>
+        event{};
+
+    // Run event on all elements.
+    for (const auto& element_id : element_ids) {
+      // 1. Get vars and mesh
+      const auto& [vars, mesh] =
+          InterpolateOnElementTestHelpers::make_volume_data_and_mesh(
+              domain_creator, domain, element_id);
+
+      // 2. Make a box
+      const auto box = db::create<
+          db::AddSimpleTags<typename metavars::temporal_id,
+                            intrp::Tags::InterpPointInfo<metavars>,
+                            domain::Tags::Mesh<metavars::volume_dim>,
+                            ::Tags::Variables<typename std::remove_reference_t<
+                                decltype(vars)>::tags_list>>>(
+          temporal_id, interp_point_info, mesh, vars);
+
+      // 3. Run the event.  This will invoke simple actions on
+      // InterpolationTarget.
+      event.run(box, runner.cache(), element_id,
+                std::add_pointer_t<elem_component>{});
+    }
+  }
+};
+
+template <bool HaveComputeItemsOnSource>
+struct MockMetavariables {
+  struct InterpolationTargetA {
+    using vars_to_interpolate_to_target = tmpl::list<tmpl::conditional_t<
+        HaveComputeItemsOnSource,
+        InterpolateOnElementTestHelpers::Tags::MultiplyByTwo,
+        InterpolateOnElementTestHelpers::Tags::TestSolution>>;
+    using compute_items_on_source = tmpl::conditional_t<
+        HaveComputeItemsOnSource,
+        tmpl::list<
+            InterpolateOnElementTestHelpers::Tags::MultiplyByTwoComputeItem>,
+        tmpl::list<>>;
+  };
+  using temporal_id = ::Tags::TimeStepId;
+  static constexpr size_t volume_dim = 3;
+  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
+
+  using component_list =
+      tmpl::list<InterpolateOnElementTestHelpers::mock_interpolation_target<
+                     MockMetavariables, InterpolationTargetA>,
+                 mock_element<MockMetavariables>>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+template <typename MockMetavariables>
+void run_test() noexcept {
+  using metavars = MockMetavariables;
+  using elem_component = mock_element<metavars>;
+  InterpolateOnElementTestHelpers::test_interpolate_on_element<metavars,
+                                                               elem_component>(
+      initialize_elements_and_queue_simple_actions<metavars, elem_component>{});
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.Interpolator.InterpolateEventNoInterpolator",
+    "[Unit]") {
+  run_test<MockMetavariables<false>>();
+  run_test<MockMetavariables<true>>();
+}
+}  // namespace

--- a/tests/Unit/Utilities/Test_TMPL.cpp
+++ b/tests/Unit/Utilities/Test_TMPL.cpp
@@ -63,6 +63,12 @@ static_assert(
         tmpl::list<Templated<int>>>,
     "Failed testing list_difference");
 
+static_assert(
+    std::is_same_v<
+        tmpl::list_difference<tmpl::list<>, tmpl::list<Templated<double>>>,
+        tmpl::list<>>,
+    "Failed testing list_difference");
+
 static_assert(tmpl::position_of_first_v<
                   tmpl::list<char, int, double, char, float>, char> == 0,
               "Failed testing `tmpl::position_of_first`");


### PR DESCRIPTION
## Proposed changes

Adds a new Action and a new Event that will interpolate without the use of an Interpolator
component.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
