### PR TITLE
Move damped harmonic rollon initialization action into separate file

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -28,6 +28,7 @@
 #include "Evolution/Initialization/NonconservativeSystem.hpp"
 #include "Evolution/Initialization/SetVariables.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Initialize.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
@@ -322,7 +323,7 @@ struct EvolutionMetavars {
       Initialization::Actions::AddComputeTags<
           tmpl::list<evolution::Tags::AnalyticCompute<
               volume_dim, initial_data_tag, analytic_solution_fields>>>,
-      GeneralizedHarmonic::Actions::InitializeDampedHarmonicRollonGauge<
+      GeneralizedHarmonic::gauges::Actions::InitializeDampedHarmonic<
           volume_dim>,
       GeneralizedHarmonic::Actions::InitializeConstraints<volume_dim>,
       dg::Actions::InitializeMortars<boundary_scheme, true>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY GeneralizedHarmonicGaugeSourceFunctions)
 set(LIBRARY_SOURCES
   DampedHarmonic.cpp
   DampedWaveHelpers.cpp
+  InitializeDampedHarmonic.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.cpp
@@ -1,0 +1,107 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <size_t Dim, typename Frame>
+using deriv_tags = tmpl::list<
+    ::Tags::deriv<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, Frame>,
+                  tmpl::size_t<Dim>, Frame>>;
+
+template <size_t Dim, typename Frame>
+using variables_tags =
+    tmpl::list<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, Frame>>;
+}  // namespace
+
+namespace GeneralizedHarmonic::gauges::Actions {
+template <size_t Dim>
+std::tuple<tnsr::a<DataVector, Dim, Frame::Inertial>,
+           tnsr::ab<DataVector, Dim, Frame::Inertial>>
+InitializeDampedHarmonic<Dim>::impl(
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
+    const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
+    const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
+        inverse_jacobian) noexcept {
+  const auto spatial_metric = gr::spatial_metric(spacetime_metric);
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto shift = gr::shift(spacetime_metric, inverse_spatial_metric);
+  const auto lapse = gr::lapse(shift, spacetime_metric);
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
+  tnsr::abb<DataVector, Dim, Frame::Inertial> da_spacetime_metric{};
+  GeneralizedHarmonic::spacetime_derivative_of_spacetime_metric(
+      make_not_null(&da_spacetime_metric), lapse, shift, pi, phi);
+  // H_a=-Gamma_a
+  auto initial_gauge_h =
+      trace_last_indices(gr::christoffel_first_kind(da_spacetime_metric),
+                         inverse_spacetime_metric);
+  for (size_t i = 0; i < initial_gauge_h.size(); ++i) {
+    initial_gauge_h[i] *= -1.0;
+  }
+
+  // set time derivatives of InitialGaugeH = 0
+  // NOTE: this will need to be generalized to handle numerical initial data
+  // and analytic initial data whose gauge is not initially stationary.
+  auto dt_initial_gauge_source =
+      make_with_value<tnsr::a<DataVector, Dim, frame>>(initial_gauge_h, 0.);
+
+  // compute spatial derivatives of InitialGaugeH
+  // The `partial_derivatives` function does not support single Tensor input,
+  // and so we must store the tensor in a Variables first.
+  using InitialGaugeHVars = ::Variables<
+      tmpl::list<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>>>;
+  InitialGaugeHVars initial_gauge_h_vars{mesh.number_of_grid_points()};
+
+  get<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>>(
+      initial_gauge_h_vars) = initial_gauge_h;
+  // compute spacetime derivatives of InitialGaugeH
+  tnsr::ab<DataVector, Dim, Frame::Inertial> initial_d4_gauge_h{};
+  GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<Dim, frame>::function(
+      make_not_null(&initial_d4_gauge_h), std::move(dt_initial_gauge_source),
+      get<::Tags::deriv<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>,
+                        tmpl::size_t<Dim>, frame>>(
+          partial_derivatives<typename InitialGaugeHVars::tags_list>(
+              initial_gauge_h_vars, mesh, inverse_jacobian)));
+
+  return std::make_tuple(std::move(initial_gauge_h),
+                         std::move(initial_d4_gauge_h));
+}
+
+}  // namespace GeneralizedHarmonic::gauges::Actions
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template Variables<deriv_tags<DIM(data), Frame::Inertial>>                 \
+  partial_derivatives<variables_tags<DIM(data), Frame::Inertial>,            \
+                      variables_tags<DIM(data), Frame::Inertial>, DIM(data), \
+                      Frame::Inertial>(                                      \
+      const Variables<variables_tags<DIM(data), Frame::Inertial>>& u,        \
+      const Mesh<DIM(data)>& mesh,                                           \
+      const InverseJacobian<DataVector, DIM(data), Frame::Logical,           \
+                            Frame::Inertial>& inverse_jacobian) noexcept;    \
+  template struct GeneralizedHarmonic::gauges::Actions::                     \
+      InitializeDampedHarmonic<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Initialization/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace GeneralizedHarmonic::gauges::Actions {
+template <size_t Dim>
+struct InitializeDampedHarmonic {
+  using frame = Frame::Inertial;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    const auto inverse_jacobian =
+        db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical, frame>>(box);
+
+    auto [initial_gauge_h, initial_d4_gauge_h] = impl(
+        db::get<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>(
+            box),
+        db::get<GeneralizedHarmonic::Tags::Pi<Dim, Frame::Inertial>>(box),
+        db::get<GeneralizedHarmonic::Tags::Phi<Dim, Frame::Inertial>>(box),
+        db::get<domain::Tags::Mesh<Dim>>(box), inverse_jacobian);
+
+    // Add gauge tags
+    using compute_tags = db::AddComputeTags<
+        GeneralizedHarmonic::gauges::DampedHarmonicHCompute<Dim, frame>,
+        GeneralizedHarmonic::gauges::SpacetimeDerivDampedHarmonicHCompute<
+            Dim, frame>>;
+
+    // Finally, insert gauge related quantities to the box
+    return std::make_tuple(
+        Initialization::merge_into_databox<
+            InitializeDampedHarmonic,
+            db::AddSimpleTags<
+                GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>,
+                GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<Dim,
+                                                                       frame>>,
+            compute_tags>(std::move(box), std::move(initial_gauge_h),
+                          std::move(initial_d4_gauge_h)));
+  }
+
+ private:
+  static std::tuple<tnsr::a<DataVector, Dim, Frame::Inertial>,
+                    tnsr::ab<DataVector, Dim, Frame::Inertial>>
+  impl(const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
+       const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
+       const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
+       const Mesh<Dim>& mesh,
+       const InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
+           inverse_jacobian) noexcept;
+};
+}  // namespace GeneralizedHarmonic::gauges::Actions

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -11,33 +11,30 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/EagerMath/Norms.hpp"
-#include "DataStructures/Variables.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
 #include "ErrorHandling/Assert.hpp"
