### PR TITLE
Outer shells in bbh domain

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -34,9 +34,7 @@ struct Logical;
 }  // namespace Frame
 /// \endcond
 
-namespace domain {
-namespace creators {
-
+namespace domain::creators {
 BinaryCompactObject::BinaryCompactObject(
     typename InnerRadiusObjectA::type inner_radius_object_A,
     typename OuterRadiusObjectA::type outer_radius_object_A,
@@ -52,6 +50,10 @@ BinaryCompactObject::BinaryCompactObject(
     typename InitialGridPoints::type initial_grid_points_per_dim,
     typename UseEquiangularMap::type use_equiangular_map,
     typename UseProjectiveMap::type use_projective_map,
+    typename UseLogarithmicMapOuterSphericalShell::type
+        use_logarithmic_map_outer_spherical_shell,
+    typename AdditionToOuterLayerRadialRefinementLevel::type
+        addition_to_outer_layer_radial_refinement_level,
     std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
         time_dependence,
     const OptionContext& context)
@@ -72,6 +74,10 @@ BinaryCompactObject::BinaryCompactObject(
           std::move(initial_grid_points_per_dim)),                     // NOLINT
       use_equiangular_map_(std::move(use_equiangular_map)),            // NOLINT
       use_projective_map_(std::move(use_projective_map)),              // NOLINT
+      use_logarithmic_map_outer_spherical_shell_(
+          std::move(use_logarithmic_map_outer_spherical_shell)),  // NOLINT
+      addition_to_outer_layer_radial_refinement_level_(
+          addition_to_outer_layer_radial_refinement_level),  // NOLINT
       time_dependence_(std::move(time_dependence)) {
   // Determination of parameters for domain construction:
   translation_ = 0.5 * (xcoord_object_B_ + xcoord_object_A_);
@@ -112,6 +118,19 @@ BinaryCompactObject::BinaryCompactObject(
     time_dependence_ =
         std::make_unique<domain::creators::time_dependence::None<3>>();
   }
+
+  // Calculate number of blocks
+  // Layers 1, 2, 3, 4, and 5 have 12, 12, 10, 10, and 10 blocks, respectively,
+  // for 54 total.
+  number_of_blocks_ = 54;
+
+  // For each object whose interior is not excised, add 1 block
+  if (not excise_interior_A_) {
+    number_of_blocks_++;
+  }
+  if (not excise_interior_B_) {
+    number_of_blocks_++;
+  }
 }
 
 Domain<3> BinaryCompactObject::create_domain() const noexcept {
@@ -138,9 +157,6 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
   Maps maps_frustums = frustum_coordinate_maps<Frame::Inertial>(
       length_inner_cube_, length_outer_cube_, use_equiangular_map_,
       {{-translation_, 0.0, 0.0}}, projective_scale_factor_);
-  Maps maps_outer_shell = wedge_coordinate_maps<Frame::Inertial>(
-      sqrt(3.0) * 0.5 * length_outer_cube_, radius_enveloping_sphere_, 0.0, 1.0,
-      use_equiangular_map_, 0.0, true);
 
   std::move(maps_center_A.begin(), maps_center_A.end(),
             std::back_inserter(maps));
@@ -150,7 +166,39 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
   std::move(maps_cube_B.begin(), maps_cube_B.end(), std::back_inserter(maps));
   std::move(maps_frustums.begin(), maps_frustums.end(),
             std::back_inserter(maps));
-  std::move(maps_outer_shell.begin(), maps_outer_shell.end(),
+
+  // The first shell (Layer 4) goes from sphericity == 0.0 to sphericity
+  // == 1.0. This shell is surrounded by a shell with sphericity == 1.0
+  // throughout (Layer 5) that will have a radial refinement level of
+  // (addition_to_outer_layer_radial_refinement_level_ + initial_refinement_).
+  const double inner_radius_first_outer_shell =
+      sqrt(3.0) * 0.5 * length_outer_cube_;
+
+  // Adjust the outer boundary of the cubed sphere to conform to the
+  // spacing of the spherical shells after refinement, so the cubed sphere is
+  // the same size as the first radial division of the spherical shell
+  // (for linear mapping) or smaller by the same factor as adjacent radial
+  // divisions in the spherical shell (for logarithmic mapping)
+  const double radial_divisions_in_outer_layers =
+      pow(2, addition_to_outer_layer_radial_refinement_level_) + 1;
+  const double outer_radius_first_outer_shell =
+      use_logarithmic_map_outer_spherical_shell_
+          ? inner_radius_first_outer_shell *
+                pow(radius_enveloping_sphere_ / inner_radius_first_outer_shell,
+                    1.0 / static_cast<double>(radial_divisions_in_outer_layers))
+          : inner_radius_first_outer_shell +
+                (radius_enveloping_sphere_ - inner_radius_first_outer_shell) /
+                    static_cast<double>(radial_divisions_in_outer_layers);
+  Maps maps_first_outer_shell = wedge_coordinate_maps<Frame::Inertial>(
+      inner_radius_first_outer_shell, outer_radius_first_outer_shell, 0.0, 1.0,
+      use_equiangular_map_, 0.0, true, 1.0, false, ShellWedges::All, 1);
+  Maps maps_second_outer_shell = wedge_coordinate_maps<Frame::Inertial>(
+      outer_radius_first_outer_shell, radius_enveloping_sphere_, 1.0, 1.0,
+      use_equiangular_map_, 0.0, true, 1.0,
+      use_logarithmic_map_outer_spherical_shell_, ShellWedges::All, 1);
+  std::move(maps_first_outer_shell.begin(), maps_first_outer_shell.end(),
+            std::back_inserter(maps));
+  std::move(maps_second_outer_shell.begin(), maps_second_outer_shell.end(),
             std::back_inserter(maps));
 
   // Set up the maps for the central cubes, if any exist.
@@ -216,19 +264,12 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
   }
   Domain<3> domain{std::move(maps),
                    corners_for_biradially_layered_domains(
-                       2, 2, not excise_interior_A_, not excise_interior_B_)};
+                       2, 3, not excise_interior_A_, not excise_interior_B_)};
   if (not time_dependence_->is_none()) {
-    size_t number_of_blocks = 44;
-    if (not excise_interior_A_) {
-      number_of_blocks++;
-    }
-    if (not excise_interior_B_) {
-      number_of_blocks++;
-    }
-    for (size_t block = 0; block < number_of_blocks; ++block) {
+    for (size_t block = 0; block < number_of_blocks_; ++block) {
       domain.inject_time_dependent_map_for_block(
           block,
-          std::move(time_dependence_->block_maps(number_of_blocks)[block]));
+          std::move(time_dependence_->block_maps(number_of_blocks_)[block]));
     }
   }
   return domain;
@@ -241,26 +282,31 @@ BinaryCompactObject::TimeDependence::default_value() noexcept {
 
 std::vector<std::array<size_t, 3>> BinaryCompactObject::initial_extents() const
     noexcept {
-  size_t number_of_blocks = 44;
-  if (not excise_interior_A_) {
-    number_of_blocks++;
-  }
-  if (not excise_interior_B_) {
-    number_of_blocks++;
-  }
-  return {number_of_blocks, make_array<3>(initial_grid_points_per_dim_)};
+  return {number_of_blocks_, make_array<3>(initial_grid_points_per_dim_)};
 }
 
 std::vector<std::array<size_t, 3>>
 BinaryCompactObject::initial_refinement_levels() const noexcept {
-  size_t number_of_blocks = 44;
-  if (not excise_interior_A_) {
-    number_of_blocks++;
+  std::vector<std::array<size_t, 3>> initial_levels{
+      number_of_blocks_, make_array<3>(initial_refinement_)};
+  // Increase the radial refinement of the blocks corresponding to the outer
+  // spherical shell (with sphericity == 1 throughout) to achieve the desired
+  // number of radial refinements. The outer layer consists of 10 blocks,
+  // created via wedge_coordinate_maps() with use_half_wedges == true. Because
+  // this outer layer of blocks is added last to the CoordinateMaps in
+  // create_domain(), the 10 blocks to refine are the last 10 blocks in the
+  // domain--unless one or both of the interiors are not excised. (For each
+  // interior not excised, there is one extra block appended to the list of
+  // CoordinateMaps.)
+  if (addition_to_outer_layer_radial_refinement_level_ > 0) {
+    for (size_t block = 44; block < 54; ++block) {
+      // Refine in the radial direction, which is direction 2
+      // (i.e. the zeta direction)
+      gsl::at(initial_levels[block], 2) +=
+          addition_to_outer_layer_radial_refinement_level_;
+    }
   }
-  if (not excise_interior_B_) {
-    number_of_blocks++;
-  }
-  return {number_of_blocks, make_array<3>(initial_refinement_)};
+  return initial_levels;
 }
 
 std::unordered_map<std::string,
@@ -272,5 +318,4 @@ BinaryCompactObject::functions_of_time() const noexcept {
     return time_dependence_->functions_of_time();
   }
 }
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -31,8 +31,11 @@ Domain<VolumeDim>::Domain(
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
     const std::vector<PairOfFaces>& identifications) noexcept {
-  ASSERT(maps.size() == corners_of_all_blocks.size(),
-         "Must pass same number of maps as block corner sets.");
+  ASSERT(
+      maps.size() == corners_of_all_blocks.size(),
+      "Must pass same number of maps as block corner sets, but maps.size() == "
+          << maps.size() << " and corners_of_all_blocks.size() == "
+          << corners_of_all_blocks.size());
   std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>
       neighbors_of_all_blocks;
   set_internal_boundaries<VolumeDim>(corners_of_all_blocks,

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -118,7 +118,7 @@ size_t find_block_id_of_external_face(
 template <size_t VolumeDim>
 std::array<size_t, two_to_the(VolumeDim - 1)> get_common_local_corners(
     const std::array<size_t, two_to_the(VolumeDim)>& block_global_corners,
-    const std::vector<size_t> block_global_common_corners) noexcept {
+    const std::vector<size_t>& block_global_common_corners) noexcept {
   std::array<size_t, two_to_the(VolumeDim - 1)> result{{0}};
   size_t i = 0;
   for (const auto global_id : block_global_common_corners) {
@@ -1074,7 +1074,7 @@ std::ostream& operator<<(std::ostream& os,
 
 template <>
 ShellWedges create_from_yaml<ShellWedges>::create<void>(const Option& options) {
-  const std::string which_wedges = options.parse_as<std::string>();
+  const auto which_wedges = options.parse_as<std::string>();
   if (which_wedges == "All") {
     return ShellWedges::All;
   } else if (which_wedges == "FourOnEquator") {

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -521,7 +521,7 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
 
   using Wedge3DMap = domain::CoordinateMaps::Wedge3D;
   using Halves = Wedge3DMap::WedgeHalves;
-  std::vector<Wedge3DMap> wedges{};
+  std::vector<Wedge3DMap> wedges_for_all_layers{};
 
   // Set up layers:
   const double delta_zeta = 2.0 / number_of_layers;
@@ -541,12 +541,39 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
                   pow(outer_radius, 0.5 * (1.0 + global_zeta_outer))
             : inner_radius * 0.5 * (1.0 - global_zeta_outer) +
                   outer_radius * 0.5 * (1.0 + global_zeta_outer);
-    for (size_t face_j = which_wedge_index(which_wedges); face_j < 6;
-         face_j++) {
-      wedges.emplace_back(inner_radius_layer_i, outer_radius_layer_i,
-                          gsl::at(wedge_orientations, face_j), inner_sphericity,
-                          outer_sphericity, use_equiangular_map, Halves::Both,
-                          use_logarithmic_map);
+    // Generate wedges/half-wedges a layer at a time.
+    std::vector<Wedge3DMap> wedges_for_this_layer{};
+    if (not use_half_wedges) {
+      for (size_t face_j = which_wedge_index(which_wedges); face_j < 6;
+           face_j++) {
+        wedges_for_this_layer.emplace_back(
+            inner_radius_layer_i, outer_radius_layer_i,
+            gsl::at(wedge_orientations, face_j), inner_sphericity,
+            outer_sphericity, use_equiangular_map, Halves::Both,
+            use_logarithmic_map);
+      }
+    } else {
+      for (size_t i = 0; i < 4; i++) {
+        wedges_for_this_layer.emplace_back(
+            inner_radius_layer_i, outer_radius_layer_i,
+            gsl::at(wedge_orientations, i), inner_sphericity, outer_sphericity,
+            use_equiangular_map, Halves::LowerOnly, use_logarithmic_map);
+        wedges_for_this_layer.emplace_back(
+            inner_radius_layer_i, outer_radius_layer_i,
+            gsl::at(wedge_orientations, i), inner_sphericity, outer_sphericity,
+            use_equiangular_map, Halves::UpperOnly, use_logarithmic_map);
+      }
+      wedges_for_this_layer.emplace_back(
+          inner_radius_layer_i, outer_radius_layer_i,
+          gsl::at(wedge_orientations, 4), inner_sphericity, outer_sphericity,
+          use_equiangular_map, Halves::Both, use_logarithmic_map);
+      wedges_for_this_layer.emplace_back(
+          inner_radius_layer_i, outer_radius_layer_i,
+          gsl::at(wedge_orientations, 5), inner_sphericity, outer_sphericity,
+          use_equiangular_map, Halves::Both, use_logarithmic_map);
+    }
+    for (const auto& wedge : wedges_for_this_layer) {
+      wedges_for_all_layers.push_back(wedge);
     }
   }
 
@@ -563,29 +590,9 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
   const auto compression =
       domain::CoordinateMaps::EquatorialCompression{aspect_ratio};
 
-  if (use_half_wedges) {
-    std::vector<Wedge3DMap> wedges_and_half_wedges{};
-    for (size_t i = 0; i < 4; i++) {
-      wedges_and_half_wedges.emplace_back(
-          inner_radius, outer_radius, gsl::at(wedge_orientations, i),
-          inner_sphericity, outer_sphericity, use_equiangular_map,
-          Halves::LowerOnly, use_logarithmic_map);
-      wedges_and_half_wedges.emplace_back(
-          inner_radius, outer_radius, gsl::at(wedge_orientations, i),
-          inner_sphericity, outer_sphericity, use_equiangular_map,
-          Halves::UpperOnly, use_logarithmic_map);
-    }
-    wedges_and_half_wedges.push_back(wedges[4]);
-    wedges_and_half_wedges.push_back(wedges[5]);
-
-    return domain::make_vector_coordinate_map_base<Frame::Logical, TargetFrame,
-                                                   3>(
-        std::move(wedges_and_half_wedges), compression, translation);
-  }
-
   return domain::make_vector_coordinate_map_base<Frame::Logical, TargetFrame,
-                                                 3>(std::move(wedges),
-                                                    compression, translation);
+                                                 3>(
+      std::move(wedges_for_all_layers), compression, translation);
 }
 
 template <typename TargetFrame>

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <iterator>
 #include <limits>
@@ -15,6 +16,7 @@
 #include <utility>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
 #include "Domain/Block.hpp"                       // IWYU pragma: keep
 #include "Domain/BlockNeighbor.hpp"               // IWYU pragma: keep
@@ -28,11 +30,9 @@
 #include "Helpers/Domain/Creators/TestHelpers.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 
-namespace domain {
-namespace FunctionsOfTime {
+namespace domain::FunctionsOfTime {
 class FunctionOfTime;
-}  // namespace FunctionsOfTime
-}  // namespace domain
+}  // namespace domain::FunctionsOfTime
 
 namespace {
 using Translation = domain::CoordinateMaps::TimeDependent::Translation;
@@ -60,46 +60,81 @@ void test_binary_compact_object_construction(
 
 void test_connectivity() {
   // ObjectA:
-  const double inner_radius_objectA = 0.5;
-  const double outer_radius_objectA = 1.0;
-  const double xcoord_objectA = -3.0;
+  constexpr double inner_radius_objectA = 0.5;
+  constexpr double outer_radius_objectA = 1.0;
+  constexpr double xcoord_objectA = -3.0;
 
   // ObjectB:
-  const double inner_radius_objectB = 0.3;
-  const double outer_radius_objectB = 1.0;
-  const double xcoord_objectB = 3.0;
+  constexpr double inner_radius_objectB = 0.3;
+  constexpr double outer_radius_objectB = 1.0;
+  constexpr double xcoord_objectB = 3.0;
 
   // Enveloping Cube:
-  const double radius_enveloping_cube = 25.5;
-  const double radius_enveloping_sphere = 32.4;
+  constexpr double radius_enveloping_cube = 25.5;
+  constexpr double radius_enveloping_sphere = 32.4;
 
   // Misc.:
-  const size_t refinement = 2;
-  const size_t grid_points = 6;
+  constexpr size_t refinement = 2;
+  constexpr size_t grid_points = 6;
+  constexpr bool use_projective_map = true;
+
+  // Options for outer sphere
+  constexpr size_t addition_to_outer_layer_radial_refinement_level = 3;
 
   for (const bool excise_interiorA : {true, false}) {
     for (const bool excise_interiorB : {true, false}) {
       for (const bool use_equiangular_map : {true, false}) {
-        const domain::creators::BinaryCompactObject binary_compact_object{
-            inner_radius_objectA,
-            outer_radius_objectA,
-            xcoord_objectA,
-            excise_interiorA,
-            inner_radius_objectB,
-            outer_radius_objectB,
-            xcoord_objectB,
-            excise_interiorB,
-            radius_enveloping_cube,
-            radius_enveloping_sphere,
-            refinement,
-            grid_points,
-            use_equiangular_map};
-        test_binary_compact_object_construction(binary_compact_object);
+        for (const bool use_logarithmic_map_outer_spherical_shell :
+             {true, false}) {
+          const domain::creators::BinaryCompactObject binary_compact_object{
+              inner_radius_objectA,
+              outer_radius_objectA,
+              xcoord_objectA,
+              excise_interiorA,
+              inner_radius_objectB,
+              outer_radius_objectB,
+              xcoord_objectB,
+              excise_interiorB,
+              radius_enveloping_cube,
+              radius_enveloping_sphere,
+              refinement,
+              grid_points,
+              use_equiangular_map,
+              use_projective_map,
+              use_logarithmic_map_outer_spherical_shell,
+              addition_to_outer_layer_radial_refinement_level};
+          test_binary_compact_object_construction(binary_compact_object);
+
+          // Also check whether the radius of the inner boundary of Layer 5 is
+          // chosen correctly.
+          // Compute the radius of a point in the grid frame on this boundary.
+          // Block 44 is one block whose -zeta face is on this boundary.
+          const auto map{binary_compact_object.create_domain()
+                             .blocks()[44]
+                             .stationary_map()
+                             .get_clone()};
+          tnsr::I<double, 3, Frame::Logical> logical_point(
+              std::array<double, 3>{{0.0, 0.0, -1.0}});
+          const double layer_5_inner_radius = get(
+              magnitude(std::move(map)->operator()(logical_point)));
+          // The number of radial divisions in layers 4 and 5, excluding those
+          // resulting from InitialRefinement > 0.
+          const auto radial_divisions_in_outer_layers = static_cast<double>(
+              pow(2, addition_to_outer_layer_radial_refinement_level) + 1);
+          if (use_logarithmic_map_outer_spherical_shell) {
+            CHECK(layer_5_inner_radius / radius_enveloping_cube ==
+                  approx(pow(radius_enveloping_sphere / radius_enveloping_cube,
+                             1.0 / radial_divisions_in_outer_layers)));
+          } else {
+            CHECK(layer_5_inner_radius - radius_enveloping_cube ==
+                  approx((radius_enveloping_sphere - radius_enveloping_cube) /
+                         radial_divisions_in_outer_layers));
+          }
+        }
       }
-    }
   }
 }
-
+}
 void test_bbh_time_dependent_factory() {
   const auto binary_compact_object =
       TestHelpers::test_factory_creation<DomainCreator<3>>(
@@ -189,6 +224,53 @@ void test_bbh_equiangular_factory() {
           "    InitialRefinement: 2\n"
           "    InitialGridPoints: 6\n"
           "    UseEquiangularMap: true\n");
+  test_binary_compact_object_construction(
+      dynamic_cast<const domain::creators::BinaryCompactObject&>(
+          *binary_compact_object));
+}
+
+void test_bbh_2_outer_radial_refinements_linear_map_factory() {
+  const auto binary_compact_object =
+      TestHelpers::test_factory_creation<DomainCreator<3>>(
+          "  BinaryCompactObject:\n"
+          "    InnerRadiusObjectA: 0.2\n"
+          "    OuterRadiusObjectA: 1.0\n"
+          "    XCoordObjectA: -2.0\n"
+          "    ExciseInteriorA: true\n"
+          "    InnerRadiusObjectB: 1.0\n"
+          "    OuterRadiusObjectB: 2.0\n"
+          "    XCoordObjectB: 3.0\n"
+          "    ExciseInteriorB: true\n"
+          "    RadiusOuterCube: 22.0\n"
+          "    RadiusOuterSphere: 25.0\n"
+          "    InitialRefinement: 2\n"
+          "    InitialGridPoints: 6\n"
+          "    UseEquiangularMap: true\n"
+          "    AdditionToOuterLayerRadialRefinementLevel: 2\n");
+  test_binary_compact_object_construction(
+      dynamic_cast<const domain::creators::BinaryCompactObject&>(
+          *binary_compact_object));
+}
+
+void test_bbh_3_outer_radial_refinements_log_map_factory() {
+  const auto binary_compact_object =
+      TestHelpers::test_factory_creation<DomainCreator<3>>(
+          "  BinaryCompactObject:\n"
+          "    InnerRadiusObjectA: 0.2\n"
+          "    OuterRadiusObjectA: 1.0\n"
+          "    XCoordObjectA: -2.0\n"
+          "    ExciseInteriorA: true\n"
+          "    InnerRadiusObjectB: 1.0\n"
+          "    OuterRadiusObjectB: 2.0\n"
+          "    XCoordObjectB: 3.0\n"
+          "    ExciseInteriorB: true\n"
+          "    RadiusOuterCube: 22.0\n"
+          "    RadiusOuterSphere: 25.0\n"
+          "    InitialRefinement: 2\n"
+          "    InitialGridPoints: 6\n"
+          "    UseEquiangularMap: true\n"
+          "    UseLogarithmicMapOuterSphericalShell: true\n"
+          "    AdditionToOuterLayerRadialRefinementLevel: 3");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
           *binary_compact_object));
@@ -350,10 +432,13 @@ void test_nsbh_equidistant_factory() {
 }  // namespace
 
 // Test times out sometimes, increase timeout to make it pass reliably.
-// [[TimeOut, 10]]
+// [[TimeOut, 20]]
 SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.FactoryTests",
                   "[Domain][Unit]") {
   test_connectivity();
+  test_bbh_time_dependent_factory();
+  test_bbh_2_outer_radial_refinements_linear_map_factory();
+  test_bbh_3_outer_radial_refinements_log_map_factory();
   test_bbh_time_dependent_factory();
   test_bbh_equiangular_factory();
   test_bbh_equidistant_factory();


### PR DESCRIPTION
## Proposed changes

Allow the BinaryCompactBinaryObject domain to radially refine the outer layer ("layer 4" in the help text). The radial coordinates in the outer spheres can use linear or log mapping. Depends on #2258.

Here is an example

![OuterSpheres](https://user-images.githubusercontent.com/867015/81861517-38566e00-951d-11ea-8e96-77bfd44ec001.png)


Top left: the original BBH domain, with 0 initial global refinement and 0 initial radial refinement in the outer layer.
Top right: same as top left, except add a spherical shell and radially refine that shell 4 times, using linear scaling in the outer spheres
Bottom right: same as top right, except use log instead of linear scaling in the outer shell
Bottom left: same as top left, except globally refine twice and radially refine the outer shell twice, using log scaling in the outer spheres

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
