### PR TITLE
Adds potential energy to Elasticity

### DIFF
--- a/src/Elliptic/Systems/Elasticity/Tags.hpp
+++ b/src/Elliptic/Systems/Elasticity/Tags.hpp
@@ -66,5 +66,14 @@ struct Stress : db::SimpleTag {
   using type = tnsr::II<DataVector, Dim>;
 };
 
+/*!
+ * \brief The energy density \f$U=-\frac{1}{2}S_{ij}T^{ij}\f$ stored in the
+ * deformation of the elastic material.
+ */
+template <size_t Dim>
+struct PotentialEnergyDensity : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
 }  // namespace Tags
 }  // namespace Elasticity

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
@@ -14,8 +14,7 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-namespace Elasticity {
-namespace Solutions {
+namespace Elasticity::Solutions {
 
 BentBeam::BentBeam(double length, double height, double bending_moment,
                    constitutive_relation_type constitutive_relation) noexcept
@@ -59,10 +58,15 @@ tuples::TaggedTuple<Tags::Stress<2>> BentBeam::variables(
   return {std::move(result)};
 }
 
+double BentBeam::potential_energy() const {
+  return 6. * length_ * square(bending_moment_) /
+         (cube(height_) * constitutive_relation_.youngs_modulus());
+}
+
 tuples::TaggedTuple<::Tags::FixedSource<Tags::Displacement<2>>>
 BentBeam::variables(
     const tnsr::I<DataVector, 2>& x,
-    tmpl::list<::Tags::FixedSource<Tags::Displacement<2>>> /*meta*/) const
+    tmpl::list<::Tags::FixedSource<Tags::Displacement<2>>> /*meta*/)
     noexcept {
   return {make_with_value<tnsr::I<DataVector, 2>>(x, 0.)};
 }
@@ -84,5 +88,4 @@ bool operator!=(const BentBeam& lhs, const BentBeam& rhs) noexcept {
   return not(lhs == rhs);
 }
 
-}  // namespace Solutions
-}  // namespace Elasticity
+}  // namespace Elasticity::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
@@ -23,17 +23,16 @@ class er;
 }  // namespace PUP
 /// \endcond
 
