### PR TITLE
Create separate EndTime tags

### DIFF
--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -55,8 +55,8 @@ namespace Actions {
  */
 struct InitializeCharacteristicEvolutionTime {
   using initialization_tags = tmpl::list<InitializationTags::TargetStepSize>;
-  using const_global_cache_tags = tmpl::list<::Tags::TimeStepper<TimeStepper>,
-                                             Tags::StartTime, Tags::EndTime>;
+  using const_global_cache_tags =
+      tmpl::list<::Tags::TimeStepper<TimeStepper>, Tags::StartTime>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -56,7 +56,7 @@ namespace Actions {
 struct InitializeCharacteristicEvolutionTime {
   using initialization_tags = tmpl::list<InitializationTags::TargetStepSize>;
   using const_global_cache_tags =
-      tmpl::list<::Tags::TimeStepper<TimeStepper>, Tags::StartTime>;
+      tmpl::list<::Tags::TimeStepper<TimeStepper>>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,

--- a/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
@@ -49,7 +49,7 @@ struct InitializeH5WorldtubeBoundary {
   using initialization_tags =
       tmpl::list<InitializationTags::H5WorldtubeBoundaryDataManager>;
 
-  using const_global_cache_tags = tmpl::list<Tags::LMax>;
+  using const_global_cache_tags = tmpl::list<Tags::LMax, Tags::EndTimeFromFile>;
 
   template <class Metavariables>
   using h5_boundary_manager_simple_tags = db::AddSimpleTags<
@@ -135,7 +135,8 @@ struct InitializeGhWorldtubeBoundary {
   using initialization_tags_to_keep = tmpl::list<Tags::GhInterfaceManager>;
 
   using const_global_cache_tags =
-      tmpl::list<Tags::LMax, InitializationTags::ExtractionRadius>;
+      tmpl::list<Tags::LMax, InitializationTags::ExtractionRadius,
+                 Tags::NoEndTime>;
 
   template <class Metavariables>
   using gh_boundary_manager_simple_tags = db::AddSimpleTags<

--- a/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
@@ -49,7 +49,8 @@ struct InitializeH5WorldtubeBoundary {
   using initialization_tags =
       tmpl::list<InitializationTags::H5WorldtubeBoundaryDataManager>;
 
-  using const_global_cache_tags = tmpl::list<Tags::LMax, Tags::EndTimeFromFile>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::LMax, Tags::EndTimeFromFile, Tags::StartTimeFromFile>;
 
   template <class Metavariables>
   using h5_boundary_manager_simple_tags = db::AddSimpleTags<
@@ -136,7 +137,7 @@ struct InitializeGhWorldtubeBoundary {
 
   using const_global_cache_tags =
       tmpl::list<Tags::LMax, InitializationTags::ExtractionRadius,
-                 Tags::NoEndTime>;
+                 Tags::NoEndTime, Tags::SpecifiedStartTime>;
 
   template <class Metavariables>
   using gh_boundary_manager_simple_tags = db::AddSimpleTags<

--- a/src/Evolution/Systems/Cce/Actions/RequestBoundaryData.hpp
+++ b/src/Evolution/Systems/Cce/Actions/RequestBoundaryData.hpp
@@ -82,6 +82,9 @@ struct RequestBoundaryData {
  */
 template <typename WorldtubeBoundaryComponent, typename EvolutionComponent>
 struct RequestNextBoundaryData {
+  using const_global_cache_tags =
+      tmpl::list<typename WorldtubeBoundaryComponent::end_time_tag>;
+
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>

--- a/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
@@ -37,6 +37,7 @@ namespace Cce {
  */
 template <class Metavariables>
 struct H5WorldtubeBoundary {
+  using end_time_tag = Tags::EndTimeFromFile;
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
   using initialize_action_list =
@@ -103,6 +104,7 @@ struct H5WorldtubeBoundary {
  */
 template <class Metavariables>
 struct GhWorldtubeBoundary {
+  using end_time_tag = Tags::NoEndTime;
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
   using initialize_action_list =

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -298,11 +298,12 @@ struct StartTime : db::SimpleTag {
 /// \brief Represents the final time of a bounded CCE evolution, determined
 /// either from option specification or from the file
 ///
-/// \details If the option `OptionTags::EndTime` is set to
-/// `std::numeric_limits<double>::%infinity()`, this will find the end time from
-/// the provided H5 file. If `OptionTags::EndTime` takes any other value, it
-/// will be used directly as the end time for the CCE evolution instead.
-struct EndTime : db::SimpleTag {
+/// \details If no end time is specified in the input file (so the option
+/// `OptionTags::EndTime` is set to the default
+/// `std::numeric_limits<double>::%infinity()`), this will find the end time
+/// from the provided H5 file. If `OptionTags::EndTime` takes any other value,
+/// it will be used directly as the final time for the CCE evolution instead.
+struct EndTimeFromFile : Tags::EndTime, db::SimpleTag {
   using type = double;
   using option_tags =
       tmpl::list<OptionTags::EndTime, OptionTags::BoundaryDataFilename>;
@@ -315,6 +316,31 @@ struct EndTime : db::SimpleTag {
       const auto& time_buffer = h5_boundary_updater.get_time_buffer();
       end_time = time_buffer[time_buffer.size() - 1];
     }
+    return end_time;
+  }
+};
+
+/// \brief Represents the final time of a CCE evolution that should just proceed
+/// until it receives no more boundary data and becomes quiescent.
+struct NoEndTime : Tags::EndTime, db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<>;
+
+  static constexpr bool pass_metavariables = false;
+  static double create_from_options() noexcept {
+    return std::numeric_limits<double>::infinity();
+  }
+};
+
+/// \brief Represents the final time of a bounded CCE evolution that must be
+/// supplied in the input file (for e.g. analytic tests).
+struct SpecifiedEndTime : Tags::EndTime, db::SimpleTag {
+  using type = double;
+  using option_tags =
+      tmpl::list<OptionTags::EndTime>;
+
+  static constexpr bool pass_metavariables = false;
+  static double create_from_options(const double end_time) noexcept {
     return end_time;
   }
 };

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -336,6 +336,8 @@ struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
   using type = WorldtubeDataManager;
 };
 
+struct EndTime : db::BaseTag {};
+
 /// The Weyl scalar \f$\Psi_0\f$
 struct Psi0 : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 2>>;

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -338,6 +338,8 @@ struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
 
 struct EndTime : db::BaseTag {};
 
+struct StartTime : db::BaseTag {};
+
 /// The Weyl scalar \f$\Psi_0\f$
 struct Psi0 : db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 2>>;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -103,6 +103,8 @@ struct metavariables {
       Spectral::Swsh::Tags::Derivative<Tags::GaugeOmega,
                                        Spectral::Swsh::Tags::Eth>>>;
 
+  using const_global_cache_tags = tmpl::list<Tags::SpecifiedStartTime>;
+
   using scri_values_to_observe = tmpl::list<>;
   using cce_integrand_tags = tmpl::flatten<tmpl::transform<
       bondi_hypersurface_step_tags,
@@ -179,8 +181,8 @@ SPECTRE_TEST_CASE(
   const double target_step_size = 0.01 * value_dist(gen);
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{
-      {l_max, number_of_radial_points,
-       std::make_unique<::TimeSteppers::RungeKutta3>(), start_time,
+      {start_time, l_max, number_of_radial_points,
+       std::make_unique<::TimeSteppers::RungeKutta3>(),
        std::make_unique<InitializeJ::InverseCubic>()}};
 
   ActionTesting::set_phase(make_not_null(&runner),

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -181,7 +181,6 @@ SPECTRE_TEST_CASE(
   ActionTesting::MockRuntimeSystem<metavariables> runner{
       {l_max, number_of_radial_points,
        std::make_unique<::TimeSteppers::RungeKutta3>(), start_time,
-       start_time + target_step_size,
        std::make_unique<InitializeJ::InverseCubic>()}};
 
   ActionTesting::set_phase(make_not_null(&runner),

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -175,8 +175,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       tuples::tagged_tuple_from_typelist<
           Parallel::get_const_global_cache_tags<test_metavariables>>{
-          l_max, extraction_radius, end_time, number_of_radial_points,
-          std::make_unique<::TimeSteppers::RungeKutta3>(), start_time}};
+          l_max, extraction_radius, end_time, start_time,
+          number_of_radial_points,
+          std::make_unique<::TimeSteppers::DormandPrince5>()}};
 
   // first prepare the input for the modal version
   const double mass = value_dist(gen);
@@ -195,7 +196,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
       &runner, 0, target_step_size, scri_plus_interpolation_order);
   ActionTesting::emplace_component<worldtube_component>(
       &runner, 0,
-      Tags::GhInterfaceManager::create_from_options<test_metavariables>(
+      Tags::GhInterfaceManager::create_from_options(
           std::make_unique<InterfaceManagers::GhLockstep>()));
 
   // this should run the initializations

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -175,9 +175,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       tuples::tagged_tuple_from_typelist<
           Parallel::get_const_global_cache_tags<test_metavariables>>{
-          l_max, extraction_radius, number_of_radial_points,
-          std::make_unique<::TimeSteppers::RungeKutta3>(), start_time,
-          end_time}};
+          l_max, extraction_radius, end_time, number_of_radial_points,
+          std::make_unique<::TimeSteppers::RungeKutta3>(), start_time}};
 
   // first prepare the input for the modal version
   const double mass = value_dist(gen);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -188,9 +188,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
   const double target_step_size = 0.01 * value_dist(gen);
   const double end_time = std::numeric_limits<double>::quiet_NaN();
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
-      {l_max, number_of_radial_points,
-       std::make_unique<::TimeSteppers::RungeKutta3>(), start_time,
-       Tags::EndTime::create_from_options(end_time, filename)}};
+      {l_max, Tags::EndTimeFromFile::create_from_options(end_time, filename),
+       number_of_radial_points, std::make_unique<::TimeSteppers::RungeKutta3>(),
+       start_time}};
 
   // create the test file, because on initialization the manager will need
   // to get basic data out of the file

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -189,8 +189,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
   const double end_time = std::numeric_limits<double>::quiet_NaN();
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       {l_max, Tags::EndTimeFromFile::create_from_options(end_time, filename),
-       number_of_radial_points, std::make_unique<::TimeSteppers::RungeKutta3>(),
-       start_time}};
+       start_time, number_of_radial_points,
+       std::make_unique<::TimeSteppers::RungeKutta3>()}};
 
   // create the test file, because on initialization the manager will need
   // to get basic data out of the file

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -85,6 +85,8 @@ struct metavariables {
       Spectral::Swsh::Tags::Derivative<Tags::GaugeOmega,
                                        Spectral::Swsh::Tags::Eth>>>;
 
+  using const_global_cache_tags = tmpl::list<Tags::SpecifiedStartTime>;
+
   using scri_values_to_observe = tmpl::list<>;
   using cce_integrand_tags = tmpl::flatten<tmpl::transform<
       bondi_hypersurface_step_tags,
@@ -151,8 +153,8 @@ SPECTRE_TEST_CASE(
   const double target_step_size = 0.01 * value_dist(gen);
   const size_t scri_plus_interpolation_order = 3;
   ActionTesting::MockRuntimeSystem<metavariables> runner{
-      {l_max, number_of_radial_points,
-       std::make_unique<::TimeSteppers::RungeKutta3>(), start_time}};
+      {start_time, l_max, number_of_radial_points,
+       std::make_unique<::TimeSteppers::RungeKutta3>()}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            metavariables::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -148,13 +148,11 @@ SPECTRE_TEST_CASE(
   // create the test file, because on initialization the manager will need
   // to get basic data out of the file
   const double start_time = value_dist(gen);
-  const double end_time = std::numeric_limits<double>::infinity();
   const double target_step_size = 0.01 * value_dist(gen);
   const size_t scri_plus_interpolation_order = 3;
   ActionTesting::MockRuntimeSystem<metavariables> runner{
       {l_max, number_of_radial_points,
-       std::make_unique<::TimeSteppers::RungeKutta3>(), start_time,
-       Tags::EndTime::create_from_options(end_time, filename)}};
+       std::make_unique<::TimeSteppers::RungeKutta3>(), start_time}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            metavariables::Phase::Initialization);
@@ -287,12 +285,6 @@ SPECTRE_TEST_CASE(
               number_of_radial_points,
           0.0};
   CHECK(swsh_derivatives_variables == expected_zeroed_swsh_derivatives);
-
-  // check the end time is consistent with what should have been written to the
-  // file
-  const auto& end_time_initialized =
-      ActionTesting::get_databox_tag<component, Tags::EndTime>(runner, 0);
-  CHECK(end_time_initialized == approx(1.4 + target_time));
 
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -51,10 +51,11 @@ void test_h5_initialization(const gsl::not_null<Generator*> gen) noexcept {
   using component = mock_h5_worldtube_boundary<H5Metavariables>;
   const size_t l_max = 8;
   const size_t end_time = 100.0;
+  const size_t start_time = 0.0;
   ActionTesting::MockRuntimeSystem<H5Metavariables> runner{
       tuples::tagged_tuple_from_typelist<
-          Parallel::get_const_global_cache_tags<H5Metavariables>>{l_max,
-                                                                  end_time}};
+          Parallel::get_const_global_cache_tags<H5Metavariables>>{
+          l_max, end_time, start_time}};
 
   const size_t buffer_size = 8;
   const std::string filename = "InitializeWorldtubeBoundaryTest_CceR0100.h5";
@@ -125,12 +126,13 @@ void test_gh_initialization() noexcept {
   ActionTesting::MockRuntimeSystem<GhMetavariables> runner{
       tuples::tagged_tuple_from_typelist<
           Parallel::get_const_global_cache_tags<GhMetavariables>>{
-          l_max, std::numeric_limits<double>::infinity(), extraction_radius}};
+          l_max, extraction_radius, std::numeric_limits<double>::infinity(),
+          0.0}};
 
   runner.set_phase(GhMetavariables::Phase::Initialization);
   ActionTesting::emplace_component<component>(
       &runner, 0,
-      Tags::GhInterfaceManager::create_from_options<GhMetavariables>(
+      Tags::GhInterfaceManager::create_from_options(
           std::make_unique<InterfaceManagers::GhLockstep>()));
 
   // this should run the initialization

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -50,9 +50,11 @@ template <typename Generator>
 void test_h5_initialization(const gsl::not_null<Generator*> gen) noexcept {
   using component = mock_h5_worldtube_boundary<H5Metavariables>;
   const size_t l_max = 8;
+  const size_t end_time = 100.0;
   ActionTesting::MockRuntimeSystem<H5Metavariables> runner{
       tuples::tagged_tuple_from_typelist<
-          Parallel::get_const_global_cache_tags<H5Metavariables>>{l_max}};
+          Parallel::get_const_global_cache_tags<H5Metavariables>>{l_max,
+                                                                  end_time}};
 
   const size_t buffer_size = 8;
   const std::string filename = "InitializeWorldtubeBoundaryTest_CceR0100.h5";
@@ -123,7 +125,7 @@ void test_gh_initialization() noexcept {
   ActionTesting::MockRuntimeSystem<GhMetavariables> runner{
       tuples::tagged_tuple_from_typelist<
           Parallel::get_const_global_cache_tags<GhMetavariables>>{
-          l_max, extraction_radius}};
+          l_max, std::numeric_limits<double>::infinity(), extraction_radius}};
 
   runner.set_phase(GhMetavariables::Phase::Initialization);
   ActionTesting::emplace_component<component>(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -166,14 +166,12 @@ SPECTRE_TEST_CASE(
 
 
   const double start_time = value_dist(gen);
-  const double end_time = start_time + 1.0;
   const double target_step_size = 0.01 * value_dist(gen);
   const size_t buffer_size = 5;
 
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       {l_max, number_of_radial_points,
        std::make_unique<::TimeSteppers::RungeKutta3>(), start_time,
-       Tags::EndTime::create_from_options(end_time, "unused"),
        scri_output_density}};
 
   runner.set_phase(test_metavariables::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -116,6 +116,8 @@ struct test_metavariables {
       Spectral::Swsh::Tags::Derivative<Tags::GaugeOmega,
                                        Spectral::Swsh::Tags::Eth>>>;
 
+  using const_global_cache_tags = tmpl::list<Tags::SpecifiedStartTime>;
+
   using cce_integrand_tags = tmpl::flatten<tmpl::transform<
       bondi_hypersurface_step_tags,
       tmpl::bind<integrand_terms_to_compute_for_bondi_variable, tmpl::_1>>>;
@@ -170,9 +172,8 @@ SPECTRE_TEST_CASE(
   const size_t buffer_size = 5;
 
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
-      {l_max, number_of_radial_points,
-       std::make_unique<::TimeSteppers::RungeKutta3>(), start_time,
-       scri_output_density}};
+      {start_time, l_max, number_of_radial_points,
+       std::make_unique<::TimeSteppers::RungeKutta3>(), scri_output_density}};
 
   runner.set_phase(test_metavariables::Phase::Initialization);
   ActionTesting::emplace_component<evolution_component>(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -175,9 +175,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
   const double end_time = start_time + 10 * target_step_size;
   const size_t buffer_size = 5;
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
-      {l_max, number_of_radial_points,
-       std::make_unique<::TimeSteppers::RungeKutta3>(), start_time,
-       Tags::EndTime::create_from_options(end_time, filename)}};
+      {l_max, Tags::EndTimeFromFile::create_from_options(end_time, filename),
+       number_of_radial_points, std::make_unique<::TimeSteppers::RungeKutta3>(),
+       start_time}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            test_metavariables::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -176,8 +176,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
   const size_t buffer_size = 5;
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       {l_max, Tags::EndTimeFromFile::create_from_options(end_time, filename),
-       number_of_radial_points, std::make_unique<::TimeSteppers::RungeKutta3>(),
-       start_time}};
+       start_time, number_of_radial_points,
+       std::make_unique<::TimeSteppers::RungeKutta3>()}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            test_metavariables::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -146,6 +146,7 @@ struct test_metavariables {
       Spectral::Swsh::Tags::Derivative<Tags::GaugeOmega,
                                        Spectral::Swsh::Tags::Eth>>>;
 
+  using const_global_cache_tags = tmpl::list<Tags::SpecifiedStartTime>;
   using cce_integrand_tags = tmpl::flatten<tmpl::transform<
       bondi_hypersurface_step_tags,
       tmpl::bind<integrand_terms_to_compute_for_bondi_variable, tmpl::_1>>>;
@@ -191,9 +192,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
   const size_t scri_interpolation_size = 3;
 
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
-      {filename, l_max, number_of_radial_points,
-       std::make_unique<::TimeSteppers::RungeKutta3>(), start_time,
-       scri_output_density, observation_l_max}};
+      {start_time, filename, l_max, number_of_radial_points,
+       std::make_unique<::TimeSteppers::RungeKutta3>(), scri_output_density,
+       observation_l_max}};
 
   runner.set_phase(test_metavariables::Phase::Initialization);
   ActionTesting::emplace_component<evolution_component>(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -187,13 +187,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
   const std::string filename = "ScriObserveInterpolatedTest_CceVolumeOutput";
 
   const double start_time = 0.0;
-  const double end_time = 100.0;
   const double target_step_size = 0.1;
   const size_t scri_interpolation_size = 3;
 
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       {filename, l_max, number_of_radial_points,
-       std::make_unique<::TimeSteppers::RungeKutta3>(), start_time, end_time,
+       std::make_unique<::TimeSteppers::RungeKutta3>(), start_time,
        scri_output_density, observation_l_max}};
 
   runner.set_phase(test_metavariables::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_TimeManagement.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_TimeManagement.cpp
@@ -33,7 +33,8 @@ struct mock_characteristic_evolution {
   using replace_these_simple_actions = tmpl::list<>;
   using with_these_simple_actions = tmpl::list<>;
 
-  using simple_tags = db::AddSimpleTags<::Tags::TimeStepId, Tags::EndTime>;
+  using simple_tags =
+      db::AddSimpleTags<::Tags::TimeStepId, Tags::EndTimeFromFile>;
   using compute_tags = db::AddComputeTags<>;
 
   using initialize_action_list =
@@ -78,10 +79,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.TimeManagement",
   ActionTesting::next_action<component>(make_not_null(&runner), 0);
   CHECK_FALSE(ActionTesting::get_terminate<component>(runner, 0));
 
-  auto& box =
-      ActionTesting::get_databox<component,
-                                 tmpl::list<::Tags::TimeStepId, Tags::EndTime>>(
-          make_not_null(&runner), 0);
+  auto& box = ActionTesting::get_databox<
+      component, tmpl::list<::Tags::TimeStepId, Tags::EndTimeFromFile>>(
+      make_not_null(&runner), 0);
   db::mutate<::Tags::TimeStepId>(
       make_not_null(&box), [](const gsl::not_null<TimeStepId*> time_step_id) {
         *time_step_id = TimeStepId{true, 0, Time{{1.5, 2.5}, {3, 4}}};

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -33,7 +33,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
       "ScriOutputDensity");
 
   TestHelpers::db::test_simple_tag<Cce::Tags::StartTime>("StartTime");
-  TestHelpers::db::test_simple_tag<Cce::Tags::EndTime>("EndTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::EndTimeFromFile>(
+      "EndTimeFromFile");
+  TestHelpers::db::test_simple_tag<Cce::Tags::NoEndTime>("NoEndTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::SpecifiedEndTime>(
+      "SpecifiedEndTime");
   TestHelpers::db::test_simple_tag<Cce::Tags::InitializeJ>("InitializeJ");
 
   CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::LMax>("8") == 8_st);
@@ -103,10 +107,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   CHECK(Cce::Tags::StartTime::create_from_options(
             3.3, "OptionTagsTestCceR0100.h5") == 3.3);
 
-  CHECK(Cce::Tags::EndTime::create_from_options(
+  CHECK(Cce::Tags::EndTimeFromFile::create_from_options(
             std::numeric_limits<double>::infinity(),
             "OptionTagsTestCceR0100.h5") == 5.4);
-  CHECK(Cce::Tags::EndTime::create_from_options(
+  CHECK(Cce::Tags::EndTimeFromFile::create_from_options(
             2.2, "OptionTagsTestCceR0100.h5") == 2.2);
 
   CHECK(Cce::Tags::ObservationLMax::create_from_options(5_st) == 5_st);

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -32,10 +32,13 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   TestHelpers::db::test_simple_tag<Cce::InitializationTags::ScriOutputDensity>(
       "ScriOutputDensity");
 
-  TestHelpers::db::test_simple_tag<Cce::Tags::StartTime>("StartTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::StartTimeFromFile>(
+      "StartTimeFromFile");
   TestHelpers::db::test_simple_tag<Cce::Tags::EndTimeFromFile>(
       "EndTimeFromFile");
   TestHelpers::db::test_simple_tag<Cce::Tags::NoEndTime>("NoEndTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::SpecifiedStartTime>(
+      "SpecifiedStartTime");
   TestHelpers::db::test_simple_tag<Cce::Tags::SpecifiedEndTime>(
       "SpecifiedEndTime");
   TestHelpers::db::test_simple_tag<Cce::Tags::InitializeJ>("InitializeJ");
@@ -101,10 +104,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   CHECK(Cce::Tags::LMax::create_from_options(8u) == 8u);
   CHECK(Cce::Tags::NumberOfRadialPoints::create_from_options(6u) == 6u);
 
-  CHECK(Cce::Tags::StartTime::create_from_options(
+  CHECK(Cce::Tags::StartTimeFromFile::create_from_options(
             -std::numeric_limits<double>::infinity(),
             "OptionTagsTestCceR0100.h5") == 2.5);
-  CHECK(Cce::Tags::StartTime::create_from_options(
+  CHECK(Cce::Tags::StartTimeFromFile::create_from_options(
             3.3, "OptionTagsTestCceR0100.h5") == 3.3);
 
   CHECK(Cce::Tags::EndTimeFromFile::create_from_options(


### PR DESCRIPTION
## Proposed changes

As I put in more boundary types, the original end time is less suitable. This creates three derived tags to be more fitting for the different data sources.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
