### PR TITLE
Cce weyl time transform

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -160,6 +160,20 @@
       SLACcitation   = "%%CITATION = GR-QC/9801070;%%"
 }
 
+@article{Boyle:2015nqa,
+  author =       "Boyle, Michael",
+  title =        "{Transformations of asymptotic gravitational-wave data}",
+  eprint =       "1509.00862",
+  archivePrefix ="arXiv",
+  primaryClass = "gr-qc",
+  doi =          "10.1103/PhysRevD.93.084031",
+  journal =      "Phys.Rev.D",
+  volume =       "93",
+  number =       "8",
+  pages =        "084031",
+  year =         "2016"
+}
+
 @article{Boyle2019kee,
       author         = "Boyle, Michael and others",
       title          = "{The SXS Collaboration catalog of binary black hole

--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -56,22 +56,22 @@ struct EvolutionMetavars {
 
   using scri_values_to_observe =
       tmpl::list<Cce::Tags::News, Cce::Tags::ScriPlus<Cce::Tags::Strain>,
-                 Cce::Tags::ScriPlus<Cce::Tags::Psi0>,
-                 Cce::Tags::ScriPlus<Cce::Tags::Psi1>,
-                 Cce::Tags::ScriPlus<Cce::Tags::Psi2>,
                  Cce::Tags::ScriPlus<Cce::Tags::Psi3>,
-                 Tags::Multiplies<Cce::Tags::Du<Cce::Tags::TimeIntegral<
-                                      Cce::Tags::ScriPlus<Cce::Tags::Psi4>>>,
-                                  Cce::Tags::ScriPlusFactor<Cce::Tags::Psi4>>>;
+                 Cce::Tags::ScriPlus<Cce::Tags::Psi2>,
+                 Cce::Tags::ScriPlus<Cce::Tags::Psi1>,
+                 Cce::Tags::ScriPlus<Cce::Tags::Psi0>,
+                 Cce::Tags::Du<Cce::Tags::TimeIntegral<
+                     Cce::Tags::ScriPlus<Cce::Tags::Psi4>>>,
+                 Cce::Tags::EthInertialRetardedTime>;
 
   using cce_scri_tags =
       tmpl::list<Cce::Tags::News, Cce::Tags::ScriPlus<Cce::Tags::Strain>,
-                 Cce::Tags::ScriPlus<Cce::Tags::Psi0>,
-                 Cce::Tags::ScriPlus<Cce::Tags::Psi1>,
-                 Cce::Tags::ScriPlus<Cce::Tags::Psi2>,
                  Cce::Tags::ScriPlus<Cce::Tags::Psi3>,
+                 Cce::Tags::ScriPlus<Cce::Tags::Psi2>,
+                 Cce::Tags::ScriPlus<Cce::Tags::Psi1>,
+                 Cce::Tags::ScriPlus<Cce::Tags::Psi0>,
                  Cce::Tags::TimeIntegral<Cce::Tags::ScriPlus<Cce::Tags::Psi4>>,
-                 Cce::Tags::ScriPlusFactor<Cce::Tags::Psi4>>;
+                 Cce::Tags::EthInertialRetardedTime>;
   using cce_integrand_tags = tmpl::flatten<tmpl::transform<
       Cce::bondi_hypersurface_step_tags,
       tmpl::bind<Cce::integrand_terms_to_compute_for_bondi_variable,

--- a/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.cpp
+++ b/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.cpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp"
+
+namespace Cce::Actions::detail {
+void correct_weyl_scalars_for_inertial_time(
+    const gsl::not_null<Variables<weyl_correction_list>*>
+        weyl_correction_variables) noexcept {
+  const auto& psi_4 =
+      get<Tags::Du<Tags::TimeIntegral<Tags::ScriPlus<Tags::Psi4>>>>(
+          *weyl_correction_variables);
+  auto& psi_3 = get<Tags::ScriPlus<Tags::Psi3>>(*weyl_correction_variables);
+  auto& psi_2 = get<Tags::ScriPlus<Tags::Psi2>>(*weyl_correction_variables);
+  auto& psi_1 = get<Tags::ScriPlus<Tags::Psi1>>(*weyl_correction_variables);
+  auto& psi_0 = get<Tags::ScriPlus<Tags::Psi0>>(*weyl_correction_variables);
+  // note the variable `eth_u` corresponds to $\eth u^\prime$ in the
+  // documentation
+  const auto& eth_u =
+      get<Tags::EthInertialRetardedTime>(*weyl_correction_variables);
+  get(psi_0) += 2.0 * get(eth_u) * get(psi_1) +
+               0.75 * square(get(eth_u)) * get(psi_2) +
+               0.5 * pow<3>(get(eth_u)) * get(psi_3) +
+               0.0625 * pow<4>(get(eth_u)) * get(psi_4);
+  get(psi_1) += 1.5 * get(eth_u) * get(psi_2) +
+                0.75 * square(get(eth_u)) * get(psi_3) +
+                0.125 * pow<3>(get(eth_u)) * get(psi_4);
+  get(psi_2) +=
+      get(eth_u) * get(psi_3) + 0.25 * square(get(eth_u)) * get(psi_4);
+  get(psi_3) += 0.5 * get(eth_u) * get(psi_4);
+}
+}  // namespace Cce::Actions::detail

--- a/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp
+++ b/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp
@@ -26,6 +26,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
+namespace Actions {
 namespace detail {
 // Provide a nicer name for the output h5 files for some of the uglier
 // combinations we need
@@ -35,19 +36,23 @@ struct ScriOutput {
 };
 template <typename Tag>
 struct ScriOutput<Tags::ScriPlus<Tag>> {
-  static std::string name() noexcept {
-    return pretty_type::short_name<Tag>();
-  }
+  static std::string name() noexcept { return pretty_type::short_name<Tag>(); }
 };
 template <>
-struct ScriOutput<::Tags::Multiplies<
-  Tags::Du<Tags::TimeIntegral<Tags::ScriPlus<Tags::Psi4>>>,
-  Tags::ScriPlusFactor<Tags::Psi4>>> {
+struct ScriOutput<Tags::Du<Tags::TimeIntegral<Tags::ScriPlus<Tags::Psi4>>>> {
   static std::string name() noexcept { return "Psi4"; }
 };
-}  // namespace detail
 
-namespace Actions {
+using weyl_correction_list =
+    tmpl::list<Tags::Du<Tags::TimeIntegral<Tags::ScriPlus<Tags::Psi4>>>,
+               Tags::ScriPlus<Tags::Psi3>, Tags::ScriPlus<Tags::Psi2>,
+               Tags::ScriPlus<Tags::Psi1>, Tags::ScriPlus<Tags::Psi0>,
+               Tags::EthInertialRetardedTime>;
+
+void correct_weyl_scalars_for_inertial_time(
+    gsl::not_null<Variables<weyl_correction_list>*>
+        weyl_correction_variables) noexcept;
+}  // namespace detail
 
 /*!
  * \ingroup ActionsGroup
@@ -59,6 +64,32 @@ namespace Actions {
  * interpolations of all requested scri quantities (determined by
  * `scri_values_to_observe` in the metavariables), and write them to disk using
  * `observers::threadedActions::WriteSimpleData`.
+ *
+ * \note This action also uses the `Tags::EthInertialRetardedTime`, interpolated
+ * to the inertial frame, to perform the coordinate transformations presented in
+ * \cite Boyle:2015nqa to the Weyl scalars after interpolation. For our
+ * formulas, we need to adjust the signs and factors of two to be compatible
+ * with our definitions of \f$\eth\f$ and choice of Newman-Penrose tetrad.
+ *
+ * \f{align*}{
+ * \Psi_0^{\prime (5)}
+ * =&  \Psi_0^{(5)} + 2 \eth u^\prime \Psi_1^{(4)}
+ * + \frac{3}{4} \left(\eth u^\prime\right)^2 \Psi_2^{(3)}
+ * + \frac{1}{2} \left( \eth u^\prime\right)^3  \Psi_3^{(2)}
+ * + \frac{1}{16} \left(\eth u^\prime\right)^4 \Psi_4^{(1)}, \\
+ * \Psi_1^{\prime (4)}
+ * =&  \Psi_1^{(4)} + \frac{3}{2} \eth u^\prime \Psi_2^{(3)}
+ * + \frac{3}{4} \left(\eth u^\prime\right)^2  \Psi_3^{(2)}
+ * + \frac{1}{8} \left(\eth u^\prime\right)^3 \Psi_4^{(1)}, \\
+ * \Psi_2^{\prime (3)}
+ * =&  \Psi_2^{(3)}
+ * + \eth u^\prime  \Psi_3^{(2)}
+ * + \frac{1}{4} \left(\eth  u^\prime\right)^2 \Psi_4^{(1)}, \\
+ * \Psi_3^{\prime (2)}
+ * =& \Psi_3^{(2)} + \frac{1}{2} \eth u^{\prime} \Psi_4^{ (1)}, \\
+ * \Psi_4^{\prime (1)}
+ * =& \Psi_4^{(1)}.
+ * \f}
  *
  * \ref DataBoxGroup changes:
  * - Adds: nothing
@@ -81,27 +112,36 @@ struct ScriObserveInterpolated {
     const size_t observation_l_max = db::get<Tags::ObservationLMax>(box);
     const size_t l_max = db::get<Tags::LMax>(box);
     std::vector<double> data_to_write(2 * square(observation_l_max + 1) + 1);
+    ComplexModalVector goldberg_modes{square(l_max + 1)};
     std::vector<std::string> file_legend;
     file_legend.reserve(2 * square(observation_l_max + 1) + 1);
     file_legend.emplace_back("time");
     for (int i = 0; i <= static_cast<int>(observation_l_max); ++i) {
-      for(int j = -i; j <= i; ++j) {
+      for (int j = -i; j <= i; ++j) {
         file_legend.push_back(MakeString{} << "Real Y_" << i << "," << j);
         file_legend.push_back(MakeString{} << "Imag Y_" << i << "," << j);
       }
     }
-    auto observer_proxy =
-        Parallel::get_parallel_component<ObserverWriterComponent>(
-            cache)[static_cast<size_t>(Parallel::my_node())];
+    // alternative for the coordinate transformation getting scri+ values of the
+    // weyl scalars:
+    // need to obtain the eth of the inertial retarded time, each of the Weyl
+    // scalars, and then we'll perform a transformation on that temporary
+    // variables object, then output.
+    // it won't be as general, but that's largely fine. The main frustration is
+    // the loss of precision.
+    Variables<detail::weyl_correction_list> corrected_scri_plus_weyl{
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+
     while (
         db::get<Tags::InterpolationManager<
             ComplexDataVector,
             tmpl::front<typename Metavariables::scri_values_to_observe>>>(box)
             .first_time_is_ready_to_interpolate()) {
-      tmpl::for_each<typename Metavariables::scri_values_to_observe>([
-        &box, &data_to_write, &observer_proxy, &file_legend, &observation_l_max,
-        &l_max
-      ](auto tag_v) noexcept {
+      // first get the weyl scalars and correct them
+      double interpolation_time = 0.0;
+      tmpl::for_each<detail::weyl_correction_list>([&interpolation_time,
+                                                    &corrected_scri_plus_weyl,
+                                                    &box](auto tag_v) noexcept {
         using tag = typename decltype(tag_v)::type;
         std::pair<double, ComplexDataVector> interpolation;
         db::mutate<Tags::InterpolationManager<ComplexDataVector, tag>>(
@@ -113,26 +153,86 @@ struct ScriObserveInterpolated {
               interpolation =
                   interpolation_manager->interpolate_and_pop_first_time();
             });
-        // swsh transform
-        const auto to_transform =
-            SpinWeighted<ComplexDataVector, tag::type::type::spin>{
-                interpolation.second};
-        const ComplexModalVector goldberg_modes =
-            Spectral::Swsh::libsharp_to_goldberg_modes(
-                Spectral::Swsh::swsh_transform(l_max, 1, to_transform), l_max)
-                .data();
-
-        data_to_write[0] = interpolation.first;
-        for(size_t i = 0; i < square(observation_l_max + 1); ++i) {
-          data_to_write[2 * i + 1] = real(goldberg_modes[i]);
-          data_to_write[2 * i + 2] = imag(goldberg_modes[i]);
-        }
-        Parallel::threaded_action<observers::ThreadedActions::WriteSimpleData>(
-            observer_proxy, file_legend, data_to_write,
-            "/" + ::Cce::detail::ScriOutput<tag>::name());
+        interpolation_time = interpolation.first;
+        get(get<tag>(corrected_scri_plus_weyl)).data() = interpolation.second;
       });
+
+      detail::correct_weyl_scalars_for_inertial_time(
+          make_not_null(&corrected_scri_plus_weyl));
+
+      // then output each of them
+      tmpl::for_each<detail::weyl_correction_list>(
+          [&data_to_write, &corrected_scri_plus_weyl, &interpolation_time,
+           &file_legend, &observation_l_max, &l_max, &cache,
+           &goldberg_modes](auto tag_v) noexcept {
+            using tag = typename decltype(tag_v)::type;
+            if constexpr (tmpl::list_contains_v<
+                              typename Metavariables::scri_values_to_observe,
+                              tag>) {
+              ScriObserveInterpolated::transform_and_write<
+                  tag, tag::type::type::spin>(
+                  get(get<tag>(corrected_scri_plus_weyl)).data(),
+                  interpolation_time, make_not_null(&goldberg_modes),
+                  make_not_null(&data_to_write), file_legend, l_max,
+                  observation_l_max, cache);
+            }
+          });
+
+      // then do the interpolation and output of each of the rest of the tags.
+      tmpl::for_each<
+          tmpl::list_difference<typename Metavariables::scri_values_to_observe,
+                                detail::weyl_correction_list>>(
+          [&box, &data_to_write, &file_legend, &observation_l_max, &l_max,
+           &cache, &goldberg_modes](auto tag_v) noexcept {
+            using tag = typename decltype(tag_v)::type;
+            std::pair<double, ComplexDataVector> interpolation;
+            db::mutate<Tags::InterpolationManager<ComplexDataVector, tag>>(
+                make_not_null(&box),
+                [&interpolation](
+                    const gsl::not_null<
+                        ScriPlusInterpolationManager<ComplexDataVector, tag>*>
+                        interpolation_manager) {
+                  interpolation =
+                      interpolation_manager->interpolate_and_pop_first_time();
+                });
+            ScriObserveInterpolated::transform_and_write<tag,
+                                                         tag::type::type::spin>(
+                interpolation.second, interpolation.first,
+                make_not_null(&goldberg_modes), make_not_null(&data_to_write),
+                file_legend, l_max, observation_l_max, cache);
+          });
     }
     return std::forward_as_tuple(std::move(box));
+  }
+
+ private:
+  template <typename Tag, int Spin, typename Metavariables>
+  static void transform_and_write(
+      const ComplexDataVector& data, const double time,
+      const gsl::not_null<ComplexModalVector*> goldberg_mode_buffer,
+      const gsl::not_null<std::vector<double>*> data_to_write_buffer,
+      const std::vector<std::string>& legend, const size_t l_max,
+      const size_t observation_l_max,
+      Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
+    const SpinWeighted<ComplexDataVector, Spin> to_transform;
+    make_const_view(make_not_null(&to_transform.data()), data, 0, data.size());
+    SpinWeighted<ComplexModalVector, Spin> goldberg_modes;
+    goldberg_modes.set_data_ref(goldberg_mode_buffer);
+    Spectral::Swsh::libsharp_to_goldberg_modes(
+        make_not_null(&goldberg_modes),
+        Spectral::Swsh::swsh_transform(l_max, 1, to_transform), l_max);
+
+    (*data_to_write_buffer)[0] = time;
+    for (size_t i = 0; i < square(observation_l_max + 1); ++i) {
+      (*data_to_write_buffer)[2 * i + 1] = real(goldberg_modes.data()[i]);
+      (*data_to_write_buffer)[2 * i + 2] = imag(goldberg_modes.data()[i]);
+    }
+    auto observer_proxy =
+        Parallel::get_parallel_component<ObserverWriterComponent>(
+            cache)[static_cast<size_t>(Parallel::my_node())];
+    Parallel::threaded_action<observers::ThreadedActions::WriteSimpleData>(
+        observer_proxy, legend, *data_to_write_buffer,
+        "/" + detail::ScriOutput<Tag>::name());
   }
 };
 }  // namespace Actions

--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Actions/ScriObserveInterpolated.cpp
   AnalyticBoundaryDataManager.cpp
   BoundaryData.cpp
   Equations.cpp

--- a/src/Evolution/Systems/Cce/ScriPlusValues.cpp
+++ b/src/Evolution/Systems/Cce/ScriPlusValues.cpp
@@ -90,28 +90,11 @@ void CalculateScriPlusValue<Tags::TimeIntegral<Tags::ScriPlus<Tags::Psi4>>>::
                   number_of_angular_points);
 
   get(*integral_of_psi_4) =
-      get(boundary_r) *
+      2.0 * get(boundary_r) *
       ((conj(eth_dy_u_at_scri) +
         conj(eth_r_divided_by_r_view) * conj(dy_u_at_scri)) +
        conj(dy_du_j_at_scri)) /
       exp_2_beta_at_scri;
-}
-
-void CalculateScriPlusValue<Tags::ScriPlusFactor<Tags::Psi4>>::apply(
-    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
-        scri_plus_factor,
-    const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta,
-    const size_t l_max, const size_t number_of_radial_points) noexcept {
-  const size_t number_of_angular_points =
-      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
-
-  const SpinWeighted<ComplexDataVector, 0> exp_2_beta_at_scri;
-  make_const_view(make_not_null(&exp_2_beta_at_scri), get(exp_2_beta),
-                  (number_of_radial_points - 1) * number_of_angular_points,
-                  number_of_angular_points);
-
-  // extra factor of 2 for tetrad matching to SXS conventions
-  get(*scri_plus_factor) = 2.0 / exp_2_beta_at_scri;
 }
 
 void CalculateScriPlusValue<Tags::ScriPlus<Tags::Psi3>>::apply(

--- a/src/Evolution/Systems/Cce/ScriPlusValues.cpp
+++ b/src/Evolution/Systems/Cce/ScriPlusValues.cpp
@@ -363,6 +363,15 @@ void CalculateScriPlusValue<Tags::ScriPlus<Tags::Strain>>::apply(
       conj(-2.0 * get(boundary_r) * dy_j_at_scri + get(eth_eth_retarded_time));
 }
 
+void CalculateScriPlusValue<Tags::EthInertialRetardedTime>::apply(
+    gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*>
+        eth_inertial_time,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& inertial_time,
+    const size_t l_max) noexcept {
+  Spectral::Swsh::angular_derivatives<tmpl::list<Spectral::Swsh::Tags::Eth>>(
+      l_max, 1, make_not_null(&get(*eth_inertial_time)), get(inertial_time));
+}
+
 void CalculateScriPlusValue<::Tags::dt<Tags::InertialRetardedTime>>::apply(
     const gsl::not_null<Scalar<DataVector>*> dt_inertial_time,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta) noexcept {

--- a/src/Evolution/Systems/Cce/ScriPlusValues.hpp
+++ b/src/Evolution/Systems/Cce/ScriPlusValues.hpp
@@ -409,6 +409,21 @@ struct CalculateScriPlusValue<::Tags::dt<Tags::InertialRetardedTime>> {
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta) noexcept;
 };
 
+/// Determines the angular derivative of the asymptotic inertial time, useful
+/// for asymptotic coordinate transformations.
+template <>
+struct CalculateScriPlusValue<Tags::EthInertialRetardedTime> {
+  using return_tags = tmpl::list<Tags::EthInertialRetardedTime>;
+  using argument_tags =
+      tmpl::list<Tags::ComplexInertialRetardedTime, Tags::LMax>;
+
+  static void apply(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*>
+          eth_inertial_time,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& inertial_time,
+      size_t l_max) noexcept;
+};
+
 /// Initialize the \f$\mathcal I^+\f$ value `Tag` for the first hypersurface.
 template <typename Tag>
 struct InitializeScriPlusValue;

--- a/src/Evolution/Systems/Cce/ScriPlusValues.hpp
+++ b/src/Evolution/Systems/Cce/ScriPlusValues.hpp
@@ -61,15 +61,21 @@ struct CalculateScriPlusValue<Tags::News> {
  * has the form
  *
  * \f{align*}{
- * \Psi_4^{(1)} = A \partial_u B,
+ * \Psi_4^{(1)} = \partial_{u_{\text{inertial}}} B,
  * \f}
  *
  * where superscripts denote orders in the expansion in powers of \f$r^{-1}\f$.
  * This mutator computes \f$B\f$:
  *
  * \f{align*}{
- * B = e^{-2 \beta^{(0)}} (\bar \eth \bar U^{(1)} + \partial_u \bar J)
+ * B = 2 e^{-2 \beta^{(0)}} (\bar \eth \bar U^{(1)} + \partial_u \bar J^{(1)})
  * \f}
+ *
+ * and the time derivative that appears the original equation obeys,
+ *
+ * \f[
+ * \partial_{u_{\text{inertial}}} = e^{-2 \beta} \partial_u
+ * \f]
  */
 template <>
 struct CalculateScriPlusValue<Tags::TimeIntegral<Tags::ScriPlus<Tags::Psi4>>> {
@@ -99,38 +105,6 @@ struct CalculateScriPlusValue<Tags::TimeIntegral<Tags::ScriPlus<Tags::Psi4>>> {
       size_t l_max, size_t number_of_radial_points) noexcept;
 };
 
-/*!
- * \brief Compute the contribution to the leading \f$\Psi_4\f$ that multiplies
- * the total time derivative
- *
- * \details The value \f$\Psi_4\f$ scales asymptotically as \f$r^{-1}\f$, and
- * has the form
- *
- * \f{align*}{
- * \Psi_4^{(1)} = A \partial_u B,
- * \f}
- *
- * where superscripts denote orders in the expansion in powers of \f$r^{-1}\f$.
- * This mutator computes \f$A\f$:
- *
- * \f{align*}{
- * A = e^{-2 \beta^{(0)}}
- * \f}
- */
-template <>
-struct CalculateScriPlusValue<Tags::ScriPlusFactor<Tags::Psi4>> {
-  using return_tags = tmpl::list<Tags::ScriPlusFactor<Tags::Psi4>>;
-  // extra typelist for more convenient testing
-  using tensor_argument_tags = tmpl::list<Tags::Exp2Beta>;
-  using argument_tags = tmpl::push_back<tensor_argument_tags, Tags::LMax,
-                                        Tags::NumberOfRadialPoints>;
-
-  static void apply(
-      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
-          scri_plus_factor,
-      const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta,
-      size_t l_max, size_t number_of_radial_points) noexcept;
-};
 
 /*!
  * \brief Computes the leading part of \f$\Psi_3\f$ near \f$\mathcal I^+\f$.

--- a/src/Evolution/Systems/Cce/ScriPlusValues.hpp
+++ b/src/Evolution/Systems/Cce/ScriPlusValues.hpp
@@ -11,6 +11,15 @@
 
 namespace Cce {
 
+/// The tags that are needed to be interpolated at scri+ for the available
+/// observation tags.
+using scri_plus_interpolation_set =
+    tmpl::list<Tags::News, Tags::ScriPlus<Tags::Strain>,
+               Tags::ScriPlus<Tags::Psi3>, Tags::ScriPlus<Tags::Psi2>,
+               Tags::ScriPlus<Tags::Psi1>, Tags::ScriPlus<Tags::Psi0>,
+               Tags::Du<Tags::TimeIntegral<Tags::ScriPlus<Tags::Psi4>>>,
+               Tags::EthInertialRetardedTime>;
+
 template <typename Tag>
 struct CalculateScriPlusValue;
 

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -179,6 +179,12 @@ struct InertialRetardedTime : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
+/// Represents \f$\eth u_{\rm inertial}\f$, which is a useful quantity for
+/// asymptotic coordinate transformations.
+struct EthInertialRetardedTime : db::SimpleTag {
+  using type = Scalar<SpinWeighted<ComplexDataVector, 1>>;
+};
+
 /// Complex storage form for the asymptotically inertial retarded time, for
 /// taking spin-weighted derivatives
 struct ComplexInertialRetardedTime : db::SimpleTag {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.py
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.py
@@ -1,0 +1,81 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def compute_News(linear_coefficient, quadratic_coefficient, time,
+                 news_coefficient, _1, _2, _3, _4, _5, _6):
+    return news_coefficient * (1.0 + linear_coefficient * time +
+                               quadratic_coefficient * time**2)
+
+
+def compute_EthInertialRetardedTime(linear_coefficient, quadratic_coefficient,
+                                    time, _1, _2, _3, _4, _5, _6,
+                                    eth_u_coefficient):
+    return eth_u_coefficient * (1.0 + linear_coefficient * time +
+                                quadratic_coefficient * time**2)
+
+
+def compute_Du_TimeIntegral_ScriPlus_Psi4(linear_coefficient,
+                                          quadratic_coefficient, time, _1, _2,
+                                          _3, _4, _5, psi4_coefficient, _6):
+    return psi4_coefficient * (linear_coefficient +
+                               2.0 * quadratic_coefficient * time)
+
+
+def compute_ScriPlus_Psi3(linear_coefficient, quadratic_coefficient, time, _1,
+                          psi3_coefficient, _2, _3, _4, psi4_coefficient,
+                          eth_u_coefficient):
+    time_factor = (1.0 + linear_coefficient * time +
+                   quadratic_coefficient * time**2)
+    psi4 = psi4_coefficient * (linear_coefficient +
+                               2.0 * quadratic_coefficient * time)
+    psi3 = psi3_coefficient * time_factor
+    eth_u = eth_u_coefficient * time_factor
+    return psi3 + 0.5 * eth_u * psi4
+
+
+def compute_ScriPlus_Psi2(linear_coefficient, quadratic_coefficient, time, _1,
+                          psi3_coefficient, psi2_coefficient, _2, _3,
+                          psi4_coefficient, eth_u_coefficient):
+    time_factor = (1.0 + linear_coefficient * time +
+                   quadratic_coefficient * time**2)
+    psi4 = psi4_coefficient * (linear_coefficient +
+                               2.0 * quadratic_coefficient * time)
+    psi3 = psi3_coefficient * time_factor
+    psi2 = psi2_coefficient * time_factor
+    eth_u = eth_u_coefficient * time_factor
+    return psi2 + psi3 * eth_u + 0.25 * psi4 * eth_u**2
+
+
+def compute_ScriPlus_Psi1(linear_coefficient, quadratic_coefficient, time, _1,
+                          psi3_coefficient, psi2_coefficient, psi1_coefficient,
+                          _2, psi4_coefficient, eth_u_coefficient):
+    time_factor = (1.0 + linear_coefficient * time +
+                   quadratic_coefficient * time**2)
+    psi4 = psi4_coefficient * (linear_coefficient +
+                               2.0 * quadratic_coefficient * time)
+    psi3 = psi3_coefficient * time_factor
+    psi2 = psi2_coefficient * time_factor
+    psi1 = psi1_coefficient * time_factor
+    eth_u = eth_u_coefficient * time_factor
+    return psi1 + 1.5 * psi2 * eth_u + 0.75 * psi3 * eth_u**2 \
+        + 0.125 * psi4 * eth_u**3
+
+
+def compute_ScriPlus_Psi0(linear_coefficient, quadratic_coefficient, time, _1,
+                          psi3_coefficient, psi2_coefficient, psi1_coefficient,
+                          psi0_coefficient, psi4_coefficient,
+                          eth_u_coefficient):
+    time_factor = (1.0 + linear_coefficient * time +
+                   quadratic_coefficient * time**2)
+    psi4 = psi4_coefficient * (linear_coefficient +
+                               2.0 * quadratic_coefficient * time)
+    psi3 = psi3_coefficient * time_factor
+    psi2 = psi2_coefficient * time_factor
+    psi1 = psi1_coefficient * time_factor
+    psi0 = psi0_coefficient * time_factor
+    eth_u = eth_u_coefficient * time_factor
+    return psi0 + 2.0 * psi1 * eth_u + 0.75 * psi2 * eth_u**2 \
+        + 0.5 * psi3 * eth_u**3 + 0.0625 * psi4 * eth_u**4

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -3,6 +3,8 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <boost/algorithm/string/erase.hpp>
+#include <boost/algorithm/string/replace.hpp>
 #include <cstddef>
 #include <limits>
 #include <memory>
@@ -19,9 +21,12 @@
 #include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
 #include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
+#include "Helpers/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp"
 #include "IO/Observer/Initialize.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
@@ -49,12 +54,12 @@ struct SetBoundaryValues {
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     ComplexDataVector set_values) noexcept {
-    db::mutate<Tag>(
-        make_not_null(&box), [&set_values](
-                                 const gsl::not_null<db::item_type<Tag>*>
-                                     spin_weighted_scalar_quantity) noexcept {
-          get(*spin_weighted_scalar_quantity).data() = std::move(set_values);
-        });
+    db::mutate<Tag>(make_not_null(&box),
+                    [&set_values](const gsl::not_null<db::item_type<Tag>*>
+                                      spin_weighted_scalar_quantity) noexcept {
+                      get(*spin_weighted_scalar_quantity).data() =
+                          std::move(set_values);
+                    });
   }
 
   template <
@@ -66,9 +71,9 @@ struct SetBoundaryValues {
                     const ArrayIndex& /*array_index*/,
                     DataVector set_values) noexcept {
     db::mutate<Tag>(
-        make_not_null(&box), [&set_values](
-                                 const gsl::not_null<db::item_type<Tag>*>
-                                     scalar_quantity) noexcept {
+        make_not_null(&box),
+        [&set_values](
+            const gsl::not_null<db::item_type<Tag>*> scalar_quantity) noexcept {
           get(*scalar_quantity) = std::move(set_values);
         });
   }
@@ -123,7 +128,9 @@ struct mock_characteristic_evolution {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Evolve,
           tmpl::list<
-              Actions::InsertInterpolationScriData<Tags::News>,
+              tmpl::transform<
+                  typename Metavariables::scri_values_to_observe,
+                  tmpl::bind<Actions::InsertInterpolationScriData, tmpl::_1>>,
               Actions::ScriObserveInterpolated<mock_observer<Metavariables>>,
               ::Actions::AdvanceTime>>>;
 };
@@ -159,9 +166,19 @@ struct test_metavariables {
   using cce_transform_buffer_tags = all_transform_buffer_tags;
   using cce_swsh_derivative_tags = all_swsh_derivative_tags;
   using cce_angular_coordinate_tags = tmpl::list<Tags::CauchyAngularCoords>;
-  using cce_scri_tags = tmpl::list<Cce::Tags::News>;
+  using cce_scri_tags =
+      tmpl::list<Tags::News, Tags::ScriPlus<Tags::Psi3>,
+                 Tags::ScriPlus<Tags::Psi2>, Tags::ScriPlus<Tags::Psi1>,
+                 Tags::ScriPlus<Tags::Psi0>,
+                 Tags::TimeIntegral<Tags::ScriPlus<Tags::Psi4>>,
+                 Tags::EthInertialRetardedTime>;
 
-  using scri_values_to_observe = tmpl::list<Cce::Tags::News>;
+  using scri_values_to_observe =
+      tmpl::list<Tags::News, Tags::ScriPlus<Tags::Psi3>,
+                 Tags::ScriPlus<Tags::Psi2>, Tags::ScriPlus<Tags::Psi1>,
+                 Tags::ScriPlus<Tags::Psi0>,
+                 Tags::Du<Tags::TimeIntegral<Tags::ScriPlus<Tags::Psi4>>>,
+                 Tags::EthInertialRetardedTime>;
 
   using observed_reduction_data_tags = tmpl::list<>;
 
@@ -172,18 +189,41 @@ struct test_metavariables {
 };
 }  // namespace
 
+template <typename TagToCalculate, typename... Tags>
+ComplexDataVector compute_expected_field_from_pypp(
+    const Variables<tmpl::list<Tags...>>& random_values,
+    const double linear_coefficient, const double quadratic_coefficient,
+    const double time, TagToCalculate /*meta*/) noexcept {
+  const size_t size = random_values.number_of_grid_points();
+  Scalar<DataVector> linear_coefficient_vector;
+  get(linear_coefficient_vector) = DataVector{size, linear_coefficient};
+  Scalar<DataVector> quadratic_coefficient_vector;
+  get(quadratic_coefficient_vector) = DataVector{size, quadratic_coefficient};
+  Scalar<DataVector> time_vector;
+  get(time_vector) = DataVector{size, time};
+  std::string tag_name = db::tag_name<TagToCalculate>();
+  boost::algorithm::replace_all(tag_name, "(", "_");
+  boost::algorithm::erase_all(tag_name, ")");
+  return get(pypp::call<typename TagToCalculate::type>(
+                 "ScriObserveInterpolated", "compute_" + tag_name,
+                 linear_coefficient_vector, quadratic_coefficient_vector,
+                 time_vector, get<Tags>(random_values)...))
+      .data();
+}
+
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
                   "[Unit][Cce]") {
   using evolution_component = mock_characteristic_evolution<test_metavariables>;
   using observation_component = mock_observer<test_metavariables>;
-
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/Cce/Actions/"};
   MAKE_GENERATOR(gen);
   UniformCustomDistribution<double> value_dist{0.1, 0.5};
   UniformCustomDistribution<double> coefficient_distribution{-2.0, 2.0};
 
-  const size_t number_of_radial_points = 10;
-  const size_t l_max = 8;
-  const size_t observation_l_max = 4;
+  const size_t number_of_radial_points = 6;
+  const size_t l_max = 6;
+  const size_t observation_l_max = 3;
   const size_t scri_output_density = 1;
   const std::string filename = "ScriObserveInterpolatedTest_CceVolumeOutput";
 
@@ -222,26 +262,21 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
       Spectral::Swsh::number_of_swsh_collocation_points(l_max);
   const size_t data_points = 30;
 
-  // random vector based on modes
-  // Generate data uniform in r with all angular modes
-  SpinWeighted<ComplexModalVector, -2> generated_modes;
-  generated_modes.data() = make_with_random_values<ComplexModalVector>(
-      make_not_null(&gen), make_not_null(&coefficient_distribution),
-      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max));
-  for (const auto& mode : Spectral::Swsh::cached_coefficients_metadata(l_max)) {
-    if (mode.l < 2) {
-      generated_modes.data()[mode.transform_of_real_part_offset] = 0.0;
-      generated_modes.data()[mode.transform_of_imag_part_offset] = 0.0;
-    }
-    if (mode.m == 0) {
-      generated_modes.data()[mode.transform_of_real_part_offset] =
-          real(generated_modes.data()[mode.transform_of_real_part_offset]);
-      generated_modes.data()[mode.transform_of_imag_part_offset] =
-          real(generated_modes.data()[mode.transform_of_imag_part_offset]);
-    }
-  }
-  const SpinWeighted<ComplexDataVector, -2> random_vector =
-      Spectral::Swsh::inverse_swsh_transform(l_max, 1, generated_modes);
+  Variables<typename test_metavariables::cce_scri_tags> random_scri_values{
+      vector_size};
+  tmpl::for_each<typename test_metavariables::cce_scri_tags>(
+      [&l_max, &random_scri_values, &gen,
+       &coefficient_distribution](auto tag_v) noexcept {
+        using tag = typename decltype(tag_v)::type;
+        SpinWeighted<ComplexModalVector, tag::type::type::spin> generated_modes{
+            Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+        Spectral::Swsh::TestHelpers::generate_swsh_modes<tag::type::type::spin>(
+            make_not_null(&generated_modes.data()), make_not_null(&gen),
+            make_not_null(&coefficient_distribution), 1, l_max);
+        Spectral::Swsh::inverse_swsh_transform(
+            l_max, 1, make_not_null(&get(get<tag>(random_scri_values))),
+            generated_modes);
+      });
 
   for (size_t i = 0; i < 3 * data_points; ++i) {
     // this will give random times that are nonetheless guaranteed to be
@@ -253,14 +288,24 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
     ActionTesting::simple_action<evolution_component,
                                  SetBoundaryValues<Tags::InertialRetardedTime>>(
         make_not_null(&runner), 0, time_vector);
-    ActionTesting::simple_action<evolution_component,
-                                 SetBoundaryValues<Tags::News>>(
-        make_not_null(&runner), 0,
-        random_vector.data() * (1.0 + linear_coefficient * (time_vector) +
-                                quadratic_coefficient * square(time_vector)));
+    tmpl::for_each<typename test_metavariables::cce_scri_tags>(
+        [&runner, &random_scri_values, &linear_coefficient, &time_vector,
+         &quadratic_coefficient](auto tag_v) noexcept {
+          using tag = typename decltype(tag_v)::type;
+          ActionTesting::simple_action<evolution_component,
+                                       SetBoundaryValues<tag>>(
+              make_not_null(&runner), 0,
+              get(get<tag>(random_scri_values)).data() *
+                  (1.0 + linear_coefficient * (time_vector) +
+                   quadratic_coefficient * square(time_vector)));
+        });
 
     // should put the data we just set into the interpolator
-    ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
+    for (size_t j = 0; j < tmpl::size<test_metavariables::cce_scri_tags>::value;
+         ++j) {
+      ActionTesting::next_action<evolution_component>(make_not_null(&runner),
+                                                      0);
+    }
     // should process the interpolation and write to file
     ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
     ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
@@ -285,27 +330,39 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
   // scoped to close the file
   {
     h5::H5File<h5::AccessType::ReadOnly> read_file{filename + "0.h5"};
-    const auto& dataset = read_file.get<h5::Dat>("/News");
-    const Matrix data_matrix = dataset.get_data();
-    CHECK(data_matrix.rows() > 20);
-    const auto expected_goldberg_modes =
-        Spectral::Swsh::libsharp_to_goldberg_modes(generated_modes, l_max);
-
     Approx interpolation_approx =
         Approx::custom()
-            .epsilon(std::numeric_limits<double>::epsilon() * 1.0e4)
+            .epsilon(std::numeric_limits<double>::epsilon() * 1.0e5)
             .scale(1.0);
-    // skip the first time because the extrapolation will make that value
-    // unreliable
-    for (size_t i = 1; i < data_matrix.rows(); ++i) {
-      for (size_t j = 0; j < square(observation_l_max + 1); ++j) {
-        CHECK(data_matrix(i, 2 * j + 1) ==
-              interpolation_approx(
-                  real(expected_goldberg_modes.data()[j] *
-                       (1.0 + linear_coefficient * data_matrix(i, 0) +
-                        quadratic_coefficient * square(data_matrix(i, 0))))));
-      }
-    }
+    tmpl::for_each<typename test_metavariables::scri_values_to_observe>(
+        [&random_scri_values, &linear_coefficient, &quadratic_coefficient,
+         &l_max, &interpolation_approx, &read_file](auto tag_v) noexcept {
+          using tag = typename decltype(tag_v)::type;
+          const auto& dataset = read_file.get<h5::Dat>(
+              "/" + Actions::detail::ScriOutput<tag>::name());
+          const Matrix data_matrix = dataset.get_data();
+          CHECK(data_matrix.rows() > 20);
+          // skip the first time because the extrapolation will make that value
+          // unreliable
+          INFO(db::tag_name<tag>());
+          for (size_t i = 1; i < data_matrix.rows(); ++i) {
+            SpinWeighted<ComplexDataVector, tag::type::type::spin> expected;
+            expected.data() = compute_expected_field_from_pypp(
+                random_scri_values, linear_coefficient, quadratic_coefficient,
+                data_matrix(i, 0), tag{});
+            const auto expected_goldberg_modes =
+                Spectral::Swsh::libsharp_to_goldberg_modes(
+                    Spectral::Swsh::swsh_transform(l_max, 1, expected), l_max);
+            for (size_t j = 0; j < square(observation_l_max + 1); ++j) {
+              CHECK(data_matrix(i, 2 * j + 1) ==
+                    interpolation_approx(
+                        real(expected_goldberg_modes.data()[j])));
+              CHECK(data_matrix(i, 2 * j + 2) ==
+                    interpolation_approx(
+                        imag(expected_goldberg_modes.data()[j])));
+            }
+          }
+        });
   }
   if (file_system::check_if_file_exists(filename + "0.h5")) {
     file_system::rm(filename + "0.h5", true);

--- a/tests/Unit/Evolution/Systems/Cce/ScriPlusValues.py
+++ b/tests/Unit/Evolution/Systems/Cce/ScriPlusValues.py
@@ -11,12 +11,8 @@ def news(dy_du_bondi_j, beta, eth_beta, eth_eth_beta, boundary_r):
 
 def time_integral_psi_4(exp_2_beta, dy_bondi_u, eth_dy_bondi_u, dy_du_bondi_j,
                         boundary_r, eth_r_divided_by_r):
-    return (boundary_r / exp_2_beta) * np.conj(
+    return 2.0 * (boundary_r / exp_2_beta) * np.conj(
         eth_dy_bondi_u + eth_r_divided_by_r * dy_bondi_u + dy_du_bondi_j)
-
-
-def constant_factor_psi_4(exp_2_beta):
-    return 2.0 / exp_2_beta
 
 
 def psi_3(exp_2_beta, eth_beta, eth_ethbar_beta, ethbar_eth_ethbar_beta,

--- a/tests/Unit/Evolution/Systems/Cce/Test_ScriPlusValues.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_ScriPlusValues.cpp
@@ -110,10 +110,13 @@ void check_inertial_retarded_time_utilities() noexcept {
   const size_t number_of_radial_points = 5;
 
   auto time_box = db::create<db::AddSimpleTags<
-      Tags::InertialRetardedTime, Tags::ComplexInertialRetardedTime,
-      Tags::Exp2Beta, ::Tags::dt<Tags::InertialRetardedTime>>>(
+      Tags::LMax, Tags::InertialRetardedTime, Tags::ComplexInertialRetardedTime,
+      Tags::EthInertialRetardedTime, Tags::Exp2Beta,
+      ::Tags::dt<Tags::InertialRetardedTime>>>(
+           l_max,
       Scalar<DataVector>{number_of_angular_points},
       Scalar<SpinWeighted<ComplexDataVector, 0>>{number_of_angular_points},
+      Scalar<SpinWeighted<ComplexDataVector, 1>>{number_of_angular_points},
       Scalar<SpinWeighted<ComplexDataVector, 0>>{number_of_angular_points *
                                                  number_of_radial_points},
       Scalar<DataVector>{number_of_angular_points});
@@ -154,6 +157,31 @@ void check_inertial_retarded_time_utilities() noexcept {
                    .data()[i + number_of_angular_points *
                                    (number_of_radial_points - 1)]));
   }
+
+  const double random_time_delta = 0.1 * value_dist(gen);
+  const ComplexDataVector expected_retarded_time_intermediate_value =
+      std::complex<double>(1.0, 0.0) *
+      get(db::get<::Tags::dt<Tags::InertialRetardedTime>>(time_box));
+  auto expected_eth_retarded_time =
+      Spectral::Swsh::angular_derivative<Spectral::Swsh::Tags::Eth>(
+          l_max, 1,
+          SpinWeighted<ComplexDataVector, 0>(
+              expected_retarded_time_intermediate_value));
+  expected_eth_retarded_time.data() *= random_time_delta;
+  db::mutate<Tags::ComplexInertialRetardedTime>(
+      make_not_null(&time_box),
+      [&random_time_delta](
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+              complex_retarded_time,
+          const Scalar<DataVector>& dt_inertial_time) noexcept {
+        get(*complex_retarded_time) = std::complex<double>(1.0, 0.0) *
+                                      random_time_delta * get(dt_inertial_time);
+      },
+      db::get<::Tags::dt<Tags::InertialRetardedTime>>(time_box));
+  db::mutate_apply<CalculateScriPlusValue<Tags::EthInertialRetardedTime>>(
+      make_not_null(&time_box));
+  CHECK_ITERABLE_APPROX(expected_eth_retarded_time,
+                        get(db::get<Tags::EthInertialRetardedTime>(time_box)));
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/Cce/Test_ScriPlusValues.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_ScriPlusValues.cpp
@@ -59,13 +59,6 @@ void pypp_test_scri_plus_computation_steps() noexcept {
   pypp::check_with_random_values<1>(
       &WrapScriPlusComputation<
           l_max, number_of_radial_points,
-          CalculateScriPlusValue<Tags::ScriPlusFactor<Tags::Psi4>>>::apply,
-      "ScriPlusValues", {"constant_factor_psi_4"}, {{{0.1, 1.0}}},
-      DataVector{Spectral::Swsh::number_of_swsh_collocation_points(l_max)});
-
-  pypp::check_with_random_values<1>(
-      &WrapScriPlusComputation<
-          l_max, number_of_radial_points,
           CalculateScriPlusValue<Tags::ScriPlus<Tags::Psi3>>>::apply,
       "ScriPlusValues", {"psi_3"}, {{{0.1, 1.0}}},
       DataVector{Spectral::Swsh::number_of_swsh_collocation_points(l_max)});

--- a/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
@@ -44,6 +44,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Tags", "[Unit][Cce]") {
       "InertialRetardedTime");
   TestHelpers::db::test_simple_tag<Cce::Tags::ComplexInertialRetardedTime>(
       "ComplexInertialRetardedTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::EthInertialRetardedTime>(
+      "EthInertialRetardedTime");
   TestHelpers::db::test_simple_tag<Cce::Tags::OneMinusY>("OneMinusY");
   TestHelpers::db::test_simple_tag<Cce::Tags::DuR>("DuR");
   TestHelpers::db::test_simple_tag<Cce::Tags::DuRDividedByR>("DuRDividedByR");


### PR DESCRIPTION
## Proposed changes

Include a missing coordinate transformation to the Weyl scalars, ensuring that their frame is consistent with the asymptotic inertial time that they are interpolated to before being output to the h5.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
