### PR TITLE
Remove remaining compute target points action

### DIFF
--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -150,7 +150,7 @@ Scalar<DataVector> expansion(
  */
 template <typename Frame>
 void extrinsic_curvature(
-    const gsl::not_null<tnsr::ii<DataVector, 3, Frame>*> result,
+    gsl::not_null<tnsr::ii<DataVector, 3, Frame>*> result,
     const tnsr::ii<DataVector, 3, Frame>& grad_normal,
     const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector) noexcept;

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -110,7 +110,7 @@ template <typename Frame>
 struct Radius : db::ComputeTag {
   static std::string name() noexcept { return "Radius"; }
   using return_type = DataVector;
-  static void function(const gsl::not_null<DataVector*> radius,
+  static void function(gsl::not_null<DataVector*> radius,
                        const ::Strahlkorper<Frame>& strahlkorper) noexcept;
   using argument_tags = tmpl::list<Strahlkorper<Frame>>;
 };

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
@@ -91,7 +91,7 @@ struct FindApparentHorizon {
     const auto& indices_of_invalid_pts =
         db::get<Tags::IndicesOfInvalidInterpPoints<TemporalId>>(*box);
     if (indices_of_invalid_pts.count(temporal_id) > 0 and
-        indices_of_invalid_pts.at(temporal_id).size() > 0) {
+        not indices_of_invalid_pts.at(temporal_id).empty()) {
       ERROR("FindApparentHorizon: Found points that are not in any block");
     }
 

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
@@ -12,6 +12,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/VariablesTag.hpp"
+#include "NumericalAlgorithms/Interpolation/Actions/SendPointsToInterpolator.hpp"
 #include "NumericalAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
@@ -70,10 +71,11 @@ namespace Actions {
 template <typename InterpolationTargetTag>
 struct InterpolationTargetReceiveVars {
   /// For requirements on Metavariables, see InterpolationTarget
-  template <typename ParallelComponent, typename DbTags, typename Metavariables,
-            typename ArrayIndex, typename TemporalId,
-            Requires<tmpl::list_contains_v<
-                DbTags, Tags::TemporalIds<TemporalId>>> = nullptr>
+  template <
+      typename ParallelComponent, typename DbTags, typename Metavariables,
+      typename ArrayIndex, typename TemporalId,
+      Requires<tmpl::list_contains_v<DbTags, Tags::TemporalIds<TemporalId>>> =
+          nullptr>
   static void apply(
       db::DataBox<DbTags>& box,
       Parallel::ConstGlobalCache<Metavariables>& cache,
@@ -110,7 +112,7 @@ struct InterpolationTargetReceiveVars {
                 InterpolationTarget<Metavariables, InterpolationTargetTag>>(
                 cache);
             Parallel::simple_action<
-                typename InterpolationTargetTag::compute_target_points>(
+                SendPointsToInterpolator<InterpolationTargetTag>>(
                 my_proxy, temporal_ids.front());
           }
         }


### PR DESCRIPTION
## Proposed changes

Modifies the ApparentHorizonFinder unit test to find the AH at two temporal_ids,
which reveals the problem causing #2262.

Then fixes #2262 by removing use of an Action that doesn't exist anymore,
and updating the tests accordingly.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
