### PR TITLE
Fix accuracy loss in continued fraction expansion

### DIFF
--- a/src/Utilities/FractionUtilities.hpp
+++ b/src/Utilities/FractionUtilities.hpp
@@ -3,16 +3,14 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <limits>
 #include <type_traits>
-#include <utility>
 
-#include "ErrorHandling/Assert.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/TypeTraits.hpp"
 
 /// Type trait to check if a type looks like a fraction (specifically,
 /// if it has numerator and denominator methods)
@@ -80,14 +78,13 @@ class ContinuedFraction {
   }
 
  private:
-  template <typename U, Requires<is_fraction_v<U>> = nullptr>
+  template <typename U>
   static value_type ifloor(const U& x) noexcept {
-    return static_cast<value_type>(x.numerator() / x.denominator());
-  }
-
-  template <typename U, Requires<not is_fraction_v<U>> = nullptr>
-  static value_type ifloor(const U& x) noexcept {
-    return static_cast<value_type>(std::floor(x));
+    if constexpr (is_fraction_v<U>) {
+      return static_cast<value_type>(x.numerator() / x.denominator());
+    } else {
+      return static_cast<value_type>(std::floor(x));
+    }
   }
 
   value_type term_;
@@ -157,7 +154,8 @@ Fraction simplest_fraction_in_interval(const T1& end1,
       if (++cf2) {
         ++term2;
       }
-      result.insert(gsl::narrow<Term_t>(std::min(term1, term2)));
+      using std::min;
+      result.insert(gsl::narrow<Term_t>(min(term1, term2)));
       return result.value();
     }
     result.insert(gsl::narrow<Term_t>(term1));

--- a/tests/Unit/Utilities/Test_FractionUtilities.cpp
+++ b/tests/Unit/Utilities/Test_FractionUtilities.cpp
@@ -8,10 +8,12 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <random>
 #include <set>
 #include <vector>
 
 #include "ErrorHandling/Assert.hpp"
+#include "Framework/TestHelpers.hpp"
 #include "Utilities/FractionUtilities.hpp"
 
 namespace {
@@ -28,18 +30,68 @@ std::vector<typename Source::value_type> collect(
 
 SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFraction",
                   "[Utilities][Unit]") {
-  using Rational = boost::rational<int>;
+  using Rational = boost::rational<int64_t>;
 
-  CHECK((std::vector<int>{1, 2, 4, 2}) ==
+  CHECK((std::vector<int64_t>{1, 2, 4, 2}) ==
         collect(ContinuedFraction<Rational>(Rational(29, 20))));
   CHECK((std::vector<int64_t>{0, 8}) ==
         collect(ContinuedFraction<double>(0.125)));
+  CHECK((std::vector<int64_t>{-1, 1, 7}) ==
+        collect(ContinuedFraction<double>(-0.125)));
   CHECK(std::vector<int64_t>(20, 1) ==
         collect(ContinuedFraction<double>(0.5 * (1. + sqrt(5.))), 20));
+  CHECK((std::vector<int64_t>{0}) ==
+        collect(ContinuedFraction<Rational>(Rational(0))));
+  CHECK((std::vector<int64_t>{0}) == collect(ContinuedFraction<double>(0.)));
 
   // Check that the iterator terminates because of precision loss.
   CHECK(collect(ContinuedFraction<double>(0.5 * (1. + sqrt(5.))), 100).size() <
         100);
+
+  // Check that the iterator doesn't terminate prematurely
+  // because of precision loss.
+  const int64_t two_to_the_fourty = 1099511627776;
+  CHECK(std::vector<int64_t>{0, two_to_the_fourty} ==
+        collect(ContinuedFraction<double>(1. / two_to_the_fourty)));
+  CHECK(std::vector<int64_t>{1, two_to_the_fourty} ==
+        collect(ContinuedFraction<double>(1 + 1. / two_to_the_fourty)));
+  CHECK(std::vector<int64_t>{0, two_to_the_fourty, 2} ==
+        collect(ContinuedFraction<double>(1. / (two_to_the_fourty + 0.5))));
+
+  MAKE_GENERATOR(gen);
+  {
+    std::uniform_real_distribution<> dist(-10., 10.);
+    const double value = dist(gen);
+    CAPTURE_PRECISE(value);
+    // Set the scale because the fractional part of a negative number
+    // (defined as `x - floor(x)`) can be larger than the number.
+    auto approx_value = approx.scale(std::abs(std::floor(value)))(value);
+    ContinuedFractionSummer<Rational> summer;
+    bool should_be_smaller = true;
+    std::vector<int64_t> terms{};  // Only for output
+    std::vector<double> convergents{};  // Only for output
+    for (ContinuedFraction<double> source(value); source; ++source) {
+      summer.insert(*source);
+      terms.push_back(*source);
+      convergents.push_back(boost::rational_cast<double>(summer.value()));
+      CAPTURE_PRECISE(terms);
+      CAPTURE_PRECISE(convergents);
+
+      // Convergents to a continued fraction always alternate between
+      // over- and underestimates.
+      if (convergents.back() != approx_value) {
+        if (should_be_smaller) {
+          CHECK(convergents.back() <= value);
+        } else {
+          CHECK(convergents.back() >= value);
+        }
+      }
+      should_be_smaller = !should_be_smaller;
+    }
+    CAPTURE_PRECISE(terms);
+    CAPTURE_PRECISE(convergents);
+    CHECK(convergents.back() == approx_value);
+  }
 }
 
 SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFractionSummer",

--- a/tools/Iwyu/iwyu.imp
+++ b/tools/Iwyu/iwyu.imp
@@ -24,7 +24,7 @@
   { symbol: ["PUP::er", private, "<pup.h>", public]},
 
   { include: ["<catch.hpp>", public,
-              "\"tests/Unit/TestingFramework.hpp\"", public]},
+              "\"Framework/TestingFramework.hpp\"", public]},
 
   { include: ["<type_traits>", public,
               "\"Utilities/TypeTraits.hpp\"", public]},


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
