### PR TITLE
Convert some compute tags to be mutating

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -253,9 +253,14 @@ struct EuclideanSurfaceIntegral : db::ComputeTag {
   static std::string name() noexcept {
     return "EuclideanSurfaceIntegral(" + db::tag_name<IntegrandTag>() + ")";
   }
-  // return type is `double` so returning by value is OK
-  static constexpr auto function =
-      ::StrahlkorperGr::surface_integral_of_scalar<Frame>;
+  using return_type = double;
+  static void function(const gsl::not_null<double*> surface_integral,
+                       const Scalar<DataVector>& euclidean_area_element,
+                       const Scalar<DataVector>& integrand,
+                       const ::Strahlkorper<Frame>& strahlkorper) noexcept {
+    *surface_integral = ::StrahlkorperGr::surface_integral_of_scalar<Frame>(
+        euclidean_area_element, integrand, strahlkorper);
+  }
   using argument_tags = tmpl::list<EuclideanAreaElement<Frame>, IntegrandTag,
                                    StrahlkorperTags::Strahlkorper<Frame>>;
 };
@@ -272,9 +277,16 @@ struct EuclideanSurfaceIntegralVector : db::ComputeTag {
     return "EuclideanSurfaceIntegralVector(" + db::tag_name<IntegrandTag>() +
            ")";
   }
-  // return type is `double` so returning by value is OK
-  static constexpr auto function =
-      ::StrahlkorperGr::euclidean_surface_integral_of_vector<Frame>;
+  using return_type = double;
+  static void function(const gsl::not_null<double*> surface_integral,
+                       const Scalar<DataVector>& euclidean_area_element,
+                       const tnsr::I<DataVector, 3, Frame>& integrand,
+                       const tnsr::i<DataVector, 3, Frame>& normal_one_form,
+                       const ::Strahlkorper<Frame>& strahlkorper) noexcept {
+    *surface_integral =
+        ::StrahlkorperGr::euclidean_surface_integral_of_vector<Frame>(
+            euclidean_area_element, integrand, normal_one_form, strahlkorper);
+  }
   using argument_tags = tmpl::list<EuclideanAreaElement<Frame>, IntegrandTag,
                                    StrahlkorperTags::NormalOneForm<Frame>,
                                    StrahlkorperTags::Strahlkorper<Frame>>;
@@ -320,8 +332,14 @@ struct SurfaceIntegral : db::ComputeTag {
   static std::string name() noexcept {
     return "SurfaceIntegral(" + db::tag_name<IntegrandTag>() + ")";
   }
-  // return type is `double` so returning by value is OK
-  static constexpr auto function = surface_integral_of_scalar<Frame>;
+  using return_type = double;
+  static void function(const gsl::not_null<double*> surface_integral,
+                       const Scalar<DataVector>& area_element,
+                       const Scalar<DataVector>& integrand,
+                       const ::Strahlkorper<Frame>& strahlkorper) noexcept {
+    *surface_integral = ::StrahlkorperGr::surface_integral_of_scalar<Frame>(
+        area_element, integrand, strahlkorper);
+  }
   using argument_tags = tmpl::list<AreaElement<Frame>, IntegrandTag,
                                    StrahlkorperTags::Strahlkorper<Frame>>;
 };

--- a/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
@@ -13,6 +13,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -408,6 +409,7 @@ auto determinant_and_inverse(
 }
 // @}
 
+// @{
 /*!
  * \ingroup TensorGroup
  * \brief Computes the determinant and inverse of a rank-2 Tensor.
@@ -415,20 +417,17 @@ auto determinant_and_inverse(
  * Computes the determinant and inverse together, because this leads to fewer
  * operations compared to computing the determinant independently.
  *
- * \param tensor the input rank-2 Tensor.
  * \tparam DetTag the Tag for the determinant of input Tensor.
  * \tparam InvTag the Tag for the inverse of input Tensor.
- * \return a `Variables` that holds the determinant and inverse of the input
- * tensor, tagged by `DetTag` and `InvTag` respectively.
  *
  * \details
  * See determinant_and_inverse().
  */
 template <typename DetTag, typename InvTag, typename T, typename Symm,
           typename Index0, typename Index1>