-#include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
-#include "Evolution/Initialization/Evolution.hpp"
-#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
-#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
-#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
-#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+/// \endcond
 
 namespace GeneralizedHarmonic {
 namespace Actions {
@@ -126,97 +123,6 @@ struct InitializeGhAnd3Plus1Variables {
         Initialization::merge_into_databox<InitializeGhAnd3Plus1Variables,
                                            db::AddSimpleTags<>, compute_tags>(
             std::move(box)));
-  }
-};
-
-template <size_t Dim>
-struct InitializeDampedHarmonicRollonGauge {
-  using frame = Frame::Inertial;
-
-  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent>
-  static auto apply(db::DataBox<DbTagsList>& box,
-                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/,
-                    const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/) noexcept {
-    // compute initial-gauge related quantities
-    const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
-    const size_t num_grid_points = mesh.number_of_grid_points();
-
-    const auto& spacetime_metric =
-        db::get<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>(
-            box);
-    const auto& pi =
-        db::get<GeneralizedHarmonic::Tags::Pi<Dim, Frame::Inertial>>(box);
-    const auto& phi =
-        db::get<GeneralizedHarmonic::Tags::Phi<Dim, Frame::Inertial>>(box);
-
-    const auto spatial_metric = gr::spatial_metric(spacetime_metric);
-    const auto inverse_spatial_metric =
-        determinant_and_inverse(spatial_metric).second;
-    const auto shift = gr::shift(spacetime_metric, inverse_spatial_metric);
-    const auto lapse = gr::lapse(shift, spacetime_metric);
-    const auto inverse_spacetime_metric =
-        gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
-    tnsr::abb<DataVector, Dim, Frame::Inertial> da_spacetime_metric{};
-    GeneralizedHarmonic::spacetime_derivative_of_spacetime_metric(
-        make_not_null(&da_spacetime_metric), lapse, shift, pi, phi);
-    // H_a=-Gamma_a
-    auto initial_gauge_h =
-        trace_last_indices(gr::christoffel_first_kind(da_spacetime_metric),
-                           inverse_spacetime_metric);
-    for (size_t i = 0; i < initial_gauge_h.size(); ++i) {
-      initial_gauge_h[i] *= -1.0;
-    }
-
-    // set time derivatives of InitialGaugeH = 0
-    // NOTE: this will need to be generalized to handle numerical initial data
-    // and analytic initial data whose gauge is not initially stationary.
-    auto dt_initial_gauge_source =
-        make_with_value<tnsr::a<DataVector, Dim, frame>>(initial_gauge_h, 0.);
-
-    // compute spatial derivatives of InitialGaugeH
-    // The `partial_derivatives` function does not support single Tensor input,
-    // and so we must store the tensor in a Variables first.
-    using InitialGaugeHVars = ::Variables<
-        tmpl::list<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>>>;
-    InitialGaugeHVars initial_gauge_h_vars{num_grid_points};
-
-    get<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>>(
-        initial_gauge_h_vars) = initial_gauge_h;
-    const auto& inverse_jacobian =
-        db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical, frame>>(box);
-    auto d_initial_gauge_source =
-        get<::Tags::deriv<GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>,
-                          tmpl::size_t<Dim>, frame>>(
-            partial_derivatives<typename InitialGaugeHVars::tags_list>(
-                initial_gauge_h_vars, mesh, inverse_jacobian));
-
-    // compute spacetime derivatives of InitialGaugeH
-    tnsr::ab<DataVector, Dim, Frame::Inertial> initial_d4_gauge_h{};
-    GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<
-        Dim, frame>::function(make_not_null(&initial_d4_gauge_h),
-                              std::move(dt_initial_gauge_source),
-                              std::move(d_initial_gauge_source));
-    // Add gauge tags
-    using compute_tags = db::AddComputeTags<
-        GeneralizedHarmonic::gauges::DampedHarmonicHCompute<Dim, frame>,
-        GeneralizedHarmonic::gauges::SpacetimeDerivDampedHarmonicHCompute<
-            Dim, frame>>;
-
-    // Finally, insert gauge related quantities to the box
-    return std::make_tuple(
-        Initialization::merge_into_databox<
-            InitializeDampedHarmonicRollonGauge,
-            db::AddSimpleTags<
-                GeneralizedHarmonic::Tags::InitialGaugeH<Dim, frame>,
-                GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<Dim,
-                                                                       frame>>,
-            compute_tags>(std::move(box), std::move(initial_gauge_h),
-                          std::move(initial_d4_gauge_h)));
   }
 };
 


### PR DESCRIPTION
## Proposed changes

- The action that initializes the gauge should be in the same file that the gauge is in. This also helps de-clutter the `Initialize.hpp` file.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