-namespace Elasticity {
-namespace Solutions {
+namespace Elasticity::Solutions {
 /*!
  * \brief A state of pure bending of an elastic beam in 2D
  *
  * \details This solution describes a 2D slice through an elastic beam of length
- * \f$L\f$ and height \f$H\f$ that is subject to a bending moment \f$M=\int
- * T^{xx}y\mathrm{d}y\f$ (see e.g. \cite ThorneBlandford2017, Eq. 11.41c for a
- * bending moment in 1D). The beam material is characterized by an isotropic and
- * homogeneous constitutive relation \f$Y^{ijkl}\f$ in the plane-stress
- * approximation (see
+ * \f$L\f$ and height \f$H\f$, centered around (0, 0), that is subject to a
+ * bending moment \f$M=\int T^{xx}y\mathrm{d}y\f$ (see e.g.
+ * \cite ThorneBlandford2017, Eq. 11.41c for a bending moment in 1D). The beam
+ * material is characterized by an isotropic and homogeneous constitutive
+ * relation \f$Y^{ijkl}\f$ in the plane-stress approximation (see
  * `Elasticity::ConstitutiveRelations::IsotropicHomogeneous`). In this scenario,
  * no body-forces \f$f_\mathrm{ext}^j\f$ act on the material, so the
  * \ref Elasticity equations reduce to \f$\nabla_i T^{ij}=0\f$, but the bending
@@ -63,11 +62,18 @@ namespace Solutions {
  * \f{align}
  * S_{xx} &= -\frac{12 M}{EH^3} y \\
  * S_{yy} &= \frac{12 M}{EH^3} \nu y \\
- * S_{xy} &= S_{yx} = 0 \text{.}
+ * S_{xy} &= S_{yx} = 0
  * \f}
+ *
+ * and the potential energy stored in the entire infinitesimal slice is
+ *
+ * \f[
+ * \int_{-L/2}^{L/2} \int_{-H/2}^{H/2} U dy\,dx = \frac{6M^2}{EH^3}L \text{.}
+ * \f]
  */
 class BentBeam {
  public:
+  static constexpr size_t volume_dim = 2;
   using constitutive_relation_type =
       Elasticity::ConstitutiveRelations::IsotropicHomogeneous<2>;
 
@@ -113,6 +119,9 @@ class BentBeam {
     return constitutive_relation_;
   }
 
+  /// Return potential energy integrated over the whole beam material
+  double potential_energy() const;
+
   // @{
   /// Retrieve variable at coordinates `x`
   auto variables(const tnsr::I<DataVector, 2>& x,
@@ -127,10 +136,9 @@ class BentBeam {
                  tmpl::list<Tags::Stress<2>> /*meta*/) const noexcept
       -> tuples::TaggedTuple<Tags::Stress<2>>;
 
-  auto variables(
+  static auto variables(
       const tnsr::I<DataVector, 2>& x,
-      tmpl::list<::Tags::FixedSource<Tags::Displacement<2>>> /*meta*/) const
-      noexcept
+      tmpl::list<::Tags::FixedSource<Tags::Displacement<2>>> /*meta*/) noexcept
       -> tuples::TaggedTuple<::Tags::FixedSource<Tags::Displacement<2>>>;
   // @}
 
@@ -159,5 +167,4 @@ class BentBeam {
 
 bool operator!=(const BentBeam& lhs, const BentBeam& rhs) noexcept;
 
-}  // namespace Solutions
-}  // namespace Elasticity
+}  // namespace Elasticity::Solutions

--- a/src/PointwiseFunctions/Elasticity/CMakeLists.txt
+++ b/src/PointwiseFunctions/Elasticity/CMakeLists.txt
@@ -2,3 +2,21 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(ConstitutiveRelations)
+
+set(LIBRARY ElasticPotentialEnergy)
+
+set(LIBRARY_SOURCES
+  PotentialEnergy.cpp
+  )
+
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  ConstitutiveRelations
+  DataStructures
+  Domain
+  Elasticity
+  Utilities
+  )

--- a/src/PointwiseFunctions/Elasticity/PotentialEnergy.cpp
+++ b/src/PointwiseFunctions/Elasticity/PotentialEnergy.cpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Elasticity/PotentialEnergy.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace Elasticity {
+
+template <size_t Dim>
+void potential_energy_density(
+    const gsl::not_null<Scalar<DataVector>*> potential_energy_density,
+    const tnsr::ii<DataVector, Dim>& strain,
+    const tnsr::I<DataVector, Dim>& coordinates,
+    const ConstitutiveRelations::ConstitutiveRelation<Dim>&
+        constitutive_relation) noexcept {
+  destructive_resize_components(potential_energy_density,
+                                coordinates.begin()->size());
+  get(*potential_energy_density) = 0.;
+  const auto stress = constitutive_relation.stress(strain, coordinates);
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t j = 0; j < Dim; j++) {
+      get(*potential_energy_density) -=
+          0.5 * stress.get(i, j) * strain.get(i, j);
+    }
+  }
+}
+
+template <size_t Dim>
+Scalar<DataVector> potential_energy_density(
+    const tnsr::ii<DataVector, Dim>& strain,
+    const tnsr::I<DataVector, Dim>& coordinates,
+    const ConstitutiveRelations::ConstitutiveRelation<Dim>&
+        constitutive_relation) noexcept {
+  Scalar<DataVector> result =
+      make_with_value<Scalar<DataVector>>(coordinates, 0.);
+  potential_energy_density(make_not_null(&result), strain, coordinates,
+                           constitutive_relation);
+  return result;
+}
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                        \
+  template void potential_energy_density<DIM(data)>(                \
+      gsl::not_null<Scalar<DataVector>*> potential_energy_density,  \
+      const tnsr::ii<DataVector, DIM(data)>& strain,                \
+      const tnsr::I<DataVector, DIM(data)>& coordinates,            \
+      const ConstitutiveRelations::ConstitutiveRelation<DIM(data)>& \
+          constitutive_relation) noexcept;                          \
+  template Scalar<DataVector> potential_energy_density<DIM(data)>(  \
+      const tnsr::ii<DataVector, DIM(data)>& strain,                \
+      const tnsr::I<DataVector, DIM(data)>& coordinates,            \
+      const ConstitutiveRelations::ConstitutiveRelation<DIM(data)>& \
+          constitutive_relation) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+/// \endcond
+
+}  // namespace Elasticity

