### PR TITLE
Move snippet end marker to cover entire 'EventsAndTriggers' section, …

### DIFF
--- a/docs/Tutorials/Visualization.md
+++ b/docs/Tutorials/Visualization.md
@@ -12,7 +12,7 @@ SpECTRE source files for evolution executables are located in
 as defined in the `CMakeLists.txt` file located in the same directory as the
 source file. For example, to compile the executable that evolves a scalar wave
 using a three-dimensional domain, one runs the command:
-`make EvolveScalarWave3D`, which then results in an executable of the same name
+`make EvolvePlaneWave3D`, which then results in an executable of the same name
 in the `bin` directory of the user's build directory.
 
 ### Running an Evolution Executable
@@ -25,7 +25,7 @@ which the user can then modify as desired. Copy the executable and YAML file
 to a directory of your choice. The YAML file is then passed as an argument to
 the executable using the flag `--input-file`. For example, for a scalar wave
 evolution, run the command:
-`./EvolveScalarWave3D --input-file Input3DPeriodic.yaml`.
+`./EvolvePlaneWave3D --input-file Input3DPeriodic.yaml`.
 By default, the example input files do not produce any output. This can be
 changed by modifying the options passed to `EventsAndTriggers`:
 
@@ -33,7 +33,9 @@ changed by modifying the options passed to `EventsAndTriggers`:
 
 This will observe the norms of the errors in the system every three
 slabs starting with slab five and the volume data of Psi at the start
-of slabs 0 and 100.  A successful observation will result in the
+of slabs 0 and 100. Be sure to keep the Completion event, as without
+it the executable will run indefinitely. In this case, it will terminate
+after 100 slabs. A successful observation will result in the
 creation of H5 files whose names can be specified in the YAML file
 under the options `VolumeFileName` and `ReductionFileName`. One volume
 data file will be produced from each Charm++ node that is used to run

--- a/tests/InputFiles/ScalarWave/ObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/ObserveExample.yaml
@@ -58,10 +58,10 @@ EventsAndTriggers:
       Slabs: [0, 100]
   : - ObserveFields:
         VariablesToObserve: ["Psi"]
-# [observe_event_trigger]
   ? SpecifiedSlabs:
-      Slabs: [10]
+      Slabs: [100]
   : - Completion
+# [observe_event_trigger]
 
 Observers:
   VolumeFileName: "ObserveExample1DPlaneWavePeriodicVolume"


### PR DESCRIPTION
…change Completion event to occur on final slab (slab 100)

## Proposed changes

<!--
This is a simple edit to ObserveExample.yaml, which is used on the [Running and Visualizing](https://spectre-code.org/tutorial_visualization.html) User Tutorial page.
Previously, the code snippet under 'Running an Evolution Executable' was missing the 'Completion' event in order for an example execution of ScalarWave to terminate properly.
Also, the slab to finish computation on has been changed to 100 from 10, since observation is being carried out on slabs 0-100.
-->

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
