### PR TITLE
Factor damped wave gauge functions for reuse

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY GeneralizedHarmonicGaugeSourceFunctions)
 
 set(LIBRARY_SOURCES
   DampedHarmonic.cpp
+  DampedWaveHelpers.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -22,49 +23,8 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-namespace GeneralizedHarmonic {
-namespace gauges {
+namespace GeneralizedHarmonic::gauges {
 namespace DampedHarmonicGauge_detail {
-// Spatial weight function used in the damped harmonic gauge source
-// function.
-//
-// The spatial weight function is: \f[ W(x^i) = \exp(- (r / \sigma_r)^2) \f]
-// This function can be written with an extra factor inside the exponent in
-// literature, e.g. \cite Deppe2018uye. We absorb that in \f$\sigma_r\f$.
-template <size_t SpatialDim, typename Frame, typename DataType>
-void spatial_weight_function(const gsl::not_null<Scalar<DataType>*> weight,
-                             const tnsr::I<DataType, SpatialDim, Frame>& coords,
-                             const double sigma_r) noexcept {
-  if (UNLIKELY(get_size(get(*weight)) != get_size(get<0>(coords)))) {
-    *weight = Scalar<DataType>(get_size(get<0>(coords)));
-  }
-  const auto r_squared = dot_product(coords, coords);
-  get(*weight) = exp(-get(r_squared) / square(sigma_r));
-}
-
-// Spacetime derivatives of the spatial weight function that enters the
-// damped harmonic gauge source function.
-//
-// Compute the derivatives :
-// \partial_a W(x^i)= \partial_a \exp(- (r/\sigma_r)^2)
-//                  = (-2 * x^i / \sigma_r^2) * exp(-(r/\sigma_r)^2)
-template <size_t SpatialDim, typename Frame, typename DataType>
-void spacetime_deriv_of_spatial_weight_function(
-    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_weight,
-    const tnsr::I<DataType, SpatialDim, Frame>& coords, const double sigma_r,
-    const Scalar<DataType>& spatial_weight_function) noexcept {
-  if (UNLIKELY(get_size(get<0>(*d4_weight)) != get_size(get<0>(coords)))) {
-    *d4_weight = tnsr::a<DataType, SpatialDim, Frame>(get_size(get<0>(coords)));
-  }
-  // use 0th component to avoid allocations
-  get<0>(*d4_weight) = get(spatial_weight_function) * (-2. / square(sigma_r));
-  for (size_t i = 0; i < SpatialDim; ++i) {
-    d4_weight->get(1 + i) = get<0>(*d4_weight) * coords.get(i);
-  }
-  // time derivative of weight function is zero
-  get<0>(*d4_weight) = 0.;
-}
-
 // Roll-on function for the damped harmonic gauge.
 //
 // For times after \f$t_0\f$, compute the roll-on function
@@ -91,195 +51,6 @@ double time_deriv_of_roll_on_function(const double time, const double t_start,
   const double time_since_start_over_sigma = (time - t_start) / sigma_t;
   return exp(-pow<4>(time_since_start_over_sigma)) * 4. *
          pow<3>(time_since_start_over_sigma) / sigma_t;
-}
-
-// The log factor that appears in damped harmonic gauge source function.
-//
-// Calculates:  \f$ logF = \mathrm{log}(g^p/N) \f$.
-template <typename DataType>
-void log_factor_metric_lapse(const gsl::not_null<Scalar<DataType>*> logfac,
-                             const Scalar<DataType>& lapse,
-                             const Scalar<DataType>& sqrt_det_spatial_metric,
-                             const double exponent) noexcept {
-  if (UNLIKELY(get_size(get(*logfac)) != get_size(get(lapse)))) {
-    *logfac = Scalar<DataType>(get_size(get(lapse)));
-  }
-  // branching below is to avoid using pow for performance reasons
-  if (exponent == 0.) {
-    get(*logfac) = -log(get(lapse));
-  } else if (exponent == 0.5) {
-    get(*logfac) = log(get(sqrt_det_spatial_metric) / get(lapse));
-  } else {
-    get(*logfac) =
-        2. * exponent * log(get(sqrt_det_spatial_metric)) - log(get(lapse));
-  }
-}
-
-template <typename DataType>
-Scalar<DataType> log_factor_metric_lapse(
-    const Scalar<DataType>& lapse,
-    const Scalar<DataType>& sqrt_det_spatial_metric,
-    const double exponent) noexcept {
-  Scalar<DataType> logfac{};
-  log_factor_metric_lapse(make_not_null(&logfac), lapse,
-                          sqrt_det_spatial_metric, exponent);
-  return logfac;
-}
-
-// Spacetime derivatives of the log factor that appears in the
-// damped harmonic gauge source function.
-//
-// Computes the spacetime derivatives:
-//  \partial_a logF = (p/g)\partial_a g - (1/N)\partial_a N
-template <size_t SpatialDim, typename Frame, typename DataType>
-void spacetime_deriv_of_log_factor_metric_lapse(
-    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_logfac,
-    const Scalar<DataType>& lapse,
-    const tnsr::I<DataType, SpatialDim, Frame>& shift,
-    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
-    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
-    const Scalar<DataType>& sqrt_det_spatial_metric,
-    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
-    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
-    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
-    const double exponent) noexcept {
-  if (UNLIKELY(get_size(get<0>(*d4_logfac)) != get_size(get(lapse)))) {
-    *d4_logfac = tnsr::a<DataType, SpatialDim, Frame>(get_size(get(lapse)));
-  }
-  // Use a TempBuffer to reduce total number of allocations. This is especially
-  // important in a multithreaded environment.
-  TempBuffer<tmpl::list<::Tags::Tempa<0, SpatialDim, Frame, DataType>,
-                        ::Tags::Tempi<1, SpatialDim, Frame, DataType>,
-                        ::Tags::Tempa<2, SpatialDim, Frame, DataType>,
-                        ::Tags::TempScalar<3, DataType>,
-                        ::Tags::TempScalar<4, DataType>>>
-      buffer(get_size(get(lapse)));
-  auto& d_g = get<::Tags::Tempa<0, SpatialDim, Frame, DataType>>(buffer);
-  auto& d3_lapse = get<::Tags::Tempi<1, SpatialDim, Frame, DataType>>(buffer);
-  auto& d_lapse = get<::Tags::Tempa<2, SpatialDim, Frame, DataType>>(buffer);
-  auto& dt_lapse = get<::Tags::TempScalar<3, DataType>>(buffer);
-  auto& one_over_lapse = get<::Tags::TempScalar<4, DataType>>(buffer);
-
-  // Get \f$ \partial_a g\f$
-  spacetime_deriv_of_det_spatial_metric<SpatialDim, Frame, DataType>(
-      make_not_null(&d_g), sqrt_det_spatial_metric, inverse_spatial_metric,
-      dt_spatial_metric, phi);
-  // Get \f$ \partial_a N\f$
-  time_deriv_of_lapse<SpatialDim, Frame, DataType>(
-      make_not_null(&dt_lapse), lapse, shift, spacetime_unit_normal, phi, pi);
-  spatial_deriv_of_lapse<SpatialDim, Frame, DataType>(
-      make_not_null(&d3_lapse), lapse, spacetime_unit_normal, phi);
-  get<0>(d_lapse) = get(dt_lapse);
-  for (size_t i = 0; i < SpatialDim; ++i) {
-    d_lapse.get(1 + i) = d3_lapse.get(i);
-  }
-  // Compute
-  get(one_over_lapse) = 1. / get(lapse);
-  if (exponent == 0.) {
-    for (size_t a = 0; a < SpatialDim + 1; ++a) {
-      d4_logfac->get(a) = -get(one_over_lapse) * d_lapse.get(a);
-    }
-  } else {
-    const auto p_over_g = exponent / square(get(sqrt_det_spatial_metric));
-    for (size_t a = 0; a < SpatialDim + 1; ++a) {
-      d4_logfac->get(a) =
-          p_over_g * d_g.get(a) - get(one_over_lapse) * d_lapse.get(a);
-    }
-  }
-}
-
-template <size_t SpatialDim, typename Frame, typename DataType>
-tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_log_factor_metric_lapse(
-    const Scalar<DataType>& lapse,
-    const tnsr::I<DataType, SpatialDim, Frame>& shift,
-    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
-    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
-    const Scalar<DataType>& sqrt_det_spatial_metric,
-    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
-    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
-    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
-    const double exponent) noexcept {
-  tnsr::a<DataType, SpatialDim, Frame> d4_logfac{};
-  spacetime_deriv_of_log_factor_metric_lapse(
-      make_not_null(&d4_logfac), lapse, shift, spacetime_unit_normal,
-      inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric, pi,
-      phi, exponent);
-  return d4_logfac;
-}
-
-// Spacetime derivatives of the log factor (that appears in
-// damped harmonic gauge source function), raised to an exponent.
-//
-// Computes the spacetime derivatives:
-//  \partial_a (logF)^q = q (logF)^{q-1} \partial_a (logF)
-template <size_t SpatialDim, typename Frame, typename DataType>
-void spacetime_deriv_of_power_log_factor_metric_lapse(
-    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_powlogfac,
-    const Scalar<DataType>& lapse,
-    const tnsr::I<DataType, SpatialDim, Frame>& shift,
-    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
-    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
-    const Scalar<DataType>& sqrt_det_spatial_metric,
-    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
-    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
-    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, const double g_exponent,
-    const int exponent) noexcept {
-  if (UNLIKELY(get_size(get<0>(*d4_powlogfac)) != get_size(get(lapse)))) {
-    *d4_powlogfac = tnsr::a<DataType, SpatialDim, Frame>(get_size(get(lapse)));
-  }
-  // Use a TempBuffer to reduce total number of allocations. This is especially
-  // important in a multithreaded environment.
-  TempBuffer<tmpl::list<::Tags::Tempa<0, SpatialDim, Frame, DataType>,
-                        ::Tags::TempScalar<1, DataType>,
-                        ::Tags::TempScalar<2, DataType>>>
-      buffer(get_size(get(lapse)));
-  auto& dlogfac = get<::Tags::Tempa<0, SpatialDim, Frame, DataType>>(buffer);
-  auto& logfac = get<::Tags::TempScalar<1, DataType>>(buffer);
-  auto& prefac = get<::Tags::TempScalar<2, DataType>>(buffer);
-
-  // Compute derivative
-  spacetime_deriv_of_log_factor_metric_lapse<SpatialDim, Frame, DataType>(
-      make_not_null(&dlogfac), lapse, shift, spacetime_unit_normal,
-      inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric, pi,
-      phi, g_exponent);
-  // Apply pre-factor
-  if (UNLIKELY(exponent == 0)) {
-    for (size_t a = 0; a < SpatialDim + 1; ++a) {
-      d4_powlogfac->get(a) = 0.;
-    }
-  } else if (UNLIKELY(exponent == 1)) {
-    for (size_t a = 0; a < SpatialDim + 1; ++a) {
-      d4_powlogfac->get(a) = dlogfac.get(a);
-    }
-  } else {
-    log_factor_metric_lapse<DataType>(make_not_null(&logfac), lapse,
-                                      sqrt_det_spatial_metric, g_exponent);
-    get(prefac) =
-        static_cast<double>(exponent) * pow(get(logfac), exponent - 1);
-    for (size_t a = 0; a < SpatialDim + 1; ++a) {
-      d4_powlogfac->get(a) = get(prefac) * dlogfac.get(a);
-    }
-  }
-}
-
-template <size_t SpatialDim, typename Frame, typename DataType>
-tnsr::a<DataType, SpatialDim, Frame>
-spacetime_deriv_of_power_log_factor_metric_lapse(
-    const Scalar<DataType>& lapse,
-    const tnsr::I<DataType, SpatialDim, Frame>& shift,
-    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
-    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
-    const Scalar<DataType>& sqrt_det_spatial_metric,
-    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
-    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
-    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, const double g_exponent,
-    const int exponent) noexcept {
-  tnsr::a<DataType, SpatialDim, Frame> d4_powlogfac{};
-  spacetime_deriv_of_power_log_factor_metric_lapse(
-      make_not_null(&d4_powlogfac), lapse, shift, spacetime_unit_normal,
-      inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric, pi,
-      phi, g_exponent, exponent);
-  return d4_powlogfac;
 }
 }  // namespace DampedHarmonicGauge_detail
 
@@ -710,78 +481,6 @@ void spacetime_deriv_damped_harmonic_h(
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 #define DTYPE_SCAL(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                  \
-  template void DampedHarmonicGauge_detail::spatial_weight_function(          \
-      const gsl::not_null<Scalar<DTYPE(data)>*> weight,                       \
-      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,             \
-      const double sigma_r) noexcept;                                         \
-  template void                                                               \
-  DampedHarmonicGauge_detail::spacetime_deriv_of_spatial_weight_function(     \
-      const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>      \
-          d4_weight,                                                          \
-      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,             \
-      const double sigma_r,                                                   \
-      const Scalar<DTYPE(data)>& weight_function) noexcept;                   \
-  template void                                                               \
-  DampedHarmonicGauge_detail::spacetime_deriv_of_log_factor_metric_lapse(     \
-      const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>      \
-          d4_logfac,                                                          \
-      const Scalar<DTYPE(data)>& lapse,                                       \
-      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
-      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
-          spacetime_unit_normal,                                              \
-      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
-          inverse_spatial_metric,                                             \
-      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                     \
-      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
-      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,                \
-      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
-      const double exponent) noexcept;                                        \
-  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \
-  DampedHarmonicGauge_detail::spacetime_deriv_of_log_factor_metric_lapse(     \
-      const Scalar<DTYPE(data)>& lapse,                                       \
-      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
-      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
-          spacetime_unit_normal,                                              \
-      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
-          inverse_spatial_metric,                                             \
-      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                     \
-      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
-      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,                \
-      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
-      const double exponent) noexcept;                                        \
-  template void DampedHarmonicGauge_detail::                                  \
-      spacetime_deriv_of_power_log_factor_metric_lapse(                       \
-          const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>  \
-              d4_powlogfac,                                                   \
-          const Scalar<DTYPE(data)>& lapse,                                   \
-          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,          \
-          const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                 \
-              spacetime_unit_normal,                                          \
-          const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
-              inverse_spatial_metric,                                         \
-          const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                 \
-          const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                \
-              dt_spatial_metric,                                              \
-          const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,            \
-          const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,          \
-          const double g_exponent, const int exponent) noexcept;              \
-  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \
-  DampedHarmonicGauge_detail::                                                \
-      spacetime_deriv_of_power_log_factor_metric_lapse(                       \
-          const Scalar<DTYPE(data)>& lapse,                                   \
-          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,          \
-          const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                 \
-              spacetime_unit_normal,                                          \
-          const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
-              inverse_spatial_metric,                                         \
-          const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                 \
-          const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                \
-              dt_spatial_metric,                                              \
-          const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,            \
-          const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,          \
-          const double g_exponent, const int exponent) noexcept;
-
 #define INSTANTIATE_DV_FUNC(_, data)                                           \
   template void damped_harmonic_h(                                             \
       const gsl::not_null<                                                     \
@@ -831,33 +530,14 @@ void spacetime_deriv_damped_harmonic_h(
       const double sigma_t_L2, const double t_start_S, const double sigma_t_S, \
       const double sigma_r) noexcept;
 
-#define INSTANTIATE_SCALAR_FUNC(_, data)                             \
-  template void DampedHarmonicGauge_detail::log_factor_metric_lapse( \
-      const gsl::not_null<Scalar<DTYPE_SCAL(data)>*> logfac,         \
-      const Scalar<DTYPE_SCAL(data)>& lapse,                         \
-      const Scalar<DTYPE_SCAL(data)>& sqrt_det_spatial_metric,       \
-      const double exponent) noexcept;                               \
-  template Scalar<DTYPE_SCAL(data)>                                  \
-  DampedHarmonicGauge_detail::log_factor_metric_lapse(               \
-      const Scalar<DTYPE_SCAL(data)>& lapse,                         \
-      const Scalar<DTYPE_SCAL(data)>& sqrt_det_spatial_metric,       \
-      const double exponent) noexcept;
-
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
-                        (Frame::Inertial))
-
 GENERATE_INSTANTIATIONS(INSTANTIATE_DV_FUNC, (1, 2, 3), (DataVector),
                         (Frame::Inertial))
-
-GENERATE_INSTANTIATIONS(INSTANTIATE_SCALAR_FUNC, (double, DataVector))
 
 #undef DIM
 #undef DTYPE
 #undef FRAME
 #undef DTYPE_SCAL
-#undef INSTANTIATE
 #undef INSTANTIATE_DV_FUNC
 #undef INSTANTIATE_SCALAR_FUNC
 /// \endcond
-}  // namespace gauges
-}  // namespace GeneralizedHarmonic
+}  // namespace GeneralizedHarmonic::gauges

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.cpp
@@ -25,9 +25,7 @@ template <size_t SpatialDim, typename Frame, typename DataType>
 void spatial_weight_function(const gsl::not_null<Scalar<DataType>*> weight,
                              const tnsr::I<DataType, SpatialDim, Frame>& coords,
                              const double sigma_r) noexcept {
-  if (UNLIKELY(get_size(get(*weight)) != get_size(get<0>(coords)))) {
-    *weight = Scalar<DataType>(get_size(get<0>(coords)));
-  }
+  destructive_resize_components(weight, get_size(get<0>(coords)));
   const auto r_squared = dot_product(coords, coords);
   get(*weight) = exp(-get(r_squared) / pow<2>(sigma_r));
 }
@@ -37,9 +35,7 @@ void spacetime_deriv_of_spatial_weight_function(
     const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_weight,
     const tnsr::I<DataType, SpatialDim, Frame>& coords, const double sigma_r,
     const Scalar<DataType>& weight_function) noexcept {
-  if (UNLIKELY(get_size(get<0>(*d4_weight)) != get_size(get<0>(coords)))) {
-    *d4_weight = tnsr::a<DataType, SpatialDim, Frame>(get_size(get<0>(coords)));
-  }
+  destructive_resize_components(d4_weight, get_size(get<0>(coords)));
   // use 0th component to avoid allocations
   get<0>(*d4_weight) = get(weight_function) * (-2. / pow<2>(sigma_r));
   for (size_t i = 0; i < SpatialDim; ++i) {
@@ -54,9 +50,7 @@ void log_factor_metric_lapse(const gsl::not_null<Scalar<DataType>*> logfac,
                              const Scalar<DataType>& lapse,
                              const Scalar<DataType>& sqrt_det_spatial_metric,
                              const double exponent) noexcept {
-  if (UNLIKELY(get_size(get(*logfac)) != get_size(get(lapse)))) {
-    *logfac = Scalar<DataType>(get_size(get(lapse)));
-  }
+  destructive_resize_components(logfac, get_size(get(lapse)));
   // branching below is to avoid using pow for performance reasons
   if (exponent == 0.) {
     get(*logfac) = -log(get(lapse));
@@ -73,7 +67,7 @@ Scalar<DataType> log_factor_metric_lapse(
     const Scalar<DataType>& lapse,
     const Scalar<DataType>& sqrt_det_spatial_metric,
     const double exponent) noexcept {
-  Scalar<DataType> logfac{};
+  Scalar<DataType> logfac{get_size(get(lapse))};
   log_factor_metric_lapse(make_not_null(&logfac), lapse,
                           sqrt_det_spatial_metric, exponent);
   return logfac;
@@ -91,9 +85,7 @@ void spacetime_deriv_of_log_factor_metric_lapse(
     const tnsr::aa<DataType, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
     const double exponent) noexcept {
-  if (UNLIKELY(get_size(get<0>(*d4_logfac)) != get_size(get(lapse)))) {
-    *d4_logfac = tnsr::a<DataType, SpatialDim, Frame>(get_size(get(lapse)));
-  }
+  destructive_resize_components(d4_logfac, get_size(get(lapse)));
   // Use a TempBuffer to reduce total number of allocations. This is especially
   // important in a multithreaded environment.
   TempBuffer<tmpl::list<::Tags::Tempa<0, SpatialDim, Frame, DataType>,
@@ -147,7 +139,7 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_log_factor_metric_lapse(
     const tnsr::aa<DataType, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
     const double exponent) noexcept {
-  tnsr::a<DataType, SpatialDim, Frame> d4_logfac{};
+  tnsr::a<DataType, SpatialDim, Frame> d4_logfac{get_size(get(lapse))};
   spacetime_deriv_of_log_factor_metric_lapse(
       make_not_null(&d4_logfac), lapse, shift, spacetime_unit_normal,
       inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric, pi,
@@ -167,9 +159,7 @@ void spacetime_deriv_of_power_log_factor_metric_lapse(
     const tnsr::aa<DataType, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi, const double g_exponent,
     const int exponent) noexcept {
-  if (UNLIKELY(get_size(get<0>(*d4_powlogfac)) != get_size(get(lapse)))) {
-    *d4_powlogfac = tnsr::a<DataType, SpatialDim, Frame>(get_size(get(lapse)));
-  }
+  destructive_resize_components(d4_powlogfac, get_size(get(lapse)));
   // Use a TempBuffer to reduce total number of allocations. This is especially
   // important in a multithreaded environment.
   TempBuffer<tmpl::list<::Tags::Tempa<0, SpatialDim, Frame, DataType>,
@@ -217,7 +207,7 @@ spacetime_deriv_of_power_log_factor_metric_lapse(
     const tnsr::aa<DataType, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi, const double g_exponent,
     const int exponent) noexcept {
-  tnsr::a<DataType, SpatialDim, Frame> d4_powlogfac{};
+  tnsr::a<DataType, SpatialDim, Frame> d4_powlogfac{get_size(get(lapse))};
   spacetime_deriv_of_power_log_factor_metric_lapse(
       make_not_null(&d4_powlogfac), lapse, shift, spacetime_unit_normal,
       inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric, pi,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.cpp
@@ -1,0 +1,324 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.hpp"
+
+#include <cmath>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail {
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spatial_weight_function(const gsl::not_null<Scalar<DataType>*> weight,
+                             const tnsr::I<DataType, SpatialDim, Frame>& coords,
+                             const double sigma_r) noexcept {
+  if (UNLIKELY(get_size(get(*weight)) != get_size(get<0>(coords)))) {
+    *weight = Scalar<DataType>(get_size(get<0>(coords)));
+  }
+  const auto r_squared = dot_product(coords, coords);
+  get(*weight) = exp(-get(r_squared) / pow<2>(sigma_r));
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_deriv_of_spatial_weight_function(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_weight,
+    const tnsr::I<DataType, SpatialDim, Frame>& coords, const double sigma_r,
+    const Scalar<DataType>& weight_function) noexcept {
+  if (UNLIKELY(get_size(get<0>(*d4_weight)) != get_size(get<0>(coords)))) {
+    *d4_weight = tnsr::a<DataType, SpatialDim, Frame>(get_size(get<0>(coords)));
+  }
+  // use 0th component to avoid allocations
+  get<0>(*d4_weight) = get(weight_function) * (-2. / pow<2>(sigma_r));
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d4_weight->get(1 + i) = get<0>(*d4_weight) * coords.get(i);
+  }
+  // time derivative of weight function is zero
+  get<0>(*d4_weight) = 0.;
+}
+
+template <typename DataType>
+void log_factor_metric_lapse(const gsl::not_null<Scalar<DataType>*> logfac,
+                             const Scalar<DataType>& lapse,
+                             const Scalar<DataType>& sqrt_det_spatial_metric,
+                             const double exponent) noexcept {
+  if (UNLIKELY(get_size(get(*logfac)) != get_size(get(lapse)))) {
+    *logfac = Scalar<DataType>(get_size(get(lapse)));
+  }
+  // branching below is to avoid using pow for performance reasons
+  if (exponent == 0.) {
+    get(*logfac) = -log(get(lapse));
+  } else if (exponent == 0.5) {
+    get(*logfac) = log(get(sqrt_det_spatial_metric) / get(lapse));
+  } else {
+    get(*logfac) =
+        2. * exponent * log(get(sqrt_det_spatial_metric)) - log(get(lapse));
+  }
+}
+
+template <typename DataType>
+Scalar<DataType> log_factor_metric_lapse(
+    const Scalar<DataType>& lapse,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const double exponent) noexcept {
+  Scalar<DataType> logfac{};
+  log_factor_metric_lapse(make_not_null(&logfac), lapse,
+                          sqrt_det_spatial_metric, exponent);
+  return logfac;
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_deriv_of_log_factor_metric_lapse(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_logfac,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const double exponent) noexcept {
+  if (UNLIKELY(get_size(get<0>(*d4_logfac)) != get_size(get(lapse)))) {
+    *d4_logfac = tnsr::a<DataType, SpatialDim, Frame>(get_size(get(lapse)));
+  }
+  // Use a TempBuffer to reduce total number of allocations. This is especially
+  // important in a multithreaded environment.
+  TempBuffer<tmpl::list<::Tags::Tempa<0, SpatialDim, Frame, DataType>,
+                        ::Tags::Tempi<1, SpatialDim, Frame, DataType>,
+                        ::Tags::Tempa<2, SpatialDim, Frame, DataType>,
+                        ::Tags::TempScalar<3, DataType>,
+                        ::Tags::TempScalar<4, DataType>>>
+      buffer(get_size(get(lapse)));
+  auto& d_g = get<::Tags::Tempa<0, SpatialDim, Frame, DataType>>(buffer);
+  auto& d3_lapse = get<::Tags::Tempi<1, SpatialDim, Frame, DataType>>(buffer);
+  auto& d_lapse = get<::Tags::Tempa<2, SpatialDim, Frame, DataType>>(buffer);
+  auto& dt_lapse = get<::Tags::TempScalar<3, DataType>>(buffer);
+  auto& one_over_lapse = get<::Tags::TempScalar<4, DataType>>(buffer);
+
+  // Get \f$ \partial_a g\f$
+  spacetime_deriv_of_det_spatial_metric<SpatialDim, Frame, DataType>(
+      make_not_null(&d_g), sqrt_det_spatial_metric, inverse_spatial_metric,
+      dt_spatial_metric, phi);
+  // Get \f$ \partial_a N\f$
+  time_deriv_of_lapse<SpatialDim, Frame, DataType>(
+      make_not_null(&dt_lapse), lapse, shift, spacetime_unit_normal, phi, pi);
+  spatial_deriv_of_lapse<SpatialDim, Frame, DataType>(
+      make_not_null(&d3_lapse), lapse, spacetime_unit_normal, phi);
+  get<0>(d_lapse) = get(dt_lapse);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d_lapse.get(1 + i) = d3_lapse.get(i);
+  }
+  // Compute
+  get(one_over_lapse) = 1. / get(lapse);
+  if (exponent == 0.) {
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      d4_logfac->get(a) = -get(one_over_lapse) * d_lapse.get(a);
+    }
+  } else {
+    const auto p_over_g = exponent / square(get(sqrt_det_spatial_metric));
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      d4_logfac->get(a) =
+          p_over_g * d_g.get(a) - get(one_over_lapse) * d_lapse.get(a);
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_log_factor_metric_lapse(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const double exponent) noexcept {
+  tnsr::a<DataType, SpatialDim, Frame> d4_logfac{};
+  spacetime_deriv_of_log_factor_metric_lapse(
+      make_not_null(&d4_logfac), lapse, shift, spacetime_unit_normal,
+      inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric, pi,
+      phi, exponent);
+  return d4_logfac;
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_deriv_of_power_log_factor_metric_lapse(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_powlogfac,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, const double g_exponent,
+    const int exponent) noexcept {
+  if (UNLIKELY(get_size(get<0>(*d4_powlogfac)) != get_size(get(lapse)))) {
+    *d4_powlogfac = tnsr::a<DataType, SpatialDim, Frame>(get_size(get(lapse)));
+  }
+  // Use a TempBuffer to reduce total number of allocations. This is especially
+  // important in a multithreaded environment.
+  TempBuffer<tmpl::list<::Tags::Tempa<0, SpatialDim, Frame, DataType>,
+                        ::Tags::TempScalar<1, DataType>,
+                        ::Tags::TempScalar<2, DataType>>>
+      buffer(get_size(get(lapse)));
+  auto& dlogfac = get<::Tags::Tempa<0, SpatialDim, Frame, DataType>>(buffer);
+  auto& logfac = get<::Tags::TempScalar<1, DataType>>(buffer);
+  auto& prefac = get<::Tags::TempScalar<2, DataType>>(buffer);
+
+  // Compute derivative
+  spacetime_deriv_of_log_factor_metric_lapse<SpatialDim, Frame, DataType>(
+      make_not_null(&dlogfac), lapse, shift, spacetime_unit_normal,
+      inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric, pi,
+      phi, g_exponent);
+  // Apply pre-factor
+  if (UNLIKELY(exponent == 0)) {
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      d4_powlogfac->get(a) = 0.;
+    }
+  } else if (UNLIKELY(exponent == 1)) {
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      d4_powlogfac->get(a) = dlogfac.get(a);
+    }
+  } else {
+    log_factor_metric_lapse<DataType>(make_not_null(&logfac), lapse,
+                                      sqrt_det_spatial_metric, g_exponent);
+    get(prefac) =
+        static_cast<double>(exponent) * pow(get(logfac), exponent - 1);
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      d4_powlogfac->get(a) = get(prefac) * dlogfac.get(a);
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame>
+spacetime_deriv_of_power_log_factor_metric_lapse(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, const double g_exponent,
+    const int exponent) noexcept {
+  tnsr::a<DataType, SpatialDim, Frame> d4_powlogfac{};
+  spacetime_deriv_of_power_log_factor_metric_lapse(
+      make_not_null(&d4_powlogfac), lapse, shift, spacetime_unit_normal,
+      inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric, pi,
+      phi, g_exponent, exponent);
+  return d4_powlogfac;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define DTYPE_SCAL(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template void spatial_weight_function(                                      \
+      const gsl::not_null<Scalar<DTYPE(data)>*> weight,                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,             \
+      const double sigma_r) noexcept;                                         \
+  template void spacetime_deriv_of_spatial_weight_function(                   \
+      const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>      \
+          d4_weight,                                                          \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,             \
+      const double sigma_r,                                                   \
+      const Scalar<DTYPE(data)>& weight_function) noexcept;                   \
+  template void spacetime_deriv_of_log_factor_metric_lapse(                   \
+      const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>      \
+          d4_logfac,                                                          \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal,                                              \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spatial_metric,                                             \
+      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                     \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,                \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const double exponent) noexcept;                                        \
+  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \
+  spacetime_deriv_of_log_factor_metric_lapse(                                 \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal,                                              \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spatial_metric,                                             \
+      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                     \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,                \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const double exponent) noexcept;                                        \
+  template void spacetime_deriv_of_power_log_factor_metric_lapse(             \
+      const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>      \
+          d4_powlogfac,                                                       \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal,                                              \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spatial_metric,                                             \
+      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                     \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,                \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const double g_exponent, const int exponent) noexcept;                  \
+  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \
+  spacetime_deriv_of_power_log_factor_metric_lapse(                           \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal,                                              \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spatial_metric,                                             \
+      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                     \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,                \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const double g_exponent, const int exponent) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Inertial))
+
+#undef INSTANTIATE
+
+#define INSTANTIATE(_, data)                                   \
+  template void log_factor_metric_lapse(                       \
+      const gsl::not_null<Scalar<DTYPE_SCAL(data)>*> logfac,   \
+      const Scalar<DTYPE_SCAL(data)>& lapse,                   \
+      const Scalar<DTYPE_SCAL(data)>& sqrt_det_spatial_metric, \
+      const double exponent) noexcept;                         \
+  template Scalar<DTYPE_SCAL(data)> log_factor_metric_lapse(   \
+      const Scalar<DTYPE_SCAL(data)>& lapse,                   \
+      const Scalar<DTYPE_SCAL(data)>& sqrt_det_spatial_metric, \
+      const double exponent) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef INSTANTIATE
+
+#undef DTYPE_SCAL
+#undef FRAME
+#undef DTYPE
+#undef DIM
+}  // namespace GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail
+/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.hpp
@@ -1,0 +1,141 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace GeneralizedHarmonic {
+namespace gauges {
+namespace DampedHarmonicGauge_detail {
+/*
+ * Spatial weight function used in the damped harmonic gauge source
+ * function.
+ *
+ * The spatial weight function is:
+ * \f{align*}{
+ *   W(x^i) = \exp(- (r / \sigma_r)^2),
+ * \f}
+ *
+ * where \f$r=\sqrt{x^i\delta_{ij}x^j}\f$ is the coordinate radius, and
+ * \f$\sigma_r\f$ is the width of the Gaussian.
+ *
+ * This function can be written with an extra factor inside the exponent in
+ * literature, e.g. \cite Deppe2018uye. We absorb that in \f$\sigma_r\f$.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spatial_weight_function(gsl::not_null<Scalar<DataType>*> weight,
+                             const tnsr::I<DataType, SpatialDim, Frame>& coords,
+                             double sigma_r) noexcept;
+
+/*
+ * Spacetime derivatives of the spatial weight function that enters the
+ * damped harmonic gauge source function.
+ *
+ * Compute the derivatives:
+ * \f{align*}{
+ * \partial_a W(x^i)= \partial_a \exp(- (r/\sigma_r)^2)
+ *                  = (-2 * x^i / \sigma_r^2) * exp(-(r/\sigma_r)^2)
+ * \f}
+ *
+ * where \f$r=\sqrt{x^i\delta_{ij}x^j}\f$ is the coordinate radius, and
+ * \f$\sigma_r\f$ is the width of the Gaussian. Since the weight function is
+ * spatial, the time derivative is always zero.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_deriv_of_spatial_weight_function(
+    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_weight,
+    const tnsr::I<DataType, SpatialDim, Frame>& coords, double sigma_r,
+    const Scalar<DataType>& weight_function) noexcept;
+
+/*
+ * The log factor that appears in damped harmonic gauge source function.
+ *
+ * Calculates:  \f$ logF = \mathrm{log}(g^p/N) \f$.
+ */
+template <typename DataType>
+void log_factor_metric_lapse(gsl::not_null<Scalar<DataType>*> logfac,
+                             const Scalar<DataType>& lapse,
+                             const Scalar<DataType>& sqrt_det_spatial_metric,
+                             double exponent) noexcept;
+
+template <typename DataType>
+Scalar<DataType> log_factor_metric_lapse(
+    const Scalar<DataType>& lapse,
+    const Scalar<DataType>& sqrt_det_spatial_metric, double exponent) noexcept;
+
+/*
+ * Spacetime derivatives of the log factor that appears in the
+ * damped harmonic gauge source function.
+ *
+ * Computes the spacetime derivatives:
+ * \f{align*}{
+ *  \partial_a logF = (p/g)\partial_a g - (1/N)\partial_a N
+ * \f}
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_deriv_of_log_factor_metric_lapse(
+    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_logfac,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    double exponent) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_log_factor_metric_lapse(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    double exponent) noexcept;
+
+/*
+ * Spacetime derivatives of the log factor (that appears in
+ * damped harmonic gauge source function), raised to an exponent.
+ *
+ * Computes the spacetime derivatives:
+ * \f{align*}{
+ *  \partial_a (logF)^q = q (logF)^{q-1} \partial_a (logF)
+ * \f}
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_deriv_of_power_log_factor_metric_lapse(
+    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_powlogfac,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, double g_exponent,
+    int exponent) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame>
+spacetime_deriv_of_power_log_factor_metric_lapse(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, double g_exponent,
+    int exponent) noexcept;
+
+}  // namespace DampedHarmonicGauge_detail
+}  // namespace gauges
+}  // namespace GeneralizedHarmonic

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_GeneralizedHarmonicGaugeSourceFunctions")
 
 set(LIBRARY_SOURCES
   Test_DampedHarmonicGaugeQuantities.cpp
+  Test_DampedWaveHelpers.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.py
@@ -2,26 +2,16 @@
 # See LICENSE.txt for details.
 
 import numpy as np
-import os
-import sys
+
 from PointwiseFunctions.GeneralRelativity.ComputeGhQuantities import (
     spacetime_deriv_detg, deriv_lapse, dt_lapse, deriv_spatial_metric,
     dt_spatial_metric, deriv_shift, dt_shift)
 from PointwiseFunctions.GeneralRelativity.ComputeSpacetimeQuantities import (
     derivatives_of_spacetime_metric, inverse_spacetime_metric,
     spacetime_normal_vector)
-
-
-def spatial_weight_function(coords, r_max):
-    r2 = np.sum([coords[i]**2 for i in range(len(coords))])
-    return np.exp(-r2 / r_max / r_max)
-
-
-def spacetime_deriv_spatial_weight_function(coords, r_max):
-    W = spatial_weight_function(coords, r_max)
-    DW = np.zeros(len(coords) + 1)
-    DW[1:] = -2. * W / r_max / r_max * coords
-    return DW
+from .DampedWaveHelpers import (spatial_weight_function,
+                                spacetime_deriv_spatial_weight_function,
+                                log_fac)
 
 
 def roll_on_function(time, t_start, sigma_t):
@@ -35,41 +25,6 @@ def time_deriv_roll_on_function(time, t_start, sigma_t):
         return 0.
     tnrm = (time - t_start) / sigma_t
     return np.exp(-tnrm**4) * 4 * tnrm**3 / sigma_t
-
-
-def log_fac(lapse, sqrt_det_spatial_metric, exponent):
-    # if exponent == 0, the first term automatically vanishes
-    return exponent * np.log(sqrt_det_spatial_metric**2) - np.log(lapse)
-
-
-def spacetime_deriv_log_fac(lapse, shift, spacetime_unit_normal,
-                            inverse_spatial_metric, sqrt_det_spatial_metric,
-                            dt_spatial_metric, pi, phi, exponent):
-    spatial_dim = len(shift)
-    detg = sqrt_det_spatial_metric**2
-    dg = spacetime_deriv_detg(sqrt_det_spatial_metric, inverse_spatial_metric,
-                              dt_spatial_metric, phi)
-    d0N = dt_lapse(lapse, shift, spacetime_unit_normal, phi, pi)
-    d3N = deriv_lapse(lapse, spacetime_unit_normal, phi)
-    d4N = np.zeros(1 + spatial_dim)
-    d4N[0] = d0N
-    d4N[1:] = d3N
-    # if exponent == 0, the first term automatically vanishes
-    d_logfac = (exponent / detg) * dg - (1. / lapse) * d4N
-    return d_logfac
-
-
-def spacetime_deriv_pow_log_fac(lapse, shift, spacetime_unit_normal,
-                                inverse_spatial_metric,
-                                sqrt_det_spatial_metric, dt_spatial_metric, pi,
-                                phi, g_exponent, exponent):
-    exponent = int(exponent)
-    dlogfac = spacetime_deriv_log_fac(lapse, shift, spacetime_unit_normal,
-                                      inverse_spatial_metric,
-                                      sqrt_det_spatial_metric,
-                                      dt_spatial_metric, pi, phi, g_exponent)
-    logfac = log_fac(lapse, sqrt_det_spatial_metric, g_exponent)
-    return exponent * np.power(logfac, exponent - 1) * dlogfac
 
 
 def spatial_metric_from_spacetime_metric(spacetime_metric):

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.py
@@ -1,0 +1,55 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+from PointwiseFunctions.GeneralRelativity.ComputeGhQuantities import (
+    spacetime_deriv_detg, deriv_lapse, dt_lapse)
+
+
+def spatial_weight_function(coords, r_max):
+    r2 = np.sum([coords[i]**2 for i in range(len(coords))])
+    return np.exp(-r2 / r_max / r_max)
+
+
+def spacetime_deriv_spatial_weight_function(coords, r_max, W=None):
+    if W is None:
+        W = spatial_weight_function(coords, r_max)
+    DW = np.zeros(len(coords) + 1)
+    DW[1:] = -2. * W / r_max / r_max * coords
+    return DW
+
+
+def log_fac(lapse, sqrt_det_spatial_metric, exponent):
+    # if exponent == 0, the first term automatically vanishes
+    return exponent * np.log(sqrt_det_spatial_metric**2) - np.log(lapse)
+
+
+def spacetime_deriv_log_fac(lapse, shift, spacetime_unit_normal,
+                            inverse_spatial_metric, sqrt_det_spatial_metric,
+                            dt_spatial_metric, pi, phi, exponent):
+    spatial_dim = len(shift)
+    detg = sqrt_det_spatial_metric**2
+    dg = spacetime_deriv_detg(sqrt_det_spatial_metric, inverse_spatial_metric,
+                              dt_spatial_metric, phi)
+    d0N = dt_lapse(lapse, shift, spacetime_unit_normal, phi, pi)
+    d3N = deriv_lapse(lapse, spacetime_unit_normal, phi)
+    d4N = np.zeros(1 + spatial_dim)
+    d4N[0] = d0N
+    d4N[1:] = d3N
+    # if exponent == 0, the first term automatically vanishes
+    d_logfac = (exponent / detg) * dg - (1. / lapse) * d4N
+    return d_logfac
+
+
+def spacetime_deriv_pow_log_fac(lapse, shift, spacetime_unit_normal,
+                                inverse_spatial_metric,
+                                sqrt_det_spatial_metric, dt_spatial_metric, pi,
+                                phi, g_exponent, exponent):
+    exponent = int(exponent)
+    dlogfac = spacetime_deriv_log_fac(lapse, shift, spacetime_unit_normal,
+                                      inverse_spatial_metric,
+                                      sqrt_det_spatial_metric,
+                                      dt_spatial_metric, pi, phi, g_exponent)
+    logfac = log_fac(lapse, sqrt_det_spatial_metric, g_exponent)
+    return exponent * np.power(logfac, exponent - 1) * dlogfac

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -26,6 +26,7 @@
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
@@ -54,22 +55,7 @@ struct dt;
 }  // namespace Tags
 /// \endcond
 
-namespace GeneralizedHarmonic {
-namespace gauges {
-namespace DampedHarmonicGauge_detail {
-// The `detail` functions below are forward-declared to enable their independent
-// testing
-template <size_t SpatialDim, typename Frame, typename DataType>
-void spatial_weight_function(gsl::not_null<Scalar<DataType>*> weight,
-                             const tnsr::I<DataType, SpatialDim, Frame>& coords,
-                             double sigma_r) noexcept;
-
-template <size_t SpatialDim, typename Frame, typename DataType>
-void spacetime_deriv_of_spatial_weight_function(
-    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_weight,
-    const tnsr::I<DataType, SpatialDim, Frame>& coords, double sigma_r,
-    const Scalar<DataType>& spatial_weight_function) noexcept;
-
+namespace GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail {
 // The return-by-value implementations of spatial_weight_function and
 // spacetime_deriv_of_spatial_weight_function are intentionally only available
 // in the test because while convenient the additional allocations are bad for
@@ -99,77 +85,7 @@ double roll_on_function(double time, double t_start, double sigma_t) noexcept;
 
 double time_deriv_of_roll_on_function(double time, double t_start,
                                       double sigma_t) noexcept;
-
-template <typename DataType>
-Scalar<DataType> log_factor_metric_lapse(
-    const Scalar<DataType>& lapse,
-    const Scalar<DataType>& sqrt_det_spatial_metric, double exponent) noexcept;
-
-template <size_t SpatialDim, typename Frame, typename DataType>
-tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_log_factor_metric_lapse(
-    const Scalar<DataType>& lapse,
-    const tnsr::I<DataType, SpatialDim, Frame>& shift,
-    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
-    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
-    const Scalar<DataType>& sqrt_det_spatial_metric,
-    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
-    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
-    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
-    double exponent) noexcept;
-
-template <size_t SpatialDim, typename Frame, typename DataType>
-void spacetime_deriv_of_power_log_factor_metric_lapse(
-    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_powlogfac,
-    const Scalar<DataType>& lapse,
-    const tnsr::I<DataType, SpatialDim, Frame>& shift,
-    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
-    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
-    const Scalar<DataType>& sqrt_det_spatial_metric,
-    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
-    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
-    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, double g_exponent,
-    int exponent) noexcept;
-
-template <size_t SpatialDim, typename Frame, typename DataType>
-tnsr::a<DataType, SpatialDim, Frame>
-spacetime_deriv_of_power_log_factor_metric_lapse(
-    const Scalar<DataType>& lapse,
-    const tnsr::I<DataType, SpatialDim, Frame>& shift,
-    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
-    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
-    const Scalar<DataType>& sqrt_det_spatial_metric,
-    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
-    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
-    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, double g_exponent,
-    int exponent) noexcept;
-}  // namespace DampedHarmonicGauge_detail
-}  // namespace gauges
-}  // namespace GeneralizedHarmonic
-
-// Wrap `wrap_spacetime_deriv_of_power_log_factor_metric_lapse` here to make its
-// last argument a double, allowing for `pypp::check_with_random_values` to
-// work.
-template <size_t SpatialDim, typename Frame, typename DataType>
-tnsr::a<DataType, SpatialDim, Frame>
-wrap_spacetime_deriv_of_power_log_factor_metric_lapse(
-    const Scalar<DataType>& lapse,
-    const tnsr::I<DataType, SpatialDim, Frame>& shift,
-    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
-    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
-    const Scalar<DataType>& sqrt_det_spatial_metric,
-    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
-    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
-    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, const double g_exponent,
-    const double d_exponent) noexcept {
-  const auto exponent = static_cast<int>(d_exponent);
-  tnsr::a<DataType, SpatialDim, Frame> d4_powlogfac{};
-  GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
-      spacetime_deriv_of_power_log_factor_metric_lapse(
-          make_not_null(&d4_powlogfac), lapse, shift, spacetime_unit_normal,
-          inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric,
-          pi, phi, g_exponent, exponent);
-  return d4_powlogfac;
-}
+}  // namespace GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail
 
 namespace {
 using Affine = domain::CoordinateMaps::Affine;
@@ -202,29 +118,6 @@ void test_options() noexcept {
 
 template <size_t SpatialDim, typename Frame, typename DataType>
 void test_detail_functions(const DataType& used_for_size) noexcept {
-  // weight_function
-  pypp::check_with_random_values<2>(
-      static_cast<Scalar<DataType> (*)(
-          const tnsr::I<DataType, SpatialDim, Frame>&, const double)>(
-          &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
-              spatial_weight_function<SpatialDim, Frame, DataType>),
-      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
-      "DampedHarmonic",
-      "spatial_weight_function",
-      {{{-10., 10.}, {std::numeric_limits<double>::denorm_min(), 10.}}},
-      used_for_size);
-  // spacetime_deriv_of_spatial_weight_function
-  pypp::check_with_random_values<2>(
-      static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
-          const tnsr::I<DataType, SpatialDim, Frame>&, const double)>(
-          &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
-              spacetime_deriv_of_spatial_weight_function<SpatialDim, Frame,
-                                                         DataType>),
-      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
-      "DampedHarmonic",
-      "spacetime_deriv_spatial_weight_function",
-      {{{-10., 10.}, {std::numeric_limits<double>::denorm_min(), 10.}}},
-      used_for_size);
   // roll_on_function
   pypp::check_with_random_values<1>(
       &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
@@ -241,42 +134,6 @@ void test_detail_functions(const DataType& used_for_size) noexcept {
       "DampedHarmonic",
       "time_deriv_roll_on_function",
       {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size);
-  // log_factor_metric_lapse
-  pypp::check_with_random_values<1>(
-      static_cast<Scalar<DataType> (*)(const Scalar<DataType>&,
-                                       const Scalar<DataType>&, const double)>(
-          &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
-              log_factor_metric_lapse<DataType>),
-      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
-      "DampedHarmonic",
-      "log_fac", {{{std::numeric_limits<double>::denorm_min(), 10.}}},
-      used_for_size);
-  // spacetime_deriv_of_log_factor_metric_lapse
-  pypp::check_with_random_values<1>(
-      static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
-          const Scalar<DataType>&, const tnsr::I<DataType, SpatialDim, Frame>&,
-          const tnsr::A<DataType, SpatialDim, Frame>&,
-          const tnsr::II<DataType, SpatialDim, Frame>&, const Scalar<DataType>&,
-          const tnsr::ii<DataType, SpatialDim, Frame>&,
-          const tnsr::aa<DataType, SpatialDim, Frame>&,
-          const tnsr::iaa<DataType, SpatialDim, Frame>&, const double)>(
-          &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
-              spacetime_deriv_of_log_factor_metric_lapse<SpatialDim, Frame,
-                                                         DataType>),
-      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
-      "DampedHarmonic",
-      "spacetime_deriv_log_fac",
-      {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size,
-      1.0e-11);
-  // spacetime_deriv_of_power_log_factor_metric_lapse
-  pypp::check_with_random_values<1>(
-      &wrap_spacetime_deriv_of_power_log_factor_metric_lapse<SpatialDim, Frame,
-                                                             DataType>,
-      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
-      "DampedHarmonic",
-      "spacetime_deriv_pow_log_fac",
-      {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size,
-      1.e-11);
 }
 
 //

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedWaveHelpers.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedWaveHelpers.cpp
@@ -1,0 +1,112 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+
+namespace {
+// Wrap `wrap_spacetime_deriv_of_power_log_factor_metric_lapse` here to make its
+// last argument a double, allowing for `pypp::check_with_random_values` to
+// work.
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame>
+wrap_spacetime_deriv_of_power_log_factor_metric_lapse(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, const double g_exponent,
+    const double d_exponent) noexcept {
+  const auto exponent = static_cast<int>(d_exponent);
+  tnsr::a<DataType, SpatialDim, Frame> d4_powlogfac{};
+  GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+      spacetime_deriv_of_power_log_factor_metric_lapse(
+          make_not_null(&d4_powlogfac), lapse, shift, spacetime_unit_normal,
+          inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric,
+          pi, phi, g_exponent, exponent);
+  return d4_powlogfac;
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void test_detail_functions(const DataType& used_for_size) noexcept {
+  // weight_function
+  pypp::check_with_random_values<2>(
+      &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+          spatial_weight_function<SpatialDim, Frame, DataType>,
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedWaveHelpers",
+      {"spatial_weight_function"},
+      {{{-10., 10.}, {std::numeric_limits<double>::denorm_min(), 10.}}},
+      used_for_size);
+  // spacetime_deriv_of_spatial_weight_function
+  pypp::check_with_random_values<3>(
+      &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+          spacetime_deriv_of_spatial_weight_function<SpatialDim, Frame,
+                                                     DataType>,
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedWaveHelpers",
+      {"spacetime_deriv_spatial_weight_function"},
+      {{{-10., 10.},
+        {std::numeric_limits<double>::denorm_min(), 10.},
+        {std::numeric_limits<double>::denorm_min(), 10.}}},
+      used_for_size);
+  // log_factor_metric_lapse
+  pypp::check_with_random_values<1>(
+      static_cast<Scalar<DataType> (*)(const Scalar<DataType>&,
+                                       const Scalar<DataType>&, const double)>(
+          &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+              log_factor_metric_lapse<DataType>),
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedWaveHelpers",
+      "log_fac", {{{std::numeric_limits<double>::denorm_min(), 10.}}},
+      used_for_size);
+  // spacetime_deriv_of_log_factor_metric_lapse
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
+          const Scalar<DataType>&, const tnsr::I<DataType, SpatialDim, Frame>&,
+          const tnsr::A<DataType, SpatialDim, Frame>&,
+          const tnsr::II<DataType, SpatialDim, Frame>&, const Scalar<DataType>&,
+          const tnsr::ii<DataType, SpatialDim, Frame>&,
+          const tnsr::aa<DataType, SpatialDim, Frame>&,
+          const tnsr::iaa<DataType, SpatialDim, Frame>&, const double)>(
+          &::GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail::
+              spacetime_deriv_of_log_factor_metric_lapse<SpatialDim, Frame,
+                                                         DataType>),
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedWaveHelpers",
+      "spacetime_deriv_log_fac",
+      {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size,
+      1.0e-11);
+  // spacetime_deriv_of_power_log_factor_metric_lapse
+  pypp::check_with_random_values<1>(
+      &wrap_spacetime_deriv_of_power_log_factor_metric_lapse<SpatialDim, Frame,
+                                                             DataType>,
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedWaveHelpers",
+      "spacetime_deriv_pow_log_fac",
+      {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size,
+      1.e-11);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.Gauge.DampedWaveHelpers",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+  const DataVector used_for_size(4);
+
+  test_detail_functions<1, Frame::Inertial>(used_for_size);
+  test_detail_functions<2, Frame::Inertial>(used_for_size);
+  test_detail_functions<3, Frame::Inertial>(used_for_size);
+
+  test_detail_functions<1, Frame::Inertial>(1.);
+  test_detail_functions<2, Frame::Inertial>(1.);
+  test_detail_functions<3, Frame::Inertial>(1.);
+}


### PR DESCRIPTION
## Proposed changes

- factor out the weight and log factor functions from the DH file. This makes the file DH file a lot easier to navigate and will make it easier to reuse the functions in other damped wave-like gauges.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
