### PR TITLE
Add named tags for the temporary tags used inside GH RHS

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace GeneralizedHarmonic {
+namespace Tags {
+/// \f$\gamma_1 \gamma_2\f$ constraint damping product
+struct Gamma1Gamma2 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/// \f$\Pi_{ab}n^an^b\f$
+struct PiTwoNormals : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/// \f$n^a \mathcal{C}_a\f$
+struct NormalDotOneIndexConstraint : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/// \f$\gamma_1 + 1\f$
+struct Gamma1Plus1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/// \f$\Pi_{ab}n^a\f$
+template <size_t Dim>
+struct PiOneNormal : db::SimpleTag {
+  using type = tnsr::a<DataVector, Dim, Frame::Inertial>;
+};
+
+/// \f$\Phi_{iab}n^an^b\f$
+template <size_t Dim>
+struct PhiTwoNormals : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+};
+
+/// \f$\beta^i \mathcal{C}_{iab}\f$
+template <size_t Dim>
+struct ShiftDotThreeIndexConstraint : db::SimpleTag {
+  using type = tnsr::aa<DataVector, Dim, Frame::Inertial>;
+};
+
+/// \f$\Phi_{iab}n^a\f$
+template <size_t Dim>
+struct PhiOneNormal : db::SimpleTag {
+  using type = tnsr::ia<DataVector, Dim, Frame::Inertial>;
+};
+
+/// \f$\Pi_a{}^b\f$
+template <size_t Dim>
+struct PiSecondIndexUp : db::SimpleTag {
+  using type = tnsr::aB<DataVector, Dim, Frame::Inertial>;
+};
+
+/// \f$\Phi^i{}_{ab}\f$
+template <size_t Dim>
+struct PhiFirstIndexUp : db::SimpleTag {
+  using type = tnsr::Iaa<DataVector, Dim, Frame::Inertial>;
+};
+
+/// \f$\Phi_{ia}{}^b\f$
+template <size_t Dim>
+struct PhiThirdIndexUp : db::SimpleTag {
+  using type = tnsr::iaB<DataVector, Dim, Frame::Inertial>;
+};
+
+/// \f$\Gamma_{ab}{}^c\f$
+template <size_t Dim>
+struct SpacetimeChristoffelFirstKindThirdIndexUp : db::SimpleTag {
+  using type = tnsr::abC<DataVector, Dim, Frame::Inertial>;
+};
+}  // namespace Tags
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
@@ -12,7 +12,9 @@
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "DataStructures/Variables.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
@@ -44,32 +46,15 @@ void ComputeDuDt<Dim>::apply(
     const tnsr::ab<DataVector, Dim>& spacetime_deriv_gauge_function) {
   const size_t n_pts = spacetime_metric[0].size();
 
-  // Scalar: TempScalar<0> = gamma12
-  //         TempScalar<1> = pi_contract_two_normal_spacetime_vectors
-  //         TempScalar<2> = normal_dot_one_index_constraint
-  //         TempScalar<3> = gamma1p1
-  // a: Tempa<0> = pi_dot_normal_spacetime_vector
-  //    Tempa<1> = one_index_constraint
-  // i: Tempi<0> = phi_contract_two_normal_spacetime_vectors
-  // aa: shift_dot_three_index_constraint
-  // ia: phi_dot_normal_spacetime_vector
-  // aB: pi_2_up
-  // iaa: three_index_constraint
-  // Iaa: phi_1_up
-  // ibC: phi_3_up
-  // abC: christoffel_first_kind_3_up
   Variables<tmpl::list<
-      ::Tags::TempScalar<0>, ::Tags::TempScalar<1>, ::Tags::TempScalar<2>,
-      ::Tags::TempScalar<3>, ::Tags::Tempa<0, Dim, Frame::Inertial, DataVector>,
-      ::Tags::Tempa<1, Dim, Frame::Inertial, DataVector>,
-      ::Tags::Tempi<0, Dim, Frame::Inertial, DataVector>,
-      ::Tags::Tempaa<0, Dim, Frame::Inertial, DataVector>,
-      ::Tags::Tempia<0, Dim, Frame::Inertial, DataVector>,
-      ::Tags::TempaB<0, Dim, Frame::Inertial, DataVector>,
-      ::Tags::Tempiaa<0, Dim, Frame::Inertial, DataVector>,
-      ::Tags::TempIaa<0, Dim, Frame::Inertial, DataVector>,
-      ::Tags::TempiaB<0, Dim, Frame::Inertial, DataVector>,
-      ::Tags::TempabC<0, Dim, Frame::Inertial, DataVector>,
+      Tags::Gamma1Gamma2, Tags::PiTwoNormals, Tags::NormalDotOneIndexConstraint,
+      Tags::Gamma1Plus1, Tags::PiOneNormal<Dim>,
+      Tags::GaugeConstraint<Dim, Frame::Inertial>, Tags::PhiTwoNormals<Dim>,
+      Tags::ShiftDotThreeIndexConstraint<Dim>, Tags::PhiOneNormal<Dim>,
+      Tags::PiSecondIndexUp<Dim>,
+      Tags::ThreeIndexConstraint<Dim, Frame::Inertial>,
+      Tags::PhiFirstIndexUp<Dim>, Tags::PhiThirdIndexUp<Dim>,
+      Tags::SpacetimeChristoffelFirstKindThirdIndexUp<Dim>,
       gr::Tags::Lapse<DataVector>,
       gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
       gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataVector>,
@@ -138,11 +123,11 @@ void ComputeDuDt<Dim>::apply(
   gr::spacetime_normal_one_form(make_not_null(&normal_spacetime_one_form),
                                 lapse);
 
-  get(get<::Tags::TempScalar<0>>(buffer)) = gamma1.get() * gamma2.get();
-  const DataVector& gamma12 = get(get<::Tags::TempScalar<0>>(buffer));
+  get(get<Tags::Gamma1Gamma2>(buffer)) = gamma1.get() * gamma2.get();
+  const DataVector& gamma12 = get(get<Tags::Gamma1Gamma2>(buffer));
 
   tnsr::Iaa<DataVector, Dim>& phi_1_up =
-      get<::Tags::TempIaa<0, Dim, Frame::Inertial, DataVector>>(buffer);
+      get<Tags::PhiFirstIndexUp<Dim>>(buffer);
   for (size_t m = 0; m < Dim; ++m) {
     for (size_t mu = 0; mu < Dim + 1; ++mu) {
       for (size_t nu = mu; nu < Dim + 1; ++nu) {
@@ -157,7 +142,7 @@ void ComputeDuDt<Dim>::apply(
   }
 
   tnsr::iaB<DataVector, Dim>& phi_3_up =
-      get<::Tags::TempiaB<0, Dim, Frame::Inertial, DataVector>>(buffer);
+      get<Tags::PhiThirdIndexUp<Dim>>(buffer);
   for (size_t m = 0; m < Dim; ++m) {
     for (size_t nu = 0; nu < Dim + 1; ++nu) {
       for (size_t alpha = 0; alpha < Dim + 1; ++alpha) {
@@ -171,8 +156,7 @@ void ComputeDuDt<Dim>::apply(
     }
   }
 
-  tnsr::aB<DataVector, Dim>& pi_2_up =
-      get<::Tags::TempaB<0, Dim, Frame::Inertial, DataVector>>(buffer);
+  tnsr::aB<DataVector, Dim>& pi_2_up = get<Tags::PiSecondIndexUp<Dim>>(buffer);
   for (size_t nu = 0; nu < Dim + 1; ++nu) {
     for (size_t alpha = 0; alpha < Dim + 1; ++alpha) {
       pi_2_up.get(nu, alpha) =
@@ -185,7 +169,7 @@ void ComputeDuDt<Dim>::apply(
   }
 
   tnsr::abC<DataVector, Dim>& christoffel_first_kind_3_up =
-      get<::Tags::TempabC<0, Dim, Frame::Inertial, DataVector>>(buffer);
+      get<Tags::SpacetimeChristoffelFirstKindThirdIndexUp<Dim>>(buffer);
   for (size_t mu = 0; mu < Dim + 1; ++mu) {
     for (size_t nu = 0; nu < Dim + 1; ++nu) {
       for (size_t alpha = 0; alpha < Dim + 1; ++alpha) {
@@ -202,7 +186,7 @@ void ComputeDuDt<Dim>::apply(
   }
 
   tnsr::a<DataVector, Dim>& pi_dot_normal_spacetime_vector =
-      get<::Tags::Tempa<0, Dim, Frame::Inertial, DataVector>>(buffer);
+      get<Tags::PiOneNormal<Dim>>(buffer);
   for (size_t mu = 0; mu < Dim + 1; ++mu) {
     pi_dot_normal_spacetime_vector.get(mu) =
         get<0>(normal_spacetime_vector) * pi.get(0, mu);
@@ -213,7 +197,7 @@ void ComputeDuDt<Dim>::apply(
   }
 
   DataVector& pi_contract_two_normal_spacetime_vectors =
-      get(get<::Tags::TempScalar<1>>(buffer));
+      get(get<Tags::PiTwoNormals>(buffer));
   pi_contract_two_normal_spacetime_vectors =
       get<0>(normal_spacetime_vector) * get<0>(pi_dot_normal_spacetime_vector);
   for (size_t mu = 1; mu < Dim + 1; ++mu) {
@@ -223,7 +207,7 @@ void ComputeDuDt<Dim>::apply(
   }
 
   tnsr::ia<DataVector, Dim>& phi_dot_normal_spacetime_vector =
-      get<::Tags::Tempia<0, Dim, Frame::Inertial, DataVector>>(buffer);
+      get<Tags::PhiOneNormal<Dim>>(buffer);
   for (size_t n = 0; n < Dim; ++n) {
     for (size_t nu = 0; nu < Dim + 1; ++nu) {
       phi_dot_normal_spacetime_vector.get(n, nu) =
@@ -236,7 +220,7 @@ void ComputeDuDt<Dim>::apply(
   }
 
   tnsr::i<DataVector, Dim>& phi_contract_two_normal_spacetime_vectors =
-      get<::Tags::Tempi<0, Dim, Frame::Inertial, DataVector>>(buffer);
+      get<Tags::PhiTwoNormals<Dim>>(buffer);
   for (size_t n = 0; n < Dim; ++n) {
     phi_contract_two_normal_spacetime_vectors.get(n) =
         get<0>(normal_spacetime_vector) *
@@ -249,7 +233,7 @@ void ComputeDuDt<Dim>::apply(
   }
 
   tnsr::iaa<DataVector, Dim>& three_index_constraint =
-      get<::Tags::Tempiaa<0, Dim, Frame::Inertial, DataVector>>(buffer);
+      get<Tags::ThreeIndexConstraint<Dim, Frame::Inertial>>(buffer);
   for (size_t n = 0; n < Dim; ++n) {
     for (size_t mu = 0; mu < Dim + 1; ++mu) {
       for (size_t nu = mu; nu < Dim + 1; ++nu) {
@@ -260,14 +244,14 @@ void ComputeDuDt<Dim>::apply(
   }
 
   tnsr::a<DataVector, Dim>& one_index_constraint =
-      get<::Tags::Tempa<1, Dim, Frame::Inertial, DataVector>>(buffer);
+      get<Tags::GaugeConstraint<Dim, Frame::Inertial>>(buffer);
   for (size_t nu = 0; nu < Dim + 1; ++nu) {
     one_index_constraint.get(nu) =
         gauge_function.get(nu) + trace_christoffel.get(nu);
   }
 
   DataVector& normal_dot_one_index_constraint =
-      get(get<::Tags::TempScalar<2>>(buffer));
+      get(get<Tags::NormalDotOneIndexConstraint>(buffer));
   normal_dot_one_index_constraint =
       get<0>(normal_spacetime_vector) * get<0>(one_index_constraint);
   for (size_t mu = 1; mu < Dim + 1; ++mu) {
@@ -275,11 +259,11 @@ void ComputeDuDt<Dim>::apply(
         normal_spacetime_vector.get(mu) * one_index_constraint.get(mu);
   }
 
-  get(get<::Tags::TempScalar<3>>(buffer)) = 1.0 + gamma1.get();
-  const DataVector& gamma1p1 = get(get<::Tags::TempScalar<3>>(buffer));
+  get(get<Tags::Gamma1Plus1>(buffer)) = 1.0 + gamma1.get();
+  const DataVector& gamma1p1 = get(get<Tags::Gamma1Plus1>(buffer));
 
   tnsr::aa<DataVector, Dim>& shift_dot_three_index_constraint =
-      get<::Tags::Tempaa<0, Dim, Frame::Inertial, DataVector>>(buffer);
+      get<Tags::ShiftDotThreeIndexConstraint<Dim>>(buffer);
   for (size_t mu = 0; mu < Dim + 1; ++mu) {
     for (size_t nu = mu; nu < Dim + 1; ++nu) {
       shift_dot_three_index_constraint.get(mu, nu) =

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_Characteristics.cpp
   Test_Constraints.cpp
   Test_DuDt.cpp
+  Test_DuDtTempTags.cpp
   Test_Fluxes.cpp
   Test_Tags.cpp
   Test_UpwindPenaltyCorrection.cpp

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDtTempTags.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDtTempTags.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+template <size_t Dim>
+void test_simple_tags() {
+  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::Gamma1Gamma2>(
+      "Gamma1Gamma2");
+  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::PiTwoNormals>(
+      "PiTwoNormals");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::NormalDotOneIndexConstraint>(
+      "NormalDotOneIndexConstraint");
+  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::Gamma1Plus1>(
+      "Gamma1Plus1");
+  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::PiOneNormal<Dim>>(
+      "PiOneNormal");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::PhiTwoNormals<Dim>>("PhiTwoNormals");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::ShiftDotThreeIndexConstraint<Dim>>(
+      "ShiftDotThreeIndexConstraint");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::PhiOneNormal<Dim>>("PhiOneNormal");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::PiSecondIndexUp<Dim>>("PiSecondIndexUp");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::PhiFirstIndexUp<Dim>>("PhiFirstIndexUp");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::PhiThirdIndexUp<Dim>>("PhiThirdIndexUp");
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::SpacetimeChristoffelFirstKindThirdIndexUp<
+          Dim>>("SpacetimeChristoffelFirstKindThirdIndexUp");
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.DuDtTempTags",
+                  "[Unit][Evolution]") {
+  test_simple_tags<1>();
+  test_simple_tags<2>();
+  test_simple_tags<3>();
+}


### PR DESCRIPTION
## Proposed changes

- I find that having the tags be named makes the code a lot easier to read.
- In the future, with the gauge computed inside the GH RHS it'll be easier to avoid duplicate computations if tags are named, rather than having the gauge code say "Oh, I want `temp::A<5>`"

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
