### PR TITLE
Add bool for controlling damped harmonic rollon

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -394,7 +394,7 @@ void damped_harmonic_impl(
 }  // namespace
 
 template <size_t SpatialDim, typename Frame>
-void damped_harmonic(
+void damped_harmonic_rollon(
     const gsl::not_null<tnsr::a<DataVector, SpatialDim, Frame>*> gauge_h,
     const gsl::not_null<tnsr::ab<DataVector, SpatialDim, Frame>*> d4_gauge_h,
     const tnsr::a<DataVector, SpatialDim, Frame>& gauge_h_init,
@@ -425,7 +425,7 @@ void damped_harmonic(
 }
 
 template <size_t SpatialDim, typename Frame>
-void DampedHarmonicCompute<SpatialDim, Frame>::function(
+void DampedHarmonicRollonCompute<SpatialDim, Frame>::function(
     const gsl::not_null<return_type*> h_and_d4_h,
     const db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>& gauge_h_init,
     const db::item_type<Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>&
@@ -448,7 +448,7 @@ void DampedHarmonicCompute<SpatialDim, Frame>::function(
   // exp_{L1, L2, S}
   // This should be read from the input file in the future.
   constexpr int exponent = 4;
-  damped_harmonic(
+  damped_harmonic_rollon(
       make_not_null(&get<Tags::GaugeH<SpatialDim, Frame>>(*h_and_d4_h)),
       make_not_null(
           &get<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>(*h_and_d4_h)),
@@ -470,7 +470,7 @@ void DampedHarmonicCompute<SpatialDim, Frame>::function(
 #define DTYPE_SCAL(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE_DV_FUNC(_, data)                                           \
-  template void damped_harmonic(                                               \
+  template void damped_harmonic_rollon(                                        \
       const gsl::not_null<tnsr::a<DataVector, DIM(data), FRAME(data)>*>        \
           gauge_h,                                                             \
       const gsl::not_null<tnsr::ab<DataVector, DIM(data), FRAME(data)>*>       \
@@ -496,7 +496,7 @@ void DampedHarmonicCompute<SpatialDim, Frame>::function(
       const double sigma_t_L1, const double t_start_L2,                        \
       const double sigma_t_L2, const double t_start_S, const double sigma_t_S, \
       const double sigma_r) noexcept;                                          \
-  template class DampedHarmonicCompute<DIM(data), FRAME(data)>;
+  template class DampedHarmonicRollonCompute<DIM(data), FRAME(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_DV_FUNC, (1, 2, 3), (DataVector),
                         (Frame::Inertial))

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -158,7 +158,7 @@ namespace gauges {
  * \f}
  */
 template <size_t SpatialDim, typename Frame>
-void damped_harmonic(
+void damped_harmonic_rollon(
     gsl::not_null<tnsr::a<DataVector, SpatialDim, Frame>*> gauge_h,
     gsl::not_null<tnsr::ab<DataVector, SpatialDim, Frame>*> d4_gauge_h,
     const tnsr::a<DataVector, SpatialDim, Frame>& gauge_h_init,
@@ -191,8 +191,8 @@ void damped_harmonic(
  * \see damped_harmonic()
  */
 template <size_t SpatialDim, typename Frame>
-struct DampedHarmonicCompute : db::ComputeTag {
-  static std::string name() noexcept { return "DampedHarmonicCompute"; }
+struct DampedHarmonicRollonCompute : db::ComputeTag {
+  static std::string name() noexcept { return "DampedHarmonicRollonCompute"; }
   using argument_tags = tmpl::list<
     Tags::InitialGaugeH<SpatialDim, Frame>,
     Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp
@@ -64,7 +64,7 @@ struct InitializeDampedHarmonic {
 
     // Add gauge tags
     using compute_tags = db::AddComputeTags<
-        GeneralizedHarmonic::gauges::DampedHarmonicCompute<Dim, frame>>;
+        GeneralizedHarmonic::gauges::DampedHarmonicRollonCompute<Dim, frame>>;
 
     // Finally, insert gauge related quantities to the box
     return std::make_tuple(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -163,7 +163,7 @@ tnsr::a<DataVector, SpatialDim, Frame> wrap_DampedHarmonicHCompute(
   for (size_t i = 0; i < SpatialDim; ++i) {
     inverse_spatial_metric.get(i, i) = 1.;
   }
-  GeneralizedHarmonic::gauges::damped_harmonic(
+  GeneralizedHarmonic::gauges::damped_harmonic_rollon(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), gauge_h_init,
       dgauge_h_init, lapse, shift, spacetime_unit_normal_one_form,
       sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric, pi,
@@ -199,7 +199,7 @@ wrap_SpacetimeDerivDampedHarmonicHCompute(
     const double sigma_r) noexcept {
   tnsr::a<DataVector, SpatialDim, Frame> gauge_h{};
   tnsr::ab<DataVector, SpatialDim, Frame> d4_gauge_h{};
-  GeneralizedHarmonic::gauges::damped_harmonic(
+  GeneralizedHarmonic::gauges::damped_harmonic_rollon(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), gauge_h_init,
       dgauge_h_init, lapse, shift, spacetime_unit_normal_one_form,
       sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric, pi,
@@ -361,7 +361,6 @@ void test_damped_harmonic_compute_tags(const size_t grid_size_each_dimension,
   const double sigma_t_S = pdist(generator) * 0.2;
   const double r_max = pdist(generator) * 0.7;
 
-  // initial H_a and D4(H_a)
   const auto gauge_h_init =
       make_with_random_values<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
           make_not_null(&generator), make_not_null(&pdist), x);
@@ -384,8 +383,8 @@ void test_damped_harmonic_compute_tags(const size_t grid_size_each_dimension,
   //
   // First, check that the names are correct
   TestHelpers::db::test_compute_tag<
-      GeneralizedHarmonic::gauges::DampedHarmonicCompute<3, Frame::Inertial>>(
-      "DampedHarmonicCompute");
+      GeneralizedHarmonic::gauges::DampedHarmonicRollonCompute<
+          3, Frame::Inertial>>("DampedHarmonicRollonCompute");
 
   const auto box = db::create<
       db::AddSimpleTags<
@@ -405,12 +404,12 @@ void test_damped_harmonic_compute_tags(const size_t grid_size_each_dimension,
           GeneralizedHarmonic::Tags::GaugeHRollOnTimeWindow,
           GeneralizedHarmonic::Tags::GaugeHSpatialWeightDecayWidth<
               Frame::Inertial>>,
-      db::AddComputeTags<GeneralizedHarmonic::gauges::DampedHarmonicCompute<
-          3, Frame::Inertial>>>(gauge_h_init, d4_gauge_h_init, lapse, shift,
-                                spacetime_unit_normal_one_form,
-                                sqrt_det_spatial_metric, inverse_spatial_metric,
-                                spacetime_metric, pi, phi, t, x, t_start_S,
-                                sigma_t_S, r_max);
+      db::AddComputeTags<GeneralizedHarmonic::gauges::
+                             DampedHarmonicRollonCompute<3, Frame::Inertial>>>(
+      gauge_h_init, d4_gauge_h_init, lapse, shift,
+      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, t, x, t_start_S,
+      sigma_t_S, r_max);
 
   // Verify that locally computed H_a matches the same obtained through its
   // ComputeTag from databox


### PR DESCRIPTION
## Proposed changes

Only these commits are new:
- Add bool to DH impl for controlling rollon
- Rename DH to DHRollon

Depends on:
- [x] #2292

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
