### PR TITLE
Add function to create a random vector within a given magnitude range

### DIFF
--- a/tests/Unit/DataStructures/Tensor/EagerMath/Test_OrthonormalOneform.cpp
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/Test_OrthonormalOneform.cpp
@@ -20,24 +20,12 @@
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/DataStructures/RandomUnitNormal.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace {
-
-template <typename DataType, size_t Dim, typename Frame>
-tnsr::ii<DataType, Dim, Frame> random_spatial_metric(
-    const gsl::not_null<std::mt19937*> generator,
-    const DataType& used_for_size) noexcept {
-  std::uniform_real_distribution<> distribution(-0.05, 0.05);
-  auto spatial_metric = make_with_random_values<tnsr::ii<DataType, Dim, Frame>>(
-      generator, make_not_null(&distribution), used_for_size);
-  for (size_t d = 0; d < Dim; ++d) {
-    spatial_metric.get(d, d) += 1.0;
-  }
-  return spatial_metric;
-}
 
 template <size_t Dim>
 struct TestOrthonormalForms {
@@ -114,7 +102,8 @@ void check_orthonormal_forms(const DataType& used_for_size) noexcept {
   const TestOrthonormalForms<Dim> test;
 
   const auto spatial_metric =
-      random_spatial_metric<DataType, Dim, Frame>(&generator, used_for_size);
+      TestHelpers::gr::random_spatial_metric<Dim, DataType, Frame>(
+          &generator, used_for_size);
   const auto inv_spatial_metric =
       determinant_and_inverse(spatial_metric).second;
   const auto unit_vector = random_unit_normal(&generator, spatial_metric);

--- a/tests/Unit/Helpers/DataStructures/MakeRandomVectorInMagnitudeRange.hpp
+++ b/tests/Unit/Helpers/DataStructures/MakeRandomVectorInMagnitudeRange.hpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cmath>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/DataStructures/RandomUnitNormal.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Construct a spatial vector in a given magnitude range
+///
+/// The magnitude is computed with respect to the given metric, where the metric
+/// is assumed to have positive signature.
+template <typename DataType, size_t Dim, UpLo Ul, typename Fr = Frame::Inertial,
+          Requires<(Ul == UpLo::Up)> = nullptr>
+tnsr::I<DataType, Dim, Fr> make_random_vector_in_magnitude_range(
+    const gsl::not_null<std::mt19937*> nn_generator,
+    const tnsr::ii<DataType, Dim, Fr>& metric, const double min_magnitude,
+    const double max_magnitude) noexcept {
+  if (min_magnitude < 0) {
+    ERROR("min_magnitude < 0. Magnitude must be non-negative");
+  }
+  if (max_magnitude < 0) {
+    ERROR("max_magnitude < 0. Magnitude must be non-negative");
+  }
+
+  // generate distribution
+  std::uniform_real_distribution<> dist_magnitude(min_magnitude, max_magnitude);
+  const auto magnitude = make_with_random_values<Scalar<DataType>>(
+      nn_generator, make_not_null(&dist_magnitude), metric);
+
+  // construct vector
+  tnsr::I<DataType, Dim, Fr> x_up = random_unit_normal(nn_generator, metric);
+
+  for (size_t i = 0; i < Dim; i++) {
+    x_up.get(i) *= magnitude.get();
+  }
+
+  return x_up;
+}
+
+template <typename DataType, size_t Dim, UpLo Ul, typename Fr = Frame::Inertial,
+          Requires<(Ul == UpLo::Lo)> = nullptr>
+tnsr::i<DataType, Dim, Fr> make_random_vector_in_magnitude_range(
+    const gsl::not_null<std::mt19937*> nn_generator,
+    const tnsr::ii<DataType, Dim, Fr>& metric, const double min_magnitude,
+    const double max_magnitude) noexcept {
+  const tnsr::I<DataType, Dim, Fr> x_up =
+      make_random_vector_in_magnitude_range<DataType, Dim, UpLo::Up, Fr>(
+          nn_generator, metric, min_magnitude, max_magnitude);
+
+  return raise_or_lower_index(x_up, metric);
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Construct a spatial vector in a given magnitude range
+///
+/// The magnitude is computed with respect to the flat space Euclidian metric.
+template <typename DataType, size_t Dim, UpLo Ul, typename Fr = Frame::Inertial,
+          typename T>
+Tensor<DataType, Symmetry<1>, index_list<SpatialIndex<Dim, Ul, Fr>>>
+make_random_vector_in_magnitude_range_flat(
+    const gsl::not_null<std::mt19937*> nn_generator, const T& used_for_size,
+    const double min_magnitude, const double max_magnitude) noexcept {
+  // construct flat spatial metric
+  tnsr::ii<DataType, Dim, Fr> metric =
+      make_with_value<tnsr::ii<DataType, Dim, Fr>>(used_for_size, 0.0);
+  for (size_t i = 0; i < Dim; i++) {
+    metric.get(i, i) = 1.0;
+  }
+
+  return make_random_vector_in_magnitude_range<DataType, Dim, Ul, Fr>(
+      nn_generator, metric, min_magnitude, max_magnitude);
+}

--- a/tests/Unit/Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.cpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.cpp
@@ -9,8 +9,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-namespace TestHelpers {
-namespace gr {
+namespace TestHelpers::gr {
 template <typename DataType>
 Scalar<DataType> random_lapse(const gsl::not_null<std::mt19937*> generator,
                               const DataType& used_for_size) noexcept {
@@ -28,12 +27,12 @@ tnsr::I<DataType, Dim> random_shift(
       generator, make_not_null(&distribution), used_for_size);
 }
 
-template <size_t Dim, typename DataType>
-tnsr::ii<DataType, Dim> random_spatial_metric(
+template <size_t Dim, typename DataType, typename Fr>
+tnsr::ii<DataType, Dim, Fr> random_spatial_metric(
     const gsl::not_null<std::mt19937*> generator,
     const DataType& used_for_size) noexcept {
   std::uniform_real_distribution<> distribution(-0.05, 0.05);
-  auto spatial_metric = make_with_random_values<tnsr::ii<DataType, Dim>>(
+  auto spatial_metric = make_with_random_values<tnsr::ii<DataType, Dim, Fr>>(
       generator, make_not_null(&distribution), used_for_size);
   for (size_t d = 0; d < Dim; ++d) {
     spatial_metric.get(d, d) += 1.0;
@@ -65,5 +64,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_TENSORS, (double, DataVector), (1, 2, 3))
 #undef INSTANTIATE_TENSORS
 #undef DIM
 #undef DTYPE
-}  // namespace gr
-}  // namespace TestHelpers
+}  // namespace TestHelpers::gr

--- a/tests/Unit/Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp
@@ -31,8 +31,8 @@ template <size_t Dim, typename DataType>
 tnsr::I<DataType, Dim> random_shift(gsl::not_null<std::mt19937*> generator,
                                     const DataType& used_for_size) noexcept;
 
-template <size_t Dim, typename DataType>
-tnsr::ii<DataType, Dim> random_spatial_metric(
+template <size_t Dim, typename DataType, typename Fr = Frame::Inertial>
+tnsr::ii<DataType, Dim, Fr> random_spatial_metric(
     gsl::not_null<std::mt19937*> generator,
     const DataType& used_for_size) noexcept;
 }  // namespace gr

--- a/tests/Unit/Helpers/Tests/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Helpers")
 set(LIBRARY_SOURCES
   Test_MakeWithRandomValues.cpp
   Test_RandomUnitNormal.cpp
+  Test_MakeRandomVectorInMagnitudeRange.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Helpers/Tests/Test_MakeRandomVectorInMagnitudeRange.cpp
+++ b/tests/Unit/Helpers/Tests/Test_MakeRandomVectorInMagnitudeRange.cpp
@@ -1,0 +1,138 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <limits>
+
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeRandomVectorInMagnitudeRange.hpp"
+#include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
+
+void check_random_values(const double v, const double bound1,
+                         const double bound2) noexcept {
+  CHECK(approx(v) >= std::min(bound1, bound2));
+  CHECK(approx(v) <= std::max(bound1, bound2));
+}
+
+// clang-tidy is wrong, this is a function definition
+template <typename T>
+void check_random_values(const T& c,                      // NOLINT
+                         const double bound1,             // NOLINT
+                         const double bound2) noexcept {  // NOLINT
+  for (const auto& v : c) {
+    check_random_values(v, bound1, bound2);
+  }
+}
+
+template <typename... Tags>
+void check_random_values(const Variables<tmpl::list<Tags...>>& v,
+                         const double bound1, const double bound2) noexcept {
+  expand_pack((
+      check_random_values<decltype(get<Tags>(v))>(get<Tags>(v), bound1, bound2),
+      cpp17::void_type{})...);
+}
+
+// Compute Magnitude
+template <typename DataType, size_t Dim, typename Fr>
+Scalar<DataType> magnitude_auto_invert(
+    const tnsr::I<DataType, Dim, Fr>& vector,
+    const tnsr::ii<DataType, Dim, Fr>& metric) {
+  return magnitude(vector, metric);
+}
+
+template <typename DataType, size_t Dim, typename Fr>
+Scalar<DataType> magnitude_auto_invert(
+    const tnsr::i<DataType, Dim, Fr>& covector,
+    const tnsr::ii<DataType, Dim, Fr>& metric) {
+  const tnsr::II<DataType, Dim, Fr> inverse_metric =
+      determinant_and_inverse(metric).second;
+
+  return magnitude(covector, inverse_metric);
+}
+
+template <size_t Dim, UpLo Ul, typename DataType>
+void test_range(const gsl::not_null<std::mt19937*> generator,
+                const DataType& used_for_size) noexcept {
+  using Fr = Frame::Inertial;
+
+  std::uniform_real_distribution<> distribution1(0.0, 100.0);
+  double r1 = distribution1(*generator);
+  std::uniform_real_distribution<> distribution2(0.0, 100.0);
+  double r2 = distribution2(*generator);
+  INFO("Interval is [" << r1 << "," << r2 << "]");
+
+  //****** FIRST TEST WITH EUCLIDIAN METRIC ******//
+
+  auto vector =
+      make_random_vector_in_magnitude_range_flat<DataType, Dim, Ul, Fr>(
+          generator, used_for_size, r1, r2);
+  auto vector_mag = magnitude(vector);
+
+  check_random_values(vector_mag, r1, r2);
+
+  //****** NOW TEST WITH RANDOM METRIC ******//
+
+  const tnsr::ii<DataType, Dim, Fr> metric =
+      TestHelpers::gr::random_spatial_metric<Dim, DataType, Fr>(generator,
+                                                                used_for_size);
+
+  vector = make_random_vector_in_magnitude_range<DataType, Dim, Ul, Fr>(
+      generator, metric, r1, r2);
+
+  vector_mag = magnitude_auto_invert(vector, metric);
+
+  check_random_values(vector_mag, r1, r2);
+
+  //****** TEST EDGE CASES ******//
+
+  r2 = r1;
+  INFO("Interval is [" << r1 << "," << r2 << "]");
+
+  vector = make_random_vector_in_magnitude_range<DataType, Dim, Ul, Fr>(
+      generator, metric, r1, r2);
+
+  vector_mag = magnitude_auto_invert(vector, metric);
+
+  check_random_values(vector_mag, r1, r2);
+
+  r1 = 0.0;
+  r2 = 0.0;
+  INFO("Interval is [" << r1 << "," << r2 << "]");
+
+  vector = make_random_vector_in_magnitude_range<DataType, Dim, Ul, Fr>(
+      generator, metric, r1, r2);
+
+  vector_mag = magnitude_auto_invert(vector, metric);
+
+  check_random_values(vector_mag, r1, r2);
+}
+
+SPECTRE_TEST_CASE("Test.TestHelpers.MakeRandomVectorInMagnitudeRange",
+                  "[Unit]") {
+  MAKE_GENERATOR(generator);
+
+  SECTION("double") {
+    const double d = std::numeric_limits<double>::signaling_NaN();
+    test_range<1, UpLo::Up>(&generator, d);
+    test_range<2, UpLo::Up>(&generator, d);
+    test_range<3, UpLo::Up>(&generator, d);
+
+    test_range<1, UpLo::Lo>(&generator, d);
+    test_range<2, UpLo::Lo>(&generator, d);
+    test_range<3, UpLo::Lo>(&generator, d);
+  }
+
+  SECTION("DataVector") {
+    const DataVector dv(5);
+    test_range<1, UpLo::Up>(&generator, dv);
+    test_range<2, UpLo::Up>(&generator, dv);
+    test_range<3, UpLo::Up>(&generator, dv);
+
+    test_range<1, UpLo::Lo>(&generator, dv);
+    test_range<2, UpLo::Lo>(&generator, dv);
+    test_range<3, UpLo::Lo>(&generator, dv);
+  }
+}

--- a/tests/Unit/Helpers/Tests/Test_RandomUnitNormal.cpp
+++ b/tests/Unit/Helpers/Tests/Test_RandomUnitNormal.cpp
@@ -13,29 +13,18 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/DataStructures/RandomUnitNormal.hpp"
+#include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 namespace {
 
-template <typename DataType, size_t Dim>
-tnsr::ii<DataType, Dim> random_spatial_metric(
-    const gsl::not_null<std::mt19937*> generator,
-    const DataType& used_for_size) noexcept {
-  std::uniform_real_distribution<> distribution(-0.05, 0.05);
-  auto spatial_metric = make_with_random_values<tnsr::ii<DataType, Dim>>(
-      generator, make_not_null(&distribution), used_for_size);
-  for (size_t d = 0; d < Dim; ++d) {
-    spatial_metric.get(d, d) += 1.0;
-  }
-  return spatial_metric;
-}
-
 template <size_t Dim, typename DataType>
 void test_random_unit_normal(const gsl::not_null<std::mt19937*> generator,
                              const DataType& used_for_size) noexcept {
   const auto spatial_metric =
-      random_spatial_metric<DataType, Dim>(generator, used_for_size);
+      TestHelpers::gr::random_spatial_metric<Dim, DataType>(generator,
+                                                            used_for_size);
   const auto unit_normal = random_unit_normal(generator, spatial_metric);
   const auto expected_magnitude =
       make_with_value<Scalar<DataType>>(used_for_size, 1.0);


### PR DESCRIPTION
## Proposed changes

Given a magnitude range return a random vector with a random magnitude in this range.
The application for this is in particular to generate random vectors that are guaranteed to be non-zero.

This code could be used in RandomUnitNormal.cpp to reduce code as they have some some partial overlap in functionality.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).