### PR TITLE
NOLINT Charm++ PUPABLE macros

### DIFF
--- a/src/Parallel/CharmPupable.hpp
+++ b/src/Parallel/CharmPupable.hpp
@@ -20,7 +20,7 @@
  * this macro if it is to be serialized.
  */
 #define WRAPPED_PUPable_decl_template(className) \
-  PUPable_decl_template(SINGLE_ARG(className))
+  PUPable_decl_template(SINGLE_ARG(className))  // NOLINT
 
 /*!
  * \ingroup ParallelGroup
@@ -30,11 +30,13 @@
  * this macro if it is to be serialized.
  */
 #define WRAPPED_PUPable_decl_base_template(baseClassName, className) \
-  PUPable_decl_base_template(SINGLE_ARG(baseClassName), SINGLE_ARG(className))
+  PUPable_decl_base_template(SINGLE_ARG(baseClassName), /* NOLINT */ \
+                             SINGLE_ARG(className))     // NOLINT
 
 /// Wraps the Charm++ macro, see the Charm++ documentation
-#define WRAPPED_PUPable_decl(className) PUPable_decl(SINGLE_ARG(className))
+#define WRAPPED_PUPable_decl(className) \
+  PUPable_decl(SINGLE_ARG(className))  // NOLINT
 
 /// Wraps the Charm++ macro, see the Charm++ documentation
 #define WRAPPED_PUPable_abstract(className) \
-  PUPable_abstract(SINGLE_ARG(className))
+  PUPable_abstract(SINGLE_ARG(className))  // NOLINT


### PR DESCRIPTION
## Proposed changes

We can't go around fixing all 3rd part libraries, so just globally ignore things
from these macros. This also means we don't need to `NOLINT` everywhere we use them, since that would be annoying.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
