### PR TITLE
Optionally do nothing in Dirichlet BC if nonconservative, only outgoing char fields

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
@@ -76,7 +76,7 @@ double min_characteristic_speed(
 ///      - External<typename system::variables_tag>
 ///
 /// \see ReceiveDataForFluxes
-template <typename Metavariables, bool SkipBCWhenCharSpeedsAllOutgoing = false>
+template <typename Metavariables, bool SkipBcWhenCharSpeedsAllOutgoing = false>
 struct ImposeDirichletBoundaryConditions {
  private:
   // BoundaryConditionMethod and BcSelector are used to select exactly how to
@@ -147,7 +147,7 @@ struct ImposeDirichletBoundaryConditions {
             auto& direction = external_direction_and_vars.first;
             auto& vars = external_direction_and_vars.second;
 
-            if (SkipBCWhenCharSpeedsAllOutgoing) {
+            if (SkipBcWhenCharSpeedsAllOutgoing) {
               // Do nothing if char speeds are all outgoing (i.e., all positive)
               const auto& char_speeds = boundary_char_speeds.at(direction);
               if (BoundaryConditions_detail::min_characteristic_speed<

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
@@ -141,8 +141,8 @@ struct ImposeDirichletBoundaryConditions {
                typename system::variables_tag>>*>
                external_bdry_vars,
            const double time, const auto& boundary_condition,
-           const auto& boundary_coords,
-           const auto& boundary_char_speeds) noexcept {
+           const auto& boundary_coords, const auto& boundary_char_speeds,
+           const auto& boundary_vars) noexcept {
           for (auto& external_direction_and_vars : *external_bdry_vars) {
             auto& direction = external_direction_and_vars.first;
             auto& vars = external_direction_and_vars.second;
@@ -152,6 +152,11 @@ struct ImposeDirichletBoundaryConditions {
               const auto& char_speeds = boundary_char_speeds.at(direction);
               if (BoundaryConditions_detail::min_characteristic_speed<
                       VolumeDim>(char_speeds) >= 0.) {
+                for (auto& interior_direction_and_vars : boundary_vars) {
+                  if (interior_direction_and_vars.first == direction) {
+                    vars = interior_direction_and_vars.second;
+                  }
+                }
                 continue;
               }
             }
@@ -167,7 +172,11 @@ struct ImposeDirichletBoundaryConditions {
             domain::Tags::Coordinates<VolumeDim, Frame::Inertial>>>(box),
         db::get<domain::Tags::Interface<
             domain::Tags::BoundaryDirectionsInterior<VolumeDim>,
-            typename system::char_speeds_tag>>(box));
+            typename system::char_speeds_tag>>(box),
+        db::get<domain::Tags::Interface<
+            domain::Tags::BoundaryDirectionsInterior<VolumeDim>,
+            typename Tags::Variables<
+                typename system::variables_tag::type::tags_list>>>(box));
 
     return std::forward_as_tuple(std::move(box));
   }

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
@@ -45,13 +45,15 @@ double min_characteristic_speed(
   return *std::min_element(min_speeds.begin(), min_speeds.end());
 }
 }  // namespace BoundaryConditions_detail
+
 /// \ingroup ActionsGroup
 /// \ingroup DiscontinuousGalerkinGroup
 /// \brief Packages data on external boundaries for calculating numerical flux.
 /// Computes contributions on the interior side from the volume, and imposes
 /// Dirichlet boundary conditions on the exterior side. Optionally, instead do
-/// nothing if all characteristic speeds are outgoing and the system is
-/// nonconservative.
+/// nothing if all characteristic speeds (specifically, the characteristic
+/// speeds computed numerically on the interior side of the external boundary)
+/// are outgoing and the system is nonconservative.
 ///
 /// With:
 /// - External<Tag> =
@@ -74,8 +76,7 @@ double min_characteristic_speed(
 ///      - External<typename system::variables_tag>
 ///
 /// \see ReceiveDataForFluxes
-template <typename Metavariables,
-          bool ApplyUnlessOnlyOutgoingCharSpeeds = false>
+template <typename Metavariables, bool SkipBCWhenCharSpeedsAllOutgoing = false>
 struct ImposeDirichletBoundaryConditions {
  private:
   // BoundaryConditionMethod and BcSelector are used to select exactly how to
@@ -146,7 +147,7 @@ struct ImposeDirichletBoundaryConditions {
             auto& direction = external_direction_and_vars.first;
             auto& vars = external_direction_and_vars.second;
 
-            if (ApplyUnlessOnlyOutgoingCharSpeeds) {
+            if (SkipBCWhenCharSpeedsAllOutgoing) {
               // Do nothing if char speeds are all outgoing (i.e., all positive)
               const auto& char_speeds = boundary_char_speeds.at(direction);
               if (BoundaryConditions_detail::min_characteristic_speed<


### PR DESCRIPTION
## Proposed changes

Currently, the Dirichlet boundary condition is applied on all external boundaries. However, if a boundary has only outgoing characteristic speeds, then the correct thing to do is to do nothing. Doing nothing if only outgoing char speeds is necessary to evolve with an excision surface.

This PR adds an option to the Dirichlet boundary condition. It operates exactly as before, unless i) the system is nonconservative, and ii) the char speeds are only outgoing. If both i) and ii), then it does nothing.

This change is implemented as an option to the Dirichlet boundary condition because some systems do not have characteristic speeds implemented yet. It's implemented only for non-conservative systems here; an implementation for conservative systems would work differently, and could be done in a future PR.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
