### PR TITLE
Update container to Ubuntu 20.04

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -216,7 +216,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [gcc-7, gcc-8, gcc-9, clang-5.0, clang-8, clang-9]
+        compiler: [gcc-7,
+                   gcc-8,
+                   gcc-9,
+                   clang-6.0,
+                   clang-8,
+                   clang-9,
+                   clang-10
+                   ]
         build_type: [Debug, Release]
         use_pch: [OFF, ON]
 
@@ -245,10 +252,16 @@ jobs:
             compiler: gcc-9
           - use_pch: OFF
             build_type: Debug
-            compiler: clang-5.0
+            compiler: gcc-10
+          - use_pch: OFF
+            build_type: Debug
+            compiler: clang-6.0
           - use_pch: OFF
             build_type: Debug
             compiler: clang-8
+          - use_pch: OFF
+            build_type: Debug
+            compiler: clang-10
         include:
           # Prevent random failures of Debug builds.
           # See issue https://github.com/sxs-collaboration/spectre/issues/1807
@@ -263,6 +276,7 @@ jobs:
             # bindings enabled.
             ASAN: ON
             BUILD_PYTHON_BINDINGS: OFF
+            MEMORY_ALLOCATOR: JEMALLOC
           # Test with Python 2 so that we retain backwards compatibility. We
           # keep track of Python versions on supercomputers in this issue:
           # https://github.com/sxs-collaboration/spectre/issues/442
@@ -276,6 +290,7 @@ jobs:
             build_type: Debug
             BUILD_PYTHON_BINDINGS: OFF
             BUILD_SHARED_LIBS: ON
+            MEMORY_ALLOCATOR: JEMALLOC
 
     container:
       image: sxscollaboration/spectrebuildenv:latest
@@ -334,6 +349,7 @@ jobs:
           BUILD_SHARED_LIBS=${{ matrix.BUILD_SHARED_LIBS }}
           PYTHON_EXECUTABLE=${{ matrix.PYTHON_EXECUTABLE }}
           ASAN=${{ matrix.ASAN }}
+          MEMORY_ALLOCATOR=${{ matrix.MEMORY_ALLOCATOR }}
           UBSAN_UNDEFINED=${{ matrix.UBSAN_UNDEFINED }}
           UBSAN_INTEGER=${{ matrix.UBSAN_INTEGER }}
           USE_PCH=${{ matrix.use_pch }}
@@ -359,6 +375,7 @@ jobs:
           -D ASAN=${ASAN:-'OFF'}
           -D UBSAN_UNDEFINED=${UBSAN_UNDEFINED:-'OFF'}
           -D UBSAN_INTEGER=${UBSAN_INTEGER:-'OFF'}
+          -D MEMORY_ALLOCATOR=${MEMORY_ALLOCATOR:-'SYSTEM'}
           --warn-uninitialized
           $GITHUB_WORKSPACE 2>&1 | tee CMakeOutput.txt 2>&1
 

--- a/containers/Dockerfile.buildenv1804
+++ b/containers/Dockerfile.buildenv1804
@@ -1,11 +1,22 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+# This Ubuntu 18.04 Dockerfile is kept around as a starting point in case
+# someone needs to use a container (either Docker or Singularity) on a system
+# that has a kernel that is older than the ones support by Ubuntu 20.04. Since
+# supercomputers are usually commissioned with 5 year old kernels, it's not
+# uncommon to have to deal with kernels that are over a decade old. We
+# do not test this container in CI since that would mean a lot of text
+# duplication in the CI file, as well as having to actively maintain multiple
+# containers. In general, it is unlikely there will be any changes other than
+# version upgrades of third party libraries that would cause the Ubuntu
+# 18.04 container to break.
+#
 # If you change this file please push a new image to DockerHub so that the
 # new image is used for testing. Docker must be run as root on your machine,
 # so to build a new image run the following as root (e.g. sudo su):
 #   cd $SPECTRE_HOME/containers
-#   docker build  -t sxscollaboration/spectrebuildenv:latest \
+#   docker build  -t sxscollaboration/spectrebuildenv:Ubuntu1804 \
 #                 -f ./Dockerfile.buildenv .
 # and then to push to DockerHub:
 #   docker push sxscollaboration/spectrebuildenv
@@ -13,14 +24,16 @@
 # someone who does. Since changes to this image effect our testing
 # infrastructure it is important all changes be carefully reviewed.
 
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 
 ARG PARALLEL_MAKE_ARG=-j2
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install add-apt-repository
+# Add ubuntu test repo for GCC9 and newer versions of git
 RUN apt-get update -y \
