### PR TITLE
Add extents tag

### DIFF
--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -17,6 +17,7 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/EagerMath/Determinant.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
@@ -105,6 +106,14 @@ struct Element : db::SimpleTag {
 template <size_t VolumeDim>
 struct Mesh : db::SimpleTag {
   using type = ::Mesh<VolumeDim>;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// \brief The number of grid points in each dimension
+template <size_t Dim>
+struct Extents : db::SimpleTag {
+  using type = ::Index<Dim>;
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/tests/Unit/Domain/Test_Tags.cpp
+++ b/tests/Unit/Domain/Test_Tags.cpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/EagerMath/Determinant.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
@@ -31,6 +32,7 @@ void test_simple_tags() noexcept {
       "InitialRefinementLevels");
   TestHelpers::db::test_simple_tag<Tags::Element<Dim>>("Element");
   TestHelpers::db::test_simple_tag<Tags::Mesh<Dim>>("Mesh");
+  TestHelpers::db::test_simple_tag<Tags::Extents<Dim>>("Extents");
   TestHelpers::db::test_simple_tag<Tags::ElementMap<Dim>>(
       "ElementMap(Inertial)");
   TestHelpers::db::test_simple_tag<Tags::ElementMap<Dim, Frame::Grid>>(


### PR DESCRIPTION
## Proposed changes

Tag to store only the number of grid points in each dimension.
Useful for code that is agnostic to the Mesh and only needs to know
its extents. An example is the Schwarz linear solver that handles
overlaps with neighbors but doesn't need to know how those grid
points are laid out.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
