### PR TITLE
Fix finding libsharp when installed by Spack

### DIFF
--- a/cmake/FindLibsharp.cmake
+++ b/cmake/FindLibsharp.cmake
@@ -15,7 +15,7 @@ endif()
 
 # find the libsharp include directory
 find_path(LIBSHARP_INCLUDE_DIRS sharp_cxx.h
-    PATH_SUFFIXES include
+    PATH_SUFFIXES include include/libsharp
     HINTS ${LIBSHARP_ROOT}/include/)
 
 find_library(LIBSHARP_LIBFFTPACK


### PR DESCRIPTION
## Proposed changes

This commit in upstream Spack broke our CI builds on macOS: https://github.com/spack/spack/commit/3896a401db18e0c84984df88ce094a1a601ad743
This PR fixes #2304.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
