### PR TITLE
 AnalyticSolution for HalfSpaceMirror

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -623,6 +623,23 @@
   SLACcitation   = "%%CITATION = GR-QC/0512093;%%"
 }
 
+@article{Lovelace2007tn,
+  author         = "Lovelace, Geoffrey",
+  title          = "The dependence of test-mass thermal noises on beam shape
+                    in gravitational-wave interferometers",
+  journal        = "Class. Quant. Grav.",
+  volume         = "24",
+  year           = "2007",
+  number         = "17",
+  pages          = "4491-4512",
+  doi            = "10.1088/0264-9381/24/17/014",
+  url            = "https://doi.org/10.1088/0264-9381/24/17/014",
+  eprint         = "gr-qc/0610041",
+  archivePrefix  = "arXiv",
+  primaryClass   = "gr-qc",
+  SLACcitation   = "%%CITATION = GR-QC/0610041;%%"
+}
+
 @article{Lovelace2008tw,
   author         = "Lovelace, Geoffrey and Owen, Robert and Pfeiffer, Harald
                     P. and Chu, Tony",

--- a/src/Elliptic/Systems/Elasticity/Tags.hpp
+++ b/src/Elliptic/Systems/Elasticity/Tags.hpp
@@ -7,6 +7,8 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Elliptic/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 
 /// \cond
 class DataVector;
@@ -64,6 +66,31 @@ struct Strain : db::SimpleTag {
 template <size_t Dim>
 struct Stress : db::SimpleTag {
   using type = tnsr::II<DataVector, Dim>;
+};
+
+/*!
+ * \brief The energy density \f$U\f$ stored in the deformation of the
+ * elastic material.
+ */
+template <size_t Dim>
+struct PotentialEnergy : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <typename FluxesComputerType, typename SolutionType>
+struct FluxesComputer : elliptic::Tags::FluxesComputer<FluxesComputerType> {
+  using type = FluxesComputerType;
+  static std::string name() noexcept {
+    return pretty_type::short_name<FluxesComputerType>();
+  }
+  using option_tags = tmpl::list<::OptionTags::AnalyticSolution<SolutionType>>;
+
+  static constexpr bool pass_metavariables = false;
+  static FluxesComputerType create_from_options(const SolutionType& solution) {
+    return FluxesComputerType{
+        std::make_unique<typename SolutionType::constitutive_relation_type>(
+            solution.constitutive_relation())};
+  }
 };
 
 }  // namespace Tags

--- a/src/Elliptic/Systems/Elasticity/Tags.hpp
+++ b/src/Elliptic/Systems/Elasticity/Tags.hpp
@@ -39,8 +39,7 @@ class DataVector;
  * describes the elastic properties of the material (see
  * `Elasticity::ConstitutiveRelations::ConstitutiveRelation`).
  */
-namespace Elasticity {
-namespace Tags {
+namespace Elasticity::Tags {
 
 /*!
  * \brief The material displacement field \f$\boldsymbol{u}(x)\f$
@@ -93,5 +92,4 @@ struct FluxesComputer : elliptic::Tags::FluxesComputer<FluxesComputerType> {
   }
 };
 
-}  // namespace Tags
-}  // namespace Elasticity
+}  // namespace Elasticity::Tags

--- a/src/NumericalAlgorithms/Integration/GslQuadAdaptive.hpp
+++ b/src/NumericalAlgorithms/Integration/GslQuadAdaptive.hpp
@@ -128,8 +128,8 @@ class GslQuadAdaptive<GslIntegralType::StandardGaussKronrod>
   double operator()(IntegrandType&& integrand, const double lower_boundary,
                     const double upper_boundary, const double tolerance_abs,
                     const int key, const double tolerance_rel = 0.) const {
-    double result;
-    double error;
+    double result = std::numeric_limits<double>::signaling_NaN();
+    double error = std::numeric_limits<double>::signaling_NaN();
     detail::disable_gsl_error_handling();
     const int status_code = gsl_integration_qag(
         gsl_integrand(std::forward<IntegrandType>(integrand)), lower_boundary,
@@ -158,8 +158,8 @@ class GslQuadAdaptive<GslIntegralType::IntegrableSingularitiesPresent>
   double operator()(IntegrandType&& integrand, const double lower_boundary,
                     const double upper_boundary, const double tolerance_abs,
                     const double tolerance_rel = 0.) const {
-    double result;
-    double error;
+    double result = std::numeric_limits<double>::signaling_NaN();
+    double error = std::numeric_limits<double>::signaling_NaN();
     detail::disable_gsl_error_handling();
     const int status_code = gsl_integration_qags(
         gsl_integrand(std::forward<IntegrandType>(integrand)), lower_boundary,
@@ -187,8 +187,8 @@ class GslQuadAdaptive<GslIntegralType::IntegrableSingularitiesKnown>
                     const std::vector<double>& points,
                     const double tolerance_abs,
                     const double tolerance_rel = 0.) const {
-    double result;
-    double error;
+    double result = std::numeric_limits<double>::signaling_NaN();
+    double error = std::numeric_limits<double>::signaling_NaN();
     detail::disable_gsl_error_handling();
     // The const_cast is necessary because GSL has a weird interface where
     // the number of singularities does not change, but it doesn't take
@@ -225,8 +225,8 @@ class GslQuadAdaptive<GslIntegralType::InfiniteInterval>
   template <typename IntegrandType>
   double operator()(IntegrandType&& integrand, const double tolerance_abs,
                     const double tolerance_rel = 0.) const {
-    double result;
-    double error;
+    double result = std::numeric_limits<double>::signaling_NaN();
+    double error = std::numeric_limits<double>::signaling_NaN();
     detail::disable_gsl_error_handling();
     const int status_code = gsl_integration_qagi(
         gsl_integrand(std::forward<IntegrandType>(integrand)), tolerance_abs,
@@ -253,8 +253,8 @@ class GslQuadAdaptive<GslIntegralType::UpperBoundaryInfinite>
   double operator()(IntegrandType&& integrand, const double lower_boundary,
                     const double tolerance_abs,
                     const double tolerance_rel = 0.) const {
-    double result;
-    double error;
+    double result = std::numeric_limits<double>::signaling_NaN();
+    double error = std::numeric_limits<double>::signaling_NaN();
     detail::disable_gsl_error_handling();
     const int status_code = gsl_integration_qagiu(
         gsl_integrand(std::forward<IntegrandType>(integrand)), lower_boundary,
@@ -281,8 +281,8 @@ class GslQuadAdaptive<GslIntegralType::LowerBoundaryInfinite>
   double operator()(IntegrandType&& integrand, const double upper_boundary,
                     const double tolerance_abs,
                     const double tolerance_rel = 0.) const {
-    double result;
-    double error;
+    double result = std::numeric_limits<double>::signaling_NaN();
+    double error = std::numeric_limits<double>::signaling_NaN();
     detail::disable_gsl_error_handling();
     const int status_code = gsl_integration_qagil(
         gsl_integrand(std::forward<IntegrandType>(integrand)), upper_boundary,

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
@@ -59,6 +59,11 @@ tuples::TaggedTuple<Tags::Stress<2>> BentBeam::variables(
   return {std::move(result)};
 }
 
+double BentBeam::potential_energy() const {
+  return 6. * length_ * square(bending_moment_) /
+         (cube(height_) * constitutive_relation_.youngs_modulus());
+}
+
 tuples::TaggedTuple<::Tags::FixedSource<Tags::Displacement<2>>>
 BentBeam::variables(
     const tnsr::I<DataVector, 2>& x,

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
@@ -24,6 +24,15 @@ BentBeam::BentBeam(double length, double height, double bending_moment,
       bending_moment_(bending_moment),
       constitutive_relation_(std::move(constitutive_relation)) {}
 
+BentBeam::BentBeam(double length, double height, double bending_moment,
+                   double bulk_modulus, double shear_modulus) noexcept
+    : length_(length),
+      height_(height),
+      bending_moment_(bending_moment),
+      constitutive_relation_(
+          Elasticity::ConstitutiveRelations::IsotropicHomogeneous<2>{
+              bulk_modulus, shear_modulus}) {}
+
 tuples::TaggedTuple<Tags::Displacement<2>> BentBeam::variables(
     const tnsr::I<DataVector, 2>& x,
     tmpl::list<Tags::Displacement<2>> /*meta*/) const noexcept {

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
@@ -14,8 +14,7 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-namespace Elasticity {
-namespace Solutions {
+namespace Elasticity::Solutions {
 
 BentBeam::BentBeam(double length, double height, double bending_moment,
                    constitutive_relation_type constitutive_relation) noexcept
@@ -76,7 +75,7 @@ double BentBeam::potential_energy() const {
 tuples::TaggedTuple<::Tags::FixedSource<Tags::Displacement<2>>>
 BentBeam::variables(
     const tnsr::I<DataVector, 2>& x,
-    tmpl::list<::Tags::FixedSource<Tags::Displacement<2>>> /*meta*/) const
+    tmpl::list<::Tags::FixedSource<Tags::Displacement<2>>> /*meta*/)
     noexcept {
   return {make_with_value<tnsr::I<DataVector, 2>>(x, 0.)};
 }
@@ -98,5 +97,4 @@ bool operator!=(const BentBeam& lhs, const BentBeam& rhs) noexcept {
   return not(lhs == rhs);
 }
 
-}  // namespace Solutions
-}  // namespace Elasticity
+}  // namespace Elasticity::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
@@ -29,11 +29,11 @@ namespace Solutions {
  * \brief A state of pure bending of an elastic beam in 2D
  *
  * \details This solution describes a 2D slice through an elastic beam of length
- * \f$L\f$ and height \f$H\f$ that is subject to a bending moment \f$M=\int
- * T^{xx}y\mathrm{d}y\f$ (see e.g. \cite ThorneBlandford2017, Eq. 11.41c for a
- * bending moment in 1D). The beam material is characterized by an isotropic and
- * homogeneous constitutive relation \f$Y^{ijkl}\f$ in the plane-stress
- * approximation (see
+ * \f$L\f$ and height \f$H\f$, centered around (0, 0), that is subject to a
+ * bending moment \f$M=\int T^{xx}y\mathrm{d}y\f$ (see e.g.
+ * \cite ThorneBlandford2017, Eq. 11.41c for a bending moment in 1D). The beam
+ * material is characterized by an isotropic and homogeneous constitutive
+ * relation \f$Y^{ijkl}\f$ in the plane-stress approximation (see
  * `Elasticity::ConstitutiveRelations::IsotropicHomogeneous`). In this scenario,
  * no body-forces \f$f_\mathrm{ext}^j\f$ act on the material, so the
  * \ref Elasticity equations reduce to \f$\nabla_i T^{ij}=0\f$, but the bending

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
@@ -23,8 +23,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
-namespace Elasticity {
-namespace Solutions {
+namespace Elasticity::Solutions {
 /*!
  * \brief A state of pure bending of an elastic beam in 2D
  *
@@ -134,10 +133,9 @@ class BentBeam {
                  tmpl::list<Tags::Stress<2>> /*meta*/) const noexcept
       -> tuples::TaggedTuple<Tags::Stress<2>>;
 
-  auto variables(
+  static auto variables(
       const tnsr::I<DataVector, 2>& x,
-      tmpl::list<::Tags::FixedSource<Tags::Displacement<2>>> /*meta*/) const
-      noexcept
+      tmpl::list<::Tags::FixedSource<Tags::Displacement<2>>> /*meta*/) noexcept
       -> tuples::TaggedTuple<::Tags::FixedSource<Tags::Displacement<2>>>;
   // @}
 
@@ -166,5 +164,4 @@ class BentBeam {
 
 bool operator!=(const BentBeam& lhs, const BentBeam& rhs) noexcept;
 
-}  // namespace Solutions
-}  // namespace Elasticity
+}  // namespace Elasticity::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
@@ -113,6 +113,9 @@ class BentBeam {
     return constitutive_relation_;
   }
 
+  /// Return potential energy integrated over the whole domain
+  double potential_energy() const;
+
   // @{
   /// Retrieve variable at coordinates `x`
   auto variables(const tnsr::I<DataVector, 2>& x,

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
@@ -68,6 +68,7 @@ namespace Solutions {
  */
 class BentBeam {
  public:
+  static constexpr size_t volume_dim = 2;
   using constitutive_relation_type =
       Elasticity::ConstitutiveRelations::IsotropicHomogeneous<2>;
 
@@ -108,6 +109,9 @@ class BentBeam {
 
   BentBeam(double length, double height, double bending_moment,
            constitutive_relation_type constitutive_relation) noexcept;
+
+  BentBeam(double length, double height, double bending_moment,
+           double bulk_modulus, double shear_modulus) noexcept;
 
   const constitutive_relation_type& constitutive_relation() const noexcept {
     return constitutive_relation_;

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY ElasticitySolutions)
 
 set(LIBRARY_SOURCES
   BentBeam.cpp
+  HalfSpaceMirror.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
@@ -15,4 +16,5 @@ target_link_libraries(
   INTERFACE ErrorHandling
   INTERFACE Utilities
   INTERFACE ConstitutiveRelations
+  INTERFACE Integration
   )

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.cpp
@@ -20,8 +20,7 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-namespace Elasticity {
-namespace Solutions {
+namespace Elasticity::Solutions {
 
 static constexpr size_t dim = HalfSpaceMirror::dim;
 
@@ -55,16 +54,16 @@ tuples::TaggedTuple<Tags::Displacement<dim>> HalfSpaceMirror::variables(
   auto result = make_with_value<tnsr::I<DataVector, dim>>(x, 0.);
   const auto w = sqrt(square(get<0>(x)) + square(get<1>(x))) +
                  std::numeric_limits<double>::epsilon();
-  double cos_phi;
-  double sin_phi;
+  double cos_phi = std::numeric_limits<double>::signaling_NaN();
+  double sin_phi = std::numeric_limits<double>::signaling_NaN();
 
   const integration::GslQuadAdaptive<
       integration::GslIntegralType::UpperBoundaryInfinite>
       integration{no_intervals_};
   const double lower_boundary = 0.;
   const size_t num_points = get<0>(x).size();
-  double z;
-  double r;
+  double z = std::numeric_limits<double>::signaling_NaN();
+  double r = std::numeric_limits<double>::signaling_NaN();
   for (size_t i = 0; i < num_points; i++) {
     z = get<2>(x)[i];
     r = w[i];
@@ -119,16 +118,16 @@ tuples::TaggedTuple<Tags::Strain<dim>> HalfSpaceMirror::variables(
   auto strain = make_with_value<tnsr::ii<DataVector, dim>>(x, 0.);
   const auto w = sqrt(square(get<0>(x)) + square(get<1>(x))) +
                  std::numeric_limits<double>::epsilon();
-  double cos_phi;
-  double sin_phi;
+  double cos_phi = std::numeric_limits<double>::signaling_NaN();
+  double sin_phi = std::numeric_limits<double>::signaling_NaN();
 
   const integration::GslQuadAdaptive<
       integration::GslIntegralType::UpperBoundaryInfinite>
       integration{no_intervals_};
   const double lower_boundary = 0.;
   const size_t num_points = get<0>(x).size();
-  double r;
-  double z;
+  double r = std::numeric_limits<double>::signaling_NaN();
+  double z = std::numeric_limits<double>::signaling_NaN();
   for (size_t i = 0; i < num_points; i++) {
     r = w[i];
     z = get<2>(x)[i];
@@ -159,8 +158,8 @@ tuples::TaggedTuple<Tags::Strain<dim>> HalfSpaceMirror::variables(
         },
         lower_boundary, absolute_tolerance_);
 
-    double strain_rr;
-    double strain_pp;
+    double strain_rr = std::numeric_limits<double>::signaling_NaN();
+    double strain_pp = std::numeric_limits<double>::signaling_NaN();
     if (w[i] <= 1e-13) {
       cos_phi = 0.;
       sin_phi = 0.;
@@ -207,8 +206,8 @@ Scalar<DataVector> HalfSpaceMirror::pointwise_isotropic_energy(
       make_with_value<Scalar<DataVector>>(x, 0.);
   auto strain = get<::Elasticity::Tags::Strain<dim>>(
       variables(x, tmpl::list<::Elasticity::Tags::Strain<dim>>{}));
-  double strain_square;
-  double theta;
+  double strain_square = std::numeric_limits<double>::signaling_NaN();
+  double theta = std::numeric_limits<double>::signaling_NaN();
   const size_t num_points = get<0>(x).size();
   for (size_t i = 0; i < num_points; i++) {
     theta = 0;
@@ -231,17 +230,23 @@ Scalar<DataVector> HalfSpaceMirror::pointwise_isotropic_energy(
 tuples::TaggedTuple<::Tags::FixedSource<Tags::Displacement<dim>>>
 HalfSpaceMirror::variables(
     const tnsr::I<DataVector, dim>& x,
-    tmpl::list<::Tags::FixedSource<Tags::Displacement<dim>>> /*meta*/) const
-    noexcept {
+    tmpl::list<
+        ::Tags::FixedSource<Tags::Displacement<dim>>> /*meta*/) noexcept {
   return {make_with_value<tnsr::I<DataVector, dim>>(x, 0.)};
 }
 
 tuples::TaggedTuple<::Tags::Initial<Tags::Displacement<dim>>>
 HalfSpaceMirror::variables(
     const tnsr::I<DataVector, dim>& x,
-    tmpl::list<::Tags::Initial<Tags::Displacement<dim>>> /*meta*/) const
-    noexcept {
+    tmpl::list<::Tags::Initial<Tags::Displacement<dim>>> /*meta*/) noexcept {
   return {make_with_value<tnsr::I<DataVector, dim>>(x, 0.)};
+}
+
+tuples::TaggedTuple<::Tags::Initial<Tags::Strain<dim>>>
+HalfSpaceMirror::variables(
+    const tnsr::I<DataVector, dim>& x,
+    tmpl::list<::Tags::Initial<Tags::Strain<dim>>> /*meta*/) noexcept {
+  return {make_with_value<tnsr::ii<DataVector, dim>>(x, 0.)};
 }
 
 void HalfSpaceMirror::pup(PUP::er& p) noexcept {
@@ -262,5 +267,4 @@ bool operator!=(const HalfSpaceMirror& lhs,
   return not(lhs == rhs);
 }
 
-}  // namespace Solutions
-}  // namespace Elasticity
+}  // namespace Elasticity::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.cpp
@@ -1,0 +1,293 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp"
+#include "NumericalAlgorithms/Integration/GslQuadAdaptive.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <gsl/gsl_integration.h>
+#include <gsl/gsl_sf_bessel.h>
+#include <pup.h>  // IWYU pragma: keep
+
+#include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "ErrorHandling/Error.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace Elasticity {
+namespace Solutions {
+
+double alpha(const double k, const double shear_modulus,
+             const double beam_width, const double applied_force) {
+  return 1 / (4. * M_PI * shear_modulus) * exp(-square(k * beam_width / 2.)) *
+         applied_force;
+}
+
+double integrand_displacement_w(const double k, const double w, const double z,
+                                const double shear_modulus,
+                                const double poisson_ratio,
+                                const double beam_width,
+                                const double applied_force) noexcept {
+  return (-1 + 2. * poisson_ratio + k * z) * exp(-k * z) *
+         gsl_sf_bessel_J1(w * k) *
+         alpha(k, shear_modulus, beam_width, applied_force);
+}
+
+double integrand_displacement_z(const double k, const double w, const double z,
+                                const double shear_modulus,
+                                const double poisson_ratio,
+                                const double beam_width,
+                                const double applied_force) noexcept {
+  return (2 - 2. * poisson_ratio + k * z) * exp(-k * z) *
+         gsl_sf_bessel_J0(w * k) *
+         alpha(k, shear_modulus, beam_width, applied_force);
+}
+
+double integrand_displacement_w_dw(const double k, const double w,
+                                   const double z, const double shear_modulus,
+                                   const double poisson_ratio,
+                                   const double beam_width,
+                                   const double applied_force) noexcept {
+  return (-1 + 2. * poisson_ratio + k * z) * exp(-k * z) * k *
+         (gsl_sf_bessel_J0(w * k) - gsl_sf_bessel_Jn(2, w * k)) / 2. *
+         alpha(k, shear_modulus, beam_width, applied_force);
+}
+
+double integrand_displacement_w_dz(const double k, const double w,
+                                   const double z, const double shear_modulus,
+                                   const double poisson_ratio,
+                                   const double beam_width,
+                                   const double applied_force) noexcept {
+  return (2 - 2. * poisson_ratio - k * z) * k * exp(-k * z) *
+         gsl_sf_bessel_J1(w * k) *
+         alpha(k, shear_modulus, beam_width, applied_force);
+}
+
+double integrand_displacement_z_dw(const double k, const double w,
+                                   const double z, const double shear_modulus,
+                                   const double poisson_ratio,
+                                   const double beam_width,
+                                   const double applied_force) noexcept {
+  return (2 - 2. * poisson_ratio + k * z) * exp(-k * z) * k *
+         (-gsl_sf_bessel_J1(w * k)) *
+         alpha(k, shear_modulus, beam_width, applied_force);
+}
+
+double integrand_displacement_z_dz(const double k, const double w,
+                                   const double z, const double shear_modulus,
+                                   const double poisson_ratio,
+                                   const double beam_width,
+                                   const double applied_force) noexcept {
+  return (-1 + 2. * poisson_ratio - k * z) * k * exp(-k * z) *
+         gsl_sf_bessel_J0(w * k) *
+         alpha(k, shear_modulus, beam_width, applied_force);
+}
+
+HalfSpaceMirror::HalfSpaceMirror(
+    double beam_width, double applied_force,
+    constitutive_relation_type constitutive_relation, size_t no_intervals,
+    double absolute_tolerance) noexcept
+    : beam_width_(beam_width),
+      applied_force_(applied_force),
+      constitutive_relation_(std::move(constitutive_relation)),
+      no_intervals_(no_intervals),
+      absolute_tolerance_(absolute_tolerance) {}
+
+HalfSpaceMirror::HalfSpaceMirror(double beam_width, double applied_force,
+                                 double bulk_modulus, double shear_modulus,
+                                 size_t no_intervals,
+                                 double absolute_tolerance) noexcept
+    : beam_width_(beam_width),
+      applied_force_(applied_force),
+      constitutive_relation_(
+          Elasticity::ConstitutiveRelations::IsotropicHomogeneous<dim>{
+              bulk_modulus, shear_modulus}),
+      no_intervals_(no_intervals),
+      absolute_tolerance_(absolute_tolerance) {}
+
+tuples::TaggedTuple<Tags::Displacement<dim>> HalfSpaceMirror::variables(
+    const tnsr::I<DataVector, dim>& x,
+    tmpl::list<Tags::Displacement<dim>> /*meta*/) const noexcept {
+  const double shear_modulus = constitutive_relation_.shear_modulus();
+  const double poisson_ratio = constitutive_relation_.poisson_ratio();
+  auto result = make_with_value<tnsr::I<DataVector, 3>>(x, 0.);
+  const auto w = sqrt(square(get<0>(x)) + square(get<1>(x))) +
+                 std::numeric_limits<double>::epsilon();
+  double cos_phi;
+  double sin_phi;
+
+  const integration::GslQuadAdaptive<
+      integration::GslIntegralType::UpperBoundaryInfinite>
+      integration{no_intervals_};
+  const double lower_boundary = 0.;
+  const size_t num_points = get<0>(x).size();
+  double z;
+  double r;
+  for (size_t i = 0; i < num_points; i++) {
+    z = get<2>(x)[i];
+    r = w[i];
+    auto result_w = integration(
+        [&r, &z, &shear_modulus, &poisson_ratio, this](const double k) {
+          return integrand_displacement_w(k, r, z, shear_modulus, poisson_ratio,
+                                          this->beam_width_,
+                                          this->applied_force_);
+        },
+        lower_boundary, absolute_tolerance_);
+
+    if (w[i] <= 1e-13) {
+      ASSERT(
+          result_w <= 1e-13,
+          "The Jacobian is singular at the origin, the field value has to be "
+          "zero there for the transformation to make sense");
+      cos_phi = 0.;
+      sin_phi = 0.;
+    }
+
+    else {
+      cos_phi = get<0>(x)[i] / w[i];
+      sin_phi = get<1>(x)[i] / w[i];
+    }
+
+    get<0>(result)[i] = result_w * cos_phi;
+    get<1>(result)[i] = result_w * sin_phi;
+
+    auto result_z = integration(
+        [&r, &z, &shear_modulus, &poisson_ratio, this](const double k) {
+          return integrand_displacement_z(k, r, z, shear_modulus, poisson_ratio,
+                                          this->beam_width_,
+                                          this->applied_force_);
+        },
+        lower_boundary, absolute_tolerance_);
+    get<2>(result)[i] = result_z;
+  }
+  return {std::move(result)};
+}
+
+tuples::TaggedTuple<Tags::Strain<dim>> HalfSpaceMirror::variables(
+    const tnsr::I<DataVector, dim>& x,
+    tmpl::list<Tags::Strain<dim>> /*meta*/) const noexcept {
+  const double shear_modulus = constitutive_relation_.shear_modulus();
+  const double poisson_ratio = constitutive_relation_.poisson_ratio();
+  auto result = make_with_value<tnsr::ii<DataVector, 3>>(x, 0.);
+  const auto w = sqrt(square(get<0>(x)) + square(get<1>(x))) +
+                 std::numeric_limits<double>::epsilon();
+  double cos_phi;
+  double sin_phi;
+
+  const integration::GslQuadAdaptive<
+      integration::GslIntegralType::UpperBoundaryInfinite>
+      integration{no_intervals_};
+  const double lower_boundary = 0.;
+  const size_t num_points = get<0>(x).size();
+  double r;
+  double z;
+  for (size_t i = 0; i < num_points; i++) {
+    r = w[i];
+    z = get<2>(x)[i];
+    auto result_xiw_dw = integration(
+        [&r, &z, &shear_modulus, &poisson_ratio, this](const double k) {
+          return integrand_displacement_w_dw(k, r, z, shear_modulus,
+                                             poisson_ratio, this->beam_width_,
+                                             this->applied_force_);
+        },
+        lower_boundary, absolute_tolerance_);
+
+    auto result_xiw_dz = integration(
+        [&r, &z, &shear_modulus, &poisson_ratio, this](const double k) {
+          return integrand_displacement_w_dz(k, r, z, shear_modulus,
+                                             poisson_ratio, this->beam_width_,
+                                             this->applied_force_);
+        },
+        lower_boundary, absolute_tolerance_);
+
+    auto result_xiz_dw = integration(
+        [&r, &z, &shear_modulus, &poisson_ratio, this](const double k) {
+          return integrand_displacement_z_dw(k, r, z, shear_modulus,
+                                             poisson_ratio, this->beam_width_,
+                                             this->applied_force_);
+        },
+        lower_boundary, absolute_tolerance_);
+
+    auto result_xiz_dz = integration(
+        [&r, &z, &shear_modulus, &poisson_ratio, this](const double k) {
+          return integrand_displacement_z_dz(k, r, z, shear_modulus,
+                                             poisson_ratio, this->beam_width_,
+                                             this->applied_force_);
+        },
+        lower_boundary, absolute_tolerance_);
+
+    double xi_w_over_w;
+    if (w[i] <= 1e-13) {
+      cos_phi = 0.;
+      sin_phi = 0.;
+      xi_w_over_w = result_xiw_dw;
+    } else {
+      cos_phi = get<0>(x)[i] / w[i];
+      sin_phi = get<1>(x)[i] / w[i];
+      auto result_w = integration(
+          [&r, &z, &shear_modulus, &poisson_ratio, this](const double k) {
+            return integrand_displacement_w(k, r, z, shear_modulus,
+                                            poisson_ratio, this->beam_width_,
+                                            this->applied_force_);
+          },
+          lower_boundary, absolute_tolerance_);
+
+      xi_w_over_w = result_w / w[i];
+    }
+    get<0, 0>(result)[i] =
+        xi_w_over_w + square(cos_phi) * (result_xiw_dw - xi_w_over_w);
+    get<0, 1>(result)[i] = cos_phi * sin_phi * (result_xiw_dw - xi_w_over_w);
+    get<0, 2>(result)[i] = cos_phi * (result_xiw_dz + result_xiz_dw) / 2.;
+    get<1, 1>(result)[i] =
+        xi_w_over_w + square(sin_phi) * (result_xiw_dw - xi_w_over_w);
+    get<1, 2>(result)[i] = sin_phi * (result_xiw_dz + result_xiz_dw) / 2.;
+    get<1, 0>(result)[i] = get<0, 1>(result)[i];
+    get<2, 0>(result)[i] = get<0, 2>(result)[i];
+    get<2, 1>(result)[i] = get<1, 2>(result)[i];
+    get<2, 2>(result)[i] = result_xiz_dz;
+  }
+  return {std::move(result)};
+}
+
+tuples::TaggedTuple<::Tags::FixedSource<Tags::Displacement<dim>>>
+HalfSpaceMirror::variables(
+    const tnsr::I<DataVector, dim>& x,
+    tmpl::list<::Tags::FixedSource<Tags::Displacement<dim>>> /*meta*/) const
+    noexcept {
+  return {make_with_value<tnsr::I<DataVector, dim>>(x, 0.)};
+}
+
+tuples::TaggedTuple<::Tags::Initial<Tags::Displacement<dim>>>
+HalfSpaceMirror::variables(
+    const tnsr::I<DataVector, dim>& x,
+    tmpl::list<::Tags::Initial<Tags::Displacement<dim>>> /*meta*/) const
+    noexcept {
+  return {make_with_value<tnsr::I<DataVector, dim>>(x, 0.)};
+}
+
+void HalfSpaceMirror::pup(PUP::er& p) noexcept {
+  p | beam_width_;
+  p | applied_force_;
+  p | constitutive_relation_;
+}
+
+bool operator==(const HalfSpaceMirror& lhs,
+                const HalfSpaceMirror& rhs) noexcept {
+  return lhs.beam_width_ == rhs.beam_width_ and
+         lhs.applied_force_ == rhs.applied_force_ and
+         lhs.constitutive_relation_ == rhs.constitutive_relation_;
+}
+
+bool operator!=(const HalfSpaceMirror& lhs,
+                const HalfSpaceMirror& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace Solutions
+}  // namespace Elasticity

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
@@ -24,8 +24,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
-namespace Elasticity {
-namespace Solutions {
+namespace Elasticity::Solutions {
 /*!
  * \brief The solution for a deformed half-space mirror.
  *
@@ -124,22 +123,23 @@ class HalfSpaceMirror {
                  tmpl::list<Tags::Stress<dim>> /*meta*/) const noexcept
       -> tuples::TaggedTuple<Tags::Stress<dim>>;
 
-  auto variables(
+  static auto variables(
       const tnsr::I<DataVector, dim>& x,
-      tmpl::list<::Tags::FixedSource<Tags::Displacement<dim>>> /*meta*/) const
-      noexcept
+      tmpl::list<
+          ::Tags::FixedSource<Tags::Displacement<dim>>> /*meta*/) noexcept
       -> tuples::TaggedTuple<::Tags::FixedSource<Tags::Displacement<dim>>>;
   // @}
 
   /// Initial guess for variables
-  auto variables(
+  static auto variables(
       const tnsr::I<DataVector, dim>& x,
-      tmpl::list<::Tags::Initial<Tags::Displacement<dim>>> /*meta*/) const
-      noexcept -> tuples::TaggedTuple<::Tags::Initial<Tags::Displacement<dim>>>;
+      tmpl::list<::Tags::Initial<Tags::Displacement<dim>>> /*meta*/) noexcept
+      -> tuples::TaggedTuple<::Tags::Initial<Tags::Displacement<dim>>>;
 
-  auto variables(const tnsr::I<DataVector, dim>& x,
-                 tmpl::list<::Tags::Initial<Tags::Strain<dim>>> /*meta*/) const
-      noexcept -> tuples::TaggedTuple<::Tags::Initial<Tags::Strain<dim>>>;
+  static auto variables(
+      const tnsr::I<DataVector, dim>& x,
+      tmpl::list<::Tags::Initial<Tags::Strain<dim>>> /*meta*/) noexcept
+      -> tuples::TaggedTuple<::Tags::Initial<Tags::Strain<dim>>>;
 
   /// Retrieve a collection of variables at coordinates `x`
   template <typename... Tags>
@@ -167,5 +167,4 @@ class HalfSpaceMirror {
 bool operator!=(const HalfSpaceMirror& lhs,
                 const HalfSpaceMirror& rhs) noexcept;
 
-}  // namespace Solutions
-}  // namespace Elasticity
+}  // namespace Elasticity::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
@@ -1,0 +1,168 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <limits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"     // IWYU pragma: keep
+#include "Elliptic/Systems/Elasticity/FirstOrderSystem.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"  // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Elasticity {
+namespace Solutions {
+/*!
+ * \brief The solution for a deformed half-space mirror.
+ *
+ * \details This solution describes the displacement of a semi-infinite mirror
+ * with a perpendicularly acting force at its center. The beam material is
+ * characterized by an isotropic homogeneous constitutive relation
+ * \f$Y^{ijkl}\f$ (see
+ * `Elasticity::ConstitutiveRelations::IsotropicHomogeneous`). In this scenario,
+ * the force introduces a pressure in the form of a Gaussian distribution
+ *
+ * \f{align}
+ * T^{zz} &= \frac{e^{-\frac{\omega^2}{\omega_0^2}}}{\pi\omega_0^2} F \\
+ * T^{xy} &= T^{yy} = 0 \text{.}
+ * \f}
+ *
+ * as a Neumann boundary condition. The implementation here matches with
+ * Eqs. 11.93 and 11.97 in \cite ThorneBlandford2017.
+ */
+
+class HalfSpaceMirror {
+ public:
+  static constexpr size_t dim = 3;
+
+  using constitutive_relation_type =
+      Elasticity::ConstitutiveRelations::IsotropicHomogeneous<dim>;
+
+  struct BeamWidth {
+    using type = double;
+    static constexpr OptionString help{"The lasers beam width"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct AppliedForce {
+    using type = double;
+    static constexpr OptionString help{"The applied force"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct Material {
+    using type = constitutive_relation_type;
+    static constexpr OptionString help{"The material properties of the beam"};
+  };
+
+  struct IntegrationIntervals {
+    using type = size_t;
+    static constexpr OptionString help{"Intervals used in Integration"};
+    static type lower_bound() noexcept { return 1; }
+  };
+
+  struct IntergrationTolerance {
+    using type = double;
+    static constexpr OptionString help{"Tolerance used in Integration"};
+    static type lower_bound() noexcept { return 0.; }
+    static type upper_bound() noexcept { return 1e-5; }
+  };
+
+  using options = tmpl::list<BeamWidth, AppliedForce, Material,
+                             IntegrationIntervals, IntergrationTolerance>;
+  static constexpr OptionString help{
+      "A semi-infinite mirror on which a laser introduces stress perpendicular "
+      "to the mirrors surface. The displacement then is the Hankel-Transform "
+      "of the general solution multiplied by the beam profile"};
+
+  HalfSpaceMirror() = default;
+  HalfSpaceMirror(const HalfSpaceMirror&) noexcept = delete;
+  HalfSpaceMirror& operator=(const HalfSpaceMirror&) noexcept = delete;
+  HalfSpaceMirror(HalfSpaceMirror&&) noexcept = default;
+  HalfSpaceMirror& operator=(HalfSpaceMirror&&) noexcept = default;
+  ~HalfSpaceMirror() noexcept = default;
+
+  HalfSpaceMirror(double beam_width, double applied_force,
+                  constitutive_relation_type constitutive_relation,
+                  size_t no_intervals, double absolute_tolerance) noexcept;
+
+  HalfSpaceMirror(double beam_width, double applied_force, double bulk_modulus,
+                  double shear_modulus, size_t no_intervals,
+                  double absolute_tolerance) noexcept;
+
+  const constitutive_relation_type& constitutive_relation() const noexcept {
+    return constitutive_relation_;
+  }
+
+  // @{
+  /// Retrieve variable at coordinates `x`
+  auto variables(const tnsr::I<DataVector, dim>& x,
+                 tmpl::list<Tags::Displacement<dim>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<Tags::Displacement<dim>>;
+
+  auto variables(const tnsr::I<DataVector, dim>& x,
+                 tmpl::list<Tags::Strain<dim>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<Tags::Strain<dim>>;
+
+  auto variables(const tnsr::I<DataVector, dim>& x,
+                 tmpl::list<Tags::Stress<dim>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<Tags::Stress<dim>>;
+
+  auto variables(
+      const tnsr::I<DataVector, dim>& x,
+      tmpl::list<::Tags::FixedSource<Tags::Displacement<dim>>> /*meta*/) const
+      noexcept
+      -> tuples::TaggedTuple<::Tags::FixedSource<Tags::Displacement<dim>>>;
+  // @}
+
+  /// Initial guess for variables
+  auto variables(
+      const tnsr::I<DataVector, dim>& x,
+      tmpl::list<::Tags::Initial<Tags::Displacement<dim>>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<::Tags::Initial<Tags::Displacement<dim>>>;
+
+  auto variables(const tnsr::I<DataVector, dim>& x,
+                 tmpl::list<::Tags::Initial<Tags::Strain<dim>>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<::Tags::Initial<Tags::Strain<dim>>>;
+
+  /// Retrieve a collection of variables at coordinates `x`
+  template <typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataVector, dim>& x,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
+    static_assert(sizeof...(Tags) > 1, "An unsupported Tag was requested.");
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  // clang-tidy: no pass by reference
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  friend bool operator==(const HalfSpaceMirror& lhs,
+                         const HalfSpaceMirror& rhs) noexcept;
+
+  double beam_width_{std::numeric_limits<double>::signaling_NaN()};
+  double applied_force_{std::numeric_limits<double>::signaling_NaN()};
+  constitutive_relation_type constitutive_relation_{};
+  size_t no_intervals_{};
+  double absolute_tolerance_{};
+};
+
+bool operator!=(const HalfSpaceMirror& lhs,
+                const HalfSpaceMirror& rhs) noexcept;
+
+}  // namespace Solutions
+}  // namespace Elasticity

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
@@ -41,8 +41,8 @@ namespace Solutions {
  * T^{xy} &= T^{yy} = 0 \text{.}
  * \f}
  *
- * as a Neumann boundary condition. The implementation here matches with
- * Eqs. 11.93 and 11.97 in \cite ThorneBlandford2017.
+ * as a Neumann boundary condition. The implementation used here matches with
+ * Eqs. 11 and 12 in \cite Lovelace2007tn.
  */
 
 class HalfSpaceMirror {

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
@@ -107,6 +107,9 @@ class HalfSpaceMirror {
     return constitutive_relation_;
   }
 
+  Scalar<DataVector> pointwise_isotropic_energy(
+      const tnsr::I<DataVector, dim>& x) const noexcept;
+
   // @{
   /// Retrieve variable at coordinates `x`
   auto variables(const tnsr::I<DataVector, dim>& x,

--- a/src/PointwiseFunctions/Elasticity/CMakeLists.txt
+++ b/src/PointwiseFunctions/Elasticity/CMakeLists.txt
@@ -2,3 +2,21 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(ConstitutiveRelations)
+
+set(LIBRARY PotentialEnergy)
+
+set(LIBRARY_SOURCES
+  PotentialEnergy.cpp
+  )
+
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  ConstitutiveRelations
+  DataStructures
+  Domain
+  Elasticity
+  Utilities
+  )

--- a/src/PointwiseFunctions/Elasticity/PotentialEnergy.cpp
+++ b/src/PointwiseFunctions/Elasticity/PotentialEnergy.cpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Elasticity/PotentialEnergy.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace Elasticity {
+
+template <size_t Dim>
+Scalar<DataVector> evaluate_potential_energy(
+    const tnsr::ii<DataVector, Dim, Frame::Inertial>& strain,
+    const tnsr::I<DataVector, Dim>& coordinates,
+    const ConstitutiveRelations::ConstitutiveRelation<Dim>&
+        constitutive_relation) noexcept {
+  auto stress = constitutive_relation.stress(strain, coordinates);
+  Scalar<DataVector> pointwise_potential =
+      make_with_value<Scalar<DataVector>>(coordinates, 0.);
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t j = 0; j < Dim; j++) {
+      get(pointwise_potential) -= 0.5 * stress.get(i, j) * strain.get(i, j);
+    }
+  }
+  return pointwise_potential;
+}
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                        \
+  template Scalar<DataVector> evaluate_potential_energy<DIM(data)>( \
+      const tnsr::ii<DataVector, DIM(data)>& strain,                \
+      const tnsr::I<DataVector, DIM(data)>& coordinates,            \
+      const ConstitutiveRelations::ConstitutiveRelation<DIM(data)>& \
+          constitutive_relation) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+/// \endcond
+
+}  // namespace Elasticity

--- a/src/PointwiseFunctions/Elasticity/PotentialEnergy.hpp
+++ b/src/PointwiseFunctions/Elasticity/PotentialEnergy.hpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
+
+namespace Elasticity {
+
+template <size_t Dim>
+Scalar<DataVector> evaluate_potential_energy(
+    const tnsr::ii<DataVector, Dim, Frame::Inertial>& strain,
+    const tnsr::I<DataVector, Dim>& coordinates,
+    const ConstitutiveRelations::ConstitutiveRelation<Dim>&
+        constitutive_relation) noexcept;
+
+namespace Tags {
+template <size_t Dim>
+struct PotentialEnergyCompute : Elasticity::Tags::PotentialEnergy<Dim>,
+                                db::ComputeTag {
+  using base = Elasticity::Tags::PotentialEnergy<Dim>;
+  using argument_tags =
+      tmpl::list<Elasticity::Tags::Strain<Dim>,
+                 domain::Tags::Coordinates<Dim, Frame::Inertial>,
+                 Elasticity::Tags::ConstitutiveRelationBase>;
+  // static constexpr auto function = &evaluate_potential_energy<Dim>;
+  static Scalar<DataVector> function(
+      const tnsr::ii<DataVector, Dim, Frame::Inertial>& strain,
+      const tnsr::I<DataVector, Dim>& coordinates,
+      const Elasticity::ConstitutiveRelations::ConstitutiveRelation<Dim>&
+          constitutive_relation) {
+    return evaluate_potential_energy<Dim>(strain, coordinates,
+                                          constitutive_relation);
+  }
+};
+}  // namespace Tags
+}  // namespace Elasticity

--- a/tests/Unit/Elliptic/Systems/Elasticity/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/Test_Tags.cpp
@@ -8,10 +8,11 @@
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
-SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Elasticity.Tags",
-                  "[Unit][Elliptic]") {
+SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Elasticity.Tags", "[Unit][Elliptic]") {
   TestHelpers::db::test_simple_tag<Elasticity::Tags::Displacement<1>>(
       "Displacement");
   TestHelpers::db::test_simple_tag<Elasticity::Tags::Strain<1>>("Strain");
   TestHelpers::db::test_simple_tag<Elasticity::Tags::Stress<1>>("Stress");
+  TestHelpers::db::test_simple_tag<Elasticity::Tags::PotentialEnergy<1>>(
+      "PotentialEnergy");
 }

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
@@ -136,13 +136,15 @@ void verify_solution(
  * per dimension.
  */
 template <typename System, typename SolutionType,
-          size_t Dim = System::volume_dim, typename... Maps>
+          size_t Dim = System::volume_dim, typename... Maps,
+          typename... FluxesArgs>
 void verify_smooth_solution(
     const SolutionType& solution,
     const typename System::fluxes& fluxes_computer,
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, Maps...>&
         coord_map,
-    const double tolerance_offset, const double tolerance_scaling) {
+    const double tolerance_offset, const double tolerance_scaling,
+    const std::tuple<FluxesArgs...>& fluxes_args = std::tuple<>{}) {
   INFO("Verify smooth solution");
   for (size_t num_points = Spectral::minimum_number_of_points<
            Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
@@ -153,11 +155,10 @@ void verify_smooth_solution(
     const double tolerance =
         tolerance_offset * exp(-tolerance_scaling * num_points);
     CAPTURE(tolerance);
+    const Mesh<Dim> mesh{num_points, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
     FirstOrderEllipticSolutionsTestHelpers::verify_solution<System>(
-        solution, fluxes_computer,
-        Mesh<Dim>{num_points, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto},
-        coord_map, tolerance);
+        solution, fluxes_computer, mesh, coord_map, tolerance, fluxes_args);
   }
 }
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
@@ -5,11 +5,12 @@ set(LIBRARY "Test_ElasticitySolutions")
 
 set(LIBRARY_SOURCES
   Test_BentBeam.cpp
+  Test_HalfSpaceMirror.cpp
   )
 
 add_test_library(
   ${LIBRARY}
   "PointwiseFunctions/AnalyticSolutions/Elasticity/"
   "${LIBRARY_SOURCES}"
-  "ElasticitySolutions;Utilities"
+  "ElasticitySolutions;Utilities;Integration"
   )

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.py
@@ -1,0 +1,144 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+import scipy.integrate as integrate
+from scipy.special import jv
+
+
+def alpha(k, shear_modulus, beam_width, applied_force):
+    return 1 / (4. * np.pi * shear_modulus
+                ) * np.exp(-(k * beam_width / 2.)**2) * applied_force
+
+
+def integrand_xi_w(k, w, z, poisson_ratio, shear_modulus, beam_width,
+                   applied_force):
+    return (-1 + 2.*poisson_ratio + k*z)*np.exp(-k*z)*jv(1, k*w) * \
+        alpha(k, shear_modulus, beam_width, applied_force)
+
+
+def integrand_xi_z(k, w, z, poisson_ratio, shear_modulus, beam_width,
+                   applied_force):
+    return (2 - 2.*poisson_ratio + k*z)*np.exp(-k*z)*jv(0, k*w) * \
+        alpha(k, shear_modulus, beam_width, applied_force)
+
+
+def integrand_xi_w_dw(k, w, z, poisson_ratio, shear_modulus, beam_width,
+                      applied_force):
+    return (-1 + 2. * poisson_ratio + k * z) * np.exp(
+        -k * z) * k * (jv(0, k * w) - jv(2, k * w)) / 2. * alpha(
+            k, shear_modulus, beam_width, applied_force)
+
+
+def integrand_xi_w_dz(k, w, z, poisson_ratio, shear_modulus, beam_width,
+                      applied_force):
+    return (2 - 2.*poisson_ratio - k*z)*k*np.exp(-k*z)*jv(1, k*w) * \
+        alpha(k, shear_modulus, beam_width, applied_force)
+
+
+def integrand_xi_z_dw(k, w, z, poisson_ratio, shear_modulus, beam_width,
+                      applied_force):
+    return (2 - 2.*poisson_ratio + k*z)*np.exp(-k*z)*k*(-jv(1, k*w)) * \
+        alpha(k, shear_modulus, beam_width, applied_force)
+
+
+def integrand_xi_z_dz(k, w, z, poisson_ratio, shear_modulus, beam_width,
+                      applied_force):
+    return (-1 + 2.*poisson_ratio - k*z)*k*np.exp(-k*z)*jv(0, k*w) * \
+        alpha(k, shear_modulus, beam_width, applied_force)
+
+
+def displacement(r, beam_width, applied_force, bulk_modulus, shear_modulus):
+    poisson_ratio = (3. * bulk_modulus - 2. * shear_modulus) / \
+        (6. * bulk_modulus + 2. * shear_modulus)
+
+    x = r[0]
+    y = r[1]
+    z = r[2]
+    w = np.sqrt(x**2 + y**2)
+    xi_w = integrate.quad(lambda k: integrand_xi_w(
+        k, w, z, poisson_ratio, shear_modulus, beam_width, applied_force),
+                          0,
+                          np.inf,
+                          limit=100,
+                          epsabs=1e-15)[0]
+    xi_z = integrate.quad(lambda k: integrand_xi_z(
+        k, w, z, poisson_ratio, shear_modulus, beam_width, applied_force),
+                          0,
+                          np.inf,
+                          limit=100,
+                          epsabs=1e-15)[0]
+    if w == 0.:
+        assert xi_w <= 1e-13, 'xi_w is not zero at the origin'
+        cos_phi = 0.
+        sin_phi = 0.
+    else:
+        cos_phi = x / float(w)
+        sin_phi = y / float(w)
+    return np.asarray([xi_w * cos_phi, xi_w * sin_phi, xi_z])
+
+
+def strain(r, beam_width, applied_force, bulk_modulus, shear_modulus):
+    poisson_ratio = (3. * bulk_modulus - 2. * shear_modulus) / \
+        (6. * bulk_modulus + 2. * shear_modulus)
+
+    x = r[0]
+    y = r[1]
+    z = r[2]
+    w = np.sqrt(x**2 + y**2)
+
+    xi_z_dw = integrate.quad(lambda k: integrand_xi_z_dw(
+        k, w, z, poisson_ratio, shear_modulus, beam_width, applied_force),
+                             0,
+                             np.inf,
+                             limit=100,
+                             epsabs=1e-15)[0]
+
+    xi_w_dz = integrate.quad(lambda k: integrand_xi_w_dz(
+        k, w, z, poisson_ratio, shear_modulus, beam_width, applied_force),
+                             0,
+                             np.inf,
+                             limit=100,
+                             epsabs=1e-15)[0]
+
+    xi_z_dz = integrate.quad(lambda k: integrand_xi_z_dz(
+        k, w, z, poisson_ratio, shear_modulus, beam_width, applied_force),
+                             0,
+                             np.inf,
+                             limit=100,
+                             epsabs=1e-15)[0]
+
+    xi_w_dw = integrate.quad(lambda k: integrand_xi_w_dw(
+        k, w, z, poisson_ratio, shear_modulus, beam_width, applied_force),
+                             0,
+                             np.inf,
+                             limit=100,
+                             epsabs=1e-15)[0]
+    if w == 0:
+        w = 1.
+        xi_w_over_w = xi_w_dw
+    else:
+        xi_w_over_w = integrate.quad(lambda k: integrand_xi_w(
+            k, w, z, poisson_ratio, shear_modulus, beam_width, applied_force),
+                                     0,
+                                     np.inf,
+                                     limit=100,
+                                     epsabs=1e-15)[0] / w
+    return np.asarray([[
+        (y / w)**2 * xi_w_over_w + (x / w)**2 * xi_w_dw,
+        x * y / w**2 * (xi_w_dw - xi_w_over_w),
+        x / w * (xi_w_dz + xi_z_dw) / 2.
+    ],
+    [
+        x * y / w**2 * (xi_w_dw - xi_w_over_w),
+        (x / w)**2 * xi_w_over_w + (y / w)**2 * xi_w_dw,
+        y / w * (xi_w_dz + xi_z_dw) / 2.
+    ],
+    [
+        x / w * (xi_w_dz + xi_z_dw) / 2.,
+        y / w * (xi_w_dz + xi_z_dw) / 2., xi_z_dz
+    ]])
+
+
+def source(r):
+    return np.zeros(r.shape)

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.py
@@ -4,70 +4,71 @@
 import numpy as np
 import scipy.integrate as integrate
 from scipy.special import jv
+from Elasticity.ConstitutiveRelations.IsotropicHomogeneous import (
+    lame_parameter)
 
 
-def alpha(k, shear_modulus, beam_width, applied_force):
-    return 1 / (4. * np.pi * shear_modulus
-                ) * np.exp(-(k * beam_width / 2.)**2) * applied_force
+def alpha(k, beam_width, applied_force):
+    return 1 / (2. * np.pi) * np.exp(-(k * beam_width / 2.)**2) * applied_force
 
 
-def integrand_xi_w(k, w, z, poisson_ratio, shear_modulus, beam_width,
+def integrand_xi_w(k, w, z, lame_parameter, shear_modulus, beam_width,
                    applied_force):
-    return (-1 + 2.*poisson_ratio + k*z)*np.exp(-k*z)*jv(1, k*w) * \
-        alpha(k, shear_modulus, beam_width, applied_force)
+    return 1 / (2. * shear_modulus) * jv(1, k * w) * np.exp(-k * z) * \
+        (1 - (lame_parameter + 2. * shear_modulus) / \
+        (lame_parameter + shear_modulus) + k * z) * \
+        alpha(k, beam_width, applied_force)
 
 
-def integrand_xi_z(k, w, z, poisson_ratio, shear_modulus, beam_width,
+def integrand_xi_z(k, w, z, lame_parameter, shear_modulus, beam_width,
                    applied_force):
-    return (2 - 2.*poisson_ratio + k*z)*np.exp(-k*z)*jv(0, k*w) * \
-        alpha(k, shear_modulus, beam_width, applied_force)
+    return 1 / (2. * shear_modulus) * jv(0, k * w) * np.exp(-k * z) * \
+        (1 + shear_modulus / (lame_parameter + shear_modulus) + k * z) * \
+        alpha(k, beam_width, applied_force)
 
 
-def integrand_xi_w_dw(k, w, z, poisson_ratio, shear_modulus, beam_width,
-                      applied_force):
-    return (-1 + 2. * poisson_ratio + k * z) * np.exp(
-        -k * z) * k * (jv(0, k * w) - jv(2, k * w)) / 2. * alpha(
-            k, shear_modulus, beam_width, applied_force)
+def integrand_theta(k, w, z, lame_parameter, shear_modulus, beam_width,
+                    applied_force):
+    return 1 / (2. * shear_modulus) * k * jv(0, k * w) * np.exp(-k * z) * \
+        (-2. * shear_modulus /(lame_parameter + shear_modulus)) * \
+        alpha(k, beam_width, applied_force)
 
 
-def integrand_xi_w_dz(k, w, z, poisson_ratio, shear_modulus, beam_width,
-                      applied_force):
-    return (2 - 2.*poisson_ratio - k*z)*k*np.exp(-k*z)*jv(1, k*w) * \
-        alpha(k, shear_modulus, beam_width, applied_force)
+def integrand_strain_rz(k, w, z, lame_parameter, shear_modulus, beam_width,
+                        applied_force):
+    return -1 / (2. * shear_modulus) * k * jv(1, k * w) * (k * z) * \
+        np.exp(-k * z) * alpha(k, beam_width, applied_force)
 
 
-def integrand_xi_z_dw(k, w, z, poisson_ratio, shear_modulus, beam_width,
-                      applied_force):
-    return (2 - 2.*poisson_ratio + k*z)*np.exp(-k*z)*k*(-jv(1, k*w)) * \
-        alpha(k, shear_modulus, beam_width, applied_force)
-
-
-def integrand_xi_z_dz(k, w, z, poisson_ratio, shear_modulus, beam_width,
-                      applied_force):
-    return (-1 + 2.*poisson_ratio - k*z)*k*np.exp(-k*z)*jv(0, k*w) * \
-        alpha(k, shear_modulus, beam_width, applied_force)
+def integrand_strain_zz(k, w, z, lame_parameter, shear_modulus, beam_width,
+                        applied_force):
+    return 1 / (2. * shear_modulus) * k * jv(0, k * w) * np.exp(-k * z) * \
+        (-shear_modulus /(lame_parameter + shear_modulus) - k * z) * \
+        alpha(k, beam_width, applied_force)
 
 
 def displacement(r, beam_width, applied_force, bulk_modulus, shear_modulus):
-    poisson_ratio = (3. * bulk_modulus - 2. * shear_modulus) / \
-        (6. * bulk_modulus + 2. * shear_modulus)
-
+    local_lame_parameter = lame_parameter(bulk_modulus, shear_modulus)
     x = r[0]
     y = r[1]
     z = r[2]
     w = np.sqrt(x**2 + y**2)
-    xi_w = integrate.quad(lambda k: integrand_xi_w(
-        k, w, z, poisson_ratio, shear_modulus, beam_width, applied_force),
-                          0,
-                          np.inf,
-                          limit=100,
-                          epsabs=1e-15)[0]
-    xi_z = integrate.quad(lambda k: integrand_xi_z(
-        k, w, z, poisson_ratio, shear_modulus, beam_width, applied_force),
-                          0,
-                          np.inf,
-                          limit=100,
-                          epsabs=1e-15)[0]
+    xi_w = integrate.quad(
+        lambda k: integrand_xi_w(k, w, z, local_lame_parameter, shear_modulus,
+                                 beam_width, applied_force),
+        0,
+        np.inf,
+        limit=100,
+        epsabs=1e-13)[0]
+
+    xi_z = integrate.quad(
+        lambda k: integrand_xi_z(k, w, z, local_lame_parameter, shear_modulus,
+                                 beam_width, applied_force),
+        0,
+        np.inf,
+        limit=100,
+        epsabs=1e-13)[0]
+
     if w == 0.:
         assert xi_w <= 1e-13, 'xi_w is not zero at the origin'
         cos_phi = 0.
@@ -79,65 +80,61 @@ def displacement(r, beam_width, applied_force, bulk_modulus, shear_modulus):
 
 
 def strain(r, beam_width, applied_force, bulk_modulus, shear_modulus):
-    poisson_ratio = (3. * bulk_modulus - 2. * shear_modulus) / \
-        (6. * bulk_modulus + 2. * shear_modulus)
+    local_lame_parameter = lame_parameter(bulk_modulus, shear_modulus)
 
     x = r[0]
     y = r[1]
     z = r[2]
     w = np.sqrt(x**2 + y**2)
 
-    xi_z_dw = integrate.quad(lambda k: integrand_xi_z_dw(
-        k, w, z, poisson_ratio, shear_modulus, beam_width, applied_force),
-                             0,
-                             np.inf,
-                             limit=100,
-                             epsabs=1e-15)[0]
+    theta = integrate.quad(
+        lambda k: integrand_theta(k, w, z, local_lame_parameter, shear_modulus,
+                                  beam_width, applied_force),
+        0,
+        np.inf,
+        limit=100,
+        epsabs=1e-13)[0]
 
-    xi_w_dz = integrate.quad(lambda k: integrand_xi_w_dz(
-        k, w, z, poisson_ratio, shear_modulus, beam_width, applied_force),
-                             0,
-                             np.inf,
-                             limit=100,
-                             epsabs=1e-15)[0]
+    strain_rz = integrate.quad(lambda k: integrand_strain_rz(
+        k, w, z, local_lame_parameter, shear_modulus, beam_width, applied_force
+    ),
+                               0,
+                               np.inf,
+                               limit=100,
+                               epsabs=1e-13)[0]
 
-    xi_z_dz = integrate.quad(lambda k: integrand_xi_z_dz(
-        k, w, z, poisson_ratio, shear_modulus, beam_width, applied_force),
-                             0,
-                             np.inf,
-                             limit=100,
-                             epsabs=1e-15)[0]
+    strain_zz = integrate.quad(lambda k: integrand_strain_zz(
+        k, w, z, local_lame_parameter, shear_modulus, beam_width, applied_force
+    ),
+                               0,
+                               np.inf,
+                               limit=100,
+                               epsabs=1e-13)[0]
 
-    xi_w_dw = integrate.quad(lambda k: integrand_xi_w_dw(
-        k, w, z, poisson_ratio, shear_modulus, beam_width, applied_force),
-                             0,
-                             np.inf,
-                             limit=100,
-                             epsabs=1e-15)[0]
     if w == 0:
         w = 1.
-        xi_w_over_w = xi_w_dw
+        strain_rr = 0.5 * (theta - strain_zz)
+        strain_pp = strain_rr
+
     else:
-        xi_w_over_w = integrate.quad(lambda k: integrand_xi_w(
-            k, w, z, poisson_ratio, shear_modulus, beam_width, applied_force),
-                                     0,
-                                     np.inf,
-                                     limit=100,
-                                     epsabs=1e-15)[0] / w
+        xi_w = integrate.quad(
+            lambda k: integrand_xi_w(k, w, z, local_lame_parameter,
+                                     shear_modulus, beam_width, applied_force),
+            0,
+            np.inf,
+            limit=100,
+            epsabs=1e-13)[0]
+        strain_pp = xi_w / w
+        strain_rr = theta - strain_pp - strain_zz
     return np.asarray([[
-        (y / w)**2 * xi_w_over_w + (x / w)**2 * xi_w_dw,
-        x * y / w**2 * (xi_w_dw - xi_w_over_w),
-        x / w * (xi_w_dz + xi_z_dw) / 2.
+        strain_pp + (x / w)**2 * (strain_rr - strain_pp),
+        x * y / w**2 * (strain_rr - strain_pp), x / w * strain_rz
     ],
-    [
-        x * y / w**2 * (xi_w_dw - xi_w_over_w),
-        (x / w)**2 * xi_w_over_w + (y / w)**2 * xi_w_dw,
-        y / w * (xi_w_dz + xi_z_dw) / 2.
-    ],
-    [
-        x / w * (xi_w_dz + xi_z_dw) / 2.,
-        y / w * (xi_w_dz + xi_z_dw) / 2., xi_z_dz
-    ]])
+                       [
+                           x * y / w**2 * (strain_rr - strain_pp),
+                           strain_pp + (y / w)**2 * (strain_rr - strain_pp),
+                           y / w * strain_rz
+                       ], [x / w * strain_rz, y / w * strain_rz, strain_zz]])
 
 
 def source(r):

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
@@ -70,7 +70,7 @@ SPECTRE_TEST_CASE(
       // Iron: E=100, nu=0.29
       Elasticity::ConstitutiveRelations::IsotropicHomogeneous<2>{
           79.36507936507935, 38.75968992248062}};
-  const Elasticity::Solutions::BentBeam created_solution =
+  const auto created_solution =
       TestHelpers::test_creation<Elasticity::Solutions::BentBeam>(
           "Length: 5.\n"
           "Height: 1.\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
@@ -54,6 +54,10 @@ struct BentBeamProxy : Elasticity::Solutions::BentBeam {
       const tnsr::I<DataVector, 2>& x) const noexcept {
     return Elasticity::Solutions::BentBeam::variables(x, source_tags{});
   }
+
+  double potential_energy() const noexcept {
+    return Elasticity::Solutions::BentBeam::potential_energy();
+  }
 };
 
 }  // namespace
@@ -104,6 +108,7 @@ SPECTRE_TEST_CASE(
   get<1, 0>(expected_stress) = DataVector{0., 0.};
   get<1, 1>(expected_stress) = DataVector{0., 0.};
   CHECK_VARIABLES_APPROX(solution_vars, expected_vars);
+  CHECK_ITERABLE_APPROX(solution.potential_energy(), 0.075);
 
   pypp::check_with_random_values<
       1, tmpl::list<Elasticity::Tags::Displacement<2>,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
@@ -70,7 +70,7 @@ SPECTRE_TEST_CASE(
           // Iron: E=72, nu=0.17
           36.36363636363637, 30.76923076923077},
       50, 1.e-13};
-  const Elasticity::Solutions::HalfSpaceMirror created_solution =
+  const auto created_solution =
       TestHelpers::test_creation<Elasticity::Solutions::HalfSpaceMirror>(
           "BeamWidth: 0.177\n"
           "AppliedForce: 1.0\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
@@ -61,6 +61,7 @@ struct HalfSpaceMirrorProxy : Elasticity::Solutions::HalfSpaceMirror {
 SPECTRE_TEST_CASE(
     "Unit.PointwiseFunctions.AnalyticSolutions.Elasticity.HalfSpaceMirror",
     "[PointwiseFunctions][Unit][Elasticity]") {
+  const size_t dim = Elasticity::Solutions::HalfSpaceMirror::dim;
   const Elasticity::Solutions::HalfSpaceMirror check_solution{
       0.177, 1.0,
       Elasticity::ConstitutiveRelations::IsotropicHomogeneous<3>{
@@ -79,23 +80,24 @@ SPECTRE_TEST_CASE(
   CHECK(created_solution == check_solution);
   test_serialization(check_solution);
 
-  pypp::SetupLocalPythonEnvironment local_python_env{
-      "PointwiseFunctions/AnalyticSolutions/Elasticity"};
-  const Elasticity::ConstitutiveRelations::IsotropicHomogeneous<3>
+  pypp::SetupLocalPythonEnvironment local_python_env{"PointwiseFunctions"};
+  const Elasticity::ConstitutiveRelations::IsotropicHomogeneous<dim>
       constitutive_relation{36.36363636363637, 30.76923076923077};
   const HalfSpaceMirrorProxy solution{0.177, 1.0, constitutive_relation, 50,
                                       1.e-13};
   pypp::check_with_random_values<1,
-                                 tmpl::list<Elasticity::Tags::Displacement<3>,
-                                            Elasticity::Tags::Strain<3>>>(
-      &HalfSpaceMirrorProxy::field_variables, solution, "HalfSpaceMirror",
+                                 tmpl::list<Elasticity::Tags::Displacement<dim>,
+                                            Elasticity::Tags::Strain<dim>>>(
+      &HalfSpaceMirrorProxy::field_variables, solution,
+      "AnalyticSolutions.Elasticity.HalfSpaceMirror",
       {"displacement", "strain"}, {{{0., 5.}}},
       std::make_tuple(0.177, 1.0, 36.36363636363637, 30.76923076923077),
       DataVector(5));
   pypp::check_with_random_values<
-      1, tmpl::list<Tags::FixedSource<Elasticity::Tags::Displacement<3>>>>(
-      &HalfSpaceMirrorProxy::source_variables, solution, "HalfSpaceMirror",
-      {"source"}, {{{0., 5.}}}, std::make_tuple(), DataVector(5));
+      1, tmpl::list<Tags::FixedSource<Elasticity::Tags::Displacement<dim>>>>(
+      &HalfSpaceMirrorProxy::source_variables, solution,
+      "AnalyticSolutions.Elasticity.HalfSpaceMirror", {"source"}, {{{0., 5.}}},
+      std::make_tuple(), DataVector(5));
 
   {
     INFO("Test elasticity system with half-space mirror");

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
@@ -1,0 +1,119 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Elliptic/Systems/Elasticity/Equations.hpp"
+#include "Elliptic/Systems/Elasticity/FirstOrderSystem.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"  // IWYU pragma: keep
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+
+struct HalfSpaceMirrorProxy : Elasticity::Solutions::HalfSpaceMirror {
+  using Elasticity::Solutions::HalfSpaceMirror::HalfSpaceMirror;
+
+  using field_tags = tmpl::list<Elasticity::Tags::Displacement<3>,
+                                Elasticity::Tags::Strain<3>>;
+  using source_tags =
+      tmpl::list<Tags::FixedSource<Elasticity::Tags::Displacement<3>>>;
+
+  tuples::tagged_tuple_from_typelist<field_tags> field_variables(
+      const tnsr::I<DataVector, 3>& x) const noexcept {
+    return Elasticity::Solutions::HalfSpaceMirror::variables(x, field_tags{});
+  }
+
+  tuples::tagged_tuple_from_typelist<source_tags> source_variables(
+      const tnsr::I<DataVector, 3>& x) const noexcept {
+    return Elasticity::Solutions::HalfSpaceMirror::variables(x, source_tags{});
+  }
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.Elasticity.HalfSpaceMirror",
+    "[PointwiseFunctions][Unit][Elasticity]") {
+  const Elasticity::Solutions::HalfSpaceMirror check_solution{
+      0.177, 1.0,
+      Elasticity::ConstitutiveRelations::IsotropicHomogeneous<3>{
+          // Iron: E=72, nu=0.17
+          36.36363636363637, 30.76923076923077},
+      50, 1.e-13};
+  const Elasticity::Solutions::HalfSpaceMirror created_solution =
+      TestHelpers::test_creation<Elasticity::Solutions::HalfSpaceMirror>(
+          "BeamWidth: 0.177\n"
+          "AppliedForce: 1.0\n"
+          "Material:\n"
+          "  BulkModulus: 36.36363636363637\n"
+          "  ShearModulus: 30.76923076923077\n"
+          "IntegrationIntervals: 20\n"
+          "IntergrationTolerance: 1.e-13\n");
+  CHECK(created_solution == check_solution);
+  test_serialization(check_solution);
+
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/Elasticity"};
+  const Elasticity::ConstitutiveRelations::IsotropicHomogeneous<3>
+      constitutive_relation{36.36363636363637, 30.76923076923077};
+  const HalfSpaceMirrorProxy solution{0.177, 1.0, constitutive_relation, 50,
+                                      1.e-13};
+  pypp::check_with_random_values<1,
+                                 tmpl::list<Elasticity::Tags::Displacement<3>,
+                                            Elasticity::Tags::Strain<3>>>(
+      &HalfSpaceMirrorProxy::field_variables, solution, "HalfSpaceMirror",
+      {"displacement", "strain"}, {{{0., 5.}}},
+      std::make_tuple(0.177, 1.0, 36.36363636363637, 30.76923076923077),
+      DataVector(5));
+  pypp::check_with_random_values<
+      1, tmpl::list<Tags::FixedSource<Elasticity::Tags::Displacement<3>>>>(
+      &HalfSpaceMirrorProxy::source_variables, solution, "HalfSpaceMirror",
+      {"source"}, {{{0., 5.}}}, std::make_tuple(), DataVector(5));
+
+  {
+    INFO("Test elasticity system with half-space mirror");
+    // Verify that the solution numerically solves the system and that the
+    // discretization error decreases exponentially with polynomial order
+    using system = Elasticity::FirstOrderSystem<dim>;
+    const typename system::fluxes fluxes_computer{};
+    using AffineMap = domain::CoordinateMaps::Affine;
+    using AffineMap3D =
+        domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+    const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap3D>
+        coord_map{{{-1., 1., 0., 0.5}, {-1., 1., 0., 0.5}, {-1., 1., 0., 0.5}}};
+    const Mesh<dim> mesh{10, Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+    const auto logical_coords = logical_coordinates(mesh);
+    const auto inertial_coords = coord_map(logical_coords);
+    FirstOrderEllipticSolutionsTestHelpers::verify_smooth_solution<system>(
+        solution, fluxes_computer, coord_map, 1.e4, 1.,
+        std::make_tuple(constitutive_relation, inertial_coords));
+  };
+}

--- a/tests/Unit/PointwiseFunctions/Elasticity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Elasticity/CMakeLists.txt
@@ -13,5 +13,5 @@ set(LIBRARY_SOURCES
   ${LIBRARY}
   "PointwiseFunctions/Elasticity/"
   "${LIBRARY_SOURCES}"
-  "Utilities"
+  "PotentialEnergy;ElasticitySolutions;Utilities"
   )

--- a/tests/Unit/PointwiseFunctions/Elasticity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Elasticity/CMakeLists.txt
@@ -2,3 +2,16 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(ConstitutiveRelations)
+
+set(LIBRARY Test_PotentialEnergy)
+
+set(LIBRARY_SOURCES
+  Test_PotentialEnergy.cpp
+  )
+
+  add_test_library(
+  ${LIBRARY}
+  "PointwiseFunctions/Elasticity/"
+  "${LIBRARY_SOURCES}"
+  "Utilities"
+  )

--- a/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.py
+++ b/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.py
@@ -28,3 +28,7 @@ def youngs_modulus(bulk_modulus, shear_modulus):
 def poisson_ratio(bulk_modulus, shear_modulus):
     return (3. * bulk_modulus - 2. * shear_modulus) / \
         (6. * bulk_modulus + 2. * shear_modulus)
+
+
+def lame_parameter(bulk_modulus, shear_modulus):
+    return bulk_modulus - 2 / 3. * shear_modulus

--- a/tests/Unit/PointwiseFunctions/Elasticity/PotentialEnergy.py
+++ b/tests/Unit/PointwiseFunctions/Elasticity/PotentialEnergy.py
@@ -1,0 +1,35 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def potential_energy_2d(strain, bulk_modulus, shear_modulus):
+    stress = constitutive_relation_2d(strain, bulk_modulus, shear_modulus)
+    return -0.5 * np.einsum('ij, ij', strain, stress)
+
+
+def potential_energy_3d(strain, bulk_modulus, shear_modulus):
+    stress = constitutive_relation_3d(strain, bulk_modulus, shear_modulus)
+    return -0.5 * np.einsum('ij, ij', strain, stress)
+
+
+def potential_energy(strain, coordinates, bulk_modulus, shear_modulus):
+    dim = coordinates.shape[0]
+    if dim == 2:
+        return potential_energy_2d(strain, bulk_modulus, shear_modulus)
+    elif dim == 3:
+        return potential_energy_3d(strain, bulk_modulus, shear_modulus)
+
+
+def constitutive_relation_2d(strain, bulk_modulus, shear_modulus):
+    lame_constant = bulk_modulus - 2. / 3. * shear_modulus
+    return -2. * shear_modulus * lame_constant / (
+        lame_constant + 2. * shear_modulus
+    ) * np.trace(strain) * np.eye(2) - 2. * shear_modulus * strain
+
+
+def constitutive_relation_3d(strain, bulk_modulus, shear_modulus):
+    lame_constant = bulk_modulus - 2. / 3. * shear_modulus
+    return -2. * shear_modulus * strain - lame_constant * np.trace(
+        strain) * np.eye(3)

--- a/tests/Unit/PointwiseFunctions/Elasticity/Test_PotentialEnergy.cpp
+++ b/tests/Unit/PointwiseFunctions/Elasticity/Test_PotentialEnergy.cpp
@@ -1,0 +1,87 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
+#include "PointwiseFunctions/Elasticity/PotentialEnergy.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+template <size_t Dim>
+Scalar<DataVector> potential_energy(  // This wrapper function is needed to
+                                      // construct a constitutive relation for
+                                      // the random values of its parameters.
+    const tnsr::ii<DataVector, Dim, Frame::Inertial>& strain,
+    const tnsr::I<DataVector, Dim>& coordinates, const double bulk_modulus,
+    const double shear_modulus) noexcept {
+  Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>
+      constitutive_relation{bulk_modulus, shear_modulus};
+  return Elasticity::evaluate_potential_energy<Dim>(
+      strain, coordinates, std::move(constitutive_relation));
+}
+
+template <size_t Dim>
+void test_potential_energy(const DataVector& used_for_size) {
+  pypp::check_with_random_values<4>(
+      &potential_energy<Dim>, "PotentialEnergy", "potential_energy",
+      {{{-1., 1.}, {0., 1.}, {0., 1.}, {0., 1.}}}, used_for_size);
+}
+
+template <size_t Dim>
+void test_compute_tags(const DataVector& used_for_size) noexcept {
+  using strain_tag = Elasticity::Tags::Strain<Dim>;
+  using energy_tag = Elasticity::Tags::PotentialEnergy<Dim>;
+  using energy_compute_tag = Elasticity::Tags::PotentialEnergyCompute<Dim>;
+  using constitutive_relation_tag = Elasticity::Tags::ConstitutiveRelation<
+      Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>>;
+  using coordinates_tag = domain::Tags::Coordinates<Dim, Frame::Inertial>;
+  const size_t num_points = used_for_size.size();
+  {
+    INFO("Energy" << Dim << "D");
+    auto box =
+        db::create<db::AddSimpleTags<strain_tag, constitutive_relation_tag,
+                                     coordinates_tag>,
+                   db::AddComputeTags<energy_compute_tag>>(
+            tnsr::ii<DataVector, Dim>{num_points, 1.},
+            Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>{3.,
+                                                                         4.},
+            tnsr::I<DataVector, Dim>{num_points, 2.});
+
+    auto expected_energy = Elasticity::evaluate_potential_energy<Dim>(
+        get<strain_tag>(box), get<coordinates_tag>(box),
+        get<constitutive_relation_tag>(box));
+    CHECK(get<energy_tag>(box) == expected_energy);
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Elasticity",
+                  "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/Elasticity"};
+
+  GENERATE_UNINITIALIZED_DATAVECTOR;
+  CHECK_FOR_DATAVECTORS(test_potential_energy, (2, 3));
+
+  CHECK_FOR_DATAVECTORS(test_compute_tags, (2, 3));
+}

--- a/tests/Unit/PointwiseFunctions/Elasticity/Test_PotentialEnergy.cpp
+++ b/tests/Unit/PointwiseFunctions/Elasticity/Test_PotentialEnergy.cpp
@@ -11,25 +11,34 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/Tags.hpp"
-#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"  // IWYU pragma: keep
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
 #include "PointwiseFunctions/Elasticity/PotentialEnergy.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/MakeString.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 
+// IWYU pragma: no_forward_declare Tensor
+
 namespace {
 
+// This wrapper function is needed to construct a constitutive relation for the
+// random values of its parameters.
 template <size_t Dim>
-Scalar<DataVector> potential_energy(  // This wrapper function is needed to
-                                      // construct a constitutive relation for
-                                      // the random values of its parameters.
+Scalar<DataVector> potential_energy(
     const tnsr::ii<DataVector, Dim, Frame::Inertial>& strain,
     const tnsr::I<DataVector, Dim>& coordinates, const double bulk_modulus,
     const double shear_modulus) noexcept {
@@ -73,15 +82,48 @@ void test_compute_tags(const DataVector& used_for_size) noexcept {
   }
 }
 
+void test_energy_with_bent_beam() {
+  using BentBeam = Elasticity::Solutions::BentBeam;
+  const size_t dim = BentBeam::volume_dim;
+  const double length = 5.;
+  const double height = 1.;
+  const Elasticity::ConstitutiveRelations::IsotropicHomogeneous<dim>
+      constitutive_relation{// Iron: E=100, nu=0.29
+                            79.36507936507935, 38.75968992248062};
+  const BentBeam& solution{length, height, 0.5, constitutive_relation};
+  using AffineMap = ::domain::CoordinateMaps::Affine;
+  using AffineMap2D =
+      ::domain::CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
+  const ::domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap2D>
+      coord_map{{{-1., 1., -length / 2., length / 2.},
+                 {-1., 1., -height / 2., height / 2.}}};
+  const Mesh<2> mesh{3, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  // Since the solution is a polynomial of degree 2 it should be fully
+  // characterized to machine precision on 3 grid points per dimension.
+  const auto logical_coords = logical_coordinates(mesh);
+  const auto inertial_coords = coord_map(logical_coords);
+  auto jacobian = coord_map.jacobian(logical_coords);
+  typename ::Elasticity::Tags::Strain<dim>::type strain =
+      get<::Elasticity::Tags::Strain<dim>>(solution.variables(
+          inertial_coords, tmpl::list<::Elasticity::Tags::Strain<dim>>{}));
+  auto pointwise_energy = ::Elasticity::evaluate_potential_energy<dim>(
+      strain, inertial_coords, constitutive_relation);
+  const DataVector det_jacobian = get(determinant(jacobian));
+  double potential_energy =
+      definite_integral(det_jacobian * pointwise_energy[0], mesh);
+  CHECK_ITERABLE_APPROX(potential_energy, solution.potential_energy());
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Elasticity",
                   "[Unit][PointwiseFunctions]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
       "PointwiseFunctions/Elasticity"};
-
   GENERATE_UNINITIALIZED_DATAVECTOR;
   CHECK_FOR_DATAVECTORS(test_potential_energy, (2, 3));
-
   CHECK_FOR_DATAVECTORS(test_compute_tags, (2, 3));
+  INFO("test_potential_energy_of_bent_beam");
+  test_energy_with_bent_beam();
 }


### PR DESCRIPTION
## Proposed changes

This PR adds the analytic solution for a half-space mirror. The displacement and strain are, but for a change from cylindrical to cartesian coordinates, in accordance with the equations in Blandford & Thorne Modern Classical Physics, and are changed in a latter commit to match with "The dependence of test-mass thermal noises on beam shape in gravitational-wave interferometers" by Geoffrey Lovelace, where the strain is specified explicitly. 
The PR is dependent on a different PR: Adds potential energy to Elasticity #2279 

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

The addition of the energy density through `pointwise_potential_energy()` to the solution will probably be dropped and replaced by the total potential energy stored in the HalfSpaceMirror.
