### PR TITLE
Add DifferenceFromAnalyticCompute tag

### DIFF
--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -38,16 +38,6 @@ struct dt : db::PrefixTag, db::SimpleTag {
 };
 
 /// \ingroup DataBoxTagsGroup
-/// \brief Prefix indicating the analytic solution value for a quantity
-///
-/// \snippet Test_DataBoxPrefixes.cpp analytic_name
-template <typename Tag>
-struct Analytic : db::PrefixTag, db::SimpleTag {
-  using type = db::const_item_type<Tag>;
-  using tag = Tag;
-};
-
-/// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating a flux
 ///
 /// \snippet Test_DataBoxPrefixes.cpp flux_name

--- a/src/Elliptic/Actions/InitializeAnalyticSolution.hpp
+++ b/src/Elliptic/Actions/InitializeAnalyticSolution.hpp
@@ -17,6 +17,7 @@
 #include "Domain/Tags.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 

--- a/src/Evolution/ComputeTags.hpp
+++ b/src/Evolution/ComputeTags.hpp
@@ -4,12 +4,12 @@
 #pragma once
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp
@@ -63,6 +63,13 @@ class WrappedGr : public SolutionType {
   using IntermediateVars = tuples::tagged_tuple_from_typelist<
       typename SolutionType::template tags<DataVector>>;
 
+  template <typename DataType>
+  using tags = tmpl::push_back<
+      typename SolutionType::template tags<DataType>,
+      gr::Tags::SpacetimeMetric<volume_dim, Frame::Inertial, DataType>,
+      GeneralizedHarmonic::Tags::Pi<volume_dim, Frame::Inertial>,
+      GeneralizedHarmonic::Tags::Phi<volume_dim, Frame::Inertial>>;
+
   template <typename... Tags>
   tuples::TaggedTuple<Tags...> variables(
       const tnsr::I<DataVector, volume_dim>& x, double t,

--- a/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
@@ -73,4 +73,14 @@ struct BoundaryCondition : BoundaryConditionBase, db::SimpleTag {
     return boundary_condition;
   }
 };
+
+/// \ingroup DataBoxTagsGroup
+/// \brief Prefix indicating the analytic solution value for a quantity
+///
+/// \snippet AnalyticSolutions/Test_Tags.cpp analytic_name
+template <typename Tag>
+struct Analytic : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+};
 }  // namespace Tags

--- a/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
@@ -83,4 +83,13 @@ struct Analytic : db::PrefixTag, db::SimpleTag {
   using type = typename Tag::type;
   using tag = Tag;
 };
+
+/*!
+ * \brief Prefix indicating the error of a value represented by `Tag`
+ */
+template <typename Tag>
+struct Error : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+};
 }  // namespace Tags

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
@@ -30,9 +30,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Prefixes",
   /// [dt_name]
   TestHelpers::db::test_prefix_tag<Tags::dt<Tag>>("dt(Tag)");
   /// [dt_name]
-  /// [analytic_name]
-  TestHelpers::db::test_prefix_tag<Tags::Analytic<Tag>>("Analytic(Tag)");
-  /// [analytic_name]
   using Dim = tmpl::size_t<2>;
   using Frame = Frame::Inertial;
   using VariablesTag = Tags::Variables<tmpl::list<TensorTag>>;

--- a/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <string>
 
-#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/ElementId.hpp"
@@ -15,6 +14,7 @@
 #include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 

--- a/tests/Unit/Evolution/Test_ComputeTags.cpp
+++ b/tests/Unit/Evolution/Test_ComputeTags.cpp
@@ -3,6 +3,7 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <cstddef>
 #include <pup.h>
 #include <string>
 
@@ -11,8 +12,12 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/Tags.hpp"
 #include "Evolution/ComputeTags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/TMPL.hpp"
@@ -37,7 +42,6 @@ struct AnalyticSolutionTag : db::SimpleTag {
 };
 
 }  // namespace
