### PR TITLE
Let ReadSpecThirdOrderPiecewisePolynomial work with GH exec

### DIFF
--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
@@ -36,8 +36,9 @@ class PiecewisePolynomial : public FunctionOfTime {
 
   auto get_clone() const noexcept -> std::unique_ptr<FunctionOfTime> override;
 
-  // NOLINTNEXTLINE(google-runtime-references)
-  WRAPPED_PUPable_decl_template(PiecewisePolynomial<MaxDeriv>);
+  // clang-tidy: google-runtime-references
+  // clang-tidy: cppcoreguidelines-owning-memory,-warnings-as-errors
+  WRAPPED_PUPable_decl_template(PiecewisePolynomial<MaxDeriv>);  // NOLINT
 
   /// Returns the function at an arbitrary time `t`.
   std::array<DataVector, 1> func(double t) const noexcept override {

--- a/src/IO/Importers/ReadSpecThirdOrderPiecewisePolynomial.hpp
+++ b/src/IO/Importers/ReadSpecThirdOrderPiecewisePolynomial.hpp
@@ -60,6 +60,9 @@ namespace Actions {
 /// component and its derivatives, etc.
 ///
 struct ReadSpecThirdOrderPiecewisePolynomial {
+  using const_global_cache_tags =
+       tmpl::list<importers::Tags::FunctionOfTimeFile,
+                  importers::Tags::FunctionOfTimeNameMap>;
   template <
       typename DbTagsList, typename... InboxTags, typename Metavariables,
       typename ArrayIndex, typename ActionList, typename ParallelComponent,

--- a/src/IO/Importers/Tags.hpp
+++ b/src/IO/Importers/Tags.hpp
@@ -178,7 +178,6 @@ struct FunctionOfTimeFile : db::SimpleTag {
   using type = std::string;
   using option_tags = tmpl::list<::importers::OptionTags::FunctionOfTimeFile>;
   static constexpr bool pass_metavariables = false;
-  template <typename Metavariables>
   static std::string create_from_options(
       const std::string& function_of_time_file) noexcept {
     return function_of_time_file;
@@ -200,7 +199,6 @@ struct FunctionOfTimeNameMap : db::SimpleTag {
   using option_tags =
       tmpl::list<::importers::OptionTags::FunctionOfTimeNameMap>;
   static constexpr bool pass_metavariables = false;
-  template <typename Metavariables>
   static std::map<std::string, std::string> create_from_options(
       const std::map<std::string, std::string>& dataset_names) noexcept {
     return dataset_names;

--- a/tests/Unit/IO/Importers/Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
+++ b/tests/Unit/IO/Importers/Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
@@ -40,9 +40,7 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using simple_tags = tmpl::list<importers::Tags::FunctionOfTimeFile,
-                                 importers::Tags::FunctionOfTimeNameMap,
-                                 ::domain::Tags::FunctionsOfTime>;
+  using simple_tags = tmpl::list<::domain::Tags::FunctionsOfTime>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -132,7 +130,10 @@ SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomial",
       "/" + expected_names[1], rotation_legend, version_number);
   rotation_file.append(test_rotation);
 
-  MockRuntimeSystem runner{{}};
+  MockRuntimeSystem runner{
+      {std::string{test_filename}, std::map<std::string, std::string>{
+                                       {"ExpansionFactor", "ExpansionFactor"},
+                                       {"RotationAngle", "RotationAngle"}}}};
   std::unordered_map<std::string,
                      std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
       initial_functions_of_time{};
@@ -147,12 +148,7 @@ SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomial",
           0.0, initial_coefficients);
 
   ActionTesting::emplace_component_and_initialize<component<Metavariables>>(
-      &runner, self_id,
-      {std::string{test_filename},
-       std::map<std::string, std::string>{
-           {"ExpansionFactor", "ExpansionFactor"},
-           {"RotationAngle", "RotationAngle"}},
-       std::move(initial_functions_of_time)});
+      &runner, self_id, {std::move(initial_functions_of_time)});
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Metavariables::Phase::Testing);
@@ -232,7 +228,9 @@ SPECTRE_TEST_CASE(
       "/RotationAngle", rotation_legend, version_number);
   rotation_file.append(test_rotation);
 
-  MockRuntimeSystem runner{{}};
+  MockRuntimeSystem runner{
+      {std::string{test_filename},
+       std::map<std::string, std::string>{{"RotationAngle", "RotationAngle"}}}};
   std::unordered_map<std::string,
                      std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
       initial_functions_of_time{};
@@ -244,11 +242,7 @@ SPECTRE_TEST_CASE(
           0.0, initial_coefficients);
 
   ActionTesting::emplace_component_and_initialize<component<Metavariables>>(
-      &runner, self_id,
-      {std::string{test_filename},
-       std::map<std::string, std::string>{
-           {"RotationAngle", "RotationAngle"}},
-       std::move(initial_functions_of_time)});
+      &runner, self_id, {std::move(initial_functions_of_time)});
 
   runner.set_phase(Metavariables::Phase::Testing);
   runner.next_action<component<Metavariables>>(self_id);


### PR DESCRIPTION
## Proposed changes

Minor changes needed for ReadSpecThirdOrderPiecewisePolynomial to work with GH exec
### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
