### PR TITLE
Add IrreducibleMassTag

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -361,6 +361,21 @@ struct AreaCompute : Area, db::ComputeTag {
   using argument_tags =
       tmpl::list<StrahlkorperTags::Strahlkorper<Frame>, AreaElement<Frame>>;
 };
+/// The Irreducible (areal) mass of an apparent horizon
+struct IrreducibleMass : db::SimpleTag {
+  using type = double;
+};
+/// Computes the Irreducible mass of an apparent horizon from its area
+template <typename Frame>
+struct IrreducibleMassCompute : IrreducibleMass, db::ComputeTag {
+  using base = IrreducibleMass;
+  using return_type = double;
+  static void function(const gsl::not_null<double*> result,
+                       const double area) noexcept {
+    *result = ::StrahlkorperGr::irreducible_mass(area);
+  }
 
+  using argument_tags = tmpl::list<Area>;
+};
 }  // namespace Tags
 }  // namespace StrahlkorperGr

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -35,10 +35,7 @@ template <typename Frame>
 struct EuclideanAreaElement;
 template <typename IntegrandTag, typename Frame>
 struct EuclideanSurfaceIntegral;
-template <typename Frame>
-struct Area;
-template <typename Frame>
-struct AreaCompute;
+
 }  // namespace StrahlkorperTags
 
 namespace StrahlkorperGr {
@@ -47,5 +44,11 @@ template <typename Frame>
 struct AreaElement;
 template <typename IntegrandTag, typename Frame>
 struct SurfaceIntegral;
+struct Area;
+template <typename Frame>
+struct AreaCompute;
+struct IrreducibleMass;
+template <typename Frame>
+struct IrreducibleMassCompute;
 }  // namespace Tags
 }  // namespace StrahlkorperGr

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -299,6 +299,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   test_normals();
   TestHelpers::db::test_simple_tag<ah::Tags::FastFlow>("FastFlow");
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::Area>("Area");
+  TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::IrreducibleMass>(
+      "IrreducibleMass");
   TestHelpers::db::test_simple_tag<
       StrahlkorperTags::Strahlkorper<Frame::Inertial>>("Strahlkorper");
   TestHelpers::db::test_compute_tag<
@@ -342,4 +344,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
       "SurfaceIntegral(SomeTag)");
   TestHelpers::db::test_compute_tag<
       StrahlkorperGr::Tags::AreaCompute<Frame::Inertial>>("Area");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperGr::Tags::IrreducibleMassCompute<Frame::Inertial>>(
+      "IrreducibleMass");
 }


### PR DESCRIPTION
## Proposed changes

Add IrreducibleMassTag and IrreducibileMassCompute for computing the irreducible mass of an apparent horizon. 

### Types of changes:

- [ ] Bugfix
- [x ] New feature
- [ ] Refactor

### Component:

- [x ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
