### PR TITLE
Fix some interface code to work with base tags and function templates

### DIFF
--- a/src/Domain/InterfaceHelpers.hpp
+++ b/src/Domain/InterfaceHelpers.hpp
@@ -268,12 +268,21 @@ SPECTRE_ALWAYS_INLINE constexpr auto interface_apply(
           std::forward<ExtraArgs>(extra_args)...);
 }
 
+// The `box` argument to this function overload is not constrained to
+// `db::DataBox` to work around an issue with GCC <= 8.
+//
+// Details on the issue:
+//
+// GCC <= 8 tries to instantiate the `db::DataBox<DbTagsList>` template even
+// when this function overload is _not_ SFINAE-selected. In that case the
+// template parameter substitution for `DbTagsList` may contain base tags that
+// causes errors with the `db::DataBox` template instantiation.
 template <typename DirectionsTag, typename InterfaceInvokable,
-          typename DbTagsList, typename... ExtraArgs,
+          typename DataBoxType, typename... ExtraArgs,
           // Needed to disambiguate the overloads
           typename ArgumentTags = typename InterfaceInvokable::argument_tags>
 SPECTRE_ALWAYS_INLINE constexpr auto interface_apply(
-    const db::DataBox<DbTagsList>& box, ExtraArgs&&... extra_args) noexcept {
+    const DataBoxType& box, ExtraArgs&&... extra_args) noexcept {
   return interface_apply<DirectionsTag, ArgumentTags,
                          get_volume_tags<InterfaceInvokable>>(
       InterfaceInvokable{}, box, std::forward<ExtraArgs>(extra_args)...);

--- a/tests/Unit/Domain/Test_InterfaceHelpers.cpp
+++ b/tests/Unit/Domain/Test_InterfaceHelpers.cpp
@@ -87,16 +87,6 @@ void test_interface_apply(
   /// [interface_apply_example]
 
   // Test volume base tag
-  // GCC <= 8 can't handle the recursive template instantiations for base tags
-  // in `db::DataBox_detail::storage_type_impl` that occur when instantiating
-  // the `interface_apply` overload for a _stateless_ invokable here, i.e. the
-  // one that is _not_ SFINAE-selected in the function call below. The template
-  // parameter substitutions `InterfaceInvokable=tmpl::list<SomeNumber,
-  // VolumeArgumentBase>` and `DbTagsList=tmpl::list<VolumeArgumentBase>` is
-  // made, which fails the SFINAE-selection but still tries to (unsuccessfully)
-  // instantiate `storage_type_impl` for the `DbTagsList` and the
-  // `VolumeArgumentBase` tag.
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ > 8)
   const auto computed_numbers_with_base_tag =
       interface_apply<DirectionsTag, tmpl::list<SomeNumber, VolumeArgumentBase>,
                       tmpl::list<VolumeArgumentBase>>(
@@ -106,7 +96,6 @@ void test_interface_apply(
           },
           box, 2.);
   CHECK(computed_numbers_with_base_tag == computed_number_on_interfaces);
-#endif  // defined(__clang__) || (defined(__GNUC__) && __GNUC__ > 8)
 
   // Test overload that takes a stateless invokable
   /// [interface_apply_example_stateless]


### PR DESCRIPTION
## Proposed changes

These are a few remaining places in the code where I had to add support for base tags to make the elasticity executable #2100 work.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
