### PR TITLE
Template MathFunctions on Dimension and Frame

### DIFF
--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -295,7 +295,8 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::FunctionsOfTime::register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<
         Event<metavariables::events>>,
-    &Parallel::register_derived_classes_with_charm<MathFunction<1>>,
+    &Parallel::register_derived_classes_with_charm<
+        MathFunction<1, Frame::Inertial>>,
     &Parallel::register_derived_classes_with_charm<
         StepChooser<metavariables::slab_choosers>>,
     &Parallel::register_derived_classes_with_charm<

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
@@ -17,9 +17,9 @@
 namespace ScalarWave::Solutions {
 
 template <size_t Dim>
-PlaneWave<Dim>::PlaneWave(std::array<double, Dim> wave_vector,
-                          std::array<double, Dim> center,
-                          std::unique_ptr<MathFunction<1>> profile) noexcept
+PlaneWave<Dim>::PlaneWave(
+    std::array<double, Dim> wave_vector, std::array<double, Dim> center,
+    std::unique_ptr<MathFunction<1, Frame::Inertial>> profile) noexcept
     : wave_vector_(std::move(wave_vector)),
       center_(std::move(center)),
       profile_(std::move(profile)),

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -30,7 +30,7 @@ namespace Tags {
 template <typename Tag>
 struct dt;
 }  // namespace Tags
-template <size_t VolumeDim>
+template <size_t VolumeDim, typename Fr>
 class MathFunction;
 
 namespace PUP {
@@ -69,7 +69,7 @@ class PlaneWave : public MarkAsAnalyticSolution {
   };
 
   struct Profile {
-    using type = std::unique_ptr<MathFunction<1>>;
+    using type = std::unique_ptr<MathFunction<1, Frame::Inertial>>;
     static constexpr OptionString help = {"The profile of the wave."};
   };
 
@@ -80,7 +80,7 @@ class PlaneWave : public MarkAsAnalyticSolution {
 
   PlaneWave() = default;
   PlaneWave(std::array<double, Dim> wave_vector, std::array<double, Dim> center,
-            std::unique_ptr<MathFunction<1>> profile) noexcept;
+            std::unique_ptr<MathFunction<1, Frame::Inertial>> profile) noexcept;
   PlaneWave(const PlaneWave&) noexcept = delete;
   PlaneWave& operator=(const PlaneWave&) noexcept = delete;
   PlaneWave(PlaneWave&&) noexcept = default;
@@ -140,7 +140,7 @@ class PlaneWave : public MarkAsAnalyticSolution {
 
   std::array<double, Dim> wave_vector_{};
   std::array<double, Dim> center_{};
-  std::unique_ptr<MathFunction<1>> profile_;
+  std::unique_ptr<MathFunction<1, Frame::Inertial>> profile_;
   double omega_{};
 };
 }  // namespace Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
@@ -22,7 +22,7 @@
 namespace ScalarWave::Solutions {
 
 RegularSphericalWave::RegularSphericalWave(
-    std::unique_ptr<MathFunction<1>> profile) noexcept
+    std::unique_ptr<MathFunction<1, Frame::Inertial>> profile) noexcept
     : profile_(std::move(profile)) {}
 
 tuples::TaggedTuple<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
@@ -29,7 +29,7 @@ namespace Tags {
 template <typename Tag>
 struct dt;
 }  // namespace Tags
-template <size_t VolumeDim>
+template <size_t VolumeDim, typename Fr>
 class MathFunction;
 namespace PUP {
 class er;
@@ -67,7 +67,7 @@ class RegularSphericalWave : public MarkAsAnalyticSolution {
  public:
   static constexpr size_t volume_dim = 3;
   struct Profile {
-    using type = std::unique_ptr<MathFunction<1>>;
+    using type = std::unique_ptr<MathFunction<1, Frame::Inertial>>;
     static constexpr OptionString help = {
         "The radial profile of the spherical wave."};
   };
@@ -80,7 +80,7 @@ class RegularSphericalWave : public MarkAsAnalyticSolution {
 
   RegularSphericalWave() = default;
   explicit RegularSphericalWave(
-      std::unique_ptr<MathFunction<1>> profile) noexcept;
+      std::unique_ptr<MathFunction<1, Frame::Inertial>> profile) noexcept;
   RegularSphericalWave(const RegularSphericalWave&) noexcept = delete;
   RegularSphericalWave& operator=(const RegularSphericalWave&) noexcept =
       delete;
@@ -105,7 +105,7 @@ class RegularSphericalWave : public MarkAsAnalyticSolution {
   void pup(PUP::er& p) noexcept;  // NOLINT
 
  private:
-  std::unique_ptr<MathFunction<1>> profile_;
+  std::unique_ptr<MathFunction<1, Frame::Inertial>> profile_;
 };
 }  // namespace Solutions
 }  // namespace ScalarWave

--- a/src/PointwiseFunctions/MathFunctions/Gaussian.cpp
+++ b/src/PointwiseFunctions/MathFunctions/Gaussian.cpp
@@ -6,87 +6,345 @@
 #include <cmath>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
 
 namespace MathFunctions {
 
-Gaussian::Gaussian(const double amplitude, const double width,
-                   const double center) noexcept
+template <typename Fr>
+Gaussian<1, Fr>::Gaussian(const double amplitude, const double width,
+                          const double center) noexcept
     : amplitude_(amplitude), inverse_width_(1.0 / width), center_(center) {}
 
-double Gaussian::operator()(const double& x) const noexcept {
+template <typename Fr>
+Gaussian<1, Fr>::Gaussian(double amplitude, double width,
+                          const std::array<double, 1>& center) noexcept
+    : Gaussian(amplitude, width, center[0]) {}
+
+template <typename Fr>
+double Gaussian<1, Fr>::operator()(const double& x) const noexcept {
   return apply_call_operator(x);
 }
-DataVector Gaussian::operator()(const DataVector& x) const noexcept {
+
+template <typename Fr>
+DataVector Gaussian<1, Fr>::operator()(const DataVector& x) const noexcept {
   return apply_call_operator(x);
 }
 
-double Gaussian::first_deriv(const double& x) const noexcept {
+template <typename Fr>
+double Gaussian<1, Fr>::first_deriv(const double& x) const noexcept {
   return apply_first_deriv(x);
 }
-DataVector Gaussian::first_deriv(const DataVector& x) const noexcept {
+
+template <typename Fr>
+DataVector Gaussian<1, Fr>::first_deriv(const DataVector& x) const noexcept {
   return apply_first_deriv(x);
 }
 
-double Gaussian::second_deriv(const double& x) const noexcept {
-  return apply_second_deriv(x);
-}
-DataVector Gaussian::second_deriv(const DataVector& x) const noexcept {
+template <typename Fr>
+double Gaussian<1, Fr>::second_deriv(const double& x) const noexcept {
   return apply_second_deriv(x);
 }
 
-double Gaussian::third_deriv(const double& x) const noexcept {
-  return apply_third_deriv(x);
+template <typename Fr>
+DataVector Gaussian<1, Fr>::second_deriv(const DataVector& x) const noexcept {
+  return apply_second_deriv(x);
 }
-DataVector Gaussian::third_deriv(const DataVector& x) const noexcept {
+
+template <typename Fr>
+double Gaussian<1, Fr>::third_deriv(const double& x) const noexcept {
   return apply_third_deriv(x);
 }
 
+template <typename Fr>
+DataVector Gaussian<1, Fr>::third_deriv(const DataVector& x) const noexcept {
+  return apply_third_deriv(x);
+}
+
+template <typename Fr>
 template <typename T>
-T Gaussian::apply_call_operator(const T& x) const noexcept {
+T Gaussian<1, Fr>::apply_call_operator(const T& x) const noexcept {
   return amplitude_ * exp(-square((x - center_) * inverse_width_));
 }
 
+template <typename Fr>
 template <typename T>
-T Gaussian::apply_first_deriv(const T& x) const noexcept {
+T Gaussian<1, Fr>::apply_first_deriv(const T& x) const noexcept {
   return (-2.0 * amplitude_ * square(inverse_width_)) * (x - center_) *
          exp(-square((x - center_) * inverse_width_));
 }
 
+template <typename Fr>
 template <typename T>
-T Gaussian::apply_second_deriv(const T& x) const noexcept {
+T Gaussian<1, Fr>::apply_second_deriv(const T& x) const noexcept {
   return (-2.0 * amplitude_ * square(inverse_width_)) *
          (1.0 - 2.0 * square(x - center_) * square(inverse_width_)) *
          exp(-square((x - center_) * inverse_width_));
 }
 
+template <typename Fr>
 template <typename T>
-T Gaussian::apply_third_deriv(const T& x) const noexcept {
+T Gaussian<1, Fr>::apply_third_deriv(const T& x) const noexcept {
   return 4.0 * amplitude_ * pow<4>(inverse_width_) * (x - center_) *
          (3.0 - 2.0 * square((x - center_) * inverse_width_)) *
          exp(-square((x - center_) * inverse_width_));
 }
 
-void Gaussian::pup(PUP::er& p) {
-  MathFunction<1>::pup(p);
+template <typename Fr>
+void Gaussian<1, Fr>::pup(PUP::er& p) {
+  MathFunction<1, Fr>::pup(p);
   p | amplitude_;
   p | inverse_width_;
   p | center_;
 }
 
-bool operator==(const Gaussian& lhs, const Gaussian& rhs) noexcept {
-  return lhs.amplitude_ == rhs.amplitude_ and
-         lhs.inverse_width_ == rhs.inverse_width_ and
-         lhs.center_ == rhs.center_;
+template <size_t VolumeDim, typename Fr>
+Gaussian<VolumeDim, Fr>::Gaussian(
+    const double amplitude, const double width,
+    const std::array<double, VolumeDim>& center) noexcept
+    : amplitude_(amplitude), inverse_width_(1.0 / width), center_(center) {}
+
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+tnsr::I<T, VolumeDim, Fr> Gaussian<VolumeDim, Fr>::centered_coordinates(
+    const tnsr::I<T, VolumeDim, Fr>& x) const noexcept {
+  tnsr::I<T, VolumeDim, Fr> centered_coords = x;
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    centered_coords.get(i) -= gsl::at(center_, i);
+  }
+  return centered_coords;
 }
 
-bool operator!=(const Gaussian& lhs, const Gaussian& rhs) noexcept {
-  return not(lhs == rhs);
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+Scalar<T> Gaussian<VolumeDim, Fr>::apply_call_operator(
+    const tnsr::I<T, VolumeDim, Fr>& centered_coords) const noexcept {
+  Scalar<T> result = dot_product(centered_coords, centered_coords);
+  get(result) = amplitude_ * exp(-get(result) * square(inverse_width_));
+  return result;
 }
 
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+tnsr::i<T, VolumeDim, Fr> Gaussian<VolumeDim, Fr>::apply_first_deriv(
+    const tnsr::I<T, VolumeDim, Fr>& centered_coords,
+    const Scalar<T>& gaussian) const noexcept {
+  auto result = make_with_value<tnsr::i<T, VolumeDim, Fr>>(get(gaussian), 0.0);
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    result.get(i) =
+        -2.0 * square(inverse_width_) * get(gaussian) * centered_coords.get(i);
+  }
+  return result;
+}
+
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+tnsr::ii<T, VolumeDim, Fr> Gaussian<VolumeDim, Fr>::apply_second_deriv(
+    const tnsr::I<T, VolumeDim, Fr>& centered_coords, const Scalar<T>& gaussian,
+    const tnsr::i<T, VolumeDim, Fr>& d_gaussian) const noexcept {
+  auto result = make_with_value<tnsr::ii<T, VolumeDim, Fr>>(get(gaussian), 0.0);
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {
+      result.get(i, j) = centered_coords.get(i) * d_gaussian.get(j);
+      if (i == j) {
+        result.get(i, i) += get(gaussian);
+      }
+      result.get(i, j) *= -2.0 * square(inverse_width_);
+    }
+  }
+  return result;
+}
+
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+tnsr::iii<T, VolumeDim, Fr> Gaussian<VolumeDim, Fr>::apply_third_deriv(
+    const tnsr::I<T, VolumeDim, Fr>& centered_coords, const Scalar<T>& gaussian,
+    const tnsr::i<T, VolumeDim, Fr>& d_gaussian,
+    const tnsr::ii<T, VolumeDim, Fr>& d2_gaussian) const noexcept {
+  auto result =
+      make_with_value<tnsr::iii<T, VolumeDim, Fr>>(get(gaussian), 0.0);
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {
+      for (size_t k = j; k < VolumeDim; ++k) {
+        result.get(i, j, k) = centered_coords.get(j) * d2_gaussian.get(i, k);
+        if (j == k) {
+          result.get(i, j, k) += d_gaussian.get(i);
+        }
+        if (i == j) {
+          result.get(i, j, k) += d_gaussian.get(k);
+        }
+        result.get(i, j, k) *= -2.0 * square(inverse_width_);
+      }
+    }
+  }
+  return result;
+}
+
+template <size_t VolumeDim, typename Fr>
+Scalar<double> Gaussian<VolumeDim, Fr>::operator()(
+    const tnsr::I<double, VolumeDim, Fr>& x) const noexcept {
+  return apply_call_operator(centered_coordinates(x));
+}
+template <size_t VolumeDim, typename Fr>
+Scalar<DataVector> Gaussian<VolumeDim, Fr>::operator()(
+    const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept {
+  return apply_call_operator(centered_coordinates(x));
+}
+
+template <size_t VolumeDim, typename Fr>
+tnsr::i<double, VolumeDim, Fr> Gaussian<VolumeDim, Fr>::first_deriv(
+    const tnsr::I<double, VolumeDim, Fr>& x) const noexcept {
+  const tnsr::I<double, VolumeDim, Fr>& centered_coords =
+      centered_coordinates(x);
+  return apply_first_deriv(centered_coords,
+                           apply_call_operator(centered_coords));
+}
+template <size_t VolumeDim, typename Fr>
+tnsr::i<DataVector, VolumeDim, Fr> Gaussian<VolumeDim, Fr>::first_deriv(
+    const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept {
+  const tnsr::I<DataVector, VolumeDim, Fr>& centered_coords =
+      centered_coordinates(x);
+  return apply_first_deriv(centered_coords,
+                           apply_call_operator(centered_coords));
+}
+
+template <size_t VolumeDim, typename Fr>
+tnsr::ii<double, VolumeDim, Fr> Gaussian<VolumeDim, Fr>::second_deriv(
+    const tnsr::I<double, VolumeDim, Fr>& x) const noexcept {
+  const tnsr::I<double, VolumeDim, Fr> centered_coords =
+      centered_coordinates(x);
+  const Scalar<double>& gauss = apply_call_operator(centered_coords);
+  return apply_second_deriv(centered_coords, gauss,
+                            apply_first_deriv(centered_coords, gauss));
+}
+template <size_t VolumeDim, typename Fr>
+tnsr::ii<DataVector, VolumeDim, Fr> Gaussian<VolumeDim, Fr>::second_deriv(
+    const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept {
+  const tnsr::I<DataVector, VolumeDim, Fr> centered_coords =
+      centered_coordinates(x);
+  const Scalar<DataVector>& gauss = apply_call_operator(centered_coords);
+  return apply_second_deriv(centered_coords, gauss,
+                            apply_first_deriv(centered_coords, gauss));
+}
+
+template <size_t VolumeDim, typename Fr>
+tnsr::iii<double, VolumeDim, Fr> Gaussian<VolumeDim, Fr>::third_deriv(
+    const tnsr::I<double, VolumeDim, Fr>& x) const noexcept {
+  const tnsr::I<double, VolumeDim, Fr> centered_coords =
+      centered_coordinates(x);
+  const Scalar<double>& gauss = apply_call_operator(centered_coords);
+  const tnsr::i<double, VolumeDim, Fr> d_gauss =
+      apply_first_deriv(centered_coords, gauss);
+  return apply_third_deriv(centered_coords, gauss, d_gauss,
+                           apply_second_deriv(centered_coords, gauss, d_gauss));
+}
+template <size_t VolumeDim, typename Fr>
+tnsr::iii<DataVector, VolumeDim, Fr> Gaussian<VolumeDim, Fr>::third_deriv(
+    const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept {
+  const tnsr::I<DataVector, VolumeDim, Fr> centered_coords =
+      centered_coordinates(x);
+  const Scalar<DataVector>& gauss = apply_call_operator(centered_coords);
+  const tnsr::i<DataVector, VolumeDim, Fr> d_gauss =
+      apply_first_deriv(centered_coords, gauss);
+  return apply_third_deriv(centered_coords, gauss, d_gauss,
+                           apply_second_deriv(centered_coords, gauss, d_gauss));
+}
+
+template <size_t VolumeDim, typename Fr>
+void Gaussian<VolumeDim, Fr>::pup(PUP::er& p) {
+  MathFunction<VolumeDim, Fr>::pup(p);
+  p | amplitude_;
+  p | inverse_width_;
+  p | center_;
+}
 }  // namespace MathFunctions
 
 /// \cond
-PUP::able::PUP_ID MathFunctions::Gaussian::my_PUP_ID =  // NOLINT
-    0;
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATE(_, data)                                          \
+  template MathFunctions::Gaussian<DIM(data), FRAME(data)>::Gaussian( \
+      const double amplitude, const double width,                     \
+      const std::array<double, DIM(data)>& center) noexcept;          \
+  template void MathFunctions::Gaussian<DIM(data), FRAME(data)>::pup( \
+      PUP::er& p);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3), (Frame::Grid, Frame::Inertial))
+#undef DIM
+#undef FRAME
+#undef INSTANTIATE
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template Scalar<DTYPE(data)>                                               \
+  MathFunctions::Gaussian<DIM(data), FRAME(data)>::operator()(               \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x) const noexcept; \
+  template tnsr::i<DTYPE(data), DIM(data), FRAME(data)>                      \
+  MathFunctions::Gaussian<DIM(data), FRAME(data)>::first_deriv(              \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x) const noexcept; \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>                     \
+  MathFunctions::Gaussian<DIM(data), FRAME(data)>::second_deriv(             \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x) const noexcept; \
+  template tnsr::iii<DTYPE(data), DIM(data), FRAME(data)>                    \
+  MathFunctions::Gaussian<DIM(data), FRAME(data)>::third_deriv(              \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+#undef FRAME
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE
+
+template MathFunctions::Gaussian<1, Frame::Grid>::Gaussian(
+    const double amplitude, const double width, const double center) noexcept;
+template MathFunctions::Gaussian<1, Frame::Inertial>::Gaussian(
+    const double amplitude, const double width, const double center) noexcept;
+template MathFunctions::Gaussian<1, Frame::Grid>::Gaussian(
+    double amplitude, double width,
+    const std::array<double, 1>& center) noexcept;
+template MathFunctions::Gaussian<1, Frame::Inertial>::Gaussian(
+    double amplitude, double width,
+    const std::array<double, 1>& center) noexcept;
+template void MathFunctions::Gaussian<1, Frame::Grid>::pup(PUP::er& p);
+template void MathFunctions::Gaussian<1, Frame::Inertial>::pup(PUP::er& p);
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template DTYPE(data) MathFunctions::Gaussian<1, FRAME(data)>::operator()(   \
+      const DTYPE(data) & x) const noexcept;                                  \
+  template DTYPE(data) MathFunctions::Gaussian<1, FRAME(data)>::first_deriv(  \
+      const DTYPE(data) & x) const noexcept;                                  \
+  template DTYPE(data) MathFunctions::Gaussian<1, FRAME(data)>::second_deriv( \
+      const DTYPE(data) & x) const noexcept;                                  \
+  template DTYPE(data) MathFunctions::Gaussian<1, FRAME(data)>::third_deriv(  \
+      const DTYPE(data) & x) const noexcept;                                  \
+  template DTYPE(data)                                                        \
+      MathFunctions::Gaussian<1, FRAME(data)>::apply_call_operator(           \
+          const DTYPE(data) & x) const noexcept;                              \
+  template DTYPE(data)                                                        \
+      MathFunctions::Gaussian<1, FRAME(data)>::apply_first_deriv(             \
+          const DTYPE(data) & x) const noexcept;                              \
+  template DTYPE(data)                                                        \
+      MathFunctions::Gaussian<1, FRAME(data)>::apply_second_deriv(            \
+          const DTYPE(data) & x) const noexcept;                              \
+  template DTYPE(data)                                                        \
+      MathFunctions::Gaussian<1, FRAME(data)>::apply_third_deriv(             \
+          const DTYPE(data) & x) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+
 /// \endcond

--- a/src/PointwiseFunctions/MathFunctions/Gaussian.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Gaussian.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <array>
 #include <pup.h>
 
 #include "Options/Options.hpp"
@@ -18,14 +19,19 @@ class DataVector;
 /// \endcond
 
 namespace MathFunctions {
+template <size_t VolumeDim, typename Fr>
+class Gaussian;
 
 /*!
  *  \ingroup MathFunctionsGroup
- *  \brief Gaussian \f$f = A \exp\left(-\frac{(x-x_0)^2}{w^2}\right)\f$.
+ *  \brief 1D Gaussian \f$f = A \exp\left(-\frac{(x-x_0)^2}{w^2}\right)\f$
  *
- *  \details Input file options are: Amplitude, Width, and Center
+ *  \details Input file options are: Amplitude, Width, and Center. The function
+ *  takes input of type `double` or `DataVector` and returns
+ *  the same type as the input type.
  */
-class Gaussian : public MathFunction<1> {
+template <typename Fr>
+class Gaussian<1, Fr> : public MathFunction<1, Fr> {
  public:
   struct Amplitude {
     using type = double;
@@ -45,13 +51,17 @@ class Gaussian : public MathFunction<1> {
   using options = tmpl::list<Amplitude, Width, Center>;
 
   static constexpr OptionString help = {
-      "Applies a Gaussian function to the input value"};
+      "Computes a Gaussian about an arbitrary coordinate center with given "
+      "width and amplitude"};
 
-  WRAPPED_PUPable_decl_template(Gaussian);  // NOLINT
+  WRAPPED_PUPable_decl_base_template(SINGLE_ARG(MathFunction<1, Fr>),
+                                     Gaussian);  // NOLINT
 
   explicit Gaussian(CkMigrateMessage* /*unused*/) noexcept {}
 
   Gaussian(double amplitude, double width, double center) noexcept;
+  Gaussian(double amplitude, double width,
+           const std::array<double, 1>& center) noexcept;
 
   Gaussian() = default;
   ~Gaussian() override = default;
@@ -62,21 +72,34 @@ class Gaussian : public MathFunction<1> {
 
   double operator()(const double& x) const noexcept override;
   DataVector operator()(const DataVector& x) const noexcept override;
+  using MathFunction<1, Fr>::operator();
 
   double first_deriv(const double& x) const noexcept override;
   DataVector first_deriv(const DataVector& x) const noexcept override;
+  using MathFunction<1, Fr>::first_deriv;
 
   double second_deriv(const double& x) const noexcept override;
   DataVector second_deriv(const DataVector& x) const noexcept override;
+  using MathFunction<1, Fr>::second_deriv;
 
   double third_deriv(const double& x) const noexcept override;
   DataVector third_deriv(const DataVector& x) const noexcept override;
+  using MathFunction<1, Fr>::third_deriv;
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) override;  // NOLINT
 
  private:
-  friend bool operator==(const Gaussian& lhs, const Gaussian& rhs) noexcept;
+  double amplitude_{};
+  double inverse_width_{};
+  double center_{};
+  friend bool operator==(const Gaussian<1, Fr>& lhs,
+                         const Gaussian<1, Fr>& rhs) noexcept {
+    return lhs.amplitude_ == rhs.amplitude_ and
+           lhs.inverse_width_ == rhs.inverse_width_ and
+           lhs.center_ == rhs.center_;
+  }
+
   template <typename T>
   T apply_call_operator(const T& x) const noexcept;
   template <typename T>
@@ -85,12 +108,124 @@ class Gaussian : public MathFunction<1> {
   T apply_second_deriv(const T& x) const noexcept;
   template <typename T>
   T apply_third_deriv(const T& x) const noexcept;
-
-  double amplitude_{};
-  double inverse_width_{};
-  double center_{};
 };
 
-bool operator!=(const Gaussian& lhs, const Gaussian& rhs) noexcept;
+/*!
+ * \ingroup MathFunctionsGroup
+ * \brief Gaussian \f$f = A \exp\left(-\frac{(x-x_0)^2}{w^2}\right)\f$
+ *
+ * \details Input file options are: Amplitude, Width, and Center. The function
+ * takes input coordinates of type `tnsr::I<T, VolumeDim, Fr>`, where `T` is
+ * e.g. `double` or `DataVector`, `Fr` is a frame (e.g. `Frame::Inertial`), and
+ * `VolumeDim` is the dimension of the spatial volume, i.e. 2 or 3. (The case of
+ * VolumeDim == 1 is handled specially by Gaussian<1, T, Frame::Inertial>.)
+ */
+template <size_t VolumeDim, typename Fr>
+class Gaussian : public MathFunction<VolumeDim, Fr> {
+ public:
+  struct Amplitude {
+    using type = double;
+    static constexpr OptionString help = {"The amplitude."};
+  };
 
+  struct Width {
+    using type = double;
+    static constexpr OptionString help = {"The width."};
+    static type lower_bound() noexcept { return 0.; }
+  };
+
+  struct Center {
+    using type = std::array<double, VolumeDim>;
+    static constexpr OptionString help = {"The center."};
+  };
+  using options = tmpl::list<Amplitude, Width, Center>;
+
+  static constexpr OptionString help = {
+      "Computes a Gaussian about an arbitrary coordinate center with given "
+      "width and amplitude"};
+
+  WRAPPED_PUPable_decl_base_template(SINGLE_ARG(MathFunction<VolumeDim, Fr>),
+                                     Gaussian);  // NOLINT
+
+  explicit Gaussian(CkMigrateMessage* /*unused*/) noexcept {}
+
+  Gaussian(double amplitude, double width,
+           const std::array<double, VolumeDim>& center) noexcept;
+
+  Gaussian() = default;
+  ~Gaussian() override = default;
+  Gaussian(const Gaussian& /*rhs*/) = delete;
+  Gaussian& operator=(const Gaussian& /*rhs*/) = delete;
+  Gaussian(Gaussian&& /*rhs*/) noexcept = default;
+  Gaussian& operator=(Gaussian&& /*rhs*/) noexcept = default;
+
+  Scalar<double> operator()(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
+  Scalar<DataVector> operator()(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+
+  tnsr::i<double, VolumeDim, Fr> first_deriv(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
+  tnsr::i<DataVector, VolumeDim, Fr> first_deriv(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+
+  tnsr::ii<double, VolumeDim, Fr> second_deriv(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
+  tnsr::ii<DataVector, VolumeDim, Fr> second_deriv(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+
+  tnsr::iii<double, VolumeDim, Fr> third_deriv(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
+  tnsr::iii<DataVector, VolumeDim, Fr> third_deriv(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) override;  // NOLINT
+
+ private:
+  double amplitude_{};
+  double inverse_width_{};
+  std::array<double, VolumeDim> center_{};
+  friend bool operator==(const Gaussian& lhs, const Gaussian& rhs) noexcept {
+    return lhs.amplitude_ == rhs.amplitude_ and
+           lhs.inverse_width_ == rhs.inverse_width_ and
+           lhs.center_ == rhs.center_;
+  }
+
+  template <typename T>
+  tnsr::I<T, VolumeDim, Fr> centered_coordinates(
+      const tnsr::I<T, VolumeDim, Fr>& x) const noexcept;
+  template <typename T>
+  Scalar<T> apply_call_operator(
+      const tnsr::I<T, VolumeDim, Fr>& centered_coords) const noexcept;
+  template <typename T>
+  tnsr::i<T, VolumeDim, Fr> apply_first_deriv(
+      const tnsr::I<T, VolumeDim, Fr>& centered_coords,
+      const Scalar<T>& gaussian) const noexcept;
+  template <typename T>
+  tnsr::ii<T, VolumeDim, Fr> apply_second_deriv(
+      const tnsr::I<T, VolumeDim, Fr>& centered_coords,
+      const Scalar<T>& gaussian,
+      const tnsr::i<T, VolumeDim, Fr>& d_gaussian) const noexcept;
+  template <typename T>
+  tnsr::iii<T, VolumeDim, Fr> apply_third_deriv(
+      const tnsr::I<T, VolumeDim, Fr>& centered_coords,
+      const Scalar<T>& gaussian, const tnsr::i<T, VolumeDim, Fr>& d_gaussian,
+      const tnsr::ii<T, VolumeDim, Fr>& d2_gaussian) const noexcept;
+};
+
+template <size_t VolumeDim, typename Fr>
+bool operator!=(const Gaussian<VolumeDim, Fr>& lhs,
+                const Gaussian<VolumeDim, Fr>& rhs) noexcept {
+  return not(lhs == rhs);
+}
 }  // namespace MathFunctions
+
+/// \cond
+template <size_t VolumeDim, typename Fr>
+PUP::able::PUP_ID MathFunctions::Gaussian<VolumeDim, Fr>::my_PUP_ID =
+    0;  // NOLINT
+
+template <typename Fr>
+PUP::able::PUP_ID MathFunctions::Gaussian<1, Fr>::my_PUP_ID = 0;  // NOLINT
+/// \endcond

--- a/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
+++ b/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
@@ -6,37 +6,42 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "Utilities/MakeWithValue.hpp"
 
 /// \ingroup MathFunctionsGroup
 /// Holds classes implementing MathFunction (functions \f$R^n \to R\f$).
 namespace MathFunctions {
+template <size_t VolumeDim, typename Fr>
 class Gaussian;
+template <size_t VolumeDim, typename Fr>
 class PowX;
+template <size_t VolumeDim, typename Fr>
 class Sinusoid;
 }  // namespace MathFunctions
 
 /*!
- *  \ingroup MathFunctionsGroup
- *  Encodes a function \f$R^n \to R\f$ where n is `VolumeDim`.
+ * \ingroup MathFunctionsGroup
+ * Encodes a function \f$R^n \to R\f$ where n is `VolumeDim`.
  */
-template <size_t VolumeDim>
+template <size_t VolumeDim, typename Fr>
 class MathFunction;
 
 /*!
  * \ingroup MathFunctionsGroup
- * Partial template specialization of MathFunction which encodes a
- * function \f$R \to R\f$.
+ * Encodes a function \f$R^n \to R\f$ where n is `VolumeDim` and where the
+ * function input (i.e., the spatial coordinates) is given as a rank-1 tensor.
  */
-template <>
-class MathFunction<1> : public PUP::able {
+template <size_t VolumeDim, typename Fr>
+class MathFunction : public PUP::able {
  public:
-  using creatable_classes =
-      tmpl::list<MathFunctions::Gaussian, MathFunctions::PowX,
-                 MathFunctions::Sinusoid>;
+  using creatable_classes = tmpl::list<MathFunctions::Gaussian<VolumeDim, Fr>>;
+  constexpr static size_t volume_dim = VolumeDim;
+  using frame = Fr;
 
   WRAPPED_PUPable_abstract(MathFunction);  // NOLINT
 
@@ -48,28 +53,120 @@ class MathFunction<1> : public PUP::able {
   ~MathFunction() override = default;
 
   //@{
-  /// Returns the function value at the coordinate 'x'.
+  /// Returns the value of the function at the coordinate 'x'.
+  virtual Scalar<double> operator()(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept = 0;
+  virtual Scalar<DataVector> operator()(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept = 0;
+  //@}
+
+  //@{
+  /// Returns the first partial derivatives of the function at 'x'.
+  virtual tnsr::i<double, VolumeDim, Fr> first_deriv(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept = 0;
+  virtual tnsr::i<DataVector, VolumeDim, Fr> first_deriv(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept = 0;
+  //@}
+
+  //@{
+  /// Returns the second partial derivatives of the function at 'x'.
+  virtual tnsr::ii<double, VolumeDim, Fr> second_deriv(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept = 0;
+  virtual tnsr::ii<DataVector, VolumeDim, Fr> second_deriv(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept = 0;
+  //@}
+
+  //@{
+  /// Returns the third partial derivatives of the function at 'x'.
+  virtual tnsr::iii<double, VolumeDim, Fr> third_deriv(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept = 0;
+  virtual tnsr::iii<DataVector, VolumeDim, Fr> third_deriv(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept = 0;
+  //@}
+};
+
+/*!
+ * \ingroup MathFunctionsGroup
+ * Partial template specialization of MathFunction which encodes a
+ * function \f$R \to R\f$. In this 1D specialization, the input and output can
+ * be `Tensors`, `doubles`, or `DataVectors`.
+ */
+template <typename Fr>
+class MathFunction<1, Fr> : public PUP::able {
+ public:
+  using creatable_classes =
+      tmpl::list<MathFunctions::Gaussian<1, Fr>, MathFunctions::PowX<1, Fr>,
+                 MathFunctions::Sinusoid<1, Fr>>;
+  constexpr static size_t volume_dim = 1;
+  using frame = Fr;
+
+  WRAPPED_PUPable_abstract(MathFunction);  // NOLINT
+
+  MathFunction() = default;
+  MathFunction(const MathFunction& /*rhs*/) = delete;
+  MathFunction& operator=(const MathFunction& /*rhs*/) = delete;
+  MathFunction(MathFunction&& /*rhs*/) noexcept = default;
+  MathFunction& operator=(MathFunction&& /*rhs*/) noexcept = default;
+  ~MathFunction() override = default;
+
+  /// Returns the function value at the coordinate 'x'
   virtual double operator()(const double& x) const noexcept = 0;
   virtual DataVector operator()(const DataVector& x) const noexcept = 0;
-  //@}
+  Scalar<double> operator()(const tnsr::I<double, 1, Fr>& x) const noexcept {
+    return Scalar<double>{{{operator()(get<0>(x))}}};
+  }
+  Scalar<DataVector> operator()(
+      const tnsr::I<DataVector, 1, Fr>& x) const noexcept {
+    return Scalar<DataVector>{{{operator()(get<0>(x))}}};
+  }
 
-  //@{
-  /// Returns the first derivative at 'x'.
+  /// Returns the first derivative at 'x'
   virtual double first_deriv(const double& x) const noexcept = 0;
   virtual DataVector first_deriv(const DataVector& x) const noexcept = 0;
-  //@}
+  tnsr::i<double, 1, Fr> first_deriv(
+      const tnsr::I<double, 1, Fr>& x) const noexcept {
+    auto result = make_with_value<tnsr::i<double, 1, Fr>>(get<0>(x), 0.0);
+    get<0>(result) = first_deriv(get<0>(x));
+    return result;
+  }
+  tnsr::i<DataVector, 1, Fr> first_deriv(
+      const tnsr::I<DataVector, 1, Fr>& x) const noexcept {
+    auto result = make_with_value<tnsr::i<DataVector, 1, Fr>>(get<0>(x), 0.0);
+    get<0>(result) = first_deriv(get<0>(x));
+    return result;
+  }
 
-  //@{
-  /// Returns the second derivative at 'x'.
+  /// Returns the second derivative at 'x'
   virtual double second_deriv(const double& x) const noexcept = 0;
   virtual DataVector second_deriv(const DataVector& x) const noexcept = 0;
-  //@}
+  tnsr::ii<double, 1, Fr> second_deriv(
+      const tnsr::I<double, 1, Fr>& x) const noexcept {
+    auto result = make_with_value<tnsr::ii<double, 1, Fr>>(get<0>(x), 0.0);
+    get<0, 0>(result) = second_deriv(get<0>(x));
+    return result;
+  }
+  tnsr::ii<DataVector, 1, Fr> second_deriv(
+      const tnsr::I<DataVector, 1, Fr>& x) const noexcept {
+    auto result = make_with_value<tnsr::ii<DataVector, 1, Fr>>(get<0>(x), 0.0);
+    get<0, 0>(result) = second_deriv(get<0>(x));
+    return result;
+  }
 
-  //@{
-  /// Returns the third derivative at 'x'.
+  /// Returns the third derivative at 'x'
   virtual double third_deriv(const double& x) const noexcept = 0;
   virtual DataVector third_deriv(const DataVector& x) const noexcept = 0;
-  //@}
+  tnsr::iii<double, 1, Fr> third_deriv(
+      const tnsr::I<double, 1, Fr>& x) const noexcept {
+    auto result = make_with_value<tnsr::iii<double, 1, Fr>>(get<0>(x), 0.0);
+    get<0, 0, 0>(result) = third_deriv(get<0>(x));
+    return result;
+  }
+  tnsr::iii<DataVector, 1, Fr> third_deriv(
+      const tnsr::I<DataVector, 1, Fr>& x) const noexcept {
+    auto result = make_with_value<tnsr::iii<DataVector, 1, Fr>>(get<0>(x), 0.0);
+    get<0, 0, 0>(result) = third_deriv(get<0>(x));
+    return result;
+  }
 };
 
 #include "PointwiseFunctions/MathFunctions/Gaussian.hpp"

--- a/src/PointwiseFunctions/MathFunctions/PowX.cpp
+++ b/src/PointwiseFunctions/MathFunctions/PowX.cpp
@@ -4,80 +4,126 @@
 #include "PointwiseFunctions/MathFunctions/PowX.hpp"
 
 #include "DataStructures/DataVector.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 namespace MathFunctions {
 
-PowX::PowX(const int power) noexcept : power_(power) {}
+template <typename Fr>
+PowX<1, Fr>::PowX(const int power) noexcept : power_(power) {}
 
-double PowX::operator()(const double& x) const noexcept {
+template <typename Fr>
+double PowX<1, Fr>::operator()(const double& x) const noexcept {
   return apply_call_operator(x);
 }
-DataVector PowX::operator()(const DataVector& x) const noexcept {
+
+template <typename Fr>
+DataVector PowX<1, Fr>::operator()(const DataVector& x) const noexcept {
   return apply_call_operator(x);
 }
 
-double PowX::first_deriv(const double& x) const noexcept {
+template <typename Fr>
+double PowX<1, Fr>::first_deriv(const double& x) const noexcept {
   return apply_first_deriv(x);
 }
-DataVector PowX::first_deriv(const DataVector& x) const noexcept {
+
+template <typename Fr>
+DataVector PowX<1, Fr>::first_deriv(const DataVector& x) const noexcept {
   return apply_first_deriv(x);
 }
 
-double PowX::second_deriv(const double& x) const noexcept {
-  return apply_second_deriv(x);
-}
-DataVector PowX::second_deriv(const DataVector& x) const noexcept {
+template <typename Fr>
+double PowX<1, Fr>::second_deriv(const double& x) const noexcept {
   return apply_second_deriv(x);
 }
 
-double PowX::third_deriv(const double& x) const noexcept {
-  return apply_third_deriv(x);
+template <typename Fr>
+DataVector PowX<1, Fr>::second_deriv(const DataVector& x) const noexcept {
+  return apply_second_deriv(x);
 }
-DataVector PowX::third_deriv(const DataVector& x) const noexcept {
+
+template <typename Fr>
+double PowX<1, Fr>::third_deriv(const double& x) const noexcept {
   return apply_third_deriv(x);
 }
 
+template <typename Fr>
+DataVector PowX<1, Fr>::third_deriv(const DataVector& x) const noexcept {
+  return apply_third_deriv(x);
+}
+
+template <typename Fr>
 template <typename T>
-T PowX::apply_call_operator(const T& x) const noexcept {
+T PowX<1, Fr>::apply_call_operator(const T& x) const noexcept {
   return pow(x, power_);
 }
 
+template <typename Fr>
 template <typename T>
-T PowX::apply_first_deriv(const T& x) const noexcept {
-  return 0 == power_ ? make_with_value<T>(x, 0.0)
-                     : power_ * pow(x, power_ - 1);
+T PowX<1, Fr>::apply_first_deriv(const T& x) const noexcept {
+  return 0 == power_ ? make_with_value<T>(x, 0.0) : power_ * pow(x, power_ - 1);
 }
 
+template <typename Fr>
 template <typename T>
-T PowX::apply_second_deriv(const T& x) const noexcept {
+T PowX<1, Fr>::apply_second_deriv(const T& x) const noexcept {
   return 0 == power_ or 1 == power_
              ? make_with_value<T>(x, 0.0)
              : power_ * (power_ - 1) * pow(x, power_ - 2);
 }
 
+template <typename Fr>
 template <typename T>
-T PowX::apply_third_deriv(const T& x) const noexcept {
+T PowX<1, Fr>::apply_third_deriv(const T& x) const noexcept {
   return 0 == power_ or 1 == power_ or 2 == power_
              ? make_with_value<T>(x, 0.0)
              : power_ * (power_ - 1) * (power_ - 2) * pow(x, power_ - 3);
 }
 
-void PowX::pup(PUP::er& p) {
-  MathFunction<1>::pup(p);
+template <typename Fr>
+void PowX<1, Fr>::pup(PUP::er& p) {
+  MathFunction<1, Fr>::pup(p);
   p | power_;
 }
 
-bool operator==(const PowX& lhs, const PowX& rhs) noexcept {
-  return lhs.power_ == rhs.power_;
-}
-
-bool operator!=(const PowX& lhs, const PowX& rhs) noexcept {
-  return not(lhs == rhs);
-}
-}  // namespace MathFunctions
-
 /// \cond
-PUP::able::PUP_ID MathFunctions::PowX::my_PUP_ID =  // NOLINT
-    0;
+template MathFunctions::PowX<1, Frame::Grid>::PowX(const int power) noexcept;
+template MathFunctions::PowX<1, Frame::Inertial>::PowX(
+    const int power) noexcept;
+template void MathFunctions::PowX<1, Frame::Grid>::pup(PUP::er& p);
+template void MathFunctions::PowX<1, Frame::Inertial>::pup(PUP::er& p);
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template DTYPE(data)                                                         \
+      MathFunctions::PowX<1, FRAME(data)>::operator()(const DTYPE(data) & x)   \
+          const noexcept;                                                      \
+  template DTYPE(data)                                                         \
+      MathFunctions::PowX<1, FRAME(data)>::first_deriv(const DTYPE(data) & x)  \
+          const noexcept;                                                      \
+  template DTYPE(data)                                                         \
+      MathFunctions::PowX<1, FRAME(data)>::second_deriv(const DTYPE(data) & x) \
+          const noexcept;                                                      \
+  template DTYPE(data)                                                         \
+      MathFunctions::PowX<1, FRAME(data)>::third_deriv(const DTYPE(data) & x)  \
+          const noexcept;                                                      \
+  template DTYPE(data)                                                         \
+      MathFunctions::PowX<1, FRAME(data)>::apply_call_operator(                \
+          const DTYPE(data) & x) const noexcept;                               \
+  template DTYPE(data) MathFunctions::PowX<1, FRAME(data)>::apply_first_deriv( \
+      const DTYPE(data) & x) const noexcept;                                   \
+  template DTYPE(data)                                                         \
+      MathFunctions::PowX<1, FRAME(data)>::apply_second_deriv(                 \
+          const DTYPE(data) & x) const noexcept;                               \
+  template DTYPE(data) MathFunctions::PowX<1, FRAME(data)>::apply_third_deriv( \
+      const DTYPE(data) & x) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
 /// \endcond
+}  // namespace MathFunctions

--- a/src/PointwiseFunctions/MathFunctions/PowX.hpp
+++ b/src/PointwiseFunctions/MathFunctions/PowX.hpp
@@ -18,12 +18,15 @@ class DataVector;
 /// \endcond
 
 namespace MathFunctions {
+template <size_t VolumeDim, typename Fr>
+class PowX;
 
 /*!
  * \ingroup MathFunctionsGroup
  * \brief Power of X \f$f(x)=x^X\f$
  */
-class PowX : public MathFunction<1> {
+template <typename Fr>
+class PowX<1, Fr> : public MathFunction<1, Fr> {
  public:
   struct Power {
     using type = int;
@@ -42,7 +45,8 @@ class PowX : public MathFunction<1> {
   PowX(PowX&& /*rhs*/) noexcept = default;
   PowX& operator=(PowX&& /*rhs*/) noexcept = default;
 
-  WRAPPED_PUPable_decl_template(PowX);  // NOLINT
+  WRAPPED_PUPable_decl_base_template(SINGLE_ARG(MathFunction<1, Fr>),
+                                     PowX);  // NOLINT
 
   explicit PowX(int power) noexcept;
 
@@ -64,7 +68,11 @@ class PowX : public MathFunction<1> {
   void pup(PUP::er& p) override;  // NOLINT
 
  private:
-  friend bool operator==(const PowX& lhs, const PowX& rhs) noexcept;
+  double power_{};
+  friend bool operator==(const PowX& lhs, const PowX& rhs) noexcept {
+    return lhs.power_ == rhs.power_;
+  }
+
   template <typename T>
   T apply_call_operator(const T& x) const noexcept;
   template <typename T>
@@ -73,10 +81,15 @@ class PowX : public MathFunction<1> {
   T apply_second_deriv(const T& x) const noexcept;
   template <typename T>
   T apply_third_deriv(const T& x) const noexcept;
-
-  double power_{};
 };
 
-bool operator!=(const PowX& lhs, const PowX& rhs) noexcept;
-
+template <typename Fr>
+bool operator!=(const PowX<1, Fr>& lhs, const PowX<1, Fr>& rhs) noexcept {
+  return not(lhs == rhs);
+}
 }  // namespace MathFunctions
+
+/// \cond
+template <typename Fr>
+PUP::able::PUP_ID MathFunctions::PowX<1, Fr>::my_PUP_ID = 0;  // NOLINT
+/// \endcond

--- a/src/PointwiseFunctions/MathFunctions/Sinusoid.cpp
+++ b/src/PointwiseFunctions/MathFunctions/Sinusoid.cpp
@@ -7,81 +7,125 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 
 namespace MathFunctions {
-
-Sinusoid::Sinusoid(const double amplitude, const double wavenumber,
-                   const double phase) noexcept
+template <typename Fr>
+Sinusoid<1, Fr>::Sinusoid(const double amplitude, const double wavenumber,
+                          const double phase) noexcept
     : amplitude_(amplitude), wavenumber_(wavenumber), phase_(phase) {}
-
-double Sinusoid::operator()(const double& x) const noexcept {
-  return apply_call_operator(x);
-}
-DataVector Sinusoid::operator()(const DataVector& x) const noexcept {
+template <typename Fr>
+double Sinusoid<1, Fr>::operator()(const double& x) const noexcept {
   return apply_call_operator(x);
 }
 
-double Sinusoid::first_deriv(const double& x) const noexcept {
+template <typename Fr>
+DataVector Sinusoid<1, Fr>::operator()(const DataVector& x) const noexcept {
+  return apply_call_operator(x);
+}
+
+template <typename Fr>
+double Sinusoid<1, Fr>::first_deriv(const double& x) const noexcept {
   return apply_first_deriv(x);
 }
-DataVector Sinusoid::first_deriv(const DataVector& x) const noexcept {
+
+template <typename Fr>
+DataVector Sinusoid<1, Fr>::first_deriv(const DataVector& x) const noexcept {
   return apply_first_deriv(x);
 }
 
-double Sinusoid::second_deriv(const double& x) const noexcept {
-  return apply_second_deriv(x);
-}
-DataVector Sinusoid::second_deriv(const DataVector& x) const noexcept {
+template <typename Fr>
+double Sinusoid<1, Fr>::second_deriv(const double& x) const noexcept {
   return apply_second_deriv(x);
 }
 
-double Sinusoid::third_deriv(const double& x) const noexcept {
-  return apply_third_deriv(x);
+template <typename Fr>
+DataVector Sinusoid<1, Fr>::second_deriv(const DataVector& x) const noexcept {
+  return apply_second_deriv(x);
 }
-DataVector Sinusoid::third_deriv(const DataVector& x) const noexcept {
+
+template <typename Fr>
+double Sinusoid<1, Fr>::third_deriv(const double& x) const noexcept {
   return apply_third_deriv(x);
 }
 
+template <typename Fr>
+DataVector Sinusoid<1, Fr>::third_deriv(const DataVector& x) const noexcept {
+  return apply_third_deriv(x);
+}
+
+template <typename Fr>
 template <typename T>
-T Sinusoid::apply_call_operator(const T& x) const noexcept {
+T Sinusoid<1, Fr>::apply_call_operator(const T& x) const noexcept {
   return amplitude_ * sin(wavenumber_ * x + phase_);
 }
 
+template <typename Fr>
 template <typename T>
-T Sinusoid::apply_first_deriv(const T& x) const noexcept {
+T Sinusoid<1, Fr>::apply_first_deriv(const T& x) const noexcept {
   return wavenumber_ * amplitude_ * cos(wavenumber_ * x + phase_);
 }
 
+template <typename Fr>
 template <typename T>
-T Sinusoid::apply_second_deriv(const T& x) const noexcept {
+T Sinusoid<1, Fr>::apply_second_deriv(const T& x) const noexcept {
   return -amplitude_ * square(wavenumber_) * sin(wavenumber_ * x + phase_);
 }
 
+template <typename Fr>
 template <typename T>
-T Sinusoid::apply_third_deriv(const T& x) const noexcept {
+T Sinusoid<1, Fr>::apply_third_deriv(const T& x) const noexcept {
   return -amplitude_ * cube(wavenumber_) * cos(wavenumber_ * x + phase_);
 }
 
-void Sinusoid::pup(PUP::er& p) {
-  MathFunction<1>::pup(p);
+template <typename Fr>
+void Sinusoid<1, Fr>::pup(PUP::er& p) {
+  MathFunction<1, Fr>::pup(p);
   p | amplitude_;
   p | wavenumber_;
   p | phase_;
 }
-
-bool operator==(const Sinusoid& lhs, const Sinusoid& rhs) noexcept {
-  return lhs.amplitude_ == rhs.amplitude_ and
-         lhs.wavenumber_ == rhs.wavenumber_ and
-         lhs.phase_ == rhs.phase_;
-}
-
-bool operator!=(const Sinusoid& lhs, const Sinusoid& rhs) noexcept {
-  return not(lhs == rhs);
-}
-
 }  // namespace MathFunctions
 
 /// \cond
-PUP::able::PUP_ID MathFunctions::Sinusoid::my_PUP_ID =  // NOLINT
-    0;
+template MathFunctions::Sinusoid<1, Frame::Grid>::Sinusoid(
+    const double amplitude, const double wavenumber,
+    const double phase) noexcept;
+template MathFunctions::Sinusoid<1, Frame::Inertial>::Sinusoid(
+    const double amplitude, const double wavenumber,
+    const double phase) noexcept;
+template void MathFunctions::Sinusoid<1, Frame::Grid>::pup(PUP::er& p);
+template void MathFunctions::Sinusoid<1, Frame::Inertial>::pup(PUP::er& p);
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template DTYPE(data) MathFunctions::Sinusoid<1, FRAME(data)>::operator()(   \
+      const DTYPE(data) & x) const noexcept;                                  \
+  template DTYPE(data) MathFunctions::Sinusoid<1, FRAME(data)>::first_deriv(  \
+      const DTYPE(data) & x) const noexcept;                                  \
+  template DTYPE(data) MathFunctions::Sinusoid<1, FRAME(data)>::second_deriv( \
+      const DTYPE(data) & x) const noexcept;                                  \
+  template DTYPE(data) MathFunctions::Sinusoid<1, FRAME(data)>::third_deriv(  \
+      const DTYPE(data) & x) const noexcept;                                  \
+  template DTYPE(data)                                                        \
+      MathFunctions::Sinusoid<1, FRAME(data)>::apply_call_operator(           \
+          const DTYPE(data) & x) const noexcept;                              \
+  template DTYPE(data)                                                        \
+      MathFunctions::Sinusoid<1, FRAME(data)>::apply_first_deriv(             \
+          const DTYPE(data) & x) const noexcept;                              \
+  template DTYPE(data)                                                        \
+      MathFunctions::Sinusoid<1, FRAME(data)>::apply_second_deriv(            \
+          const DTYPE(data) & x) const noexcept;                              \
+  template DTYPE(data)                                                        \
+      MathFunctions::Sinusoid<1, FRAME(data)>::apply_third_deriv(             \
+          const DTYPE(data) & x) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+
 /// \endcond

--- a/src/PointwiseFunctions/MathFunctions/Sinusoid.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Sinusoid.hpp
@@ -18,6 +18,8 @@ class DataVector;
 /// \endcond
 
 namespace MathFunctions {
+template <size_t VolumeDim, typename Fr>
+class Sinusoid;
 
 /*!
  *  \ingroup MathFunctionsGroup
@@ -25,7 +27,8 @@ namespace MathFunctions {
  *
  *  \details Input file options are: Amplitude, Phase, and Wavenumber
  */
-class Sinusoid : public MathFunction<1> {
+template <typename Fr>
+class Sinusoid<1, Fr> : public MathFunction<1, Fr> {
  public:
   struct Amplitude {
     using type = double;
@@ -56,7 +59,8 @@ class Sinusoid : public MathFunction<1> {
   Sinusoid(Sinusoid&& /*rhs*/) noexcept = default;
   Sinusoid& operator=(Sinusoid&& /*rhs*/) noexcept = default;
 
-  WRAPPED_PUPable_decl_template(Sinusoid); //NOLINT
+  WRAPPED_PUPable_decl_base_template(SINGLE_ARG(MathFunction<1, Fr>),
+                                     Sinusoid);  // NOLINT
 
   explicit Sinusoid(CkMigrateMessage* /*unused*/) noexcept {}
 
@@ -76,7 +80,14 @@ class Sinusoid : public MathFunction<1> {
   void pup(PUP::er& p) override;  // NOLINT
 
  private:
-  friend bool operator==(const Sinusoid& lhs, const Sinusoid& rhs) noexcept;
+  friend bool operator==(const Sinusoid& lhs, const Sinusoid& rhs) noexcept {
+    return lhs.amplitude_ == rhs.amplitude_ and
+           lhs.wavenumber_ == rhs.wavenumber_ and lhs.phase_ == rhs.phase_;
+  }
+  double amplitude_{};
+  double wavenumber_{};
+  double phase_{};
+
   template <typename T>
   T apply_call_operator(const T& x) const noexcept;
   template <typename T>
@@ -85,12 +96,16 @@ class Sinusoid : public MathFunction<1> {
   T apply_second_deriv(const T& x) const noexcept;
   template <typename T>
   T apply_third_deriv(const T& x) const noexcept;
-
-  double amplitude_{};
-  double wavenumber_{};
-  double phase_{};
 };
 
-bool operator!=(const Sinusoid& lhs, const Sinusoid& rhs) noexcept;
-
+template <typename Fr>
+bool operator!=(const Sinusoid<1, Fr>& lhs,
+                const Sinusoid<1, Fr>& rhs) noexcept {
+  return not(lhs == rhs);
+}
 }  // namespace MathFunctions
+
+/// \cond
+template <typename Fr>
+PUP::able::PUP_ID MathFunctions::Sinusoid<1, Fr>::my_PUP_ID = 0;  // NOLINT
+/// \endcond

--- a/src/PointwiseFunctions/MathFunctions/TensorProduct.cpp
+++ b/src/PointwiseFunctions/MathFunctions/TensorProduct.cpp
@@ -14,7 +14,9 @@ namespace MathFunctions {
 
 template <size_t Dim>
 TensorProduct<Dim>::TensorProduct(
-    double scale, std::array<std::unique_ptr<MathFunction<1>>, Dim>&& functions)
+    double scale,
+    std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>, Dim>&&
+        functions)
     : scale_(scale), functions_(std::move(functions)) {}
 
 template <size_t Dim>
@@ -74,10 +76,6 @@ tnsr::ii<T, Dim> TensorProduct<Dim>::second_derivatives(
 }  // namespace MathFunctions
 
 /// \cond
-template class MathFunctions::TensorProduct<1>;
-template class MathFunctions::TensorProduct<2>;
-template class MathFunctions::TensorProduct<3>;
-
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -92,6 +90,20 @@ template class MathFunctions::TensorProduct<3>;
       const tnsr::I<DTYPE(data), DIM(data)>& x) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector))
+
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                        \
+  template MathFunctions::TensorProduct<DIM(data)>::TensorProduct(  \
+      double scale,                                                 \
+      std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>, \
+                 DIM(data)>&& functions);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef DTYPE

--- a/src/PointwiseFunctions/MathFunctions/TensorProduct.hpp
+++ b/src/PointwiseFunctions/MathFunctions/TensorProduct.hpp
@@ -11,11 +11,7 @@
 #include <memory>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
-
-/// \cond
-template <size_t Dim>
-class MathFunction;
-/// \endcond
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 
 namespace MathFunctions {
 
@@ -25,7 +21,8 @@ template <size_t Dim>
 class TensorProduct {
  public:
   TensorProduct(double scale,
-                std::array<std::unique_ptr<MathFunction<1>>, Dim>&& functions);
+                std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>,
+                           Dim>&& functions);
 
   TensorProduct(const TensorProduct&) = delete;
   TensorProduct(TensorProduct&&) = default;
@@ -47,6 +44,6 @@ class TensorProduct {
 
  private:
   double scale_{1.0};
-  std::array<std::unique_ptr<MathFunction<1>>, Dim> functions_;
+  std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>, Dim> functions_;
 };
 }  // namespace MathFunctions

--- a/tests/Unit/Evolution/Conservative/Test_ConservativeDuDt.cpp
+++ b/tests/Unit/Evolution/Conservative/Test_ConservativeDuDt.cpp
@@ -217,12 +217,13 @@ auto make_affine_map<3>() noexcept {
 }
 
 template <dg::Formulation DgFormulation, size_t Dim>
-void test(
-    const Mesh<Dim>& mesh,
-    std::array<std::unique_ptr<MathFunction<1>>, Dim> functions) noexcept {
-  using flux_tags =
-      tmpl::list<Tags::Flux<Var1, tmpl::size_t<Dim>, Frame::Inertial>,
-                 Tags::Flux<Var2<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
+void test(const Mesh<Dim>& mesh,
+          std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>, Dim>
+              functions) noexcept {
+  using flux_tags = tmpl::list<
+      db::add_tag_prefix<Tags::Flux, Var1, tmpl::size_t<Dim>, Frame::Inertial>,
+      db::add_tag_prefix<Tags::Flux, Var2<Dim>, tmpl::size_t<Dim>,
+                         Frame::Inertial>>;
   using Flux1 = tmpl::at_c<flux_tags, 0>;
   using Flux2 = tmpl::at_c<flux_tags, 1>;
 
@@ -317,18 +318,24 @@ SPECTRE_TEST_CASE("Unit.Evolution.ConservativeDuDt", "[Unit][Evolution]") {
   const Mesh<1> mesh_1d{num_points, Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
   test<dg::Formulation::StrongInertial>(
-      mesh_1d, {{std::make_unique<MathFunctions::PowX>(num_points - 1)}});
+      mesh_1d, {{std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(
+                   num_points - 1)}});
 
   const Mesh<2> mesh_2d{num_points, Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
   test<dg::Formulation::StrongInertial>(
-      mesh_2d, {{std::make_unique<MathFunctions::PowX>(num_points - 1),
-                 std::make_unique<MathFunctions::PowX>(num_points - 1)}});
+      mesh_2d, {{std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(
+                     num_points - 1),
+                 std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(
+                     num_points - 1)}});
 
   const Mesh<3> mesh_3d{num_points, Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
   test<dg::Formulation::StrongInertial>(
-      mesh_3d, {{std::make_unique<MathFunctions::PowX>(num_points - 1),
-                 std::make_unique<MathFunctions::PowX>(num_points - 1),
-                 std::make_unique<MathFunctions::PowX>(num_points - 1)}});
+      mesh_3d, {{std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(
+                     num_points - 1),
+                 std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(
+                     num_points - 1),
+                 std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(
+                     num_points - 1)}});
 }

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
@@ -32,6 +32,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"
 #include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "PointwiseFunctions/MathFunctions/PowX.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -369,7 +370,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Characteristics",
   const std::array<double, 3> upper_bound{{0.78, 1.18, 1.28}};
 
   const ScalarWave::Solutions::RegularSphericalWave spherical_wave_solution(
-      std::make_unique<MathFunctions::Gaussian>(1., 1., 0.));
+      std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(1., 1.,
+                                                                    0.));
 
   test_characteristic_speeds_analytic<3>(grid_size);
   test_characteristic_fields_analytic<3>(spherical_wave_solution, grid_size,
@@ -386,7 +388,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Characteristics",
   const double center_z = 8.4;
   const ScalarWave::Solutions::PlaneWave<3> plane_wave_solution(
       {{kx, ky, kz}}, {{center_x, center_y, center_z}},
-      std::make_unique<MathFunctions::PowX>(3));
+      std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(3));
 
   test_characteristic_speeds_analytic<3>(grid_size);
   test_characteristic_fields_analytic<3>(plane_wave_solution, grid_size,

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Constraints.cpp
@@ -194,7 +194,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Constraints",
     const std::array<double, 3> lower_bound{{0., 0., 0.}};
 
     const ScalarWave::Solutions::RegularSphericalWave solution(
-        std::make_unique<MathFunctions::Gaussian>(1., 1., 0.));
+        std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(1., 1.,
+                                                                      0.));
 
     // Note: looser numerical tolerance because this check
     // uses numerical derivatives

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
@@ -52,7 +52,8 @@ template <size_t Dim>
 void check_du_dt(const size_t npts, const double time) {
   ScalarWave::Solutions::PlaneWave<Dim> solution(
       make_array<Dim>(0.1), make_array<Dim>(0.0),
-      std::make_unique<MathFunctions::Gaussian>(1.0, 1.0, 0.0));
+      std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(1.0, 1.0,
+                                                                    0.0));
 
   tnsr::I<DataVector, Dim> x = [npts]() {
     auto logical_coords = logical_coordinates(Mesh<Dim>{
@@ -139,7 +140,8 @@ template <size_t Dim>
 void check_normal_dot_fluxes(const size_t npts, const double t) {
   const ScalarWave::Solutions::PlaneWave<Dim> solution(
       make_array<Dim>(0.1), make_array<Dim>(0.0),
-      std::make_unique<MathFunctions::Gaussian>(1.0, 1.0, 0.0));
+      std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(1.0, 1.0,
+                                                                    0.0));
 
   const tnsr::I<DataVector, Dim> x = [npts]() {
     auto logical_coords = logical_coordinates(Mesh<Dim>{

--- a/tests/Unit/Helpers/PointwiseFunctions/MathFunctions/TestHelpers.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/MathFunctions/TestHelpers.hpp
@@ -1,0 +1,165 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Overloader.hpp"
+
+namespace TestHelpers {
+namespace MathFunctions {
+namespace detail {
+template <size_t VolumeDim, typename Fr, class... MemberArgs, class T>
+void check_impl(
+    const std::unique_ptr<MathFunction<VolumeDim, Fr>>& in_math_function,
+    const std::string& python_function_prefix, const T& used_for_size,
+    const std::array<std::pair<double, double>, 1> random_value_bounds,
+    const MemberArgs&... member_args) noexcept {
+  using MathFunc = MathFunction<VolumeDim, Fr>;
+  using CallOperatorFunction =
+      Scalar<T> (MathFunc::*)(const tnsr::I<T, VolumeDim, Fr>&) const noexcept;
+  using FirstDerivFunction =
+      tnsr::i<T, VolumeDim, Fr> (MathFunc::*)(const tnsr::I<T, VolumeDim, Fr>&)
+          const noexcept;
+  using SecondDerivFunction =
+      tnsr::ii<T, VolumeDim, Fr> (MathFunc::*)(const tnsr::I<T, VolumeDim, Fr>&)
+          const noexcept;
+  using ThirdDerivFunction = tnsr::iii<T, VolumeDim, Fr> (MathFunc::*)(
+      const tnsr::I<T, VolumeDim, Fr>&) const noexcept;
+
+  const auto member_args_tuple = std::make_tuple(member_args...);
+  const auto helper =
+      [&](const std::unique_ptr<MathFunc>& math_function) noexcept {
+        // need func variable to work around GCC bug
+        CallOperatorFunction func{&MathFunc::operator()};
+
+        INFO("Testing call operator...")
+        pypp::check_with_random_values<1>(
+            func, *math_function, "TestFunctions",
+            python_function_prefix + "_call_operator", random_value_bounds,
+            member_args_tuple, used_for_size);
+        INFO("Done testing call operator...")
+
+        FirstDerivFunction d_func{&MathFunc::first_deriv};
+        INFO("Testing first derivative...")
+        pypp::check_with_random_values<1>(
+            d_func, *math_function, "TestFunctions",
+            python_function_prefix + "_first_deriv", random_value_bounds,
+            member_args_tuple, used_for_size);
+        INFO("Done testing first derivative...")
+
+        SecondDerivFunction d2_func{&MathFunc::second_deriv};
+        INFO("Testing second derivative...")
+        pypp::check_with_random_values<1>(
+            d2_func, *math_function, "TestFunctions",
+            python_function_prefix + "_second_deriv", random_value_bounds,
+            member_args_tuple, used_for_size);
+        INFO("Done testing second derivative...")
+
+        ThirdDerivFunction d3_func{&MathFunc::third_deriv};
+        INFO("Testing third derivative...")
+        pypp::check_with_random_values<1>(
+            d3_func, *math_function, "TestFunctions",
+            python_function_prefix + "_third_deriv", random_value_bounds,
+            member_args_tuple, used_for_size);
+        INFO("Done testing third derivative...")
+
+        INFO("Done\n\n")
+      };
+  helper(in_math_function);
+  helper(serialize_and_deserialize(in_math_function));
+
+  if constexpr (VolumeDim == 1) {
+    // Check that the tensor interface agrees with the double/DataVector
+    // interface
+
+    MAKE_GENERATOR(gen);
+    std::uniform_real_distribution<> real_dis(-1, 1);
+    const auto nn_generator = make_not_null(&gen);
+    const auto nn_distribution = make_not_null(&real_dis);
+
+    auto coords_tensor = make_with_random_values<tnsr::I<T, VolumeDim, Fr>>(
+        nn_generator, nn_distribution, used_for_size);
+    T coords_T = get<0>(coords_tensor);
+
+    CHECK_ITERABLE_APPROX(get((*in_math_function)(coords_tensor)),
+                          (*in_math_function)(coords_T));
+
+    const T deriv_from_tensor =
+        std::move(get<0>(in_math_function->first_deriv(coords_tensor)));
+    CHECK_ITERABLE_APPROX(deriv_from_tensor,
+                          in_math_function->first_deriv(coords_T));
+
+    const T second_deriv_from_tensor =
+        std::move(get<0, 0>(in_math_function->second_deriv(coords_tensor)));
+    CHECK_ITERABLE_APPROX(second_deriv_from_tensor,
+                          in_math_function->second_deriv(coords_T));
+
+    const T third_deriv_from_tensor =
+        std::move(get<0, 0, 0>(in_math_function->third_deriv(coords_tensor)));
+    CHECK_ITERABLE_APPROX(third_deriv_from_tensor,
+                          in_math_function->third_deriv(coords_T));
+  }
+}
+}  // namespace detail
+// @{
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Test a MathFunction by comparing to python functions
+ *
+ * The python functions must be added to
+ * tests/Unit/PointwiseFunctions/MathFunctions/Python/TestFunctions.py. The
+ * prefix for each class of MathFunction is arbitrary, but should generally
+ * be descriptive (e.g. 'gaussian', 'sinusoid', 'pow_x') of the MathFunction.
+ *
+ * The `python_function_prefix` argument passed to `check` must be `PREFIX`. If
+ * a MathFunction class has member variables set by its constructor, then these
+ * member variables must be passed in as the last arguments to the `check`
+ * function`. Each python function must take these same arguments as the
+ * trailing arguments.
+ */
+template <class MathFunctionType, class T, class... MemberArgs>
+void check(std::unique_ptr<MathFunctionType> in_math_function,
+           const std::string& python_function_prefix, const T& used_for_size,
+           const std::array<std::pair<double, double>, 1> random_value_bounds,
+           const MemberArgs&... member_args) noexcept {
+  detail::check_impl(
+      std::unique_ptr<MathFunction<MathFunctionType::volume_dim,
+                                   typename MathFunctionType::frame>>(
+          std::move(in_math_function)),
+      python_function_prefix, used_for_size, random_value_bounds,
+      member_args...);
+}
+
+template <class MathFunctionType, class T, class... MemberArgs>
+void check(MathFunctionType in_math_function,
+           const std::string& python_function_prefix, const T& used_for_size,
+           const std::array<std::pair<double, double>, 1> random_value_bounds,
+           const MemberArgs&... member_args) noexcept {
+  detail::check_impl(
+      std::unique_ptr<MathFunction<MathFunctionType::volume_dim,
+                                   typename MathFunctionType::frame>>(
+          std::make_unique<MathFunctionType>(std::move(in_math_function))),
+      python_function_prefix, used_for_size, random_value_bounds,
+      member_args...);
+}
+// @}
+}  // namespace MathFunctions
+}  // namespace TestHelpers

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -164,9 +164,11 @@ void test_interpolate_to_points(const Mesh<Dim>& mesh) noexcept {
     // interpolate to arbitrary points, and then check that the
     // values at arbitrary points match this solution.
     // We choose polynomials so that interpolation is exact on an LGL grid.
-    std::array<std::unique_ptr<MathFunction<1>>, Dim> functions;
+    std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>, Dim>
+        functions;
     for (size_t d = 0; d < Dim; ++d) {
-      gsl::at(functions, d) = std::make_unique<MathFunctions::PowX>(iter()[d]);
+      gsl::at(functions, d) =
+          std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(iter()[d]);
     }
     MathFunctions::TensorProduct<Dim> f(1.0, std::move(functions));
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
@@ -123,9 +123,11 @@ void test_regular_interpolation(const Mesh<Dim>& source_mesh,
     // interpolate to arbitrary points, and then check that the
     // values at arbitrary points match this solution.
     // We choose polynomials so that interpolation is exact on an LGL grid.
-    std::array<std::unique_ptr<MathFunction<1>>, Dim> functions;
+    std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>, Dim>
+        functions;
     for (size_t d = 0; d < Dim; ++d) {
-      gsl::at(functions, d) = std::make_unique<MathFunctions::PowX>(iter()[d]);
+      gsl::at(functions, d) =
+          std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(iter()[d]);
     }
     MathFunctions::TensorProduct<Dim> f(1.0, std::move(functions));
 
@@ -209,10 +211,12 @@ void test_regular_interpolation_override(
         source_mesh, target_mesh, override_target_mesh_with_1d_coords);
 
     // Test only the highest-order polynomial x^a y^b z^c on the source mesh.
-    std::array<std::unique_ptr<MathFunction<1>>, Dim> functions;
+    std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>, Dim>
+        functions;
     for (size_t d = 0; d < Dim; ++d) {
       gsl::at(functions, d) =
-          std::make_unique<MathFunctions::PowX>(source_mesh.extents(d) - 1);
+          std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(
+              source_mesh.extents(d) - 1);
     }
     MathFunctions::TensorProduct<Dim> f(1.0, std::move(functions));
 

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -124,7 +124,8 @@ using two_fluxes = tmpl::list<Flux1<Dim, Frame>, Flux2<Dim, Frame>>;
 template <size_t Dim, typename Frame = Frame::Inertial>
 void test_divergence_impl(
     const Mesh<Dim>& mesh,
-    std::array<std::unique_ptr<MathFunction<1>>, Dim> functions) noexcept {
+    std::array<std::unique_ptr<MathFunction<1, Frame>>, Dim>
+        functions) noexcept {
   const auto coordinate_map = make_affine_map<Dim>();
   const size_t num_grid_points = mesh.number_of_grid_points();
   const auto xi = logical_coordinates(mesh);
@@ -178,19 +179,22 @@ void test_divergence() noexcept {
                         Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
   for (size_t a = 0; a < 5; ++a) {
-    std::array<std::unique_ptr<MathFunction<1>>, 1> functions_1d{
-        {std::make_unique<MathFunctions::PowX>(a)}};
+    std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>, 1>
+        functions_1d{
+            {std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(a)}};
     test_divergence_impl(mesh_1d, std::move(functions_1d));
     for (size_t b = 0; b < 4; ++b) {
-      std::array<std::unique_ptr<MathFunction<1>>, 2> functions_2d{
-          {std::make_unique<MathFunctions::PowX>(a),
-           std::make_unique<MathFunctions::PowX>(b)}};
+      std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>, 2>
+          functions_2d{
+              {std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(a),
+               std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(b)}};
       test_divergence_impl(mesh_2d, std::move(functions_2d));
       for (size_t c = 0; c < 3; ++c) {
-        std::array<std::unique_ptr<MathFunction<1>>, 3> functions_3d{
-            {std::make_unique<MathFunctions::PowX>(a),
-             std::make_unique<MathFunctions::PowX>(b),
-             std::make_unique<MathFunctions::PowX>(c)}};
+        std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>, 3>
+            functions_3d{
+                {std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(a),
+                 std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(b),
+                 std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(c)}};
         test_divergence_impl(mesh_3d, std::move(functions_3d));
       }
     }
@@ -209,7 +213,8 @@ struct MapTag : db::SimpleTag {
 template <size_t Dim, typename Frame = Frame::Inertial>
 void test_divergence_compute_item_impl(
     const Mesh<Dim>& mesh,
-    std::array<std::unique_ptr<MathFunction<1>>, Dim> functions) noexcept {
+    std::array<std::unique_ptr<MathFunction<1, Frame>>, Dim>
+        functions) noexcept {
   const auto coordinate_map = make_affine_map<Dim>();
   using map_tag = MapTag<std::decay_t<decltype(coordinate_map)>>;
   using inv_jac_tag = domain::Tags::InverseJacobianCompute<
@@ -279,19 +284,22 @@ void test_divergence_compute() noexcept {
                         Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
   for (size_t a = 0; a < 5; ++a) {
-    std::array<std::unique_ptr<MathFunction<1>>, 1> functions_1d{
-        {std::make_unique<MathFunctions::PowX>(a)}};
+    std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>, 1>
+        functions_1d{
+            {std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(a)}};
     test_divergence_compute_item_impl(mesh_1d, std::move(functions_1d));
     for (size_t b = 0; b < 4; ++b) {
-      std::array<std::unique_ptr<MathFunction<1>>, 2> functions_2d{
-          {std::make_unique<MathFunctions::PowX>(a),
-           std::make_unique<MathFunctions::PowX>(b)}};
+      std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>, 2>
+          functions_2d{
+              {std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(a),
+               std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(b)}};
       test_divergence_compute_item_impl(mesh_2d, std::move(functions_2d));
       for (size_t c = 0; c < 3; ++c) {
-        std::array<std::unique_ptr<MathFunction<1>>, 3> functions_3d{
-            {std::make_unique<MathFunctions::PowX>(a),
-             std::make_unique<MathFunctions::PowX>(b),
-             std::make_unique<MathFunctions::PowX>(c)}};
+        std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>, 3>
+            functions_3d{
+                {std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(a),
+                 std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(b),
+                 std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(c)}};
         test_divergence_compute_item_impl(mesh_3d, std::move(functions_3d));
       }
     }

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveGr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveGr.cpp
@@ -161,7 +161,8 @@ void test_construct_from_options() noexcept {
     const gr::Solutions::KerrSchild bh_solution(0.7, {{0.1, -0.2, 0.3}},
                                                 {{0.7, 0.6, -2.}});
     const ScalarWave::Solutions::RegularSphericalWave flat_wave_solution{
-        std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)};
+        std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(11., 1.4,
+                                                                      0.3)};
 
     CHECK(curved_wave_data_constructed_from_opts ==
           CurvedScalarWave::AnalyticData::ScalarWaveGr<
@@ -171,7 +172,8 @@ void test_construct_from_options() noexcept {
               // cannot use `flat_wave_solution` in construction here
               // as it has a `std::unique_ptr` member
               ScalarWave::Solutions::RegularSphericalWave(
-                  std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3))));
+                  std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                      11., 1.4, 0.3))));
 
     test_kerr(curved_wave_data_constructed_from_opts, bh_solution,
               flat_wave_solution);
@@ -202,7 +204,8 @@ void test_construct_from_options() noexcept {
     const ScalarWave::Solutions::PlaneWave<3> flat_wave_solution{
         {{1.0, 1.0, 1.0}},
         {{0.0, 0.0, 0.0}},
-        std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)};
+        std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(11., 1.4,
+                                                                      0.3)};
 
     CHECK(curved_wave_data_constructed_from_opts ==
           CurvedScalarWave::AnalyticData::ScalarWaveGr<
@@ -212,7 +215,8 @@ void test_construct_from_options() noexcept {
               // as it has a `std::unique_ptr` member
               ScalarWave::Solutions::PlaneWave<3>(
                   {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}},
-                  std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3))));
+                  std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                      11., 1.4, 0.3))));
 
     test_kerr(curved_wave_data_constructed_from_opts, bh_solution,
               flat_wave_solution);
@@ -227,8 +231,10 @@ void test_serialize(const double mass, const std::array<double, 3>& spin,
         curved_wave_data(
             gr::Solutions::KerrSchild(mass, spin, center),
             ScalarWave::Solutions::RegularSphericalWave(
-                std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)));
-    Parallel::register_derived_classes_with_charm<MathFunction<1>>();
+                std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                    11., 1.4, 0.3)));
+    Parallel::register_derived_classes_with_charm<
+        MathFunction<1, Frame::Inertial>>();
     const auto snd_curved_wave_data =
         serialize_and_deserialize(curved_wave_data);
     CHECK(curved_wave_data == snd_curved_wave_data);
@@ -236,7 +242,8 @@ void test_serialize(const double mass, const std::array<double, 3>& spin,
     // test internals of deserialized data
     const gr::Solutions::KerrSchild bh_solution(mass, spin, center);
     const ScalarWave::Solutions::RegularSphericalWave flat_wave_solution{
-        std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)};
+        std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(11., 1.4,
+                                                                      0.3)};
 
     test_kerr(snd_curved_wave_data, bh_solution, flat_wave_solution);
   }
@@ -247,8 +254,10 @@ void test_serialize(const double mass, const std::array<double, 3>& spin,
             gr::Solutions::KerrSchild(mass, spin, center),
             ScalarWave::Solutions::PlaneWave<3>(
                 {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}},
-                std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)));
-    Parallel::register_derived_classes_with_charm<MathFunction<1>>();
+                std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                    11., 1.4, 0.3)));
+    Parallel::register_derived_classes_with_charm<
+        MathFunction<1, Frame::Inertial>>();
     const auto snd_curved_wave_data =
         serialize_and_deserialize(curved_wave_data);
     CHECK(curved_wave_data == snd_curved_wave_data);
@@ -258,7 +267,8 @@ void test_serialize(const double mass, const std::array<double, 3>& spin,
     const ScalarWave::Solutions::PlaneWave<3> flat_wave_solution{
         {{1.0, 1.0, 1.0}},
         {{0.0, 0.0, 0.0}},
-        std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)};
+        std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(11., 1.4,
+                                                                      0.3)};
 
     test_kerr(snd_curved_wave_data, bh_solution, flat_wave_solution);
   }
@@ -272,14 +282,16 @@ void test_move(const double mass, const std::array<double, 3>& spin,
         curved_wave_data(
             gr::Solutions::KerrSchild(mass, spin, center),
             ScalarWave::Solutions::RegularSphericalWave(
-                std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)));
+                std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                    11., 1.4, 0.3)));
     // since it can't actually be copied
     CurvedScalarWave::AnalyticData::ScalarWaveGr<
         ScalarWave::Solutions::RegularSphericalWave, gr::Solutions::KerrSchild>
         copy_of_curved_wave_data(
             gr::Solutions::KerrSchild(mass, spin, center),
             ScalarWave::Solutions::RegularSphericalWave(
-                std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)));
+                std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                    11., 1.4, 0.3)));
     test_move_semantics(std::move(curved_wave_data), copy_of_curved_wave_data);
   }
   {  // test with wave profile = plane
@@ -289,7 +301,8 @@ void test_move(const double mass, const std::array<double, 3>& spin,
             gr::Solutions::KerrSchild(mass, spin, center),
             ScalarWave::Solutions::PlaneWave<3>(
                 {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}},
-                std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)));
+                std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                    11., 1.4, 0.3)));
     // since it can't actually be copied
     CurvedScalarWave::AnalyticData::ScalarWaveGr<
         ScalarWave::Solutions::PlaneWave<3>, gr::Solutions::KerrSchild>
@@ -297,7 +310,8 @@ void test_move(const double mass, const std::array<double, 3>& spin,
             gr::Solutions::KerrSchild(mass, spin, center),
             ScalarWave::Solutions::PlaneWave<3>(
                 {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}},
-                std::make_unique<MathFunctions::Gaussian>(11., 1.4, 0.3)));
+                std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                    11., 1.4, 0.3)));
     test_move_semantics(std::move(curved_wave_data), copy_of_curved_wave_data);
   }
 }
@@ -321,13 +335,18 @@ SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGr",
     const CurvedScalarWave::AnalyticData::ScalarWaveGr<sw_tag, background_tag>
         curved_wave_data_bh_far_away{
             background_tag(mass, spin, {{1.e20, 1., 1.}}),
-            sw_tag(std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.))};
+            sw_tag(
+                std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                    11., 1.5, 0.))};
     const CurvedScalarWave::AnalyticData::ScalarWaveGr<sw_tag, background_tag>
         curved_wave_data{
             background_tag(mass, spin, center),
-            sw_tag(std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.))};
+            sw_tag(
+                std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                    11., 1.5, 0.))};
     const sw_tag flat_wave_solution{
-        std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.)};
+        std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(11., 1.5,
+                                                                      0.)};
 
     test_tag_retrieval(curved_wave_data_bh_far_away);
     test_tag_retrieval(curved_wave_data);
@@ -340,17 +359,22 @@ SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGr",
     const CurvedScalarWave::AnalyticData::ScalarWaveGr<sw_tag, background_tag>
         curved_wave_data_bh_far_away{
             background_tag(mass, spin, {{1.e20, 1., 1.}}),
-            sw_tag({{1., 1., 1.}}, {{0., 0., 0.}},
-                   std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.))};
+            sw_tag(
+                {{1., 1., 1.}}, {{0., 0., 0.}},
+                std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                    11., 1.5, 0.))};
     const CurvedScalarWave::AnalyticData::ScalarWaveGr<sw_tag, background_tag>
         curved_wave_data{
             background_tag(mass, spin, center),
-            sw_tag({{1., 1., 1.}}, {{0., 0., 0.}},
-                   std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.))};
+            sw_tag(
+                {{1., 1., 1.}}, {{0., 0., 0.}},
+                std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                    11., 1.5, 0.))};
     const sw_tag flat_wave_solution{
         {{1., 1., 1.}},
         {{0., 0., 0.}},
-        std::make_unique<MathFunctions::Gaussian>(11., 1.5, 0.)};
+        std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(11., 1.5,
+                                                                      0.)};
 
     test_tag_retrieval(curved_wave_data_bh_far_away);
     test_tag_retrieval(curved_wave_data);
@@ -368,10 +392,12 @@ SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGrMass",
   ERROR_TEST();
   CurvedScalarWave::AnalyticData::ScalarWaveGr<
       ScalarWave::Solutions::RegularSphericalWave, gr::Solutions::KerrSchild>
-      solution(gr::Solutions::KerrSchild(-0.2, {{0.1, -0.2, 0.3}},
-                                         {{0.3, 0.2, 0.4}}),
-               ScalarWave::Solutions::RegularSphericalWave(
-                   std::make_unique<MathFunctions::Gaussian>(1., 1., 0.)));
+      solution(
+          gr::Solutions::KerrSchild(-0.2, {{0.1, -0.2, 0.3}},
+                                    {{0.3, 0.2, 0.4}}),
+          ScalarWave::Solutions::RegularSphericalWave(
+              std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                  1., 1., 0.)));
 }
 
 // [[OutputRegex, In string:.*At line 3 column 11:.Value -0.5 is below the
@@ -406,5 +432,6 @@ SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGrSpin",
       solution(
           gr::Solutions::KerrSchild(0.2, {{1.0, 1.0, 1.0}}, {{0.3, 0.2, 0.4}}),
           ScalarWave::Solutions::RegularSphericalWave(
-              std::make_unique<MathFunctions::Gaussian>(1., 1., 0.)));
+              std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                  1., 1., 0.)));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
@@ -142,14 +142,16 @@ void test_1d() {
   const DataVector u(
       {kx * (x1 - center_x) - omega * t, kx * (x2 - center_x) - omega * t});
   const ScalarWave::Solutions::PlaneWave<1> pw(
-      {{kx}}, {{center_x}}, std::make_unique<MathFunctions::PowX>(3));
+      {{kx}}, {{center_x}},
+      std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(3));
   check_solution<1>(
       cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
       3.0 * kx * square(u),
       std::array<DataVector, 2>{{-6.0 * omega * kx * u, 6.0 * square(kx) * u}},
       pw, x, t);
 
-  Parallel::register_derived_classes_with_charm<MathFunction<1>>();
+  Parallel::register_derived_classes_with_charm<
+      MathFunction<1, Frame::Inertial>>();
   const auto deserialized_pw = serialize_and_deserialize(pw);
   check_solution<1>(
       cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
@@ -190,7 +192,7 @@ void test_2d() {
                       kx * (x2 - center_x) + ky * (y2 - center_y) - omega * t});
   const ScalarWave::Solutions::PlaneWave<2> pw(
       {{kx, ky}}, {{center_x, center_y}},
-      std::make_unique<MathFunctions::PowX>(3));
+      std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(3));
   check_solution<1>(
       cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
       3.0 * kx * square(u),
@@ -203,7 +205,8 @@ void test_2d() {
           {-6.0 * omega * ky * u, 6.0 * kx * ky * u, 6.0 * square(ky) * u}},
       pw, x, t);
 
-  Parallel::register_derived_classes_with_charm<MathFunction<1>>();
+  Parallel::register_derived_classes_with_charm<
+      MathFunction<1, Frame::Inertial>>();
   const auto deserialized_pw = serialize_and_deserialize(pw);
   check_solution<1>(
       cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
@@ -256,7 +259,7 @@ void test_3d() {
                           kz * (z2 - center_z) - omega * t});
   const ScalarWave::Solutions::PlaneWave<3> pw(
       {{kx, ky, kz}}, {{center_x, center_y, center_z}},
-      std::make_unique<MathFunctions::PowX>(3));
+      std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(3));
   check_solution<1>(
       cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
       3.0 * kx * square(u),
@@ -275,7 +278,8 @@ void test_3d() {
                                  6.0 * ky * kz * u, 6.0 * square(kz) * u}},
       pw, x, t);
 
-  Parallel::register_derived_classes_with_charm<MathFunction<1>>();
+  Parallel::register_derived_classes_with_charm<
+      MathFunction<1, Frame::Inertial>>();
   const auto deserialized_pw = serialize_and_deserialize(pw);
   check_solution<1>(
       cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
@@ -20,7 +20,8 @@
 SPECTRE_TEST_CASE("Unit.AnalyticSolutions.WaveEquation.RegularSphericalWave",
                   "[PointwiseFunctions][Unit]") {
   const ScalarWave::Solutions::RegularSphericalWave solution{
-      std::make_unique<MathFunctions::Gaussian>(1., 1., 0.)};
+      std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(1., 1.,
+                                                                    0.)};
 
   const tnsr::I<DataVector, 3> x{std::array<DataVector, 3>{
       {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Python/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Python/TestFunctions.py
@@ -1,0 +1,97 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def centered_coordinates(coords, center):
+    return coords - center
+
+
+def squared_distance_from_center(centered_coords, center):
+    return np.einsum("i,i", centered_coords, centered_coords)
+
+
+def gaussian_call_operator(coords, amplitude, width, center):
+    one_over_width = 1.0 / width
+    distance = squared_distance_from_center(
+        centered_coordinates(coords, center), center)
+    return amplitude * np.exp(-1.0 * distance * np.square(one_over_width))
+
+
+def gaussian_first_deriv(coords, amplitude, width, center):
+    one_over_width = 1.0 / width
+    result = -2.0 * np.square(one_over_width) * gaussian_call_operator(
+        coords, amplitude, width, center) * centered_coordinates(
+            coords, center)
+    return result
+
+
+def gaussian_second_deriv(coords, amplitude, width, center):
+    one_over_width = 1.0 / width
+    result = np.einsum("i,j", centered_coordinates(coords, center),
+                       gaussian_first_deriv(coords, amplitude, width, center))
+    result += np.eye(len(center)) * gaussian_call_operator(
+        coords, amplitude, width, center)
+    return result * -2.0 * np.square(one_over_width)
+
+
+def gaussian_third_deriv(coords, amplitude, width, center):
+    one_over_width = 1.0 / width
+    centered_coords = centered_coordinates(coords, center)
+    df = gaussian_first_deriv(coords, amplitude, width, center)
+    d2f = gaussian_second_deriv(coords, amplitude, width, center)
+    kronecker_delta = np.eye(len(center))
+    result = np.einsum("j,ik", centered_coords, d2f)
+    result += np.einsum("ij,k", kronecker_delta, df)
+    result += np.einsum("jk,i", kronecker_delta, df)
+    return result * -2.0 * np.square(one_over_width)
+
+
+def sinusoid_call_operator(coords, amplitude, wavenumber, phase):
+    return amplitude * np.sin(wavenumber * coords + phase)[0]
+
+
+def sinusoid_first_deriv(coords, amplitude, wavenumber, phase):
+    return amplitude * wavenumber * np.cos(wavenumber * coords + phase)
+
+
+def sinusoid_second_deriv(coords, amplitude, wavenumber, phase):
+    return np.array([
+        -amplitude * np.square(wavenumber) *
+        np.sin(wavenumber * coords + phase)
+    ])
+
+
+def sinusoid_third_deriv(coords, amplitude, wavenumber, phase):
+    return np.array([[
+        -amplitude * wavenumber * np.square(wavenumber) *
+        np.cos(wavenumber * coords + phase)
+    ]])
+
+
+def pow_x_call_operator(coords, power):
+    return np.power(coords, power)[0]
+
+
+def pow_x_first_deriv(coords, power):
+    if power == 0.0:
+        return np.array([0.0])
+    else:
+        return power * np.power(coords, power - 1.0)
+
+
+def pow_x_second_deriv(coords, power):
+    if power == 0.0 or power == 1.0:
+        return np.array([[0.0]])
+    else:
+        return np.array([(power - 1.0) * power * np.power(coords, power - 2.0)
+                         ])
+
+
+def pow_x_third_deriv(coords, power):
+    if power == 0.0 or power == 1.0 or power == 2.0:
+        return np.array([[[0.0]]])
+    else:
+        return np.array([[(power - 2.0) * (power - 1.0) * power *
+                          np.power(coords, power - 3.0)]])


### PR DESCRIPTION
## Proposed changes
This PR generalizes MathFunctions to support higher-dimension MathFunctions that are templated on DataType and Dimension. The MathFunctions continue to work for both doubles and DataVectors.

The existing 1D interface has the same MathFunction accept and return either doubles or DataVectors and hard-codes Frame::Inertial. The new interface, which works for higher dimensions, templates on Dimension and Frame and overloads on double/DataVector.

In this implementation, the 1D case is treated specially, to preserve the existing interface, except that users now must specify the data type, dimension, and frame.

Needed for specifying constraint damping scalars using MathFunctions and input-file options, instead of hard-coding them.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