-    && apt-get install -y software-properties-common
+    && apt-get install -y software-properties-common \
+    && add-apt-repository ppa:ubuntu-toolchain-r/test \
+    && add-apt-repository ppa:git-core/ppa
 
 # Install required packages for SpECTRE
 #
@@ -34,25 +47,29 @@ RUN apt-get update -y \
     && apt-get install -y gcc-7 g++-7 gfortran-7 \
                           gcc-8 g++-8 gfortran-8 \
                           gcc-9 g++-9 gfortran-9 \
-                          gcc-10 g++-10 gfortran-10 \
                           gdb git cmake autoconf \
                           libopenblas-dev liblapack-dev \
                           libhdf5-dev hdf5-tools \
                           libgsl0-dev \
-                          clang-6.0 clang-8 clang-9 \
-                          clang-10 clang-format-10 clang-tidy-10 \
-                          wget libncurses-dev \
+                          clang-5.0 clang-format-5.0 clang-tidy-5.0 \
+                          libclang-5.0-dev wget libncurses-dev \
                           lcov cppcheck \
                           libboost-dev libboost-program-options-dev \
                           libboost-thread-dev libboost-tools-dev libssl-dev \
                           libbenchmark-dev
+
+# Add clang 8 and 9
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main' \
+    && apt-get update -y \
+    && apt-get install -y clang-8 clang-9
 
 # Update is needed to get libc++ correctly
 # Install jemalloc
 RUN apt-get update -y \
     && apt-get install -y libc++-dev libc++1 libc++abi-dev \
     && apt-get update -y \
-    && apt-get install -y libjemalloc2 libjemalloc-dev
+    && apt-get install -y libjemalloc1 libjemalloc-dev
 
 # Install ccache to cache compilations for reduced compile time, and Doxygen
 RUN apt-get install -y ccache doxygen
@@ -61,20 +78,12 @@ RUN apt-get install -y ccache doxygen
 # We only install packages that are needed by the build system (e.g. to compile
 # Python bindings or build documentation) or used by Python code that is
 # unit-tested. Any other packages can be installed on-demand.
-# - We use python-is-python3 because on Ubuntu 20.04 /usr/bin/python was removed
-#   to aid in tracking down anything that depends on python 2. However, many
-#   scripts use `/usr/bin/env python` to find python so restore it.
 # - We need `coverxygen`, `beautifulsoup4` and `pybtex` for both Python 2 and
 # Python 3 so that people can build the documentation with either.
 # - We need `yapf` so the CI can check Python formatting. We use a specific
 # version of it in order to avoid formatting differences between versions.
 # `futures` is needed for `yapf` parallelization on Python 2.
-RUN add-apt-repository universe \
-    && apt-get update -y \
-    && apt-get install -y curl python2 python2-dev \
-    && curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py \
-    && python2 get-pip.py \
-    && apt-get install -y python3-pip python-is-python3 \
+RUN apt-get install -y python-pip python3-pip \
     && pip2 --no-cache-dir install numpy scipy h5py \
     && pip3 --no-cache-dir install numpy scipy h5py \
     && pip2 --no-cache-dir install coverxygen beautifulsoup4 pybtex \
@@ -97,9 +106,7 @@ RUN apt-get update -y \
 # Spack since Spack ends up building a lot of dependencies from scratch
 # that we don't need. Thus, not building the deps with Spack reduces total
 # build time of the Docker image.
-#
-# Build with GCC7 when easily possible to maximize ABI compatibility.
-#
+
 # Install blaze, brigand, catch2, libsharp, libxsmm, yaml-cpp in /usr/local
 RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.7.tar.gz -O blaze.tar.gz \
     && tar -xzf blaze.tar.gz \
@@ -133,8 +140,7 @@ RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.7.tar.gz -O bla
     && tar -xzf libxsmm.tar.gz \
     && mv libxsmm-* libxsmm \
     && cd libxsmm \
-    && make $PARALLEL_MAKE_ARG PREFIX=/usr/local/ CXX=g++-7 CC=gcc-7 \
-        FC=gfortran-7 install \
+    && make $PARALLEL_MAKE_ARG PREFIX=/usr/local/ install \
     && cd .. \
     && rm -rf libxsmm libxsmm.tar.gz \
     && wget https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.6.3.tar.gz -O yaml-cpp.tar.gz \
