### PR TITLE
Inner shells in bbh domain

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -240,6 +240,40 @@ class BinaryCompactObject : public DomainCreator<3> {
     static type lower_bound() noexcept { return 0; }
   };
 
+  struct UseLogarithmicMapObjectA {
+    using type = bool;
+    static constexpr OptionString help = {
+        "Use a logarithmically spaced radial grid in the part of Layer 1 "
+        "enveloping Object A (requires ExciseInteriorA == true)"};
+    static type default_value() noexcept { return false; }
+  };
+
+  struct AdditionToObjectARadialRefinementLevel {
+    using type = size_t;
+    static constexpr OptionString help = {
+        "Addition to radial refinement level in the part of Layer 1 enveloping "
+        "Object A, beyond the refinement level set by InitialRefinement."};
+    static constexpr type default_value() noexcept { return 0; }
+    static type lower_bound() noexcept { return 0; }
+  };
+
+  struct UseLogarithmicMapObjectB {
+    using type = bool;
+    static constexpr OptionString help = {
+        "Use a logarithmically spaced radial grid in the part of Layer 1 "
+        "enveloping Object B (requires ExciseInteriorB == true)"};
+    static type default_value() noexcept { return false; }
+  };
+
+  struct AdditionToObjectBRadialRefinementLevel {
+    using type = size_t;
+    static constexpr OptionString help = {
+        "Addition to radial refinement level in the part of Layer 1 enveloping "
+        "Object B, beyond the refinement level set by InitialRefinement."};
+    static constexpr type default_value() noexcept { return 0; }
+    static type lower_bound() noexcept { return 0; }
+  };
+
   struct TimeDependence {
     using type =
         std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>;
@@ -253,12 +287,17 @@ class BinaryCompactObject : public DomainCreator<3> {
       InnerRadiusObjectB, OuterRadiusObjectB, XCoordObjectB, ExciseInteriorB,
       RadiusOuterCube, RadiusOuterSphere, InitialRefinement, InitialGridPoints,
       UseEquiangularMap, UseProjectiveMap, UseLogarithmicMapOuterSphericalShell,
-      AdditionToOuterLayerRadialRefinementLevel, TimeDependence>;
+      AdditionToOuterLayerRadialRefinementLevel, UseLogarithmicMapObjectA,
+      AdditionToObjectARadialRefinementLevel, UseLogarithmicMapObjectB,
+      AdditionToObjectBRadialRefinementLevel, TimeDependence>;
 
   static constexpr OptionString help{
       "The BinaryCompactObject domain is a general domain for two compact "
       "objects. The user must provide the inner and outer radii of the "
-      "spherical shells surrounding each of the two compact objects A and B. "
+      "spherical shells surrounding each of the two compact objects A and "
+      "B. The radial refinement levels for these shells are (InitialRefinement "
+      "+ AdditionToObjectARadialRefinementLevel) and (InitialRefinement + "
+      "AdditionToObjectBRadialRefinementLevel), respectively.\n\n"
       "The user must also provide the radius of the sphere that "
       "circumscribes the cube containing both compact objects, and the "
       "radius of the outer boundary. The options ExciseInteriorA and "
@@ -298,6 +337,14 @@ class BinaryCompactObject : public DomainCreator<3> {
           use_logarithmic_map_outer_spherical_shell = false,
       typename AdditionToOuterLayerRadialRefinementLevel::type
           addition_to_outer_layer_radial_refinement_level = 0,
+      typename UseLogarithmicMapObjectA::type use_logarithmic_map_object_A =
+          false,
+      typename AdditionToObjectARadialRefinementLevel::type
+          addition_to_object_A_radial_refinement_level = 0,
+      typename UseLogarithmicMapObjectB::type use_logarithmic_map_object_B =
+          false,
+      typename AdditionToObjectBRadialRefinementLevel::type
+          addition_to_object_B_radial_refinement_level = 0,
       std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
           time_dependence = nullptr,
       const OptionContext& context = {});
@@ -339,6 +386,12 @@ class BinaryCompactObject : public DomainCreator<3> {
       use_logarithmic_map_outer_spherical_shell_ = false;
   typename AdditionToOuterLayerRadialRefinementLevel::type
       addition_to_outer_layer_radial_refinement_level_{};
+  typename UseLogarithmicMapObjectA::type use_logarithmic_map_object_A_ = false;
+  typename AdditionToObjectARadialRefinementLevel::type
+      addition_to_object_A_radial_refinement_level_{};
+  typename UseLogarithmicMapObjectB::type use_logarithmic_map_object_B_ = false;
+  typename AdditionToObjectBRadialRefinementLevel::type
+      addition_to_object_B_radial_refinement_level_{};
   double projective_scale_factor_{};
   double translation_{};
   double length_inner_cube_{};

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -245,6 +245,7 @@ void test_bbh_2_outer_radial_refinements_linear_map_factory() {
           "    RadiusOuterSphere: 25.0\n"
           "    InitialRefinement: 2\n"
           "    InitialGridPoints: 6\n"
+          "    AdditionToObjectBRadialRefinementLevel: 2\n"
           "    UseEquiangularMap: true\n"
           "    AdditionToOuterLayerRadialRefinementLevel: 2\n");
   test_binary_compact_object_construction(
@@ -269,7 +270,9 @@ void test_bbh_3_outer_radial_refinements_log_map_factory() {
           "    InitialRefinement: 2\n"
           "    InitialGridPoints: 6\n"
           "    UseEquiangularMap: true\n"
-          "    UseLogarithmicMapOuterSphericalShell: true\n"
+          "    UseLogarithmicMapObjectA: true\n"
+          "    AdditionToObjectARadialRefinementLevel: 3\n"
+          "    UseLogarithmicMapObjectB: true\n"
           "    AdditionToOuterLayerRadialRefinementLevel: 3");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(


### PR DESCRIPTION
## Proposed changes

Add options for extra radial refinement and log scaling to inner spheres in BinaryCompactObject domain. Depends on #2265 ; please only look at the commit "Extra radial refinement for BBH inner spheres" when reviewing this PR.

Here are examples of extra radial refinement with linear and log scaling:

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/867015/82214940-6cd67b00-98cb-11ea-82ae-10d7982aff42.png">


### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
