### PR TITLE
Cce analytic data manager

### DIFF
--- a/src/Evolution/Systems/Cce/AnalyticBoundaryDataManager.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticBoundaryDataManager.cpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/AnalyticBoundaryDataManager.hpp"
+
+#include <cstddef>
+#include <utility>
+
+#include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
+
+namespace Cce {
+AnalyticBoundaryDataManager::AnalyticBoundaryDataManager(
+    const size_t l_max, const double extraction_radius,
+    std::unique_ptr<Solutions::WorldtubeData> generator) noexcept
+    : l_max_{l_max},
+      generator_{std::move(generator)},
+      extraction_radius_{extraction_radius} {}
+
+void AnalyticBoundaryDataManager::pup(PUP::er& p) noexcept {
+  p | l_max_;
+  p | extraction_radius_;
+  p | generator_;
+}
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/AnalyticBoundaryDataManager.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticBoundaryDataManager.hpp
@@ -1,0 +1,133 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/ReadBoundaryDataH5.hpp"
+#include "Evolution/Systems/Cce/SpecBoundaryData.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/WriteSimpleData.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/MakeString.hpp"
+
+namespace Cce {
+namespace Tags {
+/// \cond
+struct ObservationLMax;
+/// \endcond
+}  // namespace Tags
+
+/// A boundary data manager that constructs the desired boundary data into
+/// the \ref DataBoxGroup from the data provided by the analytic solution.
+class AnalyticBoundaryDataManager {
+ public:
+  // charm needs an empty constructor.
+  AnalyticBoundaryDataManager() noexcept = default;
+
+  AnalyticBoundaryDataManager(
+      size_t l_max, double extraction_radius,
+      std::unique_ptr<Solutions::WorldtubeData> generator) noexcept;
+
+  /*!
+   * \brief Update the `boundary_data_box` entries for all tags in
+   * `Tags::characteristic_worldtube_boundary_tags` to the boundary data from
+   * the analytic solution at  `time`.
+   *
+   * \details This class retrieves metric boundary data from the
+   * `Cce::Solutions::WorldtubeData` derived class that represents an analytic
+   * solution, then dispatches to `Cce::create_bondi_boundary_data()` to
+   * construct the Bondi values into the provided \ref DataBoxGroup.
+   */
+  template <typename TagList>
+  bool populate_hypersurface_boundary_data(
+      gsl::not_null<db::DataBox<TagList>*> boundary_data_box,
+      double time) const noexcept;
+
+  /// Use `observers::ThreadedActions::WriteSimpleData` to output the expected
+  /// news at `time` from the analytic data to dataset `/expected_news.dat`.
+  template <typename Metavariables>
+  void write_news(Parallel::ConstGlobalCache<Metavariables>& cache,
+                  double time) const noexcept;
+
+  size_t get_l_max() const noexcept { return l_max_; }
+
+  /// Serialization for Charm++.
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept;
+
+ private:
+  size_t l_max_ = 0;
+  std::unique_ptr<Solutions::WorldtubeData> generator_;
+  double extraction_radius_ = std::numeric_limits<double>::signaling_NaN();
+};
+
+template <typename TagList>
+bool AnalyticBoundaryDataManager::populate_hypersurface_boundary_data(
+    const gsl::not_null<db::DataBox<TagList>*> boundary_data_box,
+    const double time) const noexcept {
+  const auto boundary_tuple = generator_->variables(
+      l_max_, time,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>,
+                 GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>{});
+  const auto& spacetime_metric =
+      get<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>>(
+          boundary_tuple);
+  const auto& pi =
+      get<GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>>(boundary_tuple);
+  const auto& phi =
+      get<GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>(boundary_tuple);
+  create_bondi_boundary_data(boundary_data_box, phi, pi, spacetime_metric,
+                             extraction_radius_, l_max_);
+  return true;
+}
+
+template <typename Metavariables>
+void AnalyticBoundaryDataManager::write_news(
+    Parallel::ConstGlobalCache<Metavariables>& cache,
+    const double time) const noexcept {
+  const auto news = get<Tags::News>(
+      generator_->variables(l_max_, time, tmpl::list<Tags::News>{}));
+  const size_t observation_l_max = Parallel::get<Tags::ObservationLMax>(cache);
+  std::vector<double> data_to_write(2 * square(observation_l_max + 1) + 1);
+  std::vector<std::string> file_legend;
+  file_legend.reserve(2 * square(observation_l_max + 1) + 1);
+  file_legend.emplace_back("time");
+  for (int i = 0; i <= static_cast<int>(observation_l_max); ++i) {
+    for (int j = -i; j <= i; ++j) {
+      file_legend.push_back(MakeString{} << "Real Y_" << i << "," << j);
+      file_legend.push_back(MakeString{} << "Imag Y_" << i << "," << j);
+    }
+  }
+  const ComplexModalVector goldberg_modes =
+      Spectral::Swsh::libsharp_to_goldberg_modes(
+          Spectral::Swsh::swsh_transform(l_max_, 1, get(news)), l_max_)
+          .data();
+  data_to_write[0] = time;
+  for (size_t i = 0; i < square(observation_l_max + 1); ++i) {
+    data_to_write[2 * i + 1] = real(goldberg_modes[i]);
+    data_to_write[2 * i + 2] = imag(goldberg_modes[i]);
+  }
+  auto observer_proxy = Parallel::get_parallel_component<
+      observers::ObserverWriter<Metavariables>>(
+      cache)[static_cast<size_t>(Parallel::my_node())];
+  Parallel::threaded_action<observers::ThreadedActions::WriteSimpleData>(
+      observer_proxy, file_legend, data_to_write, "/expected_news"s);
+}
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.hpp
@@ -69,7 +69,8 @@ struct BouncingBlackHole : public WorldtubeData {
   explicit BouncingBlackHole(CkMigrateMessage* /*unused*/) noexcept {}
 
   // clang doesn't manage to use = default correctly in this case
-  BouncingBlackHole() noexcept {}  // NOLINT
+  // NOLINTNEXTLINE(modernize-use-equals-default)
+  BouncingBlackHole() noexcept {};
 
   BouncingBlackHole(double amplitude, double extraction_radius, double mass,
                     double period) noexcept;

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.cpp
@@ -310,16 +310,16 @@ void LinearizedBondiSachs::spherical_metric(
             square(extraction_radius_) *
                 (conj(bondi_j.data()) * square(bondi_u.data()) +
                  bondi_k.data() * bondi_u.data() * conj(bondi_u.data())));
-  get<0, 1>(*spherical_metric) = -1.0;
+  get<0, 1>(*spherical_metric) = -1.0 - get<0, 0>(*spherical_metric);
   get<0, 2>(*spherical_metric) =
       square(extraction_radius_) * real(bondi_j.data() * conj(bondi_u.data()) +
                                         bondi_k.data() * bondi_u.data());
   get<0, 3>(*spherical_metric) =
       square(extraction_radius_) * imag(bondi_j.data() * conj(bondi_u.data()) +
                                         bondi_k.data() * bondi_u.data());
-  get<1, 1>(*spherical_metric) = 0.0;
-  get<1, 2>(*spherical_metric) = 0.0;
-  get<1, 3>(*spherical_metric) = 0.0;
+  get<1, 1>(*spherical_metric) = get<0, 0>(*spherical_metric) + 2.0;
+  get<1, 2>(*spherical_metric) = -get<0, 2>(*spherical_metric);
+  get<1, 3>(*spherical_metric) = -get<0, 3>(*spherical_metric);
   get<2, 2>(*spherical_metric) =
       square(extraction_radius_) * real(bondi_j.data() + bondi_k.data());
   get<2, 3>(*spherical_metric) =
@@ -381,7 +381,7 @@ void LinearizedBondiSachs::dr_spherical_metric(
       real(dr_r_squared_jbar_u_squared + dr_r_squared_k_u_ubar -
            bondi_w.data() - extraction_radius_ * dr_bondi_w.data());
 
-  get<0, 1>(*dr_spherical_metric) = 0.0;
+  get<0, 1>(*dr_spherical_metric) = -get<0, 0>(*dr_spherical_metric);
 
   const ComplexDataVector dr_r_squared_j_ubar =
       2.0 * bondi_j.data() * extraction_radius_ * conj(bondi_u.data()) +
@@ -397,9 +397,10 @@ void LinearizedBondiSachs::dr_spherical_metric(
   get<0, 3>(*dr_spherical_metric) =
       -get<0, 3>(*dr_spherical_metric) +
       imag(dr_r_squared_j_ubar + dr_r_squared_k_u);
-  get<1, 1>(*dr_spherical_metric) = 0.0;
-  get<1, 2>(*dr_spherical_metric) = 0.0;
-  get<1, 3>(*dr_spherical_metric) = 0.0;
+
+  get<1, 1>(*dr_spherical_metric) = get<0, 0>(*dr_spherical_metric) ;
+  get<1, 2>(*dr_spherical_metric) = -get<0, 2>(*dr_spherical_metric);
+  get<1, 3>(*dr_spherical_metric) = -get<0, 3>(*dr_spherical_metric);
   get<2, 2>(*dr_spherical_metric) =
       -get<2, 2>(*dr_spherical_metric) +
       2.0 * extraction_radius_ * real(bondi_j.data() + bondi_k.data()) +
@@ -461,7 +462,7 @@ void LinearizedBondiSachs::dt_spherical_metric(
       real(du_r_squared_jbar_u_squared + du_r_squared_k_u_ubar -
            extraction_radius_ * du_bondi_w.data());
 
-  get<0, 1>(*dt_spherical_metric) = 0.0;
+  get<0, 1>(*dt_spherical_metric) = -get<0, 0>(*dt_spherical_metric);
 
   const ComplexDataVector du_r_squared_j_ubar =
       square(extraction_radius_) * (du_bondi_j.data() * conj(bondi_u.data()) +
@@ -473,9 +474,9 @@ void LinearizedBondiSachs::dt_spherical_metric(
       real(du_r_squared_j_ubar + du_r_squared_k_u);
   get<0, 3>(*dt_spherical_metric) =
       imag(du_r_squared_j_ubar + du_r_squared_k_u);
-  get<1, 1>(*dt_spherical_metric) = 0.0;
-  get<1, 2>(*dt_spherical_metric) = 0.0;
-  get<1, 3>(*dt_spherical_metric) = 0.0;
+  get<1, 1>(*dt_spherical_metric) = get<0, 0>(*dt_spherical_metric);
+  get<1, 2>(*dt_spherical_metric) = -get<0, 2>(*dt_spherical_metric);
+  get<1, 3>(*dt_spherical_metric) = -get<0, 3>(*dt_spherical_metric);
   get<2, 2>(*dt_spherical_metric) =
       square(extraction_radius_) * real(du_bondi_j.data() + du_bondi_k.data());
   get<2, 3>(*dt_spherical_metric) =

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp
@@ -351,8 +351,9 @@ struct LinearizedBondiSachs : public SphericalMetricData {
    * \f$\beta = 0\f$ in this solution)
    *
    * \f{align*}{
-   * ds^2 =& - ((1 + r W) - r^2 h_{A B} U^A U^B) du^2 - 2  du dr \\
-   * &- 2 r^2 h_{A B} U^B du dx^A + r^2 h_{A B} dx^A dx^B,
+   * ds^2 =& - ((1 + r W) - r^2 h_{A B} U^A U^B) (dt - dr)^2
+   * - 2  (dt - dr) dr \\
+   * &- 2 r^2 h_{A B} U^B (dt - dr) dx^A + r^2 h_{A B} dx^A dx^B,
    * \f}
    *
    * where indices with capital letters refer to angular coordinates and the
@@ -360,11 +361,14 @@ struct LinearizedBondiSachs : public SphericalMetricData {
    * gives the metric components,
    *
    * \f{align*}{
-   * g_{u u} &= -\left(1 + r W
-   * - r^2 \Re\left(\bar J U^2 + K U \bar U\right)\right)\ \
-   * g_{u r} &= -1\\
-   * g_{u \theta} &= r^2 \Re\left(K U + J \bar U\right)\\
-   * g_{u \phi} &= r^2 \Im\left(K U + J \bar U\right)\\
+   * g_{t t} &= -\left(1 + r W
+   * - r^2 \Re\left(\bar J U^2 + K U \bar U\right)\right)\\
+   * g_{t r} &= -1 - g_{t t}\\
+   * g_{r r} &= 2 + g_{t t}\\
+   * g_{t \theta} &= r^2 \Re\left(K U + J \bar U\right)\\
+   * g_{t \phi} &= r^2 \Im\left(K U + J \bar U\right)\\
+   * g_{r \theta} &= -g_{t \theta}\\
+   * g_{r \phi} &= -g_{t \phi}\\
    * g_{\theta \theta} &= r^2 \Re\left(J + K\right)\\
    * g_{\theta \phi} &= r^2 \Im\left(J\right)\\
    * g_{\phi \phi} &= r^2 \Re\left(K - J\right),
@@ -390,9 +394,9 @@ struct LinearizedBondiSachs : public SphericalMetricData {
    * \f{align*}{
    * \partial_r g_{a b} dx^a dx^b =& - (W + r \partial_r W
    * - 2 r h_{A B} U^A U^B - r^2 (\partial_r h_{A B}) U^A U^B
-   * - 2 r^2 h_{A B} U^A \partial_r U^B) du^2 \\
+   * - 2 r^2 h_{A B} U^A \partial_r U^B) (dt - dr)^2 \\
    * &- (4 r h_{A B} U^B + 2 r^2 ((\partial_r h_{A B}) U^B
-   * + h_{AB} \partial_r U^B) ) du dx^A
+   * + h_{AB} \partial_r U^B) ) (dt - dr) dx^A
    * + (2 r h_{A B} + r^2 \partial_r h_{A B}) dx^A dx^B,
    * \f}
    *
@@ -401,13 +405,17 @@ struct LinearizedBondiSachs : public SphericalMetricData {
    * gives the metric components,
    *
    * \f{align*}{
-   * \partial_r g_{u u} &= -\left( W + r \partial_r W
+   * \partial_r g_{t t} &= -\left( W + r \partial_r W
    *  - 2 r \Re\left(\bar J U^2 + K U \bar U\right)
    * - r^2 \partial_r \Re\left(\bar J U^2 + K U \bar U\right)\right) \\
-   * \partial_r g_{u \theta} &= 2 r \Re\left(K U + J \bar U\right)
+   * \partial_r g_{t r} &= -\partial_r g_{t t}\\
+   * \partial_r g_{t \theta} &= 2 r \Re\left(K U + J \bar U\right)
    *   + r^2 \partial_r \Re\left(K U + J \bar U\right) \\
-   * \partial_r g_{u \phi} &= 2r \Im\left(K U + J \bar U\right)
+   * \partial_r g_{t \phi} &= 2r \Im\left(K U + J \bar U\right)
    *   + r^2 \partial_r \Im\left(K U + J \bar U\right) \\
+   * \partial_r g_{r r} &= \partial_r g_{t t}\\
+   * \partial_r g_{r \theta} &= -\partial_r g_{t \theta}\\
+   * \partial_r g_{r \phi} &= -\partial_r g_{t \phi}\\
    * \partial_r g_{\theta \theta} &= 2 r \Re\left(J + K\right)
    *   + r^2 \Re\left(\partial_r J + \partial_r K\right) \\
    * \partial_r g_{\theta \phi} &= 2 r \Im\left(J\right)
@@ -437,8 +445,8 @@ struct LinearizedBondiSachs : public SphericalMetricData {
    * \f{align*}{
    * \partial_t g_{a b} dx^a dx^b =& - (r \partial_u W
    * - r^2 \partial_u h_{A B} U^A U^B
-   * - 2 r^2 h_{A B} U^B \partial_u U^A) du^2 \\
-   * &- 2 r^2 (\partial_u h_{A B} U^B + h_{A B} \partial_u U^B) du dx^A
+   * - 2 r^2 h_{A B} U^B \partial_u U^A) (dt - dr)^2 \\
+   * &- 2 r^2 (\partial_u h_{A B} U^B + h_{A B} \partial_u U^B) (dt - dr) dx^A
    * + r^2 \partial_u h_{A B} dx^A dx^B,
    * \f}
    *
@@ -447,10 +455,14 @@ struct LinearizedBondiSachs : public SphericalMetricData {
    * gives the metric components,
    *
    * \f{align*}{
-   * \partial_t g_{u u} &= -\left(r \partial_u W
+   * \partial_t g_{t t} &= -\left(r \partial_u W
    * - r^2 \partial_u \Re\left(\bar J U^2 + K U \bar U\right)\right)\\
-   * \partial_t g_{u \theta} &= r^2 \partial_u \Re\left(K U + J \bar U\right)\\
-   * \partial_t g_{u \phi} &= r^2 \partial_u \Im\left(K U + J \bar U\right)\\
+   * \partial_t g_{t r} &= -\partial_t g_{t t}\\
+   * \partial_t g_{t \theta} &= r^2 \partial_u \Re\left(K U + J \bar U\right)\\
+   * \partial_t g_{t \phi} &= r^2 \partial_u \Im\left(K U + J \bar U\right)\\
+   * \partial_t g_{r r} &= \partial_t g_{t t}\\
+   * \partial_t g_{r \theta} &= -\partial_t g_{t \theta}\\
+   * \partial_t g_{r \phi} &= -\partial_t g_{t \phi}\\
    * \partial_t g_{\theta \theta} &= r^2 \Re\left(\partial_u J
    *  + \partial_u K\right)\\
    * \partial_t g_{\theta \phi} &= r^2 \Im\left(\partial_u J\right)\\

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp
@@ -74,7 +74,7 @@ struct LinearizedBondiSachs : public SphericalMetricData {
   explicit LinearizedBondiSachs(CkMigrateMessage* /*unused*/) noexcept {}
 
   // clang doesn't manage to use = default correctly in this case
-  // NOLINTNEXTLINE(modernize-use-equals-default)
+  // NOLINTNEXTLINE(hicpp-use-equals-default,modernize-use-equals-default)
   LinearizedBondiSachs() noexcept {}
 
   LinearizedBondiSachs(const std::vector<std::complex<double>>& mode_constants,

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
@@ -25,6 +25,7 @@ namespace Solutions {
 
 /// \cond
 class BouncingBlackHole;
+class LinearizedBondiSachs;
 /// \endcond
 
 /*!
@@ -63,7 +64,7 @@ class BouncingBlackHole;
  * calculations.
  */
 struct WorldtubeData : public PUP::able {
-  using creatable_classes = tmpl::list<BouncingBlackHole>;
+  using creatable_classes = tmpl::list<BouncingBlackHole, LinearizedBondiSachs>;
 
   /// The set of available tags provided by the analytic solution
   using tags = tmpl::list<
@@ -102,10 +103,10 @@ struct WorldtubeData : public PUP::able {
    * Jacobian quantities as well as metric quantities and derivatives thereof.
    */
   template <typename... Tags>
-  tuples::TaggedTuple<Tags...> variables(const size_t output_l_max,
-                                         const double time,
-                                         tmpl::list<Tags...> /*meta*/) const
-      noexcept {
+  tuples::TaggedTuple<Tags...> variables(
+      // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
+      const size_t output_l_max, const double time,
+      tmpl::list<Tags...> /*meta*/) const noexcept {
     prepare_solution(output_l_max, time);
     return {cache_or_compute<Tags>(output_l_max, time)...};
   }

--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(AnalyticSolutions)
 set(LIBRARY Cce)
 
 set(LIBRARY_SOURCES
+  AnalyticBoundaryDataManager.cpp
   BoundaryData.cpp
   Equations.cpp
   GaugeTransformBoundaryData.cpp

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -16,6 +16,7 @@ namespace Cce {
 
 /// \cond
 struct WorldtubeDataManager;
+struct AnalyticBoundaryDataManager;
 template <typename ToInterpolate, typename Tag>
 struct ScriPlusInterpolationManager;
 /// \endcond
@@ -339,6 +340,12 @@ struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
 struct EndTime : db::BaseTag {};
 
 struct StartTime : db::BaseTag {};
+
+/// The manager for populating the worldtube \ref DataBoxGroup from an analytic
+/// solution `Cce::Solutions::WorldtubeData`
+struct AnalyticBoundaryDataManager : db::SimpleTag {
+  using type = ::Cce::AnalyticBoundaryDataManager;
+};
 
 /// The Weyl scalar \f$\Psi_0\f$
 struct Psi0 : db::SimpleTag {

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_LinearizedBondiSachs.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_LinearizedBondiSachs.cpp
@@ -69,13 +69,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.LinearizedBondiSachs",
       {c_2a, c_3a}, extraction_radius, frequency};
   const double time = 10.0 * parameter_dist(gen);
   const auto boundary_data = boundary_solution.variables(
-      l_max, time,
-      tmpl::list<
-          Tags::Dr<Tags::CauchyCartesianCoords>,
-          gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>,
-          ::Tags::dt<
-              gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>>,
-          GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>, Tags::News>{});
+      l_max, time, Solutions::LinearizedBondiSachs::tags{});
   const auto& spacetime_metric =
       get<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>>(
           boundary_data);
@@ -303,7 +297,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.LinearizedBondiSachs",
     check_22_and_33_modes(dt_w_goldberg_modes, expected_dt_bondi_w_22_mode,
                           expected_dt_bondi_w_33_mode, l_max, bondi_approx);
   }
-
   // check j and its derivatives
   const auto j_goldberg_modes = Spectral::Swsh::libsharp_to_goldberg_modes(
       Spectral::Swsh::swsh_transform(l_max, 1,
@@ -379,6 +372,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.LinearizedBondiSachs",
     check_22_and_33_modes(news_goldberg_modes, expected_news_22_mode,
                           expected_news_33_mode, l_max, bondi_approx);
   }
+  Solutions::TestHelpers::check_adm_metric_quantities(
+      boundary_data, spacetime_metric, dt_spacetime_metric, d_spacetime_metric);
 }
 }  // namespace
 }  // namespace Cce::Solutions

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY "Test_Cce")
 set(LIBRARY_SOURCES
   InterfaceManagers/Test_GhLocalTimeStepping.cpp
   InterfaceManagers/Test_GhLockstep.cpp
+  Test_AnalyticBoundaryDataManager.cpp
   Test_BoundaryData.cpp
   Test_Equations.cpp
   Test_GaugeTransformBoundaryData.cpp

--- a/tests/Unit/Evolution/Systems/Cce/Test_AnalyticBoundaryDataManager.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_AnalyticBoundaryDataManager.cpp
@@ -1,0 +1,197 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <complex>
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "Evolution/Systems/Cce/AnalyticBoundaryDataManager.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "IO/Observer/Initialize.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Cce {
+namespace {
+std::vector<double> output_news_data;
+std::string data_set_name;
+struct MockWriteSimpleData {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagsList>& /*box*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const gsl::not_null<CmiNodeLock*> /*node_lock*/,
+                    const std::vector<std::string>& /*file_legend*/,
+                    const std::vector<double>& data_row,
+                    const std::string& subfile_name) noexcept {
+    data_set_name = subfile_name;
+    output_news_data = data_row;
+  }
+};
+
+struct TestCallWriteNews {
+  template <typename ParallelComponent, typename... DbTags,
+            typename Metavariables, typename ArrayIndex,
+            Requires<tmpl2::flat_any_v<std::is_same_v<
+                Tags::AnalyticBoundaryDataManager, DbTags>...>> = nullptr>
+  static void apply(const db::DataBox<tmpl::list<DbTags...>>& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/) noexcept {
+    db::get<Tags::AnalyticBoundaryDataManager>(box).write_news(
+        cache, db::get<::Tags::TimeStepId>(box).substep_time().value());
+  }
+};
+
+template <typename Metavariables>
+struct mock_observer_writer {
+  using component_being_mocked = observers::ObserverWriter<Metavariables>;
+  using replace_these_threaded_actions =
+      tmpl::list<observers::ThreadedActions::WriteSimpleData>;
+  using with_these_threaded_actions = tmpl::list<MockWriteSimpleData>;
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tags = tmpl::list<>;
+
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+template <typename Metavariables>
+struct mock_boundary {
+  using simple_tags =
+      tmpl::list<Tags::AnalyticBoundaryDataManager, ::Tags::TimeStepId>;
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tags = tmpl::list<Tags::ObservationLMax>;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags,
+                                                  db::AddComputeTags<>>>>>;
+};
+
+struct metavariables {
+  using component_list = tmpl::list<mock_observer_writer<metavariables>,
+                                    mock_boundary<metavariables>>;
+  using observed_reduction_data_tags = tmpl::list<>;
+  enum class Phase { Initialization, Exit };
+};
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.AnalyticBoundaryDataManager",
+                  "[Unit][Cce]") {
+  // set up the analytic data parameters
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> sdist{7, 10};
+  const size_t l_max = sdist(gen);
+  UniformCustomDistribution<double> parameter_dist{0.1, 1.0};
+  const double extraction_radius = 100.0 * parameter_dist(gen);
+  const double frequency = parameter_dist(gen);
+
+  const double time = 2.0;
+
+  Solutions::LinearizedBondiSachs analytic_solution{
+      {0.01 * parameter_dist(gen), 0.01 * parameter_dist(gen)},
+      extraction_radius,
+      frequency};
+  AnalyticBoundaryDataManager analytic_manager{l_max, extraction_radius,
+                                               analytic_solution.get_clone()};
+  // test the boundary computation
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  using boundary_variables_tag = ::Tags::Variables<
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>;
+  auto boundary_box_from_manager =
+      db::create<db::AddSimpleTags<boundary_variables_tag>>(
+          Variables<Tags::characteristic_worldtube_boundary_tags<
+              Tags::BoundaryValue>>{number_of_angular_points});
+  auto expected_boundary_box =
+      db::create<db::AddSimpleTags<boundary_variables_tag>>(
+          Variables<Tags::characteristic_worldtube_boundary_tags<
+              Tags::BoundaryValue>>{number_of_angular_points});
+
+  analytic_manager.populate_hypersurface_boundary_data(
+      make_not_null(&boundary_box_from_manager), time);
+  const auto analytic_solution_gh_variables = analytic_solution.variables(
+      l_max, time,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>,
+                 GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>{});
+  create_bondi_boundary_data(
+      make_not_null(&expected_boundary_box),
+      get<GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>(
+          analytic_solution_gh_variables),
+      get<GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>>(
+          analytic_solution_gh_variables),
+      get<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>>(
+          analytic_solution_gh_variables),
+      extraction_radius, l_max);
+  tmpl::for_each<
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>(
+      [&boundary_box_from_manager,
+       &expected_boundary_box](auto tag_v) noexcept {
+        using tag = typename decltype(tag_v)::type;
+        CHECK_ITERABLE_APPROX(get<tag>(boundary_box_from_manager),
+                              get<tag>(expected_boundary_box));
+      });
+
+  Parallel::register_derived_classes_with_charm<
+      Cce::Solutions::WorldtubeData>();
+  // test writing news
+  ActionTesting::MockRuntimeSystem<metavariables> runner{{l_max}};
+  runner.set_phase(metavariables::Phase::Initialization);
+  ActionTesting::emplace_component<mock_observer_writer<metavariables>>(&runner,
+                                                                        0_st);
+  ActionTesting::emplace_component_and_initialize<mock_boundary<metavariables>>(
+      &runner, 0_st,
+      tuples::TaggedTuple<Cce::Tags::AnalyticBoundaryDataManager,
+                          ::Tags::TimeStepId>{
+          std::move(analytic_manager),
+          TimeStepId{true, 0_st, {{2.0, 3.0}, {0_st, 1_st}}}});
+  ActionTesting::simple_action<mock_boundary<metavariables>, TestCallWriteNews>(
+      make_not_null(&runner), 0_st);
+  ActionTesting::invoke_queued_threaded_action<
+      mock_observer_writer<metavariables>>(make_not_null(&runner), 0_st);
+
+  const auto expected_news = get<Tags::News>(
+      analytic_solution.variables(l_max, time, tmpl::list<Tags::News>{}));
+  SpinWeighted<ComplexModalVector, -2> output_news_goldberg_modes{
+      square(l_max + 1)};
+  for (size_t i = 0; i < square(l_max + 1); ++i) {
+    output_news_goldberg_modes.data()[i] = std::complex<double>(
+        output_news_data[2 * i + 1], output_news_data[2 * i + 2]);
+  }
+  SpinWeighted<ComplexModalVector, -2> output_news_libsharp_modes{
+      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+  Spectral::Swsh::goldberg_to_libsharp_modes(
+      make_not_null(&output_news_libsharp_modes), output_news_goldberg_modes,
+      l_max);
+  const auto output_news = Spectral::Swsh::inverse_swsh_transform(
+      l_max, 1, output_news_libsharp_modes);
+  CHECK_ITERABLE_APPROX(output_news.data(), get(expected_news).data());
+  CHECK(approx(output_news_data[0]) == time);
+  CHECK(data_set_name == "/expected_news");
+}
+}  // namespace
+}  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
@@ -58,6 +58,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Tags", "[Unit][Cce]") {
   TestHelpers::db::test_simple_tag<Cce::Tags::BondiR>("R");
   TestHelpers::db::test_simple_tag<Cce::Tags::H5WorldtubeBoundaryDataManager>(
       "H5WorldtubeBoundaryDataManager");
+  TestHelpers::db::test_simple_tag<Cce::Tags::AnalyticBoundaryDataManager>(
+      "AnalyticBoundaryDataManager");
 
   auto box =
       db::create<db::AddSimpleTags<Cce::Tags::H5WorldtubeBoundaryDataManager>>(

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.cpp
@@ -273,4 +273,5 @@ extract_dr_bondi_scalars_from_cartesian_metric(
                                 (get<2, 3>(inverse_spherical_metric)));
   return {dr_bondi_beta, dr_bondi_u, dr_bondi_w, dr_bondi_j};
 }
+
 }  // namespace Cce::Solutions::TestHelpers

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.cpp
@@ -42,6 +42,12 @@ extract_bondi_scalars_from_cartesian_metric(
       }
     }
   }
+  get<0, 0>(inverse_spherical_metric) +=
+      -2.0 * get<0, 1>(inverse_spherical_metric) +
+      get<1, 1>(inverse_spherical_metric);
+  for(size_t i = 0; i < 3; ++i) {
+    inverse_spherical_metric.get(0, i) -= inverse_spherical_metric.get(1, i);
+  }
   Scalar<SpinWeighted<ComplexDataVector, 0>> bondi_beta{
       get<0, 0>(spacetime_metric).size()};
   get(bondi_beta).data() = std::complex<double>(1.0, 0.0) * 0.5 *
@@ -122,6 +128,17 @@ extract_dt_bondi_scalars_from_cartesian_metric(
         }
       }
     }
+  }
+  get<0, 0>(inverse_spherical_metric) +=
+      -2.0 * get<0, 1>(inverse_spherical_metric) +
+      get<1, 1>(inverse_spherical_metric);
+  get<0, 0>(dt_inverse_spherical_metric) +=
+      -2.0 * get<0, 1>(dt_inverse_spherical_metric) +
+      get<1, 1>(dt_inverse_spherical_metric);
+  for(size_t i = 0; i < 3; ++i) {
+    inverse_spherical_metric.get(0, i) -= inverse_spherical_metric.get(1, i);
+    dt_inverse_spherical_metric.get(0, i) -=
+        dt_inverse_spherical_metric.get(1, i);
   }
 
   // The formulas for these scalars can be determined by differentiating the
@@ -223,6 +240,18 @@ extract_dr_bondi_scalars_from_cartesian_metric(
         }
       }
     }
+  }
+
+  get<0, 0>(inverse_spherical_metric) +=
+      -2.0 * get<0, 1>(inverse_spherical_metric) +
+      get<1, 1>(inverse_spherical_metric);
+  get<0, 0>(dr_inverse_spherical_metric) +=
+      -2.0 * get<0, 1>(dr_inverse_spherical_metric) +
+      get<1, 1>(dr_inverse_spherical_metric);
+  for (size_t i = 0; i < 3; ++i) {
+    inverse_spherical_metric.get(0, i) -= inverse_spherical_metric.get(1, i);
+    dr_inverse_spherical_metric.get(0, i) -=
+        dr_inverse_spherical_metric.get(1, i);
   }
 
   // The formulas for these scalars can be determined by differentiating the

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.hpp
@@ -12,6 +12,17 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfShift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivativeOfSpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
 namespace Cce {
@@ -54,6 +65,123 @@ extract_dr_bondi_scalars_from_cartesian_metric(
     const CartesianiSphericalJ& inverse_jacobian,
     const CartesianiSphericalJ& dr_inverse_jacobian,
     double extraction_radius) noexcept;
+
+// This function checks the consistency of the 3+1 ADM quantities in the
+// `boundary_tuple` with quantities computed from `expected_spacetime_metric`,
+// `expected_dt_spacetime_metric`, and `expected_d_spacetime_metric`. If the
+// expected quantities are also extracted from the tuple, this simply checks
+// that the boundary computation has produced a consistent set of quantities
+// and has not generated NaNs or other pathological values (e.g. a degenerate
+// spacetime metric) in the process.
+template <typename... TupleTags>
+void check_adm_metric_quantities(
+    const tuples::TaggedTuple<TupleTags...>& boundary_tuple,
+    const tnsr::aa<DataVector, 3>& expected_spacetime_metric,
+    const tnsr::aa<DataVector, 3>& expected_dt_spacetime_metric,
+    const tnsr::iaa<DataVector, 3>& expected_d_spacetime_metric) noexcept {
+  // check the 3+1 quantities are computed correctly in the abstract base class
+  // `WorldtubeData`
+  const auto& dr_cartesian_coordinates =
+      get<Tags::Dr<Tags::CauchyCartesianCoords>>(boundary_tuple);
+
+  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(boundary_tuple);
+  const auto& shift =
+      get<gr::Tags::Shift<3, ::Frame::Inertial, DataVector>>(boundary_tuple);
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<3, ::Frame::Inertial, DataVector>>(
+          boundary_tuple);
+
+  const auto expected_spatial_metric =
+      gr::spatial_metric(expected_spacetime_metric);
+  const auto expected_inverse_spatial_metric =
+      determinant_and_inverse(expected_spatial_metric).second;
+  const auto expected_shift =
+      gr::shift(expected_spacetime_metric, expected_inverse_spatial_metric);
+  const auto expected_lapse =
+      gr::lapse(expected_shift, expected_spacetime_metric);
+  CHECK_ITERABLE_APPROX(spatial_metric, expected_spatial_metric);
+  CHECK_ITERABLE_APPROX(shift, expected_shift);
+  CHECK_ITERABLE_APPROX(lapse, expected_lapse);
+
+  const auto& pi =
+      get<GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>>(boundary_tuple);
+  const auto dt_spacetime_metric_from_pi =
+      GeneralizedHarmonic::time_derivative_of_spacetime_metric(
+          expected_lapse, expected_shift, pi, expected_d_spacetime_metric);
+  CHECK_ITERABLE_APPROX(expected_dt_spacetime_metric,
+                        dt_spacetime_metric_from_pi);
+  // Check that the time derivative values are consistent with the Generalized
+  // Harmonic `pi` -- these are redundant if the boundary calculation uses `pi`
+  // to derive these, but it is not required to do so.
+  const auto& dt_lapse =
+      get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(boundary_tuple);
+  const auto& dt_shift =
+      get<::Tags::dt<gr::Tags::Shift<3, ::Frame::Inertial, DataVector>>>(
+          boundary_tuple);
+  const auto& dt_spatial_metric = get<
+      ::Tags::dt<gr::Tags::SpatialMetric<3, ::Frame::Inertial, DataVector>>>(
+      boundary_tuple);
+  const auto expected_dt_spatial_metric =
+      GeneralizedHarmonic::time_deriv_of_spatial_metric(
+          expected_lapse, expected_shift, expected_d_spacetime_metric, pi);
+  const auto expected_spacetime_unit_normal =
+      gr::spacetime_normal_vector(expected_lapse, expected_shift);
+  const auto expected_dt_lapse = GeneralizedHarmonic::time_deriv_of_lapse(
+      expected_lapse, expected_shift, expected_spacetime_unit_normal,
+      expected_d_spacetime_metric, pi);
+  const auto expected_dt_shift = GeneralizedHarmonic::time_deriv_of_shift(
+      expected_lapse, expected_shift, expected_inverse_spatial_metric,
+      expected_spacetime_unit_normal, expected_d_spacetime_metric, pi);
+  CHECK_ITERABLE_APPROX(dt_lapse, expected_dt_lapse);
+  CHECK_ITERABLE_APPROX(dt_shift, expected_dt_shift);
+  CHECK_ITERABLE_APPROX(dt_spatial_metric, expected_dt_spatial_metric);
+
+  const auto& dr_lapse =
+      get<Tags::Dr<gr::Tags::Lapse<DataVector>>>(boundary_tuple);
+  const auto& dr_shift =
+      get<Tags::Dr<gr::Tags::Shift<3, ::Frame::Inertial, DataVector>>>(
+          boundary_tuple);
+  const auto& dr_spatial_metric =
+      get<Tags::Dr<gr::Tags::SpatialMetric<3, ::Frame::Inertial, DataVector>>>(
+          boundary_tuple);
+  const auto expected_spatial_derivative_of_lapse =
+      GeneralizedHarmonic::spatial_deriv_of_lapse(
+          expected_lapse, expected_spacetime_unit_normal,
+          expected_d_spacetime_metric);
+  const auto expected_inverse_spacetime_metric = gr::inverse_spacetime_metric(
+      expected_lapse, expected_shift, expected_inverse_spatial_metric);
+  const auto expected_spatial_derivative_of_shift =
+      GeneralizedHarmonic::spatial_deriv_of_shift(
+          expected_lapse, expected_inverse_spacetime_metric,
+          expected_spacetime_unit_normal, expected_d_spacetime_metric);
+  DataVector expected_buffer =
+      get<0>(dr_cartesian_coordinates) *
+          get<0>(expected_spatial_derivative_of_lapse) +
+      get<1>(dr_cartesian_coordinates) *
+          get<1>(expected_spatial_derivative_of_lapse) +
+      get<2>(dr_cartesian_coordinates) *
+          get<2>(expected_spatial_derivative_of_lapse);
+  CHECK_ITERABLE_APPROX(expected_buffer, get(dr_lapse));
+  for (size_t i = 0; i < 3; ++i) {
+    expected_buffer = get<0>(dr_cartesian_coordinates) *
+                          expected_spatial_derivative_of_shift.get(0, i) +
+                      get<1>(dr_cartesian_coordinates) *
+                          expected_spatial_derivative_of_shift.get(1, i) +
+                      get<2>(dr_cartesian_coordinates) *
+                          expected_spatial_derivative_of_shift.get(2, i);
+    CHECK_ITERABLE_APPROX(expected_buffer, dr_shift.get(i));
+    for (size_t j = i; j < 3; ++j) {
+      expected_buffer = get<0>(dr_cartesian_coordinates) *
+                            expected_d_spacetime_metric.get(0, i + 1, j + 1) +
+                        get<1>(dr_cartesian_coordinates) *
+                            expected_d_spacetime_metric.get(1, i + 1, j + 1) +
+                        get<2>(dr_cartesian_coordinates) *
+                            expected_d_spacetime_metric.get(2, i + 1, j + 1);
+      CHECK_ITERABLE_APPROX(expected_buffer, dr_spatial_metric.get(i, j));
+    }
+  }
+}
+
 }  // namespace TestHelpers
 }  // namespace Solutions
 }  // namespace Cce


### PR DESCRIPTION
## Proposed changes

Adds the object for writing boundary data into the databox or outputting the analytic news to file.
The first two commits are to rework the linearized Bondi-Sachs solution to a different coordinate system, as it is better for working with the lapse and shift. I've also factored the checks of the ADM quantities so that the linearized Bondi-Sachs solution also now checks that those are well behaved.
Those changes are related because I use the linearized Bondi-Sachs solution as a test for checking that the analytic data manager is doing its job right.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies
- [x] #2287