--- a/src/PointwiseFunctions/Elasticity/PotentialEnergy.hpp
+++ b/src/PointwiseFunctions/Elasticity/PotentialEnergy.hpp
@@ -1,0 +1,69 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
+
+namespace Elasticity {
+
+// @{
+/*!
+ * \brief The potential energy density \f$U=-\frac{1}{2}S_{ij}T^{ij}\f$ stored
+ * in the deformation of the elastic material (see Eq. (11.25) in
+ * \cite ThorneBlandford2017)
+ *
+ * Note that the two-dimensional instantiation of this function assumes that
+ * only the terms of \f$S_{ij}T^{ij}\f$ where both \f$i\f$ and \f$j\f$
+ * correspond to one of the computational dimensions contribute to the sum. This
+ * is the case for the plane-stress approximation employed in the
+ * two-dimensional `Elasticity::ConstitutiveRelations::IsotropicHomogeneous`,
+ * for example, where \f$T^{i3}=0=T^{3i}\f$.
+ */
+template <size_t Dim>
+void potential_energy_density(
+    gsl::not_null<Scalar<DataVector>*> potential_energy_density,
+    const tnsr::ii<DataVector, Dim>& strain,
+    const tnsr::I<DataVector, Dim>& coordinates,
+    const ConstitutiveRelations::ConstitutiveRelation<Dim>&
+        constitutive_relation) noexcept;
+
+template <size_t Dim>
+Scalar<DataVector> potential_energy_density(
+    const tnsr::ii<DataVector, Dim>& strain,
+    const tnsr::I<DataVector, Dim>& coordinates,
+    const ConstitutiveRelations::ConstitutiveRelation<Dim>&
+        constitutive_relation) noexcept;
+// @}
+
+namespace Tags {
+
+/// \brief Computes the energy density stored in the deformation of the elastic
+/// material.
+/// \see `Elasticity::Tags::PotentialEnergyDensity`
+template <size_t Dim>
+struct PotentialEnergyDensityCompute
+    : Elasticity::Tags::PotentialEnergyDensity<Dim>,
+      db::ComputeTag {
+  using base = Elasticity::Tags::PotentialEnergyDensity<Dim>;
+  using return_type = Scalar<DataVector>;
+  using argument_tags =
+      tmpl::list<Elasticity::Tags::Strain<Dim>,
+                 domain::Tags::Coordinates<Dim, Frame::Inertial>,
+                 Elasticity::Tags::ConstitutiveRelationBase>;
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<DataVector>*>, const tnsr::ii<DataVector, Dim>&,
+      const tnsr::I<DataVector, Dim>&,
+      const ConstitutiveRelations::ConstitutiveRelation<Dim>&) noexcept>(
+      &potential_energy_density<Dim>);
+};
+
+}  // namespace Tags
+}  // namespace Elasticity

--- a/tests/Unit/Elliptic/Systems/Elasticity/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/Test_Tags.cpp
@@ -8,10 +8,11 @@
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
-SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Elasticity.Tags",
-                  "[Unit][Elliptic]") {
+SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Elasticity.Tags", "[Unit][Elliptic]") {
   TestHelpers::db::test_simple_tag<Elasticity::Tags::Displacement<1>>(
       "Displacement");
   TestHelpers::db::test_simple_tag<Elasticity::Tags::Strain<1>>("Strain");
   TestHelpers::db::test_simple_tag<Elasticity::Tags::Stress<1>>("Stress");
+  TestHelpers::db::test_simple_tag<Elasticity::Tags::PotentialEnergyDensity<1>>(
+      "PotentialEnergyDensity");
 }

--- a/tests/Unit/PointwiseFunctions/Elasticity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Elasticity/CMakeLists.txt
@@ -2,3 +2,16 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(ConstitutiveRelations)
+
+set(LIBRARY Test_ElasticPotentialEnergy)
+
+set(LIBRARY_SOURCES
+  Test_PotentialEnergy.cpp
+  )
+
+  add_test_library(
+  ${LIBRARY}
+  "PointwiseFunctions/Elasticity/"
+  "${LIBRARY_SOURCES}"
+  "ElasticPotentialEnergy;Utilities"
+  )