@@ -144,7 +150,6 @@ RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.7.tar.gz -O bla
     && mkdir build \
     && cd build \
     && cmake -D CMAKE_BUILD_TYPE=Release -D YAML_CPP_BUILD_TESTS=OFF \
-             -D CMAKE_C_COMPILER=gcc-7 -D CMAKE_CXX_COMPILER=g++-7 \
              -D YAML_CPP_BUILD_CONTRIB=OFF \
              -D YAML_CPP_BUILD_TOOLS=ON \
              -D CMAKE_INSTALL_PREFIX=/usr/local/ \
@@ -154,16 +159,34 @@ RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.7.tar.gz -O bla
     && cd ../.. \
     && rm -rf yaml-cpp*
 
+# Install include-what-you-use
+# We patch it to allow cyclic includes in boost
+WORKDIR /work
+RUN wget https://github.com/include-what-you-use/include-what-you-use/archive/clang_5.0.tar.gz \
+    && tar -xzf clang_5.0.tar.gz \
+    && rm clang_5.0.tar.gz \
+    && mkdir /work/include-what-you-use-clang_5.0/build \
+    && cd /work/include-what-you-use-clang_5.0/ \
+    && sed -i 's^\\\"third_party/^<boost/^' iwyu_include_picker.cc \
+    && cd /work/include-what-you-use-clang_5.0/build \
+    && cmake -D CMAKE_CXX_COMPILER=clang++-5.0 \
+        -D CMAKE_C_COMPILER=clang-5.0 \
+        -D IWYU_LLVM_ROOT_PATH=/usr/lib/llvm-5.0 .. \
+    && make $PARALLEL_MAKE_ARG \
+    && make install \
+    && cd /work \
+    && rm -rf /work/include-what-you-use-clang_5.0
+
 # Download and build the Charm++ version used by SpECTRE
 # We build both Clang and GCC versions of Charm++ so that all our tests can
 # use the same build environment.
 WORKDIR /work
 ARG CHARM_GIT_TAG=v6.8.0
-# Charm doesn't support compiling with clang without symbolic links
-RUN ln -s $(which clang++-10) /usr/local/bin/clang++ \
-    && ln -s $(which clang-10) /usr/local/bin/clang \
-    && ln -s $(which clang-format-10) /usr/local/bin/clang-format \
-    && ln -s $(which clang-tidy-10) /usr/local/bin/clang-tidy
+# Charm doesn't support compiling with clang-5 without symbolic links
+RUN ln -s $(which clang++-5.0) /usr/local/bin/clang++ \
+    && ln -s $(which clang-5.0) /usr/local/bin/clang \
+    && ln -s $(which clang-format-5.0) /usr/local/bin/clang-format \
+    && ln -s $(which clang-tidy-5.0) /usr/local/bin/clang-tidy
 # Build charm with both GCC and clang.
 #
 # We check out only a specific branch in order to reduce the repo size.

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -202,8 +202,6 @@ DIRECTORY_GRAPH        = NO
 
 DOT_IMAGE_FORMAT       = png
 
-DOT_PATH               = @DOXYGEN_DOT_PATH@
-
 MAX_DOT_GRAPH_DEPTH    = 0
 
 GENERATE_LEGEND        = NO


### PR DESCRIPTION
## Proposed changes

- Updates the container to Ubuntu 20.04, the most recent LTS release

Some notes:
- Installing clang-5 on 20.04 was harder than `apt-get install -y clang-5.0` so I went with clang-6.0 for testing.
- I did not enable GCC-10 because there were some compiler errors that need to be sorted out. However, everything is in place for it so once we have the code building with GCC10 updating CI will be a one line change.
- I removed IWYU because there is no version that works with clang-10. The most recent is clang-8 or something like that.
- python 3 is now the default.
- I had to disable jemalloc on most builds when building python bindings because of a TLS allocation error. I searched a bit about this and it sounds like it's related to something dlopening jemalloc, which jemalloc doesn't really support.
- clang-format-10, clang-tidy-10, and clang-10 are the default clang versions. I figured jumping to the most recent should give us the most features.
- I've made a copy of the buildenv for Ubuntu 18.04 because that will support older kernel versions. This is important because HPC systems tend to have very old kernels running on them, and at one point I had to try to get an Ubuntu 16.04 env working for BlueWaters. To avoid this in the future, I think we should keep the 18.04 env around, at least for the next 5-10 years.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
