### PR TITLE
Compute elliptic DG penalty from element geometry

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -883,6 +883,23 @@
   publisher  = "Springer-Verlag Berlin Heidelberg",
 }
 
+@article{Vincent2019qpd,
+  author        = "Vincent, Trevor and Pfeiffer, Harald P. and Fischer, Nils
+                   L.",
+  title         = "{hp-adaptive} discontinuous {Galerkin} solver for elliptic
+                   equations in numerical relativity",
+  eprint        = "1907.01572",
+  archivePrefix = "arXiv",
+  primaryClass  = "physics.comp-ph",
+  doi           = "10.1103/PhysRevD.100.084052",
+  url           = "https://journals.aps.org/prd/abstract/10.1103/PhysRevD.100.084052",
+  journal       = "Phys. Rev. D",
+  volume        = "100",
+  number        = "8",
+  pages         = "084052",
+  year          = "2019"
+}
+
 @article{White2015omx,
   author         = "White, Christopher J. and Stone, James M. and Gammie,
                     Charles F.",

--- a/src/Elliptic/DiscontinuousGalerkin/ImposeInhomogeneousBoundaryConditionsOnSource.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/ImposeInhomogeneousBoundaryConditionsOnSource.hpp
@@ -86,14 +86,18 @@ struct ImposeInhomogeneousBoundaryConditionsOnSource {
           numerical_fluxes,
       const NormalDotNumericalFluxComputer& normal_dot_numerical_flux_computer,
       const Variables<tmpl::list<BoundaryDataTags...>>& boundary_data,
+      const Mesh<volume_dim>& volume_mesh,
+      const Direction<volume_dim>& direction,
       const tnsr::i<DataVector, volume_dim, Frame::Inertial>&
           normalized_face_normal,
+      const Scalar<DataVector>& face_normal_magnitude,
       const FluxesType& fluxes_computer,
       const FluxesArgs&... fluxes_args) noexcept {
     normal_dot_numerical_flux_computer.compute_dirichlet_boundary(
         make_not_null(&get<NumericalFluxTags>(*numerical_fluxes))...,
-        get<BoundaryDataTags>(boundary_data)..., normalized_face_normal,
-        fluxes_computer, fluxes_args...);
+        get<BoundaryDataTags>(boundary_data)..., volume_mesh, direction,
+        normalized_face_normal, face_normal_magnitude, fluxes_computer,
+        fluxes_args...);
   }
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
@@ -152,8 +156,9 @@ struct ImposeInhomogeneousBoundaryConditionsOnSource {
           compute_dirichlet_boundary_normal_dot_numerical_flux(
               make_not_null(&boundary_normal_dot_numerical_fluxes),
               normal_dot_numerical_flux_computer,
-              std::move(dirichlet_boundary_data), normalized_face_normal,
-              fluxes_computer, fluxes_args...);
+              std::move(dirichlet_boundary_data), volume_mesh, direction,
+              normalized_face_normal, magnitude_of_face_normal, fluxes_computer,
+              fluxes_args...);
           // Flip sign of the boundary contributions, making them
           // contributions to the source
           return db::item_type<fixed_sources_tag>{

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -21,7 +21,7 @@ DomainCreator:
 
 NumericalFlux:
   InternalPenalty:
-    PenaltyParameter: 5.729577951308232 # p^2 / h
+    PenaltyParameter: 1.
 
 Observers:
   VolumeFileName: "PoissonProductOfSinusoids1DVolume"

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -21,7 +21,7 @@ DomainCreator:
 
 NumericalFlux:
   InternalPenalty:
-    PenaltyParameter: 5.729577951308232 # p^2 / h
+    PenaltyParameter: 1.
 
 Observers:
   VolumeFileName: "PoissonProductOfSinusoids2DVolume"

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -21,7 +21,7 @@ DomainCreator:
 
 NumericalFlux:
   InternalPenalty:
-    PenaltyParameter: 2.5464790894703255 # p^2 / h
+    PenaltyParameter: 1.
 
 Observers:
   VolumeFileName: "PoissonProductOfSinusoids3DVolume"

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.py
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.py
@@ -4,6 +4,10 @@
 import numpy as np
 
 
+def penalty(element_size, perpendicular_num_points, penalty_parameter):
+    return penalty_parameter * perpendicular_num_points**2 / element_size
+
+
 def average(int, ext):
     return 0.5 * (int + ext)
 
@@ -23,8 +27,12 @@ def flux_for_auxiliary_field(field, fluxes_argument, dim):
 def normal_dot_numerical_flux_for_field(n_dot_aux_flux_int, n_dot_aux_flux_ext,
                                         div_aux_flux_int, div_aux_flux_ext,
                                         fluxes_argument, penalty_parameter,
+                                        face_normal_magnitude_int,
+                                        face_normal_magnitude_ext,
                                         face_normal_int):
-    sigma = penalty_parameter
+    sigma = penalty(
+        np.minimum(2. / face_normal_magnitude_int,
+                   2. / face_normal_magnitude_ext), 4, penalty_parameter)
     return np.dot(
         face_normal_int,
         average(flux_for_field(div_aux_flux_int, fluxes_argument),
@@ -35,7 +43,8 @@ def normal_dot_numerical_flux_for_field(n_dot_aux_flux_int, n_dot_aux_flux_ext,
 
 def normal_dot_numerical_flux_for_auxiliary_field(
     n_dot_aux_flux_int, minus_n_dot_aux_flux_ext, div_aux_flux_int,
-    div_aux_flux_ext, fluxes_argument, penalty_parameter, face_normal_int):
+    div_aux_flux_ext, fluxes_argument, penalty_parameter,
+    face_normal_magnitude_int, face_normal_magnitude_ext, face_normal_int):
     # `minus_n_dot_aux_flux_ext` is from the element on the other side of the
     # interface, so it is _minus_ the same quantity if it was computed with the
     # normal from this element (assuming normals don't depend on the dynamic
@@ -45,8 +54,10 @@ def normal_dot_numerical_flux_for_auxiliary_field(
 
 
 def normal_dot_dirichlet_flux_for_field(dirichlet_field, fluxes_argument,
-                                        penalty_parameter, face_normal, dim):
-    sigma = penalty_parameter
+                                        penalty_parameter,
+                                        face_normal_magnitude, face_normal,
+                                        dim):
+    sigma = penalty(2. / face_normal_magnitude, 3, penalty_parameter)
     return 2. * sigma * np.dot(
         face_normal,
         flux_for_field(
@@ -71,6 +82,7 @@ def normal_dot_dirichlet_flux_for_field_3d(*args, **kwargs):
 def normal_dot_dirichlet_flux_for_auxiliary_field(dirichlet_field,
                                                   fluxes_argument,
                                                   penalty_parameter,
+                                                  face_normal_magnitude,
                                                   face_normal, dim):
     return np.dot(
         face_normal,

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/Test_FirstOrderInternalPenalty.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/Test_FirstOrderInternalPenalty.cpp
@@ -9,13 +9,16 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Mesh.hpp"
 #include "Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Elliptic/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp"
 #include "Helpers/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/NumericalFluxHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 
@@ -69,6 +72,8 @@ void apply_ip_flux(
     const tnsr::i<DataVector, Dim>& div_aux_flux_int,
     const tnsr::i<DataVector, Dim>& div_aux_flux_ext,
     const double fluxes_argument, const double penalty_parameter,
+    const Scalar<DataVector>& face_normal_magnitude_int,
+    const Scalar<DataVector>& face_normal_magnitude_ext,
     const tnsr::i<DataVector, Dim>& face_normal_int) noexcept {
   using NumericalFlux =
       elliptic::dg::NumericalFluxes::FirstOrderInternalPenalty<
@@ -79,15 +84,23 @@ void apply_ip_flux(
   NumericalFlux numerical_flux{penalty_parameter};
   Fluxes<Dim> fluxes_computer{};
 
+  const Mesh<Dim> volume_mesh_int{3, Spectral::Basis::Legendre,
+                                  Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim> volume_mesh_ext{4, Spectral::Basis::Legendre,
+                                  Spectral::Quadrature::GaussLobatto};
+  const auto direction = Direction<Dim>::lower_xi();
+
   auto packaged_data_interior = TestHelpers::NumericalFluxes::get_packaged_data(
-      numerical_flux, used_for_size, n_dot_aux_flux_int, div_aux_flux_int,
+      numerical_flux, used_for_size, volume_mesh_int, direction,
+      face_normal_magnitude_int, n_dot_aux_flux_int, div_aux_flux_int,
       face_normal_int, fluxes_computer, fluxes_argument);
   tnsr::i<DataVector, Dim> face_normal_ext{face_normal_int};
   for (size_t d = 0; d < Dim; d++) {
     face_normal_ext.get(d) *= -1.;
   }
   auto packaged_data_exterior = TestHelpers::NumericalFluxes::get_packaged_data(
-      numerical_flux, used_for_size, n_dot_aux_flux_ext, div_aux_flux_ext,
+      numerical_flux, used_for_size, volume_mesh_ext, direction.opposite(),
+      face_normal_magnitude_ext, n_dot_aux_flux_ext, div_aux_flux_ext,
       face_normal_ext, fluxes_computer, fluxes_argument);
 
   dg::NumericalFluxes::normal_dot_numerical_fluxes(
@@ -101,6 +114,7 @@ void apply_ip_dirichlet_flux(
     const gsl::not_null<tnsr::i<DataVector, Dim>*> n_dot_num_f_aux,
     const Scalar<DataVector>& dirichlet_field, const double fluxes_argument,
     const double penalty_parameter,
+    const Scalar<DataVector>& face_normal_magnitude,
     const tnsr::i<DataVector, Dim>& face_normal) noexcept {
   using NumericalFlux =
       elliptic::dg::NumericalFluxes::FirstOrderInternalPenalty<
@@ -110,9 +124,14 @@ void apply_ip_dirichlet_flux(
   NumericalFlux numerical_flux{penalty_parameter};
   Fluxes<Dim> fluxes_computer{};
 
-  numerical_flux.compute_dirichlet_boundary(n_dot_num_f_field, n_dot_num_f_aux,
-                                            dirichlet_field, face_normal,
-                                            fluxes_computer, fluxes_argument);
+  const Mesh<Dim> volume_mesh{3, Spectral::Basis::Legendre,
+                              Spectral::Quadrature::GaussLobatto};
+  const auto direction = Direction<Dim>::lower_xi();
+
+  numerical_flux.compute_dirichlet_boundary(
+      n_dot_num_f_field, n_dot_num_f_aux, dirichlet_field, volume_mesh,
+      direction, face_normal, face_normal_magnitude, fluxes_computer,
+      fluxes_argument);
 }
 
 template <size_t Dim>
@@ -142,9 +161,33 @@ void test_conservation(const DataVector& used_for_size) {
       Dim, FluxesComputerTag<Dim>, tmpl::list<ScalarFieldTag>,
       tmpl::list<AuxiliaryFieldTag<Dim>>>
       numerical_flux{1.5};
-  EllipticNumericalFluxesTestHelpers::test_conservation<
-      Dim, tmpl::list<ScalarFieldTag, AuxiliaryFieldTag<Dim>>>(numerical_flux,
-                                                               used_for_size);
+
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+  std::uniform_int_distribution<size_t> dist_poly_degree(1, 6);
+  const auto gen_nn = make_not_null(&gen);
+  const auto dist_nn = make_not_null(&dist);
+  const auto dist_poly_degree_nn = make_not_null(&dist_poly_degree);
+
+  EllipticNumericalFluxesTestHelpers::test_conservation<Dim>(
+      numerical_flux,
+      [&gen_nn, &dist_nn, &dist_poly_degree_nn, &used_for_size]() {
+        return std::make_tuple(
+            Mesh<Dim>{(*dist_poly_degree_nn)(*gen_nn) + 1,
+                      Spectral::Basis::Legendre,
+                      Spectral::Quadrature::GaussLobatto},
+            Direction<Dim>::upper_xi(),
+            make_with_random_values<Scalar<DataVector>>(gen_nn, dist_nn,
+                                                        used_for_size),
+            make_with_random_values<tnsr::i<DataVector, Dim>>(gen_nn, dist_nn,
+                                                              used_for_size),
+            make_with_random_values<tnsr::i<DataVector, Dim>>(gen_nn, dist_nn,
+                                                              used_for_size),
+            make_with_random_values<tnsr::i<DataVector, Dim>>(gen_nn, dist_nn,
+                                                              used_for_size),
+            Fluxes<Dim>{}, (*dist_nn)(*gen_nn));
+      },
+      used_for_size);
 }
 
 }  // namespace

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
@@ -89,9 +89,11 @@ template <size_t Dim>
 struct NumericalFlux {
   void compute_dirichlet_boundary(
       const gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
-      const Scalar<DataVector>& field,
+      const Scalar<DataVector>& field, const Mesh<Dim>& /*volume_mesh*/,
+      const Direction<Dim>& /*direction*/,
       const tnsr::i<DataVector, Dim,
                     Frame::Inertial>& /*interface_unit_normal*/,
+      const Scalar<DataVector>& /*face_normal_magnitude*/,
       const Fluxes<Dim>& /*flux_computer*/) const noexcept {
     numerical_flux_for_field->get() = 2. * get(field);
   }

--- a/tests/Unit/Helpers/Elliptic/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Elliptic/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp
@@ -11,7 +11,6 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Framework/TestHelpers.hpp"
-#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/NumericalFluxHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
 #include "Utilities/TMPL.hpp"
@@ -21,35 +20,38 @@ namespace EllipticNumericalFluxesTestHelpers {
 /// Test that the flux is single-valued on the interface, i.e. that the elements
 /// on either side of the interface are working with the same numerical flux
 /// data
-template <size_t Dim, typename VariablesTags, typename FluxType>
-void test_conservation(const FluxType& flux_computer,
+template <size_t Dim, typename NumericalFluxComputer, typename MakeRandomArgs>
+void test_conservation(const NumericalFluxComputer& numerical_flux_computer,
+                       MakeRandomArgs&& make_random_args,
                        const DataVector& used_for_size) {
-  MAKE_GENERATOR(gen);
-  std::uniform_real_distribution<> dist(0.0, 1.0);
   const size_t num_points = used_for_size.size();
+  using PackagedData = dg::SimpleBoundaryData<
+      typename NumericalFluxComputer::package_field_tags,
+      typename NumericalFluxComputer::package_extra_tags>;
+  const auto make_random_packaged_data = [&numerical_flux_computer,
+                                          &make_random_args, &num_points]() {
+    return std::apply(
+        [&numerical_flux_computer, &num_points](const auto... args) noexcept {
+          PackagedData packaged_data{num_points};
+          dg::NumericalFluxes::package_data(make_not_null(&packaged_data),
+                                            numerical_flux_computer, args...);
+          return packaged_data;
+        },
+        make_random_args());
+  };
+  const auto packaged_data_interior = make_random_packaged_data();
+  const auto packaged_data_exterior = make_random_packaged_data();
 
-  using PackagedData =
-      dg::SimpleBoundaryData<typename FluxType::package_field_tags,
-                             typename FluxType::package_extra_tags>;
-  PackagedData packaged_data_interior{};
-  packaged_data_interior.field_data =
-      make_with_random_values<Variables<typename FluxType::package_field_tags>>(
-          make_not_null(&gen), make_not_null(&dist), used_for_size);
-  PackagedData packaged_data_exterior{};
-  packaged_data_exterior.field_data =
-      make_with_random_values<Variables<typename FluxType::package_field_tags>>(
-          make_not_null(&gen), make_not_null(&dist), used_for_size);
-
-  Variables<VariablesTags> n_dot_num_flux_interior(
-      num_points, std::numeric_limits<double>::signaling_NaN());
+  using Vars = Variables<typename NumericalFluxComputer::variables_tags>;
+  Vars n_dot_num_flux_interior(num_points,
+                               std::numeric_limits<double>::signaling_NaN());
   dg::NumericalFluxes::normal_dot_numerical_fluxes(
-      make_not_null(&n_dot_num_flux_interior), flux_computer,
+      make_not_null(&n_dot_num_flux_interior), numerical_flux_computer,
       packaged_data_interior, packaged_data_exterior);
-
-  Variables<VariablesTags> n_dot_num_flux_exterior(
-      num_points, std::numeric_limits<double>::signaling_NaN());
+  Vars n_dot_num_flux_exterior(num_points,
+                               std::numeric_limits<double>::signaling_NaN());
   dg::NumericalFluxes::normal_dot_numerical_fluxes(
-      make_not_null(&n_dot_num_flux_exterior), flux_computer,
+      make_not_null(&n_dot_num_flux_exterior), numerical_flux_computer,
       packaged_data_exterior, packaged_data_interior);
 
   CHECK_VARIABLES_APPROX(n_dot_num_flux_interior, -n_dot_num_flux_exterior);


### PR DESCRIPTION
# Proposed changes

This PR allows the elliptic internal penalty flux to compute the penalty from the element geometry. This is possible as of #1725, since we can communicate non-tensor quantities across element boundaries in numerical fluxes now.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