-auto determinant_and_inverse(
-    const Tensor<T, Symm, tmpl::list<Index0, Index1>>& tensor) noexcept
-    -> Variables<tmpl::list<DetTag, InvTag>> {
+void determinant_and_inverse(
+    const gsl::not_null<Variables<tmpl::list<DetTag, InvTag>>*> det_and_inv,
+    const Tensor<T, Symm, tmpl::list<Index0, Index1>>& tensor) noexcept {
   static_assert(std::is_same_v<typename DetTag::type, Scalar<T>>,
                 "Type of first return tag must correspond to that of input's "
                 "determinant.");
@@ -438,9 +437,34 @@ auto determinant_and_inverse(
                             tmpl::list<change_index_up_lo<Index1>,
                                        change_index_up_lo<Index0>>>>,
       "Type of second return tag must correspond to that of input's inverse.");
+  const auto number_of_grid_points = get<0, 0>(tensor).size();
+  if (UNLIKELY(number_of_grid_points != det_and_inv->number_of_grid_points())) {
+    det_and_inv->initialize(number_of_grid_points);
+  }
+  determinant_and_inverse_detail::DetAndInverseImpl<
+      Symm, Index0, Index1>::apply(make_not_null(&get<DetTag>(*det_and_inv)),
+                                   make_not_null(&get<InvTag>(*det_and_inv)),
+                                   tensor);
+}
+
+template <typename DetTag, typename InvTag, typename T, typename Symm,
+          typename Index0, typename Index1>
+auto determinant_and_inverse(
+    const Tensor<T, Symm, tmpl::list<Index0, Index1>>& tensor) noexcept
+    -> Variables<tmpl::list<DetTag, InvTag>> {
+  static_assert(std::is_same_v<typename DetTag::type, Scalar<T>>,
+                "Type of first return tag must correspond to that of input's "
+                "determinant.");
+  static_assert(std::is_same_v<typename InvTag::type,
+                               Tensor<T, Symm,
+                                      tmpl::list<change_index_up_lo<Index1>,
+                                                 change_index_up_lo<Index0>>>>,
+                "Type of second return tag must correspond to that of input's "
+                "inverse.");
   Variables<tmpl::list<DetTag, InvTag>> result(get<0, 0>(tensor).size());
   determinant_and_inverse_detail::DetAndInverseImpl<
       Symm, Index0, Index1>::apply(make_not_null(&get<DetTag>(result)),
                                    make_not_null(&get<InvTag>(result)), tensor);
   return result;
 }
+// @}

--- a/src/DataStructures/Tensor/EagerMath/DotProduct.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DotProduct.hpp
@@ -54,6 +54,7 @@ Scalar<DataType> dot_product(
  */
 template <typename DataType, typename Index>
 void dot_product(
+    // NOLINTNEXTLINE(readability-avoid-const-params-in-decls) false positive
     const gsl::not_null<Scalar<DataType>*> dot_product,
     const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector_a,
     const Tensor<DataType, Symmetry<1>, index_list<change_index_up_lo<Index>>>&

--- a/src/Evolution/ComputeTags.hpp
+++ b/src/Evolution/ComputeTags.hpp
@@ -27,17 +27,19 @@ struct AnalyticCompute
       db::ComputeTag {
   using base = db::add_tag_prefix<::Tags::Analytic,
                                   ::Tags::Variables<AnalyticFieldsTagList>>;
+  using return_type = typename base::type;
   using argument_tags =
       tmpl::list<AnalyticSolutionTag,
                  domain::Tags::Coordinates<Dim, Frame::Inertial>, ::Tags::Time>;
-  static db::const_item_type<base> function(
+  static void function(
+      const gsl::not_null<return_type*> analytic_solution,
       const db::const_item_type<AnalyticSolutionTag>&
           analytic_solution_computer,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
       const double time) noexcept {
-    return db::const_item_type<base>(
+    *analytic_solution =
         variables_from_tagged_tuple(analytic_solution_computer.variables(
-            inertial_coords, time, AnalyticFieldsTagList{})));
+            inertial_coords, time, AnalyticFieldsTagList{}));
   }
 };
 }  // namespace Tags

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
@@ -57,6 +57,10 @@ void characteristic_fields(
     const tnsr::aa<DataVector, Dim, Frame>& pi,
     const tnsr::iaa<DataVector, Dim, Frame>& phi,
     const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept {
+  const auto number_of_grid_points = get(gamma_2).size();
+  if (UNLIKELY(number_of_grid_points != char_fields->number_of_grid_points())) {
+    char_fields->initialize(number_of_grid_points);
+  }
   auto phi_dot_normal =
       make_with_value<tnsr::aa<DataVector, Dim, Frame>>(pi, 0.);
   auto unit_normal_vector =
@@ -127,6 +131,11 @@ void evolved_fields_from_characteristic_fields(
     const tnsr::aa<DataVector, Dim, Frame>& u_plus,
     const tnsr::aa<DataVector, Dim, Frame>& u_minus,
     const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept {
+  const auto number_of_grid_points = get(gamma_2).size();
+  if (UNLIKELY(number_of_grid_points !=
+               evolved_fields->number_of_grid_points())) {
+    evolved_fields->initialize(number_of_grid_points);
+  }
   // Invert Eq.(32) of Lindblom+ (2005) for Psi
   get<::gr::Tags::SpacetimeMetric<Dim, Frame, DataVector>>(*evolved_fields) =
       u_psi;

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -161,7 +161,7 @@ template <size_t Dim, typename Frame>
 struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim, Frame>,
                                      db::ComputeTag {
   using base = Tags::CharacteristicFields<Dim, Frame>;
-  using type = typename base::type;
+  using return_type = typename base::type;
   using argument_tags = tmpl::list<
       Tags::ConstraintGamma2,
       gr::Tags::InverseSpatialMetric<Dim, Frame, DataVector>,
@@ -169,17 +169,13 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim, Frame>,
       Tags::Phi<Dim, Frame>,
       ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
 
-  static typename Tags::CharacteristicFields<Dim, Frame>::type function(
-      const Scalar<DataVector>& gamma_2,
-      const tnsr::II<DataVector, Dim, Frame>& inverse_spatial_metric,
-      const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
-      const tnsr::aa<DataVector, Dim, Frame>& pi,
-      const tnsr::iaa<DataVector, Dim, Frame>& phi,
-      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept {
-    return characteristic_fields(gamma_2, inverse_spatial_metric,
-                                 spacetime_metric, pi, phi,
-                                 unit_normal_one_form);
-  };
+  static constexpr auto function = static_cast<void (*)(
+      const gsl::not_null<return_type*>, const Scalar<DataVector>&,
+      const tnsr::II<DataVector, Dim, Frame>&,
+      const tnsr::aa<DataVector, Dim, Frame>&,
+      const tnsr::aa<DataVector, Dim, Frame>&,
+      const tnsr::iaa<DataVector, Dim, Frame>&,
+      const tnsr::i<DataVector, Dim, Frame>&) noexcept>(&characteristic_fields);
 };
 // @}
 
@@ -215,24 +211,21 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
     : Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>,
       db::ComputeTag {
   using base = Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>;
-  using type = typename base::type;
+  using return_type = typename base::type;
   using argument_tags = tmpl::list<
       Tags::ConstraintGamma2, Tags::VSpacetimeMetric<Dim, Frame>,
       Tags::VZero<Dim, Frame>, Tags::VPlus<Dim, Frame>,
       Tags::VMinus<Dim, Frame>,
       ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
 
-  static typename Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>::type
-  function(
-      const Scalar<DataVector>& gamma_2,
+  static constexpr auto function = static_cast<void (*)(
+      const gsl::not_null<return_type*>, const Scalar<DataVector>& gamma_2,
       const tnsr::aa<DataVector, Dim, Frame>& u_psi,
       const tnsr::iaa<DataVector, Dim, Frame>& u_zero,
       const tnsr::aa<DataVector, Dim, Frame>& u_plus,
       const tnsr::aa<DataVector, Dim, Frame>& u_minus,
-      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept {
-    return evolved_fields_from_characteristic_fields(
-        gamma_2, u_psi, u_zero, u_plus, u_minus, unit_normal_one_form);
-  };
+      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept>(
+      &evolved_fields_from_characteristic_fields);
 };
 // @}
 

--- a/src/Evolution/Systems/ScalarWave/Constraints.hpp
+++ b/src/Evolution/Systems/ScalarWave/Constraints.hpp
@@ -61,14 +61,6 @@ void two_index_constraint(
 // @}
 
 namespace Tags {
-struct ConstraintGamma2Compute : ConstraintGamma2, db::ComputeTag {
-  using argument_tags = tmpl::list<Psi>;
-  static auto function(const Scalar<DataVector>& psi) noexcept {
-    return make_with_value<type>(psi, 0.);
-  }
-  using base = ConstraintGamma2;
-};
-
 /*!
  * \brief Compute item to get the one-index constraint for the scalar-wave
  * evolution system.

--- a/src/Evolution/Systems/ScalarWave/Initialize.hpp
+++ b/src/Evolution/Systems/ScalarWave/Initialize.hpp
@@ -46,9 +46,10 @@ struct InitializeConstraints {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
+    const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
+    Scalar<DataVector> gamma_2{mesh.number_of_grid_points(), 0.};
     using compute_tags =
-        db::AddComputeTags<ScalarWave::Tags::ConstraintGamma2Compute,
-                           ScalarWave::Tags::OneIndexConstraintCompute<Dim>,
+        db::AddComputeTags<ScalarWave::Tags::OneIndexConstraintCompute<Dim>,
                            ScalarWave::Tags::TwoIndexConstraintCompute<Dim>,
                            ::Tags::PointwiseL2NormCompute<
                                ScalarWave::Tags::OneIndexConstraint<Dim>>,
@@ -56,9 +57,10 @@ struct InitializeConstraints {
                                ScalarWave::Tags::TwoIndexConstraint<Dim>>>;
 
     return std::make_tuple(
-        Initialization::merge_into_databox<InitializeConstraints,
-                                           db::AddSimpleTags<>, compute_tags>(
-            std::move(box)));
+        Initialization::merge_into_databox<
+            InitializeConstraints,
+            db::AddSimpleTags<ScalarWave::Tags::ConstraintGamma2>,
+            compute_tags>(std::move(box), std::move(gamma_2)));
   }
 };
 }  // namespace Actions

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -69,6 +69,7 @@ struct div<Tag, Requires<tt::is_a_v<::Variables, db::const_item_type<Tag>>>>
 /// \endcond
 }  // namespace Tags
 
+// @{
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Compute the (Euclidean) divergence of fluxes
 template <typename FluxTags, size_t Dim, typename DerivativeFrame>
@@ -78,6 +79,16 @@ auto divergence(
         inverse_jacobian) noexcept
     -> Variables<db::wrap_tags_in<Tags::div, FluxTags>>;
 
+template <typename FluxTags, size_t Dim, typename DerivativeFrame>
+void divergence(
+    gsl::not_null<Variables<db::wrap_tags_in<Tags::div, FluxTags>>*>
+        divergence_of_F,
+    const Variables<FluxTags>& F, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
+        inverse_jacobian) noexcept;
+// @}
+
+// @{
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Compute the divergence of the vector `input`
 template <size_t Dim, typename DerivativeFrame>
@@ -86,6 +97,15 @@ Scalar<DataVector> divergence(
     const Mesh<Dim>& mesh,
     const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
         inverse_jacobian) noexcept;
+
+template <size_t Dim, typename DerivativeFrame>
+void divergence(
+    gsl::not_null<Scalar<DataVector>*> div_input,
+    const tnsr::I<DataVector, Dim, DerivativeFrame>& input,
+    const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
+        inverse_jacobian) noexcept;
+// @}
 
 namespace Tags {
 /*!
@@ -122,7 +142,11 @@ struct DivVariablesCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
                 "Must map from the logical frame.");
 
  public:
-  static constexpr auto function =
+  using base = db::add_tag_prefix<div, Tag>;
+  using return_type = typename base::type;
+  static constexpr void (*function)(const gsl::not_null<return_type*>,
+                                    const typename Tag::type&, const Mesh<dim>&,
+                                    const typename InverseJacobianTag::type&) =
       divergence<typename db::const_item_type<Tag>::tags_list, dim,
                  typename tmpl::back<inv_jac_indices>::Frame>;
   using argument_tags =
@@ -144,7 +168,11 @@ struct DivVectorCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
                 "Must map from the logical frame.");
 
  public:
-  static constexpr auto function =
+  using base = db::add_tag_prefix<div, Tag>;
+  using return_type = typename base::type;
+  static constexpr void (*function)(const gsl::not_null<return_type*>,
+                                    const typename Tag::type&, const Mesh<dim>&,
+                                    const typename InverseJacobianTag::type&) =
       divergence<dim, typename tmpl::back<inv_jac_indices>::Frame>;
   using argument_tags =
       tmpl::list<Tag, domain::Tags::Mesh<dim>, InverseJacobianTag>;

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
@@ -16,11 +16,26 @@ Variables<db::wrap_tags_in<Tags::div, FluxTags>> divergence(
     const Variables<FluxTags>& F, const Mesh<Dim>& mesh,
     const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
         inverse_jacobian) noexcept {
+  Variables<db::wrap_tags_in<Tags::div, FluxTags>> divergence_of_F(
+      F.number_of_grid_points());
+  divergence(make_not_null(&divergence_of_F), F, mesh, inverse_jacobian);
+  return divergence_of_F;
+}
+
+template <typename FluxTags, size_t Dim, typename DerivativeFrame>
+void divergence(
+    const gsl::not_null<Variables<db::wrap_tags_in<Tags::div, FluxTags>>*>
+        divergence_of_F,
+    const Variables<FluxTags>& F, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
+        inverse_jacobian) noexcept {
+  if (UNLIKELY(divergence_of_F->number_of_grid_points() !=
+               mesh.number_of_grid_points())) {
+    divergence_of_F->initialize(mesh.number_of_grid_points());
+  }
+
   const auto logical_partial_derivatives_of_F =
       logical_partial_derivatives<FluxTags>(F, mesh);
-
-  Variables<db::wrap_tags_in<Tags::div, FluxTags>>
-      divergence_of_F(F.number_of_grid_points(), 0.0);
 
   tmpl::for_each<FluxTags>([
     &divergence_of_F, &inverse_jacobian, &logical_partial_derivatives_of_F
@@ -37,9 +52,10 @@ Variables<db::wrap_tags_in<Tags::div, FluxTags>> divergence(
         "because either it is in the wrong frame or it has the wrong "
         "valence");
 
-    auto& divergence_of_flux = get<DivFluxTag>(divergence_of_F);
+    auto& divergence_of_flux = get<DivFluxTag>(*divergence_of_F);
     for (auto it = divergence_of_flux.begin(); it != divergence_of_flux.end();
          ++it) {
+      *it = 0.0;
       const auto div_flux_indices = divergence_of_flux.get_tensor_index(it);
       for (size_t i0 = 0; i0 < Dim; ++i0) {
         const auto flux_indices = prepend(div_flux_indices, i0);
@@ -51,6 +67,4 @@ Variables<db::wrap_tags_in<Tags::div, FluxTags>> divergence(
       }
     }
   });
-
-  return divergence_of_F;
 }

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -215,11 +215,17 @@ struct DerivCompute
   using deriv_frame = typename tmpl::back<inv_jac_indices>::Frame;
 
  public:
-  static constexpr ::Variables<db::wrap_tags_in<
-      Tags::deriv, DerivTags, tmpl::size_t<Dim>, deriv_frame>> (*function)(
-      const ::Variables<typename db::const_item_type<VariablesTag>::tags_list>&,
-      const ::Mesh<Dim>&,
-      const ::InverseJacobian<DataVector, Dim, Frame::Logical, deriv_frame>&) =
+  using base = db::add_tag_prefix<
+      deriv, db::variables_tag_with_tags_list<VariablesTag, DerivTags>,
+      tmpl::size_t<tmpl::back<
+          typename db::const_item_type<InverseJacobianTag>::index_list>::dim>,
+      typename tmpl::back<
+          typename db::const_item_type<InverseJacobianTag>::index_list>::Frame>;
+  using return_type = typename base::type;
+  static constexpr void (*function)(
+      gsl::not_null<return_type*>, const typename VariablesTag::type&,
+      const Mesh<Dim>&,
+      const InverseJacobian<DataVector, Dim, Frame::Logical, deriv_frame>&) =
       partial_derivatives<DerivTags,
                           typename db::const_item_type<VariablesTag>::tags_list,
                           Dim, deriv_frame>;

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -449,12 +449,14 @@ struct DetAndInverseSpatialMetricCompute
   using base = ::Tags::Variables<
       tmpl::list<DetSpatialMetric<DataType>,
                  InverseSpatialMetric<SpatialDim, Frame, DataType>>>;
-  static constexpr auto function = &determinant_and_inverse<
-      DetSpatialMetric<DataType>,
-      InverseSpatialMetric<SpatialDim, Frame, DataType>, DataType,
-      tmpl::integral_list<std::int32_t, 1, 1>,
-      SpatialIndex<SpatialDim, UpLo::Lo, Frame>,
-      SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
+  using return_type = typename base::type;
+  static constexpr auto function = static_cast<void (*)(
+      const gsl::not_null<return_type*>,
+      const Tensor<
+          DataType, tmpl::integral_list<std::int32_t, 1, 1>,
+          tmpl::list<SpatialIndex<SpatialDim, UpLo::Lo, Frame>,
+                     SpatialIndex<SpatialDim, UpLo::Lo, Frame>>>&) noexcept>(
+      &determinant_and_inverse);
 };
 
 /*!

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -60,8 +60,10 @@ struct SubstepTime : db::SimpleTag {
 /// \see SubstepTime
 struct SubstepTimeCompute : SubstepTime, db::ComputeTag {
   using base = SubstepTime;
-  static auto function(const ::TimeStepId& id) noexcept {
-    return id.substep_time();
+  using return_type = typename base::type;
+  static void function(const gsl::not_null<return_type*> substep_time,
+                       const ::TimeStepId& id) noexcept {
+    *substep_time = id.substep_time();
   }
   using argument_tags = tmpl::list<TimeStepId>;
 };

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -166,10 +166,9 @@ typename Tag::type field_with_tag(
     const tnsr::aa<DataVector, Dim, Frame>& pi,
     const tnsr::iaa<DataVector, Dim, Frame>& phi,
     const tnsr::i<DataVector, Dim, Frame>& normal_one_form) {
-  return get<Tag>(
-      GeneralizedHarmonic::CharacteristicFieldsCompute<Dim, Frame>::function(
-          gamma_2, inverse_spatial_metric, spacetime_metric, pi, phi,
-          normal_one_form));
+  return get<Tag>(GeneralizedHarmonic::characteristic_fields(
+      gamma_2, inverse_spatial_metric, spacetime_metric, pi, phi,
+      normal_one_form));
 }
 
 template <size_t Dim, typename Frame>
@@ -318,10 +317,9 @@ void test_characteristic_fields_analytic(
   }
 
   // Check that locally computed fields match returned ones
-  const auto uvars = GeneralizedHarmonic::CharacteristicFieldsCompute<
-      spatial_dim, Frame::Inertial>::function(gamma_2, inverse_spatial_metric,
-                                              spacetime_metric, pi, phi,
-                                              unit_normal_one_form);
+  const auto uvars = GeneralizedHarmonic::characteristic_fields(
+      gamma_2, inverse_spatial_metric, spacetime_metric, pi, phi,
+      unit_normal_one_form);
 
   const auto& upsi_from_func =
       get<GeneralizedHarmonic::Tags::VSpacetimeMetric<spatial_dim,
@@ -353,9 +351,8 @@ typename Tag::type evol_field_with_tag(
     const tnsr::aa<DataVector, Dim, Frame>& u_minus,
     const tnsr::i<DataVector, Dim, Frame>& normal_one_form) {
   return get<Tag>(
-      GeneralizedHarmonic::EvolvedFieldsFromCharacteristicFieldsCompute<
-          Dim, Frame>::function(gamma_2, u_psi, u_zero, u_plus, u_minus,
-                                normal_one_form));
+      GeneralizedHarmonic::evolved_fields_from_characteristic_fields(
+          gamma_2, u_psi, u_zero, u_plus, u_minus, normal_one_form));
 }
 
 template <size_t Dim, typename Frame>
@@ -490,9 +487,8 @@ void test_evolved_from_characteristic_fields_analytic(
     }
   }
   const auto ffields =
-      GeneralizedHarmonic::EvolvedFieldsFromCharacteristicFieldsCompute<
-          spatial_dim, Frame::Inertial>::function(gamma_2, upsi, uzero, uplus,
-                                                  uminus, unit_normal_one_form);
+      GeneralizedHarmonic::evolved_fields_from_characteristic_fields(
+          gamma_2, upsi, uzero, uplus, uminus, unit_normal_one_form);
   const auto& psi_from_func =
       get<gr::Tags::SpacetimeMetric<spatial_dim, Frame::Inertial>>(ffields);
   const auto& pi_from_func =
@@ -569,16 +565,11 @@ void check_max_char_speed(const DataVector& used_for_size) noexcept {
   // vector will point along the maximum speed direction)
   const double check_maximum = 1.0 + 1e-12;
 
-  double trial_failure_rate;
-  if (Dim == 1) {
-    // The correct value is actually 0.0, but we don't want to take
-    // the logarithm of 0.
-    trial_failure_rate = 0.1;
-  } else if (Dim == 2) {
-    trial_failure_rate = 1.0 - 2.0 * acos(check_minimum) / M_PI;
-  } else {
-    trial_failure_rate = check_minimum;
-  }
+  const double trial_failure_rate =
+      Dim == 1
+          ? 0.1  // correct value is 0.0, but cannot take log of that
+          : (Dim == 2 ? 1.0 - 2.0 * acos(check_minimum) / M_PI : check_minimum);
+
   const size_t trials =
       static_cast<size_t>(log(failure_tolerance) / log(trial_failure_rate)) + 1;
 

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Constraints.cpp
@@ -180,9 +180,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Constraints",
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/ScalarWave/"};
 
-  TestHelpers::db::test_compute_tag<ScalarWave::Tags::ConstraintGamma2Compute>(
-      "ConstraintGamma2");
-
   {
     INFO("Testing constraints with randomized input");
     // Test the one-index constraint with random numbers

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -41,6 +41,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/CollectDataForFluxes.hpp"


### PR DESCRIPTION
## Proposed changes

Change some compute tags such that their `function` now uses a `gsl::not_null<return_type*>`  argument to evaluate the compute item instead of returning it.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
