### PR TITLE
Support preconditioning in parallel GMRES linear solver

### DIFF
--- a/src/Elliptic/Executables/Linear/SolveLinearEllipticProblem.hpp
+++ b/src/Elliptic/Executables/Linear/SolveLinearEllipticProblem.hpp
@@ -89,7 +89,7 @@ struct Metavariables {
   // not positive-definite for the first-order system.
   using linear_solver = LinearSolver::gmres::Gmres<
       Metavariables, typename system::fields_tag,
-      SolveLinearEllipticProblem::OptionTags::LinearSolverGroup>;
+      SolveLinearEllipticProblem::OptionTags::LinearSolverGroup, false>;
   using linear_solver_iteration_id =
       LinearSolver::Tags::IterationId<typename linear_solver::options_group>;
   // For the GMRES linear solver we need to apply the DG operator to its

--- a/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
@@ -184,7 +184,7 @@ struct PrepareSolve {
         make_not_null(&box),
         [](const gsl::not_null<size_t*> iteration_id,
            const gsl::not_null<double*> residual_magnitude_square,
-           const db::const_item_type<residual_tag>& residual) noexcept {
+           const auto& residual) noexcept {
           *iteration_id = 0;
           *residual_magnitude_square = inner_product(residual, residual);
         },
@@ -224,7 +224,7 @@ struct CompleteStep {
         make_not_null(&box),
         [](const gsl::not_null<double*> residual_magnitude_square,
            const gsl::not_null<size_t*> iteration_id,
-           const db::const_item_type<residual_tag>& residual) noexcept {
+           const auto& residual) noexcept {
           *residual_magnitude_square = inner_product(residual, residual);
           ++(*iteration_id);
         },

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/InitializeElement.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/InitializeElement.hpp
@@ -22,7 +22,7 @@ class TaggedTuple;
 
 namespace LinearSolver::gmres::detail {
 
-template <typename FieldsTag, typename OptionsGroup>
+template <typename FieldsTag, typename OptionsGroup, bool Preconditioned>
 struct InitializeElement {
  private:
   using fields_tag = FieldsTag;
@@ -32,12 +32,17 @@ struct InitializeElement {
       db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, fields_tag>;
   using operand_tag =
       db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
-  using operator_applied_to_operand_tag =
-      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, operand_tag>;
+  using preconditioned_operand_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Preconditioned, operand_tag>;
+  using operator_applied_to_operand_tag = db::add_tag_prefix<
+      LinearSolver::Tags::OperatorAppliedTo,
+      std::conditional_t<Preconditioned, preconditioned_operand_tag,
+                         operand_tag>>;
   using orthogonalization_iteration_id_tag =
       db::add_tag_prefix<LinearSolver::Tags::Orthogonalization,
                          LinearSolver::Tags::IterationId<OptionsGroup>>;
-  using basis_history_tag = LinearSolver::Tags::KrylovSubspaceBasis<fields_tag>;
+  using basis_history_tag =
+      LinearSolver::Tags::KrylovSubspaceBasis<operand_tag>;
 
  public:
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
@@ -49,28 +54,39 @@ struct InitializeElement {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    return std::make_tuple(
-        ::Initialization::merge_into_databox<
-            InitializeElement,
-            db::AddSimpleTags<
-                LinearSolver::Tags::IterationId<OptionsGroup>,
-                initial_fields_tag, operator_applied_to_fields_tag, operand_tag,
-                operator_applied_to_operand_tag,
-                orthogonalization_iteration_id_tag, basis_history_tag,
-                LinearSolver::Tags::HasConverged<OptionsGroup>>>(
-            std::move(box),
-            // The `PrepareSolve` action populates these tags with initial
-            // values, except for `operator_applied_to_fields_tag` which is
-            // expected to be filled at that point and
-            // `operator_applied_to_operand_tag` which is expected to be updated
-            // in every iteration of the algorithm.
-            std::numeric_limits<size_t>::max(),
-            db::item_type<initial_fields_tag>{},
-            db::item_type<operator_applied_to_fields_tag>{},
-            db::item_type<operand_tag>{},
-            db::item_type<operator_applied_to_operand_tag>{},
-            std::numeric_limits<size_t>::max(),
-            db::item_type<basis_history_tag>{}, Convergence::HasConverged{}));
+    auto initial_box = ::Initialization::merge_into_databox<
+        InitializeElement,
+        db::AddSimpleTags<LinearSolver::Tags::IterationId<OptionsGroup>,
+                          initial_fields_tag, operator_applied_to_fields_tag,
+                          operand_tag, operator_applied_to_operand_tag,
+                          orthogonalization_iteration_id_tag, basis_history_tag,
+                          LinearSolver::Tags::HasConverged<OptionsGroup>>>(
+        std::move(box),
+        // The `PrepareSolve` action populates these tags with initial values,
+        // except for `operator_applied_to_fields_tag` which is expected to be
+        // filled at that point and `operator_applied_to_operand_tag` which is
+        // expected to be updated in every iteration of the algorithm.
+        std::numeric_limits<size_t>::max(), db::item_type<initial_fields_tag>{},
+        db::item_type<operator_applied_to_fields_tag>{},
+        db::item_type<operand_tag>{},
+        db::item_type<operator_applied_to_operand_tag>{},
+        std::numeric_limits<size_t>::max(), db::item_type<basis_history_tag>{},
+        Convergence::HasConverged{});
+
+    if constexpr (not Preconditioned) {
+      return std::make_tuple(std::move(initial_box));
+    } else {
+      using preconditioned_basis_history_tag =
+          LinearSolver::Tags::KrylovSubspaceBasis<preconditioned_operand_tag>;
+
+      return std::make_tuple(::Initialization::merge_into_databox<
+                             InitializeElement,
+                             db::AddSimpleTags<preconditioned_basis_history_tag,
+                                               preconditioned_operand_tag>>(
+          std::move(initial_box),
+          db::item_type<preconditioned_basis_history_tag>{},
+          db::item_type<preconditioned_operand_tag>{}));
+    }
   }
 };
 

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
@@ -141,8 +141,7 @@ struct StoreOrthogonalization {
                orthogonalization_iteration_id_tag>(
         make_not_null(&box),
         [orthogonalization](
-            const gsl::not_null<db::item_type<orthogonalization_history_tag>*>
-                orthogonalization_history,
+            const auto orthogonalization_history,
             const gsl::not_null<size_t*> orthogonalization_iteration_id,
             const size_t& iteration_id) noexcept {
           (*orthogonalization_history)(*orthogonalization_iteration_id,

--- a/src/ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp
@@ -51,8 +51,7 @@ struct UpdateFields {
     // Update the solution fields according to the Richardson scheme
     db::mutate<FieldsTag>(
         make_not_null(&box),
-        [](const gsl::not_null<db::item_type<FieldsTag>*> fields,
-           const db::const_item_type<residual_tag>& residual,
+        [](const auto fields, const auto& residual,
            const double relaxation_parameter) noexcept {
           *fields += relaxation_parameter * residual;
         },

--- a/src/ParallelAlgorithms/LinearSolver/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Tags.hpp
@@ -224,8 +224,14 @@ struct KrylovSubspaceBasis : db::PrefixTag, db::SimpleTag {
     // operator
     return "KrylovSubspaceBasis(" + db::tag_name<Tag>() + ")";
   }
-  using type =
-      std::vector<db::const_item_type<db::add_tag_prefix<Operand, Tag>>>;
+  using type = std::vector<db::const_item_type<Tag>>;
+  using tag = Tag;
+};
+
+/// Indicates the `Tag` is related to preconditioning of the linear solve
+template <typename Tag>
+struct Preconditioned : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
   using tag = Tag;
 };
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
@@ -28,6 +28,7 @@ struct Metavariables {
   using linear_solver =
       LinearSolver::cg::ConjugateGradient<Metavariables, helpers::fields_tag,
                                           SerialCg>;
+  using preconditioner = void;
 
   using component_list = helpers::component_list<Metavariables>;
   using observed_reduction_data_tags =

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
@@ -30,6 +30,7 @@ struct Metavariables {
 
   using linear_solver = LinearSolver::cg::ConjugateGradient<
       Metavariables, typename helpers_distributed::fields_tag, ParallelCg>;
+  using preconditioner = void;
 
   using component_list = helpers_distributed::component_list<Metavariables>;
   using observed_reduction_data_tags =

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
@@ -21,4 +21,6 @@ add_dependencies(
   )
 
 add_linear_solver_algorithm_test("GmresAlgorithm")
+add_linear_solver_algorithm_test("GmresPreconditionedAlgorithm")
 add_linear_solver_algorithm_test("DistributedGmresAlgorithm")
+add_linear_solver_algorithm_test("DistributedGmresPreconditionedAlgorithm")

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
@@ -29,7 +29,8 @@ struct Metavariables {
 
   using linear_solver =
       LinearSolver::gmres::Gmres<Metavariables, helpers_distributed::fields_tag,
-                                 ParallelGmres>;
+                                 ParallelGmres, false>;
+  using preconditioner = void;
 
   using component_list = helpers_distributed::component_list<Metavariables>;
   using observed_reduction_data_tags =

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.yaml
@@ -1,0 +1,55 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# The test problem being solved here is a DG-discretized 1D Poisson equation
+# -u''(x) = f(x) on the interval [0, pi] with source f(x)=sin(x) and homogeneous
+# Dirichlet boundary conditions such that the solution is u(x)=sin(x) as well.
+#
+# Details:
+# - Domain decomposition: 2 elements with 3 LGL grid-points each
+# - "Primal" DG formulation (no auxiliary variable)
+# - Multiplied by mass matrix and no mass-lumping
+# - Internal penalty flux with sigma = 1.5 * (N_points - 1)^2 / h
+# - The operator is symmetric, which helps the Richardson preconditioner
+#   converge.
+
+NumberOfElements: 2
+
+LinearOperator:
+  - [[ 5.305164769729845,  0.848826363156775, -0.742723067762178],
+      [ 0.848826363156775,  3.395305452627101, -0.424413181578388],
+      [-0.742723067762178, -0.424413181578388,  3.395305452627101],
+      [ 0.318309886183791, -1.273239544735163, -1.909859317102744],
+      [ 0.               ,  0.               , -1.273239544735163],
+      [ 0.               ,  0.               ,  0.318309886183791]]
+  - [[ 0.318309886183791,  0.               ,  0.               ],
+      [-1.273239544735163,  0.               ,  0.               ],
+      [-1.909859317102744, -1.273239544735163,  0.318309886183791],
+      [ 3.395305452627101, -0.424413181578388, -0.742723067762178],
+      [-0.424413181578388,  3.395305452627101,  0.848826363156775],
+      [-0.742723067762178,  0.848826363156775,  5.305164769729845]]
+
+Source:
+  - [0.                , 0.740480489693061, 0.2617993877991494]
+  - [0.2617993877991494, 0.740480489693061, 0.                ]
+
+ExpectedResult:
+  - [-0.0363482510397858,  0.7235793356729757,  0.9928055333486293]
+  - [ 0.9928055333486292,  0.7235793356729758, -0.0363482510397858]
+
+Observers:
+  VolumeFileName: "Test_DistributedGmresPreconditionedAlgorithm_Volume"
+  ReductionFileName: "Test_DistributedGmresPreconditionedAlgorithm_Reductions"
+
+ParallelGmres:
+  ConvergenceCriteria:
+    MaxIterations: 2
+    AbsoluteResidual: 1e-14
+    RelativeResidual: 0
+  Verbosity: Verbose
+
+Preconditioner:
+  RelaxationParameter: 0.2916330767929102
+  Iterations: 65
+
+ConvergenceReason: AbsoluteResidual

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
@@ -27,7 +27,8 @@ struct Metavariables {
 
   using linear_solver =
       LinearSolver::gmres::Gmres<Metavariables, helpers::fields_tag,
-                                 SerialGmres>;
+                                 SerialGmres, false>;
+  using preconditioner = void;
 
   using component_list = helpers::component_list<Metavariables>;
   using observed_reduction_data_tags =

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresPreconditionedAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresPreconditionedAlgorithm.cpp
@@ -9,6 +9,7 @@
 #include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Main.hpp"
+#include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
 #include "ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -16,19 +17,25 @@ namespace helpers = LinearSolverAlgorithmTestHelpers;
 
 namespace {
 
-struct SerialRichardson {
+struct SerialGmres {
   static constexpr OptionString help =
       "Options for the iterative linear solver";
 };
 
+struct Preconditioner {
+  static constexpr OptionString help = "Options for the preconditioner";
+};
+
 struct Metavariables {
   static constexpr const char* const help{
-      "Test the Richardson linear solver algorithm"};
+      "Test the preconditioned GMRES linear solver algorithm"};
 
   using linear_solver =
-      LinearSolver::Richardson::Richardson<helpers::fields_tag,
-                                           SerialRichardson>;
-  using preconditioner = void;
+      LinearSolver::gmres::Gmres<Metavariables, helpers::fields_tag,
+                                 SerialGmres, true>;
+  using preconditioner = LinearSolver::Richardson::Richardson<
+      typename linear_solver::operand_tag, Preconditioner,
+      typename linear_solver::preconditioner_source_tag>;
 
   using component_list = helpers::component_list<Metavariables>;
   using observed_reduction_data_tags =

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresPreconditionedAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresPreconditionedAlgorithm.yaml
@@ -1,0 +1,24 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+LinearOperator: [[4, 1], [1, 3]]
+Source: [1, 2]
+InitialGuess: [2, 1]
+ExpectedResult: [0.0909090909090909, 0.6363636363636364]
+
+Observers:
+  VolumeFileName: "Test_GmresPreconditionedAlgorithm_Volume"
+  ReductionFileName: "Test_GmresPreconditionedAlgorithm_Reductions"
+
+SerialGmres:
+  ConvergenceCriteria:
+    MaxIterations: 1
+    AbsoluteResidual: 1e-14
+    RelativeResidual: 0
+  Verbosity: Verbose
+
+Preconditioner:
+  RelaxationParameter: 0.2857142857142857
+  Iterations: 2
+
+ConvergenceReason: AbsoluteResidual

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.cpp
@@ -29,6 +29,7 @@ struct Metavariables {
 
   using linear_solver = LinearSolver::Richardson::Richardson<
       typename helpers_distributed::fields_tag, ParallelRichardson>;
+  using preconditioner = void;
 
   using component_list = helpers_distributed::component_list<Metavariables>;
   using observed_reduction_data_tags =

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Test_Tags.cpp
@@ -58,6 +58,8 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Tags",
       "LinearOrthogonalizationHistory(Tag)");
   TestHelpers::db::test_prefix_tag<
       LinearSolver::Tags::KrylovSubspaceBasis<Tag>>("KrylovSubspaceBasis(Tag)");
+  TestHelpers::db::test_prefix_tag<LinearSolver::Tags::Preconditioned<Tag>>(
+      "Preconditioned(Tag)");
   TestHelpers::db::test_simple_tag<
       LinearSolver::Tags::ConvergenceCriteria<TestOptionsGroup>>(
       "ConvergenceCriteria(TestLinearSolver)");


### PR DESCRIPTION
## Proposed changes

Preconditioning an iterative linear solve Ax=b means approximately solving the linear problem in each iteration to help the linear solve converge. This PR adds support for preconditioning to the parallel GMRES linear solver. It tests preconditioning by running a few Richardson steps in each GMRES iteration for both the serial as well as the parallel GMRES linear solver.

Upcoming PRs will add two linear solvers that will primarily be used for preconditioning: A Schwarz solver that decomposes the domain into element-centered subdomains and solves them in parallel, and a Multigrid solver that builds a hierarchy of coarser grids and uses a smoother (such as the Schwarz solver) to solve for coarse-grid corrections to the solution.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
