### PR TITLE
Add AreaTag

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -13,6 +13,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
@@ -324,6 +325,23 @@ struct SurfaceIntegral : db::ComputeTag {
   static constexpr auto function = surface_integral_of_scalar<Frame>;
   using argument_tags = tmpl::list<AreaElement<Frame>, IntegrandTag,
                                    StrahlkorperTags::Strahlkorper<Frame>>;
+};
+/// Tag representing the surface area of a Strahlkorper
+struct Area : db::SimpleTag {
+  using type = double;
+};
+/// Computes the surface area of a Strahlkorer, \f$A = \oint_S dA\f$ given an
+/// AreaElement \f$dA\f$ and a Strahlkorper \f$S\f$.
+template <typename Frame>
+struct AreaCompute : Area, db::ComputeTag {
+  using base = Area;
+  static double function(const Strahlkorper<Frame>& strahlkorper,
+                         const Scalar<DataVector>& area_element) noexcept {
+    return strahlkorper.ylm_spherepack().definite_integral(
+        get(area_element).data());
+  }
+  using argument_tags =
+      tmpl::list<StrahlkorperTags::Strahlkorper<Frame>, AreaElement<Frame>>;
 };
 
 }  // namespace Tags

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -35,6 +35,10 @@ template <typename Frame>
 struct EuclideanAreaElement;
 template <typename IntegrandTag, typename Frame>
 struct EuclideanSurfaceIntegral;
+template <typename Frame>
+struct Area;
+template <typename Frame>
+struct AreaCompute;
 }  // namespace StrahlkorperTags
 
 namespace StrahlkorperGr {

--- a/src/ApparentHorizons/YlmSpherepack.hpp
+++ b/src/ApparentHorizons/YlmSpherepack.hpp
@@ -281,16 +281,16 @@ class YlmSpherepack {
 
   /// Adds a constant (i.e. \f$f(\theta,\phi)\f$ += \f$c\f$) to the function
   /// given by the spectral coefficients, by modifying the coefficients.
-  SPECTRE_ALWAYS_INLINE void add_constant(
-      const gsl::not_null<DataVector*> spectral_coefs, const double c) const
-      noexcept {
+  SPECTRE_ALWAYS_INLINE static void add_constant(
+      const gsl::not_null<DataVector*> spectral_coefs,
+      const double c) noexcept {
     // The factor of sqrt(8) is because of the normalization of
     // SPHEREPACK's coefficients.
     (*spectral_coefs)[0] += sqrt(8.0) * c;
   }
 
   /// Returns the average of \f$f(\theta,\phi)\f$ over \f$(\theta,\phi)\f$.
-  SPECTRE_ALWAYS_INLINE double average(const DataVector& spectral_coefs) const
+  SPECTRE_ALWAYS_INLINE static double average(const DataVector& spectral_coefs)
       noexcept {
     // The factor of sqrt(8) is because of the normalization of
     // SPHEREPACK's coefficients.  All other coefficients average to zero.

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -30,7 +30,8 @@ namespace {
 // a given average radius and a given center.
 auto create_strahlkorper_y11(const double y11_amplitude, const double radius,
                              const std::array<double, 3>& center) {
-  const size_t l_max = 4, m_max = 4;
+  static const size_t l_max = 4;
+  static const size_t m_max = 4;
 
   Strahlkorper<Frame::Inertial> strahlkorper_sphere(l_max, m_max, radius,
                                                     center);

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -297,6 +297,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   test_radius_and_derivs();
   test_normals();
   TestHelpers::db::test_simple_tag<ah::Tags::FastFlow>("FastFlow");
+  TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::Area>("Area");
   TestHelpers::db::test_simple_tag<
       StrahlkorperTags::Strahlkorper<Frame::Inertial>>("Strahlkorper");
   TestHelpers::db::test_compute_tag<
@@ -338,4 +339,6 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_compute_tag<
       StrahlkorperGr::Tags::SurfaceIntegral<SomeTag, Frame::Inertial>>(
       "SurfaceIntegral(SomeTag)");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperGr::Tags::AreaCompute<Frame::Inertial>>("Area");
 }


### PR DESCRIPTION
## Proposed changes

Add AreaTag and AreaTagCompute for computing the area of a Strahlkorper. 

### Types of changes:

- [ ] Bugfix
- [x ] New feature
- [ ] Refactor

### Component:

- [x ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
