### PR TITLE
Damped harmonic errors on moving mesh, move DH option tags

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -232,12 +232,9 @@ struct EvolutionMetavars {
 
   // A tmpl::list of tags to be added to the ConstGlobalCache by the
   // metavariables
-  using const_global_cache_tags = tmpl::list<
-      initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,
-      GeneralizedHarmonic::Tags::GaugeHRollOnStartTime,
-      GeneralizedHarmonic::Tags::GaugeHRollOnTimeWindow,
-      GeneralizedHarmonic::Tags::GaugeHSpatialWeightDecayWidth<frame>,
-      Tags::EventsAndTriggers<events, triggers>>;
+  using const_global_cache_tags =
+      tmpl::list<initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,
+                 Tags::EventsAndTriggers<events, triggers>>;
 
   struct ObservationType {};
   using element_observation_type = ObservationType;

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp
@@ -9,8 +9,10 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
+#include "ErrorHandling/Error.hpp"
 #include "Evolution/Initialization/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
@@ -33,6 +35,18 @@ struct InitializeDampedHarmonic {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
+    if (not db::get<domain::CoordinateMaps::Tags::CoordinateMap<
+                Metavariables::volume_dim, Frame::Grid, Frame::Inertial>>(box)
+                .is_identity()) {
+      ERROR(
+          "Cannot use the damped harmonic rollon gauge with a moving mesh "
+          "because the rollon is not implemented for a moving mesh. The issue "
+          "is that the initial H_a needs to be in the grid frame, and then "
+          "transformed to the inertial frame at each time step. Transforming "
+          "the spacetime derivative requires spacetime Hessians, which are not "
+          "implemented for the maps and there is currently no plan to add them "
+          "because we do not need them for anything else.");
+    }
     const auto inverse_jacobian =
         db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical, frame>>(box);
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp
@@ -26,6 +26,11 @@ template <size_t Dim>
 struct InitializeDampedHarmonic {
   using frame = Frame::Inertial;
 
+  using const_global_cache_tags = tmpl::list<
+      GeneralizedHarmonic::Tags::GaugeHRollOnStartTime,
+      GeneralizedHarmonic::Tags::GaugeHRollOnTimeWindow,
+      GeneralizedHarmonic::Tags::GaugeHSpatialWeightDecayWidth<frame>>;
+
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>


### PR DESCRIPTION
## Proposed changes

- Since the rollon damped harmonic gauge condition doesn't work on a moving mesh, have it error if the mesh is moving.
- Specify tho const global cache tags for DH inside the DH action instead of the global typelist

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
