### PR TITLE
Clarify comment in lift_flux

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp
@@ -42,7 +42,8 @@ auto lift_flux(Variables<tmpl::list<FluxTags...>> flux,
                Scalar<DataVector> magnitude_of_face_normal) noexcept
     -> Variables<tmpl::list<db::remove_tag_prefix<FluxTags>...>> {
   auto lift_factor = std::move(get(magnitude_of_face_normal));
-  // The LGL weights are:
+  // For an Nth degree basis (i.e., one with N+1 basis functions), the LGL
+  // weights are:
   //   w_i = 2 / ((N + 1) * N * (P_{N}(xi_i))^2)
   // and so at the end points (xi = +/- 1) we get:
   //   w_0 = 2 / ((N + 1) * N)


### PR DESCRIPTION
N could reasonably be interpreted as either the order or the extent,
so be explicit about which it is.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
