### PR TITLE
Add Sum and Constant MathFunctions

### DIFF
--- a/src/PointwiseFunctions/MathFunctions/CMakeLists.txt
+++ b/src/PointwiseFunctions/MathFunctions/CMakeLists.txt
@@ -8,9 +8,11 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Constant.cpp
   Gaussian.cpp
   PowX.cpp
   Sinusoid.cpp
+  Sum.cpp
   TensorProduct.cpp
   )
 
@@ -18,10 +20,12 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Constant.hpp
   Gaussian.hpp
   MathFunction.hpp
   PowX.hpp
   Sinusoid.hpp
+  Sum.hpp
   TensorProduct.hpp
   )
 

--- a/src/PointwiseFunctions/MathFunctions/Constant.cpp
+++ b/src/PointwiseFunctions/MathFunctions/Constant.cpp
@@ -1,0 +1,252 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/MathFunctions/Constant.hpp"
+
+#include <cmath>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace MathFunctions {
+
+template <typename Fr>
+Constant<1, Fr>::Constant(const double value) noexcept : value_(value) {}
+
+template <typename Fr>
+double Constant<1, Fr>::operator()(const double& x) const noexcept {
+  return apply_call_operator(x);
+}
+
+template <typename Fr>
+DataVector Constant<1, Fr>::operator()(const DataVector& x) const noexcept {
+  return apply_call_operator(x);
+}
+
+template <typename Fr>
+double Constant<1, Fr>::first_deriv(const double& x) const noexcept {
+  return apply_first_deriv(x);
+}
+
+template <typename Fr>
+DataVector Constant<1, Fr>::first_deriv(const DataVector& x) const noexcept {
+  return apply_first_deriv(x);
+}
+
+template <typename Fr>
+double Constant<1, Fr>::second_deriv(const double& x) const noexcept {
+  return apply_second_deriv(x);
+}
+
+template <typename Fr>
+DataVector Constant<1, Fr>::second_deriv(const DataVector& x) const noexcept {
+  return apply_second_deriv(x);
+}
+
+template <typename Fr>
+double Constant<1, Fr>::third_deriv(const double& x) const noexcept {
+  return apply_third_deriv(x);
+}
+
+template <typename Fr>
+DataVector Constant<1, Fr>::third_deriv(const DataVector& x) const noexcept {
+  return apply_third_deriv(x);
+}
+
+template <typename Fr>
+template <typename T>
+T Constant<1, Fr>::apply_call_operator(const T& x) const noexcept {
+  return make_with_value<T>(x, value_);
+}
+
+template <typename Fr>
+template <typename T>
+T Constant<1, Fr>::apply_first_deriv(const T& x) const noexcept {
+  return make_with_value<T>(x, 0.0);
+  ;
+}
+
+template <typename Fr>
+template <typename T>
+T Constant<1, Fr>::apply_second_deriv(const T& x) const noexcept {
+  return make_with_value<T>(x, 0.0);
+}
+
+template <typename Fr>
+template <typename T>
+T Constant<1, Fr>::apply_third_deriv(const T& x) const noexcept {
+  return make_with_value<T>(x, 0.0);
+}
+
+template <typename Fr>
+void Constant<1, Fr>::pup(PUP::er& p) {
+  MathFunction<1, Fr>::pup(p);
+  p | value_;
+}
+
+template <size_t VolumeDim, typename Fr>
+Constant<VolumeDim, Fr>::Constant(const double value) noexcept
+    : value_(value) {}
+
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+Scalar<T> Constant<VolumeDim, Fr>::apply_call_operator(
+    const tnsr::I<T, VolumeDim, Fr>& x) const noexcept {
+  return make_with_value<Scalar<T>>(x, value_);
+}
+
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+tnsr::i<T, VolumeDim, Fr> Constant<VolumeDim, Fr>::apply_first_deriv(
+    const tnsr::I<T, VolumeDim, Fr>& x) const noexcept {
+  return make_with_value<tnsr::i<T, VolumeDim, Fr>>(x, 0.0);
+}
+
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+tnsr::ii<T, VolumeDim, Fr> Constant<VolumeDim, Fr>::apply_second_deriv(
+    const tnsr::I<T, VolumeDim, Fr>& x) const noexcept {
+  return make_with_value<tnsr::ii<T, VolumeDim, Fr>>(x, 0.0);
+}
+
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+tnsr::iii<T, VolumeDim, Fr> Constant<VolumeDim, Fr>::apply_third_deriv(
+    const tnsr::I<T, VolumeDim, Fr>& x) const noexcept {
+  return make_with_value<tnsr::iii<T, VolumeDim, Fr>>(x, 0.0);
+}
+
+template <size_t VolumeDim, typename Fr>
+Scalar<double> Constant<VolumeDim, Fr>::operator()(
+    const tnsr::I<double, VolumeDim, Fr>& x) const noexcept {
+  return apply_call_operator(x);
+}
+template <size_t VolumeDim, typename Fr>
+Scalar<DataVector> Constant<VolumeDim, Fr>::operator()(
+    const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept {
+  return apply_call_operator(x);
+}
+
+template <size_t VolumeDim, typename Fr>
+tnsr::i<double, VolumeDim, Fr> Constant<VolumeDim, Fr>::first_deriv(
+    const tnsr::I<double, VolumeDim, Fr>& x) const noexcept {
+  return apply_first_deriv(x);
+}
+template <size_t VolumeDim, typename Fr>
+tnsr::i<DataVector, VolumeDim, Fr> Constant<VolumeDim, Fr>::first_deriv(
+    const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept {
+  return apply_first_deriv(x);
+}
+
+template <size_t VolumeDim, typename Fr>
+tnsr::ii<double, VolumeDim, Fr> Constant<VolumeDim, Fr>::second_deriv(
+    const tnsr::I<double, VolumeDim, Fr>& x) const noexcept {
+  return apply_second_deriv(x);
+}
+template <size_t VolumeDim, typename Fr>
+tnsr::ii<DataVector, VolumeDim, Fr> Constant<VolumeDim, Fr>::second_deriv(
+    const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept {
+  return apply_second_deriv(x);
+}
+
+template <size_t VolumeDim, typename Fr>
+tnsr::iii<double, VolumeDim, Fr> Constant<VolumeDim, Fr>::third_deriv(
+    const tnsr::I<double, VolumeDim, Fr>& x) const noexcept {
+  return apply_third_deriv(x);
+}
+template <size_t VolumeDim, typename Fr>
+tnsr::iii<DataVector, VolumeDim, Fr> Constant<VolumeDim, Fr>::third_deriv(
+    const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept {
+  return apply_third_deriv(x);
+}
+
+template <size_t VolumeDim, typename Fr>
+void Constant<VolumeDim, Fr>::pup(PUP::er& p) {
+  MathFunction<VolumeDim, Fr>::pup(p);
+  p | value_;
+}
+}  // namespace MathFunctions
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATE(_, data)                                          \
+  template MathFunctions::Constant<DIM(data), FRAME(data)>::Constant( \
+      const double value) noexcept;                                   \
+  template void MathFunctions::Constant<DIM(data), FRAME(data)>::pup( \
+      PUP::er& p);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3), (Frame::Grid, Frame::Inertial))
+#undef DIM
+#undef FRAME
+#undef INSTANTIATE
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template Scalar<DTYPE(data)>                                               \
+  MathFunctions::Constant<DIM(data), FRAME(data)>::operator()(               \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x) const noexcept; \
+  template tnsr::i<DTYPE(data), DIM(data), FRAME(data)>                      \
+  MathFunctions::Constant<DIM(data), FRAME(data)>::first_deriv(              \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x) const noexcept; \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>                     \
+  MathFunctions::Constant<DIM(data), FRAME(data)>::second_deriv(             \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x) const noexcept; \
+  template tnsr::iii<DTYPE(data), DIM(data), FRAME(data)>                    \
+  MathFunctions::Constant<DIM(data), FRAME(data)>::third_deriv(              \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+#undef FRAME
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE
+
+template MathFunctions::Constant<1, Frame::Grid>::Constant(
+    const double value) noexcept;
+template MathFunctions::Constant<1, Frame::Inertial>::Constant(
+    const double value) noexcept;
+template void MathFunctions::Constant<1, Frame::Grid>::pup(PUP::er& p);
+template void MathFunctions::Constant<1, Frame::Inertial>::pup(PUP::er& p);
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template DTYPE(data) MathFunctions::Constant<1, FRAME(data)>::operator()(   \
+      const DTYPE(data) & x) const noexcept;                                  \
+  template DTYPE(data) MathFunctions::Constant<1, FRAME(data)>::first_deriv(  \
+      const DTYPE(data) & x) const noexcept;                                  \
+  template DTYPE(data) MathFunctions::Constant<1, FRAME(data)>::second_deriv( \
+      const DTYPE(data) & x) const noexcept;                                  \
+  template DTYPE(data) MathFunctions::Constant<1, FRAME(data)>::third_deriv(  \
+      const DTYPE(data) & x) const noexcept;                                  \
+  template DTYPE(data)                                                        \
+      MathFunctions::Constant<1, FRAME(data)>::apply_call_operator(           \
+          const DTYPE(data) & x) const noexcept;                              \
+  template DTYPE(data)                                                        \
+      MathFunctions::Constant<1, FRAME(data)>::apply_first_deriv(             \
+          const DTYPE(data) & x) const noexcept;                              \
+  template DTYPE(data)                                                        \
+      MathFunctions::Constant<1, FRAME(data)>::apply_second_deriv(            \
+          const DTYPE(data) & x) const noexcept;                              \
+  template DTYPE(data)                                                        \
+      MathFunctions::Constant<1, FRAME(data)>::apply_third_deriv(             \
+          const DTYPE(data) & x) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+
+/// \endcond

--- a/src/PointwiseFunctions/MathFunctions/Constant.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Constant.hpp
@@ -1,0 +1,192 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines MathFunctions::Constant.
+
+#pragma once
+
+#include <array>
+#include <pup.h>
+
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace MathFunctions {
+template <size_t VolumeDim, typename Fr>
+class Constant;
+
+/*!
+ *  \ingroup MathFunctionsGroup
+ *  \brief Returns a constant value, independent of the input.
+ *
+ *  \details The input file takes one option: Value, the constant value
+ * returned. The function takes input of type `double` or `DataVector` and
+ * returns the same type as the input type.
+ */
+template <typename Fr>
+class Constant<1, Fr> : public MathFunction<1, Fr> {
+ public:
+  struct Value {
+    using type = double;
+    static constexpr OptionString help = {"The constant value."};
+  };
+
+  using options = tmpl::list<Value>;
+
+  static constexpr OptionString help = {
+      "Returns a constant independent of the input value"};
+
+  WRAPPED_PUPable_decl_base_template(SINGLE_ARG(MathFunction<1, Fr>),
+                                     Constant);  // NOLINT
+
+  explicit Constant(CkMigrateMessage* /*unused*/) noexcept {}
+
+  explicit Constant(double value) noexcept;
+
+  Constant() = default;
+  ~Constant() override = default;
+  Constant(const Constant& /*rhs*/) = delete;
+  Constant& operator=(const Constant& /*rhs*/) = delete;
+  Constant(Constant&& /*rhs*/) noexcept = default;
+  Constant& operator=(Constant&& /*rhs*/) noexcept = default;
+
+  double operator()(const double& x) const noexcept override;
+  DataVector operator()(const DataVector& x) const noexcept override;
+  using MathFunction<1, Fr>::operator();
+
+  double first_deriv(const double& x) const noexcept override;
+  DataVector first_deriv(const DataVector& x) const noexcept override;
+  using MathFunction<1, Fr>::first_deriv;
+
+  double second_deriv(const double& x) const noexcept override;
+  DataVector second_deriv(const DataVector& x) const noexcept override;
+  using MathFunction<1, Fr>::second_deriv;
+
+  double third_deriv(const double& x) const noexcept override;
+  DataVector third_deriv(const DataVector& x) const noexcept override;
+  using MathFunction<1, Fr>::third_deriv;
+
+  double value() const noexcept { return value_; }
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) override;  // NOLINT
+
+ private:
+  double value_{};
+  friend bool operator==(const Constant<1, Fr>& lhs,
+                         const Constant<1, Fr>& rhs) noexcept {
+    return lhs.value_ == rhs.value_;
+  }
+
+  template <typename T>
+  T apply_call_operator(const T& x) const noexcept;
+  template <typename T>
+  T apply_first_deriv(const T& x) const noexcept;
+  template <typename T>
+  T apply_second_deriv(const T& x) const noexcept;
+  template <typename T>
+  T apply_third_deriv(const T& x) const noexcept;
+};
+
+/*!
+ *  \ingroup MathFunctionsGroup
+ *  \brief Returns a constant value, independent of the input.
+ *
+ *  \details Input file options are: Value. The function
+ *  takes input coordinates of type `tnsr::I<T, VolumeDim, Fr>`, where `T` is
+ * e.g. `double` or `DataVector`, `Fr` is a frame (e.g. `Frame::Inertial`), and
+ * `VolumeDim` is the dimension of the spatial volume, i.e. 2 or 3. (The case of
+ * VolumeDim == 1 is handled specially by Constant<1, T, Frame::Inertial>.)
+ */
+template <size_t VolumeDim, typename Fr>
+class Constant : public MathFunction<VolumeDim, Fr> {
+ public:
+  struct Value {
+    using type = double;
+    static constexpr OptionString help = {"The constant value."};
+  };
+
+  using options = tmpl::list<Value>;
+
+  static constexpr OptionString help = {
+      "Returns a Constant independent of the input coordinates"};
+
+  WRAPPED_PUPable_decl_base_template(SINGLE_ARG(MathFunction<VolumeDim, Fr>),
+                                     Constant);  // NOLINT
+
+  explicit Constant(CkMigrateMessage* /*unused*/) noexcept {}
+
+  explicit Constant(double value) noexcept;
+
+  Constant() = default;
+  ~Constant() override = default;
+  Constant(const Constant& /*rhs*/) = delete;
+  Constant& operator=(const Constant& /*rhs*/) = delete;
+  Constant(Constant&& /*rhs*/) noexcept = default;
+  Constant& operator=(Constant&& /*rhs*/) noexcept = default;
+
+  Scalar<double> operator()(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
+  Scalar<DataVector> operator()(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+
+  tnsr::i<double, VolumeDim, Fr> first_deriv(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
+  tnsr::i<DataVector, VolumeDim, Fr> first_deriv(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+
+  tnsr::ii<double, VolumeDim, Fr> second_deriv(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
+  tnsr::ii<DataVector, VolumeDim, Fr> second_deriv(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+
+  tnsr::iii<double, VolumeDim, Fr> third_deriv(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
+  tnsr::iii<DataVector, VolumeDim, Fr> third_deriv(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) override;  // NOLINT
+
+ private:
+  double value_{};
+  friend bool operator==(const Constant& lhs, const Constant& rhs) noexcept {
+    return lhs.value_ == rhs.value_;
+  }
+
+  template <typename T>
+  Scalar<T> apply_call_operator(
+      const tnsr::I<T, VolumeDim, Fr>& x) const noexcept;
+  template <typename T>
+  tnsr::i<T, VolumeDim, Fr> apply_first_deriv(
+      const tnsr::I<T, VolumeDim, Fr>& x) const noexcept;
+  template <typename T>
+  tnsr::ii<T, VolumeDim, Fr> apply_second_deriv(
+      const tnsr::I<T, VolumeDim, Fr>& x) const noexcept;
+  template <typename T>
+  tnsr::iii<T, VolumeDim, Fr> apply_third_deriv(
+      const tnsr::I<T, VolumeDim, Fr>& x) const noexcept;
+};
+
+template <size_t VolumeDim, typename Fr>
+bool operator!=(const Constant<VolumeDim, Fr>& lhs,
+                const Constant<VolumeDim, Fr>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace MathFunctions
+
+/// \cond
+template <size_t VolumeDim, typename Fr>
+PUP::able::PUP_ID MathFunctions::Constant<VolumeDim, Fr>::my_PUP_ID =
+    0;  // NOLINT
+
+template <typename Fr>
+PUP::able::PUP_ID MathFunctions::Constant<1, Fr>::my_PUP_ID = 0;  // NOLINT
+/// \endcond

--- a/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
+++ b/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
@@ -17,11 +17,15 @@
 /// Holds classes implementing MathFunction (functions \f$R^n \to R\f$).
 namespace MathFunctions {
 template <size_t VolumeDim, typename Fr>
+class Constant;
+template <size_t VolumeDim, typename Fr>
 class Gaussian;
 template <size_t VolumeDim, typename Fr>
 class PowX;
 template <size_t VolumeDim, typename Fr>
 class Sinusoid;
+template <size_t VolumeDim, typename Fr>
+class Sum;
 }  // namespace MathFunctions
 
 /*!
@@ -39,7 +43,9 @@ class MathFunction;
 template <size_t VolumeDim, typename Fr>
 class MathFunction : public PUP::able {
  public:
-  using creatable_classes = tmpl::list<MathFunctions::Gaussian<VolumeDim, Fr>>;
+  using creatable_classes = tmpl::list<MathFunctions::Constant<VolumeDim, Fr>,
+                                       MathFunctions::Gaussian<VolumeDim, Fr>,
+                                       MathFunctions::Sum<VolumeDim, Fr>>;
   constexpr static size_t volume_dim = VolumeDim;
   using frame = Fr;
 
@@ -95,8 +101,9 @@ template <typename Fr>
 class MathFunction<1, Fr> : public PUP::able {
  public:
   using creatable_classes =
-      tmpl::list<MathFunctions::Gaussian<1, Fr>, MathFunctions::PowX<1, Fr>,
-                 MathFunctions::Sinusoid<1, Fr>>;
+      tmpl::list<MathFunctions::Constant<1, Fr>, MathFunctions::Gaussian<1, Fr>,
+                 MathFunctions::PowX<1, Fr>, MathFunctions::Sinusoid<1, Fr>,
+                 MathFunctions::Sum<1, Fr>>;
   constexpr static size_t volume_dim = 1;
   using frame = Fr;
 
@@ -169,6 +176,8 @@ class MathFunction<1, Fr> : public PUP::able {
   }
 };
 
+#include "PointwiseFunctions/MathFunctions/Constant.hpp"
 #include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
 #include "PointwiseFunctions/MathFunctions/PowX.hpp"
 #include "PointwiseFunctions/MathFunctions/Sinusoid.hpp"
+#include "PointwiseFunctions/MathFunctions/Sum.hpp"

--- a/src/PointwiseFunctions/MathFunctions/Sum.cpp
+++ b/src/PointwiseFunctions/MathFunctions/Sum.cpp
@@ -1,0 +1,284 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/MathFunctions/Sum.hpp"
+
+#include <cmath>
+#include <memory>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Expressions/AddSubtract.hpp"
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace MathFunctions {
+
+template <typename Fr>
+Sum<1, Fr>::Sum(std::unique_ptr<MathFunction<1, Fr>> math_function_a,
+                std::unique_ptr<MathFunction<1, Fr>> math_function_b) noexcept
+    : math_function_a_(std::move(math_function_a)),
+      math_function_b_(std::move(math_function_b)) {}
+
+template <typename Fr>
+double Sum<1, Fr>::operator()(const double& x) const noexcept {
+  return apply_call_operator(x);
+}
+
+template <typename Fr>
+DataVector Sum<1, Fr>::operator()(const DataVector& x) const noexcept {
+  return apply_call_operator(x);
+}
+
+template <typename Fr>
+double Sum<1, Fr>::first_deriv(const double& x) const noexcept {
+  return apply_first_deriv(x);
+}
+
+template <typename Fr>
+DataVector Sum<1, Fr>::first_deriv(const DataVector& x) const noexcept {
+  return apply_first_deriv(x);
+}
+
+template <typename Fr>
+double Sum<1, Fr>::second_deriv(const double& x) const noexcept {
+  return apply_second_deriv(x);
+}
+
+template <typename Fr>
+DataVector Sum<1, Fr>::second_deriv(const DataVector& x) const noexcept {
+  return apply_second_deriv(x);
+}
+
+template <typename Fr>
+double Sum<1, Fr>::third_deriv(const double& x) const noexcept {
+  return apply_third_deriv(x);
+}
+
+template <typename Fr>
+DataVector Sum<1, Fr>::third_deriv(const DataVector& x) const noexcept {
+  return apply_third_deriv(x);
+}
+
+template <typename Fr>
+template <typename T>
+T Sum<1, Fr>::apply_call_operator(const T& x) const noexcept {
+  return math_function_a_->operator()(x) + math_function_b_->operator()(x);
+}
+
+template <typename Fr>
+template <typename T>
+T Sum<1, Fr>::apply_first_deriv(const T& x) const noexcept {
+  return math_function_a_->first_deriv(x) + math_function_b_->first_deriv(x);
+}
+
+template <typename Fr>
+template <typename T>
+T Sum<1, Fr>::apply_second_deriv(const T& x) const noexcept {
+  return math_function_a_->second_deriv(x) + math_function_b_->second_deriv(x);
+}
+
+template <typename Fr>
+template <typename T>
+T Sum<1, Fr>::apply_third_deriv(const T& x) const noexcept {
+  return math_function_a_->third_deriv(x) + math_function_b_->third_deriv(x);
+}
+
+template <typename Fr>
+void Sum<1, Fr>::pup(PUP::er& p) {
+  MathFunction<1, Fr>::pup(p);
+  p | math_function_a_;
+  p | math_function_b_;
+}
+
+template <size_t VolumeDim, typename Fr>
+Sum<VolumeDim, Fr>::Sum(
+    std::unique_ptr<MathFunction<VolumeDim, Fr>> math_function_a,
+    std::unique_ptr<MathFunction<VolumeDim, Fr>> math_function_b) noexcept
+    : math_function_a_(std::move(math_function_a)),
+      math_function_b_(std::move(math_function_b)) {}
+
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+Scalar<T> Sum<VolumeDim, Fr>::apply_call_operator(
+    const tnsr::I<T, VolumeDim, Fr>& x) const noexcept {
+  Scalar<T> result = math_function_a_->operator()(x);
+  get(result) += get(math_function_b_->operator()(x));
+  return result;
+}
+
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+tnsr::i<T, VolumeDim, Fr> Sum<VolumeDim, Fr>::apply_first_deriv(
+    const tnsr::I<T, VolumeDim, Fr>& x) const noexcept {
+  const tnsr::i<T, VolumeDim, Fr>& first_deriv_a =
+      math_function_a_->first_deriv(x);
+  const tnsr::i<T, VolumeDim, Fr>& first_deriv_b =
+      math_function_b_->first_deriv(x);
+  return TensorExpressions::evaluate<ti_a_t>(first_deriv_a(ti_a) +
+                                             first_deriv_b(ti_a));
+}
+
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+tnsr::ii<T, VolumeDim, Fr> Sum<VolumeDim, Fr>::apply_second_deriv(
+    const tnsr::I<T, VolumeDim, Fr>& x) const noexcept {
+  const tnsr::ii<T, VolumeDim, Fr>& second_deriv_a =
+      math_function_a_->second_deriv(x);
+  const tnsr::ii<T, VolumeDim, Fr>& second_deriv_b =
+      math_function_b_->second_deriv(x);
+  return TensorExpressions::evaluate<ti_a_t, ti_b_t>(
+      second_deriv_a(ti_a, ti_b) + second_deriv_b(ti_a, ti_b));
+}
+
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+tnsr::iii<T, VolumeDim, Fr> Sum<VolumeDim, Fr>::apply_third_deriv(
+    const tnsr::I<T, VolumeDim, Fr>& x) const noexcept {
+  const tnsr::iii<T, VolumeDim, Fr>& third_deriv_a =
+      math_function_a_->third_deriv(x);
+  const tnsr::iii<T, VolumeDim, Fr>& third_deriv_b =
+      math_function_b_->third_deriv(x);
+  return TensorExpressions::evaluate<ti_a_t, ti_b_t, ti_c_t>(
+      third_deriv_a(ti_a, ti_b, ti_c) + third_deriv_b(ti_a, ti_b, ti_c));
+}
+
+template <size_t VolumeDim, typename Fr>
+Scalar<double> Sum<VolumeDim, Fr>::operator()(
+    const tnsr::I<double, VolumeDim, Fr>& x) const noexcept {
+  return apply_call_operator(x);
+}
+template <size_t VolumeDim, typename Fr>
+Scalar<DataVector> Sum<VolumeDim, Fr>::operator()(
+    const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept {
+  return apply_call_operator(x);
+}
+
+template <size_t VolumeDim, typename Fr>
+tnsr::i<double, VolumeDim, Fr> Sum<VolumeDim, Fr>::first_deriv(
+    const tnsr::I<double, VolumeDim, Fr>& x) const noexcept {
+  return apply_first_deriv(x);
+}
+template <size_t VolumeDim, typename Fr>
+tnsr::i<DataVector, VolumeDim, Fr> Sum<VolumeDim, Fr>::first_deriv(
+    const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept {
+  return apply_first_deriv(x);
+}
+
+template <size_t VolumeDim, typename Fr>
+tnsr::ii<double, VolumeDim, Fr> Sum<VolumeDim, Fr>::second_deriv(
+    const tnsr::I<double, VolumeDim, Fr>& x) const noexcept {
+  return apply_second_deriv(x);
+}
+template <size_t VolumeDim, typename Fr>
+tnsr::ii<DataVector, VolumeDim, Fr> Sum<VolumeDim, Fr>::second_deriv(
+    const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept {
+  return apply_second_deriv(x);
+}
+
+template <size_t VolumeDim, typename Fr>
+tnsr::iii<double, VolumeDim, Fr> Sum<VolumeDim, Fr>::third_deriv(
+    const tnsr::I<double, VolumeDim, Fr>& x) const noexcept {
+  return apply_third_deriv(x);
+}
+template <size_t VolumeDim, typename Fr>
+tnsr::iii<DataVector, VolumeDim, Fr> Sum<VolumeDim, Fr>::third_deriv(
+    const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept {
+  return apply_third_deriv(x);
+}
+
+template <size_t VolumeDim, typename Fr>
+void Sum<VolumeDim, Fr>::pup(PUP::er& p) {
+  MathFunction<VolumeDim, Fr>::pup(p);
+  p | math_function_a_;
+  p | math_function_b_;
+}
+}  // namespace MathFunctions
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATE(_, data)                                                 \
+  template MathFunctions::Sum<DIM(data), FRAME(data)>::Sum(                  \
+      std::unique_ptr<MathFunction<DIM(data), FRAME(data)>> math_function_a, \
+      std::unique_ptr<MathFunction<DIM(data), FRAME(data)>>                  \
+          math_function_b) noexcept;                                         \
+  template void MathFunctions::Sum<DIM(data), FRAME(data)>::pup(PUP::er& p);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3), (Frame::Grid, Frame::Inertial))
+#undef DIM
+#undef FRAME
+#undef INSTANTIATE
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template Scalar<DTYPE(data)>                                               \
+  MathFunctions::Sum<DIM(data), FRAME(data)>::operator()(                    \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x) const noexcept; \
+  template tnsr::i<DTYPE(data), DIM(data), FRAME(data)>                      \
+  MathFunctions::Sum<DIM(data), FRAME(data)>::first_deriv(                   \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x) const noexcept; \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>                     \
+  MathFunctions::Sum<DIM(data), FRAME(data)>::second_deriv(                  \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x) const noexcept; \
+  template tnsr::iii<DTYPE(data), DIM(data), FRAME(data)>                    \
+  MathFunctions::Sum<DIM(data), FRAME(data)>::third_deriv(                   \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+#undef FRAME
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE
+
+template MathFunctions::Sum<1, Frame::Grid>::Sum(
+    std::unique_ptr<MathFunction<1, Frame::Grid>> math_function_a,
+    std::unique_ptr<MathFunction<1, Frame::Grid>> math_function_b) noexcept;
+template MathFunctions::Sum<1, Frame::Inertial>::Sum(
+    std::unique_ptr<MathFunction<1, Frame::Inertial>> math_function_a,
+    std::unique_ptr<MathFunction<1, Frame::Inertial>> math_function_b) noexcept;
+template void MathFunctions::Sum<1, Frame::Grid>::pup(PUP::er& p);
+template void MathFunctions::Sum<1, Frame::Inertial>::pup(PUP::er& p);
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template DTYPE(data)                                                         \
+      MathFunctions::Sum<1, FRAME(data)>::operator()(const DTYPE(data) & x)    \
+          const noexcept;                                                      \
+  template DTYPE(data)                                                         \
+      MathFunctions::Sum<1, FRAME(data)>::first_deriv(const DTYPE(data) & x)   \
+          const noexcept;                                                      \
+  template DTYPE(data)                                                         \
+      MathFunctions::Sum<1, FRAME(data)>::second_deriv(const DTYPE(data) & x)  \
+          const noexcept;                                                      \
+  template DTYPE(data)                                                         \
+      MathFunctions::Sum<1, FRAME(data)>::third_deriv(const DTYPE(data) & x)   \
+          const noexcept;                                                      \
+  template DTYPE(data)                                                         \
+      MathFunctions::Sum<1, FRAME(data)>::apply_call_operator(                 \
+          const DTYPE(data) & x) const noexcept;                               \
+  template DTYPE(data) MathFunctions::Sum<1, FRAME(data)>::apply_first_deriv(  \
+      const DTYPE(data) & x) const noexcept;                                   \
+  template DTYPE(data) MathFunctions::Sum<1, FRAME(data)>::apply_second_deriv( \
+      const DTYPE(data) & x) const noexcept;                                   \
+  template DTYPE(data) MathFunctions::Sum<1, FRAME(data)>::apply_third_deriv(  \
+      const DTYPE(data) & x) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+
+/// \endcond

--- a/src/PointwiseFunctions/MathFunctions/Sum.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Sum.hpp
@@ -1,0 +1,185 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines MathFunctions::Sum.
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include <pup.h>
+
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace MathFunctions {
+template <size_t VolumeDim, typename Fr>
+class Sum;
+
+/*!
+ *  \ingroup MathFunctionsGroup
+ *  \brief 1D sum \f$A + B\f$ of two `MathFunction`s \f$A\f$ and \f$B\f$
+ *
+ *  \details Input file options are: `MathFunctionA` and `MathFunctionB`,
+ *  which are two 1-dimensional `MathFunction`s.
+ */
+template <typename Fr>
+class Sum<1, Fr> : public MathFunction<1, Fr> {
+ public:
+  struct MathFunctionA {
+    using type = std::unique_ptr<MathFunction<1, Fr>>;
+    static constexpr OptionString help = {"A MathFunction."};
+  };
+
+  struct MathFunctionB {
+    using type = std::unique_ptr<MathFunction<1, Fr>>;
+    static constexpr OptionString help = {"A MathFunction."};
+  };
+
+  using options = tmpl::list<MathFunctionA, MathFunctionB>;
+
+  static constexpr OptionString help = {"Sums the input MathFunctions"};
+
+  WRAPPED_PUPable_decl_base_template(SINGLE_ARG(MathFunction<1, Fr>),
+                                     Sum);  // NOLINT
+
+  explicit Sum(CkMigrateMessage* /*unused*/) noexcept {}
+
+  Sum(std::unique_ptr<MathFunction<1, Fr>> math_function_a,
+      std::unique_ptr<MathFunction<1, Fr>> math_function_b) noexcept;
+
+  Sum() = default;
+  ~Sum() override = default;
+  Sum(const Sum& /*rhs*/) = delete;
+  Sum& operator=(const Sum& /*rhs*/) = delete;
+  Sum(Sum&& /*rhs*/) noexcept = default;
+  Sum& operator=(Sum&& /*rhs*/) noexcept = default;
+
+  double operator()(const double& x) const noexcept override;
+  DataVector operator()(const DataVector& x) const noexcept override;
+  using MathFunction<1, Fr>::operator();
+
+  double first_deriv(const double& x) const noexcept override;
+  DataVector first_deriv(const DataVector& x) const noexcept override;
+  using MathFunction<1, Fr>::first_deriv;
+
+  double second_deriv(const double& x) const noexcept override;
+  DataVector second_deriv(const DataVector& x) const noexcept override;
+  using MathFunction<1, Fr>::second_deriv;
+
+  double third_deriv(const double& x) const noexcept override;
+  DataVector third_deriv(const DataVector& x) const noexcept override;
+  using MathFunction<1, Fr>::third_deriv;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) override;  // NOLINT
+
+ private:
+  std::unique_ptr<MathFunction<1, Fr>> math_function_a_;
+  std::unique_ptr<MathFunction<1, Fr>> math_function_b_;
+
+  template <typename T>
+  T apply_call_operator(const T& x) const noexcept;
+  template <typename T>
+  T apply_first_deriv(const T& x) const noexcept;
+  template <typename T>
+  T apply_second_deriv(const T& x) const noexcept;
+  template <typename T>
+  T apply_third_deriv(const T& x) const noexcept;
+};
+
+/*!
+ *  \ingroup MathFunctionsGroup
+ *  \brief N-dimensional sum \f$A + B\f$ of two `MathFunction`s \f$A\f$ and
+ * \f$B\f$
+ *
+ *  \details Input file options are: `MathFunctionA` and `MathFunctionB`,
+ *  which are two N-dimensional `MathFunction`s.
+ */
+template <size_t VolumeDim, typename Fr>
+class Sum : public MathFunction<VolumeDim, Fr> {
+ public:
+  struct MathFunctionA {
+    using type = std::unique_ptr<MathFunction<VolumeDim, Fr>>;
+    static constexpr OptionString help = {"A MathFunction."};
+  };
+
+  struct MathFunctionB {
+    using type = std::unique_ptr<MathFunction<VolumeDim, Fr>>;
+    static constexpr OptionString help = {"A MathFunction."};
+  };
+  using options = tmpl::list<MathFunctionA, MathFunctionB>;
+
+  static constexpr OptionString help = {
+      "Applies a Sum function to the input coordinates"};
+
+  WRAPPED_PUPable_decl_base_template(SINGLE_ARG(MathFunction<VolumeDim, Fr>),
+                                     Sum);  // NOLINT
+
+  explicit Sum(CkMigrateMessage* /*unused*/) noexcept {}
+
+  Sum(std::unique_ptr<MathFunction<VolumeDim, Fr>> math_function_a,
+      std::unique_ptr<MathFunction<VolumeDim, Fr>> math_function_b) noexcept;
+
+  Sum() = default;
+  ~Sum() override = default;
+  Sum(const Sum& /*rhs*/) = delete;
+  Sum& operator=(const Sum& /*rhs*/) = delete;
+  Sum(Sum&& /*rhs*/) noexcept = default;
+  Sum& operator=(Sum&& /*rhs*/) noexcept = default;
+
+  Scalar<double> operator()(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
+  Scalar<DataVector> operator()(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+
+  tnsr::i<double, VolumeDim, Fr> first_deriv(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
+  tnsr::i<DataVector, VolumeDim, Fr> first_deriv(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+
+  tnsr::ii<double, VolumeDim, Fr> second_deriv(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
+  tnsr::ii<DataVector, VolumeDim, Fr> second_deriv(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+
+  tnsr::iii<double, VolumeDim, Fr> third_deriv(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
+  tnsr::iii<DataVector, VolumeDim, Fr> third_deriv(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) override;  // NOLINT
+ private:
+  std::unique_ptr<MathFunction<VolumeDim, Fr>> math_function_a_;
+  std::unique_ptr<MathFunction<VolumeDim, Fr>> math_function_b_;
+
+  template <typename T>
+  Scalar<T> apply_call_operator(
+      const tnsr::I<T, VolumeDim, Fr>& x) const noexcept;
+  template <typename T>
+  tnsr::i<T, VolumeDim, Fr> apply_first_deriv(
+      const tnsr::I<T, VolumeDim, Fr>& x) const noexcept;
+  template <typename T>
+  tnsr::ii<T, VolumeDim, Fr> apply_second_deriv(
+      const tnsr::I<T, VolumeDim, Fr>& x) const noexcept;
+  template <typename T>
+  tnsr::iii<T, VolumeDim, Fr> apply_third_deriv(
+      const tnsr::I<T, VolumeDim, Fr>& x) const noexcept;
+};
+}  // namespace MathFunctions
+
+/// \cond
+template <size_t VolumeDim, typename Fr>
+PUP::able::PUP_ID MathFunctions::Sum<VolumeDim, Fr>::my_PUP_ID = 0;  // NOLINT
+
+template <typename Fr>
+PUP::able::PUP_ID MathFunctions::Sum<1, Fr>::my_PUP_ID = 0;  // NOLINT
+/// \endcond

--- a/tests/Unit/PointwiseFunctions/MathFunctions/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/CMakeLists.txt
@@ -4,9 +4,11 @@
 set(LIBRARY "Test_MathFunctions")
 
 set(LIBRARY_SOURCES
+  Test_Constant.cpp
   Test_Gaussian.cpp
   Test_PowX.cpp
   Test_Sinusoid.cpp
+  Test_Sum.cpp
   Test_TensorProduct.cpp
   )
 

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Python/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Python/TestFunctions.py
@@ -4,6 +4,22 @@
 import numpy as np
 
 
+def constant_call_operator(coords, value):
+    return value
+
+
+def constant_first_deriv(coords, value):
+    return np.zeros(coords.size)
+
+
+def constant_second_deriv(coords, value):
+    return np.zeros((coords.size, coords.size))
+
+
+def constant_third_deriv(coords, value):
+    return np.zeros((coords.size, coords.size, coords.size))
+
+
 def centered_coordinates(coords, center):
     return coords - center
 
@@ -95,3 +111,65 @@ def pow_x_third_deriv(coords, power):
     else:
         return np.array([[(power - 2.0) * (power - 1.0) * power *
                           np.power(coords, power - 3.0)]])
+
+
+def sum_call_operator(coords, amplitude_A, width_A, center_A, amplitude_B,
+                      width_B, center_B):
+    return gaussian_call_operator(coords, amplitude_A, width_A,
+                                  center_A) + gaussian_call_operator(
+                                      coords, amplitude_B, width_B, center_B)
+
+
+def sum_first_deriv(coords, amplitude_A, width_A, center_A, amplitude_B,
+                    width_B, center_B):
+    return gaussian_first_deriv(coords, amplitude_A, width_A,
+                                center_A) + gaussian_first_deriv(
+                                    coords, amplitude_B, width_B, center_B)
+
+
+def sum_second_deriv(coords, amplitude_A, width_A, center_A, amplitude_B,
+                     width_B, center_B):
+    return gaussian_second_deriv(coords, amplitude_A, width_A,
+                                 center_A) + gaussian_second_deriv(
+                                     coords, amplitude_B, width_B, center_B)
+
+
+def sum_third_deriv(coords, amplitude_A, width_A, center_A, amplitude_B,
+                    width_B, center_B):
+    return gaussian_third_deriv(coords, amplitude_A, width_A,
+                                center_A) + gaussian_third_deriv(
+                                    coords, amplitude_B, width_B, center_B)
+
+
+def sum_of_sum_call_operator(coords, amplitude_A, width_A, center_A,
+                             amplitude_B, width_B, center_B, amplitude_C,
+                             width_C, center_C):
+    return gaussian_call_operator(
+        coords, amplitude_A, width_A, center_A) + gaussian_call_operator(
+            coords, amplitude_B, width_B, center_B) + gaussian_call_operator(
+                coords, amplitude_C, width_C, center_C)
+
+
+def sum_of_sum_first_deriv(coords, amplitude_A, width_A, center_A, amplitude_B,
+                           width_B, center_B, amplitude_C, width_C, center_C):
+    return gaussian_first_deriv(
+        coords, amplitude_A, width_A, center_A) + gaussian_first_deriv(
+            coords, amplitude_B, width_B, center_B) + gaussian_first_deriv(
+                coords, amplitude_C, width_C, center_C)
+
+
+def sum_of_sum_second_deriv(coords, amplitude_A, width_A, center_A,
+                            amplitude_B, width_B, center_B, amplitude_C,
+                            width_C, center_C):
+    return gaussian_second_deriv(
+        coords, amplitude_A, width_A, center_A) + gaussian_second_deriv(
+            coords, amplitude_B, width_B, center_B) + gaussian_second_deriv(
+                coords, amplitude_C, width_C, center_C)
+
+
+def sum_of_sum_third_deriv(coords, amplitude_A, width_A, center_A, amplitude_B,
+                           width_B, center_B, amplitude_C, width_C, center_C):
+    return gaussian_third_deriv(
+        coords, amplitude_A, width_A, center_A) + gaussian_third_deriv(
+            coords, amplitude_B, width_B, center_B) + gaussian_third_deriv(
+                coords, amplitude_C, width_C, center_C)

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Constant.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Constant.cpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/MathFunctions/TestHelpers.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/MathFunctions/Constant.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/Gsl.hpp"
+
+template <size_t VolumeDim, typename Fr>
+class MathFunction;
+
+namespace Frame {
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+
+namespace {
+template <size_t VolumeDim, typename DataType, typename Fr>
+void test_constant_random(const DataType& used_for_size) noexcept {
+  Parallel::register_derived_classes_with_charm<
+      MathFunctions::Constant<VolumeDim, Fr>>();
+
+  // Generate the amplitude and width
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> real_dis(-5, 5);
+
+  const double value = real_dis(gen);
+
+  MathFunctions::Constant<VolumeDim, Fr> constant{value};
+
+  TestHelpers::MathFunctions::check(std::move(constant), "constant",
+                                    used_for_size, {{{-1.0, 1.0}}}, value);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Constant",
+                  "[PointwiseFunctions][Unit]") {
+  const DataVector dv{{std::numeric_limits<double>::signaling_NaN(),
+                       std::numeric_limits<double>::signaling_NaN()}};
+
+  pypp::SetupLocalPythonEnvironment{"PointwiseFunctions/MathFunctions/Python"};
+
+  using VolumeDims = tmpl::integral_list<size_t, 1, 2, 3>;
+  using Frames = tmpl::list<Frame::Grid, Frame::Inertial>;
+
+  tmpl::for_each<VolumeDims>([&dv](auto dim_v) {
+    using VolumeDim = typename decltype(dim_v)::type;
+    tmpl::for_each<Frames>([&dv](auto frame_v) {
+      using Fr = typename decltype(frame_v)::type;
+      test_constant_random<VolumeDim::value, DataVector, Fr>(dv);
+      test_constant_random<VolumeDim::value, double, Fr>(
+          std::numeric_limits<double>::signaling_NaN());
+    });
+  });
+}
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Constant.Factory",
+                  "[PointwiseFunctions][Unit]") {
+  TestHelpers::test_factory_creation<MathFunction<1, Frame::Inertial>>(
+      "Constant:\n"
+      "  Value: -4.0\n");
+
+  const double value{4.0};
+  const MathFunctions::Constant<3, Frame::Inertial> constant{value};
+  const auto created_constant =
+      TestHelpers::test_creation<MathFunctions::Constant<3, Frame::Inertial>>(
+          "Value: 4.0\n");
+  CHECK(created_constant == constant);
+  const auto created_constant_mathfunction =
+      TestHelpers::test_factory_creation<MathFunction<3, Frame::Inertial>>(
+          "Constant:\n"
+          "  Value: 4.444\n");
+}

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sum.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sum.cpp
@@ -1,0 +1,209 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <random>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/MathFunctions/TestHelpers.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "PointwiseFunctions/MathFunctions/Sum.hpp"
+#include "Utilities/Gsl.hpp"
+
+template <size_t VolumeDim, typename Fr>
+class MathFunction;
+
+namespace Frame {
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+
+namespace {
+template <size_t VolumeDim, typename DataType, typename Fr>
+void test_sum_random(const DataType& used_for_size) noexcept {
+  Parallel::register_derived_classes_with_charm<
+      MathFunctions::Gaussian<VolumeDim, Fr>>();
+  Parallel::register_derived_classes_with_charm<
+      MathFunctions::Sum<VolumeDim, Fr>>();
+
+  // Generate the amplitude and width
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> real_dis(-1, 1);
+  std::uniform_real_distribution<> positive_dis(0, 1);
+
+  const double amplitude_A = positive_dis(gen);
+  const double amplitude_B = positive_dis(gen);
+
+  // If the width is too small then the terms in the second derivative
+  // can become very large and fail the test due to rounding errors.
+  const double width_A = positive_dis(gen) + 0.5;
+  const double width_B = positive_dis(gen) + 0.5;
+
+  // Generate the center
+  std::array<double, VolumeDim> center_A{};
+  std::array<double, VolumeDim> center_B{};
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    gsl::at(center_A, i) = real_dis(gen);
+    gsl::at(center_B, i) = real_dis(gen);
+  }
+
+  MathFunctions::Gaussian<VolumeDim, Fr> gauss_A{amplitude_A, width_A,
+                                                 center_A};
+  MathFunctions::Gaussian<VolumeDim, Fr> gauss_B{amplitude_B, width_B,
+                                                 center_B};
+  MathFunctions::Sum<VolumeDim, Fr> sum{
+      std::make_unique<MathFunctions::Gaussian<VolumeDim, Fr>>(
+          std::move(gauss_A)),
+      std::make_unique<MathFunctions::Gaussian<VolumeDim, Fr>>(
+          std::move(gauss_B))};
+
+  TestHelpers::MathFunctions::check(std::move(sum), "sum", used_for_size,
+                                    {{{-1.0, 1.0}}}, amplitude_A, width_A,
+                                    center_A, amplitude_B, width_B, center_B);
+
+  const double amplitude_C = positive_dis(gen);
+  const double amplitude_D = positive_dis(gen);
+  const double amplitude_E = positive_dis(gen);
+  const double width_C = positive_dis(gen) + 0.5;
+  const double width_D = positive_dis(gen) + 0.5;
+  const double width_E = positive_dis(gen) + 0.5;
+  std::array<double, VolumeDim> center_C{};
+  std::array<double, VolumeDim> center_D{};
+  std::array<double, VolumeDim> center_E{};
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    gsl::at(center_C, i) = real_dis(gen);
+    gsl::at(center_D, i) = real_dis(gen);
+    gsl::at(center_E, i) = real_dis(gen);
+  }
+  MathFunctions::Gaussian<VolumeDim, Fr> gauss_C{amplitude_C, width_C,
+                                                 center_C};
+  MathFunctions::Gaussian<VolumeDim, Fr> gauss_D{amplitude_D, width_D,
+                                                 center_D};
+  MathFunctions::Gaussian<VolumeDim, Fr> gauss_E{amplitude_E, width_E,
+                                                 center_E};
+
+  MathFunctions::Sum<VolumeDim, Fr> sum_cd{
+      std::make_unique<MathFunctions::Gaussian<VolumeDim, Fr>>(
+          std::move(gauss_C)),
+      std::make_unique<MathFunctions::Gaussian<VolumeDim, Fr>>(
+          std::move(gauss_D))};
+
+  MathFunctions::Sum<VolumeDim, Fr> sum_of_sum{
+      std::make_unique<MathFunctions::Gaussian<VolumeDim, Fr>>(
+          std::move(gauss_E)),
+      std::make_unique<MathFunctions::Sum<VolumeDim, Fr>>(std::move(sum_cd))};
+
+  TestHelpers::MathFunctions::check(std::move(sum_of_sum), "sum_of_sum",
+                                    used_for_size, {{{-1.0, 1.0}}}, amplitude_C,
+                                    width_C, center_C, amplitude_D, width_D,
+                                    center_D, amplitude_E, width_E, center_E);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sum",
+                  "[PointwiseFunctions][Unit]") {
+  const DataVector dv{{std::numeric_limits<double>::signaling_NaN(),
+                       std::numeric_limits<double>::signaling_NaN()}};
+
+  pypp::SetupLocalPythonEnvironment{"PointwiseFunctions/MathFunctions/Python"};
+
+  using VolumeDims = tmpl::integral_list<size_t, 1, 2, 3>;
+  using Frames = tmpl::list<Frame::Grid, Frame::Inertial>;
+
+  tmpl::for_each<VolumeDims>([&dv](auto dim_v) {
+    using VolumeDim = typename decltype(dim_v)::type;
+    tmpl::for_each<Frames>([&dv](auto frame_v) {
+      using Fr = typename decltype(frame_v)::type;
+      test_sum_random<VolumeDim::value, DataVector, Fr>(dv);
+      test_sum_random<VolumeDim::value, double, Fr>(
+          std::numeric_limits<double>::signaling_NaN());
+    });
+  });
+}
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sum.Factory",
+                  "[PointwiseFunctions][Unit]") {
+  // Tests must have at least one assertion to pass, but here just test
+  // that factory creation works. Other MathFunctions test operator== here,
+  // but Sum does not support operator== because Sum objects cannot
+  // be copied (since their std::unique_ptr members) cannot be copied
+  CHECK(true);
+
+  TestHelpers::test_factory_creation<MathFunction<1, Frame::Inertial>>(
+      "Sum:\n"
+      "  MathFunctionA:\n"
+      "    Sinusoid:\n"
+      "      Amplitude: 3\n"
+      "      Wavenumber: 2\n"
+      "      Phase: -9\n"
+      "  MathFunctionB:\n"
+      "    PowX:\n"
+      "      Power: 4\n");
+
+  const auto created_sum =
+      TestHelpers::test_creation<MathFunctions::Sum<3, Frame::Inertial>>(
+          "MathFunctionA:\n"
+          "  Gaussian:\n"
+          "    Amplitude: 4.0\n"
+          "    Width: 1.5\n"
+          "    Center: [1.1, 2.2, -3.3]\n"
+          "MathFunctionB:\n"
+          "  Gaussian:\n"
+          "    Amplitude: 4.4\n"
+          "    Width: 1.4\n"
+          "    Center: [1.4, 2.4, -3.4]");
+  const auto created_sum_mathfunction =
+      TestHelpers::test_factory_creation<MathFunction<3, Frame::Inertial>>(
+          "Sum:\n"
+          "  MathFunctionA:\n"
+          "    Gaussian:\n"
+          "      Amplitude: 1.1\n"
+          "      Width: 2.2\n"
+          "      Center: [1.1, 2.2, -3.3]\n"
+          "  MathFunctionB:\n"
+          "    Gaussian:\n"
+          "      Amplitude: 1.4\n"
+          "      Width: 2.4\n"
+          "      Center: [1.2, 2.3, -3.4]\n");
+
+  // Test creating a Sum where MathFunctionB is itself a Sum
+  const auto created_sum_mathfunction_recursive =
+      TestHelpers::test_factory_creation<MathFunction<3, Frame::Inertial>>(
+          "Sum:\n"
+          "  MathFunctionA:\n"
+          "    Sum:\n"
+          "      MathFunctionA:\n"
+          "        Gaussian:\n"
+          "          Amplitude: 1.1\n"
+          "          Width: 2.2\n"
+          "          Center: [1.2, 2.3, -3.4]\n"
+          "      MathFunctionB:\n"
+          "        Gaussian:\n"
+          "          Amplitude: 1.2\n"
+          "          Width: 2.1\n"
+          "          Center: [1.1, 2.2, -3.3]\n"
+          "  MathFunctionB:\n"
+          "    Sum:\n"
+          "      MathFunctionA:\n"
+          "        Gaussian:\n"
+          "          Amplitude: 1.5\n"
+          "          Width: 2.1\n"
+          "          Center: [1.5, 2.5, -3.5]\n"
+          "      MathFunctionB:\n"
+          "        Gaussian:\n"
+          "          Amplitude: 1.6\n"
+          "          Width: 2.6\n"
+          "          Center: [1.6, 2.6, -3.6]\n");
+}


### PR DESCRIPTION
## Proposed changes

Depends on #2300 

This PR adds a MathFunction called Sum, that adds two other MathFunctions. It also adds a Constant MathFunction, that returns a constant independent of the input.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