--- a/tests/Unit/PointwiseFunctions/Elasticity/PotentialEnergy.py
+++ b/tests/Unit/PointwiseFunctions/Elasticity/PotentialEnergy.py
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+from Elasticity.ConstitutiveRelations.IsotropicHomogeneous import stress
+
+
+def potential_energy_density(strain, coordinates, bulk_modulus, shear_modulus):
+    local_stress = stress(strain, coordinates, bulk_modulus, shear_modulus)
+    return -0.5 * np.einsum('ij, ij', strain, local_stress)

--- a/tests/Unit/PointwiseFunctions/Elasticity/Test_PotentialEnergy.cpp
+++ b/tests/Unit/PointwiseFunctions/Elasticity/Test_PotentialEnergy.cpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
+#include "PointwiseFunctions/Elasticity/PotentialEnergy.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+template <size_t Dim>
+Scalar<DataVector> potential_energy_density(
+    // The wrapper constructs a constitutive relation for use in
+    // check_with_random_values.
+    const tnsr::ii<DataVector, Dim, Frame::Inertial>& strain,
+    const tnsr::I<DataVector, Dim>& coordinates, const double bulk_modulus,
+    const double shear_modulus) noexcept {
+  Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>
+      constitutive_relation{bulk_modulus, shear_modulus};
+  return Elasticity::potential_energy_density<Dim>(
+      strain, coordinates, std::move(constitutive_relation));
+}
+
+template <size_t Dim>
+void test_elastic_potential_energy(const DataVector& used_for_size) {
+  pypp::check_with_random_values<4>(
+      &potential_energy_density<Dim>, "Elasticity.PotentialEnergy",
+      "potential_energy_density", {{{-1., 1.}, {0., 1.}, {0., 1.}, {0., 1.}}},
+      used_for_size);
+}
+
+template <size_t Dim>
+void test_compute_tags(const DataVector& used_for_size) noexcept {
+  CAPTURE(Dim);
+  using strain_tag = Elasticity::Tags::Strain<Dim>;
+  using energy_tag = Elasticity::Tags::PotentialEnergyDensity<Dim>;
+  using energy_compute_tag =
+      Elasticity::Tags::PotentialEnergyDensityCompute<Dim>;
+  using constitutive_relation_tag = Elasticity::Tags::ConstitutiveRelation<
+      Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>>;
+  using coordinates_tag = domain::Tags::Coordinates<Dim, Frame::Inertial>;
+  const size_t num_points = used_for_size.size();
+  {
+    INFO("Energy");
+    const auto box =
+        db::create<db::AddSimpleTags<strain_tag, constitutive_relation_tag,
+                                     coordinates_tag>,
+                   db::AddComputeTags<energy_compute_tag>>(
+            tnsr::ii<DataVector, Dim>{num_points, 1.},
+            Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>{3.,
+                                                                         4.},
+            tnsr::I<DataVector, Dim>{num_points, 2.});
+
+    const auto expected_energy = Elasticity::potential_energy_density<Dim>(
+        get<strain_tag>(box), get<coordinates_tag>(box),
+        get<constitutive_relation_tag>(box));
+    CHECK(get<energy_tag>(box) == expected_energy);
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Elasticity",
+                  "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{"PointwiseFunctions"};
+  GENERATE_UNINITIALIZED_DATAVECTOR;
+  CHECK_FOR_DATAVECTORS(test_elastic_potential_energy, (2, 3));
+  CHECK_FOR_DATAVECTORS(test_compute_tags, (2, 3));
+}


### PR DESCRIPTION
## Proposed changes

This PR adds both a tag and a compute tag for the potential energy stored in the displacement of an elastic material. The potential energy is calculated with an evaluate_potential_energy() taking the strain, applying the constitutive relation to it and contracting strain and stress in accordance with 11.25 in Blandford & Thorne Modern Classical Physics.
As a side note there's also a commit to improve upon the documentation for the BentBeam.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