-
 SPECTRE_TEST_CASE("Unit.Evolution.ComputeTags", "[Unit][Evolution]") {
   tnsr::I<DataVector, 1, Frame::Inertial> inertial_coords{{{{1., 2., 3., 4.}}}};
   const double current_time = 2.;
@@ -53,4 +57,46 @@ SPECTRE_TEST_CASE("Unit.Evolution.ComputeTags", "[Unit][Evolution]") {
   TestHelpers::db::test_compute_tag<evolution::Tags::AnalyticCompute<
       1, AnalyticSolutionTag, tmpl::list<FieldTag>>>(
       "Analytic(Variables(Analytic(FieldTag)))");
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.ComputeTags.Errors",
+                  "[Unit][PointwiseFunctions]") {
+  static constexpr size_t volume_dim = 1;
+  using system = GeneralizedHarmonic::System<volume_dim>;
+  using solution = GeneralizedHarmonic::Solutions::WrappedGr<
+      gr::Solutions::GaugeWave<volume_dim>>;
+  using solution_tag = Tags::AnalyticSolution<solution>;
+
+  using simple_tags =
+      tmpl::list<domain::Tags::Coordinates<volume_dim, Frame::Inertial>,
+                 ::Tags::Time, system::variables_tag, solution_tag>;
+  using compute_tags = tmpl::list<evolution::Tags::ErrorsCompute<
+      volume_dim, solution_tag, system::variables_tag::tags_list>>;
+
+  constexpr double amplitude = 0.1;
+  constexpr double wavelength = 4.0;
+  const solution& analytic_solution_computer{amplitude, wavelength};
+
+  tnsr::I<DataVector, volume_dim, Frame::Inertial> inertial_coords{
+      {{{1., 2., 3., 4.}}}};
+  constexpr double time = 2.;
+  const auto& analytic =
+      variables_from_tagged_tuple(analytic_solution_computer.variables(
+          inertial_coords, time, system::variables_tag::tags_list{}));
+
+  constexpr double constant_numeric_value = 5.0;
+  db::item_type<system::variables_tag> numeric{4, constant_numeric_value};
+
+  const auto box = db::create<simple_tags, compute_tags>(
+      std::move(inertial_coords), time, numeric,
+      solution(amplitude, wavelength));
+
+  tmpl::for_each<system::variables_tag::tags_list>([&box,
+                                                    &analytic](auto tag_v) {
+    using tensor_tag = typename decltype(tag_v)::type;
+    const auto& diff = db::get<Tags::Error<tensor_tag>>(box);
+    for (size_t i = 0; i < db::item_type<tensor_tag>::size(); ++i) {
+      CHECK_ITERABLE_APPROX(diff[i], -1.0 * get<tensor_tag>(analytic)[i] + 5.0);
+    }
+  });
 }

--- a/tests/Unit/Evolution/Test_ComputeTags.cpp
+++ b/tests/Unit/Evolution/Test_ComputeTags.cpp
@@ -7,13 +7,13 @@
 #include <string>
 
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/ComputeTags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -24,9 +24,9 @@ struct FieldTag : db::SimpleTag {
 };
 
 struct AnalyticSolution {
-  tuples::TaggedTuple<FieldTag> variables(
+  static tuples::TaggedTuple<FieldTag> variables(
       const tnsr::I<DataVector, 1>& x, const double t,
-      const tmpl::list<FieldTag> /*meta*/) const noexcept {
+      const tmpl::list<FieldTag> /*meta*/) noexcept {
     return {Scalar<DataVector>{t * get<0>(x)}};
   }
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Test_Tags.cpp
@@ -25,4 +25,8 @@ SPECTRE_TEST_CASE("Unit.AnalyticSolutions.Tags", "[Unit][PointwiseFunctions]") {
       "BoundaryConditionBase");
   TestHelpers::db::test_simple_tag<Tags::BoundaryCondition<DummyType>>(
       "BoundaryCondition");
+  /// [analytic_name]
+  TestHelpers::db::test_prefix_tag<Tags::Analytic<DummyTag>>(
+      "Analytic(DummyTag)");
+  /// [analytic_name]
 }


### PR DESCRIPTION
## Proposed changes

Add a compute tag `DifferenceFromAnalyticCompute` that takes a `Variables` from a `DataBox`, subtracts the analytic solution `Analytic<Tag>` from each `Tag` in that `Variables`, and puts the result in the `DataBox` in a `Variables` whose tags are wrapped in the new `Difference<>` prefix tag.

This is a prerequisite to modifying `ObserveErrorNorms` so that we can output other error measures, such as constraints; currently, `ObserveErrorNorms` can only output differences from the analytic solution.

I also updated `WrappedGr`, so that it has the same `tags` alias as all other `AnalyticSolution`s do, so that it can work properly with `DifferenceFromAnalyticCompute`, and I moved `Tags::Analytic` to `PointwiseFunctions/AnalyticSolutions/Tags.hpp`.

Thanks to @moxcodes @markscheel for helping me out a lot in understanding how the template meta-programming works in this change!

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
