### PR TITLE
Cce lts interface

### DIFF
--- a/src/Evolution/Systems/Cce/Actions/ReceiveGhWorldtubeData.hpp
+++ b/src/Evolution/Systems/Cce/Actions/ReceiveGhWorldtubeData.hpp
@@ -57,6 +57,7 @@ struct ReceiveGhWorldtubeData {
       const ArrayIndex& /*array_index*/, const TimeStepId& time,
       const tnsr::aa<DataVector, 3>& spacetime_metric,
       const tnsr::iaa<DataVector, 3>& phi, const tnsr::aa<DataVector, 3>& pi,
+      const TimeStepId& next_time = TimeStepId{},
       const tnsr::aa<DataVector, 3>& dt_spacetime_metric =
           tnsr::aa<DataVector, 3>{},
       const tnsr::iaa<DataVector, 3>& dt_phi = tnsr::iaa<DataVector, 3>{},
@@ -65,11 +66,12 @@ struct ReceiveGhWorldtubeData {
     db::mutate<Tags::GhInterfaceManager>(
         make_not_null(&box),
         [&spacetime_metric, &phi, &pi, &dt_spacetime_metric, &dt_phi, &dt_pi,
-         &time, &cache](const gsl::not_null<
-                        std::unique_ptr<InterfaceManagers::GhInterfaceManager>*>
-                            interface_manager) noexcept {
+         &next_time, &time,
+         &cache](const gsl::not_null<
+                 std::unique_ptr<InterfaceManagers::GhInterfaceManager>*>
+                     interface_manager) noexcept {
           (*interface_manager)
-              ->insert_gh_data(time, spacetime_metric, phi, pi,
+              ->insert_gh_data(time, spacetime_metric, phi, pi, next_time,
                                dt_spacetime_metric, dt_phi, dt_pi);
           const auto gh_data =
               (*interface_manager)->retrieve_and_remove_first_ready_gh_data();
@@ -78,8 +80,7 @@ struct ReceiveGhWorldtubeData {
                 GhWorldtubeBoundary<Metavariables>, EvolutionComponent>>(
                 Parallel::get_parallel_component<
                     GhWorldtubeBoundary<Metavariables>>(cache),
-                get<0>(*gh_data), get<1>(*gh_data), get<2>(*gh_data),
-                get<3>(*gh_data));
+                get<0>(*gh_data), get<1>(*gh_data));
           }
         });
   }

--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Initialize/InverseCubic.cpp
   Initialize/NoIncomingRadiation.cpp
   Initialize/ZeroNonSmooth.cpp
+  InterfaceManagers/GhLocalTimeStepping.cpp
   InterfaceManagers/GhLockstep.cpp
   LinearOperators.cpp
   LinearSolve.cpp

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhInterfaceManager.hpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhInterfaceManager.hpp
@@ -19,6 +19,7 @@ namespace Cce {
 namespace InterfaceManagers {
 
 /// \cond
+class GhLocalTimeStepping;
 class GhLockstep;
 /// \endcond
 
@@ -56,20 +57,19 @@ class GhInterfaceManager : public PUP::able {
               GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>,
               GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>>;
 
-  using creatable_classes = tmpl::list<GhLockstep>;
+  using creatable_classes = tmpl::list<GhLocalTimeStepping, GhLockstep>;
 
   WRAPPED_PUPable_abstract(GhInterfaceManager);  // NOLINT
 
   virtual std::unique_ptr<GhInterfaceManager> get_clone() const noexcept = 0;
 
-  virtual void insert_gh_data(TimeStepId time_id,
-                              tnsr::aa<DataVector, 3> spacetime_metric,
-                              tnsr::iaa<DataVector, 3> phi,
-                              tnsr::aa<DataVector, 3> pi,
-                              TimeStepId next_time_id,
-                              tnsr::aa<DataVector, 3> dt_spacetime_metric,
-                              tnsr::iaa<DataVector, 3> dt_phi,
-                              tnsr::aa<DataVector, 3> dt_pi) noexcept = 0;
+  virtual void insert_gh_data(
+      TimeStepId time_id, const tnsr::aa<DataVector, 3>& spacetime_metric,
+      const tnsr::iaa<DataVector, 3>& phi, const tnsr::aa<DataVector, 3>& pi,
+      TimeStepId next_time_id,
+      const tnsr::aa<DataVector, 3>& dt_spacetime_metric,
+      const tnsr::iaa<DataVector, 3>& dt_phi,
+      const tnsr::aa<DataVector, 3>& dt_pi) noexcept = 0;
 
   virtual void request_gh_data(const TimeStepId&) noexcept = 0;
 

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhInterfaceManager.hpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhInterfaceManager.hpp
@@ -9,8 +9,10 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/TimeStepId.hpp"
 
 namespace Cce {
@@ -49,6 +51,11 @@ class GhLockstep;
  */
 class GhInterfaceManager : public PUP::able {
  public:
+  using gh_variables = Variables<
+   tmpl::list<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>,
+              GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>,
+              GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>>;
+
   using creatable_classes = tmpl::list<GhLockstep>;
 
   WRAPPED_PUPable_abstract(GhInterfaceManager);  // NOLINT
@@ -59,6 +66,7 @@ class GhInterfaceManager : public PUP::able {
                               tnsr::aa<DataVector, 3> spacetime_metric,
                               tnsr::iaa<DataVector, 3> phi,
                               tnsr::aa<DataVector, 3> pi,
+                              TimeStepId next_time_id,
                               tnsr::aa<DataVector, 3> dt_spacetime_metric,
                               tnsr::iaa<DataVector, 3> dt_phi,
                               tnsr::aa<DataVector, 3> dt_pi) noexcept = 0;
@@ -66,9 +74,7 @@ class GhInterfaceManager : public PUP::able {
   virtual void request_gh_data(const TimeStepId&) noexcept = 0;
 
   virtual auto retrieve_and_remove_first_ready_gh_data() noexcept
-      -> boost::optional<
-          std::tuple<TimeStepId, tnsr::aa<DataVector, 3>,
-                     tnsr::iaa<DataVector, 3>, tnsr::aa<DataVector, 3>>> = 0;
+      -> boost::optional<std::tuple<TimeStepId, gh_variables>> = 0;
 
   virtual size_t number_of_pending_requests() const noexcept = 0;
 

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.cpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.cpp
@@ -1,0 +1,138 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.hpp"
+
+#include <cstddef>
+#include <deque>
+#include <memory>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/History.hpp"
+#include "Time/TimeStepId.hpp"
+
+namespace Cce::InterfaceManagers {
+
+std::unique_ptr<GhInterfaceManager> GhLocalTimeStepping::get_clone()
+    const noexcept {
+  return std::make_unique<GhLocalTimeStepping>(*this);
+}
+
+void GhLocalTimeStepping::insert_gh_data(
+    TimeStepId time_id, const tnsr::aa<DataVector, 3>& spacetime_metric,
+    const tnsr::iaa<DataVector, 3>& phi, const tnsr::aa<DataVector, 3>& pi,
+    TimeStepId next_time_id, const tnsr::aa<DataVector, 3>& dt_spacetime_metric,
+    const tnsr::iaa<DataVector, 3>& dt_phi,
+    const tnsr::aa<DataVector, 3>& dt_pi) noexcept {
+  gh_variables input_gh_variables{get<0, 0>(spacetime_metric).size()};
+  dt_gh_variables input_dt_gh_variables{get<0, 0>(spacetime_metric).size()};
+  get<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>>(
+      input_gh_variables) = spacetime_metric;
+  get<::Tags::dt<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>>>(
+      input_dt_gh_variables) = dt_spacetime_metric;
+  get<GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>>(input_gh_variables) =
+      pi;
+  get<::Tags::dt<GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>>>(
+      input_dt_gh_variables) = dt_pi;
+  get<GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>(
+      input_gh_variables) = phi;
+  get<::Tags::dt<GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>>(
+      input_dt_gh_variables) = dt_phi;
+
+  // If no pending requests, we don't know what time will be needed next, so
+  // just stash the data in the deque.
+  if (requests_.empty() or
+      requests_.front().substep_time().value() <=
+          time_id.substep_time().value() or
+      not pre_history_.empty()) {
+    // NOLINTNEXTLINE(performance-move-const-arg)
+    pre_history_.emplace_back(std::move(time_id), std::move(input_gh_variables),
+                              // NOLINTNEXTLINE(performance-move-const-arg)
+                              std::move(next_time_id),
+                              std::move(input_dt_gh_variables));
+    return;
+  }
+
+  // if we have pending requests, we know how much history to insert, so we take
+  // from the deque and then add in the current data if suitable
+  // NOLINTNEXTLINE(performance-move-const-arg)
+  boundary_history_.insert(std::move(time_id), input_gh_variables,
+                           input_dt_gh_variables);
+  // NOLINTNEXTLINE(performance-move-const-arg)
+  latest_next_ = std::move(next_time_id);
+
+  if (boundary_history_.size() > order_) {
+    boundary_history_.mark_unneeded(
+        boundary_history_.begin() +
+        static_cast<ptrdiff_t>(boundary_history_.size() - order_));
+  }
+}
+
+void GhLocalTimeStepping::request_gh_data(const TimeStepId& time_id) noexcept {
+  requests_.push_back(time_id);
+  if (requests_.size() == 1) {
+    update_history();
+  }
+}
+
+void GhLocalTimeStepping::update_history() noexcept {
+  if (requests_.empty()) {
+    return;
+  }
+  while (not pre_history_.empty() and
+         requests_.front().substep_time().value() >
+             get<0>(pre_history_.front()).substep_time().value()) {
+    boundary_history_.insert(get<0>(pre_history_.front()),
+                             get<1>(pre_history_.front()),
+                             get<3>(pre_history_.front()));
+    latest_next_ = get<2>(pre_history_.front());
+    pre_history_.pop_front();
+  }
+
+  if (boundary_history_.size() > order_) {
+    boundary_history_.mark_unneeded(
+        boundary_history_.begin() +
+        static_cast<ptrdiff_t>(boundary_history_.size() - order_));
+  }
+}
+
+auto GhLocalTimeStepping::retrieve_and_remove_first_ready_gh_data() noexcept
+    -> boost::optional<std::tuple<TimeStepId, gh_variables>> {
+  if (requests_.empty()) {
+    return boost::none;
+  }
+  const double first_request = requests_.front().substep_time().value();
+  if ((boundary_history_.end() - 1)->value() < first_request and
+      latest_next_.substep_time().value() >= first_request) {
+    gh_variables latest_values = (boundary_history_.end() - 1).value();
+    time_stepper_.dense_update_u(make_not_null(&latest_values),
+                                 boundary_history_, first_request);
+    // NOLINTNEXTLINE(performance-move-const-arg)
+    std::tuple requested_data{std::move(requests_.front()),
+                              std::move(latest_values)};
+    requests_.pop_front();
+    update_history();
+    return requested_data;
+  }
+  return boost::none;
+}
+
+void GhLocalTimeStepping::pup(PUP::er& p) noexcept {
+  p | order_;
+  p | pre_history_;
+  p | requests_;
+  p | boundary_history_;
+  p | latest_next_;
+  p | time_stepper_;
+}
+
+/// \cond
+PUP::able::PUP_ID GhLocalTimeStepping::my_PUP_ID = 0;
+/// \endcond
+}  // namespace Cce::InterfaceManagers

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.hpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.hpp
@@ -1,0 +1,136 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <deque>
+#include <memory>
+#include <tuple>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/GhInterfaceManager.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/History.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/AdamsBashforthN.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce::InterfaceManagers {
+
+/*!
+ * \brief Implementation of a `GhInterfaceManager` that provides data according
+ * to local time-stepping dense output.
+ *
+ * \details This class receives data from the Generalized Harmonic system
+ * sufficient to perform the time-stepping dense output to arbitrary times
+ * required by CCE. From the Generalized Harmonic system, it receives the
+ * spacetime metric \f$g_{a b}\f$ and Generalized Harmonic \f$\Phi_{i a b}\f$
+ * and \f$\Pi_{ab}\f$, as well as each of their time derivatives, the current
+ * `TimeStepId`, and the next `TimeStepId` via
+ * `GhLocalTimeStepping::insert_gh_data()`. The CCE system supplies requests for
+ * time steps via `GhLocalTimeStepping::request_gh_data()` and receives dense
+ * output boundary data via
+ * `GhLocalTimeStepping::retrieve_and_remove_first_ready_gh_data()`.
+ */
+class GhLocalTimeStepping : public GhInterfaceManager {
+ public:
+  using dt_gh_variables = Variables<tmpl::list<
+      ::Tags::dt<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>>,
+      ::Tags::dt<GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>>,
+      ::Tags::dt<GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>>>;
+
+  struct AdamsBashforthOrder {
+    using type = size_t;
+    static constexpr OptionString help = {
+        "Convergence order for the internal Adams-Bashforth stepper"};
+    static type lower_bound() noexcept { return 1; }
+    static type upper_bound() noexcept {
+      return TimeSteppers::AdamsBashforthN::maximum_order;
+    }
+  };
+
+  static constexpr OptionString help{
+      "Pass data between GH and CCE systems via Adams-Bashforth local "
+      "time-stepping"};
+
+  using options = tmpl::list<AdamsBashforthOrder>;
+
+  GhLocalTimeStepping() = default;
+
+  explicit GhLocalTimeStepping(const size_t order)
+      : order_{order}, time_stepper_{order} {}
+
+  explicit GhLocalTimeStepping(CkMigrateMessage* /*unused*/) noexcept {}
+
+  WRAPPED_PUPable_decl_template(GhLocalTimeStepping);  // NOLINT
+
+  std::unique_ptr<GhInterfaceManager> get_clone() const noexcept override;
+
+  /// \brief Store the provided data set to prepare for time-stepping dense
+  /// output.
+  ///
+  /// \details The `next_time_id` is required to infer the span of time values
+  /// that should be permitted for the dense output, and at what point the CCE
+  /// system should wait for additional data from the GH system.
+  void insert_gh_data(TimeStepId time_id,
+                      const tnsr::aa<DataVector, 3>& spacetime_metric,
+                      const tnsr::iaa<DataVector, 3>& phi,
+                      const tnsr::aa<DataVector, 3>& pi,
+                      TimeStepId next_time_id,
+                      const tnsr::aa<DataVector, 3>& dt_spacetime_metric,
+                      const tnsr::iaa<DataVector, 3>& dt_phi,
+                      const tnsr::aa<DataVector, 3>& dt_pi) noexcept override;
+
+  /// \brief Store the next time step that will be required by the CCE system to
+  /// proceed with the evolution.
+  ///
+  /// \details The values of these time steps will be used to generate the dense
+  /// output from the provided GH data.
+  void request_gh_data(const TimeStepId& time_id) noexcept override;
+
+  /// \brief Return a `boost::optional` of either the dense-output data at the
+  /// least recently requested time, or `boost::none` if not enough GH data has
+  /// been supplied yet.
+  auto retrieve_and_remove_first_ready_gh_data() noexcept
+      -> boost::optional<std::tuple<TimeStepId, gh_variables>> override;
+
+  /// The number of requests that have been submitted and not yet retrieved.
+  size_t number_of_pending_requests() const noexcept override {
+    return requests_.size();
+  }
+
+  /// \brief  The number of times for which data from the GH system is stored.
+  ///
+  /// \details  This will be roughly the order of the time stepper plus the
+  /// number of times that the GH system is ahead of the CCE system.
+  size_t number_of_gh_times() const noexcept override {
+    return pre_history_.size() + boundary_history_.size();
+  }
+
+  /// Serialization for Charm++.
+  void pup(PUP::er& p) noexcept override;
+
+ private:
+  // performs the needed logic to move entries from pre_history_ into the
+  // boundary_history_ as appropriate for the current requests_
+  void update_history() noexcept;
+
+  size_t order_ = 3;
+
+  std::deque<std::tuple<TimeStepId, gh_variables, TimeStepId, dt_gh_variables>>
+      pre_history_;
+  std::deque<TimeStepId> requests_;
+
+  TimeSteppers::History<gh_variables, dt_gh_variables> boundary_history_;
+  TimeStepId latest_next_;
+  TimeSteppers::AdamsBashforthN time_stepper_;
+};
+
+}  // namespace Cce::InterfaceManagers

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.cpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.cpp
@@ -21,12 +21,12 @@ std::unique_ptr<GhInterfaceManager> GhLockstep::get_clone() const noexcept {
 }
 
 void GhLockstep::insert_gh_data(
-    TimeStepId time_id, tnsr::aa<DataVector, 3> spacetime_metric,
-    tnsr::iaa<DataVector, 3> phi, tnsr::aa<DataVector, 3> pi,
+    TimeStepId time_id, const tnsr::aa<DataVector, 3>& spacetime_metric,
+    const tnsr::iaa<DataVector, 3>& phi, const tnsr::aa<DataVector, 3>& pi,
     TimeStepId /*next_time_id*/,
-    const tnsr::aa<DataVector, 3> /*dt_spacetime_metric*/,
-    const tnsr::iaa<DataVector, 3> /*dt_phi*/,
-    const tnsr::aa<DataVector, 3> /*dt_pi*/) noexcept {
+    const tnsr::aa<DataVector, 3>& /*dt_spacetime_metric*/,
+    const tnsr::iaa<DataVector, 3>& /*dt_phi*/,
+    const tnsr::aa<DataVector, 3>& /*dt_pi*/) noexcept {
   // NOLINTNEXTLINE(performance-move-const-arg)
   gh_variables input_gh_variables{get<0, 0>(spacetime_metric).size()};
   get<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>>(
@@ -35,6 +35,7 @@ void GhLockstep::insert_gh_data(
       pi;
   get<GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>(
       input_gh_variables) = phi;
+  // NOLINTNEXTLINE(performance-move-const-arg)
   provided_data_.emplace_back(std::move(time_id),
                               std::move(input_gh_variables));
 }

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.cpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.cpp
@@ -9,7 +9,9 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/TimeStepId.hpp"
 
 namespace Cce::InterfaceManagers {
@@ -21,17 +23,24 @@ std::unique_ptr<GhInterfaceManager> GhLockstep::get_clone() const noexcept {
 void GhLockstep::insert_gh_data(
     TimeStepId time_id, tnsr::aa<DataVector, 3> spacetime_metric,
     tnsr::iaa<DataVector, 3> phi, tnsr::aa<DataVector, 3> pi,
+    TimeStepId /*next_time_id*/,
     const tnsr::aa<DataVector, 3> /*dt_spacetime_metric*/,
     const tnsr::iaa<DataVector, 3> /*dt_phi*/,
     const tnsr::aa<DataVector, 3> /*dt_pi*/) noexcept {
   // NOLINTNEXTLINE(performance-move-const-arg)
-  provided_data_.emplace_back(std::move(time_id), std::move(spacetime_metric),
-                              std::move(phi), std::move(pi));
+  gh_variables input_gh_variables{get<0, 0>(spacetime_metric).size()};
+  get<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>>(
+      input_gh_variables) = spacetime_metric;
+  get<GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>>(input_gh_variables) =
+      pi;
+  get<GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>(
+      input_gh_variables) = phi;
+  provided_data_.emplace_back(std::move(time_id),
+                              std::move(input_gh_variables));
 }
 
-boost::optional<std::tuple<TimeStepId, tnsr::aa<DataVector, 3>,
-                           tnsr::iaa<DataVector, 3>, tnsr::aa<DataVector, 3>>>
-GhLockstep::retrieve_and_remove_first_ready_gh_data() noexcept {
+auto GhLockstep::retrieve_and_remove_first_ready_gh_data() noexcept
+    -> boost::optional<std::tuple<TimeStepId, gh_variables>> {
   if (provided_data_.empty()) {
     return boost::none;
   }

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.hpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.hpp
@@ -36,6 +36,8 @@ namespace Cce::InterfaceManagers {
  */
 class GhLockstep : public GhInterfaceManager {
  public:
+  using GhInterfaceManager::gh_variables;
+
   static constexpr OptionString help{
       "Pass data between GH and CCE systems on matching timesteps only."};
 
@@ -58,6 +60,7 @@ class GhLockstep : public GhInterfaceManager {
   void insert_gh_data(TimeStepId time_id,
                       tnsr::aa<DataVector, 3> spacetime_metric,
                       tnsr::iaa<DataVector, 3> phi, tnsr::aa<DataVector, 3> pi,
+                      TimeStepId next_time_id = {},
                       tnsr::aa<DataVector, 3> dt_spacetime_metric = {},
                       tnsr::iaa<DataVector, 3> dt_phi = {},
                       tnsr::aa<DataVector, 3> dt_pi = {}) noexcept override;
@@ -68,9 +71,8 @@ class GhLockstep : public GhInterfaceManager {
   /// \brief Return a `boost::optional<std::tuple>` of the least recently
   /// submitted generalized harmonic boundary data if any exists and removes it
   /// from the internal `std::deque`, otherwise returns `boost::none`.
-  auto retrieve_and_remove_first_ready_gh_data() noexcept -> boost::optional<
-      std::tuple<TimeStepId, tnsr::aa<DataVector, 3>, tnsr::iaa<DataVector, 3>,
-                 tnsr::aa<DataVector, 3>>> override;
+  auto retrieve_and_remove_first_ready_gh_data() noexcept
+      -> boost::optional<std::tuple<TimeStepId, gh_variables>> override;
 
   /// \brief This class ignores requests to ensure a one-way communication
   /// pattern, so the number of requests is always 0.
@@ -86,9 +88,7 @@ class GhLockstep : public GhInterfaceManager {
   void pup(PUP::er& p) noexcept override;
 
  private:
-  std::deque<std::tuple<TimeStepId, tnsr::aa<DataVector, 3>,
-                        tnsr::iaa<DataVector, 3>, tnsr::aa<DataVector, 3>>>
-      provided_data_;
+  std::deque<std::tuple<TimeStepId, gh_variables>> provided_data_;
 };
 
 }  // namespace Cce::InterfaceManagers

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.hpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.hpp
@@ -57,13 +57,13 @@ class GhLockstep : public GhInterfaceManager {
   /// harmonic variables `spacetime_metric`, `phi`, and `pi` are used. The
   /// remaining variables are accepted to comply with the more general abstract
   /// interface.
-  void insert_gh_data(TimeStepId time_id,
-                      tnsr::aa<DataVector, 3> spacetime_metric,
-                      tnsr::iaa<DataVector, 3> phi, tnsr::aa<DataVector, 3> pi,
-                      TimeStepId next_time_id = {},
-                      tnsr::aa<DataVector, 3> dt_spacetime_metric = {},
-                      tnsr::iaa<DataVector, 3> dt_phi = {},
-                      tnsr::aa<DataVector, 3> dt_pi = {}) noexcept override;
+  void insert_gh_data(
+      TimeStepId time_id, const tnsr::aa<DataVector, 3>& spacetime_metric,
+      const tnsr::iaa<DataVector, 3>& phi, const tnsr::aa<DataVector, 3>& pi,
+      TimeStepId next_time_id = {},
+      const tnsr::aa<DataVector, 3>& dt_spacetime_metric = {},
+      const tnsr::iaa<DataVector, 3>& dt_phi = {},
+      const tnsr::aa<DataVector, 3>& dt_pi = {}) noexcept override;
 
   /// \brief Requests are ignored by this implementation, so this is a no-op.
   void request_gh_data(const TimeStepId& /*time_id*/) noexcept override {}

--- a/src/Time/History.hpp
+++ b/src/Time/History.hpp
@@ -41,9 +41,9 @@ class History {
   using size_type = size_t;
 
   History() = default;
-  History(const History&) = delete;
+  History(const History&) = default;
   History(History&&) = default;
-  History& operator=(const History&) = delete;
+  History& operator=(const History&) = default;
   History& operator=(History&&) = default;
   ~History() = default;
 

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(AnalyticSolutions)
 set(LIBRARY "Test_Cce")
 
 set(LIBRARY_SOURCES
+  InterfaceManagers/Test_GhLocalTimeStepping.cpp
   InterfaceManagers/Test_GhLockstep.cpp
   Test_BoundaryData.cpp
   Test_Equations.cpp

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -12,6 +12,7 @@
 #include "Evolution/Systems/Cce/Initialize/NoIncomingRadiation.hpp"
 #include "Evolution/Systems/Cce/Initialize/ZeroNonSmooth.hpp"
 #include "Evolution/Systems/Cce/InterfaceManagers/GhInterfaceManager.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.hpp"
 #include "Evolution/Systems/Cce/InterfaceManagers/GhLockstep.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"


### PR DESCRIPTION
## Proposed changes

Add an InterfaceManager that performs a calculation with the Adams-Bashforth stepper to allow different time steps in GH and CCE.

This PR includes a commit that allows copy of `History` which might be controversial, so I'm happy to discuss other options -- that just seemed like the simplest solution to being able to easily clone this class

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies

- [ ] #2281