### PR TITLE
Adds AnalyticSolution for HalfSpaceMirror

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -637,6 +637,23 @@
   SLACcitation   = "%%CITATION = GR-QC/0512093;%%"
 }
 
+@article{Lovelace2007tn,
+  author         = "Lovelace, Geoffrey",
+  title          = "The dependence of test-mass thermal noises on beam shape
+                    in gravitational-wave interferometers",
+  journal        = "Class. Quant. Grav.",
+  volume         = "24",
+  year           = "2007",
+  number         = "17",
+  pages          = "4491-4512",
+  doi            = "10.1088/0264-9381/24/17/014",
+  url            = "https://doi.org/10.1088/0264-9381/24/17/014",
+  eprint         = "gr-qc/0610041",
+  archivePrefix  = "arXiv",
+  primaryClass   = "gr-qc",
+  SLACcitation   = "%%CITATION = GR-QC/0610041;%%"
+}
+
 @article{Lovelace2008tw,
   author         = "Lovelace, Geoffrey and Owen, Robert and Pfeiffer, Harald
                     P. and Chu, Tony",

--- a/src/NumericalAlgorithms/Integration/GslQuadAdaptive.hpp
+++ b/src/NumericalAlgorithms/Integration/GslQuadAdaptive.hpp
@@ -25,7 +25,7 @@ namespace detail {
 template <typename IntegrandType>
 double integrand(const double x, void* const params) {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  const auto function = reinterpret_cast<IntegrandType*>(params);
+  auto* const function = reinterpret_cast<IntegrandType*>(params);
   return (*function)(x);
 }
 
@@ -128,8 +128,8 @@ class GslQuadAdaptive<GslIntegralType::StandardGaussKronrod>
   double operator()(IntegrandType&& integrand, const double lower_boundary,
                     const double upper_boundary, const double tolerance_abs,
                     const int key, const double tolerance_rel = 0.) const {
-    double result;
-    double error;
+    double result = std::numeric_limits<double>::signaling_NaN();
+    double error = std::numeric_limits<double>::signaling_NaN();
     detail::disable_gsl_error_handling();
     const int status_code = gsl_integration_qag(
         gsl_integrand(std::forward<IntegrandType>(integrand)), lower_boundary,
@@ -158,8 +158,8 @@ class GslQuadAdaptive<GslIntegralType::IntegrableSingularitiesPresent>
   double operator()(IntegrandType&& integrand, const double lower_boundary,
                     const double upper_boundary, const double tolerance_abs,
                     const double tolerance_rel = 0.) const {
-    double result;
-    double error;
+    double result = std::numeric_limits<double>::signaling_NaN();
+    double error = std::numeric_limits<double>::signaling_NaN();
     detail::disable_gsl_error_handling();
     const int status_code = gsl_integration_qags(
         gsl_integrand(std::forward<IntegrandType>(integrand)), lower_boundary,
@@ -187,8 +187,8 @@ class GslQuadAdaptive<GslIntegralType::IntegrableSingularitiesKnown>
                     const std::vector<double>& points,
                     const double tolerance_abs,
                     const double tolerance_rel = 0.) const {
-    double result;
-    double error;
+    double result = std::numeric_limits<double>::signaling_NaN();
+    double error = std::numeric_limits<double>::signaling_NaN();
     detail::disable_gsl_error_handling();
     // The const_cast is necessary because GSL has a weird interface where
     // the number of singularities does not change, but it doesn't take
@@ -225,8 +225,8 @@ class GslQuadAdaptive<GslIntegralType::InfiniteInterval>
   template <typename IntegrandType>
   double operator()(IntegrandType&& integrand, const double tolerance_abs,
                     const double tolerance_rel = 0.) const {
-    double result;
-    double error;
+    double result = std::numeric_limits<double>::signaling_NaN();
+    double error = std::numeric_limits<double>::signaling_NaN();
     detail::disable_gsl_error_handling();
     const int status_code = gsl_integration_qagi(
         gsl_integrand(std::forward<IntegrandType>(integrand)), tolerance_abs,
@@ -253,8 +253,8 @@ class GslQuadAdaptive<GslIntegralType::UpperBoundaryInfinite>
   double operator()(IntegrandType&& integrand, const double lower_boundary,
                     const double tolerance_abs,
                     const double tolerance_rel = 0.) const {
-    double result;
-    double error;
+    double result = std::numeric_limits<double>::signaling_NaN();
+    double error = std::numeric_limits<double>::signaling_NaN();
     detail::disable_gsl_error_handling();
     const int status_code = gsl_integration_qagiu(
         gsl_integrand(std::forward<IntegrandType>(integrand)), lower_boundary,
@@ -281,8 +281,8 @@ class GslQuadAdaptive<GslIntegralType::LowerBoundaryInfinite>
   double operator()(IntegrandType&& integrand, const double upper_boundary,
                     const double tolerance_abs,
                     const double tolerance_rel = 0.) const {
-    double result;
-    double error;
+    double result = std::numeric_limits<double>::signaling_NaN();
+    double error = std::numeric_limits<double>::signaling_NaN();
     detail::disable_gsl_error_handling();
     const int status_code = gsl_integration_qagil(
         gsl_integrand(std::forward<IntegrandType>(integrand)), upper_boundary,

--- a/src/NumericalAlgorithms/Integration/GslQuadAdaptive.hpp
+++ b/src/NumericalAlgorithms/Integration/GslQuadAdaptive.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <gsl/gsl_integration.h>
+#include <limits>
 #include <memory>
 #include <vector>
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   BentBeam.cpp
+  HalfSpaceMirror.cpp
   )
 
 spectre_target_headers(
@@ -16,13 +17,16 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BentBeam.hpp
+  HalfSpaceMirror.hpp
   Solutions.hpp
   )
 
 target_link_libraries(
   ${LIBRARY}
+  PUBLIC ConstitutiveRelations
   PUBLIC DataStructures
-  INTERFACE ErrorHandling
-  INTERFACE Utilities
-  INTERFACE ConstitutiveRelations
+  PUBLIC ErrorHandling
+  PUBLIC Integration
+  PUBLIC Utilities
+  PRIVATE GSL::gsl
   )

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.cpp
@@ -1,0 +1,218 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <gsl/gsl_sf_bessel.h>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "ErrorHandling/Exceptions.hpp"
+#include "NumericalAlgorithms/Integration/GslQuadAdaptive.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace Elasticity::Solutions {
+
+namespace {
+double displacement_r_integrand(const double k, const double r, const double z,
+                                const double beam_width,
+                                const double modulus_term_r) noexcept {
+  return gsl_sf_bessel_J1(k * r) * exp(-k * z - square(0.5 * k * beam_width)) *
+         (modulus_term_r + k * z);
+}
+}  // namespace
+
+HalfSpaceMirror::HalfSpaceMirror(
+    const double beam_width, constitutive_relation_type constitutive_relation,
+    const size_t integration_intervals, const double absolute_tolerance,
+    const double relative_tolerance) noexcept
+    : beam_width_(beam_width),
+      constitutive_relation_(std::move(constitutive_relation)),
+      integration_intervals_(integration_intervals),
+      absolute_tolerance_(absolute_tolerance),
+      relative_tolerance_(relative_tolerance) {}
+
+tuples::TaggedTuple<Tags::Displacement<3>> HalfSpaceMirror::variables(
+    const tnsr::I<DataVector, 3>& x,
+    tmpl::list<Tags::Displacement<3>> /*meta*/) const noexcept {
+  const double shear_modulus = constitutive_relation_.shear_modulus();
+  const double lame_parameter = constitutive_relation_.lame_parameter();
+  auto result = make_with_value<tnsr::I<DataVector, 3>>(x, 0.);
+  const auto radius = sqrt(square(get<0>(x)) + square(get<1>(x)));
+
+  const integration::GslQuadAdaptive<
+      integration::GslIntegralType::UpperBoundaryInfinite>
+      integration{integration_intervals_};
+  const double lower_boundary = 0.;
+  const size_t num_points = get<0>(x).size();
+
+  const double prefactor = 0.25 / (shear_modulus * M_PI);
+  const double modulus_term_r = 1. - (lame_parameter + 2. * shear_modulus) /
+                                         (lame_parameter + shear_modulus);
+  const double modulus_term_z =
+      1. + shear_modulus / (lame_parameter + shear_modulus);
+  for (size_t i = 0; i < num_points; i++) {
+    const double z = get<2>(x)[i];
+    const double r = radius[i];
+    try {
+      if (not equal_within_roundoff(r, 0.)) {
+        const double displacement_r =
+            prefactor *
+            integration(
+                [&r, &z, &modulus_term_r, this](const double k) noexcept {
+                  return displacement_r_integrand(k, r, z, beam_width_,
+                                                  modulus_term_r);
+                },
+                lower_boundary, absolute_tolerance_, relative_tolerance_);
+        // projection on cartesian grid
+        get<0>(result)[i] = get<0>(x)[i] / r * displacement_r;
+        get<1>(result)[i] = get<1>(x)[i] / r * displacement_r;
+      }  // else x and y component vanish for r = 0
+      const double displacement_z =
+          prefactor *
+          integration(
+              [&r, &z, &modulus_term_z, this](const double k) noexcept {
+                return gsl_sf_bessel_J0(k * r) *
+                       exp(-k * z - square(0.5 * k * beam_width_)) *
+                       (modulus_term_z + k * z);
+              },
+              lower_boundary, absolute_tolerance_, relative_tolerance_);
+      get<2>(result)[i] = displacement_z;
+    } catch (convergence_error& error) {
+      ERROR("The numerical integral failed at r="
+            << r << ", z=" << z << " (" << error.what()
+            << "). Try to increase 'IntegrationIntervals' or make the domain "
+               "smaller.\n");
+    }
+  }
+  return {std::move(result)};
+}
+
+tuples::TaggedTuple<Tags::Strain<3>> HalfSpaceMirror::variables(
+    const tnsr::I<DataVector, 3>& x, tmpl::list<Tags::Strain<3>> /*meta*/) const
+    noexcept {
+  const double shear_modulus = constitutive_relation_.shear_modulus();
+  const double lame_parameter = constitutive_relation_.lame_parameter();
+  auto strain = make_with_value<tnsr::ii<DataVector, 3>>(x, 0.);
+  const auto radius = sqrt(square(get<0>(x)) + square(get<1>(x)));
+  const integration::GslQuadAdaptive<
+      integration::GslIntegralType::UpperBoundaryInfinite>
+      integration{integration_intervals_};
+  const double lower_boundary = 0.;
+  const size_t num_points = get<0>(x).size();
+
+  const double prefactor = 0.25 / (shear_modulus * M_PI);
+  const double modulus_term_trace =
+      -2. * shear_modulus / (lame_parameter + shear_modulus);
+  const double modulus_term_zz =
+      shear_modulus / (lame_parameter + shear_modulus);
+  const double modulus_term_r = 1. - (lame_parameter + 2. * shear_modulus) /
+                                         (lame_parameter + shear_modulus);
+  for (size_t i = 0; i < num_points; i++) {
+    const double r = radius[i];
+    const double z = get<2>(x)[i];
+    try {
+      const double trace_term =
+          prefactor *
+          integration(
+              [&r, &z, &modulus_term_trace, this](const double k) noexcept {
+                return k * gsl_sf_bessel_J0(k * r) *
+                       exp(-k * z - square(0.5 * k * beam_width_)) *
+                       modulus_term_trace;
+              },
+              lower_boundary, absolute_tolerance_, relative_tolerance_);
+
+      const double strain_zz =
+          -prefactor *
+          integration(
+              [&r, &z, &modulus_term_zz, this](const double k) noexcept {
+                return k * gsl_sf_bessel_J0(k * r) *
+                       exp(-k * z - square(0.5 * k * beam_width_)) *
+                       (modulus_term_zz + k * z);
+              },
+              lower_boundary, absolute_tolerance_, relative_tolerance_);
+
+      if (not equal_within_roundoff(r, 0)) {
+        const double strain_rz =
+            -prefactor *
+            integration(
+                [&r, &z, this](const double k) noexcept {
+                  return k * gsl_sf_bessel_J1(k * r) *
+                         exp(-k * z - square(0.5 * k * beam_width_)) * (k * z);
+                },
+                lower_boundary, absolute_tolerance_, relative_tolerance_);
+
+        const double displacement_r =
+            prefactor *
+            integration(
+                [&r, &z, &modulus_term_r, this](const double k) noexcept {
+                  return displacement_r_integrand(k, r, z, beam_width_,
+                                                  modulus_term_r);
+                },
+                lower_boundary, absolute_tolerance_, relative_tolerance_);
+        const double cos_phi = get<0>(x)[i] / r;
+        const double sin_phi = get<1>(x)[i] / r;
+        const double strain_pp = displacement_r / r;
+        const double strain_rr = trace_term - strain_pp - strain_zz;
+        get<0, 0>(strain)[i] =
+            strain_pp + square(cos_phi) * (strain_rr - strain_pp);
+        get<0, 1>(strain)[i] = cos_phi * sin_phi * (strain_rr - strain_pp);
+        get<0, 2>(strain)[i] = cos_phi * strain_rz;
+        get<1, 1>(strain)[i] =
+            strain_pp + square(sin_phi) * (strain_rr - strain_pp);
+        get<1, 2>(strain)[i] = sin_phi * strain_rz;
+        get<2, 2>(strain)[i] = strain_zz;
+      } else {
+        get<0, 0>(strain)[i] = 0.5 * (trace_term - strain_zz);
+        get<1, 1>(strain)[i] = get<0, 0>(strain)[i];
+        get<2, 2>(strain)[i] = strain_zz;
+        // off-diagonal components vanish for r = 0
+      }
+    } catch (convergence_error& error) {
+      ERROR("The numerical integral failed at r="
+            << r << ", z=" << z << " (" << error.what()
+            << "). Try to increase 'IntegrationIntervals' or make the domain "
+               "smaller.\n");
+    }
+  }
+  return {std::move(strain)};
+}
+
+tuples::TaggedTuple<::Tags::FixedSource<Tags::Displacement<3>>>
+HalfSpaceMirror::variables(
+    const tnsr::I<DataVector, 3>& x,
+    tmpl::list<::Tags::FixedSource<Tags::Displacement<3>>> /*meta*/) noexcept {
+  return {make_with_value<tnsr::I<DataVector, 3>>(x, 0.)};
+}
+
+void HalfSpaceMirror::pup(PUP::er& p) noexcept {
+  p | beam_width_;
+  p | constitutive_relation_;
+  p | integration_intervals_;
+  p | absolute_tolerance_;
+  p | relative_tolerance_;
+}
+
+bool operator==(const HalfSpaceMirror& lhs,
+                const HalfSpaceMirror& rhs) noexcept {
+  return lhs.beam_width_ == rhs.beam_width_ and
+         lhs.constitutive_relation_ == rhs.constitutive_relation_ and
+         lhs.integration_intervals_ == rhs.integration_intervals_ and
+         lhs.absolute_tolerance_ == rhs.absolute_tolerance_ and
+         lhs.relative_tolerance_ == rhs.relative_tolerance_;
+}
+
+bool operator!=(const HalfSpaceMirror& lhs,
+                const HalfSpaceMirror& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace Elasticity::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
@@ -1,0 +1,199 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Elasticity::Solutions {
+/*!
+ * \brief The solution for a half-space mirror deformed by a laser beam.
+ *
+ * \details This solution is mapping (via the fluctuation dissipation theorem)
+ * thermal noise to an elasticity problem where a normally incident and
+ * axisymmetric laser beam with a Gaussian beam profile acts on the face of a
+ * semi-infinite mirror. Here we assume the face to be at \f$z = 0\f$ and the
+ * material to extend to \f$+\infty\f$ in the z-direction as well as for the
+ * mirror diameter to be comparatively large to the `beam width`. The mirror
+ * material is characterized by an isotropic homogeneous constitutive relation
+ * \f$Y^{ijkl}\f$ (see
+ * `Elasticity::ConstitutiveRelations::IsotropicHomogeneous`). In this scenario,
+ * the auxiliary elastic problem has an applied pressure distribution equal to
+ * the laser beam intensity profile \f$p(r)\f$ (see Eq. (11.94) and Eq. (11.95)
+ * in \cite ThorneBlandford2017 with F = 1 and the time dependency dropped)
+ *
+ * \f{align}
+ * T^{zr} &= T^{rz} = 0 \\
+ * T^{zz} &= p(r) = \frac{e^{-\frac{r^2}{r_0^2}}}{\pi r_0^2}\text{.}
+ * \f}
+ *
+ * in the form of a Neumann boundary condition to the face of the mirror. We
+ * find that this stress in cylinder coordinates is produced by the displacement
+ * field
+ *
+ * \f{align}
+ * \xi_{r} &= \frac{1}{2 \mu} \int_0^{\infty} dk J_1(kr)e^{(-kz)}\left(1 -
+ * \frac{\lambda + 2\mu}{\lambda + \mu} + kz \right) \tilde{p}(k) \\
+ * \xi_{\phi} &= 0 \\
+ * \xi_{z} &=  \frac{1}{2 \mu} \int_0^{\infty} dk J_0(kr)e^{(-kz)}\left(1 +
+ * \frac{\mu}{\lambda + \mu} + kz \right) \tilde{p}(k)
+ * \f}
+ *
+ * and the strain
+ *
+ * \f{align}
+ * \Theta &= \frac{1}{2 \mu} \int_0^{\infty} dk
+ * J_0(kr) k e^{(-kz)}\left(\frac{-2\mu}{\lambda + \mu}\right) \tilde{p}(k) \\
+ * S_{rr} &= \Theta - S_{\phi\phi} - S_{zz} \\
+ * S_{\phi\phi} &= \frac{\xi_{r}}{r} \\
+ * S_{(rz)} &= -\frac{1}{2 \mu} \int_0^{\infty} dk J_1(kr) k e^{(-kz)}\left(kz
+ * \right) \tilde{p}(k) \\
+ * S_{zz} &= \frac{1}{2 \mu} \int_0^{\infty} dk
+ * J_0(kr) k e^{(-kz)}\left(-\frac{\mu}{\lambda + \mu} - kz \right) \tilde{p}(k)
+ * \f}
+ *
+ * (see Eqs. (11 a) - (11 c) and (13 a) - (13 e), with (13 c) swapped in favor
+ * of (12 c) in \cite Lovelace2007tn), where \f$\tilde{p}(k)= \frac{1}{2\pi}
+ * e^{-(\frac{kr_0}{2})^2}\f$ is the Hankel-Transform of the lasers intensity
+ * profile and \f$ \Theta = \mathrm{Tr}(S)\f$ the materials expansion.
+ *
+ */
+class HalfSpaceMirror {
+ public:
+  static constexpr size_t volume_dim = 3;
+
+  using constitutive_relation_type =
+      Elasticity::ConstitutiveRelations::IsotropicHomogeneous<3>;
+
+  struct BeamWidth {
+    using type = double;
+    static constexpr OptionString help{
+        "The lasers beam width r_0 with FWHM = 2*sqrt(ln 2)*r_0"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct Material {
+    using type = constitutive_relation_type;
+    static constexpr OptionString help{"The material properties of the beam"};
+  };
+
+  struct IntegrationIntervals {
+    using type = size_t;
+    static constexpr OptionString help{
+        "Workspace size for numerical integrals. Increase if integrals fail to "
+        "reach the prescribed tolerance at large distances relative to the "
+        "beam width. The default values for workspace size and tolerances "
+        "should accommodate distances of up to ~100 beam widths."};
+    static type lower_bound() noexcept { return 1; }
+    static type default_value() noexcept { return 350; }
+  };
+
+  struct AbsoluteTolerance {
+    using type = double;
+    static constexpr OptionString help{
+        "Absolute tolerance for numerical integrals"};
+    static type lower_bound() noexcept { return 0.; }
+    static type default_value() noexcept { return 1e-12; }
+  };
+
+  struct RelativeTolerance {
+    using type = double;
+    static constexpr OptionString help{
+        "Relative tolerance for numerical integrals"};
+    static type lower_bound() noexcept { return 0.; }
+    static type upper_bound() noexcept { return 1.; }
+    static type default_value() noexcept { return 1e-10; }
+  };
+
+  using options = tmpl::list<BeamWidth, Material, IntegrationIntervals,
+                             AbsoluteTolerance, RelativeTolerance>;
+  static constexpr OptionString help{
+      "A semi-infinite mirror on which a laser introduces stress perpendicular "
+      "to the mirrors surface."};
+
+  HalfSpaceMirror() = default;
+  HalfSpaceMirror(const HalfSpaceMirror&) noexcept = default;
+  HalfSpaceMirror& operator=(const HalfSpaceMirror&) noexcept = default;
+  HalfSpaceMirror(HalfSpaceMirror&&) noexcept = default;
+  HalfSpaceMirror& operator=(HalfSpaceMirror&&) noexcept = default;
+  ~HalfSpaceMirror() noexcept = default;
+
+  HalfSpaceMirror(double beam_width,
+                  constitutive_relation_type constitutive_relation,
+                  size_t integration_intervals = 350,
+                  double absolute_tolerance = 1e-12,
+                  double relative_tolerance = 1e-10) noexcept;
+
+  const constitutive_relation_type& constitutive_relation() const noexcept {
+    return constitutive_relation_;
+  }
+
+  // @{
+  /// Retrieve variable at coordinates `x`
+  auto variables(const tnsr::I<DataVector, 3>& x,
+                 tmpl::list<Tags::Displacement<3>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<Tags::Displacement<3>>;
+
+  auto variables(const tnsr::I<DataVector, 3>& x,
+                 tmpl::list<Tags::Strain<3>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<Tags::Strain<3>>;
+
+  // FixedSource in Elasticity equates to external forces
+  // (see Elasticity::FirstOrderSystem)
+  static auto variables(
+      const tnsr::I<DataVector, 3>& x,
+      tmpl::list<::Tags::FixedSource<Tags::Displacement<3>>> /*meta*/) noexcept
+      -> tuples::TaggedTuple<::Tags::FixedSource<Tags::Displacement<3>>>;
+  // @}
+
+  /// Retrieve a collection of variables at coordinates `x`
+  template <typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataVector, 3>& x,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
+    static_assert(sizeof...(Tags) > 1, "An unsupported Tag was requested.");
+    for (size_t i = 0; i < get<2>(x).size(); i++) {
+      if (UNLIKELY(get<2>(x)[i] < 0)) {
+        ERROR(
+            "The HalfSpaceMirror solution is not defined for negative values "
+            "of z.");
+      }
+    }
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  // clang-tidy: no pass by reference
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  friend bool operator==(const HalfSpaceMirror& lhs,
+                         const HalfSpaceMirror& rhs) noexcept;
+
+  double beam_width_{std::numeric_limits<double>::signaling_NaN()};
+  constitutive_relation_type constitutive_relation_{};
+  size_t integration_intervals_{std::numeric_limits<size_t>::max()};
+  double absolute_tolerance_{std::numeric_limits<double>::signaling_NaN()};
+  double relative_tolerance_{std::numeric_limits<double>::signaling_NaN()};
+};
+
+bool operator!=(const HalfSpaceMirror& lhs,
+                const HalfSpaceMirror& rhs) noexcept;
+
+}  // namespace Elasticity::Solutions

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
@@ -136,13 +136,15 @@ void verify_solution(
  * per dimension.
  */
 template <typename System, typename SolutionType,
-          size_t Dim = System::volume_dim, typename... Maps>
+          size_t Dim = System::volume_dim, typename... Maps,
+          typename PackageFluxesArgs>
 void verify_smooth_solution(
     const SolutionType& solution,
     const typename System::fluxes& fluxes_computer,
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, Maps...>&
         coord_map,
-    const double tolerance_offset, const double tolerance_scaling) {
+    const double tolerance_offset, const double tolerance_scaling,
+    PackageFluxesArgs&& package_fluxes_args) {
   INFO("Verify smooth solution");
   for (size_t num_points = Spectral::minimum_number_of_points<
            Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
@@ -153,11 +155,11 @@ void verify_smooth_solution(
     const double tolerance =
         tolerance_offset * exp(-tolerance_scaling * num_points);
     CAPTURE(tolerance);
+    const Mesh<Dim> mesh{num_points, Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
     FirstOrderEllipticSolutionsTestHelpers::verify_solution<System>(
-        solution, fluxes_computer,
-        Mesh<Dim>{num_points, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto},
-        coord_map, tolerance);
+        solution, fluxes_computer, mesh, coord_map, tolerance,
+        package_fluxes_args(mesh));
   }
 }
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
@@ -5,11 +5,12 @@ set(LIBRARY "Test_ElasticitySolutions")
 
 set(LIBRARY_SOURCES
   Test_BentBeam.cpp
+  Test_HalfSpaceMirror.cpp
   )
 
 add_test_library(
   ${LIBRARY}
   "PointwiseFunctions/AnalyticSolutions/Elasticity/"
   "${LIBRARY_SOURCES}"
-  "ElasticitySolutions;Utilities"
+  "ElasticitySolutions;Utilities;Integration"
   )

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.py
@@ -1,0 +1,127 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+import scipy.integrate as integrate
+from scipy.special import jv
+from Elasticity.ConstitutiveRelations.IsotropicHomogeneous import (
+    lame_parameter)
+
+
+def beam_profile(k, beam_width):
+    return (1. / (2. * np.pi) * np.exp(-(k * beam_width / 2.)**2))
+
+
+def integrand_xi_w(k, w, z, lame_parameter, shear_modulus, beam_width):
+    return (1. / (2. * shear_modulus) * jv(1, k * w) * np.exp(-k * z) *
+            (1. - (lame_parameter + 2. * shear_modulus) /
+             (lame_parameter + shear_modulus) + k * z) *
+            beam_profile(k, beam_width))
+
+
+def integrand_xi_z(k, w, z, lame_parameter, shear_modulus, beam_width):
+    return (1. / (2. * shear_modulus) * jv(0, k * w) * np.exp(-k * z) *
+            (1. + shear_modulus / (lame_parameter + shear_modulus) + k * z) *
+            beam_profile(k, beam_width))
+
+
+def integrand_theta(k, w, z, lame_parameter, shear_modulus, beam_width):
+    return (1. / (2. * shear_modulus) * k * jv(0, k * w) * np.exp(-k * z) *
+            (-2. * shear_modulus /
+             (lame_parameter + shear_modulus)) * beam_profile(k, beam_width))
+
+
+def integrand_strain_rz(k, w, z, lame_parameter, shear_modulus, beam_width):
+    return (-1. / (2. * shear_modulus) * k * jv(1, k * w) * (k * z) *
+            np.exp(-k * z) * beam_profile(k, beam_width))
+
+
+def integrand_strain_zz(k, w, z, lame_parameter, shear_modulus, beam_width):
+    return (1. / (2. * shear_modulus) * k * jv(0, k * w) * np.exp(-k * z) *
+            (-shear_modulus / (lame_parameter + shear_modulus) - k * z) *
+            beam_profile(k, beam_width))
+
+
+def displacement(r, beam_width, bulk_modulus, shear_modulus):
+    local_lame_parameter = lame_parameter(bulk_modulus, shear_modulus)
+    x = r[0]
+    y = r[1]
+    z = r[2]
+    radius = np.sqrt(x**2 + y**2)
+    xi_z = integrate.quad(lambda k: integrand_xi_z(
+        k, radius, z, local_lame_parameter, shear_modulus, beam_width),
+                          0,
+                          np.inf,
+                          limit=100,
+                          epsabs=1e-13)[0]
+    if radius <= 1e-13:
+        return np.asarray(0., 0., xi_z)
+    xi_w = integrate.quad(lambda k: integrand_xi_w(
+        k, radius, z, local_lame_parameter, shear_modulus, beam_width),
+                          0,
+                          np.inf,
+                          limit=100,
+                          epsabs=1e-13)[0]
+
+    cos_phi = x / radius
+    sin_phi = y / radius
+    return np.asarray([xi_w * cos_phi, xi_w * sin_phi, xi_z])
+
+
+def strain(r, beam_width, bulk_modulus, shear_modulus):
+    local_lame_parameter = lame_parameter(bulk_modulus, shear_modulus)
+
+    x = r[0]
+    y = r[1]
+    z = r[2]
+    radius = np.sqrt(x**2 + y**2)
+
+    trace_term = integrate.quad(lambda k: integrand_theta(
+        k, radius, z, local_lame_parameter, shear_modulus, beam_width),
+                                0,
+                                np.inf,
+                                limit=100,
+                                epsabs=1e-13)[0]
+
+    strain_zz = integrate.quad(lambda k: integrand_strain_zz(
+        k, radius, z, local_lame_parameter, shear_modulus, beam_width),
+                               0,
+                               np.inf,
+                               limit=100,
+                               epsabs=1e-13)[0]
+
+    if radius <= 1e-13:
+        radius = 1.
+        strain_rr = 0.5 * (trace_term - strain_zz)
+        return np.asarray([[strain_rr, 0, 0], [0, strain_rr, 0],
+                           [0, 0, strain_zz]])
+    else:
+        strain_rz = integrate.quad(lambda k: integrand_strain_rz(
+            k, radius, z, local_lame_parameter, shear_modulus, beam_width),
+                                   0,
+                                   np.inf,
+                                   limit=100,
+                                   epsabs=1e-13)[0]
+        xi_w = integrate.quad(lambda k: integrand_xi_w(
+            k, radius, z, local_lame_parameter, shear_modulus, beam_width),
+                              0,
+                              np.inf,
+                              limit=100,
+                              epsabs=1e-13)[0]
+        strain_pp = xi_w / radius
+        strain_rr = trace_term - strain_pp - strain_zz
+        return np.asarray(
+            [[
+                strain_pp + (x / radius)**2 * (strain_rr - strain_pp),
+                x * y / radius**2 * (strain_rr - strain_pp),
+                x / radius * strain_rz
+            ],
+             [
+                 x * y / radius**2 * (strain_rr - strain_pp),
+                 strain_pp + (y / radius)**2 * (strain_rr - strain_pp),
+                 y / radius * strain_rz
+             ], [x / radius * strain_rz, y / radius * strain_rz, strain_zz]])
+
+
+def source(r):
+    return np.zeros(r.shape)

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
@@ -1,0 +1,160 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Elliptic/Systems/Elasticity/Equations.hpp"
+#include "Elliptic/Systems/Elasticity/FirstOrderSystem.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+struct HalfSpaceMirrorProxy : Elasticity::Solutions::HalfSpaceMirror {
+  using Elasticity::Solutions::HalfSpaceMirror::HalfSpaceMirror;
+
+  using field_tags = tmpl::list<Elasticity::Tags::Displacement<3>,
+                                Elasticity::Tags::Strain<3>>;
+  using source_tags =
+      tmpl::list<Tags::FixedSource<Elasticity::Tags::Displacement<3>>>;
+
+  tuples::tagged_tuple_from_typelist<field_tags> field_variables(
+      const tnsr::I<DataVector, 3>& x) const noexcept {
+    return Elasticity::Solutions::HalfSpaceMirror::variables(x, field_tags{});
+  }
+
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+  tuples::tagged_tuple_from_typelist<source_tags> source_variables(
+      const tnsr::I<DataVector, 3>& x) const noexcept {
+    return Elasticity::Solutions::HalfSpaceMirror::variables(x, source_tags{});
+  }
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.Elasticity.HalfSpaceMirror",
+    "[PointwiseFunctions][Unit][Elasticity]") {
+  constexpr size_t dim = Elasticity::Solutions::HalfSpaceMirror::volume_dim;
+  const Elasticity::Solutions::HalfSpaceMirror check_solution{
+      0.177, Elasticity::ConstitutiveRelations::IsotropicHomogeneous<3>{
+                 // fused silica: E=72, nu=0.17
+                 // K =\frac{E}{3(1-2\nu)}, \mu =\frac{E}{2(1+\nu)}
+                 36.36363636363637, 30.76923076923077}};
+  const auto created_solution =
+      TestHelpers::test_creation<Elasticity::Solutions::HalfSpaceMirror>(
+          "BeamWidth: 0.177\n"
+          "Material:\n"
+          "  BulkModulus: 36.36363636363637\n"
+          "  ShearModulus: 30.76923076923077\n");
+  CHECK(created_solution == check_solution);
+  test_serialization(check_solution);
+
+  pypp::SetupLocalPythonEnvironment local_python_env{"PointwiseFunctions"};
+  const Elasticity::ConstitutiveRelations::IsotropicHomogeneous<dim>
+      constitutive_relation{36.36363636363637, 30.76923076923077};
+  const HalfSpaceMirrorProxy solution{0.177, constitutive_relation, 350, 1e-11,
+                                      1e-11};
+  pypp::check_with_random_values<1,
+                                 tmpl::list<Elasticity::Tags::Displacement<dim>,
+                                            Elasticity::Tags::Strain<dim>>>(
+      &HalfSpaceMirrorProxy::field_variables, solution,
+      "AnalyticSolutions.Elasticity.HalfSpaceMirror",
+      {"displacement", "strain"}, {{{0., 3.}}},
+      std::make_tuple(0.177, 36.36363636363637, 30.76923076923077),
+      DataVector(5), 1e-10);
+  pypp::check_with_random_values<
+      1, tmpl::list<Tags::FixedSource<Elasticity::Tags::Displacement<dim>>>>(
+      &HalfSpaceMirrorProxy::source_variables, solution,
+      "AnalyticSolutions.Elasticity.HalfSpaceMirror", {"source"}, {{{0., 3.}}},
+      std::make_tuple(), DataVector(5), 1e-10);
+
+  {
+    INFO(
+        "Test that functions behave expectedly at the origin and vanish far "
+        "away from the source");
+    const tnsr::I<DataVector, 3> x{
+        {{{0., 20., 0.}, {0., 0., 0.}, {0., 0., 20.}}}};
+    const auto solution_vars = variables_from_tagged_tuple(
+        solution.variables(x, tmpl::list<Elasticity::Tags::Displacement<3>,
+                                         Elasticity::Tags::Strain<3>>{}));
+    Variables<tmpl::list<Elasticity::Tags::Displacement<3>,
+                         Elasticity::Tags::Strain<3>>>
+        expected_vars{3};
+    auto& expected_displacement =
+        get<Elasticity::Tags::Displacement<3>>(expected_vars);
+    get<0>(expected_displacement) = DataVector{0., 0., 0.};
+    get<1>(expected_displacement) = DataVector{0., 0., 0.};
+    get<2>(expected_displacement) = DataVector{4.30e-02, 0., 0.};
+    auto& expected_strain = get<Elasticity::Tags::Strain<3>>(expected_vars);
+    get<0, 0>(expected_strain) = DataVector{-5.45e-02, 0., 0.};
+    get<1, 0>(expected_strain) = DataVector{0., 0., 0.};
+    get<2, 0>(expected_strain) = DataVector{0., 0., 0.};
+    get<1, 1>(expected_strain) = DataVector{-5.45e-02, 0., 0.};
+    get<2, 1>(expected_strain) = DataVector{0., 0., 0.};
+    get<2, 2>(expected_strain) = DataVector{-10.90e-02, 0., 0.};
+    Approx custom_approx = Approx::custom().margin(5e-4);
+    CHECK_VARIABLES_CUSTOM_APPROX(solution_vars, expected_vars, custom_approx);
+  };
+
+  {
+    INFO("Test elasticity system with half-space mirror");
+    // Verify that the solution numerically solves the system and that the
+    // discretization error decreases exponentially with polynomial order
+    using system = Elasticity::FirstOrderSystem<dim>;
+    const typename system::fluxes fluxes_computer{};
+    using AffineMap = domain::CoordinateMaps::Affine;
+    using AffineMap3D =
+        domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+    const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap3D>
+        coord_map{{{-1., 1., 0., 0.5}, {-1., 1., 0., 0.5}, {-1., 1., 0., 0.5}}};
+    FirstOrderEllipticSolutionsTestHelpers::verify_smooth_solution<system>(
+        solution, fluxes_computer, coord_map, 1.e4, 1.,
+        [&constitutive_relation, &coord_map](const Mesh<3>& mesh) {
+          const auto logical_coords = logical_coordinates(mesh);
+          const auto inertial_coords = coord_map(logical_coords);
+          return std::make_tuple(constitutive_relation, inertial_coords);
+        });
+  };
+}
+
+// [[OutputRegex, The numerical integral failed]]
+SPECTRE_TEST_CASE(
+    "Unit.AnalyticSolutions.Elasticity.HalfSpaceMirror.ConvergenceError",
+    "[PointwiseFunctions][Unit][Elasticity]") {
+  ERROR_TEST();
+  constexpr size_t dim = Elasticity::Solutions::HalfSpaceMirror::volume_dim;
+  const Elasticity::ConstitutiveRelations::IsotropicHomogeneous<dim>
+      constitutive_relation{36.36363636363637, 30.76923076923077};
+  const HalfSpaceMirrorProxy solution{0.177, constitutive_relation, 5, 1e-15,
+                                      1e-15};
+  const tnsr::I<DataVector, 3> x{{{{0.3}, {1.3}, {2.3}}}};
+  const auto solution_vars = variables_from_tagged_tuple(
+      solution.variables(x, tmpl::list<Elasticity::Tags::Displacement<dim>,
+                                       Elasticity::Tags::Strain<dim>>{}));
+}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
@@ -95,7 +95,8 @@ SPECTRE_TEST_CASE(
         coord_map{
             {{-1., 1., -0.5, 0.5}, {-1., 1., -0.5, 0.5}, {-1., 1., -0.5, 0.5}}};
     FirstOrderEllipticSolutionsTestHelpers::verify_smooth_solution<system>(
-        solution, fluxes_computer, coord_map, 5.e1, 1.2);
+        solution, fluxes_computer, coord_map, 5.e1, 1.2,
+        [](const auto&... /*unused*/) noexcept { return std::tuple<>{}; });
   }
 
   {

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
@@ -100,7 +100,8 @@ SPECTRE_TEST_CASE(
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap>
         coord_map{{-1., 1., 0., M_PI}};
     FirstOrderEllipticSolutionsTestHelpers::verify_smooth_solution<system>(
-        solution, fluxes_computer, coord_map, 1.e5, 3.);
+        solution, fluxes_computer, coord_map, 1.e5, 3.,
+        [](const auto&... /*unused*/) noexcept { return std::tuple<>{}; });
   }
   {
     INFO("2D");
@@ -114,7 +115,8 @@ SPECTRE_TEST_CASE(
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap2D>
         coord_map{{{-1., 1., 0., M_PI}, {-1., 1., 0., M_PI}}};
     FirstOrderEllipticSolutionsTestHelpers::verify_smooth_solution<system>(
-        solution, fluxes_computer, coord_map, 1.e5, 3.);
+        solution, fluxes_computer, coord_map, 1.e5, 3.,
+        [](const auto&... /*unused*/) noexcept { return std::tuple<>{}; });
   }
   {
     INFO("3D");
@@ -129,6 +131,7 @@ SPECTRE_TEST_CASE(
         coord_map{
             {{-1., 1., 0., M_PI}, {-1., 1., 0., M_PI}, {-1., 1., 0., M_PI}}};
     FirstOrderEllipticSolutionsTestHelpers::verify_smooth_solution<system>(
-        solution, fluxes_computer, coord_map, 1.e5, 3.);
+        solution, fluxes_computer, coord_map, 1.e5, 3.,
+        [](const auto&... /*unused*/) noexcept { return std::tuple<>{}; });
   }
 }

--- a/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.py
+++ b/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.py
@@ -28,3 +28,7 @@ def youngs_modulus(bulk_modulus, shear_modulus):
 def poisson_ratio(bulk_modulus, shear_modulus):
     return (3. * bulk_modulus - 2. * shear_modulus) / \
         (6. * bulk_modulus + 2. * shear_modulus)
+
+
+def lame_parameter(bulk_modulus, shear_modulus):
+    return bulk_modulus - 2 / 3. * shear_modulus


### PR DESCRIPTION
## Proposed changes
This PR adds the analytic solution for a half-space mirror. The displacement and strain are, but for a change from cylindrical to cartesian coordinates, in accordance with the equations in Blandford & Thorne Modern Classical Physics, and are changed in a latter commit to match with "The dependence of test-mass thermal noises on beam shape in gravitational-wave interferometers" by Geoffrey Lovelace, where the strain is specified explicitly.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments
For now only a Gaussian beam shape is considered for the laser beam profile. This might be generalised in the future.

