### PR TITLE
Add support for Burgers evolutions from analytic data

### DIFF
--- a/src/Evolution/Executables/Burgers/CMakeLists.txt
+++ b/src/Evolution/Executables/Burgers/CMakeLists.txt
@@ -17,10 +17,17 @@ set(LIBS_TO_LINK
   Utilities
   )
 
-add_spectre_parallel_executable(
-  EvolveBurgers
-  EvolveBurgers
-  Evolution/Executables/Burgers
-  EvolutionMetavars
-  "${LIBS_TO_LINK}"
+function(add_burgers_executable EXECUTABLE_NAME INITIAL_DATA)
+  add_spectre_parallel_executable(
+    "Evolve${EXECUTABLE_NAME}"
+    EvolveBurgers
+    Evolution/Executables/Burgers
+    "EvolutionMetavars<${INITIAL_DATA}>"
+    "${LIBS_TO_LINK}"
+    )
+endfunction(add_burgers_executable)
+
+add_burgers_executable(
+  Step
+  Burgers::Solutions::Step
   )

--- a/src/Evolution/Executables/Burgers/CMakeLists.txt
+++ b/src/Evolution/Executables/Burgers/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(LIBS_TO_LINK
   Burgers
+  BurgersAnalyticData
   BurgersSolutions
   DiscontinuousGalerkin
   DomainCreators

--- a/src/Evolution/Executables/Burgers/EvolveBurgersFwd.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgersFwd.hpp
@@ -3,4 +3,17 @@
 
 #pragma once
 
+namespace Burgers {
+namespace AnalyticData {
+class Sinusoid;
+}  // namespace AnalyticData
+
+namespace Solutions {
+class Bump;
+class Linear;
+class Step;
+}  // namespace Solutions
+}  // namespace Burgers
+
+template <typename InitialData>
 struct EvolutionMetavars;

--- a/src/PointwiseFunctions/AnalyticData/Burgers/Sinusoid.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Burgers/Sinusoid.hpp
@@ -7,6 +7,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"  // IWYU pragma: keep
 #include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -86,7 +87,7 @@ namespace AnalyticData {
        return np.asarray(results)
  * \endcode
  */
-class Sinusoid {
+class Sinusoid : public MarkAsAnalyticData {
  public:
   using options = tmpl::list<>;
   static constexpr OptionString help{

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Executable: EvolveBurgers
+# Executable: EvolveStep
 # Check: parse;execute
 
 AnalyticSolution:


### PR DESCRIPTION
## Proposed changes

Updates the Burgers executable to handle evolutions starting from either AnalyticData or AnalyticSolutions, as is done in other systems.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

